### PR TITLE
ci: Build the Kafka native binding on the Docker image's Node version

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -145,7 +145,10 @@ runs:
       shell: bash
       run: node .github/scripts/verify-safechain.mjs
 
+    # Confluent ships no Node 26 prebuilt and its vendored librdkafka cannot build
+    # inside node_modules: https://github.com/confluentinc/confluent-kafka-javascript/issues/397
     - name: Skip Kafka native build (no Node 26 prebuilds)
+      if: ${{ startsWith(inputs.node-version, '26.') }}
       shell: bash
       run: |
         node -e "

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -149,6 +149,8 @@ jobs:
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs
         with:
+          # The image copies native bindings from the host build, so both need the same Node.
+          node-version: ${{ env.NODE_VERSION }}
           build-command: pnpm build:n8n
           enable-docker-cache: 'true'
         env:
@@ -175,7 +177,7 @@ jobs:
             ${{ needs.determine-build-context.outputs.push_to_docker == 'true' && '--include-docker' || '' }}
 
           echo "=== Generated Docker Tags ==="
-          cat "$GITHUB_OUTPUT" | grep "_tags=" | while IFS='=' read -r key value; do
+          grep "_tags=" "$GITHUB_OUTPUT" | while IFS='=' read -r key value; do
             echo "${key}: ${value%%,*}..."  # Show first tag for brevity
           done
 

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build full chain (no cache)
         uses: ./.github/actions/setup-nodejs
         with:
+          # Keep in sync with NODE_VERSION in docker/images/n8n/Dockerfile: the image
+          # copies native bindings from the host build.
+          node-version: '24.18.1'
           build-command: 'pnpm build:docker:clean'
           enable-docker-cache: true
 


### PR DESCRIPTION
#34032 switched the `setup-nodejs` default to Node 26.5.1 and added an unconditional step that strips `@confluentinc/kafka-javascript` from `onlyBuiltDependencies`. The Docker workflows never pinned `node-version`, so they inherited Node 26 while still building a Node 24 image, and the native binding was never built at all. So every image pushed since then fails the Kafka smoke check ([example run](https://github.com/n8n-io/n8n/actions/runs/31794168829/job/94747522037)).

## Fix

- Condition the skip step on Node 26.
- Pin `docker-build-push` and `docker-build-smoke` to the Node version their image runs.