### PR TITLE
docs: Add spec for undefined-expression failure behaviour

### DIFF
--- a/docs/product/undefined-expression-failure.md
+++ b/docs/product/undefined-expression-failure.md
@@ -2,31 +2,45 @@
 
 Status: Draft · Owner: wire · Date: 2026-08-12 · Issue: N8N-240 (parent N8N-239)
 
+## Decisions log
+
+| Date | Decision | By |
+|---|---|---|
+| 2026-08-12 | **Q1: do both cases as v1** — the whole-value `undefined` guard *and* in-expression coercion to the text `undefined`. Overrides this spec's earlier recommendation to ship the narrow guard and defer coercion to an RFC. Rationale on record: the coercion case is the symptom users actually reported, so shipping without it would not close the parent issue. | Operator |
+| 2026-08-12 | **Q2: yes** — declarative (`routing:`) nodes are in v1. | Operator |
+
+Consequence, stated plainly: v1 is roughly 3× the original slice and now touches shared
+expression codegen. The compatibility line (default-off changes nothing) still holds and is
+still non-negotiable, but the risk profile has moved from "too narrow to be useful" to
+"false positives on expressions that deliberately handle missing values". Guardrail 3 and the
+kill criteria are written against that new risk.
+
 ## Problem
 
-A node parameter driven by an expression can resolve to `undefined` when the referenced
-field is absent — a renamed API field, an empty branch, a first-run item that lacks a key.
-n8n does not treat that as an error. The node runs with a missing value and the workflow
-reports success, so the failure surfaces downstream as an email with a blank recipient, an
-HTTP request with a dropped query parameter, or a record written with a hole in it. The user
-learns about it from the person who received the broken output, not from n8n.
+A node parameter driven by an expression can silently lose its value when the referenced field
+is absent — a renamed API field, an empty branch, a first-run item missing a key. n8n does not
+treat that as an error. Either the parameter becomes `undefined` and the node runs with a hole
+in it, or the missing value gets stringified into the output as the literal text `undefined`.
+Both paths report success. The user learns about it from the person who received the broken
+output — a mail merge addressed to `Hello, undefined`, an HTTP request with a dropped query
+parameter, a record written with a missing field — not from n8n.
 
 ## Evidence
 
-- **Reported (unquantified):** the parent issue reports users sending `Hello, undefined`
-  in emails. Source: Operator, N8N-239. No ticket count, no affected-workflow count.
-- **Verified (code):** a parameter that resolves to `undefined` reaches the node silently.
-  `_getNodeParameter` (`packages/core/src/execution-engine/node-execution-context/node-execution-context.ts:489`)
-  guards the *raw* parameter (line 505: `value === undefined` → throw) but never checks
-  the *resolved* result. `extractValue` / `ensureType` / `validateValueAgainstSchema`
-  (lines 557–580) are opt-in per parameter, so most parameters have no guard at all.
-- **Verified (code + execution):** the reported symptom `Hello, undefined` **is not produced
-  by n8n's interpolation.** For a template with surrounding text, tournament emits
+- **Reported (unquantified):** users sending `Hello, undefined` in emails. Source: Operator,
+  N8N-239. No ticket count, no affected-workflow count.
+- **Verified (code):** a parameter resolving to `undefined` reaches the node silently.
+  `_getNodeParameter`
+  (`packages/core/src/execution-engine/node-execution-context/node-execution-context.ts:489`)
+  guards the *raw* parameter (line 505) but never the *resolved* result. `extractValue` /
+  `ensureType` / `validateValueAgainstSchema` (lines 557–580) are opt-in per parameter.
+- **Verified (code + execution):** the reported symptom does **not** come from n8n's
+  interpolation. For a template with surrounding text, tournament emits
   `v = (<expr>); return v || v === 0 || v === false ? v : ''` per code chunk and `.join('')`s
-  the parts (`packages/@n8n/tournament/src/ExpressionBuilder.ts:106-131` and `:204-271`).
+  the parts (`packages/@n8n/tournament/src/ExpressionBuilder.ts:106-131`, `:204-271`).
   Executing that emitted shape:
 
-  | `$json.name` | `Hello, {{ $json.name }}` | `{{ $json.name }}` |
+  | `$json.name` | `=Hello, {{ $json.name }}` | `={{ $json.name }}` |
   |---|---|---|
   | missing key | `"Hello, "` | `undefined` |
   | explicit `undefined` | `"Hello, "` | `undefined` |
@@ -35,169 +49,226 @@ learns about it from the person who received the broken output, not from n8n.
   | `0` | `"Hello, 0"` | `0` |
   | `false` | `"Hello, false"` | `false` |
 
-  Interpolation already yields empty string, never the text `undefined`. The real
-  `Hello, undefined` comes from JavaScript coercion **inside** the expression —
-  `{{ 'Hello, ' + $json.name }}` and `` {{ `Hello, ${$json.name}` }} `` both produce
-  `"Hello, undefined"`, verified. That string is a perfectly good non-empty value by the
-  time the expression returns, so **no check at the result boundary can catch it.**
-- **Verified (code):** two independent resolution paths exist. Programmatic nodes go through
-  `_getNodeParameter`; declarative nodes go through the private `getParameterValue` in
+  So `Hello, {{ $json.name }}` yields `Hello, ` — never the text `undefined`.
+- **Verified (execution):** the text `undefined` is produced by JavaScript coercion **inside**
+  the expression. Exactly which operations do it:
+
+  | Expression fragment | Result | Produces `undefined` text? |
+  |---|---|---|
+  | `'Hello, ' + $json.missing` | `"Hello, undefined"` | **yes** |
+  | `` `Hi ${$json.missing}` `` | `"Hi undefined"` | **yes** |
+  | `String($json.missing)` | `"undefined"` | **yes** |
+  | `''.concat($json.missing)` | `"undefined"` | **yes** |
+  | `1 + $json.missing` | `NaN` | no |
+  | `[1, $json.missing].join()` | `"1,"` | no |
+  | `JSON.stringify({a: $json.missing})` | `"{}"` | no |
+  | `$json.missing ?? 'default'` | `"default"` | no |
+  | `null + ' x'` | `"null x"` | no (that is `null`, not `undefined`) |
+
+  The first two are syntactic operators; the last two are call-shaped.
+- **Verified (code):** two independent resolution paths. Programmatic nodes go through
+  `_getNodeParameter`; declarative nodes use the private `getParameterValue` in
   `packages/core/src/execution-engine/routing-node.ts:760-787`. 102 files under
   `packages/nodes-base/nodes` contain `routing:`.
-- **Assumed:** that users who hit this would prefer a hard failure over a silent hole. Untested.
-  This is the assumption the default-off setting exists to hedge.
-
-**Consequence for scope, stated plainly:** the literal example in the parent issue is *not*
-fixable by "fail when an expression evaluates to `undefined`". This spec fixes the adjacent
-and more common defect — a whole parameter silently becoming `undefined`. The in-expression
-coercion case is named as a non-goal and needs its own investigation (see Open questions Q1).
+- **Assumed:** that users who hit this prefer a hard failure over a silent hole. Untested; the
+  default-off setting is the hedge.
 
 ## Users
 
-- **Served:** builders whose workflows read from sources with unstable or optional fields, and
-  who would rather the run fail loudly. Opt-in, per node, so the population is self-selecting.
-- **Not served:** anyone relying on `undefined` → empty-string as intended behaviour (the
-  default keeps working for them, untouched); users whose broken output comes from
-  in-expression string concatenation (Non-goals #1).
-- **Size: unknown.** No analytics access in this workspace, so no adoption baseline. Naming
-  this as a gap rather than guessing a number.
+- **Served:** builders reading from sources with unstable or optional fields who would rather the
+  run fail loudly. Opt-in per node, so the population is self-selecting.
+- **Not served:** anyone relying on `undefined` → empty-string as intended behaviour (default
+  keeps working, untouched); users whose broken output comes from `String()`/`.concat()`
+  coercion (documented gap, D5) or from `null` rather than `undefined` (Non-goals).
+- **Size: unknown.** No analytics access in this workspace. Recorded as a gap rather than guessed.
 
 ## Success metric + guardrail
 
 **Success:** of nodes with the setting enabled, ≥ 20% raise the new error at least once within
-60 days of enabling it. That is the test of whether the setting catches real defects rather
-than decorating the settings panel. Baseline 0 (feature does not exist).
+60 days of enabling it. That tests whether the setting catches real defects rather than
+decorating the settings panel. Baseline 0.
 
-**Guardrail 1 (the important one):** execution failure rate for workflows with the setting
-**off** does not move at all. Not "does not move much" — this branch must be unreachable
-when the setting is off.
+**Guardrail 1 — compatibility (hard gate):** execution failure rate for workflows with the
+setting **off** does not move at all. Not "does not move much": the throwing branch must be
+unreachable when the setting is off.
 
-**Guardrail 2:** p95 node execution time does not regress. One `=== undefined` comparison on
-an already-computed value, no change to expression resolution itself.
+**Guardrail 2 — performance (hard gate):** p95 expression evaluation time does not regress
+measurably. This is a real risk now, not a formality: instrumenting `+` and template literals
+means the emitted code changes for **every** expression on both engines, including the ~99.9%
+that hit the code cache. A benchmark on a representative workflow is required in the stage-2 PR
+description, and a measurable p95 regression blocks merge.
 
-**Instrumentation plan** (ships with the feature, not after):
-- Setting enablement: add the key to `collectSettings` /`foundNodeSettings` in
-  `packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts:624-660`, matching the
-  `alwaysOutputData` pattern at line 642. This is the existing node-settings telemetry hook.
-- Error occurrence: the new `ExpressionError` `type` value (below) is what makes fired errors
-  countable in execution data. No new event needed.
+**Guardrail 3 — precision (hard gate, the dominant risk):** the new error must not fire on
+expressions that deliberately handle missing values. `??`, `?.`, `=== undefined`,
+`typeof x !== 'undefined'`, and `Array.join` must never trigger it. A false positive fails a
+workflow that was working correctly, which is a worse outcome than the bug being fixed.
+
+**Instrumentation plan** (ships with the feature):
+- Setting enablement: add the key to `collectSettings` / `foundNodeSettings` in
+  `packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts:624-660`, matching
+  `alwaysOutputData` at line 642.
+- Error occurrence: the new `ExpressionError` `type` values make fired errors countable in
+  execution data. Case A and case B must be distinguishable — see D3 — so we can tell which
+  half of the feature is earning its keep.
 
 ## Decisions
 
 ### D1 — What counts as "evaluates to undefined"
 
-**Only the whole resolved parameter value being `undefined`.** `returnData === undefined`
-after resolution — a strict identity check, not a truthiness check.
+Two cases, both in v1.
+
+**Case A — whole resolved value is `undefined`.** `returnData === undefined` after resolution:
+a strict identity check, not a truthiness check.
+
+**Case B — `undefined` is converted to the string `"undefined"` during evaluation.** Scoped to
+the two **syntactic** coercion sites: the `+` operator and template-literal interpolation. These
+cover the reported symptom and, per the Evidence table, essentially all real occurrences.
 
 | Case | Throws? | Why |
 |---|---|---|
-| Whole value `undefined` (`={{ $json.missing }}`) | **Yes** | The defect being fixed |
-| `undefined` interpolated in text (`=Hello, {{ $json.missing }}`) | **No** | Already resolves to `"Hello, "`; there is nothing to catch (see Evidence) |
-| In-expression coercion (`={{ 'Hi ' + $json.missing }}`) | **No** | Returns the non-empty string `"Hi undefined"`; undetectable at this boundary. Non-goal #1 |
-| `null` | **No** | Distinct and usually deliberate — JSON `null` is a real value |
-| `""` | **No** | A legitimate value; failing on it would break far more than it fixes |
-| `NaN` | **No** | Different defect, different fix. Non-goal #4 |
-| Missing key vs. explicit `undefined` | **Both throw, indistinguishable** | Verified: both resolve to `undefined`. Do not spend effort trying to separate them |
+| `={{ $json.missing }}` → whole value `undefined` | **Yes (A)** | Silent hole in the parameter |
+| `={{ 'Hi ' + $json.missing }}` | **Yes (B)** | The reported symptom |
+| `` ={{ `Hi ${$json.missing}` }} `` | **Yes (B)** | Same symptom, template form |
+| `=Hello, {{ $json.missing }}` | **No** | Already resolves to `"Hello, "`; catching it means changing shared interpolation coercion — Non-goal #1. **Known gap, see below** |
+| `={{ String($json.missing) }}` / `.concat(...)` | **No** | Call-shaped, not syntactic; D5 gap |
+| `={{ 1 + $json.missing }}` → `NaN` | **No** | No `undefined` text produced |
+| `={{ $json.missing ?? 'x' }}`, `?.`, `=== undefined` | **No — must never throw** | Deliberate handling; Guardrail 3 |
+| `null`, `""`, `0`, `false`, `NaN` as the whole value | **No** | Legitimate values |
+| Missing key vs. explicit `undefined` | **Both throw, indistinguishable** | Verified: both resolve to `undefined`. Do not try to separate them |
 
-Non-expression parameters are untouched — a literal `undefined` cannot be authored in the UI,
-and the raw-value guard at `node-execution-context.ts:505` already covers absent parameters.
+**Known gap, called out so review does not discover it:** `=Hello, {{ $json.name }}` — plausibly
+the most common authoring form — still silently yields `Hello, `. Catching it requires changing
+`buildFunctionBody`'s falsy coercion, which is shared by both engines and would alter behaviour
+for every existing workflow (Non-goal #1). Users may reasonably find this surprising after
+enabling the setting. Revisit if reported; the help text should not overpromise.
+
+Non-expression parameters are untouched.
 
 ### D2 — Setting shape and scope
 
 - **Key:** `throwOnUndefinedExpression?: boolean` on `INode`
-  (`packages/workflow/src/interfaces.ts:1590-1621`), a top-level sibling of `alwaysOutputData`
-  — *not* inside `parameters`. Add to the zod node schema at
-  `packages/workflow/src/schemas.ts:478-488` as `z.boolean().optional()`.
-- **Default:** `false`. Absent key and `false` must behave identically; do not backfill the key
-  into existing workflows.
-- **Label:** `Error On Undefined Expression`, Title Case to match `Always Output Data` /
-  `Retry On Fail` / `Execute Once`. This drops the developer verb "throw" from the parent
-  issue's wording while keeping "undefined", which users literally see in the NDV. Low-stakes
-  copy nit — the Operator's original `Throw error on undefined expression` is acceptable if
-  preferred; either way the *key* stays `throwOnUndefinedExpression`.
-- **Help text:** "If active, the node fails when an expression resolves to no value at all
-  (`undefined`), instead of continuing with an empty value."
+  (`packages/workflow/src/interfaces.ts:1590-1621`), top-level sibling of `alwaysOutputData`,
+  *not* inside `parameters`. Add to the zod node schema at `packages/workflow/src/schemas.ts:478-488`
+  as `z.boolean().optional()`.
+- **Default:** `false`. Absent and `false` behave identically; do not backfill the key.
+- **Label:** `Error On Undefined Expression` (Title Case, matching `Always Output Data` /
+  `Retry On Fail`). Copy nit only — Q3.
+- **Help text:** must describe both cases without overpromising the known gap, e.g. "If active,
+  the node fails when an expression has no value at all (`undefined`), or when a missing value
+  would be inserted into text as `undefined`."
 - **Scope: per-node only.** No workflow-level default in v1 — n8n has no existing mechanism for
-  workflow-wide node-setting defaults, so adding one is new surface and a separate decision.
-  v2 candidate.
+  workflow-wide node-setting defaults, so that is new surface and a separate decision.
 - **i18n:** `nodeSettings.throwOnUndefinedExpression.displayName` / `.description` in
   `packages/frontend/@n8n/i18n/src/locales/en.json` (siblings at lines 2277–2314).
 
 ### D3 — Failure semantics
 
-- **Error:** `ExpressionError` (`packages/workflow/src/errors/expression.error.ts`) with a new
-  member added to its existing `type` union: `'undefined_value'`. The class already carries
-  `parameter`, `itemIndex`, `runIndex` and `descriptionKey` — use them; do not invent a new
-  error class.
-- **Message:** must name the parameter, e.g.
-  `The expression for parameter "<name>" resolved to no value (undefined)`.
-  Description should point at the fix: check the field exists on the incoming item, or
-  turn the setting off. `_getNodeParameter`'s catch block already stamps
-  `e.context.parameter` (`node-execution-context.ts:546`).
-- **Where thrown:** immediately after `cleanupParameterData(returnData)`
-  (`node-execution-context.ts:535`), gated on `node.throwOnUndefinedExpression`. This location
-  is deliberate: it keeps `packages/workflow`'s expression resolution — the hot, cached, dual-engine
-  path — completely untouched, and leaves NDV expression previews unaffected (previews do not
-  call `_getNodeParameter`, so the editor keeps showing `undefined` rather than erroring while
-  the user is still typing).
-- **Declarative nodes:** the same gate is required in `routing-node.ts:760-787`, which has
-  `this.context.node` in scope. Without it the setting silently no-ops across ~102 node files,
-  which is worse than not shipping it.
-- **`On Error`:** no special handling. Because the throw happens inside the normal node
-  execution try/catch, `stopWorkflow` / `continueRegularOutput` / `continueErrorOutput`
-  (`packages/core/src/execution-engine/workflow-execute.ts:990-991, 1912`) apply exactly as they
-  do to any node error. **Do not add a bypass.**
-- **`Retry On Fail`:** likewise unmodified — retries will run
-  (`workflow-execute.ts:1797-1815`) and will deterministically fail again, since the input item
-  does not change between tries. That is consistent, mildly wasteful, and correct to leave
-  alone; document it in the help text rather than special-casing it.
-- **NDV / execution log:** the failed node shows the error like any node failure, with the
-  parameter name visible. No new UI surface. If implementation finds one is needed, stop and
-  route to design rather than inventing it.
+- **Error:** `ExpressionError` (`packages/workflow/src/errors/expression.error.ts`) with two new
+  members on its existing `type` union: `'undefined_value'` (case A) and
+  `'undefined_coercion'` (case B). Distinct values so instrumentation can tell them apart. The
+  class already carries `parameter`, `itemIndex`, `runIndex`, `descriptionKey` — use them; do
+  not add a new error class.
+- **Messages** must name the parameter and, for case B, say where the coercion happened, e.g.
+  `Parameter "<name>": a missing value was inserted into text as "undefined"`. Descriptions
+  point at the fix (`?? ''`, or turn the setting off). `_getNodeParameter`'s catch already
+  stamps `e.context.parameter` (`node-execution-context.ts:546`).
+- **Case A location:** immediately after `cleanupParameterData(returnData)`
+  (`node-execution-context.ts:535`), gated on `node.throwOnUndefinedExpression`. Deliberate: it
+  leaves NDV previews unaffected, since previews do not call `_getNodeParameter` — the editor
+  keeps showing `undefined` while the user is mid-edit rather than erroring at them.
+- **Declarative nodes:** the same case-A gate is required in `routing-node.ts:760-787`, which has
+  `this.context.node` in scope. Without it the setting silently no-ops across ~102 node files.
+- **`On Error`:** no special handling. The throw happens inside the normal node execution
+  try/catch, so `stopWorkflow` / `continueRegularOutput` / `continueErrorOutput`
+  (`packages/core/src/execution-engine/workflow-execute.ts:990-991, 1912`) apply as they do to
+  any node error. **Do not add a bypass.**
+- **`Retry On Fail`:** unmodified. Retries will run (`workflow-execute.ts:1797-1815`) and
+  deterministically fail again, since the input item does not change between tries. Consistent
+  and correct to leave alone; note it in the help text rather than special-casing.
+- **NDV / execution log:** failed node shows the error like any node failure, parameter name
+  visible. No new UI surface. If implementation finds one is needed, stop and route to design.
 
 ### D4 — Backward compatibility
 
-Default-off must leave every existing workflow byte-identical in behaviour. What holds that line:
+Default-off must leave every existing workflow byte-identical in behaviour.
 
-- The only new runtime code is `if (node.throwOnUndefinedExpression && returnData === undefined)`.
-  Absent setting → falsy → unreachable branch.
-- No change to `Expression.resolveSimpleParameterValue`, to tournament codegen, or to the VM
-  runtime. Both engines share `getExpressionCode`
-  (`packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts:191`), so touching
-  the coercion at `ExpressionBuilder.ts:106-131` would change behaviour for **every existing
-  workflow on both engines**. Out of bounds for this issue.
-- Workflow JSON gains the key only when a user enables it, so existing stored workflows and
-  their checksums are unchanged.
+- Case A adds only `if (node.throwOnUndefinedExpression && returnData === undefined)`. Absent
+  setting → falsy → unreachable.
+- Case B changes emitted code for all expressions (D5), so identical *behaviour* when off must be
+  guaranteed by the injected helper being a faithful pass-through, not by the transform being
+  skipped. That is the crux of stage 2's contract and where review attention belongs.
+- Workflow JSON gains the key only when a user enables it, so stored workflows and their
+  checksums are unchanged.
 
-**Nothing in this spec requires breaking that line.** If stage 2 finds otherwise, that is a
-blocker to raise in-thread, not a trade-off to absorb.
+### D5 — How case B is detected: constraints, not architecture
+
+@signal owns the design and must post the contract on N8N-241 before implementing. These are the
+constraints the research turned up, so that contract does not start from a blank page.
+
+**The seam already exists.** Tournament accepts `before`/`after` AST hooks
+(`packages/@n8n/tournament/src/ast.ts`, wired at `Tournament`'s constructor in
+`packages/@n8n/tournament/src/index.ts`). n8n already ships three: `ThisSanitizer`,
+`PrototypeSanitizer`, `DollarSignValidator` (`packages/workflow/src/expression-sandboxing.ts`).
+An instrumenting hook for `+` and template literals fits this mechanism.
+
+**The injected-helper pattern already exists, with four touchpoints.** `__sanitize` is the
+working precedent — copy its shape:
+1. name + reserved-word guard — `expression-sandboxing.ts:13-18`
+2. codegen injects the call — `PrototypeSanitizer`, `expression-sandboxing.ts:498`
+3. host-side implementation on `data` — `Object.defineProperty(data, sanitizerName, …)` in
+   `packages/workflow/src/expression.ts`
+4. in-isolate implementation — `packages/@n8n/expression-runtime/src/runtime/context.ts:121`
+
+Both engines need it. Missing touchpoint 4 means the feature silently does nothing under
+`N8N_EXPRESSION_ENGINE=vm`.
+
+**Hard constraint — codegen cannot vary by setting.** Transformed code is cached keyed by
+expression string alone (`codeCache: LruCache<string, string>`,
+`packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts:42, 168-195`, ~99.9% hit
+rate). Two nodes sharing an expression string but differing in this setting would collide. So:
+**emit the instrumented form unconditionally and gate at runtime**, e.g. via a plain boolean on
+the data context (a boolean crosses the bridge; function-typed values on `data` do not — see the
+note at `packages/workflow/src/expression.ts:585`). Do not put the setting in the cache key.
+
+**Required behaviour of the helper:**
+- When the flag is off, semantics are byte-for-byte those of the operator it replaced —
+  including string/number coercion order, `NaN` results, and `null` handling.
+- When on, it throws only if an operand is `undefined` **and** the operation would insert the
+  text `undefined`. `1 + undefined` → `NaN`, no throw.
+- It must not perturb short-circuiting or evaluation order.
+
+**Foreclosed alternatives, so they are not re-proposed:** substring-sniffing the final result for
+`"undefined"` (false-positives on legitimate data containing that word); flagging any property
+access that returns `undefined` (breaks `??`, `?.`, `=== undefined` — fails Guardrail 3).
 
 ## Non-goals
 
-1. **Catching `undefined` coerced to text inside an expression** (`'Hi ' + $json.x`,
-   `` `Hi ${$json.x}` ``). This is the parent issue's literal example and it is genuinely out of
-   reach here — it would require instrumenting user JavaScript, an RFC-scale change to
-   `packages/workflow` expression semantics. Q1 below.
-2. **Changing what interpolation returns for falsy values.** Shared codegen, both engines, every
-   existing workflow.
+1. **Changing what interpolation returns for falsy values.** Shared codegen, both engines, every
+   existing workflow. This is what leaves the `=Hello, {{ $json.name }}` gap in D1.
+2. **`String()` / `.concat()` coercion sites.** Call-shaped rather than syntactic; instrumenting
+   the call graph is materially more invasive for a small share of occurrences. Documented gap.
 3. **A workflow-level or instance-level default** for this setting.
-4. **`null`, `""`, `NaN`, or empty-array strictness.** Adjacent, separately arguable, not here.
-5. **Warning-without-failing, or a "strict expressions" mode.** One behaviour, one setting.
+4. **`null`, `""`, `NaN`, or empty-array strictness**, including `null + ' x'` → `"null x"`.
+5. **Warning-without-failing, or a general "strict expressions" mode.** One behaviour, one setting.
 6. **Editor-time static detection** of expressions that might resolve to `undefined`.
 7. **Retrofitting `ensureType` / schema validation** across existing node parameters.
 
 ## Thinnest testable slice
 
-Per-node boolean, default off; strict `=== undefined` check on the resolved value in both
-resolution paths; `ExpressionError` with `type: 'undefined_value'`; the existing settings toggle
-pattern in the NDV; telemetry key added to the existing hook.
+Not thin any more, and worth saying so: the Operator's decision makes v1 three surfaces —
+case A in two resolution paths, case B in shared codegen across two engines, and the settings
+toggle. Cut scope, never quality: what keeps quality intact here is the sequencing, not a smaller
+feature. **Recommend splitting N8N-241** so case A (small, self-contained, low risk) lands and is
+verifiable before case B (codegen, perf-sensitive, both engines) starts. Same v1 scope, two PRs,
+independently revertable. @trigger owns the schedule; this is a sequencing recommendation, not a
+date.
 
-What the slice cuts, and why each cut is safe:
-- Workflow-level default → per-node proves the behaviour first; no user is blocked.
-- In-expression coercion detection → not achievable at this layer at any scope (Q1).
-- `null`/`""`/`NaN` handling → each would widen blast radius without new evidence.
-- Retry/`On Error` special-casing → inheriting standard node-error semantics is the correct
-  default and is strictly less code.
+What v1 still cuts, and why each cut is safe:
+- Interpolation coercion (Non-goal #1) → shared codegen, unbounded blast radius.
+- `String()`/`.concat()` (Non-goal #2) → small share of occurrences, disproportionate reach.
+- Workflow-level default → per-node proves the behaviour first; nobody is blocked.
+- Retry / `On Error` special-casing → inheriting standard node-error semantics is correct *and*
+  less code.
 
 ## Acceptance criteria
 
@@ -205,49 +276,60 @@ Definition-of-ready gate for stages 2–4. Observable and testable as written.
 
 **Setting**
 1. `throwOnUndefinedExpression` is an optional boolean on `INode`, accepted by the node zod schema, defaulting to `false`.
-2. The NDV Settings tab shows a toggle labelled per D2, off by default, using the same component and layout as `Always Output Data`.
+2. The NDV Settings tab shows a toggle labelled per D2, off by default, same component and layout as `Always Output Data`.
 3. The value survives save → reload, and workflow export → import.
-4. A workflow whose node has never had the setting touched contains no `throwOnUndefinedExpression` key in its exported JSON.
+4. A workflow whose node never had the setting touched contains no `throwOnUndefinedExpression` key in its exported JSON.
 
-**Behaviour — setting ON**
-5. A node with a parameter `={{ $json.missing }}` (key absent from the item) fails execution with an `ExpressionError` whose `type` is `'undefined_value'`.
+**Case A — whole value undefined, setting ON**
+5. A parameter `={{ $json.missing }}` (key absent) fails with an `ExpressionError` of type `'undefined_value'`.
 6. The error message names the offending parameter.
-7. Same failure when the value is present but explicitly `undefined`.
-8. A parameter `=Hello, {{ $json.missing }}` does **not** fail; it resolves to `"Hello, "`.
+7. Same failure when the key is present with an explicit `undefined` value.
+8. A declarative (`routing:`-based) node fails under the same conditions as a programmatic one.
 9. Parameters resolving to `null`, `""`, `0`, `false`, or `NaN` do **not** fail.
-10. A declarative (`routing:`-based) node fails under the same conditions as a programmatic one.
-11. With `On Error: continueRegularOutput`, the workflow continues past the failure; with `continueErrorOutput`, the item is routed to the error output; with `stopWorkflow`, the execution stops.
-12. With `Retry On Fail` on, the configured retries are attempted and the node then fails — no infinite loop, no swallowed error.
 
-**Behaviour — setting OFF (the regression gate)**
-13. Every case in 5–12 behaves exactly as it does on `master` today: `undefined` reaches the node, the node succeeds, no error is raised.
-14. A regression test asserts case 13 explicitly for whole-value `undefined`, and is required to land in the repo.
-15. No change to any file under `packages/workflow/src/expression*`, `packages/@n8n/tournament`, or `packages/@n8n/expression-runtime`. A diff touching expression resolution or codegen fails this criterion.
+**Case B — coercion to the text `undefined`, setting ON**
+10. `={{ 'Hi ' + $json.missing }}` fails with an `ExpressionError` of type `'undefined_coercion'`.
+11. `` ={{ `Hi ${$json.missing}` }} `` fails the same way.
+12. Fires identically under both engines: default, and `N8N_EXPRESSION_ENGINE=vm`.
+13. `={{ 1 + $json.missing }}` does **not** fail and still evaluates to `NaN`.
+14. `={{ [1, $json.missing].join() }}` does **not** fail and still evaluates to `"1,"`.
+15. **None of these ever fail:** `={{ $json.missing ?? 'x' }}`, `={{ $json.a?.b }}`, `={{ $json.missing === undefined }}`, `={{ typeof $json.missing !== 'undefined' }}`. (Guardrail 3.)
+16. `=Hello, {{ $json.missing }}` does **not** fail and still resolves to `"Hello, "` — the documented gap in D1.
+17. An item whose data legitimately contains the string `"undefined"` does **not** fail.
+
+**Failure semantics**
+18. With `On Error: continueRegularOutput` the workflow continues past the failure; with `continueErrorOutput` the item routes to the error output; with `stopWorkflow` execution stops. Applies to both error types.
+19. With `Retry On Fail` on, configured retries are attempted and the node then fails — no infinite loop, no swallowed error.
+
+**Setting OFF — the regression gate**
+20. Every case in 5–19 behaves exactly as on `master` today: `undefined` reaches the node, the text `undefined` still appears in output, no error is raised.
+21. Regression tests asserting 20 for both case A and case B land in the repo.
+22. Expression evaluation results are unchanged for the whole existing tournament fixture suite (`packages/@n8n/tournament/test/ExpressionFixtures/base.ts`) with the setting off, on both engines.
+23. A benchmark comparing p95 expression evaluation before/after the case-B transform appears in the stage-2 PR description. A measurable regression blocks merge (Guardrail 2).
 
 **Editor**
-16. NDV expression previews still render `undefined` / empty for an unresolvable expression while editing, regardless of the setting. Turning the setting on does not make the editor error as the user types.
+24. NDV expression previews still render `undefined` / empty while editing, regardless of the setting. Turning it on does not make the editor error as the user types.
 
 **Instrumentation**
-17. Enabling the setting is recorded through the existing `foundNodeSettings` hook.
+25. Enabling the setting is recorded through the existing `foundNodeSettings` hook, and the two error types are distinguishable in execution data.
 
 ## Open questions
 
 | # | Question | Owner | Resolve by |
 |---|---|---|---|
-| Q1 | The parent issue's `Hello, undefined` example comes from JS coercion inside the expression, which this spec cannot catch. Accept the narrower fix as v1, or open a separate RFC on expression semantics for the coercion case? Recommendation: accept v1, open the RFC separately if evidence justifies it. | Operator | before stage 2 starts |
-| Q2 | Declarative nodes: include `routing-node.ts` in v1 (recommended — otherwise the setting silently does nothing on ~102 node files), or ship programmatic-only and follow up? | Operator | before stage 2 starts |
-| Q3 | Final label wording — `Error On Undefined Expression` (recommended) vs. the parent's `Throw error on undefined expression`. Copy-only; does not block stage 2, which uses the i18n key. | Operator / @jinx | before stage 3 ships |
+| Q3 | Final label wording — `Error On Undefined Expression` (recommended) vs. the parent's `Throw error on undefined expression`. Copy-only; does not block stage 2, which builds against the i18n key. | Operator / @jinx | before stage 3 ships |
 
-Stages 2–4 may proceed on the recommendations above, treated as labelled assumptions, if the
-Operator does not answer first. Q1 and Q2 change scope; Q3 does not.
+Q1 and Q2 are resolved — see the decisions log.
 
 ## Kill criteria
 
+- **Precision (fastest trigger):** if case B produces confirmed false positives on expressions
+  that deliberately handle missing values, case B comes out — not forward-fixed. It fails
+  Guardrail 3, and a setting that fails working workflows destroys trust in the setting.
+- **Performance:** a measurable p95 expression-evaluation regression attributable to the case-B
+  transform reverts case B, regardless of adoption.
 - **Adoption:** if fewer than 0.5% of active workflows have the setting enabled on at least one
-  node 90 days after release, remove the setting and the code path rather than leaving it as
-  furniture.
-- **Precision:** if enabled nodes raise this error at a rate suggesting it mostly fires on values
-  users considered acceptable — or if support sees repeated "my working node started failing"
-  reports traced to it — the semantics in D1 are wrong; revert and re-spec.
-- **Immediate revert:** any confirmed behaviour change in a workflow with the setting off.
-  That is not a bug to fix forward; it fails Guardrail 1 and the change comes out.
+  node 90 days after release, remove the setting and both code paths rather than leaving
+  furniture behind.
+- **Immediate revert:** any confirmed behaviour change in a workflow with the setting off. That
+  is not a bug to fix forward; it fails Guardrail 1 and the change comes out.

--- a/docs/product/undefined-expression-failure.md
+++ b/docs/product/undefined-expression-failure.md
@@ -1,0 +1,253 @@
+# Fail a node when an expression resolves to undefined
+
+Status: Draft · Owner: wire · Date: 2026-08-12 · Issue: N8N-240 (parent N8N-239)
+
+## Problem
+
+A node parameter driven by an expression can resolve to `undefined` when the referenced
+field is absent — a renamed API field, an empty branch, a first-run item that lacks a key.
+n8n does not treat that as an error. The node runs with a missing value and the workflow
+reports success, so the failure surfaces downstream as an email with a blank recipient, an
+HTTP request with a dropped query parameter, or a record written with a hole in it. The user
+learns about it from the person who received the broken output, not from n8n.
+
+## Evidence
+
+- **Reported (unquantified):** the parent issue reports users sending `Hello, undefined`
+  in emails. Source: Operator, N8N-239. No ticket count, no affected-workflow count.
+- **Verified (code):** a parameter that resolves to `undefined` reaches the node silently.
+  `_getNodeParameter` (`packages/core/src/execution-engine/node-execution-context/node-execution-context.ts:489`)
+  guards the *raw* parameter (line 505: `value === undefined` → throw) but never checks
+  the *resolved* result. `extractValue` / `ensureType` / `validateValueAgainstSchema`
+  (lines 557–580) are opt-in per parameter, so most parameters have no guard at all.
+- **Verified (code + execution):** the reported symptom `Hello, undefined` **is not produced
+  by n8n's interpolation.** For a template with surrounding text, tournament emits
+  `v = (<expr>); return v || v === 0 || v === false ? v : ''` per code chunk and `.join('')`s
+  the parts (`packages/@n8n/tournament/src/ExpressionBuilder.ts:106-131` and `:204-271`).
+  Executing that emitted shape:
+
+  | `$json.name` | `Hello, {{ $json.name }}` | `{{ $json.name }}` |
+  |---|---|---|
+  | missing key | `"Hello, "` | `undefined` |
+  | explicit `undefined` | `"Hello, "` | `undefined` |
+  | `null` | `"Hello, "` | `null` |
+  | `""` | `"Hello, "` | `""` |
+  | `0` | `"Hello, 0"` | `0` |
+  | `false` | `"Hello, false"` | `false` |
+
+  Interpolation already yields empty string, never the text `undefined`. The real
+  `Hello, undefined` comes from JavaScript coercion **inside** the expression —
+  `{{ 'Hello, ' + $json.name }}` and `` {{ `Hello, ${$json.name}` }} `` both produce
+  `"Hello, undefined"`, verified. That string is a perfectly good non-empty value by the
+  time the expression returns, so **no check at the result boundary can catch it.**
+- **Verified (code):** two independent resolution paths exist. Programmatic nodes go through
+  `_getNodeParameter`; declarative nodes go through the private `getParameterValue` in
+  `packages/core/src/execution-engine/routing-node.ts:760-787`. 102 files under
+  `packages/nodes-base/nodes` contain `routing:`.
+- **Assumed:** that users who hit this would prefer a hard failure over a silent hole. Untested.
+  This is the assumption the default-off setting exists to hedge.
+
+**Consequence for scope, stated plainly:** the literal example in the parent issue is *not*
+fixable by "fail when an expression evaluates to `undefined`". This spec fixes the adjacent
+and more common defect — a whole parameter silently becoming `undefined`. The in-expression
+coercion case is named as a non-goal and needs its own investigation (see Open questions Q1).
+
+## Users
+
+- **Served:** builders whose workflows read from sources with unstable or optional fields, and
+  who would rather the run fail loudly. Opt-in, per node, so the population is self-selecting.
+- **Not served:** anyone relying on `undefined` → empty-string as intended behaviour (the
+  default keeps working for them, untouched); users whose broken output comes from
+  in-expression string concatenation (Non-goals #1).
+- **Size: unknown.** No analytics access in this workspace, so no adoption baseline. Naming
+  this as a gap rather than guessing a number.
+
+## Success metric + guardrail
+
+**Success:** of nodes with the setting enabled, ≥ 20% raise the new error at least once within
+60 days of enabling it. That is the test of whether the setting catches real defects rather
+than decorating the settings panel. Baseline 0 (feature does not exist).
+
+**Guardrail 1 (the important one):** execution failure rate for workflows with the setting
+**off** does not move at all. Not "does not move much" — this branch must be unreachable
+when the setting is off.
+
+**Guardrail 2:** p95 node execution time does not regress. One `=== undefined` comparison on
+an already-computed value, no change to expression resolution itself.
+
+**Instrumentation plan** (ships with the feature, not after):
+- Setting enablement: add the key to `collectSettings` /`foundNodeSettings` in
+  `packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts:624-660`, matching the
+  `alwaysOutputData` pattern at line 642. This is the existing node-settings telemetry hook.
+- Error occurrence: the new `ExpressionError` `type` value (below) is what makes fired errors
+  countable in execution data. No new event needed.
+
+## Decisions
+
+### D1 — What counts as "evaluates to undefined"
+
+**Only the whole resolved parameter value being `undefined`.** `returnData === undefined`
+after resolution — a strict identity check, not a truthiness check.
+
+| Case | Throws? | Why |
+|---|---|---|
+| Whole value `undefined` (`={{ $json.missing }}`) | **Yes** | The defect being fixed |
+| `undefined` interpolated in text (`=Hello, {{ $json.missing }}`) | **No** | Already resolves to `"Hello, "`; there is nothing to catch (see Evidence) |
+| In-expression coercion (`={{ 'Hi ' + $json.missing }}`) | **No** | Returns the non-empty string `"Hi undefined"`; undetectable at this boundary. Non-goal #1 |
+| `null` | **No** | Distinct and usually deliberate — JSON `null` is a real value |
+| `""` | **No** | A legitimate value; failing on it would break far more than it fixes |
+| `NaN` | **No** | Different defect, different fix. Non-goal #4 |
+| Missing key vs. explicit `undefined` | **Both throw, indistinguishable** | Verified: both resolve to `undefined`. Do not spend effort trying to separate them |
+
+Non-expression parameters are untouched — a literal `undefined` cannot be authored in the UI,
+and the raw-value guard at `node-execution-context.ts:505` already covers absent parameters.
+
+### D2 — Setting shape and scope
+
+- **Key:** `throwOnUndefinedExpression?: boolean` on `INode`
+  (`packages/workflow/src/interfaces.ts:1590-1621`), a top-level sibling of `alwaysOutputData`
+  — *not* inside `parameters`. Add to the zod node schema at
+  `packages/workflow/src/schemas.ts:478-488` as `z.boolean().optional()`.
+- **Default:** `false`. Absent key and `false` must behave identically; do not backfill the key
+  into existing workflows.
+- **Label:** `Error On Undefined Expression`, Title Case to match `Always Output Data` /
+  `Retry On Fail` / `Execute Once`. This drops the developer verb "throw" from the parent
+  issue's wording while keeping "undefined", which users literally see in the NDV. Low-stakes
+  copy nit — the Operator's original `Throw error on undefined expression` is acceptable if
+  preferred; either way the *key* stays `throwOnUndefinedExpression`.
+- **Help text:** "If active, the node fails when an expression resolves to no value at all
+  (`undefined`), instead of continuing with an empty value."
+- **Scope: per-node only.** No workflow-level default in v1 — n8n has no existing mechanism for
+  workflow-wide node-setting defaults, so adding one is new surface and a separate decision.
+  v2 candidate.
+- **i18n:** `nodeSettings.throwOnUndefinedExpression.displayName` / `.description` in
+  `packages/frontend/@n8n/i18n/src/locales/en.json` (siblings at lines 2277–2314).
+
+### D3 — Failure semantics
+
+- **Error:** `ExpressionError` (`packages/workflow/src/errors/expression.error.ts`) with a new
+  member added to its existing `type` union: `'undefined_value'`. The class already carries
+  `parameter`, `itemIndex`, `runIndex` and `descriptionKey` — use them; do not invent a new
+  error class.
+- **Message:** must name the parameter, e.g.
+  `The expression for parameter "<name>" resolved to no value (undefined)`.
+  Description should point at the fix: check the field exists on the incoming item, or
+  turn the setting off. `_getNodeParameter`'s catch block already stamps
+  `e.context.parameter` (`node-execution-context.ts:546`).
+- **Where thrown:** immediately after `cleanupParameterData(returnData)`
+  (`node-execution-context.ts:535`), gated on `node.throwOnUndefinedExpression`. This location
+  is deliberate: it keeps `packages/workflow`'s expression resolution — the hot, cached, dual-engine
+  path — completely untouched, and leaves NDV expression previews unaffected (previews do not
+  call `_getNodeParameter`, so the editor keeps showing `undefined` rather than erroring while
+  the user is still typing).
+- **Declarative nodes:** the same gate is required in `routing-node.ts:760-787`, which has
+  `this.context.node` in scope. Without it the setting silently no-ops across ~102 node files,
+  which is worse than not shipping it.
+- **`On Error`:** no special handling. Because the throw happens inside the normal node
+  execution try/catch, `stopWorkflow` / `continueRegularOutput` / `continueErrorOutput`
+  (`packages/core/src/execution-engine/workflow-execute.ts:990-991, 1912`) apply exactly as they
+  do to any node error. **Do not add a bypass.**
+- **`Retry On Fail`:** likewise unmodified — retries will run
+  (`workflow-execute.ts:1797-1815`) and will deterministically fail again, since the input item
+  does not change between tries. That is consistent, mildly wasteful, and correct to leave
+  alone; document it in the help text rather than special-casing it.
+- **NDV / execution log:** the failed node shows the error like any node failure, with the
+  parameter name visible. No new UI surface. If implementation finds one is needed, stop and
+  route to design rather than inventing it.
+
+### D4 — Backward compatibility
+
+Default-off must leave every existing workflow byte-identical in behaviour. What holds that line:
+
+- The only new runtime code is `if (node.throwOnUndefinedExpression && returnData === undefined)`.
+  Absent setting → falsy → unreachable branch.
+- No change to `Expression.resolveSimpleParameterValue`, to tournament codegen, or to the VM
+  runtime. Both engines share `getExpressionCode`
+  (`packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts:191`), so touching
+  the coercion at `ExpressionBuilder.ts:106-131` would change behaviour for **every existing
+  workflow on both engines**. Out of bounds for this issue.
+- Workflow JSON gains the key only when a user enables it, so existing stored workflows and
+  their checksums are unchanged.
+
+**Nothing in this spec requires breaking that line.** If stage 2 finds otherwise, that is a
+blocker to raise in-thread, not a trade-off to absorb.
+
+## Non-goals
+
+1. **Catching `undefined` coerced to text inside an expression** (`'Hi ' + $json.x`,
+   `` `Hi ${$json.x}` ``). This is the parent issue's literal example and it is genuinely out of
+   reach here — it would require instrumenting user JavaScript, an RFC-scale change to
+   `packages/workflow` expression semantics. Q1 below.
+2. **Changing what interpolation returns for falsy values.** Shared codegen, both engines, every
+   existing workflow.
+3. **A workflow-level or instance-level default** for this setting.
+4. **`null`, `""`, `NaN`, or empty-array strictness.** Adjacent, separately arguable, not here.
+5. **Warning-without-failing, or a "strict expressions" mode.** One behaviour, one setting.
+6. **Editor-time static detection** of expressions that might resolve to `undefined`.
+7. **Retrofitting `ensureType` / schema validation** across existing node parameters.
+
+## Thinnest testable slice
+
+Per-node boolean, default off; strict `=== undefined` check on the resolved value in both
+resolution paths; `ExpressionError` with `type: 'undefined_value'`; the existing settings toggle
+pattern in the NDV; telemetry key added to the existing hook.
+
+What the slice cuts, and why each cut is safe:
+- Workflow-level default → per-node proves the behaviour first; no user is blocked.
+- In-expression coercion detection → not achievable at this layer at any scope (Q1).
+- `null`/`""`/`NaN` handling → each would widen blast radius without new evidence.
+- Retry/`On Error` special-casing → inheriting standard node-error semantics is the correct
+  default and is strictly less code.
+
+## Acceptance criteria
+
+Definition-of-ready gate for stages 2–4. Observable and testable as written.
+
+**Setting**
+1. `throwOnUndefinedExpression` is an optional boolean on `INode`, accepted by the node zod schema, defaulting to `false`.
+2. The NDV Settings tab shows a toggle labelled per D2, off by default, using the same component and layout as `Always Output Data`.
+3. The value survives save → reload, and workflow export → import.
+4. A workflow whose node has never had the setting touched contains no `throwOnUndefinedExpression` key in its exported JSON.
+
+**Behaviour — setting ON**
+5. A node with a parameter `={{ $json.missing }}` (key absent from the item) fails execution with an `ExpressionError` whose `type` is `'undefined_value'`.
+6. The error message names the offending parameter.
+7. Same failure when the value is present but explicitly `undefined`.
+8. A parameter `=Hello, {{ $json.missing }}` does **not** fail; it resolves to `"Hello, "`.
+9. Parameters resolving to `null`, `""`, `0`, `false`, or `NaN` do **not** fail.
+10. A declarative (`routing:`-based) node fails under the same conditions as a programmatic one.
+11. With `On Error: continueRegularOutput`, the workflow continues past the failure; with `continueErrorOutput`, the item is routed to the error output; with `stopWorkflow`, the execution stops.
+12. With `Retry On Fail` on, the configured retries are attempted and the node then fails — no infinite loop, no swallowed error.
+
+**Behaviour — setting OFF (the regression gate)**
+13. Every case in 5–12 behaves exactly as it does on `master` today: `undefined` reaches the node, the node succeeds, no error is raised.
+14. A regression test asserts case 13 explicitly for whole-value `undefined`, and is required to land in the repo.
+15. No change to any file under `packages/workflow/src/expression*`, `packages/@n8n/tournament`, or `packages/@n8n/expression-runtime`. A diff touching expression resolution or codegen fails this criterion.
+
+**Editor**
+16. NDV expression previews still render `undefined` / empty for an unresolvable expression while editing, regardless of the setting. Turning the setting on does not make the editor error as the user types.
+
+**Instrumentation**
+17. Enabling the setting is recorded through the existing `foundNodeSettings` hook.
+
+## Open questions
+
+| # | Question | Owner | Resolve by |
+|---|---|---|---|
+| Q1 | The parent issue's `Hello, undefined` example comes from JS coercion inside the expression, which this spec cannot catch. Accept the narrower fix as v1, or open a separate RFC on expression semantics for the coercion case? Recommendation: accept v1, open the RFC separately if evidence justifies it. | Operator | before stage 2 starts |
+| Q2 | Declarative nodes: include `routing-node.ts` in v1 (recommended — otherwise the setting silently does nothing on ~102 node files), or ship programmatic-only and follow up? | Operator | before stage 2 starts |
+| Q3 | Final label wording — `Error On Undefined Expression` (recommended) vs. the parent's `Throw error on undefined expression`. Copy-only; does not block stage 2, which uses the i18n key. | Operator / @jinx | before stage 3 ships |
+
+Stages 2–4 may proceed on the recommendations above, treated as labelled assumptions, if the
+Operator does not answer first. Q1 and Q2 change scope; Q3 does not.
+
+## Kill criteria
+
+- **Adoption:** if fewer than 0.5% of active workflows have the setting enabled on at least one
+  node 90 days after release, remove the setting and the code path rather than leaving it as
+  furniture.
+- **Precision:** if enabled nodes raise this error at a rate suggesting it mostly fires on values
+  users considered acceptable — or if support sees repeated "my working node started failing"
+  reports traced to it — the semantics in D1 are wrong; revert and re-spec.
+- **Immediate revert:** any confirmed behaviour change in a workflow with the setting off.
+  That is not a bug to fix forward; it fails Guardrail 1 and the change comes out.


### PR DESCRIPTION
## Summary

Adds `docs/product/undefined-expression-failure.md` — the product spec and acceptance criteria for failing a node when an expression resolves to `undefined`, gated behind a per-node setting that defaults to off. Docs only; no runtime code changes.

This is the definition-of-ready gate for the build work that follows, so the spec settles what the implementation would otherwise have to guess: what counts as "undefined", the setting's key/shape/scope, failure semantics and their interaction with `On Error` and `Retry On Fail`, and the backward-compatibility line.

**Scope covers two cases**, both decided by the product owner for v1:

- **Case A — the whole resolved parameter value is `undefined`.** Guarded at `_getNodeParameter` (`packages/core/src/execution-engine/node-execution-context/node-execution-context.ts:489`), which today checks the *raw* parameter but never the *resolved* result. Declarative nodes need the same guard in `packages/core/src/execution-engine/routing-node.ts:760-787` — 102 files under `packages/nodes-base/nodes` use `routing:`, so covering only the first path would leave the setting inert across a large share of nodes.
- **Case B — `undefined` gets coerced into the literal text `undefined`.** This is the reported symptom, and it does *not* come from n8n's interpolation: `ExpressionBuilder` already coerces falsy chunk results to empty string (`packages/@n8n/tournament/src/ExpressionBuilder.ts:106-131`, `:204-271`), so `=Hello, {{ $json.name }}` resolves to `Hello, `. The text comes from JavaScript coercion *inside* the expression. Executing each candidate operation shows `+` with a string operand, template-literal interpolation, `String()` and `.concat()` produce it, while numeric `+` (→ `NaN`), `Array.join`, `JSON.stringify` and `??` do not. The criteria scope case B to the two syntactic sites and document the rest as gaps.

The spec deliberately stops short of choosing case B's design — that is `@signal`'s call — but records the constraints research turned up so the contract does not start from a blank page: tournament's `before`/`after` AST hook seam (`packages/@n8n/tournament/src/ast.ts`), the four-touchpoint `__sanitize` helper pattern to copy (`packages/workflow/src/expression-sandboxing.ts:13,498`, `packages/workflow/src/expression.ts`, `packages/@n8n/expression-runtime/src/runtime/context.ts:121`), and the hard constraint that transformed code is cached by expression string alone (`packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts:42,168-195`) — so the transform must be emitted unconditionally and gated at runtime rather than varying by setting.

Because case B changes emitted code for every expression on both engines, **precision and performance are hard guardrails with revert criteria**, not aspirations: a false positive on `??` / `?.` / `=== undefined` reverts case B, and so does a measurable p95 regression. Default-off must leave every existing workflow byte-identical in behaviour.

## How to test

Nothing to execute — this PR adds a single markdown file. Review is reading `docs/product/undefined-expression-failure.md` and checking the code citations resolve:

```bash
sed -n '106,131p;204,271p' packages/@n8n/tournament/src/ExpressionBuilder.ts
sed -n '489,556p'           packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
sed -n '760,787p'           packages/core/src/execution-engine/routing-node.ts
sed -n '457,530p'           packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts
sed -n '160,200p'           packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
```

Both behaviour tables in the Evidence section were produced by executing the relevant code shapes, not inferred from reading them.

## Related Linear tickets, Github issues, and Community forum posts

Tracked in Multica as N8N-240 (acceptance criteria), under parent N8N-239 (Add expression resilience). No Linear ticket exists for this work.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- This PR *is* the doc; user-facing docs land with the implementation. -->
- [x] Tests included. <!-- Not applicable: docs only. The spec requires regression tests for the setting-off path as acceptance criteria 20-22. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
