### PR TITLE
fix(Google Ads Node): Migrate from sunset v21 API to v25

### DIFF
--- a/packages/nodes-base/nodes/Google/Ads/CampaignDescription.ts
+++ b/packages/nodes-base/nodes/Google/Ads/CampaignDescription.ts
@@ -41,7 +41,7 @@ export const campaignOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'POST',
-						url: '={{"/v21/customers/" + $parameter["clientCustomerId"].toString().replace(/-/g, "")  + "/googleAds:search"}}',
+						url: '={{"/v25/customers/" + $parameter["clientCustomerId"].toString().replace(/-/g, "")  + "/googleAds:search"}}',
 						body: {
 							query:
 								'={{ "' +
@@ -89,7 +89,7 @@ export const campaignOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'POST',
-						url: '={{"/v21/customers/" + $parameter["clientCustomerId"].toString().replace(/-/g, "") + "/googleAds:search"}}',
+						url: '={{"/v25/customers/" + $parameter["clientCustomerId"].toString().replace(/-/g, "") + "/googleAds:search"}}',
 						returnFullResponse: true,
 						body: {
 							query:

--- a/packages/nodes-base/nodes/Google/Ads/GoogleAds.node.ts
+++ b/packages/nodes-base/nodes/Google/Ads/GoogleAds.node.ts
@@ -25,7 +25,7 @@ export class GoogleAds implements INodeType {
 				testedBy: {
 					request: {
 						method: 'GET',
-						url: '/v21/customers:listAccessibleCustomers',
+						url: '/v25/customers:listAccessibleCustomers',
 					},
 				},
 			},

--- a/packages/nodes-base/nodes/Google/Ads/__test__/node/GoogleAds.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Ads/__test__/node/GoogleAds.node.test.ts
@@ -19,7 +19,7 @@ describe('Google Ads Node', () => {
 
 		beforeAll(() => {
 			googleAdsNock
-				.post('/v21/customers/4445556666/googleAds:search', {
+				.post('/v25/customers/4445556666/googleAds:search', {
 					query:
 						'select ' +
 						'campaign.id, ' +
@@ -61,7 +61,7 @@ describe('Google Ads Node', () => {
 
 		beforeAll(() => {
 			googleAdsNock
-				.post('/v21/customers/4445556666/googleAds:search', {
+				.post('/v25/customers/4445556666/googleAds:search', {
 					query:
 						'select ' +
 						'campaign.id, ' +
@@ -90,7 +90,7 @@ describe('Google Ads Node', () => {
 				.reply(200, getManyResult);
 
 			googleAdsNock
-				.post('/v21/customers/4445556666/googleAds:search', {
+				.post('/v25/customers/4445556666/googleAds:search', {
 					query:
 						'select ' +
 						'campaign.id, ' +
@@ -121,7 +121,7 @@ describe('Google Ads Node', () => {
 				.reply(200, getManyResult);
 
 			googleAdsNock
-				.post('/v21/customers/4445556666/googleAds:search', {
+				.post('/v25/customers/4445556666/googleAds:search', {
 					query:
 						'select ' +
 						'campaign.id, ' +


### PR DESCRIPTION
## Summary

Google Ads API v21 sunset on 2026-08-05, so every request the Google Ads node makes now fails with:

  Version v21 is deprecated. Requests to this version will be blocked.

Point the campaign search endpoints and the credential test endpoint at v25, the current major version (released 2026-07-22, supported into July 2027). The node only queries core campaign, campaign_budget and metrics fields, none of which changed between v21 and v25, so the GAQL query and response shape are unaffected.

Nock expectations in the node tests are updated to the v25 path.

## How to test

Fire POST request to native Google Ad node. Return 200

## Related Linear tickets, Github issues, and Community forum posts

fixes #36253
Related to Internal Dev Ticket `NODE-5754`

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

