### PR TITLE
fix(core): Lay out MCP-created workflows even when the code sets positions

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
@@ -39,6 +39,14 @@ export interface ParseValidateHandlerConfig {
 	 * skip — agent-built workflows then pass validation despite real defects.
 	 */
 	nodeTypesProvider?: INodeTypes;
+	/**
+	 * Whether the layout also replaces positions the generated code set explicitly.
+	 * Defaults to false, which keeps a canvas the user arranged by hand when the agent
+	 * edits an existing workflow. Set it where the code is the only source of positions
+	 * (building a new workflow from scratch), so a position the model invented — or copied
+	 * off another workflow — can't leave the canvas untidied.
+	 */
+	overrideAuthoredPositions?: boolean;
 }
 
 /**
@@ -60,11 +68,13 @@ export class ParseValidateHandler {
 	private logger?: Logger;
 	private generatePinData: boolean;
 	private nodeTypesProvider?: INodeTypes;
+	private overrideAuthoredPositions: boolean;
 
 	constructor(config: ParseValidateHandlerConfig = {}) {
 		this.logger = config.logger;
 		this.generatePinData = config.generatePinData ?? true;
 		this.nodeTypesProvider = config.nodeTypesProvider;
+		this.overrideAuthoredPositions = config.overrideAuthoredPositions ?? false;
 	}
 
 	/**
@@ -278,7 +288,11 @@ export class ParseValidateHandler {
 			);
 
 			// Convert to JSON with Dagre layout matching the FE's tidy-up
-			const workflowJson: WorkflowJSON = builder.toJSON({ tidyUp: true, existingGroupIdsByName });
+			const workflowJson: WorkflowJSON = builder.toJSON({
+				tidyUp: true,
+				overrideAuthoredPositions: this.overrideAuthoredPositions,
+				existingGroupIdsByName,
+			});
 
 			this.logger?.debug('Parsed workflow', {
 				id: workflowJson.id,

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/parse-validate-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/parse-validate-handler.test.ts
@@ -320,11 +320,29 @@ describe('ParseValidateHandler', () => {
 
 			expect(mockBuilder.toJSON).toHaveBeenCalledWith({
 				tidyUp: true,
+				overrideAuthoredPositions: false,
 				existingGroupIdsByName: new Map([
 					['Ingestion', 'group-random-1'],
 					['Processing', 'group-random-2'],
 				]),
 			});
+		});
+
+		it('makes the layout authoritative when configured to override authored positions', async () => {
+			const mockBuilder = {
+				regenerateNodeIds: vi.fn(),
+				validate: vi.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }),
+				generatePinData: vi.fn(),
+				toJSON: vi.fn().mockReturnValue({ id: 'test', name: 'Test', nodes: [], connections: {} }),
+			};
+			mockParseWorkflowCodeToBuilder.mockReturnValue(mockBuilder);
+			mockValidateWorkflow.mockReturnValue({ valid: true, errors: [], warnings: [] });
+
+			await new ParseValidateHandler({ overrideAuthoredPositions: true }).parseAndValidate('code');
+
+			expect(mockBuilder.toJSON).toHaveBeenCalledWith(
+				expect.objectContaining({ tidyUp: true, overrideAuthoredPositions: true }),
+			);
 		});
 
 		it('should throw on parse error', async () => {

--- a/packages/@n8n/workflow-sdk/src/codegen/parse-workflow-code.test.ts
+++ b/packages/@n8n/workflow-sdk/src/codegen/parse-workflow-code.test.ts
@@ -176,4 +176,44 @@ describe('parseWorkflowCodeToBuilder', () => {
 			);
 		});
 	});
+
+	describe('layout of authored positions', () => {
+		// A three-node chain scattered across the canvas, as generated code looks when it
+		// copies positions off an existing workflow or off the reference examples.
+		const withPositions = `
+			const startTrigger = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: { name: 'Start', position: [-1120, 1360] } });
+			const fetchData = node({ type: 'n8n-nodes-base.httpRequest', version: 4.2, config: { name: 'Fetch Data', parameters: {}, position: [660, -220] } });
+			const processData = node({ type: 'n8n-nodes-base.set', version: 3.4, config: { name: 'Process Data', parameters: {}, position: [-340, 980] } });
+
+			export default workflow('wf-1', 'Chain')
+				.add(startTrigger)
+				.to(fetchData)
+				.to(processData);
+		`;
+		const withoutPositions = withPositions.replace(/, position: \[[-\d, ]+\]/g, '');
+
+		function positionsOf(code: string, overrideAuthoredPositions: boolean) {
+			return parseWorkflowCodeToBuilder(code)
+				.toJSON({ tidyUp: true, overrideAuthoredPositions })
+				.nodes.map((n) => [n.name, n.position]);
+		}
+
+		it('keeps authored positions by default, so an edit cannot move nodes the user placed', () => {
+			expect(positionsOf(withPositions, false)).toEqual([
+				['Start', [-1120, 1360]],
+				['Fetch Data', [660, -220]],
+				['Process Data', [-340, 980]],
+			]);
+		});
+
+		it('lays authored positions out when overrideAuthoredPositions is set', () => {
+			// Same arrangement as the identical code with no positions at all: a tidy row.
+			expect(positionsOf(withPositions, true)).toEqual(positionsOf(withoutPositions, false));
+			expect(positionsOf(withPositions, true)).toEqual([
+				['Start', [0, 0]],
+				['Fetch Data', [224, 0]],
+				['Process Data', [448, 0]],
+			]);
+		});
+	});
 });

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -1008,6 +1008,13 @@ export interface ToJSONOptions {
 	/** Use Dagre-based layout matching the FE's tidy-up algorithm. Defaults to false (BFS layout). */
 	tidyUp?: boolean;
 	/**
+	 * Lay out every node, including ones the code positioned explicitly. Defaults to false, where
+	 * an authored `config.position` wins over the computed layout so an edit can carry a canvas
+	 * the user arranged by hand. Set this when the code is the only source of positions (a build
+	 * from scratch), so a position the generator invented can't leave the graph untidied.
+	 */
+	overrideAuthoredPositions?: boolean;
+	/**
 	 * Reuse existing group IDs (keyed by group name) instead of deriving deterministic ones.
 	 * Lets an edit of an existing workflow keep its (UI-assigned, random) group IDs so the diff
 	 * isn't skewed; groups without a match fall back to a deterministic ID.

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -558,6 +558,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 			pinData: this._pinData,
 			meta: this._meta,
 			tidyUp: options?.tidyUp ?? false,
+			overrideAuthoredPositions: options?.overrideAuthoredPositions ?? false,
 			resolveTargetNodeName: (target: unknown) => this.resolveTargetNodeName(target),
 			nodeGroups: this._nodeGroups.length > 0 ? this.resolveNodeGroups() : undefined,
 			existingGroupIdsByName: options?.existingGroupIdsByName,

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -326,6 +326,77 @@ describe('calculateNodePositionsDagre', () => {
 			expect(positions.has('trigger')).toBe(false);
 			expect(positions.has('set')).toBe(true);
 		});
+
+		describe('overrideAuthoredPositions', () => {
+			// A chain where every node carries an explicit position, which without the override
+			// short-circuits the whole layout.
+			function makeFullyPositionedChain() {
+				const nodes = new Map<string, GraphNode>();
+				nodes.set(
+					'trigger',
+					createGraphNode(
+						'trigger',
+						'n8n-nodes-base.manualTrigger',
+						makeMainConns([[0, [makeTarget('set')]]]),
+						[-1120, 1360],
+					),
+				);
+				nodes.set(
+					'set',
+					createGraphNode('set', 'n8n-nodes-base.set', makeMainConns([]), [660, -220]),
+				);
+				return nodes;
+			}
+
+			it('lays out every node, ignoring the authored positions', () => {
+				const positions = calculateNodePositionsDagre(makeFullyPositionedChain(), {
+					overrideAuthoredPositions: true,
+				});
+
+				expect(positions.get('trigger')).toEqual([0, 0]);
+				expect(positions.get('set')).toEqual([224, 0]);
+			});
+
+			it('produces the same layout as the equivalent unpositioned graph', () => {
+				const unpositioned = new Map<string, GraphNode>();
+				unpositioned.set(
+					'trigger',
+					createGraphNode(
+						'trigger',
+						'n8n-nodes-base.manualTrigger',
+						makeMainConns([[0, [makeTarget('set')]]]),
+					),
+				);
+				unpositioned.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+
+				expect(
+					calculateNodePositionsDagre(makeFullyPositionedChain(), {
+						overrideAuthoredPositions: true,
+					}),
+				).toEqual(calculateNodePositionsDagre(unpositioned));
+			});
+
+			it('returns no positions for the same graph without the override', () => {
+				expect(calculateNodePositionsDagre(makeFullyPositionedChain()).size).toBe(0);
+			});
+
+			it('reanchors a sticky note onto where the covered nodes were moved to', () => {
+				const nodes = makeFullyPositionedChain();
+				// Sticky covering the trigger at its authored position.
+				nodes.set('note', createGraphNode('note', STICKY_NODE_TYPE, undefined, [-1120, 1360]));
+
+				const positions = calculateNodePositionsDagre(nodes, {
+					overrideAuthoredPositions: true,
+				});
+
+				// Follows the trigger to its laid-out position rather than staying behind at
+				// the authored one.
+				const notePos = positions.get('note')!;
+				expect(notePos).not.toEqual([-1120, 1360]);
+				expect(notePos[0]).toBeCloseTo(positions.get('trigger')![0], -1);
+				expect(isGridAligned(notePos)).toBe(true);
+			});
+		});
 	});
 
 	describe('grid alignment', () => {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -424,10 +424,12 @@ function repositionStickyNotes(
  * Calculate positions for nodes using Dagre hierarchical layout.
  * Mirrors the frontend's useCanvasLayout algorithm.
  *
- * Only sets positions for nodes without explicit config.position.
+ * Only sets positions for nodes without explicit config.position, unless
+ * `overrideAuthoredPositions` is set, in which case every node is laid out.
  */
 export function calculateNodePositionsDagre(
 	nodes: ReadonlyMap<string, GraphNode>,
+	{ overrideAuthoredPositions = false }: { overrideAuthoredPositions?: boolean } = {},
 ): Map<string, [number, number]> {
 	const positions = new Map<string, [number, number]>();
 
@@ -451,10 +453,12 @@ export function calculateNodePositionsDagre(
 	if (nonStickyNames.length === 0) return positions;
 
 	// Check if any nodes actually need positioning
-	const needsLayout = nonStickyNames.some((name) => {
-		const node = nodes.get(name);
-		return node && !node.instance.config?.position;
-	});
+	const needsLayout =
+		overrideAuthoredPositions ||
+		nonStickyNames.some((name) => {
+			const node = nodes.get(name);
+			return node && !node.instance.config?.position;
+		});
 
 	if (!needsLayout) return positions;
 
@@ -619,10 +623,10 @@ export function calculateNodePositionsDagre(
 			}
 		});
 
-	// Snap to grid and build result (skip nodes with explicit positions)
+	// Snap to grid and build result (skip nodes with explicit positions unless overriding)
 	for (const [name, box] of Object.entries(boundingBoxByNodeId)) {
 		const node = nodes.get(name);
-		if (node && !node.instance.config?.position) {
+		if (node && (overrideAuthoredPositions || !node.instance.config?.position)) {
 			positions.set(name, [snapToGrid(box.x), snapToGrid(box.y)]);
 		}
 	}
@@ -644,6 +648,15 @@ export function calculateNodePositionsDagre(
 		const positionsAfter = new Map<string, BoundingBox>();
 		for (const [name, graphNode] of nodes) {
 			const explicitPosition = graphNode.instance.config?.position;
+			// A node keeps its authored position unless the layout was authoritative, in which
+			// case the box dagre produced is where it actually ended up.
+			const stayedPut = explicitPosition && !overrideAuthoredPositions;
+			const box = stayedPut ? undefined : boundingBoxByNodeId[name];
+			if (box) {
+				positionsAfter.set(name, box);
+				continue;
+			}
+
 			if (explicitPosition) {
 				const { width, height } = getNodeDimensions(name, aiParentNames, aiConfigNames, nodes);
 				positionsAfter.set(name, {
@@ -652,12 +665,6 @@ export function calculateNodePositionsDagre(
 					width,
 					height,
 				});
-				continue;
-			}
-
-			const box = boundingBoxByNodeId[name];
-			if (box) {
-				positionsAfter.set(name, box);
 			}
 		}
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.test.ts
@@ -96,6 +96,36 @@ describe('jsonSerializer', () => {
 			expect(result.connections).toEqual({});
 		});
 
+		describe('node positions', () => {
+			function contextWithPositionedTrigger(overrides: Partial<SerializerContext>) {
+				const manualTrigger = trigger({
+					type: 'n8n-nodes-base.manualTrigger',
+					version: 1,
+					config: { name: 'Manual Trigger', position: [-1120, 1360] },
+				});
+				return createMockSerializerContext({
+					nodes: new Map<string, GraphNode>([
+						['Manual Trigger', { instance: manualTrigger, connections: new Map() }],
+					]),
+					...overrides,
+				});
+			}
+
+			it('keeps an authored position when tidying up', () => {
+				const result = jsonSerializer.serialize(contextWithPositionedTrigger({ tidyUp: true }));
+
+				expect(result.nodes[0]?.position).toEqual([-1120, 1360]);
+			});
+
+			it('replaces an authored position when the layout is authoritative', () => {
+				const result = jsonSerializer.serialize(
+					contextWithPositionedTrigger({ tidyUp: true, overrideAuthoredPositions: true }),
+				);
+
+				expect(result.nodes[0]?.position).toEqual([0, 0]);
+			});
+		});
+
 		it('serializes nodes without configured parameters with an empty parameters object', () => {
 			const manualTrigger = trigger({
 				type: 'n8n-nodes-base.manualTrigger',

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -42,6 +42,7 @@ function serializeNode(
 	mapKey: string,
 	graphNode: GraphNode,
 	nodePositions: Map<string, [number, number]>,
+	overrideAuthoredPositions = false,
 ): NodeJSON | undefined {
 	const instance = graphNode.instance;
 
@@ -51,7 +52,13 @@ function serializeNode(
 	}
 
 	const config = instance.config ?? {};
-	const position = config.position ?? nodePositions.get(mapKey) ?? [START_X, DEFAULT_Y];
+	// An authored position normally wins, so an edit can't move a node the user placed. When the
+	// layout is authoritative the computed position wins instead — otherwise a generator that
+	// invents positions silently opts the whole workflow out of being laid out.
+	const computedPosition = nodePositions.get(mapKey);
+	const position = (overrideAuthoredPositions
+		? (computedPosition ?? config.position)
+		: (config.position ?? computedPosition)) ?? [START_X, DEFAULT_Y];
 
 	// Determine node name:
 	// - If config has _originalName, use that (preserves undefined for sticky notes from fromJSON)
@@ -226,13 +233,20 @@ export const jsonSerializer: SerializerPlugin<WorkflowJSON> = {
 
 		// Calculate positions for nodes without explicit positions
 		const nodePositions = ctx.tidyUp
-			? calculateNodePositionsDagre(ctx.nodes)
+			? calculateNodePositionsDagre(ctx.nodes, {
+					overrideAuthoredPositions: ctx.overrideAuthoredPositions,
+				})
 			: calculateNodePositions(ctx.nodes);
 
 		// Convert nodes and connections
 		for (const [mapKey, graphNode] of ctx.nodes) {
 			// Serialize node
-			const serializedNode = serializeNode(mapKey, graphNode, nodePositions);
+			const serializedNode = serializeNode(
+				mapKey,
+				graphNode,
+				nodePositions,
+				ctx.overrideAuthoredPositions,
+			);
 			if (!serializedNode) continue;
 
 			nodes.push(serializedNode);

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
@@ -360,6 +360,9 @@ export interface SerializerContext extends PluginContext {
 	/** Whether to use Dagre-based layout for node positioning */
 	readonly tidyUp?: boolean;
 
+	/** Whether the computed layout also replaces positions the code authored explicitly */
+	readonly overrideAuthoredPositions?: boolean;
+
 	/**
 	 * Node groups carried by member node *ID* — already resolved to the IDs the emitted
 	 * nodes carry. `id`, when present, is the source group ID (from fromJSON); the serializer

--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -26,11 +26,13 @@ const {
 	mockTrackAutoassignOutcomes,
 	mockParseAndValidate,
 	mockStripImportStatements,
+	mockParseValidateHandlerConstructor,
 } = vi.hoisted(() => ({
 	mockAutoPopulateNodeCredentials: vi.fn(),
 	mockTrackAutoassignOutcomes: vi.fn(),
 	mockParseAndValidate: vi.fn(),
 	mockStripImportStatements: vi.fn((code: string) => code),
+	mockParseValidateHandlerConstructor: vi.fn(),
 }));
 
 // Mock credentials auto-assign
@@ -43,7 +45,8 @@ vi.mock('../tools/workflow-builder/credentials-auto-assign', () => ({
 
 // Mock dynamic imports
 vi.mock('@n8n/ai-workflow-builder', () => ({
-	ParseValidateHandler: vi.fn(function () {
+	ParseValidateHandler: vi.fn(function (config: unknown) {
+		mockParseValidateHandlerConstructor(config);
 		return { parseAndValidate: mockParseAndValidate };
 	}),
 	stripImportStatements: (code: string) => mockStripImportStatements(code),
@@ -256,6 +259,16 @@ describe('create-workflow-from-code MCP tool', () => {
 			expect(response.nodeCount).toBe(2);
 			expect(response.url).toBe('https://n8n.example.com/workflow/wf-saved-1');
 			expect(result.isError).toBeUndefined();
+		});
+
+		test('lays out every node, including ones the generated code positioned itself', async () => {
+			await callHandler({ code: 'const wf = ...' });
+
+			// A brand-new workflow has no canvas arrangement to protect, so a position the
+			// client invented must not opt the workflow out of being laid out.
+			expect(mockParseValidateHandlerConstructor).toHaveBeenCalledWith(
+				expect.objectContaining({ overrideAuthoredPositions: true }),
+			);
 		});
 
 		test('surfaces validation warnings in the response', async () => {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -267,6 +267,11 @@ export const createCreateWorkflowFromCodeTool = (
 			const handler = new ParseValidateHandler({
 				generatePinData: false,
 				nodeTypesProvider: nodeTypes,
+				// This tool always produces a brand-new workflow, so the code is the only source
+				// of positions and there is no canvas arrangement to protect. Lay every node out,
+				// including ones the code positioned — a client that copies positions off another
+				// workflow (or off the reference examples) would otherwise land an untidied canvas.
+				overrideAuthoredPositions: true,
 			});
 			const strippedCode = stripImportStatements(code);
 			const result = await handler.parseAndValidate(strippedCode);


### PR DESCRIPTION
## Summary

`create_workflow_from_code` already serialized with `tidyUp: true`, but a workflow could still land on the canvas untidied.

Two things combined:

- `calculateNodePositionsDagre` skips any node carrying an explicit `config.position`, and returns early with no positions at all when every node has one.
- `serializeNode` then gave the authored `config.position` precedence over the computed layout.

So whenever the generated code positions its nodes, tidy-up runs and does nothing. That happens routinely: a client copying an existing workflow echoes back the positions it read from `get_workflow_details`, and `get_sdk_reference` (no `section` arg) serves `patterns_detailed`, whose examples put a `position` on nearly every node.

Reproduced on a three-node linear chain whose nodes carry scattered positions:

```
authored:      [["Start",[-1120,1360]], ["Fetch Data",[660,-220]], ["Process Data",[-340,980]]]
after tidyUp:  [["Start",[-1120,1360]], ["Fetch Data",[660,-220]], ["Process Data",[-340,980]]]
```

The fix adds an `overrideAuthoredPositions` option to `toJSON()` that makes the layout authoritative, and turns it on in `create_workflow_from_code`. That tool always builds a brand-new `WorkflowEntity`, so the code is the only source of positions and there is no canvas arrangement to protect. The same chain now comes out at `[0,0] / [224,0] / [448,0]`, byte-identical to the layout the same graph gets when it is authored with no positions at all.

The option defaults to off, which matters because `ParseValidateHandler` is shared with the in-app builder. There, position preservation is the only thing keeping a canvas the user arranged by hand from being rearranged on every AI edit, so that path is left as it was.

Sticky notes still work out which nodes they cover in authored space, but now reanchor onto where those nodes actually ended up, instead of staying behind at the old coordinates.

Two related gaps found while investigating, both left for follow-ups:

- `update_workflow` never lays out at all. It applies JSON ops directly and gives a new node `op.node.position ?? [0, 0]`, so every MCP iteration after the first is unpositioned by construction. Fixing it properly needs a decision on how to tell a user-dragged position from a model-authored one, which we do not currently track.
- `get_sdk_reference` still serves the position-bearing `patterns_detailed` examples by default. Harmless now that the layout overrides them, but it is wasted tokens and it teaches the wrong pattern.

## How to test

1. Point an MCP client at a local n8n and ask it to recreate an existing workflow that has messy node positions, or to build one from a prompt.
2. The new workflow should open already tidied, regardless of whether the generated code set `position` values.
3. Clicking **Tidy up** on the result should now be close to a no-op. It is not byte-identical, because the FE and SDK layouts are separate implementations that differ on grid snapping and node sizing, but the arrangement should match.
4. Confirm the in-app AI builder is unaffected: arrange a workflow by hand, ask the assistant to change something, and the nodes you placed should stay put.

Automated coverage: `pnpm --filter @n8n/workflow-sdk test`, `pnpm --filter @n8n/ai-workflow-builder test`, `pnpm --filter n8n test src/modules/mcp`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5755

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

