### PR TITLE
feat: Adds a handler for n8n authenticated form backend submission rejection (no-changelog)

### DIFF
--- a/packages/cli/templates/form-shell.handlebars
+++ b/packages/cli/templates/form-shell.handlebars
@@ -284,8 +284,13 @@
 				});
 			} catch (e) {}
 			window.addEventListener('message', function (event) {
-				// Ignore the sandboxed form iframe so author content can't spoof a connect.
-				if (frame && event.source === frame.contentWindow) return;
+				// The sandboxed form iframe can't spoof a connect: its only accepted message is
+				// the POST gate's rejection, which carries ids and moves rows one way only, so
+				// the worst author script can do is degrade its own form's UX.
+				if (frame && event.source === frame.contentWindow) {
+					handleGateRejection(event.data);
+					return;
+				}
 				if (event.data === 'success') onSuccessSignal();
 			});
 
@@ -410,6 +415,21 @@
 				document.getElementById('close-dialog').addEventListener('click', function () { overlay.classList.remove('open'); });
 				document.getElementById('done-dialog').addEventListener('click', function () { overlay.classList.remove('open'); });
 				overlay.addEventListener('click', function (e) { if (e.target === overlay) overlay.classList.remove('open'); });
+			}
+
+			// The form's POST was refused by the server-side gate. Rows rendered at page load
+			// can be stale (revoked since, or disconnected in another tab), so flip the ones
+			// the server no longer considers connected and surface the panel — the 3+ layout
+			// otherwise keeps every row behind the strip. Declared after the dialog wiring so
+			// `overlay` is assigned; hoisting keeps it callable from the listener above.
+			function handleGateRejection(data) {
+				if (!data || data.type !== 'n8n-form-credentials-rejected' || !Array.isArray(data.ids)) return;
+				data.ids.forEach(function (id) {
+					// Only rows the server actually rendered, so a crafted key can't walk the
+					// prototype chain. Never markConnected from here — one direction only.
+					if (typeof id === 'string' && Object.prototype.hasOwnProperty.call(ids, id)) markDisconnected(id);
+				});
+				if (overlay) overlay.classList.add('open');
 			}
 		})();
 	</script>

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -281,6 +281,23 @@
 				visibility: visible;
 			}
 
+			{{#if hasAuthenticatedSubmitter}}
+				/* Form-level error above Submit. Unlike .error-hidden it must not reserve
+				   space while empty, or every form gets a permanent gap above Submit. */
+				#submit-error {
+					display: none;
+					color: var(--color-error);
+					text-align: left;
+					font-size: var(--font-size-error);
+					padding-top: 6px;
+					padding-bottom: 9px;
+				}
+
+				#submit-error.error-show {
+					display: block;
+				}
+			{{/if}}
+
 			/* multiselect ----------------------------------- */
 			.multiselect {
 				padding-left: 6px;
@@ -631,6 +648,8 @@
 						{{/each}}
 					</div>
 
+					{{#if hasAuthenticatedSubmitter}}<p id='submit-error'></p>{{/if}}
+
 					<button id='submit-btn' type='submit' {{#if shellInner}}disabled title='Connect the required credentials first'{{/if}}>
 						<span><svg
 								xmlns='http://www.w3.org/2000/svg'
@@ -714,6 +733,47 @@
 					errorElement.classList.remove('error-show');
 				}
 			}
+
+			{{#if hasAuthenticatedSubmitter}}
+				// True when this form is the inner frame of the hosting shell, which owns the
+				// connect panel and the submit button's enabled state.
+				const isShellInner = {{#if shellInner}}true{{else}}false{{/if}};
+
+				// The submit-time credential gate refused this submission. Explain it and hand the
+				// form back with the answers intact. The panel names the credentials, so the banner
+				// only has to say what to do next.
+				function handleCredentialGate(credentials) {
+					updateError(
+						document.querySelector('#submit-error'),
+						'add',
+						'Not all required credentials are connected. ' +
+							(isShellInner
+								? 'Connect them above, then submit again.'
+								: 'Open this form in a new tab to connect them, then come back here and submit again.'),
+					);
+
+					const btn = document.querySelector('#submit-btn');
+					btn.style.cursor = '';
+					btn.querySelector('span').style.display = '';
+
+					if (isShellInner) {
+						// The shell owns the disabled state, so hand it the rows it still shows as
+						// connected and let its readiness signal re-disable Submit. Ids only: it must
+						// not have to trust a name or a URL from this frame. targetOrigin '*' because
+						// the frame is sandboxed without allow-same-origin and can't know the parent's.
+						window.parent.postMessage(
+							{
+								type: 'n8n-form-credentials-rejected',
+								// The body lists every required credential, connected ones included.
+								ids: credentials.filter((c) => c.credentialStatus !== 'configured').map((c) => c.credentialId),
+							},
+							'*',
+						);
+					} else {
+						btn.disabled = false;
+					}
+				}
+			{{/if}}
 
 			function validateInput(input, errorElement) {
 				const value = input.value.trim();
@@ -1010,6 +1070,7 @@
  						const selectedValues = getSelectedValues(multiselect);
  						formData.append(multiselect.id, JSON.stringify(selectedValues));
  					});
+					{{#if hasAuthenticatedSubmitter}}updateError(document.querySelector('#submit-error'), 'remove');{{/if}}
 					document.querySelector('#submit-btn').disabled = true;
 					document.querySelector('#submit-btn').style.cursor = 'not-allowed';
 					document.querySelector('#submit-btn span').style.display = 'inline-block';
@@ -1034,6 +1095,22 @@
 						headers,
 					})
 						.then(async function (response) {
+							{{#if hasAuthenticatedSubmitter}}
+								// A credential-gate rejection keeps the submitter on the page with their
+								// answers, so handle it before the useResponseData branch below paints the
+								// response body over the whole document.
+								if (response.status === 428) {
+									// Clone: that branch reads the body too, and a body can only be read once.
+									// Any other 428 — the webhook trigger's gate has no `status` — falls
+									// through untouched.
+									const gate = await response.clone().json().catch(() => null);
+									if (gate && gate.status === 'credential_connections_required') {
+										handleCredentialGate(gate.credentials);
+										return;
+									}
+								}
+							{{/if}}
+
 							const useResponseData = document.getElementById("useResponseData").value;
 
 							if (useResponseData === "true") {
@@ -1132,6 +1209,13 @@
 				if (event.data.type === 'n8n-shell-credentials-ready') {
 					btn.disabled = false;
 					btn.removeAttribute('title');
+					{{#if hasAuthenticatedSubmitter}}
+						// A rejection banner asking for the credentials is stale once the panel
+						// reports them connected. Guarded because shellInner comes from a query
+						// param, so a form with no submitter identity — and so no banner in the
+						// markup — can still render this listener.
+						updateError(document.querySelector('#submit-error'), 'remove');
+					{{/if}}
 				} else if (event.data.type === 'n8n-shell-credentials-not-ready') {
 					btn.disabled = true;
 					btn.setAttribute('title', 'Connect the required credentials first');

--- a/packages/nodes-base/nodes/Form/interfaces.ts
+++ b/packages/nodes-base/nodes/Form/interfaces.ts
@@ -53,6 +53,13 @@ export type FormTriggerData = {
 	// button starts disabled (the shell enables it once the submitter's required
 	// credentials are connected). Enforcement is server-side on POST regardless.
 	shellInner?: boolean;
+	// Only a form that identifies its submitter can be refused by the submit-time
+	// credential gate, so this is what decides whether the handling for that
+	// rejection is rendered at all. Deliberately broader than the gate's own
+	// condition, which also needs `isFormOAuth2Enabled()`: with that on the GET
+	// redirects to the OAuth2 provider, which would make the client branch
+	// untestable without Keycloak and a license.
+	hasAuthenticatedSubmitter?: boolean;
 };
 
 export const FORM_TRIGGER_AUTHENTICATION_PROPERTY = 'authentication';

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -474,6 +474,22 @@ describe('FormTrigger, formWebhook', () => {
 		await expect(formWebhook(ctx)).resolves.toEqual({ noWebhookResponse: true });
 	});
 
+	// Only a form that identifies the submitter can hit the submit-time credential
+	// gate, so the rest must not ship its client-side handling.
+	it('omits the credential-gate flag for a form that cannot be gated', async () => {
+		const mockRender = vi.fn();
+
+		executeFunctions.getNodeParameter.calledWith('formFields.values').mockReturnValue([]);
+		executeFunctions.getResponseObject.mockReturnValue({
+			render: mockRender,
+			setHeader: vi.fn(),
+		} as any);
+
+		await formWebhook(executeFunctions);
+
+		expect(mockRender.mock.calls[0][1].hasAuthenticatedSubmitter).toBeUndefined();
+	});
+
 	it('should call response render', async () => {
 		const mockRender = vi.fn();
 
@@ -984,6 +1000,24 @@ describe('FormTrigger, formWebhook', () => {
 
 			expect(ctx.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
 			expect(render).toHaveBeenCalledWith('form-trigger', expect.any(Object));
+		});
+
+		// The gate can only reject a form that knows who is submitting, so this is the
+		// only rendering that carries its client-side handling.
+		it('sets hasAuthenticatedSubmitter so the form handles a submit-time gate rejection', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { render } = setupContext(ctx, {
+				method: 'GET',
+				cookie: 'n8n-auth=valid.jwt.token',
+			});
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			await formWebhook(ctx);
+
+			expect(render).toHaveBeenCalledWith(
+				'form-trigger',
+				expect.objectContaining({ hasAuthenticatedSubmitter: true }),
+			);
 		});
 
 		it('parses n8n-auth alongside other cookies', async () => {

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -242,6 +242,7 @@ export function prepareFormData({
 	nodeVersion,
 	authToken,
 	shellInner,
+	hasAuthenticatedSubmitter,
 }: {
 	formTitle: string;
 	formDescription: string;
@@ -259,6 +260,7 @@ export function prepareFormData({
 	nodeVersion?: number;
 	authToken?: string;
 	shellInner?: boolean;
+	hasAuthenticatedSubmitter?: boolean;
 }) {
 	const utm_campaign = instanceId ? `&utm_campaign=${instanceId}` : '';
 	const n8nWebsiteLink = `https://n8n.io/?utm_source=n8n-internal&utm_medium=form-trigger${utm_campaign}`;
@@ -283,6 +285,8 @@ export function prepareFormData({
 		authToken,
 		// Only set inside the hosting shell, so the plain form's render data is unchanged.
 		shellInner: shellInner || undefined,
+		// Only set for forms that can be gated, so the rest never ship the client handling.
+		hasAuthenticatedSubmitter: hasAuthenticatedSubmitter || undefined,
 	};
 
 	if (redirectUrl) {
@@ -572,6 +576,7 @@ export function renderForm({
 	customCss,
 	authToken,
 	shellInner,
+	hasAuthenticatedSubmitter,
 }: {
 	context: IWebhookFunctions;
 	res: Response;
@@ -587,6 +592,7 @@ export function renderForm({
 	customCss?: string;
 	authToken?: string;
 	shellInner?: boolean;
+	hasAuthenticatedSubmitter?: boolean;
 }) {
 	const instanceId = context.getInstanceId();
 
@@ -631,6 +637,7 @@ export function renderForm({
 		nodeVersion: context.getNode().typeVersion,
 		authToken,
 		shellInner,
+		hasAuthenticatedSubmitter,
 	});
 
 	if (!isFormHtmlSandboxingDisabled()) {
@@ -1204,6 +1211,7 @@ export async function formWebhook(
 			customCss: options.customCss,
 			authToken,
 			shellInner,
+			hasAuthenticatedSubmitter: authentication === 'n8nUserAuth',
 		});
 
 		return {

--- a/packages/testing/playwright/pages/PublicFormPage.ts
+++ b/packages/testing/playwright/pages/PublicFormPage.ts
@@ -46,6 +46,38 @@ export class PublicFormPage extends BasePage {
 		await expect(this.page.getByText(text)).toBeVisible(options);
 	}
 
+	/** Form-level error banner above Submit (rejected submissions, not per-field validation). */
+	get submitError(): Locator {
+		return this.page.locator('#submit-error');
+	}
+
+	get submitButton(): Locator {
+		return this.page.locator('#submit-btn');
+	}
+
+	/** In-flight spinner inside the submit button. */
+	get submitSpinner(): Locator {
+		return this.page.locator('#submit-btn span');
+	}
+
+	/** The "Form Submitted" card, swapped in for the form once a submission lands. */
+	get submittedCard(): Locator {
+		return this.page.locator('#submitted-form');
+	}
+
+	get body(): Locator {
+		return this.page.locator('body');
+	}
+
+	/**
+	 * Hidden flag the template renders from the node's response mode. "true" means
+	 * the response body is consumed and written into the page, so submission
+	 * handling takes a different branch.
+	 */
+	get usesResponseData(): Locator {
+		return this.page.locator('#useResponseData');
+	}
+
 	/** Wait for the form submission POST to resolve, returning the response. */
 	async waitForSubmission() {
 		return await this.page.waitForResponse(

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
@@ -8,7 +8,7 @@ import type { ApiHelpers } from '../../../services/api-helper';
 
 /**
  * E2E for how the rendered form handles the submit-time credential gate's
- * rejection (IAM-1184): the submitter stays on the page with their answers, and a
+ * rejection: the submitter stays on the page with their answers, and a
  * banner above Submit tells them what to do next.
  *
  * Unlike the other specs in this directory this one carries **no

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
@@ -1,0 +1,198 @@
+import type { BrowserContext } from '@playwright/test';
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import { test, expect } from '../../../fixtures/base';
+import type { n8nPage } from '../../../pages/n8nPage';
+import { PublicFormPage } from '../../../pages/PublicFormPage';
+import type { ApiHelpers } from '../../../services/api-helper';
+
+/**
+ * E2E for how the rendered form handles the submit-time credential gate's
+ * rejection (IAM-1184): the submitter stays on the page with their answers, and a
+ * banner above Submit tells them what to do next.
+ *
+ * Unlike the other specs in this directory this one carries **no
+ * `@capability:dynamic-credentials` / `@licensed` tag** and runs locally without
+ * Keycloak or a container: it exercises the client branch only, injecting the
+ * gate response with `context.route` instead of provisioning a private
+ * credential. The server side that produces these bodies is covered by
+ * `packages/nodes-base/nodes/Form/test/utils.test.ts` and
+ * `packages/cli/test/integration/dynamic-credentials.ee/form-trigger-submit-gate.api.test.ts`.
+ */
+
+const FIELD_LABEL = 'What is your first name?';
+
+/** The banner a plain form (no hosting shell above it) shows on a rejection. */
+const BANNER =
+	'Not all required credentials are connected. Open this form in a new tab to connect them, then come back here and submit again.';
+
+const GATE_BODY = {
+	status: 'credential_connections_required',
+	readyToExecute: false,
+	credentials: [
+		{
+			credentialId: 'gated-credential-id',
+			credentialName: 'Acme CRM account',
+			credentialType: 'oAuth2Api',
+			credentialStatus: 'missing',
+		},
+		// Already-connected entries ride along in the real body — the id filter has to
+		// drop them before the frame tells the shell which rows to reconcile.
+		{
+			credentialId: 'connected-credential-id',
+			credentialName: 'Acme Mail account',
+			credentialType: 'oAuth2Api',
+			credentialStatus: 'configured',
+		},
+	],
+};
+
+/**
+ * A form-trigger workflow. With a second Form node attached the trigger is
+ * forced into `responseMode: 'responseNode'`, the config whose response handling
+ * used to paint the raw gate JSON over the whole page.
+ */
+function formWorkflow(options: { withNextPage: boolean }): Partial<IWorkflowBase> {
+	const nodes: IWorkflowBase['nodes'] = [
+		{
+			parameters: {
+				formTitle: 'Gate test',
+				formFields: { values: [{ fieldLabel: FIELD_LABEL }] },
+				// Only a form that authenticates the submitter can ever be gated, so the
+				// client handling is rendered only for this option (added in 2.6). The GET
+				// authenticates off the editor session cookie this browser context holds.
+				authentication: 'n8nUserAuth',
+				options: {},
+			},
+			type: 'n8n-nodes-base.formTrigger',
+			typeVersion: 2.6,
+			position: [0, 0],
+			id: crypto.randomUUID(),
+			name: 'On form submission',
+			// Unique per test: the test-webhook registry is keyed by webhookId across the
+			// whole instance, and specs run in parallel.
+			webhookId: crypto.randomUUID(),
+		},
+	];
+
+	if (!options.withNextPage) {
+		return { nodes, connections: {} };
+	}
+
+	nodes.push({
+		parameters: { options: { formDescription: 'Step 2' } },
+		type: 'n8n-nodes-base.form',
+		typeVersion: 2.5,
+		position: [208, 0],
+		id: crypto.randomUUID(),
+		name: 'Form',
+		webhookId: crypto.randomUUID(),
+	});
+
+	return {
+		nodes,
+		connections: {
+			'On form submission': { main: [[{ node: 'Form', type: 'main', index: 0 }]] },
+		},
+	};
+}
+
+/**
+ * Fulfil the submission POST with the given gate response, leaving the GET that
+ * renders the form untouched. Registered on the browser context rather than the
+ * editor page because the form opens in its own tab.
+ */
+async function interceptSubmit(
+	context: BrowserContext,
+	response: { status: number; json: unknown },
+) {
+	await context.route(
+		(url) => url.pathname.includes('/form-test/'),
+		async (route) => {
+			if (route.request().method() !== 'POST') {
+				await route.continue();
+				return;
+			}
+			await route.fulfill({
+				status: response.status,
+				contentType: 'application/json',
+				body: JSON.stringify(response.json),
+			});
+		},
+	);
+}
+
+/** Open the form of a freshly created workflow that is waiting for a trigger event. */
+async function openForm(
+	api: ApiHelpers,
+	n8n: n8nPage,
+	options: { withNextPage: boolean },
+): Promise<PublicFormPage> {
+	const { workflowId } = await api.workflows.createWorkflowFromDefinition(formWorkflow(options), {
+		makeUnique: true,
+	});
+
+	await n8n.start.fromExistingWorkflow(workflowId);
+	await n8n.canvas.clickExecuteWorkflowButton();
+	await expect(n8n.canvas.getExecuteWorkflowButton()).toHaveText('Waiting for trigger event');
+
+	await n8n.canvas.openNode('On form submission');
+	const formUrl = await n8n.canvas.getTestFormUrl();
+
+	return await PublicFormPage.fromNewTab(n8n.page.context(), formUrl);
+}
+
+/** Everything the submitter must still have after a rejected submission. */
+async function expectFormRecovered(formPage: PublicFormPage, answer: string) {
+	await expect(formPage.getField(FIELD_LABEL)).toHaveValue(answer);
+	await expect(formPage.submitButton).toBeEnabled();
+	await expect(formPage.submitSpinner).toBeHidden();
+	await expect(formPage.submittedCard).toBeHidden();
+}
+
+test.describe(
+	'Form Trigger submit credential gate (client)',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test('should keep the form and explain what to do when the gate rejects the submission', async ({
+			api,
+			n8n,
+		}) => {
+			await interceptSubmit(n8n.page.context(), { status: 428, json: GATE_BODY });
+
+			const formPage = await openForm(api, n8n, { withNextPage: false });
+			await expect(formPage.usesResponseData).toHaveValue('false');
+
+			const answer = 'Ada';
+			await formPage.fillField(FIELD_LABEL, answer);
+			await formPage.submit();
+
+			await expect(formPage.submitError).toHaveText(BANNER);
+			await expectFormRecovered(formPage, answer);
+		});
+
+		test('should not paint the raw gate response over the page when responding with a response node', async ({
+			api,
+			n8n,
+		}) => {
+			await interceptSubmit(n8n.page.context(), { status: 428, json: GATE_BODY });
+
+			const formPage = await openForm(api, n8n, { withNextPage: true });
+			// Guards the test itself: without this the assertions below pass trivially on a
+			// form that never takes the response-consuming branch.
+			await expect(formPage.usesResponseData).toHaveValue('true');
+
+			const answer = 'Grace';
+			await formPage.fillField(FIELD_LABEL, answer);
+			await formPage.submit();
+
+			await expect(formPage.submitError).toHaveText(BANNER);
+			// The regression: this response mode reads the body and writes it into
+			// document.body, so an unhandled gate response replaced the form with JSON.
+			await expect(formPage.body).not.toContainText('credential_connections_required');
+			await expectFormRecovered(formPage, answer);
+		});
+	},
+);


### PR DESCRIPTION
## Summary
In the event that a users n8n authenticated form submission, i.e. one using end-user credentials, failed backend validation, a `428 Precondition Required` response is returned. Previously, this displayed an error message that replaced the form content and caused the user to lose all of their filled out progress. This PR changes it so that this response is captured and displayed to the user without replacing the form content, so their progress is preserved. Upon connecting the required credentials the error message is cleared and the user can submit again.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

https://github.com/user-attachments/assets/4a1fd2d9-9037-4b07-b5fb-4ee7778a6ae7


## How to test
1. Create a workflow with a form trigger and at least one node using end-user credentials (disconnected)
2. Open the forms URL in a new tab, observe that the credentials are listed at the top of the form and the submit button is disconnected
3. Fill out your form field content
4. Open your browser dev tools and remove the `disabled` flag to force the submission button to be enabled and allow submission to the backend
5. Click the submit button; the submission should be rejected and an error should be shown, but the form content should remain unchanged.
6. Connect your credentials, the submit button should become enabled, and the next submission should proceed without issue.
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-1184/handle-the-form-submit-credential-gate-rejection-without-losing-form
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

