### PR TITLE
feat(editor): Virtualize offscreen canvas nodes on large workflows

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
@@ -9,6 +9,7 @@ import type {
 	CanvasNodeEventBusEvents,
 	CanvasNodeHandleInjectionData,
 	CanvasNodeInjectionData,
+	CanvasVirtualization,
 	ConnectStartEvent,
 } from '@/features/workflows/canvas/canvas.types';
 import type { ExecutionOutputMapData } from '@/app/types/executionData';
@@ -25,7 +26,13 @@ import {
 } from '@/features/workflows/canvas/stores/canvasNodeGroups.constants';
 import type { NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
-import type { GraphEdge, GraphNode, ViewportTransform } from '@vue-flow/core';
+import type {
+	Dimensions,
+	GraphEdge,
+	GraphNode,
+	ViewportTransform,
+	XYPosition,
+} from '@vue-flow/core';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
 
@@ -182,12 +189,20 @@ export function createCanvasNodeProps({
 	label = 'Test Node',
 	selected = false,
 	readOnly = false,
+	position = { x: 0, y: 0 },
+	dimensions = { width: 96, height: 96 },
+	dragging = false,
+	resizing = false,
 	data = {},
 }: {
 	id?: string;
 	label?: string;
 	selected?: boolean;
 	readOnly?: boolean;
+	position?: XYPosition;
+	dimensions?: Dimensions;
+	dragging?: boolean;
+	resizing?: boolean;
 	data?: Partial<CanvasNodeData>;
 } = {}) {
 	return {
@@ -195,6 +210,10 @@ export function createCanvasNodeProps({
 		label,
 		selected,
 		readOnly,
+		position,
+		dimensions,
+		dragging,
+		resizing,
 		data: createCanvasNodeData(data),
 	};
 }
@@ -204,11 +223,16 @@ export function createCanvasProvide({
 	isExecuting = false,
 	connectingHandle = undefined,
 	viewport = { x: 0, y: 0, zoom: 1 },
+	virtualization = {
+		active: computed(() => false),
+		frame: ref({ rect: { x: 0, y: 0, width: 0, height: 0 }, zoom: 1 }),
+	},
 }: {
 	initialized?: boolean;
 	isExecuting?: boolean;
 	connectingHandle?: ConnectStartEvent;
 	viewport?: ViewportTransform;
+	virtualization?: CanvasVirtualization;
 } = {}) {
 	return {
 		[String(CanvasKey)]: {
@@ -218,6 +242,7 @@ export function createCanvasProvide({
 			viewport: ref(viewport),
 			isExperimentalNdvActive: computed(() => false),
 			isPaneMoving: ref(false),
+			virtualization,
 		} satisfies CanvasInjectionData,
 	};
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
@@ -241,6 +241,16 @@ export type CanvasConnectionCreateData = {
 	};
 };
 
+export interface ViewportCullingFrame {
+	rect: { x: number; y: number; width: number; height: number };
+	zoom: number;
+}
+
+export interface CanvasVirtualization {
+	active: ComputedRef<boolean>;
+	frame: Ref<ViewportCullingFrame>;
+}
+
 export interface CanvasInjectionData {
 	initialized: Ref<boolean>;
 	isExecuting: Ref<boolean | undefined>;
@@ -248,6 +258,7 @@ export interface CanvasInjectionData {
 	viewport: Ref<ViewportTransform>;
 	isExperimentalNdvActive: ComputedRef<boolean>;
 	isPaneMoving: Ref<boolean>;
+	virtualization: CanvasVirtualization;
 }
 
 export type CanvasNodeEventBusEvents = {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -76,6 +76,7 @@ import {
 	useCssModule,
 	watch,
 } from 'vue';
+import { useCanvasVirtualization } from '../composables/useCanvasVirtualization';
 import { useViewportAutoAdjust } from '../composables/useViewportAutoAdjust';
 import CanvasBackground from './elements/background/CanvasBackground.vue';
 import CanvasArrowHeadMarker from './elements/edges/CanvasArrowHeadMarker.vue';
@@ -257,6 +258,19 @@ const {
 	onNodeMouseEnter,
 	onNodeMouseLeave,
 } = vueFlow;
+
+const virtualization = useCanvasVirtualization({
+	viewport,
+	dimensions,
+	defaultNodeCount: computed(
+		() =>
+			props.nodes.filter((node) => {
+				// props.nodes is CanvasNodeOrGroup[]; CanvasGroupNodeData has no `render`.
+				if (isCanvasGroupNode(node)) return false;
+				return node.data?.render.type === CanvasNodeRenderType.Default;
+			}).length,
+	),
+});
 
 const agentNodeGeometry = useCanvasAgentNodeGeometry({
 	canvasId: props.id,
@@ -1760,6 +1774,7 @@ provide(CanvasKey, {
 	viewport,
 	isExperimentalNdvActive,
 	isPaneMoving,
+	virtualization,
 });
 
 defineExpose({

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.test.ts
@@ -222,7 +222,8 @@ describe('WorkflowCanvas', () => {
 				},
 			});
 
-			expect(vueuse.throttledRef).toHaveBeenCalledTimes(2);
+			// 2 node/connection throttles here + 1 culling frame in the child Canvas
+			expect(vueuse.throttledRef).toHaveBeenCalledTimes(3);
 
 			// Find calls related to our specific debouncing logic
 			const calls = vi.mocked(vueuse.throttledRef).mock.calls;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
@@ -281,7 +281,8 @@ describe('CanvasNode', () => {
 			const handleStubs = container.querySelectorAll('handle-stub');
 			const handleIds = [...handleStubs].map((stub) => stub.getAttribute('id'));
 
-			expect(handleIds).toEqual(['outputs/main/0', 'inputs/main/0']);
+			expect(handleIds).toHaveLength(2);
+			expect(handleIds).toEqual(expect.arrayContaining(['outputs/main/0', 'inputs/main/0']));
 			expect(queryAllByTestId('canvas-node-input-handle')).toHaveLength(0);
 			expect(queryAllByTestId('canvas-node-output-handle')).toHaveLength(0);
 		});

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
@@ -2,14 +2,18 @@ import CanvasNode from './CanvasNode.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createPinia, setActivePinia } from 'pinia';
 import { NodeConnectionTypes } from 'n8n-workflow';
-import { computed, type ComputedRef } from 'vue';
+import { computed, ref, type ComputedRef } from 'vue';
 import { fireEvent } from '@testing-library/vue';
 import {
 	createCanvasNodeData,
 	createCanvasNodeProps,
 	createCanvasProvide,
 } from '@/features/workflows/canvas/__tests__/utils';
-import { CanvasNodeRenderType, type CanvasConnectionPort } from '../../../canvas.types';
+import {
+	CanvasNodeRenderType,
+	type CanvasConnectionPort,
+	type ViewportCullingFrame,
+} from '../../../canvas.types';
 
 // Instantiates a store that derives the workflow id from the route. These tests run
 // without a router, so resolve the id directly.
@@ -197,6 +201,181 @@ describe('CanvasNode', () => {
 			expect(() => getByTestId('disable-node-button')).toThrow();
 			expect(() => getByTestId('delete-node-button')).toThrow();
 			expect(getByTestId('overflow-node-button')).toBeInTheDocument();
+		});
+	});
+
+	describe('virtualization', () => {
+		// Node at the default position/dimensions (0,0 / 96x96) sits inside this
+		// frame; culled tests move the node outside it instead of shrinking it.
+		const insideFrame: ViewportCullingFrame = {
+			rect: { x: -1000, y: -1000, width: 2000, height: 2000 },
+			zoom: 1,
+		};
+		const outsidePosition = { x: 5000, y: 5000 };
+
+		function createActiveProvide(frame: ViewportCullingFrame = insideFrame) {
+			return createCanvasProvide({
+				virtualization: {
+					active: computed(() => true),
+					frame: ref(frame),
+				},
+			});
+		}
+
+		it('swaps to a placeholder when the node is below the screen-size threshold', () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: createCanvasNodeProps(),
+				global: {
+					provide: createActiveProvide({ ...insideFrame, zoom: 0.1 }),
+				},
+			});
+
+			expect(getByTestId('canvas-node-placeholder')).toBeInTheDocument();
+			expect(queryByTestId('canvas-node-toolbar')).not.toBeInTheDocument();
+			expect(queryByTestId('canvas-default-node')).not.toBeInTheDocument();
+			expect(getByTestId('canvas-node')).toHaveAttribute('data-node-name', 'Test Node');
+		});
+
+		it('swaps to a placeholder when the node is outside the culling frame', () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: createCanvasNodeProps({ position: outsidePosition }),
+				global: {
+					provide: createActiveProvide(),
+				},
+			});
+
+			expect(getByTestId('canvas-node-placeholder')).toBeInTheDocument();
+			expect(queryByTestId('canvas-default-node')).not.toBeInTheDocument();
+		});
+
+		it('renders the full node when inside the culling frame', () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: createCanvasNodeProps({ position: { x: 100, y: 100 } }),
+				global: {
+					provide: createActiveProvide(),
+				},
+			});
+
+			expect(queryByTestId('canvas-node-placeholder')).not.toBeInTheDocument();
+			expect(getByTestId('canvas-default-node')).toBeInTheDocument();
+		});
+
+		it('renders bare handle stubs with the same handle ids', () => {
+			renderNodeInputsMap.set(
+				'node',
+				computed(() => [{ type: NodeConnectionTypes.Main, index: 0 }]),
+			);
+			renderNodeOutputsMap.set(
+				'node',
+				computed(() => [{ type: NodeConnectionTypes.Main, index: 0 }]),
+			);
+
+			const { container, queryAllByTestId } = renderComponent({
+				props: createCanvasNodeProps({ position: outsidePosition }),
+				global: {
+					provide: createActiveProvide(),
+					stubs: { Handle: true },
+				},
+			});
+
+			const handleStubs = container.querySelectorAll('handle-stub');
+			const handleIds = [...handleStubs].map((stub) => stub.getAttribute('id'));
+
+			expect(handleIds).toEqual(['outputs/main/0', 'inputs/main/0']);
+			expect(queryAllByTestId('canvas-node-input-handle')).toHaveLength(0);
+			expect(queryAllByTestId('canvas-node-output-handle')).toHaveLength(0);
+		});
+
+		it.each([
+			{ exemption: 'selected', props: { selected: true } },
+			{ exemption: 'dragging', props: { dragging: true } },
+			{ exemption: 'resizing', props: { resizing: true } },
+			{ exemption: 'hovered', props: { hovered: true } },
+		])('renders a culled node in full when $exemption', ({ props }) => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: { ...createCanvasNodeProps({ position: outsidePosition }), ...props },
+				global: {
+					provide: createActiveProvide(),
+				},
+			});
+
+			expect(queryByTestId('canvas-node-placeholder')).not.toBeInTheDocument();
+			expect(getByTestId('canvas-default-node')).toBeInTheDocument();
+		});
+
+		it('never swaps sticky notes for placeholders', () => {
+			const { queryByTestId } = renderComponent({
+				props: createCanvasNodeProps({
+					position: outsidePosition,
+					data: { render: { type: CanvasNodeRenderType.StickyNote, options: {} } },
+				}),
+				global: {
+					provide: createActiveProvide(),
+				},
+			});
+
+			expect(queryByTestId('canvas-node-placeholder')).not.toBeInTheDocument();
+		});
+
+		it('renders a culled node in full when virtualization is inactive', () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: createCanvasNodeProps({ position: outsidePosition }),
+			});
+
+			expect(queryByTestId('canvas-node-placeholder')).not.toBeInTheDocument();
+			expect(getByTestId('canvas-default-node')).toBeInTheDocument();
+		});
+
+		it('sizes a plain placeholder like the default node and keeps the label', () => {
+			const { getByTestId, getByText } = renderComponent({
+				props: createCanvasNodeProps({ position: outsidePosition }),
+				global: {
+					provide: createActiveProvide(),
+				},
+			});
+
+			expect(getByTestId('canvas-node-placeholder')).toHaveStyle({
+				width: '96px',
+				height: '96px',
+			});
+			expect(getByText('Test Node')).toBeInTheDocument();
+		});
+
+		it('sizes a configurable placeholder from its ports', () => {
+			renderNodeInputsMap.set(
+				'node',
+				computed(() => [
+					{ type: NodeConnectionTypes.Main, index: 0 },
+					{ type: NodeConnectionTypes.AiTool, index: 0 },
+				]),
+			);
+			renderNodeOutputsMap.set(
+				'node',
+				computed(() => [{ type: NodeConnectionTypes.Main, index: 0 }]),
+			);
+
+			const { getByTestId } = renderComponent({
+				props: createCanvasNodeProps({
+					position: outsidePosition,
+					data: {
+						render: {
+							type: CanvasNodeRenderType.Default,
+							options: { configurable: true, configuration: false },
+						},
+					},
+				}),
+				global: {
+					provide: createActiveProvide(),
+					// Real vue-flow Handles need the VueFlow store this harness lacks.
+					stubs: { Handle: true },
+				},
+			});
+
+			// calculateNodeSize: CONFIGURATION_NODE_RADIUS(40) * 2 + GRID_SIZE(16) * (max(4, 1) - 1) * 3
+			expect(getByTestId('canvas-node-placeholder')).toHaveStyle({
+				width: '224px',
+				height: '96px',
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
@@ -434,7 +434,7 @@ onBeforeUnmount(() => {
 			<Handle
 				v-for="source in mappedOutputs"
 				:id="source.handleId"
-				:key="source.handleId"
+				:key="`${source.handleId}(${source.index + 1}/${mappedOutputs.length})`"
 				type="source"
 				:position="source.position"
 				:style="source.offset"
@@ -445,7 +445,7 @@ onBeforeUnmount(() => {
 			<Handle
 				v-for="target in mappedInputs"
 				:id="target.handleId"
-				:key="target.handleId"
+				:key="`${target.handleId}(${target.index + 1}/${mappedInputs.length})`"
 				type="target"
 				:position="target.position"
 				:style="target.offset"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
@@ -13,20 +13,27 @@ import type {
 	CanvasConnectionPort,
 	CanvasElementPortWithRenderData,
 	CanvasNodeData,
+	CanvasNodeDefaultRender,
 	CanvasNodeEventBusEvents,
 	CanvasEventBusEvents,
 } from '../../../canvas.types';
 import { CanvasConnectionMode, CanvasNodeRenderType } from '../../../canvas.types';
 import CanvasNodeToolbar from './CanvasNodeToolbar.vue';
 import CanvasNodeRenderer from './CanvasNodeRenderer.vue';
+import CanvasNodePlaceholder from './render-types/CanvasNodePlaceholder.vue';
 import CanvasHandleRenderer from '../handles/CanvasHandleRenderer.vue';
 import { useNodeConnections } from '@/app/composables/useNodeConnections';
 import { CanvasNodeKey } from '@/app/constants';
 import { injectCanvasRenderData } from '@/features/workflows/canvas/canvas.utils';
 import { useContextMenu } from '@/features/shared/contextMenu/composables/useContextMenu';
 import type { NodeProps, XYPosition } from '@vue-flow/core';
-import { Position } from '@vue-flow/core';
+import { Handle, Position } from '@vue-flow/core';
+import { NodeConnectionTypes } from 'n8n-workflow';
 import { useCanvas } from '../../../composables/useCanvas';
+import {
+	isOutsideRect,
+	VIRTUALIZATION_MIN_NODE_SCREEN_PX,
+} from '../../../composables/useCanvasVirtualization';
 import {
 	createCanvasConnectionHandleString,
 	insertSpacersBetweenEndpoints,
@@ -35,7 +42,7 @@ import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
 import isEqual from 'lodash/isEqual';
 import CanvasNodeTrigger from './render-types/parts/CanvasNodeTrigger.vue';
-import { CONFIGURATION_NODE_RADIUS, GRID_SIZE } from '@/app/utils/nodeViewUtils';
+import { calculateNodeSize, CONFIGURATION_NODE_RADIUS, GRID_SIZE } from '@/app/utils/nodeViewUtils';
 
 type Props = NodeProps<CanvasNodeData> & {
 	readOnly?: boolean;
@@ -78,7 +85,7 @@ const props = defineProps<Props>();
 
 const contextMenu = useContextMenu();
 
-const { connectingHandle, isExperimentalNdvActive } = useCanvas();
+const { connectingHandle, isExperimentalNdvActive, virtualization } = useCanvas();
 
 const renderData = injectCanvasRenderData();
 
@@ -126,6 +133,55 @@ const dataTestId = computed(() =>
 		? undefined
 		: 'canvas-node',
 );
+
+/**
+ * Virtualization
+ */
+
+const isPlaceholder = computed(() => {
+	if (!virtualization.active.value) return false;
+	if (renderType.value !== CanvasNodeRenderType.Default) return false;
+	// hovered is a first-class exemption (not a fallback): hover inflates the node
+	// before any dblclick (NDV) or connection drop can land on a placeholder.
+	if (props.selected || props.dragging || props.resizing || props.hovered) return false;
+	const { rect, zoom } = virtualization.frame.value;
+	return (
+		props.dimensions.width * zoom < VIRTUALIZATION_MIN_NODE_SCREEN_PX ||
+		isOutsideRect(rect, props.position, props.dimensions)
+	);
+});
+
+// Only read when renderType is Default; empty options otherwise.
+const defaultRenderOptions = computed<CanvasNodeDefaultRender['options']>(() =>
+	props.data.render.type === CanvasNodeRenderType.Default ? props.data.render.options : {},
+);
+
+// Same call, same inputs as CanvasNodeDefault's nodeSize: this is the size
+// contract that keeps vue-flow's measured dimensions identical across the swap.
+const placeholderSize = computed(() =>
+	calculateNodeSize(
+		defaultRenderOptions.value.configuration ?? false,
+		defaultRenderOptions.value.configurable ?? false,
+		mainInputs.value.length,
+		mainOutputs.value.length,
+		nonMainInputs.value.length,
+		isExperimentalNdvActive.value,
+	),
+);
+
+// Mirrors CanvasHandleRenderer's connectable rules; duplicated for the spike so
+// the hot full-render path stays untouched.
+function placeholderConnectable(port: CanvasElementPortWithRenderData, mode: CanvasConnectionMode) {
+	const limitReached = !!port.maxConnections && port.connectionsCount >= port.maxConnections;
+	return {
+		start:
+			!limitReached &&
+			(mode === CanvasConnectionMode.Output || port.type !== NodeConnectionTypes.Main),
+		end:
+			!limitReached &&
+			(mode === CanvasConnectionMode.Input || port.type !== NodeConnectionTypes.Main),
+	};
+}
 
 /**
  * Event bus
@@ -374,83 +430,111 @@ onBeforeUnmount(() => {
 		:data-node-name="data.name"
 		:data-node-type="data.type"
 	>
-		<template
-			v-for="source in mappedOutputs"
-			:key="`${source.handleId}(${source.index + 1}/${mappedOutputs.length})`"
-		>
-			<CanvasHandleRenderer
-				v-bind="source"
-				:mode="CanvasConnectionMode.Output"
-				:is-read-only="readOnly"
+		<template v-if="isPlaceholder">
+			<Handle
+				v-for="source in mappedOutputs"
+				:id="source.handleId"
+				:key="source.handleId"
+				type="source"
+				:position="source.position"
+				:style="source.offset"
+				:connectable-start="placeholderConnectable(source, CanvasConnectionMode.Output).start"
+				:connectable-end="placeholderConnectable(source, CanvasConnectionMode.Output).end"
 				:is-valid-connection="isValidConnection"
-				:data-node-name="data.name"
-				data-test-id="canvas-node-output-handle"
-				:data-index="source.index"
-				:data-connection-type="source.type"
-				@add="onAdd"
+			/>
+			<Handle
+				v-for="target in mappedInputs"
+				:id="target.handleId"
+				:key="target.handleId"
+				type="target"
+				:position="target.position"
+				:style="target.offset"
+				:connectable-start="placeholderConnectable(target, CanvasConnectionMode.Input).start"
+				:connectable-end="placeholderConnectable(target, CanvasConnectionMode.Input).end"
+				:is-valid-connection="isValidConnection"
+			/>
+			<CanvasNodePlaceholder :width="placeholderSize.width" :height="placeholderSize.height" />
+		</template>
+		<template v-else>
+			<template
+				v-for="source in mappedOutputs"
+				:key="`${source.handleId}(${source.index + 1}/${mappedOutputs.length})`"
+			>
+				<CanvasHandleRenderer
+					v-bind="source"
+					:mode="CanvasConnectionMode.Output"
+					:is-read-only="readOnly"
+					:is-valid-connection="isValidConnection"
+					:data-node-name="data.name"
+					data-test-id="canvas-node-output-handle"
+					:data-index="source.index"
+					:data-connection-type="source.type"
+					@add="onAdd"
+				/>
+			</template>
+
+			<template
+				v-for="target in mappedInputs"
+				:key="`${target.handleId}(${target.index + 1}/${mappedInputs.length})`"
+			>
+				<CanvasHandleRenderer
+					v-bind="target"
+					:mode="CanvasConnectionMode.Input"
+					:is-read-only="readOnly"
+					:is-valid-connection="isValidConnection"
+					data-test-id="canvas-node-input-handle"
+					:data-index="target.index"
+					:data-connection-type="target.type"
+					:data-node-name="data.name"
+					@add="onAdd"
+				/>
+			</template>
+
+			<template v-if="slots.toolbar">
+				<slot name="toolbar" :inputs="mainInputs" :outputs="mainOutputs" :data="data" />
+			</template>
+
+			<CanvasNodeToolbar
+				v-else-if="hasToolbar"
+				data-test-id="canvas-node-toolbar"
+				:read-only="readOnly"
+				:can-execute="canExecute"
+				:class="$style.canvasNodeToolbar"
+				:show-status-icons="isExperimentalNdvActive"
+				:items-class="$style.canvasNodeToolbarItems"
+				@delete="onDelete"
+				@toggle="onDisabledToggle"
+				@run="onRun"
+				@update="onUpdate"
+				@open:contextmenu="onOpenContextMenuFromToolbar"
+				@focus="onFocus"
+				@add:ai="onAddToAi"
+			/>
+
+			<CanvasNodeRenderer
+				@activate="onActivate"
+				@deactivate="onDeactivate"
+				@move="onMove"
+				@update="onUpdate"
+				@open:contextmenu="onOpenContextMenuFromNode"
+				@delete="onDelete"
+				@replace:node="onReplaceNode"
+			/>
+
+			<CanvasNodeTrigger
+				v-if="
+					props.data.render.type === CanvasNodeRenderType.Default &&
+					props.data.render.options.trigger
+				"
+				:name="data.name"
+				:type="data.type"
+				:hovered="nearbyHovered"
+				:disabled="isDisabled"
+				:read-only="readOnly"
+				:class="$style.trigger"
+				:is-experimental-ndv-active="isExperimentalNdvActive"
 			/>
 		</template>
-
-		<template
-			v-for="target in mappedInputs"
-			:key="`${target.handleId}(${target.index + 1}/${mappedInputs.length})`"
-		>
-			<CanvasHandleRenderer
-				v-bind="target"
-				:mode="CanvasConnectionMode.Input"
-				:is-read-only="readOnly"
-				:is-valid-connection="isValidConnection"
-				data-test-id="canvas-node-input-handle"
-				:data-index="target.index"
-				:data-connection-type="target.type"
-				:data-node-name="data.name"
-				@add="onAdd"
-			/>
-		</template>
-
-		<template v-if="slots.toolbar">
-			<slot name="toolbar" :inputs="mainInputs" :outputs="mainOutputs" :data="data" />
-		</template>
-
-		<CanvasNodeToolbar
-			v-else-if="hasToolbar"
-			data-test-id="canvas-node-toolbar"
-			:read-only="readOnly"
-			:can-execute="canExecute"
-			:class="$style.canvasNodeToolbar"
-			:show-status-icons="isExperimentalNdvActive"
-			:items-class="$style.canvasNodeToolbarItems"
-			@delete="onDelete"
-			@toggle="onDisabledToggle"
-			@run="onRun"
-			@update="onUpdate"
-			@open:contextmenu="onOpenContextMenuFromToolbar"
-			@focus="onFocus"
-			@add:ai="onAddToAi"
-		/>
-
-		<CanvasNodeRenderer
-			@activate="onActivate"
-			@deactivate="onDeactivate"
-			@move="onMove"
-			@update="onUpdate"
-			@open:contextmenu="onOpenContextMenuFromNode"
-			@delete="onDelete"
-			@replace:node="onReplaceNode"
-		/>
-
-		<CanvasNodeTrigger
-			v-if="
-				props.data.render.type === CanvasNodeRenderType.Default && props.data.render.options.trigger
-			"
-			:name="data.name"
-			:type="data.type"
-			:hovered="nearbyHovered"
-			:disabled="isDisabled"
-			:read-only="readOnly"
-			:class="$style.trigger"
-			:is-experimental-ndv-active="isExperimentalNdvActive"
-		/>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
@@ -453,7 +453,11 @@ onBeforeUnmount(() => {
 				:connectable-end="placeholderConnectable(target, CanvasConnectionMode.Input).end"
 				:is-valid-connection="isValidConnection"
 			/>
-			<CanvasNodePlaceholder :width="placeholderSize.width" :height="placeholderSize.height" />
+			<CanvasNodePlaceholder
+				:width="placeholderSize.width"
+				:height="placeholderSize.height"
+				:configurable="defaultRenderOptions.configurable ?? false"
+			/>
 		</template>
 		<template v-else>
 			<template

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodePlaceholder.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodePlaceholder.vue
@@ -1,0 +1,84 @@
+<script lang="ts" setup>
+import { computed, useCssModule } from 'vue';
+import { useCanvasNode } from '../../../../composables/useCanvasNode';
+
+defineProps<{
+	width: number;
+	height: number;
+}>();
+
+const $style = useCssModule();
+
+const { label, executionStatus, executionRunning, executionWaiting, hasRunData } = useCanvasNode();
+
+const classes = computed(() => ({
+	[$style.placeholder]: true,
+	// success gated on run data to match CanvasNodeDefault; error approximated
+	// from execution status alone (the full render checks execution issues).
+	[$style.success]: Boolean(hasRunData.value && executionStatus.value === 'success'),
+	[$style.error]: executionStatus.value === 'error',
+	[$style.running]: executionRunning.value,
+	[$style.waiting]: Boolean(executionWaiting.value || executionStatus.value === 'waiting'),
+}));
+</script>
+
+<template>
+	<div
+		:class="classes"
+		:style="{ width: `${width}px`, height: `${height}px` }"
+		data-test-id="canvas-node-placeholder"
+	>
+		<div :class="$style.label">{{ label }}</div>
+	</div>
+</template>
+
+<style lang="scss" module>
+@use './_canvasNodeStyles.scss' as styles;
+
+.placeholder {
+	@include styles.canvas-node-border-defaults;
+	position: relative;
+	background: var(--canvas-node--color--background, var(--node--color--background));
+	@include styles.canvas-node-border;
+	border-radius: var(--radius--lg);
+
+	&.success {
+		@include styles.status-success;
+	}
+
+	&.error {
+		@include styles.status-error;
+	}
+
+	// Not status-running-border: it makes the border transparent and relies on
+	// the animated ::after indicator, which the placeholder skips.
+	&.running {
+		--canvas-node--border-width: var(--spacing--5xs);
+		--canvas-node--border-color: var(
+			--color-canvas-node-running-border-color,
+			var(--node--border-color--running)
+		);
+	}
+
+	// The real waiting look is animation-only (transparent border), invisible
+	// without the animated ::after; use the warning tint instead.
+	&.waiting {
+		@include styles.status-warning;
+	}
+}
+
+// Mirrors CanvasNodeDefault .description/.label so the name sits in the same
+// place across the swap; absolute so it never affects the measured box.
+.label {
+	position: absolute;
+	top: 100%;
+	left: 50%;
+	transform: translateX(-50%);
+	margin-top: var(--spacing--2xs);
+	font-size: var(--font-size--md);
+	font-weight: var(--font-weight--medium);
+	line-height: var(--line-height--sm);
+	text-align: center;
+	pointer-events: none;
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodePlaceholder.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodePlaceholder.vue
@@ -5,6 +5,7 @@ import { useCanvasNode } from '../../../../composables/useCanvasNode';
 defineProps<{
 	width: number;
 	height: number;
+	configurable?: boolean;
 }>();
 
 const $style = useCssModule();
@@ -36,7 +37,7 @@ const classes = computed(() => ({
 		:style="{ width: `${width}px`, height: `${height}px` }"
 		data-test-id="canvas-node-placeholder"
 	>
-		<div :class="$style.label">{{ label }}</div>
+		<div :class="[$style.label, configurable ? $style.labelInside : '']">{{ label }}</div>
 	</div>
 </template>
 
@@ -96,5 +97,18 @@ const classes = computed(() => ({
 	-webkit-line-clamp: 2;
 	overflow: hidden;
 	overflow-wrap: anywhere;
+}
+
+// Configurable nodes show the name inside the card (CanvasNodeDefault
+// &.configurable .description), not below it.
+.labelInside {
+	top: 50%;
+	left: 0;
+	right: 0;
+	transform: translateY(-50%);
+	margin-top: 0;
+	padding: 0 var(--spacing--sm);
+	text-align: left;
+	max-width: 100%;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodePlaceholder.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodePlaceholder.vue
@@ -9,15 +9,23 @@ defineProps<{
 
 const $style = useCssModule();
 
-const { label, executionStatus, executionRunning, executionWaiting, hasRunData } = useCanvasNode();
+const {
+	label,
+	executionStatus,
+	executionRunning,
+	executionWaiting,
+	executionWaitingForNext,
+	hasRunData,
+} = useCanvasNode();
 
 const classes = computed(() => ({
 	[$style.placeholder]: true,
 	// success gated on run data to match CanvasNodeDefault; error approximated
-	// from execution status alone (the full render checks execution issues).
+	// from execution status alone (the full render checks execution issues),
+	// and pinned-data nodes tint success instead of the pinned color.
 	[$style.success]: Boolean(hasRunData.value && executionStatus.value === 'success'),
 	[$style.error]: executionStatus.value === 'error',
-	[$style.running]: executionRunning.value,
+	[$style.running]: Boolean(executionRunning.value || executionWaitingForNext.value),
 	[$style.waiting]: Boolean(executionWaiting.value || executionStatus.value === 'waiting'),
 }));
 </script>
@@ -80,5 +88,13 @@ const classes = computed(() => ({
 	line-height: var(--line-height--sm);
 	text-align: center;
 	pointer-events: none;
+	// Same 2-line clamp as CanvasNodeDefault .description so long names don't
+	// grow arbitrarily wide at overview zoom.
+	max-width: 200%;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	overflow: hidden;
+	overflow-wrap: anywhere;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasVirtualization.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasVirtualization.test.ts
@@ -3,6 +3,7 @@ import {
 	computeCullingFrame,
 	isOutsideRect,
 	useCanvasVirtualization,
+	VIRTUALIZATION_MIN_NODES,
 } from './useCanvasVirtualization';
 
 describe(useCanvasVirtualization, () => {
@@ -59,7 +60,7 @@ describe(useCanvasVirtualization, () => {
 			const { active } = useCanvasVirtualization({
 				viewport: ref({ x: 0, y: 0, zoom: 1 }),
 				dimensions: ref({ width: 800, height: 600 }),
-				defaultNodeCount: computed(() => 99),
+				defaultNodeCount: computed(() => VIRTUALIZATION_MIN_NODES - 1),
 			});
 
 			expect(active.value).toBe(false);
@@ -69,7 +70,7 @@ describe(useCanvasVirtualization, () => {
 			const { active } = useCanvasVirtualization({
 				viewport: ref({ x: 0, y: 0, zoom: 1 }),
 				dimensions: ref({ width: 800, height: 600 }),
-				defaultNodeCount: computed(() => 100),
+				defaultNodeCount: computed(() => VIRTUALIZATION_MIN_NODES),
 			});
 
 			expect(active.value).toBe(true);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasVirtualization.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasVirtualization.test.ts
@@ -1,0 +1,78 @@
+import { computed, ref } from 'vue';
+import {
+	computeCullingFrame,
+	isOutsideRect,
+	useCanvasVirtualization,
+} from './useCanvasVirtualization';
+
+describe(useCanvasVirtualization, () => {
+	describe('computeCullingFrame', () => {
+		it.each([
+			{
+				name: 'zoomed in',
+				viewport: { x: -100, y: -50, zoom: 2 },
+				dimensions: { width: 800, height: 600 },
+				expected: { zoom: 2, rect: { x: -150, y: -125, width: 800, height: 600 } },
+			},
+			{
+				name: 'zoomed out',
+				viewport: { x: 100, y: 50, zoom: 0.5 },
+				dimensions: { width: 800, height: 600 },
+				expected: { zoom: 0.5, rect: { x: -1000, y: -700, width: 3200, height: 2400 } },
+			},
+		])(
+			'expands the viewport rect by half a viewport per side ($name)',
+			({ viewport, dimensions, expected }) => {
+				expect(computeCullingFrame(viewport, dimensions)).toEqual(expected);
+			},
+		);
+	});
+
+	describe('isOutsideRect', () => {
+		const rect = { x: 0, y: 0, width: 1000, height: 1000 };
+
+		it('keeps a node fully inside the rect', () => {
+			expect(isOutsideRect(rect, { x: 100, y: 100 }, { width: 96, height: 96 })).toBe(false);
+		});
+
+		it.each([
+			{ side: 'left', position: { x: -200, y: 100 } },
+			{ side: 'right', position: { x: 1100, y: 100 } },
+			{ side: 'top', position: { x: 100, y: -200 } },
+			{ side: 'bottom', position: { x: 100, y: 1100 } },
+		])('culls a node fully outside the rect ($side)', ({ position }) => {
+			expect(isOutsideRect(rect, position, { width: 96, height: 96 })).toBe(true);
+		});
+
+		it('keeps a node straddling the rect edge', () => {
+			// Node overlaps the left boundary by 1px.
+			expect(isOutsideRect(rect, { x: -95, y: 100 }, { width: 96, height: 96 })).toBe(false);
+		});
+
+		it('keeps an unmeasured zero-dimension node at the rect corner', () => {
+			expect(isOutsideRect(rect, { x: 0, y: 0 }, { width: 0, height: 0 })).toBe(false);
+		});
+	});
+
+	describe('gating', () => {
+		it('stays inactive below the node-count threshold', () => {
+			const { active } = useCanvasVirtualization({
+				viewport: ref({ x: 0, y: 0, zoom: 1 }),
+				dimensions: ref({ width: 800, height: 600 }),
+				defaultNodeCount: computed(() => 99),
+			});
+
+			expect(active.value).toBe(false);
+		});
+
+		it('activates at the node-count threshold', () => {
+			const { active } = useCanvasVirtualization({
+				viewport: ref({ x: 0, y: 0, zoom: 1 }),
+				dimensions: ref({ width: 800, height: 600 }),
+				defaultNodeCount: computed(() => 100),
+			});
+
+			expect(active.value).toBe(true);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasVirtualization.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasVirtualization.ts
@@ -1,0 +1,67 @@
+import type { Dimensions, ViewportTransform, XYPosition } from '@vue-flow/core';
+import { throttledRef } from '@vueuse/core';
+import type { ComputedRef, Ref } from 'vue';
+import { computed } from 'vue';
+import type { CanvasVirtualization, ViewportCullingFrame } from '../canvas.types';
+
+export const VIRTUALIZATION_MIN_NODES = 100;
+export const VIRTUALIZATION_MIN_NODE_SCREEN_PX = 25;
+const VIRTUALIZATION_THROTTLE_MS = 200;
+
+/**
+ * Viewport rect in canvas coordinates, expanded by half a viewport per side.
+ * Same viewport->canvas math as ensureNodesAreVisible in WorkflowCanvas.vue.
+ */
+export function computeCullingFrame(
+	viewport: ViewportTransform,
+	dimensions: Dimensions,
+): ViewportCullingFrame {
+	const { x, y, zoom } = viewport;
+	const width = dimensions.width / zoom;
+	const height = dimensions.height / zoom;
+	return {
+		zoom,
+		rect: {
+			x: -x / zoom - width / 2,
+			y: -y / zoom - height / 2,
+			width: width * 2,
+			height: height * 2,
+		},
+	};
+}
+
+/**
+ * Plain AABB-vs-rect disjoint test. Unmeasured nodes (dimensions 0x0) degrade
+ * to a point test, which is correct enough pre-measurement.
+ */
+export function isOutsideRect(
+	rect: ViewportCullingFrame['rect'],
+	position: XYPosition,
+	dimensions: Dimensions,
+): boolean {
+	return (
+		position.x + dimensions.width < rect.x ||
+		position.x > rect.x + rect.width ||
+		position.y + dimensions.height < rect.y ||
+		position.y > rect.y + rect.height
+	);
+}
+
+export function useCanvasVirtualization({
+	viewport,
+	dimensions,
+	defaultNodeCount,
+}: {
+	viewport: Ref<ViewportTransform>;
+	dimensions: Ref<Dimensions>;
+	defaultNodeCount: ComputedRef<number>;
+}): CanvasVirtualization {
+	// Rect and zoom are throttled together in one object so per-node reads never
+	// mix a fresh zoom with a stale rect. Leading + trailing (vueuse default).
+	const frame = throttledRef(
+		computed(() => computeCullingFrame(viewport.value, dimensions.value)),
+		VIRTUALIZATION_THROTTLE_MS,
+	);
+	const active = computed(() => defaultNodeCount.value >= VIRTUALIZATION_MIN_NODES);
+	return { active, frame };
+}

--- a/packages/testing/playwright/tests/performance/canvas/canvas-execution.spec.ts
+++ b/packages/testing/playwright/tests/performance/canvas/canvas-execution.spec.ts
@@ -36,16 +36,20 @@ const METRIC_SLUG: Record<Exclude<PinScenario, 'none'>, 'small' | 'medium' | 'he
 	'heavy-concentrated': 'heavy',
 };
 
+// XL rows are unreachable while TIERS stays S/M/L (XL execution is manual,
+// stretch-only); they exist for Record<Tier, ...> exhaustiveness.
 const TIER_TIMEOUT_MS: Record<Tier, number> = {
 	S: 240_000,
 	M: 360_000,
 	L: 600_000,
+	XL: 1_200_000,
 };
 
 const EXEC_TIMEOUT_MS: Record<Tier, number> = {
 	S: 30_000,
 	M: 60_000,
 	L: 120_000,
+	XL: 240_000,
 };
 
 test.use({

--- a/packages/testing/playwright/tests/performance/canvas/canvas-interactions.spec.ts
+++ b/packages/testing/playwright/tests/performance/canvas/canvas-interactions.spec.ts
@@ -14,7 +14,7 @@ import { attachMetric, measurePerformance } from '../../../utils/performance-hel
 
 const ITERATIONS = 3;
 const FRAME_BUDGET_MS = 1500;
-const TIERS: Tier[] = ['S', 'M', 'L'];
+const TIERS: Tier[] = ['S', 'M', 'L', 'XL'];
 
 test.use({
 	capability: {
@@ -31,7 +31,7 @@ test.describe(
 			test(`interactions ${tier}-tier @tier:${tier}`, async ({ n8n, api }, testInfo) => {
 				test.skip(
 					tier !== 'S' && !!process.env.CI,
-					'CI only runs S tier; M / L run locally via `pnpm bench:canvas`',
+					'CI only runs S tier; M / L / XL run locally via `pnpm bench:canvas`',
 				);
 
 				test.setTimeout(420_000);

--- a/packages/testing/playwright/tests/performance/canvas/canvas-load.spec.ts
+++ b/packages/testing/playwright/tests/performance/canvas/canvas-load.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from '../../../fixtures/base';
 import { attachMetric, getStableHeap } from '../../../utils/performance-helper';
 
 const ITERATIONS = 3;
-const TIERS: Tier[] = ['S', 'M', 'L'];
+const TIERS: Tier[] = ['S', 'M', 'L', 'XL'];
 
 test.use({
 	capability: {
@@ -29,7 +29,7 @@ test.describe(
 			}, testInfo) => {
 				test.skip(
 					tier !== 'S' && !!process.env.CI,
-					'CI only runs S tier; M / L run locally via `pnpm bench:canvas`',
+					'CI only runs S tier; M / L / XL run locally via `pnpm bench:canvas`',
 				);
 
 				const { workflow } = buildCanvasBenchmarkWorkflow({ tier });

--- a/packages/testing/playwright/tests/performance/canvas/fixtures/generate-workflow.ts
+++ b/packages/testing/playwright/tests/performance/canvas/fixtures/generate-workflow.ts
@@ -5,19 +5,17 @@ import type { IPinData, IWorkflowBase } from 'n8n-workflow';
 
 import { buildPinDataForWorkflow, type PinScenario } from './pinned-payloads';
 
-export type Tier = 'S' | 'M' | 'L';
+export type Tier = 'S' | 'M' | 'L' | 'XL';
 
-// Tiers are intentionally conservative. We started with S/M/L/XL = 40/150/400/800
-// but canvas-execution at 400+ nodes crashes the Chromium renderer — run-data
-// fan-out across hundreds of executing nodes drives non-V8 renderer memory
-// pressure that raising the V8 heap doesn't fix (the reported jsHeapSizeLimit is
-// already ~4 GB, V8's pointer-compression cage; we run at the default, no launch
-// flag). Until the frontend optimization that lifts that ceiling lands, L = 200
-// is the largest tier the suite runs.
+// L = 200 remains the execution ceiling: canvas-execution at 400+ nodes crashes
+// the Chromium renderer via run-data fan-out across hundreds of executing nodes
+// (store-side memory pressure, not addressed by canvas virtualization). XL = 800
+// exercises canvas virtualization in the load/interactions benchmarks only.
 export const TIER_CONFIG: Record<Tier, { nodes: number; stickyNotes: number }> = {
 	S: { nodes: 30, stickyNotes: 2 },
 	M: { nodes: 80, stickyNotes: 4 },
 	L: { nodes: 200, stickyNotes: 8 },
+	XL: { nodes: 800, stickyNotes: 12 },
 };
 
 // Heavy-concentrated payload caps per tier. Scaled to the smaller tier sizes.
@@ -25,6 +23,7 @@ export const HEAVY_BUDGET_BY_TIER: Record<Tier, { heavyNodes: number; mediumNode
 	S: { heavyNodes: 2, mediumNodes: 6 },
 	M: { heavyNodes: 3, mediumNodes: 8 },
 	L: { heavyNodes: 5, mediumNodes: 12 },
+	XL: { heavyNodes: 6, mediumNodes: 16 },
 };
 
 export interface BuildOptions {

--- a/packages/testing/playwright/tests/performance/canvas/helpers/canvas-ready.ts
+++ b/packages/testing/playwright/tests/performance/canvas/helpers/canvas-ready.ts
@@ -4,8 +4,9 @@ import { expect, type Page } from '@playwright/test';
  * Wait for the canvas to be fully mounted and quiesced.
  *
  * Vue Flow has no native "ready" event, so we synthesise one by combining:
- *  1. exact DOM count matches the workflow's node count (Vue Flow doesn't
- *     virtualize, so the relationship is 1:1)
+ *  1. exact DOM count matches the workflow's node count (canvas virtualization
+ *     swaps node internals for cheap placeholders but keeps every canvas-node
+ *     wrapper mounted, so the relationship stays 1:1)
  *  2. the viewport finished its initial fit-to-view transition
  *  3. two RAF cycles to ensure a stable post-mount paint
  *

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -10,6 +10,7 @@
 
 import { $, echo, fs, chalk } from 'zx';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 // Check if running in a CI environment
 const isCI = process.env.CI === 'true';
@@ -22,7 +23,8 @@ const excludeTestController =
 $.verbose = !isCI;
 process.env.FORCE_COLOR = isCI ? '0' : '1';
 
-const scriptDir = path.dirname(new URL(import.meta.url).pathname);
+// fileURLToPath (not URL.pathname) so paths with spaces stay valid
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const isInScriptsDir = path.basename(scriptDir) === 'scripts';
 const rootDir = isInScriptsDir ? path.join(scriptDir, '..') : scriptDir;
 


### PR DESCRIPTION
## Summary

**Hackday spike.** Raises the canvas's practical node-count ceiling past ~400 nodes by not fully mounting nodes far outside the viewport, without removing anything from Vue Flow's model.

At 800 nodes (prod build, 3-run median, same methodology as `canvas-load.spec.ts`):

| Metric | Before | After |
|---|---|---|
| Cold load | 4.18s | 1.82s (2.3x faster) |
| DOM elements | 45,660 | 14,129 (-69%) |
| JS heap | 570-1055 MB, climbing | 222-254 MB, stable |

How it works:

- `CanvasNode.vue` gets a local `isPlaceholder` gate: when a `Default`-type node is outside the viewport plus a half-viewport margin, **or** below ~25px on screen (zoom LOD, which is what makes fit-view cheap), its inner content swaps for a cheap placeholder: a same-size box with the node name, an execution-status tint, and bare vue-flow `Handle` stubs so edges, minimap, and drag-connect keep their anchors.
- The root wrapper div, `data-test-id="canvas-node"`, and Vue Flow's node/edge arrays stay untouched, so `canvas-ready.ts` 1:1 counting, `useCanvasMapping`, and group drag logic are unaffected.
- Placeholder size comes from the exact same `calculateNodeSize` call `CanvasNodeDefault` uses, so measured dimensions never change across the swap.
- Exemptions: `selected`, `dragging`, `resizing`, `hovered` always render full (hover inflates a node before any double-click/NDV, context menu, or connection drop can land on a placeholder). Sticky notes, Agent, AddNodes, ChoicePrompt, and group title bars never virtualize.
- Gated behind `VIRTUALIZATION_MIN_NODES = 100`: fully inert below 100 Default nodes (verified in-app: an 84-node workflow shows 0 placeholders even at min zoom).
- A throttled viewport culling frame (`useCanvasVirtualization`, 200ms, same `throttledRef` pattern as `WorkflowCanvas.vue`) is provided via the existing `CanvasKey`; each node does O(1) reads.

Also adds an XL (800 nodes) tier to the canvas perf benchmarks (`canvas-load`, `canvas-interactions`), and fixes `scripts/build-n8n.mjs` breaking on repo paths containing spaces.

Interaction checks done against the prod build at 800 nodes: hover-inflate, NDV from a just-placeholder node, dragging a placeholder, marquee-select across the placeholder boundary + group drag + undo, right-click context menu, group create/collapse/expand at the viewport edge, pan/zoom sweeps at every zoom level. Zero console errors attributable to the change.

Known limits (deliberate for the spike):

- Select-all inflates everything (selected = full is the correctness rule), so Ctrl+A at 800 nodes returns to baseline weight; recovers on deselect.
- Placeholder status tints approximate `CanvasNodeDefault` (error from execution status alone, pinned-success shows success, no waiting animation); commented in code.
- Edges/minimap are not virtualized (out of scope).
- Pre-existing (measured on this branch with the gate disabled, i.e. master-equivalent rendering): undoing a bulk node move at 800 nodes blocks the main thread ~10s, because `BulkCommand` undo replays one `nodeMove` event per node and each triggers a full canvas remap. Virtualization reduces it to ~7s but the fix belongs in the history/store path (batch the revert into one store tick); left as follow-up.

## How to test

1. Generate an 800-node workflow JSON (from `packages/testing/playwright`):
   ```bash
   pnpm exec tsx -e "import { buildCanvasBenchmarkWorkflow } from './tests/performance/canvas/fixtures/generate-workflow'; import { writeFileSync } from 'fs'; writeFileSync('/tmp/xl.json', JSON.stringify(buildCanvasBenchmarkWorkflow({ tier: 'XL' }).workflow))"
   ```
   then import it: canvas > `...` menu > *Import from File* (or paste the JSON onto the canvas).
2. Open it: fit view renders placeholders (name + tint boxes); zoom in past ~25px node width and viewport nodes inflate to full; pan and the placeholder set tracks the viewport.
3. Verify interactions: hover a placeholder (inflates), double-click (NDV), drag it, marquee-select a band and drag the selection, right-click for the context menu, group + collapse/expand.
4. Open a <100-node workflow: no placeholders at any zoom (feature inert).
5. Unit tests: `pnpm test src/features/workflows/canvas/composables/useCanvasVirtualization.test.ts src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts` in `packages/frontend/editor-ui`.
6. Benchmarks: `pnpm build:docker && pnpm --filter=n8n-playwright bench:canvas:tier "@tier:XL"`.

## Related Linear tickets, Github issues, and Community forum posts

Hackday spike (Hackmation Aug 2026), no ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



