### PR TITLE
fix(editor): Restore the connection test for Kafka and Odoo credentials

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1259,7 +1259,7 @@ function createNodeAdapterServiceForTests(
 	nodes: Array<Record<string, unknown>>,
 	options?: {
 		nodeCatalogService?: Mocked<NodeCatalogService>;
-		loadNodesAndCredentials?: { addPostProcessor?: Mock };
+		loadNodesAndCredentials?: Record<string, unknown>;
 	},
 ) {
 	const mockUser = { id: 'user-1', role: { slug: 'global:member' } } as unknown as User;
@@ -1335,7 +1335,14 @@ function createNodeAdapterServiceForTests(
 		expiresAt: Date.now() + 60_000,
 	};
 
-	return { service, nodeService: service.createContext(mockUser).nodeService, nodeCatalogService };
+	const context = service.createContext(mockUser);
+
+	return {
+		service,
+		nodeService: context.nodeService,
+		credentialService: context.credentialService,
+		nodeCatalogService,
+	};
 }
 
 function createNodeAdapterForTests(
@@ -4206,5 +4213,51 @@ describe('createContext — run model wiring', () => {
 		const service = createAdapterWithGatewayMock(vi.fn());
 
 		expect(service.createContext(mockUser).modelId).toBeUndefined();
+	});
+});
+
+describe('createCredentialAdapter', () => {
+	describe('isTestable', () => {
+		// A versioned node whose `testedBy` sits only on the versions named in `testedByOn`.
+		const loaderWithTestedByOn = (testedByOn: number[]) => {
+			const descriptionFor = (version: number) => ({
+				description: {
+					credentials: [
+						{
+							name: 'kafka',
+							...(testedByOn.includes(version) ? { testedBy: 'kafkaConnectionTest' } : {}),
+						},
+					],
+				},
+			});
+
+			return {
+				// No class-level `test`, so resolution falls through to the nodes.
+				getCredential: () => ({ type: { name: 'kafka' } }),
+				knownCredentials: { kafka: { supportedNodes: ['kafka'] } },
+				getNode: () => ({
+					type: { nodeVersions: { 1: descriptionFor(1), 2: descriptionFor(2) } },
+				}),
+			};
+		};
+
+		it('finds a test declared only on an older node version', async () => {
+			// Regression guard: reading a single version reported Kafka as untestable once v2
+			// registered without `testedBy`, which silently disabled its connection test.
+			const { credentialService } = createNodeAdapterServiceForTests([], {
+				loadNodesAndCredentials: loaderWithTestedByOn([1]),
+			});
+
+			expect(credentialService.isTestable).toBeDefined();
+			await expect(credentialService.isTestable!('kafka')).resolves.toBe(true);
+		});
+
+		it('is false when no registered version declares a test', async () => {
+			const { credentialService } = createNodeAdapterServiceForTests([], {
+				loadNodesAndCredentials: loaderWithTestedByOn([]),
+			});
+
+			await expect(credentialService.isTestable!('kafka')).resolves.toBe(false);
+		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1680,13 +1680,18 @@ export class InstanceAiAdapterService {
 						try {
 							const loaded = loadNodesAndCredentials.getNode(nodeName);
 							const nodeInstance = loaded.type;
-							const nodeDesc =
+							// Every version has to be checked, not just one: `testedBy` is often declared
+							// only on an older version, and the credential test is resolved across all
+							// versions too. Reading a single version hides tests that do exist.
+							const nodeDescriptions =
 								'nodeVersions' in nodeInstance
-									? Object.values(nodeInstance.nodeVersions).pop()?.description
-									: nodeInstance.description;
-							const hasTestedBy = nodeDesc?.credentials?.some(
-								(cred: { name: string; testedBy?: unknown }) =>
-									cred.name === credentialType && cred.testedBy,
+									? Object.values(nodeInstance.nodeVersions).map((version) => version.description)
+									: [nodeInstance.description];
+							const hasTestedBy = nodeDescriptions.some((nodeDesc) =>
+								nodeDesc?.credentials?.some(
+									(cred: { name: string; testedBy?: unknown }) =>
+										cred.name === credentialType && cred.testedBy,
+								),
 							);
 							if (hasTestedBy) return true;
 						} catch {

--- a/packages/frontend/editor-ui/src/features/credentials/__tests__/credentials.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/__tests__/credentials.store.test.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia';
 import { mock } from 'vitest-mock-extended';
+import type { ICredentialType, INodeTypeDescription } from 'n8n-workflow';
 import type { ICredentialsResponse } from '../credentials.types';
 import * as credentialsApi from '../credentials.api';
 import { useCredentialsStore } from '../credentials.store';
@@ -17,10 +18,15 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore,
 }));
 
-vi.mock('@/app/stores/nodeTypes.store', () => ({
-	useNodeTypesStore: vi.fn(() => ({
+const { mockNodeTypesStore } = vi.hoisted(() => ({
+	mockNodeTypesStore: {
 		getNodeType: vi.fn(),
-	})),
+		getNodeVersions: vi.fn(() => [] as number[]),
+	},
+}));
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: vi.fn(() => mockNodeTypesStore),
 }));
 
 vi.mock('@n8n/stores/settings.store', () => ({
@@ -38,6 +44,73 @@ describe('credentials.store', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		setActivePinia(createPinia());
+	});
+
+	describe('isCredentialTypeTestable', () => {
+		/**
+		 * Registers one credential type backed by a versioned node, with `testedBy` on
+		 * whichever versions `testedByOn` names.
+		 */
+		// Plain literals rather than `mock<T>` on purpose: an auto-mocked `test` property
+		// is a truthy proxy, which would short-circuit the getter in every case.
+		const credentialType = (overrides: Partial<ICredentialType>): ICredentialType => ({
+			name: 'kafka',
+			displayName: 'Kafka',
+			properties: [],
+			...overrides,
+		});
+
+		const setupVersionedNode = (versions: number[], testedByOn: number[]) => {
+			const store = useCredentialsStore();
+			store.setCredentialTypes([credentialType({ supportedNodes: ['kafka'] })]);
+
+			mockNodeTypesStore.getNodeVersions.mockReturnValue(versions);
+			mockNodeTypesStore.getNodeType.mockImplementation(
+				(_name: string, version?: number) =>
+					({
+						credentials: [
+							{
+								name: 'kafka',
+								...(version !== undefined && testedByOn.includes(version)
+									? { testedBy: 'kafkaConnectionTest' }
+									: {}),
+							},
+						],
+					}) as INodeTypeDescription,
+			);
+
+			return store;
+		};
+
+		it('finds a test declared only on an older version, not just the newest', () => {
+			// Regression guard: reading a single version hid Kafka's v1 test once v2 registered
+			// without `testedBy`, silently disabling the on-save connection test.
+			const store = setupVersionedNode([1, 2], [1]);
+
+			expect(store.isCredentialTypeTestable('kafka')).toBe(true);
+		});
+
+		it('is false when no registered version declares a test', () => {
+			const store = setupVersionedNode([1, 2], []);
+
+			expect(store.isCredentialTypeTestable('kafka')).toBe(false);
+		});
+
+		it('is true when the credential type defines its own test, without consulting nodes', () => {
+			const store = useCredentialsStore();
+			store.setCredentialTypes([
+				credentialType({ name: 'slackApi', test: { request: { url: '/test' } } }),
+			]);
+
+			expect(store.isCredentialTypeTestable('slackApi')).toBe(true);
+			expect(mockNodeTypesStore.getNodeVersions).not.toHaveBeenCalled();
+		});
+
+		it('is false for an unknown credential type', () => {
+			const store = useCredentialsStore();
+
+			expect(store.isCredentialTypeTestable('nopeApi')).toBe(false);
+		});
 	});
 
 	describe('testCredential', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -300,6 +300,34 @@ describe('useCredentialForm', () => {
 		});
 	});
 
+	describe('isCredentialTestable', () => {
+		// The store getter checks every registered node version; the composable must defer to
+		// it rather than deciding for itself, or a test declared on an older version stays
+		// hidden and the credential silently saves without being tested.
+		const stubStoreTestable = (testable: boolean) => {
+			Object.defineProperty(credentialsStore, 'isCredentialTypeTestable', {
+				configurable: true,
+				get: () => () => testable,
+			});
+		};
+
+		it('is testable when the store finds a test for the type', async () => {
+			stubStoreTestable(true);
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpBasicAuth' });
+			await form.initialize();
+
+			expect(form.isCredentialTestable.value).toBe(true);
+		});
+
+		it('is not testable when the store finds no test on any version', async () => {
+			stubStoreTestable(false);
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpBasicAuth' });
+			await form.initialize();
+
+			expect(form.isCredentialTestable.value).toBe(false);
+		});
+	});
+
 	describe('requiredPropertiesFilled', () => {
 		it('blocks save and test while a required placeholder has no value', async () => {
 			const form = useCredentialForm({ mode: 'new', activeId: 'httpTemplatedCustomAuth' });

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -175,10 +175,6 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 		credentialTypeName.value ? getParentTypes(credentialTypeName.value) : [],
 	);
 
-	const nodesWithAccess = computed(() =>
-		credentialTypeName.value ? credentialsStore.getNodesWithAccess(credentialTypeName.value) : [],
-	);
-
 	// --- OAuth / managed derivations ---------------------------------------
 	const isOAuthType = computed(
 		() =>
@@ -316,12 +312,9 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 		});
 		if (hasUntestableExpressions) return false;
 
-		const nodesThatCanTest = nodesWithAccess.value.filter((node) =>
-			node.credentials?.some(
-				(credential) => credential.name === credentialTypeName.value && credential.testedBy,
-			),
-		);
-		return !!nodesThatCanTest.length || (!!credentialType.value && !!credentialType.value.test);
+		if (!credentialTypeName.value) return false;
+
+		return credentialsStore.isCredentialTypeTestable(credentialTypeName.value);
 	});
 
 	const credentialPermissions = computed(
@@ -658,7 +651,6 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 		credentialType,
 		mergedProperties,
 		parentTypes,
-		nodesWithAccess,
 		isOAuthType,
 		isOAuthConnected,
 		isManagedOAuthMode,

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialTestInBackground.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialTestInBackground.ts
@@ -6,18 +6,10 @@ export function useCredentialTestInBackground() {
 
 	/**
 	 * Checks whether a credential type has a test mechanism defined.
-	 * Returns true if either the credential type itself defines a `test` block
-	 * or any node with access declares `testedBy` for it.
+	 * Kept as part of this composable's surface — several callers consume it from here.
 	 */
-	const isCredentialTypeTestable = (credentialTypeName: string): boolean => {
-		const credType = credentialsStore.getCredentialTypeByName(credentialTypeName);
-		if (credType?.test) return true;
-
-		const nodesWithAccess = credentialsStore.getNodesWithAccess(credentialTypeName);
-		return nodesWithAccess.some((node) =>
-			node.credentials?.some((cred) => cred.name === credentialTypeName && cred.testedBy),
-		);
-	};
+	const isCredentialTypeTestable = (credentialTypeName: string): boolean =>
+		credentialsStore.isCredentialTypeTestable(credentialTypeName);
 
 	/**
 	 * Tests a saved credential in the background.

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
@@ -162,6 +162,31 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 		};
 	});
 
+	const isCredentialTypeTestable = computed(() => {
+		return (credentialTypeName: string): boolean => {
+			const credentialType = getCredentialTypeByName.value(credentialTypeName);
+			if (!credentialType) return false;
+			if (credentialType.test) return true;
+
+			const nodeTypesStore = useNodeTypesStore();
+
+			// Every registered version has to be checked, not just the newest: `testedBy` is
+			// often declared only on an older version, and the backend resolves the test
+			// across all versions too. Reading one version hides tests that do exist.
+			return (credentialType.supportedNodes ?? []).some((nodeType) =>
+				nodeTypesStore
+					.getNodeVersions(nodeType)
+					.some((version) =>
+						nodeTypesStore
+							.getNodeType(nodeType, version)
+							?.credentials?.some(
+								(credential) => credential.name === credentialTypeName && credential.testedBy,
+							),
+					),
+			);
+		};
+	});
+
 	const getScopesByCredentialType = computed(() => {
 		return (credentialTypeName: string) => {
 			const credentialType = getCredentialTypeByName.value(credentialTypeName);
@@ -546,6 +571,7 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 		getCredentialTypeByName,
 		getCredentialByIdAndType,
 		getNodesWithAccess,
+		isCredentialTypeTestable,
 		getUsableCredentialByType,
 		credentialTypesById,
 		httpOnlyCredentialTypes,

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
@@ -16,7 +16,7 @@ import type { ProjectSharingData } from '@/features/collaboration/projects/proje
 import { makeRestApiRequest } from '@n8n/rest-api-client';
 import { getAppNameFromCredType } from '@/app/utils/nodeTypesUtils';
 import { splitName } from '@/features/collaboration/projects/projects.utils';
-import { isEmpty, isPresent } from '@/app/utils/typesUtils';
+import { isEmpty } from '@/app/utils/typesUtils';
 import type {
 	ICredentialsDecrypted,
 	ICredentialType,
@@ -145,20 +145,6 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 	const getUsableCredentialByType = computed(() => {
 		return (credentialType: string): ICredentialsResponse[] => {
 			return allUsableCredentialsByType.value[credentialType] || [];
-		};
-	});
-
-	const getNodesWithAccess = computed(() => {
-		return (credentialTypeName: string) => {
-			const credentialType = getCredentialTypeByName.value(credentialTypeName);
-			if (!credentialType) {
-				return [];
-			}
-			const nodeTypesStore = useNodeTypesStore();
-
-			return (credentialType.supportedNodes ?? [])
-				.map((nodeType) => nodeTypesStore.getNodeType(nodeType))
-				.filter(isPresent);
 		};
 	});
 
@@ -570,7 +556,6 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 		getCredentialById,
 		getCredentialTypeByName,
 		getCredentialByIdAndType,
-		getNodesWithAccess,
 		isCredentialTypeTestable,
 		getUsableCredentialByType,
 		credentialTypesById,

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.nodeGrouping.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.nodeGrouping.test.ts
@@ -118,7 +118,6 @@ describe('useWorkflowSetupState – node grouping', () => {
 
 		credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue(undefined);
 		credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
-		credentialsStore.getNodesWithAccess = vi.fn().mockReturnValue([]);
 		credentialsStore.isCredentialTestedOk = vi.fn().mockReturnValue(true);
 		credentialsStore.isCredentialTestPending = vi.fn().mockReturnValue(false);
 		credentialsStore.getCredentialData = vi.fn().mockResolvedValue(undefined);

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
@@ -142,7 +142,6 @@ describe('useWorkflowSetupState', () => {
 		workflowsStore.workflowId = 'test-workflow';
 		credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue(undefined);
 		credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
-		credentialsStore.getNodesWithAccess = vi.fn().mockReturnValue([]);
 		credentialsStore.isCredentialTestedOk = vi.fn().mockReturnValue(true);
 		credentialsStore.isCredentialTestPending = vi.fn().mockReturnValue(false);
 		credentialsStore.getCredentialData = vi.fn().mockResolvedValue(undefined);
@@ -1532,7 +1531,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Header Auth',
 			});
-			credentialsStore.getNodesWithAccess = vi.fn().mockReturnValue([]);
+			credentialsStore.isCredentialTypeTestable = vi.fn().mockReturnValue(false);
 			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-1',


### PR DESCRIPTION
## Summary

Saving a **Kafka** or **Odoo** credential ran no connection test at all. 

**Cause.** A credential is testable if a node using it declares `testedBy`. Kafka declares it only on **v1**. When **v2** was registered without it, three UI gates that each read a **single** node version which is the newest started answering "not testable":

| Site | How it picked a version |
| --- | --- |
| `useCredentialForm.ts` — gates the on-save test | `getNodesWithAccess` → `getNodeType(name)`, no version → newest |
| `useCredentialTestInBackground.ts` | same store getter |
| `instance-ai.adapter.service.ts` — Instance AI `isTestable` | `Object.values(nodeVersions).pop()` |

The backend that runs the test scans **every** version (`credentials-tester.service.ts:118-170`). The test worked the whole time; the frontend stopped asking for it. Postgres was unaffected because its newest version happens to declare `testedBy`.

**Fix.** One store getter, `isCredentialTypeTestable`, that scans every registered version; all three gates defer to it. No node files touched — this aligns the gates with the resolver they were meant to mirror.


**Blast radius.** Replaying old vs. new gate logic over the real built payload (403 credential types):

```
newly testable (the fix):  2 -> kafka, odooApi
lost testability:          0  (must be 0)
```

Both resolve to reachable implementations (`v1/KafkaV1.node.ts:233`, `v1/OdooV1.node.ts:233`). The other 401 types are unchanged.

## How to test

No broker or Odoo instance needed — the bug was entirely in the gates.

1. Credentials → new → **Kafka**. Put `localhost:9999` in Brokers (nothing is required, so it saves regardless). **Save.**
2. With devtools filtered to `credentials/test`: the request now fires and returns a real connection error. On `master` no request is made at all.
3. Repeat for **Odoo** — also fires. **Postgres** as a control: unchanged.

**Automated:** editor-ui `src/features/{credentials,setupPanel,ai/instanceAi}` — 1845 passing; cli `instance-ai.adapter.service.test.ts` — 182 passing. Both new regression guards fail against the pre-fix logic, so they genuinely discriminate.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-358

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
