### PR TITLE
fix(core): Fix z-indexing of expression modal over agent NDV

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
@@ -33,6 +33,7 @@ import {
 	N8nText,
 	type ResizeData,
 } from '@n8n/design-system';
+import { useStyles } from '@n8n/composables/useStyles';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 const DEFAULT_LEFT_SIDEBAR_WIDTH = 360;
 
@@ -60,6 +61,7 @@ const emit = defineEmits<{
 const ndvStore = injectNDVStore();
 const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
+const { APP_Z_INDEXES } = useStyles();
 
 const lastSuccessfulExecution = computed(
 	() => workflowExecutionStateStore.value.lastSuccessfulExecution,
@@ -166,6 +168,7 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 		:class="$style.modal"
 		:model-value="dialogVisible"
 		:before-close="closeDialog"
+		:z-index="APP_Z_INDEXES.MODALS"
 	>
 		<button :class="$style.close" @click="closeDialog">
 			<Close height="18" width="18" />


### PR DESCRIPTION
## Summary

Fix the expression full-screen modal opening behind the Agent NDV.
Pinned the dialog's `z-index` to `APP_Z_INDEXES.MODALS` (2000), matching the `Modal.vue` convention and guaranteeing it stacks above the NDV (1800).

## How to test

1. Add an **AI Agent** node to the canvas.
2. Attach an **HTTP Request** tool to the agent.
3. Open the HTTP tool's NDV.
4. Switch a parameter (e.g. the JSON body field) to **expression** mode.
5. Click the **full-screen / expand** button on the expression field.
6. Confirm the expression editor modal renders **on top of** the NDV

Demo:

https://github.com/user-attachments/assets/6b093b89-7280-4bdb-baa7-ca5d809c986f


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AGENT-600
## Review / Merge checklist
- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
  - Suggested title: `fix(editor): Pin expression modal z-index above the NDV`
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

