### PR TITLE
fix(editor): Stop the workflow actions menu shifting when a new workflow is saved

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
@@ -503,7 +503,6 @@ defineExpose({
 }
 .group {
 	display: flex;
-	gap: var(--spacing--xs);
 }
 .hiddenInput {
 	display: none;


### PR DESCRIPTION
## Summary

### Problem

When you create a new workflow, the actions menu (⋯) sits right next to the workflow name. The moment the workflow saves for the first time, the menu jumps 12px further to the right, so the name and the menu drift apart.

Before the save:
<img height="166" alt="image" src="https://github.com/user-attachments/assets/0565aa94-8fbb-430a-bb20-0872e0ccff29" />

After:
<img height="166" alt="image" src="https://github.com/user-attachments/assets/29a008b6-bc39-4a40-87cd-eb4802db2d9a" />

### Fix

This PR drops the gap to restore the state before #35502.

`.group` in `ActionsDropdownMenu.vue` has carried `gap: var(--spacing--xs)` since the V2 header landed, but it never rendered: its only children were the `display: none` file input (not a flex item) and the dropdown, so there was
nothing to space.

#35502 moved `WorkflowProductionChecklist` into `.group` with `hide-trigger`. The checklist renders nothing visible — just an empty, zero-size anchor for its popover. That empty element still counts as a second item in the row, so the gap kicks in. It's only mounted once the workflow exists, which is why the `12px` show up on first save and push the ⋯ menu right.

## How to test

1. Create a new workflow and note the space between the workflow name and the `⋯` menu.
2. Add any node so the workflow autosaves.
3. The `⋯` menu should stay exactly where it was. On master it jumps ~12px right.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/ADO-5782/workflow-header-context-menu-moves-when-new-workflow-is-saved-for-the

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

