### PR TITLE
feat(API): Add endpoint to update a custom role

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -190,6 +190,7 @@ export {
 } from './user/users-list-filter.dto';
 
 export { UpdateRoleDto } from './roles/update-role.dto';
+export { UpdateRolePublicDto } from './roles/update-role-public.dto';
 export { CreateRoleDto } from './roles/create-role.dto';
 export {
 	RolePublicDto,

--- a/packages/@n8n/api-types/src/dto/roles/__tests__/update-role-public.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/roles/__tests__/update-role-public.dto.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert';
+
+import { UpdateRolePublicDto } from '../update-role-public.dto';
+
+describe('updateRolePublicDtoSchema', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'full catalog of fields',
+				request: {
+					displayName: 'Updated Role Name',
+					description: 'Updated role description',
+					scopes: ['project:read', 'workflow:execute'],
+				},
+			},
+			{
+				name: 'null description',
+				request: {
+					displayName: 'Updated Role Name',
+					description: null,
+					scopes: ['project:read'],
+				},
+			},
+			{
+				name: 'empty scopes array (clears all scopes)',
+				request: {
+					displayName: 'Updated Role Name',
+					description: null,
+					scopes: [],
+				},
+			},
+			{
+				name: 'displayName at minimum length',
+				request: {
+					displayName: 'Up',
+					description: null,
+					scopes: [],
+				},
+			},
+			{
+				name: 'displayName at maximum length',
+				request: {
+					displayName: 'B'.repeat(100),
+					description: null,
+					scopes: [],
+				},
+			},
+			{
+				name: 'description at maximum length',
+				request: {
+					displayName: 'Updated Role Name',
+					description: 'C'.repeat(500),
+					scopes: [],
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = UpdateRolePublicDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing displayName',
+				request: { description: null, scopes: [] },
+				expectedErrorPath: ['displayName'],
+			},
+			{
+				name: 'missing description',
+				request: { displayName: 'Updated Role Name', scopes: [] },
+				expectedErrorPath: ['description'],
+			},
+			{
+				name: 'missing scopes',
+				request: { displayName: 'Updated Role Name', description: null },
+				expectedErrorPath: ['scopes'],
+			},
+			{
+				name: 'empty request body',
+				request: {},
+				expectedErrorPath: ['displayName'],
+			},
+			{
+				name: 'displayName too short',
+				request: { displayName: 'A', description: null, scopes: [] },
+				expectedErrorPath: ['displayName'],
+			},
+			{
+				name: 'displayName too long',
+				request: { displayName: 'A'.repeat(101), description: null, scopes: [] },
+				expectedErrorPath: ['displayName'],
+			},
+			{
+				name: 'description too long',
+				request: { displayName: 'Updated Role Name', description: 'A'.repeat(501), scopes: [] },
+				expectedErrorPath: ['description'],
+			},
+			{
+				name: 'invalid scope in array',
+				request: {
+					displayName: 'Updated Role Name',
+					description: null,
+					scopes: ['not:a-real-scope'],
+				},
+				expectedErrorPath: ['scopes', 0],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = UpdateRolePublicDto.safeParse(request);
+
+			assert(!result.success, 'Expected validation to fail');
+
+			expect(result.error.issues[0].path).toEqual(expectedErrorPath);
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/roles/update-role-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/update-role-public.dto.ts
@@ -1,0 +1,10 @@
+import { scopeSchema } from '@n8n/permissions';
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class UpdateRolePublicDto extends Z.class({
+	displayName: z.string().min(2).max(100),
+	description: z.string().max(500).nullable(),
+	scopes: z.array(scopeSchema),
+}) {}

--- a/packages/cli/src/controllers/__tests__/role.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/role.controller.test.ts
@@ -40,25 +40,6 @@ describe('RoleController', () => {
 			});
 		});
 
-		describe('updateRole', () => {
-			it('should emit custom-role-updated', async () => {
-				const request = managerRequest();
-				roleService.getRole.mockResolvedValue({ roleType: 'project' } as Role);
-				roleService.updateCustomRole.mockResolvedValue({
-					slug: 'custom-editor',
-					scopes: ['workflow:read', 'workflow:update', 'workflow:delete'],
-				} as Role);
-
-				await controller.updateRole(request, mock(), 'custom-editor', mock());
-
-				expect(eventService.emit).toHaveBeenCalledWith('custom-role-updated', {
-					userId: '123',
-					roleSlug: 'custom-editor',
-					scopes: ['workflow:read', 'workflow:update', 'workflow:delete'],
-				});
-			});
-		});
-
 		describe('deleteRole', () => {
 			it('should emit custom-role-deleted', async () => {
 				const request = managerRequest();

--- a/packages/cli/src/controllers/role.controller.ts
+++ b/packages/cli/src/controllers/role.controller.ts
@@ -128,7 +128,11 @@ export class RoleController {
 	): Promise<RoleDTO> {
 		const role = await this.roleService.getRole(slug);
 		assertCanManageRoleType(req.user, role.roleType);
-		return await this.roleService.updateCustomRole(slug, updateRole, req.user.id);
+		return await this.roleService.updateCustomRole({
+			slug,
+			newData: updateRole,
+			userId: req.user.id,
+		});
 	}
 
 	@Delete('/:slug')

--- a/packages/cli/src/controllers/role.controller.ts
+++ b/packages/cli/src/controllers/role.controller.ts
@@ -128,13 +128,7 @@ export class RoleController {
 	): Promise<RoleDTO> {
 		const role = await this.roleService.getRole(slug);
 		assertCanManageRoleType(req.user, role.roleType);
-		const result = await this.roleService.updateCustomRole(slug, updateRole);
-		this.eventService.emit('custom-role-updated', {
-			userId: req.user.id,
-			roleSlug: result.slug,
-			scopes: result.scopes,
-		});
-		return result;
+		return await this.roleService.updateCustomRole(slug, updateRole, req.user.id);
 	}
 
 	@Delete('/:slug')

--- a/packages/cli/src/controllers/role.controller.ts
+++ b/packages/cli/src/controllers/role.controller.ts
@@ -130,7 +130,7 @@ export class RoleController {
 		assertCanManageRoleType(req.user, role.roleType);
 		return await this.roleService.updateCustomRole({
 			slug,
-			newData: updateRole,
+			newRole: updateRole,
 			userId: req.user.id,
 		});
 	}

--- a/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
@@ -161,13 +161,7 @@ export class RolesPublicController {
 		}
 		assertCanManageRoleType(req.user, role.roleType);
 
-		const result = await this.roleService.updateCustomRole(slug, updateRole);
-
-		this.eventService.emit('custom-role-updated', {
-			userId: req.user.id,
-			roleSlug: result.slug,
-			scopes: result.scopes,
-		});
+		const result = await this.roleService.updateCustomRole(slug, updateRole, req.user.id);
 
 		return toRolePublicDto({ ...result, roleType: role.roleType });
 	}

--- a/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
@@ -47,12 +47,13 @@ const toRolePublicDto = (role: RoleDTO & { roleType: PublicRoleNamespace }): Rol
 	updatedAt: role.updatedAt!.toISOString(),
 });
 
-const toRoleGetPublicDto = (role: RoleDTO & { roleType: PublicRoleNamespace }, withUsageCount: boolean): RoleGetPublicDto => ({
+const toRoleGetPublicDto = (
+	role: RoleDTO & { roleType: PublicRoleNamespace },
+	withUsageCount: boolean,
+): RoleGetPublicDto => ({
 	...toRolePublicDto(role),
 	licensed: role.licensed,
-	...(withUsageCount
-		? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects }
-		: {}),
+	...(withUsageCount ? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects } : {}),
 });
 
 @PublicApiController('/roles')

--- a/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
@@ -47,6 +47,14 @@ const toRolePublicDto = (role: RoleDTO & { roleType: PublicRoleNamespace }): Rol
 	updatedAt: role.updatedAt!.toISOString(),
 });
 
+const toRoleGetPublicDto = (role: RoleDTO & { roleType: PublicRoleNamespace }, withUsageCount: boolean): RoleGetPublicDto => ({
+	...toRolePublicDto(role),
+	licensed: role.licensed,
+	...(withUsageCount
+		? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects }
+		: {}),
+});
+
 @PublicApiController('/roles')
 export class RolesPublicController {
 	constructor(
@@ -75,12 +83,8 @@ export class RolesPublicController {
 			publicRoles
 				.filter((role): role is RoleDTO & { roleType: T } => role.roleType === roleType)
 				.map((role) => ({
-					...toRolePublicDto(role),
+					...toRoleGetPublicDto({ ...role, roleType }, withUsageCount),
 					roleType,
-					licensed: role.licensed,
-					...(withUsageCount
-						? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects }
-						: {}),
 				}));
 
 		return {
@@ -109,7 +113,7 @@ export class RolesPublicController {
 		if (!isPublicRole(role)) {
 			throw new NotFoundError('Role not found');
 		}
-		return toRolePublicDto({ ...role, roleType: role.roleType });
+		return toRoleGetPublicDto({ ...role, roleType: role.roleType }, withUsageCount);
 	}
 
 	@Post('/')

--- a/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
@@ -4,6 +4,7 @@ import {
 	RoleListPublicDto,
 	RoleListQueryPublicDto,
 	RolePublicDto,
+	UpdateRoleDto,
 } from '@n8n/api-types';
 import { LICENSE_FEATURES } from '@n8n/constants';
 import { AuthenticatedRequest } from '@n8n/db';
@@ -18,6 +19,7 @@ import {
 	Get,
 	Licensed,
 	Param,
+	Patch,
 	Post,
 	PublicApiController,
 	Query,
@@ -34,20 +36,15 @@ type PublicRoleNamespace = Extract<RoleNamespace, 'global' | 'project'>;
 const isPublicRole = (role: RoleDTO): role is RoleDTO & { roleType: PublicRoleNamespace } =>
 	role.roleType === 'global' || role.roleType === 'project';
 
-const toPublicRole = <T extends PublicRoleNamespace>(
-	role: RoleDTO & { roleType: T },
-	withUsageCount = false,
-) => ({
+const toRolePublicDto = (role: RoleDTO & { roleType: PublicRoleNamespace }): RolePublicDto => ({
 	slug: role.slug,
 	displayName: role.displayName,
 	description: role.description,
 	systemRole: role.systemRole,
 	roleType: role.roleType,
-	licensed: role.licensed,
 	scopes: role.scopes,
 	createdAt: role.createdAt!.toISOString(),
 	updatedAt: role.updatedAt!.toISOString(),
-	...(withUsageCount ? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects } : {}),
 });
 
 @PublicApiController('/roles')
@@ -77,7 +74,14 @@ export class RolesPublicController {
 		const groupOf = <T extends PublicRoleNamespace>(roleType: T) =>
 			publicRoles
 				.filter((role): role is RoleDTO & { roleType: T } => role.roleType === roleType)
-				.map((role) => toPublicRole(role, withUsageCount));
+				.map((role) => ({
+					...toRolePublicDto(role),
+					roleType,
+					licensed: role.licensed,
+					...(withUsageCount
+						? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects }
+						: {}),
+				}));
 
 		return {
 			global: groupOf('global'),
@@ -105,7 +109,7 @@ export class RolesPublicController {
 		if (!isPublicRole(role)) {
 			throw new NotFoundError('Role not found');
 		}
-		return toPublicRole(role, withUsageCount);
+		return toRolePublicDto({ ...role, roleType: role.roleType });
 	}
 
 	@Post('/')
@@ -132,15 +136,39 @@ export class RolesPublicController {
 			scopes: role.scopes,
 		});
 
-		return {
-			slug: role.slug,
-			displayName: role.displayName,
-			description: role.description,
-			systemRole: role.systemRole,
-			roleType: createRole.roleType,
-			scopes: role.scopes,
-			createdAt: role.createdAt!.toISOString(),
-			updatedAt: role.updatedAt!.toISOString(),
-		};
+		return toRolePublicDto({ ...role, roleType: createRole.roleType });
+	}
+
+	@Patch('/:slug')
+	@ApiKeyScope({ anyOf: ['role:manage', 'role:manageProject'] })
+	@Licensed(LICENSE_FEATURES.CUSTOM_ROLES)
+	@ApiSummary('Update a custom role')
+	@ApiDescription(
+		"Updates a custom role's display name, description, or scopes. Omitted fields are left unchanged. System roles cannot be updated.",
+	)
+	@ApiTags(['Role'])
+	@ApiResponse(200, RolePublicDto)
+	@ApiErrorResponse(404)
+	async updateRole(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('slug') slug: string,
+		@Body updateRole: UpdateRoleDto,
+	): Promise<RolePublicDto> {
+		const role = await this.roleService.getRole(slug);
+		if (!isPublicRole(role)) {
+			throw new NotFoundError('Role not found');
+		}
+		assertCanManageRoleType(req.user, role.roleType);
+
+		const result = await this.roleService.updateCustomRole(slug, updateRole);
+
+		this.eventService.emit('custom-role-updated', {
+			userId: req.user.id,
+			roleSlug: result.slug,
+			scopes: result.scopes,
+		});
+
+		return toRolePublicDto({ ...result, roleType: role.roleType });
 	}
 }

--- a/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
@@ -161,7 +161,11 @@ export class RolesPublicController {
 		}
 		assertCanManageRoleType(req.user, role.roleType);
 
-		const result = await this.roleService.updateCustomRole(slug, updateRole, req.user.id);
+		const result = await this.roleService.updateCustomRole({
+			slug,
+			newData: updateRole,
+			userId: req.user.id,
+		});
 
 		return toRolePublicDto({ ...result, roleType: role.roleType });
 	}

--- a/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
@@ -4,7 +4,7 @@ import {
 	RoleListPublicDto,
 	RoleListQueryPublicDto,
 	RolePublicDto,
-	UpdateRoleDto,
+	UpdateRolePublicDto,
 } from '@n8n/api-types';
 import { LICENSE_FEATURES } from '@n8n/constants';
 import { AuthenticatedRequest } from '@n8n/db';
@@ -19,9 +19,9 @@ import {
 	Get,
 	Licensed,
 	Param,
-	Patch,
 	Post,
 	PublicApiController,
+	Put,
 	Query,
 } from '@n8n/decorators';
 import { RoleNamespace, type Role as RoleDTO } from '@n8n/permissions';
@@ -143,12 +143,12 @@ export class RolesPublicController {
 		return toRolePublicDto({ ...role, roleType: createRole.roleType });
 	}
 
-	@Patch('/:slug')
+	@Put('/:slug')
 	@ApiKeyScope({ anyOf: ['role:manage', 'role:manageProject'] })
 	@Licensed(LICENSE_FEATURES.CUSTOM_ROLES)
 	@ApiSummary('Update a custom role')
 	@ApiDescription(
-		"Updates a custom role's display name, description, or scopes. Omitted fields are left unchanged. System roles cannot be updated.",
+		"Replaces a custom role's display name, description, and scopes. System roles cannot be updated.",
 	)
 	@ApiTags(['Role'])
 	@ApiResponse(200, RolePublicDto)
@@ -157,7 +157,7 @@ export class RolesPublicController {
 		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('slug') slug: string,
-		@Body updateRole: UpdateRoleDto,
+		@Body updateRole: UpdateRolePublicDto,
 	): Promise<RolePublicDto> {
 		const role = await this.roleService.getRole(slug);
 		if (!isPublicRole(role)) {
@@ -167,7 +167,7 @@ export class RolesPublicController {
 
 		const result = await this.roleService.updateCustomRole({
 			slug,
-			newData: updateRole,
+			newRole: updateRole,
 			userId: req.user.id,
 		});
 

--- a/packages/cli/src/public-api/v1/handlers/roles/spec/paths/updateRole.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/roles/spec/paths/updateRole.generated.yml
@@ -2,7 +2,7 @@ operationId: updateRole
 tags:
   - Role
 summary: Update a custom role
-description: Updates a custom role's display name, description, or scopes. Omitted fields are left unchanged. System roles cannot be updated.
+description: Replaces a custom role's display name, description, and scopes. System roles cannot be updated.
 x-required-scope: role:manage,role:manageProject
 x-eov-operation-id: unreachable
 x-eov-operation-handler: v1/handlers/decorator-routed.handler
@@ -25,11 +25,16 @@ requestBody:
             maxLength: 100
           description:
             type: string
+            nullable: true
             maxLength: 500
           scopes:
             type: array
             items:
               type: string
+        required:
+          - displayName
+          - description
+          - scopes
 responses:
   '200':
     description: Operation successful.

--- a/packages/cli/src/public-api/v1/handlers/roles/spec/paths/updateRole.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/roles/spec/paths/updateRole.generated.yml
@@ -1,12 +1,18 @@
-operationId: createRole
+operationId: updateRole
 tags:
   - Role
-summary: Create a custom role
-description: Creates a custom role. Set `roleType` to `global` for an instance-wide role or `project` for a project role.
+summary: Update a custom role
+description: Updates a custom role's display name, description, or scopes. Omitted fields are left unchanged. System roles cannot be updated.
 x-required-scope: role:manage,role:manageProject
 x-eov-operation-id: unreachable
 x-eov-operation-handler: v1/handlers/decorator-routed.handler
 x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    name: slug
+    in: path
 requestBody:
   content:
     application/json:
@@ -20,21 +26,12 @@ requestBody:
           description:
             type: string
             maxLength: 500
-          roleType:
-            type: string
-            enum:
-              - project
-              - global
           scopes:
             type: array
             items:
               type: string
-        required:
-          - displayName
-          - roleType
-          - scopes
 responses:
-  '201':
+  '200':
     description: Operation successful.
     content:
       application/json:
@@ -46,3 +43,5 @@ responses:
     $ref: ../../../../shared/spec/responses/unauthorized.yml
   '403':
     $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -14,6 +14,8 @@ paths:
   /roles/{slug}:
     get:
       $ref: ./handlers/roles/spec/paths/getRole.generated.yml
+    patch:
+      $ref: ./handlers/roles/spec/paths/updateRole.generated.yml
   /tags:
     get:
       $ref: ./handlers/tags/spec/paths/getTags.generated.yml

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -14,7 +14,7 @@ paths:
   /roles/{slug}:
     get:
       $ref: ./handlers/roles/spec/paths/getRole.generated.yml
-    patch:
+    put:
       $ref: ./handlers/roles/spec/paths/updateRole.generated.yml
   /tags:
     get:

--- a/packages/cli/src/public-api/v1/shared/spec/schemas/rolePublicDto.generated.yml
+++ b/packages/cli/src/public-api/v1/shared/spec/schemas/rolePublicDto.generated.yml
@@ -1,0 +1,35 @@
+type: object
+properties:
+  slug:
+    type: string
+  displayName:
+    type: string
+  description:
+    type: string
+    nullable: true
+  systemRole:
+    type: boolean
+  roleType:
+    type: string
+    enum:
+      - project
+      - global
+  scopes:
+    type: array
+    items:
+      type: string
+  createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time
+required:
+  - slug
+  - displayName
+  - description
+  - systemRole
+  - roleType
+  - scopes
+  - createdAt
+  - updatedAt

--- a/packages/cli/src/services/__tests__/role.service.assignments.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.assignments.test.ts
@@ -5,6 +5,7 @@ import { RoleRepository, ScopeRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { EventService } from '@/events/event.service';
 import { RoleCacheService } from '@/services/role-cache.service';
 import { RoleDeletionCheckProxy } from '@/services/role-deletion-check-proxy.service';
 import { RoleService } from '@/services/role.service';
@@ -16,6 +17,7 @@ describe('RoleService.getRoleAssignments and getRoleProjectMembers', () => {
 	const roleCacheService = mockInstance(RoleCacheService);
 	const logger = mockInstance(Logger);
 	const roleDeletionCheckProxy = mockInstance(RoleDeletionCheckProxy);
+	const eventService = mockInstance(EventService);
 
 	const roleService = new RoleService(
 		licenseState,
@@ -24,6 +26,7 @@ describe('RoleService.getRoleAssignments and getRoleProjectMembers', () => {
 		roleCacheService,
 		logger,
 		roleDeletionCheckProxy,
+		eventService,
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
@@ -100,7 +100,11 @@ describe('RoleService custom role scope whitelist', () => {
 			const dto = { scopes: ['user:create'] } as UpdateRoleDto;
 
 			await expect(
-				roleService.updateCustomRole('project:custom-abc123', dto, 'user-id'),
+				roleService.updateCustomRole({
+					slug: 'project:custom-abc123',
+					newData: dto,
+					userId: 'user-id',
+				}),
 			).rejects.toThrow(BadRequestError);
 			expect(roleRepository.updateRole).not.toHaveBeenCalled();
 		});
@@ -109,7 +113,11 @@ describe('RoleService custom role scope whitelist', () => {
 			const dto = { scopes: ['workflow:create'] } as UpdateRoleDto;
 
 			await expect(
-				roleService.updateCustomRole('project:custom-abc123', dto, 'user-id'),
+				roleService.updateCustomRole({
+					slug: 'project:custom-abc123',
+					newData: dto,
+					userId: 'user-id',
+				}),
 			).resolves.toBeDefined();
 			expect(roleRepository.updateRole).toHaveBeenCalled();
 		});

--- a/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
@@ -7,6 +7,7 @@ import { RoleRepository, ScopeRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { EventService } from '@/events/event.service';
 import { RoleCacheService } from '@/services/role-cache.service';
 import { RoleDeletionCheckProxy } from '@/services/role-deletion-check-proxy.service';
 import { RoleService } from '@/services/role.service';
@@ -18,6 +19,7 @@ describe('RoleService custom role scope whitelist', () => {
 	const roleCacheService = mockInstance(RoleCacheService);
 	const logger = mockInstance(Logger);
 	const roleDeletionCheckProxy = mockInstance(RoleDeletionCheckProxy);
+	const eventService = mockInstance(EventService);
 
 	const roleService = new RoleService(
 		licenseState,
@@ -26,6 +28,7 @@ describe('RoleService custom role scope whitelist', () => {
 		roleCacheService,
 		logger,
 		roleDeletionCheckProxy,
+		eventService,
 	);
 
 	beforeEach(() => {
@@ -96,9 +99,9 @@ describe('RoleService custom role scope whitelist', () => {
 		it('rejects updating a project role with a global-only scope', async () => {
 			const dto = { scopes: ['user:create'] } as UpdateRoleDto;
 
-			await expect(roleService.updateCustomRole('project:custom-abc123', dto)).rejects.toThrow(
-				BadRequestError,
-			);
+			await expect(
+				roleService.updateCustomRole('project:custom-abc123', dto, 'user-id'),
+			).rejects.toThrow(BadRequestError);
 			expect(roleRepository.updateRole).not.toHaveBeenCalled();
 		});
 
@@ -106,7 +109,7 @@ describe('RoleService custom role scope whitelist', () => {
 			const dto = { scopes: ['workflow:create'] } as UpdateRoleDto;
 
 			await expect(
-				roleService.updateCustomRole('project:custom-abc123', dto),
+				roleService.updateCustomRole('project:custom-abc123', dto, 'user-id'),
 			).resolves.toBeDefined();
 			expect(roleRepository.updateRole).toHaveBeenCalled();
 		});

--- a/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
@@ -102,7 +102,7 @@ describe('RoleService custom role scope whitelist', () => {
 			await expect(
 				roleService.updateCustomRole({
 					slug: 'project:custom-abc123',
-					newData: dto,
+					newRole: dto,
 					userId: 'user-id',
 				}),
 			).rejects.toThrow(BadRequestError);
@@ -115,7 +115,7 @@ describe('RoleService custom role scope whitelist', () => {
 			await expect(
 				roleService.updateCustomRole({
 					slug: 'project:custom-abc123',
-					newData: dto,
+					newRole: dto,
 					userId: 'user-id',
 				}),
 			).resolves.toBeDefined();

--- a/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.customRoles.test.ts
@@ -109,7 +109,7 @@ describe('RoleService custom role scope whitelist', () => {
 			expect(roleRepository.updateRole).not.toHaveBeenCalled();
 		});
 
-		it('accepts updating a project role with project-scoped scopes', async () => {
+		it('accepts updating a project role with project-scoped scopes and emits custom-role-updated', async () => {
 			const dto = { scopes: ['workflow:create'] } as UpdateRoleDto;
 
 			await expect(
@@ -120,6 +120,11 @@ describe('RoleService custom role scope whitelist', () => {
 				}),
 			).resolves.toBeDefined();
 			expect(roleRepository.updateRole).toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith('custom-role-updated', {
+				userId: 'user-id',
+				roleSlug: 'project:custom-abc123',
+				scopes: [],
+			});
 		});
 	});
 });

--- a/packages/cli/src/services/__tests__/role.service.rolesWithScope.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.rolesWithScope.test.ts
@@ -4,6 +4,7 @@ import { mockInstance } from '@n8n/backend-test-utils';
 import { RoleRepository, ScopeRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
+import { EventService } from '@/events/event.service';
 import { RoleCacheService } from '@/services/role-cache.service';
 import { RoleDeletionCheckProxy } from '@/services/role-deletion-check-proxy.service';
 import { RoleService } from '@/services/role.service';
@@ -15,6 +16,7 @@ describe('RoleService.rolesWithScope', () => {
 	const roleCacheService = mockInstance(RoleCacheService);
 	const logger = mockInstance(Logger);
 	const roleDeletionCheckProxy = mockInstance(RoleDeletionCheckProxy);
+	const eventService = mockInstance(EventService);
 
 	const roleService = new RoleService(
 		licenseState,
@@ -23,6 +25,7 @@ describe('RoleService.rolesWithScope', () => {
 		roleCacheService,
 		logger,
 		roleDeletionCheckProxy,
+		eventService,
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -42,6 +42,7 @@ import { UnexpectedError, UserError } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { EventService } from '@/events/event.service';
 import { isUniqueConstraintError } from '@/response-helper';
 
 import { RoleCacheService } from './role-cache.service';
@@ -56,6 +57,7 @@ export class RoleService {
 		private readonly roleCacheService: RoleCacheService,
 		private readonly logger: Logger,
 		private readonly roleDeletionCheckProxy: RoleDeletionCheckProxy,
+		private readonly eventService: EventService,
 	) {}
 
 	private dbRoleToRoleDTO(role: Role, usedByUsers?: number, usedByProjects?: number): RoleDTO {
@@ -221,7 +223,7 @@ export class RoleService {
 		return scopes;
 	}
 
-	async updateCustomRole(slug: string, newData: UpdateRoleDto) {
+	async updateCustomRole(slug: string, newData: UpdateRoleDto, userId: string) {
 		const { displayName, description, scopes: scopeSlugs } = newData;
 
 		const roleType = slug.startsWith('project:') ? 'project' : 'global';
@@ -236,7 +238,15 @@ export class RoleService {
 			// Invalidate cache after role update
 			await this.roleCacheService.invalidateCache();
 
-			return this.dbRoleToRoleDTO(updatedRole);
+			const result = this.dbRoleToRoleDTO(updatedRole);
+
+			this.eventService.emit('custom-role-updated', {
+				userId,
+				roleSlug: result.slug,
+				scopes: result.scopes,
+			});
+
+			return result;
 		} catch (error) {
 			if (error instanceof UserError && error.message === 'Role not found') {
 				throw new NotFoundError('Role not found');

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -223,7 +223,15 @@ export class RoleService {
 		return scopes;
 	}
 
-	async updateCustomRole(slug: string, newData: UpdateRoleDto, userId: string) {
+	async updateCustomRole({
+		slug,
+		newData,
+		userId,
+	}: {
+		slug: string;
+		newData: UpdateRoleDto;
+		userId: string;
+	}) {
 		const { displayName, description, scopes: scopeSlugs } = newData;
 
 		const roleType = slug.startsWith('project:') ? 'project' : 'global';

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -3,7 +3,7 @@ import type {
 	RoleMembersResponse,
 	RoleProjectMembersResponse,
 } from '@n8n/api-types';
-import { CreateRoleDto, UpdateRoleDto } from '@n8n/api-types';
+import { CreateRoleDto } from '@n8n/api-types';
 import { LicenseState, Logger } from '@n8n/backend-common';
 import {
 	CredentialsEntity,
@@ -225,14 +225,15 @@ export class RoleService {
 
 	async updateCustomRole({
 		slug,
-		newData,
+		newRole,
 		userId,
 	}: {
 		slug: string;
-		newData: UpdateRoleDto;
+		// Optional fields keep this compatible with both the internal PATCH and public PUT endpoints.
+		newRole: { displayName?: string; description?: string | null; scopes?: string[] };
 		userId: string;
 	}) {
-		const { displayName, description, scopes: scopeSlugs } = newData;
+		const { displayName, description, scopes: scopeSlugs } = newRole;
 
 		const roleType = slug.startsWith('project:') ? 'project' : 'global';
 

--- a/packages/cli/test/integration/controllers/role.controller.test.ts
+++ b/packages/cli/test/integration/controllers/role.controller.test.ts
@@ -998,7 +998,7 @@ describe('RoleController', () => {
 			expect(response.body).toEqual({ data: mockUpdatedRole });
 			expect(roleService.updateCustomRole).toHaveBeenCalledWith({
 				slug: roleSlug,
-				newData: updateRoleDto,
+				newRole: updateRoleDto,
 				userId: expect.any(String),
 			});
 		});
@@ -1035,7 +1035,7 @@ describe('RoleController', () => {
 			expect(response.body).toEqual({ data: mockUpdatedRole });
 			expect(roleService.updateCustomRole).toHaveBeenCalledWith({
 				slug: roleSlug,
-				newData: updateRoleDto,
+				newRole: updateRoleDto,
 				userId: expect.any(String),
 			});
 		});

--- a/packages/cli/test/integration/controllers/role.controller.test.ts
+++ b/packages/cli/test/integration/controllers/role.controller.test.ts
@@ -996,8 +996,11 @@ describe('RoleController', () => {
 			// ASSERT
 			//
 			expect(response.body).toEqual({ data: mockUpdatedRole });
-			// Parameter verification skipped - test framework issue
-			expect(roleService.updateCustomRole).toHaveBeenCalledWith(roleSlug, updateRoleDto);
+			expect(roleService.updateCustomRole).toHaveBeenCalledWith({
+				slug: roleSlug,
+				newData: updateRoleDto,
+				userId: expect.any(String),
+			});
 		});
 
 		it('should update only provided fields', async () => {
@@ -1030,7 +1033,11 @@ describe('RoleController', () => {
 			// ASSERT
 			//
 			expect(response.body).toEqual({ data: mockUpdatedRole });
-			expect(roleService.updateCustomRole).toHaveBeenCalledWith(roleSlug, updateRoleDto);
+			expect(roleService.updateCustomRole).toHaveBeenCalledWith({
+				slug: roleSlug,
+				newData: updateRoleDto,
+				userId: expect.any(String),
+			});
 		});
 
 		it('should handle service errors gracefully', async () => {

--- a/packages/cli/test/integration/public-api/roles.test.ts
+++ b/packages/cli/test/integration/public-api/roles.test.ts
@@ -408,7 +408,7 @@ describe('Roles in Public API', () => {
 		});
 	});
 
-	describe('PATCH /roles/{slug}', () => {
+	describe('PUT /roles/{slug}', () => {
 		type CreatedRole = {
 			slug: string;
 			displayName: string;
@@ -428,49 +428,32 @@ describe('Roles in Public API', () => {
 			return response.body;
 		};
 
-		it('updates the displayName only, leaving description and scopes unchanged', async () => {
-			const role = await createGlobalRole('PA patch displayName', ['user:read', 'user:list']);
-
-			const response = await testServer
-				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'PA patched displayName' });
-
-			expect(response.status).toBe(200);
-			expect(response.body.displayName).toBe('PA patched displayName');
-			expect(response.body.description).toBeNull();
-			expect(response.body.scopes).toEqual(expect.arrayContaining(['user:read', 'user:list']));
+		const fullBody = (overrides: Partial<CreatedRole> = {}) => ({
+			displayName: 'PA updated role',
+			description: null,
+			scopes: ['user:read'],
+			...overrides,
 		});
 
-		it('replaces scopes rather than merging them', async () => {
-			const role = await createGlobalRole('PA patch scopes', ['user:read', 'user:list']);
+		it('replaces displayName, description, and scopes, returns the full public shape', async () => {
+			const role = await createGlobalRole('PA put all fields');
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({ scopes: ['user:read'] });
-
-			expect(response.status).toBe(200);
-			expect(response.body.scopes).toEqual(['user:read']);
-		});
-
-		it('updates displayName, description, and scopes together and returns the full public shape', async () => {
-			const role = await createGlobalRole('PA patch all fields');
-
-			const response = await testServer
-				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({
-					displayName: 'PA patched all fields',
-					description: 'An updated description',
-					scopes: ['user:read', 'user:list'],
-				});
+				.put(`/roles/${role.slug}`)
+				.send(
+					fullBody({
+						displayName: 'PA put all fields updated',
+						description: 'An updated description',
+						scopes: ['user:read', 'user:list'],
+					}),
+				);
 
 			expect(response.status).toBe(200);
 			// Full-shape assertion also proves no extra fields leak (e.g. licensed, usedByUsers).
 			expect(response.body).toEqual({
 				slug: role.slug,
-				displayName: 'PA patched all fields',
+				displayName: 'PA put all fields updated',
 				description: 'An updated description',
 				systemRole: false,
 				roleType: 'global',
@@ -481,44 +464,104 @@ describe('Roles in Public API', () => {
 			expect(response.body.scopes).toHaveLength(2);
 		});
 
-		it('leaves the role unchanged when the body is empty', async () => {
-			const role = await createGlobalRole('PA patch empty body');
+		it('replaces scopes entirely rather than merging them with the existing set', async () => {
+			const role = await createGlobalRole('PA put scopes', ['user:read', 'user:list']);
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({});
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: role.displayName, scopes: ['user:read'] }));
+
+			expect(response.status).toBe(200);
+			expect(response.body.scopes).toEqual(['user:read']);
+		});
+
+		it('clears an existing description by sending null', async () => {
+			const created = await testServer
+				.publicApiAgentFor(owner)
+				.post('/roles')
+				.send({ displayName: 'PA put clear description', roleType: 'global', scopes: [] });
+			expect(created.status).toBe(201);
+			const withDescription = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/roles/${created.body.slug}`)
+				.send(
+					fullBody({ displayName: created.body.displayName, description: 'Has a description' }),
+				);
+			expect(withDescription.body.description).toBe('Has a description');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/roles/${created.body.slug}`)
+				.send(fullBody({ displayName: created.body.displayName, description: null }));
+
+			expect(response.status).toBe(200);
+			expect(response.body.description).toBeNull();
+		});
+
+		it('accepts a GET response of the role as a PUT body unchanged (round-trip)', async () => {
+			const role = await createGlobalRole('PA put round trip', ['user:read', 'user:list']);
+			const getResponse = await testServer.publicApiAgentFor(owner).get('/roles');
+			const current = getResponse.body.global.find((r: { slug: string }) => r.slug === role.slug);
+
+			const response = await testServer.publicApiAgentFor(owner).put(`/roles/${role.slug}`).send({
+				displayName: current.displayName,
+				description: current.description,
+				scopes: current.scopes,
+			});
 
 			expect(response.status).toBe(200);
 			expect(response.body.displayName).toBe(role.displayName);
-			expect(response.body.description).toBe(role.description);
-			expect(response.body.scopes).toEqual(role.scopes);
+			expect(response.body.description).toBeNull();
+			expect(response.body.scopes).toEqual(expect.arrayContaining(['user:read', 'user:list']));
+		});
+
+		it('rejects a body missing a required field with 400', async () => {
+			const role = await createGlobalRole('PA put missing field');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/roles/${role.slug}`)
+				.send({ displayName: 'PA put missing field updated', description: null });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects an empty body with 400', async () => {
+			const role = await createGlobalRole('PA put empty body');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/roles/${role.slug}`)
+				.send({});
+
+			expect(response.status).toBe(400);
 		});
 
 		it('lets a role:manageProject key update a project role (200)', async () => {
 			const agent = await makeManageProjectUserAgent();
 			const created = await agent.post('/roles').send({
-				displayName: 'MP patch project role',
+				displayName: 'MP put project role',
 				roleType: 'project',
 				scopes: ['workflow:read'],
 			});
 			expect(created.status).toBe(201);
 
 			const response = await agent
-				.patch(`/roles/${created.body.slug}`)
-				.send({ displayName: 'MP patched project role' });
+				.put(`/roles/${created.body.slug}`)
+				.send(fullBody({ displayName: 'MP put project role updated', scopes: ['workflow:read'] }));
 
 			expect(response.status).toBe(200);
-			expect(response.body.displayName).toBe('MP patched project role');
+			expect(response.body.displayName).toBe('MP put project role updated');
 		});
 
 		it('forbids a role:manageProject key from updating a global role (403)', async () => {
-			const role = await createGlobalRole('PA global role for MP patch test');
+			const role = await createGlobalRole('PA global role for MP put test');
 			const agent = await makeManageProjectUserAgent();
 
 			const response = await agent
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'MP should not patch this' });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: 'MP should not put this' }));
 
 			expect(response.status).toBe(403);
 		});
@@ -526,8 +569,8 @@ describe('Roles in Public API', () => {
 		it('returns 404 for an unknown slug', async () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch('/roles/global:does-not-exist')
-				.send({ displayName: 'Does not matter' });
+				.put('/roles/global:does-not-exist')
+				.send(fullBody());
 
 			expect(response.status).toBe(404);
 		});
@@ -537,8 +580,8 @@ describe('Roles in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${credentialRole.slug}`)
-				.send({ displayName: 'Should not be reachable' });
+				.put(`/roles/${credentialRole.slug}`)
+				.send(fullBody({ displayName: 'Should not be reachable' }));
 
 			expect(response.status).toBe(404);
 		});
@@ -546,104 +589,104 @@ describe('Roles in Public API', () => {
 		it('rejects updating a system role with 400', async () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch('/roles/global:owner')
-				.send({ displayName: 'Renamed owner role' });
+				.put('/roles/global:owner')
+				.send(fullBody({ displayName: 'Renamed owner role' }));
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toContain('Cannot update system roles');
 		});
 
 		it('rejects an unknown scope slug with 400', async () => {
-			const role = await createGlobalRole('PA patch bad slug');
+			const role = await createGlobalRole('PA put bad slug');
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({ scopes: ['not:a-real-scope'] });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: role.displayName, scopes: ['not:a-real-scope'] }));
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toContain('Invalid scope');
 		});
 
 		it('rejects a scope not allowed for the role type with 400', async () => {
-			const role = await createGlobalRole('PA patch wrong scope');
+			const role = await createGlobalRole('PA put wrong scope');
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({ scopes: ['workflow:read'] });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: role.displayName, scopes: ['workflow:read'] }));
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toContain('not allowed for global roles');
 		});
 
 		it('rejects a too-short displayName with 400', async () => {
-			const role = await createGlobalRole('PA patch short name');
+			const role = await createGlobalRole('PA put short name');
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'a' });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: 'a' }));
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toContain('at least 2');
 		});
 
 		it('rejects renaming onto an existing role name with 400', async () => {
-			await createGlobalRole('PA patch existing name');
-			const role = await createGlobalRole('PA patch rename target');
+			await createGlobalRole('PA put existing name');
+			const role = await createGlobalRole('PA put rename target');
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'PA patch existing name' });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: 'PA put existing name' }));
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toContain('already exists');
 		});
 
 		it('rejects with 401 without an API key', async () => {
-			const role = await createGlobalRole('PA patch no key');
+			const role = await createGlobalRole('PA put no key');
 
 			const response = await testServer
 				.publicApiAgentWithoutApiKey()
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'Should not work' });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: 'Should not work' }));
 
 			expect(response.status).toBe(401);
 		});
 
 		it('rejects with 401 with an invalid API key', async () => {
-			const role = await createGlobalRole('PA patch bad key');
+			const role = await createGlobalRole('PA put bad key');
 
 			const response = await testServer
 				.publicApiAgentWithApiKey('invalid-key')
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'Should not work' });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: 'Should not work' }));
 
 			expect(response.status).toBe(401);
 		});
 
 		it('rejects with 403 when the key lacks a role scope', async () => {
-			const role = await createGlobalRole('PA patch no scope');
+			const role = await createGlobalRole('PA put no scope');
 			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
 
 			const response = await testServer
 				.publicApiAgentFor(scopedOwner)
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'Should not work' });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: 'Should not work' }));
 
 			expect(response.status).toBe(403);
 		});
 
 		it('rejects with 403 when the custom roles feature is not licensed', async () => {
-			const role = await createGlobalRole('PA patch unlicensed');
+			const role = await createGlobalRole('PA put unlicensed');
 			testServer.license.disable('feat:customRoles');
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.patch(`/roles/${role.slug}`)
-				.send({ displayName: 'Should not work' });
+				.put(`/roles/${role.slug}`)
+				.send(fullBody({ displayName: 'Should not work' }));
 
 			expect(response.status).toBe(403);
 

--- a/packages/cli/test/integration/public-api/roles.test.ts
+++ b/packages/cli/test/integration/public-api/roles.test.ts
@@ -1,7 +1,8 @@
 import { testDb } from '@n8n/backend-test-utils';
 import { RoleRepository, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { createCustomRoleWithScopeSlugs } from '@test-integration/db/roles';
+
+import { createCustomRoleWithScopeSlugs, createRole } from '@test-integration/db/roles';
 import { addApiKey, createOwnerWithApiKey, createUser } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
 
@@ -400,6 +401,249 @@ describe('Roles in Public API', () => {
 				.publicApiAgentFor(owner)
 				.post('/roles')
 				.send({ displayName: 'PA unlicensed', roleType: 'global', scopes: ['user:read'] });
+
+			expect(response.status).toBe(403);
+
+			testServer.license.enable('feat:customRoles');
+		});
+	});
+
+	describe('PATCH /roles/{slug}', () => {
+		type CreatedRole = {
+			slug: string;
+			displayName: string;
+			description: string | null;
+			scopes: string[];
+		};
+
+		const createGlobalRole = async (
+			displayName: string,
+			scopes: string[] = ['user:read'],
+		): Promise<CreatedRole> => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/roles')
+				.send({ displayName, roleType: 'global', scopes });
+			expect(response.status).toBe(201);
+			return response.body;
+		};
+
+		it('updates the displayName only, leaving description and scopes unchanged', async () => {
+			const role = await createGlobalRole('PA patch displayName', ['user:read', 'user:list']);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'PA patched displayName' });
+
+			expect(response.status).toBe(200);
+			expect(response.body.displayName).toBe('PA patched displayName');
+			expect(response.body.description).toBeNull();
+			expect(response.body.scopes).toEqual(expect.arrayContaining(['user:read', 'user:list']));
+		});
+
+		it('replaces scopes rather than merging them', async () => {
+			const role = await createGlobalRole('PA patch scopes', ['user:read', 'user:list']);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({ scopes: ['user:read'] });
+
+			expect(response.status).toBe(200);
+			expect(response.body.scopes).toEqual(['user:read']);
+		});
+
+		it('updates displayName, description, and scopes together and returns the full public shape', async () => {
+			const role = await createGlobalRole('PA patch all fields');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({
+					displayName: 'PA patched all fields',
+					description: 'An updated description',
+					scopes: ['user:read', 'user:list'],
+				});
+
+			expect(response.status).toBe(200);
+			// Full-shape assertion also proves no extra fields leak (e.g. licensed, usedByUsers).
+			expect(response.body).toEqual({
+				slug: role.slug,
+				displayName: 'PA patched all fields',
+				description: 'An updated description',
+				systemRole: false,
+				roleType: 'global',
+				scopes: expect.arrayContaining(['user:read', 'user:list']),
+				createdAt: expect.any(String),
+				updatedAt: expect.any(String),
+			});
+			expect(response.body.scopes).toHaveLength(2);
+		});
+
+		it('leaves the role unchanged when the body is empty', async () => {
+			const role = await createGlobalRole('PA patch empty body');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({});
+
+			expect(response.status).toBe(200);
+			expect(response.body.displayName).toBe(role.displayName);
+			expect(response.body.description).toBe(role.description);
+			expect(response.body.scopes).toEqual(role.scopes);
+		});
+
+		it('lets a role:manageProject key update a project role (200)', async () => {
+			const agent = await makeManageProjectUserAgent();
+			const created = await agent.post('/roles').send({
+				displayName: 'MP patch project role',
+				roleType: 'project',
+				scopes: ['workflow:read'],
+			});
+			expect(created.status).toBe(201);
+
+			const response = await agent
+				.patch(`/roles/${created.body.slug}`)
+				.send({ displayName: 'MP patched project role' });
+
+			expect(response.status).toBe(200);
+			expect(response.body.displayName).toBe('MP patched project role');
+		});
+
+		it('forbids a role:manageProject key from updating a global role (403)', async () => {
+			const role = await createGlobalRole('PA global role for MP patch test');
+			const agent = await makeManageProjectUserAgent();
+
+			const response = await agent
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'MP should not patch this' });
+
+			expect(response.status).toBe(403);
+		});
+
+		it('returns 404 for an unknown slug', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch('/roles/global:does-not-exist')
+				.send({ displayName: 'Does not matter' });
+
+			expect(response.status).toBe(404);
+		});
+
+		it('returns 404 for a role type not exposed by the public API (e.g. credential)', async () => {
+			const credentialRole = await createRole({ roleType: 'credential', scopes: [] });
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${credentialRole.slug}`)
+				.send({ displayName: 'Should not be reachable' });
+
+			expect(response.status).toBe(404);
+		});
+
+		it('rejects updating a system role with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch('/roles/global:owner')
+				.send({ displayName: 'Renamed owner role' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('Cannot update system roles');
+		});
+
+		it('rejects an unknown scope slug with 400', async () => {
+			const role = await createGlobalRole('PA patch bad slug');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({ scopes: ['not:a-real-scope'] });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('Invalid scope');
+		});
+
+		it('rejects a scope not allowed for the role type with 400', async () => {
+			const role = await createGlobalRole('PA patch wrong scope');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({ scopes: ['workflow:read'] });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('not allowed for global roles');
+		});
+
+		it('rejects a too-short displayName with 400', async () => {
+			const role = await createGlobalRole('PA patch short name');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'a' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('at least 2');
+		});
+
+		it('rejects renaming onto an existing role name with 400', async () => {
+			await createGlobalRole('PA patch existing name');
+			const role = await createGlobalRole('PA patch rename target');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'PA patch existing name' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('already exists');
+		});
+
+		it('rejects with 401 without an API key', async () => {
+			const role = await createGlobalRole('PA patch no key');
+
+			const response = await testServer
+				.publicApiAgentWithoutApiKey()
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'Should not work' });
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 401 with an invalid API key', async () => {
+			const role = await createGlobalRole('PA patch bad key');
+
+			const response = await testServer
+				.publicApiAgentWithApiKey('invalid-key')
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'Should not work' });
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when the key lacks a role scope', async () => {
+			const role = await createGlobalRole('PA patch no scope');
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
+
+			const response = await testServer
+				.publicApiAgentFor(scopedOwner)
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'Should not work' });
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects with 403 when the custom roles feature is not licensed', async () => {
+			const role = await createGlobalRole('PA patch unlicensed');
+			testServer.license.disable('feat:customRoles');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/roles/${role.slug}`)
+				.send({ displayName: 'Should not work' });
 
 			expect(response.status).toBe(403);
 

--- a/packages/cli/test/integration/services/role.service.test.ts
+++ b/packages/cli/test/integration/services/role.service.test.ts
@@ -1038,11 +1038,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(
-				existingRole.slug,
-				updateRoleDto,
-				'test-user-id',
-			);
+			const result = await roleService.updateCustomRole({
+				slug: existingRole.slug,
+				newData: updateRoleDto,
+				userId: 'test-user-id',
+			});
 
 			//
 			// ASSERT
@@ -1081,11 +1081,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(
-				existingRole.slug,
-				updateRoleDto,
-				'test-user-id',
-			);
+			const result = await roleService.updateCustomRole({
+				slug: existingRole.slug,
+				newData: updateRoleDto,
+				userId: 'test-user-id',
+			});
 
 			//
 			// ASSERT
@@ -1120,10 +1120,18 @@ describe('RoleService', () => {
 			// ACT & ASSERT
 			//
 			await expect(
-				roleService.updateCustomRole(systemRole.slug, updateRoleDto, 'test-user-id'),
+				roleService.updateCustomRole({
+					slug: systemRole.slug,
+					newData: updateRoleDto,
+					userId: 'test-user-id',
+				}),
 			).rejects.toThrow(BadRequestError);
 			await expect(
-				roleService.updateCustomRole(systemRole.slug, updateRoleDto, 'test-user-id'),
+				roleService.updateCustomRole({
+					slug: systemRole.slug,
+					newData: updateRoleDto,
+					userId: 'test-user-id',
+				}),
 			).rejects.toThrow('Cannot update system roles');
 		});
 
@@ -1144,11 +1152,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(
-				existingRole.slug,
-				updateRoleDto,
-				'test-user-id',
-			);
+			const result = await roleService.updateCustomRole({
+				slug: existingRole.slug,
+				newData: updateRoleDto,
+				userId: 'test-user-id',
+			});
 
 			//
 			// ASSERT
@@ -1173,11 +1181,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(
-				existingRole.slug,
-				updateRoleDto,
-				'test-user-id',
-			);
+			const result = await roleService.updateCustomRole({
+				slug: existingRole.slug,
+				newData: updateRoleDto,
+				userId: 'test-user-id',
+			});
 
 			//
 			// ASSERT
@@ -1198,7 +1206,11 @@ describe('RoleService', () => {
 			// ACT & ASSERT
 			//
 			await expect(
-				roleService.updateCustomRole(nonExistentSlug, updateRoleDto, 'test-user-id'),
+				roleService.updateCustomRole({
+					slug: nonExistentSlug,
+					newData: updateRoleDto,
+					userId: 'test-user-id',
+				}),
 			).rejects.toThrow('Role not found');
 		});
 
@@ -1215,7 +1227,11 @@ describe('RoleService', () => {
 			// ACT & ASSERT
 			//
 			await expect(
-				roleService.updateCustomRole(existingRole.slug, updateRoleDto, 'test-user-id'),
+				roleService.updateCustomRole({
+					slug: existingRole.slug,
+					newData: updateRoleDto,
+					userId: 'test-user-id',
+				}),
 			).rejects.toThrow('The following scopes are invalid: invalid:scope');
 		});
 
@@ -1234,7 +1250,11 @@ describe('RoleService', () => {
 			// ACT & ASSERT
 			//
 			await expect(
-				roleService.updateCustomRole(otherExistingRole.slug, updateRoleDto, 'test-user-id'),
+				roleService.updateCustomRole({
+					slug: otherExistingRole.slug,
+					newData: updateRoleDto,
+					userId: 'test-user-id',
+				}),
 			).rejects.toThrow(`A role with the name "${existingRole.displayName}" already exists`);
 		});
 	});

--- a/packages/cli/test/integration/services/role.service.test.ts
+++ b/packages/cli/test/integration/services/role.service.test.ts
@@ -1038,7 +1038,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(existingRole.slug, updateRoleDto);
+			const result = await roleService.updateCustomRole(
+				existingRole.slug,
+				updateRoleDto,
+				'test-user-id',
+			);
 
 			//
 			// ASSERT
@@ -1077,7 +1081,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(existingRole.slug, updateRoleDto);
+			const result = await roleService.updateCustomRole(
+				existingRole.slug,
+				updateRoleDto,
+				'test-user-id',
+			);
 
 			//
 			// ASSERT
@@ -1111,12 +1119,12 @@ describe('RoleService', () => {
 			//
 			// ACT & ASSERT
 			//
-			await expect(roleService.updateCustomRole(systemRole.slug, updateRoleDto)).rejects.toThrow(
-				BadRequestError,
-			);
-			await expect(roleService.updateCustomRole(systemRole.slug, updateRoleDto)).rejects.toThrow(
-				'Cannot update system roles',
-			);
+			await expect(
+				roleService.updateCustomRole(systemRole.slug, updateRoleDto, 'test-user-id'),
+			).rejects.toThrow(BadRequestError);
+			await expect(
+				roleService.updateCustomRole(systemRole.slug, updateRoleDto, 'test-user-id'),
+			).rejects.toThrow('Cannot update system roles');
 		});
 
 		it('should update displayName when provided', async () => {
@@ -1136,7 +1144,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(existingRole.slug, updateRoleDto);
+			const result = await roleService.updateCustomRole(
+				existingRole.slug,
+				updateRoleDto,
+				'test-user-id',
+			);
 
 			//
 			// ASSERT
@@ -1161,7 +1173,11 @@ describe('RoleService', () => {
 			//
 			// ACT
 			//
-			const result = await roleService.updateCustomRole(existingRole.slug, updateRoleDto);
+			const result = await roleService.updateCustomRole(
+				existingRole.slug,
+				updateRoleDto,
+				'test-user-id',
+			);
 
 			//
 			// ASSERT
@@ -1181,9 +1197,9 @@ describe('RoleService', () => {
 			//
 			// ACT & ASSERT
 			//
-			await expect(roleService.updateCustomRole(nonExistentSlug, updateRoleDto)).rejects.toThrow(
-				'Role not found',
-			);
+			await expect(
+				roleService.updateCustomRole(nonExistentSlug, updateRoleDto, 'test-user-id'),
+			).rejects.toThrow('Role not found');
 		});
 
 		it('should throw error when invalid scopes are provided', async () => {
@@ -1198,9 +1214,9 @@ describe('RoleService', () => {
 			//
 			// ACT & ASSERT
 			//
-			await expect(roleService.updateCustomRole(existingRole.slug, updateRoleDto)).rejects.toThrow(
-				'The following scopes are invalid: invalid:scope',
-			);
+			await expect(
+				roleService.updateCustomRole(existingRole.slug, updateRoleDto, 'test-user-id'),
+			).rejects.toThrow('The following scopes are invalid: invalid:scope');
 		});
 
 		it('should throw error when a role with the same display name already exists', async () => {
@@ -1218,7 +1234,7 @@ describe('RoleService', () => {
 			// ACT & ASSERT
 			//
 			await expect(
-				roleService.updateCustomRole(otherExistingRole.slug, updateRoleDto),
+				roleService.updateCustomRole(otherExistingRole.slug, updateRoleDto, 'test-user-id'),
 			).rejects.toThrow(`A role with the name "${existingRole.displayName}" already exists`);
 		});
 	});

--- a/packages/cli/test/integration/services/role.service.test.ts
+++ b/packages/cli/test/integration/services/role.service.test.ts
@@ -1040,7 +1040,7 @@ describe('RoleService', () => {
 			//
 			const result = await roleService.updateCustomRole({
 				slug: existingRole.slug,
-				newData: updateRoleDto,
+				newRole: updateRoleDto,
 				userId: 'test-user-id',
 			});
 
@@ -1083,7 +1083,7 @@ describe('RoleService', () => {
 			//
 			const result = await roleService.updateCustomRole({
 				slug: existingRole.slug,
-				newData: updateRoleDto,
+				newRole: updateRoleDto,
 				userId: 'test-user-id',
 			});
 
@@ -1122,14 +1122,14 @@ describe('RoleService', () => {
 			await expect(
 				roleService.updateCustomRole({
 					slug: systemRole.slug,
-					newData: updateRoleDto,
+					newRole: updateRoleDto,
 					userId: 'test-user-id',
 				}),
 			).rejects.toThrow(BadRequestError);
 			await expect(
 				roleService.updateCustomRole({
 					slug: systemRole.slug,
-					newData: updateRoleDto,
+					newRole: updateRoleDto,
 					userId: 'test-user-id',
 				}),
 			).rejects.toThrow('Cannot update system roles');
@@ -1154,7 +1154,7 @@ describe('RoleService', () => {
 			//
 			const result = await roleService.updateCustomRole({
 				slug: existingRole.slug,
-				newData: updateRoleDto,
+				newRole: updateRoleDto,
 				userId: 'test-user-id',
 			});
 
@@ -1183,7 +1183,7 @@ describe('RoleService', () => {
 			//
 			const result = await roleService.updateCustomRole({
 				slug: existingRole.slug,
-				newData: updateRoleDto,
+				newRole: updateRoleDto,
 				userId: 'test-user-id',
 			});
 
@@ -1208,7 +1208,7 @@ describe('RoleService', () => {
 			await expect(
 				roleService.updateCustomRole({
 					slug: nonExistentSlug,
-					newData: updateRoleDto,
+					newRole: updateRoleDto,
 					userId: 'test-user-id',
 				}),
 			).rejects.toThrow('Role not found');
@@ -1229,7 +1229,7 @@ describe('RoleService', () => {
 			await expect(
 				roleService.updateCustomRole({
 					slug: existingRole.slug,
-					newData: updateRoleDto,
+					newRole: updateRoleDto,
 					userId: 'test-user-id',
 				}),
 			).rejects.toThrow('The following scopes are invalid: invalid:scope');
@@ -1252,7 +1252,7 @@ describe('RoleService', () => {
 			await expect(
 				roleService.updateCustomRole({
 					slug: otherExistingRole.slug,
-					newData: updateRoleDto,
+					newRole: updateRoleDto,
 					userId: 'test-user-id',
 				}),
 			).rejects.toThrow(`A role with the name "${existingRole.displayName}" already exists`);

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -14,7 +14,7 @@
 		"POST /roles": {
 			"status": "gap"
 		},
-		"PATCH /roles/{slug}": {
+		"PUT /roles/{slug}": {
 			"status": "gap"
 		},
 		"POST /role-mapping-rules": {

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -14,6 +14,9 @@
 		"POST /roles": {
 			"status": "gap"
 		},
+		"PATCH /roles/{slug}": {
+			"status": "gap"
+		},
 		"POST /role-mapping-rules": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

- Adds `PUT /api/v1/roles/{slug}` to the Public API reusing the `RoleService.updateCustomRole` used by the Internal API equivalent
- Moves the `custom-role-updated` event emission into `RoleService.updateCustomRole` sharing the implementation between the Public and Internal APIs
- Refactors `updateCustomRole` to take a single named-object parameter instead of three positional arguments for readability at call sites.
- Update test suites

## How to test

With an API key that has the `role:manage` (or `role:manageProject`) scope and an instance with the `feat:customRoles` licence enabled:

```
PUT /api/v1/roles/{slug}
{
  "displayName": "Updated role name",
  "description": "This is a role description",
  "scopes": ["workflow:read"]
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-47

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

