### PR TITLE
docs: Instruct ASD-STE100 writing style in shared agent skills (no-changelog)

### DIFF
--- a/.agents/skills/content-design/SKILL.md
+++ b/.agents/skills/content-design/SKILL.md
@@ -111,6 +111,10 @@ When suggesting new keys, follow the existing hierarchy. Browse nearby keys in
 
 ### Language and grammar
 
+**ASD-STE100 Simplified Technical English.** Use short sentences, the active
+voice, and one instruction for each sentence. Use one approved word for each
+meaning.
+
 **US English.** Always. No exceptions.
 - Do: "categorizing", "color", "analyze"
 - Don't: "categorising", "colour", "analyse"

--- a/.agents/skills/conventions/SKILL.md
+++ b/.agents/skills/conventions/SKILL.md
@@ -13,6 +13,10 @@ Use this skill when you need quick reminders on critical patterns.
 
 ## Critical Rules (Must Follow)
 
+**Technical writing (comments, PRs, issues, docs):**
+- Write in ASD-STE100 Simplified Technical English: short sentences, the
+  active voice, one instruction for each sentence
+
 **TypeScript:**
 - Never `any` → use `unknown`
 - Prefer `satisfies` over `as` (except tests)

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -93,6 +93,9 @@ Creates GitHub PRs with titles that pass n8n's `check-pr-title` CI validation.
 
 Based on `.github/pull_request_template.md`:
 
+Write the PR body in ASD-STE100 Simplified Technical English: use short
+sentences, the active voice, and one instruction for each sentence.
+
 ### Summary Section
 - Describe what the PR does
 - Include screenshots/videos for UI changes


### PR DESCRIPTION
## Summary

Add an ASD-STE100 Simplified Technical English instruction to three shared agent skills in `.agents/skills/`:

- `conventions` — add a technical-writing rule to the critical rules.
- `create-pr` — instruct agents to write PR bodies in ASD-STE100.
- `content-design` — add ASD-STE100 as the first language rule for UI copy.

Each instruction is one short rule: use short sentences, the active voice, and one instruction for each sentence.

## How to test

Invoke one of the changed skills (for example `/n8n:create-pr`) and confirm the output follows the style. `pnpm check:skill-links` passes.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

