### PR TITLE
fix(core): Return final responses from workflow agents

### DIFF
--- a/packages/cli/src/modules/agents/agent-workflow-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-workflow-execution.service.ts
@@ -44,6 +44,23 @@ import { streamAgentChunks } from './utils/agent-stream';
 import { validateNodeToolConfigs, validateNodeToolExpressions } from './utils/node-tool-validation';
 import { describeStructuredOutputError } from './utils/structured-output-error';
 
+function getFinalWorkflowResponse(messageRecord: MessageRecord): string {
+	let lastToolCallIndex = -1;
+	for (let index = messageRecord.timeline.length - 1; index >= 0; index--) {
+		if (messageRecord.timeline[index]?.type === 'tool-call') {
+			lastToolCallIndex = index;
+			break;
+		}
+	}
+	if (lastToolCallIndex === -1) return messageRecord.assistantResponse;
+
+	return messageRecord.timeline
+		.slice(lastToolCallIndex + 1)
+		.filter((event) => event.type === 'text')
+		.map((event) => event.content)
+		.join('');
+}
+
 /**
  * Executes agents invoked from inside a workflow execution (the AI Agent node
  * or a "Message an Agent" tool call): non-streaming runs against isolated
@@ -354,9 +371,14 @@ export class AgentWorkflowExecutionService {
 			}
 		}
 
+		const messageRecord = recorder.getMessageRecord();
+
 		return {
 			recorder,
-			messageRecord: recorder.getMessageRecord(),
+			messageRecord: {
+				...messageRecord,
+				assistantResponse: getFinalWorkflowResponse(messageRecord),
+			},
 			structuredOutput,
 			toolCalls,
 			streamError,

--- a/packages/cli/src/modules/agents/tools/input-data-tool.ts
+++ b/packages/cli/src/modules/agents/tools/input-data-tool.ts
@@ -15,6 +15,9 @@ const DESCRIPTION =
 	'Call without arguments for the input items (trimmed if large). ' +
 	'Pass a JMESPath query to retrieve a specific part of the input, untrimmed.';
 
+const WORKFLOW_INVOCATION_INSTRUCTIONS =
+	'This is a non-streaming step inside an n8n workflow. Complete all required work and tool calls without sending progress updates, narrating actions, or exposing internal reasoning. After the work is complete, return exactly one self-contained final response containing only the result needed by downstream workflow nodes.';
+
 /**
  * Builds the always-on `fetch_input_data` tool for agents invoked from a
  * workflow. Exposes the calling node's own input — the current item or all
@@ -42,7 +45,7 @@ export function createInputDataTool(context: ExecuteAgentWorkflowContext): Built
 				}),
 			)
 			.systemInstruction(
-				`You were invoked from the n8n workflow '${workflowLabel}' by its node '${context.callingNodeName}'. ` +
+				`${WORKFLOW_INVOCATION_INSTRUCTIONS} You were invoked from the n8n workflow '${workflowLabel}' by its node '${context.callingNodeName}'. ` +
 					`Call fetch_input_data to read the data passed into this step (${scopeText}); use it whenever ` +
 					`the message references the input. ${ITEM_SHAPE_HINT} ${QUERY_WHEN_TRUNCATED_HINT}`,
 			)


### PR DESCRIPTION
## Summary

- Instruct workflow-invoked agents to return one final response without progress narration around tool calls.
- Exclude pre-tool text from workflow output while preserving execution timelines.

## Screenshot
Showing the response is now aware that it is not streaming - its a singular response, not in parts.
<img width="1397" height="795" alt="image" src="https://github.com/user-attachments/assets/008e66be-34b4-45bd-b8a2-8355f898b216" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-571

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

