### PR TITLE
fix(core): Reuse an existing consent grant to skip the OAuth consent screen (no-changelog)

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
@@ -620,4 +620,98 @@ describe('OAuthConsentService', () => {
 			expect(result.redirectUrl).not.toContain('state=');
 		});
 	});
+
+	describe('tryReuseConsent', () => {
+		const sessionPayload = {
+			clientId: 'https://n8n.example.com/form/abc',
+			redirectUri: 'https://n8n.example.com/form/abc',
+			codeChallenge: 'challenge-abc',
+			state: 'state-xyz',
+			resource: 'https://n8n.example.com/form/abc',
+		};
+
+		// Form triggers grant `[]` (full delegation), so an existing row is the whole answer.
+		const formResource = {
+			isFirstParty: true,
+			scopes: [],
+			authorize: async () => true,
+		} as unknown as ProtectedResource;
+
+		it('mints a code and redirects when a prior grant covers the request', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue(formResource);
+			userConsentRepository.findOne.mockResolvedValue({ scope: [] } as unknown as UserConsent);
+			userConsentRepository.upsert.mockResolvedValue(mock());
+			authorizationCodeService.createAuthorizationCode.mockResolvedValue('reused-code');
+
+			const result = await service.tryReuseConsent(mock<User>({ id: 'user-1' }), sessionPayload);
+
+			expect(result?.redirectUrl).toContain('code=reused-code');
+			expect(result?.redirectUrl).toContain('state=state-xyz');
+			expect(authorizationCodeService.createAuthorizationCode).toHaveBeenCalledWith(
+				sessionPayload.clientId,
+				'user-1',
+				sessionPayload.redirectUri,
+				sessionPayload.codeChallenge,
+				sessionPayload.state,
+				sessionPayload.resource,
+				[],
+			);
+		});
+
+		it('returns null when the user has no prior consent', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue(formResource);
+			userConsentRepository.findOne.mockResolvedValue(null);
+
+			const result = await service.tryReuseConsent(mock<User>({ id: 'user-1' }), sessionPayload);
+
+			expect(result).toBeNull();
+			expect(authorizationCodeService.createAuthorizationCode).not.toHaveBeenCalled();
+		});
+
+		it('returns null when the user is no longer authorized for the resource', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue({
+				isFirstParty: true,
+				scopes: [],
+				authorize: async () => false,
+			} as unknown as ProtectedResource);
+			userConsentRepository.findOne.mockResolvedValue({ scope: [] } as unknown as UserConsent);
+
+			const result = await service.tryReuseConsent(mock<User>({ id: 'user-1' }), sessionPayload);
+
+			expect(result).toBeNull();
+			expect(authorizationCodeService.createAuthorizationCode).not.toHaveBeenCalled();
+		});
+
+		it('returns null for a non-first-party resource without looking up consent', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue({
+				isFirstParty: false,
+				scopes: [],
+				authorize: async () => true,
+			} as unknown as ProtectedResource);
+
+			const result = await service.tryReuseConsent(mock<User>({ id: 'user-1' }), sessionPayload);
+
+			expect(result).toBeNull();
+			expect(userConsentRepository.findOne).not.toHaveBeenCalled();
+		});
+
+		it('returns null when the request needs a scope the prior grant does not cover', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue({
+				isFirstParty: true,
+				scopes: ['workflow:read', 'workflow:write'],
+				authorize: async () => true,
+			} as unknown as ProtectedResource);
+			userConsentRepository.findOne.mockResolvedValue({
+				scope: ['workflow:read'],
+			} as unknown as UserConsent);
+
+			const result = await service.tryReuseConsent(mock<User>({ id: 'user-1' }), {
+				...sessionPayload,
+				requestedScopes: ['workflow:write'],
+			});
+
+			expect(result).toBeNull();
+			expect(authorizationCodeService.createAuthorizationCode).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
@@ -5,10 +5,12 @@ import {
 import { Logger, type ModuleRegistry } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
+import type { User } from '@n8n/db';
 import type { Response } from 'express';
 import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import { AuthService } from '@/auth/auth.service';
 import type { EventService } from '@/events/event.service';
 import { McpProtectedResource } from '@/modules/mcp/mcp-protected-resource';
 import type { McpConfig } from '@/modules/mcp/mcp.config';
@@ -22,6 +24,7 @@ import type { OAuthClient } from '../database/entities/oauth-client.entity';
 import { OAuthClientRepository } from '../database/repositories/oauth-client.repository';
 import { UserConsentRepository } from '../database/repositories/oauth-user-consent.repository';
 import { OAuthAuthorizationCodeService } from '../oauth-authorization-code.service';
+import { OAuthConsentService } from '../oauth-consent.service';
 import { OAuthServerService } from '../oauth-server.service';
 import { OAuthSessionService } from '../oauth-session.service';
 import { OAuthTokenService } from '../oauth-token.service';
@@ -39,6 +42,8 @@ let userConsentRepository: Mocked<UserConsentRepository>;
 let mailer: Mocked<UserManagementMailer>;
 let getAllowedRedirectUris: Mock<() => Promise<string[]>>;
 let eventService: Mocked<EventService>;
+let authService: Mocked<AuthService>;
+let oauthConsentService: Mocked<OAuthConsentService>;
 
 // Shared, immutable across tests: the base URLs gate the first-party client_id guard.
 const urlServiceMock = mock<UrlService>();
@@ -56,6 +61,8 @@ describe('OAuthServerService', () => {
 		urlServiceMock.getTestWebhookBaseUrl.mockReturnValue('https://n8n.example.com/');
 		getAllowedRedirectUris = vi.fn<(...args: []) => Promise<string[]>>().mockResolvedValue([]);
 		eventService = mock<EventService>();
+		authService = mockInstance(AuthService);
+		oauthConsentService = mockInstance(OAuthConsentService);
 
 		const resourceRegistry = new ProtectedResourceRegistry(mock<Logger>());
 		resourceRegistry.register({
@@ -80,6 +87,8 @@ describe('OAuthServerService', () => {
 			mailer,
 			urlServiceMock,
 			eventService,
+			authService,
+			oauthConsentService,
 		);
 	});
 
@@ -185,6 +194,8 @@ describe('OAuthServerService', () => {
 					mailer,
 					urlServiceMock,
 					mock<EventService>(),
+					mock<AuthService>(),
+					mock<OAuthConsentService>(),
 				);
 			});
 
@@ -254,6 +265,8 @@ describe('OAuthServerService', () => {
 					mailer,
 					urlServiceMock,
 					mock<EventService>(),
+					mock<AuthService>(),
+					mock<OAuthConsentService>(),
 				);
 
 				const result = await svc.clientsStore.getClient('https://evil.example.com/form/abc');
@@ -402,6 +415,57 @@ describe('OAuthServerService', () => {
 				resource: 'https://n8n.example.com/mcp-server/http',
 			});
 			expect(res.redirect).toHaveBeenCalledWith('/oauth/consent');
+		});
+
+		describe('reusing a prior consent (auto-approval)', () => {
+			const client = {
+				client_id: 'client-123',
+				client_name: 'Test Client',
+				redirect_uris: ['https://example.com/callback'],
+				grant_types: ['authorization_code'],
+				token_endpoint_auth_method: 'none',
+				response_types: ['code'],
+				scope: 'read write',
+				logo_uri: undefined,
+				tos_uri: undefined,
+			};
+			const params = {
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge-123',
+				state: 'state-xyz',
+				resource: new URL('https://n8n.example.com/mcp-server/http'),
+			};
+
+			beforeEach(() => {
+				getAllowedRedirectUris.mockResolvedValue(['https://example.com/callback']);
+				authService.getCookieToken.mockReturnValue('valid-cookie');
+				authService.authenticateUserByCookie.mockResolvedValue(mock<User>({ id: 'user-1' }));
+			});
+
+			it('mints a code and skips the consent screen when a grant is reused', async () => {
+				const res = mock<Response>();
+				oauthConsentService.tryReuseConsent.mockResolvedValue({
+					redirectUrl: 'https://example.com/callback?code=reused&state=state-xyz',
+				});
+
+				await service.authorize(client, params, res);
+
+				expect(oauthConsentService.tryReuseConsent).toHaveBeenCalled();
+				expect(res.redirect).toHaveBeenCalledWith(
+					'https://example.com/callback?code=reused&state=state-xyz',
+				);
+				expect(oauthSessionService.createSession).not.toHaveBeenCalled();
+			});
+
+			it('falls back to the consent screen when there is no reusable grant', async () => {
+				const res = mock<Response>();
+				oauthConsentService.tryReuseConsent.mockResolvedValue(null);
+
+				await service.authorize(client, params, res);
+
+				expect(oauthSessionService.createSession).toHaveBeenCalled();
+				expect(res.redirect).toHaveBeenCalledWith('/oauth/consent');
+			});
 		});
 
 		it('should handle null state parameter', async () => {
@@ -849,6 +913,8 @@ describe('OAuthServerService', () => {
 				mailer,
 				urlServiceMock,
 				eventService,
+				mock<AuthService>(),
+				mock<OAuthConsentService>(),
 			);
 
 			const client = {
@@ -1402,6 +1468,8 @@ describe('OAuthServerService', () => {
 				mailer,
 				urlServiceMock,
 				mock<EventService>(),
+				mock<AuthService>(),
+				mock<OAuthConsentService>(),
 			);
 
 			expect(
@@ -1450,6 +1518,8 @@ describe('OAuthServerService', () => {
 				mailer,
 				urlService,
 				mock<EventService>(),
+				mock<AuthService>(),
+				mock<OAuthConsentService>(),
 			);
 		};
 

--- a/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
@@ -200,6 +200,16 @@ export class OAuthConsentService {
 
 		const grantedScopes = await this.resolveGrantedScopes(sessionPayload, scopes);
 
+		return await this.issueGrant(user, sessionPayload, grantedScopes);
+	}
+
+	private async issueGrant(
+		user: User,
+		sessionPayload: OAuthSessionPayload,
+		grantedScopes: string[],
+	): Promise<{ redirectUrl: string }> {
+		const issuer = this.urlService.getInstanceBaseUrl();
+
 		await this.userConsentRepository.upsert(
 			{
 				userId: user.id,
@@ -266,5 +276,37 @@ export class OAuthConsentService {
 		}
 
 		return scopes;
+	}
+
+	async tryReuseConsent(
+		user: User,
+		sessionPayload: OAuthSessionPayload,
+	): Promise<{ redirectUrl: string } | null> {
+		if (!sessionPayload.resource) return null;
+
+		const resource = await this.protectedResourceRegistry.getByResourceUrl(sessionPayload.resource);
+		if (!resource?.isFirstParty) return null;
+
+		const consent = await this.userConsentRepository.findOne({
+			where: { clientId: sessionPayload.clientId, userId: user.id },
+		});
+
+		if (!consent) {
+			return null;
+		}
+
+		const grantable = this.grantableScopes(resource.scopes ?? [], sessionPayload.requestedScopes);
+		if (!grantable.every((scope) => consent.scope.includes(scope))) return null;
+
+		if (!(await resource.authorize(user))) {
+			this.logger.debug('Consent reuse skipped: user no longer authorized for resource', {
+				clientId: sessionPayload.clientId,
+				userId: user.id,
+				resourceUrl: sessionPayload.resource,
+			});
+			return null;
+		}
+
+		return await this.issueGrant(user, sessionPayload, grantable);
 	}
 }

--- a/packages/cli/src/modules/oauth-server/oauth-server.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-server.service.ts
@@ -23,6 +23,7 @@ import { Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
 import type { Response } from 'express';
 
+import { AuthService } from '@/auth/auth.service';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
@@ -33,7 +34,8 @@ import { OAuthClient } from './database/entities/oauth-client.entity';
 import { OAuthClientRepository } from './database/repositories/oauth-client.repository';
 import { UserConsentRepository } from './database/repositories/oauth-user-consent.repository';
 import { OAuthAuthorizationCodeService } from './oauth-authorization-code.service';
-import { OAuthSessionService } from './oauth-session.service';
+import { OAuthConsentService } from './oauth-consent.service';
+import { OAuthSessionPayload, OAuthSessionService } from './oauth-session.service';
 import { OAuthTokenService } from './oauth-token.service';
 import { OAuthClientLimitReachedError } from './oauth.errors';
 
@@ -107,6 +109,8 @@ export class OAuthServerService implements OAuthServerProvider {
 		private readonly mailer: UserManagementMailer,
 		private readonly urlService: UrlService,
 		private readonly eventService: EventService,
+		private readonly authService: AuthService,
+		private readonly oauthConsentService: OAuthConsentService,
 	) {}
 
 	get clientsStore(): OAuthRegisteredClientsStore {
@@ -360,14 +364,23 @@ export class OAuthServerService implements OAuthServerProvider {
 			const supportedScopes = targetResource?.scopes ?? [];
 			const requestedScopes = params.scopes?.filter((scope) => supportedScopes.includes(scope));
 
-			this.oauthSessionService.createSession(res, {
+			const sessionPayload: OAuthSessionPayload = {
 				clientId: client.client_id,
 				redirectUri: params.redirectUri,
 				codeChallenge: params.codeChallenge,
 				state: params.state ?? null,
 				resource,
 				...(requestedScopes && requestedScopes.length > 0 && { requestedScopes }),
-			});
+			};
+
+			const autoApproval = await this.tryAutoApproveConsent(res, sessionPayload, client);
+
+			if (autoApproval) {
+				res.redirect(autoApproval.redirectUrl);
+				return;
+			}
+
+			this.oauthSessionService.createSession(res, sessionPayload);
 
 			res.redirect('/oauth/consent');
 		} catch (error) {
@@ -500,6 +513,35 @@ export class OAuthServerService implements OAuthServerProvider {
 
 	async verifyAccessToken(token: string): Promise<AuthInfo> {
 		return await this.tokenService.verifyAccessToken(token);
+	}
+
+	private async tryAutoApproveConsent(
+		res: Response,
+		sessionPayload: OAuthSessionPayload,
+		client: OAuthClientInformationFull,
+	): Promise<{ redirectUrl: string } | null> {
+		const req = res.req;
+		const cookie = this.authService.getCookieToken(req);
+		if (cookie) {
+			let user: User | undefined;
+
+			try {
+				user = await this.authService.authenticateUserByCookie(cookie);
+			} catch (error) {
+				this.logger.debug('Auto-approval failed: user not authenticated', {
+					clientId: client.client_id,
+				});
+			}
+
+			if (user) {
+				const reuseResult = await this.oauthConsentService.tryReuseConsent(user, sessionPayload);
+				if (reuseResult) {
+					return { redirectUrl: reuseResult.redirectUrl };
+				}
+			}
+		}
+
+		return null;
 	}
 
 	// Exact-match against a registered resource, as required by RFC 8707 §2.1.


### PR DESCRIPTION
## Summary

A Form Trigger with `Authentication = n8n User Auth` showed the OAuth consent screen on every page load. The consent grant was already stored (`UserConsent`, unique on `(userId, clientId)`) but `OAuthServerService.authorize()` never read it back — it always redirected to `/oauth/consent`.

`authorize()` now checks for an existing grant before showing the consent screen. When the request is for a first-party resource (form/webhook/MCP virtual clients) and the signed-in user already consented, it mints the authorization code and redirects straight back to the client. A returning user's re-auth becomes three invisible redirects instead of a repeated prompt. Anything else — no cookie, no prior grant, a narrower stored grant, or a user who lost access — falls through to the normal consent flow unchanged.

This is scoped to first-party resources only; third-party DCR clients (e.g. registered MCP clients) are unaffected.

### Why

Part of the "form trigger with end-user credentials" work. Track 5.2 (consent should not repeat): reloading the form, navigating away and back, or opening it in a new tab should render the form directly after the first consent.

### How to test manually

1. Create a workflow with a **Form Trigger**, set `Authentication` to **n8n User Auth**, and activate it.
2. Open the form URL in a browser, sign in, and approve the consent screen.
3. Reload the form, navigate away and back, and open it in a new tab.
   - **Expected:** the form renders directly each time — no consent screen.
4. Submit the form to confirm the credential still works.

Edge cases worth checking:
- **Deny** on first visit → the next visit prompts again (denial writes no grant).
- **Second form / second user:** a grant for `/form/A` does not skip the prompt on `/form/B`; user B consenting does not skip user A's prompt.
- **Signed-out visitor** still gets the sign-in bounce, then the normal first-visit consent.
- **Lost access:** remove the user's access to the workflow after consenting → the skip no longer applies and the existing 403 surfaces via the normal flow.
- **MCP / third-party clients:** behaviour is unchanged.

### Key implementation decisions

- The user is resolved opportunistically from the `n8n-auth` cookie inside `authorize()` (via `res.req`); the route stays `skipAuth`, so a missing or invalid cookie simply falls through to today's behaviour.
- `resource.authorize(user)` is re-evaluated on every authorization, so a revoked user is never silently let through.
- The grant/mint/redirect tail of `handleConsentDecision` is extracted into a shared `issueGrant`, reused by both the consent approval path and the new `tryReuseConsent`, so there is no duplicated code-minting logic.

Not included here: letting the submitter view and withdraw a form consent (bug bash 5.3), which needs a design decision (IAM-1214) and will follow separately.

## Related

- https://linear.app/n8n/issue/IAM-1225

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
