### PR TITLE
fix(cli): keep instance-AI model verification probe above OpenAI Responses API token minimum

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-verification.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-verification.service.test.ts
@@ -100,8 +100,14 @@ describe('InstanceAiVerificationService', () => {
 			);
 			expect(createModelMock).toHaveBeenCalledWith(modelConfig, expect.any(Function));
 			expect(generateTextMock).toHaveBeenCalledWith(
-				expect.objectContaining({ prompt: 'Reply with OK.', maxOutputTokens: 8 }),
+				expect.objectContaining({ prompt: 'Reply with OK.' }),
 			);
+			// Regression test for n8n-io/n8n#36093: OpenAI's Responses API rejects
+			// `max_output_tokens` below 16, so the verification probe must stay at or
+			// above that floor. The previous hardcoded 8 made OpenAI verification fail.
+			const probe = generateTextMock.mock.calls[0][0] as { maxOutputTokens?: number };
+			expect(probe.maxOutputTokens).toBeDefined();
+			expect(probe.maxOutputTokens as number).toBeGreaterThanOrEqual(16);
 		});
 
 		it('uses the saved model configuration when no draft connection is provided', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai-verification.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-verification.service.ts
@@ -20,6 +20,9 @@ import { InstanceAiModelService } from './instance-ai-model.service';
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 
 const VERIFICATION_TIMEOUT_MS = 30_000;
+// OpenAI's Responses API rejects `max_output_tokens` below 16, and reasoning
+// models consume part of this budget before they emit any text.
+const VERIFICATION_MAX_OUTPUT_TOKENS = 256;
 
 function numericStatus(error: unknown): number | undefined {
 	if (typeof error !== 'object' || error === null) return undefined;
@@ -97,7 +100,7 @@ export class InstanceAiVerificationService {
 			await generateText({
 				model: createModel(modelConfig, createAiProxyFetch(this.outboundHttp)),
 				prompt: 'Reply with OK.',
-				maxOutputTokens: 8,
+				maxOutputTokens: VERIFICATION_MAX_OUTPUT_TOKENS,
 				abortSignal: AbortSignal.timeout(VERIFICATION_TIMEOUT_MS),
 			});
 			return { ok: true, latencyMs: Math.round(performance.now() - startedAt) };


### PR DESCRIPTION
Fixes #36093

## What

`InstanceAiVerificationService.verifyModel()` sends a fixed `maxOutputTokens: 8` in the model-verification probe. OpenAI's Responses API (which the OpenAI model factory targets when no custom `baseURL` is set, exactly what the Instance AI setup wizard produces) enforces a minimum of `max_output_tokens = 16`, so every OpenAI credential tested from the self-hosted Instance AI setup wizard is rejected with a 400 (`Invalid 'max_output_tokens': integer below minimum value`). `classifyFailure()` maps that to `provider_error`, so the UI only shows the generic "The service couldn't complete the test." message.

## Fix

Raise the probe budget to a named constant `VERIFICATION_MAX_OUTPUT_TOKENS = 256` - comfortably above the Responses API floor of 16 (reasoning models also consume part of the budget before emitting any text).

## Verification

- Updated the existing unit test so the probe must stay at or above the Responses API minimum (16). Against current `master` the probe is 8, so the assertion fails; with the fix the probe is 256 and the assertion passes.
- Ran the affected suite:

```
N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite vitest run src/modules/instance-ai/__tests__/instance-ai-verification.service.test.ts
```

No prior or related PR exists for this issue, and no SnowingFox PR is open in this repo.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

