### PR TITLE
test(instance-ai): allow extra MCP servers in --build-via-mcp evals (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -9,6 +9,7 @@ import {
 	buildPromptFromConversation,
 	buildWorkflowViaMcp,
 	MCP_BUILD_KEY_SUPPORT,
+	readExtraMcpServers,
 	sanitizeServerName,
 	stageLaneMcpConfig,
 	tailWorkflowId,
@@ -98,6 +99,60 @@ describe('sanitizeServerName / buildAllowedTools', () => {
 	it('builds the mcp__ tool allowlist prefix', () => {
 		expect(buildAllowedTools('n8n-local')).toEqual(['mcp__n8n-local']);
 		expect(buildAllowedTools('n8n-mcp (instance)')).toEqual(['mcp__n8n-mcp__instance_']);
+	});
+
+	it('allowlists extra server names alongside n8n', () => {
+		expect(buildAllowedTools('n8n-local', ['cognee'])).toEqual(['mcp__n8n-local', 'mcp__cognee']);
+	});
+});
+
+describe('readExtraMcpServers / stageLaneMcpConfig extra servers', () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'extra-mcp-'));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('reads servers from a Claude-shaped { mcpServers } file', () => {
+		const path = join(dir, 'extra.json');
+		writeFileSync(
+			path,
+			JSON.stringify({
+				mcpServers: { cognee: { type: 'http', url: 'http://127.0.0.1:8000/mcp' } },
+			}),
+		);
+		expect(readExtraMcpServers(path)).toEqual({
+			cognee: { type: 'http', url: 'http://127.0.0.1:8000/mcp' },
+		});
+	});
+
+	it('reads servers from a bare name→block map', () => {
+		const path = join(dir, 'bare.json');
+		writeFileSync(path, JSON.stringify({ cognee: { type: 'http', url: 'http://x/mcp' } }));
+		expect(readExtraMcpServers(path)).toEqual({ cognee: { type: 'http', url: 'http://x/mcp' } });
+	});
+
+	it('throws when the file declares no servers', () => {
+		const path = join(dir, 'empty.json');
+		writeFileSync(path, JSON.stringify({ mcpServers: {} }));
+		expect(() => readExtraMcpServers(path)).toThrow(/No MCP servers/);
+	});
+
+	it('stages extra servers next to the n8n block without shadowing it', () => {
+		const configPath = stageLaneMcpConfig({
+			serverName: 'n8n-local',
+			url: 'http://lane/mcp-server/http',
+			apiKey: 'key-123',
+			extraServers: { cognee: { type: 'http', url: 'http://127.0.0.1:8000/mcp' } },
+		});
+		const staged = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+			mcpServers: Record<string, { url: string }>;
+		};
+		expect(Object.keys(staged.mcpServers).sort()).toEqual(['cognee', 'n8n-local']);
+		expect(staged.mcpServers['n8n-local'].url).toBe('http://lane/mcp-server/http');
+		expect(staged.mcpServers.cognee.url).toBe('http://127.0.0.1:8000/mcp');
 	});
 });
 

--- a/packages/@n8n/instance-ai/evaluations/cli/args.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/args.ts
@@ -103,6 +103,10 @@ export interface CliArgs {
 	/** MCP server name used in the per-lane staged `claude` config + tool allowlist
 	 *  (`--build-via-mcp` only). Arbitrary — the eval CLI stages the config itself. */
 	mcpServerName: string;
+	/** Path to a JSON file of additional MCP server blocks staged alongside the
+	 *  lane's n8n server (`--build-via-mcp`), so a run can measure the builder
+	 *  with extra servers (e.g. a memory server) attached. */
+	extraMcpConfigPath?: string;
 	/** Anthropic model id passed to `claude -p` for the MCP build (`--build-via-mcp`).
 	 *  Sourced from the ANTHROPIC_MODEL env var (the variable `claude` reads
 	 *  natively), pinned to DEFAULT_MCP_BUILD_MODEL when unset. Distinct from the
@@ -159,6 +163,7 @@ const cliArgsSchema = z.object({
 	suite: z.string().min(1).optional(),
 	buildViaMcp: z.boolean().default(false),
 	mcpServerName: z.string().min(1).default('n8n-local'),
+	extraMcpConfigPath: z.string().min(1).optional(),
 	buildModel: z.string().min(1).default('claude-opus-4-8'),
 	buildCwd: z.string().min(1).optional(),
 	buildMaxAttempts: z.number().int().positive().default(3),
@@ -253,6 +258,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
 		suite: validated.suite,
 		buildViaMcp: validated.buildViaMcp,
 		mcpServerName: validated.mcpServerName,
+		extraMcpConfigPath: validated.extraMcpConfigPath,
 		buildModel: validated.buildModel,
 		buildCwd: validated.buildCwd,
 		buildMaxAttempts: validated.buildMaxAttempts,
@@ -313,6 +319,7 @@ interface RawArgs {
 	suite?: string;
 	buildViaMcp: boolean;
 	mcpServerName: string;
+	extraMcpConfigPath?: string;
 	buildModel: string;
 	buildCwd?: string;
 	buildMaxAttempts: number;
@@ -472,6 +479,12 @@ function parseRawArgs(argv: string[]): RawArgs {
 
 			case '--mcp-server':
 				result.mcpServerName = nextArg(argv, i, '--mcp-server');
+				result.buildOnlyFlags.push(arg);
+				i++;
+				break;
+
+			case '--extra-mcp-config':
+				result.extraMcpConfigPath = nextArg(argv, i, '--extra-mcp-config');
 				result.buildOnlyFlags.push(arg);
 				i++;
 				break;

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -37,6 +37,10 @@ const claudeConfigSchema = z
 	})
 	.passthrough();
 
+const extraMcpConfigSchema = z
+	.object({ mcpServers: z.record(z.unknown()).optional() })
+	.passthrough();
+
 function readJson(path: string, label: string): unknown {
 	const content = readFileSync(path, 'utf-8');
 	try {
@@ -79,14 +83,14 @@ export function unlinkStagedMcpConfig(path: string): void {
 	}
 }
 
-function writeMcpConfig(serverName: string, block: unknown, filePrefix: string): string {
+function writeMcpConfig(servers: Readonly<Record<string, unknown>>, filePrefix: string): string {
 	// A random suffix (not just pid+time) keeps concurrent lane stages from
 	// colliding when several are written in the same millisecond.
 	const tmpPath = join(
 		tmpdir(),
 		`${filePrefix}-${String(process.pid)}-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}.json`,
 	);
-	writeFileSync(tmpPath, JSON.stringify({ mcpServers: { [serverName]: block } }), { mode: 0o600 });
+	writeFileSync(tmpPath, JSON.stringify({ mcpServers: servers }), { mode: 0o600 });
 	stagedConfigPaths.add(tmpPath);
 	return tmpPath;
 }
@@ -117,7 +121,21 @@ export function stageMcpConfigFromClaudeJson(
 		throw new Error(`MCP server "${serverName}" not configured in ${claudeConfigPath} (${scope})`);
 	}
 
-	return writeMcpConfig(serverName, block, 'n8n-mcp-config');
+	return writeMcpConfig({ [serverName]: block }, 'n8n-mcp-config');
+}
+
+/**
+ * Extra MCP server blocks to stage alongside the n8n server, read from a JSON
+ * file shaped like a Claude config (`{ "mcpServers": { "<name>": {...} } }`, or
+ * the bare `{ "<name>": {...} }` map). Lets a run measure the builder against
+ * additional servers (e.g. a memory server) without touching `~/.claude.json`.
+ */
+export function readExtraMcpServers(path: string): Record<string, unknown> {
+	const parsed = extraMcpConfigSchema.parse(readJson(path, 'extra MCP config'));
+	const servers = parsed.mcpServers ?? (parsed as Record<string, unknown>);
+	const entries = Object.entries(servers).filter(([key]) => key !== 'mcpServers');
+	if (entries.length === 0) throw new Error(`No MCP servers found in ${path}`);
+	return Object.fromEntries(entries);
 }
 
 /**
@@ -131,13 +149,16 @@ export function stageLaneMcpConfig(opts: {
 	serverName: string;
 	url: string;
 	apiKey: string;
+	/** Additional servers staged alongside n8n (see `readExtraMcpServers`). */
+	extraServers?: Readonly<Record<string, unknown>>;
 }): string {
 	const block = {
 		type: 'http',
 		url: opts.url,
 		headers: { Authorization: `Bearer ${opts.apiKey}` },
 	};
-	return writeMcpConfig(opts.serverName, block, 'n8n-mcp-lane-config');
+	// n8n last so a stray extra server can never shadow the lane's own block.
+	return writeMcpConfig({ ...opts.extraServers, [opts.serverName]: block }, 'n8n-mcp-lane-config');
 }
 
 /** Each non-alphanumeric character (excluding hyphen) becomes "_". Mirrors
@@ -147,8 +168,11 @@ export function sanitizeServerName(name: string): string {
 	return name.replace(/[^a-zA-Z0-9-]/g, '_');
 }
 
-export function buildAllowedTools(serverName: string): readonly string[] {
-	return [`mcp__${sanitizeServerName(serverName)}`];
+export function buildAllowedTools(
+	serverName: string,
+	extraServerNames: readonly string[] = [],
+): readonly string[] {
+	return [serverName, ...extraServerNames].map((name) => `mcp__${sanitizeServerName(name)}`);
 }
 
 type McpBuildKeySupport = 'supported' | 'orchestrator-only';
@@ -248,6 +272,8 @@ const KILL_GRACE_MS = 5_000;
 export interface McpBuildSettings {
 	/** MCP server name in the staged config; also derives the tool allowlist. */
 	serverName: string;
+	/** Names of any extra staged servers, so their tools are allowlisted too. */
+	extraServerNames?: readonly string[];
 	/** Anthropic model id passed to `claude -p --model`. */
 	model: string;
 	/** Retries per build when no WORKFLOW_ID is returned. */
@@ -479,7 +505,7 @@ export async function buildWorkflowViaMcp(opts: {
 }): Promise<McpBuildResult> {
 	const { conversation, slug, iteration, mcpConfigPath, settings, logDir } = opts;
 	const log = opts.log ?? ((message: string) => console.log(message));
-	const allowedTools = buildAllowedTools(settings.serverName);
+	const allowedTools = buildAllowedTools(settings.serverName, settings.extraServerNames ?? []);
 	const userMessage = buildUserMessage(conversation, settings);
 
 	let workflowId: string | null = null;

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -18,6 +18,7 @@ import { allFailVerdicts, verifyBuildExpectations } from '../build-expectations/
 import type { CliArgs } from '../cli/args';
 import {
 	buildWorkflowViaMcp,
+	readExtraMcpServers,
 	stageLaneMcpConfig,
 	unlinkStagedMcpConfig,
 	type McpBuildResult,
@@ -144,10 +145,19 @@ export interface LaneState {
 	}) => Promise<Awaited<ReturnType<typeof executeAgentScenario>>>;
 }
 
+/** Extra MCP server blocks staged alongside n8n, read once from --extra-mcp-config. */
+function loadExtraMcpServers(args: CliArgs): Record<string, unknown> {
+	return args.extraMcpConfigPath ? readExtraMcpServers(args.extraMcpConfigPath) : {};
+}
+
 /** Map eval CLI args to the shared MCP builder's settings. */
-function mcpBuildSettingsFromArgs(args: CliArgs): McpBuildSettings {
+function mcpBuildSettingsFromArgs(
+	args: CliArgs,
+	extraServerNames: readonly string[] = [],
+): McpBuildSettings {
 	return {
 		serverName: args.mcpServerName,
+		extraServerNames,
 		model: args.buildModel,
 		maxAttempts: args.buildMaxAttempts,
 		mcpTimeoutMs: args.buildMcpTimeoutMs,
@@ -205,10 +215,12 @@ async function buildWorkflowViaMcpOnLane(config: {
 		return failure(`MCP build user/credential setup failed: ${extractErrorMessage(error)}`);
 	}
 
+	const extraServers = loadExtraMcpServers(args);
 	const mcpConfigPath = stageLaneMcpConfig({
 		serverName: args.mcpServerName,
 		url: `${lane.baseUrl}/mcp-server/http`,
 		apiKey: mcpApiKey,
+		extraServers,
 	});
 
 	let result: McpBuildResult;
@@ -218,7 +230,7 @@ async function buildWorkflowViaMcpOnLane(config: {
 			slug,
 			iteration,
 			mcpConfigPath,
-			settings: mcpBuildSettingsFromArgs(args),
+			settings: mcpBuildSettingsFromArgs(args, Object.keys(extraServers)),
 			logDir,
 			log: (message) => logger.info(message),
 		});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an opt-in `--extra-mcp-config <path>` flag to the Instance AI MCP workflow-eval harness (`--build-via-mcp`). It stages one or more additional MCP server blocks into the same `claude --mcp-config` file the eval already writes per lane, and adds their tool prefixes to the `--allowedTools` allowlist.

This makes it possible to measure the MCP workflow builder while an **extra MCP server is attached alongside the lane's n8n server** — for example an AI-memory server (Cognee) — to see whether the extra tools change build quality, and whether a persistent-memory server "learns" across repeated runs.

Behaviour is unchanged when the flag is omitted: the staged config contains only the lane's n8n block, exactly as before.

### What changed
- `cli/mcp-builder.ts`: `writeMcpConfig` now takes a server map; new `readExtraMcpServers(path)` parses a Claude-shaped `{ mcpServers: {...} }` (or bare `{ name: {...} }`) file; `stageLaneMcpConfig` accepts `extraServers` and always writes the n8n block last so an extra server can't shadow it; `buildAllowedTools` accepts extra server names; `McpBuildSettings` carries `extraServerNames`.
- `cli/args.ts`: new `--extra-mcp-config` (build-only) flag, rejected without `--build-via-mcp` like the other build knobs.
- `run/build-orchestrator.ts`: reads the extra servers once and threads them into staging + the tool allowlist.
- Tests: unit coverage for `readExtraMcpServers`, extra-server staging (no shadowing), and the extended allowlist.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm vitest run evaluations/__tests__/mcp-builder.test.ts
pnpm typecheck
```

To exercise it end to end, run the MCP evals with a second server attached:

```bash
# cognee-mcp.json = { "mcpServers": { "cognee": { "type": "http", "url": "http://127.0.0.1:8000/mcp" } } }
pnpm eval:instance-ai --base-url http://127.0.0.1:5678 \
  --build-via-mcp --source langtracer --suite baseline --tier mcp-gate \
  --extra-mcp-config ./cognee-mcp.json --concurrency 1
```

## Related Linear tickets, Github issues, and Community forum posts

n/a — exploratory eval tooling.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5746100-e747-4f9e-b559-e13d56ee1d81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5746100-e747-4f9e-b559-e13d56ee1d81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

