### PR TITLE
feat: Add git-connections commands to the n8n CLI (no-changelog)

### DIFF
--- a/packages/@n8n/cli/package.json
+++ b/packages/@n8n/cli/package.json
@@ -66,6 +66,9 @@
       "source-control": {
         "description": "Pull changes from the configured source control provider"
       },
+      "git-connections": {
+        "description": "Create and manage Git repository connections"
+      },
       "package": {
         "description": "Export and import workflows as n8n packages (beta)"
       },

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -214,6 +214,38 @@ export class N8nClient {
 		return limit !== undefined ? results.slice(0, limit) : results;
 	}
 
+	// ─── Git connections ───────────────────────────────────────────
+
+	async listGitConnections(limit?: number) {
+		return await this.paginate<Record<string, unknown>>('/git-connections', {}, limit);
+	}
+
+	async getGitConnection(id: string) {
+		return await this.get<Record<string, unknown>>(`/git-connections/${id}`);
+	}
+
+	async createGitConnection(body: unknown) {
+		return await this.post<Record<string, unknown>>('/git-connections', body);
+	}
+
+	async updateGitConnection(id: string, body: unknown) {
+		return await this.put<Record<string, unknown>>(`/git-connections/${id}`, body);
+	}
+
+	async cloneGitConnection(id: string, branchName?: string) {
+		return await this.post<Record<string, unknown>>(`/git-connections/${id}/clone`, {
+			...(branchName ? { branchName } : {}),
+		});
+	}
+
+	async disconnectGitConnection(id: string) {
+		return await this.post<Record<string, unknown>>(`/git-connections/${id}/disconnect`);
+	}
+
+	async deleteGitConnection(id: string) {
+		return await this.del<undefined>(`/git-connections/${id}`);
+	}
+
 	// ─── Workflows ─────────────────────────────────────────────────
 
 	async listWorkflows(query: Record<string, string> = {}, limit?: number) {

--- a/packages/@n8n/cli/src/commands/git-connections/clone.ts
+++ b/packages/@n8n/cli/src/commands/git-connections/clone.ts
@@ -1,0 +1,19 @@
+import { Args, Flags } from '@oclif/core';
+
+import { BaseCommand } from '../../base-command';
+
+export default class GitConnectionsClone extends BaseCommand {
+	static override description = 'Clone a Git connection';
+	static override args = { id: Args.string({ description: 'Git connection ID', required: true }) };
+	static override flags = {
+		...BaseCommand.baseFlags,
+		branchName: Flags.string({ description: 'Remote branch to clone', aliases: ['branch-name'] }),
+	};
+
+	async run() {
+		const { args, flags } = await this.parse(GitConnectionsClone);
+		await this.execute(async () => {
+			this.output(await this.getClient(flags).cloneGitConnection(args.id, flags.branchName), flags);
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/git-connections/create.ts
+++ b/packages/@n8n/cli/src/commands/git-connections/create.ts
@@ -1,0 +1,20 @@
+import { Flags } from '@oclif/core';
+
+import { BaseCommand } from '../../base-command';
+
+export default class GitConnectionsCreate extends BaseCommand {
+	static override description = 'Create a Git connection from JSON';
+	static override flags = {
+		...BaseCommand.baseFlags,
+		file: Flags.string({ description: 'Path to Git connection JSON file' }),
+		stdin: Flags.boolean({ description: 'Read Git connection JSON from stdin', default: false }),
+	};
+
+	async run() {
+		const { flags } = await this.parse(GitConnectionsCreate);
+		await this.execute(async () => {
+			const body = JSON.parse(this.readInput(flags)) as unknown;
+			this.output(await this.getClient(flags).createGitConnection(body), flags);
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/git-connections/delete.ts
+++ b/packages/@n8n/cli/src/commands/git-connections/delete.ts
@@ -1,0 +1,17 @@
+import { Args } from '@oclif/core';
+
+import { BaseCommand } from '../../base-command';
+
+export default class GitConnectionsDelete extends BaseCommand {
+	static override description = 'Delete a Git connection';
+	static override args = { id: Args.string({ description: 'Git connection ID', required: true }) };
+	static override flags = { ...BaseCommand.baseFlags };
+
+	async run() {
+		const { args, flags } = await this.parse(GitConnectionsDelete);
+		await this.execute(async () => {
+			await this.getClient(flags).deleteGitConnection(args.id);
+			this.succeed(`Git connection ${args.id} deleted.`, flags, { id: args.id, deleted: true });
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/git-connections/disconnect.ts
+++ b/packages/@n8n/cli/src/commands/git-connections/disconnect.ts
@@ -1,0 +1,16 @@
+import { Args } from '@oclif/core';
+
+import { BaseCommand } from '../../base-command';
+
+export default class GitConnectionsDisconnect extends BaseCommand {
+	static override description = 'Disconnect a Git connection';
+	static override args = { id: Args.string({ description: 'Git connection ID', required: true }) };
+	static override flags = { ...BaseCommand.baseFlags };
+
+	async run() {
+		const { args, flags } = await this.parse(GitConnectionsDisconnect);
+		await this.execute(async () => {
+			this.output(await this.getClient(flags).disconnectGitConnection(args.id), flags);
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/git-connections/get.ts
+++ b/packages/@n8n/cli/src/commands/git-connections/get.ts
@@ -1,0 +1,16 @@
+import { Args } from '@oclif/core';
+
+import { BaseCommand } from '../../base-command';
+
+export default class GitConnectionsGet extends BaseCommand {
+	static override description = 'Get a Git connection by ID';
+	static override args = { id: Args.string({ description: 'Git connection ID', required: true }) };
+	static override flags = { ...BaseCommand.baseFlags };
+
+	async run() {
+		const { args, flags } = await this.parse(GitConnectionsGet);
+		await this.execute(async () => {
+			this.output(await this.getClient(flags).getGitConnection(args.id), flags);
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/git-connections/list.ts
+++ b/packages/@n8n/cli/src/commands/git-connections/list.ts
@@ -1,0 +1,21 @@
+import { Flags } from '@oclif/core';
+
+import { BaseCommand } from '../../base-command';
+
+export default class GitConnectionsList extends BaseCommand {
+	static override description = 'List Git connections';
+	static override flags = {
+		...BaseCommand.baseFlags,
+		limit: Flags.integer({ description: 'Maximum number of results' }),
+	};
+
+	async run() {
+		const { flags } = await this.parse(GitConnectionsList);
+		await this.execute(async () => {
+			const data = await this.getClient(flags).listGitConnections(flags.limit);
+			this.output(data, flags, {
+				columns: ['id', 'name', 'repositoryUrl', 'branchName', 'connectionType'],
+			});
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/git-connections/update.ts
+++ b/packages/@n8n/cli/src/commands/git-connections/update.ts
@@ -1,0 +1,21 @@
+import { Args, Flags } from '@oclif/core';
+
+import { BaseCommand } from '../../base-command';
+
+export default class GitConnectionsUpdate extends BaseCommand {
+	static override description = 'Update a Git connection from JSON';
+	static override args = { id: Args.string({ description: 'Git connection ID', required: true }) };
+	static override flags = {
+		...BaseCommand.baseFlags,
+		file: Flags.string({ description: 'Path to Git connection JSON file' }),
+		stdin: Flags.boolean({ description: 'Read Git connection JSON from stdin', default: false }),
+	};
+
+	async run() {
+		const { args, flags } = await this.parse(GitConnectionsUpdate);
+		await this.execute(async () => {
+			const body = JSON.parse(this.readInput(flags)) as unknown;
+			this.output(await this.getClient(flags).updateGitConnection(args.id, body), flags);
+		});
+	}
+}

--- a/packages/@n8n/cli/src/index.ts
+++ b/packages/@n8n/cli/src/index.ts
@@ -22,6 +22,13 @@ import ExecutionGet from './commands/execution/get';
 import ExecutionList from './commands/execution/list';
 import ExecutionRetry from './commands/execution/retry';
 import ExecutionStop from './commands/execution/stop';
+import GitConnectionsClone from './commands/git-connections/clone';
+import GitConnectionsCreate from './commands/git-connections/create';
+import GitConnectionsDelete from './commands/git-connections/delete';
+import GitConnectionsDisconnect from './commands/git-connections/disconnect';
+import GitConnectionsGet from './commands/git-connections/get';
+import GitConnectionsList from './commands/git-connections/list';
+import GitConnectionsUpdate from './commands/git-connections/update';
 import Login from './commands/login';
 import Logout from './commands/logout';
 import PackageExport from './commands/package/export';
@@ -79,6 +86,14 @@ export const commands = {
 	'execution:retry': ExecutionRetry,
 	'execution:stop': ExecutionStop,
 	'execution:delete': ExecutionDelete,
+
+	'git-connections:list': GitConnectionsList,
+	'git-connections:get': GitConnectionsGet,
+	'git-connections:create': GitConnectionsCreate,
+	'git-connections:update': GitConnectionsUpdate,
+	'git-connections:clone': GitConnectionsClone,
+	'git-connections:disconnect': GitConnectionsDisconnect,
+	'git-connections:delete': GitConnectionsDelete,
 
 	'credential:list': CredentialList,
 	'credential:get': CredentialGet,


### PR DESCRIPTION
## Summary

Adds `git-connections` commands to the `@n8n/cli` tool (PR4 of the LIGO-965 stack), wrapping the public Git connections REST API added in the base PR. Seven subcommands are registered under the `git-connections:` topic and backed by thin `N8nClient` methods that call `/git-connections`:

- `git-connections:list` — list connections (`--limit`), rendered as a table (`id`, `name`, `repositoryUrl`, `branchName`, `connectionType`)
- `git-connections:get <id>` — fetch one connection
- `git-connections:create` — create from JSON (`--file` or `--stdin`)
- `git-connections:update <id>` — update from JSON (`--file` or `--stdin`)
- `git-connections:connect <id>` — (re)connect, optional `--branch-name`
- `git-connections:disconnect <id>` — wipe the local clone
- `git-connections:delete <id>` — delete a connection

The commands follow the existing CLI conventions (`BaseCommand`, `getClient`, `output`/`succeed`, shared base flags) and reuse the client's standard `paginate` helper for listing. No secrets are echoed back — the CLI only surfaces what the API returns.

## How to test

Setup 

```bash
export N8N_URL=http://localhost:5678
export N8N_API_KEY=<API_KEY>
```

Build the CLI and point it at an n8n instance that has the Git connections feature enabled (module: git-connections; license feature: feat:gitConnections) with an API key holding the sourceControl:pull scope.

The examples use the built CLI entrypoint directly; you can alias it for brevity:

```bash
alias n8n-cli="node packages/@n8n/cli/bin/n8n-cli.mjs"
```

```bash
# LIST (optionally cap results)
n8n-cli git-connections:list
n8n-cli git-connections:list --limit 5

# CREATE — SSH (generates a keypair; response includes publicKey)
n8n-cli git-connections:create --stdin <<'EOF'
{
  "name": "my-ssh-connection",
  "repositoryUrl": "git@github.com:<owner>/<repo>.git",
  "connectionType": "ssh",
  "keyGeneratorType": "ed25519",
  "branchName": "main"
}
EOF

# CREATE — HTTPS (uses username + token)
n8n-cli git-connections:create --stdin <<'EOF'
{
  "name": "my-https-connection",
  "repositoryUrl": "https://github.com/<owner>/<repo>.git",
  "connectionType": "https",
  "username": "<git-username>",
  "password": "<personal-access-token>",
  "branchName": "main"
}
EOF

# CREATE from a file instead of stdin
n8n-cli git-connections:create --file ./connection.json

# GET
n8n-cli git-connections:get <id>

# UPDATE (only send the fields you want to change)
echo '{"name":"renamed","branchName":"develop"}' | n8n-cli git-connections:update <id> --stdin

# CONNECT (clones the repo; branch optional if already set on the connection)
n8n-cli git-connections:connect <id>
n8n-cli git-connections:connect <id> --branch-name main

# DISCONNECT (removes local clone, keeps the connection + credentials)
n8n-cli git-connections:disconnect <id>

# DELETE
n8n-cli git-connections:delete <id>
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-965

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

