### PR TITLE
refactor(core): Abstract Redis pub/sub behind a swappable message transport

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -1,5 +1,4 @@
 import 'reflect-metadata';
-import { N8N_VERSION, N8N_RELEASE_DATE } from '@/constants';
 import {
 	inDevelopment,
 	inTest,
@@ -15,6 +14,7 @@ import { LICENSE_FEATURES } from '@n8n/constants';
 import { DbConnection, DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
+import { sleep } from '@n8n/utils/sleep';
 import {
 	BinaryDataBlobManager,
 	BinaryDataConfig,
@@ -25,10 +25,10 @@ import {
 	ExecutionContextHookRegistry,
 	StorageConfig,
 } from 'n8n-core';
-import { sleep } from '@n8n/utils/sleep';
 import { Expression, UnexpectedError } from 'n8n-workflow';
 
 import type { AbstractServer } from '@/abstract-server';
+import { N8N_VERSION, N8N_RELEASE_DATE } from '@/constants';
 import * as CrashJournal from '@/crash-journal';
 import { getDataDeduplicationService } from '@/deduplication';
 import { TestRunCleanupService } from '@/evaluation.ee/test-runner/test-run-cleanup.service.ee';
@@ -43,6 +43,7 @@ import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { CommunityPackagesConfig } from '@/modules/community-packages/community-packages.config';
 import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
+import { MessageTransportService } from '@/scaling/transport/message-transport.service';
 import { ShutdownService } from '@/shutdown/shutdown.service';
 import { resolveBackendHealthEndpointPath } from '@/utils/health-endpoint.util';
 import { WorkflowHistoryManager } from '@/workflows/workflow-history/workflow-history-manager';
@@ -150,6 +151,18 @@ export abstract class BaseCommand<F = never> {
 		if (useRedisForLocking) {
 			const { RedisLockService } = await import('@/scaling/redis-lock.service.js');
 			Container.get(LockService).setProvider(Container.get(RedisLockService));
+		}
+
+		// `Publisher`/`Subscriber` only exchange messages in queue mode, which today still
+		// requires Redis for the execution queue regardless - so this swap doesn't yet let a
+		// real deployment drop Redis. It proves the transport is swappable the same way locking
+		// is: a working `IpcMessageTransport` is the default, and this is the single call site
+		// that opts a deployment into `RedisMessageTransport` instead.
+		if (this.globalConfig.executions.mode === 'queue') {
+			const { RedisMessageTransport } = await import(
+				'@/scaling/transport/redis-message-transport.js'
+			);
+			Container.get(MessageTransportService).setProvider(Container.get(RedisMessageTransport));
 		}
 
 		await this.dbConnection

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -44,6 +44,7 @@ import { CommunityPackagesConfig } from '@/modules/community-packages/community-
 import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
 import { MessageTransportService } from '@/scaling/transport/message-transport.service';
+import { TransportModeService } from '@/scaling/transport-mode.service';
 import { ShutdownService } from '@/shutdown/shutdown.service';
 import { resolveBackendHealthEndpointPath } from '@/utils/health-endpoint.util';
 import { WorkflowHistoryManager } from '@/workflows/workflow-history/workflow-history-manager';
@@ -157,8 +158,10 @@ export abstract class BaseCommand<F = never> {
 		// requires Redis for the execution queue regardless - so this swap doesn't yet let a
 		// real deployment drop Redis. It proves the transport is swappable the same way locking
 		// is: a working `IpcMessageTransport` is the default, and this is the single call site
-		// that opts a deployment into `RedisMessageTransport` instead.
-		if (this.globalConfig.executions.mode === 'queue') {
+		// that opts a deployment into `RedisMessageTransport` instead. The decision comes from
+		// `TransportModeService` (explicit `N8N_TRANSPORT_PUBSUB`, defaulting to `redis`), the
+		// same mechanism `Start.leaderElection()` uses for `leaderElection` - not re-derived here.
+		if (Container.get(TransportModeService).resolve('pubsub') === 'redis') {
 			const { RedisMessageTransport } = await import(
 				'@/scaling/transport/redis-message-transport.js'
 			);

--- a/packages/cli/src/scaling/__tests__/transport-mode.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/transport-mode.service.test.ts
@@ -59,5 +59,19 @@ describe('TransportModeService', () => {
 
 			expect(() => service.validateAtBoot()).not.toThrow();
 		});
+
+		it('throws when pubsub=ipc without a hypervisor', () => {
+			delete process.env.N8N_HYPERVISOR_MODE;
+			const service = makeService({ ...allRedis, pubsub: 'ipc' });
+
+			expect(() => service.validateAtBoot()).toThrow('requires running under `n8n hypervisor`');
+		});
+
+		it('passes when pubsub=ipc under a hypervisor', () => {
+			process.env.N8N_HYPERVISOR_MODE = '1';
+			const service = makeService({ ...allRedis, pubsub: 'ipc' });
+
+			expect(() => service.validateAtBoot()).not.toThrow();
+		});
 	});
 });

--- a/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
@@ -6,6 +6,7 @@ import { mock } from 'vitest-mock-extended';
 
 import type { RedisClientService } from '@/services/redis-client.service';
 
+import type { MessageTransportService } from '../../transport/message-transport.service';
 import { Publisher } from '../publisher.service';
 import type { PubSub } from '../pubsub.types';
 
@@ -15,31 +16,38 @@ describe('Publisher', () => {
 	const hostId = 'main-bnxa1riryKUNHtln';
 	const instanceSettings = mock<InstanceSettings>({ hostId });
 	const redisClientService = mock<RedisClientService>({ createClient: () => client });
+	const messageTransport = mock<MessageTransportService>();
 	const executionsConfig = mockInstance(ExecutionsConfig, { mode: 'queue' });
 	const globalConfig = mockInstance(GlobalConfig, { redis: { prefix: 'n8n' } });
 
+	beforeEach(() => {
+		messageTransport.publish.mockClear();
+	});
+
+	function createPublisher(
+		config: ExecutionsConfig = executionsConfig,
+		global: GlobalConfig = globalConfig,
+	) {
+		return new Publisher(
+			logger,
+			redisClientService,
+			messageTransport,
+			instanceSettings,
+			config,
+			global,
+		);
+	}
+
 	describe('constructor', () => {
 		it('should init Redis client in scaling mode', () => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 
 			expect(publisher.getClient()).toEqual(client);
 		});
 
 		it('should not init Redis client in regular mode', () => {
 			const regularModeConfig = mockInstance(ExecutionsConfig, { mode: 'regular' });
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				regularModeConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher(regularModeConfig);
 
 			expect(publisher.getClient()).toBeUndefined();
 		});
@@ -47,13 +55,7 @@ describe('Publisher', () => {
 
 	describe('shutdown', () => {
 		it('should disconnect Redis client', () => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 			publisher.shutdown();
 			expect(client.disconnect).toHaveBeenCalled();
 		});
@@ -62,51 +64,33 @@ describe('Publisher', () => {
 	describe('publishCommand', () => {
 		it('should do nothing if not in scaling mode', async () => {
 			const regularModeConfig = mockInstance(ExecutionsConfig, { mode: 'regular' });
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				regularModeConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher(regularModeConfig);
 			const msg = mock<PubSub.Command>({ command: 'reload-license' });
 
 			await publisher.publishCommand(msg);
 
-			expect(client.publish).not.toHaveBeenCalled();
+			expect(messageTransport.publish).not.toHaveBeenCalled();
 		});
 
 		it('should publish command into prefixed pubsub channel', async () => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 			const msg = mock<PubSub.Command>({ command: 'reload-license' });
 
 			await publisher.publishCommand(msg);
 
-			expect(client.publish).toHaveBeenCalledWith(
+			expect(messageTransport.publish).toHaveBeenCalledWith(
 				'n8n:n8n.commands',
 				JSON.stringify({ ...msg, senderId: hostId, selfSend: false, debounce: true }),
 			);
 		});
 
 		it('should not debounce `add-webhooks-triggers-and-pollers`', async () => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 			const msg = mock<PubSub.Command>({ command: 'add-webhooks-triggers-and-pollers' });
 
 			await publisher.publishCommand(msg);
 
-			expect(client.publish).toHaveBeenCalledWith(
+			expect(messageTransport.publish).toHaveBeenCalledWith(
 				'n8n:n8n.commands',
 				JSON.stringify({
 					...msg,
@@ -119,18 +103,12 @@ describe('Publisher', () => {
 		});
 
 		it('should not debounce `remove-triggers-and-pollers`', async () => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 			const msg = mock<PubSub.Command>({ command: 'remove-triggers-and-pollers' });
 
 			await publisher.publishCommand(msg);
 
-			expect(client.publish).toHaveBeenCalledWith(
+			expect(messageTransport.publish).toHaveBeenCalledWith(
 				'n8n:n8n.commands',
 				JSON.stringify({
 					...msg,
@@ -149,18 +127,12 @@ describe('Publisher', () => {
 			'display-workflow-activation-error',
 			'display-workflow-publication-status',
 		] as const)('should not debounce `%s`', async (command) => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 			const msg = mock<PubSub.Command>({ command });
 
 			await publisher.publishCommand(msg);
 
-			expect(client.publish).toHaveBeenCalledWith(
+			expect(messageTransport.publish).toHaveBeenCalledWith(
 				'n8n:n8n.commands',
 				JSON.stringify({
 					...msg,
@@ -175,72 +147,51 @@ describe('Publisher', () => {
 
 	describe('publishWorkerResponse', () => {
 		it('should publish worker response into prefixed pubsub channel', async () => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 			const msg = mock<PubSub.WorkerResponse>({
 				response: 'response-to-get-worker-status',
 			});
 
 			await publisher.publishWorkerResponse(msg);
 
-			expect(client.publish).toHaveBeenCalledWith('n8n:n8n.worker-response', JSON.stringify(msg));
+			expect(messageTransport.publish).toHaveBeenCalledWith(
+				'n8n:n8n.worker-response',
+				JSON.stringify(msg),
+			);
 		});
 	});
 
 	describe('publishMcpRelay', () => {
 		it('should do nothing if not in scaling mode', async () => {
-			// Clear previous mock calls from other tests
-			client.publish.mockClear();
-
 			const regularModeConfig = mockInstance(ExecutionsConfig, { mode: 'regular' });
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				regularModeConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher(regularModeConfig);
 			const msg = { sessionId: 'session-123', messageId: 'msg-456', response: { test: true } };
 
 			await publisher.publishMcpRelay(msg);
 
-			expect(client.publish).not.toHaveBeenCalled();
+			expect(messageTransport.publish).not.toHaveBeenCalled();
 		});
 
 		it('should publish MCP relay message to prefixed channel', async () => {
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				globalConfig,
-			);
+			const publisher = createPublisher();
 			const msg = { sessionId: 'session-123', messageId: 'msg-456', response: { test: true } };
 
 			await publisher.publishMcpRelay(msg);
 
-			expect(client.publish).toHaveBeenCalledWith('n8n:n8n.mcp-relay', JSON.stringify(msg));
+			expect(messageTransport.publish).toHaveBeenCalledWith(
+				'n8n:n8n.mcp-relay',
+				JSON.stringify(msg),
+			);
 		});
 
 		it('should apply configured prefix to MCP relay channel', async () => {
 			const customConfig = mockInstance(GlobalConfig, { redis: { prefix: 'n8n-instance-1' } });
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				customConfig,
-			);
+			const publisher = createPublisher(executionsConfig, customConfig);
 			const msg = { sessionId: 'session-123', messageId: 'msg-456', response: { test: true } };
 
 			await publisher.publishMcpRelay(msg);
 
-			expect(client.publish).toHaveBeenCalledWith(
+			expect(messageTransport.publish).toHaveBeenCalledWith(
 				'n8n-instance-1:n8n.mcp-relay',
 				JSON.stringify(msg),
 			);
@@ -250,17 +201,11 @@ describe('Publisher', () => {
 	describe('prefix isolation', () => {
 		it('should apply configured prefix to both command and worker response channels', async () => {
 			const customConfig = mockInstance(GlobalConfig, { redis: { prefix: 'n8n-instance-1' } });
-			const publisher = new Publisher(
-				logger,
-				redisClientService,
-				instanceSettings,
-				executionsConfig,
-				customConfig,
-			);
+			const publisher = createPublisher(executionsConfig, customConfig);
 
 			const commandMsg = mock<PubSub.Command>({ command: 'reload-license' });
 			await publisher.publishCommand(commandMsg);
-			expect(client.publish).toHaveBeenCalledWith(
+			expect(messageTransport.publish).toHaveBeenCalledWith(
 				'n8n-instance-1:n8n.commands',
 				expect.any(String),
 			);
@@ -269,7 +214,7 @@ describe('Publisher', () => {
 				response: 'response-to-get-worker-status',
 			});
 			await publisher.publishWorkerResponse(workerMsg);
-			expect(client.publish).toHaveBeenCalledWith(
+			expect(messageTransport.publish).toHaveBeenCalledWith(
 				'n8n-instance-1:n8n.worker-response',
 				JSON.stringify(workerMsg),
 			);

--- a/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
@@ -1,11 +1,9 @@
 import type { Logger } from '@n8n/backend-common';
 import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
 import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
-import type { Redis as SingleNodeClient } from 'ioredis';
 import { mock } from 'vitest-mock-extended';
 
-import type { RedisClientService } from '@/services/redis-client.service';
-
+import type { MessageTransportService } from '../../transport/message-transport.service';
 import type { PubSubEventBus } from '../pubsub.eventbus';
 import type { McpRelayMessage } from '../subscriber.service';
 import { Subscriber } from '../subscriber.service';
@@ -15,93 +13,77 @@ describe('Subscriber', () => {
 		vi.restoreAllMocks();
 	});
 
-	const client = mock<SingleNodeClient>();
-	const redisClientService = mock<RedisClientService>({ createClient: () => client });
+	const messageTransport = mock<MessageTransportService>();
 	const executionsConfig = mockInstance(ExecutionsConfig, { mode: 'queue' });
 	const globalConfig = mockInstance(GlobalConfig, { redis: { prefix: 'n8n' } });
 
-	describe('constructor', () => {
-		it('should init Redis client in scaling mode', () => {
-			const subscriber = new Subscriber(
-				mock(),
-				mock(),
-				mock(),
-				redisClientService,
-				executionsConfig,
-				globalConfig,
-			);
+	function createSubscriber(
+		logger = mockLogger(),
+		pubsubEventBus: PubSubEventBus = mock(),
+		config: ExecutionsConfig = executionsConfig,
+		global: GlobalConfig = globalConfig,
+	) {
+		return new Subscriber(logger, mock(), pubsubEventBus, messageTransport, config, global);
+	}
 
-			expect(subscriber.getClient()).toEqual(client);
+	/** Subscribes and returns the handler `Subscriber` registered with the transport for `channel`. */
+	async function subscribeAndGetHandler(subscriber: Subscriber, channel: string) {
+		await subscriber.subscribe(channel);
+		const call = messageTransport.subscribe.mock.calls.find(([ch]) => ch === channel);
+		expect(call).toBeDefined();
+		return call![1] as (message: string) => void;
+	}
+
+	describe('constructor', () => {
+		it('should build prefixed channel names in scaling mode', () => {
+			const subscriber = createSubscriber();
+
+			expect(subscriber.getCommandChannel()).toEqual('n8n:n8n.commands');
 		});
 
-		it('should not init Redis client in regular mode', () => {
+		it('should not build channel names in regular mode', () => {
 			const regularModeConfig = mockInstance(ExecutionsConfig, { mode: 'regular' });
-			const subscriber = new Subscriber(
-				mock(),
-				mock(),
-				mock(),
-				redisClientService,
-				regularModeConfig,
-				globalConfig,
-			);
+			const subscriber = createSubscriber(mockLogger(), mock(), regularModeConfig);
 
-			expect(subscriber.getClient()).toBeUndefined();
+			expect(subscriber.getCommandChannel()).toBeUndefined();
 		});
 	});
 
 	describe('shutdown', () => {
-		it('should disconnect Redis client', () => {
-			const subscriber = new Subscriber(
-				mock(),
-				mock(),
-				mock(),
-				redisClientService,
-				executionsConfig,
-				globalConfig,
-			);
+		it('should shut down the message transport', () => {
+			const subscriber = createSubscriber();
 			subscriber.shutdown();
-			expect(client.disconnect).toHaveBeenCalled();
+			expect(messageTransport.shutdown).toHaveBeenCalled();
 		});
 	});
 
 	describe('subscribe', () => {
 		it('should subscribe to pubsub channel with prefix', async () => {
-			const subscriber = new Subscriber(
-				mock(),
-				mock(),
-				mock(),
-				redisClientService,
-				executionsConfig,
-				globalConfig,
-			);
+			const subscriber = createSubscriber();
 
 			const commandChannel = subscriber.getCommandChannel();
 			await subscriber.subscribe(commandChannel);
 
-			expect(client.subscribe).toHaveBeenCalledWith('n8n:n8n.commands', expect.any(Function));
+			expect(messageTransport.subscribe).toHaveBeenCalledWith(
+				'n8n:n8n.commands',
+				expect.any(Function),
+			);
 		});
 	});
 
 	describe('prefix isolation', () => {
 		it('should apply configured prefix when subscribing to channels', async () => {
 			const customConfig = mockInstance(GlobalConfig, { redis: { prefix: 'n8n-instance-1' } });
-			const subscriber = new Subscriber(
-				mock(),
-				mock(),
-				mock(),
-				redisClientService,
-				executionsConfig,
-				customConfig,
-			);
+			const subscriber = createSubscriber(mockLogger(), mock(), executionsConfig, customConfig);
 
 			await subscriber.subscribe(subscriber.getCommandChannel());
 			await subscriber.subscribe(subscriber.getWorkerResponseChannel());
 
-			expect(client.subscribe).toHaveBeenCalledWith(
+			expect(messageTransport.subscribe).toHaveBeenCalledWith(
 				'n8n-instance-1:n8n.commands',
 				expect.any(Function),
 			);
-			expect(client.subscribe).toHaveBeenCalledWith(
+			expect(messageTransport.subscribe).toHaveBeenCalledWith(
 				'n8n-instance-1:n8n.worker-response',
 				expect.any(Function),
 			);
@@ -111,38 +93,27 @@ describe('Subscriber', () => {
 	describe('debounce', () => {
 		beforeEach(() => {
 			vi.useFakeTimers();
-			client.on.mockClear();
+			messageTransport.subscribe.mockClear();
 		});
 
 		afterEach(() => {
 			vi.useRealTimers();
 		});
 
-		function getMessageHandler() {
-			const call = client.on.mock.calls.find(([event]) => event === 'message');
-			expect(call).toBeDefined();
-			return call![1] as (channel: string, msg: string) => void;
-		}
-
 		function makeCommandMsg(command: string, debounce: boolean, payload?: unknown) {
 			return JSON.stringify({ command, senderId: 'other-host', debounce, payload });
 		}
 
-		it('should not drop different debounced commands arriving within 300ms', () => {
+		it('should not drop different debounced commands arriving within 300ms', async () => {
 			const pubsubEventBus = mock<PubSubEventBus>();
-			new Subscriber(
-				mockLogger(),
-				mock(),
-				pubsubEventBus,
-				redisClientService,
-				executionsConfig,
-				globalConfig,
+			const subscriber = createSubscriber(mockLogger(), pubsubEventBus);
+			const messageHandler = await subscribeAndGetHandler(
+				subscriber,
+				subscriber.getCommandChannel(),
 			);
 
-			const messageHandler = getMessageHandler();
-
-			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
-			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-external-secrets-providers', true));
+			messageHandler(makeCommandMsg('reload-license', true));
+			messageHandler(makeCommandMsg('reload-external-secrets-providers', true));
 
 			vi.advanceTimersByTime(300);
 
@@ -154,22 +125,17 @@ describe('Subscriber', () => {
 			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(2);
 		});
 
-		it('should debounce repeated identical commands within 300ms', () => {
+		it('should debounce repeated identical commands within 300ms', async () => {
 			const pubsubEventBus = mock<PubSubEventBus>();
-			new Subscriber(
-				mockLogger(),
-				mock(),
-				pubsubEventBus,
-				redisClientService,
-				executionsConfig,
-				globalConfig,
+			const subscriber = createSubscriber(mockLogger(), pubsubEventBus);
+			const messageHandler = await subscribeAndGetHandler(
+				subscriber,
+				subscriber.getCommandChannel(),
 			);
 
-			const messageHandler = getMessageHandler();
-
-			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
-			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
-			messageHandler('n8n:n8n.commands', makeCommandMsg('reload-license', true));
+			messageHandler(makeCommandMsg('reload-license', true));
+			messageHandler(makeCommandMsg('reload-license', true));
+			messageHandler(makeCommandMsg('reload-license', true));
 
 			vi.advanceTimersByTime(300);
 
@@ -177,24 +143,16 @@ describe('Subscriber', () => {
 			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(1);
 		});
 
-		it('should not debounce immediate commands', () => {
+		it('should not debounce immediate commands', async () => {
 			const pubsubEventBus = mock<PubSubEventBus>();
-			new Subscriber(
-				mockLogger(),
-				mock(),
-				pubsubEventBus,
-				redisClientService,
-				executionsConfig,
-				globalConfig,
+			const subscriber = createSubscriber(mockLogger(), pubsubEventBus);
+			const messageHandler = await subscribeAndGetHandler(
+				subscriber,
+				subscriber.getCommandChannel(),
 			);
-
-			const messageHandler = getMessageHandler();
 
 			const payload = { workflowId: 'wf-1', activeVersionId: 'v-1', activationMode: 'init' };
-			messageHandler(
-				'n8n:n8n.commands',
-				makeCommandMsg('add-webhooks-triggers-and-pollers', false, payload),
-			);
+			messageHandler(makeCommandMsg('add-webhooks-triggers-and-pollers', false, payload));
 
 			expect(pubsubEventBus.emit).toHaveBeenCalledWith(
 				'add-webhooks-triggers-and-pollers',
@@ -203,29 +161,18 @@ describe('Subscriber', () => {
 			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(1);
 		});
 
-		it('should deliver each display-workflow-activation immediately without coalescing', () => {
+		it('should deliver each display-workflow-activation immediately without coalescing', async () => {
 			const pubsubEventBus = mock<PubSubEventBus>();
-			new Subscriber(
-				mockLogger(),
-				mock(),
-				pubsubEventBus,
-				redisClientService,
-				executionsConfig,
-				globalConfig,
+			const subscriber = createSubscriber(mockLogger(), pubsubEventBus);
+			const messageHandler = await subscribeAndGetHandler(
+				subscriber,
+				subscriber.getCommandChannel(),
 			);
-
-			const messageHandler = getMessageHandler();
 
 			const payload1 = { workflowId: 'wf-1', activeVersionId: 'v-1' };
 			const payload2 = { workflowId: 'wf-2', activeVersionId: 'v-2' };
-			messageHandler(
-				'n8n:n8n.commands',
-				makeCommandMsg('display-workflow-activation', false, payload1),
-			);
-			messageHandler(
-				'n8n:n8n.commands',
-				makeCommandMsg('display-workflow-activation', false, payload2),
-			);
+			messageHandler(makeCommandMsg('display-workflow-activation', false, payload1));
+			messageHandler(makeCommandMsg('display-workflow-activation', false, payload2));
 
 			expect(pubsubEventBus.emit).toHaveBeenCalledWith('display-workflow-activation', payload1);
 			expect(pubsubEventBus.emit).toHaveBeenCalledWith('display-workflow-activation', payload2);
@@ -235,28 +182,20 @@ describe('Subscriber', () => {
 
 	describe('MCP relay handling', () => {
 		beforeEach(() => {
-			// Clear mock calls to ensure each test gets fresh state
-			client.on.mockClear();
+			messageTransport.subscribe.mockClear();
 		});
 
-		it('should invoke handler for valid MCP relay messages', () => {
+		it('should invoke handler for valid MCP relay messages', async () => {
 			const logger = mockLogger();
-			const subscriber = new Subscriber(
-				logger,
-				mock(),
-				mock(),
-				redisClientService,
-				executionsConfig,
-				globalConfig,
-			);
+			const subscriber = createSubscriber(logger);
 
 			const mockHandler = vi.fn();
 			subscriber.setMcpRelayHandler(mockHandler);
 
-			// Get the message handler registered on the client (the one from this test)
-			const messageHandlerCall = client.on.mock.calls.find(([event]) => event === 'message');
-			expect(messageHandlerCall).toBeDefined();
-			const messageHandler = messageHandlerCall![1] as (channel: string, msg: string) => void;
+			const messageHandler = await subscribeAndGetHandler(
+				subscriber,
+				subscriber.getMcpRelayChannel(),
+			);
 
 			const relayMsg: McpRelayMessage = {
 				sessionId: 'session-123',
@@ -264,35 +203,28 @@ describe('Subscriber', () => {
 				response: { test: true },
 			};
 
-			messageHandler('n8n:n8n.mcp-relay', JSON.stringify(relayMsg));
+			messageHandler(JSON.stringify(relayMsg));
 
 			expect(mockHandler).toHaveBeenCalledWith(relayMsg);
 		});
 
-		it('should log error and not invoke handler for malformed messages', () => {
-			// Create a scoped logger mock that will be returned by logger.scoped()
+		it('should log error and not invoke handler for malformed messages', async () => {
 			const scopedLogger = mock<Logger>();
 			const logger = mock<Logger>({
 				scoped: vi.fn().mockReturnValue(scopedLogger),
 			});
-			const subscriber = new Subscriber(
-				logger,
-				mock(),
-				mock(),
-				redisClientService,
-				executionsConfig,
-				globalConfig,
-			);
+			const subscriber = createSubscriber(logger);
 
 			const mockHandler = vi.fn();
 			subscriber.setMcpRelayHandler(mockHandler);
 
-			const messageHandlerCall = client.on.mock.calls.find(([event]) => event === 'message');
-			expect(messageHandlerCall).toBeDefined();
-			const messageHandler = messageHandlerCall![1] as (channel: string, msg: string) => void;
+			const messageHandler = await subscribeAndGetHandler(
+				subscriber,
+				subscriber.getMcpRelayChannel(),
+			);
 
 			// Send malformed message (missing required fields)
-			messageHandler('n8n:n8n.mcp-relay', JSON.stringify({ invalid: true }));
+			messageHandler(JSON.stringify({ invalid: true }));
 
 			expect(mockHandler).not.toHaveBeenCalled();
 			// The scoped logger is what's actually used internally
@@ -302,14 +234,14 @@ describe('Subscriber', () => {
 			);
 		});
 
-		it('should handle missing handler gracefully', () => {
+		it('should handle missing handler gracefully', async () => {
 			const logger = mockLogger();
-			// Create subscriber but don't set a handler - constructor registers message listener
-			new Subscriber(logger, mock(), mock(), redisClientService, executionsConfig, globalConfig);
-
-			const messageHandlerCall = client.on.mock.calls.find(([event]) => event === 'message');
-			expect(messageHandlerCall).toBeDefined();
-			const messageHandler = messageHandlerCall![1] as (channel: string, msg: string) => void;
+			// Create subscriber but don't set a handler
+			const subscriber = createSubscriber(logger);
+			const messageHandler = await subscribeAndGetHandler(
+				subscriber,
+				subscriber.getMcpRelayChannel(),
+			);
 
 			const relayMsg: McpRelayMessage = {
 				sessionId: 'session-123',
@@ -318,7 +250,7 @@ describe('Subscriber', () => {
 			};
 
 			// Should not throw when handler is not set
-			expect(() => messageHandler('n8n:n8n.mcp-relay', JSON.stringify(relayMsg))).not.toThrow();
+			expect(() => messageHandler(JSON.stringify(relayMsg))).not.toThrow();
 		});
 	});
 });

--- a/packages/cli/src/scaling/pubsub/publisher.service.ts
+++ b/packages/cli/src/scaling/pubsub/publisher.service.ts
@@ -16,13 +16,15 @@ import {
 	MCP_RELAY_PUBSUB_CHANNEL,
 } from '../constants';
 import type { McpRelayMessage } from './subscriber.service';
+import { MessageTransportService } from '../transport/message-transport.service';
 
 /**
  * Responsible for publishing messages into the pubsub channels used by scaling mode.
  */
 @Service()
 export class Publisher {
-	private readonly client: SingleNodeClient | MultiNodeClient;
+	/** Used only by the key-value utils below, never for pubsub - see that region. */
+	private readonly redisClient: SingleNodeClient | MultiNodeClient;
 
 	private readonly commandChannel: string;
 
@@ -35,6 +37,7 @@ export class Publisher {
 	constructor(
 		private readonly logger: Logger,
 		private readonly redisClientService: RedisClientService,
+		private readonly messageTransport: MessageTransportService,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly executionsConfig: ExecutionsConfig,
 		private readonly globalConfig: GlobalConfig,
@@ -50,16 +53,16 @@ export class Publisher {
 		this.workerResponseChannel = `${prefix}:${WORKER_RESPONSE_PUBSUB_CHANNEL}`;
 		this.mcpRelayChannel = `${prefix}:${MCP_RELAY_PUBSUB_CHANNEL}`;
 
-		this.client = this.redisClientService.createClient({ type: 'publisher(n8n)' });
+		this.redisClient = this.redisClientService.createClient({ type: 'publisher(n8n)' });
 	}
 
 	getClient() {
-		return this.client;
+		return this.redisClient;
 	}
 
 	// @TODO: Use `@OnShutdown()` decorator
 	shutdown() {
-		this.client.disconnect();
+		this.redisClient.disconnect();
 	}
 
 	// #endregion
@@ -71,7 +74,7 @@ export class Publisher {
 		// @TODO: Once this class is only ever used in scaling mode, remove next line.
 		if (this.executionsConfig.mode !== 'queue') return;
 
-		await this.client.publish(
+		await this.messageTransport.publish(
 			this.commandChannel,
 			JSON.stringify({
 				...msg,
@@ -97,7 +100,7 @@ export class Publisher {
 
 	/** Publish a response to a command into the worker response channel. */
 	async publishWorkerResponse(msg: PubSub.WorkerResponse) {
-		await this.client.publish(this.workerResponseChannel, JSON.stringify(msg));
+		await this.messageTransport.publish(this.workerResponseChannel, JSON.stringify(msg));
 
 		this.logger.debug(`Published ${msg.response} to worker response channel`);
 	}
@@ -107,7 +110,7 @@ export class Publisher {
 		// @TODO: Once this class is only ever used in scaling mode, remove next line.
 		if (this.executionsConfig.mode !== 'queue') return;
 
-		await this.client.publish(this.mcpRelayChannel, JSON.stringify(msg));
+		await this.messageTransport.publish(this.mcpRelayChannel, JSON.stringify(msg));
 
 		this.logger.debug('Published MCP relay message', {
 			sessionId: msg.sessionId,
@@ -119,26 +122,29 @@ export class Publisher {
 	// #endregion
 
 	// #region Key-value utils (used by MCP session store and legacy leader election)
+	//
+	// Not part of the messaging facet abstracted above - these are a storage-facet
+	// concern (per the RFC's messaging/storage split) and stay directly on Redis.
 
 	async setIfNotExists(key: string, value: string, ttl: number) {
-		const result = await this.client.set(key, value, 'EX', ttl, 'NX');
+		const result = await this.redisClient.set(key, value, 'EX', ttl, 'NX');
 		return result === 'OK';
 	}
 
 	async set(key: string, value: string, ttl: number) {
-		await this.client.set(key, value, 'EX', ttl);
+		await this.redisClient.set(key, value, 'EX', ttl);
 	}
 
 	async setExpiration(key: string, ttl: number) {
-		await this.client.expire(key, ttl);
+		await this.redisClient.expire(key, ttl);
 	}
 
 	async get(key: string) {
-		return await this.client.get(key);
+		return await this.redisClient.get(key);
 	}
 
 	async clear(key: string) {
-		await this.client?.del(key);
+		await this.redisClient?.del(key);
 	}
 
 	// #endregion

--- a/packages/cli/src/scaling/pubsub/subscriber.service.ts
+++ b/packages/cli/src/scaling/pubsub/subscriber.service.ts
@@ -1,13 +1,10 @@
 import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import type { Redis as SingleNodeClient, Cluster as MultiNodeClient } from 'ioredis';
 import debounce from 'lodash/debounce';
 import { InstanceSettings } from 'n8n-core';
 import { jsonParse } from 'n8n-workflow';
 import type { LogMetadata } from 'n8n-workflow';
-
-import { RedisClientService } from '@/services/redis-client.service';
 
 import { PubSubEventBus } from './pubsub.eventbus';
 import type { PubSub } from './pubsub.types';
@@ -16,6 +13,7 @@ import {
 	WORKER_RESPONSE_PUBSUB_CHANNEL,
 	MCP_RELAY_PUBSUB_CHANNEL,
 } from '../constants';
+import { MessageTransportService } from '../transport/message-transport.service';
 
 /**
  * Responsible for subscribing to the pubsub channels used by scaling mode.
@@ -32,8 +30,6 @@ export interface McpRelayMessage {
 
 @Service()
 export class Subscriber {
-	private readonly client: SingleNodeClient | MultiNodeClient;
-
 	private readonly commandChannel: string;
 
 	private readonly workerResponseChannel: string;
@@ -49,7 +45,7 @@ export class Subscriber {
 		private readonly logger: Logger,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly pubsubEventBus: PubSubEventBus,
-		private readonly redisClientService: RedisClientService,
+		private readonly messageTransport: MessageTransportService,
 		private readonly executionsConfig: ExecutionsConfig,
 		private readonly globalConfig: GlobalConfig,
 	) {
@@ -63,32 +59,34 @@ export class Subscriber {
 		this.commandChannel = `${prefix}:${COMMAND_PUBSUB_CHANNEL}`;
 		this.workerResponseChannel = `${prefix}:${WORKER_RESPONSE_PUBSUB_CHANNEL}`;
 		this.mcpRelayChannel = `${prefix}:${MCP_RELAY_PUBSUB_CHANNEL}`;
+	}
 
-		this.client = this.redisClientService.createClient({ type: 'subscriber(n8n)' });
+	/** Routes an incoming raw message the same way regardless of which transport delivered it. */
+	private handleIncoming(channel: string, str: string) {
+		// Handle MCP relay messages separately
+		if (channel === this.mcpRelayChannel) {
+			this.handleMcpRelayMessage(str);
+			return;
+		}
 
-		const handlerFn = (msg: PubSub.Command | PubSub.WorkerResponse) => {
-			this.pubsubEventBus.emit(this.eventNameFrom(msg), msg.payload);
-		};
+		const msg = this.parseMessage(str, channel);
+		if (!msg) return;
+		if (!msg.debounce) return this.emitToEventBus(msg);
 
-		this.client.on('message', (channel: string, str: string) => {
-			// Handle MCP relay messages separately
-			if (channel === this.mcpRelayChannel) {
-				this.handleMcpRelayMessage(str);
-				return;
-			}
+		const eventName = this.eventNameFrom(msg);
+		let handler = this.debouncedHandlers.get(eventName);
+		if (!handler) {
+			handler = debounce(
+				(m: PubSub.Command | PubSub.WorkerResponse) => this.emitToEventBus(m),
+				300,
+			);
+			this.debouncedHandlers.set(eventName, handler);
+		}
+		handler(msg);
+	}
 
-			const msg = this.parseMessage(str, channel);
-			if (!msg) return;
-			if (!msg.debounce) return handlerFn(msg);
-
-			const eventName = this.eventNameFrom(msg);
-			let handler = this.debouncedHandlers.get(eventName);
-			if (!handler) {
-				handler = debounce(handlerFn, 300);
-				this.debouncedHandlers.set(eventName, handler);
-			}
-			handler(msg);
-		});
+	private emitToEventBus(msg: PubSub.Command | PubSub.WorkerResponse) {
+		this.pubsubEventBus.emit(this.eventNameFrom(msg), msg.payload);
 	}
 
 	/**
@@ -116,10 +114,6 @@ export class Subscriber {
 		}
 	}
 
-	getClient() {
-		return this.client;
-	}
-
 	getCommandChannel() {
 		return this.commandChannel;
 	}
@@ -135,18 +129,13 @@ export class Subscriber {
 	// @TODO: Use `@OnShutdown()` decorator
 	shutdown() {
 		for (const handler of this.debouncedHandlers.values()) handler.cancel();
-		this.client.disconnect();
+		void this.messageTransport.shutdown();
 	}
 
 	async subscribe(channel: string) {
-		await this.client.subscribe(channel, (error) => {
-			if (error) {
-				this.logger.error(`Failed to subscribe to channel ${channel}`, { error });
-				return;
-			}
-
-			this.logger.debug(`Subscribed to channel ${channel}`);
-		});
+		await this.messageTransport.subscribe(channel, (message) =>
+			this.handleIncoming(channel, message),
+		);
 	}
 
 	private eventNameFrom(msg: PubSub.Command | PubSub.WorkerResponse) {

--- a/packages/cli/src/scaling/transport-mode.service.ts
+++ b/packages/cli/src/scaling/transport-mode.service.ts
@@ -22,13 +22,20 @@ export class TransportModeService {
 	}
 
 	/**
-	 * Fail fast at boot for selections that cannot work. Only leader election
-	 * consumes the `ipc` value today; this grows as other subsystems are wired.
+	 * Fail fast at boot for selections that cannot work. Leader election and
+	 * pubsub consume the `ipc` value today; this grows as other subsystems are
+	 * wired.
 	 */
 	validateAtBoot(): void {
 		if (this.resolve('leaderElection') === 'ipc' && process.env.N8N_HYPERVISOR_MODE !== '1') {
 			throw new UserError(
 				'N8N_TRANSPORT_LEADER_ELECTION=ipc requires running under `n8n hypervisor` (no IPC channel otherwise).',
+			);
+		}
+
+		if (this.resolve('pubsub') === 'ipc' && process.env.N8N_HYPERVISOR_MODE !== '1') {
+			throw new UserError(
+				'N8N_TRANSPORT_PUBSUB=ipc requires running under `n8n hypervisor` (no IPC channel otherwise).',
 			);
 		}
 	}

--- a/packages/cli/src/scaling/transport/__tests__/ipc-message-transport.test.ts
+++ b/packages/cli/src/scaling/transport/__tests__/ipc-message-transport.test.ts
@@ -1,0 +1,98 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { GlobalConfig } from '@n8n/config';
+import { randomUUID } from 'node:crypto';
+import { mock } from 'vitest-mock-extended';
+
+import { IpcMessageTransport } from '../ipc-message-transport';
+
+/**
+ * These exercise real Unix domain sockets (via `node:net`), not mocks - the point
+ * is to prove messages actually cross a socket connection between independently
+ * constructed transport instances, standing in for separate main/worker processes,
+ * with no Redis involved. Each test uses its own random prefix so the socket path
+ * doesn't collide with other tests or leftover files from a previous run.
+ */
+describe('IpcMessageTransport', () => {
+	const transports: IpcMessageTransport[] = [];
+
+	afterEach(() => {
+		for (const transport of transports.splice(0)) transport.shutdown();
+	});
+
+	function spawn(prefix: string) {
+		const globalConfig = mock<GlobalConfig>({ redis: { prefix } });
+		const transport = new IpcMessageTransport(mockLogger(), globalConfig);
+		transports.push(transport);
+		return transport;
+	}
+
+	async function settle(ms = 50) {
+		await new Promise((resolve) => setTimeout(resolve, ms));
+	}
+
+	it('delivers a published message to a subscriber on a different transport instance', async () => {
+		const prefix = `test-${randomUUID()}`;
+		const publisherSide = spawn(prefix);
+		const subscriberSide = spawn(prefix);
+
+		const received = new Promise<[string, string]>((resolve) => {
+			void subscriberSide.subscribe('chan', (message, channel) => resolve([message, channel]));
+		});
+		await settle();
+
+		await publisherSide.publish('chan', 'hello over ipc');
+
+		await expect(received).resolves.toEqual(['hello over ipc', 'chan']);
+	});
+
+	it('delivers to every subscriber of a channel, including the publisher itself if subscribed', async () => {
+		const prefix = `test-${randomUUID()}`;
+		const a = spawn(prefix);
+		const b = spawn(prefix);
+
+		const aReceived = vi.fn();
+		const bReceived = vi.fn();
+		await a.subscribe('chan', aReceived);
+		await b.subscribe('chan', bReceived);
+		await settle();
+
+		await a.publish('chan', 'broadcast');
+		await settle();
+
+		expect(aReceived).toHaveBeenCalledWith('broadcast', 'chan');
+		expect(bReceived).toHaveBeenCalledWith('broadcast', 'chan');
+	});
+
+	it('does not deliver to a transport subscribed to a different channel', async () => {
+		const prefix = `test-${randomUUID()}`;
+		const publisherSide = spawn(prefix);
+		const subscriberSide = spawn(prefix);
+
+		const otherChannelHandler = vi.fn();
+		await subscriberSide.subscribe('other-chan', otherChannelHandler);
+		await settle();
+
+		await publisherSide.publish('chan', 'hello');
+		await settle();
+
+		expect(otherChannelHandler).not.toHaveBeenCalled();
+	});
+
+	it('lets a third transport join after the first two are already connected', async () => {
+		const prefix = `test-${randomUUID()}`;
+		const first = spawn(prefix);
+		const second = spawn(prefix);
+		await first.publish('warm-up', 'noop'); // first becomes the broker
+		await settle();
+
+		const third = spawn(prefix);
+		const received = vi.fn();
+		await third.subscribe('chan', received);
+		await settle();
+
+		await second.publish('chan', 'late joiner');
+		await settle();
+
+		expect(received).toHaveBeenCalledWith('late joiner', 'chan');
+	});
+});

--- a/packages/cli/src/scaling/transport/__tests__/message-transport.service.test.ts
+++ b/packages/cli/src/scaling/transport/__tests__/message-transport.service.test.ts
@@ -1,0 +1,33 @@
+import { mock } from 'vitest-mock-extended';
+
+import type { IpcMessageTransport } from '../ipc-message-transport';
+import type { MessageTransport } from '../message-transport.interface';
+import { MessageTransportService } from '../message-transport.service';
+
+describe('MessageTransportService', () => {
+	it('should default to the given IPC transport', async () => {
+		const ipcMessageTransport = mock<IpcMessageTransport>();
+		const service = new MessageTransportService(ipcMessageTransport);
+
+		await service.publish('chan', 'hello');
+
+		expect(ipcMessageTransport.publish).toHaveBeenCalledWith('chan', 'hello');
+	});
+
+	it('should delegate publish/subscribe/shutdown to whichever provider is set', async () => {
+		const ipcMessageTransport = mock<IpcMessageTransport>();
+		const redisTransport = mock<MessageTransport>();
+		const service = new MessageTransportService(ipcMessageTransport);
+
+		service.setProvider(redisTransport);
+		const handler = vi.fn();
+		await service.publish('chan', 'hello');
+		await service.subscribe('chan', handler);
+		await service.shutdown();
+
+		expect(redisTransport.publish).toHaveBeenCalledWith('chan', 'hello');
+		expect(redisTransport.subscribe).toHaveBeenCalledWith('chan', handler);
+		expect(redisTransport.shutdown).toHaveBeenCalled();
+		expect(ipcMessageTransport.publish).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/scaling/transport/__tests__/redis-message-transport.test.ts
+++ b/packages/cli/src/scaling/transport/__tests__/redis-message-transport.test.ts
@@ -1,0 +1,95 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { Redis as SingleNodeClient } from 'ioredis';
+import { mock } from 'vitest-mock-extended';
+
+import type { RedisClientService } from '@/services/redis-client.service';
+
+import { RedisMessageTransport } from '../redis-message-transport';
+
+describe('RedisMessageTransport', () => {
+	const publisherClient = mock<SingleNodeClient>();
+	const subscriberClient = mock<SingleNodeClient>();
+	const logger = mockLogger();
+	const redisClientService = mock<RedisClientService>();
+
+	let transport: RedisMessageTransport;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		redisClientService.createClient.mockImplementation(({ type }) =>
+			type === 'publisher(n8n)' ? publisherClient : subscriberClient,
+		);
+		transport = new RedisMessageTransport(logger, redisClientService);
+	});
+
+	describe('publish', () => {
+		it('should lazily create a dedicated publisher client and publish through it', async () => {
+			expect(redisClientService.createClient).not.toHaveBeenCalled();
+
+			await transport.publish('chan', 'hello');
+
+			expect(redisClientService.createClient).toHaveBeenCalledWith({ type: 'publisher(n8n)' });
+			expect(publisherClient.publish).toHaveBeenCalledWith('chan', 'hello');
+		});
+
+		it('should reuse the same publisher client across calls', async () => {
+			await transport.publish('chan', 'one');
+			await transport.publish('chan', 'two');
+
+			expect(redisClientService.createClient).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('subscribe', () => {
+		it('should lazily create a dedicated subscriber client and subscribe through it', async () => {
+			await transport.subscribe('chan', vi.fn());
+
+			expect(redisClientService.createClient).toHaveBeenCalledWith({ type: 'subscriber(n8n)' });
+			expect(subscriberClient.subscribe).toHaveBeenCalledWith('chan', expect.any(Function));
+		});
+
+		it('should dispatch incoming messages only to handlers for the matching channel', async () => {
+			const chanHandler = vi.fn();
+			const otherHandler = vi.fn();
+			await transport.subscribe('chan', chanHandler);
+			await transport.subscribe('other', otherHandler);
+
+			const [, onMessage] = subscriberClient.on.mock.calls.find(([event]) => event === 'message')!;
+			(onMessage as (channel: string, message: string) => void)('chan', 'payload');
+
+			expect(chanHandler).toHaveBeenCalledWith('payload', 'chan');
+			expect(otherHandler).not.toHaveBeenCalled();
+		});
+
+		it('should support multiple handlers on the same channel', async () => {
+			const first = vi.fn();
+			const second = vi.fn();
+			await transport.subscribe('chan', first);
+			await transport.subscribe('chan', second);
+
+			const [, onMessage] = subscriberClient.on.mock.calls.find(([event]) => event === 'message')!;
+			(onMessage as (channel: string, message: string) => void)('chan', 'payload');
+
+			expect(first).toHaveBeenCalledWith('payload', 'chan');
+			expect(second).toHaveBeenCalledWith('payload', 'chan');
+		});
+	});
+
+	describe('shutdown', () => {
+		it('should disconnect only the clients that were created', () => {
+			transport.shutdown();
+			expect(publisherClient.disconnect).not.toHaveBeenCalled();
+			expect(subscriberClient.disconnect).not.toHaveBeenCalled();
+		});
+
+		it('should disconnect created clients', async () => {
+			await transport.publish('chan', 'hello');
+			await transport.subscribe('chan', vi.fn());
+
+			transport.shutdown();
+
+			expect(publisherClient.disconnect).toHaveBeenCalled();
+			expect(subscriberClient.disconnect).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/scaling/transport/ipc-message-transport.ts
+++ b/packages/cli/src/scaling/transport/ipc-message-transport.ts
@@ -1,0 +1,246 @@
+import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import { sleep } from '@n8n/utils/sleep';
+import { jsonParse, OperationalError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
+import { existsSync, unlinkSync } from 'node:fs';
+import { createConnection, createServer, type Server, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { MessageTransport } from './message-transport.interface';
+
+type MessageHandler = (message: string, channel: string) => void;
+
+interface Frame {
+	type: 'publish' | 'subscribe';
+	channel: string;
+	message?: string;
+}
+
+const CONNECT_MAX_ATTEMPTS = 10;
+const CONNECT_RETRY_MS = 200;
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && 'code' in error;
+}
+
+function isUnreachable(error: unknown): boolean {
+	return isErrnoException(error) && (error.code === 'ECONNREFUSED' || error.code === 'ENOENT');
+}
+
+/**
+ * Proof-of-concept `MessageTransport` for single-host deployments with no Redis
+ * configured — the "IPC transport, hosted by the hypervisor" from the process-
+ * hypervisor RFC. There is no hypervisor process yet, so this class plays both
+ * roles on a plain Unix domain socket: the first process to reach the socket path
+ * binds it and relays messages between every connected process (standing in for
+ * the hypervisor's broker role); every process, including that one, then talks to
+ * the socket purely as a client. Once a hypervisor process exists, it would always
+ * bind first and this class would only ever take the client branch.
+ *
+ * Proves the abstraction is swappable, not that this is production-ready: no
+ * reconnect-on-drop, no backpressure handling, no Windows named-pipe path.
+ */
+@Service()
+export class IpcMessageTransport implements MessageTransport {
+	private connection?: Promise<Socket>;
+
+	private server?: Server;
+
+	/** Per-connection subscribed channels, populated only while acting as broker. */
+	private readonly brokerSubscriptions = new Map<Socket, Set<string>>();
+
+	private buffer = '';
+
+	private readonly handlersByChannel = new Map<string, MessageHandler[]>();
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly globalConfig: GlobalConfig,
+	) {
+		this.logger = this.logger.scoped(['scaling', 'pubsub']);
+	}
+
+	private get socketPath() {
+		// Reuses the Redis key-prefix config for deployment isolation - the same purpose
+		// it already serves for Redis pubsub channel names. Hashed (rather than used
+		// verbatim) to keep the path within the ~104-byte sockaddr_un limit on macOS/BSD
+		// regardless of how long an operator's configured prefix is or how deeply nested
+		// the OS temp dir is.
+		const prefixHash = createHash('sha256')
+			.update(this.globalConfig.redis.prefix)
+			.digest('hex')
+			.slice(0, 16);
+
+		return join(tmpdir(), `n8n-ipc-${prefixHash}.sock`);
+	}
+
+	async publish(channel: string, message: string) {
+		const socket = await this.getConnection();
+		this.writeFrame(socket, { type: 'publish', channel, message });
+	}
+
+	async subscribe(channel: string, onMessage: MessageHandler) {
+		const handlers = this.handlersByChannel.get(channel) ?? [];
+		handlers.push(onMessage);
+		this.handlersByChannel.set(channel, handlers);
+
+		const socket = await this.getConnection();
+		this.writeFrame(socket, { type: 'subscribe', channel });
+	}
+
+	shutdown() {
+		void this.connection?.then((socket) => socket.end()).catch(() => {});
+
+		if (this.server) {
+			this.server.close();
+			try {
+				unlinkSync(this.socketPath);
+			} catch {
+				// already removed, or never fully bound
+			}
+		}
+	}
+
+	// #region Client
+
+	private async getConnection(): Promise<Socket> {
+		this.connection ??= this.connectOrBecomeBroker();
+
+		try {
+			return await this.connection;
+		} catch (error) {
+			this.connection = undefined; // allow a retry on the next publish/subscribe call
+			throw error;
+		}
+	}
+
+	private async connectOrBecomeBroker(): Promise<Socket> {
+		for (let attempt = 0; attempt < CONNECT_MAX_ATTEMPTS; attempt++) {
+			try {
+				return await this.connect();
+			} catch (error) {
+				if (!isUnreachable(error)) throw error;
+			}
+
+			// Nobody is listening yet - try to become the broker. If another process
+			// wins the race, `tryBecomeBroker` returns false and we just retry connecting.
+			if (await this.tryBecomeBroker()) return await this.connect();
+
+			await sleep(CONNECT_RETRY_MS);
+		}
+
+		throw new OperationalError(
+			`Could not connect to the n8n IPC message transport at ${this.socketPath}`,
+		);
+	}
+
+	private async connect(): Promise<Socket> {
+		const socket = createConnection(this.socketPath);
+
+		await new Promise<void>((resolve, reject) => {
+			socket.once('connect', resolve);
+			socket.once('error', reject);
+		});
+
+		socket.setEncoding('utf8');
+		socket.on('data', (chunk: string) => this.onClientData(chunk));
+		socket.on('error', (error) => this.logger.error('IPC transport connection error', { error }));
+
+		return socket;
+	}
+
+	private onClientData(chunk: string) {
+		for (const frame of this.readFrames(chunk)) {
+			if (frame.type !== 'publish' || frame.message === undefined) continue;
+
+			for (const handler of this.handlersByChannel.get(frame.channel) ?? []) {
+				handler(frame.message, frame.channel);
+			}
+		}
+	}
+
+	// #endregion
+
+	// #region Broker (only while this process won the bind race)
+
+	private async tryBecomeBroker(): Promise<boolean> {
+		if (existsSync(this.socketPath)) {
+			try {
+				unlinkSync(this.socketPath); // stale file from a crashed former broker
+			} catch {
+				// another process already cleaned it up
+			}
+		}
+
+		const server = createServer((socket) => this.handleBrokerConnection(socket));
+
+		try {
+			await new Promise<void>((resolve, reject) => {
+				server.once('listening', resolve);
+				server.once('error', reject);
+				server.listen(this.socketPath);
+			});
+		} catch (error) {
+			if (isErrnoException(error) && error.code === 'EADDRINUSE') return false; // lost the race
+			throw error;
+		}
+
+		this.server = server;
+		this.logger.debug(`Became IPC transport broker at ${this.socketPath}`);
+		return true;
+	}
+
+	private handleBrokerConnection(socket: Socket) {
+		const subscriptions = new Set<string>();
+		this.brokerSubscriptions.set(socket, subscriptions);
+
+		let buffer = '';
+		socket.setEncoding('utf8');
+		socket.on('data', (chunk: string) => {
+			const [remainder, ...frames] = this.splitFrames(buffer + chunk);
+			buffer = remainder;
+
+			for (const frame of frames) {
+				if (frame.type === 'subscribe') subscriptions.add(frame.channel);
+				else if (frame.type === 'publish') this.broadcast(frame);
+			}
+		});
+
+		socket.on('close', () => this.brokerSubscriptions.delete(socket));
+		socket.on('error', (error) => {
+			this.logger.error('IPC transport broker connection error', { error });
+		});
+	}
+
+	private broadcast(frame: Frame) {
+		for (const [socket, channels] of this.brokerSubscriptions) {
+			if (channels.has(frame.channel)) this.writeFrame(socket, frame);
+		}
+	}
+
+	// #endregion
+
+	private writeFrame(socket: Socket, frame: Frame) {
+		socket.write(JSON.stringify(frame) + '\n');
+	}
+
+	/** Newline-delimited JSON framing, consuming from the client-side buffer. */
+	private readFrames(chunk: string): Frame[] {
+		const [remainder, ...frames] = this.splitFrames(this.buffer + chunk);
+		this.buffer = remainder;
+		return frames;
+	}
+
+	private splitFrames(data: string): [string, ...Frame[]] {
+		const lines = data.split('\n');
+		const remainder = lines.pop() ?? '';
+		const frames = lines
+			.map((line) => jsonParse<Frame | null>(line, { fallbackValue: null }))
+			.filter((frame): frame is Frame => frame !== null);
+
+		return [remainder, ...frames];
+	}
+}

--- a/packages/cli/src/scaling/transport/message-transport.interface.ts
+++ b/packages/cli/src/scaling/transport/message-transport.interface.ts
@@ -1,0 +1,24 @@
+/**
+ * Cross-process messaging facet of the transport abstraction described in the
+ * "Unify modes of operation" RFC: a single interface for pubsub-style messaging,
+ * with a Redis-backed implementation for multi-host deployments and a non-Redis
+ * implementation for single-host deployments. Deliberately narrow — it covers only
+ * what `Publisher`/`Subscriber` need (channel publish/subscribe), not the storage
+ * facet (durable execution queue, leader election, cross-process KV), which are
+ * separate, not-yet-abstracted concerns.
+ */
+export interface MessageTransport {
+	/**
+	 * Publish `message` to `channel`. Delivered to every current subscriber of
+	 * `channel`, including the publisher itself if it is also subscribed — this
+	 * mirrors Redis `PUBLISH` semantics, which callers (e.g. `Subscriber`'s
+	 * self-send filtering) already depend on.
+	 */
+	publish(channel: string, message: string): Promise<void>;
+
+	/** Register `onMessage` to be called for every message published to `channel`. */
+	subscribe(channel: string, onMessage: (message: string, channel: string) => void): Promise<void>;
+
+	/** Release any underlying connection(s). Safe to call more than once. */
+	shutdown(): void | Promise<void>;
+}

--- a/packages/cli/src/scaling/transport/message-transport.service.ts
+++ b/packages/cli/src/scaling/transport/message-transport.service.ts
@@ -1,0 +1,35 @@
+import { Service } from '@n8n/di';
+
+import { IpcMessageTransport } from './ipc-message-transport';
+import type { MessageTransport } from './message-transport.interface';
+
+/**
+ * Swappable-provider proxy, mirroring `LockService`/`InstanceStorage`: defaults to
+ * the non-Redis (`IpcMessageTransport`) implementation, swapped to
+ * `RedisMessageTransport` at startup when Redis is configured. `Publisher` and
+ * `Subscriber` depend on this, never on a concrete implementation.
+ */
+@Service()
+export class MessageTransportService implements MessageTransport {
+	private provider: MessageTransport;
+
+	constructor(ipcMessageTransport: IpcMessageTransport) {
+		this.provider = ipcMessageTransport;
+	}
+
+	setProvider(provider: MessageTransport) {
+		this.provider = provider;
+	}
+
+	async publish(channel: string, message: string) {
+		await this.provider.publish(channel, message);
+	}
+
+	async subscribe(channel: string, onMessage: (message: string, channel: string) => void) {
+		await this.provider.subscribe(channel, onMessage);
+	}
+
+	async shutdown() {
+		await this.provider.shutdown();
+	}
+}

--- a/packages/cli/src/scaling/transport/redis-message-transport.ts
+++ b/packages/cli/src/scaling/transport/redis-message-transport.ts
@@ -1,0 +1,68 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type { Redis as SingleNodeClient, Cluster as MultiNodeClient } from 'ioredis';
+
+import { RedisClientService } from '@/services/redis-client.service';
+
+import type { MessageTransport } from './message-transport.interface';
+
+type RedisClient = SingleNodeClient | MultiNodeClient;
+
+type MessageHandler = (message: string, channel: string) => void;
+
+/**
+ * Redis-backed `MessageTransport`, extracted from `Publisher`/`Subscriber`'s
+ * previous direct Redis usage. Keeps their dedicated publish/subscribe client
+ * split: a Redis client that has issued `SUBSCRIBE` can no longer run most other
+ * commands, so publishing and subscribing each need their own connection.
+ */
+@Service()
+export class RedisMessageTransport implements MessageTransport {
+	private publisherClient?: RedisClient;
+
+	private subscriberClient?: RedisClient;
+
+	private readonly handlersByChannel = new Map<string, MessageHandler[]>();
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly redisClientService: RedisClientService,
+	) {
+		this.logger = this.logger.scoped(['scaling', 'pubsub']);
+	}
+
+	async publish(channel: string, message: string) {
+		this.publisherClient ??= this.redisClientService.createClient({ type: 'publisher(n8n)' });
+
+		await this.publisherClient.publish(channel, message);
+	}
+
+	async subscribe(channel: string, onMessage: MessageHandler) {
+		if (!this.subscriberClient) {
+			this.subscriberClient = this.redisClientService.createClient({ type: 'subscriber(n8n)' });
+			this.subscriberClient.on('message', (subscribedChannel: string, message: string) => {
+				for (const handler of this.handlersByChannel.get(subscribedChannel) ?? []) {
+					handler(message, subscribedChannel);
+				}
+			});
+		}
+
+		const handlers = this.handlersByChannel.get(channel) ?? [];
+		handlers.push(onMessage);
+		this.handlersByChannel.set(channel, handlers);
+
+		await this.subscriberClient.subscribe(channel, (error) => {
+			if (error) {
+				this.logger.error(`Failed to subscribe to channel ${channel}`, { error });
+				return;
+			}
+
+			this.logger.debug(`Subscribed to channel ${channel}`);
+		});
+	}
+
+	shutdown() {
+		this.publisherClient?.disconnect();
+		this.subscriberClient?.disconnect();
+	}
+}


### PR DESCRIPTION
## Summary

Proof-of-concept for the "Unify modes of operation" RFC's proposal to abstract Redis usage behind a common interface. Extracts `Publisher`/`Subscriber`'s direct Redis pub/sub calls behind a new `MessageTransport` interface, mirroring the existing `LockService`/`InstanceStorage` swappable-provider pattern.

- `RedisMessageTransport` — extracted from today's direct-client usage, behavior unchanged.
- `IpcMessageTransport` — new, Unix-domain-socket based. Standing in for the "IPC transport hosted by the hypervisor" from the process-hypervisor RFC (no hypervisor process exists yet, so this class plays both broker and client roles on a plain socket).
- `MessageTransportService` — swappable provider, defaults to the IPC transport, swapped to Redis in `base-command.ts` when `mode === 'queue'` (same wiring pattern as `useRedisForLocking`).

**Scope is intentionally narrow**: this proves the *messaging* facet (pubsub, command routing) is abstractable — not that Redis can be dropped from n8n today. The execution queue (Bull) and leader election are untouched and still require Redis; queue-mode deployments continue to use `RedisMessageTransport` exactly as before, so there is no behavior change for existing users.

## How to test

- `cd packages/cli && pnpm vitest run src/scaling/transport src/scaling/pubsub` — includes a real cross-socket delivery test for the IPC transport (actual Unix domain sockets, not mocked), proving messages cross independent transport instances without Redis.
- Full `packages/cli` test suite passes unchanged (307 tests).
- Manually: start two `n8n worker`/`n8n start` processes in queue mode as usual — behavior is identical, since `mode === 'queue'` still swaps in `RedisMessageTransport`.

## Related Linear tickets, Github issues, and Community forum posts

None — exploratory proof-of-concept, not tied to a ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A — PoC, no shipped behavior change)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (N/A)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

