### PR TITLE
fix(nodes-base): ERPNext node duplicates rows past 1000 and crashes on empty filters

### DIFF
--- a/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
+++ b/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
@@ -161,8 +161,8 @@ export class ERPNext implements INodeType {
 
 					const { fields, filters } = this.getNodeParameter('options', i) as {
 						fields: string[];
-						filters: {
-							customProperty: Array<{ field: string; operator: string; value: string }>;
+						filters?: {
+							customProperty?: Array<{ field: string; operator: string; value: string }>;
 						};
 					};
 
@@ -175,8 +175,12 @@ export class ERPNext implements INodeType {
 						}
 					}
 					// filters=[["Person","first_name","=","Jane"]]
-					// TODO: filters not working
-					if (filters) {
+					// The Filters fixedCollection's own default is {} — not
+					// {customProperty: []} — for "no rows added", so `filters` can be
+					// truthy with `customProperty` still undefined. Reading it
+					// unguarded throws before any request is made, which is what the
+					// removed TODO above was flagging.
+					if (filters?.customProperty?.length) {
 						qs.filters = JSON.stringify(
 							filters.customProperty.map((filter) => {
 								return [docType, filter.field, toSQL(filter.operator), filter.value];

--- a/packages/nodes-base/nodes/ERPNext/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ERPNext/GenericFunctions.ts
@@ -82,7 +82,11 @@ export async function erpNextApiRequestAllItems(
 	do {
 		responseData = await erpNextApiRequest.call(this, method, resource, body, query);
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
-		query.limit_start += query.limit_page_length - 1;
+		// Advancing by page length minus one re-fetches the last record of every
+		// page as the first record of the next, so returnData gets one duplicate
+		// per page boundary crossed — only visible once a doctype has more rows
+		// than a single page (1000).
+		query.limit_start += query.limit_page_length;
 	} while (responseData.data && responseData.data.length > 0);
 
 	return returnData;

--- a/packages/nodes-base/nodes/ERPNext/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/ERPNext/test/GenericFunctions.test.ts
@@ -1,0 +1,88 @@
+import { erpNextApiRequestAllItems } from '../GenericFunctions';
+
+describe('erpNextApiRequestAllItems', () => {
+	/**
+	 * Fakes a server that pages through TOTAL_RECORDS in chunks of whatever
+	 * limit_page_length the caller asks for, and asserts on the exact
+	 * limit_start values the paginator requests — the most direct evidence
+	 * of the off-by-one, since it doesn't depend on any particular record
+	 * layout to expose it.
+	 */
+	function fakeThis(totalRecords: number) {
+		const requestedStarts: number[] = [];
+		return {
+			ctx: {
+				getCredentials: async () => ({
+					apiKey: 'k',
+					apiSecret: 's',
+					environment: 'selfHosted',
+					domain: 'https://example.com',
+				}),
+				helpers: {
+					requestWithAuthentication: async (
+						_credType: string,
+						options: { qs: { limit_start: number; limit_page_length: number } },
+					) => {
+						const { limit_start, limit_page_length } = options.qs;
+						requestedStarts.push(limit_start);
+						const end = Math.min(limit_start + limit_page_length, totalRecords);
+						const data =
+							limit_start >= totalRecords
+								? []
+								: Array.from({ length: end - limit_start }, (_, i) => ({ id: limit_start + i }));
+						return { data };
+					},
+				},
+			},
+			requestedStarts,
+		};
+	}
+
+	it('requests non-overlapping pages and returns exactly one row per record', async () => {
+		const { ctx, requestedStarts } = fakeThis(2500);
+
+		const result = await erpNextApiRequestAllItems.call(
+			ctx as any,
+			'data',
+			'GET',
+			'/api/resource/Sales Order',
+			{},
+		);
+
+		expect(result).toHaveLength(2500);
+		const ids = result.map((r: { id: number }) => r.id);
+		expect(new Set(ids).size).toBe(2500); // no duplicate ids
+
+		// Each page should start exactly where the previous one ended:
+		// 0, 1000, 2000 — not 0, 999, 1998 (the pre-fix increment).
+		expect(requestedStarts).toEqual([0, 1000, 2000]);
+	});
+
+	it('returns exactly the total when it is a multiple of the page size', async () => {
+		const { ctx } = fakeThis(2000);
+
+		const result = await erpNextApiRequestAllItems.call(
+			ctx as any,
+			'data',
+			'GET',
+			'/api/resource/Item',
+			{},
+		);
+
+		expect(result).toHaveLength(2000);
+	});
+
+	it('handles fewer records than a single page with no duplicates', async () => {
+		const { ctx } = fakeThis(3);
+
+		const result = await erpNextApiRequestAllItems.call(
+			ctx as any,
+			'data',
+			'GET',
+			'/api/resource/Customer',
+			{},
+		);
+
+		expect(result).toHaveLength(3);
+	});
+});


### PR DESCRIPTION
## What's wrong

Two independent bugs in the built-in ERPNext node (`packages/nodes-base/nodes/ERPNext/`), both found by reading the source directly rather than from an issue report.

**1. "Return All" duplicates rows past 1000.**

```ts
// GenericFunctions.ts, erpNextApiRequestAllItems
query.limit_start += query.limit_page_length - 1;
```

Should be `+= query.limit_page_length`. As written, page 2 starts at `limit_start = 999` instead of `1000`, so it re-fetches record 999 — the last record of page 1 — as its own first record. Every page boundary produces one duplicate. Invisible on any doctype with fewer than 1000 rows (the default page size), which is likely why it's gone unnoticed.

**2. "Get All" throws before making a request if Options is touched without adding a filter.**

```ts
// DocumentDescription.ts — the Filters fixedCollection's own default
{
  displayName: 'Filters',
  name: 'filters',
  type: 'fixedCollection',
  default: {},   // <- not { customProperty: [] }
  ...
}
```

```ts
// ERPNext.node.ts
if (filters) {
  qs.filters = JSON.stringify(
    filters.customProperty.map((filter) => { ... }),  // throws: customProperty is undefined
  );
}
```

`{}` is truthy, so `if (filters)` passes, and `filters.customProperty` is `undefined` on that default shape — `.map()` throws a `TypeError` before any HTTP request is made. This is exactly what the `// TODO: filters not working` comment sitting directly above the code was flagging.

## Fix

1. `limit_start += limit_page_length` (drop the `- 1`).
2. `if (filters?.customProperty?.length)`, and loosened the destructuring type annotation (`filters?: { customProperty?: ... }`) to match what the field can actually hand back.

## On #19271

That issue is a different bug in the same node — double URL-encoding a docType name with spaces (`getDocTypes()` calling `encodeURI()` manually, then the HTTP library encoding again). #22338 is already open with the correct diagnosis and fix; left it alone rather than duplicate it. Worth noting for triage, though: the issue's own reproduction steps say the failure is specific to combining "Get All" with a filter, but the actual error in the trace (`DocType Sales%20Order not found`) is a doctype-name-encoding problem independent of filters — a doctype with a space in its name fails with or without one. Neither of the two bugs in this PR is that one.

## Verification

**Bug 1** — reproduced the exact arithmetic standalone before touching any code (2500 records, page size 1000: 2 duplicates before the fix, 0 after). Then added `test/GenericFunctions.test.ts`, which calls the real exported `erpNextApiRequestAllItems` against a faked paginated server and asserts on the actual `limit_start` sequence requested — `[0, 1000, 2000]`, not `[0, 999, 1998]` — plus a duplicate-count check on the returned rows and two edge cases (exact multiple of page size, fewer rows than one page).

**Bug 2** — confirmed by reading `DocumentDescription.ts`'s field definition directly, not just the crash site, to establish that `{}` really is the field's own default rather than assuming it from the stack trace.

**What I could not do:** run `pnpm test` against the full workspace — a targeted fix in one node didn't seem to warrant bootstrapping the entire monorepo. Did type-check both changed files in isolation (`tsc --noEmit --skipLibCheck`); no errors on the changed lines (the only errors present are pre-existing environment noise — missing `@types/lodash` and a strict `unknown` catch-binding in code I didn't touch). The new test file is written against the project's real Jest/TS conventions and exercises the actual exported function rather than a reimplementation of its logic, but I have not run it through the project's own `pnpm test` — flagging that plainly rather than claiming CI-equivalent confidence I don't have.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

