### PR TITLE
fix(editor): Show agent context after assistant handoff

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -685,7 +685,7 @@ function isCurrentThreadRuntime(): boolean {
 
 const composerContextChip = computed(() => {
 	const agentAttachment = currentAgentAttachment.value;
-	if (pendingAgentAttachment.value?.pending && agentAttachment) {
+	if (agentAttachment && pendingComposerContext.value?.source !== 'agent-preview') {
 		return {
 			key: `pending-agent:${agentAttachment.id}`,
 			label: agentAttachment.name ?? i18n.baseText('agents.new.defaultName'),
@@ -1017,7 +1017,7 @@ function dismissPendingComposerContext(key: string): boolean {
 async function dismissComposerContextChip() {
 	if (!composerContextChip.value) return;
 
-	if (pendingAgentAttachment.value?.pending) {
+	if (pendingAgentAttachment.value && pendingComposerContext.value?.source !== 'agent-preview') {
 		clearPendingAgentAttachment(props.threadId);
 		pendingAgentAttachment.value = null;
 		return;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -1278,7 +1278,7 @@ describe('InstanceAiThreadView', () => {
 		);
 	});
 
-	it('detaches dismissed new-agent context without closing its preview', async () => {
+	it('detaches dismissed saved-agent context without closing its preview', async () => {
 		thread.sseState = 'disconnected';
 		vi.mocked(thread.loadHistoricalMessages).mockResolvedValue('skipped');
 		thread.producedArtifacts = new Map([
@@ -1288,22 +1288,21 @@ describe('InstanceAiThreadView', () => {
 					type: 'agent',
 					id: 'agent-1',
 					projectId: 'project-1',
-					name: 'New Agent',
-					pending: true,
+					name: 'Support Agent',
 				},
 			],
 		]) as typeof thread.producedArtifacts;
 		stashPendingAgentAttachment('thread-1', {
 			type: 'agent',
 			id: 'agent-1',
-			name: 'New Agent',
+			name: 'Support Agent',
 			projectId: 'project-1',
-			pending: true,
 		});
 
 		const { findByTestId, getByTestId } = renderView({ props: { threadId: 'thread-1' } });
 		const preview = await findByTestId('instance-ai-agent-preview-stub');
 
+		expect(getByTestId('instance-ai-input-context-chip')).toHaveTextContent('Support Agent');
 		await userEvent.click(getByTestId('instance-ai-input-dismiss-context-chip'));
 
 		expect(getPendingAgentAttachment('thread-1')).toBeNull();


### PR DESCRIPTION
## Summary

- Show the saved agent context in the Instance AI chat input before the user sends a message.
- Let the user dismiss the context without closing the agent preview.

## How to test

1. Open a saved agent in the Agent Builder.
2. Select **Assistant**.
3. Confirm that the agent name appears in the Instance AI chat input before you send a message.
4. Dismiss the context chip and confirm that the agent preview stays open.

Run the focused regression test:

`pnpm test src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts -t \"detaches dismissed saved-agent context without closing its preview\"`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-661

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

