### PR TITLE
feat(core): Add knowledge connectors module for indexing external sources

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -338,4 +338,17 @@ export {
 export { UpdateOtelSettingsDto } from './otel/update-otel-settings.dto';
 export { TestOtelTraceDto } from './otel/test-otel-trace.dto';
 
+export {
+	UpdateKnowledgeSettingsDto,
+	knowledgeEmbeddingSettingsSchema,
+	knowledgeVectorStoreSettingsSchema,
+} from './knowledge/update-knowledge-settings.dto';
+export {
+	CreateKnowledgeSourceDto,
+	knowledgeSourceTypeSchema,
+} from './knowledge/create-knowledge-source.dto';
+export { UpdateKnowledgeSourceDto } from './knowledge/update-knowledge-source.dto';
+export { SyncKnowledgeSourceDto } from './knowledge/sync-knowledge-source.dto';
+export { SearchKnowledgeDto } from './knowledge/search-knowledge.dto';
+
 export { InstanceAiExamplesQueryDto } from './instance-ai-examples/instance-ai-examples-query.dto';

--- a/packages/@n8n/api-types/src/dto/knowledge/create-knowledge-source.dto.ts
+++ b/packages/@n8n/api-types/src/dto/knowledge/create-knowledge-source.dto.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/** Kept in sync with `KNOWLEDGE_SOURCE_TYPES` in the cli knowledge module. */
+export const knowledgeSourceTypeSchema = z.enum(['github', 'n8n']);
+
+export class CreateKnowledgeSourceDto extends Z.class({
+	name: z.string().min(1).max(128),
+	type: knowledgeSourceTypeSchema,
+	/** Required for connectors that declare `requiresCredential`. */
+	credentialId: z.string().max(36).optional(),
+	/** Connector-specific settings, validated by the connector itself. */
+	config: z.record(z.unknown()).default({}),
+}) {}

--- a/packages/@n8n/api-types/src/dto/knowledge/search-knowledge.dto.ts
+++ b/packages/@n8n/api-types/src/dto/knowledge/search-knowledge.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class SearchKnowledgeDto extends Z.class({
+	query: z.string().min(1),
+	/** Restrict the search to these sources; omit to search all of them. */
+	sourceIds: z.array(z.string()).optional(),
+	topK: z.number().int().positive().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/knowledge/sync-knowledge-source.dto.ts
+++ b/packages/@n8n/api-types/src/dto/knowledge/sync-knowledge-source.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class SyncKnowledgeSourceDto extends Z.class({
+	/** Ignore the stored checkpoint and re-read the source from scratch. */
+	fullResync: z.boolean().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/knowledge/update-knowledge-settings.dto.ts
+++ b/packages/@n8n/api-types/src/dto/knowledge/update-knowledge-settings.dto.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/** Only credential ids and a model name are stored — never credential data itself. */
+export const knowledgeEmbeddingSettingsSchema = z.object({
+	provider: z.literal('openai'),
+	credentialId: z.string().min(1),
+	model: z.string().min(1),
+});
+
+export const knowledgeVectorStoreSettingsSchema = z.object({
+	provider: z.literal('qdrant'),
+	credentialId: z.string().min(1),
+	/** Defaults to the module's collection name when omitted. */
+	collectionName: z.string().min(1).optional(),
+});
+
+/** An omitted field keeps its stored value; an explicit `null` clears it. */
+export class UpdateKnowledgeSettingsDto extends Z.class({
+	embedding: knowledgeEmbeddingSettingsSchema.nullable().optional(),
+	vectorStore: knowledgeVectorStoreSettingsSchema.nullable().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/knowledge/update-knowledge-source.dto.ts
+++ b/packages/@n8n/api-types/src/dto/knowledge/update-knowledge-source.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/** Only the fields present in the body are changed; `credentialId: null` clears it. */
+export class UpdateKnowledgeSourceDto extends Z.class({
+	name: z.string().min(1).max(128).optional(),
+	credentialId: z.string().max(36).nullable().optional(),
+	config: z.record(z.unknown()).optional(),
+}) {}

--- a/packages/@n8n/api-types/src/schemas/mcp.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/mcp.schema.ts
@@ -35,6 +35,7 @@ export const MCP_INSTANCE_SCOPES = [
 	'dataTable:write',
 	'project:read',
 	'tag:read',
+	'knowledge:read',
 ] as const;
 
 export type McpScope = (typeof MCP_INSTANCE_SCOPES)[number];

--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -35,6 +35,7 @@ export const MODULE_NAMES = [
 	'runtime-credentials',
 	'n8n-packages',
 	'workflow-reviews',
+	'knowledge',
 ] as const;
 
 export type ModuleName = (typeof MODULE_NAMES)[number];

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -52,6 +52,7 @@ export const LOG_SCOPES = [
 	'metrics',
 	'scheduler',
 	'enqueued-execution-recovery',
+	'knowledge',
 ] as const;
 
 export type LogScope = (typeof LOG_SCOPES)[number];

--- a/packages/@n8n/db/src/migrations/common/1785930000000-CreateKnowledgeTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1785930000000-CreateKnowledgeTables.ts
@@ -1,0 +1,102 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const SOURCE_TABLE = 'knowledge_sources';
+const DOCUMENT_TABLE = 'knowledge_documents';
+const SYNC_RUN_TABLE = 'knowledge_sync_runs';
+
+/**
+ * Bookkeeping for knowledge connectors. The indexed text and its vectors live
+ * in the external vector store; these tables only track what was indexed, from
+ * where, and how the last sync went.
+ */
+export class CreateKnowledgeTables1785930000000 implements ReversibleMigration {
+	async up(context: MigrationContext) {
+		await this.createSourceTable(context);
+		await this.createDocumentTable(context);
+		await this.createSyncRunTable(context);
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(SYNC_RUN_TABLE);
+		await dropTable(DOCUMENT_TABLE);
+		await dropTable(SOURCE_TABLE);
+	}
+
+	private async createSourceTable({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(SOURCE_TABLE).withColumns(
+			column('id').varchar(36).primary,
+			column('name').varchar(128).notNull,
+			column('type')
+				.varchar(16)
+				.notNull.withEnumCheck(['github', 'n8n'])
+				.comment('Selects which connector implementation syncs this source.'),
+			column('credentialId')
+				.varchar(36)
+				.comment('NULL for connectors that need no credential, e.g. the internal n8n source.'),
+			column('config')
+				.json.notNull.default("'{}'")
+				.comment('Connector-specific settings, validated by the connector.'),
+			column('status')
+				.varchar(16)
+				.notNull.default("'pending'")
+				.withEnumCheck(['pending', 'syncing', 'ready', 'error']),
+			column('lastSyncedAt').timestampTimezone(),
+			column('checkpoint').json.comment(
+				'Connector-owned cursor for the next incremental sync; NULL before the first sync.',
+			),
+			column('lastError').text,
+		).withTimestamps;
+	}
+
+	private async createDocumentTable({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(DOCUMENT_TABLE)
+			.withColumns(
+				column('id').varchar(36).primary,
+				column('sourceId').varchar(36).notNull,
+				column('externalId')
+					.varchar(255)
+					.notNull.comment("Stable identifier within the source, e.g. 'issue:123'."),
+				column('title').varchar(512).notNull,
+				column('url').varchar(1024),
+				column('contentHash')
+					.varchar(64)
+					.notNull.comment(
+						'Fingerprint of the indexed text; an unchanged hash skips re-embedding.',
+					),
+				column('chunkCount').int.notNull.default(0),
+				column('meta').json.comment('Flat metadata copied onto every chunk of this document.'),
+				column('sourceUpdatedAt').timestampTimezone(),
+			)
+			// One row per document per source; also indexes the FK for cascade deletes.
+			.withIndexOn(['sourceId', 'externalId'], true)
+			.withForeignKey('sourceId', {
+				tableName: SOURCE_TABLE,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+
+	private async createSyncRunTable({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(SYNC_RUN_TABLE)
+			.withColumns(
+				column('id').varchar(36).primary,
+				column('sourceId').varchar(36).notNull,
+				column('mode').varchar(16).notNull.withEnumCheck(['full', 'incremental']),
+				column('status')
+					.varchar(16)
+					.notNull.default("'running'")
+					.withEnumCheck(['running', 'success', 'error']),
+				column('stats').json.comment('Counters for the run, e.g. documentsIndexed, chunksWritten.'),
+				column('error').text,
+				column('startedAt').timestampTimezone().notNull.default('NOW()'),
+				column('finishedAt').timestampTimezone().comment('NULL while the run is still going.'),
+			)
+			// Serves "recent runs for this source" and indexes the FK for cascade deletes.
+			.withIndexOn(['sourceId', 'startedAt'])
+			.withForeignKey('sourceId', {
+				tableName: SOURCE_TABLE,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+}

--- a/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
+++ b/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
@@ -179,5 +179,6 @@ exports[`Scope Information > ensure scopes are defined correctly 1`] = `
   "roleMappingRule:delete",
   "roleMappingRule:list",
   "otel:manage",
+  "knowledge:manage",
 ]
 `;

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -84,6 +84,7 @@ export const RESOURCES = {
 	instanceAi: ['message', 'manage', 'gateway', 'eval'] as const,
 	roleMappingRule: [...DEFAULT_OPERATIONS] as const,
 	otel: ['manage'] as const,
+	knowledge: ['manage'] as const,
 } as const;
 
 export const API_KEY_RESOURCES = {

--- a/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
@@ -164,6 +164,7 @@ export const GLOBAL_OWNER_SCOPES: Scope[] = [
 	'roleMappingRule:delete',
 	'roleMappingRule:list',
 	'otel:manage',
+	'knowledge:manage',
 ];
 
 export const GLOBAL_ADMIN_SCOPES = GLOBAL_OWNER_SCOPES.concat();

--- a/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
+++ b/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
@@ -52,6 +52,7 @@ describe('permissions', () => {
 			instanceAi: {},
 			roleMappingRule: {},
 			otel: {},
+			knowledge: {},
 		});
 	});
 	it('getResourcePermissions', () => {
@@ -181,6 +182,7 @@ describe('permissions', () => {
 			instanceAi: {},
 			roleMappingRule: {},
 			otel: {},
+			knowledge: {},
 		};
 
 		expect(getResourcePermissions(scopes)).toEqual(permissionRecord);

--- a/packages/cli/src/modules/knowledge/README.md
+++ b/packages/cli/src/modules/knowledge/README.md
@@ -1,0 +1,160 @@
+# Knowledge connectors (experimental)
+
+Indexes external and internal data sources into a vector store and makes them
+searchable over REST and MCP. A source is synced by a **connector**, chunked and
+embedded by the **indexing service**, and queried by the **search service**.
+
+The module is experimental and off by default.
+
+```mermaid
+graph LR
+    SRC["Source row<br/>(type, config, credential, checkpoint)"] --> SYNC["KnowledgeSyncService<br/>timer on the leader"]
+    SYNC --> CONN["Connector<br/>github / n8n"]
+    CONN -->|document drafts| IDX["KnowledgeIndexingService"]
+    IDX --> EMB["Embeddings (OpenAI)"]
+    IDX --> VS["Vector store (Qdrant)"]
+    VS --> SEARCH["KnowledgeSearchService"]
+    SEARCH --> REST["POST /rest/knowledge/search"]
+    SEARCH --> MCP["MCP tool search_knowledge"]
+```
+
+## Enabling
+
+```bash
+export N8N_ENABLED_MODULES=knowledge
+```
+
+## Configuration flow
+
+1. In the UI, create the two credentials the module needs: an **OpenAI** credential
+   (embeddings) and a **Qdrant** credential (vector store). Note their ids.
+2. Point the module at them (instance admin, `knowledge:manage`):
+
+   ```bash
+   curl -X PUT "$N8N_URL/rest/knowledge/settings" \
+     -H 'content-type: application/json' -b cookies.txt \
+     -d '{
+       "embedding": { "provider": "openai", "credentialId": "<openai-cred-id>", "model": "text-embedding-3-small" },
+       "vectorStore": { "provider": "qdrant", "credentialId": "<qdrant-cred-id>", "collectionName": "n8n_knowledge" }
+     }'
+   ```
+
+   `collectionName` is optional and defaults to `n8n_knowledge`. Omitting a field
+   keeps its stored value; passing `null` clears it.
+
+3. Create a source:
+
+   ```bash
+   curl -X POST "$N8N_URL/rest/knowledge/sources" \
+     -H 'content-type: application/json' -b cookies.txt \
+     -d '{
+       "name": "n8n repo",
+       "type": "github",
+       "credentialId": "<github-cred-id>",
+       "config": { "owner": "n8n-io", "repo": "n8n", "includeIssues": true, "includePullRequests": true, "historyDays": 90 }
+     }'
+   ```
+
+4. Sync it (returns immediately; the run continues in the background):
+
+   ```bash
+   curl -X POST "$N8N_URL/rest/knowledge/sources/<source-id>/sync" \
+     -H 'content-type: application/json' -b cookies.txt -d '{"fullResync": false}'
+
+   curl "$N8N_URL/rest/knowledge/sources/<source-id>/runs" -b cookies.txt   # progress and errors
+   ```
+
+5. Search it (any authenticated user):
+
+   ```bash
+   curl -X POST "$N8N_URL/rest/knowledge/search" \
+     -H 'content-type: application/json' -b cookies.txt \
+     -d '{"query": "how is the queue mode configured?", "topK": 5}'
+   ```
+
+## Endpoints
+
+| Method   | Path                          | Access                        |
+| -------- | ----------------------------- | ----------------------------- |
+| `GET`    | `/rest/knowledge/settings`    | `knowledge:manage`            |
+| `PUT`    | `/rest/knowledge/settings`    | `knowledge:manage`            |
+| `GET`    | `/rest/knowledge/sources`     | any authenticated user        |
+| `POST`   | `/rest/knowledge/sources`     | `knowledge:manage`            |
+| `PATCH`  | `/rest/knowledge/sources/:id` | `knowledge:manage`            |
+| `DELETE` | `/rest/knowledge/sources/:id` | `knowledge:manage`            |
+| `POST`   | `/rest/knowledge/sources/:id/sync` | `knowledge:manage` (409 while a sync runs) |
+| `GET`    | `/rest/knowledge/sources/:id/runs` | `knowledge:manage`       |
+| `POST`   | `/rest/knowledge/search`      | any authenticated user        |
+
+## Source configuration
+
+**`github`** — requires a credential of type `githubApi`. Indexes issues and pull
+requests (one pass covers both) together with their comments.
+
+```json
+{
+  "owner": "n8n-io",
+  "repo": "n8n",
+  "includeIssues": true,
+  "includePullRequests": true,
+  "historyDays": 365
+}
+```
+
+**`n8n`** — no credential. Indexes this instance's own metadata.
+
+```json
+{
+  "includeWorkflows": true,
+  "includeDataTables": true,
+  "includeCredentials": true
+}
+```
+
+## MCP
+
+When the module is active, the instance MCP server exposes a read-only
+`search_knowledge` tool, granted by the `knowledge:read` OAuth scope. The scope
+and the tool are hidden from the consent screen on instances where the module is
+off.
+
+## Environment variables
+
+| Variable                                | Default  | Purpose                                             |
+| --------------------------------------- | -------- | --------------------------------------------------- |
+| `N8N_KNOWLEDGE_SYNC_INTERVAL_MINUTES`   | `60`     | How often a source becomes eligible for a new sync   |
+| `N8N_KNOWLEDGE_CHUNK_SIZE`              | `1500`   | Characters per chunk                                 |
+| `N8N_KNOWLEDGE_CHUNK_OVERLAP`           | `200`    | Characters shared between consecutive chunks         |
+| `N8N_KNOWLEDGE_MAX_DOCUMENT_CHARS`      | `200000` | Documents longer than this are truncated             |
+| `N8N_KNOWLEDGE_EMBEDDING_BATCH_SIZE`    | `100`    | Chunks per embedding request                         |
+| `N8N_KNOWLEDGE_DEFAULT_TOP_K`           | `8`      | Results per search when the caller does not say      |
+
+## Limitations
+
+- **Instance-level visibility.** Indexed content is not scoped to projects or
+  users: anyone who can call `/rest/knowledge/search` (or hold the
+  `knowledge:read` MCP scope) sees everything indexed, regardless of who can see
+  the underlying workflow, credential or repository. There is no per-user
+  permission mirroring yet — only index sources everyone on the instance may read.
+- **GitHub deletions are not pruned.** The GitHub connector cannot enumerate its
+  ids cheaply, so issues deleted upstream stay indexed until the source is
+  re-created. The `n8n` connector does prune.
+- **Single-main sync.** The timer only runs on the leader, and a run is bound to
+  the process that started it. A source left in `syncing` by a crashed instance is
+  taken over by the next run rather than staying stuck.
+- **One embedding model per instance**, and changing it means re-indexing:
+  existing vectors keep the old model's dimensions.
+- Sync failures never persist a checkpoint, so a failed incremental run re-reads
+  the same window next time rather than skipping documents.
+
+## Security notes
+
+- The `n8n` connector indexes **metadata only**. Credential `data` is never read,
+  and node `parameters` are never emitted — with one deliberate exception: sticky
+  note content, which is user-authored documentation, is indexed. Keep that in
+  mind before enabling the `n8n` source on an instance whose sticky notes carry
+  sensitive text.
+- Settings store credential **ids**, never credential data. Credentials are
+  decrypted per sync and handed only to the connector that needs them.
+- The vector-store filter is built server-side from source ids; a search caller
+  cannot supply a raw filter.

--- a/packages/cli/src/modules/knowledge/__tests__/knowledge-embedding.service.test.ts
+++ b/packages/cli/src/modules/knowledge/__tests__/knowledge-embedding.service.test.ts
@@ -1,0 +1,265 @@
+import { createEmbeddingModel } from '@n8n/agents';
+import type { CredentialsEntity, CredentialsRepository } from '@n8n/db';
+import { embed, embedMany } from 'ai';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+
+import { KnowledgeNotConfiguredError } from '../errors';
+import { KnowledgeEmbeddingService } from '../knowledge-embedding.service';
+import type { KnowledgeSettings, KnowledgeSettingsService } from '../knowledge-settings.service';
+import { KnowledgeConfig } from '../knowledge.config';
+
+vi.mock('@n8n/agents', () => ({
+	createEmbeddingModel: vi.fn(),
+}));
+
+vi.mock('ai', () => ({
+	embed: vi.fn(),
+	embedMany: vi.fn(),
+}));
+
+/** Plain-object results: `mock()` proxies arrays, which breaks deep equality on vectors. */
+const embedResult = (embedding: number[]) =>
+	({ embedding }) as unknown as Awaited<ReturnType<typeof embed>>;
+const embedManyResult = (embeddings: number[][]) =>
+	({ embeddings }) as unknown as Awaited<ReturnType<typeof embedMany>>;
+
+const settings = (overrides: Partial<KnowledgeSettings> = {}): KnowledgeSettings => ({
+	embedding: { provider: 'openai', credentialId: 'cred-1', model: 'text-embedding-3-small' },
+	vectorStore: { provider: 'qdrant', credentialId: 'cred-2', collectionName: 'n8n_knowledge' },
+	...overrides,
+});
+
+describe('KnowledgeEmbeddingService', () => {
+	const settingsService = mock<KnowledgeSettingsService>();
+	const credentialsRepository = mock<CredentialsRepository>();
+	const credentialsService = mock<CredentialsService>();
+	const credential = mock<CredentialsEntity>({ id: 'cred-1', type: 'openAiApi' });
+
+	let service: KnowledgeEmbeddingService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		settingsService.getSettings.mockResolvedValue(settings());
+		credentialsRepository.findOneBy.mockResolvedValue(credential);
+		credentialsService.decrypt.mockResolvedValue({ apiKey: 'sk-test' });
+		vi.mocked(createEmbeddingModel).mockImplementation((modelId) =>
+			mock({ modelId: String(modelId) }),
+		);
+		vi.mocked(embed).mockResolvedValue(embedResult([0.1, 0.2, 0.3]));
+
+		service = new KnowledgeEmbeddingService(
+			settingsService,
+			credentialsRepository,
+			credentialsService,
+			new KnowledgeConfig(),
+		);
+	});
+
+	describe('when not configured', () => {
+		test('embedQuery throws', async () => {
+			settingsService.getSettings.mockResolvedValue(settings({ embedding: null }));
+
+			await expect(service.embedQuery('hello')).rejects.toThrow(KnowledgeNotConfiguredError);
+			expect(createEmbeddingModel).not.toHaveBeenCalled();
+		});
+
+		test('embedMany throws', async () => {
+			settingsService.getSettings.mockResolvedValue(settings({ embedding: null }));
+
+			await expect(service.embedMany(['hello'])).rejects.toThrow(KnowledgeNotConfiguredError);
+		});
+
+		test('getDimension throws', async () => {
+			settingsService.getSettings.mockResolvedValue(settings({ embedding: null }));
+
+			await expect(service.getDimension()).rejects.toThrow(KnowledgeNotConfiguredError);
+		});
+	});
+
+	describe('model construction', () => {
+		test('prefixes the model name with the provider and passes the credential', async () => {
+			await service.embedQuery('hello');
+
+			expect(credentialsRepository.findOneBy).toHaveBeenCalledWith({ id: 'cred-1' });
+			expect(credentialsService.decrypt).toHaveBeenCalledWith(credential, true);
+			expect(createEmbeddingModel).toHaveBeenCalledWith('openai/text-embedding-3-small', {
+				apiKey: 'sk-test',
+			});
+		});
+
+		test('keeps an already prefixed model name as is', async () => {
+			settingsService.getSettings.mockResolvedValue(
+				settings({
+					embedding: {
+						provider: 'openai',
+						credentialId: 'cred-1',
+						model: 'openai/text-embedding-3-large',
+					},
+				}),
+			);
+
+			await service.embedQuery('hello');
+
+			expect(createEmbeddingModel).toHaveBeenCalledWith(
+				'openai/text-embedding-3-large',
+				expect.anything(),
+			);
+		});
+
+		test("forwards the credential's custom base URL", async () => {
+			credentialsService.decrypt.mockResolvedValue({
+				apiKey: 'sk-test',
+				url: 'https://proxy.example.com/v1',
+			});
+
+			await service.embedQuery('hello');
+
+			expect(createEmbeddingModel).toHaveBeenCalledWith('openai/text-embedding-3-small', {
+				apiKey: 'sk-test',
+				baseURL: 'https://proxy.example.com/v1',
+			});
+		});
+
+		test('throws when the configured credential no longer exists', async () => {
+			credentialsRepository.findOneBy.mockResolvedValue(null);
+
+			await expect(service.embedQuery('hello')).rejects.toThrow('no longer exists');
+		});
+
+		test('throws when the credential has no API key', async () => {
+			credentialsService.decrypt.mockResolvedValue({});
+
+			await expect(service.embedQuery('hello')).rejects.toThrow('no API key');
+		});
+	});
+
+	describe('model cache', () => {
+		test('builds the model once across calls', async () => {
+			await service.embedQuery('one');
+			await service.embedQuery('two');
+
+			expect(createEmbeddingModel).toHaveBeenCalledTimes(1);
+			expect(credentialsService.decrypt).toHaveBeenCalledTimes(1);
+		});
+
+		test('rebuilds when the configured model changes', async () => {
+			await service.embedQuery('one');
+
+			settingsService.getSettings.mockResolvedValue(
+				settings({
+					embedding: {
+						provider: 'openai',
+						credentialId: 'cred-1',
+						model: 'text-embedding-3-large',
+					},
+				}),
+			);
+			await service.embedQuery('two');
+
+			expect(createEmbeddingModel).toHaveBeenCalledTimes(2);
+			expect(createEmbeddingModel).toHaveBeenLastCalledWith(
+				'openai/text-embedding-3-large',
+				expect.anything(),
+			);
+		});
+
+		test('rebuilds when the configured credential changes', async () => {
+			await service.embedQuery('one');
+
+			settingsService.getSettings.mockResolvedValue(
+				settings({
+					embedding: {
+						provider: 'openai',
+						credentialId: 'cred-99',
+						model: 'text-embedding-3-small',
+					},
+				}),
+			);
+			await service.embedQuery('two');
+
+			expect(createEmbeddingModel).toHaveBeenCalledTimes(2);
+			expect(credentialsRepository.findOneBy).toHaveBeenLastCalledWith({ id: 'cred-99' });
+		});
+	});
+
+	describe('embedQuery', () => {
+		test('returns the embedding for the given text', async () => {
+			await expect(service.embedQuery('hello')).resolves.toEqual([0.1, 0.2, 0.3]);
+			expect(embed).toHaveBeenCalledWith({ model: expect.anything(), value: 'hello' });
+		});
+	});
+
+	describe('embedMany', () => {
+		beforeEach(() => {
+			// Each batch echoes its values back as single-element vectors, so the
+			// assertions can check ordering across batch boundaries.
+			vi.mocked(embedMany).mockImplementation(async ({ values }) =>
+				embedManyResult(values.map((value: string) => [Number(value)])),
+			);
+		});
+
+		test('returns no vectors and calls no provider for an empty input', async () => {
+			await expect(service.embedMany([])).resolves.toEqual([]);
+			expect(embedMany).not.toHaveBeenCalled();
+			expect(createEmbeddingModel).not.toHaveBeenCalled();
+		});
+
+		test('sends everything in one batch when it fits', async () => {
+			const texts = ['1', '2', '3'];
+
+			await expect(service.embedMany(texts)).resolves.toEqual([[1], [2], [3]]);
+			expect(embedMany).toHaveBeenCalledTimes(1);
+			expect(embedMany).toHaveBeenCalledWith({ model: expect.anything(), values: texts });
+		});
+
+		test('splits into batches of embeddingBatchSize and preserves order', async () => {
+			const config = new KnowledgeConfig();
+			config.embeddingBatchSize = 2;
+			service = new KnowledgeEmbeddingService(
+				settingsService,
+				credentialsRepository,
+				credentialsService,
+				config,
+			);
+
+			const texts = ['1', '2', '3', '4', '5'];
+
+			await expect(service.embedMany(texts)).resolves.toEqual([[1], [2], [3], [4], [5]]);
+			expect(embedMany).toHaveBeenCalledTimes(3);
+			expect(vi.mocked(embedMany).mock.calls.map(([args]) => args.values)).toEqual([
+				['1', '2'],
+				['3', '4'],
+				['5'],
+			]);
+		});
+	});
+
+	describe('getDimension', () => {
+		test('probes the model once and caches the length', async () => {
+			await expect(service.getDimension()).resolves.toBe(3);
+			await expect(service.getDimension()).resolves.toBe(3);
+
+			expect(embed).toHaveBeenCalledTimes(1);
+		});
+
+		test('probes again after the model changes', async () => {
+			await service.getDimension();
+
+			settingsService.getSettings.mockResolvedValue(
+				settings({
+					embedding: {
+						provider: 'openai',
+						credentialId: 'cred-1',
+						model: 'text-embedding-3-large',
+					},
+				}),
+			);
+			vi.mocked(embed).mockResolvedValue(embedResult([0, 0, 0, 0]));
+
+			await expect(service.getDimension()).resolves.toBe(4);
+			expect(embed).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/__tests__/knowledge-indexing.service.test.ts
+++ b/packages/cli/src/modules/knowledge/__tests__/knowledge-indexing.service.test.ts
@@ -1,0 +1,299 @@
+import type { Logger } from '@n8n/backend-common';
+import { createHash } from 'node:crypto';
+import { mock } from 'vitest-mock-extended';
+
+import type { KnowledgeDocumentDraft } from '../connectors/connector.types';
+import type { KnowledgeDocument, KnowledgeSource } from '../database/entities';
+import type { KnowledgeDocumentRepository } from '../database/repositories';
+import type { KnowledgeEmbeddingService } from '../knowledge-embedding.service';
+import { KnowledgeIndexingService } from '../knowledge-indexing.service';
+import type { KnowledgeVectorStoreService } from '../knowledge-vector-store.service';
+import { KnowledgeConfig } from '../knowledge.config';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const source = mock<KnowledgeSource>({ id: 'source-1', name: 'Docs', type: 'github' });
+
+const draft = (overrides: Partial<KnowledgeDocumentDraft> = {}): KnowledgeDocumentDraft => ({
+	externalId: 'issue:1',
+	title: 'First issue',
+	url: 'https://example.com/issue/1',
+	text: 'Some indexable content.',
+	metadata: { author: 'alice', number: 1 },
+	...overrides,
+});
+
+const sha256 = (text: string) => createHash('sha256').update(text, 'utf8').digest('hex');
+
+const documentRow = (overrides: Partial<KnowledgeDocument> = {}) =>
+	mock<KnowledgeDocument>({
+		id: 'doc-1',
+		sourceId: 'source-1',
+		externalId: 'issue:1',
+		contentHash: 'stale',
+		chunkCount: 0,
+		...overrides,
+	});
+
+describe('KnowledgeIndexingService', () => {
+	const documentRepository = mock<KnowledgeDocumentRepository>();
+	const embeddingService = mock<KnowledgeEmbeddingService>();
+	const vectorStoreService = mock<KnowledgeVectorStoreService>();
+	const logger = mock<Logger>();
+
+	let service: KnowledgeIndexingService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger.scoped.mockReturnValue(logger);
+		documentRepository.findBySourceAndExternalId.mockResolvedValue(null);
+		documentRepository.upsertDocument.mockResolvedValue(documentRow());
+		embeddingService.getDimension.mockResolvedValue(3);
+		embeddingService.embedMany.mockImplementation(async (texts) => texts.map((_, i) => [i, i, i]));
+
+		service = new KnowledgeIndexingService(
+			documentRepository,
+			embeddingService,
+			vectorStoreService,
+			new KnowledgeConfig(),
+			logger,
+		);
+	});
+
+	describe('skip by hash', () => {
+		test('skips when the indexed content hash still matches', async () => {
+			const unchanged = draft();
+			documentRepository.findBySourceAndExternalId.mockResolvedValue(
+				documentRow({ contentHash: sha256(unchanged.text), chunkCount: 2 }),
+			);
+
+			await expect(service.indexDocument(source, unchanged)).resolves.toBe('skipped');
+
+			expect(embeddingService.embedMany).not.toHaveBeenCalled();
+			expect(vectorStoreService.upsertChunks).not.toHaveBeenCalled();
+			expect(documentRepository.upsertDocument).not.toHaveBeenCalled();
+		});
+
+		test('indexes when the content hash differs', async () => {
+			documentRepository.findBySourceAndExternalId.mockResolvedValue(
+				documentRow({ contentHash: sha256('older content'), chunkCount: 1 }),
+			);
+
+			await expect(service.indexDocument(source, draft())).resolves.toBe('indexed');
+
+			expect(vectorStoreService.upsertChunks).toHaveBeenCalled();
+		});
+	});
+
+	describe('indexing a new document', () => {
+		test('writes the row before the vectors and finalizes the hash after', async () => {
+			await expect(service.indexDocument(source, draft())).resolves.toBe('indexed');
+
+			const [placeholder, finalized] = documentRepository.upsertDocument.mock.calls.map(
+				([args]) => args,
+			);
+			expect(placeholder).toMatchObject({ contentHash: 'pending', chunkCount: 0 });
+			expect(finalized).toMatchObject({
+				sourceId: 'source-1',
+				externalId: 'issue:1',
+				title: 'First issue',
+				url: 'https://example.com/issue/1',
+				contentHash: sha256(draft().text),
+				chunkCount: 1,
+				meta: { author: 'alice', number: 1 },
+			});
+			expect(vectorStoreService.upsertChunks.mock.invocationCallOrder[0]).toBeLessThan(
+				documentRepository.upsertDocument.mock.invocationCallOrder[1],
+			);
+		});
+
+		test('ensures the collection with the embedding dimension first', async () => {
+			await service.indexDocument(source, draft());
+
+			expect(vectorStoreService.ensureCollection).toHaveBeenCalledWith(3);
+			expect(vectorStoreService.ensureCollection.mock.invocationCallOrder[0]).toBeLessThan(
+				embeddingService.embedMany.mock.invocationCallOrder[0],
+			);
+		});
+
+		test('does not delete vectors when there is nothing to replace', async () => {
+			await service.indexDocument(source, draft());
+
+			expect(vectorStoreService.deleteByDocumentId).not.toHaveBeenCalled();
+		});
+
+		test('builds one point per chunk with a uuid id and the matching vector', async () => {
+			const config = new KnowledgeConfig();
+			config.chunkSize = 10;
+			config.chunkOverlap = 0;
+			service = new KnowledgeIndexingService(
+				documentRepository,
+				embeddingService,
+				vectorStoreService,
+				config,
+				logger,
+			);
+
+			await service.indexDocument(source, draft({ text: 'alpha beta gamma delta' }));
+
+			const [points] = vectorStoreService.upsertChunks.mock.calls[0];
+			expect(points).toHaveLength(3);
+			expect(points.map((point) => point.vector)).toEqual([
+				[0, 0, 0],
+				[1, 1, 1],
+				[2, 2, 2],
+			]);
+			expect(points.map((point) => point.payload.chunkIndex)).toEqual([0, 1, 2]);
+			for (const point of points) expect(point.id).toMatch(UUID_PATTERN);
+			expect(new Set(points.map((point) => point.id)).size).toBe(3);
+		});
+	});
+
+	describe('chunk payload', () => {
+		const payloadOf = async (documentDraft: KnowledgeDocumentDraft) => {
+			await service.indexDocument(source, documentDraft);
+			const [points] = vectorStoreService.upsertChunks.mock.calls[0];
+			return points[0].payload;
+		};
+
+		test('carries the reserved fields plus the connector metadata', async () => {
+			await expect(payloadOf(draft())).resolves.toEqual({
+				author: 'alice',
+				number: 1,
+				sourceId: 'source-1',
+				documentId: 'doc-1',
+				externalId: 'issue:1',
+				chunkIndex: 0,
+				title: 'First issue',
+				url: 'https://example.com/issue/1',
+				text: 'Some indexable content.',
+			});
+		});
+
+		test('reserved keys win over connector metadata', async () => {
+			const payload = await payloadOf(
+				draft({
+					metadata: {
+						sourceId: 'spoofed-source',
+						documentId: 'spoofed-doc',
+						externalId: 'spoofed-external',
+						title: 'spoofed title',
+						url: 'https://spoofed.example.com',
+						text: 'spoofed text',
+						chunkIndex: 99,
+						safe: 'kept',
+					},
+				}),
+			);
+
+			expect(payload).toEqual({
+				safe: 'kept',
+				sourceId: 'source-1',
+				documentId: 'doc-1',
+				externalId: 'issue:1',
+				chunkIndex: 0,
+				title: 'First issue',
+				url: 'https://example.com/issue/1',
+				text: 'Some indexable content.',
+			});
+		});
+
+		test('stores a missing url as null', async () => {
+			const payload = await payloadOf(draft({ url: undefined }));
+
+			expect(payload.url).toBeNull();
+		});
+	});
+
+	describe('re-indexing', () => {
+		beforeEach(() => {
+			documentRepository.findBySourceAndExternalId.mockResolvedValue(
+				documentRow({ contentHash: sha256('older content'), chunkCount: 4 }),
+			);
+		});
+
+		test('deletes the previous vectors before writing the new ones', async () => {
+			await service.indexDocument(source, draft());
+
+			expect(vectorStoreService.deleteByDocumentId).toHaveBeenCalledWith('source-1', 'doc-1');
+			expect(vectorStoreService.deleteByDocumentId.mock.invocationCallOrder[0]).toBeLessThan(
+				vectorStoreService.upsertChunks.mock.invocationCallOrder[0],
+			);
+		});
+
+		test('drops the vectors of a document that lost all its content', async () => {
+			await expect(service.indexDocument(source, draft({ text: '   ' }))).resolves.toBe('indexed');
+
+			expect(vectorStoreService.deleteByDocumentId).toHaveBeenCalledWith('source-1', 'doc-1');
+			expect(vectorStoreService.upsertChunks).not.toHaveBeenCalled();
+			expect(documentRepository.upsertDocument).toHaveBeenLastCalledWith(
+				expect.objectContaining({ chunkCount: 0, contentHash: sha256('   ') }),
+			);
+		});
+
+		test('sweeps vectors an interrupted run may have left behind', async () => {
+			// `chunkCount` is still 0 because the previous run never got to write
+			// the final row, but its vectors may already be in the store.
+			documentRepository.findBySourceAndExternalId.mockResolvedValue(
+				documentRow({ contentHash: 'pending', chunkCount: 0 }),
+			);
+
+			await service.indexDocument(source, draft());
+
+			expect(vectorStoreService.deleteByDocumentId).toHaveBeenCalledWith('source-1', 'doc-1');
+		});
+	});
+
+	describe('a document with no chunkable content', () => {
+		test('records the row without touching the vector store', async () => {
+			await expect(service.indexDocument(source, draft({ text: '\n\n' }))).resolves.toBe('indexed');
+
+			expect(vectorStoreService.ensureCollection).not.toHaveBeenCalled();
+			expect(vectorStoreService.upsertChunks).not.toHaveBeenCalled();
+			expect(documentRepository.upsertDocument).toHaveBeenLastCalledWith(
+				expect.objectContaining({ chunkCount: 0 }),
+			);
+		});
+	});
+
+	describe('removeDocuments', () => {
+		test('deletes the vectors before the rows', async () => {
+			documentRepository.deleteBySourceAndExternalIds.mockResolvedValue(2);
+
+			await expect(service.removeDocuments(source, ['issue:1', 'issue:2'])).resolves.toBe(2);
+
+			expect(vectorStoreService.deleteByExternalIds).toHaveBeenCalledWith('source-1', [
+				'issue:1',
+				'issue:2',
+			]);
+			expect(documentRepository.deleteBySourceAndExternalIds).toHaveBeenCalledWith('source-1', [
+				'issue:1',
+				'issue:2',
+			]);
+			expect(vectorStoreService.deleteByExternalIds.mock.invocationCallOrder[0]).toBeLessThan(
+				documentRepository.deleteBySourceAndExternalIds.mock.invocationCallOrder[0],
+			);
+		});
+
+		test('does nothing for an empty list', async () => {
+			await expect(service.removeDocuments(source, [])).resolves.toBe(0);
+
+			expect(vectorStoreService.deleteByExternalIds).not.toHaveBeenCalled();
+			expect(documentRepository.deleteBySourceAndExternalIds).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('removeSource', () => {
+		test('drops every vector and every document row of the source', async () => {
+			documentRepository.listExternalIds.mockResolvedValue(['issue:1', 'issue:2']);
+
+			await service.removeSource('source-1');
+
+			expect(vectorStoreService.deleteBySourceId).toHaveBeenCalledWith('source-1');
+			expect(documentRepository.deleteBySourceAndExternalIds).toHaveBeenCalledWith('source-1', [
+				'issue:1',
+				'issue:2',
+			]);
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/__tests__/knowledge-search.service.test.ts
+++ b/packages/cli/src/modules/knowledge/__tests__/knowledge-search.service.test.ts
@@ -1,0 +1,198 @@
+import { mock } from 'vitest-mock-extended';
+
+import type { KnowledgeSource } from '../database/entities';
+import type { KnowledgeSourceRepository } from '../database/repositories';
+import { KnowledgeNotConfiguredError } from '../errors';
+import type { KnowledgeEmbeddingService } from '../knowledge-embedding.service';
+import { KnowledgeSearchService } from '../knowledge-search.service';
+import type { KnowledgeSettingsService } from '../knowledge-settings.service';
+import type {
+	KnowledgeVectorHit,
+	KnowledgeVectorStoreService,
+} from '../knowledge-vector-store.service';
+import { KnowledgeConfig } from '../knowledge.config';
+
+const knowledgeSource = (id: string, name: string) => mock<KnowledgeSource>({ id, name });
+
+const hit = (overrides: Partial<KnowledgeVectorHit> = {}): KnowledgeVectorHit => ({
+	id: 'point-1',
+	score: 0.87,
+	payload: {
+		sourceId: 'source-1',
+		documentId: 'doc-1',
+		externalId: 'issue:1',
+		chunkIndex: 2,
+		title: 'First issue',
+		url: 'https://example.com/issue/1',
+		text: 'Some indexable content.',
+		author: 'alice',
+		number: 1,
+	},
+	...overrides,
+});
+
+describe('KnowledgeSearchService', () => {
+	const settingsService = mock<KnowledgeSettingsService>();
+	const sourceRepository = mock<KnowledgeSourceRepository>();
+	const embeddingService = mock<KnowledgeEmbeddingService>();
+	const vectorStoreService = mock<KnowledgeVectorStoreService>();
+
+	let service: KnowledgeSearchService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		settingsService.isConfigured.mockResolvedValue(true);
+		sourceRepository.findAllSources.mockResolvedValue([
+			knowledgeSource('source-1', 'Docs'),
+			knowledgeSource('source-2', 'Issues'),
+		]);
+		embeddingService.embedQuery.mockResolvedValue([0.1, 0.2, 0.3]);
+		vectorStoreService.search.mockResolvedValue([]);
+
+		service = new KnowledgeSearchService(
+			settingsService,
+			sourceRepository,
+			embeddingService,
+			vectorStoreService,
+			new KnowledgeConfig(),
+		);
+	});
+
+	test('throws when the module is not configured', async () => {
+		settingsService.isConfigured.mockResolvedValue(false);
+
+		await expect(service.search('anything')).rejects.toThrow(KnowledgeNotConfiguredError);
+		expect(embeddingService.embedQuery).not.toHaveBeenCalled();
+	});
+
+	test('returns nothing for a blank query', async () => {
+		await expect(service.search('   ')).resolves.toEqual([]);
+
+		expect(embeddingService.embedQuery).not.toHaveBeenCalled();
+		expect(vectorStoreService.search).not.toHaveBeenCalled();
+	});
+
+	describe('source scoping', () => {
+		test('searches every existing source by default', async () => {
+			await service.search('how do I deploy?');
+
+			expect(vectorStoreService.search).toHaveBeenCalledWith([0.1, 0.2, 0.3], {
+				sourceIds: ['source-1', 'source-2'],
+				topK: 8,
+			});
+		});
+
+		test('intersects pinned source ids with the existing ones', async () => {
+			await service.search('how do I deploy?', { sourceIds: ['source-2', 'source-gone'] });
+
+			expect(vectorStoreService.search).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ sourceIds: ['source-2'] }),
+			);
+		});
+
+		test('returns nothing when the intersection is empty', async () => {
+			await expect(service.search('query', { sourceIds: ['source-gone'] })).resolves.toEqual([]);
+
+			expect(embeddingService.embedQuery).not.toHaveBeenCalled();
+			expect(vectorStoreService.search).not.toHaveBeenCalled();
+		});
+
+		test('returns nothing when no source exists at all', async () => {
+			sourceRepository.findAllSources.mockResolvedValue([]);
+
+			await expect(service.search('query')).resolves.toEqual([]);
+			expect(vectorStoreService.search).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('topK', () => {
+		test('falls back to the configured default', async () => {
+			await service.search('query');
+
+			expect(vectorStoreService.search).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ topK: 8 }),
+			);
+		});
+
+		test('uses the caller-provided value', async () => {
+			await service.search('query', { topK: 3 });
+
+			expect(vectorStoreService.search).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ topK: 3 }),
+			);
+		});
+	});
+
+	describe('result mapping', () => {
+		test('splits the payload into result fields and leftover metadata', async () => {
+			vectorStoreService.search.mockResolvedValue([hit()]);
+
+			await expect(service.search('query')).resolves.toEqual([
+				{
+					text: 'Some indexable content.',
+					score: 0.87,
+					title: 'First issue',
+					url: 'https://example.com/issue/1',
+					sourceId: 'source-1',
+					sourceName: 'Docs',
+					externalId: 'issue:1',
+					metadata: { externalId: 'issue:1', author: 'alice', number: 1 },
+				},
+			]);
+		});
+
+		test('leaves url null when the chunk has none', async () => {
+			vectorStoreService.search.mockResolvedValue([
+				hit({ payload: { ...hit().payload, url: null } }),
+			]);
+
+			const [result] = await service.search('query');
+
+			expect(result.url).toBeNull();
+		});
+
+		test('resolves the source name from the fetched sources', async () => {
+			vectorStoreService.search.mockResolvedValue([
+				hit({ payload: { ...hit().payload, sourceId: 'source-2' } }),
+			]);
+
+			const [result] = await service.search('query');
+
+			expect(result.sourceName).toBe('Issues');
+		});
+
+		test('drops a hit whose source no longer exists', async () => {
+			vectorStoreService.search.mockResolvedValue([
+				hit(),
+				hit({ id: 'point-2', payload: { ...hit().payload, sourceId: 'source-deleted' } }),
+			]);
+
+			const results = await service.search('query');
+
+			expect(results).toHaveLength(1);
+			expect(results[0].sourceId).toBe('source-1');
+		});
+
+		test('tolerates a payload missing the optional fields', async () => {
+			vectorStoreService.search.mockResolvedValue([
+				{ id: 'point-1', score: 0.5, payload: { sourceId: 'source-1' } },
+			]);
+
+			await expect(service.search('query')).resolves.toEqual([
+				{
+					text: '',
+					score: 0.5,
+					title: '',
+					url: null,
+					sourceId: 'source-1',
+					sourceName: 'Docs',
+					externalId: '',
+					metadata: {},
+				},
+			]);
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/__tests__/knowledge-settings.service.test.ts
+++ b/packages/cli/src/modules/knowledge/__tests__/knowledge-settings.service.test.ts
@@ -1,0 +1,164 @@
+import type { Logger } from '@n8n/backend-common';
+import type { Settings, SettingsRepository } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import { KnowledgeSettingsService } from '../knowledge-settings.service';
+
+const SETTINGS_KEY = 'knowledge.settings';
+
+const storedSettings = (value: string) =>
+	mock<Settings>({ key: SETTINGS_KEY, value, loadOnStartup: false });
+
+describe('KnowledgeSettingsService', () => {
+	const settingsRepository = mock<SettingsRepository>();
+	const logger = mock<Logger>();
+
+	let service: KnowledgeSettingsService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger.scoped.mockReturnValue(logger);
+		service = new KnowledgeSettingsService(settingsRepository, logger);
+	});
+
+	describe('getSettings', () => {
+		test('returns both parts unset when nothing is stored', async () => {
+			settingsRepository.findByKey.mockResolvedValue(null);
+
+			await expect(service.getSettings()).resolves.toEqual({
+				embedding: null,
+				vectorStore: null,
+			});
+			expect(settingsRepository.findByKey).toHaveBeenCalledWith(SETTINGS_KEY);
+		});
+
+		test('returns the stored settings', async () => {
+			const settings = {
+				embedding: { provider: 'openai', credentialId: 'cred-1', model: 'text-embedding-3-small' },
+				vectorStore: { provider: 'qdrant', credentialId: 'cred-2', collectionName: 'docs' },
+			};
+			settingsRepository.findByKey.mockResolvedValue(storedSettings(JSON.stringify(settings)));
+
+			await expect(service.getSettings()).resolves.toEqual(settings);
+		});
+
+		test('falls back to defaults when the stored value does not match the schema', async () => {
+			settingsRepository.findByKey.mockResolvedValue(
+				storedSettings('{"embedding":{"provider":"cohere"},"vectorStore":null}'),
+			);
+
+			await expect(service.getSettings()).resolves.toEqual({
+				embedding: null,
+				vectorStore: null,
+			});
+			expect(logger.warn).toHaveBeenCalled();
+		});
+	});
+
+	describe('updateSettings', () => {
+		test('merges the patch into the stored settings and persists it', async () => {
+			settingsRepository.findByKey.mockResolvedValue(
+				storedSettings(
+					JSON.stringify({
+						embedding: {
+							provider: 'openai',
+							credentialId: 'cred-1',
+							model: 'text-embedding-3-small',
+						},
+						vectorStore: null,
+					}),
+				),
+			);
+
+			const updated = await service.updateSettings({
+				vectorStore: { provider: 'qdrant', credentialId: 'cred-2' },
+			});
+
+			expect(updated).toEqual({
+				embedding: { provider: 'openai', credentialId: 'cred-1', model: 'text-embedding-3-small' },
+				vectorStore: {
+					provider: 'qdrant',
+					credentialId: 'cred-2',
+					collectionName: 'n8n_knowledge',
+				},
+			});
+			expect(settingsRepository.upsertByKey).toHaveBeenCalledWith(
+				SETTINGS_KEY,
+				JSON.stringify(updated),
+				false,
+				{},
+			);
+		});
+
+		test('clears a part when the patch passes null', async () => {
+			settingsRepository.findByKey.mockResolvedValue(
+				storedSettings(
+					JSON.stringify({
+						embedding: {
+							provider: 'openai',
+							credentialId: 'cred-1',
+							model: 'text-embedding-3-small',
+						},
+						vectorStore: { provider: 'qdrant', credentialId: 'cred-2', collectionName: 'docs' },
+					}),
+				),
+			);
+
+			const updated = await service.updateSettings({ embedding: null });
+
+			expect(updated.embedding).toBeNull();
+			expect(updated.vectorStore).toEqual({
+				provider: 'qdrant',
+				credentialId: 'cred-2',
+				collectionName: 'docs',
+			});
+		});
+
+		test('rejects an invalid patch without persisting', async () => {
+			settingsRepository.findByKey.mockResolvedValue(null);
+
+			await expect(
+				service.updateSettings({
+					embedding: { provider: 'openai', credentialId: '', model: 'text-embedding-3-small' },
+				}),
+			).rejects.toThrow();
+			expect(settingsRepository.upsertByKey).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('isConfigured', () => {
+		test('is false while only one part is set', async () => {
+			settingsRepository.findByKey.mockResolvedValue(
+				storedSettings(
+					JSON.stringify({
+						embedding: {
+							provider: 'openai',
+							credentialId: 'cred-1',
+							model: 'text-embedding-3-small',
+						},
+						vectorStore: null,
+					}),
+				),
+			);
+
+			await expect(service.isConfigured()).resolves.toBe(false);
+		});
+
+		test('is true once both parts are set', async () => {
+			settingsRepository.findByKey.mockResolvedValue(
+				storedSettings(
+					JSON.stringify({
+						embedding: {
+							provider: 'openai',
+							credentialId: 'cred-1',
+							model: 'text-embedding-3-small',
+						},
+						vectorStore: { provider: 'qdrant', credentialId: 'cred-2', collectionName: 'docs' },
+					}),
+				),
+			);
+
+			await expect(service.isConfigured()).resolves.toBe(true);
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/__tests__/knowledge-sync.service.test.ts
+++ b/packages/cli/src/modules/knowledge/__tests__/knowledge-sync.service.test.ts
@@ -1,0 +1,495 @@
+import type { Logger } from '@n8n/backend-common';
+import type { CredentialsEntity, CredentialsRepository } from '@n8n/db';
+import type { InstanceSettings } from 'n8n-core';
+import { OperationalError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+
+import type { KnowledgeConnectorRegistry } from '../connectors/connector-registry';
+import type {
+	ConnectorSyncContext,
+	ConnectorSyncResult,
+	KnowledgeConnector,
+	KnowledgeDocumentDraft,
+} from '../connectors/connector.types';
+import type { KnowledgeDocument, KnowledgeSource, KnowledgeSyncRun } from '../database/entities';
+import type {
+	KnowledgeDocumentRepository,
+	KnowledgeSourceRepository,
+	KnowledgeSyncRunRepository,
+} from '../database/repositories';
+import { KnowledgeSourceNotFoundError, KnowledgeSyncInProgressError } from '../errors';
+import type { KnowledgeIndexingService } from '../knowledge-indexing.service';
+import { KnowledgeSyncService } from '../knowledge-sync.service';
+import { KnowledgeConfig } from '../knowledge.config';
+
+// vitest-mock-extended re-proxies nested values, which mangles plain objects and
+// dates, so fixtures carrying them are assigned onto the mock instead.
+const makeSource = (overrides: Partial<KnowledgeSource> = {}): KnowledgeSource =>
+	Object.assign(mock<KnowledgeSource>(), {
+		id: 'source-1',
+		name: 'Docs',
+		type: 'github' as const,
+		credentialId: 'cred-1',
+		config: { owner: 'n8n-io', repo: 'n8n' },
+		status: 'ready' as const,
+		lastSyncedAt: null,
+		checkpoint: null,
+		lastError: null,
+		...overrides,
+	});
+
+const makeDraft = (externalId: string): KnowledgeDocumentDraft => ({
+	externalId,
+	title: `Title ${externalId}`,
+	text: `Text of ${externalId}`,
+	metadata: {},
+});
+
+const makeConnector = (overrides: Partial<KnowledgeConnector> = {}): KnowledgeConnector => ({
+	type: 'github',
+	requiresCredential: false,
+	parseConfig: vi.fn().mockReturnValue({}),
+	sync: vi.fn(),
+	...overrides,
+});
+
+/** Builds a `sync` implementation yielding `drafts` and returning `result`. */
+const syncYielding = (drafts: KnowledgeDocumentDraft[], result: ConnectorSyncResult) =>
+	async function* (
+		_ctx: ConnectorSyncContext,
+	): AsyncGenerator<KnowledgeDocumentDraft, ConnectorSyncResult> {
+		for (const draft of drafts) yield draft;
+
+		return result;
+	};
+
+describe('KnowledgeSyncService', () => {
+	const sourceRepository = mock<KnowledgeSourceRepository>();
+	const documentRepository = mock<KnowledgeDocumentRepository>();
+	const syncRunRepository = mock<KnowledgeSyncRunRepository>();
+	const connectorRegistry = mock<KnowledgeConnectorRegistry>();
+	const indexingService = mock<KnowledgeIndexingService>();
+	const credentialsRepository = mock<CredentialsRepository>();
+	const credentialsService = mock<CredentialsService>();
+	const instanceSettings = mock<InstanceSettings>();
+	const logger = mock<Logger>();
+
+	let service: KnowledgeSyncService;
+
+	const buildService = () =>
+		new KnowledgeSyncService(
+			sourceRepository,
+			documentRepository,
+			syncRunRepository,
+			connectorRegistry,
+			indexingService,
+			credentialsRepository,
+			credentialsService,
+			new KnowledgeConfig(),
+			instanceSettings,
+			logger,
+		);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger.scoped.mockReturnValue(logger);
+		syncRunRepository.createRun.mockResolvedValue(mock<KnowledgeSyncRun>({ id: 'run-1' }));
+		documentRepository.listExternalIds.mockResolvedValue([]);
+		documentRepository.findBySourceAndExternalId.mockResolvedValue(
+			mock<KnowledgeDocument>({ chunkCount: 2 }),
+		);
+		indexingService.indexDocument.mockResolvedValue('indexed');
+		indexingService.removeDocuments.mockResolvedValue(0);
+		service = buildService();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('runSync', () => {
+		it('indexes drafts, then persists the checkpoint and marks the source ready', async () => {
+			const source = makeSource();
+			sourceRepository.findSourceById.mockResolvedValue(source);
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					sync: syncYielding([makeDraft('issue:1'), makeDraft('issue:2')], {
+						checkpoint: { since: '2026-01-01T00:00:00.000Z' },
+					}),
+				}),
+			);
+			indexingService.indexDocument.mockResolvedValueOnce('indexed');
+			indexingService.indexDocument.mockResolvedValueOnce('skipped');
+
+			await service.runSync('source-1');
+
+			expect(sourceRepository.updateStatus).toHaveBeenNthCalledWith(1, 'source-1', 'syncing');
+			expect(sourceRepository.updateStatus).toHaveBeenNthCalledWith(2, 'source-1', 'ready', {
+				checkpoint: { since: '2026-01-01T00:00:00.000Z' },
+				lastSyncedAt: expect.any(Date),
+				lastError: null,
+			});
+			expect(syncRunRepository.createRun).toHaveBeenCalledWith('source-1', 'full');
+			expect(syncRunRepository.finishRun).toHaveBeenCalledWith('run-1', 'success', {
+				documentsSeen: 2,
+				documentsIndexed: 1,
+				documentsSkipped: 1,
+				documentsDeleted: 0,
+				chunksWritten: 2,
+			});
+		});
+
+		it('runs in incremental mode when a checkpoint exists, and full on a full resync', async () => {
+			const source = makeSource({ checkpoint: { since: '2025-12-01T00:00:00.000Z' } });
+			sourceRepository.findSourceById.mockResolvedValue(source);
+			const sync = vi.fn(syncYielding([], { checkpoint: { since: 'next' } }));
+			connectorRegistry.getConnector.mockReturnValue(makeConnector({ sync }));
+
+			await service.runSync('source-1');
+
+			expect(syncRunRepository.createRun).toHaveBeenCalledWith('source-1', 'incremental');
+			expect(sync.mock.calls[0][0]).toMatchObject({
+				checkpoint: { since: '2025-12-01T00:00:00.000Z' },
+			});
+
+			await service.runSync('source-1', { fullResync: true });
+
+			expect(syncRunRepository.createRun).toHaveBeenLastCalledWith('source-1', 'full');
+			expect(sync.mock.calls[1][0]).toMatchObject({ checkpoint: null });
+		});
+
+		it('keeps the checkpoint and marks the source errored when the connector throws', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					// eslint-disable-next-line require-yield
+					async *sync() {
+						throw new OperationalError('Sync aborted');
+					},
+				}),
+			);
+
+			await expect(service.runSync('source-1')).rejects.toThrow('Sync aborted');
+
+			expect(sourceRepository.updateStatus).toHaveBeenLastCalledWith('source-1', 'error', {
+				lastError: 'Sync aborted',
+			});
+			const checkpointWrites = sourceRepository.updateStatus.mock.calls.filter(
+				([, , update]) => update?.checkpoint !== undefined,
+			);
+			expect(checkpointWrites).toEqual([]);
+			expect(syncRunRepository.finishRun).toHaveBeenCalledWith(
+				'run-1',
+				'error',
+				expect.objectContaining({ documentsIndexed: 0 }),
+				'Sync aborted',
+			);
+		});
+
+		it('throws when the source does not exist', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(null);
+
+			await expect(service.runSync('missing')).rejects.toThrow(KnowledgeSourceNotFoundError);
+			expect(syncRunRepository.createRun).not.toHaveBeenCalled();
+		});
+
+		it('rejects a second sync while one is running for the same source', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			let release = () => {};
+			const gate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			indexingService.indexDocument.mockImplementation(async () => {
+				await gate;
+				return 'indexed';
+			});
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({ sync: syncYielding([makeDraft('issue:1')], { checkpoint: {} }) }),
+			);
+
+			const inFlight = service.runSync('source-1');
+			await vi.waitFor(() => expect(indexingService.indexDocument).toHaveBeenCalled());
+
+			await expect(service.runSync('source-1')).rejects.toThrow(KnowledgeSyncInProgressError);
+
+			release();
+			await inFlight;
+
+			// The guard is released once the run is over.
+			await expect(service.runSync('source-1')).resolves.toBeUndefined();
+		});
+
+		it('takes over a source left in the syncing state by a crashed run', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource({ status: 'syncing' }));
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({ sync: syncYielding([], { checkpoint: {} }) }),
+			);
+
+			await service.runSync('source-1');
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Taking over a knowledge source left in the syncing state',
+				{ sourceId: 'source-1' },
+			);
+			expect(syncRunRepository.finishRun).toHaveBeenCalledWith(
+				'run-1',
+				'success',
+				expect.anything(),
+			);
+		});
+
+		it('removes the externalIds the connector reports as deleted', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					sync: syncYielding([], { checkpoint: {}, deletedExternalIds: ['issue:9'] }),
+				}),
+			);
+			indexingService.removeDocuments.mockResolvedValue(1);
+
+			await service.runSync('source-1');
+
+			expect(indexingService.removeDocuments).toHaveBeenCalledWith(expect.anything(), ['issue:9']);
+			expect(syncRunRepository.finishRun).toHaveBeenCalledWith(
+				'run-1',
+				'success',
+				expect.objectContaining({ documentsDeleted: 1 }),
+			);
+		});
+
+		it('prunes indexed documents the connector no longer lists', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			documentRepository.listExternalIds.mockResolvedValue([
+				'workflow:1',
+				'workflow:2',
+				'workflow:3',
+			]);
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					sync: syncYielding([], { checkpoint: {} }),
+					listExternalIds: vi.fn().mockResolvedValue(['workflow:1', 'workflow:3']),
+				}),
+			);
+			indexingService.removeDocuments.mockResolvedValue(1);
+
+			await service.runSync('source-1');
+
+			expect(indexingService.removeDocuments).toHaveBeenCalledWith(expect.anything(), [
+				'workflow:2',
+			]);
+		});
+
+		it('decrypts the credential for connectors that require one', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			const sync = vi.fn(syncYielding([], { checkpoint: {} }));
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({ requiresCredential: true, sync }),
+			);
+			const credential = mock<CredentialsEntity>({ id: 'cred-1' });
+			credentialsRepository.findOneBy.mockResolvedValue(credential);
+			credentialsService.decrypt.mockResolvedValue({ accessToken: 'token' });
+
+			await service.runSync('source-1');
+
+			expect(credentialsService.decrypt).toHaveBeenCalledWith(credential, true);
+			expect(sync.mock.calls[0][0]).toMatchObject({ credential: { accessToken: 'token' } });
+		});
+
+		it('fails with a clear error when a required credential is missing', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource({ credentialId: null }));
+			connectorRegistry.getConnector.mockReturnValue(makeConnector({ requiresCredential: true }));
+
+			await expect(service.runSync('source-1')).rejects.toThrow(/needs a credential/);
+			expect(sourceRepository.updateStatus).toHaveBeenLastCalledWith(
+				'source-1',
+				'error',
+				expect.objectContaining({ lastError: expect.stringContaining('needs a credential') }),
+			);
+		});
+	});
+
+	describe('triggerSync', () => {
+		it('returns before the run finishes and logs its failure', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					// eslint-disable-next-line require-yield
+					async *sync() {
+						throw new OperationalError('boom');
+					},
+				}),
+			);
+
+			await expect(service.triggerSync('source-1')).resolves.toBeUndefined();
+
+			await vi.waitFor(() =>
+				expect(logger.error).toHaveBeenCalledWith('Knowledge source sync failed', {
+					sourceId: 'source-1',
+					error: 'boom',
+				}),
+			);
+		});
+
+		it('surfaces an already-running sync to the caller', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			let release = () => {};
+			const gate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			indexingService.indexDocument.mockImplementation(async () => {
+				await gate;
+				return 'indexed';
+			});
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({ sync: syncYielding([makeDraft('issue:1')], { checkpoint: {} }) }),
+			);
+
+			const inFlight = service.runSync('source-1');
+			await vi.waitFor(() => expect(indexingService.indexDocument).toHaveBeenCalled());
+
+			await expect(service.triggerSync('source-1')).rejects.toThrow(KnowledgeSyncInProgressError);
+
+			release();
+			await inFlight;
+		});
+	});
+
+	describe('deleteSource', () => {
+		it('aborts an in-flight sync, drops the index and deletes the source', async () => {
+			const source = makeSource();
+			sourceRepository.findSourceById.mockResolvedValue(source);
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					async *sync(ctx): AsyncGenerator<KnowledgeDocumentDraft, ConnectorSyncResult> {
+						yield makeDraft('issue:1');
+						if (ctx.abortSignal?.aborted) throw new OperationalError('Sync aborted');
+
+						return { checkpoint: {} };
+					},
+				}),
+			);
+			let release = () => {};
+			const gate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			indexingService.indexDocument.mockImplementation(async () => {
+				await gate;
+				return 'indexed';
+			});
+
+			const inFlight = service.runSync('source-1');
+			await vi.waitFor(() => expect(indexingService.indexDocument).toHaveBeenCalled());
+
+			const deletion = service.deleteSource('source-1');
+			release();
+			await expect(inFlight).rejects.toThrow('Sync aborted');
+			await deletion;
+
+			expect(indexingService.removeSource).toHaveBeenCalledWith('source-1');
+			expect(sourceRepository.delete).toHaveBeenCalledWith({ id: 'source-1' });
+		});
+
+		it('throws when the source does not exist', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(null);
+
+			await expect(service.deleteSource('missing')).rejects.toThrow(KnowledgeSourceNotFoundError);
+			expect(indexingService.removeSource).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('the sync timer', () => {
+		it('starts only on the leader', () => {
+			vi.useFakeTimers();
+			const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+			Object.assign(instanceSettings, { isLeader: false });
+			buildService().start();
+			expect(setIntervalSpy).not.toHaveBeenCalled();
+
+			Object.assign(instanceSettings, { isLeader: true });
+			buildService().start();
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('syncs due sources on leader takeover and stops on stepdown', async () => {
+			vi.useFakeTimers();
+			const dueSource = makeSource({ id: 'due-1' });
+			sourceRepository.findSourcesDueForSync.mockResolvedValue([dueSource]);
+			sourceRepository.findSourceById.mockResolvedValue(dueSource);
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({ sync: syncYielding([], { checkpoint: {} }) }),
+			);
+
+			service.startTimer();
+			await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+			expect(sourceRepository.findSourcesDueForSync).toHaveBeenCalledWith(60);
+			expect(syncRunRepository.createRun).toHaveBeenCalledWith('due-1', 'full');
+
+			service.stopTimer();
+			await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+			expect(sourceRepository.findSourcesDueForSync).toHaveBeenCalledTimes(1);
+		});
+
+		it('keeps syncing the remaining sources when one fails', async () => {
+			sourceRepository.findSourcesDueForSync.mockResolvedValue([
+				makeSource({ id: 'broken' }),
+				makeSource({ id: 'fine' }),
+			]);
+			sourceRepository.findSourceById.mockImplementation(
+				async (id: string) => makeSource({ id }) as never,
+			);
+			connectorRegistry.getConnector.mockImplementation(() =>
+				makeConnector({ sync: syncYielding([], { checkpoint: {} }) }),
+			);
+			syncRunRepository.createRun.mockRejectedValueOnce(new Error('db is down'));
+
+			await service.syncDueSources();
+
+			expect(logger.error).toHaveBeenCalledWith('Knowledge source sync failed', {
+				sourceId: 'broken',
+				error: 'db is down',
+			});
+			expect(syncRunRepository.createRun).toHaveBeenCalledWith('fine', 'full');
+		});
+	});
+
+	describe('shutdown', () => {
+		it('stops the timer and aborts in-flight syncs', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(makeSource());
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					async *sync(ctx): AsyncGenerator<KnowledgeDocumentDraft, ConnectorSyncResult> {
+						yield makeDraft('issue:1');
+						if (ctx.abortSignal?.aborted) throw new OperationalError('Sync aborted');
+
+						return { checkpoint: {} };
+					},
+				}),
+			);
+			let release = () => {};
+			const gate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			indexingService.indexDocument.mockImplementation(async () => {
+				await gate;
+				return 'indexed';
+			});
+
+			const inFlight = service.runSync('source-1');
+			await vi.waitFor(() => expect(indexingService.indexDocument).toHaveBeenCalled());
+
+			const shutdown = service.shutdown();
+			release();
+			await expect(inFlight).rejects.toThrow('Sync aborted');
+			await shutdown;
+
+			expect(sourceRepository.updateStatus).toHaveBeenLastCalledWith('source-1', 'error', {
+				lastError: 'Sync aborted',
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/__tests__/knowledge-vector-store.service.test.ts
+++ b/packages/cli/src/modules/knowledge/__tests__/knowledge-vector-store.service.test.ts
@@ -1,0 +1,305 @@
+import type { CredentialsEntity, CredentialsRepository } from '@n8n/db';
+import { QdrantClient } from '@qdrant/js-client-rest';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+
+import { KnowledgeNotConfiguredError } from '../errors';
+import type { KnowledgeSettings, KnowledgeSettingsService } from '../knowledge-settings.service';
+import { KnowledgeVectorStoreService } from '../knowledge-vector-store.service';
+
+const client = {
+	collectionExists: vi.fn(),
+	createCollection: vi.fn(),
+	getCollection: vi.fn(),
+	createPayloadIndex: vi.fn(),
+	upsert: vi.fn(),
+	delete: vi.fn(),
+	query: vi.fn(),
+};
+
+// A function expression, not an arrow: the service calls `new QdrantClient(...)`.
+vi.mock('@qdrant/js-client-rest', () => ({
+	QdrantClient: vi.fn(function () {
+		return client;
+	}),
+}));
+
+const COLLECTION = 'n8n_knowledge';
+
+const settings = (overrides: Partial<KnowledgeSettings> = {}): KnowledgeSettings => ({
+	embedding: { provider: 'openai', credentialId: 'cred-1', model: 'text-embedding-3-small' },
+	vectorStore: { provider: 'qdrant', credentialId: 'cred-2', collectionName: COLLECTION },
+	...overrides,
+});
+
+const collectionInfo = (size: number) => ({ config: { params: { vectors: { size } } } });
+
+describe('KnowledgeVectorStoreService', () => {
+	const settingsService = mock<KnowledgeSettingsService>();
+	const credentialsRepository = mock<CredentialsRepository>();
+	const credentialsService = mock<CredentialsService>();
+	const credential = mock<CredentialsEntity>({ id: 'cred-2', type: 'qdrantApi' });
+
+	let service: KnowledgeVectorStoreService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		settingsService.getSettings.mockResolvedValue(settings());
+		credentialsRepository.findOneBy.mockResolvedValue(credential);
+		credentialsService.decrypt.mockResolvedValue({
+			qdrantUrl: 'https://qdrant.example.com',
+			apiKey: 'qdrant-key',
+		});
+		client.collectionExists.mockResolvedValue({ exists: true });
+		client.getCollection.mockResolvedValue(collectionInfo(3));
+		client.query.mockResolvedValue({ points: [] });
+
+		service = new KnowledgeVectorStoreService(
+			settingsService,
+			credentialsRepository,
+			credentialsService,
+		);
+	});
+
+	describe('client construction', () => {
+		test('builds the client from the configured credential', async () => {
+			await service.ensureCollection(3);
+
+			expect(credentialsRepository.findOneBy).toHaveBeenCalledWith({ id: 'cred-2' });
+			expect(credentialsService.decrypt).toHaveBeenCalledWith(credential, true);
+			expect(QdrantClient).toHaveBeenCalledWith({
+				url: 'https://qdrant.example.com',
+				apiKey: 'qdrant-key',
+			});
+		});
+
+		test('omits the API key when the credential has none', async () => {
+			credentialsService.decrypt.mockResolvedValue({ qdrantUrl: 'http://localhost:6333' });
+
+			await service.ensureCollection(3);
+
+			expect(QdrantClient).toHaveBeenCalledWith({ url: 'http://localhost:6333' });
+		});
+
+		test('reuses the client across calls', async () => {
+			await service.ensureCollection(3);
+			await service.search([1, 2, 3], { sourceIds: ['source-1'], topK: 4 });
+
+			expect(QdrantClient).toHaveBeenCalledTimes(1);
+		});
+
+		test('rebuilds when the configured collection changes', async () => {
+			await service.ensureCollection(3);
+
+			settingsService.getSettings.mockResolvedValue(
+				settings({
+					vectorStore: { provider: 'qdrant', credentialId: 'cred-2', collectionName: 'other' },
+				}),
+			);
+			await service.ensureCollection(3);
+
+			expect(QdrantClient).toHaveBeenCalledTimes(2);
+			expect(client.collectionExists).toHaveBeenLastCalledWith('other');
+		});
+
+		test('throws when the vector store is not configured', async () => {
+			settingsService.getSettings.mockResolvedValue(settings({ vectorStore: null }));
+
+			await expect(service.ensureCollection(3)).rejects.toThrow(KnowledgeNotConfiguredError);
+		});
+
+		test('throws when the configured credential no longer exists', async () => {
+			credentialsRepository.findOneBy.mockResolvedValue(null);
+
+			await expect(service.ensureCollection(3)).rejects.toThrow('no longer exists');
+		});
+
+		test('throws when the credential has no URL', async () => {
+			credentialsService.decrypt.mockResolvedValue({ apiKey: 'qdrant-key' });
+
+			await expect(service.ensureCollection(3)).rejects.toThrow('no URL');
+		});
+	});
+
+	describe('ensureCollection', () => {
+		test('creates the collection when it is missing', async () => {
+			client.collectionExists.mockResolvedValue({ exists: false });
+
+			await service.ensureCollection(1536);
+
+			expect(client.createCollection).toHaveBeenCalledWith(COLLECTION, {
+				vectors: { size: 1536, distance: 'Cosine' },
+			});
+		});
+
+		test('creates keyword payload indexes for every filtered field', async () => {
+			await service.ensureCollection(3);
+
+			expect(client.createPayloadIndex.mock.calls.map(([, args]) => args)).toEqual([
+				{ field_name: 'sourceId', field_schema: 'keyword', wait: true },
+				{ field_name: 'documentId', field_schema: 'keyword', wait: true },
+				{ field_name: 'externalId', field_schema: 'keyword', wait: true },
+			]);
+		});
+
+		test('does not recreate an existing collection', async () => {
+			await service.ensureCollection(3);
+
+			expect(client.createCollection).not.toHaveBeenCalled();
+		});
+
+		test('is a no-op on repeat calls for the same dimension', async () => {
+			await service.ensureCollection(3);
+			await service.ensureCollection(3);
+
+			expect(client.collectionExists).toHaveBeenCalledTimes(1);
+			expect(client.createPayloadIndex).toHaveBeenCalledTimes(3);
+		});
+
+		test('throws a user error when the collection has a different vector size', async () => {
+			client.getCollection.mockResolvedValue(collectionInfo(768));
+
+			await expect(service.ensureCollection(1536)).rejects.toThrow(
+				/stores 768-dimensional vectors but the configured embedding model produces 1536/,
+			);
+			expect(client.createPayloadIndex).not.toHaveBeenCalled();
+		});
+
+		test('reads the vector size of a named-vector collection', async () => {
+			client.getCollection.mockResolvedValue({
+				config: { params: { vectors: { dense: { size: 768 } } } },
+			});
+
+			await expect(service.ensureCollection(1536)).rejects.toThrow('stores 768-dimensional');
+		});
+
+		test('tolerates a collection created concurrently', async () => {
+			client.collectionExists.mockResolvedValueOnce({ exists: false });
+			client.createCollection.mockRejectedValue(new Error('Conflict'));
+			client.collectionExists.mockResolvedValueOnce({ exists: true });
+
+			await expect(service.ensureCollection(3)).resolves.toBeUndefined();
+			expect(client.getCollection).toHaveBeenCalledWith(COLLECTION);
+		});
+
+		test('rethrows when the collection is still missing after a failed create', async () => {
+			client.collectionExists.mockResolvedValue({ exists: false });
+			client.createCollection.mockRejectedValue(new Error('Unauthorized'));
+
+			await expect(service.ensureCollection(3)).rejects.toThrow('Unauthorized');
+		});
+	});
+
+	describe('upsertChunks', () => {
+		const point = (id: string) => ({ id, vector: [1, 2, 3], payload: { sourceId: 'source-1' } });
+
+		test('does nothing for an empty list', async () => {
+			await service.upsertChunks([]);
+
+			expect(client.upsert).not.toHaveBeenCalled();
+		});
+
+		test('upserts in a single batch and waits for the write', async () => {
+			const points = [point('a'), point('b')];
+
+			await service.upsertChunks(points);
+
+			expect(client.upsert).toHaveBeenCalledTimes(1);
+			expect(client.upsert).toHaveBeenCalledWith(COLLECTION, { wait: true, points });
+		});
+
+		test('splits large writes into batches of 200', async () => {
+			const points = Array.from({ length: 450 }, (_, index) => point(`p-${index}`));
+
+			await service.upsertChunks(points);
+
+			expect(client.upsert).toHaveBeenCalledTimes(3);
+			expect(client.upsert.mock.calls.map(([, args]) => args.points.length)).toEqual([
+				200, 200, 50,
+			]);
+		});
+	});
+
+	describe('deletes', () => {
+		test('deleteByDocumentId filters on the source and the document', async () => {
+			await service.deleteByDocumentId('source-1', 'doc-1');
+
+			expect(client.delete).toHaveBeenCalledWith(COLLECTION, {
+				wait: true,
+				filter: {
+					must: [
+						{ key: 'sourceId', match: { value: 'source-1' } },
+						{ key: 'documentId', match: { value: 'doc-1' } },
+					],
+				},
+			});
+		});
+
+		test('deleteBySourceId filters on the source only', async () => {
+			await service.deleteBySourceId('source-1');
+
+			expect(client.delete).toHaveBeenCalledWith(COLLECTION, {
+				wait: true,
+				filter: { must: [{ key: 'sourceId', match: { value: 'source-1' } }] },
+			});
+		});
+
+		test('deleteByExternalIds keeps the delete scoped to the source', async () => {
+			await service.deleteByExternalIds('source-1', ['issue:1', 'issue:2']);
+
+			expect(client.delete).toHaveBeenCalledWith(COLLECTION, {
+				wait: true,
+				filter: {
+					must: [
+						{ key: 'sourceId', match: { value: 'source-1' } },
+						// eslint-disable-next-line id-denylist -- Qdrant's match-schema field name
+						{ key: 'externalId', match: { any: ['issue:1', 'issue:2'] } },
+					],
+				},
+			});
+		});
+
+		test('deleteByExternalIds does nothing for an empty list', async () => {
+			await service.deleteByExternalIds('source-1', []);
+
+			expect(client.delete).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('search', () => {
+		test('always scopes the query to the given source ids', async () => {
+			await service.search([0.1, 0.2], { sourceIds: ['source-1', 'source-2'], topK: 5 });
+
+			expect(client.query).toHaveBeenCalledWith(COLLECTION, {
+				query: [0.1, 0.2],
+				limit: 5,
+				with_payload: true,
+				filter: {
+					// eslint-disable-next-line id-denylist -- Qdrant's match-schema field name
+					must: [{ key: 'sourceId', match: { any: ['source-1', 'source-2'] } }],
+				},
+			});
+		});
+
+		test('returns no hits and queries nothing when no source is allowed', async () => {
+			await expect(service.search([0.1], { sourceIds: [], topK: 5 })).resolves.toEqual([]);
+
+			expect(client.query).not.toHaveBeenCalled();
+		});
+
+		test('maps the returned points', async () => {
+			client.query.mockResolvedValue({
+				points: [
+					{ id: 'point-1', score: 0.92, payload: { text: 'hello', sourceId: 'source-1' } },
+					{ id: 7, score: 0.4, payload: null },
+				],
+			});
+
+			await expect(service.search([0.1], { sourceIds: ['source-1'], topK: 2 })).resolves.toEqual([
+				{ id: 'point-1', score: 0.92, payload: { text: 'hello', sourceId: 'source-1' } },
+				{ id: '7', score: 0.4, payload: {} },
+			]);
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/__tests__/knowledge.controller.test.ts
+++ b/packages/cli/src/modules/knowledge/__tests__/knowledge.controller.test.ts
@@ -1,0 +1,247 @@
+import {
+	CreateKnowledgeSourceDto,
+	SearchKnowledgeDto,
+	SyncKnowledgeSourceDto,
+	UpdateKnowledgeSourceDto,
+} from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import type { Response } from 'express';
+import { UserError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import type { KnowledgeConnectorRegistry } from '../connectors/connector-registry';
+import type { KnowledgeConnector } from '../connectors/connector.types';
+import type { KnowledgeSource } from '../database/entities';
+import type {
+	KnowledgeDocumentRepository,
+	KnowledgeSourceRepository,
+	KnowledgeSyncRunRepository,
+} from '../database/repositories';
+import { KnowledgeSourceNotFoundError, KnowledgeSyncInProgressError } from '../errors';
+import type { KnowledgeSearchService } from '../knowledge-search.service';
+import type { KnowledgeSettingsService } from '../knowledge-settings.service';
+import type { KnowledgeSyncService } from '../knowledge-sync.service';
+import { KnowledgeController } from '../knowledge.controller';
+
+const req = mock<AuthenticatedRequest>();
+const res = mock<Response>();
+
+const makeSource = (overrides: Partial<KnowledgeSource> = {}): KnowledgeSource =>
+	Object.assign(mock<KnowledgeSource>(), {
+		id: 'source-1',
+		name: 'Docs',
+		type: 'github' as const,
+		credentialId: 'cred-1',
+		config: { owner: 'n8n-io', repo: 'n8n' },
+		status: 'ready' as const,
+		lastSyncedAt: null,
+		lastError: null,
+		checkpoint: null,
+		...overrides,
+	});
+
+const makeConnector = (overrides: Partial<KnowledgeConnector> = {}): KnowledgeConnector => ({
+	type: 'github',
+	requiresCredential: true,
+	parseConfig: vi.fn((config: unknown) => ({ ...(config as Record<string, unknown>) })),
+	sync: vi.fn(),
+	...overrides,
+});
+
+describe('KnowledgeController', () => {
+	const settingsService = mock<KnowledgeSettingsService>();
+	const searchService = mock<KnowledgeSearchService>();
+	const syncService = mock<KnowledgeSyncService>();
+	const connectorRegistry = mock<KnowledgeConnectorRegistry>();
+	const sourceRepository = mock<KnowledgeSourceRepository>();
+	const documentRepository = mock<KnowledgeDocumentRepository>();
+	const syncRunRepository = mock<KnowledgeSyncRunRepository>();
+
+	let controller: KnowledgeController;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		documentRepository.countBySource.mockResolvedValue(3);
+		connectorRegistry.getConnector.mockReturnValue(makeConnector());
+		controller = new KnowledgeController(
+			settingsService,
+			searchService,
+			syncService,
+			connectorRegistry,
+			sourceRepository,
+			documentRepository,
+			syncRunRepository,
+		);
+	});
+
+	describe('listSources', () => {
+		it('returns the sources with their document counts', async () => {
+			sourceRepository.findAllSources.mockResolvedValue([makeSource()]);
+
+			await expect(controller.listSources()).resolves.toEqual([
+				{
+					id: 'source-1',
+					name: 'Docs',
+					type: 'github',
+					status: 'ready',
+					lastSyncedAt: null,
+					lastError: null,
+					documentCount: 3,
+				},
+			]);
+		});
+	});
+
+	describe('createSource', () => {
+		it('validates the config through the connector and stores a pending source', async () => {
+			const connector = makeConnector();
+			connectorRegistry.getConnector.mockReturnValue(connector);
+			sourceRepository.create.mockReturnValue(makeSource({ status: 'pending' }));
+			sourceRepository.save.mockResolvedValue(makeSource({ status: 'pending' }));
+
+			const result = await controller.createSource(
+				req,
+				res,
+				new CreateKnowledgeSourceDto({
+					name: 'Docs',
+					type: 'github',
+					credentialId: 'cred-1',
+					config: { owner: 'n8n-io', repo: 'n8n' },
+				}),
+			);
+
+			expect(connector.parseConfig).toHaveBeenCalledWith({ owner: 'n8n-io', repo: 'n8n' });
+			expect(sourceRepository.create).toHaveBeenCalledWith({
+				name: 'Docs',
+				type: 'github',
+				credentialId: 'cred-1',
+				config: { owner: 'n8n-io', repo: 'n8n' },
+				status: 'pending',
+			});
+			expect(result).toMatchObject({ id: 'source-1', status: 'pending' });
+		});
+
+		it('rejects a source that needs a credential without one', async () => {
+			await expect(
+				controller.createSource(
+					req,
+					res,
+					new CreateKnowledgeSourceDto({ name: 'Docs', type: 'github', config: {} }),
+				),
+			).rejects.toThrow(BadRequestError);
+			expect(sourceRepository.save).not.toHaveBeenCalled();
+		});
+
+		it('turns an invalid config into a bad request', async () => {
+			connectorRegistry.getConnector.mockReturnValue(
+				makeConnector({
+					parseConfig: vi.fn(() => {
+						throw new UserError('Invalid GitHub knowledge source configuration: owner: required');
+					}),
+				}),
+			);
+
+			await expect(
+				controller.createSource(
+					req,
+					res,
+					new CreateKnowledgeSourceDto({
+						name: 'Docs',
+						type: 'github',
+						credentialId: 'cred-1',
+						config: {},
+					}),
+				),
+			).rejects.toThrow(BadRequestError);
+		});
+	});
+
+	describe('updateSource', () => {
+		it('re-validates the config against the stored connector', async () => {
+			const source = makeSource();
+			sourceRepository.findSourceById.mockResolvedValue(source);
+			sourceRepository.save.mockResolvedValue(source);
+			const connector = makeConnector();
+			connectorRegistry.getConnector.mockReturnValue(connector);
+
+			await controller.updateSource(
+				req,
+				res,
+				'source-1',
+				new UpdateKnowledgeSourceDto({
+					name: 'Renamed',
+					config: { owner: 'n8n-io', repo: 'docs' },
+				}),
+			);
+
+			expect(connector.parseConfig).toHaveBeenCalledWith({ owner: 'n8n-io', repo: 'docs' });
+			expect(sourceRepository.save).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'Renamed', config: { owner: 'n8n-io', repo: 'docs' } }),
+			);
+		});
+
+		it('is a 404 for an unknown source', async () => {
+			sourceRepository.findSourceById.mockResolvedValue(null);
+
+			await expect(
+				controller.updateSource(req, res, 'missing', new UpdateKnowledgeSourceDto({})),
+			).rejects.toThrow(NotFoundError);
+		});
+	});
+
+	describe('syncSource', () => {
+		it('starts a sync and answers right away', async () => {
+			await expect(
+				controller.syncSource(req, res, 'source-1', new SyncKnowledgeSourceDto({})),
+			).resolves.toEqual({ started: true });
+			expect(syncService.triggerSync).toHaveBeenCalledWith('source-1', { fullResync: undefined });
+		});
+
+		it('is a 409 while a sync is already running', async () => {
+			syncService.triggerSync.mockRejectedValue(new KnowledgeSyncInProgressError('source-1'));
+
+			await expect(
+				controller.syncSource(req, res, 'source-1', new SyncKnowledgeSourceDto({})),
+			).rejects.toThrow(ConflictError);
+		});
+	});
+
+	describe('deleteSource', () => {
+		it('is a 404 for an unknown source', async () => {
+			syncService.deleteSource.mockRejectedValue(new KnowledgeSourceNotFoundError('missing'));
+
+			await expect(controller.deleteSource(req, res, 'missing')).rejects.toThrow(NotFoundError);
+		});
+	});
+
+	describe('search', () => {
+		it('caps topK and returns the hits', async () => {
+			searchService.search.mockResolvedValue([]);
+
+			await controller.search(
+				req,
+				res,
+				new SearchKnowledgeDto({ query: 'how do I deploy?', topK: 500 }),
+			);
+
+			expect(searchService.search).toHaveBeenCalledWith('how do I deploy?', {
+				sourceIds: undefined,
+				topK: 50,
+			});
+		});
+
+		it('turns a not-configured error into a bad request', async () => {
+			searchService.search.mockRejectedValue(
+				new UserError('Knowledge connectors are not configured'),
+			);
+
+			await expect(
+				controller.search(req, res, new SearchKnowledgeDto({ query: 'anything' })),
+			).rejects.toThrow(BadRequestError);
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/connectors/__tests__/github.connector.test.ts
+++ b/packages/cli/src/modules/knowledge/connectors/__tests__/github.connector.test.ts
@@ -1,0 +1,531 @@
+import type { Logger } from '@n8n/backend-common';
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { KnowledgeSource } from '../../database/entities';
+import type {
+	ConnectorSyncContext,
+	ConnectorSyncResult,
+	KnowledgeDocumentDraft,
+} from '../connector.types';
+import { GithubKnowledgeConnector } from '../github.connector';
+
+/** Records the backoff instead of waiting it out. */
+class TestGithubConnector extends GithubKnowledgeConnector {
+	readonly sleeps: number[] = [];
+
+	protected override sleepFn = async (ms: number) => {
+		this.sleeps.push(ms);
+		await Promise.resolve();
+	};
+}
+
+interface IssuePayload {
+	number: number;
+	title: string;
+	html_url?: string;
+	state?: string;
+	body?: string | null;
+	user?: { login: string } | null;
+	labels?: Array<{ name: string }>;
+	comments?: number;
+	created_at: string;
+	updated_at: string;
+	pull_request?: { url: string };
+}
+
+interface CommentPayload {
+	user?: { login: string } | null;
+	body?: string | null;
+	created_at: string;
+}
+
+const anIssue = (over: Partial<IssuePayload> = {}): IssuePayload => ({
+	number: 1,
+	title: 'Something broke',
+	html_url: 'https://github.com/acme/docs/issues/1',
+	state: 'open',
+	body: 'Body text',
+	user: { login: 'alice' },
+	labels: [],
+	comments: 0,
+	created_at: '2024-01-01T00:00:00Z',
+	updated_at: '2024-01-05T00:00:00Z',
+	...over,
+});
+
+const aPullRequest = (over: Partial<IssuePayload> = {}): IssuePayload =>
+	anIssue({
+		number: 2,
+		title: 'Fix the thing',
+		html_url: 'https://github.com/acme/docs/pull/2',
+		pull_request: { url: 'https://api.github.com/repos/acme/docs/pulls/2' },
+		...over,
+	});
+
+const aComment = (over: Partial<CommentPayload> = {}): CommentPayload => ({
+	user: { login: 'bob' },
+	body: 'Looks fine to me',
+	created_at: '2024-01-02T00:00:00Z',
+	...over,
+});
+
+const jsonResponse = (
+	body: unknown,
+	init: { status?: number; headers?: Record<string, string> } = {},
+) =>
+	new Response(JSON.stringify(body), {
+		status: init.status ?? 200,
+		headers: { 'content-type': 'application/json', ...init.headers },
+	});
+
+const logger = mock<Logger>();
+const source = mock<KnowledgeSource>();
+
+const defaultCredential: ICredentialDataDecryptedObject = {
+	server: 'https://api.github.com',
+	user: 'octocat',
+	accessToken: 'ghp_secret',
+};
+
+const createContext = (
+	over: {
+		config?: Record<string, unknown>;
+		checkpoint?: Record<string, unknown> | null;
+		credential?: ICredentialDataDecryptedObject | null;
+		abortSignal?: AbortSignal;
+	} = {},
+): ConnectorSyncContext => {
+	source.config = over.config ?? { owner: 'acme', repo: 'docs' };
+
+	return {
+		source,
+		checkpoint: over.checkpoint ?? null,
+		credential: over.credential === undefined ? defaultCredential : over.credential,
+		logger,
+		abortSignal: over.abortSignal,
+	};
+};
+
+const urlOf = (input: RequestInfo | URL): string => {
+	if (typeof input === 'string') return input;
+
+	return input instanceof URL ? input.href : input.url;
+};
+
+/** Serves the queued responses in order; a function entry can run a side effect first. */
+const stubFetch = (queue: Array<Response | (() => Response)>) => {
+	const urls: string[] = [];
+	const inits: Array<RequestInit | undefined> = [];
+	let index = 0;
+
+	const impl: typeof globalThis.fetch = async (input, init) => {
+		const url = urlOf(input);
+		urls.push(url);
+		inits.push(init);
+
+		const next = queue[index++];
+		if (next === undefined) throw new Error(`Unexpected GitHub request: ${url}`);
+
+		return await Promise.resolve(typeof next === 'function' ? next() : next);
+	};
+
+	return { impl, urls, inits };
+};
+
+const drain = async (
+	generator: AsyncGenerator<KnowledgeDocumentDraft, ConnectorSyncResult>,
+): Promise<{ documents: KnowledgeDocumentDraft[]; result: ConnectorSyncResult }> => {
+	const documents: KnowledgeDocumentDraft[] = [];
+
+	let step = await generator.next();
+	while (!step.done) {
+		documents.push(step.value);
+		step = await generator.next();
+	}
+
+	return { documents, result: step.value };
+};
+
+describe('GithubKnowledgeConnector', () => {
+	let connector: TestGithubConnector;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		connector = new TestGithubConnector();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('is a credential-backed github connector', () => {
+		expect(connector.type).toBe('github');
+		expect(connector.requiresCredential).toBe(true);
+	});
+
+	describe('parseConfig', () => {
+		test('applies defaults', () => {
+			expect(connector.parseConfig({ owner: 'acme', repo: 'docs' })).toEqual({
+				owner: 'acme',
+				repo: 'docs',
+				includeIssues: true,
+				includePullRequests: true,
+				historyDays: 365,
+			});
+		});
+
+		test('keeps explicit values', () => {
+			expect(
+				connector.parseConfig({
+					owner: 'acme',
+					repo: 'docs',
+					includeIssues: false,
+					includePullRequests: true,
+					historyDays: 30,
+				}),
+			).toEqual({
+				owner: 'acme',
+				repo: 'docs',
+				includeIssues: false,
+				includePullRequests: true,
+				historyDays: 30,
+			});
+		});
+
+		const invalidConfigs: Array<[string, Record<string, unknown>, string]> = [
+			['an empty owner', { owner: '', repo: 'docs' }, 'owner'],
+			['a missing repo', { owner: 'acme' }, 'repo'],
+			['a zero history window', { owner: 'acme', repo: 'docs', historyDays: 0 }, 'historyDays'],
+			[
+				'a fractional history window',
+				{ owner: 'acme', repo: 'docs', historyDays: 1.5 },
+				'historyDays',
+			],
+			[
+				'a wrongly typed flag',
+				{ owner: 'acme', repo: 'docs', includeIssues: 'yes' },
+				'includeIssues',
+			],
+		];
+
+		test.each(invalidConfigs)('rejects %s', (_label, config, mentioned) => {
+			expect(() => connector.parseConfig(config)).toThrow(UserError);
+			expect(() => connector.parseConfig(config)).toThrow(mentioned);
+		});
+
+		test('rejects a non-object config', () => {
+			expect(() => connector.parseConfig(null)).toThrow(UserError);
+		});
+	});
+
+	describe('sync', () => {
+		test('pages through issues until an empty page comes back', async () => {
+			const { impl, urls, inits } = stubFetch([
+				jsonResponse([anIssue({ number: 1 })]),
+				jsonResponse([anIssue({ number: 2, updated_at: '2024-01-06T00:00:00Z' })]),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			const { documents, result } = await drain(connector.sync(createContext()));
+
+			expect(documents.map((doc) => doc.externalId)).toEqual(['issue:1', 'issue:2']);
+			expect(urls).toHaveLength(3);
+			expect(urls[0]).toContain('https://api.github.com/repos/acme/docs/issues?');
+			expect(urls[0]).toContain('state=all&sort=updated&direction=asc');
+			expect(urls[0]).toContain('per_page=100&page=1');
+			expect(urls[1]).toContain('per_page=100&page=2');
+			expect(urls[2]).toContain('per_page=100&page=3');
+			expect(result.checkpoint).toEqual({ since: '2024-01-06T00:00:00Z' });
+
+			const headers = new Headers(inits[0]?.headers);
+			expect(headers.get('authorization')).toBe('Bearer ghp_secret');
+			expect(headers.get('accept')).toBe('application/vnd.github+json');
+			expect(headers.get('x-github-api-version')).toBe('2022-11-28');
+			expect(headers.get('user-agent')).toBe('n8n-knowledge');
+		});
+
+		test('trims a trailing slash off the configured server', async () => {
+			const { impl, urls } = stubFetch([jsonResponse([])]);
+			connector.fetchImpl = impl;
+
+			await drain(
+				connector.sync(
+					createContext({
+						credential: { ...defaultCredential, server: 'https://github.acme.com/api/v3/' },
+					}),
+				),
+			);
+
+			expect(urls[0]).toContain('https://github.acme.com/api/v3/repos/acme/docs/issues?');
+		});
+
+		test('skips pull requests when they are excluded', async () => {
+			const { impl } = stubFetch([
+				jsonResponse([anIssue({ number: 1 }), aPullRequest({ number: 2 })]),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			const { documents } = await drain(
+				connector.sync(
+					createContext({ config: { owner: 'acme', repo: 'docs', includePullRequests: false } }),
+				),
+			);
+
+			expect(documents.map((doc) => doc.externalId)).toEqual(['issue:1']);
+		});
+
+		test('skips plain issues when they are excluded', async () => {
+			const { impl } = stubFetch([
+				jsonResponse([anIssue({ number: 1 }), aPullRequest({ number: 2 })]),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			const { documents } = await drain(
+				connector.sync(
+					createContext({ config: { owner: 'acme', repo: 'docs', includeIssues: false } }),
+				),
+			);
+
+			expect(documents).toHaveLength(1);
+			expect(documents[0].externalId).toBe('pr:2');
+			expect(documents[0].metadata.kind).toBe('pr');
+			expect(documents[0].url).toBe('https://github.com/acme/docs/pull/2');
+		});
+
+		test('assembles the document text from the issue and its comments', async () => {
+			const { impl, urls } = stubFetch([
+				jsonResponse([
+					anIssue({
+						number: 7,
+						title: 'Search is slow',
+						html_url: 'https://github.com/acme/docs/issues/7',
+						labels: [{ name: 'bug' }, { name: 'ui' }],
+						comments: 2,
+					}),
+				]),
+				jsonResponse([
+					aComment(),
+					aComment({
+						user: { login: 'carol' },
+						body: 'Fixed in main',
+						created_at: '2024-01-03T00:00:00Z',
+					}),
+				]),
+				jsonResponse([]),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			const { documents } = await drain(connector.sync(createContext()));
+
+			expect(urls[1]).toBe(
+				'https://api.github.com/repos/acme/docs/issues/7/comments?per_page=100&page=1',
+			);
+			expect(urls[2]).toContain('/issues/7/comments?per_page=100&page=2');
+			expect(documents).toHaveLength(1);
+			expect(documents[0]).toEqual({
+				externalId: 'issue:7',
+				title: '#7 Search is slow',
+				url: 'https://github.com/acme/docs/issues/7',
+				text: [
+					'Issue #7 (open) by @alice | labels: bug, ui | created: 2024-01-01T00:00:00Z | updated: 2024-01-05T00:00:00Z',
+					'',
+					'Body text',
+					'',
+					'--- @bob (2024-01-02T00:00:00Z):',
+					'Looks fine to me',
+					'',
+					'--- @carol (2024-01-03T00:00:00Z):',
+					'Fixed in main',
+				].join('\n'),
+				metadata: {
+					kind: 'issue',
+					number: 7,
+					state: 'open',
+					author: 'alice',
+					labels: 'bug, ui',
+					repo: 'acme/docs',
+				},
+				sourceUpdatedAt: new Date('2024-01-05T00:00:00Z'),
+			});
+		});
+
+		test('does not fetch comments for items without any', async () => {
+			const { impl, urls } = stubFetch([
+				jsonResponse([anIssue({ comments: 0, body: null })]),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			const { documents } = await drain(connector.sync(createContext()));
+
+			expect(urls.every((url) => !url.includes('/comments'))).toBe(true);
+			expect(documents[0].text).toContain('(no description)');
+		});
+
+		test('uses the history horizon on the first sync', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2024-06-01T00:00:00Z'));
+
+			const { impl, urls } = stubFetch([jsonResponse([])]);
+			connector.fetchImpl = impl;
+
+			const { result } = await drain(
+				connector.sync(createContext({ config: { owner: 'acme', repo: 'docs', historyDays: 10 } })),
+			);
+
+			expect(urls[0]).toContain(`since=${encodeURIComponent('2024-05-22T00:00:00.000Z')}`);
+			expect(result.checkpoint).toEqual({ since: '2024-05-22T00:00:00.000Z' });
+		});
+
+		test('resumes from the stored checkpoint on later syncs', async () => {
+			const { impl, urls } = stubFetch([
+				jsonResponse([anIssue({ updated_at: '2024-05-20T10:00:00Z' })]),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			const { result } = await drain(
+				connector.sync(createContext({ checkpoint: { since: '2024-05-01T00:00:00.000Z' } })),
+			);
+
+			expect(urls[0]).toContain(`since=${encodeURIComponent('2024-05-01T00:00:00.000Z')}`);
+			expect(result.checkpoint).toEqual({ since: '2024-05-20T10:00:00Z' });
+		});
+
+		test('keeps the previous checkpoint when nothing changed', async () => {
+			const { impl } = stubFetch([jsonResponse([])]);
+			connector.fetchImpl = impl;
+
+			const { result } = await drain(
+				connector.sync(createContext({ checkpoint: { since: '2024-05-01T00:00:00.000Z' } })),
+			);
+
+			expect(result.checkpoint).toEqual({ since: '2024-05-01T00:00:00.000Z' });
+		});
+
+		test('retries once the rate limit window is reported as exhausted', async () => {
+			const resetAt = Math.floor(Date.now() / 1000) + 5;
+			const { impl, urls } = stubFetch([
+				jsonResponse(
+					{ message: 'API rate limit exceeded' },
+					{
+						status: 403,
+						headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': `${resetAt}` },
+					},
+				),
+				jsonResponse([anIssue()]),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			const { documents } = await drain(connector.sync(createContext()));
+
+			expect(documents).toHaveLength(1);
+			expect(urls).toHaveLength(3);
+			expect(connector.sleeps).toHaveLength(1);
+			expect(connector.sleeps[0]).toBeGreaterThan(0);
+			expect(connector.sleeps[0]).toBeLessThanOrEqual(5_000);
+			expect(logger.warn).toHaveBeenCalled();
+		});
+
+		test('caps the retry wait at a minute', async () => {
+			const { impl } = stubFetch([
+				jsonResponse({}, { status: 429, headers: { 'retry-after': '600' } }),
+				jsonResponse([]),
+			]);
+			connector.fetchImpl = impl;
+
+			await drain(connector.sync(createContext()));
+
+			expect(connector.sleeps).toEqual([60_000]);
+		});
+
+		test('gives up after three throttled attempts', async () => {
+			const throttled = () => jsonResponse({}, { status: 429, headers: { 'retry-after': '1' } });
+			const { impl, urls } = stubFetch([throttled, throttled, throttled]);
+			connector.fetchImpl = impl;
+
+			await expect(drain(connector.sync(createContext()))).rejects.toThrow(OperationalError);
+			expect(urls).toHaveLength(3);
+			expect(connector.sleeps).toEqual([1_000, 1_000]);
+		});
+
+		test('reports an unauthorized credential as a user error', async () => {
+			const { impl } = stubFetch([jsonResponse({ message: 'Bad credentials' }, { status: 401 })]);
+			connector.fetchImpl = impl;
+
+			await expect(drain(connector.sync(createContext()))).rejects.toThrow(
+				'GitHub credential is invalid or lacks access',
+			);
+		});
+
+		test('reports an unreachable repository as a user error', async () => {
+			const { impl } = stubFetch([jsonResponse({ message: 'Not Found' }, { status: 404 })]);
+			connector.fetchImpl = impl;
+
+			const error = await drain(connector.sync(createContext())).catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(UserError);
+			expect(error).toHaveProperty('message', expect.stringContaining('acme/docs'));
+		});
+
+		test('reports other failures as operational errors', async () => {
+			const { impl } = stubFetch([jsonResponse({ message: 'Server error' }, { status: 500 })]);
+			connector.fetchImpl = impl;
+
+			const error = await drain(connector.sync(createContext())).catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(OperationalError);
+			expect(error).toHaveProperty('message', expect.stringContaining('status 500'));
+		});
+
+		test('rejects a response that is not a list of issues', async () => {
+			const { impl } = stubFetch([jsonResponse({ message: 'unexpected' })]);
+			connector.fetchImpl = impl;
+
+			await expect(drain(connector.sync(createContext()))).rejects.toThrow(OperationalError);
+		});
+
+		test('requires an access token on the credential', async () => {
+			const { impl } = stubFetch([]);
+			connector.fetchImpl = impl;
+
+			await expect(
+				drain(connector.sync(createContext({ credential: { server: 'https://api.github.com' } }))),
+			).rejects.toThrow('The GitHub credential is missing an access token');
+		});
+
+		test('stops at the next page boundary once aborted', async () => {
+			const controller = new AbortController();
+			const { impl, urls } = stubFetch([
+				() => {
+					controller.abort();
+					return jsonResponse([anIssue()]);
+				},
+			]);
+			connector.fetchImpl = impl;
+
+			const generator = connector.sync(createContext({ abortSignal: controller.signal }));
+
+			await expect(generator.next()).resolves.toMatchObject({ done: false });
+			await expect(generator.next()).rejects.toThrow('Sync aborted');
+			expect(urls).toHaveLength(1);
+		});
+
+		test('does not fetch at all when aborted upfront', async () => {
+			const { impl, urls } = stubFetch([]);
+			connector.fetchImpl = impl;
+
+			const generator = connector.sync(createContext({ abortSignal: AbortSignal.abort() }));
+
+			await expect(generator.next()).rejects.toThrow(OperationalError);
+			expect(urls).toHaveLength(0);
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/connectors/__tests__/n8n.connector.test.ts
+++ b/packages/cli/src/modules/knowledge/connectors/__tests__/n8n.connector.test.ts
@@ -1,0 +1,453 @@
+import { ModuleRegistry } from '@n8n/backend-common';
+import type { Logger } from '@n8n/backend-common';
+import type {
+	CredentialsEntity,
+	CredentialsRepository,
+	TagEntity,
+	WorkflowEntity,
+	WorkflowRepository,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+import { STICKY_NODE_TYPE, UserError, type INode } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { DataTableColumn } from '@/modules/data-table/data-table-column.entity';
+import type { DataTable } from '@/modules/data-table/data-table.entity';
+import type { DataTableRepository } from '@/modules/data-table/data-table.repository';
+
+import type { KnowledgeSource } from '../../database/entities';
+import type {
+	ConnectorSyncContext,
+	ConnectorSyncResult,
+	KnowledgeDocumentDraft,
+} from '../connector.types';
+import { N8nKnowledgeConnector } from '../n8n.connector';
+
+const SECRET_PARAMETER = 'xoxb-super-secret-token';
+const ENCRYPTED_BLOB = 'U2FsdGVkX1+encrypted-credential-blob';
+
+const node = (over: Partial<INode> = {}): INode => ({
+	id: 'node-1',
+	name: 'Send message',
+	type: 'n8n-nodes-base.slack',
+	typeVersion: 2.2,
+	position: [0, 0],
+	parameters: { token: SECRET_PARAMETER, channel: '#finance-private' },
+	...over,
+});
+
+const stickyNote = (content: string): INode =>
+	node({
+		id: 'sticky-1',
+		name: 'Sticky Note',
+		type: STICKY_NODE_TYPE,
+		parameters: { content },
+	});
+
+/**
+ * `mock<T>(values)` re-proxies nested values, which turns a `Date` into something
+ * that no longer compares as one, so the real values are assigned on top instead.
+ */
+const fixture = <T extends object>(values: Partial<T>): T => Object.assign(mock<T>(), values);
+
+const tag = (name: string) => fixture<TagEntity>({ id: `tag-${name}`, name });
+
+const workflow = (over: Partial<WorkflowEntity> = {}) =>
+	fixture<WorkflowEntity>({
+		id: 'wf-1',
+		name: 'Daily digest',
+		activeVersionId: null,
+		nodes: [],
+		tags: [],
+		updatedAt: new Date('2024-05-01T10:00:00.000Z'),
+		...over,
+	});
+
+const column = (name: string, type: DataTableColumn['type'], index: number) =>
+	fixture<DataTableColumn>({ id: `col-${name}`, name, type, index });
+
+const dataTable = (over: Partial<DataTable> = {}) =>
+	fixture<DataTable>({
+		id: 'dt-1',
+		name: 'Customers',
+		projectId: 'project-1',
+		columns: [],
+		updatedAt: new Date('2024-05-02T10:00:00.000Z'),
+		...over,
+	});
+
+const credential = (over: Partial<CredentialsEntity> = {}) =>
+	fixture<CredentialsEntity>({
+		id: 'cred-1',
+		name: 'Slack account',
+		type: 'slackApi',
+		// Present on the fixture on purpose: the drafts must never carry it.
+		data: ENCRYPTED_BLOB,
+		updatedAt: new Date('2024-05-03T10:00:00.000Z'),
+		...over,
+	});
+
+describe('N8nKnowledgeConnector', () => {
+	const workflowRepository = mock<WorkflowRepository>();
+	const credentialsRepository = mock<CredentialsRepository>();
+	const dataTableRepository = mock<DataTableRepository>();
+	const moduleRegistry = mock<ModuleRegistry>();
+	const logger = mock<Logger>();
+
+	const connector = new N8nKnowledgeConnector(workflowRepository, credentialsRepository);
+
+	const syncContext = (
+		config: Record<string, unknown> = {},
+		over: Partial<ConnectorSyncContext> = {},
+	): ConnectorSyncContext => ({
+		source: fixture<KnowledgeSource>({
+			id: 'source-1',
+			name: 'This instance',
+			type: 'n8n',
+			config,
+		}),
+		checkpoint: null,
+		credential: null,
+		logger,
+		...over,
+	});
+
+	const drain = async (ctx: ConnectorSyncContext) => {
+		const generator = connector.sync(ctx);
+		const drafts: KnowledgeDocumentDraft[] = [];
+
+		let next = await generator.next();
+		while (!next.done) {
+			drafts.push(next.value);
+			next = await generator.next();
+		}
+
+		const result: ConnectorSyncResult = next.value;
+
+		return { drafts, result };
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		workflowRepository.find.mockResolvedValue([]);
+		credentialsRepository.find.mockResolvedValue([]);
+		dataTableRepository.find.mockResolvedValue([]);
+		moduleRegistry.isActive.mockReturnValue(false);
+
+		// The connector resolves `ModuleRegistry` and the data-table repository through
+		// the container, so both tokens are routed to their mocks here.
+		vi.spyOn(Container, 'get').mockImplementation((token: unknown) =>
+			token === ModuleRegistry ? moduleRegistry : dataTableRepository,
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('parseConfig', () => {
+		test('enables every kind by default', () => {
+			expect(connector.parseConfig({})).toEqual({
+				includeWorkflows: true,
+				includeDataTables: true,
+				includeCredentials: true,
+			});
+		});
+
+		test('keeps explicitly disabled kinds', () => {
+			expect(connector.parseConfig({ includeCredentials: false })).toEqual({
+				includeWorkflows: true,
+				includeDataTables: true,
+				includeCredentials: false,
+			});
+		});
+
+		test('throws a UserError when a flag has the wrong type', () => {
+			expect(() => connector.parseConfig({ includeWorkflows: 'yes' })).toThrow(UserError);
+		});
+	});
+
+	describe('sync - workflows', () => {
+		test('emits a workflow document with its tags, node inventory and sticky notes', async () => {
+			workflowRepository.find.mockResolvedValue([
+				workflow({
+					activeVersionId: 'version-1',
+					tags: [tag('marketing'), tag('ops')],
+					nodes: [
+						node({ id: 'node-1', name: 'Schedule', type: 'n8n-nodes-base.scheduleTrigger' }),
+						node({ id: 'node-2', name: 'Send message' }),
+						stickyNote('Runs every morning before the standup.'),
+					],
+				}),
+			]);
+
+			const { drafts } = await drain(syncContext({ includeCredentials: false }));
+
+			expect(drafts).toHaveLength(1);
+			const [draft] = drafts;
+
+			expect(draft.externalId).toBe('workflow:wf-1');
+			expect(draft.title).toBe('Daily digest');
+			expect(draft.url).toBe('/workflow/wf-1');
+			expect(draft.sourceUpdatedAt).toEqual(new Date('2024-05-01T10:00:00.000Z'));
+			expect(draft.metadata).toEqual({
+				kind: 'workflow',
+				workflowId: 'wf-1',
+				active: true,
+				nodeCount: 2,
+			});
+			expect(draft.text).toBe(
+				[
+					'Workflow "Daily digest"',
+					'Status: active',
+					'Tags: marketing, ops',
+					'Nodes:',
+					'- Schedule (n8n-nodes-base.scheduleTrigger)',
+					'- Send message (n8n-nodes-base.slack)',
+					'Notes:',
+					'- Runs every morning before the standup.',
+				].join('\n'),
+			);
+		});
+
+		test('never emits node parameters', async () => {
+			workflowRepository.find.mockResolvedValue([
+				workflow({ nodes: [node(), stickyNote('Documented on purpose.')] }),
+			]);
+
+			const { drafts } = await drain(syncContext({ includeCredentials: false }));
+
+			const serialized = JSON.stringify(drafts);
+			expect(serialized).not.toContain(SECRET_PARAMETER);
+			expect(serialized).not.toContain('#finance-private');
+			// Sticky notes are the one exception - their content is user documentation.
+			expect(serialized).toContain('Documented on purpose.');
+		});
+
+		test('marks a workflow without a published version as inactive', async () => {
+			workflowRepository.find.mockResolvedValue([workflow()]);
+
+			const { drafts } = await drain(syncContext({ includeCredentials: false }));
+
+			expect(drafts[0].text).toContain('Status: inactive');
+			expect(drafts[0].metadata.active).toBe(false);
+		});
+	});
+
+	describe('sync - credentials', () => {
+		test('emits metadata only, never the encrypted data blob', async () => {
+			credentialsRepository.find.mockResolvedValue([credential()]);
+
+			const { drafts } = await drain(syncContext({ includeWorkflows: false }));
+
+			expect(drafts).toHaveLength(1);
+			expect(drafts[0]).toEqual({
+				externalId: 'credential:cred-1',
+				title: 'Slack account',
+				text: 'Credential "Slack account" of type "slackApi" is available on this instance.',
+				metadata: {
+					kind: 'credential',
+					credentialId: 'cred-1',
+					credentialType: 'slackApi',
+				},
+				sourceUpdatedAt: new Date('2024-05-03T10:00:00.000Z'),
+			});
+			expect(JSON.stringify(drafts)).not.toContain(ENCRYPTED_BLOB);
+		});
+
+		test('does not even read the encrypted data column', async () => {
+			await drain(syncContext({ includeWorkflows: false }));
+
+			expect(credentialsRepository.find).toHaveBeenCalledWith(
+				expect.objectContaining({ select: ['id', 'name', 'type', 'updatedAt'] }),
+			);
+		});
+	});
+
+	describe('sync - data tables', () => {
+		test('skips data tables when the data-table module is not active', async () => {
+			const { drafts } = await drain(
+				syncContext({ includeWorkflows: false, includeCredentials: false }),
+			);
+
+			expect(moduleRegistry.isActive).toHaveBeenCalledWith('data-table');
+			expect(dataTableRepository.find).not.toHaveBeenCalled();
+			expect(drafts).toEqual([]);
+		});
+
+		test('emits a data table document with its columns when the module is active', async () => {
+			moduleRegistry.isActive.mockReturnValue(true);
+			dataTableRepository.find.mockResolvedValue([
+				dataTable({
+					columns: [column('age', 'number', 1), column('email', 'string', 0)],
+				}),
+			]);
+
+			const { drafts } = await drain(
+				syncContext({ includeWorkflows: false, includeCredentials: false }),
+			);
+
+			expect(drafts).toHaveLength(1);
+			expect(drafts[0].externalId).toBe('dataTable:dt-1');
+			expect(drafts[0].title).toBe('Customers');
+			expect(drafts[0].text).toBe(
+				[
+					'Data table "Customers"',
+					'Project: project-1',
+					'Columns:',
+					'- email (string)',
+					'- age (number)',
+				].join('\n'),
+			);
+			expect(drafts[0].metadata).toEqual({
+				kind: 'dataTable',
+				dataTableId: 'dt-1',
+				projectId: 'project-1',
+			});
+		});
+	});
+
+	describe('sync - config flags', () => {
+		test('reads nothing for the kinds the source disabled', async () => {
+			const { drafts } = await drain(
+				syncContext({
+					includeWorkflows: false,
+					includeDataTables: false,
+					includeCredentials: false,
+				}),
+			);
+
+			expect(drafts).toEqual([]);
+			expect(workflowRepository.find).not.toHaveBeenCalled();
+			expect(credentialsRepository.find).not.toHaveBeenCalled();
+			expect(moduleRegistry.isActive).not.toHaveBeenCalled();
+		});
+
+		test('emits every kind by default', async () => {
+			moduleRegistry.isActive.mockReturnValue(true);
+			workflowRepository.find.mockResolvedValue([workflow()]);
+			dataTableRepository.find.mockResolvedValue([dataTable()]);
+			credentialsRepository.find.mockResolvedValue([credential()]);
+
+			const { drafts } = await drain(syncContext());
+
+			expect(drafts.map(({ externalId }) => externalId)).toEqual([
+				'workflow:wf-1',
+				'dataTable:dt-1',
+				'credential:cred-1',
+			]);
+		});
+	});
+
+	describe('sync - checkpoint', () => {
+		test('returns the newest updatedAt it emitted', async () => {
+			workflowRepository.find.mockResolvedValue([
+				workflow({ id: 'wf-old', updatedAt: new Date('2024-05-01T10:00:00.000Z') }),
+				workflow({ id: 'wf-new', updatedAt: new Date('2024-06-09T08:30:00.000Z') }),
+			]);
+			credentialsRepository.find.mockResolvedValue([
+				credential({ updatedAt: new Date('2024-05-03T10:00:00.000Z') }),
+			]);
+
+			const { result } = await drain(syncContext({ includeDataTables: false }));
+
+			expect(result).toEqual({ checkpoint: { since: '2024-06-09T08:30:00.000Z' } });
+		});
+
+		test('only emits entities updated after the checkpoint', async () => {
+			workflowRepository.find.mockResolvedValue([
+				workflow({ id: 'wf-stale', updatedAt: new Date('2024-05-01T10:00:00.000Z') }),
+				workflow({ id: 'wf-touched', updatedAt: new Date('2024-05-20T10:00:00.000Z') }),
+			]);
+			credentialsRepository.find.mockResolvedValue([
+				credential({ id: 'cred-stale', updatedAt: new Date('2024-05-03T10:00:00.000Z') }),
+			]);
+
+			const { drafts, result } = await drain(
+				syncContext(
+					{ includeDataTables: false },
+					{ checkpoint: { since: '2024-05-10T00:00:00.000Z' } },
+				),
+			);
+
+			expect(drafts.map(({ externalId }) => externalId)).toEqual(['workflow:wf-touched']);
+			expect(result).toEqual({ checkpoint: { since: '2024-05-20T10:00:00.000Z' } });
+		});
+
+		test('carries the previous checkpoint forward when nothing changed', async () => {
+			workflowRepository.find.mockResolvedValue([
+				workflow({ updatedAt: new Date('2024-05-01T10:00:00.000Z') }),
+			]);
+
+			const { drafts, result } = await drain(
+				syncContext(
+					{ includeDataTables: false, includeCredentials: false },
+					{ checkpoint: { since: '2024-05-10T00:00:00.000Z' } },
+				),
+			);
+
+			expect(drafts).toEqual([]);
+			expect(result).toEqual({ checkpoint: { since: '2024-05-10T00:00:00.000Z' } });
+		});
+
+		test('ignores an unreadable checkpoint and resyncs everything', async () => {
+			workflowRepository.find.mockResolvedValue([workflow()]);
+
+			const { drafts } = await drain(
+				syncContext(
+					{ includeDataTables: false, includeCredentials: false },
+					{ checkpoint: { since: 'not-a-date' } },
+				),
+			);
+
+			expect(drafts).toHaveLength(1);
+		});
+	});
+
+	describe('sync - abort', () => {
+		test('stops with an error when the abort signal fires', async () => {
+			const controller = new AbortController();
+			controller.abort();
+
+			await expect(drain(syncContext({}, { abortSignal: controller.signal }))).rejects.toThrow(
+				'aborted',
+			);
+			expect(workflowRepository.find).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('listExternalIds', () => {
+		test('enumerates the ids of every enabled kind', async () => {
+			moduleRegistry.isActive.mockReturnValue(true);
+			workflowRepository.find.mockResolvedValue([
+				workflow({ id: 'wf-1' }),
+				workflow({ id: 'wf-2' }),
+			]);
+			dataTableRepository.find.mockResolvedValue([dataTable({ id: 'dt-1' })]);
+			credentialsRepository.find.mockResolvedValue([credential({ id: 'cred-1' })]);
+
+			await expect(connector.listExternalIds(syncContext())).resolves.toEqual([
+				'workflow:wf-1',
+				'workflow:wf-2',
+				'dataTable:dt-1',
+				'credential:cred-1',
+			]);
+
+			expect(workflowRepository.find).toHaveBeenCalledWith(
+				expect.objectContaining({ select: ['id'] }),
+			);
+		});
+
+		test('leaves out the kinds the source disabled and an inactive data-table module', async () => {
+			workflowRepository.find.mockResolvedValue([workflow({ id: 'wf-1' })]);
+
+			await expect(
+				connector.listExternalIds(syncContext({ includeCredentials: false })),
+			).resolves.toEqual(['workflow:wf-1']);
+
+			expect(dataTableRepository.find).not.toHaveBeenCalled();
+			expect(credentialsRepository.find).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/connectors/connector-registry.ts
+++ b/packages/cli/src/modules/knowledge/connectors/connector-registry.ts
@@ -1,0 +1,37 @@
+import { Service } from '@n8n/di';
+import { UserError } from 'n8n-workflow';
+
+import type { KnowledgeConnector } from './connector.types';
+import { GithubKnowledgeConnector } from './github.connector';
+import { N8nKnowledgeConnector } from './n8n.connector';
+import { KNOWLEDGE_SOURCE_TYPES } from '../knowledge.constants';
+
+/**
+ * Single lookup from a source's `type` to the connector that can sync it.
+ * Connectors are constructor-injected, so adding one means adding it here and
+ * to `KNOWLEDGE_SOURCE_TYPES`.
+ */
+@Service()
+export class KnowledgeConnectorRegistry {
+	/** Keyed by plain string so callers can hand over unvalidated input. */
+	private readonly connectors: Map<string, KnowledgeConnector>;
+
+	constructor(githubConnector: GithubKnowledgeConnector, n8nConnector: N8nKnowledgeConnector) {
+		this.connectors = new Map<string, KnowledgeConnector>([
+			[githubConnector.type, githubConnector],
+			[n8nConnector.type, n8nConnector],
+		]);
+	}
+
+	getConnector(type: string): KnowledgeConnector {
+		const connector = this.connectors.get(type);
+
+		if (!connector) {
+			throw new UserError(
+				`Unknown knowledge source type: '${type}'. Supported types: ${KNOWLEDGE_SOURCE_TYPES.join(', ')}`,
+			);
+		}
+
+		return connector;
+	}
+}

--- a/packages/cli/src/modules/knowledge/connectors/connector.types.ts
+++ b/packages/cli/src/modules/knowledge/connectors/connector.types.ts
@@ -1,0 +1,45 @@
+import type { Logger } from '@n8n/backend-common';
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+
+import type { KnowledgeSource } from '../database/entities';
+import type { KnowledgeSourceType } from '../knowledge.constants';
+
+export interface KnowledgeDocumentDraft {
+	/** Stable identifier within the source, e.g. 'issue:123', 'workflow:<id>' */
+	externalId: string;
+	title: string;
+	url?: string;
+	/** Full text content to be chunked and embedded */
+	text: string;
+	/** Flat metadata stored on every chunk of this document */
+	metadata: Record<string, string | number | boolean>;
+	sourceUpdatedAt?: Date;
+}
+
+export interface ConnectorSyncContext {
+	source: KnowledgeSource;
+	/** null on first (full) sync */
+	checkpoint: Record<string, unknown> | null;
+	/** Decrypted credential data, null for connectors that need none */
+	credential: ICredentialDataDecryptedObject | null;
+	logger: Logger;
+	abortSignal?: AbortSignal;
+}
+
+export interface ConnectorSyncResult {
+	checkpoint: Record<string, unknown>;
+	/** externalIds that no longer exist at the source (used to prune); omit if unknown */
+	deletedExternalIds?: string[];
+}
+
+export interface KnowledgeConnector {
+	readonly type: KnowledgeSourceType;
+	/** true when this connector requires a credential to be configured on the source */
+	readonly requiresCredential: boolean;
+	/** Parse + validate source.config; throw UserError with a clear message on invalid config */
+	parseConfig(config: unknown): Record<string, unknown>;
+	/** Yield document drafts; return the new checkpoint. Must honor ctx.abortSignal. */
+	sync(ctx: ConnectorSyncContext): AsyncGenerator<KnowledgeDocumentDraft, ConnectorSyncResult>;
+	/** Cheap enumeration of all current externalIds at the source, for deletion pruning. Optional. */
+	listExternalIds?(ctx: ConnectorSyncContext): Promise<string[]>;
+}

--- a/packages/cli/src/modules/knowledge/connectors/github.connector.ts
+++ b/packages/cli/src/modules/knowledge/connectors/github.connector.ts
@@ -1,0 +1,351 @@
+import { Service } from '@n8n/di';
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
+import { z } from 'zod';
+
+import type {
+	ConnectorSyncContext,
+	ConnectorSyncResult,
+	KnowledgeConnector,
+	KnowledgeDocumentDraft,
+} from './connector.types';
+import type { KnowledgeSourceType } from '../knowledge.constants';
+
+const DEFAULT_SERVER = 'https://api.github.com';
+const API_VERSION = '2022-11-28';
+const USER_AGENT = 'n8n-knowledge';
+const PER_PAGE = 100;
+/** Safety valve so a misbehaving endpoint can never spin forever. */
+const MAX_PAGES = 100;
+const MAX_ATTEMPTS = 3;
+const MAX_RETRY_WAIT_MS = 60_000;
+const FALLBACK_RETRY_WAIT_MS = 1_000;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const githubConfigSchema = z.object({
+	owner: z.string().min(1),
+	repo: z.string().min(1),
+	includeIssues: z.boolean().default(true),
+	includePullRequests: z.boolean().default(true),
+	historyDays: z.number().int().positive().default(365),
+});
+
+export type GithubKnowledgeConfig = z.infer<typeof githubConfigSchema>;
+
+/** Only the fields we read; everything optional stays lenient so GitHub can add or omit keys. */
+const githubIssueSchema = z.object({
+	// eslint-disable-next-line id-denylist -- `number` is GitHub's field name
+	number: z.number(),
+	title: z.string(),
+	html_url: z.string().optional(),
+	state: z.string().optional(),
+	body: z.string().nullish(),
+	user: z.object({ login: z.string().optional() }).nullish(),
+	labels: z.array(z.union([z.string(), z.object({ name: z.string().optional() })])).optional(),
+	comments: z.number().optional(),
+	created_at: z.string(),
+	updated_at: z.string(),
+	/** Present only on pull requests — this is how the issues endpoint marks them. */
+	pull_request: z.unknown().optional(),
+});
+
+const githubCommentSchema = z.object({
+	user: z.object({ login: z.string().optional() }).nullish(),
+	body: z.string().nullish(),
+	created_at: z.string(),
+});
+
+type GithubIssue = z.infer<typeof githubIssueSchema>;
+type GithubComment = z.infer<typeof githubCommentSchema>;
+
+/**
+ * Indexes issues and pull requests of a single GitHub repository.
+ *
+ * The issues endpoint returns pull requests too, so one pass covers both kinds;
+ * `pull_request` on an item is what distinguishes them.
+ */
+@Service()
+export class GithubKnowledgeConnector implements KnowledgeConnector {
+	readonly type: KnowledgeSourceType = 'github';
+
+	readonly requiresCredential = true;
+
+	/** Overridable so tests can drive the connector without real HTTP. */
+	fetchImpl: typeof globalThis.fetch = globalThis.fetch;
+
+	/** Overridable so tests do not have to wait out rate-limit backoff. */
+	protected sleepFn: (ms: number) => Promise<void> = async (ms) => {
+		await new Promise((resolve) => setTimeout(resolve, ms));
+	};
+
+	parseConfig(config: unknown): GithubKnowledgeConfig {
+		const parsed = githubConfigSchema.safeParse(config);
+
+		if (!parsed.success) {
+			const details = parsed.error.issues
+				.map((issue) => `${issue.path.join('.') || 'config'}: ${issue.message}`)
+				.join('; ');
+
+			throw new UserError(`Invalid GitHub knowledge source configuration: ${details}`);
+		}
+
+		return parsed.data;
+	}
+
+	async *sync(
+		ctx: ConnectorSyncContext,
+	): AsyncGenerator<KnowledgeDocumentDraft, ConnectorSyncResult> {
+		const config = this.parseConfig(ctx.source.config);
+		const { server, token } = this.parseCredential(ctx.credential);
+		const repoRef = `${config.owner}/${config.repo}`;
+		const since = this.resolveSince(ctx.checkpoint, config.historyDays);
+
+		let maxUpdatedAt: string | null = null;
+
+		for (let page = 1; page <= MAX_PAGES; page++) {
+			this.assertNotAborted(ctx);
+
+			const url =
+				`${server}/repos/${config.owner}/${config.repo}/issues` +
+				`?state=all&sort=updated&direction=asc&since=${encodeURIComponent(since)}` +
+				`&per_page=${PER_PAGE}&page=${page}`;
+
+			const items = await this.fetchList(url, githubIssueSchema, token, ctx, repoRef);
+
+			if (items.length === 0) break;
+
+			for (const item of items) {
+				// Advance the cursor for every item we saw, including filtered-out ones:
+				// items arrive sorted by `updated` ascending, so anything skipped here
+				// would only be skipped again on the next run.
+				maxUpdatedAt = this.laterOf(maxUpdatedAt, item.updated_at);
+
+				const isPullRequest = item.pull_request !== undefined && item.pull_request !== null;
+
+				if (isPullRequest && !config.includePullRequests) continue;
+				if (!isPullRequest && !config.includeIssues) continue;
+
+				const comments =
+					(item.comments ?? 0) > 0
+						? await this.fetchComments(server, config, item.number, token, ctx, repoRef)
+						: [];
+
+				yield this.toDraft(item, comments, isPullRequest, repoRef);
+			}
+
+			if (page === MAX_PAGES) {
+				ctx.logger.warn(
+					`Stopped syncing "${repoRef}" at the page limit; the next sync resumes from the checkpoint`,
+					{ pages: MAX_PAGES },
+				);
+			}
+		}
+
+		return { checkpoint: { since: maxUpdatedAt ?? since } };
+	}
+
+	private async fetchComments(
+		server: string,
+		config: GithubKnowledgeConfig,
+		issueNumber: number,
+		token: string,
+		ctx: ConnectorSyncContext,
+		repoRef: string,
+	): Promise<GithubComment[]> {
+		const comments: GithubComment[] = [];
+
+		for (let page = 1; page <= MAX_PAGES; page++) {
+			this.assertNotAborted(ctx);
+
+			const url =
+				`${server}/repos/${config.owner}/${config.repo}/issues/${issueNumber}/comments` +
+				`?per_page=${PER_PAGE}&page=${page}`;
+
+			const items = await this.fetchList(url, githubCommentSchema, token, ctx, repoRef);
+
+			if (items.length === 0) break;
+
+			comments.push(...items);
+		}
+
+		return comments;
+	}
+
+	private toDraft(
+		item: GithubIssue,
+		comments: GithubComment[],
+		isPullRequest: boolean,
+		repoRef: string,
+	): KnowledgeDocumentDraft {
+		const author = item.user?.login ?? '';
+		const labels = (item.labels ?? [])
+			.map((label) => (typeof label === 'string' ? label : (label.name ?? '')))
+			.filter((label) => label !== '');
+
+		const headerParts = [
+			`${isPullRequest ? 'Pull request' : 'Issue'} #${item.number} (${item.state ?? 'unknown'}) by @${author || 'unknown'}`,
+			labels.length > 0 ? `labels: ${labels.join(', ')}` : null,
+			`created: ${item.created_at}`,
+			`updated: ${item.updated_at}`,
+		].filter((part) => part !== null);
+
+		const sections = [
+			headerParts.join(' | '),
+			item.body?.trim() ? item.body.trim() : '(no description)',
+			...comments.map(
+				(comment) =>
+					`--- @${comment.user?.login ?? 'unknown'} (${comment.created_at}):\n${comment.body?.trim() ?? ''}`,
+			),
+		];
+
+		return {
+			externalId: `${isPullRequest ? 'pr' : 'issue'}:${item.number}`,
+			title: `#${item.number} ${item.title}`,
+			url: item.html_url,
+			text: sections.join('\n\n'),
+			metadata: {
+				kind: isPullRequest ? 'pr' : 'issue',
+				// eslint-disable-next-line id-denylist -- `number` mirrors GitHub's field name
+				number: item.number,
+				state: item.state ?? '',
+				author,
+				labels: labels.join(', '),
+				repo: repoRef,
+			},
+			sourceUpdatedAt: new Date(item.updated_at),
+		};
+	}
+
+	private parseCredential(credential: ICredentialDataDecryptedObject | null): {
+		server: string;
+		token: string;
+	} {
+		const accessToken = credential?.accessToken;
+
+		if (typeof accessToken !== 'string' || accessToken.trim() === '') {
+			throw new UserError('The GitHub credential is missing an access token');
+		}
+
+		const configuredServer = credential?.server;
+		const server =
+			typeof configuredServer === 'string' && configuredServer.trim() !== ''
+				? configuredServer.trim()
+				: DEFAULT_SERVER;
+
+		return { server: server.replace(/\/+$/, ''), token: accessToken.trim() };
+	}
+
+	/** Checkpoint wins when it holds a usable date; otherwise fall back to the history horizon. */
+	private resolveSince(checkpoint: Record<string, unknown> | null, historyDays: number): string {
+		const stored = checkpoint?.since;
+
+		if (typeof stored === 'string') {
+			const parsed = new Date(stored);
+			if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+		}
+
+		return new Date(Date.now() - historyDays * MS_PER_DAY).toISOString();
+	}
+
+	private laterOf(current: string | null, candidate: string): string | null {
+		const candidateTime = new Date(candidate).getTime();
+
+		if (Number.isNaN(candidateTime)) return current;
+		if (current === null) return candidate;
+
+		return candidateTime > new Date(current).getTime() ? candidate : current;
+	}
+
+	private assertNotAborted(ctx: ConnectorSyncContext): void {
+		if (ctx.abortSignal?.aborted) throw new OperationalError('Sync aborted');
+	}
+
+	private async fetchList<T>(
+		url: string,
+		schema: z.ZodType<T>,
+		token: string,
+		ctx: ConnectorSyncContext,
+		repoRef: string,
+	): Promise<T[]> {
+		const body = await this.request(url, token, ctx, repoRef);
+		const parsed = z.array(schema).safeParse(body);
+
+		if (!parsed.success) {
+			throw new OperationalError(`GitHub returned an unexpected response shape for ${url}`);
+		}
+
+		return parsed.data;
+	}
+
+	private async request(
+		url: string,
+		token: string,
+		ctx: ConnectorSyncContext,
+		repoRef: string,
+	): Promise<unknown> {
+		for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+			const response = await this.fetchImpl(url, {
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: 'application/vnd.github+json',
+					'X-GitHub-Api-Version': API_VERSION,
+					'User-Agent': USER_AGENT,
+				},
+			});
+
+			if (response.ok) {
+				try {
+					const body: unknown = await response.json();
+					return body;
+				} catch {
+					throw new OperationalError(`GitHub returned a malformed JSON response for ${url}`);
+				}
+			}
+
+			if (response.status === 401) {
+				throw new UserError('GitHub credential is invalid or lacks access');
+			}
+
+			if (response.status === 404) {
+				throw new UserError(
+					`GitHub repository "${repoRef}" was not found, or the credential cannot access it`,
+				);
+			}
+
+			if (this.isThrottled(response) && attempt < MAX_ATTEMPTS) {
+				const waitMs = this.retryDelayMs(response.headers);
+
+				ctx.logger.warn('Throttled by GitHub, retrying after a wait', { url, attempt, waitMs });
+				await this.sleepFn(waitMs);
+				continue;
+			}
+
+			throw new OperationalError(`GitHub request failed with status ${response.status} for ${url}`);
+		}
+
+		throw new OperationalError(`GitHub request failed after ${MAX_ATTEMPTS} attempts for ${url}`);
+	}
+
+	private isThrottled(response: Response): boolean {
+		if (response.status === 429) return true;
+
+		return response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0';
+	}
+
+	private retryDelayMs(headers: Headers): number {
+		const retryAfterSeconds = Number(headers.get('retry-after'));
+
+		if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+			return Math.min(retryAfterSeconds * 1000, MAX_RETRY_WAIT_MS);
+		}
+
+		const resetEpochSeconds = Number(headers.get('x-ratelimit-reset'));
+
+		if (Number.isFinite(resetEpochSeconds) && resetEpochSeconds > 0) {
+			const waitMs = resetEpochSeconds * 1000 - Date.now();
+			return Math.min(Math.max(waitMs, 0), MAX_RETRY_WAIT_MS);
+		}
+
+		return FALLBACK_RETRY_WAIT_MS;
+	}
+}

--- a/packages/cli/src/modules/knowledge/connectors/n8n.connector.ts
+++ b/packages/cli/src/modules/knowledge/connectors/n8n.connector.ts
@@ -1,0 +1,373 @@
+import { ModuleRegistry } from '@n8n/backend-common';
+import {
+	CredentialsRepository,
+	WorkflowRepository,
+	type CredentialsEntity,
+	type WorkflowEntity,
+} from '@n8n/db';
+import { Container, Service } from '@n8n/di';
+import { OperationalError, STICKY_NODE_TYPE, UserError, type INode } from 'n8n-workflow';
+import { z } from 'zod';
+
+import type { DataTable } from '@/modules/data-table/data-table.entity';
+
+import type {
+	ConnectorSyncContext,
+	ConnectorSyncResult,
+	KnowledgeConnector,
+	KnowledgeDocumentDraft,
+} from './connector.types';
+import type { KnowledgeSourceType } from '../knowledge.constants';
+
+/** Rows read per round trip. Instance metadata is small enough that a page fits comfortably in memory. */
+const BATCH_SIZE = 100;
+
+const configSchema = z.object({
+	includeWorkflows: z.boolean().default(true),
+	includeDataTables: z.boolean().default(true),
+	includeCredentials: z.boolean().default(true),
+});
+
+export type N8nConnectorConfig = {
+	includeWorkflows: boolean;
+	includeDataTables: boolean;
+	includeCredentials: boolean;
+};
+
+/**
+ * Indexes the instance's own metadata - workflows, data tables and credentials -
+ * so an agent can answer "what exists on this n8n instance?".
+ *
+ * Only metadata is emitted, never anything that can carry a secret: credential
+ * `data` is never read, and node `parameters` are never emitted. The single
+ * exception is a sticky note's `content`, which is user-authored documentation.
+ */
+@Service()
+export class N8nKnowledgeConnector implements KnowledgeConnector {
+	readonly type: KnowledgeSourceType = 'n8n';
+
+	readonly requiresCredential = false;
+
+	constructor(
+		private readonly workflowRepository: WorkflowRepository,
+		private readonly credentialsRepository: CredentialsRepository,
+	) {}
+
+	parseConfig(config: unknown): N8nConnectorConfig {
+		const parsed = configSchema.safeParse(config ?? {});
+
+		if (!parsed.success) {
+			const issues = parsed.error.issues
+				.map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+				.join('; ');
+
+			throw new UserError(`Invalid configuration for the n8n knowledge source: ${issues}`);
+		}
+
+		return parsed.data;
+	}
+
+	async *sync(
+		ctx: ConnectorSyncContext,
+	): AsyncGenerator<KnowledgeDocumentDraft, ConnectorSyncResult> {
+		const config = this.parseConfig(ctx.source.config);
+		const since = parseSince(ctx.checkpoint);
+		const startedAt = new Date();
+
+		ctx.logger.debug('Syncing n8n instance metadata', {
+			sourceId: ctx.source.id,
+			since: since?.toISOString() ?? null,
+		});
+
+		const streams: Array<AsyncGenerator<KnowledgeDocumentDraft>> = [];
+		if (config.includeWorkflows) streams.push(this.workflowDocuments(ctx, since));
+		if (config.includeDataTables) streams.push(this.dataTableDocuments(ctx, since));
+		if (config.includeCredentials) streams.push(this.credentialDocuments(ctx, since));
+
+		let maxUpdatedAt = since;
+
+		for (const stream of streams) {
+			for await (const draft of stream) {
+				const { sourceUpdatedAt } = draft;
+				if (sourceUpdatedAt && (maxUpdatedAt === null || sourceUpdatedAt > maxUpdatedAt)) {
+					maxUpdatedAt = sourceUpdatedAt;
+				}
+
+				yield draft;
+			}
+		}
+
+		// Falling back to the sync start (rather than the epoch) keeps the next
+		// incremental run cheap on an instance that has nothing to index yet.
+		return { checkpoint: { since: (maxUpdatedAt ?? startedAt).toISOString() } };
+	}
+
+	async listExternalIds(ctx: ConnectorSyncContext): Promise<string[]> {
+		const config = this.parseConfig(ctx.source.config);
+		const externalIds: string[] = [];
+
+		if (config.includeWorkflows) {
+			externalIds.push(
+				...(await this.collectIds(
+					ctx,
+					'workflow',
+					async (skip) =>
+						await this.workflowRepository.find({
+							select: ['id'],
+							order: { id: 'ASC' },
+							take: BATCH_SIZE,
+							skip,
+						}),
+				)),
+			);
+		}
+
+		if (config.includeDataTables) {
+			const repository = await this.dataTableRepository();
+
+			if (repository) {
+				externalIds.push(
+					...(await this.collectIds(
+						ctx,
+						'dataTable',
+						async (skip) =>
+							await repository.find({
+								select: ['id'],
+								order: { id: 'ASC' },
+								take: BATCH_SIZE,
+								skip,
+							}),
+					)),
+				);
+			}
+		}
+
+		if (config.includeCredentials) {
+			externalIds.push(
+				...(await this.collectIds(
+					ctx,
+					'credential',
+					async (skip) =>
+						await this.credentialsRepository.find({
+							select: ['id'],
+							order: { id: 'ASC' },
+							take: BATCH_SIZE,
+							skip,
+						}),
+				)),
+			);
+		}
+
+		return externalIds;
+	}
+
+	private async *workflowDocuments(ctx: ConnectorSyncContext, since: Date | null) {
+		const pages = this.paginate(
+			ctx,
+			async (skip) =>
+				await this.workflowRepository.find({
+					// `nodes` is needed for the inventory; `connections`, `pinData` and
+					// `staticData` are deliberately left unread - they are large and can carry PII.
+					select: ['id', 'name', 'activeVersionId', 'nodes', 'updatedAt'],
+					relations: { tags: true },
+					order: { id: 'ASC' },
+					take: BATCH_SIZE,
+					skip,
+				}),
+		);
+
+		for await (const page of pages) {
+			for (const workflow of page) {
+				if (isUnchanged(workflow.updatedAt, since)) continue;
+
+				yield workflowDraft(workflow);
+			}
+		}
+	}
+
+	private async *dataTableDocuments(ctx: ConnectorSyncContext, since: Date | null) {
+		const repository = await this.dataTableRepository();
+
+		if (!repository) {
+			ctx.logger.debug('Skipping data tables, the data-table module is not active');
+			return;
+		}
+
+		const pages = this.paginate(
+			ctx,
+			async (skip) =>
+				await repository.find({
+					select: ['id', 'name', 'projectId', 'updatedAt'],
+					relations: { columns: true },
+					order: { id: 'ASC' },
+					take: BATCH_SIZE,
+					skip,
+				}),
+		);
+
+		for await (const page of pages) {
+			for (const dataTable of page) {
+				if (isUnchanged(dataTable.updatedAt, since)) continue;
+
+				yield dataTableDraft(dataTable);
+			}
+		}
+	}
+
+	private async *credentialDocuments(ctx: ConnectorSyncContext, since: Date | null) {
+		const pages = this.paginate(
+			ctx,
+			async (skip) =>
+				await this.credentialsRepository.find({
+					// `data` (the encrypted blob) must never be read, let alone indexed.
+					select: ['id', 'name', 'type', 'updatedAt'],
+					order: { id: 'ASC' },
+					take: BATCH_SIZE,
+					skip,
+				}),
+		);
+
+		for await (const page of pages) {
+			for (const credential of page) {
+				if (isUnchanged(credential.updatedAt, since)) continue;
+
+				yield credentialDraft(credential);
+			}
+		}
+	}
+
+	/**
+	 * Data table entities belong to the separately-enableable `data-table` module,
+	 * so the repository is resolved lazily and only while that module is active -
+	 * constructor-injecting it would break every instance running without it.
+	 */
+	private async dataTableRepository() {
+		if (!Container.get(ModuleRegistry).isActive('data-table')) return null;
+
+		const { DataTableRepository } = await import('@/modules/data-table/data-table.repository.js');
+
+		return Container.get(DataTableRepository);
+	}
+
+	/** Reads `find` page by page until it returns a short page, checking the abort signal between pages. */
+	private async *paginate<T>(
+		ctx: ConnectorSyncContext,
+		find: (skip: number) => Promise<T[]>,
+	): AsyncGenerator<T[]> {
+		for (let skip = 0; ; skip += BATCH_SIZE) {
+			if (ctx.abortSignal?.aborted) {
+				throw new OperationalError('n8n knowledge sync was aborted');
+			}
+
+			const page = await find(skip);
+			if (page.length > 0) yield page;
+			if (page.length < BATCH_SIZE) return;
+		}
+	}
+
+	private async collectIds(
+		ctx: ConnectorSyncContext,
+		prefix: string,
+		find: (skip: number) => Promise<Array<{ id: string }>>,
+	): Promise<string[]> {
+		const externalIds: string[] = [];
+
+		for await (const page of this.paginate(ctx, find)) {
+			externalIds.push(...page.map(({ id }) => `${prefix}:${id}`));
+		}
+
+		return externalIds;
+	}
+}
+
+function parseSince(checkpoint: Record<string, unknown> | null): Date | null {
+	const since = checkpoint?.since;
+	if (typeof since !== 'string') return null;
+
+	const parsed = new Date(since);
+
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function isUnchanged(updatedAt: Date | undefined, since: Date | null): boolean {
+	return since !== null && updatedAt !== undefined && updatedAt <= since;
+}
+
+/** Sticky notes are the one node whose parameters are documentation rather than configuration. */
+function stickyNoteContent(node: INode): string | null {
+	if (node.type !== STICKY_NODE_TYPE) return null;
+
+	const content = node.parameters?.content;
+
+	return typeof content === 'string' && content.trim().length > 0 ? content.trim() : null;
+}
+
+function workflowDraft(workflow: WorkflowEntity): KnowledgeDocumentDraft {
+	const inventory: string[] = [];
+	const notes: string[] = [];
+
+	for (const node of workflow.nodes ?? []) {
+		const note = stickyNoteContent(node);
+
+		if (note !== null) notes.push(`- ${note}`);
+		else inventory.push(`- ${node.name} (${node.type})`);
+	}
+
+	const active = (workflow.activeVersionId ?? null) !== null;
+	const tags = (workflow.tags ?? []).map((tag) => tag.name);
+
+	const lines = [`Workflow "${workflow.name}"`, `Status: ${active ? 'active' : 'inactive'}`];
+	if (tags.length > 0) lines.push(`Tags: ${tags.join(', ')}`);
+	if (inventory.length > 0) lines.push('Nodes:', ...inventory);
+	if (notes.length > 0) lines.push('Notes:', ...notes);
+
+	return {
+		externalId: `workflow:${workflow.id}`,
+		title: workflow.name,
+		url: `/workflow/${workflow.id}`,
+		text: lines.join('\n'),
+		metadata: {
+			kind: 'workflow',
+			workflowId: workflow.id,
+			active,
+			// Sticky notes are documentation, not steps, so they are not counted as nodes.
+			nodeCount: inventory.length,
+		},
+		sourceUpdatedAt: workflow.updatedAt,
+	};
+}
+
+function dataTableDraft(dataTable: DataTable): KnowledgeDocumentDraft {
+	const columns = [...(dataTable.columns ?? [])].sort((a, b) => a.index - b.index);
+
+	const lines = [`Data table "${dataTable.name}"`, `Project: ${dataTable.projectId}`];
+	if (columns.length > 0) {
+		lines.push('Columns:', ...columns.map((column) => `- ${column.name} (${column.type})`));
+	}
+
+	return {
+		externalId: `dataTable:${dataTable.id}`,
+		title: dataTable.name,
+		text: lines.join('\n'),
+		metadata: {
+			kind: 'dataTable',
+			dataTableId: dataTable.id,
+			projectId: dataTable.projectId,
+		},
+		sourceUpdatedAt: dataTable.updatedAt,
+	};
+}
+
+function credentialDraft(credential: CredentialsEntity): KnowledgeDocumentDraft {
+	return {
+		externalId: `credential:${credential.id}`,
+		title: credential.name,
+		text: `Credential "${credential.name}" of type "${credential.type}" is available on this instance.`,
+		metadata: {
+			kind: 'credential',
+			credentialId: credential.id,
+			credentialType: credential.type,
+		},
+		sourceUpdatedAt: credential.updatedAt,
+	};
+}

--- a/packages/cli/src/modules/knowledge/database/entities/index.ts
+++ b/packages/cli/src/modules/knowledge/database/entities/index.ts
@@ -1,0 +1,4 @@
+export { KnowledgeSource } from './knowledge-source.entity';
+export { KnowledgeDocument } from './knowledge-document.entity';
+export { KnowledgeSyncRun } from './knowledge-sync-run.entity';
+export type { KnowledgeSyncStats } from './knowledge-sync-run.entity';

--- a/packages/cli/src/modules/knowledge/database/entities/knowledge-document.entity.ts
+++ b/packages/cli/src/modules/knowledge/database/entities/knowledge-document.entity.ts
@@ -1,0 +1,42 @@
+import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from '@n8n/db';
+import { Column, Entity, Index, JoinColumn, ManyToOne, type Relation } from '@n8n/typeorm';
+
+import { KnowledgeSource } from './knowledge-source.entity';
+
+/**
+ * A document indexed from a source. Holds only the bookkeeping needed to decide
+ * whether to re-embed; the text and its vectors live in the vector store.
+ */
+@Entity({ name: 'knowledge_documents' })
+@Index(['sourceId', 'externalId'], { unique: true })
+export class KnowledgeDocument extends WithTimestampsAndStringId {
+	@ManyToOne(() => KnowledgeSource, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'sourceId' })
+	source: Relation<KnowledgeSource>;
+
+	@Column({ type: 'varchar', length: 36 })
+	sourceId: string;
+
+	/** Stable identifier within the source, e.g. `issue:123`. */
+	@Column({ type: 'varchar', length: 255 })
+	externalId: string;
+
+	@Column({ type: 'varchar', length: 512 })
+	title: string;
+
+	@Column({ type: 'varchar', length: 1024, nullable: true })
+	url: string | null;
+
+	/** Fingerprint of the indexed text; an unchanged hash lets a sync skip re-embedding. */
+	@Column({ type: 'varchar', length: 64 })
+	contentHash: string;
+
+	@Column({ type: 'int', default: 0 })
+	chunkCount: number;
+
+	@JsonColumn({ nullable: true })
+	meta: Record<string, string | number | boolean> | null;
+
+	@DateTimeColumn({ precision: 3, nullable: true })
+	sourceUpdatedAt: Date | null;
+}

--- a/packages/cli/src/modules/knowledge/database/entities/knowledge-source.entity.ts
+++ b/packages/cli/src/modules/knowledge/database/entities/knowledge-source.entity.ts
@@ -1,0 +1,35 @@
+import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from '@n8n/db';
+import { Column, Entity } from '@n8n/typeorm';
+
+import type { KnowledgeSourceStatus, KnowledgeSourceType } from '../../knowledge.constants';
+
+/** An external or internal data source that gets indexed into the vector store. */
+@Entity({ name: 'knowledge_sources' })
+export class KnowledgeSource extends WithTimestampsAndStringId {
+	@Column({ type: 'varchar', length: 128 })
+	name: string;
+
+	@Column({ type: 'varchar', length: 16 })
+	type: KnowledgeSourceType;
+
+	/** Null for connectors that need no credential, e.g. the internal `n8n` source. */
+	@Column({ type: 'varchar', length: 36, nullable: true })
+	credentialId: string | null;
+
+	/** Connector-specific settings, validated by the connector's `parseConfig`. */
+	@JsonColumn()
+	config: Record<string, unknown>;
+
+	@Column({ type: 'varchar', length: 16, default: 'pending' })
+	status: KnowledgeSourceStatus;
+
+	@DateTimeColumn({ precision: 3, nullable: true })
+	lastSyncedAt: Date | null;
+
+	/** Connector-owned cursor carried between incremental syncs; null before the first full sync. */
+	@JsonColumn({ nullable: true })
+	checkpoint: Record<string, unknown> | null;
+
+	@Column({ type: 'text', nullable: true })
+	lastError: string | null;
+}

--- a/packages/cli/src/modules/knowledge/database/entities/knowledge-sync-run.entity.ts
+++ b/packages/cli/src/modules/knowledge/database/entities/knowledge-sync-run.entity.ts
@@ -1,0 +1,43 @@
+import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from '@n8n/db';
+import { Column, Entity, Index, JoinColumn, ManyToOne, type Relation } from '@n8n/typeorm';
+
+import { KnowledgeSource } from './knowledge-source.entity';
+import type { KnowledgeSyncMode, KnowledgeSyncRunStatus } from '../../knowledge.constants';
+
+export interface KnowledgeSyncStats {
+	documentsSeen: number;
+	documentsIndexed: number;
+	documentsSkipped: number;
+	documentsDeleted: number;
+	chunksWritten: number;
+}
+
+/** One sync attempt against a source, kept for troubleshooting and for surfacing progress. */
+@Entity({ name: 'knowledge_sync_runs' })
+@Index(['sourceId', 'startedAt'])
+export class KnowledgeSyncRun extends WithTimestampsAndStringId {
+	@ManyToOne(() => KnowledgeSource, { onDelete: 'CASCADE' })
+	@JoinColumn({ name: 'sourceId' })
+	source: Relation<KnowledgeSource>;
+
+	@Column({ type: 'varchar', length: 36 })
+	sourceId: string;
+
+	@Column({ type: 'varchar', length: 16 })
+	mode: KnowledgeSyncMode;
+
+	@Column({ type: 'varchar', length: 16, default: 'running' })
+	status: KnowledgeSyncRunStatus;
+
+	@JsonColumn({ nullable: true })
+	stats: KnowledgeSyncStats | null;
+
+	@Column({ type: 'text', nullable: true })
+	error: string | null;
+
+	@DateTimeColumn({ precision: 3 })
+	startedAt: Date;
+
+	@DateTimeColumn({ precision: 3, nullable: true })
+	finishedAt: Date | null;
+}

--- a/packages/cli/src/modules/knowledge/database/repositories/index.ts
+++ b/packages/cli/src/modules/knowledge/database/repositories/index.ts
@@ -1,0 +1,5 @@
+export { KnowledgeSourceRepository } from './knowledge-source.repository';
+export type { KnowledgeSourceStatusUpdate } from './knowledge-source.repository';
+export { KnowledgeDocumentRepository } from './knowledge-document.repository';
+export type { KnowledgeDocumentUpsert } from './knowledge-document.repository';
+export { KnowledgeSyncRunRepository } from './knowledge-sync-run.repository';

--- a/packages/cli/src/modules/knowledge/database/repositories/knowledge-document.repository.ts
+++ b/packages/cli/src/modules/knowledge/database/repositories/knowledge-document.repository.ts
@@ -1,0 +1,69 @@
+import { Service } from '@n8n/di';
+import { DataSource, In, Repository } from '@n8n/typeorm';
+
+import { KnowledgeDocument } from '../entities/knowledge-document.entity';
+
+export interface KnowledgeDocumentUpsert {
+	sourceId: string;
+	externalId: string;
+	title: string;
+	url?: string | null;
+	contentHash: string;
+	chunkCount: number;
+	meta?: Record<string, string | number | boolean> | null;
+	sourceUpdatedAt?: Date | null;
+}
+
+@Service()
+export class KnowledgeDocumentRepository extends Repository<KnowledgeDocument> {
+	constructor(dataSource: DataSource) {
+		super(KnowledgeDocument, dataSource.manager);
+	}
+
+	async findBySourceAndExternalId(
+		sourceId: string,
+		externalId: string,
+	): Promise<KnowledgeDocument | null> {
+		return await this.findOneBy({ sourceId, externalId });
+	}
+
+	/** Every externalId currently indexed for a source, used to prune documents deleted at the source. */
+	async listExternalIds(sourceId: string): Promise<string[]> {
+		const rows = await this.find({ where: { sourceId }, select: ['externalId'] });
+
+		return rows.map((row) => row.externalId);
+	}
+
+	/**
+	 * Read-modify-write rather than `upsert`, so callers get the persisted row
+	 * back (chunk ids are derived from it) and the `updatedAt` hook still fires.
+	 */
+	async upsertDocument(document: KnowledgeDocumentUpsert): Promise<KnowledgeDocument> {
+		const existing = await this.findBySourceAndExternalId(document.sourceId, document.externalId);
+
+		const entity =
+			existing ?? this.create({ sourceId: document.sourceId, externalId: document.externalId });
+
+		entity.title = document.title;
+		entity.url = document.url ?? null;
+		entity.contentHash = document.contentHash;
+		entity.chunkCount = document.chunkCount;
+		entity.meta = document.meta ?? null;
+		entity.sourceUpdatedAt = document.sourceUpdatedAt ?? null;
+
+		return await this.save(entity);
+	}
+
+	/** Returns the number of rows removed. */
+	async deleteBySourceAndExternalIds(sourceId: string, externalIds: string[]): Promise<number> {
+		if (externalIds.length === 0) return 0;
+
+		const result = await this.delete({ sourceId, externalId: In(externalIds) });
+
+		return result.affected ?? 0;
+	}
+
+	async countBySource(sourceId: string): Promise<number> {
+		return await this.countBy({ sourceId });
+	}
+}

--- a/packages/cli/src/modules/knowledge/database/repositories/knowledge-source.repository.ts
+++ b/packages/cli/src/modules/knowledge/database/repositories/knowledge-source.repository.ts
@@ -1,0 +1,62 @@
+import { Service } from '@n8n/di';
+import { DataSource, IsNull, LessThan, Not, Repository } from '@n8n/typeorm';
+import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
+
+import type { KnowledgeSourceStatus } from '../../knowledge.constants';
+import { KnowledgeSource } from '../entities/knowledge-source.entity';
+
+export interface KnowledgeSourceStatusUpdate {
+	lastError?: string | null;
+	lastSyncedAt?: Date | null;
+	checkpoint?: Record<string, unknown> | null;
+}
+
+@Service()
+export class KnowledgeSourceRepository extends Repository<KnowledgeSource> {
+	constructor(dataSource: DataSource) {
+		super(KnowledgeSource, dataSource.manager);
+	}
+
+	async findAllSources(): Promise<KnowledgeSource[]> {
+		return await this.find({ order: { createdAt: 'ASC' } });
+	}
+
+	async findSourceById(id: string): Promise<KnowledgeSource | null> {
+		return await this.findOneBy({ id });
+	}
+
+	/**
+	 * Sources whose sync interval has elapsed, oldest first. Sources already
+	 * syncing are excluded so a slow run is never started a second time.
+	 */
+	async findSourcesDueForSync(intervalMinutes: number): Promise<KnowledgeSource[]> {
+		const cutoff = new Date(Date.now() - intervalMinutes * 60 * 1000);
+		const notSyncing = Not<KnowledgeSourceStatus>('syncing');
+
+		return await this.find({
+			where: [
+				{ status: notSyncing, lastSyncedAt: IsNull() },
+				{ status: notSyncing, lastSyncedAt: LessThan(cutoff) },
+			],
+			order: { lastSyncedAt: 'ASC' },
+		});
+	}
+
+	/** Only the fields present in `update` are written, so a partial write keeps the rest intact. */
+	async updateStatus(
+		id: string,
+		status: KnowledgeSourceStatus,
+		update: KnowledgeSourceStatusUpdate = {},
+	): Promise<void> {
+		// `checkpoint` is an open-ended JSON blob, which TypeORM's
+		// QueryDeepPartialEntity cannot express — hence the cast.
+		const values = {
+			status,
+			...(update.lastError !== undefined ? { lastError: update.lastError } : {}),
+			...(update.lastSyncedAt !== undefined ? { lastSyncedAt: update.lastSyncedAt } : {}),
+			...(update.checkpoint !== undefined ? { checkpoint: update.checkpoint } : {}),
+		} as QueryDeepPartialEntity<KnowledgeSource>;
+
+		await this.update({ id }, values);
+	}
+}

--- a/packages/cli/src/modules/knowledge/database/repositories/knowledge-sync-run.repository.ts
+++ b/packages/cli/src/modules/knowledge/database/repositories/knowledge-sync-run.repository.ts
@@ -1,0 +1,36 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import type { KnowledgeSyncMode, KnowledgeSyncRunStatus } from '../../knowledge.constants';
+import type { KnowledgeSyncStats } from '../entities/knowledge-sync-run.entity';
+import { KnowledgeSyncRun } from '../entities/knowledge-sync-run.entity';
+
+@Service()
+export class KnowledgeSyncRunRepository extends Repository<KnowledgeSyncRun> {
+	constructor(dataSource: DataSource) {
+		super(KnowledgeSyncRun, dataSource.manager);
+	}
+
+	async createRun(sourceId: string, mode: KnowledgeSyncMode): Promise<KnowledgeSyncRun> {
+		const run = this.create({ sourceId, mode, status: 'running', startedAt: new Date() });
+
+		return await this.save(run);
+	}
+
+	async finishRun(
+		id: string,
+		status: KnowledgeSyncRunStatus,
+		stats: KnowledgeSyncStats | null,
+		error?: string,
+	): Promise<void> {
+		await this.update({ id }, { status, stats, error: error ?? null, finishedAt: new Date() });
+	}
+
+	async findRecentRuns(sourceId: string, limit: number): Promise<KnowledgeSyncRun[]> {
+		return await this.find({
+			where: { sourceId },
+			order: { startedAt: 'DESC' },
+			take: limit,
+		});
+	}
+}

--- a/packages/cli/src/modules/knowledge/errors/index.ts
+++ b/packages/cli/src/modules/knowledge/errors/index.ts
@@ -1,0 +1,3 @@
+export { KnowledgeNotConfiguredError } from './knowledge-not-configured.error';
+export { KnowledgeSourceNotFoundError } from './knowledge-source-not-found.error';
+export { KnowledgeSyncInProgressError } from './knowledge-sync-in-progress.error';

--- a/packages/cli/src/modules/knowledge/errors/knowledge-not-configured.error.ts
+++ b/packages/cli/src/modules/knowledge/errors/knowledge-not-configured.error.ts
@@ -1,0 +1,11 @@
+import { UserError } from 'n8n-workflow';
+
+/** Thrown when indexing or search runs before an embedding provider and vector store are set. */
+export class KnowledgeNotConfiguredError extends UserError {
+	constructor() {
+		super(
+			'Knowledge connectors are not configured. Set an embedding provider and a vector store first.',
+			{ level: 'warning' },
+		);
+	}
+}

--- a/packages/cli/src/modules/knowledge/errors/knowledge-source-not-found.error.ts
+++ b/packages/cli/src/modules/knowledge/errors/knowledge-source-not-found.error.ts
@@ -1,0 +1,7 @@
+import { UserError } from 'n8n-workflow';
+
+export class KnowledgeSourceNotFoundError extends UserError {
+	constructor(sourceId: string) {
+		super(`Could not find the knowledge source: '${sourceId}'`, { level: 'warning' });
+	}
+}

--- a/packages/cli/src/modules/knowledge/errors/knowledge-sync-in-progress.error.ts
+++ b/packages/cli/src/modules/knowledge/errors/knowledge-sync-in-progress.error.ts
@@ -1,0 +1,10 @@
+import { UserError } from 'n8n-workflow';
+
+/** A sync was requested for a source that is already syncing — the caller should retry later. */
+export class KnowledgeSyncInProgressError extends UserError {
+	constructor(sourceId: string) {
+		super(`A sync is already running for the knowledge source: '${sourceId}'`, {
+			level: 'warning',
+		});
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge-embedding.service.ts
+++ b/packages/cli/src/modules/knowledge/knowledge-embedding.service.ts
@@ -1,0 +1,138 @@
+import { createEmbeddingModel } from '@n8n/agents';
+import { CredentialsRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { EmbeddingModel } from 'ai';
+import { UserError } from 'n8n-workflow';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+
+import { KnowledgeNotConfiguredError } from './errors';
+import { KnowledgeSettingsService } from './knowledge-settings.service';
+import { KnowledgeConfig } from './knowledge.config';
+
+/** Short, stable string used to discover a model's vector size. */
+const DIMENSION_PROBE = 'n8n knowledge dimension probe';
+
+interface CachedEmbedding {
+	/** `credentialId:model` — a settings change produces a different key. */
+	key: string;
+	model: EmbeddingModel;
+	dimension?: number;
+}
+
+/**
+ * Turns text into vectors using the instance-level embedding credential.
+ *
+ * Mirrors how `@n8n/agents`' `VectorStore` embeds internally (`createEmbeddingModel`
+ * plus the AI SDK's `embed`/`embedMany`), but reads its provider and credential
+ * from the admin-configured knowledge settings instead of a per-project config.
+ */
+@Service()
+export class KnowledgeEmbeddingService {
+	private cached: CachedEmbedding | null = null;
+
+	constructor(
+		private readonly settingsService: KnowledgeSettingsService,
+		private readonly credentialsRepository: CredentialsRepository,
+		private readonly credentialsService: CredentialsService,
+		private readonly knowledgeConfig: KnowledgeConfig,
+	) {}
+
+	async embedQuery(text: string): Promise<number[]> {
+		const model = await this.getModel();
+		const { embed } = await import('ai');
+		const { embedding } = await embed({ model, value: text });
+
+		return embedding;
+	}
+
+	/** Embeds in batches of `embeddingBatchSize`; the result keeps the input order. */
+	async embedMany(texts: string[]): Promise<number[][]> {
+		if (texts.length === 0) return [];
+
+		const model = await this.getModel();
+		const { embedMany } = await import('ai');
+		const batchSize = Math.max(1, Math.floor(this.knowledgeConfig.embeddingBatchSize));
+		const vectors: number[][] = [];
+
+		for (let start = 0; start < texts.length; start += batchSize) {
+			const { embeddings } = await embedMany({
+				model,
+				values: texts.slice(start, start + batchSize),
+			});
+			vectors.push(...embeddings);
+		}
+
+		return vectors;
+	}
+
+	/**
+	 * Vector size of the configured model, needed to create the collection.
+	 * Discovered by embedding a probe string once per model, then cached
+	 * alongside the model itself.
+	 */
+	async getDimension(): Promise<number> {
+		const cached = await this.resolveCached();
+
+		if (cached.dimension === undefined) {
+			const { embed } = await import('ai');
+			const { embedding } = await embed({ model: cached.model, value: DIMENSION_PROBE });
+			cached.dimension = embedding.length;
+		}
+
+		return cached.dimension;
+	}
+
+	private async getModel(): Promise<EmbeddingModel> {
+		return (await this.resolveCached()).model;
+	}
+
+	/**
+	 * Settings are re-read on every call so an admin's change takes effect
+	 * immediately; the model itself is only rebuilt when the credential or
+	 * model name actually changed.
+	 */
+	private async resolveCached(): Promise<CachedEmbedding> {
+		const { embedding } = await this.settingsService.getSettings();
+
+		if (!embedding) throw new KnowledgeNotConfiguredError();
+
+		const key = `${embedding.credentialId}:${embedding.model}`;
+		const cached = this.cached;
+
+		if (cached?.key === key) return cached;
+
+		const credential = await this.credentialsRepository.findOneBy({ id: embedding.credentialId });
+
+		if (!credential) {
+			throw new UserError(
+				`The embedding credential "${embedding.credentialId}" configured for knowledge no longer exists.`,
+			);
+		}
+
+		const data = await this.credentialsService.decrypt(credential, true);
+		const apiKey = typeof data.apiKey === 'string' ? data.apiKey : '';
+
+		if (apiKey === '') {
+			throw new UserError('The embedding credential configured for knowledge has no API key.');
+		}
+
+		// n8n's OpenAI credential spells the custom endpoint `url`; the AI SDK
+		// providers take it as `baseURL`. Absent means "use the provider default".
+		const baseURL = typeof data.url === 'string' && data.url !== '' ? data.url : undefined;
+		// Settings store the bare model name, but tolerate an already-prefixed one.
+		const modelId = embedding.model.includes('/')
+			? embedding.model
+			: `${embedding.provider}/${embedding.model}`;
+
+		const model = createEmbeddingModel(modelId, {
+			apiKey,
+			...(baseURL ? { baseURL } : {}),
+		});
+
+		const entry: CachedEmbedding = { key, model };
+		this.cached = entry;
+
+		return entry;
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge-indexing.service.ts
+++ b/packages/cli/src/modules/knowledge/knowledge-indexing.service.ts
@@ -1,0 +1,164 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import { createHash } from 'node:crypto';
+import { v4 as uuid } from 'uuid';
+
+import type { KnowledgeDocumentDraft } from './connectors/connector.types';
+import type { KnowledgeDocument, KnowledgeSource } from './database/entities';
+import { KnowledgeDocumentRepository } from './database/repositories';
+import { KnowledgeEmbeddingService } from './knowledge-embedding.service';
+import type { KnowledgeVectorPoint } from './knowledge-vector-store.service';
+import { KnowledgeVectorStoreService } from './knowledge-vector-store.service';
+import { KnowledgeConfig } from './knowledge.config';
+import { KNOWLEDGE_MODULE_NAME } from './knowledge.constants';
+import { chunkText } from './utils/chunk-text';
+
+/**
+ * Placeholder written before the vectors are, so a crash mid-index leaves a
+ * hash that can never match real content — the next sync re-indexes instead of
+ * skipping a document whose vectors were only half-written.
+ */
+const PENDING_CONTENT_HASH = 'pending';
+
+export type KnowledgeIndexOutcome = 'indexed' | 'skipped';
+
+@Service()
+export class KnowledgeIndexingService {
+	constructor(
+		private readonly documentRepository: KnowledgeDocumentRepository,
+		private readonly embeddingService: KnowledgeEmbeddingService,
+		private readonly vectorStoreService: KnowledgeVectorStoreService,
+		private readonly knowledgeConfig: KnowledgeConfig,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped(KNOWLEDGE_MODULE_NAME);
+	}
+
+	/**
+	 * Chunks, embeds and stores one document, replacing whatever was indexed
+	 * for the same `externalId` before. Returns `'skipped'` when the content is
+	 * byte-identical to what is already indexed.
+	 */
+	async indexDocument(
+		source: KnowledgeSource,
+		draft: KnowledgeDocumentDraft,
+	): Promise<KnowledgeIndexOutcome> {
+		const contentHash = createHash('sha256').update(draft.text, 'utf8').digest('hex');
+		const existing = await this.documentRepository.findBySourceAndExternalId(
+			source.id,
+			draft.externalId,
+		);
+
+		if (existing?.contentHash === contentHash) return 'skipped';
+
+		const chunks = chunkText(draft.text, {
+			chunkSize: this.knowledgeConfig.chunkSize,
+			chunkOverlap: this.knowledgeConfig.chunkOverlap,
+			maxChars: this.knowledgeConfig.maxDocumentChars,
+		});
+
+		// The document row is written first so its id can go into every chunk
+		// payload, and with a placeholder hash so an interrupted run re-indexes.
+		const document = await this.documentRepository.upsertDocument({
+			sourceId: source.id,
+			externalId: draft.externalId,
+			title: draft.title,
+			url: draft.url ?? null,
+			contentHash: PENDING_CONTENT_HASH,
+			chunkCount: 0,
+			meta: draft.metadata,
+			sourceUpdatedAt: draft.sourceUpdatedAt ?? null,
+		});
+
+		// Keyed on the row existing rather than on its `chunkCount`: an
+		// interrupted run can leave vectors behind while the count still reads 0,
+		// and those must be swept before the replacements are written.
+		const isReplacing = existing !== null;
+
+		if (chunks.length > 0 || isReplacing) {
+			await this.vectorStoreService.ensureCollection(await this.embeddingService.getDimension());
+
+			if (isReplacing) {
+				await this.vectorStoreService.deleteByDocumentId(source.id, document.id);
+			}
+
+			if (chunks.length > 0) {
+				const vectors = await this.embeddingService.embedMany(chunks);
+				await this.vectorStoreService.upsertChunks(
+					chunks.map((chunk, index) =>
+						this.toPoint(source, document, draft, chunk, index, vectors[index]),
+					),
+				);
+			}
+		}
+
+		await this.documentRepository.upsertDocument({
+			sourceId: source.id,
+			externalId: draft.externalId,
+			title: draft.title,
+			url: draft.url ?? null,
+			contentHash,
+			chunkCount: chunks.length,
+			meta: draft.metadata,
+			sourceUpdatedAt: draft.sourceUpdatedAt ?? null,
+		});
+
+		if (chunks.length === 0) {
+			this.logger.debug('Indexed a document with no chunkable content', {
+				sourceId: source.id,
+				externalId: draft.externalId,
+			});
+		}
+
+		return 'indexed';
+	}
+
+	/** Drops documents that no longer exist at the source, vectors first. Returns the number of rows removed. */
+	async removeDocuments(source: KnowledgeSource, externalIds: string[]): Promise<number> {
+		if (externalIds.length === 0) return 0;
+
+		await this.vectorStoreService.deleteByExternalIds(source.id, externalIds);
+
+		return await this.documentRepository.deleteBySourceAndExternalIds(source.id, externalIds);
+	}
+
+	/**
+	 * Removes everything indexed for a source. Document rows are deleted
+	 * explicitly: the FK cascade only fires when the source row itself is
+	 * deleted, and callers may keep the source around to re-index it.
+	 */
+	async removeSource(sourceId: string): Promise<void> {
+		await this.vectorStoreService.deleteBySourceId(sourceId);
+
+		const externalIds = await this.documentRepository.listExternalIds(sourceId);
+		await this.documentRepository.deleteBySourceAndExternalIds(sourceId, externalIds);
+	}
+
+	/**
+	 * Connector metadata is spread first so the reserved fields the search layer
+	 * relies on (and the source scoping filter) can never be overwritten by it.
+	 */
+	private toPoint(
+		source: KnowledgeSource,
+		document: KnowledgeDocument,
+		draft: KnowledgeDocumentDraft,
+		chunk: string,
+		chunkIndex: number,
+		vector: number[],
+	): KnowledgeVectorPoint {
+		return {
+			id: uuid(),
+			vector,
+			payload: {
+				...draft.metadata,
+				sourceId: source.id,
+				documentId: document.id,
+				externalId: draft.externalId,
+				chunkIndex,
+				title: draft.title,
+				url: draft.url ?? null,
+				text: chunk,
+			},
+		};
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge-search.service.ts
+++ b/packages/cli/src/modules/knowledge/knowledge-search.service.ts
@@ -1,0 +1,99 @@
+import { Service } from '@n8n/di';
+
+import { KnowledgeSourceRepository } from './database/repositories';
+import { KnowledgeNotConfiguredError } from './errors';
+import { KnowledgeEmbeddingService } from './knowledge-embedding.service';
+import { KnowledgeSettingsService } from './knowledge-settings.service';
+import { KnowledgeVectorStoreService } from './knowledge-vector-store.service';
+import { KnowledgeConfig } from './knowledge.config';
+
+/**
+ * Payload fields the result shape already exposes as first-class properties;
+ * everything else in the payload is connector metadata.
+ */
+const RESERVED_PAYLOAD_KEYS = ['sourceId', 'documentId', 'text', 'title', 'url', 'chunkIndex'];
+
+export interface KnowledgeSearchResult {
+	text: string;
+	score: number;
+	title: string;
+	url: string | null;
+	sourceId: string;
+	sourceName: string;
+	externalId: string;
+	metadata: Record<string, unknown>;
+}
+
+export interface KnowledgeSearchOptions {
+	/** Restrict the search to these sources; unknown ids are dropped. */
+	sourceIds?: string[];
+	topK?: number;
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === 'string' ? value : undefined;
+}
+
+function stripReserved(payload: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(payload).filter(([key]) => !RESERVED_PAYLOAD_KEYS.includes(key)),
+	);
+}
+
+/** Semantic search across indexed knowledge sources. */
+@Service()
+export class KnowledgeSearchService {
+	constructor(
+		private readonly settingsService: KnowledgeSettingsService,
+		private readonly sourceRepository: KnowledgeSourceRepository,
+		private readonly embeddingService: KnowledgeEmbeddingService,
+		private readonly vectorStoreService: KnowledgeVectorStoreService,
+		private readonly knowledgeConfig: KnowledgeConfig,
+	) {}
+
+	async search(query: string, opts?: KnowledgeSearchOptions): Promise<KnowledgeSearchResult[]> {
+		if (!(await this.settingsService.isConfigured())) throw new KnowledgeNotConfiguredError();
+
+		if (query.trim() === '') return [];
+
+		// Existing sources are the allow-list: a pinned id that no longer exists
+		// (or never did) is dropped rather than widening the search.
+		const sources = await this.sourceRepository.findAllSources();
+		const sourceNames = new Map(sources.map((source) => [source.id, source.name]));
+		const allowedSourceIds = opts?.sourceIds
+			? opts.sourceIds.filter((id) => sourceNames.has(id))
+			: [...sourceNames.keys()];
+
+		if (allowedSourceIds.length === 0) return [];
+
+		const vector = await this.embeddingService.embedQuery(query);
+		const hits = await this.vectorStoreService.search(vector, {
+			sourceIds: allowedSourceIds,
+			topK: opts?.topK ?? this.knowledgeConfig.defaultTopK,
+		});
+
+		const results: KnowledgeSearchResult[] = [];
+
+		for (const hit of hits) {
+			const sourceId = readString(hit.payload.sourceId);
+			const sourceName = sourceId === undefined ? undefined : sourceNames.get(sourceId);
+
+			// Defensive: a chunk whose source has been deleted but whose vectors
+			// were not pruned must not leak into results.
+			if (sourceId === undefined || sourceName === undefined) continue;
+
+			results.push({
+				text: readString(hit.payload.text) ?? '',
+				score: hit.score,
+				title: readString(hit.payload.title) ?? '',
+				url: readString(hit.payload.url) ?? null,
+				sourceId,
+				sourceName,
+				externalId: readString(hit.payload.externalId) ?? '',
+				metadata: stripReserved(hit.payload),
+			});
+		}
+
+		return results;
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge-settings.service.ts
+++ b/packages/cli/src/modules/knowledge/knowledge-settings.service.ts
@@ -1,0 +1,112 @@
+import { Logger } from '@n8n/backend-common';
+import { SettingsRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { jsonParse } from 'n8n-workflow';
+import { z } from 'zod';
+
+import {
+	KNOWLEDGE_DEFAULT_COLLECTION_NAME,
+	KNOWLEDGE_MODULE_NAME,
+	KNOWLEDGE_SETTINGS_KEY,
+} from './knowledge.constants';
+
+export interface KnowledgeSettings {
+	embedding: { provider: 'openai'; credentialId: string; model: string } | null;
+	vectorStore: { provider: 'qdrant'; credentialId: string; collectionName: string } | null;
+}
+
+export interface KnowledgeSettingsPatch {
+	embedding?: KnowledgeSettings['embedding'];
+	/** `collectionName` may be omitted; it falls back to {@link KNOWLEDGE_DEFAULT_COLLECTION_NAME}. */
+	vectorStore?: { provider: 'qdrant'; credentialId: string; collectionName?: string } | null;
+}
+
+const embeddingSchema = z.object({
+	provider: z.literal('openai'),
+	credentialId: z.string().min(1),
+	model: z.string().min(1),
+});
+
+const vectorStoreSchema = z.object({
+	provider: z.literal('qdrant'),
+	credentialId: z.string().min(1),
+	collectionName: z.string().min(1),
+});
+
+const knowledgeSettingsSchema = z.object({
+	embedding: embeddingSchema.nullable(),
+	vectorStore: vectorStoreSchema.nullable(),
+});
+
+const defaultSettings = (): KnowledgeSettings => ({ embedding: null, vectorStore: null });
+
+/**
+ * Instance-level admin settings for knowledge connectors, persisted as a single
+ * JSON row in the shared `settings` table.
+ */
+@Service()
+export class KnowledgeSettingsService {
+	constructor(
+		private readonly settingsRepository: SettingsRepository,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped(KNOWLEDGE_MODULE_NAME);
+	}
+
+	async getSettings(): Promise<KnowledgeSettings> {
+		const row = await this.settingsRepository.findByKey(KNOWLEDGE_SETTINGS_KEY);
+
+		if (!row?.value) return defaultSettings();
+
+		const parsed = knowledgeSettingsSchema.safeParse(
+			jsonParse<unknown>(row.value, { fallbackValue: null }),
+		);
+
+		if (!parsed.success) {
+			this.logger.warn('Stored knowledge settings are unreadable, falling back to defaults', {
+				issues: parsed.error.issues,
+			});
+
+			return defaultSettings();
+		}
+
+		return parsed.data;
+	}
+
+	/** Fields absent from `patch` keep their stored value; passing `null` clears one. */
+	async updateSettings(patch: KnowledgeSettingsPatch): Promise<KnowledgeSettings> {
+		const current = await this.getSettings();
+
+		const next: KnowledgeSettings = {
+			embedding: patch.embedding === undefined ? current.embedding : patch.embedding,
+			vectorStore:
+				patch.vectorStore === undefined
+					? current.vectorStore
+					: patch.vectorStore === null
+						? null
+						: {
+								...patch.vectorStore,
+								collectionName:
+									patch.vectorStore.collectionName ?? KNOWLEDGE_DEFAULT_COLLECTION_NAME,
+							},
+		};
+
+		const validated = knowledgeSettingsSchema.parse(next);
+
+		// Not loaded on startup: these settings are read on demand by this module only.
+		await this.settingsRepository.upsertByKey(
+			KNOWLEDGE_SETTINGS_KEY,
+			JSON.stringify(validated),
+			false,
+			{},
+		);
+
+		return validated;
+	}
+
+	async isConfigured(): Promise<boolean> {
+		const { embedding, vectorStore } = await this.getSettings();
+
+		return embedding !== null && vectorStore !== null;
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge-sync.service.ts
+++ b/packages/cli/src/modules/knowledge/knowledge-sync.service.ts
@@ -1,0 +1,342 @@
+import { Logger } from '@n8n/backend-common';
+import { CredentialsRepository } from '@n8n/db';
+import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+
+import type { ConnectorSyncContext, KnowledgeConnector } from './connectors/connector.types';
+import { KnowledgeConnectorRegistry } from './connectors/connector-registry';
+import type { KnowledgeSource, KnowledgeSyncStats } from './database/entities';
+import {
+	KnowledgeDocumentRepository,
+	KnowledgeSourceRepository,
+	KnowledgeSyncRunRepository,
+} from './database/repositories';
+import { KnowledgeSourceNotFoundError, KnowledgeSyncInProgressError } from './errors';
+import { KnowledgeIndexingService } from './knowledge-indexing.service';
+import { KnowledgeConfig } from './knowledge.config';
+import { KNOWLEDGE_MODULE_NAME } from './knowledge.constants';
+
+/** `lastError` is troubleshooting context, not a stack trace dump. */
+const MAX_ERROR_LENGTH = 1000;
+
+export interface KnowledgeSyncOptions {
+	/** Ignore the stored checkpoint and re-read the source from the beginning. */
+	fullResync?: boolean;
+}
+
+interface RunningSync {
+	controller: AbortController;
+	/** Settles when the run is over; already has a rejection handler attached. */
+	promise: Promise<void>;
+}
+
+const emptyStats = (): KnowledgeSyncStats => ({
+	documentsSeen: 0,
+	documentsIndexed: 0,
+	documentsSkipped: 0,
+	documentsDeleted: 0,
+	chunksWritten: 0,
+});
+
+/**
+ * Drives connectors: runs them on a timer on the leader, one source at a time,
+ * and turns the drafts they yield into indexed documents.
+ *
+ * A run only persists its checkpoint after the connector returns normally — a
+ * failed or aborted run keeps the previous cursor, so the documents it did not
+ * reach are picked up next time instead of being skipped forever.
+ */
+@Service()
+export class KnowledgeSyncService {
+	private timer: NodeJS.Timeout | undefined;
+
+	/** Syncs running in this process, keyed by source id. */
+	private readonly running = new Map<string, RunningSync>();
+
+	constructor(
+		private readonly sourceRepository: KnowledgeSourceRepository,
+		private readonly documentRepository: KnowledgeDocumentRepository,
+		private readonly syncRunRepository: KnowledgeSyncRunRepository,
+		private readonly connectorRegistry: KnowledgeConnectorRegistry,
+		private readonly indexingService: KnowledgeIndexingService,
+		private readonly credentialsRepository: CredentialsRepository,
+		private readonly credentialsService: CredentialsService,
+		private readonly knowledgeConfig: KnowledgeConfig,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped(KNOWLEDGE_MODULE_NAME);
+	}
+
+	start() {
+		if (this.instanceSettings.isLeader) this.startTimer();
+	}
+
+	@OnLeaderTakeover()
+	startTimer() {
+		if (this.timer) return;
+
+		const intervalMs = Math.max(1, this.knowledgeConfig.syncIntervalMinutes) * 60_000;
+
+		this.timer = setInterval(() => {
+			// Nothing awaits the tick, so its errors are logged rather than left
+			// to surface as an unhandled rejection.
+			void this.syncDueSources().catch((error: unknown) => {
+				this.logger.error('Knowledge sync tick failed', { error: this.toMessage(error) });
+			});
+		}, intervalMs);
+		this.timer.unref();
+
+		this.logger.debug('Started the knowledge sync timer', { intervalMs });
+	}
+
+	@OnLeaderStepdown()
+	stopTimer() {
+		if (!this.timer) return;
+
+		clearInterval(this.timer);
+		this.timer = undefined;
+	}
+
+	@OnShutdown()
+	async shutdown() {
+		this.stopTimer();
+
+		const running = [...this.running.values()];
+		for (const { controller } of running) controller.abort();
+
+		await Promise.allSettled(running.map(async ({ promise }) => await promise));
+	}
+
+	/** Syncs every source whose interval has elapsed, one after another. */
+	async syncDueSources() {
+		const sources = await this.sourceRepository.findSourcesDueForSync(
+			this.knowledgeConfig.syncIntervalMinutes,
+		);
+
+		for (const source of sources) {
+			try {
+				await this.runSync(source.id);
+			} catch (error) {
+				// One broken source must not stop the others from syncing.
+				this.logger.error('Knowledge source sync failed', {
+					sourceId: source.id,
+					error: this.toMessage(error),
+				});
+			}
+		}
+	}
+
+	/** Runs a sync and resolves when it is done. Rejects with whatever made the run fail. */
+	async runSync(sourceId: string, opts: KnowledgeSyncOptions = {}): Promise<void> {
+		const { promise } = await this.startSync(sourceId, opts);
+
+		await promise;
+	}
+
+	/**
+	 * Starts a sync and returns as soon as it is under way, so an HTTP caller
+	 * gets an immediate answer. Errors raised while starting (unknown source,
+	 * sync already running) still surface to the caller; failures of the run
+	 * itself are only logged and end up on the source and its run row.
+	 */
+	async triggerSync(sourceId: string, opts: KnowledgeSyncOptions = {}): Promise<void> {
+		const { promise } = await this.startSync(sourceId, opts);
+
+		promise.catch((error) => {
+			this.logger.error('Knowledge source sync failed', {
+				sourceId,
+				error: this.toMessage(error),
+			});
+		});
+	}
+
+	/**
+	 * Removes a source and everything indexed for it. Document and run rows
+	 * cascade with the source row, but the vectors do not, so they are dropped
+	 * explicitly first.
+	 */
+	async deleteSource(sourceId: string): Promise<void> {
+		const source = await this.sourceRepository.findSourceById(sourceId);
+
+		if (!source) throw new KnowledgeSourceNotFoundError(sourceId);
+
+		const running = this.running.get(sourceId);
+
+		if (running) {
+			running.controller.abort();
+			// An aborted run rejects by design; the deletion continues regardless.
+			await running.promise.catch(() => {});
+		}
+
+		await this.indexingService.removeSource(sourceId);
+		await this.sourceRepository.delete({ id: sourceId });
+	}
+
+	private async startSync(
+		sourceId: string,
+		opts: KnowledgeSyncOptions,
+	): Promise<{ promise: Promise<void> }> {
+		const source = await this.sourceRepository.findSourceById(sourceId);
+
+		if (!source) throw new KnowledgeSourceNotFoundError(sourceId);
+
+		if (this.running.has(sourceId)) throw new KnowledgeSyncInProgressError(sourceId);
+
+		if (source.status === 'syncing') {
+			// A stored 'syncing' status with no run in this process is left over
+			// from an instance that died mid-sync. Treating it as blocking would
+			// wedge the source until someone edited the database by hand, so the
+			// stale status is taken over instead.
+			this.logger.warn('Taking over a knowledge source left in the syncing state', { sourceId });
+		}
+
+		const controller = new AbortController();
+		const promise = this.executeSync(source, controller.signal, opts.fullResync === true).finally(
+			() => {
+				this.running.delete(sourceId);
+			},
+		);
+
+		this.running.set(sourceId, { controller, promise });
+
+		return { promise };
+	}
+
+	private async executeSync(
+		source: KnowledgeSource,
+		abortSignal: AbortSignal,
+		fullResync: boolean,
+	): Promise<void> {
+		const checkpoint = fullResync ? null : source.checkpoint;
+		const mode = checkpoint ? 'incremental' : 'full';
+		const stats = emptyStats();
+
+		await this.sourceRepository.updateStatus(source.id, 'syncing');
+		const run = await this.syncRunRepository.createRun(source.id, mode);
+
+		this.logger.info('Starting a knowledge source sync', { sourceId: source.id, mode });
+
+		try {
+			const connector = this.connectorRegistry.getConnector(source.type);
+
+			// Validated up front so a broken config fails before anything is indexed.
+			connector.parseConfig(source.config);
+
+			const ctx: ConnectorSyncContext = {
+				source,
+				checkpoint,
+				credential: await this.resolveCredential(source, connector),
+				logger: this.logger,
+				abortSignal,
+			};
+
+			// Driven by hand rather than with `for await`, which discards the
+			// generator's return value — and that value carries the checkpoint.
+			const iterator = connector.sync(ctx);
+			let step = await iterator.next();
+
+			while (step.done !== true) {
+				const draft = step.value;
+				stats.documentsSeen++;
+
+				const outcome = await this.indexingService.indexDocument(source, draft);
+
+				if (outcome === 'indexed') {
+					stats.documentsIndexed++;
+					// `indexDocument` reports the outcome only, so the chunk count is
+					// read back off the row it just wrote.
+					const document = await this.documentRepository.findBySourceAndExternalId(
+						source.id,
+						draft.externalId,
+					);
+					stats.chunksWritten += document?.chunkCount ?? 0;
+				} else {
+					stats.documentsSkipped++;
+				}
+
+				step = await iterator.next();
+			}
+
+			const result = step.value;
+
+			if (result.deletedExternalIds && result.deletedExternalIds.length > 0) {
+				stats.documentsDeleted += await this.indexingService.removeDocuments(
+					source,
+					result.deletedExternalIds,
+				);
+			}
+
+			stats.documentsDeleted += await this.pruneMissingDocuments(source, connector, ctx);
+
+			await this.sourceRepository.updateStatus(source.id, 'ready', {
+				checkpoint: result.checkpoint,
+				lastSyncedAt: new Date(),
+				lastError: null,
+			});
+			await this.syncRunRepository.finishRun(run.id, 'success', stats);
+
+			this.logger.info('Finished a knowledge source sync', { sourceId: source.id, ...stats });
+		} catch (error) {
+			const message = this.toMessage(error).slice(0, MAX_ERROR_LENGTH);
+
+			// The checkpoint is deliberately left untouched: a partial cursor would
+			// permanently skip the documents this run never reached.
+			await this.sourceRepository.updateStatus(source.id, 'error', { lastError: message });
+			await this.syncRunRepository.finishRun(run.id, 'error', stats, message);
+
+			throw error;
+		}
+	}
+
+	/**
+	 * Drops documents that vanished at the source. Only possible for connectors
+	 * that can enumerate their ids cheaply; the rest rely on
+	 * `deletedExternalIds`.
+	 */
+	private async pruneMissingDocuments(
+		source: KnowledgeSource,
+		connector: KnowledgeConnector,
+		ctx: ConnectorSyncContext,
+	): Promise<number> {
+		if (!connector.listExternalIds) return 0;
+
+		const known = await this.documentRepository.listExternalIds(source.id);
+		const current = new Set(await connector.listExternalIds(ctx));
+		const stale = known.filter((externalId) => !current.has(externalId));
+
+		return await this.indexingService.removeDocuments(source, stale);
+	}
+
+	private async resolveCredential(
+		source: KnowledgeSource,
+		connector: KnowledgeConnector,
+	): Promise<ICredentialDataDecryptedObject | null> {
+		if (!connector.requiresCredential) return null;
+
+		if (!source.credentialId) {
+			throw new UserError(
+				`The knowledge source "${source.name}" needs a credential of type "${source.type}", but none is set.`,
+			);
+		}
+
+		const credential = await this.credentialsRepository.findOneBy({ id: source.credentialId });
+
+		if (!credential) {
+			throw new UserError(
+				`The credential "${source.credentialId}" configured for the knowledge source "${source.name}" no longer exists.`,
+			);
+		}
+
+		return await this.credentialsService.decrypt(credential, true);
+	}
+
+	private toMessage(error: unknown): string {
+		return error instanceof Error ? error.message : String(error);
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge-vector-store.service.ts
+++ b/packages/cli/src/modules/knowledge/knowledge-vector-store.service.ts
@@ -1,0 +1,248 @@
+import { CredentialsRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { QdrantClient, Schemas } from '@qdrant/js-client-rest';
+import { UserError } from 'n8n-workflow';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+
+import { KnowledgeNotConfiguredError } from './errors';
+import { KnowledgeSettingsService } from './knowledge-settings.service';
+
+/** Points per upsert request — large enough to amortize round trips, small enough to stay under Qdrant's body limits. */
+const UPSERT_BATCH_SIZE = 200;
+
+/**
+ * Payload fields we filter on. Qdrant (and Qdrant Cloud in strict mode)
+ * rejects filters on unindexed fields, so every filtered key needs a keyword
+ * index — including `externalId`, which document pruning filters by.
+ */
+const INDEXED_PAYLOAD_FIELDS = ['sourceId', 'documentId', 'externalId'] as const;
+
+export interface KnowledgeVectorPoint {
+	/** Must be a UUID — Qdrant only accepts UUID or unsigned-integer point ids. */
+	id: string;
+	vector: number[];
+	payload: Record<string, unknown>;
+}
+
+export interface KnowledgeVectorHit {
+	id: string;
+	score: number;
+	payload: Record<string, unknown>;
+}
+
+interface QdrantConnection {
+	/** `credentialId:collectionName` — a settings change produces a different key. */
+	key: string;
+	client: QdrantClient;
+	collectionName: string;
+}
+
+function readVectorSize(value: unknown): number | undefined {
+	if (!value || typeof value !== 'object') return undefined;
+	if ('size' in value && typeof value.size === 'number') return value.size;
+	return undefined;
+}
+
+/** Reads the vector size off either a single default-vector or named-vector collection config. */
+function extractVectorSize(vectorsConfig: unknown): number | undefined {
+	if (!vectorsConfig || typeof vectorsConfig !== 'object') return undefined;
+
+	const direct = readVectorSize(vectorsConfig);
+	if (direct !== undefined) return direct;
+
+	const firstNamedVector: unknown = Object.values(vectorsConfig)[0];
+	return readVectorSize(firstNamedVector);
+}
+
+function matchValue(key: string, value: string): Schemas['Condition'] {
+	return { key, match: { value } };
+}
+
+/**
+ * Owns every Qdrant detail of the knowledge module: client construction from
+ * the admin-configured credential, collection lifecycle, and the payload
+ * filters used for reads and deletes.
+ *
+ * Filters are built here and never accepted from a caller — `search` only
+ * takes a list of source ids, which is the boundary that keeps a query from
+ * reaching chunks of a source the caller is not allowed to see.
+ */
+@Service()
+export class KnowledgeVectorStoreService {
+	private connection: QdrantConnection | null = null;
+
+	/** `connectionKey:dimension` combinations already verified in this process. */
+	private readonly ensured = new Set<string>();
+
+	constructor(
+		private readonly settingsService: KnowledgeSettingsService,
+		private readonly credentialsRepository: CredentialsRepository,
+		private readonly credentialsService: CredentialsService,
+	) {}
+
+	/**
+	 * Creates the collection when missing and makes sure the payload indexes
+	 * exist. Idempotent; a collection whose vector size does not match the
+	 * configured embedding model is a hard error rather than a silent failure
+	 * at query time.
+	 */
+	async ensureCollection(dimension: number): Promise<void> {
+		const { key, client, collectionName } = await this.getConnection();
+		const ensuredKey = `${key}:${dimension}`;
+
+		if (this.ensured.has(ensuredKey)) return;
+
+		const { exists } = await client.collectionExists(collectionName);
+
+		if (exists) {
+			await this.assertVectorSize(client, collectionName, dimension);
+		} else {
+			try {
+				await client.createCollection(collectionName, {
+					vectors: { size: dimension, distance: 'Cosine' },
+				});
+			} catch (error) {
+				// A concurrent sync may have created it in between; only re-throw
+				// when it is still missing.
+				const { exists: existsNow } = await client.collectionExists(collectionName);
+				if (!existsNow) throw error;
+				await this.assertVectorSize(client, collectionName, dimension);
+			}
+		}
+
+		for (const field of INDEXED_PAYLOAD_FIELDS) {
+			await client.createPayloadIndex(collectionName, {
+				field_name: field,
+				field_schema: 'keyword',
+				wait: true,
+			});
+		}
+
+		this.ensured.add(ensuredKey);
+	}
+
+	async upsertChunks(points: KnowledgeVectorPoint[]): Promise<void> {
+		if (points.length === 0) return;
+
+		const { client, collectionName } = await this.getConnection();
+
+		for (let start = 0; start < points.length; start += UPSERT_BATCH_SIZE) {
+			await client.upsert(collectionName, {
+				wait: true,
+				points: points.slice(start, start + UPSERT_BATCH_SIZE),
+			});
+		}
+	}
+
+	async deleteByDocumentId(sourceId: string, documentId: string): Promise<void> {
+		await this.deleteByFilter({
+			must: [matchValue('sourceId', sourceId), matchValue('documentId', documentId)],
+		});
+	}
+
+	async deleteBySourceId(sourceId: string): Promise<void> {
+		await this.deleteByFilter({ must: [matchValue('sourceId', sourceId)] });
+	}
+
+	async deleteByExternalIds(sourceId: string, externalIds: string[]): Promise<void> {
+		if (externalIds.length === 0) return;
+
+		await this.deleteByFilter({
+			must: [
+				matchValue('sourceId', sourceId),
+				// eslint-disable-next-line id-denylist -- `any` is Qdrant's match-schema field name
+				{ key: 'externalId', match: { any: externalIds } },
+			],
+		});
+	}
+
+	/**
+	 * Nearest neighbours restricted to `sourceIds`. The filter is built here on
+	 * purpose: callers pass ids they have already authorized, never raw filters.
+	 */
+	async search(
+		vector: number[],
+		opts: { sourceIds: string[]; topK: number },
+	): Promise<KnowledgeVectorHit[]> {
+		if (opts.sourceIds.length === 0) return [];
+
+		const { client, collectionName } = await this.getConnection();
+
+		const response = await client.query(collectionName, {
+			query: vector,
+			limit: opts.topK,
+			with_payload: true,
+			filter: {
+				// eslint-disable-next-line id-denylist -- `any` is Qdrant's match-schema field name
+				must: [{ key: 'sourceId', match: { any: opts.sourceIds } }],
+			},
+		});
+
+		return response.points.map((point) => ({
+			id: String(point.id),
+			score: point.score,
+			payload: point.payload ?? {},
+		}));
+	}
+
+	private async deleteByFilter(filter: Schemas['Filter']): Promise<void> {
+		const { client, collectionName } = await this.getConnection();
+
+		await client.delete(collectionName, { wait: true, filter });
+	}
+
+	private async assertVectorSize(
+		client: QdrantClient,
+		collectionName: string,
+		dimension: number,
+	): Promise<void> {
+		const info = await client.getCollection(collectionName);
+		const existing = extractVectorSize(info.config?.params?.vectors);
+
+		if (existing !== undefined && existing !== dimension) {
+			throw new UserError(
+				`Qdrant collection "${collectionName}" stores ${existing}-dimensional vectors but the configured embedding model produces ${dimension}. ` +
+					'This happens when the embedding model changes after indexing. Point the knowledge settings at a new collection name, or delete the collection and re-index every source.',
+			);
+		}
+	}
+
+	private async getConnection(): Promise<QdrantConnection> {
+		const { vectorStore } = await this.settingsService.getSettings();
+
+		if (!vectorStore) throw new KnowledgeNotConfiguredError();
+
+		const key = `${vectorStore.credentialId}:${vectorStore.collectionName}`;
+		const connection = this.connection;
+
+		if (connection?.key === key) return connection;
+
+		const credential = await this.credentialsRepository.findOneBy({ id: vectorStore.credentialId });
+
+		if (!credential) {
+			throw new UserError(
+				`The vector store credential "${vectorStore.credentialId}" configured for knowledge no longer exists.`,
+			);
+		}
+
+		const data = await this.credentialsService.decrypt(credential, true);
+		const url = typeof data.qdrantUrl === 'string' ? data.qdrantUrl : '';
+
+		if (url === '') {
+			throw new UserError('The Qdrant credential configured for knowledge has no URL.');
+		}
+
+		const apiKey = typeof data.apiKey === 'string' && data.apiKey !== '' ? data.apiKey : undefined;
+		const { QdrantClient: QdrantClientCtor } = await import('@qdrant/js-client-rest');
+		const client = new QdrantClientCtor({ url, ...(apiKey ? { apiKey } : {}) });
+
+		const next: QdrantConnection = { key, client, collectionName: vectorStore.collectionName };
+		this.connection = next;
+		// A new connection may point at a different collection; its readiness has
+		// not been verified yet.
+		this.ensured.clear();
+
+		return next;
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge.config.ts
+++ b/packages/cli/src/modules/knowledge/knowledge.config.ts
@@ -1,0 +1,49 @@
+import { Config, Env } from '@n8n/config';
+
+/** Configuration for the knowledge connectors module. */
+@Config
+export class KnowledgeConfig {
+	/**
+	 * How often in minutes a source becomes eligible for another sync.
+	 * Default: 60
+	 */
+	@Env('N8N_KNOWLEDGE_SYNC_INTERVAL_MINUTES')
+	syncIntervalMinutes: number = 60;
+
+	/**
+	 * Characters per chunk when splitting a document for embedding.
+	 * Default: 1500
+	 */
+	@Env('N8N_KNOWLEDGE_CHUNK_SIZE')
+	chunkSize: number = 1500;
+
+	/**
+	 * Characters shared between two consecutive chunks, so context spanning a
+	 * chunk boundary stays retrievable.
+	 * Default: 200
+	 */
+	@Env('N8N_KNOWLEDGE_CHUNK_OVERLAP')
+	chunkOverlap: number = 200;
+
+	/**
+	 * Documents longer than this are truncated before chunking.
+	 * Default: 200000
+	 */
+	@Env('N8N_KNOWLEDGE_MAX_DOCUMENT_CHARS')
+	maxDocumentChars: number = 200_000;
+
+	/**
+	 * Number of chunks sent to the embedding provider in a single request.
+	 * Default: 100
+	 */
+	@Env('N8N_KNOWLEDGE_EMBEDDING_BATCH_SIZE')
+	embeddingBatchSize: number = 100;
+
+	/**
+	 * Number of results returned by a search when the caller does not ask for a
+	 * specific amount.
+	 * Default: 8
+	 */
+	@Env('N8N_KNOWLEDGE_DEFAULT_TOP_K')
+	defaultTopK: number = 8;
+}

--- a/packages/cli/src/modules/knowledge/knowledge.constants.ts
+++ b/packages/cli/src/modules/knowledge/knowledge.constants.ts
@@ -1,0 +1,18 @@
+export const KNOWLEDGE_MODULE_NAME = 'knowledge';
+
+export const KNOWLEDGE_SOURCE_TYPES = ['github', 'n8n'] as const;
+export type KnowledgeSourceType = (typeof KNOWLEDGE_SOURCE_TYPES)[number];
+
+export const KNOWLEDGE_SOURCE_STATUSES = ['pending', 'syncing', 'ready', 'error'] as const;
+export type KnowledgeSourceStatus = (typeof KNOWLEDGE_SOURCE_STATUSES)[number];
+
+export const KNOWLEDGE_SYNC_MODES = ['full', 'incremental'] as const;
+export type KnowledgeSyncMode = (typeof KNOWLEDGE_SYNC_MODES)[number];
+
+export const KNOWLEDGE_SYNC_RUN_STATUSES = ['running', 'success', 'error'] as const;
+export type KnowledgeSyncRunStatus = (typeof KNOWLEDGE_SYNC_RUN_STATUSES)[number];
+
+export const KNOWLEDGE_SETTINGS_KEY = 'knowledge.settings';
+
+/** Qdrant collection used when the admin does not name one explicitly. */
+export const KNOWLEDGE_DEFAULT_COLLECTION_NAME = 'n8n_knowledge';

--- a/packages/cli/src/modules/knowledge/knowledge.controller.ts
+++ b/packages/cli/src/modules/knowledge/knowledge.controller.ts
@@ -1,0 +1,232 @@
+import {
+	CreateKnowledgeSourceDto,
+	SearchKnowledgeDto,
+	SyncKnowledgeSourceDto,
+	UpdateKnowledgeSettingsDto,
+	UpdateKnowledgeSourceDto,
+} from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import {
+	Body,
+	Delete,
+	Get,
+	GlobalScope,
+	Param,
+	Patch,
+	Post,
+	Put,
+	RestController,
+} from '@n8n/decorators';
+import type { Response } from 'express';
+import { UserError } from 'n8n-workflow';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { KnowledgeConnectorRegistry } from './connectors/connector-registry';
+import type { KnowledgeSource } from './database/entities';
+import {
+	KnowledgeDocumentRepository,
+	KnowledgeSourceRepository,
+	KnowledgeSyncRunRepository,
+} from './database/repositories';
+import { KnowledgeSourceNotFoundError, KnowledgeSyncInProgressError } from './errors';
+import { KnowledgeSearchService } from './knowledge-search.service';
+import { KnowledgeSettingsService } from './knowledge-settings.service';
+import { KnowledgeSyncService } from './knowledge-sync.service';
+
+/** Runs shown per source; enough to see a pattern without paginating. */
+const RECENT_RUNS_LIMIT = 20;
+
+/** Upper bound on results per search, whatever the caller asks for. */
+const MAX_TOP_K = 50;
+
+/**
+ * Managing sources and the instance-level embedding/vector-store settings is
+ * admin work (`knowledge:manage`, mirroring `otel:manage` and `chatHub:manage`).
+ * Reading — listing sources and searching — is open to any authenticated user,
+ * since indexed knowledge is instance-wide by design.
+ */
+@RestController('/knowledge')
+export class KnowledgeController {
+	constructor(
+		private readonly settingsService: KnowledgeSettingsService,
+		private readonly searchService: KnowledgeSearchService,
+		private readonly syncService: KnowledgeSyncService,
+		private readonly connectorRegistry: KnowledgeConnectorRegistry,
+		private readonly sourceRepository: KnowledgeSourceRepository,
+		private readonly documentRepository: KnowledgeDocumentRepository,
+		private readonly syncRunRepository: KnowledgeSyncRunRepository,
+	) {}
+
+	/** Settings hold credential ids and a model name only, so they need no redaction. */
+	@Get('/settings')
+	@GlobalScope('knowledge:manage')
+	async getSettings() {
+		return await this.settingsService.getSettings();
+	}
+
+	@Put('/settings')
+	@GlobalScope('knowledge:manage')
+	async updateSettings(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Body dto: UpdateKnowledgeSettingsDto,
+	) {
+		try {
+			return await this.settingsService.updateSettings(dto);
+		} catch (error) {
+			this.rethrowAsHttpError(error);
+		}
+	}
+
+	@Get('/sources')
+	async listSources() {
+		const sources = await this.sourceRepository.findAllSources();
+
+		return await Promise.all(sources.map(async (source) => await this.toSourceResponse(source)));
+	}
+
+	@Post('/sources')
+	@GlobalScope('knowledge:manage')
+	async createSource(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Body dto: CreateKnowledgeSourceDto,
+	) {
+		try {
+			const connector = this.connectorRegistry.getConnector(dto.type);
+			const config = connector.parseConfig(dto.config);
+
+			if (connector.requiresCredential && !dto.credentialId) {
+				throw new UserError(`A knowledge source of type "${dto.type}" requires a credential.`);
+			}
+
+			const source = await this.sourceRepository.save(
+				this.sourceRepository.create({
+					name: dto.name,
+					type: dto.type,
+					credentialId: dto.credentialId ?? null,
+					config,
+					status: 'pending',
+				}),
+			);
+
+			return await this.toSourceResponse(source);
+		} catch (error) {
+			this.rethrowAsHttpError(error);
+		}
+	}
+
+	@Patch('/sources/:id')
+	@GlobalScope('knowledge:manage')
+	async updateSource(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Param('id') id: string,
+		@Body dto: UpdateKnowledgeSourceDto,
+	) {
+		try {
+			const source = await this.getSourceOrThrow(id);
+			const connector = this.connectorRegistry.getConnector(source.type);
+
+			if (dto.name !== undefined) source.name = dto.name;
+			if (dto.credentialId !== undefined) source.credentialId = dto.credentialId;
+			if (dto.config !== undefined) source.config = connector.parseConfig(dto.config);
+
+			if (connector.requiresCredential && !source.credentialId) {
+				throw new UserError(`A knowledge source of type "${source.type}" requires a credential.`);
+			}
+
+			return await this.toSourceResponse(await this.sourceRepository.save(source));
+		} catch (error) {
+			this.rethrowAsHttpError(error);
+		}
+	}
+
+	@Delete('/sources/:id')
+	@GlobalScope('knowledge:manage')
+	async deleteSource(_req: AuthenticatedRequest, _res: Response, @Param('id') id: string) {
+		try {
+			await this.syncService.deleteSource(id);
+
+			return { success: true };
+		} catch (error) {
+			this.rethrowAsHttpError(error);
+		}
+	}
+
+	/** Returns as soon as the sync is under way; progress shows up in the run list. */
+	@Post('/sources/:id/sync')
+	@GlobalScope('knowledge:manage')
+	async syncSource(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Param('id') id: string,
+		@Body dto: SyncKnowledgeSourceDto,
+	) {
+		try {
+			await this.syncService.triggerSync(id, { fullResync: dto.fullResync });
+
+			return { started: true };
+		} catch (error) {
+			this.rethrowAsHttpError(error);
+		}
+	}
+
+	@Get('/sources/:id/runs')
+	@GlobalScope('knowledge:manage')
+	async listRuns(_req: AuthenticatedRequest, _res: Response, @Param('id') id: string) {
+		try {
+			await this.getSourceOrThrow(id);
+
+			return await this.syncRunRepository.findRecentRuns(id, RECENT_RUNS_LIMIT);
+		} catch (error) {
+			this.rethrowAsHttpError(error);
+		}
+	}
+
+	@Post('/search')
+	async search(_req: AuthenticatedRequest, _res: Response, @Body dto: SearchKnowledgeDto) {
+		try {
+			const results = await this.searchService.search(dto.query, {
+				sourceIds: dto.sourceIds,
+				topK: dto.topK === undefined ? undefined : Math.min(dto.topK, MAX_TOP_K),
+			});
+
+			return { results };
+		} catch (error) {
+			this.rethrowAsHttpError(error);
+		}
+	}
+
+	private async getSourceOrThrow(id: string): Promise<KnowledgeSource> {
+		const source = await this.sourceRepository.findSourceById(id);
+
+		if (!source) throw new KnowledgeSourceNotFoundError(id);
+
+		return source;
+	}
+
+	private async toSourceResponse(source: KnowledgeSource) {
+		return {
+			id: source.id,
+			name: source.name,
+			type: source.type,
+			status: source.status,
+			lastSyncedAt: source.lastSyncedAt,
+			lastError: source.lastError,
+			documentCount: await this.documentRepository.countBySource(source.id),
+		};
+	}
+
+	/** Subclasses are checked before `UserError` itself, which they extend. */
+	private rethrowAsHttpError(error: unknown): never {
+		if (error instanceof KnowledgeSourceNotFoundError) throw new NotFoundError(error.message);
+		if (error instanceof KnowledgeSyncInProgressError) throw new ConflictError(error.message);
+		if (error instanceof UserError) throw new BadRequestError(error.message);
+
+		throw error;
+	}
+}

--- a/packages/cli/src/modules/knowledge/knowledge.module.ts
+++ b/packages/cli/src/modules/knowledge/knowledge.module.ts
@@ -1,5 +1,6 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 
 /**
  * Knowledge connectors: index external and internal data sources into a vector
@@ -11,12 +12,17 @@ import { BackendModule, OnShutdown } from '@n8n/decorators';
 @BackendModule({ name: 'knowledge', instanceTypes: ['main'] })
 export class KnowledgeModule implements ModuleInterface {
 	async init() {
-		// Controllers, the indexing/sync services and the MCP tool are registered
-		// here in a later wave; this wave ships the DB layer and connector contract only.
+		await import('./knowledge.controller.js');
+
+		const { KnowledgeSyncService } = await import('./knowledge-sync.service.js');
+		Container.get(KnowledgeSyncService).start();
 	}
 
 	@OnShutdown()
-	async shutdown() {}
+	async shutdown() {
+		// The sync service registers its own shutdown hook, which stops the timer
+		// and aborts in-flight runs.
+	}
 
 	async entities() {
 		const { KnowledgeSource } = await import('./database/entities/knowledge-source.entity.js');
@@ -27,6 +33,11 @@ export class KnowledgeModule implements ModuleInterface {
 	}
 
 	async settings() {
-		return { enabled: true };
+		const { KnowledgeSettingsService } = await import('./knowledge-settings.service.js');
+
+		return {
+			enabled: true,
+			configured: await Container.get(KnowledgeSettingsService).isConfigured(),
+		};
 	}
 }

--- a/packages/cli/src/modules/knowledge/knowledge.module.ts
+++ b/packages/cli/src/modules/knowledge/knowledge.module.ts
@@ -1,0 +1,32 @@
+import type { ModuleInterface } from '@n8n/decorators';
+import { BackendModule, OnShutdown } from '@n8n/decorators';
+
+/**
+ * Knowledge connectors: index external and internal data sources into a vector
+ * store and query them over REST and MCP.
+ *
+ * Opt-in via `N8N_ENABLED_MODULES=knowledge` — the module is experimental and
+ * deliberately not in the default set.
+ */
+@BackendModule({ name: 'knowledge', instanceTypes: ['main'] })
+export class KnowledgeModule implements ModuleInterface {
+	async init() {
+		// Controllers, the indexing/sync services and the MCP tool are registered
+		// here in a later wave; this wave ships the DB layer and connector contract only.
+	}
+
+	@OnShutdown()
+	async shutdown() {}
+
+	async entities() {
+		const { KnowledgeSource } = await import('./database/entities/knowledge-source.entity.js');
+		const { KnowledgeDocument } = await import('./database/entities/knowledge-document.entity.js');
+		const { KnowledgeSyncRun } = await import('./database/entities/knowledge-sync-run.entity.js');
+
+		return [KnowledgeSource, KnowledgeDocument, KnowledgeSyncRun];
+	}
+
+	async settings() {
+		return { enabled: true };
+	}
+}

--- a/packages/cli/src/modules/knowledge/utils/__tests__/chunk-text.test.ts
+++ b/packages/cli/src/modules/knowledge/utils/__tests__/chunk-text.test.ts
@@ -1,0 +1,213 @@
+import { chunkText } from '../chunk-text';
+
+const options = (overrides: Partial<Parameters<typeof chunkText>[1]> = {}) => ({
+	chunkSize: 100,
+	chunkOverlap: 0,
+	maxChars: 10_000,
+	...overrides,
+});
+
+describe('chunkText', () => {
+	describe('empty input', () => {
+		test.each([
+			['empty string', ''],
+			['spaces', '   '],
+			['newlines and tabs', '\n\n\t \r\n'],
+		])('returns no chunks for %s', (_name, text) => {
+			expect(chunkText(text, options())).toEqual([]);
+		});
+
+		test('returns no chunks when maxChars is 0', () => {
+			expect(chunkText('some text', options({ maxChars: 0 }))).toEqual([]);
+		});
+	});
+
+	describe('short input', () => {
+		test('returns a single chunk when the text fits', () => {
+			expect(chunkText('hello world', options())).toEqual(['hello world']);
+		});
+
+		test('trims surrounding whitespace', () => {
+			expect(chunkText('  hello world  ', options())).toEqual(['hello world']);
+		});
+
+		test('keeps a chunk that is exactly chunkSize', () => {
+			const text = 'a'.repeat(20);
+
+			expect(chunkText(text, options({ chunkSize: 20 }))).toEqual([text]);
+		});
+
+		test('splits one character past chunkSize', () => {
+			const text = 'a'.repeat(21);
+			const chunks = chunkText(text, options({ chunkSize: 20 }));
+
+			expect(chunks).toEqual(['a'.repeat(20), 'a']);
+		});
+	});
+
+	describe('separator priority', () => {
+		test('prefers paragraph breaks', () => {
+			const paragraphs = ['A'.repeat(30), 'B'.repeat(30), 'C'.repeat(30)];
+			const chunks = chunkText(paragraphs.join('\n\n'), options({ chunkSize: 70 }));
+
+			// 30 + 2 + 30 = 62 fits, adding the third would not.
+			expect(chunks).toEqual([`${paragraphs[0]}\n\n${paragraphs[1]}`, paragraphs[2]]);
+		});
+
+		test('falls back to single newlines inside an oversized paragraph', () => {
+			const lines = ['A'.repeat(40), 'B'.repeat(40), 'C'.repeat(40)];
+			const chunks = chunkText(lines.join('\n'), options({ chunkSize: 50 }));
+
+			expect(chunks).toEqual(lines);
+		});
+
+		test('falls back to sentence boundaries', () => {
+			const text = 'First sentence here. Second sentence here. Third sentence here.';
+			const chunks = chunkText(text, options({ chunkSize: 45 }));
+
+			expect(chunks).toEqual([
+				'First sentence here. Second sentence here.',
+				'Third sentence here.',
+			]);
+		});
+
+		test('falls back to spaces', () => {
+			const chunks = chunkText('alpha beta gamma delta', options({ chunkSize: 12 }));
+
+			expect(chunks).toEqual(['alpha beta', 'gamma delta']);
+		});
+	});
+
+	describe('no separators', () => {
+		test('hard-slices a long run of characters', () => {
+			const chunks = chunkText('x'.repeat(25), options({ chunkSize: 10 }));
+
+			expect(chunks).toEqual(['x'.repeat(10), 'x'.repeat(10), 'x'.repeat(5)]);
+		});
+
+		test('hard-slices only the oversized unit and keeps its siblings intact', () => {
+			const chunks = chunkText(`short ${'y'.repeat(25)} tail`, options({ chunkSize: 10 }));
+
+			expect(chunks).toEqual(['short', 'y'.repeat(10), 'y'.repeat(10), 'y'.repeat(5), 'tail']);
+		});
+	});
+
+	describe('truncation', () => {
+		test('drops everything past maxChars before splitting', () => {
+			const chunks = chunkText('abcdefghij', options({ chunkSize: 100, maxChars: 4 }));
+
+			expect(chunks).toEqual(['abcd']);
+		});
+
+		test('does not truncate when the text is shorter than maxChars', () => {
+			expect(chunkText('abc', options({ maxChars: 4 }))).toEqual(['abc']);
+		});
+	});
+
+	describe('overlap', () => {
+		test('prefixes every chunk after the first with the previous chunk tail', () => {
+			const chunks = chunkText(
+				'alpha beta gamma delta',
+				options({ chunkSize: 12, chunkOverlap: 5 }),
+			);
+
+			expect(chunks[0]).toBe('alpha beta');
+			// 'beta' is what survives the word-boundary trim of the last 5 chars.
+			expect(chunks[1]).toBe('beta gamma delta');
+		});
+
+		test('repeats the whole previous chunk when it is shorter than the overlap', () => {
+			const chunks = chunkText('ab cdefghijklmnopqr', options({ chunkSize: 11, chunkOverlap: 8 }));
+
+			expect(chunks[0]).toBe('ab');
+			expect(chunks[1]).toBe('ab cdefghijklm');
+		});
+
+		test('drops an overlap window that is a single partial word', () => {
+			const chunks = chunkText('ab cdefghijklmnopqr', options({ chunkSize: 11, chunkOverlap: 8 }));
+
+			// The tail of 'cdefghijklm' has no word boundary, so nothing is repeated.
+			expect(chunks[2]).toBe('nopqr');
+		});
+
+		test('overlaps from the original chunk, so the prefix never compounds', () => {
+			const chunks = chunkText(
+				'one two three four five six',
+				options({ chunkSize: 9, chunkOverlap: 4 }),
+			);
+
+			expect(chunks).toEqual(['one two', 'two three', 'four five', 'five six']);
+		});
+
+		test('keeps a tail that already starts on a word boundary', () => {
+			const chunks = chunkText('alpha beta gamma', options({ chunkSize: 10, chunkOverlap: 5 }));
+
+			expect(chunks).toEqual(['alpha beta', 'beta gamma']);
+		});
+
+		test('is a no-op when chunkOverlap is 0', () => {
+			const chunks = chunkText('alpha beta gamma', options({ chunkSize: 10, chunkOverlap: 0 }));
+
+			expect(chunks).toEqual(['alpha beta', 'gamma']);
+		});
+
+		test('clamps an overlap that is not smaller than the chunk size', () => {
+			const chunks = chunkText('alpha beta gamma', options({ chunkSize: 10, chunkOverlap: 50 }));
+
+			expect(chunks).toEqual(['alpha beta', 'beta gamma']);
+		});
+	});
+
+	describe('unicode', () => {
+		test('does not split a surrogate pair when hard-slicing', () => {
+			const chunks = chunkText('😀😀😀', options({ chunkSize: 3 }));
+
+			expect(chunks).toEqual(['😀', '😀', '😀']);
+			expect(chunks.join('')).toBe('😀😀😀');
+		});
+
+		test('does not split a surrogate pair when truncating', () => {
+			const chunks = chunkText('a😀b', options({ chunkSize: 100, maxChars: 2 }));
+
+			expect(chunks).toEqual(['a']);
+		});
+
+		test('chunks non-latin text on its separators', () => {
+			const chunks = chunkText('привет мир\n\nこんにちは', options({ chunkSize: 12 }));
+
+			expect(chunks).toEqual(['привет мир', 'こんにちは']);
+		});
+	});
+
+	describe('invariants', () => {
+		const longText = Array.from(
+			{ length: 40 },
+			(_, i) => `Paragraph ${i} with a few words in it. And a second sentence.`,
+		).join('\n\n');
+
+		test('never returns an empty or whitespace-only chunk', () => {
+			const chunks = chunkText(longText, options({ chunkSize: 90, chunkOverlap: 20 }));
+
+			expect(chunks.length).toBeGreaterThan(1);
+			for (const chunk of chunks) expect(chunk.trim()).not.toBe('');
+		});
+
+		test('is deterministic', () => {
+			const opts = options({ chunkSize: 90, chunkOverlap: 20 });
+
+			expect(chunkText(longText, opts)).toEqual(chunkText(longText, opts));
+		});
+
+		test('keeps chunks within chunkSize plus the overlap prefix', () => {
+			const chunks = chunkText(longText, options({ chunkSize: 90, chunkOverlap: 20 }));
+
+			for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(90 + 20 + 1);
+		});
+
+		test('covers every non-whitespace character of the input', () => {
+			const chunks = chunkText(longText, options({ chunkSize: 90, chunkOverlap: 0 }));
+
+			expect(chunks.join('').replace(/\s/g, '')).toBe(longText.replace(/\s/g, ''));
+		});
+	});
+});

--- a/packages/cli/src/modules/knowledge/utils/chunk-text.ts
+++ b/packages/cli/src/modules/knowledge/utils/chunk-text.ts
@@ -1,0 +1,162 @@
+/**
+ * Separators tried in order of decreasing semantic weight: a paragraph break
+ * keeps more meaning together than a space, so a weaker one is only used when
+ * a unit is still too large.
+ *
+ * `keep` is the part of the separator that belongs to the text rather than to
+ * the layout — the sentence period stays on the unit it ends, while whitespace
+ * separators only reappear when two units end up in the same chunk.
+ */
+const SEPARATORS = [
+	{ split: '\n\n', keep: '' },
+	{ split: '\n', keep: '' },
+	{ split: '. ', keep: '.' },
+	{ split: ' ', keep: '' },
+] as const;
+
+export interface ChunkTextOptions {
+	/** Target maximum characters per chunk, before the overlap prefix is added. */
+	chunkSize: number;
+	/** Characters of the previous chunk repeated at the start of the next one. */
+	chunkOverlap: number;
+	/** Input longer than this is truncated before any splitting happens. */
+	maxChars: number;
+}
+
+function isHighSurrogate(code: number): boolean {
+	return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number): boolean {
+	return code >= 0xdc00 && code <= 0xdfff;
+}
+
+/** Moves `index` back by one when it would land between the halves of a surrogate pair. */
+function safeIndex(text: string, index: number): number {
+	if (index <= 0 || index >= text.length) return index;
+
+	return isHighSurrogate(text.charCodeAt(index - 1)) && isLowSurrogate(text.charCodeAt(index))
+		? index - 1
+		: index;
+}
+
+/** Last resort for a run of text with no usable separator (e.g. a base64 blob). */
+function hardSlice(text: string, chunkSize: number): string[] {
+	const slices: string[] = [];
+	let start = 0;
+
+	while (start < text.length) {
+		// A `chunkSize` of 1 in front of a surrogate pair would make `safeIndex`
+		// return `start`, so never let the window collapse.
+		const end = Math.max(safeIndex(text, Math.min(start + chunkSize, text.length)), start + 1);
+		slices.push(text.slice(start, end));
+		start = end;
+	}
+
+	return slices;
+}
+
+/**
+ * Packs text into chunks of at most `chunkSize`: split on the current
+ * separator, greedily fill a chunk with whole units, and recurse into any unit
+ * that is oversized on its own using the next weaker separator.
+ */
+function splitToSize(text: string, chunkSize: number, separatorIndex: number): string[] {
+	if (text.length <= chunkSize) return text.length > 0 ? [text] : [];
+	if (separatorIndex >= SEPARATORS.length) return hardSlice(text, chunkSize);
+
+	const { split, keep } = SEPARATORS[separatorIndex];
+	const parts = text.split(split);
+
+	// The separator is absent: nothing gained here, move on to the next one.
+	if (parts.length <= 1) return splitToSize(text, chunkSize, separatorIndex + 1);
+
+	const units = parts.map((part, index) => (index < parts.length - 1 ? part + keep : part));
+	// What is left of the separator once `keep` has been folded into the unit.
+	const glue = split.slice(keep.length);
+
+	const chunks: string[] = [];
+	let buffer = '';
+	const flush = () => {
+		if (buffer !== '') chunks.push(buffer);
+		buffer = '';
+	};
+
+	for (const unit of units) {
+		// Runs of consecutive separators produce empty units.
+		if (unit === '') continue;
+
+		if (unit.length > chunkSize) {
+			flush();
+			chunks.push(...splitToSize(unit, chunkSize, separatorIndex + 1));
+			continue;
+		}
+
+		const candidate = buffer === '' ? unit : buffer + glue + unit;
+
+		if (candidate.length <= chunkSize) {
+			buffer = candidate;
+		} else {
+			flush();
+			buffer = unit;
+		}
+	}
+
+	flush();
+
+	return chunks;
+}
+
+/**
+ * Tail of the previous chunk, cut back to a word boundary so an overlap never
+ * starts mid-word. A window that contains no boundary at all is a single
+ * partial word and is dropped rather than repeated as a fragment.
+ */
+function overlapPrefix(previous: string, chunkOverlap: number): string {
+	if (chunkOverlap <= 0) return '';
+
+	const start = safeIndex(previous, Math.max(previous.length - chunkOverlap, 0));
+	let tail = previous.slice(start);
+
+	// Only realign when the window opens inside a word — a window that already
+	// starts right after whitespace is on a boundary.
+	if (start > 0 && !/\s/.test(previous[start - 1])) {
+		const firstBoundary = tail.search(/\s/);
+		tail = firstBoundary === -1 ? '' : tail.slice(firstBoundary + 1);
+	}
+
+	return tail.trim();
+}
+
+/**
+ * Splits `text` into overlapping chunks ready for embedding.
+ *
+ * Deterministic and dependency-free: the same input always yields the same
+ * chunks, and no chunk is ever empty. Note that the overlap prefix is added
+ * *after* packing, so a chunk can exceed `chunkSize` by up to `chunkOverlap`.
+ */
+export function chunkText(text: string, options: ChunkTextOptions): string[] {
+	if (text.trim() === '') return [];
+
+	const chunkSize = Math.max(1, Math.floor(options.chunkSize));
+	// An overlap at or above the chunk size would repeat a whole chunk.
+	const chunkOverlap = Math.min(Math.max(0, Math.floor(options.chunkOverlap)), chunkSize - 1);
+	const maxChars = Math.max(0, Math.floor(options.maxChars));
+
+	if (maxChars === 0) return [];
+
+	const truncated =
+		text.length > maxChars ? text.slice(0, Math.max(safeIndex(text, maxChars), 1)) : text;
+
+	const chunks = splitToSize(truncated, chunkSize, 0)
+		.map((chunk) => chunk.trim())
+		.filter((chunk) => chunk !== '');
+
+	return chunks.map((chunk, index) => {
+		if (index === 0) return chunk;
+
+		const prefix = overlapPrefix(chunks[index - 1], chunkOverlap);
+
+		return prefix === '' ? chunk : `${prefix} ${chunk}`;
+	});
+}

--- a/packages/cli/src/modules/mcp/__tests__/knowledge/search-knowledge.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/knowledge/search-knowledge.tool.test.ts
@@ -1,0 +1,129 @@
+import type {
+	KnowledgeSearchResult,
+	KnowledgeSearchService,
+} from '@/modules/knowledge/knowledge-search.service';
+
+import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
+import { createSearchKnowledgeTool } from '../../tools/knowledge/search-knowledge.tool';
+import { createTelemetry, user } from '../data-table/test-utils';
+
+const hit = (overrides: Partial<KnowledgeSearchResult> = {}): KnowledgeSearchResult => ({
+	text: 'Deployments are described in the runbook.',
+	score: 0.82,
+	title: '#12 How do I deploy?',
+	url: 'https://github.com/n8n-io/n8n/issues/12',
+	sourceId: 'source-1',
+	sourceName: 'n8n repo',
+	externalId: 'issue:12',
+	metadata: { kind: 'issue' },
+	...overrides,
+});
+
+const createMocks = (result: KnowledgeSearchResult[] | Error) => {
+	const search =
+		result instanceof Error ? vi.fn().mockRejectedValue(result) : vi.fn().mockResolvedValue(result);
+	const searchService = { search } as unknown as KnowledgeSearchService;
+
+	return { searchService, telemetry: createTelemetry() };
+};
+
+describe('search_knowledge MCP tool', () => {
+	test('creates the tool as read-only', () => {
+		const { searchService, telemetry } = createMocks([]);
+		const tool = createSearchKnowledgeTool(user, () => searchService, telemetry);
+
+		expect(tool.name).toBe('search_knowledge');
+		expect(tool.config.annotations?.readOnlyHint).toBe(true);
+		expect(tool.config.inputSchema).toBeDefined();
+		expect(tool.config.outputSchema).toBeDefined();
+	});
+
+	test('resolves the search service lazily, only when called', async () => {
+		const { searchService, telemetry } = createMocks([]);
+		const getSearchService = vi.fn(() => searchService);
+		const tool = createSearchKnowledgeTool(user, getSearchService, telemetry);
+
+		expect(getSearchService).not.toHaveBeenCalled();
+
+		await tool.handler({ query: 'deploy' }, {} as never);
+
+		expect(getSearchService).toHaveBeenCalledTimes(1);
+	});
+
+	test('returns the hits and tracks the call', async () => {
+		const { searchService, telemetry } = createMocks([hit()]);
+		const tool = createSearchKnowledgeTool(user, () => searchService, telemetry);
+
+		const result = await tool.handler({ query: 'deploy', sourceIds: ['source-1'] }, {} as never);
+
+		expect(searchService.search).toHaveBeenCalledWith('deploy', {
+			sourceIds: ['source-1'],
+			topK: 25,
+		});
+		expect(result.structuredContent).toEqual({
+			results: [
+				{
+					text: 'Deployments are described in the runbook.',
+					title: '#12 How do I deploy?',
+					url: 'https://github.com/n8n-io/n8n/issues/12',
+					sourceName: 'n8n repo',
+					externalId: 'issue:12',
+					score: 0.82,
+				},
+			],
+			total: 1,
+		});
+		expect(telemetry.track).toHaveBeenCalledWith(USER_CALLED_MCP_TOOL_EVENT, {
+			user_id: user.id,
+			tool_name: 'search_knowledge',
+			// the query itself is never tracked
+			parameters: { sourceIds: ['source-1'], topK: undefined },
+			results: { success: true, data: { count: 1 } },
+		});
+	});
+
+	test('truncates long passages', async () => {
+		const { searchService, telemetry } = createMocks([hit({ text: 'x'.repeat(5000) })]);
+		const tool = createSearchKnowledgeTool(user, () => searchService, telemetry);
+
+		const result = await tool.handler({ query: 'deploy' }, {} as never);
+		const [first] = (result.structuredContent as { results: Array<{ text: string }> }).results;
+
+		expect(first.text).toHaveLength(1201);
+		expect(first.text.endsWith('…')).toBe(true);
+	});
+
+	test('clamps topK to the tool maximum', async () => {
+		const { searchService, telemetry } = createMocks([]);
+		const tool = createSearchKnowledgeTool(user, () => searchService, telemetry);
+
+		await tool.handler({ query: 'deploy', topK: 999 }, {} as never);
+
+		expect(searchService.search).toHaveBeenCalledWith('deploy', {
+			sourceIds: undefined,
+			topK: 25,
+		});
+	});
+
+	test('reports a failed search as a tool error', async () => {
+		const { searchService, telemetry } = createMocks(
+			new Error('Knowledge connectors are not configured.'),
+		);
+		const tool = createSearchKnowledgeTool(user, () => searchService, telemetry);
+
+		const result = await tool.handler({ query: 'deploy' }, {} as never);
+
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toEqual({
+			results: [],
+			total: 0,
+			error: 'Knowledge connectors are not configured.',
+		});
+		expect(telemetry.track).toHaveBeenCalledWith(
+			USER_CALLED_MCP_TOOL_EVENT,
+			expect.objectContaining({
+				results: { success: false, error: 'Knowledge connectors are not configured.' },
+			}),
+		);
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/mcp-protected-resource.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-protected-resource.test.ts
@@ -43,6 +43,7 @@ describe('McpProtectedResource', () => {
 			expect(scopeTools['workflow:read']).toContain('search_nodes');
 			expect(scopeTools['agent:read']).toContain('search_agents');
 			expect(scopeTools['tag:read']).toContain('list_workflow_tags');
+			expect(scopeTools['knowledge:read']).toContain('search_knowledge');
 		});
 
 		it('should drop tools this instance does not expose', () => {
@@ -76,6 +77,15 @@ describe('McpProtectedResource', () => {
 			expect(resource.scopes).not.toContain('agent:write');
 			expect(resource.getScopeTools()).not.toHaveProperty('agent:read');
 			expect(resource.getScopeTools()).not.toHaveProperty('agent:write');
+		});
+
+		it('should drop the knowledge scope when the knowledge module is inactive', () => {
+			moduleRegistry.isActive.mockImplementation((module: string) => module !== 'knowledge');
+
+			expect(resource.scopes).not.toContain('knowledge:read');
+			expect(resource.getScopeTools()).not.toHaveProperty('knowledge:read');
+			// unrelated scopes are untouched
+			expect(resource.scopes).toContain('workflow:read');
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/__tests__/mcp-scopes.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-scopes.test.ts
@@ -36,7 +36,13 @@ import { WorkflowService } from '@/workflows/workflow.service';
 
 import { registerWorkflowPreviewApp } from '@n8n/mcp-apps/server';
 
-import { AGENT_TOOLS, BUILDER_TOOLS, getAllowedToolNames, TOOLS_BY_SCOPE } from '../mcp-scopes';
+import {
+	AGENT_TOOLS,
+	BUILDER_TOOLS,
+	getAllowedToolNames,
+	KNOWLEDGE_TOOLS,
+	TOOLS_BY_SCOPE,
+} from '../mcp-scopes';
 import { McpService, type McpFeatureFlags } from '../mcp.service';
 
 vi.mock('@n8n/mcp-apps/server', async (importOriginal) => ({
@@ -157,9 +163,10 @@ describe('McpService scope enforcement', () => {
 		const registered = getRegisteredToolNames(server);
 
 		// Agent tools require the agents module (inactive here); their own
-		// drift guard lives in agent-tools.service.test.ts.
+		// drift guard lives in agent-tools.service.test.ts. Knowledge tools are
+		// likewise gated on their optional module.
 		const unregistered = [...ALL_MAPPED_TOOLS].filter(
-			(name) => !registered.has(name) && !AGENT_TOOLS.has(name),
+			(name) => !registered.has(name) && !AGENT_TOOLS.has(name) && !KNOWLEDGE_TOOLS.has(name),
 		);
 		expect(unregistered).toEqual([]);
 	});

--- a/packages/cli/src/modules/mcp/mcp-protected-resource.ts
+++ b/packages/cli/src/modules/mcp/mcp-protected-resource.ts
@@ -9,7 +9,7 @@ import type { ProtectedResource } from '@/services/protected-resource.registry';
 import { UrlService } from '@/services/url.service';
 
 import { BUILDER_TOOLS, TOOLS_BY_SCOPE } from './mcp-scopes';
-import { areAgentToolsAvailable } from './mcp-tool-availability';
+import { areAgentToolsAvailable, areKnowledgeToolsAvailable } from './mcp-tool-availability';
 import { McpConfig } from './mcp.config';
 import { McpSettingsService } from './mcp.settings.service';
 
@@ -19,6 +19,7 @@ import { McpSettingsService } from './mcp.settings.service';
  */
 export const SUPPORTED_SCOPES: string[] = [...MCP_INSTANCE_SCOPES];
 const AGENT_SCOPES = new Set<string>(MCP_AGENT_SCOPES);
+const KNOWLEDGE_SCOPE = 'knowledge:read';
 
 const MCP_RESOURCE_PATH = '/mcp-server/http';
 
@@ -55,8 +56,19 @@ export class McpProtectedResource implements ProtectedResource {
 	) {}
 
 	get scopes(): string[] {
-		if (areAgentToolsAvailable(this.globalConfig, this.moduleRegistry)) return SUPPORTED_SCOPES;
-		return SUPPORTED_SCOPES.filter((scope) => !AGENT_SCOPES.has(scope));
+		// A scope whose tools this instance cannot expose is never offered on the
+		// consent screen.
+		const unavailable = new Set<string>();
+
+		if (!areAgentToolsAvailable(this.globalConfig, this.moduleRegistry)) {
+			for (const scope of AGENT_SCOPES) unavailable.add(scope);
+		}
+
+		if (!areKnowledgeToolsAvailable(this.moduleRegistry)) unavailable.add(KNOWLEDGE_SCOPE);
+
+		if (unavailable.size === 0) return SUPPORTED_SCOPES;
+
+		return SUPPORTED_SCOPES.filter((scope) => !unavailable.has(scope));
 	}
 
 	/**

--- a/packages/cli/src/modules/mcp/mcp-scopes.ts
+++ b/packages/cli/src/modules/mcp/mcp-scopes.ts
@@ -85,7 +85,15 @@ export const TOOLS_BY_SCOPE: Record<McpScope, readonly string[]> = {
 	],
 	'project:read': ['search_projects', 'search_folders'],
 	'tag:read': ['list_workflow_tags'],
+	'knowledge:read': ['search_knowledge'],
 };
+
+/**
+ * Tools only registered while the optional `knowledge` module is active. Kept
+ * out of the "everything is registered" drift guard for the same reason as
+ * AGENT_TOOLS: the module is off in that test's environment.
+ */
+export const KNOWLEDGE_TOOLS: ReadonlySet<string> = new Set(TOOLS_BY_SCOPE['knowledge:read']);
 
 /**
  * Tools only registered when the workflow builder is enabled

--- a/packages/cli/src/modules/mcp/mcp-tool-availability.ts
+++ b/packages/cli/src/modules/mcp/mcp-tool-availability.ts
@@ -7,3 +7,8 @@ export function areAgentToolsAvailable(
 ): boolean {
 	return globalConfig.endpoints.mcpBuilderEnabled && moduleRegistry.isActive('agents');
 }
+
+/** The knowledge module is opt-in, so its tool only exists where it is enabled. */
+export function areKnowledgeToolsAvailable(moduleRegistry: ModuleRegistry): boolean {
+	return moduleRegistry.isActive('knowledge');
+}

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -53,7 +53,7 @@ import { WorkflowService } from '@/workflows/workflow.service';
 
 import { MCP_CREATE_AGENT_TOOL_NAME, MCP_PREVIEW_RENDER_REQUESTED_EVENT } from './mcp.constants';
 import { getAllowedToolNames } from './mcp-scopes';
-import { areAgentToolsAvailable } from './mcp-tool-availability';
+import { areAgentToolsAvailable, areKnowledgeToolsAvailable } from './mcp-tool-availability';
 import type {
 	McpAppsTelemetryVariant,
 	McpClientInfo,
@@ -76,6 +76,7 @@ import { createGetExecutionTool } from './tools/get-execution.tool';
 import { createWorkflowDetailsTool } from './tools/get-workflow-details.tool';
 import { createGetWorkflowHistoryTool } from './tools/get-workflow-history.tool';
 import { createGetWorkflowVersionTool } from './tools/get-workflow-version.tool';
+import { createSearchKnowledgeTool } from './tools/knowledge/search-knowledge.tool';
 import { createListCredentialsTool } from './tools/list-credentials.tool';
 import { createListN8nConnectServicesTool } from './tools/list-n8n-connect-services.tool';
 import { createListTagsTool } from './tools/list-tags.tool';
@@ -581,6 +582,22 @@ export class McpService {
 
 		const addDataTableRowsTool = createAddDataTableRowsTool(user, dataTableOps, this.telemetry);
 		registerIfAllowed(addDataTableRowsTool);
+
+		// Knowledge search, only when the optional knowledge module is enabled.
+		// The service is imported lazily so an instance running without the
+		// module never loads it.
+		if (areKnowledgeToolsAvailable(this.moduleRegistry)) {
+			const { KnowledgeSearchService } = await import(
+				'@/modules/knowledge/knowledge-search.service.js'
+			);
+
+			const searchKnowledgeTool = createSearchKnowledgeTool(
+				user,
+				() => Container.get(KnowledgeSearchService),
+				this.telemetry,
+			);
+			registerIfAllowed(searchKnowledgeTool);
+		}
 
 		// Workflow builder tools (enabled via N8N_MCP_BUILDER_ENABLED)
 		if (builderEnabled) {

--- a/packages/cli/src/modules/mcp/tools/knowledge/search-knowledge.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/knowledge/search-knowledge.tool.ts
@@ -1,0 +1,130 @@
+import type { User } from '@n8n/db';
+import z from 'zod';
+
+import type { KnowledgeSearchService } from '@/modules/knowledge/knowledge-search.service';
+import type { Telemetry } from '@/telemetry';
+
+import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
+import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
+
+const SEARCH_MAX_RESULTS = 25;
+
+/** Chunks are ~1500 characters; this keeps a full page of results readable in a context window. */
+const MAX_TEXT_LENGTH = 1200;
+
+const searchInputSchema = {
+	query: z.string().describe('What to look for; matched semantically, not by keyword'),
+	sourceIds: z
+		.array(z.string())
+		.optional()
+		.describe('Restrict the search to these knowledge source IDs'),
+	topK: z
+		.number()
+		.int()
+		.positive()
+		.max(SEARCH_MAX_RESULTS)
+		.optional()
+		.describe(`Number of results to return (max ${SEARCH_MAX_RESULTS})`),
+} satisfies z.ZodRawShape;
+
+const searchOutputSchema = {
+	results: z
+		.array(
+			z.object({
+				text: z.string(),
+				title: z.string(),
+				url: z.string().nullable(),
+				sourceName: z.string(),
+				externalId: z.string(),
+				score: z.number(),
+			}),
+		)
+		.describe('Matching passages, most relevant first'),
+	total: z.number().int().min(0).describe('Number of passages returned'),
+} satisfies z.ZodRawShape;
+
+const truncate = (text: string) =>
+	text.length > MAX_TEXT_LENGTH ? `${text.slice(0, MAX_TEXT_LENGTH)}…` : text;
+
+/**
+ * `getSearchService` is a lazy accessor rather than the service itself: the
+ * knowledge module is optional, so its container entry is only resolved once
+ * the tool is actually called.
+ */
+export const createSearchKnowledgeTool = (
+	user: User,
+	getSearchService: () => KnowledgeSearchService,
+	telemetry: Telemetry,
+): ToolDefinition<typeof searchInputSchema> => ({
+	name: 'search_knowledge',
+	config: {
+		description:
+			"Search the knowledge indexed on this n8n instance (connected sources such as GitHub repositories and the instance's own workflows, data tables and credentials). Use this to answer questions about what exists on the instance or what a connected source documents.",
+		inputSchema: searchInputSchema,
+		outputSchema: searchOutputSchema,
+		annotations: {
+			title: 'Search Knowledge',
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+	},
+	handler: async ({
+		query,
+		sourceIds,
+		topK,
+	}: {
+		query: string;
+		sourceIds?: string[];
+		topK?: number;
+	}) => {
+		// The query itself is left out of telemetry — it is free-form user text.
+		const telemetryPayload: UserCalledMCPToolEventPayload = {
+			user_id: user.id,
+			tool_name: 'search_knowledge',
+			parameters: { sourceIds, topK },
+		};
+
+		try {
+			const safeTopK = Math.min(Math.max(1, topK ?? SEARCH_MAX_RESULTS), SEARCH_MAX_RESULTS);
+
+			const hits = await getSearchService().search(query, { sourceIds, topK: safeTopK });
+
+			const results = hits.map((hit) => ({
+				text: truncate(hit.text),
+				title: hit.title,
+				url: hit.url,
+				sourceName: hit.sourceName,
+				externalId: hit.externalId,
+				score: hit.score,
+			}));
+
+			telemetryPayload.results = {
+				success: true,
+				data: { count: results.length },
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+			const output = { results, total: results.length };
+			return {
+				content: [{ type: 'text', text: JSON.stringify(output) }],
+				structuredContent: output,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			telemetryPayload.results = {
+				success: false,
+				error: errorMessage,
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+			const output = { results: [], total: 0, error: errorMessage };
+			return {
+				content: [{ type: 'text', text: JSON.stringify(output) }],
+				structuredContent: output,
+				isError: true,
+			};
+		}
+	},
+});


### PR DESCRIPTION
## Summary

Adds a new experimental **knowledge connectors** module that indexes external and internal data sources into a vector store, making them searchable via REST API and MCP tools.

The module provides:
- **Connectors** for GitHub (issues/PRs) and n8n instance metadata (workflows, data tables, credentials)
- **Sync service** that runs connectors on a timer on the leader node, persisting checkpoints for incremental updates
- **Indexing service** that chunks documents, generates embeddings (OpenAI), and stores vectors (Qdrant)
- **Search service** that queries the vector store and returns ranked results
- **REST API** (`POST /rest/knowledge/search`) and **MCP tool** (`search_knowledge`) for querying
- **Database schema** to track sources, documents, and sync runs

The module is experimental and disabled by default. It can be enabled via `N8N_ENABLED_MODULES=knowledge`.

### Key Features
- **Incremental syncing**: Connectors use checkpoints to resume from where they left off
- **Credential security**: Never stores or emits credential data; only metadata
- **Semantic search**: Uses embeddings for meaning-based queries, not keyword matching
- **Leader-only execution**: Sync runs only on the cluster leader to avoid duplication
- **Configurable**: Settings for embedding provider, vector store, and per-source configuration

### Architecture
```
Source → Connector → Drafts → Indexing Service → Embeddings + Vector Store → Search Service → REST/MCP
```

## How to test

1. Enable the module: `export N8N_ENABLED_MODULES=knowledge`
2. Configure embedding and vector store credentials in the UI (OpenAI + Qdrant)
3. Create a knowledge source (GitHub repo or n8n instance)
4. Trigger a sync via the API or UI
5. Search via `POST /rest/knowledge/search` with a query
6. Verify results are semantically relevant (not keyword-matched)

The module includes comprehensive unit tests covering:
- GitHub connector (pagination, rate limiting, issue/PR parsing)
- N8n connector (workflow/data table/credential indexing)
- Sync service (checkpoint persistence, error handling, leader election)
- Indexing service (chunking, deduplication, embedding)
- Search service (vector queries, result ranking)
- Vector store and embedding services

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included (comprehensive unit test coverage for all services and connectors).
- [ ] PR Labeled with backport label if needed.

https://claude.ai/code/session_01HbUCKbdUy4ZL9WLzM2bLSs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

