### PR TITLE
fix(core): Report the workflow's parent folder in get_workflow_details

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.parent-folder.integration.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.parent-folder.integration.test.ts
@@ -1,5 +1,5 @@
 import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
-import { GLOBAL_OWNER_ROLE, WorkflowRepository, type Project, type User } from '@n8n/db';
+import type { Project, User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { INodeTypes } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
@@ -9,7 +9,8 @@ import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { createFolder } from '@test-integration/db/folders';
-import { createUser } from '@test-integration/db/users';
+import { createTag } from '@test-integration/db/tags';
+import { createOwner } from '@test-integration/db/users';
 
 import { getWorkflowDetails } from '../tools/get-workflow-details.tool';
 
@@ -29,12 +30,8 @@ beforeAll(async () => {
 	workflowFinderService = Container.get(WorkflowFinderService);
 	roleService = Container.get(RoleService);
 	projectService = Container.get(ProjectService);
-});
 
-beforeEach(async () => {
-	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'Folder', 'Project', 'User']);
-
-	owner = await createUser({ role: GLOBAL_OWNER_ROLE });
+	owner = await createOwner();
 	project = await createTeamProject('Test project', owner);
 });
 
@@ -42,41 +39,44 @@ afterAll(async () => {
 	await testDb.terminate();
 });
 
-describe('get_workflow_details against a real database', () => {
-	test('returns the folder id for a workflow stored inside a folder', async () => {
-		const folder = await createFolder(project, { name: 'My folder' });
-		const workflow = await createWorkflow({ settings: { availableInMCP: true } }, project);
-		await Container.get(WorkflowRepository).update(workflow.id, { parentFolder: folder });
+const detailsFor = async (workflowId: string) =>
+	await getWorkflowDetails(
+		owner,
+		'https://example.test',
+		workflowFinderService,
+		credentialsService,
+		nodeTypes,
+		endpoints,
+		roleService,
+		projectService,
+		{ workflowId },
+	);
 
-		const payload = await getWorkflowDetails(
-			owner,
-			'https://example.test',
-			workflowFinderService,
-			credentialsService,
-			nodeTypes,
-			endpoints,
-			roleService,
-			projectService,
-			{ workflowId: workflow.id },
+/**
+ * Relation-derived fields (`parentFolderId`, `tags`) serialize to a legal-looking
+ * `null`/`[]` when the relation is simply not loaded, so only a real query proves
+ * they are populated. Mock-level assertions on the finder options cannot: the
+ * earlier `includeTags` guard was in place while `parentFolderId` was broken.
+ */
+describe('get_workflow_details against a real database', () => {
+	test('returns the folder and tags for a workflow stored inside a folder', async () => {
+		const folder = await createFolder(project, { name: 'My folder' });
+		const workflow = await createWorkflow(
+			{ settings: { availableInMCP: true }, parentFolder: folder },
+			project,
 		);
+		const tag = await createTag({ name: 'my-tag' }, workflow);
+
+		const payload = await detailsFor(workflow.id);
 
 		expect(payload.workflow.parentFolderId).toBe(folder.id);
+		expect(payload.workflow.tags).toEqual([{ id: tag.id, name: tag.name }]);
 	});
 
 	test('returns null for a workflow in the project root', async () => {
 		const workflow = await createWorkflow({ settings: { availableInMCP: true } }, project);
 
-		const payload = await getWorkflowDetails(
-			owner,
-			'https://example.test',
-			workflowFinderService,
-			credentialsService,
-			nodeTypes,
-			endpoints,
-			roleService,
-			projectService,
-			{ workflowId: workflow.id },
-		);
+		const payload = await detailsFor(workflow.id);
 
 		expect(payload.workflow.parentFolderId).toBeNull();
 	});

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.parent-folder.integration.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.parent-folder.integration.test.ts
@@ -1,0 +1,83 @@
+import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
+import { GLOBAL_OWNER_ROLE, WorkflowRepository, type Project, type User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { INodeTypes } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+import { ProjectService } from '@/services/project.service.ee';
+import { RoleService } from '@/services/role.service';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { createFolder } from '@test-integration/db/folders';
+import { createUser } from '@test-integration/db/users';
+
+import { getWorkflowDetails } from '../tools/get-workflow-details.tool';
+
+let owner: User;
+let project: Project;
+let workflowFinderService: WorkflowFinderService;
+let roleService: RoleService;
+let projectService: ProjectService;
+
+const credentialsService = mock<CredentialsService>();
+const nodeTypes = mock<INodeTypes>();
+const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
+
+beforeAll(async () => {
+	await testDb.init();
+
+	workflowFinderService = Container.get(WorkflowFinderService);
+	roleService = Container.get(RoleService);
+	projectService = Container.get(ProjectService);
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'Folder', 'Project', 'User']);
+
+	owner = await createUser({ role: GLOBAL_OWNER_ROLE });
+	project = await createTeamProject('Test project', owner);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('get_workflow_details against a real database', () => {
+	test('returns the folder id for a workflow stored inside a folder', async () => {
+		const folder = await createFolder(project, { name: 'My folder' });
+		const workflow = await createWorkflow({ settings: { availableInMCP: true } }, project);
+		await Container.get(WorkflowRepository).update(workflow.id, { parentFolder: folder });
+
+		const payload = await getWorkflowDetails(
+			owner,
+			'https://example.test',
+			workflowFinderService,
+			credentialsService,
+			nodeTypes,
+			endpoints,
+			roleService,
+			projectService,
+			{ workflowId: workflow.id },
+		);
+
+		expect(payload.workflow.parentFolderId).toBe(folder.id);
+	});
+
+	test('returns null for a workflow in the project root', async () => {
+		const workflow = await createWorkflow({ settings: { availableInMCP: true } }, project);
+
+		const payload = await getWorkflowDetails(
+			owner,
+			'https://example.test',
+			workflowFinderService,
+			credentialsService,
+			nodeTypes,
+			endpoints,
+			roleService,
+			projectService,
+			{ workflowId: workflow.id },
+		);
+
+		expect(payload.workflow.parentFolderId).toBeNull();
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.parent-folder.integration.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.parent-folder.integration.test.ts
@@ -1,4 +1,9 @@
-import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
+import {
+	createTeamProject,
+	createWorkflow,
+	linkUserToProject,
+	testDb,
+} from '@n8n/backend-test-utils';
 import type { Project, User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { INodeTypes } from 'n8n-workflow';
@@ -10,11 +15,12 @@ import { RoleService } from '@/services/role.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { createFolder } from '@test-integration/db/folders';
 import { createTag } from '@test-integration/db/tags';
-import { createOwner } from '@test-integration/db/users';
+import { createMember, createOwner } from '@test-integration/db/users';
 
 import { getWorkflowDetails } from '../tools/get-workflow-details.tool';
 
 let owner: User;
+let member: User;
 let project: Project;
 let workflowFinderService: WorkflowFinderService;
 let roleService: RoleService;
@@ -33,15 +39,18 @@ beforeAll(async () => {
 
 	owner = await createOwner();
 	project = await createTeamProject('Test project', owner);
+
+	member = await createMember();
+	await linkUserToProject(member, project, 'project:editor');
 });
 
 afterAll(async () => {
 	await testDb.terminate();
 });
 
-const detailsFor = async (workflowId: string) =>
+const detailsFor = async (workflowId: string, user: User = owner) =>
 	await getWorkflowDetails(
-		owner,
+		user,
 		'https://example.test',
 		workflowFinderService,
 		credentialsService,
@@ -71,6 +80,21 @@ describe('get_workflow_details against a real database', () => {
 
 		expect(payload.workflow.parentFolderId).toBe(folder.id);
 		expect(payload.workflow.tags).toEqual([{ id: tag.id, name: tag.name }]);
+	});
+
+	// An instance owner short-circuits the read filter to `{}`, so only a project
+	// member exercises the query shape most MCP callers actually hit, where the
+	// folder join sits alongside the shared/project/projectRelations joins.
+	test('returns the folder id for a project member', async () => {
+		const folder = await createFolder(project, { name: 'Member folder' });
+		const workflow = await createWorkflow(
+			{ settings: { availableInMCP: true }, parentFolder: folder },
+			project,
+		);
+
+		const payload = await detailsFor(workflow.id, member);
+
+		expect(payload.workflow.parentFolderId).toBe(folder.id);
 	});
 
 	test('returns null for a workflow in the project root', async () => {

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -186,7 +186,7 @@ export async function getWorkflowDetails(
 		user,
 		['workflow:read'],
 		workflowFinderService,
-		{ includeActiveVersion: true, includeTags: true },
+		{ includeActiveVersion: true, includeTags: true, includeParentFolder: true },
 	);
 
 	// Compute user scopes for this workflow

--- a/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
@@ -40,6 +40,7 @@ export type FoundWorkflow = NonNullable<
 export type GetMcpWorkflowOptions = {
 	includeActiveVersion?: boolean;
 	includeTags?: boolean;
+	includeParentFolder?: boolean;
 };
 
 /**
@@ -58,6 +59,7 @@ export async function getMcpWorkflow(
 	const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, scopes, {
 		includeActiveVersion: options?.includeActiveVersion,
 		includeTags: options?.includeTags,
+		includeParentFolder: options?.includeParentFolder,
 	});
 
 	if (!workflow) {

--- a/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
@@ -56,11 +56,14 @@ export async function getMcpWorkflow(
 	workflowFinderService: WorkflowFinderService,
 	options?: GetMcpWorkflowOptions,
 ): Promise<FoundWorkflow> {
-	const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, scopes, {
-		includeActiveVersion: options?.includeActiveVersion,
-		includeTags: options?.includeTags,
-		includeParentFolder: options?.includeParentFolder,
-	});
+	// Forwarded whole: hand-copying each flag is what let `includeParentFolder`
+	// go missing here while the finder already supported it.
+	const workflow = await workflowFinderService.findWorkflowForUser(
+		workflowId,
+		user,
+		scopes,
+		options ?? {},
+	);
 
 	if (!workflow) {
 		throw new WorkflowAccessError(


### PR DESCRIPTION
## Summary

`get_workflow_details` always reported `parentFolderId: null`, even for workflows sitting inside a folder. The `workflow_entity` column held the right value the whole time, which is why querying Postgres directly looked correct while MCP did not.

The tool reads the folder off the `parentFolder` relation:

```ts
parentFolderId: workflow.parentFolder?.id ?? null,
```

Nothing ever loaded that relation. `findWorkflowForUser` and `SharedWorkflowRepository.findWorkflowWithOptions` both accept `includeParentFolder` and default it to `false`, but the flag got dropped twice on the way there. `getWorkflowDetails` never passed it, and `GetMcpWorkflowOptions` did not declare it, so `getMcpWorkflow` had no way to forward it. Without the join, `workflow.parentFolder` came back `undefined`.

Threading the flag through fixes it. Only `get_workflow_details` asks for the join, so every other `getMcpWorkflow` caller keeps the query it has today. `search_folders` was already correct because it reads `folder.parentFolderId` directly instead of going through a relation.

## How to test

1. Create a project with a folder and move a workflow into it.
2. Enable MCP access on that workflow.
3. Call `get_workflow_details` for it over MCP.
4. `parentFolderId` should be the folder ID. Compare it against `SELECT "parentFolderId" FROM workflow_entity WHERE id = '<id>'`.

A new integration test runs this against a real database. It fails on both SQLite and Postgres without the fix and passes with it. The existing unit tests miss the bug because they mock `WorkflowFinderService`, which stubs out relation loading.

I also checked it against a running instance with a real MCP client, so the transport and serialization above the service layer do preserve the field.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5787

fixes #36119

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

