### PR TITLE
feat(core): Add baseline Prometheus metrics for poll triggers (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -68,6 +68,10 @@ export class PrometheusMetricsConfig {
 	@Env('N8N_METRICS_SCHEDULER_INTERVAL')
 	schedulerMetricsInterval: number = 20;
 
+	/** Whether to include poll-trigger metrics (poll duration, errors, overlapping ticks, cursor commits). */
+	@Env('N8N_METRICS_INCLUDE_POLL_TRIGGER_METRICS')
+	includePollTriggerMetrics: boolean = false;
+
 	/** How often (in seconds) to update active workflow metric */
 	@Env('N8N_METRICS_ACTIVE_WORKFLOW_METRIC_INTERVAL')
 	activeWorkflowCountInterval: number = 60;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -254,6 +254,7 @@ describe('GlobalConfig', () => {
 				queueMetricsInterval: 20,
 				includeSchedulerMetrics: false,
 				schedulerMetricsInterval: 20,
+				includePollTriggerMetrics: false,
 				activeWorkflowCountInterval: 60,
 				includeWorkflowStatistics: false,
 				workflowStatisticsInterval: 300,

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -253,6 +253,7 @@ describe('GlobalConfig', () => {
 				queueMetricsInterval: 20,
 				includeSchedulerMetrics: false,
 				schedulerMetricsInterval: 20,
+				includePollTriggerMetrics: false,
 				activeWorkflowCountInterval: 60,
 				includeWorkflowStatistics: false,
 				workflowStatisticsInterval: 300,

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -1505,6 +1505,23 @@ describe('createScheduler metrics', () => {
 		expect(metrics.recordDeadLettered).not.toHaveBeenCalled();
 	});
 
+	it('maps a handler that finished after losing its lease onto a lease-lost metric', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		scheduler.registerTaskHandler('test-task', { execute: vi.fn().mockResolvedValue(undefined) });
+		taskStore.claimDueTasks.mockResolvedValue([claimedTask()]);
+		taskStore.beginDispatch.mockResolvedValue(1);
+		// The lease was reclaimed while the handler ran: the terminal write matches no row.
+		taskStore.completeTask.mockResolvedValue(0);
+
+		await scheduler.execute();
+
+		await vi.waitFor(() => {
+			expect(metrics.recordLeaseLost).toHaveBeenCalledWith('test-task');
+		});
+		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+	});
+
 	it('does not let a throwing metrics sink break a pass', async () => {
 		const metrics = mock<SchedulerMetrics>();
 		metrics.recordPruned.mockImplementation(() => {

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -1500,6 +1500,23 @@ describe('createScheduler metrics', () => {
 		expect(metrics.recordDeadLettered).not.toHaveBeenCalled();
 	});
 
+	it('maps a handler that finished after losing its lease onto a lease-lost metric', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		scheduler.registerTaskHandler('test-task', { execute: vi.fn().mockResolvedValue(undefined) });
+		taskStore.claimDueTasks.mockResolvedValue([claimedTask()]);
+		taskStore.beginDispatch.mockResolvedValue(1);
+		// The lease was reclaimed while the handler ran: the terminal write matches no row.
+		taskStore.completeTask.mockResolvedValue(0);
+
+		await scheduler.execute();
+
+		await vi.waitFor(() => {
+			expect(metrics.recordLeaseLost).toHaveBeenCalledWith('test-task');
+		});
+		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+	});
+
 	it('does not let a throwing metrics sink break a pass', async () => {
 		const metrics = mock<SchedulerMetrics>();
 		metrics.recordPruned.mockImplementation(() => {

--- a/packages/@n8n/scheduler/src/core/executor/__tests__/executor.test.ts
+++ b/packages/@n8n/scheduler/src/core/executor/__tests__/executor.test.ts
@@ -48,6 +48,7 @@ const setup = (options?: Partial<ExecutorOptions>) => {
 		onDispatch: vi.fn(),
 		onFire: vi.fn(),
 		onRetry: vi.fn(),
+		onLeaseLost: vi.fn(),
 	} satisfies ExecutorHooks;
 	// A see-through tracing hook that records its calls and just runs the fire.
 	// The executor's only obligation is to route every fire through this hook;
@@ -622,6 +623,8 @@ describe('Executor.fire metrics hooks', () => {
 
 		expect(hooks.onDispatch).not.toHaveBeenCalled();
 		expect(hooks.onFire).not.toHaveBeenCalled();
+		// The handler never ran, so a lost pre-dispatch mutex is not a lease loss.
+		expect(hooks.onLeaseLost).not.toHaveBeenCalled();
 	});
 
 	it('calls onFire with success when the handler completes', async () => {
@@ -691,6 +694,53 @@ describe('Executor.fire metrics hooks', () => {
 		const terminalResult = await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 1 }));
 		expect(terminalResult).toEqual({ outcome: 'skipped-not-owned', errorMessage: 'boom' });
 		expect(hooks.onFire).not.toHaveBeenCalled();
+	});
+
+	it('calls onLeaseLost when a handler ran but its terminal write affects no row', async () => {
+		const { store, registry, hooks, executor } = setup();
+		store.beginDispatch.mockResolvedValue(1);
+		registry.resolve.mockReturnValue(succeeds());
+		// Every terminal write resolves 0: the lease was reclaimed while the handler ran.
+		store.completeTask.mockResolvedValue(0);
+		store.failTaskTerminal.mockResolvedValue(0);
+		store.rescheduleTask.mockResolvedValue(0);
+
+		// Success path with a 0-row complete.
+		const task = claimedTask();
+		await executor.fire(HOST, task);
+		expect(hooks.onLeaseLost).toHaveBeenCalledTimes(1);
+
+		// Retry path with a 0-row reschedule.
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
+		await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 3 }));
+		expect(hooks.onLeaseLost).toHaveBeenCalledTimes(2);
+
+		// Terminal-failure path with a 0-row failTaskTerminal.
+		await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 1 }));
+		expect(hooks.onLeaseLost).toHaveBeenCalledTimes(3);
+
+		expect(hooks.onLeaseLost).toHaveBeenCalledWith(task.taskType);
+		expect(hooks.onFire).not.toHaveBeenCalled();
+		expect(hooks.onRetry).not.toHaveBeenCalled();
+	});
+
+	it('calls onLeaseLost when a dispatched handler threw on its last attempt and the 0-row complete shows the lease is gone', async () => {
+		const { store, registry, hooks, executor } = setup();
+		store.beginDispatch.mockResolvedValue(1);
+		store.completeTask.mockResolvedValue(0);
+		// The handler hands off its effect, then throws.
+		registry.resolve.mockReturnValue({
+			execute: vi.fn(async (_task: ClaimedTask, report: DispatchReporter) => {
+				await Promise.resolve();
+				report.dispatched();
+				throw new Error('boom');
+			}),
+		});
+
+		const result = await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 1 }));
+
+		expect(result).toEqual({ outcome: 'skipped-not-owned', errorMessage: 'boom' });
+		expect(hooks.onLeaseLost).toHaveBeenCalledTimes(1);
 	});
 
 	it('defaults to no-op hooks and pass-through tracing when neither is supplied', async () => {

--- a/packages/@n8n/scheduler/src/core/executor/executor.ts
+++ b/packages/@n8n/scheduler/src/core/executor/executor.ts
@@ -49,6 +49,13 @@ export interface ExecutorHooks {
 	onFire?: (taskType: string, result: 'success' | 'failure') => void;
 	/** A fire failed but has attempts left; it was rescheduled with backoff. */
 	onRetry?: (taskType: string) => void;
+	/**
+	 * A handler finished but its terminal write matched no row: the lease was
+	 * reclaimed while the handler ran, so another instance may have run the same
+	 * occurrence concurrently. This is the at-least-once contract's residual
+	 * overlap, surfaced so it can be counted.
+	 */
+	onLeaseLost?: (taskType: string) => void;
 }
 
 /**
@@ -281,6 +288,7 @@ export class Executor {
 						this.hooks.onFire?.(task.taskType, 'success');
 						return { outcome: 'completed' };
 					}
+					this.hooks.onLeaseLost?.(task.taskType);
 					return { outcome: 'skipped-not-owned', errorMessage };
 				}
 				// A terminal write resolves 0 (it does not reject) when the row was
@@ -293,6 +301,7 @@ export class Executor {
 					this.hooks.onFire?.(task.taskType, 'failure');
 					return { outcome: 'dead-lettered', errorMessage };
 				}
+				this.hooks.onLeaseLost?.(task.taskType);
 				return { outcome: 'skipped-not-owned', errorMessage };
 			}
 			const rowsAffected = await this.store.rescheduleTask(
@@ -304,6 +313,7 @@ export class Executor {
 				this.hooks.onRetry?.(task.taskType);
 				return { outcome: 'rescheduled', errorMessage };
 			}
+			this.hooks.onLeaseLost?.(task.taskType);
 			return { outcome: 'skipped-not-owned', errorMessage };
 		}
 
@@ -314,6 +324,7 @@ export class Executor {
 			this.hooks.onFire?.(task.taskType, 'success');
 			return { outcome: 'completed' };
 		}
+		this.hooks.onLeaseLost?.(task.taskType);
 		return { outcome: 'skipped-not-owned' };
 	}
 

--- a/packages/@n8n/scheduler/src/core/executor/executor.ts
+++ b/packages/@n8n/scheduler/src/core/executor/executor.ts
@@ -294,8 +294,8 @@ export class Executor {
 				// A terminal write resolves 0 (it does not reject) when the row was
 				// reclaimed by the reaper after a lease overrun. The result is then no
 				// longer ours to record: report the fire as skipped, not as a state
-				// transition we did not make, and count no metric. Same on every
-				// terminal write below.
+				// transition we did not make, and count only the lease-lost metric,
+				// not a fire outcome. Same on every terminal write below.
 				const rowsAffected = await this.store.failTaskTerminal(claim, errorMessage);
 				if (rowsAffected > 0) {
 					this.hooks.onFire?.(task.taskType, 'failure');

--- a/packages/@n8n/scheduler/src/core/factory.ts
+++ b/packages/@n8n/scheduler/src/core/factory.ts
@@ -287,6 +287,14 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 					if (result === 'failure') metrics.recordDeadLettered();
 				}),
 			onRetry: (taskType) => recordMetric(() => metrics.recordRetry(taskType)),
+			onLeaseLost: (taskType) => {
+				recordMetric(() => metrics.recordLeaseLost(taskType));
+				emit(
+					'warn',
+					'Scheduler task finished after losing its lease; another instance may have run the same occurrence concurrently',
+					{ taskType },
+				);
+			},
 		},
 		createExecutorTracing(tracer),
 	);

--- a/packages/@n8n/scheduler/src/observability/metrics.ts
+++ b/packages/@n8n/scheduler/src/observability/metrics.ts
@@ -15,6 +15,11 @@ export interface SchedulerMetrics {
 	recordRetry(taskType: string): void;
 	/** Delay between when a task was due (`scheduledFor`) and when it actually fired. */
 	observeDispatchLagSeconds(taskType: string, seconds: number): void;
+	/**
+	 * A handler finished after its lease was reclaimed, so another instance may
+	 * have run the same occurrence concurrently.
+	 */
+	recordLeaseLost(taskType: string): void;
 
 	/** Outcome of one materialization pass. */
 	recordMaterialized(occurrences: number, deferredJobs: number): void;
@@ -40,6 +45,7 @@ export const noopMetrics: SchedulerMetrics = {
 	recordFireOutcome() {},
 	recordRetry() {},
 	observeDispatchLagSeconds() {},
+	recordLeaseLost() {},
 	recordMaterialized() {},
 	recordMisfired() {},
 	recordRetired() {},

--- a/packages/cli/src/events/event.service.ts
+++ b/packages/cli/src/events/event.service.ts
@@ -4,6 +4,7 @@ import { Service } from '@n8n/di';
 import type { AiEventMap } from './maps/ai.event-map';
 import type { ExecutionDataEventMap } from './maps/execution-data.event-map';
 import type { InstanceAiEventMap } from './maps/instance-ai.event-map';
+import type { PollTriggerMetricsEventMap } from './maps/poll-trigger-metrics.event-map';
 import type { QueueMetricsEventMap } from './maps/queue-metrics.event-map';
 import type { RelayEventMap } from './maps/relay.event-map';
 import type { WorkflowPublicationMetricsEventMap } from './maps/workflow-publication-metrics.event-map';
@@ -13,7 +14,8 @@ type EventMap = RelayEventMap &
 	AiEventMap &
 	ExecutionDataEventMap &
 	InstanceAiEventMap &
-	WorkflowPublicationMetricsEventMap;
+	WorkflowPublicationMetricsEventMap &
+	PollTriggerMetricsEventMap;
 
 @Service()
 export class EventService extends TypedEmitter<EventMap> {}

--- a/packages/cli/src/events/maps/poll-trigger-metrics.event-map.ts
+++ b/packages/cli/src/events/maps/poll-trigger-metrics.event-map.ts
@@ -1,0 +1,23 @@
+/**
+ * Low-cardinality metrics events emitted by the poll-cursor persistence path and
+ * consumed by the Prometheus poll-trigger collector. Payloads carry only the
+ * metric labels and values, so the collector stays a dumb recorder and the
+ * cursor code stays decoupled from `prom-client`.
+ */
+
+/** Which cursor write was attempted. */
+export type PollCursorCommitOperation = 'with_execution' | 'cursor_only';
+
+/**
+ * How the write ended: committed, rejected by the lease fence (the poll lost
+ * the race against a reclaimed lease), or failed outright.
+ */
+export type PollCursorCommitResult = 'success' | 'fence_rejected' | 'failure';
+
+export type PollTriggerMetricsEventMap = {
+	'poll-cursor-commit-settled': {
+		operation: PollCursorCommitOperation;
+		result: PollCursorCommitResult;
+		durationMs: number;
+	};
+};

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -14,8 +14,8 @@ import type { PrometheusEventBusMetricsService } from '../prometheus/event-bus-m
 import type { PrometheusExecutionDataMetricsService } from '../prometheus/execution-data-metrics.service';
 import type { PrometheusInstanceAiMetricsService } from '../prometheus/instance-ai-metrics.service';
 import type { PrometheusInstanceRoleMetricsService } from '../prometheus/instance-role-metrics.service';
-import { PrometheusMetricsService } from '../prometheus/prometheus.service';
 import type { PrometheusPollTriggerMetricsService } from '../prometheus/poll-trigger-metrics.service';
+import { PrometheusMetricsService } from '../prometheus/prometheus.service';
 import type { PrometheusPssMetricsService } from '../prometheus/pss-metrics.service';
 import type { PrometheusQueueMetricsService } from '../prometheus/queue-metrics.service';
 import type { PrometheusRouteMetricsService } from '../prometheus/route-metrics.service';

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -15,6 +15,7 @@ import type { PrometheusExecutionDataMetricsService } from '../prometheus/execut
 import type { PrometheusInstanceAiMetricsService } from '../prometheus/instance-ai-metrics.service';
 import type { PrometheusInstanceRoleMetricsService } from '../prometheus/instance-role-metrics.service';
 import { PrometheusMetricsService } from '../prometheus/prometheus.service';
+import type { PrometheusPollTriggerMetricsService } from '../prometheus/poll-trigger-metrics.service';
 import type { PrometheusPssMetricsService } from '../prometheus/pss-metrics.service';
 import type { PrometheusQueueMetricsService } from '../prometheus/queue-metrics.service';
 import type { PrometheusRouteMetricsService } from '../prometheus/route-metrics.service';
@@ -55,6 +56,7 @@ describe('PrometheusMetricsService', () => {
 	let dbPool: Mocked<PrometheusDbPoolMetricsService>;
 	let workflowPublication: Mocked<PrometheusWorkflowPublicationMetricsService>;
 	let scheduler: Mocked<PrometheusSchedulerMetricsService>;
+	let pollTrigger: Mocked<PrometheusPollTriggerMetricsService>;
 
 	let service: PrometheusMetricsService;
 
@@ -82,6 +84,7 @@ describe('PrometheusMetricsService', () => {
 			dbPool,
 			workflowPublication,
 			scheduler,
+			pollTrigger,
 		);
 
 	beforeEach(() => {
@@ -116,6 +119,7 @@ describe('PrometheusMetricsService', () => {
 		dbPool = mock<PrometheusDbPoolMetricsService>({ enabled: true });
 		workflowPublication = mock<PrometheusWorkflowPublicationMetricsService>({ enabled: true });
 		scheduler = mock<PrometheusSchedulerMetricsService>({ enabled: true });
+		pollTrigger = mock<PrometheusPollTriggerMetricsService>({ enabled: true });
 
 		service = buildService();
 	});
@@ -149,6 +153,7 @@ describe('PrometheusMetricsService', () => {
 			expect(dbPool.init).toHaveBeenCalledWith(app);
 			expect(workflowPublication.init).toHaveBeenCalledWith(app);
 			expect(scheduler.init).toHaveBeenCalledWith(app);
+			expect(pollTrigger.init).toHaveBeenCalledWith(app);
 		});
 
 		it('should NOT call init on disabled collectors', () => {

--- a/packages/cli/src/metrics/prometheus/__tests__/poll-trigger-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/poll-trigger-metrics.service.test.ts
@@ -1,0 +1,219 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PrometheusMetricsConfig } from '@n8n/config';
+import type { InstanceSettings, TriggersAndPollers } from 'n8n-core';
+import promClient from 'prom-client';
+import type { Mock } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { EventService } from '@/events/event.service';
+
+import { PrometheusPollTriggerMetricsService } from '../poll-trigger-metrics.service';
+
+vi.mock('prom-client');
+
+describe('PrometheusPollTriggerMetricsService', () => {
+	const config = mockInstance(PrometheusMetricsConfig, {
+		prefix: 'n8n_',
+		includePollTriggerMetrics: true,
+	});
+	const instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
+	const eventService = mock<EventService>();
+	const pollTickEvents = { on: vi.fn() };
+	const triggersAndPollers = { events: pollTickEvents } as unknown as TriggersAndPollers;
+
+	let service: PrometheusPollTriggerMetricsService;
+	let counterCtor: Mock;
+	const counterIncByName = new Map<string, Mock>();
+	let histogramCtor: Mock;
+	const histogramObserveByName = new Map<string, Mock>();
+
+	beforeEach(() => {
+		Object.assign(config, { prefix: 'n8n_', includePollTriggerMetrics: true });
+		Object.assign(instanceSettings, { instanceType: 'main' });
+
+		service = new PrometheusPollTriggerMetricsService(
+			config,
+			instanceSettings,
+			eventService,
+			triggersAndPollers,
+		);
+
+		counterCtor = vi.fn();
+		counterIncByName.clear();
+		histogramCtor = vi.fn();
+		histogramObserveByName.clear();
+		// Replace the auto-mocked classes (whose instances share one prototype method)
+		// with real fake classes, so each construction yields its own `inc`/`observe`
+		// and a test can assert the right metric received the right value.
+		class FakeCounter {
+			inc = vi.fn();
+
+			constructor(opts: { name: string }) {
+				counterCtor(opts);
+				counterIncByName.set(opts.name, this.inc);
+			}
+		}
+		class FakeHistogram {
+			observe = vi.fn();
+
+			constructor(opts: { name: string }) {
+				histogramCtor(opts);
+				histogramObserveByName.set(opts.name, this.observe);
+			}
+		}
+		(promClient as unknown as { Counter: unknown }).Counter = FakeCounter;
+		(promClient as unknown as { Histogram: unknown }).Histogram = FakeHistogram;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const counterIncFor = (name: string) => counterIncByName.get(name)!;
+	const histogramObserveFor = (name: string) => histogramObserveByName.get(name)!;
+
+	function getPollTickHandler() {
+		const calls = pollTickEvents.on.mock.calls as Array<[string, (payload: unknown) => void]>;
+		return calls.find((c) => c[0] === 'poll-tick-completed')![1];
+	}
+
+	function getCursorCommitHandler() {
+		const calls = eventService.on.mock.calls as unknown as Array<
+			[string, (payload: unknown) => void]
+		>;
+		return calls.find((c) => c[0] === 'poll-cursor-commit-settled')![1];
+	}
+
+	describe('enabled', () => {
+		it('is true when opted in and the instance is main', () => {
+			expect(service.enabled).toBe(true);
+		});
+
+		it('is false when not opted in', () => {
+			config.includePollTriggerMetrics = false;
+			expect(service.enabled).toBe(false);
+		});
+
+		it('is false on a non-main instance', () => {
+			Object.assign(instanceSettings, { instanceType: 'worker' });
+			expect(service.enabled).toBe(false);
+		});
+	});
+
+	describe('init', () => {
+		it('registers the counters and histograms', () => {
+			service.init();
+
+			const counterNames = counterCtor.mock.calls.map((c) => c[0].name);
+			expect(counterNames).toEqual(
+				expect.arrayContaining([
+					'n8n_poll_trigger_errors_total',
+					'n8n_poll_trigger_overlapping_ticks_total',
+					'n8n_poll_trigger_cursor_commits_total',
+				]),
+			);
+
+			const histogramNames = histogramCtor.mock.calls.map((c) => c[0].name);
+			expect(histogramNames).toEqual(
+				expect.arrayContaining([
+					'n8n_poll_trigger_duration_seconds',
+					'n8n_poll_trigger_cursor_commit_duration_seconds',
+				]),
+			);
+		});
+
+		it('applies a custom prefix to metric names', () => {
+			config.prefix = 'myapp_';
+			service.init();
+
+			const counterNames = counterCtor.mock.calls.map((c) => c[0].name);
+			expect(counterNames).toContain('myapp_poll_trigger_errors_total');
+		});
+
+		it('subscribes to the poll-tick and cursor-commit event streams', () => {
+			service.init();
+
+			expect(pollTickEvents.on).toHaveBeenCalledWith('poll-tick-completed', expect.any(Function));
+			expect(eventService.on).toHaveBeenCalledWith(
+				'poll-cursor-commit-settled',
+				expect.any(Function),
+			);
+		});
+	});
+
+	describe('poll-tick-completed handler', () => {
+		it('observes the tick duration in seconds by node type and status', () => {
+			service.init();
+
+			getPollTickHandler()({
+				nodeType: 'n8n-nodes-base.testPoll',
+				status: 'success',
+				durationMs: 250,
+				overlapped: false,
+			});
+
+			expect(histogramObserveFor('n8n_poll_trigger_duration_seconds')).toHaveBeenCalledWith(
+				{ node_type: 'n8n-nodes-base.testPoll', status: 'success' },
+				0.25,
+			);
+			expect(counterIncFor('n8n_poll_trigger_errors_total')).not.toHaveBeenCalled();
+			expect(counterIncFor('n8n_poll_trigger_overlapping_ticks_total')).not.toHaveBeenCalled();
+		});
+
+		it('counts an error tick by node type and error kind', () => {
+			service.init();
+
+			getPollTickHandler()({
+				nodeType: 'n8n-nodes-base.testPoll',
+				status: 'error',
+				errorKind: 'rate_limited',
+				durationMs: 100,
+				overlapped: false,
+			});
+
+			expect(counterIncFor('n8n_poll_trigger_errors_total')).toHaveBeenCalledWith({
+				node_type: 'n8n-nodes-base.testPoll',
+				kind: 'rate_limited',
+			});
+			expect(histogramObserveFor('n8n_poll_trigger_duration_seconds')).toHaveBeenCalledWith(
+				{ node_type: 'n8n-nodes-base.testPoll', status: 'error' },
+				0.1,
+			);
+		});
+
+		it('counts an overlapped tick', () => {
+			service.init();
+
+			getPollTickHandler()({
+				nodeType: 'n8n-nodes-base.testPoll',
+				status: 'success',
+				durationMs: 50,
+				overlapped: true,
+			});
+
+			expect(counterIncFor('n8n_poll_trigger_overlapping_ticks_total')).toHaveBeenCalledWith({
+				node_type: 'n8n-nodes-base.testPoll',
+			});
+		});
+	});
+
+	describe('poll-cursor-commit-settled handler', () => {
+		it('counts the commit by operation and result and observes its duration in seconds', () => {
+			service.init();
+
+			getCursorCommitHandler()({
+				operation: 'with_execution',
+				result: 'fence_rejected',
+				durationMs: 40,
+			});
+
+			expect(counterIncFor('n8n_poll_trigger_cursor_commits_total')).toHaveBeenCalledWith({
+				operation: 'with_execution',
+				result: 'fence_rejected',
+			});
+			expect(
+				histogramObserveFor('n8n_poll_trigger_cursor_commit_duration_seconds'),
+			).toHaveBeenCalledWith({ operation: 'with_execution' }, 0.04);
+		});
+	});
+});

--- a/packages/cli/src/metrics/prometheus/__tests__/poll-trigger-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/poll-trigger-metrics.service.test.ts
@@ -213,7 +213,7 @@ describe('PrometheusPollTriggerMetricsService', () => {
 			});
 			expect(
 				histogramObserveFor('n8n_poll_trigger_cursor_commit_duration_seconds'),
-			).toHaveBeenCalledWith({ operation: 'with_execution' }, 0.04);
+			).toHaveBeenCalledWith({ operation: 'with_execution', result: 'fence_rejected' }, 0.04);
 		});
 	});
 });

--- a/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
@@ -124,6 +124,7 @@ describe('PrometheusSchedulerMetricsService', () => {
 					'n8n_scheduler_tasks_reclaimed_total',
 					'n8n_scheduler_tasks_dead_lettered_total',
 					'n8n_scheduler_tasks_pruned_total',
+					'n8n_scheduler_tasks_lease_lost_total',
 				]),
 			);
 
@@ -315,6 +316,14 @@ describe('PrometheusSchedulerMetricsService', () => {
 			expect(inc).toHaveBeenCalledWith(5);
 			expect(inc).toHaveBeenCalledTimes(1);
 		});
+
+		it('increments the lease-lost counter by task type', () => {
+			service.recordLeaseLost('workflow:poll-trigger');
+
+			const inc = counterIncFor('n8n_scheduler_tasks_lease_lost_total');
+			expect(inc).toHaveBeenCalledWith({ task_type: 'workflow:poll-trigger' }, 1);
+			expect(inc).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('push metrics before init', () => {
@@ -332,6 +341,7 @@ describe('PrometheusSchedulerMetricsService', () => {
 			service.recordReaped(1, 1, 1);
 			service.recordDeadLettered();
 			service.recordPruned(1);
+			service.recordLeaseLost('workflow');
 
 			expect(sharedCounterInc).not.toHaveBeenCalled();
 			expect(mockHistogramObserve).not.toHaveBeenCalled();

--- a/packages/cli/src/metrics/prometheus/poll-trigger-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/poll-trigger-metrics.service.ts
@@ -68,18 +68,18 @@ export class PrometheusPollTriggerMetricsService implements PrometheusMetricsCol
 			buckets: DURATION_BUCKETS_SECONDS,
 		});
 
-		this.triggersAndPollers.events.on(
-			'poll-tick-completed',
-			({ nodeType, status, errorKind, durationMs, overlapped }) => {
-				tickDuration.observe({ node_type: nodeType, status }, durationMs / 1000);
-				if (status === 'error') {
-					tickErrors.inc({ node_type: nodeType, kind: errorKind ?? 'thrown' });
-				}
-				if (overlapped) {
-					overlappingTicks.inc({ node_type: nodeType });
-				}
-			},
-		);
+		this.triggersAndPollers.events.on('poll-tick-completed', (tick) => {
+			tickDuration.observe(
+				{ node_type: tick.nodeType, status: tick.status },
+				tick.durationMs / 1000,
+			);
+			if (tick.status === 'error') {
+				tickErrors.inc({ node_type: tick.nodeType, kind: tick.errorKind });
+			}
+			if (tick.overlapped) {
+				overlappingTicks.inc({ node_type: tick.nodeType });
+			}
+		});
 
 		this.eventService.on('poll-cursor-commit-settled', ({ operation, result, durationMs }) => {
 			cursorCommits.inc({ operation, result });

--- a/packages/cli/src/metrics/prometheus/poll-trigger-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/poll-trigger-metrics.service.ts
@@ -1,0 +1,89 @@
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import { InstanceSettings, TriggersAndPollers } from 'n8n-core';
+import promClient from 'prom-client';
+
+import { EventService } from '@/events/event.service';
+
+import type { PrometheusMetricsCollector } from './base';
+import { DURATION_BUCKETS_SECONDS } from './constant';
+
+/**
+ * Collects Prometheus metrics for poll triggers, the baseline instrumentation
+ * for the poll reliability work. Opt-in via `includePollTriggerMetrics` and only
+ * active on a main instance. Tick duration, errors, and same-process overlap come
+ * from the core poll engine's event stream ({@link TriggersAndPollers.events});
+ * cursor-commit outcomes come from `EventService`. Cross-instance overlap is not
+ * observable from inside a poll, so it is covered by the scheduler collector's
+ * `scheduler_tasks_lease_lost_total` instead.
+ *
+ * Labels are bounded (node type, status, kind, operation, result): no
+ * workflow or instance label, per the metrics cardinality rule.
+ */
+@Service()
+export class PrometheusPollTriggerMetricsService implements PrometheusMetricsCollector {
+	constructor(
+		private readonly config: PrometheusMetricsConfig,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly eventService: EventService,
+		private readonly triggersAndPollers: TriggersAndPollers,
+	) {}
+
+	get enabled(): boolean {
+		return this.config.includePollTriggerMetrics && this.instanceSettings.instanceType === 'main';
+	}
+
+	init() {
+		const prefix = this.config.prefix;
+
+		const tickDuration = new promClient.Histogram({
+			name: `${prefix}poll_trigger_duration_seconds`,
+			help: "Duration in seconds of a poll trigger's poll() call, by node type and status.",
+			labelNames: ['node_type', 'status'],
+			buckets: DURATION_BUCKETS_SECONDS,
+		});
+
+		const tickErrors = new promClient.Counter({
+			name: `${prefix}poll_trigger_errors_total`,
+			help: 'Total number of poll trigger ticks that threw, by node type and error kind (auth, rate_limited, thrown).',
+			labelNames: ['node_type', 'kind'],
+		});
+
+		const overlappingTicks = new promClient.Counter({
+			name: `${prefix}poll_trigger_overlapping_ticks_total`,
+			help: 'Total number of poll ticks that started while another tick for the same node was still in flight in this process.',
+			labelNames: ['node_type'],
+		});
+
+		const cursorCommits = new promClient.Counter({
+			name: `${prefix}poll_trigger_cursor_commits_total`,
+			help: 'Total number of poll cursor commits by operation and result (success, fence_rejected, failure).',
+			labelNames: ['operation', 'result'],
+		});
+
+		const cursorCommitDuration = new promClient.Histogram({
+			name: `${prefix}poll_trigger_cursor_commit_duration_seconds`,
+			help: 'Duration in seconds of poll cursor commits, by operation.',
+			labelNames: ['operation'],
+			buckets: DURATION_BUCKETS_SECONDS,
+		});
+
+		this.triggersAndPollers.events.on(
+			'poll-tick-completed',
+			({ nodeType, status, errorKind, durationMs, overlapped }) => {
+				tickDuration.observe({ node_type: nodeType, status }, durationMs / 1000);
+				if (status === 'error') {
+					tickErrors.inc({ node_type: nodeType, kind: errorKind ?? 'thrown' });
+				}
+				if (overlapped) {
+					overlappingTicks.inc({ node_type: nodeType });
+				}
+			},
+		);
+
+		this.eventService.on('poll-cursor-commit-settled', ({ operation, result, durationMs }) => {
+			cursorCommits.inc({ operation, result });
+			cursorCommitDuration.observe({ operation }, durationMs / 1000);
+		});
+	}
+}

--- a/packages/cli/src/metrics/prometheus/poll-trigger-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/poll-trigger-metrics.service.ts
@@ -63,8 +63,8 @@ export class PrometheusPollTriggerMetricsService implements PrometheusMetricsCol
 
 		const cursorCommitDuration = new promClient.Histogram({
 			name: `${prefix}poll_trigger_cursor_commit_duration_seconds`,
-			help: 'Duration in seconds of poll cursor commits, by operation.',
-			labelNames: ['operation'],
+			help: 'Duration in seconds of poll cursor commits, by operation and result.',
+			labelNames: ['operation', 'result'],
 			buckets: DURATION_BUCKETS_SECONDS,
 		});
 
@@ -83,7 +83,7 @@ export class PrometheusPollTriggerMetricsService implements PrometheusMetricsCol
 
 		this.eventService.on('poll-cursor-commit-settled', ({ operation, result, durationMs }) => {
 			cursorCommits.inc({ operation, result });
-			cursorCommitDuration.observe({ operation }, durationMs / 1000);
+			cursorCommitDuration.observe({ operation, result }, durationMs / 1000);
 		});
 	}
 }

--- a/packages/cli/src/metrics/prometheus/prometheus.service.ts
+++ b/packages/cli/src/metrics/prometheus/prometheus.service.ts
@@ -13,6 +13,7 @@ import { PrometheusEventBusMetricsService } from './event-bus-metrics.service';
 import { PrometheusExecutionDataMetricsService } from './execution-data-metrics.service';
 import { PrometheusInstanceAiMetricsService } from './instance-ai-metrics.service';
 import { PrometheusInstanceRoleMetricsService } from './instance-role-metrics.service';
+import { PrometheusPollTriggerMetricsService } from './poll-trigger-metrics.service';
 import { PrometheusPssMetricsService } from './pss-metrics.service';
 import { PrometheusQueueMetricsService } from './queue-metrics.service';
 import { PrometheusRouteMetricsService } from './route-metrics.service';
@@ -55,6 +56,7 @@ export class PrometheusMetricsService {
 		dbPool: PrometheusDbPoolMetricsService,
 		workflowPublication: PrometheusWorkflowPublicationMetricsService,
 		scheduler: PrometheusSchedulerMetricsService,
+		pollTrigger: PrometheusPollTriggerMetricsService,
 	) {
 		this.logger = logger.scoped('metrics');
 		this.collectors = [
@@ -79,6 +81,7 @@ export class PrometheusMetricsService {
 			dbPool,
 			workflowPublication,
 			scheduler,
+			pollTrigger,
 		];
 	}
 

--- a/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
@@ -39,6 +39,7 @@ export class PrometheusSchedulerMetricsService
 	private tasksReclaimed!: promClient.Counter;
 	private tasksDeadLettered!: promClient.Counter;
 	private tasksPruned!: promClient.Counter;
+	private tasksLeaseLost!: promClient.Counter<'task_type'>;
 	private dispatchLagSeconds!: promClient.Histogram<'task_type'>;
 
 	constructor(
@@ -118,6 +119,12 @@ export class PrometheusSchedulerMetricsService
 		this.tasksPruned = new promClient.Counter({
 			name: `${prefix}scheduler_tasks_pruned_total`,
 			help: 'Total number of finished scheduler tasks deleted by retention.',
+		});
+
+		this.tasksLeaseLost = new promClient.Counter({
+			name: `${prefix}scheduler_tasks_lease_lost_total`,
+			help: 'Total number of scheduler tasks whose handler finished after the lease was reclaimed, so another instance may have run the same occurrence concurrently, by task type.',
+			labelNames: ['task_type'],
 		});
 
 		this.dispatchLagSeconds = new promClient.Histogram({
@@ -219,6 +226,12 @@ export class PrometheusSchedulerMetricsService
 	observeDispatchLagSeconds(taskType: string, seconds: number) {
 		if (this.initialized) {
 			this.dispatchLagSeconds.observe({ task_type: taskType }, seconds);
+		}
+	}
+
+	recordLeaseLost(taskType: string) {
+		if (this.initialized) {
+			this.tasksLeaseLost.inc({ task_type: taskType }, 1);
 		}
 	}
 

--- a/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
@@ -412,6 +412,22 @@ describe('PollCursorService', () => {
 			expectSettledEvent('cursor_only', 'fence_rejected');
 		});
 
+		it('does not let a throwing event sink fail a commit', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
+			eventService.emit.mockImplementation(() => {
+				throw new Error('metrics sink failed');
+			});
+
+			await expect(
+				service.commitCursorOnly({
+					workflowId: 'wf-1',
+					nodeId: 'node-1',
+					cursor: { lastItemId: 'b' },
+				}),
+			).resolves.toBe(true);
+		});
+
 		it('emits a failure event when commitCursorOnly throws', async () => {
 			const service = buildService();
 			pollerStateRepository.advanceCursor.mockRejectedValue(new Error('write failed'));

--- a/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
@@ -10,6 +10,7 @@ import type { IWorkflowBase } from 'n8n-workflow';
 import { mock, type MockProxy } from 'vitest-mock-extended';
 
 import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
+import type { EventService } from '@/events/event.service';
 import type { ExecutionPersistence } from '@/executions/execution-persistence';
 import type { DurablePollerGateService } from '@/workflows/triggers/durable-poller-gate.service';
 import { PollCursorService } from '@/workflows/triggers/poll-cursor.service';
@@ -17,6 +18,7 @@ import { PollCursorService } from '@/workflows/triggers/poll-cursor.service';
 describe('PollCursorService', () => {
 	const pollerStateRepository = mock<PollerStateRepository>();
 	const executionPersistence = mock<ExecutionPersistence>();
+	const eventService = mock<EventService>();
 
 	let txRunner: MockProxy<TransactionRunner>;
 
@@ -32,6 +34,7 @@ describe('PollCursorService', () => {
 			executionPersistence,
 			mock<PollerConfig>({ durableCursorsEnabled }),
 			mock<DurablePollerGateService>({ allowed: durablePollersAllowed }),
+			eventService,
 		);
 	};
 
@@ -323,6 +326,105 @@ describe('PollCursorService', () => {
 				{},
 				fence,
 			);
+		});
+	});
+
+	describe('metrics events', () => {
+		const expectSettledEvent = (operation: string, result: string) => {
+			expect(eventService.emit).toHaveBeenCalledTimes(1);
+			expect(eventService.emit).toHaveBeenCalledWith('poll-cursor-commit-settled', {
+				operation,
+				result,
+				durationMs: expect.any(Number),
+			});
+		};
+
+		it('emits a success event when commitWithExecution advances the cursor', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
+			executionPersistence.create.mockResolvedValue('exec-1');
+
+			await service.commitWithExecution({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				payload: payload(),
+			});
+
+			expectSettledEvent('with_execution', 'success');
+		});
+
+		it('emits a fence_rejected event when the fence rejects commitWithExecution', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(false);
+
+			await service.commitWithExecution({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				payload: payload(),
+				fence: { taskId: 'task-1', leaseEpoch: 3 },
+			});
+
+			expectSettledEvent('with_execution', 'fence_rejected');
+		});
+
+		it('emits a failure event when commitWithExecution throws', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockRejectedValue(new Error('write failed'));
+
+			await expect(
+				service.commitWithExecution({
+					workflowId: 'wf-1',
+					nodeId: 'node-1',
+					cursor: { lastItemId: 'b' },
+					payload: payload(),
+				}),
+			).rejects.toThrow('write failed');
+
+			expectSettledEvent('with_execution', 'failure');
+		});
+
+		it('emits a success event when commitCursorOnly advances the cursor', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
+
+			await service.commitCursorOnly({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+			});
+
+			expectSettledEvent('cursor_only', 'success');
+		});
+
+		it('emits a fence_rejected event when the fence rejects commitCursorOnly', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(false);
+
+			await service.commitCursorOnly({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				fence: { taskId: 'task-1', leaseEpoch: 3 },
+			});
+
+			expectSettledEvent('cursor_only', 'fence_rejected');
+		});
+
+		it('emits a failure event when commitCursorOnly throws', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockRejectedValue(new Error('write failed'));
+
+			await expect(
+				service.commitCursorOnly({
+					workflowId: 'wf-1',
+					nodeId: 'node-1',
+					cursor: { lastItemId: 'b' },
+				}),
+			).rejects.toThrow('write failed');
+
+			expectSettledEvent('cursor_only', 'failure');
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
@@ -10,12 +10,14 @@ import type { IWorkflowBase } from 'n8n-workflow';
 import { mock, type MockProxy } from 'vitest-mock-extended';
 
 import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
+import type { EventService } from '@/events/event.service';
 import type { ExecutionPersistence } from '@/executions/execution-persistence';
 import { PollCursorService } from '@/workflows/triggers/poll-cursor.service';
 
 describe('PollCursorService', () => {
 	const pollerStateRepository = mock<PollerStateRepository>();
 	const executionPersistence = mock<ExecutionPersistence>();
+	const eventService = mock<EventService>();
 
 	let txRunner: MockProxy<TransactionRunner>;
 
@@ -30,6 +32,7 @@ describe('PollCursorService', () => {
 			txRunner,
 			executionPersistence,
 			mock<PollerConfig>({ durableCursorsEnabled }),
+			eventService,
 		);
 	};
 
@@ -305,6 +308,105 @@ describe('PollCursorService', () => {
 				{},
 				fence,
 			);
+		});
+	});
+
+	describe('metrics events', () => {
+		const expectSettledEvent = (operation: string, result: string) => {
+			expect(eventService.emit).toHaveBeenCalledTimes(1);
+			expect(eventService.emit).toHaveBeenCalledWith('poll-cursor-commit-settled', {
+				operation,
+				result,
+				durationMs: expect.any(Number),
+			});
+		};
+
+		it('emits a success event when commitWithExecution advances the cursor', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
+			executionPersistence.create.mockResolvedValue('exec-1');
+
+			await service.commitWithExecution({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				payload: payload(),
+			});
+
+			expectSettledEvent('with_execution', 'success');
+		});
+
+		it('emits a fence_rejected event when the fence rejects commitWithExecution', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(false);
+
+			await service.commitWithExecution({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				payload: payload(),
+				fence: { taskId: 'task-1', leaseEpoch: 3 },
+			});
+
+			expectSettledEvent('with_execution', 'fence_rejected');
+		});
+
+		it('emits a failure event when commitWithExecution throws', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockRejectedValue(new Error('write failed'));
+
+			await expect(
+				service.commitWithExecution({
+					workflowId: 'wf-1',
+					nodeId: 'node-1',
+					cursor: { lastItemId: 'b' },
+					payload: payload(),
+				}),
+			).rejects.toThrow('write failed');
+
+			expectSettledEvent('with_execution', 'failure');
+		});
+
+		it('emits a success event when commitCursorOnly advances the cursor', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
+
+			await service.commitCursorOnly({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+			});
+
+			expectSettledEvent('cursor_only', 'success');
+		});
+
+		it('emits a fence_rejected event when the fence rejects commitCursorOnly', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(false);
+
+			await service.commitCursorOnly({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				fence: { taskId: 'task-1', leaseEpoch: 3 },
+			});
+
+			expectSettledEvent('cursor_only', 'fence_rejected');
+		});
+
+		it('emits a failure event when commitCursorOnly throws', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockRejectedValue(new Error('write failed'));
+
+			await expect(
+				service.commitCursorOnly({
+					workflowId: 'wf-1',
+					nodeId: 'node-1',
+					cursor: { lastItemId: 'b' },
+				}),
+			).rejects.toThrow('write failed');
+
+			expectSettledEvent('cursor_only', 'failure');
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -36,13 +36,13 @@ export class PollCursorService {
 		operation: PollCursorCommitOperation,
 		commit: () => Promise<{ value: T; advanced: boolean }>,
 	): Promise<T> {
-		const startedAt = Date.now();
+		const startedAt = performance.now();
 		const emitSettled = (result: PollCursorCommitResult) => {
 			try {
 				this.eventService.emit('poll-cursor-commit-settled', {
 					operation,
 					result,
-					durationMs: Date.now() - startedAt,
+					durationMs: performance.now() - startedAt,
 				});
 			} catch {
 				// Deliberately swallowed: a metrics sink must not fail a commit.

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -38,11 +38,15 @@ export class PollCursorService {
 	): Promise<T> {
 		const startedAt = Date.now();
 		const emitSettled = (result: PollCursorCommitResult) => {
-			this.eventService.emit('poll-cursor-commit-settled', {
-				operation,
-				result,
-				durationMs: Date.now() - startedAt,
-			});
+			try {
+				this.eventService.emit('poll-cursor-commit-settled', {
+					operation,
+					result,
+					durationMs: Date.now() - startedAt,
+				});
+			} catch {
+				// Deliberately swallowed: a metrics sink must not fail a commit.
+			}
 		};
 
 		try {

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -4,6 +4,11 @@ import { PollerStateRepository, TransactionRunner } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { PollCursor } from 'n8n-workflow';
 
+import { EventService } from '@/events/event.service';
+import type {
+	PollCursorCommitOperation,
+	PollCursorCommitResult,
+} from '@/events/maps/poll-trigger-metrics.event-map';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 import { DurablePollerGateService } from './durable-poller-gate.service';
@@ -19,7 +24,36 @@ export class PollCursorService {
 		private readonly executionPersistence: ExecutionPersistence,
 		private readonly pollerConfig: PollerConfig,
 		private readonly durablePollerGateService: DurablePollerGateService,
+		private readonly eventService: EventService,
 	) {}
+
+	/**
+	 * Runs a cursor commit and emits its outcome and latency as a metrics event.
+	 * `commit` reports whether the cursor advanced, so a write the lease fence
+	 * rejected is counted apart from one that failed outright.
+	 */
+	private async measureCommit<T>(
+		operation: PollCursorCommitOperation,
+		commit: () => Promise<{ value: T; advanced: boolean }>,
+	): Promise<T> {
+		const startedAt = Date.now();
+		const emitSettled = (result: PollCursorCommitResult) => {
+			this.eventService.emit('poll-cursor-commit-settled', {
+				operation,
+				result,
+				durationMs: Date.now() - startedAt,
+			});
+		};
+
+		try {
+			const { value, advanced } = await commit();
+			emitSettled(advanced ? 'success' : 'fence_rejected');
+			return value;
+		} catch (error) {
+			emitSettled('failure');
+			throw error;
+		}
+	}
 
 	get enabled(): boolean {
 		return this.pollerConfig.durableCursorsEnabled && this.durablePollerGateService.allowed;
@@ -89,35 +123,37 @@ export class PollCursorService {
 	}): Promise<{ executionId: string } | null> {
 		const { workflowId, nodeId, cursor, payload, fence } = args;
 
-		if (this.enabled) {
-			return await this.transactionRunner.run({}, async (ctx) => {
-				const advanced = await this.pollerStateRepository.advanceCursor(
-					workflowId,
-					nodeId,
-					cursor,
-					ctx,
-					fence,
-				);
-				if (advanced) {
-					const executionId = await this.executionPersistence.create(payload, ctx);
-					return { executionId };
-				}
-				return null;
-			});
-		}
+		return await this.measureCommit('with_execution', async () => {
+			if (this.enabled) {
+				return await this.transactionRunner.run({}, async (ctx) => {
+					const advanced = await this.pollerStateRepository.advanceCursor(
+						workflowId,
+						nodeId,
+						cursor,
+						ctx,
+						fence,
+					);
+					if (advanced) {
+						const executionId = await this.executionPersistence.create(payload, ctx);
+						return { value: { executionId }, advanced };
+					}
+					return { value: null, advanced };
+				});
+			}
 
-		const advanced = await this.pollerStateRepository.advanceCursor(
-			workflowId,
-			nodeId,
-			cursor,
-			{},
-			fence,
-		);
-		if (advanced) {
-			const executionId = await this.executionPersistence.create(payload, {});
-			return { executionId };
-		}
-		return null;
+			const advanced = await this.pollerStateRepository.advanceCursor(
+				workflowId,
+				nodeId,
+				cursor,
+				{},
+				fence,
+			);
+			if (advanced) {
+				const executionId = await this.executionPersistence.create(payload, {});
+				return { value: { executionId }, advanced };
+			}
+			return { value: null, advanced };
+		});
 	}
 
 	/**
@@ -131,6 +167,15 @@ export class PollCursorService {
 		fence?: PollLeaseFence;
 	}): Promise<boolean> {
 		const { workflowId, nodeId, cursor, fence } = args;
-		return await this.pollerStateRepository.advanceCursor(workflowId, nodeId, cursor, {}, fence);
+		return await this.measureCommit('cursor_only', async () => {
+			const advanced = await this.pollerStateRepository.advanceCursor(
+				workflowId,
+				nodeId,
+				cursor,
+				{},
+				fence,
+			);
+			return { value: advanced, advanced };
+		});
 	}
 }

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -4,6 +4,11 @@ import { PollerStateRepository, TransactionRunner } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { PollCursor } from 'n8n-workflow';
 
+import { EventService } from '@/events/event.service';
+import type {
+	PollCursorCommitOperation,
+	PollCursorCommitResult,
+} from '@/events/maps/poll-trigger-metrics.event-map';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 /** Narrows a stored cursor, which the persistence layer types more loosely. */
@@ -16,7 +21,36 @@ export class PollCursorService {
 		private readonly transactionRunner: TransactionRunner,
 		private readonly executionPersistence: ExecutionPersistence,
 		private readonly pollerConfig: PollerConfig,
+		private readonly eventService: EventService,
 	) {}
+
+	/**
+	 * Runs a cursor commit and emits its outcome and latency as a metrics event.
+	 * `commit` reports whether the cursor advanced, so a write the lease fence
+	 * rejected is counted apart from one that failed outright.
+	 */
+	private async measureCommit<T>(
+		operation: PollCursorCommitOperation,
+		commit: () => Promise<{ value: T; advanced: boolean }>,
+	): Promise<T> {
+		const startedAt = Date.now();
+		const emitSettled = (result: PollCursorCommitResult) => {
+			this.eventService.emit('poll-cursor-commit-settled', {
+				operation,
+				result,
+				durationMs: Date.now() - startedAt,
+			});
+		};
+
+		try {
+			const { value, advanced } = await commit();
+			emitSettled(advanced ? 'success' : 'fence_rejected');
+			return value;
+		} catch (error) {
+			emitSettled('failure');
+			throw error;
+		}
+	}
 
 	get enabled(): boolean {
 		return this.pollerConfig.durableCursorsEnabled;
@@ -86,35 +120,37 @@ export class PollCursorService {
 	}): Promise<{ executionId: string } | null> {
 		const { workflowId, nodeId, cursor, payload, fence } = args;
 
-		if (this.enabled) {
-			return await this.transactionRunner.run({}, async (ctx) => {
-				const advanced = await this.pollerStateRepository.advanceCursor(
-					workflowId,
-					nodeId,
-					cursor,
-					ctx,
-					fence,
-				);
-				if (advanced) {
-					const executionId = await this.executionPersistence.create(payload, ctx);
-					return { executionId };
-				}
-				return null;
-			});
-		}
+		return await this.measureCommit('with_execution', async () => {
+			if (this.enabled) {
+				return await this.transactionRunner.run({}, async (ctx) => {
+					const advanced = await this.pollerStateRepository.advanceCursor(
+						workflowId,
+						nodeId,
+						cursor,
+						ctx,
+						fence,
+					);
+					if (advanced) {
+						const executionId = await this.executionPersistence.create(payload, ctx);
+						return { value: { executionId }, advanced };
+					}
+					return { value: null, advanced };
+				});
+			}
 
-		const advanced = await this.pollerStateRepository.advanceCursor(
-			workflowId,
-			nodeId,
-			cursor,
-			{},
-			fence,
-		);
-		if (advanced) {
-			const executionId = await this.executionPersistence.create(payload, {});
-			return { executionId };
-		}
-		return null;
+			const advanced = await this.pollerStateRepository.advanceCursor(
+				workflowId,
+				nodeId,
+				cursor,
+				{},
+				fence,
+			);
+			if (advanced) {
+				const executionId = await this.executionPersistence.create(payload, {});
+				return { value: { executionId }, advanced };
+			}
+			return { value: null, advanced };
+		});
 	}
 
 	/**
@@ -128,6 +164,15 @@ export class PollCursorService {
 		fence?: PollLeaseFence;
 	}): Promise<boolean> {
 		const { workflowId, nodeId, cursor, fence } = args;
-		return await this.pollerStateRepository.advanceCursor(workflowId, nodeId, cursor, {}, fence);
+		return await this.measureCommit('cursor_only', async () => {
+			const advanced = await this.pollerStateRepository.advanceCursor(
+				workflowId,
+				nodeId,
+				cursor,
+				{},
+				fence,
+			);
+			return { value: advanced, advanced };
+		});
 	}
 }

--- a/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
@@ -250,6 +250,24 @@ describe('TriggersAndPollers', () => {
 			expect(ticks[2].overlapped).toBe(false);
 		});
 
+		it('does not let a throwing tick listener fail a successful poll', async () => {
+			pollers.events.on('poll-tick-completed', () => {
+				throw new Error('metrics sink failed');
+			});
+			pollFn.mockResolvedValue(null);
+
+			await expect(runPoll()).resolves.toBeNull();
+		});
+
+		it('does not let a throwing tick listener mask the poll error', async () => {
+			pollers.events.on('poll-tick-completed', () => {
+				throw new Error('metrics sink failed');
+			});
+			pollFn.mockRejectedValue(new Error('Poll function failed'));
+
+			await expect(runPoll()).rejects.toThrow('Poll function failed');
+		});
+
 		it('does not mark ticks of different nodes as overlapping', async () => {
 			let finishFirstPoll!: (value: null) => void;
 			pollFn

--- a/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
@@ -1,4 +1,4 @@
-import { UnexpectedError } from 'n8n-workflow';
+import { NodeApiError, UnexpectedError } from 'n8n-workflow';
 import type {
 	Workflow,
 	INode,
@@ -13,7 +13,7 @@ import type {
 import { mock } from 'vitest-mock-extended';
 
 import { ExecutionLifecycleHooks } from '../execution-lifecycle-hooks';
-import { TriggersAndPollers } from '../triggers-and-pollers';
+import { TriggersAndPollers, type PollTickEventMap } from '../triggers-and-pollers';
 
 describe('TriggersAndPollers', () => {
 	const node = mock<INode>();
@@ -150,6 +150,120 @@ describe('TriggersAndPollers', () => {
 
 			await expect(runPollHelper()).rejects.toThrow('Poll function failed');
 			expect(pollFn).toHaveBeenCalled();
+		});
+	});
+
+	describe('poll tick metrics', () => {
+		const pollFunctions = mock<IPollFunctions>();
+		const pollFn = vi.fn();
+		const pollWorkflow = mock<Workflow>({ id: 'workflow-1', nodeTypes });
+		const pollNode = mock<INode>({ id: 'node-1', type: 'n8n-nodes-base.testPoll' });
+
+		let pollers: TriggersAndPollers;
+		let ticks: Array<PollTickEventMap['poll-tick-completed']>;
+
+		beforeEach(() => {
+			nodeType.poll = pollFn;
+			pollers = new TriggersAndPollers();
+			ticks = [];
+			pollers.events.on('poll-tick-completed', (tick) => ticks.push(tick));
+		});
+
+		const runPoll = async (workflow = pollWorkflow, node = pollNode) =>
+			await pollers.runPollFunction(workflow, node, pollFunctions);
+
+		it('emits a success tick with the node type and duration', async () => {
+			pollFn.mockResolvedValue(null);
+
+			await runPoll();
+
+			expect(ticks).toEqual([
+				{
+					nodeType: 'n8n-nodes-base.testPoll',
+					status: 'success',
+					durationMs: expect.any(Number),
+					overlapped: false,
+				},
+			]);
+		});
+
+		it('emits an error tick and still propagates the error', async () => {
+			pollFn.mockRejectedValue(new Error('Poll function failed'));
+
+			await expect(runPoll()).rejects.toThrow('Poll function failed');
+
+			expect(ticks).toEqual([
+				{
+					nodeType: 'n8n-nodes-base.testPoll',
+					status: 'error',
+					errorKind: 'thrown',
+					durationMs: expect.any(Number),
+					overlapped: false,
+				},
+			]);
+		});
+
+		it.each([
+			{ httpCode: '429', errorKind: 'rate_limited' },
+			{ httpCode: '401', errorKind: 'auth' },
+			{ httpCode: '403', errorKind: 'auth' },
+			{ httpCode: '500', errorKind: 'thrown' },
+		])(
+			'classifies a NodeApiError with HTTP $httpCode as $errorKind',
+			async ({ httpCode, errorKind }) => {
+				pollFn.mockRejectedValue(
+					new NodeApiError(pollNode, {}, { httpCode, message: 'API error' }),
+				);
+
+				await expect(runPoll()).rejects.toThrow(NodeApiError);
+
+				expect(ticks).toEqual([expect.objectContaining({ status: 'error', errorKind })]);
+			},
+		);
+
+		it('emits no tick when the node type has no poll function', async () => {
+			nodeType.poll = undefined;
+
+			await expect(runPoll()).rejects.toThrow(UnexpectedError);
+
+			expect(ticks).toHaveLength(0);
+		});
+
+		it('marks a tick as overlapped when another tick for the same node is still in flight', async () => {
+			let finishFirstPoll!: (value: null) => void;
+			pollFn
+				.mockImplementationOnce(
+					async () => await new Promise((resolve) => (finishFirstPoll = resolve)),
+				)
+				.mockResolvedValueOnce(null);
+
+			const firstPoll = runPoll();
+			await runPoll();
+			finishFirstPoll(null);
+			await firstPoll;
+
+			expect(ticks.map((tick) => tick.overlapped)).toEqual([true, false]);
+
+			// The overlap window has closed, so the next tick is back to normal.
+			pollFn.mockResolvedValueOnce(null);
+			await runPoll();
+			expect(ticks[2].overlapped).toBe(false);
+		});
+
+		it('does not mark ticks of different nodes as overlapping', async () => {
+			let finishFirstPoll!: (value: null) => void;
+			pollFn
+				.mockImplementationOnce(
+					async () => await new Promise((resolve) => (finishFirstPoll = resolve)),
+				)
+				.mockResolvedValueOnce(null);
+
+			const firstPoll = runPoll();
+			await runPoll(pollWorkflow, mock<INode>({ id: 'node-2', type: 'n8n-nodes-base.testPoll' }));
+			finishFirstPoll(null);
+			await firstPoll;
+
+			expect(ticks.map((tick) => tick.overlapped)).toEqual([false, false]);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
@@ -1,4 +1,4 @@
-import { NodeApiError, UnexpectedError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError, UnexpectedError } from 'n8n-workflow';
 import type {
 	Workflow,
 	INode,
@@ -220,6 +220,21 @@ describe('TriggersAndPollers', () => {
 				expect(ticks).toEqual([expect.objectContaining({ status: 'error', errorKind })]);
 			},
 		);
+
+		it('classifies a NodeApiError wrapped as another error cause by its HTTP code', async () => {
+			pollFn.mockRejectedValue(
+				new NodeOperationError(
+					pollNode,
+					new NodeApiError(pollNode, {}, { httpCode: '429', message: 'API error' }),
+				),
+			);
+
+			await expect(runPoll()).rejects.toThrow(NodeOperationError);
+
+			expect(ticks).toEqual([
+				expect.objectContaining({ status: 'error', errorKind: 'rate_limited' }),
+			]);
+		});
 
 		it('emits no tick when the node type has no poll function', async () => {
 			nodeType.poll = undefined;

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -108,6 +108,7 @@ export { isEngineRequest } from './requests-response';
 export * from './routing-node';
 export * from './scheduled-task-manager';
 export { TriggersAndPollers } from './triggers-and-pollers';
+export type { PollErrorKind, PollTickEventMap } from './triggers-and-pollers';
 export * from './workflow-execute';
 // Exposed so eval-mode credential helpers (e.g. `EvalMockedCredentialsHelper`)
 // can reuse the same schema-driven cred synthesizer the wire-server URL

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -42,17 +42,18 @@ const classifyPollError = (error: unknown): PollErrorKind => {
 	return 'thrown';
 };
 
+type PollTickBase = {
+	nodeType: string;
+	durationMs: number;
+	/** Whether another tick for the same node was still in flight in this process when this one started. */
+	overlapped: boolean;
+};
+
 export type PollTickEventMap = {
 	/** One `poll()` call finished, successfully or not. */
-	'poll-tick-completed': {
-		nodeType: string;
-		status: 'success' | 'error';
-		/** Only present when `status` is `error`. */
-		errorKind?: PollErrorKind;
-		durationMs: number;
-		/** Whether another tick for the same node was still in flight in this process when this one started. */
-		overlapped: boolean;
-	};
+	'poll-tick-completed':
+		| (PollTickBase & { status: 'success' })
+		| (PollTickBase & { status: 'error'; errorKind: PollErrorKind });
 };
 
 @Service()

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -1,6 +1,7 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
-import { UnexpectedError } from 'n8n-workflow';
+import { NodeApiError, UnexpectedError } from 'n8n-workflow';
 import type {
 	Workflow,
 	INode,
@@ -18,8 +19,42 @@ import assert from 'node:assert';
 
 import type { IGetExecuteTriggerFunctions } from './interfaces';
 
+/** How a poll tick's error presented, from the HTTP status the source returned. */
+export type PollErrorKind = 'auth' | 'rate_limited' | 'thrown';
+
+const classifyPollError = (error: unknown): PollErrorKind => {
+	if (error instanceof NodeApiError) {
+		if (error.httpCode === '429') {
+			return 'rate_limited';
+		}
+		if (error.httpCode === '401' || error.httpCode === '403') {
+			return 'auth';
+		}
+	}
+	return 'thrown';
+};
+
+export type PollTickEventMap = {
+	/** One `poll()` call finished, successfully or not. */
+	'poll-tick-completed': {
+		nodeType: string;
+		status: 'success' | 'error';
+		/** Only present when `status` is `error`. */
+		errorKind?: PollErrorKind;
+		durationMs: number;
+		/** Whether another tick for the same node was still in flight in this process when this one started. */
+		overlapped: boolean;
+	};
+};
+
 @Service()
 export class TriggersAndPollers {
+	/** Metrics event stream for poll ticks; the host's metrics collector subscribes to it. */
+	readonly events = new TypedEmitter<PollTickEventMap>();
+
+	/** In-flight `poll()` calls per `workflowId:nodeId`, to detect overlapping ticks. */
+	private readonly inFlightPolls = new Map<string, number>();
+
 	/**
 	 * Runs the trigger() implementation for an active trigger or schedule trigger node.
 	 */
@@ -106,6 +141,36 @@ export class TriggersAndPollers {
 			});
 		}
 
-		return await nodeType.poll.call(pollFunctions);
+		const pollKey = `${workflow.id}:${node.id}`;
+		const inFlight = this.inFlightPolls.get(pollKey) ?? 0;
+		const overlapped = inFlight > 0;
+		this.inFlightPolls.set(pollKey, inFlight + 1);
+		const startedAt = Date.now();
+		try {
+			const result = await nodeType.poll.call(pollFunctions);
+			this.events.emit('poll-tick-completed', {
+				nodeType: node.type,
+				status: 'success',
+				durationMs: Date.now() - startedAt,
+				overlapped,
+			});
+			return result;
+		} catch (error) {
+			this.events.emit('poll-tick-completed', {
+				nodeType: node.type,
+				status: 'error',
+				errorKind: classifyPollError(error),
+				durationMs: Date.now() - startedAt,
+				overlapped,
+			});
+			throw error;
+		} finally {
+			const remaining = (this.inFlightPolls.get(pollKey) ?? 1) - 1;
+			if (remaining > 0) {
+				this.inFlightPolls.set(pollKey, remaining);
+			} else {
+				this.inFlightPolls.delete(pollKey);
+			}
+		}
 	}
 }

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -154,13 +154,13 @@ export class TriggersAndPollers {
 		const inFlight = this.inFlightPolls.get(pollKey) ?? 0;
 		const overlapped = inFlight > 0;
 		this.inFlightPolls.set(pollKey, inFlight + 1);
-		const startedAt = Date.now();
+		const startedAt = performance.now();
 		try {
 			const result = await nodeType.poll.call(pollFunctions);
 			this.emitTick({
 				nodeType: node.type,
 				status: 'success',
-				durationMs: Date.now() - startedAt,
+				durationMs: performance.now() - startedAt,
 				overlapped,
 			});
 			return result;
@@ -169,7 +169,7 @@ export class TriggersAndPollers {
 				nodeType: node.type,
 				status: 'error',
 				errorKind: classifyPollError(error),
-				durationMs: Date.now() - startedAt,
+				durationMs: performance.now() - startedAt,
 				overlapped,
 			});
 			throw error;

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -55,6 +55,15 @@ export class TriggersAndPollers {
 	/** In-flight `poll()` calls per `workflowId:nodeId`, to detect overlapping ticks. */
 	private readonly inFlightPolls = new Map<string, number>();
 
+	/** Emits a tick, swallowing listener errors: a metrics sink must not fail a poll. */
+	private emitTick(tick: PollTickEventMap['poll-tick-completed']): void {
+		try {
+			this.events.emit('poll-tick-completed', tick);
+		} catch {
+			// Deliberately swallowed; see above.
+		}
+	}
+
 	/**
 	 * Runs the trigger() implementation for an active trigger or schedule trigger node.
 	 */
@@ -148,7 +157,7 @@ export class TriggersAndPollers {
 		const startedAt = Date.now();
 		try {
 			const result = await nodeType.poll.call(pollFunctions);
-			this.events.emit('poll-tick-completed', {
+			this.emitTick({
 				nodeType: node.type,
 				status: 'success',
 				durationMs: Date.now() - startedAt,
@@ -156,7 +165,7 @@ export class TriggersAndPollers {
 			});
 			return result;
 		} catch (error) {
-			this.events.emit('poll-tick-completed', {
+			this.emitTick({
 				nodeType: node.type,
 				status: 'error',
 				errorKind: classifyPollError(error),

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -23,11 +23,19 @@ import type { IGetExecuteTriggerFunctions } from './interfaces';
 export type PollErrorKind = 'auth' | 'rate_limited' | 'thrown';
 
 const classifyPollError = (error: unknown): PollErrorKind => {
-	if (error instanceof NodeApiError) {
-		if (error.httpCode === '429') {
+	// Poll implementations often rethrow the API error wrapped in another node
+	// error, so unwrap one level of `cause` before classifying.
+	const apiError =
+		error instanceof NodeApiError
+			? error
+			: error instanceof Error && error.cause instanceof NodeApiError
+				? error.cause
+				: undefined;
+	if (apiError) {
+		if (apiError.httpCode === '429') {
 			return 'rate_limited';
 		}
-		if (error.httpCode === '401' || error.httpCode === '403') {
+		if (apiError.httpCode === '401' || apiError.httpCode === '403') {
 			return 'auth';
 		}
 	}


### PR DESCRIPTION
## Summary

New metrics, all behind a new opt-in flag `N8N_METRICS_INCLUDE_POLL_TRIGGER_METRICS`.

| Metric | Labels | What it tells you |
| --- | --- | --- |
| `n8n_poll_trigger_duration_seconds` | `node_type`, `status` | How long `poll()` takes, measured in `TriggersAndPollers.runPollFunction` |
| `n8n_poll_trigger_errors_total` | `node_type`, `kind` | Error rate per tick, classified from `NodeApiError.httpCode` as `auth` (401/403), `rate_limited` (429), or `thrown`. |
| `n8n_poll_trigger_overlapping_ticks_total` | `node_type` | Ticks that started while another tick for the same node was still in flight **in the same process**. |
| `n8n_poll_trigger_cursor_commits_total` | `operation`, `result` | Poll-cursor commit outcomes; `result=fence_rejected` counts writes rejected by the scheduler-lease fence. |
| `n8n_poll_trigger_cursor_commit_duration_seconds` | `operation` | Latency of those cursor commits. |
| `n8n_scheduler_tasks_lease_lost_total` | `task_type` | Cross-instance overlap: a handler finished but its terminal write matched no row (lease reclaimed mid-run). Filter `task_type="workflow:poll-trigger"` for the poll view. |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4013
- Grafana dashboard: https://github.com/n8n-io/n8n-observability/pull/10
- Documentation: https://github.com/n8n-io/n8n-docs/pull/5223

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
