### PR TITLE
fix(Microsoft SharePoint Node): Render unclassified list columns as text fields (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/columns.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/columns.test.ts
@@ -197,6 +197,14 @@ const V1_CONTENT_TYPES_REPLY: IDataObject = {
 					readOnly: false,
 					type: 'unknownFutureValue',
 				},
+				{
+					displayName: 'Name',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'FileLeafRef',
+					readOnly: false,
+					type: 'unknownFutureValue',
+				},
 			],
 		},
 	],
@@ -245,7 +253,10 @@ const EXPECTED_CREATE_FIELDS = [
 	{ ...sharedFieldShape, id: 'currency', displayName: 'Currency', type: 'number' },
 	{ ...sharedFieldShape, id: 'image', displayName: 'Image', type: 'object' },
 	{ ...sharedFieldShape, id: 'lookupLookupId', displayName: 'Lookup (Lookup ID)', type: 'number' },
-	{ ...sharedFieldShape, id: 'AverageRating', displayName: 'Rating (0-5)', type: 'number' },
+	// unknownFutureValue columns must never map to a numeric input: the type also covers
+	// text columns like a Documents library's Name (FileLeafRef)
+	{ ...sharedFieldShape, id: 'AverageRating', displayName: 'Rating (0-5)', type: 'string' },
+	{ ...sharedFieldShape, id: 'FileLeafRef', displayName: 'Name', type: 'string' },
 ];
 
 const SYNTHETIC_ID_FIELD = {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/list/columns.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/list/columns.ts
@@ -31,8 +31,6 @@ const FIELD_TYPE_BY_COLUMN_TYPE: Record<string, FieldType> = {
 	text: 'string',
 	number: 'number',
 	currency: 'number',
-	// Rating columns report unknownFutureValue
-	unknownFutureValue: 'number',
 	boolean: 'boolean',
 	dateTime: 'dateTime',
 	thumbnail: 'object',
@@ -95,6 +93,8 @@ function toMapperFields(column: SharePointListColumn): ResourceMapperField[] {
 		id: column.name,
 		displayName: column.displayName,
 		canBeUsedToMatch: Boolean(column.enforceUniqueValues && column.required),
+		// unknownFutureValue spans text columns too (a Documents library's Name), so
+		// unclassified types get a string input — it accepts numbers, a number input rejects text
 		type: FIELD_TYPE_BY_COLUMN_TYPE[columnType] ?? 'string',
 	};
 	if (field.type === 'options') {


### PR DESCRIPTION
## Summary

In the v2 item column mapper, any list column whose type Graph can't classify (`unknownFutureValue`) was explicitly mapped to a **number** input. That type spans text columns too — most visibly the Name (`FileLeafRef`) column of every Documents library, which rendered as a number-only field that rejects filenames. Found by @Minilfat at approval of #34608; the suggested follow-up was never filed — now tracked as ENT-364.

The fix deletes the explicit mapping so unclassified types hit the existing `?? 'string'` fallback. Rating columns (the original reason for the number mapping) become text inputs, which still accept numeric values — nothing that works today breaks. Applies to Item Create, Update, and Create or Update via the shared mapper. v2 remains unregistered, so nothing is user-visible until launch (ENT-190).

## How to test

Unit tests: `cd packages/nodes-base && pnpm test nodes/Microsoft/SharePoint` (324 passing). The AverageRating (`unknownFutureValue`) expectation is flipped to `string`, and a Documents-library-shaped `Name`/`FileLeafRef` fixture pins the regression by name.

Manually (v2 is dormant): uncomment the v2 registration in `MicrosoftSharePoint.node.ts`, add the node, pick a Documents library in Item Create — the Name column is a text input.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-364

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

