### PR TITLE
fix(editor): Position AI-generated canvas groups without overlap

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -3271,9 +3271,11 @@ export function useCanvasOperations() {
 				startCollapsed: true,
 				description: group.description,
 			});
+
 			if (trackHistory) {
 				historyStore.pushCommandToUndo(new AddNodeGroupCommand(createdGroup, Date.now()));
 			}
+
 			existingGroupNames.add(name);
 		}
 	}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -14,7 +14,7 @@ import { mockedStore } from '@/__tests__/utils';
 import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
 import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
-import type { Workflow } from 'n8n-workflow';
+import type { IWorkflowGroup, Workflow } from 'n8n-workflow';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
 
 // Instantiates a store that derives the workflow id from the route. These tests run
@@ -62,6 +62,9 @@ const mockDocumentStore = vi.hoisted(() => ({
 	}),
 	connectionsBySourceNode: {},
 	workflowTriggerNodes: [] as INodeUi[],
+	allGroups: [] as IWorkflowGroup[],
+	upsertGroups: vi.fn().mockReturnValue([]),
+	deleteGroup: vi.fn(),
 })) as unknown as ReturnType<typeof useWorkflowDocumentStore>;
 
 vi.mock('@/app/stores/workflowDocument.store', () => ({
@@ -111,6 +114,7 @@ describe('useWorkflowUpdate', () => {
 
 		// Setup default mocks
 		(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [];
+		(mockDocumentStore as { allGroups: IWorkflowGroup[] }).allGroups = [];
 		(mockDocumentStore as { name: string }).name = '';
 		vi.mocked(mockDocumentStore.setName).mockClear();
 		vi.mocked(mockDocumentStore.setNodes).mockClear();
@@ -796,6 +800,101 @@ describe('useWorkflowUpdate', () => {
 				);
 
 				expect(setNameSpy).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('canvas groups', () => {
+			// The layout treats a collapsed group as one fixed-width chip, so groups
+			// that reach the canvas after the layout ran end up overlapping.
+			it('should apply incoming groups collapsed', async () => {
+				const node = createTestNode({ id: 'node-1', name: 'Node 1' }) as INodeUi;
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [node];
+
+				const { updateWorkflow } = useWorkflowUpdate();
+
+				await updateWorkflow({
+					nodes: [node],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Ingest', nodeIds: ['node-1'] }],
+				});
+
+				expect(mockDocumentStore.upsertGroups).toHaveBeenCalledWith(
+					[{ id: 'g1', name: 'Ingest', nodeIds: ['node-1'] }],
+					{ startCollapsed: true },
+				);
+			});
+
+			it('should apply groups before emitting tidyUp', async () => {
+				const node = createTestNode({ id: 'node-1', name: 'Node 1' }) as INodeUi;
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [node];
+
+				const calls: string[] = [];
+				vi.mocked(mockDocumentStore.upsertGroups).mockImplementation(() => {
+					calls.push('upsertGroups');
+					return [];
+				});
+
+				canvasEventBusEmitMock.mockImplementation((event: string) => {
+					if (event === 'tidyUp') calls.push('tidyUp');
+				});
+
+				const { updateWorkflow } = useWorkflowUpdate();
+
+				await updateWorkflow({
+					nodes: [node],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Ingest', nodeIds: ['node-1'] }],
+				});
+
+				expect(calls).toEqual(['upsertGroups', 'tidyUp']);
+			});
+
+			it('should skip a group whose member nodes are not all present yet', async () => {
+				const node = createTestNode({ id: 'node-1', name: 'Node 1' }) as INodeUi;
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [node];
+
+				const { updateWorkflow } = useWorkflowUpdate();
+
+				await updateWorkflow({
+					nodes: [node],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Ingest', nodeIds: ['node-1', 'not-yet-added'] }],
+				});
+
+				expect(mockDocumentStore.upsertGroups).toHaveBeenCalledWith([], { startCollapsed: true });
+			});
+
+			it('should remove groups the update no longer lists', async () => {
+				const node = createTestNode({ id: 'node-1', name: 'Node 1' }) as INodeUi;
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [node];
+				(mockDocumentStore as { allGroups: IWorkflowGroup[] }).allGroups = [
+					{ id: 'stale', name: 'Removed', nodeIds: ['node-1'] },
+				];
+
+				const { updateWorkflow } = useWorkflowUpdate();
+
+				await updateWorkflow({
+					nodes: [node],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Ingest', nodeIds: ['node-1'] }],
+				});
+
+				expect(mockDocumentStore.deleteGroup).toHaveBeenCalledWith('stale');
+			});
+
+			it('should leave existing groups untouched when the update carries no group data', async () => {
+				const node = createTestNode({ id: 'node-1', name: 'Node 1' }) as INodeUi;
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [node];
+				(mockDocumentStore as { allGroups: IWorkflowGroup[] }).allGroups = [
+					{ id: 'existing', name: 'Ingest', nodeIds: ['node-1'] },
+				];
+
+				const { updateWorkflow } = useWorkflowUpdate();
+
+				await updateWorkflow({ nodes: [node], connections: {} });
+
+				expect(mockDocumentStore.deleteGroup).not.toHaveBeenCalled();
+				expect(mockDocumentStore.upsertGroups).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -882,6 +882,30 @@ describe('useWorkflowUpdate', () => {
 				expect(mockDocumentStore.deleteGroup).toHaveBeenCalledWith('stale');
 			});
 
+			it('should map group members through regenerated node ids', async () => {
+				const existing = createTestNode({ id: 'store-1', name: 'Node 1' }) as INodeUi;
+				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [existing];
+				(mockDocumentStore as { allGroups: IWorkflowGroup[] }).allGroups = [
+					{ id: 'g1', name: 'Ingest', nodeIds: ['store-1'] },
+				];
+
+				const { updateWorkflow } = useWorkflowUpdate();
+
+				// The SDK regenerates node ids between streamed chunks; the store keeps
+				// the id it already had, so incoming group members must be translated.
+				await updateWorkflow({
+					nodes: [createTestNode({ id: 'regenerated-1', name: 'Node 1' })],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Ingest', nodeIds: ['regenerated-1'] }],
+				});
+
+				expect(mockDocumentStore.deleteGroup).not.toHaveBeenCalled();
+				expect(mockDocumentStore.upsertGroups).toHaveBeenCalledWith(
+					[{ id: 'g1', name: 'Ingest', nodeIds: ['store-1'] }],
+					{ startCollapsed: true },
+				);
+			});
+
 			it('should leave existing groups untouched when the update carries no group data', async () => {
 				const node = createTestNode({ id: 'node-1', name: 'Node 1' }) as INodeUi;
 				(mockDocumentStore as { allNodes: INodeUi[] }).allNodes = [node];

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -318,19 +318,55 @@ export function useWorkflowUpdate() {
 		}
 	}
 
-	function updateNodeGroups(nodeGroups: WorkflowDataUpdate['nodeGroups']): void {
+	/**
+	 * Incoming node id -> stored node id, resolved the same way `categorizeNodes`
+	 * matches nodes. The SDK regenerates node ids between streamed chunks while
+	 * the store keeps the id it already had, so group members arrive pointing at
+	 * ids the store has never seen.
+	 */
+	function mapIncomingNodeIds(incomingNodes: WorkflowDataUpdate['nodes']): Map<string, string> {
+		const storedNodes = workflowDocumentStore.value.allNodes;
+		const storedIds = new Set(storedNodes.map((node) => node.id));
+		const storedIdsByNameType = new Map(
+			storedNodes.map((node) => [`${node.type}::${node.name}`, node.id]),
+		);
+
+		const remapped = new Map<string, string>();
+		for (const node of incomingNodes ?? []) {
+			const storedId = storedIds.has(node.id)
+				? node.id
+				: storedIdsByNameType.get(`${node.type}::${node.name}`);
+
+			if (storedId) {
+				remapped.set(node.id, storedId);
+			}
+		}
+
+		return remapped;
+	}
+
+	function updateNodeGroups(
+		nodeGroups: WorkflowDataUpdate['nodeGroups'],
+		incomingNodes: WorkflowDataUpdate['nodes'],
+	): void {
 		// Undefined means "no group data in this update", which must NOT be read
 		// as "the user deleted every group".
 		if (!nodeGroups) {
 			return;
 		}
 
-		const nodeIds = new Set(workflowDocumentStore.value.allNodes.map((node) => node.id));
+		const storedIdByIncomingId = mapIncomingNodeIds(incomingNodes);
+
 		// A group whose nodes haven't all arrived yet would render an incomplete
 		// frame; a later chunk brings it back once its members exist.
-		const applicable = nodeGroups.filter(
-			(group) => group.nodeIds.length > 0 && group.nodeIds.every((id) => nodeIds.has(id)),
-		);
+		const applicable = nodeGroups.flatMap((group) => {
+			const nodeIds = group.nodeIds.map((id) => storedIdByIncomingId.get(id));
+			if (nodeIds.length === 0 || nodeIds.some((id) => id === undefined)) {
+				return [];
+			}
+
+			return [{ ...group, nodeIds: nodeIds as string[] }];
+		});
 
 		const keptNames = new Set(applicable.map((group) => group.name));
 		for (const group of workflowDocumentStore.value.allGroups) {
@@ -400,7 +436,7 @@ export function useWorkflowUpdate() {
 			builderStore.setBuilderMadeEdits(true);
 
 			// Must update the node groups before tidying the WF up, or the layout might become messy
-			updateNodeGroups(workflowData.nodeGroups);
+			updateNodeGroups(workflowData.nodeGroups, workflowData.nodes);
 
 			tidyUpNodes();
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -318,6 +318,30 @@ export function useWorkflowUpdate() {
 		}
 	}
 
+	function updateNodeGroups(nodeGroups: WorkflowDataUpdate['nodeGroups']): void {
+		// Undefined means "no group data in this update", which must NOT be read
+		// as "the user deleted every group".
+		if (!nodeGroups) {
+			return;
+		}
+
+		const nodeIds = new Set(workflowDocumentStore.value.allNodes.map((node) => node.id));
+		// A group whose nodes haven't all arrived yet would render an incomplete
+		// frame; a later chunk brings it back once its members exist.
+		const applicable = nodeGroups.filter(
+			(group) => group.nodeIds.length > 0 && group.nodeIds.every((id) => nodeIds.has(id)),
+		);
+
+		const keptNames = new Set(applicable.map((group) => group.name));
+		for (const group of workflowDocumentStore.value.allGroups) {
+			if (!keptNames.has(group.name)) {
+				workflowDocumentStore.value.deleteGroup(group.id);
+			}
+		}
+
+		workflowDocumentStore.value.upsertGroups(applicable, { startCollapsed: true });
+	}
+
 	/**
 	 * Tidy up node positions. When nodeIdsFilter is provided, only those nodes
 	 * are laid out. When omitted, all nodes are laid out (full re-layout).
@@ -374,6 +398,9 @@ export function useWorkflowUpdate() {
 			}
 
 			builderStore.setBuilderMadeEdits(true);
+
+			// Must update the node groups before tidying the WF up, or the layout might become messy
+			updateNodeGroups(workflowData.nodeGroups);
 
 			tidyUpNodes();
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeGroups.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeGroups.test.ts
@@ -69,6 +69,76 @@ describe('useWorkflowDocumentNodeGroups', () => {
 		});
 	});
 
+	describe('upsertGroups', () => {
+		it('creates the incoming groups', () => {
+			const [group] = nodeGroups.upsertGroups([{ id: 'g1', name: 'Ingest', nodeIds: ['a', 'b'] }]);
+
+			expect(group.name).toBe('Ingest');
+			expect(group.nodeIds).toEqual(['a', 'b']);
+			expect(nodeGroups.allGroups.value).toHaveLength(1);
+		});
+
+		it('updates the matching group instead of duplicating it on a repeated call', () => {
+			nodeGroups.upsertGroups([{ id: 'g1', name: 'Ingest', nodeIds: ['a'] }]);
+			const [group] = nodeGroups.upsertGroups([{ id: 'g1', name: 'Ingest', nodeIds: ['a', 'b'] }]);
+
+			expect(nodeGroups.allGroups.value).toHaveLength(1);
+			expect(group.nodeIds).toEqual(['a', 'b']);
+			expect(group.name).toBe('Ingest');
+		});
+
+		it('matches by name so a regenerated id reuses the existing group', () => {
+			const [first] = nodeGroups.upsertGroups([{ id: 'g1', name: 'Ingest', nodeIds: ['a'] }]);
+			const [second] = nodeGroups.upsertGroups([{ id: 'g2', name: 'Ingest', nodeIds: ['a', 'b'] }]);
+
+			expect(nodeGroups.allGroups.value).toHaveLength(1);
+			expect(second.id).toBe(first.id);
+		});
+
+		it('emits UPDATE rather than ADD for a group that already exists', () => {
+			nodeGroups.upsertGroups([{ id: 'g1', name: 'Ingest', nodeIds: ['a'] }]);
+
+			const changeSpy = vi.fn();
+			nodeGroups.onNodeGroupsChange(changeSpy);
+			nodeGroups.upsertGroups([{ id: 'g1', name: 'Ingest', nodeIds: ['a', 'b'] }]);
+
+			expect(changeSpy).toHaveBeenCalledWith(expect.objectContaining({ action: 'update' }));
+		});
+
+		it('carries startCollapsed on the ADD event', () => {
+			const changeSpy = vi.fn();
+			nodeGroups.onNodeGroupsChange(changeSpy);
+
+			const [group] = nodeGroups.upsertGroups([{ id: 'g1', name: 'Ingest', nodeIds: ['a'] }], {
+				startCollapsed: true,
+			});
+
+			expect(changeSpy).toHaveBeenCalledWith({
+				action: 'add',
+				payload: { group, startCollapsed: true },
+			});
+		});
+
+		it('normalizes the description', () => {
+			const [group] = nodeGroups.upsertGroups([
+				{
+					id: 'g1',
+					name: 'Ingest',
+					nodeIds: ['a'],
+					description: 'x'.repeat(GROUP_DESCRIPTION_MAX_LENGTH + 50),
+				},
+			]);
+
+			expect(group.description).toHaveLength(GROUP_DESCRIPTION_MAX_LENGTH);
+		});
+
+		it('generates an id when the payload omits one', () => {
+			const [group] = nodeGroups.upsertGroups([{ id: '', name: 'Ingest', nodeIds: ['a'] }]);
+
+			expect(group.id).toBeTruthy();
+		});
+	});
+
 	describe('getNextDefaultName', () => {
 		it('starts at 1 for the first group', () => {
 			expect(nodeGroups.getNextDefaultName('Group')).toBe('Group 1');

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeGroups.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeGroups.ts
@@ -152,6 +152,40 @@ export function useWorkflowDocumentNodeGroups() {
 		applyDeleteGroup(id);
 	}
 
+	/**
+	 * Upsert groups coming from an AI builder update, matched by name.
+	 *
+	 * Uses group names since they are unique. Matching by id would recreate
+	 * groups whenever the builder regenerates ids on next passes of the process,
+	 * and `createGroup` would then rename each copy via `getNextDefaultName`.
+	 */
+	function upsertGroups(
+		nextGroups: IWorkflowGroup[],
+		{ markDirty = true, startCollapsed }: NodeGroupCreateOptions = {},
+	): IWorkflowGroup[] {
+		const existingByName = new Map(allGroups.value.map((group) => [group.name, group]));
+
+		return nextGroups.map((group) => {
+			const existing = existingByName.get(group.name);
+			const description = normalizeGroupDescription(group.description);
+			const next: IWorkflowGroup = {
+				// Keep the existing id on update so subscribers see the same group.
+				// `||` also covers AI payloads that send an empty id.
+				id: existing?.id || group.id || window.crypto.randomUUID(),
+				nodeIds: [...group.nodeIds],
+				name: group.name,
+				...(description ? { description } : {}),
+			};
+
+			applyUpsertGroup(next, existing ? CHANGE_ACTION.UPDATE : CHANGE_ACTION.ADD, {
+				markDirty,
+				startCollapsed,
+			});
+
+			return next;
+		});
+	}
+
 	// Id-preserving upsert used by undo/redo to restore a group snapshot.
 	function restoreGroup(group: IWorkflowGroup) {
 		const action = groups.value.has(group.id) ? CHANGE_ACTION.UPDATE : CHANGE_ACTION.ADD;
@@ -216,6 +250,7 @@ export function useWorkflowDocumentNodeGroups() {
 		nodeIdToGroupId,
 		setNodeGroups,
 		createGroup,
+		upsertGroups,
 		getNextDefaultName,
 		updateName,
 		updateDescription,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -1556,8 +1556,14 @@ async function onTidyUp(payload: CanvasEventBusEvents['tidyUp']) {
 		});
 	};
 
-	for (let attempt = 0; attempt < 5 && !hasGraphCaughtUpWithChanges(); attempt++) {
+	// Always await at least one tick before the first check: onTidyUp can run
+	// synchronously in the same tick as the store mutation it's reacting to,
+	// before VueFlow's internal graph has had any chance to sync at all.
+	for (let attempt = 0; attempt < 5; attempt++) {
 		await nextTick();
+		if (hasGraphCaughtUpWithChanges()) {
+			break;
+		}
 	}
 
 	if (payload.nodeIdsFilter && payload.nodeIdsFilter.length > 0) {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -1537,12 +1537,36 @@ async function onContextMenuAction(action: ContextMenuAction, nodeIds: string[],
 }
 
 async function onTidyUp(payload: CanvasEventBusEvents['tidyUp']) {
+	// VueFlow's graph lags the nodes prop by a flush, so a layout requested in
+	// the same tick as a store mutation can still see a group's members as loose nodes.
+	const hasGraphCaughtUpWithChanges = () => {
+		return vueFlowNodes.value.every((node) => {
+			const graphNode = findNode(node.id);
+			if (!graphNode) {
+				return false;
+			}
+
+			const { data } = node;
+			// A collapsed group only lays out as one chip once its members are hidden.
+			if (!data || !('isCollapsed' in data) || !data.isCollapsed) {
+				return true;
+			}
+
+			return data.group.nodeIds.every((memberId) => findNode(memberId)?.hidden);
+		});
+	};
+
+	for (let attempt = 0; attempt < 5 && !hasGraphCaughtUpWithChanges(); attempt++) {
+		await nextTick();
+	}
+
 	if (payload.nodeIdsFilter && payload.nodeIdsFilter.length > 0) {
 		clearSelectedNodes();
 		addSelectedNodes(payload.nodeIdsFilter.map(findNode).filter(isPresent));
 	}
 	const applyOnSelection = selectedNodes.value.length > 1;
 	const target = applyOnSelection ? 'selection' : 'all';
+
 	const result = layout(target);
 
 	emit(

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
@@ -15,6 +15,7 @@ import {
 	type CanvasNodeData,
 } from '../canvas.types';
 import { useCanvasLayout, type CanvasLayoutResult } from './useCanvasLayout';
+import { titleBarFromNodesRect } from './useCanvasMapping.groups';
 import { STICKY_NODE_TYPE } from '@/app/constants';
 import { AGENT_NODE_SIZE, DEFAULT_NODE_SIZE, GRID_SIZE } from '@/app/utils/nodeViewUtils';
 
@@ -433,16 +434,18 @@ describe('useCanvasLayout', () => {
 		});
 
 		test('keeps a top-left collapsed group anchored in place', () => {
-			// Group owns the top-left corner, where the chip box (944, 908) and the
-			// member box (1008, 1008) disagree — the anchor must not absorb that gap.
+			// Group owns the top-left corner, where the chip box and the member box
+			// (1008, 1008) disagree by the group padding — the anchor must not
+			// absorb that gap.
+			const nodesRect = { x: 1008, y: 1008, width: 192, height: 96 };
 			const m1 = createCanvasGraphNode({ id: 'm1', position: { x: 1008, y: 1008 } });
 			const m2 = createCanvasGraphNode({ id: 'm2', position: { x: 1104, y: 1008 } });
 			const group = createCanvasGraphGroupNode({
 				id: groupId,
 				nodeIds: ['m1', 'm2'],
 				isCollapsed: true,
-				nodesRect: { x: 1008, y: 1008, width: 192, height: 96 },
-				position: { x: 944, y: 908 },
+				nodesRect,
+				position: titleBarFromNodesRect(nodesRect, true).position,
 			});
 
 			const { layout } = createTestSetup([m1, m2, group], []);
@@ -452,6 +455,123 @@ describe('useCanvasLayout', () => {
 			assert(rm1);
 			// A lone group has nothing to re-flow, so its members stay put.
 			expect(rm1).toMatchObject({ x: 1008, y: 1008 });
+		});
+
+		// The chip position the canvas renders is derived from the member
+		// positions, so a layout pass must land on a fixpoint: pressing tidy-up
+		// again has to leave everything where it is.
+		test('is idempotent for a collapsed group whose chip is derived from its members', () => {
+			function runPass(
+				memberPositions: Array<{ x: number; y: number }>,
+				staleChipPosition?: { x: number; y: number },
+			) {
+				const [p1, p2] = memberPositions;
+				const m1 = createCanvasGraphNode({ id: 'm1', position: p1 });
+				const m2 = createCanvasGraphNode({ id: 'm2', position: p2 });
+				const before = createCanvasGraphNode({ id: 'before', position: { x: 0, y: 0 } });
+				const after = createCanvasGraphNode({ id: 'after', position: { x: 2000, y: 0 } });
+
+				const nodesRect = {
+					x: Math.min(p1.x, p2.x),
+					y: Math.min(p1.y, p2.y),
+					width: Math.max(p1.x, p2.x) + DEFAULT_NODE_SIZE[0] - Math.min(p1.x, p2.x),
+					height: Math.max(p1.y, p2.y) + DEFAULT_NODE_SIZE[1] - Math.min(p1.y, p2.y),
+				};
+
+				const group = createCanvasGraphGroupNode({
+					id: groupId,
+					nodeIds: ['m1', 'm2'],
+					isCollapsed: true,
+					nodesRect,
+					// Exactly what the canvas renders for this member rect.
+					position: staleChipPosition ?? titleBarFromNodesRect(nodesRect, true).position,
+				});
+
+				const { layout } = createTestSetup(
+					[before, m1, m2, after, group],
+					[
+						['before', chipId],
+						[chipId, 'after'],
+					],
+				);
+
+				const result = layout('all');
+				const positionOf = (id: string) => {
+					const node = result.nodes.find((n) => n.id === id);
+					assert(node);
+					return { x: node.x, y: node.y };
+				};
+
+				return {
+					members: [positionOf('m1'), positionOf('m2')],
+					before: positionOf('before'),
+					after: positionOf('after'),
+					chipPosition: titleBarFromNodesRect(nodesRect, true).position,
+				};
+			}
+
+			const first = runPass([
+				{ x: 1008, y: 1008 },
+				{ x: 1104, y: 1008 },
+			]);
+			const second = runPass(first.members);
+
+			expect(second.members).toEqual(first.members);
+		});
+
+		// Each streamed chunk triggers a tidy-up, so passes run back to back. The
+		// chip position feeding the next pass is still the one derived from the
+		// previous member positions, and the members must not drift because of it.
+		test('does not drift when a second pass runs before the chip position catches up', () => {
+			const p1 = { x: 1008, y: 1008 };
+			const p2 = { x: 1104, y: 1008 };
+			const staleNodesRect = { x: p1.x, y: p1.y, width: 192, height: 96 };
+			const staleChipPosition = titleBarFromNodesRect(staleNodesRect, true).position;
+
+			function runPass(
+				memberPositions: Array<{ x: number; y: number }>,
+				chipPosition: { x: number; y: number },
+			) {
+				const [a, b] = memberPositions;
+				const m1 = createCanvasGraphNode({ id: 'm1', position: a });
+				const m2 = createCanvasGraphNode({ id: 'm2', position: b });
+				const before = createCanvasGraphNode({ id: 'before', position: { x: 0, y: 0 } });
+				const after = createCanvasGraphNode({ id: 'after', position: { x: 2000, y: 0 } });
+				const group = createCanvasGraphGroupNode({
+					id: groupId,
+					nodeIds: ['m1', 'm2'],
+					isCollapsed: true,
+					nodesRect: {
+						x: Math.min(a.x, b.x),
+						y: Math.min(a.y, b.y),
+						width: 192,
+						height: 96,
+					},
+					position: chipPosition,
+				});
+
+				const { layout } = createTestSetup(
+					[before, m1, m2, after, group],
+					[
+						['before', chipId],
+						[chipId, 'after'],
+					],
+				);
+
+				const result = layout('all');
+				const positionOf = (id: string) => {
+					const node = result.nodes.find((n) => n.id === id);
+					assert(node);
+					return { x: node.x, y: node.y };
+				};
+				return [positionOf('m1'), positionOf('m2')];
+			}
+
+			const first = runPass([p1, p2], staleChipPosition);
+			// Second pass still sees the chip where the first pass found it.
+			const second = runPass(first, staleChipPosition);
+
+			expect(second).toEqual(first);
 		});
 
 		test('lays out expanded group members individually and excludes the chip', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
@@ -24,6 +24,7 @@ import {
 } from '../stores/canvasNodeGroups.constants';
 import type { ComputedRef, Ref } from 'vue';
 import { computeNodeDisplaySize, type CanvasRenderData } from '../canvas.utils';
+import { titleBarFromNodesRect } from './useCanvasMapping.groups';
 
 export type CanvasLayoutTarget = 'selection' | 'all';
 export type CanvasLayoutSource =
@@ -558,24 +559,40 @@ export function useCanvasLayout(
 		// then remove the chip since its position is derived from the nodes
 		for (const groupNode of collapsedGroups) {
 			const chipBox = boundingBoxByNodeId[groupNode.id];
-			if (!chipBox || !groupNode.data) continue;
+			if (!chipBox || !groupNode.data) {
+				continue;
+			}
 
+			const members = groupNode.data.group.nodeIds
+				.map((memberId) => findNode<CanvasNodeData>(memberId))
+				.filter(isPresent);
+
+			if (members.length === 0) {
+				delete boundingBoxByNodeId[groupNode.id];
+				continue;
+			}
+
+			// groupNode.position can be stale during back-to-back streaming layouts,
+			// so recompute it fresh from the current members instead of trusting it.
+			const memberBoxes = members.map(boundingBoxFromCanvasNode);
+			const chipOrigin = titleBarFromNodesRect(compositeBoundingBox(memberBoxes), true).position;
+
+			// When the group moves, the chip moves with it, and the node members must move by
+			// the same delta to stay in place relative to the chip.
 			const delta = {
-				x: chipBox.x - groupNode.position.x,
-				y: chipBox.y - groupNode.position.y,
+				x: chipBox.x - chipOrigin.x,
+				y: chipBox.y - chipOrigin.y,
 			};
 
-			for (const memberId of groupNode.data.group.nodeIds) {
-				const member = findNode<CanvasNodeData>(memberId);
-				if (!member) continue;
-				const box = boundingBoxFromCanvasNode(member);
-				boundingBoxByNodeId[memberId] = {
+			members.forEach((member, index) => {
+				const box = memberBoxes[index];
+				boundingBoxByNodeId[member.id] = {
 					x: box.x + delta.x,
 					y: box.y + delta.y,
 					width: box.width,
 					height: box.height,
 				};
-			}
+			});
 
 			delete boundingBoxByNodeId[groupNode.id];
 		}


### PR DESCRIPTION
## Summary

When the AI Assistant generated a workflow with canvas groups, the groups rendered stacked on top of each other instead of spaced apart.

Two independent causes:

1. **The AI-generated groups were never applied during streaming.** `updateWorkflow()` (the only path the AI Assistant uses to apply a generated workflow to the canvas) read `nodes`, `connections`, `name`, and `pinData` from the update, but never `nodeGroups`. Groups only appeared after a reload — by which point the auto tidy-up had already laid out the nodes without reserving room for a collapsed group's chip, so the chips ended up overlapping.
2. **A collapsed group's layout delta could drift across back-to-back layout passes.** The AI builder triggers a tidy-up once per streamed chunk. The delta used to move a collapsed group's (hidden) members was computed against the group chip's *rendered* position, which can lag one Vue flush behind the members' real positions. A stale read there compounds across passes and drags the group off.

Fix:
- Apply incoming `nodeGroups` (collapsed, matched by name so repeated streaming updates don't duplicate or rename groups) before the auto tidy-up runs.
- Derive a collapsed group's layout delta from its current members instead of trusting the chip's rendered position.
- Wait for VueFlow's graph to reflect the just-applied nodes/groups before laying out, since a builder update mutates the store and requests a layout in the same tick.

**Known remaining limitation (cosmetic, not blocking):** the connection into a freshly-collapsed group's chip can still render with a slight curve instead of perfectly straight, in some timing scenarios during streaming. Groups no longer overlap or drift, which was the reported bug.

**This is reported and will be addressed as a separate issue.**

## How to test

1. Open the AI Assistant and ask it to build a multi-step workflow that naturally splits into stages, e.g.:
   > Build a WhatsApp automation that: receives incoming messages, saves them to Google Sheets, sends them to an AI model for a reply, sends the reply back on WhatsApp, and notifies a human by email if the AI isn't confident.
2. Let it generate the workflow (accept the default answers to its clarifying questions, or skip credential setup).
3. Confirm the resulting canvas groups are spaced apart, not overlapping.
4. Manually pulling the tidy-up (the brush icon, or Shift+Alt+T) should leave the layout unchanged or improve it, never worse.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5792

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

