### PR TITLE
ci: Force bundle checkout and skip npm installs on bundle sync

### DIFF
--- a/.github/scripts/rebase-bundle-branch.mjs
+++ b/.github/scripts/rebase-bundle-branch.mjs
@@ -76,7 +76,7 @@ export function rebaseBundleBranch({ git = runGit, env = process.env, log = cons
 	git(['fetch', remote, base]);
 	const baseSha = git(['rev-parse', 'FETCH_HEAD']);
 	git(['fetch', remote, bundle]);
-	git(['checkout', '-B', bundle, 'FETCH_HEAD']);
+	git(['checkout', '--force', '-B', bundle, 'FETCH_HEAD']);
 	const preHead = git(['rev-parse', 'HEAD']);
 
 	if (isAncestor(git, baseSha, preHead)) {

--- a/.github/scripts/rebase-bundle-branch.test.mjs
+++ b/.github/scripts/rebase-bundle-branch.test.mjs
@@ -75,6 +75,10 @@ test('a clean replay force-pushes with the pre-replay tip as the lease', () => {
 	const result = rebaseBundleBranch({ git, env, log: silent });
 
 	assert.deepEqual(result, { status: 'replayed' });
+	assert.deepEqual(
+		git.calls.find((a) => a[0] === 'checkout'),
+		['checkout', '--force', '-B', 'bundle/2.x', 'FETCH_HEAD'],
+	);
 	// Commits already on the base are dropped rather than stopping the replay.
 	assert.deepEqual(git.calls.find(isRebase), ['rebase', '--empty=drop', BASE]);
 	assert.deepEqual(git.calls.find(isPush), [

--- a/.github/workflows/sec-rebase-bundle-branches.yml
+++ b/.github/workflows/sec-rebase-bundle-branches.yml
@@ -69,13 +69,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false # we push with an explicit token URL instead
 
-      # Node toolchain only — the replay runs no install and no build.
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
-        with:
-          install-command: ''
-          build-command: ''
-
       - name: Replay bundle branch onto its base
         # On a merged bundle PR, only the branch that received it needs replaying.
         # (`matrix` is not available in a job-level `if`, so the filter lives here.)


### PR DESCRIPTION
## Summary

The first trial failed on bundle/1.x due to [local changes](https://github.com/n8n-io/n8n-private/actions/runs/31791755117/job/94740006537).

Checkout doesn't need the pnpm install so opt out of it in this workflow. Should prevent any dirtying actions.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

