### PR TITLE
test(core): Add MCP registry discovery evals (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -100,7 +100,9 @@ export type {
 	ObservationLogStatus,
 	ObservationLogTaskKind,
 	ObservationLogTaskLockHandle,
+	FinishReason,
 } from './types';
+export { FINISH_REASONS, isFinishReason } from './types';
 export type { ProviderOptions } from '@ai-sdk/provider-utils';
 export { AgentEvent } from './types';
 export type { AgentEventData, AgentEventHandler } from './types';

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -61,6 +61,7 @@ export type {
 	OpenAIPromptCachingConfig,
 	PromptCachingConfig,
 } from './sdk/agent';
+export { FINISH_REASONS, isFinishReason } from './sdk/agent';
 
 export type { SerializedMessageList } from './runtime/message-list';
 

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -22,14 +22,21 @@ import type { JSONObject, JSONValue } from '../utils/json';
 
 export type SmoothStreamOptions = NonNullable<Parameters<typeof smoothStream>[0]>;
 
-export type FinishReason =
-	| 'stop'
-	| 'max-iterations'
-	| 'length'
-	| 'content-filter'
-	| 'tool-calls'
-	| 'error'
-	| 'other';
+export const FINISH_REASONS = [
+	'stop',
+	'max-iterations',
+	'length',
+	'content-filter',
+	'tool-calls',
+	'error',
+	'other',
+] as const;
+
+export type FinishReason = (typeof FINISH_REASONS)[number];
+
+export function isFinishReason(value: unknown): value is FinishReason {
+	return typeof value === 'string' && FINISH_REASONS.some((reason) => reason === value);
+}
 
 export type TokenUsage<T extends Record<string, unknown> = Record<string, unknown>> = {
 	promptTokens: number;

--- a/packages/@n8n/instance-ai/evaluations/__tests__/stub-workspace.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/stub-workspace.test.ts
@@ -1,0 +1,38 @@
+import { createStubWorkspace, stubWorkspaceRoot } from '../harness/stub-workspace';
+
+describe('createStubWorkspace', () => {
+	const filesystem = () => {
+		const fs = createStubWorkspace().filesystem;
+		if (!fs) throw new Error('stub workspace has no filesystem');
+		return fs;
+	};
+
+	it('reads back what was written', async () => {
+		const fs = filesystem();
+		await fs.writeFile('src/workflows/a.workflow.ts', 'export default 1;');
+
+		await expect(fs.readFile('src/workflows/a.workflow.ts')).resolves.toBe('export default 1;');
+	});
+
+	it.each([
+		['an absolute path under the workspace root', `${stubWorkspaceRoot}/src/a.ts`],
+		['a dot-relative path', './src/a.ts'],
+	])('resolves %s to the same file', async (_label, path) => {
+		const fs = filesystem();
+		await fs.writeFile('src/a.ts', 'content');
+
+		await expect(fs.readFile(path)).resolves.toBe('content');
+	});
+
+	it('rejects a read of a file that was never written', async () => {
+		await expect(filesystem().readFile('missing.ts')).rejects.toThrow('No such file');
+	});
+
+	it('offers only the tools production exposes', () => {
+		expect(
+			createStubWorkspace()
+				.getTools()
+				.map((tool) => tool.name),
+		).not.toContain('workspace_file_stat');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/data-table-workflow-skill-loading.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/data-table-workflow-skill-loading.json
@@ -17,5 +17,6 @@
 		],
 		"noneOf": ["create-tasks"]
 	},
-	"rationale": "Regression coverage for single-workflow build prompts that depend on Data Tables. The orchestrator should load both the data-table-manager skill and the workflow-builder skill, include workflow-local table requirements in the build, and avoid task planning or delegation."
+	"rationale": "Regression coverage for single-workflow build prompts that depend on Data Tables. The orchestrator should load both the data-table-manager skill and the workflow-builder skill, include workflow-local table requirements in the build, and avoid task planning or delegation.",
+	"timeoutMs": 180000
 }

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/google-oauth-credential-setup.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/google-oauth-credential-setup.json
@@ -17,5 +17,6 @@
 			{ "toolName": "browser_screenshot" }
 		]
 	},
-	"rationale": "Google OAuth involves multiple console screens; the orchestrator must reach for the Computer Use credential skill or browser_* tools rather than asking the user to copy values into chat."
+	"rationale": "Google OAuth involves multiple console screens; the orchestrator must reach for the Computer Use credential skill or browser_* tools rather than asking the user to copy values into chat.",
+	"timeoutMs": 120000
 }

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/index.ts
@@ -3,12 +3,18 @@ import { basename, join } from 'path';
 import { z } from 'zod';
 
 import type { LocalGatewayStatus } from '../../../src/types';
-import type { DiscoveryTestCase } from '../../discovery/types';
+import type { DiscoveryMcpState } from '../../discovery/stub-mcp-registry';
+import type { DiscoveryConfirmations, DiscoveryTestCase } from '../../discovery/types';
 
 const forbiddenToolCallSchema = z
 	.object({
 		toolName: z.string().min(1),
+		args: z
+			.record(z.string(), z.unknown())
+			.refine((pattern) => Object.keys(pattern).length > 0, { message: 'args must not be empty' })
+			.optional(),
 		argsContainAny: z.array(z.string().min(1)).min(1).optional(),
+		declined: z.boolean().optional(),
 	})
 	.strict();
 
@@ -20,6 +26,44 @@ const localGatewayStatusSchema: z.ZodType<LocalGatewayStatus> = z.discriminatedU
 	z.object({ status: z.literal('disconnected') }).strict(),
 	z.object({ status: z.literal('disabled') }).strict(),
 ]);
+
+const mcpStateSchema: z.ZodType<DiscoveryMcpState> = z
+	.object({
+		registry: z.array(z.string().min(1)).optional(),
+		connected: z
+			.array(
+				z
+					.object({ slug: z.string().min(1), tools: z.array(z.string().min(1)).optional() })
+					.strict(),
+			)
+			.optional(),
+	})
+	.strict();
+
+const confirmationDecisionSchema = z.enum(['approve', 'deny']);
+
+/** An empty map is dead config: the default (approve everything) already applies. */
+const confirmationsSchema: z.ZodType<DiscoveryConfirmations> = z
+	.record(
+		z.string().min(1),
+		z.union([
+			confirmationDecisionSchema,
+			z
+				.object({
+					decision: confirmationDecisionSchema,
+					resumeWith: z
+						.record(z.string(), z.unknown())
+						.refine((fields) => Object.keys(fields).length > 0, {
+							message: 'resumeWith must not be empty',
+						})
+						.optional(),
+				})
+				.strict(),
+		]),
+	)
+	.refine((entries) => Object.keys(entries).length > 0, {
+		message: 'confirmations must not be empty',
+	});
 
 /** Strict authoring schema for discovery cases — a typo'd key or an empty
  *  expectation must fail at load time, not pass vacuously at run time (the
@@ -33,9 +77,11 @@ export const discoveryTestCaseSchema = z
 			.object({
 				localGateway: localGatewayStatusSchema.optional(),
 				browserAvailable: z.boolean().optional(),
+				mcp: mcpStateSchema.optional(),
 			})
 			.strict()
 			.optional(),
+		confirmations: confirmationsSchema.optional(),
 		expectedToolInvocations: z
 			.object({
 				// min(1) on every list: an empty expectation array is dead config that
@@ -52,6 +98,7 @@ export const discoveryTestCaseSchema = z
 			}),
 		rationale: z.string().optional(),
 		maxSteps: z.number().int().positive().optional(),
+		timeoutMs: z.number().int().positive().optional(),
 	})
 	.strict();
 

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/index.ts
@@ -56,6 +56,9 @@ const confirmationsSchema: z.ZodType<DiscoveryConfirmations> = z
 						.refine((fields) => Object.keys(fields).length > 0, {
 							message: 'resumeWith must not be empty',
 						})
+						.refine((fields) => !('approved' in fields), {
+							message: 'resumeWith must not set `approved` — use `decision` instead',
+						})
 						.optional(),
 				})
 				.strict(),

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-broken-connection-reconnect.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-broken-connection-reconnect.json
@@ -1,0 +1,18 @@
+{
+	"id": "mcp-broken-connection-reconnect",
+	"userMessage": "Search my Notion for the Q3 roadmap page and tell me what's in it.",
+	"instanceState": {
+		"mcp": {
+			"registry": ["notion", "linear"],
+			"connected": [{ "slug": "notion", "tools": [] }]
+		}
+	},
+	"expectedToolInvocations": {
+		"allOfToolCalls": [
+			{ "toolName": "mcp-servers", "args": { "action": "connect", "serverSlugs": ["notion"] } }
+		],
+		"noneOfToolCalls": [{ "toolName": "mcp-servers", "args": { "action": "search" } }]
+	},
+	"rationale": "A connected server serving no tools is a broken connection: the agent must reconnect the slug it already has, not fall back to a registry search that filters connected servers out and dead-ends.",
+	"maxSteps": 12
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-connect-unconnected-service.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-connect-unconnected-service.json
@@ -1,0 +1,18 @@
+{
+	"id": "mcp-connect-unconnected-service",
+	"userMessage": "Pull up the notes from my last product review in Notion and give me a short summary.",
+	"instanceState": {
+		"mcp": { "registry": ["notion", "linear"], "connected": [] }
+	},
+	"expectedToolInvocations": {
+		"allOfToolCalls": [
+			{ "toolName": "mcp-servers", "args": { "action": "search" } },
+			{ "toolName": "mcp-servers", "args": { "action": "connect", "serverSlugs": ["notion"] } }
+		],
+		"noneOfToolCalls": [
+			{ "toolName": "mcp-servers", "args": { "action": "connect", "serverSlugs": ["linear"] } }
+		]
+	},
+	"rationale": "Nothing is connected: the agent must find Notion in the registry and offer it, not declare it unreachable or recite manual setup steps. Linear is a decoy.",
+	"maxSteps": 12
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-declined-tool-call-no-reconnect.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-declined-tool-call-no-reconnect.json
@@ -1,0 +1,17 @@
+{
+	"id": "mcp-declined-tool-call-no-reconnect",
+	"userMessage": "Find the 'Launch checklist' page in my Notion and summarise what's still open.",
+	"instanceState": {
+		"mcp": {
+			"registry": ["notion", "linear"],
+			"connected": [{ "slug": "notion", "tools": ["notion-search"] }]
+		}
+	},
+	"confirmations": { "mcp_notion_notion-search": "deny" },
+	"expectedToolInvocations": {
+		"allOfToolCalls": [{ "toolName": "mcp_notion_notion-search", "declined": true }],
+		"noneOfToolCalls": [{ "toolName": "mcp-servers", "args": { "action": "connect" } }]
+	},
+	"rationale": "A refused tool call is the user withholding permission, not a broken connection: the agent must report back rather than reconnect a server that is already connected.",
+	"maxSteps": 12
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-no-registry-match.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-no-registry-match.json
@@ -1,0 +1,13 @@
+{
+	"id": "mcp-no-registry-match",
+	"userMessage": "Pull up my latest deals from HubSpot and give me a short summary.",
+	"instanceState": {
+		"mcp": { "registry": ["notion", "linear"], "connected": [] }
+	},
+	"expectedToolInvocations": {
+		"allOfToolCalls": [{ "toolName": "mcp-servers", "args": { "action": "search" } }],
+		"noneOfToolCalls": [{ "toolName": "mcp-servers", "args": { "action": "connect" } }]
+	},
+	"rationale": "HubSpot is not in the registry: the agent must search before declaring it unavailable, and must not offer an invented slug or a near-miss server.",
+	"maxSteps": 12
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-not-offered-for-workflow-build.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-not-offered-for-workflow-build.json
@@ -12,5 +12,6 @@
 		]
 	},
 	"rationale": "A workflow talks to a service through its node and credential, not an MCP connection. Slack is in the registry to make the wrong move available. `connected` is allowed — only offering a connection is the regression.",
-	"maxSteps": 24
+	"maxSteps": 24,
+	"timeoutMs": 120000
 }

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-not-offered-for-workflow-build.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-not-offered-for-workflow-build.json
@@ -1,0 +1,16 @@
+{
+	"id": "mcp-not-offered-for-workflow-build",
+	"userMessage": "Build me a workflow that posts a standup reminder to our Slack channel every weekday at 9am.",
+	"instanceState": {
+		"mcp": { "registry": ["slack", "notion"], "connected": [] }
+	},
+	"expectedToolInvocations": {
+		"allOfToolCalls": [{ "toolName": "build-workflow" }],
+		"noneOfToolCalls": [
+			{ "toolName": "mcp-servers", "args": { "action": "search" } },
+			{ "toolName": "mcp-servers", "args": { "action": "connect" } }
+		]
+	},
+	"rationale": "A workflow talks to a service through its node and credential, not an MCP connection. Slack is in the registry to make the wrong move available. `connected` is allowed — only offering a connection is the regression.",
+	"maxSteps": 24
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-uses-connected-server-tools.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/mcp-uses-connected-server-tools.json
@@ -1,0 +1,16 @@
+{
+	"id": "mcp-uses-connected-server-tools",
+	"userMessage": "Pull up the notes from my last product review in Notion and give me a short summary.",
+	"instanceState": {
+		"mcp": { "registry": ["notion", "linear"], "connected": [{ "slug": "notion" }] }
+	},
+	"expectedToolInvocations": {
+		"anyOfToolCalls": [
+			{ "toolName": "mcp_notion_notion-search" },
+			{ "toolName": "mcp_notion_notion-fetch" }
+		],
+		"noneOfToolCalls": [{ "toolName": "mcp-servers", "args": { "action": "connect" } }]
+	},
+	"rationale": "Notion is already connected: the agent must use its tools instead of re-offering a connection the user already has.",
+	"maxSteps": 12
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/slack-oauth-credential-setup.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/slack-oauth-credential-setup.json
@@ -17,5 +17,6 @@
 			{ "toolName": "browser_screenshot" }
 		]
 	},
-	"rationale": "OAuth credential setup is the canonical browser-discovery moment. The orchestrator must reach for the Computer Use credential skill or browser_* tools directly; falling through to research/ask-user without browser involvement is the regression."
+	"rationale": "OAuth credential setup is the canonical browser-discovery moment. The orchestrator must reach for the Computer Use credential skill or browser_* tools directly; falling through to research/ask-user without browser involvement is the regression.",
+	"timeoutMs": 120000
 }

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/workflow-builder-no-agent-builder-leak.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/workflow-builder-no-agent-builder-leak.json
@@ -14,5 +14,6 @@
 			}
 		]
 	},
-	"rationale": "Regression gate for the agent-builder path into Instance AI. A plain workflow-building prompt must route through the workflow-builder skill and must never invoke the build-agent orchestration tool. Meaningful in both module modes; the strongest signal is a run with N8N_ENABLED_MODULES including 'agents', where build-agent is registered (it is always-loaded, not deferred) yet must still not be selected."
+	"rationale": "Regression gate for the agent-builder path into Instance AI. A plain workflow-building prompt must route through the workflow-builder skill and must never invoke the build-agent orchestration tool. Meaningful in both module modes; the strongest signal is a run with N8N_ENABLED_MODULES including 'agents', where build-agent is registered (it is always-loaded, not deferred) yet must still not be selected.",
+	"timeoutMs": 120000
 }

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/workflow-builder-no-credential-ask.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/workflow-builder-no-credential-ask.json
@@ -24,5 +24,6 @@
 		]
 	},
 	"rationale": "Regression coverage for INS-204. A clear single-workflow build should route through the workflow-builder skill directly, may use credentials(action=\"list\") for discovery, and must not ask the user which credential/account to use when the builder can auto-select or mock unresolved credentials. It should also use contextual timezone data rather than asking for it.",
-	"maxSteps": 24
+	"maxSteps": 24,
+	"timeoutMs": 150000
 }

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/confirmation-policy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/confirmation-policy.test.ts
@@ -1,6 +1,10 @@
 import type { SuspensionInfo } from '../../../src/utils/stream-helpers';
 import { discoveryTestCaseSchema } from '../../data/discovery';
-import { buildConfirmationPolicy, resolveConfirmation } from '../confirmation-policy';
+import {
+	buildConfirmationPolicy,
+	resolveConfirmation,
+	unmatchedConfirmations,
+} from '../confirmation-policy';
 import { credentialAutoSetupResponder } from '../credential-approval';
 import { createMcpConnectResponder, createStubMcpRegistry } from '../stub-mcp-registry';
 import type { DiscoveryTestCase } from '../types';
@@ -158,6 +162,48 @@ describe('resolveConfirmation', () => {
 			approved: true,
 			answer: 'yes',
 		});
+	});
+});
+
+describe('unmatchedConfirmations', () => {
+	const policy = buildConfirmationPolicy(
+		scenario({
+			confirmations: {
+				'mcp_notion_notion-search': 'deny',
+				credentials: { decision: 'approve', resumeWith: { autoSetup: { credentialType: 'x' } } },
+			},
+		}),
+	);
+
+	it('reports every behaviour-changing answer no suspension asked for', () => {
+		expect(unmatchedConfirmations(policy, [])).toEqual(['mcp_notion_notion-search', 'credentials']);
+	});
+
+	it('reports nothing once each declared tool has suspended', () => {
+		const asked = [suspension('mcp_notion_notion-search'), suspension('credentials')];
+		expect(unmatchedConfirmations(policy, asked)).toEqual([]);
+	});
+
+	it('exempts a bare approve, which only asks for the default', () => {
+		const approveOnly = buildConfirmationPolicy(
+			scenario({ confirmations: { 'ask-user': 'approve' } }),
+		);
+		expect(unmatchedConfirmations(approveOnly, [])).toEqual([]);
+	});
+
+	it('matches the tool name echoed into the suspend payload', () => {
+		const gated: SuspensionInfo = {
+			toolCallId: 'call-1',
+			requestId: 'req-1',
+			suspendPayload: { type: 'approval', toolName: 'mcp_notion_notion-search' },
+		};
+		expect(unmatchedConfirmations(policy, [gated, suspension('credentials')])).toEqual([]);
+	});
+
+	it('ignores suspensions the scenario never declared', () => {
+		expect(
+			unmatchedConfirmations(buildConfirmationPolicy(scenario()), [suspension('nodes')]),
+		).toEqual([]);
 	});
 });
 

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/confirmation-policy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/confirmation-policy.test.ts
@@ -127,6 +127,27 @@ describe('resolveConfirmation', () => {
 		]);
 	});
 
+	it('keeps a deny denied even when resumeWith claims approval', () => {
+		const policy = buildConfirmationPolicy(
+			scenario({
+				confirmations: { 'mcp-servers': { decision: 'deny', resumeWith: { approved: true } } },
+			}),
+		);
+		const { responders } = mcpResponders();
+		expect(
+			resolveConfirmation(suspension('mcp-servers', connectPayload), policy, responders),
+		).toEqual({ approved: false });
+	});
+
+	it('keeps an approve approved even when resumeWith claims refusal', () => {
+		const policy = buildConfirmationPolicy(
+			scenario({
+				confirmations: { 'ask-user': { decision: 'approve', resumeWith: { approved: false } } },
+			}),
+		);
+		expect(resolveConfirmation(suspension('ask-user'), policy)).toEqual({ approved: true });
+	});
+
 	it('carries resumeWith when no responder recognises the payload', () => {
 		const policy = buildConfirmationPolicy(
 			scenario({
@@ -192,6 +213,10 @@ describe('discoveryTestCaseSchema', () => {
 			{ confirmations: { 'mcp-servers': { decision: 'approve', resumeWith: {} } } },
 		],
 		['a misspelled key', { confirmation: { 'mcp-servers': 'deny' } }],
+		[
+			'a resumeWith setting the reserved `approved` field',
+			{ confirmations: { 'mcp-servers': { decision: 'deny', resumeWith: { approved: true } } } },
+		],
 	])('rejects %s', (_label, invalid) => {
 		expect(discoveryTestCaseSchema.safeParse({ ...base, ...invalid }).success).toBe(false);
 	});

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/confirmation-policy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/confirmation-policy.test.ts
@@ -1,0 +1,198 @@
+import type { SuspensionInfo } from '../../../src/utils/stream-helpers';
+import { discoveryTestCaseSchema } from '../../data/discovery';
+import { buildConfirmationPolicy, resolveConfirmation } from '../confirmation-policy';
+import { credentialAutoSetupResponder } from '../credential-approval';
+import { createMcpConnectResponder, createStubMcpRegistry } from '../stub-mcp-registry';
+import type { DiscoveryTestCase } from '../types';
+
+function scenario(overrides: Partial<DiscoveryTestCase> = {}): DiscoveryTestCase {
+	return {
+		id: 'test',
+		userMessage: 'do the thing',
+		expectedToolInvocations: { anyOf: ['mcp-servers'] },
+		...overrides,
+	};
+}
+
+function suspension(
+	toolName: string,
+	suspendPayload: Record<string, unknown> = {},
+): SuspensionInfo {
+	return { toolCallId: 'call-1', requestId: 'req-1', toolName, suspendPayload };
+}
+
+const connectPayload = {
+	mcpConnectRequest: { servers: [{ serverSlug: 'notion' }, { serverSlug: 'linear' }] },
+};
+
+const credentialPayload = {
+	credentialRequests: [{ credentialType: 'slackOAuth2Api' }],
+};
+
+function mcpResponders() {
+	const registry = createStubMcpRegistry({ registry: ['notion', 'linear'], connected: [] });
+	return { registry, responders: [createMcpConnectResponder(registry)] };
+}
+
+describe('buildConfirmationPolicy', () => {
+	it('is empty when the scenario declares nothing', () => {
+		expect(buildConfirmationPolicy(scenario()).size).toBe(0);
+	});
+
+	it('normalizes a bare decision into an answer', () => {
+		const policy = buildConfirmationPolicy(scenario({ confirmations: { 'mcp-servers': 'deny' } }));
+		expect(policy.get('mcp-servers')).toEqual({ decision: 'deny' });
+	});
+
+	it('keeps an answer object as declared', () => {
+		const answer = { decision: 'approve' as const, resumeWith: { connectedSlugs: ['notion'] } };
+		const policy = buildConfirmationPolicy(scenario({ confirmations: { 'mcp-servers': answer } }));
+		expect(policy.get('mcp-servers')).toEqual(answer);
+	});
+});
+
+describe('resolveConfirmation', () => {
+	const empty = buildConfirmationPolicy(scenario());
+
+	it('approves a suspension no policy entry covers', () => {
+		expect(resolveConfirmation(suspension('some-tool'), empty)).toEqual({ approved: true });
+	});
+
+	it('approves when the suspension is unknown', () => {
+		expect(resolveConfirmation(undefined, empty)).toEqual({ approved: true });
+	});
+
+	it('denies when the scenario says so', async () => {
+		const policy = buildConfirmationPolicy(scenario({ confirmations: { 'mcp-servers': 'deny' } }));
+		const { responders, registry } = mcpResponders();
+		expect(
+			resolveConfirmation(suspension('mcp-servers', connectPayload), policy, responders),
+		).toEqual({ approved: false });
+		await expect(registry.service.listConnections()).resolves.toEqual([]);
+	});
+
+	it('denies an mcp tool call by its prefixed name', () => {
+		const policy = buildConfirmationPolicy(
+			scenario({ confirmations: { 'mcp_notion_notion-search': 'deny' } }),
+		);
+		const approval = { type: 'approval', toolName: 'mcp_notion_notion-search', args: {} };
+		expect(resolveConfirmation(suspension('mcp_notion_notion-search', approval), policy)).toEqual({
+			approved: false,
+		});
+		expect(resolveConfirmation(suspension('mcp_linear_list_issues', approval), policy)).toEqual({
+			approved: true,
+		});
+	});
+
+	it('falls back to the tool name the approval gate echoes into the payload', () => {
+		const policy = buildConfirmationPolicy(
+			scenario({ confirmations: { 'mcp_notion_notion-search': 'deny' } }),
+		);
+		const gated: SuspensionInfo = {
+			toolCallId: 'call-1',
+			requestId: 'req-1',
+			suspendPayload: { type: 'approval', toolName: 'mcp_notion_notion-search', args: {} },
+		};
+		expect(resolveConfirmation(gated, policy)).toEqual({ approved: false });
+	});
+
+	it('takes the first responder that recognises the payload', () => {
+		const { responders } = mcpResponders();
+		const all = [credentialAutoSetupResponder, ...responders];
+		expect(resolveConfirmation(suspension('mcp-servers', connectPayload), empty, all)).toEqual({
+			approved: true,
+			connectedSlugs: ['notion', 'linear'],
+		});
+		expect(resolveConfirmation(suspension('credentials', credentialPayload), empty, all)).toEqual({
+			approved: true,
+			autoSetup: { credentialType: 'slackOAuth2Api' },
+		});
+	});
+
+	it('lets the scenario override responder fields without losing their side effects', async () => {
+		const { registry, responders } = mcpResponders();
+		const policy = buildConfirmationPolicy(
+			scenario({
+				confirmations: {
+					'mcp-servers': { decision: 'approve', resumeWith: { connectedSlugs: ['notion'] } },
+				},
+			}),
+		);
+		expect(
+			resolveConfirmation(suspension('mcp-servers', connectPayload), policy, responders),
+		).toEqual({ approved: true, connectedSlugs: ['notion'] });
+		await expect(registry.service.listConnections()).resolves.toEqual([
+			{ slug: 'notion' },
+			{ slug: 'linear' },
+		]);
+	});
+
+	it('carries resumeWith when no responder recognises the payload', () => {
+		const policy = buildConfirmationPolicy(
+			scenario({
+				confirmations: { 'ask-user': { decision: 'approve', resumeWith: { answer: 'yes' } } },
+			}),
+		);
+		expect(resolveConfirmation(suspension('ask-user'), policy)).toEqual({
+			approved: true,
+			answer: 'yes',
+		});
+	});
+});
+
+describe('credentialAutoSetupResponder', () => {
+	it('requests browser auto-setup for the first credential', () => {
+		expect(credentialAutoSetupResponder(credentialPayload)).toEqual({
+			autoSetup: { credentialType: 'slackOAuth2Api' },
+		});
+	});
+
+	it.each([
+		['a payload with no credential requests', {}],
+		['an empty request list', { credentialRequests: [] }],
+		['a request with no credential type', { credentialRequests: [{}] }],
+	])('passes on %s', (_label, payload) => {
+		expect(credentialAutoSetupResponder(payload)).toBeUndefined();
+	});
+});
+
+describe('createMcpConnectResponder', () => {
+	it('marks the offered slugs live on the registry', async () => {
+		const { registry, responders } = mcpResponders();
+		expect(responders[0](connectPayload)).toEqual({ connectedSlugs: ['notion', 'linear'] });
+		await expect(registry.service.listConnections()).resolves.toEqual([
+			{ slug: 'notion' },
+			{ slug: 'linear' },
+		]);
+	});
+
+	it('passes on a payload carrying no connect request', () => {
+		const { responders } = mcpResponders();
+		expect(responders[0]({ credentialRequests: [] })).toBeUndefined();
+	});
+});
+
+describe('discoveryTestCaseSchema', () => {
+	const base = { id: 'x', userMessage: 'y', expectedToolInvocations: { anyOf: ['a'] } };
+
+	it.each([
+		['a bare decision', { 'mcp-servers': 'deny' }],
+		['an answer object', { 'mcp-servers': { decision: 'approve' } }],
+		['an answer with resume data', { credentials: { decision: 'approve', resumeWith: { a: 1 } } }],
+	])('accepts %s', (_label, confirmations) => {
+		expect(discoveryTestCaseSchema.safeParse({ ...base, confirmations }).success).toBe(true);
+	});
+
+	it.each([
+		['an unknown decision', { confirmations: { 'mcp-servers': 'maybe' } }],
+		['an empty map', { confirmations: {} }],
+		['a missing decision', { confirmations: { 'mcp-servers': { resumeWith: { a: 1 } } } }],
+		[
+			'an empty resumeWith',
+			{ confirmations: { 'mcp-servers': { decision: 'approve', resumeWith: {} } } },
+		],
+		['a misspelled key', { confirmation: { 'mcp-servers': 'deny' } }],
+	])('rejects %s', (_label, invalid) => {
+		expect(discoveryTestCaseSchema.safeParse({ ...base, ...invalid }).success).toBe(false);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
@@ -1,6 +1,6 @@
 import type { AgentActivity, CapturedToolCall, EventOutcome } from '../../types';
-import { runExpectedToolsInvokedCheck } from '../expected-tools-invoked';
-import type { DiscoveryTestCase } from '../types';
+import { evaluateDiscoveryTrial, runExpectedToolsInvokedCheck } from '../expected-tools-invoked';
+import type { DiscoveryTestCase, DiscoveryTrialFacts } from '../types';
 
 type ToolCallInput = Pick<CapturedToolCall, 'toolName'> &
 	Partial<Pick<CapturedToolCall, 'args' | 'result'>>;
@@ -599,5 +599,98 @@ describe('runExpectedToolsInvokedCheck', () => {
 				),
 			).toThrow();
 		});
+	});
+});
+
+describe('evaluateDiscoveryTrial', () => {
+	const trial = (overrides: Partial<DiscoveryTrialFacts> = {}): DiscoveryTrialFacts => ({
+		streamStatus: 'completed',
+		timeoutMs: 60_000,
+		unmatchedConfirmations: [],
+		...overrides,
+	});
+
+	const negativeOnly: DiscoveryTestCase = {
+		id: 'test',
+		userMessage: 'Set up a Slack credential.',
+		expectedToolInvocations: { noneOf: ['browser_navigate'] },
+	};
+
+	const positiveOnly: DiscoveryTestCase = {
+		id: 'test',
+		userMessage: 'Screenshot my dashboard.',
+		expectedToolInvocations: { anyOf: ['browser_navigate'] },
+	};
+
+	const satisfied = makeOutcome({ toolCalls: [{ toolName: 'browser_navigate' }] });
+
+	it('passes a satisfied expectation on a completed run', () => {
+		expect(evaluateDiscoveryTrial(negativeOnly, makeOutcome({}), trial()).pass).toBe(true);
+		expect(evaluateDiscoveryTrial(positiveOnly, satisfied, trial()).pass).toBe(true);
+	});
+
+	it.each([
+		['negative-only', negativeOnly, makeOutcome({})],
+		['positive-only', positiveOnly, satisfied],
+	])('fails a satisfied %s expectation when the run stopped at its step cap', (_l, s, outcome) => {
+		const result = evaluateDiscoveryTrial(s, outcome, trial({ streamStatus: 'step-exhausted' }));
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('step cap');
+	});
+
+	it.each(['errored', 'suspended'] as const)(
+		'fails a satisfied expectation when the run %s',
+		(streamStatus) => {
+			const result = evaluateDiscoveryTrial(positiveOnly, satisfied, trial({ streamStatus }));
+
+			expect(result.pass).toBe(false);
+			expect(result.comment).toContain('Run did not complete');
+		},
+	);
+
+	it('fails a satisfied expectation when the run exceeded its budget', () => {
+		const result = evaluateDiscoveryTrial(
+			positiveOnly,
+			satisfied,
+			trial({ streamStatus: 'timed-out', timeoutMs: 150_000 }),
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('exceeded its 150000ms budget');
+	});
+
+	it('reports the run error alongside the invalid trial', () => {
+		const result = evaluateDiscoveryTrial(
+			negativeOnly,
+			makeOutcome({}),
+			trial({ streamStatus: 'errored', runError: 'overloaded_error' }),
+		);
+
+		expect(result.comment).toContain('errored: overloaded_error');
+	});
+
+	it('keeps the expectation diagnostic when an invalid trial also failed its expectation', () => {
+		const result = evaluateDiscoveryTrial(
+			positiveOnly,
+			makeOutcome({ toolCalls: [{ toolName: 'nodes' }] }),
+			trial({ streamStatus: 'timed-out' }),
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('budget and was abandoned');
+		expect(result.comment).toContain('Expected at least one of');
+	});
+
+	it('fails when a declared confirmation answer was never asked for', () => {
+		const result = evaluateDiscoveryTrial(
+			negativeOnly,
+			makeOutcome({}),
+			trial({ unmatchedConfirmations: ['mcp_notion_notion-search'] }),
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('mcp_notion_notion-search');
+		expect(result.comment).toContain('never ran');
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
@@ -3,7 +3,9 @@ import { runExpectedToolsInvokedCheck } from '../expected-tools-invoked';
 import type { DiscoveryTestCase } from '../types';
 
 function makeOutcome(opts: {
-	toolCalls?: Array<Pick<CapturedToolCall, 'toolName'> & Partial<Pick<CapturedToolCall, 'args'>>>;
+	toolCalls?: Array<
+		Pick<CapturedToolCall, 'toolName'> & Partial<Pick<CapturedToolCall, 'args' | 'result'>>
+	>;
 	agents?: Array<Pick<AgentActivity, 'role' | 'tools'>>;
 }): EventOutcome {
 	return {
@@ -16,6 +18,7 @@ function makeOutcome(opts: {
 			toolCallId: `call-${i}`,
 			toolName: tc.toolName,
 			args: tc.args ?? {},
+			...(tc.result === undefined ? {} : { result: tc.result }),
 			durationMs: 0,
 		})),
 		agentActivities: (opts.agents ?? []).map((a, i) => ({
@@ -340,6 +343,192 @@ describe('runExpectedToolsInvokedCheck', () => {
 
 			expect(result.pass).toBe(false);
 			expect(result.comment).toContain('list');
+		});
+	});
+
+	describe('args — structured argument matching', () => {
+		const connectNotion: DiscoveryTestCase = {
+			id: 'test',
+			userMessage: 'Search my Notion.',
+			expectedToolInvocations: {
+				anyOfToolCalls: [
+					{ toolName: 'mcp-servers', args: { action: 'connect', serverSlugs: ['notion'] } },
+				],
+			},
+		};
+
+		it('passes on a deep-partial match, ignoring unlisted keys', () => {
+			const result = runExpectedToolsInvokedCheck(
+				connectNotion,
+				makeOutcome({
+					toolCalls: [
+						{
+							toolName: 'mcp-servers',
+							args: { action: 'connect', serverSlugs: ['notion'], reason: 'unlocks search' },
+						},
+					],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+		});
+
+		it('matches an array as a subset, not by length or order', () => {
+			const result = runExpectedToolsInvokedCheck(
+				connectNotion,
+				makeOutcome({
+					toolCalls: [
+						{
+							toolName: 'mcp-servers',
+							args: { action: 'connect', serverSlugs: ['linear', 'notion'] },
+						},
+					],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+		});
+
+		it('fails when a listed key differs, even though a substring match would pass', () => {
+			const result = runExpectedToolsInvokedCheck(
+				connectNotion,
+				makeOutcome({
+					toolCalls: [
+						{
+							toolName: 'mcp-servers',
+							args: {
+								action: 'connect',
+								serverSlugs: ['linear'],
+								reason: 'Linear covers this instead of Notion',
+							},
+						},
+					],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
+		});
+
+		it('fails when the action differs', () => {
+			const result = runExpectedToolsInvokedCheck(
+				connectNotion,
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp-servers', args: { action: 'search', queries: ['notion'] } }],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('declined tool calls', () => {
+		const declined = {
+			declined: true,
+			message: 'Tool "mcp_notion_notion-search" was not approved',
+		};
+
+		it('does not count a declined call as a violation', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: {
+						noneOfToolCalls: [{ toolName: 'mcp_notion_notion-search' }],
+					},
+				},
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp_notion_notion-search', result: declined }],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+		});
+
+		it('does not count a declined call as satisfying a positive expectation', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: {
+						anyOfToolCalls: [{ toolName: 'mcp_notion_notion-search' }],
+					},
+				},
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp_notion_notion-search', result: declined }],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
+			expect(result.comment).toContain('declined');
+		});
+
+		it('still counts a call that was approved and ran', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: {
+						anyOfToolCalls: [{ toolName: 'mcp_notion_notion-search' }],
+					},
+				},
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp_notion_notion-search', result: { ok: true } }],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+		});
+
+		it('matches a refusal when the expectation asks for one', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: {
+						allOfToolCalls: [{ toolName: 'mcp_notion_notion-search', declined: true }],
+					},
+				},
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp_notion_notion-search', result: declined }],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+		});
+
+		it('does not match a call that ran when the expectation asks for a refusal', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: {
+						allOfToolCalls: [{ toolName: 'mcp_notion_notion-search', declined: true }],
+					},
+				},
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp_notion_notion-search', result: { ok: true } }],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
+			expect(result.comment).toContain('a declined result');
+		});
+
+		it('forbids a refusal when noneOfToolCalls asks for one', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: {
+						noneOfToolCalls: [{ toolName: 'mcp_notion_notion-search', declined: true }],
+					},
+				},
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp_notion_notion-search', result: declined }],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
 		});
 	});
 

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
@@ -2,11 +2,22 @@ import type { AgentActivity, CapturedToolCall, EventOutcome } from '../../types'
 import { runExpectedToolsInvokedCheck } from '../expected-tools-invoked';
 import type { DiscoveryTestCase } from '../types';
 
+type ToolCallInput = Pick<CapturedToolCall, 'toolName'> &
+	Partial<Pick<CapturedToolCall, 'args' | 'result'>>;
+
+function makeToolCall(tc: ToolCallInput, i: number): CapturedToolCall {
+	return {
+		toolCallId: `call-${i}`,
+		toolName: tc.toolName,
+		args: tc.args ?? {},
+		...(tc.result === undefined ? {} : { result: tc.result }),
+		durationMs: 0,
+	};
+}
+
 function makeOutcome(opts: {
-	toolCalls?: Array<
-		Pick<CapturedToolCall, 'toolName'> & Partial<Pick<CapturedToolCall, 'args' | 'result'>>
-	>;
-	agents?: Array<Pick<AgentActivity, 'role' | 'tools'>>;
+	toolCalls?: ToolCallInput[];
+	agents?: Array<Pick<AgentActivity, 'role' | 'tools'> & { toolCalls?: ToolCallInput[] }>;
 }): EventOutcome {
 	return {
 		workflowIds: [],
@@ -14,18 +25,12 @@ function makeOutcome(opts: {
 		dataTableIds: [],
 		artifactRefs: [],
 		finalText: '',
-		toolCalls: (opts.toolCalls ?? []).map((tc, i) => ({
-			toolCallId: `call-${i}`,
-			toolName: tc.toolName,
-			args: tc.args ?? {},
-			...(tc.result === undefined ? {} : { result: tc.result }),
-			durationMs: 0,
-		})),
+		toolCalls: (opts.toolCalls ?? []).map(makeToolCall),
 		agentActivities: (opts.agents ?? []).map((a, i) => ({
 			agentId: `agent-${i}`,
 			role: a.role,
 			tools: a.tools,
-			toolCalls: [],
+			toolCalls: (a.toolCalls ?? []).map(makeToolCall),
 			textContent: '',
 			reasoning: '',
 			status: 'completed',
@@ -512,6 +517,50 @@ describe('runExpectedToolsInvokedCheck', () => {
 
 			expect(result.pass).toBe(false);
 			expect(result.comment).toContain('a declined result');
+		});
+
+		it('does not count a sub-agent call the user refused as invoked', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: { noneOf: ['mcp_notion_notion-search'] },
+				},
+				makeOutcome({
+					toolCalls: [{ toolName: 'mcp_notion_notion-search', result: declined }],
+					agents: [
+						{
+							role: 'researcher',
+							tools: [],
+							toolCalls: [{ toolName: 'mcp_notion_notion-search', result: declined }],
+						},
+					],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+			expect(result.invokedTools).not.toContain('mcp_notion_notion-search');
+		});
+
+		it('counts a sub-agent call that ran as invoked', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: 'Search my Notion.',
+					expectedToolInvocations: { anyOf: ['mcp_notion_notion-search'] },
+				},
+				makeOutcome({
+					agents: [
+						{
+							role: 'researcher',
+							tools: [],
+							toolCalls: [{ toolName: 'mcp_notion_notion-search', result: { ok: true } }],
+						},
+					],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
 		});
 
 		it('forbids a refusal when noneOfToolCalls asks for one', () => {

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/stream-status.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/stream-status.test.ts
@@ -23,12 +23,16 @@ describe('resolveStreamStatus', () => {
 		);
 	});
 
-	it.each(['length', 'content-filter', 'error', 'other'] as const)(
+	it.each(['length', 'content-filter', 'error', 'other', 'tool-calls'] as const)(
 		'reports a run cut short by %s as errored',
 		(finishReason) => {
 			expect(resolveStreamStatus(streamResult({ finishReason }), false)).toBe('errored');
 		},
 	);
+
+	it('never reads a missing finish chunk as a clean finish', () => {
+		expect(resolveStreamStatus(streamResult(), false)).toBe('errored');
+	});
 
 	it('prefers timed-out over the step cap', () => {
 		expect(resolveStreamStatus(streamResult({ finishReason: 'max-iterations' }), true)).toBe(

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/stream-status.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/stream-status.test.ts
@@ -23,6 +23,13 @@ describe('resolveStreamStatus', () => {
 		);
 	});
 
+	it.each(['length', 'content-filter', 'error', 'other'] as const)(
+		'reports a run cut short by %s as errored',
+		(finishReason) => {
+			expect(resolveStreamStatus(streamResult({ finishReason }), false)).toBe('errored');
+		},
+	);
+
 	it('prefers timed-out over the step cap', () => {
 		expect(resolveStreamStatus(streamResult({ finishReason: 'max-iterations' }), true)).toBe(
 			'timed-out',

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/stream-status.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/stream-status.test.ts
@@ -1,0 +1,52 @@
+import type { ExecuteResumableStreamResult } from '../../../src/runtime/resumable-stream-executor';
+import { resolveStreamStatus } from '../stream-status';
+
+function streamResult(
+	overrides: Partial<ExecuteResumableStreamResult> = {},
+): ExecuteResumableStreamResult {
+	return {
+		status: 'completed',
+		agentRunId: 'run-1',
+		workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+		...overrides,
+	};
+}
+
+describe('resolveStreamStatus', () => {
+	it('reports a clean finish as completed', () => {
+		expect(resolveStreamStatus(streamResult({ finishReason: 'stop' }), false)).toBe('completed');
+	});
+
+	it('reports a run that hit its step cap as step-exhausted', () => {
+		expect(resolveStreamStatus(streamResult({ finishReason: 'max-iterations' }), false)).toBe(
+			'step-exhausted',
+		);
+	});
+
+	it('prefers timed-out over the step cap', () => {
+		expect(resolveStreamStatus(streamResult({ finishReason: 'max-iterations' }), true)).toBe(
+			'timed-out',
+		);
+	});
+
+	it('prefers errored over the step cap', () => {
+		expect(
+			resolveStreamStatus(
+				streamResult({ status: 'errored', finishReason: 'max-iterations' }),
+				false,
+			),
+		).toBe('errored');
+	});
+
+	it('reports the budget sentinel as timed-out', () => {
+		expect(resolveStreamStatus('timed-out', false)).toBe('timed-out');
+	});
+
+	it('reports a suspended run as suspended', () => {
+		expect(resolveStreamStatus(streamResult({ status: 'suspended' }), false)).toBe('suspended');
+	});
+
+	it('never reads a cancelled run as a clean finish', () => {
+		expect(resolveStreamStatus(streamResult({ status: 'cancelled' }), false)).toBe('timed-out');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/discovery/cli.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/cli.ts
@@ -27,7 +27,7 @@ interface CliArgs {
 	trials: number;
 	passThreshold: number;
 	timeoutMs: number;
-	/** Optional iteration cap; default uncapped — the wall-clock timeout bounds a run. */
+	/** Optional iteration cap; unset uses the SDK default. */
 	maxSteps?: number;
 	modelId: string;
 	concurrency: number;
@@ -273,7 +273,11 @@ async function main(): Promise<void> {
 	await runLocalMode(args);
 }
 
-main().catch((error) => {
-	console.error('Fatal error:', error);
-	process.exit(1);
-});
+main()
+	.then(() => {
+		process.stdout.write('', () => process.exit(process.exitCode ?? 0));
+	})
+	.catch((error) => {
+		console.error('Fatal error:', error);
+		process.exit(1);
+	});

--- a/packages/@n8n/instance-ai/evaluations/discovery/confirmation-policy.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/confirmation-policy.ts
@@ -41,14 +41,14 @@ export function resolveConfirmation(
 	responders: ApprovalResponder[] = [],
 ): Record<string, unknown> {
 	const answer = policy.get(suspendedToolName(suspension));
-	if (answer?.decision === 'deny') return { approved: false, ...answer.resumeWith };
+	if (answer?.decision === 'deny') return { ...answer.resumeWith, approved: false };
 
 	const payload = suspension?.suspendPayload ?? {};
 	for (const responder of responders) {
 		const responderAnswer = responder(payload);
-		if (responderAnswer) return { approved: true, ...responderAnswer, ...answer?.resumeWith };
+		if (responderAnswer) return { ...responderAnswer, ...answer?.resumeWith, approved: true };
 	}
-	return { approved: true, ...answer?.resumeWith };
+	return { ...answer?.resumeWith, approved: true };
 }
 
 function suspendedToolName(suspension: SuspensionInfo | undefined): string {

--- a/packages/@n8n/instance-ai/evaluations/discovery/confirmation-policy.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/confirmation-policy.ts
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------
+// How the harness answers confirmation / HITL suspensions.
+//
+// Production waits for the user; the harness answers from the scenario, keyed on
+// the suspending tool's name and defaulting to approve, so a scenario only
+// declares the answers it wants to differ. A bare approval resumes
+// `{ approved: true }`, which is the whole contract for an `approval` card — an
+// MCP tool call included.
+//
+// Cards that need the user to *supply* something (a credential choice, a
+// connect card's slugs, a Q&A wizard's answers) are filled in by an
+// ApprovalResponder living with that domain — `credential-approval.ts`,
+// `stub-mcp-registry.ts`. This module stays payload-agnostic: to cover a new
+// card kind, write a responder next to its domain and register it in the
+// runner. A scenario can always bypass the lot with `resumeWith`.
+// ---------------------------------------------------------------------------
+
+import { isRecord } from '@n8n/utils/is-record';
+
+import type { ConfirmationAnswer, DiscoveryTestCase } from './types';
+import type { SuspensionInfo } from '../../src/utils/stream-helpers';
+
+export type ConfirmationPolicy = Map<string, ConfirmationAnswer>;
+
+// Supplies what an approving user would have filled in for one kind of card.
+export type ApprovalResponder = (
+	payload: Record<string, unknown>,
+) => Record<string, unknown> | undefined;
+
+export function buildConfirmationPolicy(scenario: DiscoveryTestCase): ConfirmationPolicy {
+	const policy: ConfirmationPolicy = new Map();
+	for (const [toolName, answer] of Object.entries(scenario.confirmations ?? {})) {
+		policy.set(toolName, typeof answer === 'string' ? { decision: answer } : answer);
+	}
+	return policy;
+}
+
+export function resolveConfirmation(
+	suspension: SuspensionInfo | undefined,
+	policy: ConfirmationPolicy,
+	responders: ApprovalResponder[] = [],
+): Record<string, unknown> {
+	const answer = policy.get(suspendedToolName(suspension));
+	if (answer?.decision === 'deny') return { approved: false, ...answer.resumeWith };
+
+	const payload = suspension?.suspendPayload ?? {};
+	for (const responder of responders) {
+		const responderAnswer = responder(payload);
+		if (responderAnswer) return { approved: true, ...responderAnswer, ...answer?.resumeWith };
+	}
+	return { approved: true, ...answer?.resumeWith };
+}
+
+function suspendedToolName(suspension: SuspensionInfo | undefined): string {
+	if (suspension?.toolName) return suspension.toolName;
+	const payload = suspension?.suspendPayload;
+	return isRecord(payload) && typeof payload.toolName === 'string' ? payload.toolName : '';
+}

--- a/packages/@n8n/instance-ai/evaluations/discovery/confirmation-policy.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/confirmation-policy.ts
@@ -51,6 +51,18 @@ export function resolveConfirmation(
 	return { ...answer?.resumeWith, approved: true };
 }
 
+export function unmatchedConfirmations(
+	policy: ConfirmationPolicy,
+	suspensions: Iterable<SuspensionInfo>,
+): string[] {
+	const asked = new Set([...suspensions].map(suspendedToolName));
+	return [...policy]
+		.filter(
+			([tool, answer]) => !asked.has(tool) && (answer.decision === 'deny' || answer.resumeWith),
+		)
+		.map(([tool]) => tool);
+}
+
 function suspendedToolName(suspension: SuspensionInfo | undefined): string {
 	if (suspension?.toolName) return suspension.toolName;
 	const payload = suspension?.suspendPayload;

--- a/packages/@n8n/instance-ai/evaluations/discovery/credential-approval.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/credential-approval.ts
@@ -1,0 +1,19 @@
+import { isRecord } from '@n8n/utils/is-record';
+
+import type { ApprovalResponder } from './confirmation-policy';
+
+/** Approving a credential card means "Auto-setup with browser". A bare approval
+ *  takes the "user picked an existing credential" branch, so the orchestrator never
+ *  sees `needsBrowserSetup=true` — the flag that wires it to the Computer Use
+ *  credential setup skill. The card offers one credential at a time once browser
+ *  setup is in play, so the first request is the one `autoSetup` names. */
+export const credentialAutoSetupResponder: ApprovalResponder = (payload) => {
+	const requests = payload.credentialRequests;
+	if (!Array.isArray(requests)) return undefined;
+
+	const first: unknown = requests[0];
+	if (!isRecord(first) || typeof first.credentialType !== 'string' || !first.credentialType) {
+		return undefined;
+	}
+	return { autoSetup: { credentialType: first.credentialType } };
+};

--- a/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
@@ -22,6 +22,7 @@ import type { EventOutcome } from '../types';
 import type {
 	DiscoveryCheckResult,
 	DiscoveryTestCase,
+	DiscoveryTrialFacts,
 	ExpectedToolInvocations,
 	ForbiddenToolCall,
 } from './types';
@@ -213,4 +214,37 @@ export function runExpectedToolsInvokedCheck(
 		invokedTools,
 		spawnedAgents,
 	};
+}
+
+/**
+ * Only a run that finished on its own terms can settle an expectation, so anything else
+ * fails whichever way the expectation points — a truncated run that satisfied a positive
+ * expectation still means the agent never got to finish what it was doing.
+ */
+export function evaluateDiscoveryTrial(
+	scenario: DiscoveryTestCase,
+	outcome: EventOutcome,
+	trial: DiscoveryTrialFacts,
+): DiscoveryCheckResult {
+	const check = runExpectedToolsInvokedCheck(scenario, outcome);
+	const invalid = invalidTrialReason(trial);
+	if (!invalid) return check;
+
+	return { ...check, pass: false, comment: check.pass ? invalid : `${invalid} ${check.comment}` };
+}
+
+function invalidTrialReason(trial: DiscoveryTrialFacts): string | undefined {
+	switch (trial.streamStatus) {
+		case 'timed-out':
+			return `Run exceeded its ${String(trial.timeoutMs)}ms budget and was abandoned.`;
+		case 'step-exhausted':
+			return 'Run stopped at its step cap instead of finishing.';
+		case 'errored':
+		case 'suspended':
+			return `Run did not complete (${trial.runError ? `${trial.streamStatus}: ${trial.runError}` : trial.streamStatus}).`;
+		case 'completed':
+			return trial.unmatchedConfirmations.length > 0
+				? `Scenario declared confirmation answers for [${trial.unmatchedConfirmations.join(', ')}] that no suspension asked for, so those decisions never ran.`
+				: undefined;
+	}
 }

--- a/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
@@ -16,6 +16,8 @@
 // its own tool calls.
 // ---------------------------------------------------------------------------
 
+import { isRecord } from '@n8n/utils/is-record';
+
 import type { EventOutcome } from '../types';
 import type {
 	DiscoveryCheckResult,
@@ -29,7 +31,7 @@ const SPAWN_PREFIX = 'spawn_sub_agent:';
 function collectInvokedTools(outcome: EventOutcome): string[] {
 	const tools = new Set<string>();
 	for (const tc of outcome.toolCalls) {
-		if (tc.toolName) tools.add(tc.toolName);
+		if (tc.toolName && !wasDeclined(tc)) tools.add(tc.toolName);
 	}
 	for (const agent of outcome.agentActivities) {
 		for (const t of agent.tools) tools.add(t);
@@ -66,11 +68,17 @@ function validateRule(rule: ExpectedToolInvocations): void {
 	}
 }
 
+function wasDeclined(toolCall: EventOutcome['toolCalls'][number]): boolean {
+	return isRecord(toolCall.result) && toolCall.result.declined === true;
+}
+
 function toolCallMatchesExpectation(
 	toolCall: EventOutcome['toolCalls'][number],
 	expectation: ForbiddenToolCall,
 ): boolean {
+	if (wasDeclined(toolCall) !== (expectation.declined ?? false)) return false;
 	if (toolCall.toolName !== expectation.toolName) return false;
+	if (expectation.args && !matchesArgPattern(expectation.args, toolCall.args)) return false;
 
 	const argsContainAny = expectation.argsContainAny ?? [];
 	if (argsContainAny.length === 0) return true;
@@ -79,12 +87,40 @@ function toolCallMatchesExpectation(
 	return argsContainAny.some((term) => argsText.includes(term.toLowerCase()));
 }
 
+function matchesArgPattern(pattern: unknown, actual: unknown): boolean {
+	if (Array.isArray(pattern)) {
+		return (
+			Array.isArray(actual) &&
+			pattern.every((item) => actual.some((candidate) => matchesArgPattern(item, candidate)))
+		);
+	}
+	if (isRecord(pattern)) {
+		return (
+			isRecord(actual) &&
+			Object.entries(pattern).every(([key, value]) => matchesArgPattern(value, actual[key]))
+		);
+	}
+	return pattern === actual;
+}
+
+function describeActualToolCalls(outcome: EventOutcome): string {
+	return (
+		outcome.toolCalls
+			.map((tc) => (wasDeclined(tc) ? `${tc.toolName} (declined)` : tc.toolName))
+			.join(', ') || '∅'
+	);
+}
+
 function formatToolCallExpectation(expectation: ForbiddenToolCall): string {
-	const args =
-		expectation.argsContainAny && expectation.argsContainAny.length > 0
-			? ` with args containing one of [${expectation.argsContainAny.join(', ')}]`
-			: '';
-	return `${expectation.toolName}${args}`;
+	const clauses: string[] = [];
+	if (expectation.declined) clauses.push('a declined result');
+	if (expectation.args) clauses.push(`args matching ${JSON.stringify(expectation.args)}`);
+	if (expectation.argsContainAny && expectation.argsContainAny.length > 0) {
+		clauses.push(`args containing one of [${expectation.argsContainAny.join(', ')}]`);
+	}
+	return clauses.length > 0
+		? `${expectation.toolName} with ${clauses.join(' and ')}`
+		: expectation.toolName;
 }
 
 export function runExpectedToolsInvokedCheck(
@@ -128,7 +164,7 @@ export function runExpectedToolsInvokedCheck(
 			outcome.toolCalls.some((toolCall) => toolCallMatchesExpectation(toolCall, expectation)),
 		);
 		if (!matched) {
-			const actualToolCalls = outcome.toolCalls.map((tc) => tc.toolName).join(', ') || '∅';
+			const actualToolCalls = describeActualToolCalls(outcome);
 			return {
 				pass: false,
 				comment: `Expected at least one actual tool call matching [${anyOfToolCalls.map(formatToolCallExpectation).join(', ')}]. Actual tool calls: [${actualToolCalls}].`,
@@ -144,7 +180,7 @@ export function runExpectedToolsInvokedCheck(
 				toolCallMatchesExpectation(toolCall, expectation),
 			);
 			if (!matched) {
-				const actualToolCalls = outcome.toolCalls.map((tc) => tc.toolName).join(', ') || '∅';
+				const actualToolCalls = describeActualToolCalls(outcome);
 				return {
 					pass: false,
 					comment: `Expected actual tool call matching [${formatToolCallExpectation(expectation)}]. Actual tool calls: [${actualToolCalls}].`,

--- a/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
@@ -36,7 +36,7 @@ function collectInvokedTools(outcome: EventOutcome): string[] {
 	for (const agent of outcome.agentActivities) {
 		for (const t of agent.tools) tools.add(t);
 		for (const tc of agent.toolCalls) {
-			if (tc.toolName) tools.add(tc.toolName);
+			if (tc.toolName && !wasDeclined(tc)) tools.add(tc.toolName);
 		}
 	}
 	return [...tools];

--- a/packages/@n8n/instance-ai/evaluations/discovery/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/runner.ts
@@ -11,8 +11,9 @@
 // stubbed — when the orchestrator loads a runtime skill or reaches for a
 // Computer Use browser tool, the tool-call event fires before any downstream
 // failure, so the discovery check still sees the dispatch intent. The wall-clock
-// timeout bounds the loop so an erroring tool can't drive API spend; scenarios
-// or --max-steps can additionally opt into an iteration cap.
+// timeout bounds the trial, not the run: at the budget the trial stops and fails,
+// and the abandoned stream is left to unwind on its own. Scenarios or --max-steps
+// can additionally opt into an iteration cap.
 // ---------------------------------------------------------------------------
 
 import type { InstanceAiEvent, TaskList } from '@n8n/api-types';
@@ -21,10 +22,12 @@ import { nanoid } from 'nanoid';
 import {
 	buildConfirmationPolicy,
 	resolveConfirmation,
+	unmatchedConfirmations,
 	type ApprovalResponder,
 } from './confirmation-policy';
 import { credentialAutoSetupResponder } from './credential-approval';
-import { runExpectedToolsInvokedCheck } from './expected-tools-invoked';
+import { evaluateDiscoveryTrial } from './expected-tools-invoked';
+import { resolveStreamStatus } from './stream-status';
 import { createStubLocalMcpServer } from './stub-local-mcp';
 import {
 	createMcpConnectResponder,
@@ -34,7 +37,7 @@ import {
 	stubMcpServerConfigs,
 	type StubMcpRegistry,
 } from './stub-mcp-registry';
-import type { DiscoveryCheckResult, DiscoveryTestCase } from './types';
+import type { DiscoveryCheckResult, DiscoveryStreamStatus, DiscoveryTestCase } from './types';
 import { createInstanceAgent } from '../../src/agent/instance-agent';
 import type { InstanceAiEventBus } from '../../src/event-bus';
 import type { Logger } from '../../src/logger';
@@ -55,6 +58,7 @@ import type {
 import { asResumable, type SuspensionInfo } from '../../src/utils/stream-helpers';
 import { createInMemoryEventBus, wrapEventBusWithObserver } from '../harness/in-memory-event-bus';
 import { createStubServices, defaultNodesJsonPath } from '../harness/stub-services';
+import { createStubWorkspace, stubWorkspaceRoot } from '../harness/stub-workspace';
 import { extractOutcomeFromEvents } from '../outcome/event-parser';
 import type { CapturedEvent, EventOutcome } from '../types';
 
@@ -67,7 +71,7 @@ export interface DiscoveryRunOptions {
 	modelId: ModelConfig;
 	/** Defaults to `defaultNodesJsonPath()`. */
 	nodesJsonPath?: string;
-	/** Hard cap on agent steps. Discovery scenarios are single-turn — 5 is plenty. */
+	/** Hard cap on agent steps. Unset leaves the SDK's own 30-iteration ceiling in place. */
 	maxSteps?: number;
 	/** Per-trial timeout in ms. */
 	timeoutMs?: number;
@@ -80,7 +84,7 @@ export interface DiscoveryRunResult {
 	outcome: EventOutcome;
 	durationMs: number;
 	/** Final agent status — useful for diagnosing why noop / unexpected loops happened. */
-	streamStatus: 'completed' | 'errored' | 'cancelled' | 'suspended';
+	streamStatus: DiscoveryStreamStatus;
 	/** Populated when the run errored before reaching the check. */
 	runError?: string;
 }
@@ -89,9 +93,9 @@ export async function runDiscoveryScenario(
 	options: DiscoveryRunOptions,
 ): Promise<DiscoveryRunResult> {
 	const started = Date.now();
-	// Uncapped by default, matching live behavior: today's orchestrator legitimately
-	// explores past any small fixed cap (data-table-workflow needs >8 iterations), and
-	// the wall-clock timeout below bounds runaway runs. Scenarios/CLI opt in to a cap.
+	// Unset by default: the orchestrator legitimately explores past any small fixed cap
+	// (data-table-workflow needs >8 iterations). Unset still lands on the SDK's own
+	// 30-iteration ceiling, which reports `step-exhausted`.
 	const maxSteps = options.scenario?.maxSteps ?? options.maxSteps;
 	const timeoutMs = options.scenario?.timeoutMs ?? options.timeoutMs ?? 60_000;
 	const nodesJsonPath = options.nodesJsonPath ?? defaultNodesJsonPath();
@@ -101,25 +105,37 @@ export async function runDiscoveryScenario(
 	let streamStatus: DiscoveryRunResult['streamStatus'] = 'completed';
 	let runError: string | undefined;
 
+	const confirmationPolicy = buildConfirmationPolicy(options.scenario);
+	const suspensions = new Map<string, SuspensionInfo>();
+
 	const abortController = new AbortController();
-	const timeoutHandle = setTimeout(() => abortController.abort(), timeoutMs);
+	let mcpManager: StubMcpClientManager | undefined;
+	let timeoutHandle: NodeJS.Timeout | undefined;
+	const budgetExpired = new Promise<'timed-out'>((resolve) => {
+		timeoutHandle = setTimeout(() => {
+			abortController.abort();
+			resolve('timed-out');
+		}, timeoutMs);
+	});
 
 	try {
 		const services = await createStubServices({ nodesJsonPath });
 		const mcpState = options.scenario.instanceState?.mcp;
 		const mcpRegistry = mcpState ? createStubMcpRegistry(mcpState) : undefined;
-		const context = applyInstanceState(services.context, options.scenario, mcpRegistry);
+		const context: InstanceAiContext = {
+			...applyInstanceState(services.context, options.scenario, mcpRegistry),
+			workspace: createStubWorkspace(),
+			workspaceRoot: stubWorkspaceRoot,
+		};
 
-		const mcpManager = new StubMcpClientManager(createStubMcpToolRegistry(mcpState ?? {}));
+		mcpManager = new StubMcpClientManager(createStubMcpToolRegistry(mcpState ?? {}));
 		const threadId = 'discovery-thread-' + nanoid(6);
 		const runId = 'discovery-run-' + nanoid(6);
 
-		const confirmationPolicy = buildConfirmationPolicy(options.scenario);
 		const approvalResponders: ApprovalResponder[] = [
 			credentialAutoSetupResponder,
 			...(mcpRegistry ? [createMcpConnectResponder(mcpRegistry)] : []),
 		];
-		const suspensions = new Map<string, SuspensionInfo>();
 
 		const eventBus = wrapEventBusWithObserver(createInMemoryEventBus(), (event) => {
 			events.push(toCapturedEvent(event));
@@ -159,7 +175,7 @@ export async function runDiscoveryScenario(
 			}),
 		);
 
-		const result = await executeResumableStream({
+		const run = executeResumableStream({
 			agent: asResumable(agent),
 			stream: streamSource,
 			context: {
@@ -179,30 +195,32 @@ export async function runDiscoveryScenario(
 					),
 			},
 		});
+		void run.catch(() => {});
+		const result = await Promise.race([run, budgetExpired]);
 
-		if (abortController.signal.aborted || result.status === 'cancelled') {
-			streamStatus = 'cancelled';
-		} else if (result.status === 'errored') {
-			streamStatus = 'errored';
-		} else if (result.status === 'suspended') {
-			streamStatus = 'suspended';
-		}
-
-		await mcpManager.disconnect();
+		streamStatus = resolveStreamStatus(result, abortController.signal.aborted);
 	} catch (error) {
 		runError = error instanceof Error ? error.message : String(error);
-		streamStatus = 'errored';
+		streamStatus = abortController.signal.aborted ? 'timed-out' : 'errored';
 	} finally {
 		clearTimeout(timeoutHandle);
+		await mcpManager?.disconnect();
 	}
 
-	const outcome = extractOutcomeFromEvents(events);
-	const check = runExpectedToolsInvokedCheck(options.scenario, outcome);
+	const observedEvents = [...events];
+	const outcome = extractOutcomeFromEvents(observedEvents);
+	const check = evaluateDiscoveryTrial(options.scenario, outcome, {
+		streamStatus,
+		timeoutMs,
+		...(runError ? { runError } : {}),
+		unmatchedConfirmations: unmatchedConfirmations(confirmationPolicy, suspensions.values()),
+	});
 
 	return {
 		scenario: options.scenario,
 		check,
-		events,
+		// An abandoned stream can still publish, so hand back what the verdict saw.
+		events: [...events],
 		outcome,
 		durationMs: Date.now() - started,
 		streamStatus,
@@ -292,6 +310,9 @@ function createStubOrchestrationContext(
 		// Surface the localMcpServer so Computer Use browser tools are available to the
 		// orchestrator.
 		...(opts.context.localMcpServer ? { localMcpServer: opts.context.localMcpServer } : {}),
+		// Registers the `workspace_*` file tools for build-workflow
+		...(opts.context.workspace ? { workspace: opts.context.workspace } : {}),
+		...(opts.context.workspaceRoot ? { workspaceRoot: opts.context.workspaceRoot } : {}),
 		// Used for the orchestrator's untrusted-content doctrine and other domain references.
 		// Provide the same context the orchestrator sees.
 		domainContext: opts.context,

--- a/packages/@n8n/instance-ai/evaluations/discovery/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/runner.ts
@@ -18,13 +18,26 @@
 import type { InstanceAiEvent, TaskList } from '@n8n/api-types';
 import { nanoid } from 'nanoid';
 
+import {
+	buildConfirmationPolicy,
+	resolveConfirmation,
+	type ApprovalResponder,
+} from './confirmation-policy';
+import { credentialAutoSetupResponder } from './credential-approval';
 import { runExpectedToolsInvokedCheck } from './expected-tools-invoked';
 import { createStubLocalMcpServer } from './stub-local-mcp';
+import {
+	createMcpConnectResponder,
+	createStubMcpRegistry,
+	createStubMcpToolRegistry,
+	StubMcpClientManager,
+	stubMcpServerConfigs,
+	type StubMcpRegistry,
+} from './stub-mcp-registry';
 import type { DiscoveryCheckResult, DiscoveryTestCase } from './types';
 import { createInstanceAgent } from '../../src/agent/instance-agent';
 import type { InstanceAiEventBus } from '../../src/event-bus';
 import type { Logger } from '../../src/logger';
-import { McpClientManager } from '../../src/mcp/mcp-client-manager';
 import {
 	executeResumableStream,
 	normalizeStreamSource,
@@ -39,7 +52,7 @@ import type {
 	OrchestrationContext,
 	TaskStorage,
 } from '../../src/types';
-import { asResumable } from '../../src/utils/stream-helpers';
+import { asResumable, type SuspensionInfo } from '../../src/utils/stream-helpers';
 import { createInMemoryEventBus, wrapEventBusWithObserver } from '../harness/in-memory-event-bus';
 import { createStubServices, defaultNodesJsonPath } from '../harness/stub-services';
 import { extractOutcomeFromEvents } from '../outcome/event-parser';
@@ -80,7 +93,7 @@ export async function runDiscoveryScenario(
 	// explores past any small fixed cap (data-table-workflow needs >8 iterations), and
 	// the wall-clock timeout below bounds runaway runs. Scenarios/CLI opt in to a cap.
 	const maxSteps = options.scenario?.maxSteps ?? options.maxSteps;
-	const timeoutMs = options.timeoutMs ?? 60_000;
+	const timeoutMs = options.scenario?.timeoutMs ?? options.timeoutMs ?? 60_000;
 	const nodesJsonPath = options.nodesJsonPath ?? defaultNodesJsonPath();
 
 	const events: CapturedEvent[] = [];
@@ -93,23 +106,23 @@ export async function runDiscoveryScenario(
 
 	try {
 		const services = await createStubServices({ nodesJsonPath });
-		const context = applyInstanceState(services.context, options.scenario);
+		const mcpState = options.scenario.instanceState?.mcp;
+		const mcpRegistry = mcpState ? createStubMcpRegistry(mcpState) : undefined;
+		const context = applyInstanceState(services.context, options.scenario, mcpRegistry);
 
-		const mcpManager = new McpClientManager();
+		const mcpManager = new StubMcpClientManager(createStubMcpToolRegistry(mcpState ?? {}));
 		const threadId = 'discovery-thread-' + nanoid(6);
 		const runId = 'discovery-run-' + nanoid(6);
 
-		// Track outstanding confirmation requests so the auto-approve can simulate the
-		// production "user clicks Auto-setup with browser" path for credential setup
-		// suspensions. Without this, `credentials(action="setup")` returns the
-		// "user picked existing credentials" branch and the orchestrator never sees
-		// `needsBrowserSetup=true` — which is what wires it to the Computer Use
-		// credential setup skill per the system prompt.
-		const pendingConfirmations = new Map<string, { credentialType?: string }>();
+		const confirmationPolicy = buildConfirmationPolicy(options.scenario);
+		const approvalResponders: ApprovalResponder[] = [
+			credentialAutoSetupResponder,
+			...(mcpRegistry ? [createMcpConnectResponder(mcpRegistry)] : []),
+		];
+		const suspensions = new Map<string, SuspensionInfo>();
 
 		const eventBus = wrapEventBusWithObserver(createInMemoryEventBus(), (event) => {
 			events.push(toCapturedEvent(event));
-			recordConfirmationRequest(event, pendingConfirmations);
 		});
 
 		// `OrchestrationContext` is required for the orchestrator to receive tools like
@@ -129,12 +142,10 @@ export async function runDiscoveryScenario(
 			modelId: options.modelId,
 			context,
 			orchestrationContext,
+			mcpServers: stubMcpServerConfigs(mcpState ?? {}),
 			mcpManager,
 			// No memory: discovery measures stateless first-step tool dispatch.
 			memoryConfig: {},
-			// Eager tool loading — discovery measures dispatch given the full toolset,
-			// not whether the orchestrator can find a tool through search.
-			disableDeferredTools: true,
 			thinkingEnabled: false,
 		});
 
@@ -161,18 +172,11 @@ export async function runDiscoveryScenario(
 			},
 			control: {
 				mode: 'auto',
-				// Auto-approve every confirmation/HITL suspension so the run drives to
-				// completion. For credentials(action="setup") suspensions, pretend the user
-				// chose "Auto-setup with browser" — that's what unlocks the production
-				// `needsBrowserSetup=true` → Computer Use credential skill path.
-				// eslint-disable-next-line @typescript-eslint/require-await
-				waitForConfirmation: async (requestId: string): Promise<Record<string, unknown>> => {
-					const pending = pendingConfirmations.get(requestId);
-					if (pending?.credentialType) {
-						return { approved: true, autoSetup: { credentialType: pending.credentialType } };
-					}
-					return { approved: true };
-				},
+				onSuspension: (suspension) => suspensions.set(suspension.requestId, suspension),
+				waitForConfirmation: async (requestId: string): Promise<Record<string, unknown>> =>
+					await Promise.resolve(
+						resolveConfirmation(suspensions.get(requestId), confirmationPolicy, approvalResponders),
+					),
 			},
 		});
 
@@ -213,6 +217,7 @@ export async function runDiscoveryScenario(
 function applyInstanceState(
 	base: InstanceAiContext,
 	scenario: DiscoveryTestCase,
+	mcpRegistry: StubMcpRegistry | undefined,
 ): InstanceAiContext {
 	const state = scenario.instanceState;
 	if (!state) return base;
@@ -234,6 +239,7 @@ function applyInstanceState(
 		...base,
 		...(localGateway ? { localGatewayStatus: localGateway } : {}),
 		...(localMcpServer ? { localMcpServer } : {}),
+		...(mcpRegistry ? { mcpService: mcpRegistry.service } : {}),
 	};
 }
 
@@ -290,29 +296,6 @@ function createStubOrchestrationContext(
 		// Provide the same context the orchestrator sees.
 		domainContext: opts.context,
 	};
-}
-
-/**
- * Capture credentialType from `confirmation-request` events whose payload includes
- * a credentialRequests array. The first request's credentialType is what the
- * `autoSetup` resume payload needs — the production credentials tool only
- * exposes one credential at a time when needsBrowserSetup is involved.
- */
-function recordConfirmationRequest(
-	event: InstanceAiEvent,
-	pending: Map<string, { credentialType?: string }>,
-): void {
-	if (event.type !== 'confirmation-request') return;
-	const payload = event.payload as
-		| {
-				requestId?: string;
-				credentialRequests?: Array<{ credentialType?: string }>;
-		  }
-		| undefined;
-	const requestId = payload?.requestId;
-	if (typeof requestId !== 'string' || requestId.length === 0) return;
-	const credentialType = payload?.credentialRequests?.[0]?.credentialType;
-	pending.set(requestId, credentialType ? { credentialType } : {});
 }
 
 function toCapturedEvent(event: InstanceAiEvent): CapturedEvent {

--- a/packages/@n8n/instance-ai/evaluations/discovery/stream-status.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/stream-status.ts
@@ -1,0 +1,14 @@
+import type { DiscoveryStreamStatus } from './types';
+import type { ExecuteResumableStreamResult } from '../../src/runtime/resumable-stream-executor';
+
+export function resolveStreamStatus(
+	result: ExecuteResumableStreamResult | 'timed-out',
+	aborted: boolean,
+): DiscoveryStreamStatus {
+	if (result === 'timed-out' || aborted) return 'timed-out';
+	if (result.status === 'errored') return 'errored';
+	if (result.status === 'suspended') return 'suspended';
+	if (result.status === 'cancelled') return 'timed-out';
+	if (result.finishReason === 'max-iterations') return 'step-exhausted';
+	return 'completed';
+}

--- a/packages/@n8n/instance-ai/evaluations/discovery/stream-status.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/stream-status.ts
@@ -1,3 +1,5 @@
+import type { FinishReason } from '@n8n/agents';
+
 import type { DiscoveryStreamStatus } from './types';
 import type { ExecuteResumableStreamResult } from '../../src/runtime/resumable-stream-executor';
 
@@ -9,6 +11,19 @@ export function resolveStreamStatus(
 	if (result.status === 'errored') return 'errored';
 	if (result.status === 'suspended') return 'suspended';
 	if (result.status === 'cancelled') return 'timed-out';
-	if (result.finishReason === 'max-iterations') return 'step-exhausted';
-	return 'completed';
+	return statusForFinishReason(result.finishReason);
+}
+
+function statusForFinishReason(finishReason: FinishReason | undefined): DiscoveryStreamStatus {
+	switch (finishReason) {
+		case 'max-iterations':
+			return 'step-exhausted';
+		case 'length':
+		case 'content-filter':
+		case 'error':
+		case 'other':
+			return 'errored';
+		default:
+			return 'completed';
+	}
 }

--- a/packages/@n8n/instance-ai/evaluations/discovery/stream-status.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/stream-status.ts
@@ -11,19 +11,25 @@ export function resolveStreamStatus(
 	if (result.status === 'errored') return 'errored';
 	if (result.status === 'suspended') return 'suspended';
 	if (result.status === 'cancelled') return 'timed-out';
+	if (result.finishReason === undefined) return 'errored';
 	return statusForFinishReason(result.finishReason);
 }
 
-function statusForFinishReason(finishReason: FinishReason | undefined): DiscoveryStreamStatus {
+function statusForFinishReason(finishReason: FinishReason): DiscoveryStreamStatus {
 	switch (finishReason) {
+		case 'stop':
+			return 'completed';
 		case 'max-iterations':
 			return 'step-exhausted';
+		case 'tool-calls':
 		case 'length':
 		case 'content-filter':
 		case 'error':
 		case 'other':
 			return 'errored';
-		default:
-			return 'completed';
+		default: {
+			const unhandled: never = finishReason;
+			throw new Error(`Unhandled finish reason: ${String(unhandled)}`);
+		}
 	}
 }

--- a/packages/@n8n/instance-ai/evaluations/discovery/stub-mcp-registry.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/stub-mcp-registry.ts
@@ -1,0 +1,190 @@
+// ---------------------------------------------------------------------------
+// Stub MCP registry + connections for discovery evals. Fakes the registry
+// service; `stub-local-mcp.ts` fakes the computer-use gateway.
+//
+// ---------------------------------------------------------------------------
+
+import { sanitizeToolName, wrapToolForApproval, type BuiltTool } from '@n8n/agents';
+import { isRecord } from '@n8n/utils/is-record';
+
+import type { ApprovalResponder } from './confirmation-policy';
+import type { Logger } from '../../src/logger';
+import { McpClientManager } from '../../src/mcp/mcp-client-manager';
+import { createToolRegistry } from '../../src/tool-registry';
+import type {
+	InstanceAiMcpService,
+	InstanceAiToolRegistry,
+	McpRegistryServerSummary,
+	McpServerConfig,
+} from '../../src/types';
+
+/** What production derives for cli's shared e2e fixtures (`registry/mock-servers.ts`):
+ *  `description` is the tagline, `credentialType` is derived. Search below drops the
+ *  real relevance scoring, only observable past the tool's 5-result cap. */
+const CATALOGUE: McpRegistryServerSummary[] = [
+	{
+		slug: 'notion',
+		title: 'Notion',
+		description: 'Connect to the Notion MCP Server',
+		credentialType: 'notionMcpOAuth2Api',
+		tools: ['notion-search', 'notion-fetch', 'notion-create-pages'],
+	},
+	{
+		slug: 'linear',
+		title: 'Linear',
+		description: 'Connect to the Linear MCP Server',
+		credentialType: 'linearMcpOAuth2Api',
+		tools: ['list_issues', 'get_issue', 'save_issue'],
+	},
+	{
+		slug: 'slack',
+		title: 'Slack',
+		description: 'Connect to the Slack MCP Server',
+		credentialType: 'slackMcpOAuth2Api',
+		tools: [],
+	},
+];
+
+export interface StubMcpConnection {
+	slug: string;
+	/** Defaults to the catalogue's tools; empty models a broken connection. */
+	tools?: string[];
+}
+
+export interface DiscoveryMcpState {
+	registry?: string[];
+	connected?: StubMcpConnection[];
+}
+
+export interface StubMcpRegistry {
+	service: InstanceAiMcpService;
+	markConnected: (slugs: string[]) => void;
+}
+
+function catalogueServer(slug: string): McpRegistryServerSummary {
+	const server = CATALOGUE.find((entry) => entry.slug === slug);
+	if (!server) {
+		const known = CATALOGUE.map((entry) => entry.slug).join(', ');
+		throw new Error(`Unknown MCP registry slug "${slug}" — expected one of ${known}.`);
+	}
+	return server;
+}
+
+export function createStubMcpRegistry(state: DiscoveryMcpState): StubMcpRegistry {
+	const servers = (state.registry ?? []).map(catalogueServer);
+	const connected = new Set((state.connected ?? []).map((entry) => entry.slug));
+
+	const matches = (server: McpRegistryServerSummary, query: string): boolean =>
+		`${server.slug} ${server.title} ${server.description}`
+			.toLowerCase()
+			.includes(query.trim().toLowerCase());
+
+	return {
+		markConnected: (slugs) => slugs.forEach((slug) => connected.add(slug)),
+		service: {
+			// Connected servers are filtered out, as in the adapter.
+			search: async (queries) =>
+				await Promise.resolve(
+					servers.filter(
+						(server) =>
+							!connected.has(server.slug) && queries.some((query) => matches(server, query)),
+					),
+				),
+			getServers: async (slugs) =>
+				await Promise.resolve(servers.filter((server) => slugs.includes(server.slug))),
+			listConnections: async () => await Promise.resolve([...connected].map((slug) => ({ slug }))),
+		},
+	};
+}
+
+/** Approving a connect card claims the offered slugs on resume *and* makes them
+ *  live here — `resumeConnect` counts a slug only when both hold. */
+export function createMcpConnectResponder(registry: StubMcpRegistry): ApprovalResponder {
+	return (payload) => {
+		const request = payload.mcpConnectRequest;
+		if (!isRecord(request) || !Array.isArray(request.servers)) return undefined;
+
+		const slugs = request.servers
+			.map((server) => (isRecord(server) ? server.serverSlug : undefined))
+			.filter((slug): slug is string => typeof slug === 'string' && slug.length > 0);
+		if (slugs.length === 0) return undefined;
+
+		registry.markConnected(slugs);
+		return { connectedSlugs: slugs };
+	};
+}
+
+/** `listConnectedMcpServices` pairs a tool with its slug through this name. */
+function serverName(slug: string): string {
+	return `mcp_${slug}`;
+}
+
+export function stubMcpServerConfigs(state: DiscoveryMcpState): McpServerConfig[] {
+	return (state.connected ?? []).map(({ slug }) => ({
+		name: serverName(slug),
+		url: `https://${slug}.mcp.invalid/mcp`,
+		metadata: { serverSlug: slug },
+	}));
+}
+
+/** Mirrors `mcp-tool-resolver`'s output, down to the server-prefixed name. */
+function stubMcpTool(rawName: string, slug: string): BuiltTool {
+	return {
+		name: sanitizeToolName(`${serverName(slug)}_${rawName}`),
+		description: `${slug} MCP tool.`,
+		inputSchema: { type: 'object', properties: {} },
+		mcpTool: true,
+		mcpServerName: serverName(slug),
+		mcpToolName: rawName,
+		// An empty or apologetic result reads to the agent as an expired connection
+		// and sends it to `connect` — a stub artefact that looks like a regression.
+		handler: async () =>
+			await Promise.resolve({
+				ok: true,
+				items: [{ id: `${slug}-eval-stub-1`, title: 'Eval harness result' }],
+			}),
+	};
+}
+
+export function createStubMcpToolRegistry(state: DiscoveryMcpState): InstanceAiToolRegistry {
+	const registry = createToolRegistry();
+	for (const { slug, tools } of state.connected ?? []) {
+		for (const rawName of tools ?? catalogueServer(slug).tools) {
+			const tool = stubMcpTool(rawName, slug);
+			registry.set(tool.name, tool);
+		}
+	}
+	return registry;
+}
+
+/** Production wraps MCP tools in the same gate whenever the caller asks for
+ *  approval; the real path goes through `McpConnection.listTools`, which this stub
+ *  bypasses. */
+function withApprovalGate(tools: InstanceAiToolRegistry): InstanceAiToolRegistry {
+	const gated = createToolRegistry();
+	for (const [name, tool] of tools) {
+		gated.set(name, wrapToolForApproval(tool, { requireApproval: true }));
+	}
+	return gated;
+}
+
+/** `CreateInstanceAgentOptions.mcpManager` is the concrete class, so this
+ *  subclasses rather than structurally fakes it. */
+export class StubMcpClientManager extends McpClientManager {
+	constructor(private readonly stubTools: InstanceAiToolRegistry) {
+		super();
+	}
+
+	override async getRegularTools(
+		_configs: McpServerConfig[],
+		_logger?: Logger,
+		requireApproval = true,
+	) {
+		const tools = requireApproval ? withApprovalGate(this.stubTools) : this.stubTools;
+		return await Promise.resolve({ tools, connectionFailures: [] });
+	}
+
+	override async disconnect() {
+		await Promise.resolve();
+	}
+}

--- a/packages/@n8n/instance-ai/evaluations/discovery/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/types.ts
@@ -8,6 +8,7 @@
 // scenarios assert the *agent's tool/dispatch behavior*.
 // ---------------------------------------------------------------------------
 
+import type { DiscoveryMcpState } from './stub-mcp-registry';
 import type { LocalGatewayStatus } from '../../src/types';
 
 /**
@@ -31,8 +32,17 @@ import type { LocalGatewayStatus } from '../../src/types';
  */
 export interface ForbiddenToolCall {
 	toolName: string;
-	/** Optional case-insensitive substrings to match against the serialized tool args. */
+	/** Deep-partial match: listed keys must match, extra keys ignored, pattern
+	 *  arrays matched as subsets. Prefer this for schema'd fields — a substring
+	 *  can't tell a value from the same word in a free-text sibling. */
+	args?: Record<string, unknown>;
+	/** Case-insensitive substrings over the serialized args, for free-text
+	 *  fields. Combines with `args`; both must hold on the same call. */
 	argsContainAny?: string[];
+	/** Match a call the user refused (an approval-gated tool resuming with
+	 *  `{ declined: true }`) instead of one that ran. Defaults to false, so an
+	 *  expectation never matches a refusal by accident. */
+	declined?: boolean;
 }
 
 export interface ExpectedToolInvocations {
@@ -51,7 +61,18 @@ export interface ExpectedToolInvocations {
 export interface DiscoveryInstanceState {
 	localGateway?: LocalGatewayStatus;
 	browserAvailable?: boolean;
+	mcp?: DiscoveryMcpState;
 }
+
+export type ConfirmationDecision = 'approve' | 'deny';
+
+export interface ConfirmationAnswer {
+	decision: ConfirmationDecision;
+	resumeWith?: Record<string, unknown>;
+}
+
+// Keyed by the suspending tool's name
+export type DiscoveryConfirmations = Record<string, ConfirmationDecision | ConfirmationAnswer>;
 
 export interface DiscoveryTestCase {
 	/** Unique scenario identifier — also used as the scenario filename (without .json). */
@@ -60,12 +81,16 @@ export interface DiscoveryTestCase {
 	userMessage: string;
 	/** Optional instance state overrides applied when constructing the agent. */
 	instanceState?: DiscoveryInstanceState;
+	/** Answers for the tools listed; every other suspension is approved. */
+	confirmations?: DiscoveryConfirmations;
 	/** Pass condition. At least one expectation key is required. */
 	expectedToolInvocations: ExpectedToolInvocations;
 	/** Free-form note explaining what regression this scenario protects against. */
 	rationale?: string;
 	/** Override the runner step cap when orchestrator-inline work needs more iterations. */
 	maxSteps?: number;
+	/** Override the runner timeout when a scenario needs more time. */
+	timeoutMs?: number;
 }
 
 export interface DiscoveryCheckResult {

--- a/packages/@n8n/instance-ai/evaluations/discovery/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/types.ts
@@ -93,6 +93,20 @@ export interface DiscoveryTestCase {
 	timeoutMs?: number;
 }
 
+export type DiscoveryStreamStatus =
+	| 'completed'
+	| 'errored'
+	| 'timed-out'
+	| 'suspended'
+	| 'step-exhausted';
+
+export interface DiscoveryTrialFacts {
+	streamStatus: DiscoveryStreamStatus;
+	timeoutMs: number;
+	runError?: string;
+	unmatchedConfirmations: string[];
+}
+
 export interface DiscoveryCheckResult {
 	pass: boolean;
 	/** Human-readable reason — included in failure reports. */

--- a/packages/@n8n/instance-ai/evaluations/harness/stub-workspace.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/stub-workspace.ts
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// In-memory runtime workspace for in-process eval harnesses.
+//
+// Without a workspace, `build-workflow` fails its source read with a
+// `code_fixable` remediation telling the agent to write the file with
+// `workspace_write_file` — a tool that only exists when a workspace is attached.
+// ---------------------------------------------------------------------------
+
+import {
+	CORE_WORKSPACE_TOOL_NAMES,
+	Workspace,
+	type FileContent,
+	type ProviderStatus,
+	type WorkspaceFilesystem,
+} from '@n8n/agents';
+import { getPromptWorkspaceRoot } from '@n8n/agents/sandbox';
+
+export const stubWorkspaceRoot = getPromptWorkspaceRoot('n8n-sandbox');
+
+function relativePath(path: string): string {
+	const trimmed = path.trim();
+	const rooted = `${stubWorkspaceRoot}/`;
+	return (trimmed.startsWith(rooted) ? trimmed.slice(rooted.length) : trimmed).replace(
+		/^\.?\/+/,
+		'',
+	);
+}
+
+async function unreachable(): Promise<never> {
+	return await Promise.reject(new Error('Stub workspace exposes only CORE_WORKSPACE_TOOL_NAMES'));
+}
+
+class InMemoryWorkspaceFilesystem implements WorkspaceFilesystem {
+	readonly id = 'stub-workspace-filesystem';
+	readonly name = 'stub-workspace-filesystem';
+	readonly provider = 'in-memory';
+	readonly basePath = stubWorkspaceRoot;
+	status: ProviderStatus = 'ready';
+
+	private readonly files = new Map<string, string>();
+
+	async readFile(path: string): Promise<string> {
+		const content = this.files.get(relativePath(path));
+		if (content === undefined) throw new Error(`No such file: ${path}`);
+		return await Promise.resolve(content);
+	}
+
+	async writeFile(path: string, content: FileContent): Promise<void> {
+		this.files.set(
+			relativePath(path),
+			typeof content === 'string' ? content : Buffer.from(content).toString('utf-8'),
+		);
+		await Promise.resolve();
+	}
+
+	// Directories are implicit: a path exists as long as a file sits under it.
+	async mkdir(): Promise<void> {
+		await Promise.resolve();
+	}
+
+	appendFile = unreachable;
+	deleteFile = unreachable;
+	copyFile = unreachable;
+	moveFile = unreachable;
+	rmdir = unreachable;
+	readdir = unreachable;
+	exists = unreachable;
+	stat = unreachable;
+}
+
+export function createStubWorkspace(): Workspace {
+	const workspace = new Workspace({
+		id: 'stub-workspace',
+		name: 'stub-workspace',
+		filesystem: new InMemoryWorkspaceFilesystem(),
+	});
+
+	const allTools = workspace.getTools.bind(workspace);
+	workspace.getTools = () => allTools().filter((tool) => CORE_WORKSPACE_TOOL_NAMES.has(tool.name));
+
+	return workspace;
+}

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/resumable-stream-executor.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/resumable-stream-executor.test.ts
@@ -181,6 +181,68 @@ describe('executeResumableStream', () => {
 		expect(result.error).toBe(error);
 	});
 
+	it('reports the terminal finish reason of a completed run', async () => {
+		const result = await executeResumableStream({
+			agent: {},
+			stream: {
+				runId: 'agent-run-1',
+				fullStream: fromChunks([
+					textChunk('Working...'),
+					{ type: 'finish', finishReason: 'max-iterations' },
+				]),
+			},
+			context: {
+				threadId: 'thread-1',
+				runId: 'run-1',
+				agentId: 'agent-1',
+				eventBus: createEventBus(),
+				signal: new AbortController().signal,
+				logger: createLogger(),
+			},
+			control: { mode: 'manual' },
+		});
+
+		expect(result.status).toBe('completed');
+		expect(result.finishReason).toBe('max-iterations');
+	});
+
+	it('reports the finish reason of the resumed stream, not the suspended one', async () => {
+		const resume = vi.fn().mockResolvedValue({
+			runId: 'agent-run-2',
+			stream: readableFromChunks([
+				textChunk('Done.'),
+				{ type: 'finish', finishReason: 'max-iterations' },
+			]),
+		});
+
+		const result = await executeResumableStream({
+			agent: { resume },
+			stream: {
+				runId: 'agent-run-1',
+				fullStream: fromChunks([
+					suspensionChunk({
+						toolCallId: 'tool-call-1',
+						toolName: 'pause-for-user',
+						suspendPayload: { requestId: 'request-1', message: 'Please confirm' },
+					}),
+					{ type: 'finish', finishReason: 'tool-calls' },
+				]),
+			},
+			context: {
+				threadId: 'thread-1',
+				runId: 'run-1',
+				agentId: 'agent-1',
+				eventBus: createEventBus(),
+				signal: new AbortController().signal,
+				logger: createLogger(),
+			},
+			control: { mode: 'auto', waitForConfirmation: vi.fn().mockResolvedValue({ approved: true }) },
+		});
+
+		expect(result.status).toBe('completed');
+		expect(result.finishReason).toBe('max-iterations');
+	});
+
 	it('publishes only the quota error when a follow-on error chunk arrives', async () => {
 		const eventBus = createEventBus();
 		const quotaError = Object.assign(new Error('Have reached end of quota'), {

--- a/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
+++ b/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
@@ -1,4 +1,5 @@
-import type { RedactionOptions, StreamResult } from '@n8n/agents';
+import { isFinishReason } from '@n8n/agents';
+import type { FinishReason, RedactionOptions, StreamResult } from '@n8n/agents';
 import type { InstanceAiEvent } from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
 import { randomUUID } from 'node:crypto';
@@ -88,7 +89,7 @@ export interface ExecuteResumableStreamResult {
 	/** Reason this stream stopped early after publishing the current chunk. */
 	stopReason?: OrchestratorRunHandoffReason;
 	/** Terminal `finish` chunk's reason; `'max-iterations'` means the agent ran out of steps. */
-	finishReason?: string;
+	finishReason?: FinishReason;
 }
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
@@ -300,7 +301,7 @@ function publishRedactedEvents(
 
 interface StreamPassResult {
 	cancelled: boolean;
-	finishReason?: string;
+	finishReason?: FinishReason;
 	stopReason?: OrchestratorRunHandoffReason;
 	suspension?: SuspensionInfo;
 	hasError: boolean;
@@ -355,7 +356,7 @@ async function consumeStreamPass(args: {
 	let pendingConfirmation: Promise<Record<string, unknown>> | undefined;
 	let confirmationEvent: ConfirmationRequestEvent | undefined;
 	let confirmationEventPublished = false;
-	let finishReason: string | undefined;
+	let finishReason: FinishReason | undefined;
 	const drainedCorrectionsForResume: string[] = [];
 
 	for await (const chunk of activeStream) {
@@ -387,7 +388,7 @@ async function consumeStreamPass(args: {
 
 		options.context.onActivity?.();
 		usageAccumulator.observe(chunk);
-		if (isRecord(chunk) && chunk.type === 'finish' && typeof chunk.finishReason === 'string') {
+		if (isRecord(chunk) && chunk.type === 'finish' && isFinishReason(chunk.finishReason)) {
 			finishReason = chunk.finishReason;
 		}
 

--- a/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
+++ b/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
@@ -87,6 +87,8 @@ export interface ExecuteResumableStreamResult {
 	usage?: RunTokenUsage;
 	/** Reason this stream stopped early after publishing the current chunk. */
 	stopReason?: OrchestratorRunHandoffReason;
+	/** Terminal `finish` chunk's reason; `'max-iterations'` means the agent ran out of steps. */
+	finishReason?: string;
 }
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
@@ -298,6 +300,7 @@ function publishRedactedEvents(
 
 interface StreamPassResult {
 	cancelled: boolean;
+	finishReason?: string;
 	stopReason?: OrchestratorRunHandoffReason;
 	suspension?: SuspensionInfo;
 	hasError: boolean;
@@ -352,6 +355,7 @@ async function consumeStreamPass(args: {
 	let pendingConfirmation: Promise<Record<string, unknown>> | undefined;
 	let confirmationEvent: ConfirmationRequestEvent | undefined;
 	let confirmationEventPublished = false;
+	let finishReason: string | undefined;
 	const drainedCorrectionsForResume: string[] = [];
 
 	for await (const chunk of activeStream) {
@@ -383,6 +387,9 @@ async function consumeStreamPass(args: {
 
 		options.context.onActivity?.();
 		usageAccumulator.observe(chunk);
+		if (isRecord(chunk) && chunk.type === 'finish' && typeof chunk.finishReason === 'string') {
+			finishReason = chunk.finishReason;
+		}
 
 		if (isRecord(chunk) && chunk.type === 'start-step') {
 			nativeStepIndex += 1;
@@ -463,6 +470,7 @@ async function consumeStreamPass(args: {
 			return {
 				cancelled: false,
 				stopReason: stopSignal.reason,
+				finishReason,
 				suspension,
 				hasError,
 				error,
@@ -477,6 +485,7 @@ async function consumeStreamPass(args: {
 
 	return {
 		cancelled: false,
+		finishReason,
 		suspension,
 		hasError,
 		error,
@@ -543,6 +552,7 @@ export async function executeResumableStream(
 				agentRunId: activeAgentRunId,
 				text,
 				...(error !== undefined ? { error } : {}),
+				finishReason: pass.finishReason,
 				workSummary: workSummaryAccumulator.toSummary(),
 				usage: usageAccumulator.hasUsage() ? usageAccumulator.toUsage() : undefined,
 				stopReason: pass.stopReason,
@@ -555,6 +565,7 @@ export async function executeResumableStream(
 				agentRunId: activeAgentRunId,
 				text,
 				...(error !== undefined ? { error } : {}),
+				finishReason: pass.finishReason,
 				workSummary: workSummaryAccumulator.toSummary(),
 				usage: usageAccumulator.hasUsage() ? usageAccumulator.toUsage() : undefined,
 			};

--- a/packages/@n8n/instance-ai/src/tools/mcp-servers.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/mcp-servers.tool.ts
@@ -96,10 +96,10 @@ const mcpServersOutputSchema = z.union([
 	connectOutputSchema,
 ]);
 
-const DESCRIPTION = `The user's MCP servers: connections to third-party services that persist across conversations, exposing tools you can use here. Not \`credentials\`, which only stores what a node authenticates with when a workflow runs, and not for building — a workflow that talks to a service uses that service's node and credential.
+const DESCRIPTION = `The user's MCP servers: connections to third-party services that persist across conversations, exposing tools you can use here. Not \`credentials\`, which only stores what a node authenticates with when a workflow runs, and not for building — a workflow that talks to a service uses that service's node and credential. What separates them is who runs it: reading, fetching or summarizing a service's data yourself, in this conversation, is this tool; a workflow the user runs later is a node.
 \`connected\`: which servers are connected, and each one's tool count. Only the user connects or disconnects, so a server missing here is one they never connected or disconnected — ask here instead of answering from the conversation. A connected server with no tools has a broken or expired connection.
 \`details\`: one server's tool names; \`connected\` never returns them. \`search_tools\` finds a tool by keyword.
-\`search\`: find a server for a service nothing connected covers, before saying it is unavailable.
+\`search\`: find a server for a service nothing connected covers, before saying it is unavailable or serving that request another way.
 \`connect\`: offer servers for the user to connect, resuming once they connect or skip. Only they can complete it; also use it to switch a credential or reconnect a broken server. In the same turn, first write one sentence telling them what connecting unlocks.`;
 
 const NOTHING_CONNECTED_HINT =


### PR DESCRIPTION
## Summary

Adds discovery evals for how the assistant uses the MCP registry: connecting servers, using what's already connected, and staying out of the way when building workflows.

| Scenario | Asserts |
| --- | --- |
| `mcp-connect-unconnected-service` | Searches the registry and connects the right server for an unconnected service |
| `mcp-uses-connected-server-tools` | Uses a connected server's tools instead of reconnecting |
| `mcp-broken-connection-reconnect` | Reconnects a server serving no tools rather than falling back to registry search |
| `mcp-no-registry-match` | Doesn't invent or connect a server when nothing matches |
| `mcp-not-offered-for-workflow-build` | Doesn't push MCP during a workflow build |
| `mcp-declined-tool-call-no-reconnect` | Reads a refused tool call as withheld permission, not a broken connection |


Harness changes these needed:

- Confirmations are answered from the scenario (`confirmations`), defaulting to approve; optional `resumeWith` to pass additional data
- Deferred tool loading enabled, so dispatch matches the real agent
- Structured `args` matching on tool-call expectations, plus `declined` to assert a refused call
- Per-scenario `timeoutMs`

## How to test

```bash
npx dotenvx run -f .env.local -- pnpm --filter @n8n/instance-ai eval:discovery -- --filter mcp --trials 3
```

All evals should pass

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5578

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
