### PR TITLE
fix(ai-builder): Prevent agent from claiming integration tool call success early

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-tools.test.ts
@@ -1248,6 +1248,18 @@ describe('integration tools', () => {
 		});
 	});
 
+	it('action tool description forbids claiming an action succeeded before the tool call returns', () => {
+		const tool = createIntegrationActionTool({
+			descriptor: getIntegrationToolConnectionDescriptors([slackA])[0],
+			messageContextStore: mock<IntegrationMessageContextStore>(),
+			actionExecutor: mock<IntegrationActionExecutor>(),
+		}).build();
+
+		expect(tool.description).toContain(
+			'Never state that an action has been performed before its tool call returns',
+		);
+	});
+
 	it('action tool preserves the current subject when updating message context', async () => {
 		const messageContextStore = mock<IntegrationMessageContextStore>();
 		messageContextStore.getLatest.mockResolvedValue({

--- a/packages/cli/src/modules/agents/integrations/integration-tool-descriptions.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-tool-descriptions.ts
@@ -26,6 +26,7 @@ export function buildActionToolDescription(
 		...descriptor.actionToolDefinitions.map((definition) => `- ${definition.description}`),
 		`Batch form: pass actions as an array of up to ${MAX_BATCH_OPERATIONS} { action, input } objects. Batch actions run sequentially and cannot include cards that wait for a user response.`,
 		'respond uses the latest message context for this integration connection.',
+		'Never state that an action has been performed before its tool call returns. Before calling an action, describe what you intend to do, not a completed outcome. Only report an action as done after the tool returns ok. If a tool fails, report the failure honestly.',
 		'If this turn was triggered by an inbound chat message, your final reply text is posted to that conversation automatically — do not duplicate it with a text-only respond. Call respond only with message.card, or after switching to a different target.',
 		...(descriptor.actions.includes('do_not_respond')
 			? [


### PR DESCRIPTION
## Summary

Chat agents (Slack, Telegram, Discord) could state that an integration action had already been performed before the corresponding tool call returned. On Slack, where reply text streams to the user as it's generated, this produced a visible self-contradiction: the agent would claim success ("Yep — just added a ✅ to your message"), then post a correction once the tool actually ran and failed (e.g. `add_reaction` failing due to a missing `reactions:write` scope).

This adds a rule to the integration **action** tool description forbidding the model from stating an action was completed before its tool call returns. The rule instructs the model to describe intent before a call and only report an action as done after the tool returns `ok`.

## How to test

Unit test added.
Manual verification (optional, requires a Slack agent with the `add_reaction` action):
1. Ask the agent in a Slack thread: "are you able to react to slack messages?"
2. Confirm the agent describes intent ("I'll add a ✅…") rather than a completed outcome ("I've added a ✅…") before the tool call returns.
3. If the tool fails, confirm the agent reports the failure honestly rather than having already claimed success.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-516/bug-slack-agent-claims-a-tool-action-succeeded-before-calling-the-tool

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
   - Suggested title: `fix(agents): prevent model from claiming tool success before the call returns (no-changelog)`
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

