### PR TITLE
feat(editor): Track AI credit balance clicks (no-changelog)

### DIFF
--- a/packages/@n8n/telemetry/src/events/instance-ai.ts
+++ b/packages/@n8n/telemetry/src/events/instance-ai.ts
@@ -3,6 +3,12 @@ import { z } from 'zod/v4';
 import { defineTelemetryEvents } from '../define';
 
 export const INSTANCE_AI_TELEMETRY = defineTelemetryEvents({
+	USER_CLICKED_AI_CREDIT_BALANCE: {
+		name: 'User clicked AI credit balance',
+		description:
+			'The user clicked the AI Assistant credit balance button to open or close the balance dropdown.',
+		properties: z.object({}),
+	},
 	BUILDER_SPECCED_TEMPLATED_CRED: {
 		name: 'Builder specced templated cred',
 		description:

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditsSettingsDropdown.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditsSettingsDropdown.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import CreditsSettingsDropdown from './CreditsSettingsDropdown.vue';
+
+const { telemetryTrack } = vi.hoisted(() => ({ telemetryTrack: vi.fn() }));
+
+vi.mock('@n8n/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: telemetryTrack }),
+}));
 
 vi.mock('@n8n/i18n', () => {
 	const baseText = (key: string, options?: { interpolate?: Record<string, string> }) => {
@@ -28,6 +35,29 @@ function mountOpen(props: {
 }
 
 describe('CreditsSettingsDropdown', () => {
+	beforeEach(() => {
+		telemetryTrack.mockClear();
+	});
+
+	it('tracks every credit balance button click', async () => {
+		const wrapper = mount(CreditsSettingsDropdown, {
+			props: {
+				creditsRemaining: 50,
+				creditsQuota: 100,
+				isLowCredits: false,
+			},
+		});
+		const button = wrapper.get('[data-test-id="credits-dropdown-button"]');
+
+		await button.trigger('click');
+		await button.trigger('click');
+
+		expect(telemetryTrack.mock.calls).toEqual([
+			[TELEMETRY_EVENT.INSTANCE_AI.USER_CLICKED_AI_CREDIT_BALANCE, {}],
+			[TELEMETRY_EVENT.INSTANCE_AI.USER_CLICKED_AI_CREDIT_BALANCE, {}],
+		]);
+	});
+
 	it('rounds creditsRemaining to two decimal places', async () => {
 		const wrapper = mountOpen({
 			creditsRemaining: 97.357,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditsSettingsDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditsSettingsDropdown.vue
@@ -1,7 +1,9 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue';
 import { onClickOutside } from '@vueuse/core';
+import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useI18n } from '@n8n/i18n';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { N8nButton, N8nIcon, N8nTooltip } from '@n8n/design-system';
 import type { ButtonSize } from '@n8n/design-system';
 import { round2 } from './creditFormatting';
@@ -25,6 +27,7 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
+const telemetry = useTelemetry();
 const isOpen = ref(false);
 const dropdownRef = ref<HTMLElement>();
 
@@ -90,6 +93,7 @@ const tooltipContent = computed(() => {
 });
 
 function toggleDropdown() {
+	telemetry.track(TELEMETRY_EVENT.INSTANCE_AI.USER_CLICKED_AI_CREDIT_BALANCE, {});
 	isOpen.value = !isOpen.value;
 }
 


### PR DESCRIPTION
## Summary

Track every click on the AI Assistant credit balance button with a registered telemetry event.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

[GROP-120](https://linear.app/n8n/issue/GROP-120/add-telemetry-for-checking-the-ai-credit-balance)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

