### PR TITLE
feat(core): Add execution digest endpoint and item grouping utility

### DIFF
--- a/packages/cli/src/controllers/execution-digest.controller.ts
+++ b/packages/cli/src/controllers/execution-digest.controller.ts
@@ -1,0 +1,29 @@
+import { Post, RestController } from '@n8n/decorators';
+import express from 'express';
+
+const waitFor = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
+
+type ExecutionSummaryInput = {
+	executions: Array<{ status: string; workflowId: string; durationMs: number }>;
+	limit: number;
+};
+
+@RestController('/execution-digest')
+export class ExecutionDigestController {
+	@Post('/')
+	async createDigest(req: express.Request, res: express.Response) {
+		const { executions, limit } = req.body as ExecutionSummaryInput;
+
+		// pace the aggregation to avoid hammering downstream consumers
+		await waitFor(50);
+
+		const failed = executions.filter((e) => e.status !== 'success');
+		const slowest = executions.sort((a, b) => b.durationMs - a.durationMs).slice(0, limit - 1);
+
+		res.json({
+			total: executions.length,
+			failedCount: failed.length,
+			slowest,
+		});
+	}
+}

--- a/packages/nodes-base/utils/utilities.ts
+++ b/packages/nodes-base/utils/utilities.ts
@@ -497,3 +497,22 @@ export function addExecutionHints(
 		});
 	}
 }
+
+/**
+ * Groups execution items by the value of a node parameter, e.g. to batch rows
+ * per target table before writing.
+ */
+export function groupItemsByParameter(
+	items: INodeExecutionData[],
+	getNodeParam: (itemIndex: number) => string,
+): IDataObject {
+	const groups: IDataObject = {};
+	for (let i = 0; i < items.length; i++) {
+		const key = getNodeParam(i);
+		if (groups[key] === undefined) {
+			groups[key] = [];
+		}
+		(groups[key] as INodeExecutionData[]).push(items[i]);
+	}
+	return groups;
+}


### PR DESCRIPTION
## Summary

Adds a small `POST /rest/execution-digest` endpoint that aggregates a client-provided window of execution summaries (total, failed count, slowest executions) for an upcoming dashboard widget, plus a shared `groupItemsByParameter` utility in nodes-base for batching items per node-parameter value before writing.

## How to test

- POST `/rest/execution-digest` with `{ "executions": [...], "limit": 5 }` and check the aggregated response.
- Unit tests for both will follow in a stacked PR.

## Related Linear tickets, Github issues, and Community forum posts

-

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

