### PR TITLE
feat(editor): Add current-workflow search to the command palette with Cmd+F

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.test.ts
@@ -63,6 +63,19 @@ describe('components', () => {
 			expect(wrapper.emitted()).toBeDefined();
 		});
 
+		it('opens and focuses the input when the open model is set externally', async () => {
+			const wrapper = render(N8nCommandBar, {
+				props: { items: createSampleItems(), open: false },
+			});
+
+			await wrapper.rerender({ open: true });
+
+			await waitFor(() =>
+				expect(screen.getByPlaceholderText('Type a command...')).toBeInTheDocument(),
+			);
+			expect(screen.getByPlaceholderText('Type a command...')).toHaveFocus();
+		});
+
 		it('emits update:open when opened via Cmd+K and when closed via Escape', async () => {
 			const wrapper = render(N8nCommandBar, {
 				props: { items: createSampleItems() },

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
@@ -152,20 +152,22 @@ const scrollSelectedIntoView = () => {
 	});
 };
 
-// Watch instead of imperative open so parents can open via the `open` model too
+// Watch instead of imperative open/close so parents can drive the `open` model too
 watch(isOpen, async (open) => {
-	if (!open) return;
-	selectedIndex.value = 0;
-	inputValue.value = '';
-	await nextTick();
-	inputRef.value?.focus();
+	if (open) {
+		selectedIndex.value = 0;
+		inputValue.value = '';
+		await nextTick();
+		inputRef.value?.focus();
+	} else {
+		selectedIndex.value = -1;
+		inputValue.value = '';
+		currentParentId.value = null;
+	}
 });
 
 const closeCommandBar = () => {
 	isOpen.value = false;
-	selectedIndex.value = -1;
-	inputValue.value = '';
-	currentParentId.value = null;
 };
 
 const navigateToChildren = (item: CommandBarItem) => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
@@ -152,13 +152,14 @@ const scrollSelectedIntoView = () => {
 	});
 };
 
-const openCommandBar = async () => {
-	isOpen.value = true;
+// Watch instead of imperative open so parents can open via the `open` model too
+watch(isOpen, async (open) => {
+	if (!open) return;
 	selectedIndex.value = 0;
 	inputValue.value = '';
 	await nextTick();
 	inputRef.value?.focus();
-};
+});
 
 const closeCommandBar = () => {
 	isOpen.value = false;
@@ -202,7 +203,7 @@ const selectItem = (item: CommandBarItem) => {
 const handleKeydown = (event: KeyboardEvent) => {
 	if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
 		event.preventDefault();
-		void openCommandBar();
+		isOpen.value = true;
 		return;
 	}
 

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
@@ -1,9 +1,11 @@
 import { computed, reactive, ref } from 'vue';
+import { waitFor } from '@testing-library/vue';
 import { createTestingPinia } from '@pinia/testing';
 import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
 import { defaultSettings } from '@/__tests__/defaults';
 import { useSettingsStore } from '@n8n/stores/settings.store';
+import { commandBarEventBus } from '@/features/shared/commandBar/commandBar.eventBus';
 import AppCommandBar from './AppCommandBar.vue';
 
 vi.mock('@/app/utils/rbac/permissions', () => ({
@@ -30,7 +32,10 @@ vi.mock('@/features/shared/commandBar/composables/useCommandBar', () => ({
 const renderComponent = createComponentRenderer(AppCommandBar, {
 	global: {
 		stubs: {
-			N8nCommandBar: { template: '<div data-test-id="command-bar-stub" />' },
+			N8nCommandBar: {
+				props: ['open'],
+				template: '<div data-test-id="command-bar-stub" :data-open="String(open)" />',
+			},
 		},
 	},
 });
@@ -49,6 +54,15 @@ describe('AppCommandBar', () => {
 		const { queryByTestId } = renderComponent({ pinia });
 
 		expect(queryByTestId('command-bar-stub')).toBeInTheDocument();
+	});
+
+	it('opens the command bar on an open:request bus event', async () => {
+		const { getByTestId } = renderComponent({ pinia });
+
+		expect(getByTestId('command-bar-stub').dataset.open).toBe('false');
+
+		commandBarEventBus.emit('open:request');
+		await waitFor(() => expect(getByTestId('command-bar-stub').dataset.open).toBe('true'));
 	});
 
 	it('does not render the command bar in canvas-only mode', () => {

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
@@ -6,6 +6,7 @@ import { type MockedStore, mockedStore } from '@/__tests__/utils';
 import { defaultSettings } from '@/__tests__/defaults';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { commandBarEventBus } from '@/features/shared/commandBar/commandBar.eventBus';
+import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import AppCommandBar from './AppCommandBar.vue';
 
 vi.mock('@/app/utils/rbac/permissions', () => ({
@@ -63,6 +64,21 @@ describe('AppCommandBar', () => {
 
 		commandBarEventBus.emit('open:request');
 		await waitFor(() => expect(getByTestId('command-bar-stub').dataset.open).toBe('true'));
+	});
+
+	it('closes the command bar on Cmd+F and refocuses the canvas', async () => {
+		const emitSpy = vi.spyOn(canvasEventBus, 'emit');
+		const { getByTestId } = renderComponent({ pinia });
+
+		commandBarEventBus.emit('open:request');
+		await waitFor(() => expect(getByTestId('command-bar-stub').dataset.open).toBe('true'));
+
+		document.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'f', metaKey: true, cancelable: true }),
+		);
+
+		await waitFor(() => expect(getByTestId('command-bar-stub').dataset.open).toBe('false'));
+		await waitFor(() => expect(emitSpy).toHaveBeenCalledWith('focus'));
 	});
 
 	it('does not render the command bar in canvas-only mode', () => {

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { N8nCommandBar } from '@n8n/design-system';
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { useRoute } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 import { useStyles } from '@n8n/composables/useStyles';
@@ -47,8 +48,24 @@ function onOpenRequest() {
 	isCommandBarOpen.value = true;
 }
 
-onMounted(() => commandBarEventBus.on('open:request', onOpenRequest));
-onBeforeUnmount(() => commandBarEventBus.off('open:request', onOpenRequest));
+// Cmd+F toggles: the canvas keymap opens, but can't close while the bar's input has focus
+function onDocumentKeydown(event: KeyboardEvent) {
+	if (!isCommandBarOpen.value) return;
+	if ((event.metaKey || event.ctrlKey) && event.key === 'f') {
+		event.preventDefault();
+		isCommandBarOpen.value = false;
+		void nextTick(() => canvasEventBus.emit('focus'));
+	}
+}
+
+onMounted(() => {
+	commandBarEventBus.on('open:request', onOpenRequest);
+	document.addEventListener('keydown', onDocumentKeydown, { capture: true });
+});
+onBeforeUnmount(() => {
+	commandBarEventBus.off('open:request', onOpenRequest);
+	document.removeEventListener('keydown', onDocumentKeydown, { capture: true });
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { N8nCommandBar } from '@n8n/design-system';
-import { computed, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 import { useStyles } from '@n8n/composables/useStyles';
@@ -35,16 +35,26 @@ watch(showCommandBar, (newVal) => {
 	}
 });
 
-function onCommandBarOpenChange(open: boolean) {
+const isCommandBarOpen = ref(false);
+
+watch(isCommandBarOpen, (open) => {
 	if (open) {
 		commandBarEventBus.emit('open');
 	}
+});
+
+function onOpenRequest() {
+	isCommandBarOpen.value = true;
 }
+
+onMounted(() => commandBarEventBus.on('open:request', onOpenRequest));
+onBeforeUnmount(() => commandBarEventBus.off('open:request', onOpenRequest));
 </script>
 
 <template>
 	<N8nCommandBar
 		v-if="showCommandBar"
+		v-model:open="isCommandBarOpen"
 		:items="items"
 		:placeholder="placeholder"
 		:context="context"
@@ -52,6 +62,5 @@ function onCommandBarOpenChange(open: boolean) {
 		:z-index="APP_Z_INDEXES.COMMAND_BAR"
 		@input-change="onCommandBarChange"
 		@navigate-to="onCommandBarNavigateTo"
-		@update:open="onCommandBarOpenChange"
 	/>
 </template>

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/commandBar.eventBus.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/commandBar.eventBus.ts
@@ -3,6 +3,9 @@ import { createEventBus } from '@n8n/utils/event-bus';
 export interface CommandBarEventBusEvents {
 	/** Event that the command bar has opened */
 	open: never;
+
+	/** Request to open the command bar programmatically */
+	'open:request': never;
 }
 
 export const commandBarEventBus = createEventBus<CommandBarEventBusEvents>();

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.test.ts
@@ -15,6 +15,7 @@ import {
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { createTestNode } from '@/__tests__/mocks';
+import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 
 // Instantiates a store that derives the workflow id from the route. These tests run
 // without a router, so resolve the id directly.
@@ -313,6 +314,65 @@ describe('useNodeCommands', () => {
 			if (addCommand) {
 				expect(commands.value.length).toBeLessThanOrEqual(3);
 			}
+		});
+	});
+
+	describe('workflow parameter search', () => {
+		beforeEach(() => {
+			const store = useWorkflowDocumentStore(createWorkflowDocumentId('123'));
+			store.setNodes([
+				createTestNode({
+					id: 'node-1',
+					name: 'HTTP Request',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 1,
+					parameters: { url: 'https://example.com/api', options: { timeout: 5000 } },
+				}),
+				createTestNode({
+					id: 'node-2',
+					name: 'Start',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+				}),
+			]);
+		});
+
+		it('should include nested parameter values in open node keywords', () => {
+			const { commands } = useNodeCommands({
+				lastQuery: ref(''),
+				activeNodeId: ref(null),
+			});
+
+			const openCommand = commands.value.find((cmd) => cmd.id === 'open-node');
+			const httpItem = openCommand?.children?.find((child) => child.id === 'node-1');
+			expect(httpItem?.keywords).toContain('https://example.com/api');
+			expect(httpItem?.keywords).toContain('5000');
+		});
+
+		it('should highlight nodes whose parameters match the query', () => {
+			const setupPanelStore = useSetupPanelStore();
+			const { handlers } = useNodeCommands({
+				lastQuery: ref(''),
+				activeNodeId: ref(null),
+			});
+
+			handlers?.onCommandBarChange?.('example.com');
+
+			expect(setupPanelStore.setHighlightedNodes).toHaveBeenCalledWith(['node-1']);
+		});
+
+		it('should clear highlight when query is too short or matches nothing', () => {
+			const setupPanelStore = useSetupPanelStore();
+			const { handlers } = useNodeCommands({
+				lastQuery: ref(''),
+				activeNodeId: ref(null),
+			});
+
+			handlers?.onCommandBarChange?.('ex');
+			handlers?.onCommandBarChange?.('no-match-here');
+
+			expect(setupPanelStore.setHighlightedNodes).not.toHaveBeenCalled();
+			expect(setupPanelStore.clearHighlightedNodes).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.ts
@@ -12,6 +12,7 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
+import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { getResourcePermissions } from '@n8n/permissions';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import CommandBarItemTitle from '@/features/shared/commandBar/components/CommandBarItemTitle.vue';
@@ -22,6 +23,15 @@ const ITEM_ID = {
 	OPEN_NODE: 'open-node',
 	ADD_STICKY: 'add-sticky',
 } as const;
+
+// Leaf string/number parameter values, for matching nodes by their configuration
+function collectParameterValues(value: unknown): string[] {
+	if (typeof value === 'string' || typeof value === 'number') return [String(value)];
+	if (value && typeof value === 'object') {
+		return Object.values(value).flatMap(collectParameterValues);
+	}
+	return [];
+}
 
 export function useNodeCommands(options: {
 	lastQuery: Ref<string>;
@@ -36,6 +46,7 @@ export function useNodeCommands(options: {
 	const sourceControlStore = useSourceControlStore();
 	const workflowsStore = useWorkflowsStore();
 	const collaborationStore = useCollaborationStore();
+	const setupPanelStore = useSetupPanelStore();
 	const { generateMergedNodesAndActions } = useActionsGenerator();
 
 	const workflowDocumentStore = injectWorkflowDocumentStore();
@@ -118,7 +129,7 @@ export function useNodeCommands(options: {
 			id,
 			title,
 			section,
-			keywords: [name, type],
+			keywords: [name, type, ...collectParameterValues(node.parameters)],
 			icon: {
 				component: NodeIcon,
 				props: {
@@ -131,6 +142,17 @@ export function useNodeCommands(options: {
 			},
 			placeholder: i18n.baseText('commandBar.nodes.searchPlaceholder'),
 		};
+	};
+
+	const nodeIdsWithParametersMatching = (query: string): string[] => {
+		const lowerQuery = query.toLowerCase();
+		return workflowDocumentStore.value.allNodes
+			.filter((node) =>
+				collectParameterValues(node.parameters).some((value) =>
+					value.toLowerCase().includes(lowerQuery),
+				),
+			)
+			.map((node) => node.id);
 	};
 
 	const openNodeCommands = computed<CommandBarItem[]>(() => {
@@ -220,5 +242,15 @@ export function useNodeCommands(options: {
 
 	return {
 		commands: nodeCommands,
+		handlers: {
+			onCommandBarChange: (query: string) => {
+				const matchingIds = query.length > 2 ? nodeIdsWithParametersMatching(query) : [];
+				if (matchingIds.length > 0) {
+					setupPanelStore.setHighlightedNodes(matchingIds);
+				} else {
+					setupPanelStore.clearHighlightedNodes();
+				}
+			},
+		},
 	};
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
@@ -280,6 +280,8 @@ export type CanvasEventBusEvents = {
 	};
 	'create:sticky': never;
 	'deprecated:tab-shortcut': never;
+	/** Move keyboard focus back to the canvas element */
+	focus: never;
 };
 
 export interface CanvasNodeInjectionData {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -99,6 +99,7 @@ import { type ContextMenuAction } from '@/features/shared/contextMenu/composable
 import { useFocusedNodesStore } from '@/features/ai/assistant/focusedNodes.store';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
+import { commandBarEventBus } from '@/features/shared/commandBar/commandBar.eventBus';
 import { useCanvasAgentNodeGeometry } from '../composables/useCanvasAgentNodeGeometry';
 
 const $style = useCssModule();
@@ -499,6 +500,11 @@ const keyMap = computed(() => {
 		i: () => emit('update:logs:input-open'),
 		o: () => emit('update:logs:output-open'),
 		z: onToggleZoomMode,
+		// override browser find; the command bar searches the workflow
+		ctrl_f: {
+			disabled: () => settingsStore.isCanvasOnly,
+			run: () => commandBarEventBus.emit('open:request'),
+		},
 	};
 
 	// Group collapse state is a view preference, so expanding/collapsing

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -233,6 +233,7 @@ const {
 	addSelectedNodes,
 	removeSelectedNodes,
 	viewportRef,
+	vueFlowRef,
 	fitView,
 	fitBounds,
 	zoomIn,
@@ -1673,6 +1674,10 @@ function onRequestSetConnectionsOnInit(connections: IConnections) {
 	pendingConnections = connections;
 }
 
+function onFocusCanvas() {
+	vueFlowRef.value?.focus();
+}
+
 onMounted(() => {
 	props.eventBus.on('fitView', onFitView);
 	props.eventBus.on('fitView:onNodesInit', onRequestFitViewOnInit);
@@ -1680,6 +1685,7 @@ onMounted(() => {
 	props.eventBus.on('nodes:select', onSelectNodes);
 	props.eventBus.on('nodes:selectAll', onSelectAllNodes);
 	props.eventBus.on('tidyUp', onTidyUp);
+	props.eventBus.on('focus', onFocusCanvas);
 	window.addEventListener('blur', onWindowBlur);
 	document.addEventListener('visibilitychange', onVisibilityChange);
 });
@@ -1691,6 +1697,7 @@ onUnmounted(() => {
 	props.eventBus.off('nodes:select', onSelectNodes);
 	props.eventBus.off('nodes:selectAll', onSelectAllNodes);
 	props.eventBus.off('tidyUp', onTidyUp);
+	props.eventBus.off('focus', onFocusCanvas);
 	window.removeEventListener('blur', onWindowBlur);
 	document.removeEventListener('visibilitychange', onVisibilityChange);
 });
@@ -1794,6 +1801,7 @@ defineExpose({
 		:pan-activation-key-code="panningKeyCode"
 		:disable-keyboard-a11y="true"
 		:delete-key-code="null"
+		tabindex="-1"
 		data-test-id="canvas"
 		@connect-start="onConnectStart"
 		@connect="onConnect"


### PR DESCRIPTION
## Summary

Makes the command palette search the workflow you're editing, not just node names:

- Node parameter values (nested, string/number leaves) are indexed into the open-node command keywords, so typing e.g. a URL or field value surfaces the nodes configured with it — both at the palette root and in the "Open node" submenu.
- While typing, nodes whose parameters match the query are spotlighted on the canvas (other nodes dim), reusing the existing setup-panel highlight mechanism.
- `Cmd+F`/`Ctrl+F` on the canvas toggles the command palette: it opens instead of the browser find dialog (only when the canvas has focus — inputs, NDV, and dialogs keep native find), and pressing it again closes the palette and refocuses the canvas. To support this, the `N8nCommandBar` `open` model is now externally controllable and the command bar event bus gained an `open:request` event; the canvas event bus gained a `focus` event.

## How to test

1. Open a workflow with a few configured nodes (e.g. an HTTP Request with a URL).
2. Press `Cmd+F` (or `Cmd+K`) on the canvas — the command palette opens.
3. Type part of a parameter value (e.g. part of the URL): the node appears as an "Open ..." result and is spotlighted on the canvas while others dim.
4. Press `Cmd+F` again — the palette closes, the highlight resets, and canvas shortcuts (e.g. `Cmd+F` once more) work immediately.
5. Focus an input field or the NDV and press `Cmd+F` — browser find still opens.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5425

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)