### PR TITLE
test(editor): Harden AgentBuilderView MCP-toggle tests against a droped toggle

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import-x/no-extraneous-dependencies, @typescript-eslint/no-unsafe-assignment -- test-only patterns: @vue/test-utils is a transitive devDep and private-state reads */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mount, flushPromises } from '@vue/test-utils';
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
 import { nextTick, ref, computed, reactive } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { MAX_AGENT_KNOWLEDGE_BASE_SIZE_BYTES } from '@n8n/api-types';
@@ -395,6 +395,26 @@ async function renderView({
 	});
 	if (waitForAsyncSetup) await flushPromises();
 	return wrapper;
+}
+
+/**
+ * The view renders the editor column as soon as `initialize()` settles, including
+ * the path where the agent failed to load — and then drops `toggle-mcp-access`
+ * without a trace, because the handler bails on a null agent. Assert the agent is
+ * there first, so a mount problem reports itself instead of surfacing later as an
+ * autosave spy with zero calls.
+ */
+function expectMcpToggleIsAccepted(editorColumn: ReturnType<VueWrapper['findComponent']>) {
+	expect(editorColumn.props('agent')).toBeTruthy();
+}
+
+/**
+ * `agentAvailableInMcp` flips the moment the handler accepts the toggle, so it
+ * proves the autosave was queued — rather than trusting that one tick was enough
+ * before the assertion or the agent switch that flushes it.
+ */
+function expectMcpToggleWasRegistered(editorColumn: ReturnType<VueWrapper['findComponent']>) {
+	expect(editorColumn.props('agentAvailableInMcp')).toBe(true);
 }
 
 async function startArtifactPreviewSend(
@@ -1586,10 +1606,11 @@ describe('AgentBuilderView — preview routing', { timeout: 60_000 }, () => {
 
 		vi.useFakeTimers();
 		try {
-			wrapper
-				.findComponent({ name: 'AgentBuilderEditorColumn' })
-				.vm.$emit('toggle-mcp-access', true);
+			const editorColumn = wrapper.findComponent({ name: 'AgentBuilderEditorColumn' });
+			expectMcpToggleIsAccepted(editorColumn);
+			editorColumn.vm.$emit('toggle-mcp-access', true);
 			await nextTick();
+			expectMcpToggleWasRegistered(editorColumn);
 			await vi.advanceTimersByTimeAsync(500);
 			expect(toggleAgentMcpAccess).toHaveBeenCalledExactlyOnceWith('a2', true);
 		} finally {
@@ -2071,12 +2092,15 @@ describe('AgentBuilderView — three-column shell', () => {
 			unchangedIds: [],
 		});
 
+		// Fake timers hold the debounce open, so the agent switch below — not the
+		// timer — is what flushes the pending toggle.
 		vi.useFakeTimers();
 		try {
-			wrapper
-				.findComponent({ name: 'AgentBuilderEditorColumn' })
-				.vm.$emit('toggle-mcp-access', true);
+			const editorColumn = wrapper.findComponent({ name: 'AgentBuilderEditorColumn' });
+			expectMcpToggleIsAccepted(editorColumn);
+			editorColumn.vm.$emit('toggle-mcp-access', true);
 			await nextTick();
+			expectMcpToggleWasRegistered(editorColumn);
 
 			await wrapper.setProps({ artifactAgentId: 'a2' });
 			await flushPromises();


### PR DESCRIPTION
## Summary

Both MCP-toggle tests fail intermittently on master with `Number of calls: 0` on the autosave spy. Update expectation to fix flake.

## How to test


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-402


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

