### PR TITLE
feat: Improve Browser Use connect conditions

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -6724,6 +6724,7 @@
 	"instanceAi.browserUse.step.connect.title": "2. Connect the extension",
 	"instanceAi.browserUse.step.connect.description": "Open the extension's connect page, choose which tabs to share, and click Connect.",
 	"instanceAi.browserUse.step.connect.cta": "Open Browser Use extension",
+	"instanceAi.browserUse.unsupportedBrowser": "Browser Use requires Google Chrome or another Chromium-based browser like Microsoft Edge or Brave. Open n8n in a supported browser to continue.",
 	"instanceAi.browserUse.connected": "Browser Use is connected",
 	"instanceAi.browserUse.connected.description": "The agent can now use your browser. You can disconnect anytime from the extension or from the Connections list.",
 	"instanceAi.browserUse.connectLinkError.title": "Browser Use setup failed",

--- a/packages/frontend/editor-ui/src/experiments/instanceAiBrowserCredentialSetup/useInstanceAiBrowserCredentialSetupExperiment.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiBrowserCredentialSetup/useInstanceAiBrowserCredentialSetupExperiment.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
 
 import {
 	EXPERIMENTS_TO_TRACK,
@@ -8,6 +9,7 @@ import {
 import { useInstanceAiBrowserCredentialSetupExperiment } from './useInstanceAiBrowserCredentialSetupExperiment';
 
 const getVariant = vi.fn();
+const isBrowserUseEnabled = ref(true);
 
 vi.mock('@/app/stores/posthog.store', () => ({
 	usePostHog: vi.fn(() => ({
@@ -15,9 +17,16 @@ vi.mock('@/app/stores/posthog.store', () => ({
 	})),
 }));
 
+vi.mock('@/experiments/instanceAiBrowserUse', () => ({
+	useInstanceAiBrowserUseExperiment: vi.fn(() => ({
+		isFeatureEnabled: isBrowserUseEnabled,
+	})),
+}));
+
 describe('useInstanceAiBrowserCredentialSetupExperiment', () => {
 	beforeEach(() => {
 		getVariant.mockReset();
+		isBrowserUseEnabled.value = true;
 	});
 
 	it.each([
@@ -35,5 +44,14 @@ describe('useInstanceAiBrowserCredentialSetupExperiment', () => {
 
 	it('registers the experiment for centralized enrollment tracking', () => {
 		expect(EXPERIMENTS_TO_TRACK).toContain(INSTANCE_AI_BROWSER_CREDENTIAL_SETUP_EXPERIMENT.name);
+	});
+
+	it('returns false when Browser Use is disabled', () => {
+		getVariant.mockReturnValue(INSTANCE_AI_BROWSER_CREDENTIAL_SETUP_EXPERIMENT.variant);
+		isBrowserUseEnabled.value = false;
+
+		const { isFeatureEnabled } = useInstanceAiBrowserCredentialSetupExperiment();
+
+		expect(isFeatureEnabled.value).toBe(false);
 	});
 });

--- a/packages/frontend/editor-ui/src/experiments/instanceAiBrowserCredentialSetup/useInstanceAiBrowserCredentialSetupExperiment.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiBrowserCredentialSetup/useInstanceAiBrowserCredentialSetupExperiment.ts
@@ -2,14 +2,19 @@ import { computed } from 'vue';
 
 import { INSTANCE_AI_BROWSER_CREDENTIAL_SETUP_EXPERIMENT } from '@/app/constants/experiments';
 import { usePostHog } from '@/app/stores/posthog.store';
+import { useInstanceAiBrowserUseExperiment } from '@/experiments/instanceAiBrowserUse';
 
 export function useInstanceAiBrowserCredentialSetupExperiment() {
 	const posthogStore = usePostHog();
 
+	// Automatic setup runs through Browser Use, so it requires Browser Use itself.
+	const { isFeatureEnabled: isBrowserUseEnabled } = useInstanceAiBrowserUseExperiment();
+
 	const isFeatureEnabled = computed(
 		() =>
+			isBrowserUseEnabled.value &&
 			posthogStore.getVariant(INSTANCE_AI_BROWSER_CREDENTIAL_SETUP_EXPERIMENT.name) ===
-			INSTANCE_AI_BROWSER_CREDENTIAL_SETUP_EXPERIMENT.variant,
+				INSTANCE_AI_BROWSER_CREDENTIAL_SETUP_EXPERIMENT.variant,
 	);
 
 	return { isFeatureEnabled };

--- a/packages/frontend/editor-ui/src/experiments/instanceAiBrowserUse/index.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiBrowserUse/index.ts
@@ -1,1 +1,4 @@
-export { useInstanceAiBrowserUseExperiment } from './useInstanceAiBrowserUseExperiment';
+export {
+	isBrowserUseSupportedForBrowser,
+	useInstanceAiBrowserUseExperiment,
+} from './useInstanceAiBrowserUseExperiment';

--- a/packages/frontend/editor-ui/src/experiments/instanceAiBrowserUse/useInstanceAiBrowserUseExperiment.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiBrowserUse/useInstanceAiBrowserUseExperiment.test.ts
@@ -5,7 +5,10 @@ import {
 	INSTANCE_AI_BROWSER_USE_EXPERIMENT,
 } from '@/app/constants/experiments';
 
-import { useInstanceAiBrowserUseExperiment } from './useInstanceAiBrowserUseExperiment';
+import {
+	isBrowserUseSupportedForBrowser,
+	useInstanceAiBrowserUseExperiment,
+} from './useInstanceAiBrowserUseExperiment';
 
 const getVariant = vi.fn();
 
@@ -15,9 +18,17 @@ vi.mock('@/app/stores/posthog.store', () => ({
 	})),
 }));
 
+const CHROME_WINDOWS =
+	'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36';
+
+function setUserAgent(userAgent: string) {
+	Object.defineProperty(navigator, 'userAgent', { value: userAgent, configurable: true });
+}
+
 describe('useInstanceAiBrowserUseExperiment', () => {
 	beforeEach(() => {
 		getVariant.mockReset();
+		setUserAgent(CHROME_WINDOWS);
 	});
 
 	it.each([
@@ -35,5 +46,121 @@ describe('useInstanceAiBrowserUseExperiment', () => {
 
 	it('registers the experiment for centralized enrollment tracking', () => {
 		expect(EXPERIMENTS_TO_TRACK).toContain(INSTANCE_AI_BROWSER_USE_EXPERIMENT.name);
+	});
+
+	describe('device support', () => {
+		beforeEach(() => {
+			getVariant.mockReturnValue(INSTANCE_AI_BROWSER_USE_EXPERIMENT.variant);
+		});
+
+		it.each([
+			{ browser: 'Chrome on Windows', userAgent: CHROME_WINDOWS, enabled: true },
+			{
+				browser: 'Chrome on macOS',
+				userAgent:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36',
+				enabled: true,
+			},
+			{
+				browser: 'Chrome on Linux',
+				userAgent:
+					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36',
+				enabled: true,
+			},
+			{
+				browser: 'Chrome on Chrome OS',
+				userAgent:
+					'Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36',
+				enabled: true,
+			},
+			{
+				browser: 'Edge on Windows',
+				userAgent:
+					'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36 Edg/150.0.0.0',
+				enabled: true,
+			},
+			{
+				browser: 'Brave on macOS',
+				userAgent:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36 Brave/150.0.0.0',
+				enabled: true,
+			},
+			{
+				browser: 'Safari on macOS',
+				userAgent:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3 Safari/605.1.15',
+				enabled: true,
+			},
+			{
+				browser: 'Firefox on Windows',
+				userAgent:
+					'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0',
+				enabled: true,
+			},
+			{
+				browser: 'Safari on iOS',
+				userAgent:
+					'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1',
+				enabled: false,
+			},
+			{
+				browser: 'Chrome on Android',
+				userAgent:
+					'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36',
+				enabled: false,
+			},
+			{
+				browser: 'Chrome on Android in desktop mode',
+				userAgent:
+					'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36',
+				enabled: false,
+			},
+			{
+				browser: 'Samsung Internet on Android',
+				userAgent:
+					'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/30.0 Chrome/143.0.0.0 Mobile Safari/537.36',
+				enabled: false,
+			},
+		])('returns $enabled for $browser', ({ userAgent, enabled }) => {
+			setUserAgent(userAgent);
+
+			const { isFeatureEnabled } = useInstanceAiBrowserUseExperiment();
+
+			expect(isFeatureEnabled.value).toBe(enabled);
+		});
+	});
+
+	describe('isBrowserUseSupportedForBrowser', () => {
+		it.each([
+			{ browser: 'Chrome', userAgent: CHROME_WINDOWS, supported: true },
+			{
+				browser: 'Edge',
+				userAgent:
+					'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36 Edg/150.0.0.0',
+				supported: true,
+			},
+			{
+				browser: 'Brave',
+				userAgent:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36 Brave/150.0.0.0',
+				supported: true,
+			},
+			{
+				browser: 'Safari',
+				userAgent:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3 Safari/605.1.15',
+				supported: false,
+			},
+			{
+				browser: 'Firefox',
+				userAgent:
+					'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0',
+				supported: false,
+			},
+		])('returns $supported for $browser', ({ userAgent, supported }) => {
+			setUserAgent(userAgent);
+
+			expect(isBrowserUseSupportedForBrowser()).toBe(supported);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/experiments/instanceAiBrowserUse/useInstanceAiBrowserUseExperiment.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiBrowserUse/useInstanceAiBrowserUseExperiment.ts
@@ -1,15 +1,32 @@
+import Bowser from 'bowser';
 import { computed } from 'vue';
 
 import { INSTANCE_AI_BROWSER_USE_EXPERIMENT } from '@/app/constants/experiments';
 import { usePostHog } from '@/app/stores/posthog.store';
+
+/**
+ * Browser extensions don't exist on phones and tablets
+ */
+function isBrowserUseSupportedOnDevice(): boolean {
+	const { platform } = Bowser.parse(navigator.userAgent);
+	return platform.type !== 'mobile' && platform.type !== 'tablet';
+}
+
+/**
+ * Browser Use only supports Chromium through n8n Browser Use Chrome extension
+ */
+export function isBrowserUseSupportedForBrowser(): boolean {
+	return Bowser.parse(navigator.userAgent).engine.name === 'Blink';
+}
 
 export function useInstanceAiBrowserUseExperiment() {
 	const posthogStore = usePostHog();
 
 	const isFeatureEnabled = computed(
 		() =>
+			isBrowserUseSupportedOnDevice() &&
 			posthogStore.getVariant(INSTANCE_AI_BROWSER_USE_EXPERIMENT.name) ===
-			INSTANCE_AI_BROWSER_USE_EXPERIMENT.variant,
+				INSTANCE_AI_BROWSER_USE_EXPERIMENT.variant,
 	);
 
 	return { isFeatureEnabled };

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiBrowserUse.telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiBrowserUse.telemetry.test.ts
@@ -13,12 +13,17 @@ describe('instance ai browser use telemetry', () => {
 		track.mockClear();
 	});
 
-	test('tracks the connect modal opening', () => {
-		useInstanceAiBrowserUseTelemetry().trackModalOpened();
+	test.each([true, false])(
+		'tracks the connect modal opening with browser_supported %s',
+		(browserSupported) => {
+			useInstanceAiBrowserUseTelemetry().trackModalOpened(browserSupported);
 
-		expect(track).toHaveBeenCalledTimes(1);
-		expect(track).toHaveBeenCalledWith('Instance AI Connect Browser Use modal opened');
-	});
+			expect(track).toHaveBeenCalledTimes(1);
+			expect(track).toHaveBeenCalledWith('Instance AI Connect Browser Use modal opened', {
+				browser_supported: browserSupported,
+			});
+		},
+	);
 
 	test('tracks the install extension button click', () => {
 		useInstanceAiBrowserUseTelemetry().trackInstallExtensionClicked();

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupContent.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupContent.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
-import { N8nButton, N8nHeading, N8nIcon, N8nText } from '@n8n/design-system';
+import { N8nButton, N8nCallout, N8nHeading, N8nIcon, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
+import { isBrowserUseSupportedForBrowser } from '@/experiments/instanceAiBrowserUse';
 import { useInstanceAiSettingsStore } from '../../instanceAiSettings.store';
 import { useInstanceAiBrowserUseTelemetry } from '../../instanceAiBrowserUse.telemetry';
 
@@ -22,6 +23,7 @@ const i18n = useI18n();
 const store = useInstanceAiSettingsStore();
 const telemetry = useInstanceAiBrowserUseTelemetry();
 
+const isBrowserSupported = isBrowserUseSupportedForBrowser();
 const isConnected = computed(() => store.browserConnected);
 const connectUrl = ref<string | null>(null);
 let refreshTimer: ReturnType<typeof setTimeout> | undefined;
@@ -47,7 +49,8 @@ async function refreshConnectUrl(): Promise<void> {
 }
 
 onMounted(() => {
-	telemetry.trackModalOpened();
+	telemetry.trackModalOpened(isBrowserSupported);
+	if (!isBrowserSupported) return;
 	void store.fetchBrowserStatus();
 	if (!store.browserConnected) {
 		void refreshConnectUrl();
@@ -68,7 +71,15 @@ onBeforeUnmount(() => {
 			</N8nHeading>
 		</div>
 
-		<template v-if="isConnected">
+		<N8nCallout
+			v-if="!isBrowserSupported"
+			theme="warning"
+			data-test-id="browser-use-unsupported-browser"
+		>
+			{{ i18n.baseText('instanceAi.browserUse.unsupportedBrowser') }}
+		</N8nCallout>
+
+		<template v-else-if="isConnected">
 			<div :class="$style.statusRow">
 				<span :class="[$style.statusDot, $style.statusDotConnected]" />
 				<N8nText size="small" :bold="true">

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupContent.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupContent.vue
@@ -19,6 +19,8 @@ const props = withDefaults(
 	},
 );
 
+const emit = defineEmits<{ close: [] }>();
+
 const i18n = useI18n();
 const store = useInstanceAiSettingsStore();
 const telemetry = useInstanceAiBrowserUseTelemetry();
@@ -71,13 +73,20 @@ onBeforeUnmount(() => {
 			</N8nHeading>
 		</div>
 
-		<N8nCallout
-			v-if="!isBrowserSupported"
-			theme="warning"
-			data-test-id="browser-use-unsupported-browser"
-		>
-			{{ i18n.baseText('instanceAi.browserUse.unsupportedBrowser') }}
-		</N8nCallout>
+		<template v-if="!isBrowserSupported">
+			<N8nCallout theme="warning" data-test-id="browser-use-unsupported-browser">
+				{{ i18n.baseText('instanceAi.browserUse.unsupportedBrowser') }}
+			</N8nCallout>
+			<div v-if="!props.embedded" :class="$style.footer">
+				<N8nButton
+					:label="i18n.baseText('generic.close')"
+					variant="outline"
+					size="medium"
+					data-test-id="browser-use-unsupported-close"
+					@click="emit('close')"
+				/>
+			</div>
+		</template>
 
 		<template v-else-if="isConnected">
 			<div :class="$style.statusRow">
@@ -180,6 +189,11 @@ onBeforeUnmount(() => {
 	padding: var(--spacing--xs) var(--spacing--sm);
 	background: var(--color--background--light-2);
 	border-radius: var(--radius);
+}
+
+.footer {
+	display: flex;
+	justify-content: flex-end;
 }
 
 .statusRow {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupModal.vue
@@ -1,19 +1,23 @@
 <script lang="ts" setup>
+import { createEventBus } from '@n8n/utils/event-bus';
 import Modal from '@/app/components/Modal.vue';
 import BrowserUseSetupContent from './BrowserUseSetupContent.vue';
 
 const props = defineProps<{ modalName: string }>();
+
+const modalBus = createEventBus();
 </script>
 
 <template>
 	<Modal
 		:name="props.modalName"
 		:show-close="true"
+		:event-bus="modalBus"
 		custom-class="instance-ai-browser-use-setup-modal"
 		width="540"
 	>
 		<template #content>
-			<BrowserUseSetupContent />
+			<BrowserUseSetupContent @close="modalBus.emit('close')" />
 		</template>
 	</Modal>
 </template>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent } from '@testing-library/vue';
 import { flushPromises } from '@vue/test-utils';
 import { createComponentRenderer } from '@/__tests__/render';
+import BrowserUseSetupContent from '../BrowserUseSetupContent.vue';
 import BrowserUseSetupModal from '../BrowserUseSetupModal.vue';
 
 vi.mock('@n8n/i18n', async (importOriginal) => ({
@@ -120,6 +121,22 @@ describe('BrowserUseSetupModal', () => {
 		it('tracks the modal opening as unsupported', () => {
 			renderComponent();
 			expect(telemetryMock.trackModalOpened).toHaveBeenCalledWith(false);
+		});
+
+		it('closes the modal via the close button', async () => {
+			const { getByTestId, emitted } = createComponentRenderer(BrowserUseSetupContent)();
+
+			await fireEvent.click(getByTestId('browser-use-unsupported-close'));
+
+			expect(emitted('close')).toHaveLength(1);
+		});
+
+		it('does not render the close button when embedded', () => {
+			const { queryByTestId } = createComponentRenderer(BrowserUseSetupContent)({
+				props: { embedded: true },
+			});
+
+			expect(queryByTestId('browser-use-unsupported-close')).toBeNull();
 		});
 
 		it('does not fetch the browser status or a connect URL', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
@@ -50,15 +50,26 @@ const renderComponent = createComponentRenderer(BrowserUseSetupModal, {
 	},
 });
 
+const CHROME_WINDOWS =
+	'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36';
+const SAFARI_MACOS =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3 Safari/605.1.15';
+
+function setUserAgent(userAgent: string) {
+	Object.defineProperty(navigator, 'userAgent', { value: userAgent, configurable: true });
+}
+
 describe('BrowserUseSetupModal', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		setUserAgent(CHROME_WINDOWS);
 		settingsStoreMock.mockReturnValue(makeSettingsStore());
 	});
 
 	it('tracks the modal opening on mount', () => {
 		renderComponent();
 		expect(telemetryMock.trackModalOpened).toHaveBeenCalledTimes(1);
+		expect(telemetryMock.trackModalOpened).toHaveBeenCalledWith(true);
 	});
 
 	it('tracks the install extension button click', async () => {
@@ -85,5 +96,40 @@ describe('BrowserUseSetupModal', () => {
 
 		expect(queryByTestId('browser-use-install-extension')).toBeNull();
 		expect(queryByTestId('browser-use-open-connect-page')).toBeNull();
+	});
+
+	it('does not render the unsupported browser message on a Chromium browser', () => {
+		const { queryByTestId } = renderComponent();
+
+		expect(queryByTestId('browser-use-unsupported-browser')).toBeNull();
+	});
+
+	describe('on an unsupported browser', () => {
+		beforeEach(() => {
+			setUserAgent(SAFARI_MACOS);
+		});
+
+		it('renders the unsupported browser message instead of the connect steps', () => {
+			const { getByTestId, queryByTestId } = renderComponent();
+
+			expect(getByTestId('browser-use-unsupported-browser')).toBeInTheDocument();
+			expect(queryByTestId('browser-use-install-extension')).toBeNull();
+			expect(queryByTestId('browser-use-open-connect-page')).toBeNull();
+		});
+
+		it('tracks the modal opening as unsupported', () => {
+			renderComponent();
+			expect(telemetryMock.trackModalOpened).toHaveBeenCalledWith(false);
+		});
+
+		it('does not fetch the browser status or a connect URL', () => {
+			const store = makeSettingsStore();
+			settingsStoreMock.mockReturnValue(store);
+
+			renderComponent();
+
+			expect(store.fetchBrowserStatus).not.toHaveBeenCalled();
+			expect(store.fetchBrowserConnectUrl).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiBrowserUse.telemetry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiBrowserUse.telemetry.ts
@@ -3,8 +3,10 @@ import { useTelemetry } from '@n8n/composables/useTelemetry';
 export function useInstanceAiBrowserUseTelemetry() {
 	const telemetry = useTelemetry();
 	return {
-		trackModalOpened() {
-			telemetry.track('Instance AI Connect Browser Use modal opened');
+		trackModalOpened(browserSupported: boolean) {
+			telemetry.track('Instance AI Connect Browser Use modal opened', {
+				browser_supported: browserSupported,
+			});
 		},
 		trackInstallExtensionClicked() {
 			telemetry.track('Instance AI Install Chrome Browser Extension button clicked');


### PR DESCRIPTION
## Summary

Improves the UX for Browser Use based flows, for example automatic credential creation within AI Assistant.

1. Disable browser use on all mobile devices where browser use is technically impossible
2. On non-mobile devices where browser use is not supported we will still show the browser use and setup automatically option but the browser connect modal will display that we only support Chrome or Chromium-based browsers.
3. added a new parameter `browser_supported: true | false` to the `Instance AI Connect Browser Use modal opened` telemetry event, this way we can determine user behavior and success rates based on the used browser better

<img width="551" height="202" alt="Bildschirmfoto 2026-08-13 um 15 46 15" src="https://github.com/user-attachments/assets/341ae94e-5ce6-41d9-9b64-42e65347b2dc" />

## How to test

1. Open AI Assistant with browser use flag enabled, observe that you can connect the browser
2. Open developer tools, click on the three dots button on the top right, click "Run command" and enter "Show network conditions".
3. In the network conditions view uncheck the checkbox "Use browser default" on user agent and select different user agents. (changing the user agent requires reloading the page)
  - for any mobile user agent: Browser Use is not visible
  - for any non-chromium desktop browser: Browser Use is visible but browser connect modal displays a warning
  - for any chromium desktop browser: Browser Use is visible and displays the connect modal with install+connect steps
4. Additional test: ask the agent to run "setup credentials" tool with a credential type that you don't have - observe that automatic credential creation is not shown when browser use is disabled (mobile/tablet)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5727/only-offer-automatic-credential-setup-to-chrome-chromium-users


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

