### PR TITLE
refactor: Guard the Browser Use extension probe with an in-flight flag

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupContent.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupContent.vue
@@ -39,17 +39,17 @@ const extensionState = ref<BrowserUseExtensionState>('unknown');
 const isExtensionMissing = computed(() => extensionState.value === 'not-installed');
 const isExtensionInstalled = computed(() => extensionState.value === 'installed');
 let refreshTimer: ReturnType<typeof setTimeout> | undefined;
-let extensionProbeId = 0;
+let isProbingExtension = false;
 
 async function refreshExtensionState(): Promise<void> {
-	if (!isBrowserSupported || store.browserConnected) return;
+	// Returning to the tab can fire both triggers below, so skip a probe while one is in flight.
+	if (!isBrowserSupported || store.browserConnected || isProbingExtension) return;
 
-	// Returning to the tab can fire both triggers below, so let the newest probe win rather
-	// than whichever settles last.
-	const probeId = ++extensionProbeId;
-	const state = await detectBrowserUseExtension();
-	if (probeId === extensionProbeId) {
-		extensionState.value = state;
+	isProbingExtension = true;
+	try {
+		extensionState.value = await detectBrowserUseExtension();
+	} finally {
+		isProbingExtension = false;
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
@@ -156,6 +156,17 @@ describe('BrowserUseSetupModal', () => {
 		expect(getByTestId('browser-use-open-connect-page')).not.toBeDisabled();
 	});
 
+	it('probes once when both return triggers fire together', async () => {
+		await renderWithExtensionState('not-installed');
+		detectExtensionMock.mockClear();
+
+		document.dispatchEvent(new Event('visibilitychange'));
+		window.dispatchEvent(new Event('focus'));
+		await flushPromises();
+
+		expect(detectExtensionMock).toHaveBeenCalledTimes(1);
+	});
+
 	it('does not render the connect steps when already connected', () => {
 		settingsStoreMock.mockReturnValue(makeSettingsStore({ browserConnected: true }));
 		const { queryByTestId } = renderComponent();


### PR DESCRIPTION
## Summary

Follow-up to a review nit on #36235 (already merged).

The extension probe in `BrowserUseSetupContent.vue` used a monotonic probe-id counter so the newest probe's result won. That meant every trigger did a `fetch`, and all but one of the results were thrown away. A boolean in-flight guard is simpler: a trigger that arrives while a probe is running is skipped, so only one fetch happens.

```ts
let isProbingExtension = false;

async function refreshExtensionState(): Promise<void> {
	// Returning to the tab can fire both triggers below, so skip a probe while one is in flight.
	if (!isBrowserSupported || store.browserConnected || isProbingExtension) return;

	isProbingExtension = true;
	try {
		extensionState.value = await detectBrowserUseExtension();
	} finally {
		isProbingExtension = false;
	}
}
```

Behaviour is otherwise unchanged

## How to test


1. Open the Browser Use setup modal without the extension installed — the install step and the "extension missing" note show.
2. Install the extension, then switch back to the n8n tab.
3. The modal drops the install step and enables the connect button, same as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5730

Follows up on https://github.com/n8n-io/n8n/pull/36235#discussion_r3782288571

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

