### PR TITLE
feat(core): Add one-off operation flow and insertion-semantics rules to AI Assistant

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
@@ -49,6 +49,11 @@ const CREDENTIAL_TEMPLATES: Record<string, CredentialTemplate> = {
 		envVar: 'EVAL_GOOGLE_DRIVE_ACCESS_TOKEN',
 		buildData: (token) => ({ oauthTokenData: { access_token: token } }),
 	},
+	googleSheetsOAuth2Api: {
+		defaultName: '[eval] Google Sheets',
+		envVar: 'EVAL_GOOGLE_SHEETS_ACCESS_TOKEN',
+		buildData: (token) => ({ oauthTokenData: { access_token: token } }),
+	},
 	// MCP-registry-synthesized credential types (agent MCP servers). Creating
 	// them requires the backend to run with the `mcp-registry` module enabled;
 	// placeholder tokens are fine — agent eval runs mock the MCP wire.

--- a/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
+++ b/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
@@ -118,6 +118,14 @@ node after a side-effect needs the original data, reference it by node name
 (`$('Compute Change').item.json.status`) or wire it in parallel from the
 data-producing node instead of chaining through the send.
 
+The same trap applies in reverse when **inserting** a side-effect node into an
+existing connection: adding C between A→B (e.g. a create-if-missing step before
+a write, during a repair) makes B read C's API response instead of A's data —
+auto-mapped columns silently fill with metadata. Keep the data path intact:
+branch C in parallel off the data producer, reorder C upstream of the data
+producer (trigger → ensure-target → produce data → write), or have B reference
+`$('Data Node')` explicitly.
+
 ## Code Nodes
 
 When a Code node is necessary, use real n8n item APIs such as `$input.all()` /

--- a/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
@@ -71,7 +71,15 @@ Two orthogonal decisions per request, or per part for compound requests:
   agent-anchored (see Signals). Requests to operate on existing resources
   (debugging a failed execution, listing or managing workflows or agents,
   querying data) are not classified by this skill at all — route them
-  through their normal paths.
+  through their normal paths. Finally, a one-off task with a concrete
+  external *effect* (export/copy data somewhere once, a migration, a
+  backfill) is **workflow-anchored**, not out-of-scope — the workflow is
+  just the vehicle. Classify it by shape (bounded data already in hand,
+  imperative ask, no trigger/schedule/reuse vocabulary) — users rarely say
+  "one-off" explicitly. Load the `one-off-operations` skill before building
+  and pass `executionIntent: "one-off"` to `build-workflow`; the completion
+  criterion is then a live run with read-back instead of simulated
+  verification.
 
 **2. Embeds other** — whether the other primitive appears inside the anchor:
 

--- a/packages/@n8n/instance-ai/skills/one-off-operations/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/one-off-operations/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: one-off-operations
+description: >-
+  Handles one-off operations: the request is a concrete effect that happens
+  once — export or copy data somewhere, a migration, a backfill, a cleanup —
+  with no trigger, schedule, or reuse intent. The workflow is the vehicle, not
+  the deliverable. Users rarely say "one-off"; infer it from the task's shape.
+  Load before building for such a request, or when a build-workflow result
+  contains postBuildFlow.reason "direct-one-off-build-succeeded". Do not load
+  for automations the user will run again — that is the normal build +
+  post-build-flow path.
+recommended_tools:
+  - build-workflow
+  - workflows
+  - executions
+  - ask-user
+  - verify-built-workflow
+---
+
+# One-Off Operations
+
+Use this skill when the request is a **one-off operation**: a concrete effect
+that needs to happen once, where a workflow is only the vehicle to make it
+happen. Typical shapes: "put this data in a spreadsheet", "copy these rows to
+X", "migrate/backfill/clean up Y".
+
+These instructions are in English, but user-visible text you write while
+following them stays in the user's conversation language.
+
+## Recognizing a one-off
+
+Users rarely label a task "one-off" — **infer it from the task's shape**, not
+from explicit phrasing. It is a one-off when the deliverable is a *state
+change*, not an automation:
+
+- The user asks for an effect on data that **already exists and is bounded** —
+  pasted into the chat, sitting in a named node, table, file, or sheet — rather
+  than data that will keep arriving over time.
+- The request is imperative about the here-and-now ("add these rows", "export
+  what's in X", "clean out the duplicates"), with no trigger, schedule, or
+  event vocabulary — no "when", "every", "whenever", "daily", "each time".
+- Nothing suggests the user wants to keep and rerun the workflow; the workflow
+  is never mentioned as the thing they want, only the outcome is.
+
+Explicit markers ("just this once", "I won't need this again") confirm the
+classification but are not required — most one-offs arrive without them.
+Signals against: trigger/schedule vocabulary, "from now on", a named event
+source, or any hint the user wants the automation itself. **When in doubt,
+treat the request as reusable** and follow the normal build flow — a reusable
+workflow that runs once is harmless; a one-off flow applied to an automation
+skips verification the user would have wanted.
+
+A one-off that touches external systems is still workflow-anchored (you cannot
+write to external services directly) — the intent changes the *post-build
+flow*, not the anchor.
+
+## The one-off flow
+
+1. **Build** the workflow with a **manual trigger** — always. A one-off is
+   never published, so an event trigger (webhook, form, schedule) would never
+   fire and only misleads. If the task genuinely needs an event source or a
+   future run time, it is not a one-off — reclassify it as a reusable
+   automation or a scheduled task and use the normal flow. Pass
+   `executionIntent: "one-off"` to `build-workflow`. This marks verification
+   as optional in the build outcome — no verification follow-up is scheduled,
+   and the completion criterion becomes a live run whose output you read back.
+2. **Setup** is unchanged: if the build outcome requires credential or value
+   setup, route it through `workflows(action="setup")` as usual. A one-off
+   still needs real credentials before it can run live.
+3. **Run live** with `executions(action="run")`. The run-approval card is the
+   user's consent gate — for a one-off, the live run IS what the user asked
+   for, so the usual "reserve live runs for explicit user requests" rule is
+   satisfied by the request itself. Do not run before setup is complete.
+4. **Read back before reporting.** After the run, inspect the actual output of
+   the effect nodes with `executions(action="get-node-output")` — the run
+   result data is truncated and not enough for quantitative claims. Check that
+   each write/effect node's input was the intended data (the rows you meant to
+   write), not an upstream node's API response. Report only numbers, columns,
+   and shapes you actually read. If the target system is cheap to read (e.g. a
+   read operation of the same node type), offer a read-back of the destination
+   as final confirmation.
+5. **Offer cleanup.** When the operation succeeded, ask whether to keep the
+   workflow for future reuse or delete it now that the job is done. Never
+   delete without asking. If the user keeps it, mention it stays unpublished
+   unless they say otherwise.
+
+## Optional pre-flight verification
+
+`verify-built-workflow` is available but **not required and never the
+completion criterion** for a one-off. Offer it before the live run only when
+the wiring is complex (branching, merges, non-trivial transformations) or the
+user is cautious about touching real data.
+
+When you do run it, present results honestly:
+
+- Say which nodes were **simulated** — external writes did not happen, and the
+  data flowing into simulated write nodes was NOT validated (their output is a
+  fabricated success fixture).
+- Never call the workflow "verified", "tested", or "working" from a simulated
+  pass alone, and never let it substitute for the live run and read-back.
+
+## Claiming success
+
+Do not make quantitative claims ("22 rows written", "columns matched") that
+you did not read back from actual execution output or the target system. A
+successful run status alone does not prove the *right data* was written — read
+the effect node's real output first. If you could not read it back, say so
+plainly and name what is unconfirmed.

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -20,6 +20,11 @@ especially when the build result contains `postBuildFlow.required: true`, or whe
 the current message contains `<workflow-verification-follow-up>` or
 `<workflow-setup-required>`.
 
+One-off builds (`postBuildFlow.reason: "direct-one-off-build-succeeded"`) hand
+off to the `one-off-operations` skill instead — verification is optional there
+and completion is a live run with read-back. If both sets of instructions are
+in context for a one-off build, the one-off flow wins.
+
 These instructions are in English, but user-visible text you write while
 following them stays in the user's conversation language.
 
@@ -328,7 +333,12 @@ has "no errors" unless this turn has a passing `verify-built-workflow` or
 `build-workflow`/save, a static `workflows(action="validate")`, or your own
 narration are NOT execution evidence. For a produced artifact (a file, generated
 document, or Code-node output), read the real output before calling it complete;
-do not infer correctness from the fact that a node ran. If you could not run the
+do not infer correctness from the fact that a node ran. The same applies to rows
+or records written to an external system: never make quantitative claims ("22
+rows written", "columns matched") that you did not read back from the effect
+node's actual output (`executions(action="get-node-output")`) or from the target
+system itself — a successful run status does not prove the *right data* was
+written, only that nodes ran. If you could not run the
 failing path or inspect the artifact, say so plainly — "I couldn't verify X
 because Y" — and name what is unconfirmed. An honest "could not verify" beats an
 unverified success claim.

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -70,6 +70,13 @@ For repairs, prefer editing the workspace file directly with file tools
 (`workspace_str_replace_file`) and calling `build-workflow` again with the same
 `filePath`.
 
+When a repair adds a node into an existing chain (an ensure-the-target-exists
+step, a dedupe, a notification), check what the downstream node reads before
+wiring it in-line — workflow rule 7 applies: an inserted write/create node
+replaces the payload flowing into the next node with its own API response.
+Branch it in parallel, reorder it upstream of the data producer, or make the
+downstream node reference the data node explicitly.
+
 ## Escalation
 
 If the service or workflow shape is clear, never stop before the first
@@ -624,6 +631,15 @@ Follow these rules strictly when generating workflows:
    match time units broadly (day/days, week/weeks…), and give every classifier
    an explicit fallback bucket — a one-phrasing regex silently misroutes every
    other phrasing.
+7. Inserting a node into an existing connection A→B changes what B receives:
+   `$json` and auto-mapped fields in B now read the inserted node's output, not
+   A's. Write/create/send nodes output their **API response** (ids, metadata,
+   `ok` flags), never the data that flowed into them — so inserting one
+   in-line (e.g. an ensure-the-target-exists step before a write) silently
+   replaces the payload with metadata. Keep the data path intact instead:
+   branch the inserted node in parallel from the data producer, reorder it
+   upstream of the data producer, or have B reference `$('Data Node')`
+   explicitly.
 
 ## Tool Naming Rules
 

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -365,6 +365,22 @@ describe('Instance AI runtime skills', () => {
 		expect(loaded?.instructions).not.toContain('add-plan-item');
 	});
 
+	it('loads the bundled one-off-operations skill', async () => {
+		const source = loadInstanceAiRuntimeSkillSource();
+		const skill = source.registry.skills.find((entry) => entry.name === 'one-off-operations');
+
+		expect(skill?.description).toContain('one-off operations');
+		expect(skill?.description).toContain('direct-one-off-build-succeeded');
+
+		const loaded = await source.loadSkill('one-off-operations');
+		// Normalize whitespace so assertions survive markdown re-wrapping.
+		const flattened = loaded?.instructions.replace(/\s+/g, ' ');
+		expect(flattened).toContain('executionIntent: "one-off"');
+		expect(flattened).toContain('not required and never the completion criterion');
+		expect(flattened).toContain('get-node-output');
+		expect(flattened).toContain('keep the workflow for future reuse or delete');
+	});
+
 	it('loads the bundled post-build-flow skill and trigger input reference', async () => {
 		const source = loadInstanceAiRuntimeSkillSource();
 		const skill = source.registry.skills.find((entry) => entry.name === 'post-build-flow');

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -97,6 +97,7 @@ type BuildToolOutput = {
 		reason?: string;
 		guidance?: string;
 	};
+	executionIntent?: string;
 	setupRequirement?: {
 		status: string;
 		reason?: string;
@@ -270,6 +271,128 @@ describe('createBuildWorkflowTool', () => {
 			workflowId: 'wf-1',
 			workflowVersionId: 'v-1',
 			sourceHash: hashWorkflowSource(source),
+		});
+	});
+
+	it('hands one-off builds to the one-off-operations skill with optional verification', async () => {
+		const source = 'workflow source from workspace';
+		const { context, filePath } = makeContext({ source });
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			name: 'One-off attendee export',
+			executionIntent: 'one-off',
+		});
+
+		expect(result).toMatchObject({
+			success: true,
+			// One-off intent rides on executionIntent, NOT on a new readiness
+			// status — the readiness union is persisted and old readers hard-fail
+			// on unknown variants (rollback safety).
+			verificationReadiness: { status: 'ready' },
+			executionIntent: 'one-off',
+			postBuildFlow: {
+				required: true,
+				skillId: 'one-off-operations',
+				reason: 'direct-one-off-build-succeeded',
+			},
+		});
+		expect(result.postBuildFlow?.guidance).toContain('Simulated verification is NOT required');
+		expect(result.postBuildFlow?.instructions).toContain('# One-Off Operations');
+		expect(result.postBuildFlow?.instructions).not.toContain('recommended_tools');
+		// The verify-biased post-build-flow body must NOT ride along on a one-off build.
+		expect(result.postBuildFlow?.instructions).not.toContain('# Post-Build Flow');
+	});
+
+	it('falls back to the post-build-flow handoff for a triggerless one-off build', async () => {
+		const source = 'workflow source from workspace';
+		const { context, filePath } = makeContext({ source });
+		vi.mocked(compileWorkflowSource).mockResolvedValue({
+			success: true,
+			workflow: {
+				...structuredClone(generatedWorkflow),
+				nodes: [
+					{
+						id: 'set-1',
+						name: 'Set',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [0, 0] as [number, number],
+						parameters: {},
+					},
+				],
+			},
+			warnings: [],
+			compiler: 'sandbox-tsx',
+		});
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			name: 'One-off without a trigger',
+			executionIntent: 'one-off',
+		});
+
+		// The one-off instructions' completion criterion is a live run, which a
+		// triggerless workflow cannot start — hand off to the standard flow.
+		expect(result.verificationReadiness).toMatchObject({ status: 'not_verifiable' });
+		expect(result.postBuildFlow).toMatchObject({
+			skillId: 'post-build-flow',
+			reason: 'direct-build-succeeded',
+		});
+	});
+
+	it('keeps one-off intent sticky when a repair rebuild omits executionIntent', async () => {
+		const source = 'workflow source from workspace';
+		const priorOutcome = { executionIntent: 'one-off' };
+		const workflowTaskService = {
+			getBuildOutcome: vi.fn(async () => await Promise.resolve(priorOutcome)),
+			reportBuildOutcome: vi.fn(async () => await Promise.resolve()),
+		} as unknown as NonNullable<InstanceAiContext['workflowBuildContext']>['workflowTaskService'];
+		const { context, filePath } = makeContext({
+			source,
+			overrides: {
+				workflowBuildContext: {
+					threadId: 'thread-1',
+					runId: 'run-1',
+					taskId: 'task-1',
+					workflowTaskService,
+				} as InstanceAiContext['workflowBuildContext'],
+			},
+		});
+
+		// Repair rebuild: no executionIntent on the input.
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			name: 'One-off attendee export',
+		});
+
+		// The stored intent survives the rebuild — the outcome must not silently
+		// flip back to the verify-first flow mid-repair.
+		expect(result.executionIntent).toBe('one-off');
+		expect(result.postBuildFlow).toMatchObject({
+			skillId: 'one-off-operations',
+			reason: 'direct-one-off-build-succeeded',
+		});
+	});
+
+	it('keeps reusable builds on the post-build-flow handoff', async () => {
+		const source = 'workflow source from workspace';
+		const { context, filePath } = makeContext({ source });
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			name: 'Daily Weather to Slack',
+			executionIntent: 'reusable',
+		});
+
+		expect(result).toMatchObject({
+			success: true,
+			verificationReadiness: { status: 'ready' },
+			postBuildFlow: {
+				required: true,
+				skillId: 'post-build-flow',
+				reason: 'direct-build-succeeded',
+			},
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-routing.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-routing.test.ts
@@ -57,6 +57,37 @@ describe('withDeterministicRouting', () => {
 		}
 	});
 
+	// One-off intent deliberately does NOT get its own readiness status — the
+	// readiness union is persisted and old readers hard-fail on unknown
+	// variants (see verification-obligation.ts). The intent rides on the
+	// outcome as a plain optional field instead.
+	it('keeps one-off builds on the ready readiness and passes the intent through', () => {
+		const outcome = withDeterministicRouting(makeOutcome({ executionIntent: 'one-off' }));
+
+		expect(outcome.verificationReadiness).toEqual({ status: 'ready' });
+		expect(outcome.executionIntent).toBe('one-off');
+	});
+
+	it('keeps reusable and unspecified intents ready', () => {
+		for (const executionIntent of ['reusable', undefined] as const) {
+			const outcome = withDeterministicRouting(makeOutcome({ executionIntent }));
+
+			expect(outcome.verificationReadiness).toEqual({ status: 'ready' });
+		}
+	});
+
+	it('keeps impossible-to-verify verdicts for one-off builds', () => {
+		const outcome = withDeterministicRouting(
+			makeOutcome({ executionIntent: 'one-off', triggerNodes: [] }),
+		);
+
+		expect(outcome.verificationReadiness).toMatchObject({
+			status: 'not_verifiable',
+			reason: 'no-trigger-node',
+		});
+		expect(outcome.executionIntent).toBe('one-off');
+	});
+
 	it('keeps workflows with unresolved placeholders ready for verification', () => {
 		const outcome = withDeterministicRouting(
 			makeOutcome({

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -68,7 +68,11 @@ import { emitTraceOnlyChildRun } from '../../tracing/langsmith-tracing';
 import type { InstanceAiContext } from '../../types';
 import { BuildFailureTracker } from '../../workflow-builder/build-failure-tracker';
 import { createRemediation } from '../../workflow-loop/remediation';
-import { remediationMetadataSchema } from '../../workflow-loop/workflow-loop-state';
+import {
+	remediationMetadataSchema,
+	workflowVerificationReadinessSchema,
+	type WorkflowBuildOutcome,
+} from '../../workflow-loop/workflow-loop-state';
 import { writeWorkspaceFile } from '../../workspace/workspace-files';
 import { COMPILED_WORKFLOW_TRACE_RUN_NAME } from '../tool-ids';
 
@@ -164,6 +168,16 @@ export const buildWorkflowInputSchema = z
 				'Set true when saving a supporting sub-workflow that will be referenced by the main workflow. ' +
 					'In a planned build task, this completes the task only when the task itself is marked isSupportingWorkflow; otherwise save the main workflow later.',
 			),
+		executionIntent: z
+			.enum(['one-off', 'reusable'])
+			.optional()
+			.describe(
+				'How the user intends to use this workflow. Pass `one-off` when the user wants a concrete ' +
+					'effect once (an export, migration, backfill, or cleanup) and the workflow is only the ' +
+					'vehicle — verification becomes an optional pre-flight and completion is a live run whose ' +
+					'output was read back (see the one-off-operations skill). Omit or pass `reusable` for ' +
+					'anything the user may run again.',
+			),
 	})
 	.strict();
 
@@ -172,31 +186,9 @@ const triggerNodeOutputSchema = z.object({
 	nodeType: z.string(),
 });
 
-const verificationReadinessOutputSchema = z.discriminatedUnion('status', [
-	z.object({ status: z.literal('ready') }),
-	z.object({ status: z.literal('already_verified') }),
-	z.object({
-		status: z.literal('needs_setup'),
-		reason: z.enum([
-			'unresolved-placeholders',
-			'missing-mocked-credential-pin-data',
-			'workflow-needs-setup',
-		]),
-		guidance: z.string(),
-	}),
-	z.object({
-		status: z.literal('not_verifiable'),
-		// 'non-mockable-trigger' is the legacy spelling of 'no-trigger-node',
-		// kept so stored outcomes from older threads still parse.
-		reason: z.enum([
-			'not-submitted',
-			'missing-workflow-id',
-			'no-trigger-node',
-			'non-mockable-trigger',
-		]),
-		guidance: z.string(),
-	}),
-]);
+// Reuse the workflow-loop schema — the tool output mirrors the persisted
+// readiness verdict, and a second hand-maintained copy drifts.
+const verificationReadinessOutputSchema = workflowVerificationReadinessSchema;
 
 const setupRequirementOutputSchema = z.discriminatedUnion('status', [
 	z.object({ status: z.literal('not_required') }),
@@ -250,12 +242,16 @@ export function autoImportMissingSdkSymbols(
 }
 
 const POST_BUILD_FLOW_SKILL_ID = 'post-build-flow';
+const ONE_OFF_OPERATIONS_SKILL_ID = 'one-off-operations';
+
+const ONE_OFF_OPERATIONS_GUIDANCE =
+	'This one-off build is not complete yet. Follow the one-off instructions in `instructions` now (do NOT load the one-off-operations skill — they are the same instructions). Simulated verification is NOT required and NOT the completion criterion: route setup if needed, then run the workflow live with the user’s approval, read back the actual node output, and report only what you read. Offer to keep or delete the workflow when the operation is done.';
 
 const POST_BUILD_FLOW_GUIDANCE =
 	'This direct build is not complete yet. Follow the post-build instructions in `instructions` now (do NOT load the post-build-flow skill — they are the same instructions) before verification, setup, error-workflow follow-up, publishing, testing, or any final user-visible summary. Follow-up order is verification/setup first, then mocked/no-mock live-test when latest verification used mocks or simulations, then generic testing prompts. Offer the explicit error-workflow opt-in for direct new primary workflows only after the primary workflow is successfully published. Do not replace the error-workflow opt-in with a generic add-anything, publish, or test question.';
 
-// Inlined into successful build results; the skill stays registered for tag-driven follow-up turns.
-let postBuildFlowInstructionsCache: string | undefined;
+// Inlined into successful build results; the skills stay registered for tag-driven follow-up turns.
+const inlineSkillInstructionsCache = new Map<string, string>();
 
 /** Tag-turn-only sections, stripped from the inline copy; follow-up turns load the full skill. */
 const INLINE_SKIPPED_SECTIONS = [
@@ -264,44 +260,68 @@ const INLINE_SKIPPED_SECTIONS = [
 	'## Credentials before build',
 ];
 
-function getPostBuildFlowInstructions(): string {
-	if (postBuildFlowInstructionsCache === undefined) {
-		const raw = readFileSync(
-			join(INSTANCE_AI_SKILLS_DIR, POST_BUILD_FLOW_SKILL_ID, 'SKILL.md'),
-			'utf-8',
-		);
+function getInlineSkillInstructions(skillId: string): string {
+	let instructions = inlineSkillInstructionsCache.get(skillId);
+	if (instructions === undefined) {
+		const raw = readFileSync(join(INSTANCE_AI_SKILLS_DIR, skillId, 'SKILL.md'), 'utf-8');
 		// Strip the YAML front-matter; catalog metadata is noise in a tool result.
 		const body = raw.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
-		postBuildFlowInstructionsCache = body
+		instructions = body
 			.split(/\n(?=## )/)
 			.filter((section) => !INLINE_SKIPPED_SECTIONS.some((title) => section.startsWith(title)))
 			.join('\n')
 			.trim();
+		inlineSkillInstructionsCache.set(skillId, instructions);
 	}
-	return postBuildFlowInstructionsCache;
+	return instructions;
 }
 
-const postBuildFlowOutputSchema = z.object({
-	required: z.literal(true),
-	skillId: z.literal(POST_BUILD_FLOW_SKILL_ID),
-	reason: z.literal('direct-build-succeeded'),
-	guidance: z.string(),
-	/** Full post-build instructions (the post-build-flow skill body), inlined. */
-	instructions: z.string(),
-});
+// Discriminated on skillId so a mismatched skillId/reason pair cannot validate.
+const postBuildFlowOutputSchema = z.discriminatedUnion('skillId', [
+	z.object({
+		required: z.literal(true),
+		skillId: z.literal(POST_BUILD_FLOW_SKILL_ID),
+		reason: z.literal('direct-build-succeeded'),
+		guidance: z.string(),
+		/** Full post-build instructions (the selected skill body), inlined. */
+		instructions: z.string(),
+	}),
+	z.object({
+		required: z.literal(true),
+		skillId: z.literal(ONE_OFF_OPERATIONS_SKILL_ID),
+		reason: z.literal('direct-one-off-build-succeeded'),
+		guidance: z.string(),
+		instructions: z.string(),
+	}),
+]);
 
 function directPostBuildFlowHandoff(
 	owner: ReturnType<typeof resolveBuildIdentifiers>['owner'],
 	isAuxiliarySupportingWorkflow: boolean,
+	outcome: WorkflowBuildOutcome,
 ): z.infer<typeof postBuildFlowOutputSchema> | undefined {
 	if (owner?.type !== 'direct' || isAuxiliarySupportingWorkflow) return undefined;
+
+	// One-off instructions only apply when the workflow can actually run — their
+	// completion criterion is a live run. A triggerless or otherwise unrunnable
+	// build falls back to the standard post-build flow, which handles
+	// not_verifiable outcomes.
+	if (outcome.executionIntent === 'one-off' && outcome.verificationReadiness?.status === 'ready') {
+		return {
+			required: true,
+			skillId: ONE_OFF_OPERATIONS_SKILL_ID,
+			reason: 'direct-one-off-build-succeeded',
+			guidance: ONE_OFF_OPERATIONS_GUIDANCE,
+			instructions: getInlineSkillInstructions(ONE_OFF_OPERATIONS_SKILL_ID),
+		};
+	}
 
 	return {
 		required: true,
 		skillId: POST_BUILD_FLOW_SKILL_ID,
 		reason: 'direct-build-succeeded',
 		guidance: POST_BUILD_FLOW_GUIDANCE,
-		instructions: getPostBuildFlowInstructions(),
+		instructions: getInlineSkillInstructions(POST_BUILD_FLOW_SKILL_ID),
 	};
 }
 
@@ -328,6 +348,9 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				workItemId: z.string().optional(),
 				triggerNodes: z.array(triggerNodeOutputSchema).optional(),
 				verificationReadiness: verificationReadinessOutputSchema.optional(),
+				/** Effective intent after merging with the prior outcome for this work
+				 *  item — a repair rebuild that omits the input keeps the stored value. */
+				executionIntent: z.enum(['one-off', 'reusable']).optional(),
 				setupRequirement: setupRequirementOutputSchema.optional(),
 				postBuildFlow: postBuildFlowOutputSchema.optional(),
 				isSupportingWorkflow: z.boolean().optional(),
@@ -626,6 +649,19 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				buildContext,
 				runId: context.runId,
 			});
+			// One-off intent is sticky per work item: a repair rebuild that omits the
+			// flag must not silently flip the stored outcome back to the verify-first
+			// flow (which would re-arm verification follow-ups mid-repair).
+			let executionIntent = input.executionIntent;
+			if (executionIntent === undefined) {
+				try {
+					executionIntent = (
+						await buildContext?.workflowTaskService?.getBuildOutcome(resolvedWorkItemId)
+					)?.executionIntent;
+				} catch {
+					// Best-effort: no prior outcome just means the default flow.
+				}
+			}
 			const withEscalation = (
 				errors: string[],
 				options: { includeSdkLanguageGuidance?: boolean } = {},
@@ -927,9 +963,14 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						supportingWorkflowIds:
 							referencedWorkflowIds.length > 0 ? referencedWorkflowIds : undefined,
 						hasUnresolvedPlaceholders: hasPlaceholders || undefined,
+						executionIntent,
 						summary,
 					});
-					const postBuildFlow = directPostBuildFlowHandoff(owner, isAuxiliarySupportingWorkflow);
+					const postBuildFlow = directPostBuildFlowHandoff(
+						owner,
+						isAuxiliarySupportingWorkflow,
+						outcome,
+					);
 
 					await promoteMainWorkflow(context, saved.id);
 					await reportWorkflowBuildOutcome(context, outcome, {
@@ -960,6 +1001,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						isSupportingWorkflow: isSupportingWorkflow || undefined,
 						triggerNodes,
 						verificationReadiness: outcome.verificationReadiness,
+						executionIntent: outcome.executionIntent,
 						setupRequirement: outcome.setupRequirement,
 						...(postBuildFlow ? { postBuildFlow } : {}),
 						mockedNodeNames: hasMockedCredentialNodes ? mockResult.mockedNodeNames : undefined,

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-routing.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-routing.ts
@@ -52,6 +52,11 @@ function determineVerificationReadiness(
 		};
 	}
 
+	// One-off intent does NOT get its own readiness status: readiness is
+	// persisted inside the build outcome, and previously deployed readers
+	// hard-fail on unknown union variants (which would wipe the whole per-thread
+	// loop map on rollback). The obligation derivation reads
+	// `outcome.executionIntent` instead — see verification-obligation.ts.
 	return { status: 'ready' };
 }
 

--- a/packages/@n8n/instance-ai/src/workflow-loop/__tests__/verification-obligation.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/__tests__/verification-obligation.test.ts
@@ -2,6 +2,7 @@ import { createRemediation } from '../remediation';
 import {
 	deriveWorkflowVerificationObligation,
 	deriveWorkflowVerificationObligationFromOutcome,
+	isWorkflowVerificationObligationUnsettled,
 } from '../verification-obligation';
 import type {
 	AttemptRecord,
@@ -364,5 +365,104 @@ describe('deriveWorkflowVerificationObligationFromOutcome', () => {
 
 		expect(obligation.status).toBe('needs_setup');
 		expect(obligation.plannedTaskId).toBe('task-1');
+	});
+});
+
+// One-off builds settle immediately: executionIntent 'one-off' must never
+// derive an unsettled obligation, or the planned scheduler re-issues
+// verification follow-ups forever (the historical death loop — see the spec's
+// loop-safety audit in .agents/specs/instance-ai-one-off-operations.md).
+// The intent is deliberately a plain optional outcome field, NOT a new
+// readiness status: old readers strip unknown keys but hard-fail on unknown
+// union variants, and the loop storage parses the whole per-thread map as one
+// unit, so a new readiness variant would wipe all records on rollback.
+describe('one-off builds (executionIntent: one-off)', () => {
+	it('settles as not_verifiable with manual policy and is never unsettled', () => {
+		const obligation = deriveWorkflowVerificationObligation('thread-1', {
+			state: makeState(),
+			attempts: [makeAttempt()],
+			lastBuildOutcome: makeOutcome({ executionIntent: 'one-off' }),
+		});
+
+		expect(obligation.status).toBe('not_verifiable');
+		expect(obligation.policy).toBe('manual');
+		expect(obligation.executionIntent).toBe('one-off');
+		expect(obligation.blockingReason).toContain('verification is an optional pre-flight');
+		expect(isWorkflowVerificationObligationUnsettled(obligation)).toBe(false);
+	});
+
+	it('stays settled from outcome-only records (the planned scheduler path)', () => {
+		const obligation = deriveWorkflowVerificationObligationFromOutcome(
+			'thread-1',
+			makeOutcome({ executionIntent: 'one-off' }),
+			{ source: 'planned', plannedTaskId: 'task-1' },
+		);
+
+		expect(obligation.status).toBe('not_verifiable');
+		expect(isWorkflowVerificationObligationUnsettled(obligation)).toBe(false);
+	});
+
+	it('surfaces a blocked loop state as blocked (still settled)', () => {
+		const obligation = deriveWorkflowVerificationObligation('thread-1', {
+			state: makeState({ status: 'blocked', phase: 'blocked' }),
+			attempts: [makeAttempt()],
+			lastBuildOutcome: makeOutcome({ executionIntent: 'one-off' }),
+		});
+
+		expect(obligation.status).toBe('blocked');
+		expect(isWorkflowVerificationObligationUnsettled(obligation)).toBe(false);
+	});
+
+	it('lets successful pre-flight verify evidence win as verified, with no blocking reason', () => {
+		const obligation = deriveWorkflowVerificationObligation('thread-1', {
+			state: makeState(),
+			attempts: [makeAttempt()],
+			lastBuildOutcome: makeOutcome({
+				executionIntent: 'one-off',
+				verification: {
+					attempted: true,
+					success: true,
+					executionId: 'exec-1',
+					status: 'success',
+				},
+			}),
+		});
+
+		expect(obligation.status).toBe('verified');
+		expect(obligation.blockingReason).toBeUndefined();
+		expect(isWorkflowVerificationObligationUnsettled(obligation)).toBe(false);
+	});
+
+	it('settles failed pre-flight verify evidence with the concrete failure as blocking reason', () => {
+		const obligation = deriveWorkflowVerificationObligation('thread-1', {
+			state: makeState(),
+			attempts: [makeAttempt()],
+			lastBuildOutcome: makeOutcome({
+				executionIntent: 'one-off',
+				verification: {
+					attempted: true,
+					success: false,
+					executionId: 'exec-1',
+					status: 'error',
+					failureSignature: 'Sheet with name Registrations not found',
+				},
+			}),
+		});
+
+		expect(obligation.status).toBe('not_verifiable');
+		expect(obligation.blockingReason).toContain('Sheet with name Registrations not found');
+		expect(isWorkflowVerificationObligationUnsettled(obligation)).toBe(false);
+	});
+
+	it('leaves reusable and unspecified intents on the normal ready-to-verify path', () => {
+		for (const executionIntent of ['reusable', undefined] as const) {
+			const obligation = deriveWorkflowVerificationObligation('thread-1', {
+				state: makeState(),
+				attempts: [makeAttempt()],
+				lastBuildOutcome: makeOutcome({ executionIntent }),
+			});
+
+			expect(obligation.status).toBe('ready_to_verify');
+		}
 	});
 });

--- a/packages/@n8n/instance-ai/src/workflow-loop/verification-obligation.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/verification-obligation.ts
@@ -27,6 +27,11 @@ export interface DeriveWorkflowVerificationObligationOptions {
 	updatedAt?: string;
 }
 
+/** Blocking-reason text for one-off builds whose verification is optional. */
+const ONE_OFF_VERIFICATION_GUIDANCE =
+	'One-off operation: verification is an optional pre-flight. Completion is a live run ' +
+	'whose actual node output was read back.';
+
 const UNSETTLED_OBLIGATION_STATUSES = new Set<WorkflowVerificationObligationStatus>([
 	'pending_build',
 	'ready_to_verify',
@@ -83,6 +88,16 @@ function deriveStatus(
 	// Without this the switch below falls through to `ready_to_verify` and the
 	// planned orchestrator re-issues verification forever.
 	if (hasFailedEvidence(outcome)) return 'not_verifiable';
+
+	// One-off builds: verification is optional, so the obligation settles
+	// immediately (after the evidence checks above, which still win). This must
+	// stay an explicit settled return — falling through to `ready_to_verify`
+	// would make the planned scheduler re-issue verification follow-ups forever
+	// for one-off builds. A blocked loop state still surfaces as blocked;
+	// 'blocked' is itself settled, so loop-safety holds either way.
+	if (outcome.executionIntent === 'one-off') {
+		return state.status === 'blocked' ? 'blocked' : 'not_verifiable';
+	}
 
 	switch (outcome.verificationReadiness?.status) {
 		case 'already_verified':
@@ -150,6 +165,12 @@ function deriveBlockingReason(
 	if (outcome.setupRequirement?.status === 'required' && hasFailedEvidence(outcome)) {
 		return outcome.setupRequirement.guidance;
 	}
+	// After the evidence checks: a one-off may have run an optional pre-flight
+	// verify, and a concrete failure message outranks the generic guidance. A
+	// verified one-off carries no blockingReason at all — nothing is blocked.
+	if (outcome.executionIntent === 'one-off' && !hasSuccessfulEvidence(outcome)) {
+		return ONE_OFF_VERIFICATION_GUIDANCE;
+	}
 	if (state.status === 'blocked') {
 		return state.lastRemediation?.guidance ?? outcome.blockingReason ?? outcome.failureSignature;
 	}
@@ -187,6 +208,7 @@ export function deriveWorkflowVerificationObligation(
 		readiness: outcome?.verificationReadiness,
 		setupRequirement: outcome?.setupRequirement,
 		evidence: outcome?.verification,
+		executionIntent: outcome?.executionIntent,
 		blockingReason: deriveBlockingReason(record.state, outcome),
 		updatedAt,
 	};

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -332,6 +332,18 @@ export const workflowBuildOutcomeSchema = z.object({
 	/** Whether any node parameters contain unresolved placeholder values. */
 	hasUnresolvedPlaceholders: z.boolean().optional(),
 	/**
+	 * How the user intends to use this workflow. `one-off`: a concrete effect
+	 * wanted once — verification becomes optional and completion is a live run
+	 * with read-back. Absent means `reusable` (the default flow).
+	 *
+	 * Deliberately a NEW OPTIONAL FIELD rather than a new
+	 * `verificationReadiness` status: previously deployed readers strip unknown
+	 * object keys but hard-fail on unknown union variants — and the loop storage
+	 * parses the whole per-thread map as one unit, so a single unparseable
+	 * outcome would wipe every work-item record on rollback.
+	 */
+	executionIntent: z.enum(['one-off', 'reusable']).optional(),
+	/**
 	 * Deterministic post-build routing verdict. The orchestrator should use this
 	 * instead of reasoning over pin-data internals or trigger allow-lists.
 	 */
@@ -387,6 +399,9 @@ export const workflowVerificationObligationSchema = z.object({
 	readiness: workflowVerificationReadinessSchema.optional(),
 	setupRequirement: workflowSetupRequirementSchema.optional(),
 	evidence: workflowVerificationEvidenceSchema.optional(),
+	/** Mirrors the outcome's intent so consumers (e.g. the checklist projector)
+	 *  can tell a by-design one-off settlement from a could-not-verify one. */
+	executionIntent: z.enum(['one-off', 'reusable']).optional(),
 	blockingReason: z.string().optional(),
 	updatedAt: z.string(),
 });

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
@@ -50,4 +50,15 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
    - When wiring N branches to a Merge node, the indices are \`0, 1, ..., N-1\` — never \`1, 2, ..., N\`.
    - Counter-examples to AVOID:
      - WRONG: \`sourceA.to(merge.input(1))\` followed by \`sourceB.to(merge.input(2))\` — this skips input 0 entirely; the first branch is silently dropped.
-     - CORRECT: \`sourceA.to(merge.input(0))\` followed by \`sourceB.to(merge.input(1))\`.`;
+     - CORRECT: \`sourceA.to(merge.input(0))\` followed by \`sourceB.to(merge.input(1))\`.
+
+7. **Inserting a node into an existing connection changes what downstream receives**
+   - A node receives ONLY its immediate predecessor's output. Inserting C between A→B means B now reads C's output — \`$json\` references and auto-mapped ("map automatically") fields in B silently switch from A's data to C's.
+   - Write/create/send nodes (rows appended, sheets/pages created, messages sent) output their **API response** — ids, metadata, \`ok\` flags — NOT the data that flowed into them. Inserting one in-line before another write (e.g. a create-if-missing step before an append) replaces the payload with metadata.
+   - Keep the data path intact instead:
+     - **Branch in parallel**: wire the inserted node as a sibling branch off the data producer, so the original data still flows into the downstream node.
+     - **Reorder upstream**: place the inserted step before the data-producing node (trigger → ensure-target → produce data → write).
+     - **Reference explicitly**: have the downstream node read \`$('Data Node').item.json.field\` instead of \`$json\`.
+   - Counter-example to AVOID:
+     - WRONG: \`code.to(ensureSheet).to(appendRows)\` — appendRows maps the create-sheet response, not the rows from \`code\`.
+     - CORRECT: \`trigger.to(ensureSheet).to(code).to(appendRows)\` — the ensure step runs before the data is produced, and the write still receives the data.`;

--- a/packages/cli/src/modules/instance-ai/__tests__/workflow-verification-obligation-service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/workflow-verification-obligation-service.test.ts
@@ -1,0 +1,86 @@
+import type { PlannedTaskGraph, PlannedTaskRecord, WorkflowBuildOutcome } from '@n8n/instance-ai';
+
+import type { TypeORMAgentMemory } from '../storage/typeorm-agent-memory';
+import { WorkflowVerificationObligationService } from '../workflow-verification-obligation-service';
+
+// Memory with no stored thread: the service falls back to deriving the
+// obligation from the planned task's recorded outcome — the same path the
+// planned scheduler takes on a fresh tick.
+const emptyMemory = {
+	getThread: async () => null,
+	saveThread: async () => undefined,
+} as unknown as TypeORMAgentMemory;
+
+function makeOutcome(overrides: Partial<WorkflowBuildOutcome> = {}): WorkflowBuildOutcome {
+	return {
+		workItemId: 'src/workflows/main.workflow.ts',
+		taskId: 'task-1',
+		workflowId: 'wf-1',
+		submitted: true,
+		triggerType: 'manual_or_testable',
+		triggerNodes: [{ nodeName: 'Start', nodeType: 'n8n-nodes-base.manualTrigger' }],
+		needsUserInput: false,
+		verificationReadiness: { status: 'ready' },
+		setupRequirement: { status: 'not_required' },
+		summary: 'Workflow saved.',
+		...overrides,
+	};
+}
+
+function makeGraph(outcome: WorkflowBuildOutcome): PlannedTaskGraph {
+	const task: PlannedTaskRecord = {
+		id: 'task-1',
+		title: 'Build export workflow',
+		kind: 'build-workflow',
+		spec: 'Build it.',
+		deps: [],
+		status: 'succeeded',
+		outcome: outcome as unknown as Record<string, unknown>,
+	};
+	return { planRunId: 'run-1', status: 'active', tasks: [task] };
+}
+
+describe('WorkflowVerificationObligationService.findPendingPlannedWorkflowVerification', () => {
+	const service = new WorkflowVerificationObligationService(emptyMemory);
+
+	it('returns a pending verification for a ready build outcome', async () => {
+		const verification = await service.findPendingPlannedWorkflowVerification(
+			'thread-1',
+			makeGraph(makeOutcome()),
+		);
+
+		expect(verification?.obligation.status).toBe('ready_to_verify');
+		expect(verification?.task.id).toBe('task-1');
+	});
+
+	// The loop-safety pin for one-off builds: a settled obligation means the
+	// planned scheduler never emits `orchestrate-workflow-verification`, so a
+	// one-off build can never re-arm verification follow-ups (see
+	// .agents/specs/instance-ai-one-off-operations.md §2a).
+	it('skips one-off build outcomes (executionIntent: one-off)', async () => {
+		const verification = await service.findPendingPlannedWorkflowVerification(
+			'thread-1',
+			makeGraph(makeOutcome({ executionIntent: 'one-off' })),
+		);
+
+		expect(verification).toBeUndefined();
+	});
+
+	it('skips outcomes with successful verification evidence', async () => {
+		const verification = await service.findPendingPlannedWorkflowVerification(
+			'thread-1',
+			makeGraph(
+				makeOutcome({
+					verification: {
+						attempted: true,
+						success: true,
+						executionId: 'exec-1',
+						status: 'success',
+					},
+				}),
+			),
+		);
+
+		expect(verification).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/instance-ai/workflow-verification-task-projector.ts
+++ b/packages/cli/src/modules/instance-ai/workflow-verification-task-projector.ts
@@ -31,6 +31,7 @@ const DETAIL = {
 	verifying: 'Verifying workflow',
 	needsSetup: 'Needs setup',
 	couldNotVerify: 'Could not verify automatically',
+	verificationOptional: 'Verification optional - one-off run',
 	noWorkflow: 'No workflow to verify',
 	submitted: 'Submitted',
 	blocked: 'Blocked',
@@ -75,7 +76,13 @@ function obligationDetail(obligation: WorkflowVerificationObligation): string {
 		case 'needs_setup':
 			return DETAIL.needsSetup;
 		case 'not_verifiable':
-			return DETAIL.couldNotVerify;
+			// A one-off build settles as not_verifiable by design — verification is
+			// a choice there, not a failure. But evidence outranks the label: if a
+			// pre-flight verify actually ran and did not fully succeed, surface
+			// that instead of the benign one-off wording.
+			return obligation.executionIntent === 'one-off' && obligation.evidence?.attempted !== true
+				? DETAIL.verificationOptional
+				: DETAIL.couldNotVerify;
 		case 'blocked':
 			return obligation.blockingReason ?? DETAIL.blocked;
 	}


### PR DESCRIPTION
## Summary

Fixes the two compounding failures behind INS-990, where the assistant "repaired" a Google Sheets workflow by inserting a create-sheet node inline between the data-producing node and the append node — silently replacing the data rows with sheet metadata — then reported "22 rows written with correct columns" off a simulated verification that structurally could not catch it.

### 1. Insertion-semantics rules (both builders)

A node receives only its immediate predecessor's output, and write/create/send nodes output their **API response**, not the data that flowed in. Inserting such a node into an existing connection therefore replaces the payload downstream. This rule is now stated where it can't be missed:

- `skills/workflow-builder/SKILL.md` — new always-loaded workflow rule 7 + a repair-strategy echo (check what the downstream node reads before wiring an ensure/side-effect step inline; branch in parallel, reorder upstream of the data producer, or reference `$('Data Node')` explicitly).
- `workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts` — same rule in the shared `WORKFLOW_RULES`, so the `.ee` code-builder and the MCP server get it too.
- `knowledge-base/reference/workflow-builder-guardrails.md` — "Data After Side-Effect Nodes" reframed to name the insertion case explicitly.
- `skills/post-build-flow/SKILL.md` "Claiming success" — extended to external writes: no quantitative claims ("N rows written") that weren't read back from the effect node's actual output.

### 2. One-off operations flow

A one-off operation (export/copy/migrate/backfill data **once** — the workflow is the vehicle, not the deliverable) no longer gets pushed through simulated verification as its completion criterion:

- New `executionIntent: 'one-off' | 'reusable'` input on `build-workflow`. **Deliberately a plain optional outcome field, not a new `verificationReadiness` status**: readiness is persisted, old readers hard-fail on unknown union variants, and the loop storage parses the whole per-thread map as one unit — a new variant would have wiped all work-item records on rollback. An optional field is stripped, not rejected, by old readers.
- The verification obligation settles immediately for one-off builds (`not_verifiable`, or `blocked` when the loop state is blocked — both settled), so neither the background-task path nor the planned scheduler ever re-issues verification follow-ups. Loop-safety of the obligation state machine is audited path-by-path and pinned by unit tests, including the historical "re-issues verification forever" death-loop path.
- Intent is **sticky per work item**: a repair rebuild that omits the flag inherits it from the prior stored outcome, so a mid-repair rebuild can't silently flip back to the verify-first flow.
- New `skills/one-off-operations/SKILL.md` drives the flow: build (manual trigger, always) → setup → live run with the existing HITL approval → **read back actual node output before reporting** → offer keep-or-delete. Recognition is inferred from the task's shape (bounded data in hand, imperative ask, no trigger/schedule/reuse vocabulary) — users rarely say "one-off". Simulated verification stays available as an optional, clearly-labeled pre-flight.
- Direct one-off builds inline the one-off skill body via the `postBuildFlow` handoff (discriminated union on `skillId`); a triggerless one-off falls back to the standard flow since its completion criterion (a live run) can't start.
- UI checklist: a one-off settlement renders "Verification optional - one-off run" — unless a pre-flight verify actually ran and didn't fully succeed, in which case the failure outranks the label.

### Evals & tests

- Eval credential seeder gains a `googleSheetsOAuth2Api` template. Three local JSON eval cases (INS-990 seeded regression, implicit one-off happy path with read-back, labeled pre-flight variant) exist locally and will be pushed to the lang-tracer suite after calibration (not part of this PR).
- Unit tests pin the loop-safety invariants: one-off obligations are never unsettled (direct, outcome-only/planned-scheduler, and blocked-state paths), evidence precedence (verified wins, failures settle with the concrete reason, verified one-offs carry no `blockingReason`), sticky intent, triggerless fallback, and the planned scheduler skipping one-off outcomes.

## How to test

1. In an Instance AI conversation, ask for a one-off export, e.g. *"I have 5 attendees I need added to my Google Sheet 'Tracker' with columns name and email: …"* (no "just once" phrasing needed).
2. The assistant should build with a manual trigger, route credential setup, then offer/perform a **live run** (with the run-approval card) instead of requiring a simulated verification pass — and no `<workflow-verification-follow-up>` turns should fire afterwards.
3. After the run, the summary's numbers should come from actual execution output (`executions(action="get-node-output")` visible in the trace), followed by a keep-or-delete offer.
4. Say *"check it works first without touching my sheet"* — the pre-flight verification must be labeled simulated and never reported as final "verified/working".
5. For the insertion-semantics fix: seed a workflow `Code (rows) → Google Sheets append` targeting a missing tab, report *"Sheet with name X not found"* — the repair must keep the Code node's rows flowing into the append node (ensure-tab upstream of the data producer, parallel branch, or explicit `$('…')` references), not chain the append off the create-sheet output.

Unit tests: `pnpm vitest run src/workflow-loop src/tools/workflows src/skills` in `packages/@n8n/instance-ai`, and `pnpm vitest run src/modules/instance-ai` in `packages/cli`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-990

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

