### PR TITLE
feat(API): Add endpoint to get a single role

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -195,6 +195,7 @@ export {
 	RolePublicDto,
 	RoleListPublicDto,
 	RoleListQueryPublicDto,
+	RoleGetPublicDto,
 } from './roles/role-public.dto';
 export { CreateRoleMappingRuleDto } from './roles/create-role-mapping-rule.dto';
 export { RoleMappingRulePublicDto } from './roles/role-mapping-rule-public.dto';

--- a/packages/@n8n/api-types/src/dto/roles/role-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/role-public.dto.ts
@@ -30,3 +30,9 @@ export class RoleListPublicDto extends Z.class({
 export class RoleListQueryPublicDto extends Z.class({
 	withUsageCount: booleanFromString.optional().default('false'),
 }) {}
+
+export class RoleGetPublicDto extends RolePublicDto.extend({
+	licensed: z.boolean(),
+	usedByUsers: z.number().optional(),
+	usedByProjects: z.number().optional(),
+}) {}

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -111,7 +111,7 @@ export const API_KEY_RESOURCES = {
 	dataTableColumn: ['create', 'read', 'delete', 'update'] as const,
 	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
-	role: ['manage', 'manageProject', 'list'] as const,
+	role: ['manage', 'manageProject', 'list', 'read'] as const,
 	roleMappingRule: ['create'] as const,
 } as const;
 

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -90,6 +90,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'insights:read',
 	'role:manage',
 	'role:list',
+	'role:read',
 	'roleMappingRule:create',
 ];
 

--- a/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/roles.public.controller.ts
@@ -1,5 +1,6 @@
 import {
 	CreateRoleDto,
+	RoleGetPublicDto,
 	RoleListPublicDto,
 	RoleListQueryPublicDto,
 	RolePublicDto,
@@ -8,6 +9,7 @@ import { LICENSE_FEATURES } from '@n8n/constants';
 import { AuthenticatedRequest } from '@n8n/db';
 import {
 	ApiDescription,
+	ApiErrorResponse,
 	ApiKeyScope,
 	ApiResponse,
 	ApiSummary,
@@ -15,6 +17,7 @@ import {
 	Body,
 	Get,
 	Licensed,
+	Param,
 	Post,
 	PublicApiController,
 	Query,
@@ -22,6 +25,7 @@ import {
 import { RoleNamespace, type Role as RoleDTO } from '@n8n/permissions';
 import type { Response } from 'express';
 
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { assertCanManageRoleType } from '@/services/role-authorization';
 import { RoleService } from '@/services/role.service';
@@ -29,6 +33,22 @@ import { RoleService } from '@/services/role.service';
 type PublicRoleNamespace = Extract<RoleNamespace, 'global' | 'project'>;
 const isPublicRole = (role: RoleDTO): role is RoleDTO & { roleType: PublicRoleNamespace } =>
 	role.roleType === 'global' || role.roleType === 'project';
+
+const toPublicRole = <T extends PublicRoleNamespace>(
+	role: RoleDTO & { roleType: T },
+	withUsageCount = false,
+) => ({
+	slug: role.slug,
+	displayName: role.displayName,
+	description: role.description,
+	systemRole: role.systemRole,
+	roleType: role.roleType,
+	licensed: role.licensed,
+	scopes: role.scopes,
+	createdAt: role.createdAt!.toISOString(),
+	updatedAt: role.updatedAt!.toISOString(),
+	...(withUsageCount ? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects } : {}),
+});
 
 @PublicApiController('/roles')
 export class RolesPublicController {
@@ -57,25 +77,35 @@ export class RolesPublicController {
 		const groupOf = <T extends PublicRoleNamespace>(roleType: T) =>
 			publicRoles
 				.filter((role): role is RoleDTO & { roleType: T } => role.roleType === roleType)
-				.map((role) => ({
-					slug: role.slug,
-					displayName: role.displayName,
-					description: role.description,
-					systemRole: role.systemRole,
-					roleType: role.roleType,
-					licensed: role.licensed,
-					scopes: role.scopes,
-					createdAt: role.createdAt!.toISOString(),
-					updatedAt: role.updatedAt!.toISOString(),
-					...(withUsageCount
-						? { usedByUsers: role.usedByUsers, usedByProjects: role.usedByProjects }
-						: {}),
-				}));
+				.map((role) => toPublicRole(role, withUsageCount));
 
 		return {
 			global: groupOf('global'),
 			project: groupOf('project'),
 		};
+	}
+
+	@Get('/:slug')
+	@ApiKeyScope('role:read')
+	@ApiSummary('Retrieve a role')
+	@ApiDescription(
+		'Returns a single role with its scopes. Set `withUsageCount` to include how many users and projects use the role.',
+	)
+	@ApiTags(['Role'])
+	@ApiResponse(200, RoleGetPublicDto)
+	@ApiErrorResponse(404)
+	async getRole(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Param('slug') slug: string,
+		@Query query: RoleListQueryPublicDto,
+	): Promise<RoleGetPublicDto> {
+		const { withUsageCount } = query;
+		const role = await this.roleService.getRole(slug, withUsageCount);
+		if (!isPublicRole(role)) {
+			throw new NotFoundError('Role not found');
+		}
+		return toPublicRole(role, withUsageCount);
 	}
 
 	@Post('/')

--- a/packages/cli/src/public-api/v1/handlers/roles/spec/paths/getRole.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/roles/spec/paths/getRole.generated.yml
@@ -1,0 +1,80 @@
+operationId: getRole
+tags:
+  - Role
+summary: Retrieve a role
+description: Returns a single role with its scopes. Set `withUsageCount` to include how many users and projects use the role.
+x-required-scope: role:read
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    name: slug
+    in: path
+  - schema:
+      type: string
+      enum:
+        - 'true'
+        - 'false'
+      default: 'false'
+    required: false
+    name: withUsageCount
+    in: query
+responses:
+  '200':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            slug:
+              type: string
+            displayName:
+              type: string
+            description:
+              type: string
+              nullable: true
+            systemRole:
+              type: boolean
+            roleType:
+              type: string
+              enum:
+                - project
+                - global
+            scopes:
+              type: array
+              items:
+                type: string
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+            licensed:
+              type: boolean
+            usedByUsers:
+              type: number
+            usedByProjects:
+              type: number
+          required:
+            - slug
+            - displayName
+            - description
+            - systemRole
+            - roleType
+            - scopes
+            - createdAt
+            - updatedAt
+            - licensed
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -11,6 +11,9 @@ paths:
       $ref: ./handlers/roles/spec/paths/getAllRoles.generated.yml
     post:
       $ref: ./handlers/roles/spec/paths/createRole.generated.yml
+  /roles/{slug}:
+    get:
+      $ref: ./handlers/roles/spec/paths/getRole.generated.yml
   /tags:
     get:
       $ref: ./handlers/tags/spec/paths/getTags.generated.yml

--- a/packages/cli/test/integration/public-api/roles.test.ts
+++ b/packages/cli/test/integration/public-api/roles.test.ts
@@ -1,7 +1,6 @@
 import { testDb } from '@n8n/backend-test-utils';
 import { RoleRepository, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
-
 import { createCustomRoleWithScopeSlugs } from '@test-integration/db/roles';
 import { addApiKey, createOwnerWithApiKey, createUser } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
@@ -125,6 +124,123 @@ describe('Roles in Public API', () => {
 			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
 
 			const response = await testServer.publicApiAgentFor(scopedOwner).get('/roles');
+
+			expect(response.status).toBe(403);
+		});
+	});
+
+	describe('GET /roles/:slug', () => {
+		const systemRoleBody = (slug: string, roleType: string) => ({
+			slug,
+			displayName: expect.any(String),
+			description: expect.any(String),
+			systemRole: true,
+			roleType,
+			licensed: expect.any(Boolean),
+			scopes: expect.any(Array),
+			createdAt: expect.any(String),
+			updatedAt: expect.any(String),
+		});
+
+		it('returns a system role with its scopes', async () => {
+			const response = await testServer.publicApiAgentFor(owner).get('/roles/global:owner');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual(systemRoleBody('global:owner', 'global'));
+			expect(response.body.scopes.length).toBeGreaterThan(0);
+		});
+
+		it('returns a newly created custom role', async () => {
+			const created = await testServer
+				.publicApiAgentFor(owner)
+				.post('/roles')
+				.send({ displayName: 'PA get role', roleType: 'global', scopes: ['user:read'] });
+			expect(created.status).toBe(201);
+
+			const response = await testServer.publicApiAgentFor(owner).get(`/roles/${created.body.slug}`);
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({
+				slug: created.body.slug,
+				displayName: 'PA get role',
+				description: null,
+				systemRole: false,
+				roleType: 'global',
+				licensed: expect.any(Boolean),
+				scopes: ['user:read'],
+				createdAt: expect.any(String),
+				updatedAt: expect.any(String),
+			});
+		});
+
+		it('returns a project role', async () => {
+			const response = await testServer.publicApiAgentFor(owner).get('/roles/project:admin');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual(systemRoleBody('project:admin', 'project'));
+		});
+
+		it('omits usage counts by default', async () => {
+			const response = await testServer.publicApiAgentFor(owner).get('/roles/global:owner');
+
+			expect(response.status).toBe(200);
+			expect(response.body).not.toHaveProperty('usedByUsers');
+			expect(response.body).not.toHaveProperty('usedByProjects');
+		});
+
+		it('includes usage counts when withUsageCount is set', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.get('/roles/global:owner')
+				.query({ withUsageCount: 'true' });
+
+			expect(response.status).toBe(200);
+			expect(response.body.usedByUsers).toBeGreaterThanOrEqual(1);
+			expect(response.body.usedByProjects).toBeGreaterThanOrEqual(0);
+		});
+
+		it('returns 404 for an unknown slug', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.get('/roles/global:does-not-exist');
+
+			expect(response.status).toBe(404);
+		});
+
+		it('returns 404 for a non-public role type', async () => {
+			const response = await testServer.publicApiAgentFor(owner).get('/roles/credential:owner');
+
+			expect(response.status).toBe(404);
+		});
+
+		it('works when the custom roles feature is not licensed', async () => {
+			testServer.license.disable('feat:customRoles');
+
+			const response = await testServer.publicApiAgentFor(owner).get('/roles/global:owner');
+
+			expect(response.status).toBe(200);
+
+			testServer.license.enable('feat:customRoles');
+		});
+
+		it('rejects with 401 without an API key', async () => {
+			const response = await testServer.publicApiAgentWithoutApiKey().get('/roles/global:owner');
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 401 with an invalid API key', async () => {
+			const response = await testServer
+				.publicApiAgentWithApiKey('invalid-key')
+				.get('/roles/global:owner');
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when the key lacks the role:read scope', async () => {
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['role:list'] });
+
+			const response = await testServer.publicApiAgentFor(scopedOwner).get('/roles/global:owner');
 
 			expect(response.status).toBe(403);
 		});

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -8,6 +8,9 @@
 		"GET /roles": {
 			"status": "gap"
 		},
+		"GET /roles/{slug}": {
+			"status": "gap"
+		},
 		"POST /roles": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/roles/{slug}` to return a single global or project role with its scopes, delegated to `RoleService`.
- Gate the route on the `role:read` API-key scope (no `feat:customRoles` licence required for reads).
- Return 404 for unknown slugs and for non-public role types (`credential`, `workflow`). Optional `withUsageCount` matches the list endpoint.

## How to test

1. Start n8n and create an API key that includes the `role:read` scope (Custom → **Role** group, or use **All**).
2. Fetch a built-in role:

```bash
curl -sS -H "X-N8N-API-KEY: $N8N_API_KEY" \
  "http://localhost:5678/api/v1/roles/global:owner"
```

3. Confirm:
   - 200 with slug, displayName, scopes, `licensed`, timestamps
   - `?withUsageCount=true` adds `usedByUsers` / `usedByProjects`
   - unknown slug or `credential:owner` → 404
   - missing API key → 401
   - key with only `role:list` → 403

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-46

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

