### PR TITLE
fix(Microsoft SharePoint Node): Validate the site ID before sending it to Graph (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const FOLDER_ID = '01SPEVVYBKV2ZKHGJASRA2HC7MOGBMUMAA';
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file/download.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file/download.test.ts
@@ -20,7 +20,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const FILE_ID = '01SPEVVYELNAJ4S3XKNBBIEUJZOWXGE64U';
 const FILE_BYTES = Buffer.from('col1,col2\n1,2\n');

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file/update.test.ts
@@ -22,7 +22,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const FILE_ID = '01SPEVVYELNAJ4S3XKNBBIEUJZOWXGE64U';
 const ITEM_PATH = `/v1.0/sites/${ENCODED_SITE_ID}/drive/items/${FILE_ID}`;

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/file/upload.test.ts
@@ -21,7 +21,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const FOLDER_ID = '01SPEVVYBKV2ZKHGJASRA2HC7MOGBMUMAA';
 const FILE_BYTES = Buffer.from('col1,col2\n1,2\n');

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/folder.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/folder.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 
 describe('Microsoft SharePoint v2 — folder selection', () => {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/create.test.ts
@@ -17,7 +17,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const LIST_ID = '58a279af-1f06-4392-a5ed-2b37fa1d6c1d';
 const ITEMS_URL = `/v1.0/sites/${ENCODED_SITE_ID}/lists/${LIST_ID}/items`;

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/delete.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/delete.test.ts
@@ -16,7 +16,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const LIST_ID = 'list1';
 const ITEM_ID = 'item1';

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/get.test.ts
@@ -49,7 +49,8 @@ const buildSimplified = (): IDataObject => {
 	return expected;
 };
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const LIST_ID = 'list1';
 const ITEM_ID = 'item1';

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/getAll.test.ts
@@ -10,7 +10,8 @@ import { MicrosoftSharePointV2 } from '../../../v2/MicrosoftSharePointV2.node';
 // function reference (not an import), so mocking the transport module
 // wouldn't intercept that internal call. Stubbing the network helper one
 // layer down instead keeps both request helpers real and end-to-end.
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const LIST_ID = '58a279af-1f06-4392-a5ed-2b37fa1d6c1d';
 const GRAPH_BASE_URL = 'https://graph.microsoft.com';

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/index.test.ts
@@ -17,7 +17,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const LIST_ID = 'list1';
 const ITEMS_ENDPOINT = `/v1.0/sites/${ENCODED_SITE_ID}/lists/${LIST_ID}/items`;

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/columns.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/columns.test.ts
@@ -19,7 +19,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const LIST_ID = '58a279af-1f06-4392-a5ed-2b37fa1d6c1d';
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/get.test.ts
@@ -44,7 +44,8 @@ const V1_SIMPLIFIED_OUTPUT: IDataObject = {
 	displayName: 'list1',
 };
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const LIST_ID = '58a279af-1f06-4392-a5ed-2b37fa1d6c1d';
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/getAll.test.ts
@@ -11,7 +11,8 @@ import { MicrosoftSharePointV2 } from '../../../v2/MicrosoftSharePointV2.node';
 // wouldn't intercept that internal call. Stubbing the network helper one
 // layer down instead (as transport/index.test.ts does) keeps both
 // microsoftApiRequest and microsoftApiRequestAllItems real and end-to-end.
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 const GRAPH_BASE_URL = 'https://graph.microsoft.com';
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/index.test.ts
@@ -17,7 +17,8 @@ vi.mock('../../../v2/transport', async () => {
 	};
 });
 
-const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const SITE_ID =
+	'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
 
 describe('Microsoft SharePoint v2 — list search', () => {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/site.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/site.test.ts
@@ -6,7 +6,7 @@ import { mock, mockDeep } from 'vitest-mock-extended';
 
 import { versionDescription } from '../../v2/actions/versionDescription';
 import { MicrosoftSharePointV2 } from '../../v2/MicrosoftSharePointV2.node';
-import { getSites, resolveSiteId, siteRLC } from '../../v2/site';
+import { getSites, resolveSiteId, SITE_ID_REGEX, siteRLC } from '../../v2/site';
 import * as transport from '../../v2/transport';
 import type * as _importType0 from '../../v2/transport';
 
@@ -198,7 +198,9 @@ describe('Microsoft SharePoint v2 — resolveSiteId', () => {
 		vi.clearAllMocks();
 		ctx = mockDeep<IExecuteFunctions>();
 		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
-		apiRequest.mockResolvedValue({ id: 'contoso.sharepoint.com,g1,g2' });
+		apiRequest.mockResolvedValue({
+			id: 'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE',
+		});
 	});
 
 	// Graph documents both shapes: a bare hostname addresses that host's root
@@ -230,7 +232,9 @@ describe('Microsoft SharePoint v2 — resolveSiteId', () => {
 	])('resolves %s via the documented Graph addressing', async (_name, url, endpoint) => {
 		setSite({ mode: 'url', value: url });
 
-		await expect(resolveSiteId.call(ctx, 0)).resolves.toBe('contoso.sharepoint.com,g1,g2');
+		await expect(resolveSiteId.call(ctx, 0)).resolves.toBe(
+			'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE',
+		);
 
 		expect(apiRequest).toHaveBeenCalledWith('GET', endpoint, {}, { $select: 'id' });
 	});
@@ -261,11 +265,52 @@ describe('Microsoft SharePoint v2 — resolveSiteId', () => {
 		);
 	});
 
-	it('returns an ID as given, without a request', async () => {
-		setSite({ mode: 'id', value: 'contoso.sharepoint.com,g1,g2' });
+	const COMPOSITE_ID =
+		'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE';
 
-		await expect(resolveSiteId.call(ctx, 0)).resolves.toBe('contoso.sharepoint.com,g1,g2');
+	it.each([
+		['a composite hostname,GUID,GUID ID', COMPOSITE_ID],
+		['a bare site GUID', '2C712604-1370-44E7-A1F5-426573FDA80A'],
+		['a bare hostname', 'contoso.sharepoint.com'],
+		['the literal "root"', 'root'],
+	])('returns %s as given, without a request', async (_name, value) => {
+		setSite({ mode: 'id', value });
+
+		await expect(resolveSiteId.call(ctx, 0)).resolves.toBe(value);
 		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	// The live repro was a composite ID pasted with a trailing quote, forwarded
+	// to Graph verbatim and answered with a raw 400 that never named the field
+	it.each([
+		['a trailing quote', `${COMPOSITE_ID}"`],
+		['an embedded space', COMPOSITE_ID.replace(',2D', ', 2D')],
+		['a site URL pasted into ID mode', 'https://contoso.sharepoint.com/sites/a'],
+	])('rejects an ID with %s before any request', async (_name, value) => {
+		setSite({ mode: 'id', value });
+
+		await expect(resolveSiteId.call(ctx, 0)).rejects.toThrow("The 'Site' ID is not valid");
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it("does not regex-check list-mode values — they come from Graph's own search", async () => {
+		setSite({ mode: 'list', value: 'not a valid typed id "at all"' });
+
+		await expect(resolveSiteId.call(ctx, 0)).resolves.toBe('not a valid typed id "at all"');
+	});
+
+	it('validates typed IDs in the By ID mode with the same pattern the runtime guard uses', () => {
+		const idMode = siteRLC.modes?.find((mode) => mode.name === 'id');
+
+		expect(idMode?.validation).toEqual([
+			{
+				type: 'regex',
+				properties: {
+					regex: SITE_ID_REGEX,
+					errorMessage: expect.stringContaining('hostname,GUID,GUID'),
+				},
+			},
+		]);
 	});
 
 	it('resolves a repeated site URL once when given a per-run cache', async () => {
@@ -273,10 +318,10 @@ describe('Microsoft SharePoint v2 — resolveSiteId', () => {
 		const siteIdCache = new Map<string, string>();
 
 		await expect(resolveSiteId.call(ctx, 0, siteIdCache)).resolves.toBe(
-			'contoso.sharepoint.com,g1,g2',
+			'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE',
 		);
 		await expect(resolveSiteId.call(ctx, 1, siteIdCache)).resolves.toBe(
-			'contoso.sharepoint.com,g1,g2',
+			'contoso.sharepoint.com,2C712604-1370-44E7-A1F5-426573FDA80A,2D2244C3-251A-49EA-93A8-39E1C3A060FE',
 		);
 
 		expect(apiRequest).toHaveBeenCalledTimes(1);

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/site/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/site/index.ts
@@ -19,6 +19,15 @@ import {
 // it, and the URL resolution — so later actions and the future trigger plug
 // it in without their own copies.
 
+const GUID = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+// Every /sites/{id} form Graph documents: composite hostname,GUID,GUID, a bare
+// site GUID, a bare hostname (tenant root), or the literal `root`
+// https://learn.microsoft.com/en-us/graph/api/site-get
+export const SITE_ID_REGEX = `^(?:root|${GUID}|[a-zA-Z0-9][a-zA-Z0-9.-]*(?:,${GUID},${GUID})?)$`;
+const SITE_ID_PATTERN = new RegExp(SITE_ID_REGEX);
+const SITE_ID_FORMATS_HINT =
+	'Use the ID from the site picker or Graph (hostname,GUID,GUID), a site GUID, a hostname, or "root". For a site address, switch the field to URL mode.';
+
 export const siteRLC: INodeProperties = {
 	displayName: 'Site',
 	name: 'site',
@@ -56,6 +65,15 @@ export const siteRLC: INodeProperties = {
 			name: 'id',
 			type: 'string',
 			placeholder: 'e.g. contoso.sharepoint.com,5a58bb09-…,9f0d…',
+			validation: [
+				{
+					type: 'regex',
+					properties: {
+						regex: SITE_ID_REGEX,
+						errorMessage: SITE_ID_FORMATS_HINT,
+					},
+				},
+			],
 		},
 	],
 };
@@ -149,6 +167,13 @@ export async function resolveSiteId(
 	if (value === '') {
 		throw new NodeOperationError(this.getNode(), "The 'Site' parameter is empty", {
 			description: 'Set the site ID or URL and try again.',
+		});
+	}
+	// The field's typed validation doesn't run for expression-provided values,
+	// so ID mode re-checks here; list-mode values come from Graph's own search.
+	if (site.mode === 'id' && !SITE_ID_PATTERN.test(value)) {
+		throw new NodeOperationError(this.getNode(), "The 'Site' ID is not valid", {
+			description: `${SITE_ID_FORMATS_HINT} Check for stray characters such as quotes.`,
 		});
 	}
 	if (site.mode !== 'url') {


### PR DESCRIPTION
## Summary

The v2 Site field's **By ID** mode accepted any string and forwarded it to Graph verbatim — a pasted ID carrying a stray character (a trailing quote was the live case found in review of #34061) produced a raw Graph 400 that never named the Site field. This matters more since #35369 explicitly steers per-site-permission users into ID mode. Tracked as ENT-365.

Two layers, mirroring how the By URL mode already validates:

- **Typed validation** on the By ID mode with a regex accepting every `/sites/{id}` form Graph documents: the composite `hostname,GUID,GUID` (what the picker and Graph return), a bare site GUID, a bare hostname (tenant root), and `root`.
- **Runtime guard** in `resolveSiteId` with the same pattern — typed validation doesn't run for expression-provided values — failing with an error that names the Site field and the accepted formats before any request is sent. List-mode values are untouched (they come from Graph's own search).

Test fixtures using the placeholder composite `contoso.sharepoint.com,g1,g2` were updated to real GUIDs across the v2 suites so they represent IDs Graph would actually issue. v2 remains unregistered — nothing user-visible until launch (ENT-190).

## How to test

Unit tests: `cd packages/nodes-base && pnpm test nodes/Microsoft/SharePoint` (324 passing). New cases pin all four accepted formats, the trailing-quote rejection (the original live repro), embedded-space and pasted-URL rejections, list-mode passthrough, and that the By ID mode's UI validation uses the same pattern as the runtime guard.

Manually (v2 is dormant): uncomment the v2 registration, switch the Site field to By ID, type an ID with a trailing quote — the field shows a validation message instead of failing at run time with a raw Microsoft error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-365

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

