### PR TITLE
build: Cache the isolated-vm native compile across application changes

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -1,48 +1,35 @@
 ARG NODE_VERSION=24.18.1
 ARG N8N_VERSION=snapshot
 
-# Toolchain stage exists because the runtime base image has no compiler.
-# Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
-# Bump the digest together with the tag when updating the base image.
-# Digest pins to node:24.18.1-alpine3.24 (Node 24.18.1, Alpine 3.24).
+# The runtime base has no compiler, so this stage supplies one.
+# The digest pins node:24.18.1-alpine3.24 for amd64 and arm64. Change the tag and the digest together.
 FROM node:24.18.1-alpine3.24@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS toolchain
 RUN apk add --no-cache python3 make g++
 
-# The isolated-vm compile lives in its own stage so its only cache input is the
-# module's own source. Below `COPY ./compiled` it was invalidated by any change
-# to application code, making every rebuild pay the full node-gyp cost.
+# Build isolated-vm in a separate stage. The only cache input is the module source.
+# Below `COPY ./compiled`, each application change starts a new compile.
 FROM toolchain AS native-builder
-# Copy the real module directory rather than the node_modules/isolated-vm symlink
-# pnpm leaves behind. Version-globbed so a catalog bump needs no edit here.
+# `node_modules/isolated-vm` is a pnpm symlink, so copy the target directory.
+# The wildcard tracks the version in the catalog.
 COPY ./compiled/node_modules/.pnpm/isolated-vm@*/node_modules/isolated-vm /build/isolated-vm
 WORKDIR /build/isolated-vm
-# Rebuild isolated-vm from source. node-gyp-build's musl detection relies
-# on /etc/alpine-release which DHI Alpine omits, so the bundled prebuilt
-# loader picks the glibc binary and segfaults in musl pthread paths.
-# Removing prebuilds and invoking node-gyp directly avoids npm rebuild's
-# double-build behavior (built-in node-gyp + install-script node-gyp)
-# which races on dep-file state.
-# Use npm's bundled node-gyp rather than `npx node-gyp` so the toolchain
-# version is fixed by the pinned image digest instead of being fetched
-# from the registry at build time.
+# node-gyp-build reads /etc/alpine-release to detect musl. DHI Alpine has no such file,
+# so the loader takes the glibc prebuild and crashes. Build from source instead.
+# Call node-gyp directly: `npm rebuild` starts two builds that conflict, and
+# `npx node-gyp` downloads a different version at build time.
 RUN rm -rf prebuilds && \
     node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js rebuild --release -j max
 
 FROM toolchain AS builder
 COPY ./compiled /usr/local/lib/node_modules/n8n
 RUN cd /usr/local/lib/node_modules/n8n && npm rebuild sqlite3
-# node-gyp-build resolves build/Release ahead of prebuilds, but the prebuilds are
-# still dropped so the glibc binary cannot be reached by any fallback path.
 COPY --from=native-builder /build/isolated-vm/build/Release/isolated_vm.node \
      /usr/local/lib/node_modules/n8n/node_modules/isolated-vm/build/Release/isolated_vm.node
+# node-gyp-build finds build/Release first. Delete the prebuilds to remove the glibc fallback.
 RUN rm -rf /usr/local/lib/node_modules/n8n/node_modules/isolated-vm/prebuilds
 
-# Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
-# n8nio/base is republished by a separate workflow (docker/images/n8n-base) on every
-# base change, so a base rebuild does not reach this image until the digest is
-# manually re-pinned here. Bump the digest together with the tag whenever the base
-# image is intentionally updated.
-# Digest pins to n8nio/base:24.18.1 (Node 24.18.1, Alpine 3.24).
+# The digest pins n8nio/base:24.18.1 for amd64 and arm64. A separate workflow builds that
+# image, so a new base reaches this image only when you change the digest here.
 FROM n8nio/base:24.18.1@sha256:f7a23e449f093b8b203467919e969ca35d12ba959442aadc1f69bb174b160ad2
 
 ARG N8N_VERSION
@@ -56,7 +43,7 @@ WORKDIR /home/node
 COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
 COPY docker/images/n8n/docker-entrypoint.sh /
 
-# The Alpine 3.24 base has no /usr/local/bin (node lives in /usr/bin); create it for the symlink.
+# The base keeps node in /usr/bin and has no /usr/local/bin. Make that directory for the symlink.
 RUN mkdir -p /usr/local/bin && \
     ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -1,27 +1,41 @@
 ARG NODE_VERSION=24.18.1
 ARG N8N_VERSION=snapshot
 
-# Builder stage exists because the runtime base image has no toolchain.
+# Toolchain stage exists because the runtime base image has no compiler.
 # Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
 # Bump the digest together with the tag when updating the base image.
 # Digest pins to node:24.18.1-alpine3.24 (Node 24.18.1, Alpine 3.24).
-FROM node:24.18.1-alpine3.24@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS builder
-COPY ./compiled /usr/local/lib/node_modules/n8n
-RUN apk add --no-cache python3 make g++ && \
-    cd /usr/local/lib/node_modules/n8n && \
-    npm rebuild sqlite3 && \
-    # Rebuild isolated-vm from source. node-gyp-build's musl detection relies
-    # on /etc/alpine-release which DHI Alpine omits, so the bundled prebuilt
-    # loader picks the glibc binary and segfaults in musl pthread paths.
-    # Removing prebuilds and invoking node-gyp directly avoids npm rebuild's
-    # double-build behavior (built-in node-gyp + install-script node-gyp)
-    # which races on dep-file state.
-    # Use npm's bundled node-gyp rather than `npx node-gyp` so the toolchain
-    # version is fixed by the pinned image digest instead of being fetched
-    # from the registry at build time.
-    rm -rf node_modules/isolated-vm/prebuilds && \
-    cd node_modules/isolated-vm && \
+FROM node:24.18.1-alpine3.24@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS toolchain
+RUN apk add --no-cache python3 make g++
+
+# The isolated-vm compile lives in its own stage so its only cache input is the
+# module's own source. Below `COPY ./compiled` it was invalidated by any change
+# to application code, making every rebuild pay the full node-gyp cost.
+FROM toolchain AS native-builder
+# Copy the real module directory rather than the node_modules/isolated-vm symlink
+# pnpm leaves behind. Version-globbed so a catalog bump needs no edit here.
+COPY ./compiled/node_modules/.pnpm/isolated-vm@*/node_modules/isolated-vm /build/isolated-vm
+WORKDIR /build/isolated-vm
+# Rebuild isolated-vm from source. node-gyp-build's musl detection relies
+# on /etc/alpine-release which DHI Alpine omits, so the bundled prebuilt
+# loader picks the glibc binary and segfaults in musl pthread paths.
+# Removing prebuilds and invoking node-gyp directly avoids npm rebuild's
+# double-build behavior (built-in node-gyp + install-script node-gyp)
+# which races on dep-file state.
+# Use npm's bundled node-gyp rather than `npx node-gyp` so the toolchain
+# version is fixed by the pinned image digest instead of being fetched
+# from the registry at build time.
+RUN rm -rf prebuilds && \
     node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js rebuild --release -j max
+
+FROM toolchain AS builder
+COPY ./compiled /usr/local/lib/node_modules/n8n
+RUN cd /usr/local/lib/node_modules/n8n && npm rebuild sqlite3
+# node-gyp-build resolves build/Release ahead of prebuilds, but the prebuilds are
+# still dropped so the glibc binary cannot be reached by any fallback path.
+COPY --from=native-builder /build/isolated-vm/build/Release/isolated_vm.node \
+     /usr/local/lib/node_modules/n8n/node_modules/isolated-vm/build/Release/isolated_vm.node
+RUN rm -rf /usr/local/lib/node_modules/n8n/node_modules/isolated-vm/prebuilds
 
 # Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
 # n8nio/base is republished by a separate workflow (docker/images/n8n-base) on every


### PR DESCRIPTION
## Summary

`pnpm build:docker` got slower after the isolated-vm from-source rebuild landed (#31396). The cause is layer ordering rather than the compile itself: the node-gyp rebuild sits below `COPY ./compiled`, so **any** change to application code invalidates the layer and pays the full compile again. An incremental local build was measurably slower than a cold one.

This moves the compile into its own stage whose only cache input is the module's own source tree, then copies the resulting `.node` into the builder stage.

Behaviour is unchanged. Still compiled from source, still via npm's bundled node-gyp, still with `prebuilds` removed — the musl reasons from #31396 and #32158 are preserved, and their rationale comments move with the code.

Measured on a build where application code changed:

| Step | Before | After |
| --- | --- | --- |
| `node-gyp rebuild` | 1m52s, every build | **CACHED** |
| `apk add python3 make g++` | re-ran every build | **CACHED** |

A cold build also benefits: the compile now runs in parallel with the 1.5GB `COPY ./compiled` (76.4s compile vs 105.6s copy) instead of after it, so it costs no additional wall-clock.

Two notes for reviewers:

- The `COPY` is version-globbed (`isolated-vm@*`) and takes the real module directory rather than the `node_modules/isolated-vm` symlink pnpm leaves behind, so an isolated-vm catalog bump needs no edit here.
- End-to-end wall-clock is dominated by moving the 1.5GB `compiled/` dir (COPY + context + export ≈ 4m19s of a 5m21s build). Local timings on this hardware were too noisy to quote a reliable total — identical `COPY ./compiled` work measured anywhere from 31s to 2m04s across runs. The per-step CACHED result above is the load-bearing evidence, not a total.

## How to test

```bash
node scripts/build-n8n.mjs
node scripts/dockerize-n8n.mjs          # populate the cache
# touch any file under compiled/, then:
node scripts/dockerize-n8n.mjs          # native-builder steps should report CACHED
```

Verified on the resulting image:

```
build/Release (from-source): true    prebuilds removed: true
ivm eval 6*7 = 42                    sqlite3: function
git /usr/bin/git   ssh /usr/bin/ssh   python3 MISSING   g++ MISSING
n8n --version 2.33.0                 healthz 200 after 8s
```

Image size 2.25GB vs 2.34GB before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

