### PR TITLE
perf(editor): Harden node content search with index, EXISTS sharing, keyset scan and concurrency gate

### DIFF
--- a/packages/@n8n/api-types/src/dto/workflows/search-workflow-nodes.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/search-workflow-nodes.dto.ts
@@ -25,7 +25,7 @@ export type NodeSearchHitProject = {
 };
 
 /** Which node field the query matched. Drives ordering and the result subtitle. */
-export type NodeSearchMatchedField = 'name' | 'type' | 'notes' | 'parameters';
+export type NodeSearchMatchedField = 'name' | 'type' | 'notes' | 'parameters' | 'credentials';
 
 export type NodeSearchHit = {
 	workflowId: string;

--- a/packages/@n8n/db/src/entities/workflow-entity.ts
+++ b/packages/@n8n/db/src/entities/workflow-entity.ts
@@ -23,6 +23,10 @@ import type { WorkflowTagMapping } from './workflow-tag-mapping';
 import { objectRetriever, sqlite } from '../utils/transformers';
 
 @Entity()
+// Mirrors AddUpdatedAtIndexToWorkflowEntity1786525332822. Workflow lists and the
+// command-bar node search both order by `updatedAt`; the index lets the planner
+// stop at the limit instead of sorting the whole table.
+@Index(['updatedAt'])
 export class WorkflowEntity extends WithTimestampsAndStringId implements IWorkflowDb {
 	// TODO: Add XSS check
 	@Index({ unique: true })

--- a/packages/@n8n/db/src/migrations/common/1786525332822-AddUpdatedAtIndexToWorkflowEntity.ts
+++ b/packages/@n8n/db/src/migrations/common/1786525332822-AddUpdatedAtIndexToWorkflowEntity.ts
@@ -1,0 +1,24 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+/**
+ * `workflow_entity` is sorted by `updatedAt` on every workflow list page and by
+ * the command-bar node content search, but the column was unindexed, so both
+ * queries sorted the whole table.
+ *
+ * It matters most for the node search, which filters on a non-sargable
+ * `nodes LIKE '%...%'` and takes the top N. With the index the planner walks
+ * `updatedAt` in order and stops once the limit is filled instead of scanning
+ * and sorting every row. Measured on a 20k-workflow SQLite corpus
+ * (`packages/cli/test/performance/node-search-variants.perf.ts`):
+ * a broad query went from 149ms to 0.9ms, and the plan changed to
+ * `SCAN w USING INDEX`.
+ */
+export class AddUpdatedAtIndexToWorkflowEntity1786525332822 implements ReversibleMigration {
+	async up({ schemaBuilder: { createIndex } }: MigrationContext) {
+		await createIndex('workflow_entity', ['updatedAt']);
+	}
+
+	async down({ schemaBuilder: { dropIndex } }: MigrationContext) {
+		await dropIndex('workflow_entity', ['updatedAt'], { skipIfMissing: true });
+	}
+}

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -11,6 +11,7 @@ import type {
 	FindOptionsRelations,
 	EntityManager,
 } from '@n8n/typeorm';
+import { DateUtils } from '@n8n/typeorm/util/DateUtils';
 import type { INode } from 'n8n-workflow';
 import { PROJECT_ROOT, UserError } from 'n8n-workflow';
 
@@ -61,6 +62,8 @@ export type WorkflowFolderUnionFull = (
 export type NodeSearchCandidate = {
 	id: string;
 	name: string;
+	/** Keyset cursor position for the next batch. */
+	updatedAt: Date;
 	nodes: INode[];
 	homeProject: SlimProject | null;
 	parentFolder: { id: string; name: string } | null;
@@ -873,6 +876,10 @@ export class WorkflowRepository extends BaseRepository<WorkflowEntity> {
 	 *
 	 * Only draft `nodes` are searched: that is what the user edits and what they
 	 * navigate back to. Published versions are deliberately out of scope.
+	 *
+	 * `cursor` continues a keyset scan: only workflows strictly older than
+	 * `(cursor.updatedAt, cursor.id)` are returned, so the caller can batch
+	 * through candidates without revisiting rows.
 	 */
 	async findNodeSearchCandidates(
 		user: User,
@@ -884,6 +891,7 @@ export class WorkflowRepository extends BaseRepository<WorkflowEntity> {
 		query: string,
 		limit: number,
 		projectId?: string,
+		cursor?: { updatedAt: Date; id: string },
 	): Promise<NodeSearchCandidate[]> {
 		const qb = this.createQueryBuilder('workflow').select([
 			'workflow.id',
@@ -892,11 +900,31 @@ export class WorkflowRepository extends BaseRepository<WorkflowEntity> {
 			'workflow.updatedAt',
 		]);
 
-		const sharedWorkflowSubquery = this.buildSharedWorkflowIdsSubquery(user, sharingOptions);
-		qb.where(`workflow.id IN (${sharedWorkflowSubquery.getQuery()})`);
+		// EXISTS, not `workflow.id IN (subquery)`: the IN form makes SQLite drive
+		// from `shared_workflow` and sort every LIKE match in a temp B-tree, which
+		// discards the `updatedAt` index this query relies on to stop at the limit.
+		const sharedWorkflowSubquery = this.buildSharedWorkflowIdsSubquery(
+			user,
+			sharingOptions,
+		).andWhere('sw.workflowId = workflow.id');
+		qb.where(`EXISTS (${sharedWorkflowSubquery.getQuery()})`);
 		qb.setParameters(sharedWorkflowSubquery.getParameters());
 
 		qb.andWhere('workflow.isArchived = :isArchived', { isArchived: false });
+
+		if (cursor) {
+			// Row-value comparison, NOT the equivalent `a < x OR (a = x AND b < y)`:
+			// the OR form makes SQLite pick a MULTI-INDEX OR plan that materialises
+			// and sorts every row older than the cursor on every batch, while the
+			// row value keeps the `updatedAt<?` index seek and short-circuits at
+			// the limit (measured ~175ms vs ~3ms per batch on a 20k corpus).
+			qb.andWhere('(workflow.updatedAt, workflow.id) < (:cursorUpdatedAt, :cursorId)', {
+				// Stringified for the raw comparison; same pattern as execution.repository.
+				// String() narrows DateUtils' `any` return — always a string for a Date input.
+				cursorUpdatedAt: String(DateUtils.mixedDateToUtcDatetimeString(cursor.updatedAt)),
+				cursorId: cursor.id,
+			});
+		}
 
 		// Postgres stores `nodes` as json and needs an explicit text cast for LIKE;
 		// sqlite already stores it as text. Mirrors `applyTriggerNodeTypesFilter`.
@@ -944,9 +972,25 @@ export class WorkflowRepository extends BaseRepository<WorkflowEntity> {
 			'parentFolder.name',
 		]);
 
-		qb.orderBy('workflow.updatedAt', 'DESC').limit(limit);
+		// `id DESC` tiebreak: `updatedAt` is not unique, so without it rows sharing
+		// a timestamp could be skipped or duplicated at batch boundaries.
+		qb.orderBy('workflow.updatedAt', 'DESC').addOrderBy('workflow.id', 'DESC').limit(limit);
 
-		const workflows = await qb.getMany();
+		// Postgres cannot estimate the selectivity of `LIKE '%…%'`, so it assumes
+		// almost nothing matches and picks a sequential scan with a top-N sort over
+		// the whole table rather than walking the `updatedAt` index and stopping at
+		// the limit. The planner still falls back to a sequential scan when no index
+		// can serve the query, so this only removes a bad choice. SET LOCAL keeps it
+		// scoped to this transaction so pooled connections are unaffected.
+		const workflows =
+			this.globalConfig.database.type !== 'postgresdb'
+				? await qb.getMany()
+				: await this.manager.transaction(async (tx) => {
+						const { queryRunner } = tx;
+						if (!queryRunner) return await qb.getMany();
+						await tx.query('SET LOCAL enable_seqscan = off');
+						return await qb.setQueryRunner(queryRunner).getMany();
+					});
 
 		return workflows.map((workflow) => {
 			const ownerProject = workflow.shared?.[0]?.project ?? null;
@@ -954,6 +998,7 @@ export class WorkflowRepository extends BaseRepository<WorkflowEntity> {
 			return {
 				id: workflow.id,
 				name: workflow.name,
+				updatedAt: workflow.updatedAt,
 				nodes: workflow.nodes ?? [],
 				homeProject: ownerProject
 					? {

--- a/packages/cli/src/workflows/__tests__/workflow-node-search.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-node-search.service.test.ts
@@ -23,6 +23,7 @@ const makeNode = (overrides: Partial<INode> = {}): INode => ({
 const makeCandidate = (overrides: Partial<NodeSearchCandidate> = {}): NodeSearchCandidate => ({
 	id: 'wf-1',
 	name: 'My Workflow',
+	updatedAt: new Date('2025-01-01T00:00:00.000Z'),
 	nodes: [],
 	homeProject: { id: 'proj-1', name: 'Acme Corp', type: 'team', icon: null },
 	parentFolder: null,
@@ -69,6 +70,7 @@ describe('WorkflowNodeSearchService', () => {
 				'orders',
 				expect.any(Number),
 				undefined,
+				undefined,
 			);
 		});
 
@@ -83,6 +85,7 @@ describe('WorkflowNodeSearchService', () => {
 				'orders',
 				expect.any(Number),
 				'proj-1',
+				undefined,
 			);
 		});
 
@@ -96,6 +99,7 @@ describe('WorkflowNodeSearchService', () => {
 				expect.anything(),
 				'orders',
 				expect.any(Number),
+				undefined,
 				undefined,
 			);
 		});
@@ -277,6 +281,79 @@ describe('WorkflowNodeSearchService', () => {
 			const { hasMore } = await service.search(user, 'orders');
 
 			expect(hasMore).toBe(false);
+		});
+
+		it('matches credential names, ranked below parameter hits', async () => {
+			const { service } = setup([
+				makeCandidate({
+					nodes: [
+						makeNode({
+							id: 'cred',
+							name: 'Notify',
+							credentials: { slackApi: { id: 'c-1', name: 'Slack Prod Account' } },
+						}),
+						makeNode({ id: 'param', name: 'Other', parameters: { q: 'prod account' } }),
+					],
+				}),
+			]);
+
+			const { results } = await service.search(user, 'prod account');
+
+			expect(results.map((hit) => [hit.nodeId, hit.matchedField])).toEqual([
+				['param', 'parameters'],
+				['cred', 'credentials'],
+			]);
+			expect(results[1].snippet).toContain('Slack Prod Account');
+		});
+
+		it('scans past a full batch of blob-only false positives on a keyset cursor', async () => {
+			// A full batch where the SQL pre-filter matched but no node does (ids,
+			// webhook ids, positions) must not end the search — a fixed cap did.
+			const falsePositives = Array.from({ length: 100 }, (_, i) =>
+				makeCandidate({
+					id: `decoy-${i}`,
+					updatedAt: new Date(2025, 0, 2),
+					nodes: [makeNode({ name: 'Unrelated' })],
+				}),
+			);
+			const realHit = makeCandidate({
+				id: 'real',
+				updatedAt: new Date(2025, 0, 1),
+				nodes: [makeNode({ name: 'Fetch orders' })],
+			});
+
+			const { service, workflowRepository } = setup();
+			workflowRepository.findNodeSearchCandidates
+				.mockResolvedValueOnce(falsePositives)
+				.mockResolvedValueOnce([realHit]);
+
+			const { results } = await service.search(user, 'orders');
+
+			expect(results.map((hit) => hit.workflowId)).toEqual(['real']);
+			// Second batch continues from the last row of the first.
+			expect(workflowRepository.findNodeSearchCandidates).toHaveBeenNthCalledWith(
+				2,
+				user,
+				expect.anything(),
+				'orders',
+				expect.any(Number),
+				undefined,
+				{ updatedAt: falsePositives[99].updatedAt, id: 'decoy-99' },
+			);
+		});
+
+		it('stops scanning at the safety rail on pathological queries', async () => {
+			// Every batch full, nothing ever matches in memory: the scan must stop.
+			const batch = Array.from({ length: 100 }, (_, i) =>
+				makeCandidate({ id: `decoy-${i}`, nodes: [makeNode({ name: 'Unrelated' })] }),
+			);
+			const { service, workflowRepository } = setup(batch);
+
+			await expect(service.search(user, 'orders')).resolves.toEqual({
+				results: [],
+				hasMore: false,
+			});
+			expect(workflowRepository.findNodeSearchCandidates).toHaveBeenCalledTimes(20);
 		});
 
 		it('preserves recency order within a relevance tier', async () => {

--- a/packages/cli/src/workflows/workflow-node-search.service.ts
+++ b/packages/cli/src/workflows/workflow-node-search.service.ts
@@ -14,11 +14,21 @@ import { findNodeSearchMatch, STICKY_NODE_TYPE } from 'n8n-workflow';
 import { RoleService } from '@/services/role.service';
 
 /**
- * Workflows pulled from the DB per search. The coarse SQL pre-filter matches JSON
- * structure as well as content, so it over-fetches; this bounds the in-memory
- * re-match on queries that hit a large share of the corpus.
+ * Workflows hydrated per keyset batch. The coarse SQL pre-filter matches JSON
+ * structure as well as content (node ids, webhook ids, positions), so a batch
+ * can be entirely false positives; the scan continues on an `(updatedAt, id)`
+ * cursor instead of giving up, so those false positives cannot silently
+ * displace real hits further down — a fixed candidate cap did exactly that.
  */
-const CANDIDATE_WORKFLOW_LIMIT = NODE_SEARCH_MAX_RESULTS * 10;
+const BATCH_SIZE = 100;
+
+/**
+ * Safety rail for pathological queries where nothing matches in memory but the
+ * blob keeps matching: bounds hydration cost, not correctness of ranking.
+ * ponytail: practical-completeness bound; the real fix at ~100k+ workflows is a
+ * dedicated search index table maintained by the workflow-index module.
+ */
+const MAX_SCANNED_WORKFLOWS = 2000;
 
 /** Relevance order for matched fields — a node-name hit beats a buried parameter hit. */
 const MATCHED_FIELD_RANK: Record<NodeSearchMatchedField, number> = {
@@ -26,6 +36,7 @@ const MATCHED_FIELD_RANK: Record<NodeSearchMatchedField, number> = {
 	type: 1,
 	notes: 2,
 	parameters: 3,
+	credentials: 4,
 };
 
 type ScoredHit = NodeSearchHit & { rank: number };
@@ -56,19 +67,34 @@ export class WorkflowNodeSearchService {
 			this.roleService.rolesWithScope('workflow', scopes),
 		]);
 
-		const candidates = await this.workflowRepository.findNodeSearchCandidates(
-			user,
-			{ scopes, projectRoles, workflowRoles },
-			query,
-			CANDIDATE_WORKFLOW_LIMIT,
-			options.projectId,
-		);
-
 		const queryLower = query.toLowerCase();
 		const hits: ScoredHit[] = [];
 
-		for (const candidate of candidates) {
-			hits.push(...this.matchWorkflow(candidate, queryLower));
+		// Keyset scan, newest first. Stops as soon as enough hits exist to fill the
+		// result list and decide `hasMore`, so queries that match stop after a batch
+		// or two; only queries whose matches are blob-only false positives walk on,
+		// bounded by MAX_SCANNED_WORKFLOWS.
+		let cursor: { updatedAt: Date; id: string } | undefined;
+		let scanned = 0;
+		while (scanned < MAX_SCANNED_WORKFLOWS && hits.length <= NODE_SEARCH_MAX_RESULTS) {
+			const candidates = await this.workflowRepository.findNodeSearchCandidates(
+				user,
+				{ scopes, projectRoles, workflowRoles },
+				query,
+				BATCH_SIZE,
+				options.projectId,
+				cursor,
+			);
+
+			for (const candidate of candidates) {
+				hits.push(...this.matchWorkflow(candidate, queryLower));
+			}
+
+			scanned += candidates.length;
+			if (candidates.length < BATCH_SIZE) break; // corpus exhausted
+
+			const last = candidates[candidates.length - 1];
+			cursor = { updatedAt: last.updatedAt, id: last.id };
 		}
 
 		// Candidates arrive newest-first, so a stable sort by matched-field rank

--- a/packages/cli/src/workflows/workflow-node-search.service.ts
+++ b/packages/cli/src/workflows/workflow-node-search.service.ts
@@ -10,7 +10,9 @@ import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
 import { findNodeSearchMatch, STICKY_NODE_TYPE } from 'n8n-workflow';
+import pLimit from 'p-limit';
 
+import { TooManyRequestsError } from '@/errors/response-errors/too-many-requests.error';
 import { RoleService } from '@/services/role.service';
 
 /**
@@ -30,6 +32,25 @@ const BATCH_SIZE = 100;
  */
 const MAX_SCANNED_WORKFLOWS = 2000;
 
+/**
+ * A query that matches nothing cannot short-circuit on the `updatedAt` index — it
+ * has to read every workflow's `nodes` blob to prove absence, and the keyset
+ * scan's worst case walks MAX_SCANNED_WORKFLOWS of hydrated false positives.
+ *
+ * The per-user rate limit on the endpoint cannot bound that, because the
+ * database is shared. Measured in #30294 on a 20k-workflow corpus: with 20
+ * users each staying inside their own limit, workflow-list queries degraded
+ * 66x on SQLite and 56x on Postgres; capped at one concurrent scan the same
+ * scenario measures ~1.3x.
+ *
+ * So run one scan at a time per process and shed load past a short queue
+ * rather than letting search monopolise the connection pool. In multi-main
+ * setups the ceiling is per instance, which is the intent: it bounds what a
+ * single process can demand of a shared database.
+ */
+const MAX_CONCURRENT_SEARCHES = 1;
+const MAX_QUEUED_SEARCHES = 4;
+
 /** Relevance order for matched fields — a node-name hit beats a buried parameter hit. */
 const MATCHED_FIELD_RANK: Record<NodeSearchMatchedField, number> = {
 	name: 0,
@@ -48,10 +69,15 @@ export class WorkflowNodeSearchService {
 		private readonly roleService: RoleService,
 	) {}
 
+	private readonly limiter = pLimit(MAX_CONCURRENT_SEARCHES);
+
 	/**
 	 * Full-text search over the nodes of every non-archived workflow the user can
-	 * read. Matches node names, types, notes and parameter values.
-	 * Optionally restrict to workflows owned by `projectId`.
+	 * read. Matches node names, types, notes, parameter values and credential
+	 * names. Optionally restrict to workflows owned by `projectId`.
+	 *
+	 * Throws `TooManyRequestsError` when the process-wide concurrency gate and
+	 * its queue are full — see MAX_CONCURRENT_SEARCHES.
 	 */
 	async search(
 		user: User,
@@ -61,6 +87,18 @@ export class WorkflowNodeSearchService {
 		const query = rawQuery.trim();
 		if (!query) return { results: [], hasMore: false };
 
+		if (this.limiter.pendingCount >= MAX_QUEUED_SEARCHES) {
+			throw new TooManyRequestsError('Workflow node search is busy, please retry.');
+		}
+
+		return await this.limiter(async () => await this.runSearch(user, query, options));
+	}
+
+	private async runSearch(
+		user: User,
+		query: string,
+		options: { projectId?: string },
+	): Promise<SearchWorkflowNodesResponse> {
 		const scopes = ['workflow:read' as const];
 		const [projectRoles, workflowRoles] = await Promise.all([
 			this.roleService.rolesWithScope('project', scopes),

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -25,6 +25,7 @@ import {
 } from '@n8n/db';
 import {
 	Body,
+	createUserKeyedRateLimiter,
 	Delete,
 	Get,
 	Licensed,
@@ -164,8 +165,14 @@ export class WorkflowsController {
 	 * every project the caller has access to, so there is no single scope to check.
 	 * Access is enforced inside the query itself, via the shared-workflow subquery
 	 * restricted to `workflow:read`.
+	 *
+	 * Each call runs an unindexable substring scan, so it is rate limited per
+	 * user: the client debounces its keystrokes, which no human can sustain past
+	 * this ceiling. Cross-user load is bounded by the service's concurrency gate.
 	 */
-	@Get('/search-nodes')
+	@Get('/search-nodes', {
+		keyedRateLimit: createUserKeyedRateLimiter({ limit: 120, windowMs: 60_000 }),
+	})
 	async searchNodes(
 		req: AuthenticatedRequest,
 		_res: express.Response,

--- a/packages/cli/test/integration/workflows/workflow-node-search.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-node-search.service.test.ts
@@ -234,6 +234,31 @@ describe('WorkflowNodeSearchService', () => {
 		});
 	});
 
+	describe('load shedding', () => {
+		// The per-user rate limit cannot bound load on a shared database: 20 users
+		// each staying within their own limit measured 66x list-query degradation
+		// before the process-wide cap existed (#30294).
+		it('sheds load once the concurrency cap and its queue are full', async () => {
+			await createWorkflow({ nodes: [makeNode({ name: 'Send Slack Alert' })] }, member);
+
+			// Fire more than (max concurrent + max queued) at once. The guard is
+			// evaluated synchronously before the limiter awaits, so this is deterministic.
+			const outcomes = await Promise.allSettled(
+				Array.from({ length: 10 }, async () => await service.search(member, 'slack')),
+			);
+
+			const rejected = outcomes.filter((outcome) => outcome.status === 'rejected');
+			const fulfilled = outcomes.filter((outcome) => outcome.status === 'fulfilled');
+			expect(rejected.length).toBeGreaterThan(0);
+			expect(fulfilled.length).toBeGreaterThan(0);
+			expect(rejected[0].reason).toMatchObject({ httpStatusCode: 429 });
+
+			// The cap must not wedge the service: later calls succeed normally.
+			const { results } = await service.search(member, 'slack');
+			expect(results).toHaveLength(1);
+		});
+	});
+
 	describe('LIKE metacharacters', () => {
 		it('treats % as a literal', async () => {
 			await createWorkflow({ nodes: [makeNode({ name: 'Discount 50% off' })] }, member);

--- a/packages/cli/test/integration/workflows/workflow-node-search.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-node-search.service.test.ts
@@ -170,6 +170,50 @@ describe('WorkflowNodeSearchService', () => {
 			expect(results).toEqual([]);
 		});
 
+		it('matches credential names', async () => {
+			await createWorkflow(
+				{
+					nodes: [
+						makeNode({
+							name: 'Notify',
+							credentials: { slackApi: { id: 'c-1', name: 'My Slack account' } },
+						}),
+					],
+				},
+				member,
+			);
+
+			const { results } = await service.search(member, 'slack account');
+
+			expect(results).toHaveLength(1);
+			expect(results[0]).toMatchObject({ nodeName: 'Notify', matchedField: 'credentials' });
+		});
+
+		// The DB prefilter matches the raw JSON blob, which contains fields the
+		// in-memory matcher deliberately skips (node ids, positions, webhookIds).
+		// A hit older than a full batch of such blob-only candidates must still be
+		// found — a fixed candidate cap silently returned nothing here.
+		it('finds hits beyond a full batch of blob-only false positives', async () => {
+			// The real hit is oldest, then 100 newer workflows that match the blob
+			// only via node id and fill the first keyset batch entirely.
+			await createWorkflow({ nodes: [makeNode({ name: 'needle hit' })] }, member);
+			await new Promise((resolve) => setTimeout(resolve, 10)); // decoys must sort newer
+			await Promise.all(
+				Array.from(
+					{ length: 100 },
+					async (_, i) =>
+						await createWorkflow(
+							{ nodes: [makeNode({ id: `needle-${i}`, name: `Decoy ${i}` })] },
+							member,
+						),
+				),
+			);
+
+			const { results } = await service.search(member, 'needle');
+
+			expect(results.map((hit) => hit.nodeName)).toEqual(['needle hit']);
+		});
+
 		it('is case insensitive', async () => {
 			await createWorkflow({ nodes: [makeNode({ name: 'Fetch ORDERS' })] }, member);
 
@@ -269,6 +313,43 @@ describe('WorkflowNodeSearchService', () => {
 			);
 
 			expect(candidates.map((c) => c.id)).toEqual([newer.id, older.id]);
+		});
+
+		it('continues after the cursor without skipping or repeating rows', async () => {
+			const workflows = [];
+			for (let i = 0; i < 3; i++) {
+				workflows.push(
+					await createWorkflow({ nodes: [makeNode({ name: `orders ${i}` })] }, member),
+				);
+			}
+			// Same timestamp on every row: the id tiebreak alone must page correctly.
+			const sharedTime = new Date(Date.now() + 60_000);
+			for (const workflow of workflows) {
+				await workflowRepository.update(workflow.id, { updatedAt: sharedTime });
+			}
+
+			const sharingOptions = await readSharingOptions();
+			const first = await workflowRepository.findNodeSearchCandidates(
+				member,
+				sharingOptions,
+				'orders',
+				2,
+			);
+			expect(first).toHaveLength(2);
+
+			const last = first[first.length - 1];
+			const second = await workflowRepository.findNodeSearchCandidates(
+				member,
+				sharingOptions,
+				'orders',
+				2,
+				undefined,
+				{ updatedAt: last.updatedAt, id: last.id },
+			);
+
+			const seen = [...first, ...second].map((candidate) => candidate.id);
+			expect(seen).toHaveLength(3);
+			expect(new Set(seen).size).toBe(3);
 		});
 
 		it('respects the candidate limit', async () => {

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useGlobalNodeSearchCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useGlobalNodeSearchCommands.ts
@@ -34,6 +34,7 @@ const MATCHED_FIELD_RANK: Record<NodeSearchMatchedField, number> = {
 	type: 1,
 	notes: 2,
 	parameters: 3,
+	credentials: 4,
 };
 
 const SNIPPET_SUFFIX_MAX_LENGTH = 40;
@@ -160,7 +161,10 @@ export function useGlobalNodeSearchCommands(options: {
 
 		// Nodes is the section; project is the subsection. Keep type + workflow on the row.
 		const showSnippet =
-			(hit.matchedField === 'notes' || hit.matchedField === 'parameters') && !!hit.snippet;
+			(hit.matchedField === 'notes' ||
+				hit.matchedField === 'parameters' ||
+				hit.matchedField === 'credentials') &&
+			!!hit.snippet;
 		const suffix = [showSnippet ? formatSnippetForSuffix(hit.snippet) : typeLabel, hit.workflowName]
 			.filter(Boolean)
 			.join(' · ');

--- a/packages/workflow/src/common/node-search.ts
+++ b/packages/workflow/src/common/node-search.ts
@@ -16,7 +16,7 @@ export const NODE_SEARCH_TEXT_MAX_LENGTH = 2_000;
 /** Individual values longer than this are skipped — almost always encoded blobs. */
 const NODE_SEARCH_VALUE_MAX_LENGTH = 512;
 
-export type NodeSearchField = 'name' | 'type' | 'notes' | 'parameters';
+export type NodeSearchField = 'name' | 'type' | 'notes' | 'parameters' | 'credentials';
 
 export type NodeSearchMatch = {
 	field: NodeSearchField;
@@ -127,6 +127,16 @@ export function findNodeSearchMatch(node: INode, queryLower: string): NodeSearch
 	for (const value of collectNodeParameterValues(node.parameters)) {
 		if (value.toLowerCase().includes(queryLower)) {
 			return { field: 'parameters', snippet: buildNodeSearchSnippet(value, queryLower) };
+		}
+	}
+
+	// Credential names appear in the serialized workflow, so the SQL pre-filter
+	// matches them; without this, a credential-name query ("Slack Prod Account")
+	// only ever produces false positives. Names only — the type keys (`slackApi`)
+	// would make node-type-ish queries double-match.
+	for (const credential of Object.values(node.credentials ?? {})) {
+		if (credential.name?.toLowerCase().includes(queryLower)) {
+			return { field: 'credentials', snippet: buildNodeSearchSnippet(credential.name, queryLower) };
 		}
 	}
 

--- a/packages/workflow/test/node-search.test.ts
+++ b/packages/workflow/test/node-search.test.ts
@@ -143,6 +143,28 @@ describe('findNodeSearchMatch', () => {
 		expect(findNodeSearchMatch(node, 'url')).toBeNull();
 	});
 
+	it('matches credential names after every other field', () => {
+		const node = makeNode({
+			name: 'Notify',
+			credentials: { slackApi: { id: 'c-1', name: 'Slack Prod Account' } },
+		});
+
+		expect(findNodeSearchMatch(node, 'prod account')).toEqual({
+			field: 'credentials',
+			snippet: 'Slack Prod Account',
+		});
+	});
+
+	it('does not match credential type keys', () => {
+		const node = makeNode({
+			name: 'Notify',
+			type: 'n8n-nodes-base.noOp',
+			credentials: { slackApi: { id: 'c-1', name: 'Team credential' } },
+		});
+
+		expect(findNodeSearchMatch(node, 'slackapi')).toBeNull();
+	});
+
 	it('is case insensitive against the lowercased query', () => {
 		const node = makeNode({ parameters: { channel: '#Deploys' } });
 		expect(findNodeSearchMatch(node, 'deploys')?.field).toBe('parameters');


### PR DESCRIPTION
## Summary

Stacked on #36153. Ports the measured DB-layer hardening and multi-tenant containment from #30294 onto the node content search, and closes two correctness gaps the fixed candidate cap reintroduced. No product or UI behavior changes beyond one new match source (credential names).

**1. Sharing filter as `EXISTS`, not `workflow.id IN (subquery)`**
The `IN` form makes SQLite drive from `shared_workflow` and sort every LIKE match in a temp B-tree, discarding the `updatedAt` index this query relies on to stop at the limit (measured and plan-asserted on a 20k-workflow corpus in #30294).

**2. Index on `workflow_entity.updatedAt`**
The search orders by `updatedAt` and takes the top N; without the index every keystroke sorts the whole table (149ms → 0.9ms at 20k workflows). This branch already registered `AddUpdatedAtIndexToWorkflowEntity1786525332822` in the generated migration index, but the migration file itself was never committed — restored here together with the entity `@Index` mirror. Also ports the Postgres planner hint (`SET LOCAL enable_seqscan = off`): Postgres cannot estimate `'%…%'` selectivity and otherwise seq-scans + top-N sorts instead of walking the index (75ms → 1ms).

**3. Keyset scan instead of the fixed 500-candidate cap**
The SQL pre-filter matches the raw JSON blob — node ids, webhook ids, positions — which the in-memory matcher deliberately skips. With a fixed cap, blob-only false positives displace real hits and the search silently returns nothing. The service now batches 100 candidates on an `(updatedAt, id)` cursor (`id DESC` tiebreak, since `updatedAt` is not unique) until the result list fills, candidates run out, or a 2000-workflow safety rail stops pathological queries. The cursor is a **row-value comparison**, not the equivalent `a < x OR (a = x AND b < y)`: the OR form makes SQLite pick a MULTI-INDEX OR plan that re-materialises every older row per batch (measured 3.5s vs 96ms per search at 20k in #30294).

Credential names are matched too (new `credentials` matched field, ranked last, snippet shown in the command bar): they appear in the serialized workflow so the pre-filter matches them, and without an in-memory counterpart a credential-name query only ever produced false positives — the most realistic trigger for the silent-empty-results bug.

**4. Per-user rate limit + process-wide concurrency gate**
`GET /workflows/search-nodes` is rate limited per user (120/min — the client debounces its keystrokes, which no human can sustain past this ceiling), and the service runs at most one scan per process (`pLimit(1)`) with a short queue of 4, shedding excess with 429. A per-user rate limit cannot bound load on a shared database: #30294 measured **66× (SQLite) / 56× (Postgres)** workflow-list degradation from 20 users each staying inside their own limit; capped at one concurrent scan the same scenario measured ~1.3×. In multi-main setups the ceiling is per instance, which is the intent. The command-bar composable already treats a failed request as empty results, so a shed search degrades gracefully.

**Deliberately not ported from #30294:** the performance benchmark suite (three perf test files with plan assertions). The numbers above come from those benchmarks; if the data layer here evolves further, porting them is the cheap way to keep these properties from silently regressing.

## How to test

Feature is behind the PostHog flag from #36153: `window.featureFlags.override('104_global_node_search', 'variant')`.

1. `pnpm build && pnpm dev`, dismiss the context chip in cmd+k
2. Give a node a credential with a distinctive name (e.g. "Slack Prod Account") in one workflow, save, search `prod account` from another view — the node appears under "Nodes" with the credential name as snippet
3. Correctness regression the cap caused: create 100+ workflows whose only blob match is outside matched fields (the integration test `finds hits beyond a full batch of blob-only false positives` covers this deterministically), then search — the older real hit is still returned

Automated coverage: matcher 40/40 (`packages/workflow`), service unit 19/19 (keyset loop, cursor handoff, safety rail, credentials ranking), controller unit 11/11, integration 23/23 (incl. a deterministic load-shedding test) — run on **both SQLite and Postgres 16** (validates the timestamptz cursor binding, the EXISTS form and the migration on Postgres). Typecheck + lint clean across `@n8n/db`, `cli`, `workflow`, `@n8n/api-types`, `editor-ui`.

## Related Linear tickets, Github issues, and Community forum posts

- Stacked on #36153
- Ports data-layer work from #30294

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
