### PR TITLE
fix: Tell each codespace agent-worker turn that a turn is atomic (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -71,6 +71,19 @@ A turn stops after about 25 minutes (`TURN_TIMEOUT_MS`). This limit is below the
 n8n Wait limit. So the worker reports a clear message before n8n reports a
 generic timeout. Keep the worker limit below the n8n limit if you change either.
 
+**A turn is atomic, and the worker tells the session so.** The turn ends on the
+session's final message, and its children end with it: a background `Bash` task
+is killed, `Monitor` events never arrive, `PushNotification` has nowhere to go,
+and `ScheduleWakeup` never fires. The session also gets no turn of its own to
+report back in — the turn's resume URL continues one waiting n8n execution and is
+then spent, so nothing on the box can post to the thread unprompted. A session
+that backgrounds a build and signs off with "I'll verify once it finishes" is
+therefore describing something that cannot happen. The worker states this in
+`--append-system-prompt` on every turn (`turnContract`), together with a pointer
+to this file for the box-specific parts. This is only the n8n/Slack path: an
+interactive session (`pnpm session`, tmux) is long-lived, so background work,
+monitors and notifications behave normally there.
+
 ### Build and run the app in a session
 
 The prebuild already installed the dependencies and warmed the build. So a
@@ -100,8 +113,10 @@ session rarely needs a cold `pnpm install` or a full `pnpm build`. Both are slow
   turbo cache and is fast when warm.
 - To clear stale build outputs after a branch switch, run `pnpm reset`. Add
   `--full` if that does not clear it.
-- Give a long build its own turn. Do not chain an install and a full build
-  behind other work in one turn.
+- Run a long build in the foreground and give it its own turn. Backgrounding it
+  does not help: it is killed when the turn ends (see above). Do not chain an
+  install and a full build behind other work in one turn either — that is what
+  runs into the 25-minute limit.
 
 ## Flaky tools (MCP)
 

--- a/.devcontainer/codespaces/agent-worker.mjs
+++ b/.devcontainer/codespaces/agent-worker.mjs
@@ -67,11 +67,53 @@ const TURN_ENV = { ...process.env };
 if (BOX_ID) TURN_ENV.CODESPACE_NAME = BOX_ID;
 if (GITHUB_USER) TURN_ENV.GITHUB_USER = GITHUB_USER;
 
-function runClaude({ message, sessionId, cwd }) {
+const CODESPACE_DOCS = '.devcontainer/codespaces/README.md';
+
+// A session cannot be told any of this after its final message, and a system
+// prompt is not part of the resumed transcript, so send it on every turn. State
+// the turn's hard limits inline: a session that has to read a file to learn them
+// can reply before it gets there. Point at the box docs for the rest — they
+// already cover dev:up, ports, and build cost, and AGENTS.md does not.
+function turnContract(author) {
+	return [
+		'# Your runtime',
+		'You are one turn of a Slack thread, driven by an n8n workflow that runs you as a headless',
+		'`claude -p` on a GitHub codespace. Your final message is the reply that reaches Slack, so keep',
+		'it short and skip heavy markdown.',
+		author ? `You are replying to ${author}.` : '',
+		'',
+		'# A turn is atomic',
+		'The turn ends when you emit your final message, and everything you started ends with it:',
+		'background Bash tasks are killed, Monitor events never arrive, PushNotification has nowhere to',
+		'go, and ScheduleWakeup never fires. You get no turn of your own afterwards — you cannot speak',
+		'again until a human writes again. So run long work (builds, test suites, restarts) in the',
+		'foreground of this turn and wait for it, or do not start it at all. Never end a turn promising',
+		`to verify, check back, or follow up. Work that will not fit the turn limit of ~${Math.round(
+			TURN_TIMEOUT_MS / 60_000,
+		)} minutes`,
+		'should be split: do the part that fits, then say what to ask for next.',
+		'',
+		'# This box',
+		`You are on codespace ${BOX_ID ?? '(unknown)'}, not a laptop. Before you build, start, or expose`,
+		`the app, read ${CODESPACE_DOCS} ("Build and run the app in a session"). It is box-specific and`,
+		'the repo AGENTS.md does not cover it.',
+	]
+		.filter(Boolean)
+		.join('\n');
+}
+
+function runClaude({ message, sessionId, cwd, author }) {
 	const safeCwd = resolvePath(typeof cwd === 'string' && cwd ? cwd : `${ROOT}/n8n`);
 	if (safeCwd !== ROOT && !safeCwd.startsWith(ROOT + sep))
 		throw new Error(`cwd must be under ${ROOT}`);
-	const args = ['-p', '--output-format', 'json', '--dangerously-skip-permissions'];
+	const args = [
+		'-p',
+		'--output-format',
+		'json',
+		'--dangerously-skip-permissions',
+		'--append-system-prompt',
+		turnContract(typeof author === 'string' ? author : ''),
+	];
 	if (sessionId) args.push('--resume', sessionId);
 	args.push(message);
 	return new Promise((res, rej) => {


### PR DESCRIPTION
## Summary

The codespace agent worker runs every turn as a one-shot `claude -p`, so a session's children die with it: a background `Bash` task is killed, `Monitor` events never arrive, `PushNotification` has nowhere to go, and `ScheduleWakeup` never fires. The turn's resume URL continues one waiting n8n execution and is then spent, so nothing on the box can post to the Slack thread unprompted.

Nothing told the session that. A Slack-driven session backgrounded an `n8n-editor-ui` build, signed off with *"I'll verify once it finishes"*, and the build was killed 16 seconds later when the turn ended (`SIGTERM`, mid-`transforming...`) — so the change it was asked for never reached `dist`, and the promised follow-up could never happen.

`README.md` already said *"give a long build its own turn"*, but that reads as advice about **duration**, which backgrounding appears to satisfy. It also lives in a file a turn-path session has no reason to open — `AGENTS.md` says nothing about turns.

This passes the constraint on every turn via `--append-system-prompt` (`turnContract`), in three parts:

- **Your runtime** — one turn of a Slack thread; the final message *is* the reply, so keep it short. Names the author, taken from `turn.author` (already on the turn, previously only logged).
- **A turn is atomic** — stated inline, because a session that has to read a file to learn this can reply before it gets there. Turn limit is interpolated from `TURN_TIMEOUT_MS` so it cannot drift.
- **This box** — names the codespace and points at `.devcontainer/codespaces/README.md` ("Build and run the app in a session") rather than duplicating `dev:up`, port and rebuild guidance.

Sent on every turn because a system prompt is not part of the resumed transcript, so `--resume` would not carry it.

**Wording matters more than expected.** Given a 6-minute build and only the mechanism ("background tasks are killed"), a session still answered *"Background it — 6 minutes is too long to block on."* The committed text states the decision rule instead — foreground it or do not start it, never promise to follow up — and a session given the real cat request then planned `pnpm dev:up --build` in the foreground, in-turn, correctly citing that `dev:be` serves the built editor from `dist`.

No behaviour change for interactive sessions (`pnpm session`, tmux): those are long-lived, so background work, monitors and notifications keep working there. The README now says so explicitly.

## How to test

No n8n instance or license needed — this only affects the codespace worker.

1. Check the flag composes with the worker's arg shape:
   ```bash
   claude -p --output-format json --dangerously-skip-permissions \
     --append-system-prompt 'test' 'Reply OK' | jq .is_error   # false
   ```
2. Render the injected text and eyeball it:
   ```bash
   node -e "const s=require('fs').readFileSync('.devcontainer/codespaces/agent-worker.mjs','utf8');
   const m=s.match(/function turnContract[\s\S]*?\n}/);
   console.log(new Function('TURN_TIMEOUT_MS','BOX_ID','CODESPACE_DOCS', m[0]+'; return turnContract;')(1500000,'my-box','.devcontainer/codespaces/README.md')('Some One'))"
   ```
3. Behavioural check — pass that text as `--append-system-prompt` and ask for something needing a multi-minute build. Expect a foreground build in the same turn, and no "I'll check back" sign-off.
4. On a box with the worker running, send a turn from Slack and confirm `/tmp/agent-worker.log` still shows the turn handled normally.

`node --check` and `biome check` pass on the changed script.

## Related Linear tickets, Github issues, and Community forum posts

None — found while investigating why a Slack-driven turn reported a build it had not finished.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- .devcontainer/codespaces/README.md updated in this PR -->
- [ ] Tests included. <!-- Dev tooling outside the test surface; verified manually as described above -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

