### PR TITLE
feat(editor): Add Instance AI panel store with openWithSeed contract (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1098,6 +1098,7 @@ export class InstanceAiCorrectTaskRequest extends Z.class({
  * - `agent_builder_page` — Instance AI hand-off from the agent builder
  * - `agent_preview` — send a preview chat session to Instance AI
  * - `assistant_page` — first message typed on the Instance AI empty/home page
+ * - `proactive_offer` — user accepted a proactive floating-panel offer
  * - `evals` — Instance AI evaluation harness / offline eval runners
  * - `playwright` — Playwright E2E helpers that create threads via the REST API
  */
@@ -1112,6 +1113,7 @@ export const INSTANCE_AI_THREAD_SOURCES = [
 	'agent_builder_page',
 	'agent_preview',
 	'assistant_page',
+	'proactive_offer',
 	'evals',
 	'playwright',
 ] as const;

--- a/packages/@n8n/instance-ai/evaluations/__tests__/external-workflow-edits.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/external-workflow-edits.test.ts
@@ -1,0 +1,262 @@
+import { vi } from 'vitest';
+
+import type { N8nClient } from '../clients/n8n-client';
+import { runMultiTurnConversation } from '../harness/chat-loop';
+import type { EvalLogger } from '../harness/logger';
+import type { CapturedEvent } from '../types';
+
+/** A `tool-result` for a workflow tool — the shape the parser reads build ids
+ *  out of. `success` decides whether the build SAVED: a failed build reports a
+ *  workflowId too, and the hook must not count it. */
+function buildEvent(workflowId: string, success = true): CapturedEvent {
+	return {
+		timestamp: Date.now(),
+		type: 'tool-result',
+		data: {
+			type: 'tool-result',
+			payload: {
+				toolCallId: `call-${workflowId}-${String(success)}`,
+				toolName: 'build-workflow',
+				result: { workflowId, success },
+			},
+		},
+	};
+}
+
+/** A build that parsed but did not persist. Still carries `workflowId` — this is
+ *  the shape that made an early version of the hook rename an untouched workflow. */
+function failedBuildEvent(workflowId: string): CapturedEvent {
+	return buildEvent(workflowId, false);
+}
+
+/** A finished run, so `waitForAllActivity` returns instead of polling for one. */
+function runLifecycleEvents(): CapturedEvent[] {
+	return [
+		{ timestamp: Date.now(), type: 'run-start', data: { type: 'run-start' } },
+		{ timestamp: Date.now(), type: 'run-finish', data: { type: 'run-finish' } },
+	];
+}
+
+/** One turn boundary. A string sends that message with no rename; the tuple form
+ *  is the proxy also setting `renameWorkflowTo`; `null` ends the conversation. A
+ *  function runs at that boundary first, so a test can simulate the agent
+ *  building again mid-conversation. */
+type Turn = string | [message: string, renameWorkflowTo: string] | null;
+
+interface RunOptions {
+	events: CapturedEvent[];
+	followUps: Array<Turn | (() => Turn)>;
+	/** Current name the instance reports for every workflow — the ground truth the
+	 *  idempotence guard reads. */
+	currentName?: string;
+	updateShouldThrow?: boolean;
+	getShouldThrow?: boolean;
+}
+
+interface RunRecord {
+	renames: Array<{ workflowId: string; name: unknown }>;
+	messagesSent: string[];
+	warnings: string[];
+	infos: string[];
+}
+
+async function runLoop(options: RunOptions): Promise<RunRecord> {
+	const renames: RunRecord['renames'] = [];
+	const messagesSent: string[] = [];
+	const warnings: string[] = [];
+	const infos: string[] = [];
+	const remaining = [...options.followUps];
+
+	const client = {
+		getWorkflow: options.getShouldThrow
+			? vi.fn().mockRejectedValue(new Error('workflow not found'))
+			: vi
+					.fn()
+					.mockImplementation(
+						async (id: string) =>
+							await Promise.resolve({ id, name: options.currentName ?? 'Original name' }),
+					),
+		updateWorkflow: options.updateShouldThrow
+			? vi.fn().mockRejectedValue(new Error('workflow is read-only'))
+			: vi.fn().mockImplementation(async (id: string, updates: Record<string, unknown>) => {
+					renames.push({ workflowId: id, name: updates.name });
+					return await Promise.resolve({});
+				}),
+		sendMessage: vi.fn().mockImplementation(async (_threadId: string, message: string) => {
+			messagesSent.push(message);
+			return await Promise.resolve();
+		}),
+		getThreadStatus: vi.fn().mockResolvedValue({ backgroundTasks: [] }),
+		cancelRun: vi.fn().mockResolvedValue(undefined),
+	} as unknown as N8nClient;
+
+	const logger = {
+		verbose: () => {},
+		info: (message: string) => infos.push(message),
+		warn: (message: string) => warnings.push(message),
+	} as unknown as EvalLogger;
+
+	await runMultiTurnConversation({
+		client,
+		threadId: 'thread-1',
+		events: options.events,
+		approvedRequests: new Set<string>(),
+		startTime: Date.now(),
+		timeoutMs: 30_000,
+		logger,
+		nextMessageDecider: vi.fn().mockImplementation(async () => {
+			const next = remaining.shift() ?? null;
+			const resolved = typeof next === 'function' ? next() : next;
+			if (resolved === null) return await Promise.resolve({ kind: 'done' });
+			if (typeof resolved === 'string') {
+				return await Promise.resolve({ kind: 'followUp', message: resolved });
+			}
+			const [message, renameWorkflowTo] = resolved;
+			return await Promise.resolve({ kind: 'followUp', message, renameWorkflowTo });
+		}),
+	});
+
+	return { renames, messagesSent, warnings, infos };
+}
+
+describe('proxy-driven external rename in runMultiTurnConversation', () => {
+	it('renames the last saved workflow when the proxy asks for it', async () => {
+		const { renames } = await runLoop({
+			events: [...runLifecycleEvents(), buildEvent('wf-first')],
+			followUps: [['keep going', 'Renamed in another tab'], null],
+		});
+
+		expect(renames).toEqual([{ workflowId: 'wf-first', name: 'Renamed in another tab' }]);
+	});
+
+	it('reports a successful rename at info, so its absence is a readable signal', async () => {
+		// The failure that matters most — a direction that stops setting
+		// renameWorkflowTo — never reaches applyExternalRename and so cannot log
+		// anything itself. Printing the success in a normal (non-verbose) run is
+		// what makes a missing line mean something.
+		const { infos } = await runLoop({
+			events: [...runLifecycleEvents(), buildEvent('wf-first')],
+			followUps: [['keep going', 'Renamed in another tab'], null],
+		});
+
+		expect(infos.some((m) => m.includes('[external-edit] Renamed wf-first'))).toBe(true);
+	});
+
+	it('does nothing on a turn the proxy did not ask for a rename', async () => {
+		const { renames, messagesSent } = await runLoop({
+			events: [...runLifecycleEvents(), buildEvent('wf-first')],
+			followUps: ['just talking', null],
+		});
+
+		expect(renames).toHaveLength(0);
+		expect(messagesSent).toEqual(['just talking']);
+	});
+
+	it('does not rename on the boundary that ends the conversation', async () => {
+		const { renames } = await runLoop({
+			events: [...runLifecycleEvents(), buildEvent('wf-first')],
+			// The proxy ends the conversation at the first boundary, so the agent would
+			// never get a turn to react to the edit.
+			followUps: [null],
+		});
+
+		expect(renames).toHaveLength(0);
+	});
+
+	it('targets the most recently saved workflow', async () => {
+		const events = [...runLifecycleEvents(), buildEvent('wf-first')];
+
+		const { renames } = await runLoop({
+			events,
+			followUps: [
+				// The agent builds a second workflow during this turn; the rename on the
+				// NEXT boundary must land on that one, not the first.
+				() => {
+					events.push(buildEvent('wf-second'));
+					return 'keep going';
+				},
+				['and again', 'Renamed in another tab'],
+				null,
+			],
+		});
+
+		expect(renames).toEqual([{ workflowId: 'wf-second', name: 'Renamed in another tab' }]);
+	});
+
+	it('follows save order, not first-seen order, when a workflow is re-saved', async () => {
+		// A, then B, then A again. Deduping to distinct ids keeps FIRST-seen order,
+		// so the list is [A, B] and its last element is B — while the workflow most
+		// recently written is A. Renaming B here would conflict a workflow the agent
+		// is no longer working on, and leave the one it IS working on untouched.
+		const events = [...runLifecycleEvents(), buildEvent('wf-a')];
+
+		const { renames } = await runLoop({
+			events,
+			followUps: [
+				() => {
+					events.push(buildEvent('wf-b'));
+					return 'keep going';
+				},
+				() => {
+					events.push(buildEvent('wf-a'));
+					return 'and again';
+				},
+				['now rename', 'Renamed in another tab'],
+				null,
+			],
+		});
+
+		expect(renames).toEqual([{ workflowId: 'wf-a', name: 'Renamed in another tab' }]);
+	});
+
+	it('ignores a failed build — it reports a workflowId but saved nothing', async () => {
+		const { renames, warnings } = await runLoop({
+			events: [...runLifecycleEvents(), failedBuildEvent('wf-never-saved')],
+			followUps: [['keep going', 'Should not be applied'], null],
+		});
+
+		// Renaming here would mutate a workflow this run never created — an
+		// attached or pre-existing one the agent merely tried to save to.
+		expect(renames).toHaveLength(0);
+		expect(warnings.some((w) => w.includes('saved no workflow yet'))).toBe(true);
+	});
+
+	it('skips the rename when the workflow already carries that name', async () => {
+		const { renames, warnings } = await runLoop({
+			events: [...runLifecycleEvents(), buildEvent('wf-first')],
+			currentName: 'Renamed in another tab',
+			// A repeat PATCH would advance the checksum again and re-conflict a save
+			// the agent may already have recovered from.
+			followUps: [['keep going', 'Renamed in another tab'], null],
+		});
+
+		expect(renames).toHaveLength(0);
+		expect(warnings.some((w) => w.includes('already named'))).toBe(true);
+	});
+
+	it('warns and keeps the conversation going when the rename fails', async () => {
+		const { renames, messagesSent, warnings } = await runLoop({
+			events: [...runLifecycleEvents(), buildEvent('wf-first')],
+			followUps: [['still talking', 'Doomed rename'], null],
+			updateShouldThrow: true,
+		});
+
+		expect(renames).toHaveLength(0);
+		// The point of swallowing: the run continues so the case can grade recovery.
+		expect(messagesSent).toEqual(['still talking']);
+		// At warn, not verbose — a silent no-op reds the case as an agent failure.
+		expect(warnings.some((w) => w.includes('Failed to rename'))).toBe(true);
+	});
+
+	it('warns and keeps going when the current name cannot be read', async () => {
+		const { renames, messagesSent, warnings } = await runLoop({
+			events: [...runLifecycleEvents(), buildEvent('wf-first')],
+			followUps: [['still talking', 'Never applied'], null],
+			getShouldThrow: true,
+		});
+
+		expect(renames).toHaveLength(0);
+		expect(messagesSent).toEqual(['still talking']);
+		expect(warnings.some((w) => w.includes('Failed to rename'))).toBe(true);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -123,6 +123,14 @@ interface MultiTurnDriverConfig {
 	openingAttachments?: InstanceAiWorkflowAttachment[];
 }
 
+/** A conversation is multi-turn if it has more than one turn, or if the only
+ *  turn is from the assistant. Empty conversations are treated as single-turn. */
+function isMultiTurnConversation(conversation: ConversationTurn[]): boolean {
+	if (conversation.length === 0) return false;
+	if (conversation.length > 1) return true;
+	return conversation[0].role !== 'user';
+}
+
 async function driveMultiTurnConversation(
 	config: MultiTurnDriverConfig,
 ): Promise<ProxyDecisionStats> {
@@ -302,14 +310,6 @@ export function workflowExpectedForCase(
 		(testCase.executionScenarios?.length ?? 0) > 0 ||
 		(testCase.outcomeExpectations?.length ?? 0) > 0
 	);
-}
-
-/** A conversation is multi-turn if it has more than one turn, or if the only
- *  turn is from the assistant. Empty conversations are treated as single-turn. */
-function isMultiTurnConversation(conversation: ConversationTurn[]): boolean {
-	if (conversation.length === 0) return false;
-	if (conversation.length > 1) return true;
-	return conversation[0].role !== 'user';
 }
 
 /**

--- a/packages/@n8n/instance-ai/evaluations/harness/chat-loop.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/chat-loop.ts
@@ -18,6 +18,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import type { EvalLogger } from './logger';
 import type { N8nClient } from '../clients/n8n-client';
 import { consumeSseStream } from '../clients/sse-client';
+import { lastSavedWorkflowIdFromEvents } from '../outcome/event-parser';
 import type { CapturedEvent } from '../types';
 import { USER_TURN_EVENT } from '../types';
 import { getEventPayload, tryInfrastructureResponse } from '../utils/confirmation-payload';
@@ -275,7 +276,20 @@ function formatMemoryTasksForLog(
 // Multi-turn conversation loop
 // ---------------------------------------------------------------------------
 
-export type NextMessageDecision = { kind: 'followUp'; message: string } | { kind: 'done' };
+export type NextMessageDecision =
+	| {
+			kind: 'followUp';
+			message: string;
+			/**
+			 * The user-proxy asked for the last saved workflow to be renamed from
+			 * outside the conversation, driven by a stage direction. Lets a case
+			 * exercise the optimistic-concurrency path ("modified outside this
+			 * conversation"), which the agent otherwise only reaches by accident when
+			 * its own setup or credential work happens to advance the checksum.
+			 */
+			renameWorkflowTo?: string;
+	  }
+	| { kind: 'done' };
 
 export interface MultiTurnConfig extends WaitConfig {
 	nextMessageDecider: () => Promise<NextMessageDecision>;
@@ -298,6 +312,13 @@ export async function runMultiTurnConversation(config: MultiTurnConfig): Promise
 			return;
 		}
 
+		// After the decision, so an edit never lands on the boundary that ends the
+		// conversation: there the agent would get no turn to react, and the renamed
+		// workflow would still be what the judge and workflow checks read.
+		if (decision.renameWorkflowTo !== undefined) {
+			await applyExternalRename(config, decision.renameWorkflowTo);
+		}
+
 		config.logger.verbose(
 			`[multi-turn] Sending follow-up: ${decision.message.slice(0, 80)}${decision.message.length > 80 ? '...' : ''}`,
 		);
@@ -309,6 +330,64 @@ export async function runMultiTurnConversation(config: MultiTurnConfig): Promise
 			config.logger.verbose(`[multi-turn] sendMessage failed: ${msg} — exiting loop`);
 			return;
 		}
+	}
+}
+
+/**
+ * Renames the workflow this run last saved, from outside the conversation — the
+ * side effect behind a `renameWorkflowTo` stage direction.
+ *
+ * The proxy only ever sees the transcript, so it decides a workflow exists from
+ * what the agent *claimed*. Both guards below re-derive that from ground truth
+ * before writing anything.
+ *
+ * Logging is deliberately loud on every path. Skips and failures are `warn`, and
+ * the success is `info` rather than `verbose` — the failure that matters most is
+ * a direction that stops driving `renameWorkflowTo` at all, and that one never
+ * reaches this function, so it cannot log anything itself. Printing the rename
+ * in a normal run is what makes its ABSENCE meaningful: without it, a case whose
+ * direction silently stopped working reds on its name assertion and reads as an
+ * agent regression, with nothing in the log to say the conflict never happened.
+ *
+ * A failure is logged and swallowed rather than thrown — the case grades the
+ * agent's recovery, and killing the run here would report that as a build
+ * failure instead.
+ */
+async function applyExternalRename(config: MultiTurnConfig, rename: string): Promise<void> {
+	// Only builds that actually SAVED. Failed builds are excluded deliberately:
+	// they still report a workflowId, and acting on one would rename a workflow
+	// this run never created (an attached or pre-existing one). Last rather than
+	// first — the proxy fires at a turn boundary, so "the workflow under
+	// discussion" is the most recent one to reach the instance.
+	const workflowId = lastSavedWorkflowIdFromEvents(config.events);
+	if (workflowId === undefined) {
+		config.logger.warn(
+			`[external-edit] Skipped rename to "${rename}": this run has saved no workflow yet, so there is nothing to conflict`,
+		);
+		return;
+	}
+
+	try {
+		const current = await config.client.getWorkflow(workflowId);
+		if (current.name === rename) {
+			// Re-issuing the same rename advances the checksum a second time and
+			// re-conflicts a save the agent may already have recovered from, which
+			// would grade a successful recovery as a failure.
+			config.logger.warn(
+				`[external-edit] Skipped rename of ${workflowId}: it is already named "${rename}"`,
+			);
+			return;
+		}
+
+		await config.client.updateWorkflow(workflowId, { name: rename });
+		config.logger.info(
+			`[external-edit] Renamed ${workflowId} from "${current.name}" to "${rename}" outside the conversation`,
+		);
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		config.logger.warn(
+			`[external-edit] Failed to rename ${workflowId} to "${rename}": ${message} — the conflict path was not exercised`,
+		);
 	}
 }
 

--- a/packages/@n8n/instance-ai/evaluations/langtracer/to-exported.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/to-exported.ts
@@ -50,7 +50,7 @@ export interface ToLangTracerOptions {
 	synthetic: boolean;
 }
 
-/** Seeding modes the case-write API can't take. An INLINE seed is pushable — it's a
+/** Case content the case-write API can't take. An INLINE seed is pushable — it's a
  *  durable fixture, and the API stores it verbatim. A REPLAY seed isn't: it points at
  *  a LangSmith trace that expires, lang-tracer derives it from a source thread it
  *  already holds, and such a case is barred from suites anyway. Returns a

--- a/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
@@ -628,6 +628,38 @@ function extractIdFromRecord(record: Record<string, unknown>, keys: string[]): s
 	return undefined;
 }
 
+/**
+ * The workflow id of the MOST RECENT build that actually SAVED, or undefined if
+ * this run has saved none.
+ *
+ * Deliberately narrower than `extractOutcomeFromEvents().workflowIds`, which
+ * includes ids from FAILED builds on purpose: a save that parsed but didn't
+ * persist still returns `{ success: false, workflowId }`, and discovery wants
+ * those so cleanup can claim and delete whatever the run touched.
+ *
+ * That's the wrong set for any caller that MUTATES a workflow. A failed build
+ * against an attached or pre-existing workflow would otherwise look like a
+ * build this run performed, and the caller would act on state it never created.
+ * Requires `success === true` rather than `!== false`, so a result shape
+ * without the flag is treated as not-saved — the safe direction when the
+ * consequence is writing to someone else's workflow.
+ *
+ * Returns the last id directly rather than a deduped list for the caller to
+ * index. Dedupe keeps FIRST-seen order, so a run that saved A, then B, then A
+ * again yields [A, B] and the last element is B — while the workflow most
+ * recently written is A. Anything mutating "the workflow under discussion" has
+ * to follow save order, not first-appearance order.
+ */
+export function lastSavedWorkflowIdFromEvents(events: CapturedEvent[]): string | undefined {
+	const saved = extractOutcomeFromEvents(events)
+		.toolCalls.filter((call) => WORKFLOW_TOOLS.has(call.toolName))
+		.filter((call) => toResultRecord(call.result)?.success === true)
+		.map((call) => extractIdFromResult(call.result, 'workflowId', 'id'))
+		.filter((id): id is string => id !== undefined);
+
+	return saved.at(-1);
+}
+
 function dedupe(arr: string[]): string[] {
 	return [...new Set(arr)];
 }

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
@@ -329,7 +329,14 @@ export class UserProxyLlm {
 			if (!message) return { kind: 'done' };
 			this.messagesSent++;
 			this.actualTranscript.push({ role: 'user', text: message });
-			return { kind: 'followUp', message };
+			// The rename is a side effect the harness performs at this turn boundary,
+			// not something the user says — it stays out of `actualTranscript` so the
+			// judge reads the conversation the agent actually saw.
+			return {
+				kind: 'followUp',
+				message,
+				...(decision.renameWorkflowTo ? { renameWorkflowTo: decision.renameWorkflowTo } : {}),
+			};
 		}
 		if (decision.action !== 'declare_done') {
 			// The user-turn schema offers only the two actions above, so this only

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
@@ -129,6 +129,24 @@ const chooseCredentialSetupOptionDecisionSchema = z.object({
 const sendFollowUpMessageDecisionSchema = z.object({
 	action: z.literal('send_follow_up_message'),
 	message: z.string(),
+	/**
+	 * Rename the workflow this run last saved, from outside the conversation, at
+	 * this turn boundary — the agent is idle and is never told. `name` is one of
+	 * WORKFLOW_CHECKSUM_FIELDS, so the rename conflicts the agent's next save
+	 * without touching any node, which is how a case reaches the "modified
+	 * outside this conversation" path on purpose instead of by accident.
+	 *
+	 * Set it ONLY when a stage direction says something changed the workflow
+	 * behind the user's back. The harness performs the rename; the agent sees
+	 * nothing but `message`. A specific field rather than a general patch because
+	 * anything richer would have the model authoring workflow JSON — and
+	 * structured output cannot take a nested object here anyway (see
+	 * `nodeParametersJson` above).
+	 *
+	 * The harness ignores it when the run has saved no workflow yet, and when
+	 * that workflow already carries this name.
+	 */
+	renameWorkflowTo: z.string().min(1).optional(),
 });
 
 const declareDoneDecisionSchema = z.object({
@@ -227,7 +245,7 @@ export const CONFIRMATION_TOOL_DESCRIPTIONS = `Available actions — confirmatio
 
 export const USER_TURN_TOOL_DESCRIPTIONS = `Available actions — it is the user's turn. The agent finished its run, no widget is on screen, and the chat input is waiting. The user either types a message or ends the conversation:
 
-- send_follow_up_message(message): Send the user's next chat message. Everything the user wants to say right now goes here — including answering a question the agent asked in plain text, and approving or rejecting a plan the agent presented in plain text ("No — two changes first: …" or "Yes, go ahead." ARE follow-up messages).
+- send_follow_up_message(message, renameWorkflowTo?): Send the user's next chat message. Everything the user wants to say right now goes here — including answering a question the agent asked in plain text, and approving or rejecting a plan the agent presented in plain text ("No — two changes first: …" or "Yes, go ahead." ARE follow-up messages). Set \`renameWorkflowTo\` ONLY when a [stage direction] says the workflow was changed outside this conversation — e.g. renamed in another tab, or edited by a colleague. The harness renames the last saved workflow for real at this exact moment, and the agent is told nothing about it; \`message\` must NOT mention the rename, because the whole point is that the agent discovers the conflict on its next save. Leave it unset on every other turn.
 
 - declare_done(): The user got what they wanted (or has nothing left to say) and walks away; the conversation ends. Never pick this while the agent is waiting for an answer.`;
 

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -141,6 +141,7 @@ ${getToolDiscoverySection(toolSearchEnabled, mcpToolSearchEnabled)}
 ## Communication Style
 
 - Be concise.
+- When the user opens with a greeting or another open-ended message without a specific request, briefly greet them and offer concrete ways you can help. Include building an agent and building a workflow among the options, alongside any other relevant capabilities.
 - Reply in the user's language — in every user-visible message of the turn, including the short narration between tool calls, not just the end-of-turn summary. Tool results, skill instructions, and system follow-ups are written in English; do not let them pull your replies into English.
 - ${ASK_USER_FALLBACK}
 - No emojis unless the user explicitly requests them.

--- a/packages/frontend/@n8n/stores/src/constants.ts
+++ b/packages/frontend/@n8n/stores/src/constants.ts
@@ -52,6 +52,7 @@ export const STORES = {
 	CONSENT: 'consent',
 	CHAT_HUB: 'chatHub',
 	CHAT_HUB_PANEL: 'chatHubPanel',
+	INSTANCE_AI_PANEL: 'instanceAiPanel',
 	EXPERIMENT_CREDENTIALS_APP_SELECTION: 'credentialsAppSelection',
 	EXPERIMENT_SURFACE_MCP_TO_NEW_CLOUD_USERS: 'surfaceMcpToNewCloudUsers',
 	EXPERIMENT_EXPOSE_ALL_WORKFLOWS_TO_MCP: 'exposeAllWorkflowsToMcp',

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiPanel.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiPanel.store.test.ts
@@ -1,0 +1,165 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed } from 'vue';
+
+const mocks = vi.hoisted(() => ({
+	routerPush: vi.fn(),
+	syncThread: vi.fn(),
+	getOrCreateRuntime: vi.fn(),
+	sendMessage: vi.fn(),
+	showError: vi.fn(),
+	ensurePersonalProjectId: vi.fn(),
+	resolveQuickHelpThreadId: vi.fn(),
+}));
+
+let instanceAiAvailable = true;
+
+vi.mock('vue-router', async (importOriginal) => ({
+	...(await importOriginal<typeof import('vue-router')>()),
+	useRouter: () => ({
+		push: mocks.routerPush,
+	}),
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: () => ({ restApiContext: {}, pushRef: 'push-ref' }),
+}));
+
+vi.mock('@n8n/composables/useToast', () => ({
+	useToast: () => ({ showError: mocks.showError }),
+}));
+
+vi.mock('../composables/useInstanceAiAvailability', () => ({
+	useInstanceAiAvailable: () => computed(() => instanceAiAvailable),
+}));
+
+vi.mock('../composables/useInstanceAiHandoff', () => ({
+	ensurePersonalProjectId: mocks.ensurePersonalProjectId,
+}));
+
+vi.mock('../resolveQuickHelpThread', () => ({
+	resolveQuickHelpThreadId: mocks.resolveQuickHelpThreadId,
+}));
+
+vi.mock('../instanceAi.store', () => ({
+	useInstanceAiStore: () => ({
+		syncThread: mocks.syncThread,
+		getOrCreateRuntime: mocks.getOrCreateRuntime,
+	}),
+}));
+
+import { useInstanceAiPanelStore } from '../instanceAiPanel.store';
+import type { ProactiveOffer } from '../instanceAiPanel.types';
+import { INSTANCE_AI_THREAD_VIEW } from '../constants';
+
+const offer: ProactiveOffer = {
+	key: 'execution:4711',
+	title: 'I can help with that',
+	detail: 'HTTP Request failed',
+	message: 'Help me fix this execution.\n\n<context>…</context>',
+	projectId: 'project-1',
+	source: 'proactive_offer',
+};
+
+describe('useInstanceAiPanelStore', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.clearAllMocks();
+		instanceAiAvailable = true;
+		mocks.syncThread.mockResolvedValue(undefined);
+		mocks.ensurePersonalProjectId.mockResolvedValue('personal-1');
+		mocks.resolveQuickHelpThreadId.mockResolvedValue('thread-1');
+		mocks.getOrCreateRuntime.mockReturnValue({ sendMessage: mocks.sendMessage });
+		mocks.routerPush.mockResolvedValue(undefined);
+	});
+
+	it('opens and closes the panel', () => {
+		const store = useInstanceAiPanelStore();
+
+		store.open();
+		expect(store.isOpen).toBe(true);
+
+		store.close();
+		expect(store.isOpen).toBe(false);
+	});
+
+	it('is inert when Instance AI is unavailable', async () => {
+		instanceAiAvailable = false;
+		const store = useInstanceAiPanelStore();
+
+		store.open();
+		expect(store.isOpen).toBe(false);
+
+		await expect(store.openWithSeed(offer)).resolves.toBe(false);
+		expect(mocks.syncThread).not.toHaveBeenCalled();
+		expect(store.isOpen).toBe(false);
+	});
+
+	it('openWithSeed syncs the quick-help thread, opens the panel, and sends the message', async () => {
+		const store = useInstanceAiPanelStore();
+
+		await expect(store.openWithSeed(offer)).resolves.toBe(true);
+
+		expect(mocks.resolveQuickHelpThreadId).toHaveBeenCalledWith('project-1');
+		expect(mocks.syncThread).toHaveBeenCalledWith('thread-1', 'project-1', {
+			source: 'proactive_offer',
+			origin: 'internal',
+			sourceContext: { offerKey: 'execution:4711' },
+		});
+		expect(mocks.getOrCreateRuntime).toHaveBeenCalledWith('thread-1', 'project-1');
+		expect(mocks.sendMessage).toHaveBeenCalledWith(offer.message, undefined, 'push-ref');
+		expect(store.isOpen).toBe(true);
+		expect(store.activeThreadId).toBe('thread-1');
+		expect(store.pendingOffer).toEqual(offer);
+		expect(mocks.routerPush).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the personal project when the offer has no projectId', async () => {
+		const store = useInstanceAiPanelStore();
+		const { projectId: _projectId, ...offerWithoutProject } = offer;
+
+		await expect(store.openWithSeed(offerWithoutProject)).resolves.toBe(true);
+
+		expect(mocks.ensurePersonalProjectId).toHaveBeenCalled();
+		expect(mocks.resolveQuickHelpThreadId).toHaveBeenCalledWith('personal-1');
+		expect(mocks.syncThread).toHaveBeenCalledWith(
+			'thread-1',
+			'personal-1',
+			expect.objectContaining({ source: 'proactive_offer' }),
+		);
+	});
+
+	it('shows an error and stays closed when syncThread fails', async () => {
+		mocks.syncThread.mockRejectedValueOnce(new Error('network'));
+		const store = useInstanceAiPanelStore();
+
+		await expect(store.openWithSeed(offer)).resolves.toBe(false);
+
+		expect(mocks.showError).toHaveBeenCalled();
+		expect(store.isOpen).toBe(false);
+		expect(store.activeThreadId).toBeNull();
+		expect(mocks.sendMessage).not.toHaveBeenCalled();
+	});
+
+	it('expandToFullView navigates to the thread then closes the panel', async () => {
+		const store = useInstanceAiPanelStore();
+		await store.openWithSeed(offer);
+
+		await store.expandToFullView();
+
+		expect(mocks.routerPush).toHaveBeenCalledWith({
+			name: INSTANCE_AI_THREAD_VIEW,
+			params: { threadId: 'thread-1' },
+		});
+		expect(store.isOpen).toBe(false);
+		expect(store.pendingOffer).toBeNull();
+	});
+
+	it('expandToFullView is a no-op without an active thread', async () => {
+		const store = useInstanceAiPanelStore();
+
+		await store.expandToFullView();
+
+		expect(mocks.routerPush).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiPanel.store.ts
@@ -1,0 +1,97 @@
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+import { useRouter } from 'vue-router';
+import { STORES } from '@n8n/stores';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { useToast } from '@n8n/composables/useToast';
+
+import { INSTANCE_AI_THREAD_VIEW } from './constants';
+import { useInstanceAiAvailable } from './composables/useInstanceAiAvailability';
+import { ensurePersonalProjectId } from './composables/useInstanceAiHandoff';
+import { useInstanceAiStore } from './instanceAi.store';
+import type { ProactiveOffer } from './instanceAiPanel.types';
+import { resolveQuickHelpThreadId } from './resolveQuickHelpThread';
+
+export type { ProactiveOffer } from './instanceAiPanel.types';
+
+export const useInstanceAiPanelStore = defineStore(STORES.INSTANCE_AI_PANEL, () => {
+	const router = useRouter();
+	const rootStore = useRootStore();
+	const toast = useToast();
+	const instanceAiStore = useInstanceAiStore();
+	const instanceAiAvailable = useInstanceAiAvailable();
+
+	const isOpen = ref(false);
+	const activeThreadId = ref<string | null>(null);
+	const pendingOffer = ref<ProactiveOffer | null>(null);
+
+	const isAvailable = computed(() => instanceAiAvailable.value);
+
+	let seedInFlight = false;
+
+	function open() {
+		if (!isAvailable.value) return;
+		isOpen.value = true;
+	}
+
+	function close() {
+		isOpen.value = false;
+		pendingOffer.value = null;
+	}
+
+	/**
+	 * Open the floating panel on the project's quick-help thread and send the
+	 * offer message — same shape as handoff `startThread`, minus navigation.
+	 */
+	async function openWithSeed(offer: ProactiveOffer): Promise<boolean> {
+		if (!isAvailable.value || seedInFlight) return false;
+		seedInFlight = true;
+		try {
+			const projectId = offer.projectId ?? (await ensurePersonalProjectId());
+			if (!projectId) {
+				toast.showError(new Error('Failed to start a new thread. Try again.'), 'Open failed');
+				return false;
+			}
+
+			const threadId = await resolveQuickHelpThreadId(projectId);
+			try {
+				await instanceAiStore.syncThread(threadId, projectId, {
+					source: offer.source,
+					origin: 'internal',
+					sourceContext: { offerKey: offer.key },
+				});
+			} catch {
+				toast.showError(new Error('Failed to start a new thread. Try again.'), 'Open failed');
+				return false;
+			}
+
+			pendingOffer.value = offer;
+			activeThreadId.value = threadId;
+			isOpen.value = true;
+
+			const thread = instanceAiStore.getOrCreateRuntime(threadId, projectId);
+			void thread.sendMessage(offer.message, offer.attachments, rootStore.pushRef);
+			return true;
+		} finally {
+			seedInFlight = false;
+		}
+	}
+
+	async function expandToFullView(): Promise<void> {
+		const threadId = activeThreadId.value;
+		if (!threadId) return;
+		await router.push({ name: INSTANCE_AI_THREAD_VIEW, params: { threadId } });
+		close();
+	}
+
+	return {
+		isOpen,
+		activeThreadId,
+		pendingOffer,
+		isAvailable,
+		open,
+		close,
+		openWithSeed,
+		expandToFullView,
+	};
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiPanel.types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiPanel.types.ts
@@ -1,0 +1,21 @@
+import type { InstanceAiAttachment, InstanceAiThreadSource } from '@n8n/api-types';
+
+/**
+ * Contract for opening the Instance AI floating panel with a seeded message.
+ * Shared by the proactive offer bubble and any future trigger that should open
+ * the panel without navigating to `/assistant`.
+ */
+export type ProactiveOffer = {
+	/** Dedupe / dismissal key, e.g. `execution:4711`. */
+	key: string;
+	/** Bubble headline. */
+	title: string;
+	/** Optional secondary line under the title. */
+	detail?: string;
+	/** Full seeded text including any `<context>` block. */
+	message: string;
+	/** Resolved by the caller when known; otherwise the panel falls back to personal project. */
+	projectId?: string;
+	attachments?: InstanceAiAttachment[];
+	source: InstanceAiThreadSource;
+};

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/resolveQuickHelpThread.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/resolveQuickHelpThread.ts
@@ -1,0 +1,12 @@
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Resolve the project's persistent quick-help thread id.
+ *
+ * Stub for INS-1159: currently mints a fresh id every call. That ticket will
+ * replace this with a `localStorage` `projectId -> threadId` map so offers in
+ * the same project land in one conversation.
+ */
+export async function resolveQuickHelpThreadId(_projectId: string): Promise<string> {
+	return uuidv4();
+}


### PR DESCRIPTION
## Summary

Adds the shared `useInstanceAiPanelStore` seam that both floating-panel and proactive-offer tracks build against:

- State: `isOpen`, `activeThreadId`, `pendingOffer`
- Actions: `open` / `close`, `openWithSeed(offer)` (handoff minus navigation), `expandToFullView()`
- Exported `ProactiveOffer` contract
- Stub `resolveQuickHelpThreadId` for INS-1159 to fill with per-project persistence
- New `proactive_offer` thread source in `@n8n/api-types`
- Gated by `useInstanceAiAvailable()` so the panel is inert when Instance AI is unavailable

No UI yet — this PR only lands the store contract.

## How to test

1. Run unit tests:
   ```bash
   cd packages/frontend/editor-ui
   pnpm test src/features/ai/instanceAi/__tests__/instanceAiPanel.store.test.ts
   ```
2. Optional live poke (Instance AI enabled, `pnpm dev`): from the browser console call `openWithSeed` on the store, then `expandToFullView()` and confirm navigation to `/assistant/:threadId` with the seeded message. There is no floating panel UI in this PR.

Requires Instance AI module enabled for the optional live check.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1155

Unblocks:
- https://linear.app/n8n/issue/INS-1157
- https://linear.app/n8n/issue/INS-1158

Related:
- https://linear.app/n8n/issue/INS-1159

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

