### PR TITLE
fix(HomeAssistant Node): Only sent Home Assistant attributes on upsert if set

### DIFF
--- a/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
@@ -252,17 +252,17 @@ export class HomeAssistant implements INodeType {
 							attributes: IDataObject[];
 						};
 
-						const body = {
+						const body: { state: string; attributes?: IDataObject } = {
 							state,
-							attributes: {},
 						};
 
 						if (Object.entries(stateAttributes).length) {
 							if (stateAttributes.attributes !== undefined) {
-								stateAttributes.attributes.map((attribute) => {
-									// @ts-ignore
-									body.attributes[attribute.name as string] = attribute.value;
+								const attributes: IDataObject = {};
+								stateAttributes.attributes.forEach((attribute) => {
+									attributes[attribute.name as string] = attribute.value;
 								});
+								body.attributes = attributes;
 							}
 						}
 

--- a/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
@@ -10,6 +10,7 @@ import {
 	type INodeType,
 	type INodeTypeDescription,
 	NodeConnectionTypes,
+	setSafeObjectProperty,
 } from 'n8n-workflow';
 
 import { cameraProxyFields, cameraProxyOperations } from './CameraProxyDescription';
@@ -260,7 +261,7 @@ export class HomeAssistant implements INodeType {
 							if (stateAttributes.attributes !== undefined) {
 								const attributes: IDataObject = {};
 								stateAttributes.attributes.forEach((attribute) => {
-									attributes[attribute.name as string] = attribute.value;
+									setSafeObjectProperty(attributes, attribute.name as string, attribute.value);
 								});
 								body.attributes = attributes;
 							}

--- a/packages/nodes-base/nodes/HomeAssistant/test/HomeAssistant.node.test.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/test/HomeAssistant.node.test.ts
@@ -1,0 +1,121 @@
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INode,
+	INodeExecutionData,
+	IPairedItemData,
+} from 'n8n-workflow';
+
+import * as GenericFunctions from '../GenericFunctions';
+import { HomeAssistant } from '../HomeAssistant.node';
+import type { MockedFunction } from 'vitest';
+
+vi.mock('../GenericFunctions');
+
+describe('HomeAssistant Node', () => {
+	let homeAssistant: HomeAssistant;
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+
+	const mockHomeAssistantApiRequest = GenericFunctions.homeAssistantApiRequest as MockedFunction<
+		typeof GenericFunctions.homeAssistantApiRequest
+	>;
+
+	const mockNode: INode = {
+		id: 'test-node-id',
+		name: 'Home Assistant',
+		type: 'n8n-nodes-base.homeAssistant',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+
+	beforeEach(() => {
+		homeAssistant = new HomeAssistant();
+		mockExecuteFunctions = mock<IExecuteFunctions>({
+			helpers: {
+				constructExecutionMetaData: vi.fn(
+					(
+						data: INodeExecutionData[],
+						options: { itemData: IPairedItemData | IPairedItemData[] },
+					) => {
+						const itemIndex =
+							(Array.isArray(options?.itemData)
+								? options.itemData[0]?.item
+								: options?.itemData?.item) ?? 0;
+						return data.map((item) => ({ ...item, pairedItem: { item: itemIndex } }));
+					},
+				),
+				returnJsonArray: vi.fn((data: IDataObject | IDataObject[]) =>
+					Array.isArray(data) ? data.map((d) => ({ json: d })) : [{ json: data }],
+				),
+			},
+		});
+
+		vi.clearAllMocks();
+
+		mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
+		mockExecuteFunctions.continueOnFail.mockReturnValue(false);
+	});
+
+	describe('State resource - upsert', () => {
+		it('should not send an attributes property when no attributes are set', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				const params: Record<string, unknown> = {
+					resource: 'state',
+					operation: 'upsert',
+					entityId: 'sensor.test',
+					state: 'on',
+					stateAttributes: {},
+				};
+				return params[paramName];
+			});
+
+			mockHomeAssistantApiRequest.mockResolvedValue({ entity_id: 'sensor.test', state: 'on' });
+
+			await homeAssistant.execute.call(mockExecuteFunctions);
+
+			expect(mockHomeAssistantApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/states/sensor.test',
+				{ state: 'on' },
+			);
+			// The request body must not carry an (empty) attributes property when none are provided,
+			// otherwise existing attributes on the entity would be wiped.
+			const sentBody = mockHomeAssistantApiRequest.mock.calls[0][2] as IDataObject;
+			expect(sentBody).not.toHaveProperty('attributes');
+		});
+
+		it('should send the provided attributes when they are set', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				const params: Record<string, unknown> = {
+					resource: 'state',
+					operation: 'upsert',
+					entityId: 'sensor.test',
+					state: 'on',
+					stateAttributes: {
+						attributes: [
+							{ name: 'unit_of_measurement', value: '°C' },
+							{ name: 'friendly_name', value: 'Test Sensor' },
+						],
+					},
+				};
+				return params[paramName];
+			});
+
+			mockHomeAssistantApiRequest.mockResolvedValue({ entity_id: 'sensor.test', state: 'on' });
+
+			await homeAssistant.execute.call(mockExecuteFunctions);
+
+			expect(mockHomeAssistantApiRequest).toHaveBeenCalledWith('POST', '/states/sensor.test', {
+				state: 'on',
+				attributes: {
+					unit_of_measurement: '°C',
+					friendly_name: 'Test Sensor',
+				},
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/HomeAssistant/test/HomeAssistant.node.test.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/test/HomeAssistant.node.test.ts
@@ -117,5 +117,37 @@ describe('HomeAssistant Node', () => {
 				},
 			});
 		});
+
+		it('should not write unsafe prototype-polluting attribute keys', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				const params: Record<string, unknown> = {
+					resource: 'state',
+					operation: 'upsert',
+					entityId: 'sensor.test',
+					state: 'on',
+					stateAttributes: {
+						attributes: [
+							{ name: '__proto__', value: { polluted: true } },
+							{ name: 'friendly_name', value: 'Test Sensor' },
+						],
+					},
+				};
+				return params[paramName];
+			});
+
+			mockHomeAssistantApiRequest.mockResolvedValue({ entity_id: 'sensor.test', state: 'on' });
+
+			await homeAssistant.execute.call(mockExecuteFunctions);
+
+			const sentBody = mockHomeAssistantApiRequest.mock.calls[0][2] as {
+				attributes: IDataObject;
+			};
+			// The unsafe key must be skipped, and safe keys still written.
+			expect(Object.prototype.hasOwnProperty.call(sentBody.attributes, '__proto__')).toBe(false);
+			expect(sentBody.attributes).toEqual({ friendly_name: 'Test Sensor' });
+			// An unsafe assignment would reparent the object's prototype; the safe write leaves it intact.
+			expect(Object.getPrototypeOf(sentBody.attributes)).toBe(Object.prototype);
+			expect((sentBody.attributes as IDataObject).polluted).toBeUndefined();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

The Home Assistant node's `State: Upsert` operation always sent an `attributes: {}` object in the request body, even when no attributes were provided. Since Home Assistant overwrites an entity's attributes with whatever is sent, this wiped existing attributes on every upsert where the user didn't set any. This PR only includes `attributes` in the request body when the user actually provides them.

It also fixes a latent bug this exposed: the attribute-writing loop wrote to `body.attributes[...]` after that key was removed from the initial body, which threw `Cannot set properties of undefined` whenever attributes *were* set. Attributes are now collected into their own object and attached only when present.

## How to test

1. Add a **Home Assistant** node, resource **State**, operation **Upsert**.
2. Set an Entity ID and State, leave **State Attributes** empty → the request body sent is `{ state }` with no `attributes` key, so existing entity attributes are preserved.
3. Add one or more State Attributes → they're sent under `attributes` as expected.

Covered by the new unit test `packages/nodes-base/nodes/HomeAssistant/test/HomeAssistant.node.test.ts` (both paths).

## Related Linear tickets, Github issues, and Community forum posts

<!-- None. Add "closes #<issue-number>" here if this addresses a reported issue. -->

Closes #36307

Former PR, which was closed due to lack of tests: https://github.com/n8n-io/n8n/pull/13754

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

