### PR TITLE
docs(Kafka Node): Note that version 2 stays off-default until general availability (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Kafka/Kafka.node.ts
+++ b/packages/nodes-base/nodes/Kafka/Kafka.node.ts
@@ -11,6 +11,8 @@ export class Kafka extends VersionedNodeType {
 			name: 'kafka',
 			icon: { light: 'file:kafka.svg', dark: 'file:kafka.dark.svg' },
 			group: ['transform'],
+			// Version 2 is deliberately not the default until general availability;
+			// beta users opt in by importing a workflow with typeVersion 2.
 			defaultVersion: 1,
 			description: 'Sends messages to a Kafka topic',
 		};

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -11,6 +11,8 @@ export class KafkaTrigger extends VersionedNodeType {
 			name: 'kafkaTrigger',
 			icon: { light: 'file:kafka.svg', dark: 'file:kafka.dark.svg' },
 			group: ['trigger'],
+			// Version 2 is deliberately not the default until general availability;
+			// beta users opt in by importing a workflow with typeVersion 2.
 			defaultVersion: 1.3,
 			description: 'Consume messages from a Kafka topic',
 		};


### PR DESCRIPTION
## Summary

Comment-only change for the Kafka v2 beta packaging ([ENT-228](https://linear.app/n8n/issue/ENT-228)): both versioned entry points keep their pre-v2 defaults (`defaultVersion: 1` for the node, explicit `1.3` for the trigger), now with a comment stating that version 2 is deliberately not the default until general availability. Beta users opt in by importing a workflow with `typeVersion: 2`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-228

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [ ] Tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

