### PR TITLE
refactor(core): Clarify workflow update session-grant helper naming (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/__tests__/instance-ai.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/instance-ai.schema.test.ts
@@ -2,6 +2,7 @@ import {
 	AI_GATEWAY_MANAGED_TAG,
 	applyBranchReadOnlyOverrides,
 	buildDataTablesSessionGrantKey,
+	buildUpdateWorkflowSessionGrantKey,
 	buildFetchUrlGrantKey,
 	DEFAULT_INSTANCE_AI_PERMISSIONS,
 	errorPayloadSchema,
@@ -436,6 +437,12 @@ describe('data-tables session grant keys', () => {
 	it('builds action-scoped keys matching the frontend always-allow format', () => {
 		expect(buildDataTablesSessionGrantKey('create')).toBe('data-tables:create');
 		expect(buildDataTablesSessionGrantKey('insert-rows')).toBe('data-tables:insert-rows');
+	});
+});
+
+describe('workflow update session grant keys', () => {
+	it('builds per-workflow keys matching the frontend always-allow format', () => {
+		expect(buildUpdateWorkflowSessionGrantKey('wf-1')).toBe('workflows:update:wf-1');
 	});
 });
 

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -33,7 +33,7 @@ import {
 import { validateWorkflowConfig } from './workflows/validate-workflow.service';
 import {
 	grantSessionWorkflowUpdate,
-	isSessionOwnedWorkflow,
+	canSkipWorkflowUpdateHitl,
 } from './workflows/workflow-build-context';
 import { refreshWorkflowSourceFileBindingFromWorkflow } from './workflows/workflow-file-bindings';
 import { getReferencedWorkflowIds } from './workflows/workflow-json-utils';
@@ -903,10 +903,10 @@ async function handleUpdate(
 		return { success: false, denied: true, reason: 'Action blocked by admin' };
 	}
 
-	// Skip HITL for workflows this session created; still require approval for foreign ones.
+	// Skip HITL for session-created or always-allowed workflows; others still need approval.
 	const needsApproval =
 		context.permissions?.updateWorkflow !== 'always_allow' &&
-		!isSessionOwnedWorkflow(context, input.workflowId);
+		!canSkipWorkflowUpdateHitl(context, input.workflowId);
 
 	if (needsApproval && (resumeData === undefined || resumeData === null)) {
 		const workflowName = await resolveWorkflowName(context, input.workflowId);

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -22,7 +22,7 @@ import {
 	getBuildFailureTrackingKey,
 	grantSessionWorkflowUpdate,
 	isApprovedBuildContext,
-	isSessionOwnedWorkflow,
+	canSkipWorkflowUpdateHitl,
 	markSourceBuildFailed,
 	recordSessionOwnedWorkflow,
 	resolveBuildIdentifiers,
@@ -452,12 +452,12 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				};
 			}
 
-			const isOwnInFlightWorkflow =
-				targetWorkflowId !== undefined && isSessionOwnedWorkflow(context, targetWorkflowId);
+			const canSkipUpdateHitl =
+				targetWorkflowId !== undefined && canSkipWorkflowUpdateHitl(context, targetWorkflowId);
 
 			if (
 				targetWorkflowId &&
-				!isOwnInFlightWorkflow &&
+				!canSkipUpdateHitl &&
 				!isApprovedBuildContext(context) &&
 				context.permissions?.updateWorkflow !== 'always_allow'
 			) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-context.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-context.ts
@@ -14,13 +14,13 @@ export function isApprovedBuildContext(context: InstanceAiContext): boolean {
 }
 
 /**
- * True when this workflow is trusted for updates in this session: created
- * earlier in the current run (`aiCreatedWorkflowIds`), or covered by a
+ * True when update HITL can be skipped for this workflow in this session:
+ * created earlier in the current run (`aiCreatedWorkflowIds`), or covered by a
  * `workflows:update:<id>` thread grant (written on create, or when the user
- * chose "always allow" for an edit). Used to skip update HITL while still
- * requiring approval for untrusted foreign workflows.
+ * chose "always allow" for an edit — including foreign workflows). Untrusted
+ * workflows without a grant still require approval.
  */
-export function isSessionOwnedWorkflow(context: InstanceAiContext, workflowId: string): boolean {
+export function canSkipWorkflowUpdateHitl(context: InstanceAiContext, workflowId: string): boolean {
 	if (context.aiCreatedWorkflowIds?.has(workflowId) === true) return true;
 	const grantKey = buildUpdateWorkflowSessionGrantKey(workflowId);
 	return context.sessionApprovedToolKeys?.has(grantKey) === true;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -566,10 +566,12 @@ export function createThreadRuntime(
 
 	// --- Session "Always allow" ---
 	// Thread-scoped: cleared by `resetState()` so grants don't leak when the
-	// runtime is disposed and recreated. Key: `${toolName}:${args.action ?? ''}`
-	// for most tools; `submit-workflow` is keyed on `workflowId` presence so a
-	// create grant doesn't silently auto-approve later updates (the backend
-	// distinguishes createWorkflow vs updateWorkflow by that field).
+	// runtime is disposed and recreated. Prefer shared builders from
+	// `@n8n/api-types` so UI keys match persisted thread grants:
+	// `executions:run:<id>`, `workflows:update:<id>`, `data-tables:<action>`.
+	// Fallback for other tools: `${toolName}:${args.action ?? ''}`.
+	// `submit-workflow` is keyed on `workflowId` presence so a create grant
+	// doesn't silently auto-approve later updates.
 	const sessionAlwaysAllowKeys = ref<Set<string>>(new Set());
 
 	function resolveAlwaysAllowWorkflowId(


### PR DESCRIPTION
## Summary

Follow-up polish after #36054 / INS-1137, aligned with the session-grant patterns from #36070.

- Rename `isSessionOwnedWorkflow` → `canSkipWorkflowUpdateHitl` (and the local `isOwnInFlightWorkflow` alias) so Always-allow grants on foreign workflows aren't mislabeled as ownership
- Add api-types unit test for `buildUpdateWorkflowSessionGrantKey`
- Refresh the FE `sessionAlwaysAllowKeys` comment to document builder-backed keys (`executions:run:<id>`, `workflows:update:<id>`, `data-tables:<action>`)

No behavior change.

## How to test

1. Unit: `pnpm --filter @n8n/api-types test src/schemas/__tests__/instance-ai.schema.test.ts`
2. Smoke the parent PR (#36054) flows still work:
   - Create workflow → edit same workflow: no update approval
   - Always allow on a foreign workflow update → later edits of that workflow skip HITL
   - `updateWorkflow: blocked` still denies

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1144
Blocked by https://linear.app/n8n/issue/INS-1137 / #36054

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

