### PR TITLE
docs: Align create-issue skill feature and spike templates with our ticket structure (no-changelog)

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -73,17 +73,20 @@ Structure the description using markdown headers. Use the appropriate template:
 **For features / enhancements:**
 
 ```markdown
-## Summary
-[One-paragraph overview of what this adds or changes]
+## Goal
+[What this adds and why: the user problem it solves]
 
-## Problem
-[What limitation or gap exists today]
+## Background
+[Current state and the gap, plus the technical context needed to plan the work: relevant constraints, prior findings, and links to any related investigation.]
 
-## Proposed solution
-[How it should work — technical approach if known]
+## Scope
+[Concrete list of what changes. Name the files or areas to create or modify and any existing pattern to follow.]
+
+## Acceptance criteria
+[Testable outcomes, including automated tests.]
 
 ## Out of scope
-[Explicitly note what this does NOT cover, if helpful]
+[What this explicitly does not cover]
 ```
 
 **For tech debt:**
@@ -109,13 +112,19 @@ Structure the description using markdown headers. Use the appropriate template:
 
 ```markdown
 ## Goal
-[What question are we trying to answer]
+[What question(s) are we trying to answer]
 
 ## Context
 [Why this investigation is needed now]
 
+## Questions
+1. [Specific question to resolve]
+
 ## Expected output
-[What deliverable is expected — RFC, PoC, decision document, etc.]
+[What deliverable is expected: RFC, PoC, decision document, path matrix, etc.]
+
+## Acceptance criteria
+[How we know the spike is done: each question answered, deliverable produced]
 ```
 
 #### Attachments (Screenshots / Videos)


### PR DESCRIPTION
## Summary

Aligns the `create-issue` skill's feature/enhancement template with the **Goal / Background / Scope / Acceptance criteria / Out of scope** structure, and enriches the spike template with **Questions** + **Acceptance criteria**.

The previous feature template (Summary / Problem / Proposed solution / Out of scope) had no acceptance criteria and no concrete scope, so tickets came out thinner than they should. The new template is area-agnostic: goal, background/context, a concrete scope naming the files or areas to touch and any pattern to follow, testable acceptance criteria, and out of scope.

## Review notes

- Tooling/docs only: `.agents/skills/create-issue/SKILL.md`. No product code, no changelog.
- No linked Linear ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)