### PR TITLE
ci: Replay bundle branches onto their base instead of merging

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -382,7 +382,8 @@ Push to master/1.x
 
 | Schedule (UTC)            | Workflow                          | Purpose                  |
 |---------------------------|-----------------------------------|--------------------------|
-| Hourly :00                | `sec-sync-public-to-private.yml`  | Mirror public → private, refresh bundle branches |
+| Hourly :00                | `sec-sync-public-to-private.yml`  | Mirror public → private  |
+| Every 6h :00              | `sec-rebase-bundle-branches.yml`  | Replay `bundle/*` onto their base |
 | Daily 00:00               | `docker-build-push.yml`           | Nightly Docker images    |
 | Daily 00:00               | `test-db.yml`                     | Database compatibility   |
 | Daily 00:00               | `test-e2e-performance-reusable.yml`| Performance E2E         |
@@ -502,6 +503,18 @@ Scripts in `.github/scripts/`:
 | `validate-docs-links.js`| Check doc URLs    | `util-check-docs-urls.yml`|
 | `send-build-stats.mjs`  | Build telemetry   | `setup-nodejs` action     |
 | `db-test-matrix.mjs`    | DB test matrix from `postgres-versions.json` | `ci-pull-requests.yml` |
+
+### Branch Replay Scripts
+
+Both keep a long-lived branch that is "base + its own commits" in sync by rebasing those
+commits onto the base and force-pushing, sharing the merge-tree content guard that makes the
+rewrite safe.
+
+| Script                     | Purpose                                                              | Called By                          |
+|----------------------------|----------------------------------------------------------------------|------------------------------------|
+| `branch-replay.mjs`        | Shared primitives: merge-tree, tree guard, marker scan               | the two scripts below              |
+| `sync-master-to-3x.mjs`    | master → `3.x`; auto-resolves mechanical files, opens a conflict PR   | `util-sync-master-to-3x.yml`       |
+| `rebase-bundle-branch.mjs` | base → `bundle/*` in n8n-private; fail-loud, never resolves conflicts | `sec-rebase-bundle-branches.yml`   |
 
 ### Slack Scripts
 
@@ -698,14 +711,30 @@ mirroring public `master` and `1.x` into private with `reset --hard` +
 commits when judging "ahead". Fixes are never committed to private `master`/`1.x`
 directly: `ci-restrict-private-merges.yml` requires PRs into them to come from the
 long-lived integration branches `bundle/2.x` and `bundle/1.x` (a `bundle/2.x` merge is
-backported to `bundle/1.x` by `util-backport-bundle.yml`). The sync creates those
-branches if missing and then **merges `master` into `bundle/2.x` and `1.x` into
-`bundle/1.x`** so they don't drift; on a conflict it aborts the merge, leaves the branch
-untouched, and emits a warning annotation while **keeping the run green** — the other
-bundle branch still syncs, and a human resolves the conflict by hand. Once a bundle
-branch is merged into private `master`/`1.x` as a `chore: Bundle/*` PR,
-`sec-publish-fix.yml` / `sec-publish-fix-1x.yml` cherry-pick that merge commit onto a
-fresh branch in the public repo and open the PR there.
+backported to `bundle/1.x` by `util-backport-bundle.yml`). Once a bundle branch is merged
+into private `master`/`1.x` as a `chore: Bundle/*` PR, `sec-publish-fix.yml` /
+`sec-publish-fix-1x.yml` cherry-pick that commit onto a fresh branch in the public repo and
+open the PR there. That PR **must stay a single-parent squash** — the publish step is a bare
+`git cherry-pick` of `HEAD`, which aborts on a merge commit.
+
+`sec-rebase-bundle-branches.yml` keeps those branches current, every 6 hours plus whenever a
+PR is merged into one (and on `workflow_dispatch`). It **replays** the bundle-only commits
+onto the base with `git rebase` and force-pushes, via
+[`scripts/rebase-bundle-branch.mjs`](scripts/rebase-bundle-branch.mjs) — so a clean run
+adds **no commit at all** and `base..bundle` stays a readable list of the fixes not yet
+published. Rebasing is safe here precisely because a bundle ships as one squashed,
+deliberately obfuscated commit: SHAs and dates on these branches carry no meaning downstream,
+and the `n8n-assistant` app is a bypass actor on the `bundle/*` ruleset's `non_fast_forward`
+rule. Every push is verified to carry exactly the tree a merge of the two sides would produce
+(`git merge-tree`); a mismatch, or a conflict marker, fails the run instead of pushing. Fixes
+already published come back through the base and are dropped by `--empty=drop`.
+
+There is **one job per bundle branch**. A conflict is detected from the merge tree before the
+working tree is touched, so the branch is left exactly as it was, that job **fails** (no more
+green runs hiding a stalled branch) and `#alerts-security` gets a run link — while the other
+branch still syncs. Recovery is deliberate: rebase the branch onto its base locally, resolve,
+force-push, then re-run the workflow. The replay never resolves a conflict itself, unlike
+`util-sync-master-to-3x.yml`.
 
 See **[`../AGENTS.md`](../AGENTS.md)** ("Security Fix Hygiene") for the naming rules that
 keep the vulnerability out of public branch names, commits, and test descriptions.

--- a/.github/scripts/branch-replay.mjs
+++ b/.github/scripts/branch-replay.mjs
@@ -1,0 +1,107 @@
+/**
+ * Primitives shared by the branch-replay flows — syncing a long-lived branch that is
+ * "base + its own commits" by REBASING those commits onto the base and force-pushing,
+ * so a clean sync adds no commit of its own.
+ *
+ * Nothing here knows which branch pair it is working on. The safety property every caller
+ * relies on lives in `mergeTree` + `assertTreeMatches`: the content pushed must be exactly
+ * the tree a merge of the two sides would produce, and a mismatch fails the run instead of
+ * pushing. That invariant is what makes rewriting a shared branch safe.
+ *
+ * Callers: `sync-master-to-3x.mjs` (master → 3.x, with mechanical conflict resolution and a
+ * conflict PR) and `rebase-bundle-branch.mjs` (base → bundle/*, fail-loud).
+ *
+ * Requires git 2.38+ (`merge-tree --write-tree`).
+ */
+
+import { execFileSync } from 'node:child_process';
+
+// Real command runner: takes an args array and returns trimmed stdout, throwing on a
+// non-zero exit (mirrors `set -e`). Injectable for tests.
+export const runGit = (args, opts = {}) =>
+	execFileSync('git', args, { encoding: 'utf8', ...opts }).trim();
+
+/**
+ * Run a command for its exit status: `{ ok, out }` instead of a throw. Used for the git
+ * commands whose non-zero exit is an expected answer, not a failure. stderr is captured
+ * rather than inherited, so an expected-to-fail probe doesn't spill into the run log.
+ */
+export function attempt(run, args, opts = {}) {
+	try {
+		return { ok: true, out: run(args, { stdio: ['ignore', 'pipe', 'pipe'], ...opts }) ?? '' };
+	} catch (error) {
+		const out = `${error.stdout ?? ''}\n${error.stderr ?? ''}`.trim();
+		return { ok: false, out };
+	}
+}
+
+export function isAncestor(git, maybeAncestor, descendant) {
+	return attempt(git, ['merge-base', '--is-ancestor', maybeAncestor, descendant]).ok;
+}
+
+/**
+ * The tree a merge of the two commits would produce — the definition of the content the
+ * replayed branch should end up with, computed without touching the working tree.
+ *
+ * `ok: false` means the two sides genuinely conflict; `conflictedPaths` then names the
+ * clashing files, and `tree` is still written (conflicted blobs carry their markers) —
+ * it is the comparison baseline for the relaxed tree guard.
+ */
+export function mergeTree(git, a, b) {
+	const res = attempt(git, ['merge-tree', '--write-tree', '--name-only', a, b]);
+	// Line 0 is the toplevel tree OID (written even on conflict); every line from there to
+	// the first blank line is a conflicted filename (`--name-only`), and the informational
+	// messages ("Auto-merging x", "CONFLICT (content): ...") come strictly AFTER that blank
+	// line. So the blank line is the only delimiter needed — do not also filter lines by
+	// prefix, or a real path like `CONFLICT.md` or `warning.txt` is dropped from the report.
+	const lines = res.out.split('\n');
+	const tree = lines[0]?.trim() ?? '';
+	let conflictedPaths = [];
+	if (!res.ok) {
+		const blank = lines.indexOf('', 1);
+		const section = lines.slice(1, blank === -1 ? undefined : blank);
+		conflictedPaths = [...new Set(section.filter((l) => l))];
+	}
+	return {
+		ok: res.ok,
+		tree: res.ok || conflictedPaths.length ? tree : '',
+		conflictedPaths,
+		out: res.out,
+	};
+}
+
+/**
+ * The content guard for every push: whichever route produced HEAD, its tree must be exactly
+ * what merging the two sides yields — except on `allowedPaths`, files the merge itself could
+ * not resolve and whose resolution the caller proves another way (always derived from the
+ * merge-tree conflict list, never from what the run happened to touch). With no
+ * `allowedPaths` this is exact equality.
+ */
+export function assertTreeMatches(git, expectedTree, allowedPaths = []) {
+	const actual = git(['rev-parse', 'HEAD^{tree}']);
+	if (actual === expectedTree) return;
+	if (allowedPaths.length === 0) {
+		throw new Error(
+			`Replayed tree ${actual} does not match the merge tree ${expectedTree}; refusing to push.`,
+		);
+	}
+	const out = git(['diff-tree', '-r', '--name-only', '--no-renames', expectedTree, actual]);
+	const allowed = new Set(allowedPaths);
+	const violations = (out ? out.split('\n') : []).filter((p) => p && !allowed.has(p));
+	if (violations.length > 0) {
+		throw new Error(
+			`Replayed tree deviates from the merge tree on non-mechanical paths:\n${violations.join('\n')}\nrefusing to push.`,
+		);
+	}
+}
+
+// Conflict markers must never reach a replayed branch — releases and nightly images build
+// from these. git grep exits 0 with matches, 1 with none and >1 on error, so an error must
+// not be read as "clean".
+export function assertNoMarkers(git, rev = 'HEAD') {
+	const found = attempt(git, ['grep', '-I', '-l', '-e', '^<<<<<<< ', '-e', '^>>>>>>> ', rev]);
+	if (found.ok)
+		throw new Error(`Refusing to continue: conflict markers present in ${rev}:\n${found.out}`);
+	if (found.out.includes('fatal:'))
+		throw new Error(`Could not scan ${rev} for conflict markers:\n${found.out}`);
+}

--- a/.github/scripts/branch-replay.test.mjs
+++ b/.github/scripts/branch-replay.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { mergeTree } from './branch-replay.mjs';
+
+const fail =
+	(stdout = '') =>
+	() => {
+		const err = new Error('command failed');
+		err.status = 1;
+		err.stdout = stdout;
+		throw err;
+	};
+
+// Verbatim `git merge-tree --write-tree --name-only` output (git 2.50) for a conflict on four
+// root-level files, three of which are named like git's own informational messages. The path
+// section runs to the blank line; the messages come after it.
+const REAL_OUTPUT = `d40195cb2b4b58a22942313bcdd3e30497d48e37
+Auto-merging
+CONFLICT.md
+normal.txt
+warning.txt
+
+Auto-merging Auto-merging
+CONFLICT (content): Merge conflict in Auto-merging
+Auto-merging CONFLICT.md
+CONFLICT (content): Merge conflict in CONFLICT.md
+Auto-merging normal.txt
+CONFLICT (content): Merge conflict in normal.txt
+Auto-merging warning.txt
+CONFLICT (content): Merge conflict in warning.txt`;
+
+test('mergeTree reports conflicted paths that look like git informational messages', () => {
+	const git = () => fail(REAL_OUTPUT)();
+	const res = mergeTree(git, 'A', 'B');
+
+	assert.equal(res.ok, false);
+	assert.equal(res.tree, 'd40195cb2b4b58a22942313bcdd3e30497d48e37');
+	// Filtering these by prefix would silently drop three of the four conflicts.
+	assert.deepEqual(res.conflictedPaths, [
+		'Auto-merging',
+		'CONFLICT.md',
+		'normal.txt',
+		'warning.txt',
+	]);
+});

--- a/.github/scripts/rebase-bundle-branch.mjs
+++ b/.github/scripts/rebase-bundle-branch.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Keeps a bundle integration branch (`bundle/2.x`, `bundle/1.x` in n8n-io/n8n-private) in
+ * sync with its base by REPLAYING (rebasing) the bundle-only commits onto the base and
+ * force-pushing — so a clean run adds NO commit of its own and the branch stays exactly
+ * "base + the fixes not yet published".
+ *
+ * Why a rebase and not a merge: the bases move constantly, so merging added a merge commit
+ * on nearly every run, and the bundle is published as a single squashed, deliberately
+ * obfuscated commit anyway — SHAs and dates on these branches buy nothing, while a readable
+ * `base..bundle` list of pending fixes buys a lot.
+ *
+ * The content pushed is verified to be exactly the tree that merging the bundle branch with
+ * its base produces (`git merge-tree`); a mismatch fails the run instead of pushing. That
+ * invariant is what makes rewriting a shared branch safe — including the case where every
+ * pending fix has since been published and is correctly dropped, since the merge tree then
+ * equals the base's tree too.
+ *
+ * FAIL LOUD: this script never resolves a conflict. A conflict is detected before the working
+ * tree is touched, so the branch is left exactly as it was; a human rebases onto the base
+ * locally, force-pushes, and re-dispatches the workflow. Contrast `sync-master-to-3x.mjs`,
+ * which auto-resolves mechanical files and opens a conflict PR.
+ *
+ * Runs from a full checkout (fetch-depth 0) of any branch. Assumes credentials are NOT
+ * persisted by checkout — every fetch and the push go through an explicit token URL, which
+ * matters because the repository is private.
+ *
+ * Env: BUNDLE_BRANCH (e.g. bundle/2.x), BASE_BRANCH (e.g. master),
+ *      GH_TOKEN (installation token with contents:write),
+ *      GITHUB_REPOSITORY (owner/repo, auto-provided by Actions).
+ * Requires git 2.38+ (`merge-tree --write-tree`).
+ */
+
+import {
+	assertNoMarkers,
+	assertTreeMatches,
+	attempt,
+	isAncestor,
+	mergeTree,
+	runGit,
+} from './branch-replay.mjs';
+
+const BOT_NAME = 'n8n-assistant[bot]';
+const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
+
+function required(env, name) {
+	const value = env[name];
+	if (!value) throw new Error(`${name} env var is required`);
+	return value;
+}
+
+// A GitHub annotation is one line: fold anything multi-line into the URL-escaped form so the
+// whole message survives in the run's error list.
+export function annotation(title, message) {
+	return `::error title=${title}::${message.replace(/\n/g, '%0A')}`;
+}
+
+export function rebaseBundleBranch({ git = runGit, env = process.env, log = console.log } = {}) {
+	const bundle = required(env, 'BUNDLE_BRANCH');
+	const base = required(env, 'BASE_BRANCH');
+	const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+	const repo = required(env, 'GITHUB_REPOSITORY');
+	if (!token) throw new Error('GH_TOKEN / GITHUB_TOKEN env var is required');
+
+	git(['config', 'user.name', BOT_NAME]);
+	git(['config', 'user.email', BOT_EMAIL]);
+	// A stalled `rebase --continue` must never sit waiting for an editor.
+	git(['config', 'core.editor', 'true']);
+
+	// Every remote operation goes through this URL: checkout does not persist credentials, and
+	// the repository is private, so `git fetch origin` on its own is unauthenticated.
+	const remote = `https://x-access-token:${token}@github.com/${repo}.git`;
+
+	// Pin both sides to the fetched SHAs — fetching by URL never updates the origin/* tracking
+	// refs, so FETCH_HEAD is the only handle. Base first: the second fetch overwrites it.
+	git(['fetch', remote, base]);
+	const baseSha = git(['rev-parse', 'FETCH_HEAD']);
+	git(['fetch', remote, bundle]);
+	git(['checkout', '-B', bundle, 'FETCH_HEAD']);
+	const preHead = git(['rev-parse', 'HEAD']);
+
+	if (isAncestor(git, baseSha, preHead)) {
+		log(`${bundle} already contains ${base} (${baseSha}); nothing to replay.`);
+		return { status: 'current' };
+	}
+
+	const queue = git([
+		'log',
+		'--no-merges',
+		'--reverse',
+		'--format=%h %s',
+		`${baseSha}..${preHead}`,
+	]);
+	log(`Replaying ${bundle} onto ${base} ${baseSha}:\n${queue || '(none)'}`);
+
+	// The content the replay must produce — and whether the two sides conflict at all. Computed
+	// without touching the working tree, so a conflict costs the branch nothing.
+	const merged = mergeTree(git, preHead, baseSha);
+	if (!merged.ok) {
+		const paths = merged.conflictedPaths;
+		log(
+			annotation(
+				`${bundle} is out of sync`,
+				`${base} conflicts with ${bundle} on: ${paths.join(', ') || '(unknown)'}\n` +
+					`${bundle} is untouched. Rebase it onto ${base} locally, force-push, then re-run this workflow.`,
+			),
+		);
+		throw new Error(`${base} conflicts with ${bundle}; leaving ${bundle} untouched.`);
+	}
+
+	// `--empty=drop` (and the merge backend's default `--no-reapply-cherry-picks`) drop the
+	// fixes the base already carries — which is every fix that has since been published, since
+	// it comes back through the base as part of the squashed bundle commit.
+	const replay = attempt(git, ['rebase', '--empty=drop', baseSha]);
+	if (!replay.ok) {
+		if (replay.out) log(replay.out);
+		attempt(git, ['rebase', '--abort']);
+		log(
+			annotation(
+				`${bundle} could not be replayed`,
+				`The content of ${bundle} and ${base} reconciles, but the commits no longer apply ` +
+					`individually — usually a past conflict that was resolved in a merge commit, which ` +
+					`leaves no patch to replay.\n${bundle} is untouched. Rebase it onto ${base} locally, ` +
+					`force-push, then re-run this workflow.`,
+			),
+		);
+		throw new Error(`Could not replay ${bundle} onto ${base}; needs a human.`);
+	}
+
+	assertTreeMatches(git, merged.tree);
+	assertNoMarkers(git);
+
+	// The lease pins the tip that was replayed from, so a fix PR merging mid-run is never
+	// overwritten — the push is rejected and the next run picks the fix up.
+	git([
+		'push',
+		`--force-with-lease=refs/heads/${bundle}:${preHead}`,
+		remote,
+		`HEAD:refs/heads/${bundle}`,
+	]);
+	log(`Replayed ${bundle} onto ${base} — no merge commit created.`);
+	return { status: 'replayed' };
+}
+
+// Only run when executed directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		rebaseBundleBranch();
+	} catch (error) {
+		console.error(`Error: ${error.message}`);
+		process.exit(1);
+	}
+}

--- a/.github/scripts/rebase-bundle-branch.test.mjs
+++ b/.github/scripts/rebase-bundle-branch.test.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { annotation, rebaseBundleBranch } from './rebase-bundle-branch.mjs';
+
+// A git stub: routes calls by a matcher, records every invocation.
+function makeStub(routes = []) {
+	const calls = [];
+	const fn = (args) => {
+		calls.push(args);
+		for (const [match, result] of routes) {
+			if (match(args)) return typeof result === 'function' ? result(args) : result;
+		}
+		return '';
+	};
+	fn.calls = calls;
+	return fn;
+}
+
+const fail =
+	(stdout = '') =>
+	() => {
+		const err = new Error('command failed');
+		err.status = 1;
+		err.stdout = stdout;
+		throw err;
+	};
+
+const PRE_HEAD = 'PREHEAD';
+const BASE = 'BASESHA';
+const MERGE_TREE = 'MERGETREEOID';
+
+const env = {
+	BUNDLE_BRANCH: 'bundle/2.x',
+	BASE_BRANCH: 'master',
+	GH_TOKEN: 'tok',
+	GITHUB_REPOSITORY: 'n8n-io/n8n-private',
+};
+
+const isRebase = (a) => a[0] === 'rebase' && a[1] !== '--abort';
+const isPush = (a) => a[0] === 'push';
+
+// What `git merge-tree --write-tree --name-only` emits on a conflict: the (marker-carrying)
+// tree OID, the conflicted paths, a blank line, then informational messages.
+const conflictedMergeTree = (...paths) =>
+	fail(`${MERGE_TREE}\n${paths.join('\n')}\n\nCONFLICT (content): Merge conflict in ${paths[0]}`);
+
+// Routes shared by every path: base fetched, the bundle branch hasn't absorbed it yet, the
+// merge tree is computable, and the replay lands on exactly that tree. git grep exits
+// non-zero => no markers.
+const baseGitRoutes = [
+	[(a) => a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD', BASE],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', PRE_HEAD],
+	[(a) => a[0] === 'merge-base', fail()],
+	[(a) => a[0] === 'merge-tree', MERGE_TREE],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', MERGE_TREE],
+	[(a) => a[0] === 'grep', fail()],
+];
+
+const silent = () => {};
+
+test('a missing branch env var fails before any git command runs', () => {
+	const git = makeStub();
+	assert.throws(
+		() => rebaseBundleBranch({ git, env: { ...env, BUNDLE_BRANCH: '' }, log: silent }),
+		{
+			message: /BUNDLE_BRANCH env var is required/,
+		},
+	);
+	assert.equal(git.calls.length, 0);
+});
+
+test('a clean replay force-pushes with the pre-replay tip as the lease', () => {
+	const git = makeStub(baseGitRoutes);
+	const result = rebaseBundleBranch({ git, env, log: silent });
+
+	assert.deepEqual(result, { status: 'replayed' });
+	// Commits already on the base are dropped rather than stopping the replay.
+	assert.deepEqual(git.calls.find(isRebase), ['rebase', '--empty=drop', BASE]);
+	assert.deepEqual(git.calls.find(isPush), [
+		'push',
+		`--force-with-lease=refs/heads/bundle/2.x:${PRE_HEAD}`,
+		'https://x-access-token:tok@github.com/n8n-io/n8n-private.git',
+		'HEAD:refs/heads/bundle/2.x',
+	]);
+});
+
+test('both fetches are authenticated — the private repo rejects an anonymous origin fetch', () => {
+	const git = makeStub(baseGitRoutes);
+	rebaseBundleBranch({ git, env, log: silent });
+
+	const remote = 'https://x-access-token:tok@github.com/n8n-io/n8n-private.git';
+	assert.deepEqual(
+		git.calls.filter((a) => a[0] === 'fetch'),
+		[
+			['fetch', remote, 'master'],
+			['fetch', remote, 'bundle/2.x'],
+		],
+	);
+});
+
+test('a bundle branch that already contains its base is left alone', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge-base', ''], // --is-ancestor succeeds
+		...baseGitRoutes,
+	]);
+	const result = rebaseBundleBranch({ git, env, log: silent });
+
+	assert.deepEqual(result, { status: 'current' });
+	assert.equal(git.calls.some(isRebase), false);
+	assert.equal(git.calls.some(isPush), false);
+});
+
+test('a conflicting base fails without touching the branch', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge-tree', conflictedMergeTree('packages/cli/src/a.ts')],
+		...baseGitRoutes,
+	]);
+	const logs = [];
+
+	assert.throws(() => rebaseBundleBranch({ git, env, log: (m) => logs.push(m) }), {
+		message: /master conflicts with bundle\/2\.x/,
+	});
+	// The conflict is detected from the merge tree alone: no rebase, no push.
+	assert.equal(git.calls.some(isRebase), false);
+	assert.equal(git.calls.some(isPush), false);
+	assert.match(logs.join('\n'), /::error title=bundle\/2\.x is out of sync::/);
+	assert.match(logs.join('\n'), /packages\/cli\/src\/a\.ts/);
+});
+
+test('a replay that stalls aborts the rebase and refuses to push', () => {
+	const git = makeStub([...baseGitRoutes, [isRebase, fail('could not apply')]]);
+	const logs = [];
+
+	assert.throws(() => rebaseBundleBranch({ git, env, log: (m) => logs.push(m) }), {
+		message: /Could not replay bundle\/2\.x onto master/,
+	});
+	assert.deepEqual(git.calls.at(-1), ['rebase', '--abort']);
+	assert.equal(git.calls.some(isPush), false);
+	assert.match(logs.join('\n'), /::error title=bundle\/2\.x could not be replayed::/);
+});
+
+test('a replayed tree that is not the merge tree refuses to push', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', 'SOMEOTHERTREE'],
+		...baseGitRoutes,
+	]);
+
+	assert.throws(() => rebaseBundleBranch({ git, env, log: silent }), {
+		message: /does not match the merge tree MERGETREEOID; refusing to push/,
+	});
+	assert.equal(git.calls.some(isPush), false);
+});
+
+test('conflict markers in the replayed tree refuse to push', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'grep', 'packages/cli/src/a.ts'], // git grep found markers
+		...baseGitRoutes,
+	]);
+
+	assert.throws(() => rebaseBundleBranch({ git, env, log: silent }), {
+		message: /conflict markers present in HEAD/,
+	});
+	assert.equal(git.calls.some(isPush), false);
+});
+
+test('annotation keeps a multi-line message on one line', () => {
+	assert.equal(annotation('t', 'a\nb'), '::error title=t::a%0Ab');
+});

--- a/.github/scripts/sync-master-to-3x.mjs
+++ b/.github/scripts/sync-master-to-3x.mjs
@@ -64,11 +64,23 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
 import {
+	attempt,
+	assertNoMarkers,
+	assertTreeMatches,
+	isAncestor,
+	mergeTree,
+	runGit,
+} from './branch-replay.mjs';
+import {
 	conflictedFiles,
 	breakingShas,
 	resolveLogins,
 	buildOutputs,
 } from './sync-conflict-owners.mjs';
+
+// Re-exported so this module stays the single entry point for the master→3.x flow, tests
+// included. The implementations are branch-pair-agnostic and shared with the bundle replay.
+export { attempt, assertNoMarkers, assertTreeMatches, isAncestor, mergeTree };
 
 export const TARGET_BRANCH = '3.x';
 export const SYNC_BRANCH = 'sync/master-to-3x';
@@ -94,8 +106,8 @@ const BOT_NAME = 'n8n-assistant[bot]';
 const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
 
 // Real command runners. Each takes an args array and returns trimmed stdout,
-// throwing on a non-zero exit (mirrors `set -e`). Injectable for tests.
-const runGit = (args, opts = {}) => execFileSync('git', args, { encoding: 'utf8', ...opts }).trim();
+// throwing on a non-zero exit (mirrors `set -e`). Injectable for tests. (`runGit` is
+// shared — see branch-replay.mjs.)
 const runGh = (args, opts = {}) => execFileSync('gh', args, { encoding: 'utf8', ...opts }).trim();
 const runPnpm = (args, opts = {}) =>
 	execFileSync('pnpm', args, { encoding: 'utf8', ...opts }).trim();
@@ -106,57 +118,10 @@ export function targetBranch(env = process.env) {
 	return env.SYNC_TARGET_BRANCH || TARGET_BRANCH;
 }
 
-// Run a command for its exit status: `{ ok, out }` instead of a throw. Used for the git
-// commands whose non-zero exit is an expected answer, not a failure. stderr is captured
-// rather than inherited, so an expected-to-fail probe doesn't spill into the run log.
-export function attempt(run, args, opts = {}) {
-	try {
-		return { ok: true, out: run(args, { stdio: ['ignore', 'pipe', 'pipe'], ...opts }) ?? '' };
-	} catch (error) {
-		const out = `${error.stdout ?? ''}\n${error.stderr ?? ''}`.trim();
-		return { ok: false, out };
-	}
-}
-
 // True when a previous conflict PR is still open — the halt gate.
 export function hasOpenConflictPr(gh, label = CONFLICT_LABEL) {
 	const out = gh(['pr', 'list', '--state', 'open', '--label', label, '--json', 'number']);
 	return JSON.parse(out || '[]').length > 0;
-}
-
-export function isAncestor(git, maybeAncestor, descendant) {
-	return attempt(git, ['merge-base', '--is-ancestor', maybeAncestor, descendant]).ok;
-}
-
-/**
- * The tree a merge of the two commits would produce — the definition of the content 3.x
- * should end up with, computed without touching the working tree.
- *
- * `ok: false` means the two sides genuinely conflict; `conflictedPaths` then names the
- * clashing files, and `tree` is still written (conflicted blobs carry their markers) —
- * it is the comparison baseline for the relaxed tree guard.
- */
-export function mergeTree(git, a, b) {
-	const res = attempt(git, ['merge-tree', '--write-tree', '--name-only', a, b]);
-	// Line 0 is the toplevel tree OID (written even on conflict); the lines up to the
-	// first blank line are the conflicted filenames (`--name-only`). Informational
-	// messages follow the blank line, but `attempt` folds stderr in too — filter both.
-	const lines = res.out.split('\n');
-	const tree = lines[0]?.trim() ?? '';
-	let conflictedPaths = [];
-	if (!res.ok) {
-		const blank = lines.indexOf('', 1);
-		const section = lines.slice(1, blank === -1 ? undefined : blank);
-		conflictedPaths = [
-			...new Set(section.filter((l) => l && !/^(CONFLICT|Auto-merging|warning)/.test(l))),
-		];
-	}
-	return {
-		ok: res.ok,
-		tree: res.ok || conflictedPaths.length ? tree : '',
-		conflictedPaths,
-		out: res.out,
-	};
 }
 
 // Split conflicted paths into mechanically-resolvable ones and real code conflicts.
@@ -267,40 +232,6 @@ export function rebaseResolvingMechanical({
 		res = attempt(git, empty ? ['rebase', '--skip'] : ['rebase', '--continue']);
 	}
 	return { ok: true, resolved: [...resolved] };
-}
-
-/**
- * The content guard for every push: whichever route produced HEAD, its tree must be exactly
- * what merging 3.x with master yields — except on `allowedPaths`, the mechanical files the
- * merge itself could not resolve (always derived from the merge-tree conflict list, never
- * from what the run happened to touch). With no `allowedPaths` this is exact equality.
- */
-export function assertTreeMatches(git, expectedTree, allowedPaths = []) {
-	const actual = git(['rev-parse', 'HEAD^{tree}']);
-	if (actual === expectedTree) return;
-	if (allowedPaths.length === 0) {
-		throw new Error(
-			`Replayed tree ${actual} does not match the merge tree ${expectedTree}; refusing to push.`,
-		);
-	}
-	const out = git(['diff-tree', '-r', '--name-only', '--no-renames', expectedTree, actual]);
-	const allowed = new Set(allowedPaths);
-	const violations = (out ? out.split('\n') : []).filter((p) => p && !allowed.has(p));
-	if (violations.length > 0) {
-		throw new Error(
-			`Replayed tree deviates from the merge tree on non-mechanical paths:\n${violations.join('\n')}\nrefusing to push.`,
-		);
-	}
-}
-
-// Conflict markers must never reach 3.x — nightly images build from it. git grep exits 0
-// with matches, 1 with none and >1 on error, so an error must not be read as "clean".
-export function assertNoMarkers(git, rev = 'HEAD') {
-	const found = attempt(git, ['grep', '-I', '-l', '-e', '^<<<<<<< ', '-e', '^>>>>>>> ', rev]);
-	if (found.ok)
-		throw new Error(`Refusing to continue: conflict markers present in ${rev}:\n${found.out}`);
-	if (found.out.includes('fatal:'))
-		throw new Error(`Could not scan ${rev} for conflict markers:\n${found.out}`);
 }
 
 /**

--- a/.github/workflows/sec-rebase-bundle-branches.yml
+++ b/.github/workflows/sec-rebase-bundle-branches.yml
@@ -1,0 +1,111 @@
+# Keeps the bundle integration branches in sync with their base, in n8n-io/n8n-private.
+#
+# Fixes are integrated on bundle/2.x and bundle/1.x and eventually merged into private
+# master/1.x as a squashed `chore: Bundle/*` PR. Those branches must not drift from their
+# base, or CI on the fix PRs targeting them stops meaning anything and the bundle cut turns
+# into a conflict-resolution session.
+#
+# The base is REPLAYED, not merged: merging added a merge commit on nearly every run, and the
+# bundle publishes as a single squashed, obfuscated commit anyway — so SHAs on these branches
+# buy nothing, while a readable `base..bundle` list of pending fixes buys a lot. Every push is
+# verified to carry exactly the tree a merge would produce. See rebase-bundle-branch.mjs.
+#
+# One job per bundle branch: a conflict on one FAILS THAT JOB and leaves its branch untouched,
+# while the other still syncs. Recovery is manual and deliberate — rebase onto the base
+# locally, force-push, then re-run this workflow.
+
+name: 'Security: Rebase Bundle Branches'
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  pull_request: # a fix landing on a bundle branch is when freshness matters most
+    types: [closed]
+    branches:
+      - 'bundle/2.x'
+      - 'bundle/1.x'
+  workflow_dispatch:
+
+# Least privilege by default; the replay job opts into exactly what it needs.
+permissions: {}
+
+jobs:
+  replay:
+    name: Replay ${{ matrix.bundle }}
+    if: |
+      github.repository == 'n8n-io/n8n-private' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false # a conflict on one bundle branch must not hold back the other
+      matrix:
+        include:
+          - bundle: 'bundle/2.x'
+            base: 'master'
+          - bundle: 'bundle/1.x'
+            base: '1.x'
+    concurrency: # serialize per branch — never two replays of the same one at once
+      group: rebase-${{ matrix.bundle }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          # Scope the installation token to only what the replay needs.
+          permission-contents: write # force-push the bundle branch
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Always run the script from the default branch, never from a pull_request merge
+          # ref — the replay holds a contents:write token and fetches what it needs itself,
+          # so the checked-out branch is irrelevant beyond supplying trusted code.
+          ref: master
+          fetch-depth: 0
+          persist-credentials: false # we push with an explicit token URL instead
+
+      # Node toolchain only — the replay runs no install and no build.
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          install-command: ''
+          build-command: ''
+
+      - name: Replay bundle branch onto its base
+        # On a merged bundle PR, only the branch that received it needs replaying.
+        # (`matrix` is not available in a job-level `if`, so the filter lives here.)
+        if: github.event_name != 'pull_request' || github.event.pull_request.base.ref == matrix.bundle
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BUNDLE_BRANCH: ${{ matrix.bundle }}
+          BASE_BRANCH: ${{ matrix.base }}
+        run: node .github/scripts/rebase-bundle-branch.mjs
+
+  notify-on-failure:
+    name: Notify Slack on failure
+    needs: [replay]
+    if: ${{ always() && needs.replay.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the slack scripts
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts/slack
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      # Branch names and a run link only: conflicted paths and commit subjects hint at the
+      # vulnerability, and Slack reaches a wider audience than the private repo.
+      - name: Notify Slack
+        env:
+          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel '#alerts-security' \
+            --text "<${RUN_URL}|A bundle branch could not be replayed onto its base>. The branch is untouched; see the run for which one and why."

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -5,6 +5,8 @@
 #
 # Scheduled runs only sync if private is not ahead of public.
 # Manual runs always sync (for conflict recovery after failed cherry-pick).
+#
+# The bundle/* integration branches are kept current by sec-rebase-bundle-branches.yml.
 
 name: 'Security: Sync from Public'
 run-name: "${{ github.event_name == 'workflow_dispatch' && format('Security: Sync from Public (force={0})', inputs.force) || '' }}"
@@ -90,58 +92,3 @@ jobs:
 
           git reset --hard public-1.x
           git push origin 1.x --force-with-lease
-
-      - name: Ensure bundle/2.x exists
-        run: |
-          if git ls-remote --exit-code origin refs/heads/bundle/2.x; then
-            echo "bundle/2.x already exists, skipping"
-          else
-            echo "bundle/2.x not found, creating from master"
-            git checkout master
-            git checkout -b bundle/2.x
-            git push origin bundle/2.x
-          fi
-
-      - name: Ensure bundle/1.x exists
-        run: |
-          if git ls-remote --exit-code origin refs/heads/bundle/1.x; then
-            echo "bundle/1.x already exists, skipping"
-          else
-            echo "bundle/1.x not found, creating from 1.x"
-            git checkout 1.x
-            git checkout -b bundle/1.x
-            git push origin bundle/1.x
-          fi
-
-      - name: Update bundle/2.x from master
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git fetch origin bundle/2.x
-          git checkout -B bundle/2.x FETCH_HEAD
-
-          if git merge --no-edit master; then
-            git push origin bundle/2.x
-          else
-            # A conflict needs a human; keep the run green so the rest of the sync still reports success
-            git merge --abort || true
-            echo "::warning title=bundle/2.x is out of sync::Merging master into bundle/2.x hit a conflict. Resolve it manually, then re-run this workflow."
-            exit 0
-          fi
-
-      - name: Update bundle/1.x from 1.x
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git fetch origin bundle/1.x
-          git checkout -B bundle/1.x FETCH_HEAD
-
-          if git merge --no-edit 1.x; then
-            git push origin bundle/1.x
-          else
-            git merge --abort || true
-            echo "::warning title=bundle/1.x is out of sync::Merging 1.x into bundle/1.x hit a conflict. Resolve it manually, then re-run this workflow."
-            exit 0
-          fi


### PR DESCRIPTION
## Summary

> [!NOTE]
> This PR is mostly about refactoring the 3.x branch sync into it's own re-usable module and utilizing it in our bundle syncs.
> 
> Refactoring / cleaning up the module itself in a followup PR

The new trial of bundle branch sync started creating hourly merge commits on bundle branches, causing tens of commits of noise in them. 

Switch to using the same scripts that our 3.x / v3 syncs use to keep the conflicts in separate PRs while also keeping the noise in the branches low.

## How to test

Get this merged, sync with private, have it run the post-sync actions.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

