### PR TITLE
docs: add Cursor Cloud dev environment notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,12 +337,6 @@ names (e.g. `Acme Corp`) in tests and examples.
 These notes cover non-obvious gotchas for the Cursor Cloud VM. Standard
 commands live in **Essential Commands** above; don't duplicate them here.
 
-- **Node is pinned to `v22.22.2` by the install script** — normally no action
-  needed. (It symlinks the `nvm` binaries into `/usr/local/cargo/bin`, ahead of
-  the VM's built-in `/exec-daemon/node` `v22.14.0`, which is below this repo's
-  `node >=22.22` engine requirement.) Only if `node -v` ever shows `v22.14.0` did
-  that step not run — re-run the install script, or:
-  `ln -sf "$HOME/.nvm/versions/node/v22.22.2/bin/node" /usr/local/cargo/bin/node`.
 - **Dependencies:** the startup install script runs
   `pnpm install --frozen-lockfile`. You do **not** need to reinstall unless the
   lockfile changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,18 +337,13 @@ names (e.g. `Acme Corp`) in tests and examples.
 These notes cover non-obvious gotchas for the Cursor Cloud VM. Standard
 commands live in **Essential Commands** above; don't duplicate them here.
 
-- **Node version is pinned by the environment — no action needed.** The VM's
-  built-in `node` (`/exec-daemon/node`, `v22.14.0`) is below this repo's
-  `engines` requirement (`node >=22.22`) and is injected ahead of `nvm` on
-  `PATH`. The Cloud environment's install script fixes this at the environment
-  level by symlinking the `nvm`-provided `v22.22.2` binaries (`node`, `npm`,
-  `npx`, `corepack`) into `/usr/local/cargo/bin` — the first entry on `PATH`,
-  which is inherited by every process — so all shells, scripts, and the app
-  resolve `node v22.22.2` with no `PATH` juggling. Sanity check: `node -v` should
-  print `v22.22.2`. If you ever see `v22.14.0`, the symlink step didn't run;
-  re-run the install script, or as a one-off:
+- **Node is pinned to `v22.22.2` by the install script** — normally no action
+  needed. (It symlinks the `nvm` binaries into `/usr/local/cargo/bin`, ahead of
+  the VM's built-in `/exec-daemon/node` `v22.14.0`, which is below this repo's
+  `node >=22.22` engine requirement.) Only if `node -v` ever shows `v22.14.0` did
+  that step not run — re-run the install script, or:
   `ln -sf "$HOME/.nvm/versions/node/v22.22.2/bin/node" /usr/local/cargo/bin/node`.
-- **Dependencies:** the startup install script pins node (above) and runs
+- **Dependencies:** the startup install script runs
   `pnpm install --frozen-lockfile`. You do **not** need to reinstall unless the
   lockfile changed.
 - **Build once before dev:** dev commands rely on each package's compiled

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,3 +331,41 @@ names (e.g. `Acme Corp`) in tests and examples.
   description using `https://linear.app/n8n/issue/[TICKET-ID]`. Do not
   create a Linear ticket on your own — ask first.
 - always link to the github issue if mentioned in the linear ticket.
+
+## Cursor Cloud specific instructions
+
+These notes cover non-obvious gotchas for the Cursor Cloud VM. Standard
+commands live in **Essential Commands** above; don't duplicate them here.
+
+- **Node version gotcha (important):** the VM's default `node` on `PATH` is
+  `v22.14.0`, which is **below** this repo's `engines` requirement
+  (`node >=22.22`). The correct version (`v22.22.2`) is installed via `nvm` but
+  is shadowed on `PATH` by `/exec-daemon/node`. Before you build, run, or test,
+  put the right node first on `PATH` for your shell session:
+
+  ```bash
+  export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"   # or: nvm use 22.22.2
+  node -v   # expect v22.22.2
+  ```
+
+  `pnpm install` tolerates the mismatch (it only prints an "Unsupported engine"
+  warning because `engine-strict` is off), so the startup update script uses the
+  default node fine — but build/dev/test should use `v22.22.2` to match CI.
+- **Dependencies:** the startup update script already runs
+  `pnpm install --frozen-lockfile`. You do **not** need to reinstall unless the
+  lockfile changed.
+- **Build once before dev:** dev commands rely on each package's compiled
+  `dist`, so run `pnpm build` once (see **Building**) before `pnpm dev:be`. Built
+  output is present in a fresh Cloud VM; after switching branches or editing
+  cross-package code, rebuild (`pnpm build`) or recover with `pnpm reset`.
+- **Running the app (no Docker/DB needed):** from the repo root,
+  `pnpm dev:be` starts the backend with hot reload and serves the editor at
+  http://localhost:5678 (health at `/healthz`). It defaults to a SQLite DB in
+  `~/.n8n` — no Postgres/Redis required for single-main dev. On first launch you
+  must complete the owner-account setup screen at :5678 before the canvas is
+  usable. For live frontend HMR, additionally run `pnpm dev:fe:editor` (Vite on
+  :8080, proxies the API to :5678). `pnpm dev` at the root is intentionally
+  removed — use `pnpm dev:be` / `pnpm dev:fe:editor` (or `pnpm dev:up`).
+- **A benign log line to ignore:** `Failed to load Custom API options for the
+  node "n8n-nodes-base.confluence"` appears on backend startup and does not
+  affect running workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,21 +337,18 @@ names (e.g. `Acme Corp`) in tests and examples.
 These notes cover non-obvious gotchas for the Cursor Cloud VM. Standard
 commands live in **Essential Commands** above; don't duplicate them here.
 
-- **Node version gotcha (important):** the VM's default `node` on `PATH` is
-  `v22.14.0`, which is **below** this repo's `engines` requirement
-  (`node >=22.22`). The correct version (`v22.22.2`) is installed via `nvm` but
-  is shadowed on `PATH` by `/exec-daemon/node`. Before you build, run, or test,
-  put the right node first on `PATH` for your shell session:
-
-  ```bash
-  export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"   # or: nvm use 22.22.2
-  node -v   # expect v22.22.2
-  ```
-
-  `pnpm install` tolerates the mismatch (it only prints an "Unsupported engine"
-  warning because `engine-strict` is off), so the startup update script uses the
-  default node fine — but build/dev/test should use `v22.22.2` to match CI.
-- **Dependencies:** the startup update script already runs
+- **Node version is pinned by the environment — no action needed.** The VM's
+  built-in `node` (`/exec-daemon/node`, `v22.14.0`) is below this repo's
+  `engines` requirement (`node >=22.22`) and is injected ahead of `nvm` on
+  `PATH`. The Cloud environment's install script fixes this at the environment
+  level by symlinking the `nvm`-provided `v22.22.2` binaries (`node`, `npm`,
+  `npx`, `corepack`) into `/usr/local/cargo/bin` — the first entry on `PATH`,
+  which is inherited by every process — so all shells, scripts, and the app
+  resolve `node v22.22.2` with no `PATH` juggling. Sanity check: `node -v` should
+  print `v22.22.2`. If you ever see `v22.14.0`, the symlink step didn't run;
+  re-run the install script, or as a one-off:
+  `ln -sf "$HOME/.nvm/versions/node/v22.22.2/bin/node" /usr/local/cargo/bin/node`.
+- **Dependencies:** the startup install script pins node (above) and runs
   `pnpm install --frozen-lockfile`. You do **not** need to reinstall unless the
   lockfile changed.
 - **Build once before dev:** dev commands rely on each package's compiled


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the n8n development environment on the Cursor Cloud VM, and records durable, non-obvious setup notes in a new `## Cursor Cloud specific instructions` section of `AGENTS.md`. No product code is modified.

## Environment-level node pin (no agent instructions)

The VM's built-in `node` is `/exec-daemon/node` (`v22.14.0`), injected ahead of `nvm` on `PATH`, which is below this repo's `engines` requirement (`node >=22.22`). Rather than instructing the agent to fix `PATH` per session, the environment's **install script** now pins the correct version at the environment level by symlinking the `nvm`-provided `v22.22.2` binaries into `/usr/local/cargo/bin` (the first entry on `PATH`, inherited by every process):

```bash
if [ -d "$HOME/.nvm/versions/node/v22.22.2/bin" ]; then for b in node npm npx corepack; do ln -sf "$HOME/.nvm/versions/node/v22.22.2/bin/$b" "/usr/local/cargo/bin/$b"; done; fi
hash -r
pnpm install --frozen-lockfile
```

Verified in a pristine shell (no exports/profile): `node -v` → `v22.22.2`, and `pnpm 10.32.1` runs on `v22.22.2`. The exec-daemon launches its own node by absolute path, so shadowing `node` on `PATH` does not affect the platform.

## What was verified in the Cloud VM

- `pnpm install --frozen-lockfile` — deps install
- `pnpm build` — full monorepo build, 70/70 turbo tasks successful
- Lint — `pnpm lint` in `packages/@n8n/config` passed (0 errors)
- Tests — `pnpm test` in `packages/@n8n/config` passed (120/120)
- Run — `pnpm dev:be` serves the editor at http://localhost:5678; `/healthz` returns `{"status":"ok"}`
- Hello-world — completed owner-account setup, then built and executed a workflow (Manual Trigger → Edit Fields) producing `{ "message": "Hello from Cursor Cloud Agent" }`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dc59605-15a9-49d6-8c80-a3d2e70e6868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dc59605-15a9-49d6-8c80-a3d2e70e6868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

