### PR TITLE
fix(API): Return a request schema for decorator routes in /discover

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/discover/__tests__/discover.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/discover/__tests__/discover.service.test.ts
@@ -194,6 +194,19 @@ describe('buildDiscoverResponse', () => {
 		expect(createEndpoint?.requestSchema).toHaveProperty('type');
 	});
 
+	it('should include requestSchema for a decorator route when includeSchemas is true', async () => {
+		const result = await buildDiscoverResponse(['role:manage'] as ApiKeyScope[], {
+			includeSchemas: true,
+		});
+
+		const createEndpoint = result.resources.role?.endpoints.find(
+			(e) => e.operationId === 'createRole',
+		);
+		expect(createEndpoint).toBeDefined();
+		expect(createEndpoint?.requestSchema).toBeDefined();
+		expect(createEndpoint?.requestSchema).toHaveProperty('properties');
+	});
+
 	it('should not include requestSchema on GET endpoints even with includeSchemas', async () => {
 		const result = await buildDiscoverResponse(['tag:list'] as ApiKeyScope[], {
 			includeSchemas: true,

--- a/packages/cli/src/public-api/v1/handlers/discover/discover.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/discover/discover.service.ts
@@ -12,6 +12,7 @@ import {
 	scopesInRequirement,
 	toOpenApiPathTemplate,
 } from '../../../public-api-route-resolver';
+import { buildRequestBodyJsonSchema } from '../../openapi-gen/decorator-routes';
 import { extractScopeFromEovHandlerChain } from '../../shared/public-api-scope-lookup';
 
 import '../../controllers';
@@ -151,6 +152,7 @@ function buildDecoratorEndpoints(): EndpointInfo[] {
 		operationId: route.handlerName,
 		tag: route.tags?.[0] ?? 'Other',
 		scope: route.apiKeyScope ?? null,
+		requestSchema: buildRequestBodyJsonSchema(route),
 	}));
 }
 

--- a/packages/cli/src/public-api/v1/openapi-gen/__tests__/request-body-schema-parity.test.ts
+++ b/packages/cli/src/public-api/v1/openapi-gen/__tests__/request-body-schema-parity.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from 'yaml';
+
+import { resolvePublicApiRoutes } from '@/public-api/public-api-route-resolver';
+
+import { buildRequestBodyJsonSchema, getDecoratorGeneratedOperations } from '../decorator-routes';
+
+/**
+ * The build writes a request body schema into the spec. `/discover` builds the same schema at
+ * runtime, through `buildRequestBodyJsonSchema`. Nothing else checks that the two agree.
+ */
+const V1_DIR = path.resolve(__dirname, '../..');
+
+// The build writes one spec file per route and names it after the handler method, so the handler
+// name is what links a route to its file.
+const SPEC_FILE_BY_HANDLER = new Map(
+	getDecoratorGeneratedOperations().map((operation) => [
+		operation.config.operationId,
+		operation.outputPath,
+	]),
+);
+
+function schemaInSpecFile(handlerName: string): unknown {
+	const specFile = SPEC_FILE_BY_HANDLER.get(handlerName);
+	if (!specFile) throw new Error(`The build generated no spec file for ${handlerName}`);
+
+	const spec = parse(fs.readFileSync(path.join(V1_DIR, specFile), 'utf8')) as {
+		requestBody?: { content?: Record<string, { schema?: unknown }> };
+	};
+
+	return spec.requestBody?.content?.['application/json']?.schema;
+}
+
+describe('buildRequestBodyJsonSchema', () => {
+	const routesWithBody = resolvePublicApiRoutes().filter((route) => route.requestBodyDto);
+
+	it.each(routesWithBody)('$handlerName matches its committed spec file', (route) => {
+		expect(buildRequestBodyJsonSchema(route)).toEqual(schemaInSpecFile(route.handlerName));
+	});
+});

--- a/packages/cli/src/public-api/v1/openapi-gen/decorator-routes.ts
+++ b/packages/cli/src/public-api/v1/openapi-gen/decorator-routes.ts
@@ -5,8 +5,10 @@ import './zod-extend';
 // resolvePublicApiRoutes()
 import '../controllers';
 
+import { OpenAPIRegistry, OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
 import type { RouteConfig } from '@asteasolutions/zod-to-openapi';
 import type { ResponseDtoClass } from '@n8n/decorators';
+import { isRecord } from '@n8n/utils/is-record';
 import { UnexpectedError } from 'n8n-workflow';
 import { z } from 'zod';
 
@@ -16,6 +18,8 @@ import {
 	scopeRequirementToString,
 	toOpenApiPathTemplate,
 } from '@/public-api/public-api-route-resolver';
+
+const REQUEST_BODY_COMPONENT = 'RequestBody';
 
 // Query fields backed by shared hand-written parameter files instead of being generated
 const SHARED_PAGINATION_PARAMS: Record<string, { $ref: string }> = {
@@ -135,6 +139,25 @@ function buildRequestBody(
 			},
 		},
 	};
+}
+
+/**
+ * Converts a route's `@Body` DTO into JSON Schema, using the same conversion the build runs when
+ * it writes the OpenAPI files. zod-to-openapi can only convert a schema that a registry holds, so
+ * this registers one under a throwaway name and then reads the result back out.
+ */
+export function buildRequestBodyJsonSchema(
+	route: ResolvedPublicApiRoute,
+): Record<string, unknown> | undefined {
+	if (!route.requestBodyDto) return undefined;
+
+	const registry = new OpenAPIRegistry();
+	registry.register(REQUEST_BODY_COMPONENT, route.requestBodyDto.schema);
+
+	const { components } = new OpenApiGeneratorV3(registry.definitions).generateComponents();
+	const schema = components?.schemas?.[REQUEST_BODY_COMPONENT];
+
+	return isRecord(schema) ? schema : undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

`/api/v1/discover?include=schemas` returns no `requestSchema` for any route on a `@PublicApiController`. `buildDecoratorEndpoints()` never set the field. Only the express-openapi-validator routes carry one, read out of the hand-written spec.

Four routes declare a `@Body` DTO today, and none of them report its schema:

| Endpoint | Body DTO |
|---|---|
| `POST /roles` | `CreateRoleDto` |
| `PUT /roles/{slug}` | `UpdateRolePublicDto` |
| `POST /role-mapping-rules` | `CreateRoleMappingRuleDto` |
| `PUT /workflows/{workflowId}/tags` | `TagIdsPublicDto` |

The count grows with every route the schema-first migration moves across.

## How

Every controller endpoint that accepts a request body already declares the shape of that body. It is the same declaration the server uses to check an incoming request, and the route already carries it in memory. So the information `/discover` needs is present. Nothing has to be wired up or written by hand.

This change converts that declaration into JSON Schema and returns it. The conversion runs through the same generator that writes the committed OpenAPI files. The published spec and `/discover` therefore describe a request body from one source, and cannot drift apart.

## Verification

Checked our Swagger UI and hitting our `discover` endpoint now also returns 

<img width="1403" height="736" alt="Screenshot 2026-08-17 at 13 06 58" src="https://github.com/user-attachments/assets/d7ac3359-fd56-4eaf-b509-8d65228fbf39" />

```json
{
            "method": "PUT",
            "path": "/api/v1/workflows/{workflowId}/tags",
            "operationId": "updateWorkflowTags",
            "requestSchema": {
              "type": "array",
              "items": {
                "type": "object",
                "properties": {
                  "id": {
                    "type": "string"
                  }
                },
                "required": [
                  "id"
                ],
                "additionalProperties": false
              }
            }
```

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/API-180

This is a pre-existing defect on master, not part of any single migration, which is why it is split out.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
