### PR TITLE
test(editor): Stub window.open in frontend tests

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/setup.ts
+++ b/packages/frontend/editor-ui/src/__tests__/setup.ts
@@ -103,6 +103,13 @@ Object.defineProperty(window, 'matchMedia', {
 	})),
 });
 
+// jsdom logs an error for every unmocked popup even though the call itself does not fail.
+Object.defineProperty(window, 'open', {
+	configurable: true,
+	writable: true,
+	value: vi.fn(() => null),
+});
+
 // Create DOM containers for Element Plus components before each test
 beforeEach(() => {
 	// Create app-grid container for toasts


### PR DESCRIPTION
## Summary

Adds a shared no-op for `window.open` so jsdom no longer emits unsupported popup errors during editor unit tests. Individual tests can still spy on or override it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-663

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs not required.
- [x] Tests included.
- [ ] PR labeled for backporting if required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

