### PR TITLE
feat(ai-builder): Let the eval harness mint Simplified Custom Auth credentials from setup-card recipes (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
@@ -24,8 +24,9 @@ import {
 // Spies on the real seeder so existing credential-creation tests (which assert
 // against `client.createCredential`) keep working unchanged, while the new
 // setupHint tests below can assert on what reaches `createOneCredential`
-// itself — the boundary this task's plumbing stops at (minting the credential
-// from the hint is a later task).
+// itself. The mock wraps the real implementation, so tests execute the full
+// minting path (including the seeder's throw when `httpTemplatedCustomAuth`
+// is reached without a valid hint).
 vi.mock('../credentials/seeder', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('../credentials/seeder')>();
 	return { ...actual, createOneCredential: vi.fn(actual.createOneCredential) };

--- a/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
@@ -6,7 +6,10 @@
 // deterministic shortcuts, repeat detection, and budget enforcement.
 // ---------------------------------------------------------------------------
 
+import type { InstanceAiCredentialSetupHint } from '@n8n/api-types';
+
 import type { N8nClient } from '../clients/n8n-client';
+import { createOneCredential } from '../credentials/seeder';
 import type { EvalLogger } from '../harness/logger';
 import type { CapturedEvent } from '../types';
 import { UserProxyLlm } from '../utils/user-proxy';
@@ -17,6 +20,16 @@ import {
 	type Decision,
 	type ProxyDecisionMode,
 } from '../utils/user-proxy/tools';
+
+// Spies on the real seeder so existing credential-creation tests (which assert
+// against `client.createCredential`) keep working unchanged, while the new
+// setupHint tests below can assert on what reaches `createOneCredential`
+// itself — the boundary this task's plumbing stops at (minting the credential
+// from the hint is a later task).
+vi.mock('../credentials/seeder', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../credentials/seeder')>();
+	return { ...actual, createOneCredential: vi.fn(actual.createOneCredential) };
+});
 
 /** Returns a fresh fake each call — tests assert on individual `vi.fn()` call
  *  counts, so a single shared instance would leak state across tests. */
@@ -1138,6 +1151,88 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 			expect(response.nodeCredentials).toBeUndefined();
 		}
 		expect(logger.warn).toHaveBeenCalled();
+	});
+
+	it("workflows(action='setup'): threads a valid setupHint through to credential creation for httpTemplatedCustomAuth", async () => {
+		const setupHint: InstanceAiCredentialSetupHint = {
+			template: { headers: { Authorization: '{{apiKey}}' } },
+			placeholders: [{ name: 'apiKey', title: 'API Key', optional: false }],
+		};
+		const agent = new FakeAgent();
+		agent.enqueue({
+			action: 'apply_setup_wizard',
+			nodeParametersJson: '{}',
+			nodeCredentialsJson: JSON.stringify({ 'Call API': { httpTemplatedCustomAuth: 'new' } }),
+		});
+		const { client } = fakeCredentialClient('cred-fresh');
+		const proxy = new UserProxyLlm({
+			conversation: [
+				{ role: 'user', text: 'Call the API every morning.' },
+				{ role: 'user', text: '[Set up the API credential now.]' },
+			],
+			agent,
+			credentialCreation: { client, threadId: 'thread-1', allowlistedCredentialIds: [] },
+		});
+
+		await proxy.respondToConfirmation(
+			setupWizardEvent('req-sw-templated-auth', [
+				{
+					nodeId: 'n1',
+					nodeName: 'Call API',
+					credentialType: 'httpTemplatedCustomAuth',
+					existingCredentials: [],
+					setupHint,
+				},
+			]),
+		);
+
+		expect(createOneCredential).toHaveBeenCalledWith(
+			client,
+			'httpTemplatedCustomAuth',
+			undefined,
+			expect.anything(),
+			expect.objectContaining({ setupHint }),
+		);
+	});
+
+	it("workflows(action='setup'): drops a malformed setupHint instead of forwarding a garbage partial object", async () => {
+		const agent = new FakeAgent();
+		agent.enqueue({
+			action: 'apply_setup_wizard',
+			nodeParametersJson: '{}',
+			nodeCredentialsJson: JSON.stringify({ 'Call API': { httpTemplatedCustomAuth: 'new' } }),
+		});
+		const { client } = fakeCredentialClient('cred-fresh');
+		const proxy = new UserProxyLlm({
+			conversation: [
+				{ role: 'user', text: 'Call the API every morning.' },
+				{ role: 'user', text: '[Set up the API credential now.]' },
+			],
+			agent,
+			credentialCreation: { client, threadId: 'thread-1', allowlistedCredentialIds: [] },
+		});
+
+		const response = await proxy.respondToConfirmation(
+			setupWizardEvent('req-sw-templated-auth-malformed', [
+				{
+					nodeId: 'n1',
+					nodeName: 'Call API',
+					credentialType: 'httpTemplatedCustomAuth',
+					existingCredentials: [],
+					// Missing the required `placeholders` field.
+					setupHint: { template: { headers: { Authorization: '{{apiKey}}' } } },
+				},
+			]),
+		);
+
+		expect(response.kind).toBeDefined();
+		expect(createOneCredential).toHaveBeenCalledWith(
+			client,
+			'httpTemplatedCustomAuth',
+			undefined,
+			expect.anything(),
+			expect.objectContaining({ setupHint: undefined }),
+		);
 	});
 
 	it("credentials(action='setup'): handles credential events deterministically without invoking the agent", async () => {

--- a/packages/@n8n/instance-ai/evaluations/credentials/__tests__/seeder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/__tests__/seeder.test.ts
@@ -1,0 +1,133 @@
+import type { InstanceAiCredentialSetupHint } from '@n8n/api-types';
+import { jsonParse } from 'n8n-workflow';
+import { vi } from 'vitest';
+
+import type { N8nClient } from '../../clients/n8n-client';
+import type { EvalLogger } from '../../harness/logger';
+import { createOneCredential } from '../seeder';
+
+const makeClient = (createCredential: N8nClient['createCredential']) =>
+	({ createCredential }) as unknown as N8nClient;
+
+const makeLogger = (): EvalLogger => ({
+	isVerbose: false,
+	info: vi.fn(),
+	verbose: vi.fn(),
+	success: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+});
+
+const baseHint: InstanceAiCredentialSetupHint = {
+	template: { headers: { Authorization: 'Bearer {{api_key}}' } },
+	placeholders: [
+		{ name: 'api_key', title: 'API key', type: 'password' },
+		{ name: 'workspace_id', title: 'Workspace ID', type: 'plain', optional: true },
+	],
+	serviceHost: 'api.example.com',
+	docsUrl: 'https://example.com/docs',
+	testUrl: 'https://api.example.com/me',
+	acceptedStatusCodes: [401],
+};
+
+describe('createOneCredential — httpTemplatedCustomAuth', () => {
+	it('builds a credential from the setup hint, persisting object/array fields as JSON strings', async () => {
+		const createCredential = vi.fn(
+			async (_name: string, _type: string, _data: Record<string, unknown>) =>
+				await Promise.resolve({ id: 'cred-1' }),
+		);
+		const client = makeClient(createCredential);
+
+		const result = await createOneCredential(
+			client,
+			'httpTemplatedCustomAuth',
+			'My Custom Auth',
+			new Map(),
+			{ setupHint: baseHint },
+		);
+
+		expect(result).toEqual({
+			id: 'cred-1',
+			name: 'My Custom Auth',
+			type: 'httpTemplatedCustomAuth',
+		});
+		expect(createCredential).toHaveBeenCalledTimes(1);
+		const [, type, data] = createCredential.mock.calls[0];
+		expect(type).toBe('httpTemplatedCustomAuth');
+
+		expect(typeof data.template).toBe('string');
+		expect(jsonParse(data.template as string)).toEqual(baseHint.template);
+
+		expect(typeof data.placeholderDefs).toBe('string');
+		expect(jsonParse(data.placeholderDefs as string)).toEqual(baseHint.placeholders);
+
+		expect(typeof data.placeholderValues).toBe('string');
+		const parsedValues = jsonParse<Record<string, string>>(data.placeholderValues as string);
+		for (const placeholder of baseHint.placeholders) {
+			expect(parsedValues).toHaveProperty(placeholder.name);
+			expect(parsedValues[placeholder.name]).toBeTruthy();
+		}
+		// The optional placeholder must still be filled, not omitted.
+		expect(Object.keys(parsedValues)).toHaveLength(baseHint.placeholders.length);
+
+		expect(data.serviceHost).toBe(baseHint.serviceHost);
+
+		expect(typeof data.acceptedStatusCodes).toBe('string');
+		expect(jsonParse(data.acceptedStatusCodes as string)).toEqual(baseHint.acceptedStatusCodes);
+	});
+
+	it('warns but still creates the credential when serviceHost is missing', async () => {
+		const createCredential = vi.fn(async () => await Promise.resolve({ id: 'cred-2' }));
+		const client = makeClient(createCredential);
+		const logger = makeLogger();
+		const hintWithoutHost: InstanceAiCredentialSetupHint = {
+			...baseHint,
+			serviceHost: undefined,
+		};
+
+		const result = await createOneCredential(
+			client,
+			'httpTemplatedCustomAuth',
+			'No Host Auth',
+			new Map(),
+			{ logger, setupHint: hintWithoutHost },
+		);
+
+		expect(result.id).toBe('cred-2');
+		expect(createCredential).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(logger.warn).mock.calls[0][0]).toMatch(/serviceHost/i);
+	});
+
+	it('throws an actionable error when no setupHint is provided', async () => {
+		const createCredential = vi.fn(async () => await Promise.resolve({ id: 'cred-3' }));
+		const client = makeClient(createCredential);
+
+		await expect(
+			createOneCredential(client, 'httpTemplatedCustomAuth', 'No Hint Auth', new Map(), {}),
+		).rejects.toThrow(/setupHint/i);
+		await expect(
+			createOneCredential(client, 'httpTemplatedCustomAuth', 'No Hint Auth', new Map(), {}),
+		).rejects.toThrow(/httpTemplatedCustomAuth/);
+		expect(createCredential).not.toHaveBeenCalled();
+	});
+});
+
+describe('createOneCredential — static template path (regression)', () => {
+	it('creates a slackApi credential with the default name and de-dupes with a #2 suffix', async () => {
+		const createCredential = vi.fn(
+			async (name: string, _type: string, _data: Record<string, unknown>) =>
+				await Promise.resolve({ id: `cred-${name}` }),
+		);
+		const client = makeClient(createCredential);
+		const usedNames = new Map<string, number>();
+
+		const first = await createOneCredential(client, 'slackApi', undefined, usedNames);
+		const second = await createOneCredential(client, 'slackApi', undefined, usedNames);
+
+		expect(first.name).toBe('[eval] Slack');
+		expect(second.name).toBe('[eval] Slack #2');
+		expect(createCredential).toHaveBeenCalledTimes(2);
+		expect(createCredential.mock.calls[0][1]).toBe('slackApi');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
@@ -133,10 +133,12 @@ export async function createOneCredential(
 	credentialType: string,
 	name: string | undefined,
 	usedNames: Map<string, number>,
-	// `setupHint` is threaded through but not yet consumed here — Simplified
-	// Custom Auth minting (using the template/placeholders recipe) lands separately.
 	options?: { logger?: EvalLogger; setupHint?: InstanceAiCredentialSetupHint },
 ): Promise<CreatedCredential> {
+	if (credentialType === 'httpTemplatedCustomAuth') {
+		return await createTemplatedCustomAuthCredential(client, name, usedNames, options);
+	}
+
 	const template = CREDENTIAL_TEMPLATES[credentialType];
 	if (!template) {
 		throw new Error(
@@ -159,6 +161,61 @@ export async function createOneCredential(
 		template.buildData(token),
 	);
 	return { id, name: resolvedName, type: credentialType };
+}
+
+/**
+ * Mint an `httpTemplatedCustomAuth` ("Simplified Custom Auth") credential from
+ * a setup card's recipe. Unlike the 14 types above, this type has no fixed
+ * field shape — the AI builder researches it at runtime per service — so there
+ * is no `CREDENTIAL_TEMPLATES` entry to look up; the recipe carried on
+ * `options.setupHint` is the only source of the data to persist.
+ */
+async function createTemplatedCustomAuthCredential(
+	client: N8nClient,
+	name: string | undefined,
+	usedNames: Map<string, number>,
+	options?: { logger?: EvalLogger; setupHint?: InstanceAiCredentialSetupHint },
+): Promise<CreatedCredential> {
+	const hint = options?.setupHint;
+	if (!hint) {
+		throw new Error(
+			'No setupHint for credential type "httpTemplatedCustomAuth" — this type has no static ' +
+				'template in evaluations/credentials/seeder.ts (its field shape only exists once a ' +
+				'real setup card proposes a recipe mid-conversation), so a case cannot declare it as ' +
+				'a static credential at load time.',
+		);
+	}
+
+	const base = name ?? hint.suggestedName ?? '[eval] Simplified Custom Auth';
+	const count = (usedNames.get(base) ?? 0) + 1;
+	usedNames.set(base, count);
+	const resolvedName = count > 1 ? `${base} #${count}` : base;
+
+	if (!hint.serviceHost) {
+		options?.logger?.warn(
+			`httpTemplatedCustomAuth credential "${resolvedName}" created with no serviceHost — ` +
+				'it will not be offered to any node',
+		);
+	}
+
+	// `template`, `placeholderDefs`, `placeholderValues` and `acceptedStatusCodes`
+	// all persist as JSON strings on this credential type, even though the recipe
+	// types some of them as objects/arrays — see HttpTemplatedCustomAuth.credentials.ts.
+	const placeholderValues = Object.fromEntries(
+		hint.placeholders.map((placeholder) => [placeholder.name, PLACEHOLDER_TOKEN]),
+	);
+
+	options?.logger?.verbose(`  Creating credential ${resolvedName} (httpTemplatedCustomAuth)`);
+	const { id } = await client.createCredential(resolvedName, 'httpTemplatedCustomAuth', {
+		template: JSON.stringify(hint.template),
+		placeholderDefs: JSON.stringify(hint.placeholders),
+		placeholderValues: JSON.stringify(placeholderValues),
+		serviceHost: hint.serviceHost ?? '',
+		docsUrl: hint.docsUrl ?? '',
+		testUrl: hint.testUrl ?? '',
+		acceptedStatusCodes: hint.acceptedStatusCodes ? JSON.stringify(hint.acceptedStatusCodes) : '',
+	});
+	return { id, name: resolvedName, type: 'httpTemplatedCustomAuth' };
 }
 
 /**

--- a/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
@@ -10,6 +10,8 @@
 // POST /rest/credentials takes raw values -- n8n encrypts them server-side.
 // ---------------------------------------------------------------------------
 
+import type { InstanceAiCredentialSetupHint } from '@n8n/api-types';
+
 import type { N8nClient } from '../clients/n8n-client';
 import type { EvalLogger } from '../harness/logger';
 import type { TestCaseCredential } from '../types';
@@ -131,7 +133,9 @@ export async function createOneCredential(
 	credentialType: string,
 	name: string | undefined,
 	usedNames: Map<string, number>,
-	options?: { logger?: EvalLogger },
+	// `setupHint` is threaded through but not yet consumed here — Simplified
+	// Custom Auth minting (using the template/placeholders recipe) lands separately.
+	options?: { logger?: EvalLogger; setupHint?: InstanceAiCredentialSetupHint },
 ): Promise<CreatedCredential> {
 	const template = CREDENTIAL_TEMPLATES[credentialType];
 	if (!template) {

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
@@ -1,5 +1,6 @@
 // LLM-backed user simulator for multi-turn workflow evals.
 
+import { credentialSetupHintSchema } from '@n8n/api-types';
 import type { InstanceAiConfirmRequest } from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
 
@@ -259,7 +260,7 @@ export class UserProxyLlm {
 			credentialType,
 			undefined,
 			this.createdCredentialNameCounts,
-			{ logger: this.logger },
+			{ logger: this.logger, setupHint: options?.setupHint },
 		);
 		createdCredentialIds?.add(created.id);
 		this.allowlistedCredentialIds = [...this.allowlistedCredentialIds, created.id];
@@ -526,9 +527,17 @@ function extractSetupWizardParseContext(event: CapturedEvent): SetupWizardParseC
 
 		const credentialType = getString(item, 'credentialType');
 		if (credentialType) {
+			// Only httpTemplatedCustomAuth carries a setupHint; every other type's
+			// wire payload simply omits the field, so a failed parse is the norm,
+			// not an error — drop it silently rather than log/throw.
+			const setupHint = credentialSetupHintSchema.safeParse(item.setupHint);
 			existing.credentialRequests = [
 				...existing.credentialRequests,
-				{ credentialType, existingCredentials: extractExistingCredentials(item) },
+				{
+					credentialType,
+					existingCredentials: extractExistingCredentials(item),
+					...(setupHint.success ? { setupHint: setupHint.data } : {}),
+				},
 			];
 		}
 

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
@@ -1,7 +1,7 @@
 // Decision schema (structured-output target) + encoders to InstanceAiConfirmRequest.
 
 import { domainAccessActionSchema, instanceGatewayResourceDecisionSchema } from '@n8n/api-types';
-import type { InstanceAiConfirmRequest } from '@n8n/api-types';
+import type { InstanceAiConfirmRequest, InstanceAiCredentialSetupHint } from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
 import { z } from 'zod';
 
@@ -207,6 +207,9 @@ export interface SetupWizardParseContext {
 		credentialRequests: Array<{
 			credentialType: string;
 			existingCredentials: Array<{ id: string; name: string }>;
+			/** Simplified Custom Auth's recipe (template + placeholders) for minting
+			 *  the credential — only present for `httpTemplatedCustomAuth` requests. */
+			setupHint?: InstanceAiCredentialSetupHint;
 		}>;
 	}>;
 }
@@ -257,7 +260,7 @@ export const USER_TURN_TOOL_DESCRIPTIONS = `Available actions — it is the user
  *  case — see `UserProxyConfig.credentialCreation` in `user-proxy/index.ts`. */
 export type CreateCredentialFn = (
 	credentialType: string,
-	options?: { works?: boolean },
+	options?: { works?: boolean; setupHint?: InstanceAiCredentialSetupHint },
 ) => Promise<{ id: string; name: string }>;
 
 /**
@@ -271,7 +274,7 @@ async function tryCreateCredential(
 	credentialType: string,
 	actionLabel: string,
 	onFailure?: (raw: string, error: unknown) => void,
-	options?: { works?: boolean },
+	options?: { works?: boolean; setupHint?: InstanceAiCredentialSetupHint },
 ): Promise<{ id: string; name: string } | undefined> {
 	if (!createCredential) {
 		onFailure?.(
@@ -540,7 +543,10 @@ async function parseNodeCredentialsJson(
 					credentialType,
 					'apply_setup_wizard',
 					onFailure,
-					{ works: workingCredentialTypes?.has(credentialType) === true },
+					{
+						works: workingCredentialTypes?.has(credentialType) === true,
+						setupHint: request.setupHint,
+					},
 				);
 				if (created) (result[node.nodeName] ??= {})[credentialType] = created.id;
 				continue;


### PR DESCRIPTION
## Summary

The Instance-AI eval harness's simulated user ("user-proxy") can already engage a credential-setup card and mint a credential for known, static-shape credential types (`slackApi`, `notionApi`, etc. — 14 in total). It could not mint **Simplified Custom Auth** (`httpTemplatedCustomAuth`), the generic credential the builder emits for any third-party service with no dedicated n8n integration. That credential's shape isn't fixed — it's a recipe (a request template with `{{marker}}` placeholders, researched by the builder at runtime) attached to the setup card as `setupHint` — so a static per-type template can't cover it, and the harness dropped the field entirely.

This PR:
- Threads `setupHint` from the raw setup-wizard event, through the harness's parse context and `CreateCredentialFn` options, down to the credential seeder. Pure plumbing — no behavior change for any other credential type, no change to the proxy's LLM-facing prompt.
- Adds a recipe-driven branch to the seeder's `createOneCredential` for `httpTemplatedCustomAuth`: builds the persisted credential from the recipe instead of a static template lookup, handling two correctness-critical details — `template`/`placeholderDefs`/`placeholderValues`/`acceptedStatusCodes` must persist as JSON strings (not objects) to match what the node reads at execution time, and `serviceHost` must be stamped through or the credential is silently never offered to any node.
- Leaves the existing 14-type static-template path completely untouched.

No product/runtime code changes — everything here is under `packages/@n8n/instance-ai/evaluations/`.

Separately (not part of this diff), a new eval case (`manual-credential-setup-templated-custom-auth`) was authored, calibrated against a live local instance, and pushed to the LangTracer `baseline` suite as case #586 — it drives the manual-setup path end-to-end and passed 6/6 (1 execution scenario + 5 expectations), directly confirming the built workflow's HTTP Request node correctly authenticates via `genericAuthType: httpTemplatedCustomAuth` with a real created credential.

## How to test

This is eval-harness-only code with no UI/API surface to click through. From `packages/@n8n/instance-ai`:

```bash
pnpm test evaluations
pnpm typecheck
pnpm lint
```

To exercise the new capability live against a running Instance-AI-enabled instance:

```bash
pnpm eval:instance-ai --base-url http://localhost:5678 --filter manual-credential-setup-templated-custom-auth --source langtracer --suite baseline --keep-workflows
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-384

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

