### PR TITLE
fix: Make CODESPACE_NAME deterministic in the codespace agent worker (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/agent-worker.mjs
+++ b/.devcontainer/codespaces/agent-worker.mjs
@@ -51,6 +51,10 @@ for (const [k, v] of Object.entries({
 	}
 }
 
+// Not fatal, but box pinning needs it: without a box id every turn routes by
+// owner, so a thread cannot follow the box holding its session.
+if (!BOX_ID) console.error('CODESPACE_NAME is not set — box pinning disabled; turns route by githubUser only.');
+
 function runClaude({ message, sessionId, cwd }) {
 	const safeCwd = resolvePath(typeof cwd === 'string' && cwd ? cwd : `${ROOT}/n8n`);
 	if (safeCwd !== ROOT && !safeCwd.startsWith(ROOT + sep))

--- a/.devcontainer/codespaces/docker-compose.yml
+++ b/.devcontainer/codespaces/docker-compose.yml
@@ -28,3 +28,6 @@ services:
       DB_POSTGRESDB_PASSWORD: password
       # Prompt-cache TTL in seconds. 1 hour keeps the cache warm between turns.
       ANTHROPIC_PROMPT_CACHE_TTL: "3600"
+      # Compose does not inherit the codespace env. Pass the box name through so
+      # the worker can stamp boxId and dev:up can print the forwarded URL.
+      CODESPACE_NAME: ${CODESPACE_NAME:-}


### PR DESCRIPTION
## Summary

Box pinning for the Slack-driven codespace agent sessions (#36173) worked on some boxes and not others, with no code difference between them. Root cause: the worker reads `CODESPACE_NAME` to stamp a turn's `boxId` (which pins a Slack thread to the box holding its Claude session), but a **docker-compose** devcontainer does not put `CODESPACE_NAME` in the service container's base environment. GitHub injects it only into interactive contexts (VS Code terminals), **not** into a compose `postStartCommand`.

So whether box pinning worked depended entirely on *where the worker was started*:
- Worker (re)started from a VS Code terminal → `CODESPACE_NAME` present → `boxId` stamped, thread pins correctly.
- Worker auto-started via `postStartCommand` → `CODESPACE_NAME` absent → `boxId` empty → silently falls back to `githubUser` bootstrap routing.

## Fix

- `docker-compose.yml`: pass `CODESPACE_NAME: ${CODESPACE_NAME:-}` into the `n8n` service, so it's in the container's base env for **every** process regardless of start path. (`docker compose config` confirms interpolation resolves it.)
- `agent-worker.mjs`: warn at startup if `CODESPACE_NAME` is unset, so the degraded (`githubUser`-only) mode is visible in `/tmp/agent-worker.log` instead of silent.

## Notes

- Compose env is baked at container **create**, so this needs a codespace **rebuild** to take effect (a stop/start won't).
- Not a regression — a latent race in env propagation; this makes it deterministic.

## Related
- Follow-up to #36173, #36141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

