### PR TITLE
fix(core): Resolve agent credentials through the node decryption path so external secrets work

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-vector-stores.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-vector-stores.service.test.ts
@@ -1,7 +1,7 @@
 import type { BuiltVectorStoreBackend } from '@n8n/agents';
 import type { AgentJsonVectorStoreConfig } from '@n8n/api-types';
+import { mockInstance } from '@n8n/backend-test-utils';
 import type { CredentialsEntity, User } from '@n8n/db';
-import { Container } from '@n8n/di';
 import type { ICredentialDataDecryptedObject, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
@@ -20,15 +20,12 @@ vi.mock('../json-config/embedding-credential', () => ({
 	resolveEmbeddingProviderOptionsFromCredential: vi.fn().mockResolvedValue({}),
 }));
 
-// `AgentsCredentialProvider.resolve()` decrypts through `CredentialsHelper`, so
-// the credential's expressions (e.g. `$secrets`) are evaluated like they are for
-// nodes. Both collaborators are stubbed here — this suite is about the service.
+// `AgentsCredentialProvider.resolve()` decrypts through `CredentialsHelper`; both are stubbed — this suite tests the service.
 vi.mock('@/workflow-execute-additional-data', () => ({
 	getBase: vi.fn().mockResolvedValue(mock<IWorkflowExecuteAdditionalData>()),
 }));
 
-const credentialsHelper = mock<CredentialsHelper>();
-Container.set(CredentialsHelper, credentialsHelper);
+const credentialsHelper = mockInstance(CredentialsHelper);
 
 vi.mock('@n8n/agents', () => ({
 	createEmbeddingModel: vi.fn().mockReturnValue({ modelId: 'text-embedding-3-small' }),
@@ -79,7 +76,7 @@ function makeService(
 		},
 	]);
 	credentialsHelper.getDecrypted.mockResolvedValue(rawCredential);
-	return { service: new AgentVectorStoresService(credentialsService), credentialsService };
+	return new AgentVectorStoresService(credentialsService);
 }
 
 // Built manually instead of `mock<BuiltVectorStoreBackend>()`: `close` being an
@@ -106,7 +103,7 @@ describe('AgentVectorStoresService.testConnection', () => {
 		const backend = makeBackend();
 		backend.query.mockResolvedValue([]);
 		vi.mocked(buildVectorStoreBackend).mockResolvedValue(backend);
-		const { service } = makeService(postgresConfig.credential);
+		const service = makeService(postgresConfig.credential);
 
 		const result = await service.testConnection(projectId, user, postgresConfig);
 
@@ -125,7 +122,7 @@ describe('AgentVectorStoresService.testConnection', () => {
 			const backend = makeBackend();
 			backend.query.mockImplementation(async () => await new Promise<never>(() => {}));
 			vi.mocked(buildVectorStoreBackend).mockResolvedValue(backend);
-			const { service } = makeService(postgresConfig.credential);
+			const service = makeService(postgresConfig.credential);
 
 			const resultPromise = service.testConnection(projectId, user, postgresConfig);
 			await vi.advanceTimersByTimeAsync(15_000);
@@ -149,7 +146,7 @@ describe('AgentVectorStoresService.testConnection', () => {
 						resolveBackend = resolve;
 					}),
 			);
-			const { service } = makeService(postgresConfig.credential);
+			const service = makeService(postgresConfig.credential);
 
 			const resultPromise = service.testConnection(projectId, user, postgresConfig);
 			await vi.advanceTimersByTimeAsync(15_000);
@@ -172,7 +169,7 @@ describe('AgentVectorStoresService.testConnection', () => {
 		const backend = makeBackend();
 		backend.query.mockRejectedValue(new Error('connection refused'));
 		vi.mocked(buildVectorStoreBackend).mockResolvedValue(backend);
-		const { service } = makeService(postgresConfig.credential);
+		const service = makeService(postgresConfig.credential);
 
 		const result = await service.testConnection(projectId, user, postgresConfig);
 
@@ -195,7 +192,7 @@ describe('AgentVectorStoresService.testConnection', () => {
 		const backend = makeBackend();
 		backend.query.mockResolvedValue([]);
 		vi.mocked(buildVectorStoreBackend).mockResolvedValue(backend);
-		const { service } = makeService('pinecone-cred', { apiKey: 'pc-key' });
+		const service = makeService('pinecone-cred', { apiKey: 'pc-key' });
 		const pineconeConfig: AgentJsonVectorStoreConfig = {
 			provider: 'pinecone',
 			name: 'docs',
@@ -234,7 +231,7 @@ describe('AgentVectorStoresService.testConnection', () => {
 		const backend = makeBackend();
 		backend.query.mockResolvedValue([]);
 		vi.mocked(buildVectorStoreBackend).mockResolvedValue(backend);
-		const { service } = makeService('pinecone-cred', { apiKey: 'pc-key' });
+		const service = makeService('pinecone-cred', { apiKey: 'pc-key' });
 		const pineconeConfig: AgentJsonVectorStoreConfig = {
 			provider: 'pinecone',
 			name: 'docs',

--- a/packages/cli/src/modules/agents/__tests__/agent-vector-stores.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-vector-stores.service.test.ts
@@ -95,6 +95,9 @@ function makeBackend() {
 
 describe('AgentVectorStoresService.testConnection', () => {
 	beforeEach(() => {
+		// `credentialsHelper` is module-scoped, so its call counts would otherwise
+		// accumulate across tests (`restoreMocks` only restores spies).
+		vi.clearAllMocks();
 		vi.mocked(buildVectorStoreBackend).mockReset();
 		vi.mocked(resolveEmbeddingProviderOptionsFromCredential).mockReset().mockResolvedValue({});
 	});

--- a/packages/cli/src/modules/agents/__tests__/agent-vector-stores.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-vector-stores.service.test.ts
@@ -1,10 +1,12 @@
 import type { BuiltVectorStoreBackend } from '@n8n/agents';
 import type { AgentJsonVectorStoreConfig } from '@n8n/api-types';
 import type { CredentialsEntity, User } from '@n8n/db';
-import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { Container } from '@n8n/di';
+import type { ICredentialDataDecryptedObject, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
+import { CredentialsHelper } from '@/credentials-helper';
 
 import { AgentVectorStoresService } from '../agent-vector-stores.service';
 import { resolveEmbeddingProviderOptionsFromCredential } from '../json-config/embedding-credential';
@@ -17,6 +19,16 @@ vi.mock('../json-config/vector-store-factory', () => ({
 vi.mock('../json-config/embedding-credential', () => ({
 	resolveEmbeddingProviderOptionsFromCredential: vi.fn().mockResolvedValue({}),
 }));
+
+// `AgentsCredentialProvider.resolve()` decrypts through `CredentialsHelper`, so
+// the credential's expressions (e.g. `$secrets`) are evaluated like they are for
+// nodes. Both collaborators are stubbed here — this suite is about the service.
+vi.mock('@/workflow-execute-additional-data', () => ({
+	getBase: vi.fn().mockResolvedValue(mock<IWorkflowExecuteAdditionalData>()),
+}));
+
+const credentialsHelper = mock<CredentialsHelper>();
+Container.set(CredentialsHelper, credentialsHelper);
 
 vi.mock('@n8n/agents', () => ({
 	createEmbeddingModel: vi.fn().mockReturnValue({ modelId: 'text-embedding-3-small' }),
@@ -66,7 +78,7 @@ function makeService(
 			sharedWithProjects: [],
 		},
 	]);
-	credentialsService.decrypt.mockResolvedValue(rawCredential);
+	credentialsHelper.getDecrypted.mockResolvedValue(rawCredential);
 	return { service: new AgentVectorStoresService(credentialsService), credentialsService };
 }
 
@@ -94,12 +106,12 @@ describe('AgentVectorStoresService.testConnection', () => {
 		const backend = makeBackend();
 		backend.query.mockResolvedValue([]);
 		vi.mocked(buildVectorStoreBackend).mockResolvedValue(backend);
-		const { service, credentialsService } = makeService(postgresConfig.credential);
+		const { service } = makeService(postgresConfig.credential);
 
 		const result = await service.testConnection(projectId, user, postgresConfig);
 
 		expect(result).toEqual({ success: true });
-		expect(credentialsService.decrypt).toHaveBeenCalledTimes(1);
+		expect(credentialsHelper.getDecrypted).toHaveBeenCalledTimes(1);
 		expect(buildVectorStoreBackend).toHaveBeenCalledWith(postgresConfig, expect.anything(), {
 			apiKey: 'store-key',
 		});

--- a/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
@@ -1,10 +1,28 @@
 import type { CredentialListItem } from '@n8n/agents';
 import type { CredentialsEntity, User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
+import { CredentialsHelper } from '@/credentials-helper';
 
 import { AgentsCredentialProvider } from '../adapters/agents-credential-provider';
+
+const additionalData = mock<IWorkflowExecuteAdditionalData>();
+const getBaseMock = vi.fn<(...args: unknown[]) => Promise<IWorkflowExecuteAdditionalData>>();
+
+vi.mock('@/workflow-execute-additional-data', () => ({
+	getBase: async (...args: unknown[]) => await getBaseMock(...args),
+}));
+
+const credentialsHelper = mock<CredentialsHelper>();
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	getBaseMock.mockResolvedValue(additionalData);
+	Container.set(CredentialsHelper, credentialsHelper);
+});
 
 function credential(overrides: Partial<CredentialsEntity>): CredentialsEntity {
 	return {
@@ -112,12 +130,17 @@ describe('AgentsCredentialProvider', () => {
 		const projectCred = credential({ id: 'project-cred', name: 'Project Slack' });
 		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([projectCred]);
 		credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
-		credentialsService.decrypt.mockResolvedValue({ apiKey: 'project-secret' });
+		credentialsHelper.getDecrypted.mockResolvedValue({ apiKey: 'project-secret' });
 
 		const provider = new AgentsCredentialProvider(credentialsService, 'project-1');
 
 		await expect(provider.resolve('project-cred')).resolves.toEqual({ apiKey: 'project-secret' });
-		expect(credentialsService.decrypt).toHaveBeenCalledWith(projectCred, true);
+		expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+			additionalData,
+			{ id: 'project-cred', name: 'Project Slack' },
+			'slackApi',
+			'internal',
+		);
 	});
 
 	it('resolves a global credential when no request user is provided', async () => {
@@ -125,12 +148,58 @@ describe('AgentsCredentialProvider', () => {
 		const globalCred = credential({ id: 'global-cred', name: 'Global OpenAI', type: 'openAiApi' });
 		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([]);
 		credentialsService.findAllGlobalCredentialIds.mockResolvedValue([globalCred]);
-		credentialsService.decrypt.mockResolvedValue({ apiKey: 'global-secret' });
+		credentialsHelper.getDecrypted.mockResolvedValue({ apiKey: 'global-secret' });
 
 		const provider = new AgentsCredentialProvider(credentialsService, 'project-1');
 
 		await expect(provider.resolve('global-cred')).resolves.toEqual({ apiKey: 'global-secret' });
-		expect(credentialsService.decrypt).toHaveBeenCalledWith(globalCred, true);
+		expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+			additionalData,
+			{ id: 'global-cred', name: 'Global OpenAI' },
+			'openAiApi',
+			'internal',
+		);
+	});
+
+	it('returns the resolved secret for an External Secrets backed credential', async () => {
+		const credentialsService = mock<CredentialsService>();
+		const bearerCred = credential({
+			id: 'bearer-cred',
+			name: 'MCP bearer',
+			type: 'httpBearerAuth',
+		});
+		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([bearerCred]);
+		credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
+		// `getDecrypted` is the path that evaluates `={{ $secrets... }}`; the raw
+		// stored value would be the unevaluated expression.
+		credentialsHelper.getDecrypted.mockResolvedValue({ token: 'secret-from-1password' });
+
+		const provider = new AgentsCredentialProvider(credentialsService, 'project-1');
+
+		await expect(provider.resolve('bearer-cred')).resolves.toEqual({
+			token: 'secret-from-1password',
+			apiKey: '',
+		});
+		// Project scope must reach `getBase` — it carries the project's external
+		// secret provider keys and variables.
+		expect(getBaseMock).toHaveBeenCalledWith({ userId: undefined, projectId: 'project-1' });
+		expect(credentialsService.decrypt).not.toHaveBeenCalled();
+	});
+
+	it('propagates a failed secret lookup instead of returning empty credential data', async () => {
+		const credentialsService = mock<CredentialsService>();
+		const bearerCred = credential({
+			id: 'bearer-cred',
+			name: 'MCP bearer',
+			type: 'httpBearerAuth',
+		});
+		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([bearerCred]);
+		credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
+		credentialsHelper.getDecrypted.mockRejectedValue(new Error('Could not load secrets'));
+
+		const provider = new AgentsCredentialProvider(credentialsService, 'project-1');
+
+		await expect(provider.resolve('bearer-cred')).rejects.toThrow('Could not load secrets');
 	});
 
 	it('rejects resolve for a credential not in project or global scope when no request user is provided', async () => {
@@ -169,12 +238,18 @@ describe('AgentsCredentialProvider', () => {
 		]);
 		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([projectCred]);
 		credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
-		credentialsService.decrypt.mockResolvedValue({ apiKey: 'secret' });
+		credentialsHelper.getDecrypted.mockResolvedValue({ apiKey: 'secret' });
 
 		const provider = new AgentsCredentialProvider(credentialsService, 'project-1', user);
 
 		await expect(provider.resolve('allowed')).resolves.toEqual({ apiKey: 'secret' });
-		expect(credentialsService.decrypt).toHaveBeenCalledWith(projectCred, true);
+		expect(getBaseMock).toHaveBeenCalledWith({ userId: 'user-1', projectId: 'project-1' });
+		expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+			additionalData,
+			{ id: 'allowed', name: 'Slack' },
+			'slackApi',
+			'internal',
+		);
 	});
 
 	it('rejects resolve for a credential accessible to the project but not to the request user', async () => {
@@ -193,6 +268,6 @@ describe('AgentsCredentialProvider', () => {
 		await expect(provider.resolve('forbidden-cred')).rejects.toThrow(
 			'Credential "forbidden-cred" not found or not accessible',
 		);
-		expect(credentialsService.decrypt).not.toHaveBeenCalled();
+		expect(credentialsHelper.getDecrypted).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
@@ -140,6 +140,8 @@ describe('AgentsCredentialProvider', () => {
 			'slackApi',
 			'internal',
 		);
+		// `getBase` must be project-scoped — it supplies the project's variables.
+		expect(getBaseMock).toHaveBeenCalledWith({ userId: undefined, projectId: 'project-1' });
 	});
 
 	it('resolves a global credential when no request user is provided', async () => {
@@ -160,7 +162,10 @@ describe('AgentsCredentialProvider', () => {
 		);
 	});
 
-	it('returns the resolved secret for an External Secrets backed credential', async () => {
+	// Expression evaluation itself (a stored `={{ $secrets... }}` resolving to
+	// plaintext, and a missing secret rejecting) is covered against a real
+	// `CredentialsHelper` in `test/integration/agents/agents-credential-provider.test.ts`.
+	it('defaults apiKey to an empty string for a credential type that has none', async () => {
 		const credentialsService = mock<CredentialsService>();
 		const bearerCred = credential({
 			id: 'bearer-cred',
@@ -169,34 +174,14 @@ describe('AgentsCredentialProvider', () => {
 		});
 		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([bearerCred]);
 		credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
-		// `getDecrypted` is the path that evaluates `={{ $secrets... }}`; the raw
-		// stored value would be the unevaluated expression.
-		credentialsHelper.getDecrypted.mockResolvedValue({ token: 'secret-from-1password' });
+		credentialsHelper.getDecrypted.mockResolvedValue({ token: 'bearer-token' });
 
 		const provider = new AgentsCredentialProvider(credentialsService, 'project-1');
 
 		await expect(provider.resolve('bearer-cred')).resolves.toEqual({
-			token: 'secret-from-1password',
+			token: 'bearer-token',
 			apiKey: '',
 		});
-		// Project scope must reach `getBase` — it supplies the project's variables.
-		expect(getBaseMock).toHaveBeenCalledWith({ userId: undefined, projectId: 'project-1' });
-	});
-
-	it('propagates a failed secret lookup instead of returning empty credential data', async () => {
-		const credentialsService = mock<CredentialsService>();
-		const bearerCred = credential({
-			id: 'bearer-cred',
-			name: 'MCP bearer',
-			type: 'httpBearerAuth',
-		});
-		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([bearerCred]);
-		credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
-		credentialsHelper.getDecrypted.mockRejectedValue(new Error('Could not load secrets'));
-
-		const provider = new AgentsCredentialProvider(credentialsService, 'project-1');
-
-		await expect(provider.resolve('bearer-cred')).rejects.toThrow('Could not load secrets');
 	});
 
 	it('rejects resolve for a credential not in project or global scope when no request user is provided', async () => {

--- a/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
@@ -1,6 +1,6 @@
 import type { CredentialListItem } from '@n8n/agents';
+import { mockInstance } from '@n8n/backend-test-utils';
 import type { CredentialsEntity, User } from '@n8n/db';
-import { Container } from '@n8n/di';
 import type { IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
@@ -16,12 +16,11 @@ vi.mock('@/workflow-execute-additional-data', () => ({
 	getBase: async (...args: unknown[]) => await getBaseMock(...args),
 }));
 
-const credentialsHelper = mock<CredentialsHelper>();
+const credentialsHelper = mockInstance(CredentialsHelper);
 
 beforeEach(() => {
 	vi.clearAllMocks();
 	getBaseMock.mockResolvedValue(additionalData);
-	Container.set(CredentialsHelper, credentialsHelper);
 });
 
 function credential(overrides: Partial<CredentialsEntity>): CredentialsEntity {
@@ -180,10 +179,8 @@ describe('AgentsCredentialProvider', () => {
 			token: 'secret-from-1password',
 			apiKey: '',
 		});
-		// Project scope must reach `getBase` — it carries the project's external
-		// secret provider keys and variables.
+		// Project scope must reach `getBase` — it supplies the project's variables.
 		expect(getBaseMock).toHaveBeenCalledWith({ userId: undefined, projectId: 'project-1' });
-		expect(credentialsService.decrypt).not.toHaveBeenCalled();
 	});
 
 	it('propagates a failed secret lookup instead of returning empty credential data', async () => {

--- a/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
+++ b/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
@@ -1,9 +1,11 @@
 import type { CredentialProvider, ResolvedCredential, CredentialListItem } from '@n8n/agents';
 import type { CredentialsEntity, User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 import { UserError } from 'n8n-workflow';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
+import { CredentialsHelper } from '@/credentials-helper';
 import { AiGatewayService } from '@/services/ai-gateway.service';
 
 import type { AiGatewayModelCredentialResolver } from '../json-config/model-config';
@@ -53,7 +55,7 @@ export class AgentsCredentialProvider
 	}
 
 	/**
-	 * Resolve a credential by ID, then decrypt and return the raw data.
+	 * Resolve a credential by ID, then decrypt and return the usable data.
 	 *
 	 * Only credentials visible to this provider's scope are considered — the
 	 * same user-scoped intersection as `list()` when a request user is set, so
@@ -66,8 +68,41 @@ export class AgentsCredentialProvider
 			throw new Error(`Credential "${credentialId}" not found or not accessible`);
 		}
 
-		const data = await this.credentialsService.decrypt(credential, true);
+		const data = await this.decryptWithExpressions(credential);
 		return toResolvedCredential(data);
+	}
+
+	/**
+	 * Decrypt through `CredentialsHelper.getDecrypted` — the same path node
+	 * execution takes — so credential fields holding expressions are evaluated
+	 * rather than handed to the caller as raw `={{ ... }}` strings. Without
+	 * this, a field backed by an external secret (`{{ $secrets.store.key }}`)
+	 * reaches the MCP client / model provider verbatim and auth fails.
+	 *
+	 * The agents runtime has no workflow or execution, so `additionalData` is
+	 * built from `getBase()` and scoped to this provider's project — that is
+	 * what carries the external secrets proxy and project variables. `internal`
+	 * mode keeps dynamic (per-user resolvable) credentials out of scope; those
+	 * need an execution context that agents don't have.
+	 */
+	private async decryptWithExpressions(
+		credential: CredentialsEntity,
+	): Promise<ICredentialDataDecryptedObject> {
+		// Imported lazily: `workflow-execute-additional-data` reaches back into
+		// this module to run agents from workflows.
+		// eslint-disable-next-line import-x/no-cycle
+		const { getBase } = await import('@/workflow-execute-additional-data.js');
+		const additionalData = await getBase({
+			userId: this.user?.id,
+			projectId: this.projectId,
+		});
+
+		return await Container.get(CredentialsHelper).getDecrypted(
+			additionalData,
+			{ id: credential.id, name: credential.name },
+			credential.type,
+			'internal',
+		);
 	}
 
 	/**

--- a/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
+++ b/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
@@ -73,17 +73,15 @@ export class AgentsCredentialProvider
 	}
 
 	/**
-	 * Decrypt through `CredentialsHelper.getDecrypted` — the same path node
-	 * execution takes — so credential fields holding expressions are evaluated
-	 * rather than handed to the caller as raw `={{ ... }}` strings. Without
-	 * this, a field backed by an external secret (`{{ $secrets.store.key }}`)
-	 * reaches the MCP client / model provider verbatim and auth fails.
+	 * Decrypt through `CredentialsHelper.getDecrypted` — the path node execution
+	 * takes — so expressions in credential fields are evaluated instead of
+	 * reaching the caller as raw `={{ ... }}` strings. An external-secret-backed
+	 * field would otherwise be sent verbatim and fail auth.
 	 *
-	 * The agents runtime has no workflow or execution, so `additionalData` is
-	 * built from `getBase()` and scoped to this provider's project — that is
-	 * what carries the external secrets proxy and project variables. `internal`
-	 * mode keeps dynamic (per-user resolvable) credentials out of scope; those
-	 * need an execution context that agents don't have.
+	 * Agents have no workflow or execution, so `additionalData` comes from
+	 * `getBase()`, which supplies the secrets proxy and the project's variables.
+	 * `internal` mode keeps dynamic (per-user resolvable) credentials out of
+	 * scope; they need an execution context agents don't have.
 	 */
 	private async decryptWithExpressions(
 		credential: CredentialsEntity,
@@ -155,7 +153,9 @@ export class AgentsCredentialProvider
 		const projectCredentials = await this.credentialsService.findAllCredentialIdsForProject(
 			this.projectId,
 		);
-		const globalCredentials = await this.credentialsService.findAllGlobalCredentialIds(true);
+		// No `includeData` — only id/name/type are read here, and `getDecrypted`
+		// re-reads the row it decrypts.
+		const globalCredentials = await this.credentialsService.findAllGlobalCredentialIds();
 		const allCredsSet = new Set();
 		const allCreds: CredentialsEntity[] = [];
 

--- a/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
+++ b/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
@@ -80,8 +80,11 @@ export class AgentsCredentialProvider
 	 *
 	 * Agents have no workflow or execution, so `additionalData` comes from
 	 * `getBase()`, which supplies the secrets proxy and the project's variables.
-	 * `internal` mode keeps dynamic (per-user resolvable) credentials out of
-	 * scope; they need an execution context agents don't have.
+	 *
+	 * `internal` mode skips dynamic-credential resolution, which needs an
+	 * execution context agents don't have. A per-user resolvable credential
+	 * therefore falls back to its static stored data rather than failing — the
+	 * same behaviour as before this path existed.
 	 */
 	private async decryptWithExpressions(
 		credential: CredentialsEntity,

--- a/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
+++ b/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
@@ -575,6 +575,37 @@ describe('buildMcpClientForServer — credential domain restrictions', () => {
 });
 
 // ---------------------------------------------------------------------------
+// buildMcpClientForServer — unresolvable credential
+// ---------------------------------------------------------------------------
+
+describe('buildMcpClientForServer — unresolvable credential', () => {
+	beforeEach(() => {
+		mcpClientCtor.mockReset();
+		proxyFetchMock.mockReset();
+		proxyFetchMock.mockResolvedValue(makeOk());
+	});
+
+	it('fails the connection with the resolution error instead of connecting unauthenticated', async () => {
+		const credentialProvider = mock<CredentialProvider>();
+		credentialProvider.resolve.mockRejectedValue(
+			new Error('Could not load secrets [Error resolving credentials]'),
+		);
+		const oauthService = mock<OauthService>();
+
+		await buildMcpClientForServer(
+			makeServer({ authentication: 'bearerAuth', credential: 'cred-1' }),
+			{ credentialProvider, oauthService, projectId: 'proj-1', proxyFetch },
+		);
+
+		const [configs] = mcpClientCtor.mock.calls[0] as [Array<{ fetch: typeof fetch }>];
+		await expect(configs[0].fetch('https://example.test/mcp')).rejects.toThrow(
+			'Could not resolve the credential for MCP server "srv": Could not load secrets [Error resolving credentials]',
+		);
+		expect(proxyFetchMock).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
 // listMcpServerTools
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
+++ b/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
@@ -1,7 +1,13 @@
-import type { CredentialProvider, McpClient, McpServerConfig } from '@n8n/agents';
+import type {
+	CredentialProvider,
+	McpClient,
+	McpServerConfig,
+	ResolvedCredential,
+} from '@n8n/agents';
 import type { AgentJsonMcpServerConfig } from '@n8n/api-types';
 import type { CustomFetch } from '@n8n/backend-network';
-import { isMcpOAuth2Authentication } from 'n8n-workflow';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
+import { isMcpOAuth2Authentication, OperationalError } from 'n8n-workflow';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 
 import type { OauthService } from '@/oauth/oauth.service';
@@ -35,6 +41,12 @@ function isTokenData(tokenData: unknown): tokenData is { access_token: string } 
 type DerivedAuth = {
 	headers: Record<string, string>;
 	credentialData?: ICredentialDataDecryptedObject;
+	/**
+	 * Set when the credential could not be resolved at all — e.g. an external
+	 * secret store that is unreachable, or a field whose `$secrets` expression
+	 * doesn't match a known secret.
+	 */
+	credentialError?: Error;
 };
 
 function withCredentialData(
@@ -140,11 +152,34 @@ async function deriveAuthHeaders(
 ): Promise<DerivedAuth> {
 	if (server.authentication === 'none' || !server.credential) return { headers: {} };
 
-	const resolved = await credentialProvider.resolve(server.credential).catch(() => null);
-	if (!resolved) return { headers: {} };
+	let resolved: ResolvedCredential;
+	try {
+		resolved = await credentialProvider.resolve(server.credential);
+	} catch (error) {
+		return { headers: {}, credentialError: ensureError(error) };
+	}
 
 	const credentialData = resolved as ICredentialDataDecryptedObject;
 	return deriveHeadersForAuthentication(server, credentialData, credentialData);
+}
+
+/**
+ * Transport for a server whose credential could not be resolved. Failing at
+ * connect time routes the real reason through the SDK's connection-failure
+ * channel, which the runtime surfaces to the user as a `warning` chunk.
+ * Sending the request unauthenticated instead would come back as an opaque
+ * 401/403 that reads like a server-side problem.
+ */
+function createUnresolvedCredentialFetch(
+	server: AgentJsonMcpServerConfig,
+	error: Error,
+): typeof fetch {
+	return async () =>
+		await Promise.reject(
+			new OperationalError(
+				`Could not resolve the credential for MCP server "${server.name}": ${error.message}`,
+			),
+		);
 }
 
 export interface BuildMcpClientDeps {
@@ -189,10 +224,11 @@ export async function buildMcpClientForServer(
 	} = deps;
 	const { McpClient } = await import('@n8n/agents');
 
-	const { headers: initialHeaders, credentialData } = await deriveAuthHeaders(
-		server,
-		credentialProvider,
-	);
+	const {
+		headers: initialHeaders,
+		credentialData,
+		credentialError,
+	} = await deriveAuthHeaders(server, credentialProvider);
 	const allowedDomains = credentialData ? resolveAllowedDomains(credentialData) : undefined;
 
 	const onUnauthorized =
@@ -206,12 +242,14 @@ export async function buildMcpClientForServer(
 				}
 			: undefined;
 
-	const authFetch = createAuthFetch({
-		baseFetch: proxyFetch,
-		initialHeaders,
-		onUnauthorized,
-		allowedDomains,
-	});
+	const authFetch = credentialError
+		? createUnresolvedCredentialFetch(server, credentialError)
+		: createAuthFetch({
+				baseFetch: proxyFetch,
+				initialHeaders,
+				onUnauthorized,
+				allowedDomains,
+			});
 
 	const sdkServerConfig: McpServerConfig = {
 		name: server.name,

--- a/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
+++ b/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
@@ -1,9 +1,4 @@
-import type {
-	CredentialProvider,
-	McpClient,
-	McpServerConfig,
-	ResolvedCredential,
-} from '@n8n/agents';
+import type { CredentialProvider, McpClient, McpServerConfig } from '@n8n/agents';
 import type { AgentJsonMcpServerConfig } from '@n8n/api-types';
 import type { CustomFetch } from '@n8n/backend-network';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
@@ -41,11 +36,7 @@ function isTokenData(tokenData: unknown): tokenData is { access_token: string } 
 type DerivedAuth = {
 	headers: Record<string, string>;
 	credentialData?: ICredentialDataDecryptedObject;
-	/**
-	 * Set when the credential could not be resolved at all — e.g. an external
-	 * secret store that is unreachable, or a field whose `$secrets` expression
-	 * doesn't match a known secret.
-	 */
+	/** Set when the credential could not be resolved (e.g. unreachable secret store). */
 	credentialError?: Error;
 };
 
@@ -152,34 +143,14 @@ async function deriveAuthHeaders(
 ): Promise<DerivedAuth> {
 	if (server.authentication === 'none' || !server.credential) return { headers: {} };
 
-	let resolved: ResolvedCredential;
 	try {
-		resolved = await credentialProvider.resolve(server.credential);
+		const resolved = (await credentialProvider.resolve(
+			server.credential,
+		)) as ICredentialDataDecryptedObject;
+		return deriveHeadersForAuthentication(server, resolved, resolved);
 	} catch (error) {
 		return { headers: {}, credentialError: ensureError(error) };
 	}
-
-	const credentialData = resolved as ICredentialDataDecryptedObject;
-	return deriveHeadersForAuthentication(server, credentialData, credentialData);
-}
-
-/**
- * Transport for a server whose credential could not be resolved. Failing at
- * connect time routes the real reason through the SDK's connection-failure
- * channel, which the runtime surfaces to the user as a `warning` chunk.
- * Sending the request unauthenticated instead would come back as an opaque
- * 401/403 that reads like a server-side problem.
- */
-function createUnresolvedCredentialFetch(
-	server: AgentJsonMcpServerConfig,
-	error: Error,
-): typeof fetch {
-	return async () =>
-		await Promise.reject(
-			new OperationalError(
-				`Could not resolve the credential for MCP server "${server.name}": ${error.message}`,
-			),
-		);
 }
 
 export interface BuildMcpClientDeps {
@@ -242,8 +213,18 @@ export async function buildMcpClientForServer(
 				}
 			: undefined;
 
-	const authFetch = credentialError
-		? createUnresolvedCredentialFetch(server, credentialError)
+	// An unresolved credential fails at connect time so the real reason travels
+	// the SDK's connection-failure channel (surfaced as a `warning` chunk);
+	// connecting unauthenticated returns an opaque 401/403 instead. Rejecting
+	// rather than throwing keeps both `promise-function-async` and
+	// `require-await` satisfied.
+	const authFetch: typeof fetch = credentialError
+		? async () =>
+				await Promise.reject(
+					new OperationalError(
+						`Could not resolve the credential for MCP server "${server.name}": ${credentialError.message}`,
+					),
+				)
 		: createAuthFetch({
 				baseFetch: proxyFetch,
 				initialHeaders,

--- a/packages/cli/test/integration/agents/agents-credential-provider.test.ts
+++ b/packages/cli/test/integration/agents/agents-credential-provider.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration test for `AgentsCredentialProvider.resolve()` with a real
+ * `CredentialsHelper`.
+ *
+ * The unit tests stub `getDecrypted`, so they prove the provider calls it with
+ * the right arguments but not that a stored `$secrets` expression is actually
+ * evaluated. This drives the real decryption path — a credential encrypted in
+ * the DB whose token is an expression — so a regression in `internal`-mode
+ * expression handling fails here.
+ */
+
+import { LicenseState } from '@n8n/backend-common';
+import { getPersonalProject, mockInstance, testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { ExternalSecretsProxy } from 'n8n-core';
+import { HttpBearerAuth } from 'n8n-nodes-base/credentials/HttpBearerAuth.credentials';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { AgentsCredentialProvider } from '@/modules/agents/adapters/agents-credential-provider';
+
+import { saveCredential } from '../shared/db/credentials';
+import { createOwner } from '../shared/db/users';
+
+const SECRET_VALUE = 'bearer-token-from-the-store';
+const SECRET_NAME = 'mcpToken';
+const PROVIDER_NAME = 'testSecretsProvider';
+const TOKEN_EXPRESSION = `={{ $secrets.${PROVIDER_NAME}.${SECRET_NAME} }}`;
+
+// Resolving external secrets sits behind a license gate.
+const licenseMock = mockInstance(LicenseState);
+licenseMock.isLicensed.mockReturnValue(true);
+
+// Must be at module level so the DI entry is replaced before testDb.init() or
+// any Container.get() can cache the real service.
+const mockExternalSecretsProxy = mockInstance(ExternalSecretsProxy);
+
+function configureMockProxy() {
+	mockExternalSecretsProxy.hasProvider.mockImplementation(
+		(provider: string) => provider === PROVIDER_NAME,
+	);
+	mockExternalSecretsProxy.hasSecret.mockImplementation(
+		(provider: string, name: string) => provider === PROVIDER_NAME && name === SECRET_NAME,
+	);
+	mockExternalSecretsProxy.getSecret.mockImplementation((provider: string, name: string) =>
+		provider === PROVIDER_NAME && name === SECRET_NAME ? SECRET_VALUE : undefined,
+	);
+	mockExternalSecretsProxy.listProviders.mockReturnValue([PROVIDER_NAME]);
+	mockExternalSecretsProxy.listSecrets.mockImplementation((provider: string) =>
+		provider === PROVIDER_NAME ? [SECRET_NAME] : [],
+	);
+}
+
+describe('AgentsCredentialProvider — external secrets', () => {
+	let owner: User;
+	let projectId: string;
+	let credentialsService: CredentialsService;
+
+	beforeAll(async () => {
+		await testDb.init();
+
+		// `CredentialsHelper.getCredentialsProperties` resolves the type through
+		// LoadNodesAndCredentials, so the real bearer credential must be loadable.
+		const lnc = Container.get(LoadNodesAndCredentials);
+		lnc.loaded.credentials = {
+			...lnc.loaded.credentials,
+			httpBearerAuth: { type: new HttpBearerAuth(), sourcePath: '' },
+		};
+
+		owner = await createOwner();
+		projectId = (await getPersonalProject(owner)).id;
+		credentialsService = Container.get(CredentialsService);
+
+		configureMockProxy();
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		configureMockProxy();
+	});
+
+	afterEach(async () => {
+		await testDb.truncate(['CredentialsEntity', 'SharedCredentials']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	async function saveBearerCredential(token: string) {
+		return await saveCredential(
+			{ name: 'MCP bearer', type: 'httpBearerAuth', data: { token } },
+			{ user: owner, role: 'credential:owner' },
+		);
+	}
+
+	it('evaluates a $secrets expression stored in the credential', async () => {
+		const credential = await saveBearerCredential(TOKEN_EXPRESSION);
+
+		const provider = new AgentsCredentialProvider(credentialsService, projectId, owner);
+		const resolved = await provider.resolve(credential.id);
+
+		expect(resolved.token).toBe(SECRET_VALUE);
+		expect(mockExternalSecretsProxy.getSecret).toHaveBeenCalledWith(PROVIDER_NAME, SECRET_NAME);
+
+		// Guards against a fixture that was already plaintext: the stored value is
+		// the unevaluated expression, so the assertion above can only pass if
+		// resolution actually ran.
+		const stored = await credentialsService.decrypt(credential, true);
+		expect(stored.token).toBe(TOKEN_EXPRESSION);
+	});
+
+	it('rejects when the referenced secret does not exist', async () => {
+		const credential = await saveBearerCredential(`={{ $secrets.${PROVIDER_NAME}.missingSecret }}`);
+
+		const provider = new AgentsCredentialProvider(credentialsService, projectId, owner);
+
+		await expect(provider.resolve(credential.id)).rejects.toThrow(/secrets/i);
+	});
+
+	it('returns a literal token unchanged', async () => {
+		const credential = await saveBearerCredential('literal-token');
+
+		const provider = new AgentsCredentialProvider(credentialsService, projectId, owner);
+
+		await expect(provider.resolve(credential.id)).resolves.toMatchObject({
+			token: 'literal-token',
+		});
+		expect(mockExternalSecretsProxy.getSecret).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

An Agent's MCP server connection failed auth whenever its credential was backed by an External Secret, while the same credential worked in normal nodes and in the MCP Server Trigger.

`AgentsCredentialProvider.resolve()` used `credentialsService.decrypt()`, which only AES-decrypts the stored JSON — it never runs the expression layer. A field stored as `={{ $secrets.store.key }}` was therefore handed to the caller verbatim, so the MCP client sent `Authorization: Bearer ={{ $secrets... }}` and got a 403. Nodes don't hit this because they go through `CredentialsHelper.getDecrypted`, which resolves expressions against a `$secrets` proxy.

This routes `resolve()` through `getDecrypted` as well. The agents runtime has no workflow or execution, so `additionalData` comes from `getBase()` — already the established pattern for workflow-less credential resolution (`credentials-tester.service.ts`, `oauth.service.ts`). Going through `getDecrypted` rather than calling `applyDefaultsAndOverwrites` directly means the project-scoped external-secret provider gating is applied by exactly the same code as nodes, instead of being duplicated in the agents layer.

Fixing it in `resolve()` rather than in `mcp-client-factory` covers all six consumers at once: the MCP client, model config, embedding credential, both vector-store paths, and `from-json-config`.

Second commit: `deriveAuthHeaders` previously swallowed resolution failures with `.catch(() => null)` and connected unauthenticated. That mattered more after the fix, since an unreachable secret store now throws a useful error instead of silently yielding a bad token. The failure is now routed through the SDK's connection-failure channel, which the runtime already surfaces as a `warning` chunk:

```
Could not resolve the credential for MCP server "srv": Could not load secrets
```

## How to test

1. Configure an external secrets provider (e.g. 1Password Connect) and confirm it's healthy.
2. Create an `httpBearerAuth` credential whose token references an external secret, e.g. `{{ $secrets.opConnect.token }}`.
3. Bind an active MCP Server Trigger's bearer auth to that credential.
4. Give an Agent an MCP connection (Streamable HTTP, bearer auth) to that endpoint using the same credential.
5. Ask the Agent a question that needs an MCP tool.

Before: the connection is skipped at session start, `main` logs `Skipped MCP server that failed to connect` and `Authorization data is wrong!`, and the agent answers without the tools. After: the tool call succeeds.

To exercise the error path, point the credential at a secret that doesn't exist — the agent should now surface `Could not resolve the credential for MCP server "..."` rather than an opaque 403.

Automated: `pnpm --filter n8n test src/modules/agents` — 146 files / 1965 tests pass. New coverage in `agents-credential-provider.test.ts` (External-Secrets-backed `httpBearerAuth` resolves through `getDecrypted` with project scope; a failed lookup propagates) and `mcp-client-factory.test.ts` (connection fails with the resolution error instead of connecting unauthenticated).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-629

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

