### PR TITLE
ci: Build `node-pc` runtime on `n8nio/base` image

### DIFF
--- a/.github/workflows/build-node-pc-image.yml
+++ b/.github/workflows/build-node-pc-image.yml
@@ -44,14 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Login to DHI Registry (for pulling the runtime base)
-        uses: ./.github/actions/docker-registry-login
-        with:
-          login-ghcr: 'false'
-          login-dhi: 'true'
-          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
-          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Login to Docker registries (for pushing)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true)
         uses: ./.github/actions/docker-registry-login

--- a/docker/images/node-pc/Dockerfile
+++ b/docker/images/node-pc/Dockerfile
@@ -6,8 +6,7 @@
 # docker-node Alpine recipe with one added configure flag.
 #
 # Two published targets:
-#   runtime (default) - drop-in sibling of n8nio/base, layered on the same DHI
-#                       base with our compiled Node swapped in
+#   runtime (default) - n8nio/base with our compiled Node swapped in
 #   dev               - plain Alpine with apk usable, for the n8n builder
 #                       stage, which must compile native addons against this
 #                       Node's headers
@@ -87,44 +86,18 @@ ENV npm_config_nodedir=/usr/local
 
 # ---------------------------------------------------------------------------
 
-# Runtime layers on the same DHI base as n8n-base, so both siblings share
-# Docker's OS-layer patching and attestations. Only the Node binary is ours:
-# DHI's stock Node (at /usr/bin on Alpine) is removed and replaced by the
-# pointer-compressed build.
+# `n8nio/base:26.x` with one change, namely the stock Node files (node, npm,
+# npx, corepack) are swapped for the pointer-compressed build's files.
 # Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
 # Bump the tag and digest together when updating.
-FROM dhi.io/node:26.5.1-alpine3.24-dev@sha256:c4062f85acd1ca91ffb7d15048dcc5f15a922d630e65eb3c3c0dcdcef6ea36d8 AS runtime
+FROM n8nio/base:26.5.1@sha256:1b0bca5c94bbd04ad2120b9e9892a8bc717a1d88efa76fefe452c59bdc611d25 AS runtime
 
-RUN rm -f /usr/bin/node /usr/bin/nodejs /usr/bin/npm /usr/bin/npx /usr/bin/corepack
+RUN rm -f /usr/bin/node /usr/bin/nodejs /usr/bin/npm /usr/bin/npx /usr/bin/corepack /usr/local/bin/node
 COPY --from=builder /node-install/usr/local /usr/local
 RUN node --version \
     && node -e "if (!process.config.variables.v8_enable_pointer_compression) { throw new Error('pointer compression is not enabled') }"
-
-# Mirrors docker/images/n8n-base/Dockerfile so the n8n runtime stage can swap
-# between the two.
-RUN apk add --no-cache busybox-binsh && \
-    apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontconfig && \
-    update-ms-fonts && \
-    fc-cache -f && \
-    apk del .build-deps-fonts && \
-    find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \; && \
-    # No blanket `apk upgrade` — patched bytes come from bumping the pinned
-    # DHI digest instead, same policy as n8n-base.
-    apk add --no-cache \
-        openssh \
-        graphicsmagick \
-        tini \
-        tzdata \
-        ca-certificates \
-        libc6-compat && \
-    rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* && \
-    apk del apk-tools
 
 # The compiled build lives at /usr/local/bin, which is what the cloud launch
 # and AppArmor profile expect. Keep the stock /usr/bin path working for
 # anything that references it.
 RUN ln -sf /usr/local/bin/node /usr/bin/node
-
-WORKDIR /home/node
-ENV NODE_PATH=/usr/local/lib/node_modules
-EXPOSE 5678/tcp


### PR DESCRIPTION
## Summary

This PR rebuilds the runtime stage of the `node-pc` image (pointer-compressed Node.js) on top of `n8nio/base:26.5.1` so we reuse the base's package layer, paths, and policies. What remains is only the Node swap.

Also drops the DHI registry login from the workflow, since nothing pulls `dhi.io` anymore.

Follow-up to: https://github.com/n8n-io/n8n/pull/35756#discussion_r3750425906

## Related Linear tickets, Github issues, and Community forum posts

https://app.notion.com/p/n8n/Halving-memory-usage-via-pointer-compression-3ac5b6e0c94f8005af87e93a9f837b53

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
