### PR TITLE
test(editor): Assert Code node lint errors by message instead of mark count (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -350,6 +350,10 @@ export class NodeDetailsViewPage extends BasePage {
 		return this.codeNodeEditor.getLintTooltip();
 	}
 
+	async hoverCodeToken(token: string) {
+		await this.codeNodeEditor.hoverCodeToken(token);
+	}
+
 	getPlaceholderText(text: string) {
 		return this.page.getByText(text);
 	}
@@ -511,10 +515,8 @@ export class NodeDetailsViewPage extends BasePage {
 	}
 
 	async toggleCodeMode(switchTo: 'Run Once for Each Item' | 'Run Once for All Items') {
-		await this.getParameterInput('mode').click();
-		await this.getVisiblePopoverOption(switchTo).click();
-		// eslint-disable-next-line playwright/no-wait-for-timeout
-		await this.page.waitForTimeout(2500);
+		await this.selectOptionInParameterDropdown('mode', switchTo);
+		await expect(this.getParameterInputField('mode')).toHaveValue(switchTo);
 	}
 
 	getCopyInputButton() {

--- a/packages/testing/playwright/pages/components/CodeNodeEditor.ts
+++ b/packages/testing/playwright/pages/components/CodeNodeEditor.ts
@@ -49,6 +49,23 @@ export class CodeNodeEditor {
 		return this.getJsCodeParameter().locator('.cm-lintRange-error');
 	}
 
+	/**
+	 * Hovers a token in the editor so CodeMirror renders the lint tooltip for the
+	 * diagnostics covering it.
+	 *
+	 * Hover the token, not the `.cm-lintRange-error` span: the Code node has two
+	 * lint sources (the synchronous n8n linter and the async TypeScript language
+	 * service), and a diagnostic arriving from the second one splits the first
+	 * one's span into several. The syntax-highlighting span for the token itself
+	 * is unaffected.
+	 */
+	async hoverCodeToken(token: string): Promise<void> {
+		// Park the pointer first: a tooltip left open by a previous hover renders
+		// over the editor and would swallow the next one.
+		await this.page.mouse.move(0, 0);
+		await this.getCodeEditor().getByText(token, { exact: true }).first().hover({ force: true });
+	}
+
 	/** CodeMirror lint tooltip (teleported to the page root). */
 	getLintTooltip(): Locator {
 		return this.page.locator('.cm-tooltip-lint');

--- a/packages/testing/playwright/tests/e2e/workflows/editor/code/code-node.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/code/code-node.spec.ts
@@ -84,38 +84,45 @@ for (const item of $input.all()) {
 
 return
 `);
-				await expect(n8n.ndv.getLintErrors()).toHaveCount(6);
-				const firstLintError = n8n.ndv.getLintErrors().first();
-				await expect(firstLintError).toBeVisible();
-				await firstLintError.hover({ force: true });
+				// Assert lint errors by message, not by mark count: the TypeScript language
+				// service contributes diagnostics on its own schedule and re-splits the
+				// marks when it does, so the number of marks is not a stable signal.
+				await expect(n8n.ndv.getLintErrors().first()).toBeVisible();
 
-				// Wait for lint tooltip to appear after hover
-				await expect(n8n.ndv.getLintTooltip()).toBeVisible({ timeout: 5000 });
+				await n8n.ndv.hoverCodeToken('itemMatching');
 				await expect(n8n.ndv.getLintTooltip()).toContainText(
 					'`.itemMatching()` expects an item index to be passed in as its argument.',
 				);
+
+				await n8n.ndv.hoverCodeToken('item');
+				await expect(n8n.ndv.getLintTooltip()).toContainText(
+					"`.item` only works correctly in 'Run Once for Each Item' mode.",
+				);
 			});
-		});
 
-		test.describe
-			.serial('Run Once for Each Item', () => {
-				test('should show lint errors in `runOnceForEachItem` mode', async ({ n8n }) => {
-					await n8n.start.fromBlankCanvas();
-					await n8n.canvas.addNode(MANUAL_TRIGGER_NODE_NAME);
-					await n8n.canvas.addNode(CODE_NODE_NAME, { action: 'Code in JavaScript' });
-					await n8n.ndv.toggleCodeMode('Run Once for Each Item');
+			test('should show lint errors in `runOnceForEachItem` mode', async ({ n8n }) => {
+				await n8n.ndv.toggleCodeMode('Run Once for Each Item');
 
-					await n8n.ndv.getCodeEditor().fill(`$input.itemMatching()
+				await n8n.ndv.getCodeEditor().fill(`$input.itemMatching()
 $input.all()
 $input.first()
 $input.item()
 
 return []
 `);
-					// Verify lint errors are detected (tooltip hover tested in runOnceForAllItems test)
-					await expect(n8n.ndv.getLintErrors()).toHaveCount(7);
-				});
+				await expect(n8n.ndv.getLintErrors().first()).toBeVisible();
+
+				await n8n.ndv.hoverCodeToken('all');
+				await expect(n8n.ndv.getLintTooltip()).toContainText(
+					"Method `$input.all()` is only available in the 'Run Once for All Items' mode.",
+				);
+
+				await n8n.ndv.hoverCodeToken('item');
+				await expect(n8n.ndv.getLintTooltip()).toContainText(
+					'`item` is a property to access, not a method to call.',
+				);
 			});
+		});
 
 		test.describe('Ask AI', () => {
 			test.describe('Enabled', () => {


### PR DESCRIPTION
## Summary

`code-node.spec.ts` › *should show lint errors in `runOnceForEachItem` mode* fails **7 of 9** cold single-test runs at plain `master` (`Expected: 7, Received: 5`), and 3/3 on CI shard 11. It only passes in the whole-file run, which is why `test.describe.serial` was wrapped around it.

**Root cause — the count is a DOM shape, not a lint result.** The Code node has two lint sources feeding one CodeMirror lint pass:

1. the synchronous n8n linter (`CodeNodeEditor/linter.ts`, esprima) — produces the 5 mode-specific diagnostics this test is named after;
2. the TypeScript language service in a web worker — asynchronous, and its first `getDiagnostics()` on a cold browser process routinely does not land inside the test window at all.

`@codemirror/lint` renders partial results after 200 ms and re-renders when the slow source lands. A TS diagnostic covering `item` inside the n8n linter's `$input.item()` range **splits that one mark into three DOM spans**, so `.cm-lintRange-error` goes 5 → 7 without a single extra error being reported. Captured directly:

```
cold:  5 marks  ["itemMatching","all","first","$input.item()","return []"]
warm:  7 marks  ["itemMatching","all","first","$input.","item","()","return []"]
```

Raising the timeout would not help: cold, the TS wave stayed absent through 16 s and an extra doc-change nudge.

**Fix (test-only):** assert the lint *messages* on named tokens instead of counting marks — the settled signal is the n8n linter's dispatch, which is synchronous and complete in one go. `test.describe.serial` is gone; the test now lives in the `Code editor` describe and reuses its `beforeEach`. The same brittle count in the sibling `runOnceForAllItems` test gets the same treatment: it passes cold today only because its assertion resolves before the TS wave can fragment the marks.

Also drops the `waitForTimeout(2500)` inside `ndv.toggleCodeMode()` for a web-first assertion on the mode parameter.

No product change — the diagnostics themselves are correct and unchanged.

## How to test

```bash
pnpm --filter=n8n-playwright test:local tests/e2e/workflows/editor/code/code-node.spec.ts --grep "lint errors" --workers=1 --repeat-each=5
pnpm --filter=n8n-playwright test:local tests/e2e/workflows/editor/code/code-node.spec.ts
```

Results on this branch (darwin 25.5.0 · node v24.19.0 · pnpm 10.32.1 · chromium/playwright 1.60.0 · sqlite):

- cold single test: **10/10 green** at `--repeat-each=5` (5.3–6.1 s each, was 17 s failing / 8 s passing)
- whole file: green except `should allow switching between sibling code nodes`, which **fails 3/3 on plain `master` too** — pre-existing and unrelated, reported separately.

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

