### PR TITLE
fix(core): Detect node settings changes when comparing workflow versions

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
@@ -44,6 +44,19 @@ describe('computeTriggerDiff', () => {
 		expect(diff).toEqual({ toAdd: new Set(['a']), toRemove: new Set(['a']) });
 	});
 
+	test('ignores changes to settings that do not affect registration', () => {
+		const before = makeNode('a');
+		const after = makeNode('a', {
+			notes: 'some note',
+			onError: 'continueRegularOutput',
+			retryOnFail: true,
+		});
+
+		const diff = computeTriggerDiff([before], [after]);
+
+		expect(diff).toEqual({ toAdd: new Set(), toRemove: new Set() });
+	});
+
 	test('treats a typeVersion change as a modification', () => {
 		const diff = computeTriggerDiff(
 			[makeNode('a', { typeVersion: 1 })],

--- a/packages/cli/src/workflows/publication/trigger-diff.ts
+++ b/packages/cli/src/workflows/publication/trigger-diff.ts
@@ -1,5 +1,16 @@
+import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 import type { INode } from 'n8n-workflow';
 import { compareWorkflowsNodes, NodeDiffStatus } from 'n8n-workflow';
+
+// Only these properties affect how a trigger is registered. Comparing more
+// (notes, error-handling settings, ...) would deregister and re-register live
+// triggers on edits that don't change how they run.
+const registrationProps = ['name', 'type', 'typeVersion', 'webhookId', 'credentials', 'parameters'];
+
+function registrationEqual(base: INode | undefined, target: INode | undefined): boolean {
+	return isEqual(pick(base, registrationProps), pick(target, registrationProps));
+}
 
 /**
  * The trigger nodes that need to be deregistered (`toRemove`) and registered
@@ -22,7 +33,7 @@ export function computeTriggerDiff(
 	oldTriggerNodes: INode[],
 	newTriggerNodes: INode[],
 ): TriggerDiff {
-	const diff = compareWorkflowsNodes(oldTriggerNodes, newTriggerNodes);
+	const diff = compareWorkflowsNodes(oldTriggerNodes, newTriggerNodes, registrationEqual);
 
 	const toAdd: Set<INode['id']> = new Set();
 	const toRemove: Set<INode['id']> = new Set();

--- a/packages/workflow/src/workflow-diff.ts
+++ b/packages/workflow/src/workflow-diff.ts
@@ -43,7 +43,27 @@ export function compareNodes<T extends DiffableNode>(
 	base: T | undefined,
 	target: T | undefined,
 ): boolean {
-	const propsToCompare = ['name', 'type', 'typeVersion', 'webhookId', 'credentials', 'parameters'];
+	// All persisted node fields except `position` — moving a node on the canvas
+	// is not a content change. Kept as an allowlist because callers pass UI node
+	// objects that carry ephemeral fields (e.g. `issues`).
+	const propsToCompare = [
+		'name',
+		'type',
+		'typeVersion',
+		'webhookId',
+		'credentials',
+		'parameters',
+		'disabled',
+		'notes',
+		'notesInFlow',
+		'onError',
+		'continueOnFail',
+		'retryOnFail',
+		'maxTries',
+		'waitBetweenTries',
+		'alwaysOutputData',
+		'executeOnce',
+	];
 
 	const baseNode = pick(base, propsToCompare);
 	const targetNode = pick(target, propsToCompare);

--- a/packages/workflow/test/workflow-diff.test.ts
+++ b/packages/workflow/test/workflow-diff.test.ts
@@ -59,6 +59,15 @@ describe('compareNodes', () => {
 		parameters: INodeParameters;
 		position: [number, number];
 		disabled: boolean;
+		notes?: string;
+		notesInFlow?: boolean;
+		onError?: string;
+		continueOnFail?: boolean;
+		retryOnFail?: boolean;
+		maxTries?: number;
+		waitBetweenTries?: number;
+		alwaysOutputData?: boolean;
+		executeOnce?: boolean;
 	};
 
 	it('should return true for identical nodes', () => {
@@ -124,13 +133,33 @@ describe('compareNodes', () => {
 		expect(result).toBe(false);
 	});
 
-	it('should ignore properties not in comparison list', () => {
-		const node1 = createTestNode({ position: [100, 200], disabled: false });
-		const node2 = createTestNode({ position: [300, 400], disabled: true });
+	it('should ignore position changes', () => {
+		const node1 = createTestNode({ position: [100, 200] });
+		const node2 = createTestNode({ position: [300, 400] });
 
 		const result = compareNodes(node1, node2);
 
 		expect(result).toBe(true);
+	});
+
+	test.each([
+		['disabled', true],
+		['notes', 'handle rate limits here'],
+		['notesInFlow', true],
+		['onError', 'continueRegularOutput'],
+		['continueOnFail', true],
+		['retryOnFail', true],
+		['maxTries', 5],
+		['waitBetweenTries', 2000],
+		['alwaysOutputData', true],
+		['executeOnce', true],
+	])('should return false when nodes have different %s settings', (property, value) => {
+		const node1 = createTestNode();
+		const node2 = createTestNode({ [property]: value } as Partial<TestNode>);
+
+		const result = compareNodes(node1, node2);
+
+		expect(result).toBe(false);
 	});
 
 	it('should handle undefined base node', () => {
@@ -494,6 +523,14 @@ describe('groupWorkflows', () => {
 					baseWorkflow: createWorkflow('1', [{ id: '1', parameters: { a: 'value1' }, name: 'n1' }]),
 					nextWorkflow: createWorkflow('1', [
 						{ id: '1', parameters: { a: 'value1', b: 'value2' }, name: 'n1' },
+					]),
+					expected: false,
+				},
+				{
+					description: 'should return false when a node setting changes',
+					baseWorkflow: createWorkflow('1', [{ id: '1', parameters: { a: 'value1' }, name: 'n1' }]),
+					nextWorkflow: createWorkflow('1', [
+						{ id: '1', parameters: { a: 'value1' }, name: 'n1', disabled: true } as DiffableNode,
 					]),
 					expected: false,
 				},
@@ -1099,6 +1136,15 @@ describe('hasNonPositionalChanges', () => {
 	it('should return true when node parameters change', () => {
 		const oldNodes = [createNode('1', { parameters: { param1: 'value1' } })];
 		const newNodes = [createNode('1', { parameters: { param1: 'value2' } })];
+
+		const result = hasNonPositionalChanges(oldNodes, newNodes, {}, {});
+
+		expect(result).toBe(true);
+	});
+
+	it('should return true when a node is disabled', () => {
+		const oldNodes = [createNode('1')];
+		const newNodes = [createNode('1', { disabled: true })];
 
 		const result = hasNonPositionalChanges(oldNodes, newNodes, {}, {});
 


### PR DESCRIPTION
## Summary

`compareNodes` in `packages/workflow/src/workflow-diff.ts` only compared `name`, `type`, `typeVersion`, `webhookId`, `credentials`, and `parameters`. Every other node field — `disabled`, `notes`, `notesInFlow`, `onError`, `continueOnFail`, `retryOnFail`, `maxTries`, `waitBetweenTries`, `alwaysOutputData`, `executeOnce` — compared equal, so a version whose only change was one of these settings was reported as "no change" by every consumer of the default comparator:

- **Workflow history diff view** (`useWorkflowDiff`): disabling a node between two versions shows the node as unchanged.
- **Workflow history compaction** (`groupWorkflows` / `mergeAdditiveChanges` via `nodeIsSuperset`): a version that only toggled a setting could be pruned away, erasing the record of e.g. who disabled a node. `nodeIsSuperset` is documented as "no data is lost if we were to replace prev with next" — losing a `disabled` toggle is data loss.
- **Telemetry** (`hasNonPositionalChanges`): a settings-only edit was reported as a position-only edit (`workflow_edited_no_pos: false`).
- **AI assistant version cards** (`useReviewChanges`), **MCP builder version metadata**, and **eval insights context**: same blindness.

### Fix

Widen `propsToCompare` to all persisted `INode` fields except `position` (moving a node on the canvas is deliberately not a content change). This stays an **allowlist** rather than becoming a denylist of `position`, because frontend callers pass `INodeUi` objects carrying ephemeral fields (`issues`, `pinData`, `draggable`, ...) that must not create phantom diffs.

### Deliberately unchanged: trigger registration on publish

`computeTriggerDiff` (workflow publication) now passes an explicit comparator restricted to the registration-relevant properties (the previous six). Otherwise a settings-only edit (e.g. adding a note to a trigger) would deregister and re-register live triggers — external webhook API calls for a change that doesn't affect how the trigger runs. Publication behavior is byte-for-byte what it was before this PR.

### Behavior changes to be aware of

- **History compaction retains more versions**: settings-only versions are no longer merged away. Direction is conservative — it deletes less, never more.
- **`workflow_edited_no_pos` telemetry** is now `true` for settings-only edits (previously `false`), which is what the property claims to measure.

## How to test

### Affected surfaces

Every consumer of the default comparator, and how the fix shows up in each. For all manual tests, make a **settings-only** change between two saves: disable a node, add a note, or change On Error / Retry On Fail — no parameter or position changes.

Through the UI (all via `useWorkflowDiff` → `compareWorkflowsNodes`):

1. **Workflow history — compare versions** (`editor-ui/.../workflowDiff/useWorkflowDiff.ts`): save, disable a node, save again, compare the two versions in Workflow History. The node now gets a "modified" badge (previously shown as unchanged).
2. **Source control — push modal diff** (`SourceControlPushModal.vue`, same `WorkflowDiffModal`): with source control connected, a settings-only change now shows the node as modified in the push diff.
3. **AI assistant / builder version cards** (`editor-ui/.../assistant/composables/useReviewChanges.ts`): a builder version whose only change is a node setting now lists that node as changed (card chips + canvas highlight).

Backend:

4. **Workflow history compaction** (`@n8n/db/.../workflow-history.repository.ts` → `groupWorkflows`): a settings-only version now survives compaction instead of being merged away. Covered by the new unit test; observable live only by triggering `WorkflowHistoryCompactionService` with versions inside the same merge window.
5. **Save telemetry** (`cli/.../telemetry.event-relay.ts` via `hasNonPositionalChanges`): "User saved workflow" now reports `workflow_edited_no_pos: true` for a settings-only save.
6. **MCP builder tools' version metadata** (`cli/.../mcp/tools/workflow-builder/version-metadata.ts`, used by `update_workflow`, `create_workflow_from_code`, `restore_workflow_version`): updating only a node setting via MCP now counts that node as modified in the returned version metadata.
7. **Eval insights context** (`cli/.../evaluation.ee/insights/insights-context-builder.ts`): settings-only version changes now appear in the evaluations insights context.

The deliberate non-change to verify:

8. **Publication trigger re-registration** (`cli/.../workflows/publication/trigger-diff.ts`): publish a workflow after adding a note to an active trigger — the trigger must **not** be deregistered/re-registered (the webhook keeps working). A parameter change still re-registers it, as before.

## Related Linear tickets, Github issues, and Community forum posts

Surfaced while reviewing the MCP versions-diff tool (#35492, #35551), which had to work around this with a custom comparator; that workaround will be dropped in favor of this fix.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
