### PR TITLE
feat: Add HTTP agent broker to Codespaces agent sessions (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -41,6 +41,41 @@ pnpm session rm           # delete the codespace
 - First codespace creation takes ~20 min uncached (image + full build). After
   that, sessions attach instantly; new worktrees cost a `pnpm install` (~1–2 min).
 
+## Agent broker (call the codespace over HTTP)
+
+`agent-broker.mjs` runs one Claude turn per HTTP request, so an external caller
+(an n8n workflow, a script) can drive a session on the codespace. Each turn is a
+headless `claude -p`. State persists on disk, so `--resume` continues a
+conversation across turns and across a stop/start.
+
+The broker starts on every container start (`postStartCommand`). It needs the
+`AGENT_BROKER_TOKEN` secret and refuses to start without it. Add the token at
+[github.com/settings/codespaces](https://github.com/settings/codespaces) the
+same way as `ANTHROPIC_API_KEY`. Logs are at `/tmp/agent-broker.log`; the tmux
+session is `broker`.
+
+The port is private by default. Make it reachable, then health-check it:
+
+```bash
+gh codespace ports visibility 8787:public -c <codespace-name>
+curl https://<codespace-name>-8787.app.github.dev/healthz     # {"ok":true}
+```
+
+A public port has no auth in front of it, so the bearer token is the only
+guard. Keep it secret.
+
+Send a turn (omit `sessionId` to start one; pass it back to continue):
+
+```bash
+curl -s https://<codespace-name>-8787.app.github.dev/turns \
+  -H "Authorization: Bearer $AGENT_BROKER_TOKEN" -H 'content-type: application/json' \
+  -d '{"message":"what branch is this?"}'
+# reply carries .result.session_id — send it back as "sessionId" next turn
+```
+
+Turns take minutes. Pass a `callbackUrl` to get `202 {turnId}` at once and the
+result by POST when the turn ends. See the file header for the full contract.
+
 ## Flaky tools (MCP)
 
 Claude sessions get the `flaky` MCP server automatically: Currents

--- a/.devcontainer/codespaces/agent-broker.mjs
+++ b/.devcontainer/codespaces/agent-broker.mjs
@@ -13,11 +13,12 @@
 import { execFile } from 'node:child_process';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { createServer } from 'node:http';
+import { resolve as resolvePath, sep } from 'node:path';
 
 const PORT = Number(process.env.AGENT_BROKER_PORT ?? 8787);
 const TOKEN = process.env.AGENT_BROKER_TOKEN;
 // Confine workdirs to ROOT. Override for local tests outside a codespace.
-const ROOT = process.env.AGENT_BROKER_ROOT ?? '/workspaces';
+const ROOT = resolvePath(process.env.AGENT_BROKER_ROOT ?? '/workspaces');
 const DEFAULT_CWD = process.env.AGENT_BROKER_CWD ?? `${ROOT}/n8n`;
 const TURN_TIMEOUT_MS = 15 * 60_000;
 const MAX_TURNS_KEPT = 100;
@@ -33,13 +34,15 @@ const queues = new Map();
 
 function enqueue(key, task) {
 	const tail = (queues.get(key) ?? Promise.resolve()).then(task, task);
-	queues.set(
-		key,
-		tail.then(
-			() => {},
-			() => {},
-		),
+	const settled = tail.then(
+		() => {},
+		() => {},
 	);
+	queues.set(key, settled);
+	// Drop the key once the chain drains, unless a newer turn already replaced it.
+	settled.then(() => {
+		if (queues.get(key) === settled) queues.delete(key);
+	});
 	return tail;
 }
 
@@ -105,39 +108,52 @@ function json(res, status, body) {
 }
 
 createServer(async (req, res) => {
-	const { pathname } = new URL(req.url, 'http://localhost');
-	if (req.method === 'GET' && pathname === '/healthz') return json(res, 200, { ok: true });
-	if (!authorized(req)) return json(res, 401, { error: 'unauthorized' });
+	try {
+		const { pathname } = new URL(req.url, 'http://localhost');
+		if (req.method === 'GET' && pathname === '/healthz') return json(res, 200, { ok: true });
+		if (!authorized(req)) return json(res, 401, { error: 'unauthorized' });
 
-	const turnMatch = pathname.match(/^\/turns\/([\w-]+)$/);
-	if (req.method === 'GET' && turnMatch) {
-		const turn = turns.get(turnMatch[1]);
-		return turn ? json(res, 200, turn) : json(res, 404, { error: 'unknown turn' });
-	}
-
-	if (req.method === 'POST' && pathname === '/turns') {
-		const chunks = [];
-		for await (const chunk of req) chunks.push(chunk);
-		let body;
-		try {
-			body = JSON.parse(Buffer.concat(chunks).toString());
-		} catch {
-			return json(res, 400, { error: 'body must be JSON' });
+		const turnMatch = pathname.match(/^\/turns\/([\w-]+)$/);
+		if (req.method === 'GET' && turnMatch) {
+			const turn = turns.get(turnMatch[1]);
+			return turn ? json(res, 200, turn) : json(res, 404, { error: 'unknown turn' });
 		}
-		const { message, sessionId, callbackUrl } = body;
-		const cwd = body.cwd ?? DEFAULT_CWD;
-		if (typeof message !== 'string' || !message.trim())
-			return json(res, 400, { error: 'message (string) is required' });
-		if (!cwd.startsWith(`${ROOT}/`)) return json(res, 400, { error: `cwd must be under ${ROOT}/` });
 
-		const id = randomUUID();
-		turns.set(id, { status: 'queued' });
-		const running = executeTurn(id, { message, sessionId, cwd, callbackUrl });
-		if (callbackUrl) return json(res, 202, { turnId: id });
-		await running;
-		const turn = turns.get(id);
-		return json(res, turn.status === 'done' ? 200 : 500, { turnId: id, ...turn });
+		if (req.method === 'POST' && pathname === '/turns') {
+			const chunks = [];
+			for await (const chunk of req) chunks.push(chunk);
+			let body;
+			try {
+				body = JSON.parse(Buffer.concat(chunks).toString());
+			} catch {
+				return json(res, 400, { error: 'body must be JSON' });
+			}
+			if (body === null || typeof body !== 'object' || Array.isArray(body))
+				return json(res, 400, { error: 'body must be a JSON object' });
+			const { message, sessionId, callbackUrl } = body;
+			if (typeof message !== 'string' || !message.trim())
+				return json(res, 400, { error: 'message (string) is required' });
+			for (const [k, v] of Object.entries({ sessionId, callbackUrl, cwd: body.cwd }))
+				if (v !== undefined && typeof v !== 'string')
+					return json(res, 400, { error: `${k} must be a string` });
+			// Resolve before the prefix check so `..` segments can't escape ROOT.
+			const cwd = resolvePath(typeof body.cwd === 'string' ? body.cwd : DEFAULT_CWD);
+			if (cwd !== ROOT && !cwd.startsWith(ROOT + sep))
+				return json(res, 400, { error: `cwd must be under ${ROOT}` });
+
+			const id = randomUUID();
+			// Hold the turn object across the await: eviction may delete the map entry,
+			// but this reference still reflects the status executeTurn assigns to it.
+			const turn = { status: 'queued' };
+			turns.set(id, turn);
+			const running = executeTurn(id, { message, sessionId, cwd, callbackUrl });
+			if (callbackUrl) return json(res, 202, { turnId: id });
+			await running;
+			return json(res, turn.status === 'done' ? 200 : 500, { turnId: id, ...turn });
+		}
+
+		json(res, 404, { error: 'not found' });
+	} catch (error) {
+		if (!res.headersSent) json(res, 500, { error: error.message });
 	}
-
-	json(res, 404, { error: 'not found' });
 }).listen(PORT, () => console.log(`agent-broker listening on :${PORT}`));

--- a/.devcontainer/codespaces/agent-broker.mjs
+++ b/.devcontainer/codespaces/agent-broker.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// HTTP broker for per-turn Claude Code conversations on a codespace.
+// Each turn is one `claude -p` exec. State persists on disk via --resume, so the
+// broker holds nothing between turns and survives a codespace stop/start.
+//
+//   AGENT_BROKER_TOKEN=… node agent-broker.mjs
+//
+//   GET  /healthz                              no auth
+//   POST /turns { message, sessionId?, cwd?, callbackUrl? }   Bearer auth
+//     with callbackUrl: reply 202 { turnId }, then POST the result to callbackUrl.
+//     without callbackUrl: hold the connection, reply with the result. Short turns only.
+//   GET  /turns/<id>                           Bearer auth. Poll for a held result.
+import { execFile } from 'node:child_process';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+import { createServer } from 'node:http';
+
+const PORT = Number(process.env.AGENT_BROKER_PORT ?? 8787);
+const TOKEN = process.env.AGENT_BROKER_TOKEN;
+// Confine workdirs to ROOT. Override for local tests outside a codespace.
+const ROOT = process.env.AGENT_BROKER_ROOT ?? '/workspaces';
+const DEFAULT_CWD = process.env.AGENT_BROKER_CWD ?? `${ROOT}/n8n`;
+const TURN_TIMEOUT_MS = 15 * 60_000;
+const MAX_TURNS_KEPT = 100;
+
+if (!TOKEN) {
+	console.error('Refusing to start: set AGENT_BROKER_TOKEN (the bearer token n8n will send).');
+	process.exit(1);
+}
+
+const turns = new Map();
+// Serialize turns on the same session. Turns on other sessions run in parallel.
+const queues = new Map();
+
+function enqueue(key, task) {
+	const tail = (queues.get(key) ?? Promise.resolve()).then(task, task);
+	queues.set(
+		key,
+		tail.then(
+			() => {},
+			() => {},
+		),
+	);
+	return tail;
+}
+
+function runClaude({ message, sessionId, cwd }) {
+	const args = ['-p', '--output-format', 'json', '--dangerously-skip-permissions'];
+	if (sessionId) args.push('--resume', sessionId);
+	args.push(message);
+	return new Promise((resolve, reject) => {
+		execFile(
+			'claude',
+			args,
+			{ cwd, timeout: TURN_TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024 },
+			(err, stdout, stderr) => {
+				try {
+					resolve(JSON.parse(stdout));
+				} catch {
+					reject(new Error(stderr?.trim() || err?.message || 'claude produced no output'));
+				}
+			},
+		);
+	});
+}
+
+async function executeTurn(id, { message, sessionId, cwd, callbackUrl }) {
+	const turn = turns.get(id);
+	turn.status = 'running';
+	try {
+		const result = await enqueue(sessionId ?? id, () => runClaude({ message, sessionId, cwd }));
+		Object.assign(turn, { status: 'done', result });
+	} catch (error) {
+		Object.assign(turn, { status: 'error', error: error.message });
+	}
+	if (turns.size > MAX_TURNS_KEPT) {
+		for (const key of turns.keys()) {
+			if (turns.size <= MAX_TURNS_KEPT) break;
+			if (turns.get(key).status !== 'running') turns.delete(key);
+		}
+	}
+	if (callbackUrl) {
+		try {
+			await fetch(callbackUrl, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ turnId: id, ...turn }),
+			});
+		} catch (error) {
+			// The result is still available from GET /turns/<id>.
+			console.error(`turn ${id}: callback to ${callbackUrl} failed: ${error.message}`);
+		}
+	}
+}
+
+function authorized(req) {
+	const sent = req.headers.authorization?.replace(/^Bearer /, '') ?? '';
+	const a = Buffer.from(sent);
+	const b = Buffer.from(TOKEN);
+	return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function json(res, status, body) {
+	res.writeHead(status, { 'content-type': 'application/json' });
+	res.end(JSON.stringify(body));
+}
+
+createServer(async (req, res) => {
+	const { pathname } = new URL(req.url, 'http://localhost');
+	if (req.method === 'GET' && pathname === '/healthz') return json(res, 200, { ok: true });
+	if (!authorized(req)) return json(res, 401, { error: 'unauthorized' });
+
+	const turnMatch = pathname.match(/^\/turns\/([\w-]+)$/);
+	if (req.method === 'GET' && turnMatch) {
+		const turn = turns.get(turnMatch[1]);
+		return turn ? json(res, 200, turn) : json(res, 404, { error: 'unknown turn' });
+	}
+
+	if (req.method === 'POST' && pathname === '/turns') {
+		const chunks = [];
+		for await (const chunk of req) chunks.push(chunk);
+		let body;
+		try {
+			body = JSON.parse(Buffer.concat(chunks).toString());
+		} catch {
+			return json(res, 400, { error: 'body must be JSON' });
+		}
+		const { message, sessionId, callbackUrl } = body;
+		const cwd = body.cwd ?? DEFAULT_CWD;
+		if (typeof message !== 'string' || !message.trim())
+			return json(res, 400, { error: 'message (string) is required' });
+		if (!cwd.startsWith(`${ROOT}/`)) return json(res, 400, { error: `cwd must be under ${ROOT}/` });
+
+		const id = randomUUID();
+		turns.set(id, { status: 'queued' });
+		const running = executeTurn(id, { message, sessionId, cwd, callbackUrl });
+		if (callbackUrl) return json(res, 202, { turnId: id });
+		await running;
+		const turn = turns.get(id);
+		return json(res, turn.status === 'done' ? 200 : 500, { turnId: id, ...turn });
+	}
+
+	json(res, 404, { error: 'not found' });
+}).listen(PORT, () => console.log(`agent-broker listening on :${PORT}`));

--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -17,12 +17,21 @@
 		// needs `privileged: true` on the n8n service (compose-based config)
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
-	"forwardPorts": [8080, 5678],
+	"forwardPorts": [8080, 5678, 8787],
+	"portsAttributes": {
+		"8787": { "label": "agent-broker" }
+	},
 	// Runs in prebuilds, so a fresh codespace starts with deps installed and the build warm
 	"onCreateCommand": "corepack install && pnpm install && (pnpm build > /tmp/build.log 2>&1 || tail -n 50 /tmp/build.log) && pnpm --filter=n8n-playwright exec playwright install chromium",
+	// Start the broker on each container start. `bash -lc` loads the secrets shim, so the
+	// broker gets AGENT_BROKER_TOKEN. tmux detaches it, so it does not block startup.
+	"postStartCommand": "tmux new-session -d -s broker 'bash -lc \"node /workspaces/n8n/.devcontainer/codespaces/agent-broker.mjs >> /tmp/agent-broker.log 2>&1\"' || true",
 	"secrets": {
 		"ANTHROPIC_API_KEY": {
 			"description": "Anthropic API key for Claude Code / OpenCode sessions"
+		},
+		"AGENT_BROKER_TOKEN": {
+			"description": "Bearer token the agent broker requires on every request (see .devcontainer/codespaces/agent-broker.mjs)"
 		},
 		"CLAUDE_CODE_OAUTH_TOKEN": {
 			"description": "Alternative to an API key: token from `claude setup-token` (Max subscription)"

--- a/.devcontainer/codespaces/docker-compose.yml
+++ b/.devcontainer/codespaces/docker-compose.yml
@@ -26,3 +26,5 @@ services:
       DB_POSTGRESDB_HOST: postgres
       DB_TYPE: postgresdb
       DB_POSTGRESDB_PASSWORD: password
+      # Prompt-cache TTL in seconds. 1 hour keeps the cache warm between broker turns.
+      ANTHROPIC_PROMPT_CACHE_TTL: "3600"


### PR DESCRIPTION
## Summary

Adds `agent-broker.mjs` to the Codespaces agent-session config — a small,
zero-dependency HTTP wrapper over `claude -p --resume` so an external caller
(e.g. an n8n workflow) can drive a Claude Code session running on a codespace
over HTTP. Each request is one headless turn; conversation state persists on
disk via `--resume`, so the broker holds nothing between turns and a
conversation survives a codespace stop/start.

Wires it into the codespaces devcontainer:
- **`postStartCommand`** starts the broker on every container start, detached in
  tmux, via `bash -lc` so the Codespaces secrets shim runs and the broker sees
  its token. It refuses to start without `AGENT_BROKER_TOKEN`.
- Forwards port **8787** (labelled `agent-broker`).
- Declares the **`AGENT_BROKER_TOKEN`** secret (bearer token required on every
  request — a public forwarded port has no other auth).
- Sets **`ANTHROPIC_PROMPT_CACHE_TTL=3600`** so the conversation prefix stays
  cache-warm across the minutes-apart gaps between broker turns.

Scoped to `.devcontainer/codespaces/` only — the laptop devcontainer and the
rest of the repo are untouched. Follows on from #35879.

## How to test

1. Add `AGENT_BROKER_TOKEN` as a Codespaces secret (repo `n8n-io/n8n`).
2. Start a codespace; confirm the broker is up: `tmux ls` shows `broker`, and
   `curl localhost:8787/healthz` returns `{"ok":true}`.
3. Expose it: `gh codespace ports visibility 8787:public -c <name>`.
4. `POST /turns` with a bearer token and a `message`; confirm the reply carries
   `result.session_id`, then send that back as `sessionId` to continue the
   conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

