### PR TITLE
fix(cli): allow importing workflows and credentials with --userId for existing owner

### DIFF
--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -131,8 +131,9 @@ export class ImportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 				const result = await this.checkRelations(
 					transactionManager,
 					credentials,
-					flags.projectId,
+					project.id,
 					flags.userId,
+					flags.projectId,
 				);
 
 				if (!result.success) {
@@ -281,8 +282,9 @@ export class ImportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 	private async checkRelations(
 		transactionManager: EntityManager,
 		credentials: Array<Pick<Partial<CredentialsEntity>, 'id'>>,
-		projectId?: string,
+		targetProjectId: string,
 		userId?: string,
+		projectId?: string,
 	) {
 		// The credential is not supposed to be re-owned.
 		if (!projectId && !userId) {
@@ -310,7 +312,7 @@ export class ImportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 				continue;
 			}
 
-			if (ownerProject.id !== projectId) {
+			if (ownerProject.id !== targetProjectId) {
 				const currentOwner =
 					ownerProject.type === 'personal'
 						? `the user with the ID "${user.id}"`

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -140,7 +140,7 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 
 		const workflows = await this.readWorkflows(flags.input, flags.separate);
 
-		const result = await this.checkRelations(workflows, flags.projectId, flags.userId);
+		const result = await this.checkRelations(workflows, project.id, flags.userId, flags.projectId);
 
 		if (!result.success) {
 			throw new UserError(result.message);
@@ -161,8 +161,13 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 		});
 	}
 
-	private async checkRelations(workflows: IWorkflowBase[], projectId?: string, userId?: string) {
-		// The credential is not supposed to be re-owned.
+	private async checkRelations(
+		workflows: IWorkflowBase[],
+		targetProjectId: string,
+		userId?: string,
+		projectId?: string,
+	) {
+		// The workflow is not supposed to be re-owned.
 		if (!userId && !projectId) {
 			return {
 				success: true as const,
@@ -181,7 +186,7 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 				continue;
 			}
 
-			if (ownerProject.id !== projectId) {
+			if (ownerProject.id !== targetProjectId) {
 				const currentOwner =
 					ownerProject.type === 'personal'
 						? `the user with the ID "${user.id}"`
@@ -194,7 +199,7 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 
 				return {
 					success: false as const,
-					message: `The credential with ID "${workflow.id}" is already owned by ${currentOwner}. It can't be re-owned by ${newOwner}.`,
+					message: `The workflow with ID "${workflow.id}" is already owned by ${currentOwner}. It can't be re-owned by ${newOwner}.`,
 				};
 			}
 		}

--- a/packages/cli/test/integration/commands/credentials.cmd.test.ts
+++ b/packages/cli/test/integration/commands/credentials.cmd.test.ts
@@ -315,6 +315,68 @@ test('`import:credentials --userId ...` should fail if the credential exists alr
 	});
 });
 
+test('`import:credentials --userId ...` should succeed if the credential exists already and is owned by the same user', async () => {
+	//
+	// ARRANGE
+	//
+	const owner = await createOwner();
+	const ownerProject = await getPersonalProject(owner);
+
+	// import credential the first time, assigning it to the owner
+	await command.run([
+		'--input=./test/integration/commands/import-credentials/credentials.json',
+		`--userId=${owner.id}`,
+	]);
+
+	const before = {
+		credentials: await getAllCredentials(),
+		sharings: await getAllSharedCredentials(),
+	};
+	expect(before).toMatchObject({
+		credentials: [expect.objectContaining({ id: '123', name: 'cred-aws-test' })],
+		sharings: [
+			expect.objectContaining({
+				credentialsId: '123',
+				projectId: ownerProject.id,
+				role: 'credential:owner',
+			}),
+		],
+	});
+
+	//
+	// ACT
+	//
+	// Import again updating the name for the same owner
+	await command.run([
+		'--input=./test/integration/commands/import-credentials/credentials-updated.json',
+		`--userId=${owner.id}`,
+	]);
+
+	//
+	// ASSERT
+	//
+	const after = {
+		credentials: await getAllCredentials(),
+		sharings: await getAllSharedCredentials(),
+	};
+
+	expect(after).toMatchObject({
+		credentials: [
+			expect.objectContaining({
+				id: '123',
+				name: 'cred-aws-prod',
+			}),
+		],
+		sharings: [
+			expect.objectContaining({
+				credentialsId: '123',
+				projectId: ownerProject.id,
+				role: 'credential:owner',
+			}),
+		],
+	});
+});
+
 test("only update credential, don't create or update owner if neither `--userId` nor `--projectId` is passed", async () => {
 	//
 	// ARRANGE

--- a/packages/cli/test/integration/commands/import.cmd.test.ts
+++ b/packages/cli/test/integration/commands/import.cmd.test.ts
@@ -189,7 +189,7 @@ test('`import:workflow --userId ...` should fail if the workflow exists already 
 			`--userId=${member.id}`,
 		]),
 	).rejects.toThrowError(
-		`The credential with ID "998" is already owned by the user with the ID "${owner.id}". It can't be re-owned by the user with the ID "${member.id}"`,
+		`The workflow with ID "998" is already owned by the user with the ID "${owner.id}". It can't be re-owned by the user with the ID "${member.id}"`,
 	);
 
 	//
@@ -270,7 +270,63 @@ test("only update the workflow, don't create or update the owner if `--userId` i
 	});
 });
 
-test('`import:workflow --projectId ...` should fail if the credential already exists and is owned by another project', async () => {
+test('`import:workflow --userId ...` should succeed if the workflow already exists and is owned by the same user', async () => {
+	//
+	// ARRANGE
+	//
+	const owner = await createOwner();
+	const ownerProject = await getPersonalProject(owner);
+
+	// Import workflow the first time, assigning it to the owner.
+	await command.run([
+		'--input=./test/integration/commands/import-workflows/combined-with-update/original.json',
+		`--userId=${owner.id}`,
+	]);
+
+	const before = {
+		workflows: await getAllWorkflows(),
+		sharings: await getAllSharedWorkflows(),
+	};
+	expect(before).toMatchObject({
+		workflows: [expect.objectContaining({ id: '998', name: 'active-workflow' })],
+		sharings: [
+			expect.objectContaining({
+				workflowId: '998',
+				projectId: ownerProject.id,
+				role: 'workflow:owner',
+			}),
+		],
+	});
+
+	//
+	// ACT
+	//
+	// Import the same workflow again with updated content, for the same user.
+	await command.run([
+		'--input=./test/integration/commands/import-workflows/combined-with-update/updated.json',
+		`--userId=${owner.id}`,
+	]);
+
+	//
+	// ASSERT
+	//
+	const after = {
+		workflows: await getAllWorkflows(),
+		sharings: await getAllSharedWorkflows(),
+	};
+	expect(after).toMatchObject({
+		workflows: [expect.objectContaining({ id: '998', name: 'active-workflow updated' })],
+		sharings: [
+			expect.objectContaining({
+				workflowId: '998',
+				projectId: ownerProject.id,
+				role: 'workflow:owner',
+			}),
+		],
+	});
+});
+
+test('`import:workflow --projectId ...` should fail if the workflow already exists and is owned by another project', async () => {
 	//
 	// ARRANGE
 	//
@@ -312,7 +368,7 @@ test('`import:workflow --projectId ...` should fail if the credential already ex
 			`--projectId=${memberProject.id}`,
 		]),
 	).rejects.toThrowError(
-		`The credential with ID "998" is already owned by the user with the ID "${owner.id}". It can't be re-owned by the project with the ID "${memberProject.id}"`,
+		`The workflow with ID "998" is already owned by the user with the ID "${owner.id}". It can't be re-owned by the project with the ID "${memberProject.id}"`,
 	);
 
 	//


### PR DESCRIPTION
## Summary

Fixes an issue where CLI commands `n8n import:workflow` and `n8n import:credentials` threw an ownership conflict error when re-importing entities for a user specified via `--userId`.

- **Root Cause:** In `import/workflow.ts` and `import/credentials.ts`, `checkRelations` was receiving `flags.projectId` (which is `undefined` when `--userId` is provided) instead of the resolved target `project.id`. This caused the ownership check `ownerProject.id !== projectId` to evaluate to `true` even when the target and current owner matched.
- **Fix:** Pass the resolved `project.id` to `checkRelations`.
- **Terminology:** Corrected the error message in `workflow.ts` to reference "workflow" instead of "credential".

## How to test


1. Run the integration test suites:
   ```bash
   pnpm --filter n8n test test/integration/commands/import.cmd.test.ts
   pnpm --filter n8n test test/integration/commands/credentials.cmd.test.ts
   ```

2. Manual CLI check:
- Import a workflow or credential for a specific user: n8n import:workflow --input=<workflow.json> --userId=<user-id>
- Re-run the same command with updated content for the same --userId and confirm it updates successfully without ownership errors.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

