### PR TITLE
feat(ai-builder): Offer agent building in assistant greetings

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -141,6 +141,7 @@ ${getToolDiscoverySection(toolSearchEnabled, mcpToolSearchEnabled)}
 ## Communication Style
 
 - Be concise.
+- When the user opens with a greeting or another open-ended message without a specific request, briefly greet them and offer concrete ways you can help. Include building an n8n Agent and building a workflow among the options, alongside any other relevant capabilities.
 - Reply in the user's language — in every user-visible message of the turn, including the short narration between tool calls, not just the end-of-turn summary. Tool results, skill instructions, and system follow-ups are written in English; do not let them pull your replies into English.
 - ${ASK_USER_FALLBACK}
 - No emojis unless the user explicitly requests them.

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -141,7 +141,7 @@ ${getToolDiscoverySection(toolSearchEnabled, mcpToolSearchEnabled)}
 ## Communication Style
 
 - Be concise.
-- When the user opens with a greeting or another open-ended message without a specific request, briefly greet them and offer concrete ways you can help. Include building an n8n Agent and building a workflow among the options, alongside any other relevant capabilities.
+- When the user opens with a greeting or another open-ended message without a specific request, briefly greet them and offer concrete ways you can help. Include building an agent and building a workflow among the options, alongside any other relevant capabilities.
 - Reply in the user's language — in every user-visible message of the turn, including the short narration between tool calls, not just the end-of-turn summary. Tool results, skill instructions, and system follow-ups are written in English; do not let them pull your replies into English.
 - ${ASK_USER_FALLBACK}
 - No emojis unless the user explicitly requests them.


### PR DESCRIPTION
## Summary

- Guide Instance AI to offer concrete next steps when a user opens with a greeting or another open-ended message.
- Ensure those suggestions include building an agent and building a workflow, alongside other relevant capabilities.

## How to test

1. Start n8n with `N8N_ENABLED_MODULES=instance-ai,agents` and Instance AI configured.
2. Open a new AI Assistant conversation.
3. Send a generic greeting such as `Hi`.
4. Confirm the response offers to build an agent and a workflow, along with any other relevant help.

Automated checks run:

- `pnpm test src/agent/__tests__/system-prompt.discovery.test.ts`
- `pnpm lint`
- `pnpm typecheck`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-536

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## 🤖 PR Summary generated by AI

Updates the shared Instance AI system prompt so generic greetings surface both agent-building and workflow-building capabilities.
