### PR TITLE
fix(editor): Keep the output table usable with many warnings

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/__snapshots__/InputPanel.test.ts.snap
@@ -197,10 +197,20 @@ exports[`InputPanel > should render 1`] = `
       <!--v-if-->
       <!--v-if-->
       <!--v-if-->
+    </div>
+    <div
+      class="hints"
+      data-test-id="run-data-hints"
+      data-v-5b5900d0=""
+    >
       <!--v-if-->
       <!--v-if-->
       
       
+    </div>
+    <div
+      data-v-5b5900d0=""
+    >
       <!--v-if-->
     </div>
     <div

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
@@ -17,7 +17,7 @@ import type { NodePanelType } from '@/features/ndv/shared/ndv.types';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
-import { waitFor } from '@testing-library/vue';
+import { waitFor, within } from '@testing-library/vue';
 import {
 	createRunExecutionData,
 	TRIMMED_TASK_DATA_CONNECTIONS_KEY,
@@ -1447,6 +1447,22 @@ describe('RunData', () => {
 
 			expect(outputPane.getByText('Output pane hint')).toBeInTheDocument();
 			expect(outputPane.queryByText('Input pane hint')).not.toBeInTheDocument();
+		});
+
+		it('should render every hint inside the hints container, which caps their height', () => {
+			const { getByTestId, getAllByTestId } = render({
+				displayMode: 'table',
+				nodeTypeHints: [
+					{ message: 'First hint', location: 'outputPane' },
+					{ message: 'Second hint', location: 'outputPane' },
+				],
+				paneType: 'output',
+			});
+
+			const hintsContainer = getByTestId('run-data-hints');
+
+			expect(within(hintsContainer).getAllByTestId('node-hint')).toHaveLength(2);
+			expect(getAllByTestId('node-hint')).toHaveLength(2);
 		});
 
 		it('should hide an afterExecution hint before the node has run', () => {

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1665,7 +1665,9 @@ defineExpose({ enterEditMode });
 			</div>
 
 			<slot v-if="!displaysMultipleNodes" name="before-data" />
+		</div>
 
+		<div v-show="!binaryDataDisplayVisible" :class="$style.hints" data-test-id="run-data-hints">
 			<div v-if="props.calloutMessage || $slots['callout-message']" :class="$style.hintCallout">
 				<N8nCallout theme="info" data-test-id="run-data-callout">
 					<slot name="callout-message">
@@ -1686,7 +1688,9 @@ defineExpose({ enterEditMode });
 			>
 				<N8nText v-n8n-html="hint.message" size="small"></N8nText>
 			</N8nCallout>
+		</div>
 
+		<div v-show="!binaryDataDisplayVisible">
 			<div
 				v-if="showBranchSwitch && !isExecutionRedacted"
 				:class="$style.outputs"
@@ -2290,7 +2294,10 @@ defineExpose({ enterEditMode });
 .dataContainer {
 	position: relative;
 	overflow-y: auto;
-	height: 100%;
+	/* Take whatever the header, hints and pagination leave over, and keep shrinking
+	   (min-height: 0) instead of forcing the column to overflow */
+	flex: 1 1 auto;
+	min-height: 0;
 }
 
 .dataDisplay {
@@ -2472,6 +2479,15 @@ defineExpose({ enterEditMode });
 
 .uiBlocker {
 	border-radius: 0;
+}
+
+.hints {
+	/* Hints are secondary to the data: never let them take more than a share of the
+	   pane. Percentage resolves against .container, which has a definite height */
+	max-height: 40%;
+	overflow-y: auto;
+	flex-shrink: 0;
+	scrollbar-width: thin;
 }
 
 .hintCallout {

--- a/packages/testing/playwright/pages/components/RunDataPanel.ts
+++ b/packages/testing/playwright/pages/components/RunDataPanel.ts
@@ -43,6 +43,15 @@ export class RunDataPanel {
 		return this.root.getByTestId('ndv-data-container');
 	}
 
+	/** Container holding the node's warnings/hints, above the data */
+	getHintsContainer() {
+		return this.root.getByTestId('run-data-hints');
+	}
+
+	getNodeHints() {
+		return this.root.getByTestId('node-hint');
+	}
+
 	getPagination() {
 		return this.root.getByTestId('ndv-data-pagination');
 	}

--- a/packages/testing/playwright/tests/e2e/regression/ADO-5786-output-pane-many-warnings.spec.ts
+++ b/packages/testing/playwright/tests/e2e/regression/ADO-5786-output-pane-many-warnings.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '../../../fixtures/base';
+
+// The fixture's Split Out node is asked for 20 fields that no input item has, so the
+// output pane renders exactly 20 warning callouts above a 20 row table. No
+// credentials, no network, no code sandbox: the warning count is deterministic.
+const EXPECTED_WARNINGS = 20;
+
+// Warnings are secondary to the data: whatever their number, the table keeps the
+// larger share of the pane and the warnings stay within their capped area.
+// Pre-fix the warnings ate the whole column and the data container was 0px high.
+const MIN_DATA_SHARE_OF_PANE = 0.4;
+const MAX_WARNINGS_SHARE_OF_PANE = 0.5;
+
+// Layout settles a frame or two after the table renders, so retry the measurement
+// rather than sampling it once.
+const LAYOUT_TIMEOUT = 5000;
+
+test.describe(
+	'ADO-5786 NDV output pane stays usable with many warnings',
+	{
+		annotation: [{ type: 'owner', description: 'Adore' }],
+	},
+	() => {
+		test('keeps the output table readable when the node reports many warnings', async ({ n8n }) => {
+			await n8n.start.fromImportedWorkflow('Test_workflow_ndv_many_output_warnings.json');
+
+			await n8n.canvas.openNode('Split Out');
+			await n8n.ndv.execute();
+			await n8n.notifications.quickCloseAll();
+
+			// The state under test: many warnings stacked above the table
+			await expect(n8n.ndv.outputPanel.getNodeHints()).toHaveCount(EXPECTED_WARNINGS);
+			await expect(n8n.ndv.outputPanel.getTable()).toBeVisible();
+
+			await expect(async () => {
+				const paneHeight = (await n8n.ndv.outputPanel.get().boundingBox())?.height ?? 0;
+				const dataHeight =
+					(await n8n.ndv.outputPanel.getDataContainer().boundingBox())?.height ?? 0;
+				const warningsHeight =
+					(await n8n.ndv.outputPanel.getHintsContainer().boundingBox())?.height ?? 0;
+
+				expect(paneHeight).toBeGreaterThan(0);
+				expect(dataHeight).toBeGreaterThan(paneHeight * MIN_DATA_SHARE_OF_PANE);
+				expect(warningsHeight).toBeLessThan(paneHeight * MAX_WARNINGS_SHARE_OF_PANE);
+			}).toPass({ timeout: LAYOUT_TIMEOUT });
+
+			// Readable, not just present: the table isn't clipped out of view
+			await expect(n8n.ndv.outputPanel.getTableHeader(0)).toBeInViewport();
+			await expect(n8n.ndv.outputPanel.getTableRow(1)).toBeInViewport();
+
+			// The warnings themselves stay reachable, they just scroll within their own area
+			await expect(n8n.ndv.outputPanel.getNodeHints().first()).toBeInViewport();
+		});
+	},
+);

--- a/packages/testing/playwright/workflows/Test_workflow_ndv_many_output_warnings.json
+++ b/packages/testing/playwright/workflows/Test_workflow_ndv_many_output_warnings.json
@@ -1,0 +1,61 @@
+{
+	"name": "NDV output pane with many warnings",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "0a1cd6a6-6c0a-4c1a-9a4f-3e6a4f6bd001",
+			"name": "When clicking \"Execute workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [640, 400]
+		},
+		{
+			"parameters": {
+				"category": "randomData",
+				"randomDataSeed": "0",
+				"randomDataCount": 20
+			},
+			"id": "0a1cd6a6-6c0a-4c1a-9a4f-3e6a4f6bd002",
+			"name": "DebugHelper",
+			"type": "n8n-nodes-base.debugHelper",
+			"typeVersion": 1,
+			"position": [860, 400]
+		},
+		{
+			"parameters": {
+				"fieldToSplitOut": "firstname, missingField01, missingField02, missingField03, missingField04, missingField05, missingField06, missingField07, missingField08, missingField09, missingField10, missingField11, missingField12, missingField13, missingField14, missingField15, missingField16, missingField17, missingField18, missingField19, missingField20",
+				"options": {}
+			},
+			"id": "0a1cd6a6-6c0a-4c1a-9a4f-3e6a4f6bd003",
+			"name": "Split Out",
+			"type": "n8n-nodes-base.splitOut",
+			"typeVersion": 1,
+			"position": [1080, 400]
+		}
+	],
+	"connections": {
+		"When clicking \"Execute workflow\"": {
+			"main": [
+				[
+					{
+						"node": "DebugHelper",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"DebugHelper": {
+			"main": [
+				[
+					{
+						"node": "Split Out",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {}
+}


### PR DESCRIPTION
## Summary

When a node produced a lot of warnings, the output panel's table became unreadable — with ~20 warnings it disappeared entirely, leaving a pane full of warning boxes and no data.

The warnings and the data were competing for the same vertical space in the panel, and the warnings always won: they took as much height as they needed, and the table got whatever was left, which could be nothing.

Now the warnings are limited to at most 40% of the panel and scroll within that area, and the table always gets the rest. Nothing is hidden — all warnings are still there, you just scroll the warnings list if there are many. With a handful of warnings (the normal case) nothing changes visually.

Before:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/52c07574-4d22-4581-9132-b25d74dfcdae" />


After:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/c28109a5-f861-4ee6-b0e9-cdfc4428e9c5" />

## How to test

1. Import `packages/testing/playwright/workflows/Test_workflow_ndv_many_output_warnings.json`, run it, open the Split Out node.
2. Before: 20 warnings, no table. After: warnings in a scrollable block at the top, table with 20 rows below it.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/ADO-5786/bug-output-pane-table-view-unusable-when-there-are-many-warnings

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

