### PR TITLE
ci: Notify PR authors on merge queue removal (no-changelog)

### DIFF
--- a/.github/workflows/util-notify-merge-queue-removal.yml
+++ b/.github/workflows/util-notify-merge-queue-removal.yml
@@ -1,0 +1,22 @@
+name: 'Util: Notify Merge Queue Removal'
+
+on:
+  pull_request:
+    types: [dequeued]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # MERGE/ALREADY_MERGED are successful exits, MANUAL is the author's own doing
+    if: ${{ !contains(fromJSON('["MERGE", "ALREADY_MERGED", "MANUAL"]'), github.event.reason) }}
+    steps:
+      # A failing PR can dequeue others behind it, so the reason may not be this PR's fault
+      - run: |
+          gh pr comment "$PR_URL" --body "This PR was removed from the merge queue (reason: \`$REASON\`). Check the merge-queue run's failing checks and re-queue when ready."
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REASON: ${{ github.event.reason }}

--- a/.github/workflows/util-notify-merge-queue-removal.yml
+++ b/.github/workflows/util-notify-merge-queue-removal.yml
@@ -1,8 +1,7 @@
 name: 'Util: Notify Merge Queue Removal'
 
-# pull_request_target so the token can comment on fork PRs; safe as no PR code is checked out
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+  pull_request:
     types: [dequeued]
 
 permissions:

--- a/.github/workflows/util-notify-merge-queue-removal.yml
+++ b/.github/workflows/util-notify-merge-queue-removal.yml
@@ -1,7 +1,8 @@
 name: 'Util: Notify Merge Queue Removal'
 
+# pull_request_target so the token can comment on fork PRs; safe as no PR code is checked out
 on:
-  pull_request:
+  pull_request_target:
     types: [dequeued]
 
 permissions:

--- a/.github/workflows/util-notify-merge-queue-removal.yml
+++ b/.github/workflows/util-notify-merge-queue-removal.yml
@@ -2,7 +2,7 @@ name: 'Util: Notify Merge Queue Removal'
 
 # pull_request_target so the token can comment on fork PRs; safe as no PR code is checked out
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [dequeued]
 
 permissions:


### PR DESCRIPTION
## Summary

Adds a workflow that fires on `pull_request: dequeued` and posts a PR comment with the dequeue reason, so authors get a GitHub notification when their PR bounces off the merge queue instead of it failing silently. Successful exits (`MERGE`, `ALREADY_MERGED`) and self-initiated removals (`MANUAL`) are skipped.

## How to test

Can only be tested once merged (the `dequeued` event only fires for workflows on the default branch): queue a PR that fails a merge-queue check and verify a comment with the reason appears. Workflow passes `actionlint`.

## Related Linear tickets, Github issues, and Community forum posts

None — discussed directly.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

