### PR TITLE
fix(core): Detect deprecated workflow helpers on non-this receivers (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-deprecated-workflow-functions.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-deprecated-workflow-functions.md
@@ -10,6 +10,25 @@
 
 Prevents usage of deprecated functions from n8n-workflow package and suggests modern alternatives.
 
+A node reaches these helpers through its execution context, which it can hold in
+several ways — all of them are reported:
+
+```typescript
+this.helpers.request(options); // execute() bound to the context
+context.helpers.requestOAuth2.call(context, ...); // context passed into a transport helper
+this.executeFunctions.helpers.request(options); // context stored on a class field
+const { helpers } = this; // destructured off the context
+```
+
+> [!NOTE]
+> The rule runs without type information, so it cannot tell which object a
+> `helpers` property belongs to. Apart from `this.helpers`, it therefore only
+> reports in files that import an execution context interface
+> (`IExecuteFunctions`, `ILoadOptionsFunctions`, …) from `n8n-workflow`. The
+> check is file-scoped rather than binding-scoped: in such a file, an unrelated
+> `someClient.helpers.request()` would also be reported. Silence the rare false
+> positive with `// eslint-disable-next-line`.
+
 ## Examples
 
 ### ❌ Incorrect

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-deprecated-workflow-functions.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-deprecated-workflow-functions.test.ts
@@ -49,6 +49,17 @@ function test(options: IRequestOptions) {
 	return options.url;
 }`,
 		},
+		{
+			name: 'non-this helpers in a file that does not handle execution contexts',
+			code: `
+import { SomeApiClient } from 'some-other-package';
+
+function makeRequest(client: SomeApiClient) {
+	const { helpers } = client;
+	helpers.request('https://example.com');
+	return client.helpers.request('https://example.com');
+}`,
+		},
 	],
 	invalid: [
 		{
@@ -177,6 +188,163 @@ return this.helpers.prepareOutputData([{ json: response }]);`,
 					messageId: 'deprecatedWithoutReplacement',
 					data: { functionName: 'copyBinaryFile' },
 				},
+				{
+					messageId: 'deprecatedWithoutReplacement',
+					data: { functionName: 'prepareOutputData' },
+				},
+			],
+		},
+		{
+			name: 'execution context passed in as a parameter',
+			code: `
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+export async function apiRequest(context: IExecuteFunctions, options) {
+	return await context.helpers.requestOAuth2.call(context, 'exampleOAuth2Api', options);
+}`,
+			errors: [
+				{
+					messageId: 'deprecatedRequestFunction',
+					data: { functionName: 'requestOAuth2', replacement: 'httpRequestWithAuthentication' },
+					suggestions: [
+						{
+							messageId: 'suggestReplaceFunction',
+							data: { functionName: 'requestOAuth2', replacement: 'httpRequestWithAuthentication' },
+							output: `
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+export async function apiRequest(context: IExecuteFunctions, options) {
+	return await context.helpers.httpRequestWithAuthentication.call(context, 'exampleOAuth2Api', options);
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'execution context union type parameter',
+			code: `
+import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+
+async function loadOptions(ctx: IExecuteFunctions | ILoadOptionsFunctions) {
+	return await ctx.helpers.request({ url: 'https://example.com' });
+}`,
+			errors: [
+				{
+					messageId: 'deprecatedRequestFunction',
+					data: { functionName: 'request', replacement: 'httpRequest' },
+					suggestions: [
+						{
+							messageId: 'suggestReplaceFunction',
+							data: { functionName: 'request', replacement: 'httpRequest' },
+							output: `
+import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+
+async function loadOptions(ctx: IExecuteFunctions | ILoadOptionsFunctions) {
+	return await ctx.helpers.httpRequest({ url: 'https://example.com' });
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'helpers destructured from this',
+			code: `
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+async function run(this: IExecuteFunctions) {
+	const { helpers } = this;
+	return await helpers.requestWithAuthentication('exampleApi', options);
+}`,
+			errors: [
+				{
+					messageId: 'deprecatedRequestFunction',
+					data: {
+						functionName: 'requestWithAuthentication',
+						replacement: 'httpRequestWithAuthentication',
+					},
+					suggestions: [
+						{
+							messageId: 'suggestReplaceFunction',
+							data: {
+								functionName: 'requestWithAuthentication',
+								replacement: 'httpRequestWithAuthentication',
+							},
+							output: `
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+async function run(this: IExecuteFunctions) {
+	const { helpers } = this;
+	return await helpers.httpRequestWithAuthentication('exampleApi', options);
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'execution context held in a class field',
+			code: `
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+class ExampleApi {
+	private executeFunctions: IExecuteFunctions;
+
+	async request(options) {
+		return await this.executeFunctions.helpers.requestWithAuthentication.call(
+			this.executeFunctions,
+			'exampleApi',
+			options,
+		);
+	}
+}`,
+			errors: [
+				{
+					messageId: 'deprecatedRequestFunction',
+					data: {
+						functionName: 'requestWithAuthentication',
+						replacement: 'httpRequestWithAuthentication',
+					},
+					suggestions: [
+						{
+							messageId: 'suggestReplaceFunction',
+							data: {
+								functionName: 'requestWithAuthentication',
+								replacement: 'httpRequestWithAuthentication',
+							},
+							output: `
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+class ExampleApi {
+	private executeFunctions: IExecuteFunctions;
+
+	async request(options) {
+		return await this.executeFunctions.helpers.httpRequestWithAuthentication.call(
+			this.executeFunctions,
+			'exampleApi',
+			options,
+		);
+	}
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'execution context declared as a constructor parameter property',
+			code: `
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+class ExampleApi {
+	constructor(private readonly ctx: IExecuteFunctions) {}
+
+	async run() {
+		return await this.ctx.helpers.prepareOutputData([]);
+	}
+}`,
+			errors: [
 				{
 					messageId: 'deprecatedWithoutReplacement',
 					data: { functionName: 'prepareOutputData' },

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-deprecated-workflow-functions.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-deprecated-workflow-functions.ts
@@ -1,6 +1,11 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
-import { createRule, isThisHelpersAccess } from '../utils/index.js';
+import {
+	createRule,
+	isHelpersAccess,
+	isThisHelpersAccess,
+	EXECUTION_CONTEXT_TYPES,
+} from '../utils/index.js';
 
 const DEPRECATED_FUNCTIONS = {
 	request: 'httpRequest',
@@ -46,6 +51,7 @@ export const NoDeprecatedWorkflowFunctionsRule = createRule({
 	defaultOptions: [],
 	create(context) {
 		const n8nWorkflowTypes = new Set<string>();
+		let importsExecutionContext = false;
 
 		return {
 			ImportDeclaration(node) {
@@ -56,6 +62,9 @@ export const NoDeprecatedWorkflowFunctionsRule = createRule({
 							specifier.imported.type === AST_NODE_TYPES.Identifier
 						) {
 							n8nWorkflowTypes.add(specifier.local.name);
+							if (EXECUTION_CONTEXT_TYPES.has(specifier.imported.name)) {
+								importsExecutionContext = true;
+							}
 						}
 					});
 				}
@@ -66,7 +75,9 @@ export const NoDeprecatedWorkflowFunctionsRule = createRule({
 					node.property.type === AST_NODE_TYPES.Identifier &&
 					isDeprecatedFunctionName(node.property.name)
 				) {
-					if (!isThisHelpersAccess(node)) {
+					// `this.helpers` is unambiguous on its own; any other receiver only counts in a file
+					// that imports an execution context type, which is what makes its `helpers` n8n's.
+					if (!isThisHelpersAccess(node) && !(importsExecutionContext && isHelpersAccess(node))) {
 						return;
 					}
 

--- a/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
@@ -237,6 +237,37 @@ export function isThisHelpersAccess(node: TSESTree.MemberExpression): boolean {
 	);
 }
 
+/** Execution context interfaces from `n8n-workflow` that expose a `helpers` object. */
+export const EXECUTION_CONTEXT_TYPES = new Set([
+	'IAllExecuteFunctions',
+	'IExecuteFunctions',
+	'IExecutePaginationFunctions',
+	'IExecuteSingleFunctions',
+	'IHookFunctions',
+	'ILoadOptionsFunctions',
+	'IPollFunctions',
+	'ISupplyDataFunctions',
+	'ITriggerFunctions',
+	'IWebhookFunctions',
+]);
+
+/**
+ * Matches `<receiver>.helpers.<method>` for any receiver, and a bare `helpers.<method>` left by
+ * destructuring. Deliberately does not identify the receiver: the rule runs without type
+ * information, so callers gate this on the file importing an execution context type instead.
+ */
+export function isHelpersAccess(node: TSESTree.MemberExpression): boolean {
+	if (node.object.type === AST_NODE_TYPES.Identifier) {
+		return node.object.name === 'helpers';
+	}
+
+	return (
+		node.object.type === AST_NODE_TYPES.MemberExpression &&
+		node.object.property.type === AST_NODE_TYPES.Identifier &&
+		node.object.property.name === 'helpers'
+	);
+}
+
 /** Matches a call expression of the form `this.methodName(...)`. */
 export function isThisMethodCall(node: TSESTree.CallExpression, method: string): boolean {
 	return (


### PR DESCRIPTION
## Summary

The `no-deprecated-workflow-functions` rule (`@n8n/eslint-plugin-community-nodes`) only reported deprecated helpers reached through a literal `this.helpers.<fn>` expression, so any other route to the execution context slipped through node review. This was found via a `requestOAuth2` usage the rule failed to catch.

A node reaches its `helpers` in several ways, and all of these were silently missed:

```typescript
context.helpers.requestOAuth2.call(context, ...); // context passed into a transport helper
this.executeFunctions.helpers.request(options);   // context stored on a class field
const { helpers } = this;                         // destructured off the context
```

The rule runs without type information, so it can't tell which object a `helpers` property belongs to. Rather than resolving each receiver back to its declaration, this keys off the file's imports: `this.helpers` still reports unconditionally, and any other receiver reports only in a file that imports an execution context interface (`IExecuteFunctions`, `ILoadOptionsFunctions`, …) from `n8n-workflow`. That is what makes its `helpers` n8n's.

This keeps the change to ~30 lines of detection logic and, unlike a binding-level check, does not depend on authors having written a type annotation — a `mock<IExecuteFunctions>()` with an inferred type is still matched.

The trade-off is that precision is file-scoped rather than binding-scoped: in a file that does import an execution context, an unrelated `someClient.helpers.request()` would also be reported. There are zero such occurrences across `nodes-base`, and the caveat plus the `eslint-disable` escape hatch is documented on the rule page, matching how `no-hardcoded-secrets` and `credential-unnecessary-password` document their heuristics.

Verified against the whole of `packages/nodes-base/nodes`: 5 previously-missed deprecated calls now report, in Brevo (`ref: IHookFunctions`), Peekalink (`context`) and Rundeck (a class field). No production-code false positives.

## How to test

Automated coverage lives in `no-deprecated-workflow-functions.test.ts` — six new invalid cases (context parameter, union-typed parameter, destructured `helpers`, class field, constructor parameter property) and a valid case pinning the import gate:

```bash
cd packages/@n8n/eslint-plugin-community-nodes
pnpm test src/rules/no-deprecated-workflow-functions.test.ts
pnpm typecheck && pnpm lint
```

To see it against real code, lint a file with a non-`this` receiver — e.g. `packages/nodes-base/nodes/Brevo/GenericFunctions.ts`, which uses `ref.helpers.requestWithAuthentication` — with the rule enabled. It reports on `master`: nothing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-2165

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

