### PR TITLE
fix(Medium Node): Correct typos in tag length error message (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Medium/Medium.node.ts
+++ b/packages/nodes-base/nodes/Medium/Medium.node.ts
@@ -426,7 +426,7 @@ export class Medium implements INodeType {
 								if (returnValue.length > 25) {
 									throw new NodeOperationError(
 										this.getNode(),
-										`The tag "${returnValue}" is to long. Maximum lenght of a tag is 25 characters.`,
+										`The tag "${returnValue}" is too long. Maximum length of a tag is 25 characters.`,
 										{ itemIndex: i },
 									);
 								}


### PR DESCRIPTION
## Summary

⚠️ **This PR was opened to exercise the commit/PR tooling flow.** The code change is real and correct, but the PR's purpose is to validate branch → commit → push → `gh pr create`. Close it if the flow check is done.

Fixes two typos in the user-facing `NodeOperationError` raised when a Medium post tag exceeds 25 characters:

- `is to long` → `is too long`
- `Maximum lenght` → `Maximum length`

Single-line, string-only change in `packages/nodes-base/nodes/Medium/Medium.node.ts`. No behaviour change — only the wording of the error message a user sees.

## How to test

No special modules, license, or feature flags needed.

1. Add a **Medium** node with a Medium credential, resource **Post**, operation **Create**.
2. Under *Additional Fields*, set **Tags** to a comma-separated value where one tag is longer than 25 characters, e.g. `short,thisTagIsDefinitelyLongerThanTwentyFiveCharacters`.
3. Execute the node. It fails, as before, but the message now reads:

   > The tag "thisTagIsDefinitelyLongerThanTwentyFiveCharacters" is too long. Maximum length of a tag is 25 characters.

Nothing else references this string, so no tests needed updating (`git grep lenght` confirms no remaining references in `nodes-base`).

## Related Linear tickets, Github issues, and Community forum posts

None — no ticket, this is a tooling-flow test plus an incidental typo fix.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- n/a: error-message wording only -->
- [x] Tests included. <!-- n/a: no assertions reference this string; cosmetic string change -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

