### PR TITLE
fix(ai-builder): Bind task-initialised sessions to channels when channel integration set

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -684,6 +684,49 @@ describe('AgentChatBridge — consumeStream', () => {
 			);
 		});
 
+		it('continues a bound originating session on a subscribed follow-up', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread('slack:D123');
+			const messageContextStore = mock<IntegrationMessageContextService>();
+			messageContextStore.getLatest.mockResolvedValue(null);
+			messageContextStore.resolveSession.mockResolvedValue({
+				threadId: 'task-task-1-uuid',
+				resourceId: 'task:task-1',
+			});
+			const agentExecutor = makeAgentExecutor([{ type: 'finish', finishReason: 'stop' }]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				streamingIntegration,
+				messageContextStore,
+			);
+
+			await handlers.subscribed!(thread, {
+				text: 'what did you send me?',
+				author: { userId: 'u1', userName: 'user1' },
+			});
+
+			expect(messageContextStore.resolveSession).toHaveBeenCalledWith('agent-1:slack:D123');
+			expect(agentExecutor.executeForChatPublished).toHaveBeenCalledWith(
+				expect.objectContaining({
+					memory: expect.objectContaining({
+						threadId: expect.objectContaining({ id: 'task-task-1-uuid' }),
+						resourceId: 'task:task-1',
+					}),
+				}),
+			);
+			expect(messageContextStore.setLatest).toHaveBeenCalledWith(
+				'task-task-1-uuid',
+				'task:task-1',
+				expect.anything(),
+			);
+		});
+
 		it('keeps a formatted thread ID separate from the platform user memory partition', async () => {
 			const { bot, handlers } = makeBot();
 			const thread1 = makeThread('1001', { botUserId: 'bot-1' });

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -50,6 +50,7 @@ function makeBot() {
 			handlers.action = h;
 		},
 		getAdapter: vi.fn().mockReturnValue(undefined),
+		thread: vi.fn(),
 	};
 	return { bot, handlers };
 }
@@ -725,6 +726,84 @@ describe('AgentChatBridge — consumeStream', () => {
 				'task:task-1',
 				expect.anything(),
 			);
+		});
+
+		it('anchors a top-level Slack DM at the message and replies in its thread', async () => {
+			const { bot, handlers } = makeBot();
+			// A top-level DM arrives on the channel-level pseudo-thread (empty
+			// thread_ts); the conversation must anchor at the message's own ts.
+			const dmThread = makeThread('slack:D123:');
+			const anchoredThread = makeThread('slack:D123:111.222');
+			bot.thread.mockReturnValue(anchoredThread);
+			const messageContextStore = mock<IntegrationMessageContextService>();
+			messageContextStore.getLatest.mockResolvedValue(null);
+			messageContextStore.resolveSession.mockResolvedValue(null);
+			const agentExecutor = makeAgentExecutor([
+				{ type: 'text-delta', id: 't1', delta: 'Hi there' },
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				{ type: 'slack', credentialId: 'cred-1' } as unknown as AgentIntegrationConfig,
+				messageContextStore,
+			);
+
+			await handlers.mention!(dmThread, {
+				id: '111.222',
+				text: 'hello agent',
+				author: { userId: 'u1', userName: 'user1' },
+				raw: { channel: 'D123', channel_type: 'im', ts: '111.222' },
+			});
+
+			expect(bot.thread).toHaveBeenCalledWith('slack:D123:111.222');
+			expect(anchoredThread.subscribe).toHaveBeenCalled();
+			expect(dmThread.subscribe).not.toHaveBeenCalled();
+			expect(messageContextStore.resolveSession).toHaveBeenCalledWith('agent-1:slack:D123:111.222');
+			expect(agentExecutor.executeForChatPublished).toHaveBeenCalledWith(
+				expect.objectContaining({
+					memory: expect.objectContaining({
+						threadId: expect.objectContaining({ id: 'agent-1:slack:D123:111.222' }),
+					}),
+				}),
+			);
+			expect(anchoredThread.post).toHaveBeenCalled();
+			expect(dmThread.post).not.toHaveBeenCalled();
+		});
+
+		it('does not re-anchor a threaded Slack reply', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread('slack:D123:111.222');
+			const messageContextStore = mock<IntegrationMessageContextService>();
+			messageContextStore.getLatest.mockResolvedValue(null);
+			messageContextStore.resolveSession.mockResolvedValue(null);
+			const agentExecutor = makeAgentExecutor([{ type: 'finish', finishReason: 'stop' }]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				{ type: 'slack', credentialId: 'cred-1' } as unknown as AgentIntegrationConfig,
+				messageContextStore,
+			);
+
+			await handlers.subscribed!(thread, {
+				id: '111.333',
+				text: 'follow-up in the thread',
+				author: { userId: 'u1', userName: 'user1' },
+				raw: { channel: 'D123', channel_type: 'im', thread_ts: '111.222', ts: '111.333' },
+			});
+
+			expect(bot.thread).not.toHaveBeenCalled();
+			expect(messageContextStore.resolveSession).toHaveBeenCalledWith('agent-1:slack:D123:111.222');
 		});
 
 		it('keeps a formatted thread ID separate from the platform user memory partition', async () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-hitl-resume-handler.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-hitl-resume-handler.test.ts
@@ -38,9 +38,10 @@ it.each([
 				? `✅ Approved by ${user.fullName}`
 				: `✅ ${selectedLabel} selected by ${user.fullName}`,
 		settleActionMessage,
-		resolvePlatformThreadId: () =>
-			'discord:800000000000000001:700000000000000001:600000000000000001',
-		toAgentThreadId: () => ({ id: 'agent-thread-1' }) as never,
+		resolveAgentThread: async () => ({
+			threadId: { id: 'agent-thread-1' } as never,
+			origin: null,
+		}),
 		getPlatformAgentContext: () => ({}),
 		messageContextBridge: { updateLatest: vi.fn().mockResolvedValue(undefined) } as never,
 		streamConsumer: { consume: vi.fn().mockResolvedValue(undefined) } as never,
@@ -67,5 +68,54 @@ it.each([
 	});
 	expect(settleActionMessage.mock.invocationCallOrder[0]).toBeLessThan(
 		resumeForChat.mock.invocationCallOrder[0],
+	);
+});
+
+it('writes message context to the bound originating session', async () => {
+	const updateLatest = vi.fn().mockResolvedValue(undefined);
+	const thread = { post: vi.fn() };
+	const handler = new AgentChatHitlResumeHandler({
+		agentId: 'agent-1',
+		projectId: 'project-1',
+		integration: { type: 'discord', credentialId: 'cred-1' },
+		agentService: { resumeForChat: vi.fn(() => (async function* () {})()) },
+		logger: { warn: vi.fn() } as never,
+		callbackStore: {
+			resolve: vi.fn().mockResolvedValue({
+				actionId: 'resume:run-1:tool-1:0',
+				value: JSON.stringify({ approved: true }),
+				kind: 'approval',
+			}),
+		} as never,
+		deleteActionMessageBeforeResume: false,
+		settleActionMessage: vi.fn().mockResolvedValue(undefined),
+		resolveAgentThread: async () => ({
+			threadId: { id: 'task-task-1-uuid' } as never,
+			origin: { threadId: 'task-task-1-uuid', resourceId: 'task:task-1' },
+		}),
+		getPlatformAgentContext: () => ({}),
+		messageContextBridge: { updateLatest } as never,
+		streamConsumer: { consume: vi.fn().mockResolvedValue(undefined) } as never,
+		createResumeExecutionContext: async () => ({}),
+	});
+
+	await handler.handleAction({
+		actionId: 'callback-key',
+		thread,
+		threadId: 'discord:800000000000000001:700000000000000001:600000000000000001',
+		messageId: 'message-1',
+		user: { userId: 'user-1', userName: 'alice', fullName: 'Alice' },
+		adapter: { deleteMessage: vi.fn() },
+		raw: {},
+	} as never);
+
+	expect(updateLatest).toHaveBeenCalledWith(
+		'task-task-1-uuid',
+		'task:task-1',
+		thread,
+		expect.objectContaining({
+			messageId: 'message-1',
+			interactingUserId: 'user-1',
+		}),
 	);
 });

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-action-executor.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-action-executor.test.ts
@@ -118,9 +118,12 @@ describe('ChatIntegrationActionExecutor', () => {
 	});
 
 	it('posts channel messages through the selected integration connection and returns message context', async () => {
+		// A top-level Slack channel post goes through the channel-level pseudo
+		// thread (empty thread_ts); replies arrive in the thread anchored at the
+		// sent message's own ts.
 		const sentMessage = {
 			id: '123.456',
-			threadId: 'slack:C123:123.456',
+			threadId: 'slack:C123:',
 		};
 		const channel = {
 			post: vi.fn().mockResolvedValue(sentMessage),
@@ -210,18 +213,24 @@ describe('ChatIntegrationActionExecutor', () => {
 		});
 	});
 
-	it('subscribes Slack DM threads after sending messages', async () => {
+	it('subscribes the thread anchored at the sent Slack DM message', async () => {
+		// openDM returns a channel-level thread (empty thread_ts); follow-up
+		// replies arrive in the thread anchored at the sent message's ts.
 		const sentMessage = {
 			id: '123.456',
-			threadId: 'slack:D123:123.456',
+			threadId: 'slack:D123:',
 		};
-		const thread = {
-			id: 'slack:D123:123.456',
+		const dmThread = {
+			id: 'slack:D123:',
 			post: vi.fn().mockResolvedValue(sentMessage),
+		};
+		const sentThread = {
+			id: 'slack:D123:123.456',
 			subscribe: vi.fn().mockResolvedValue(undefined),
 		};
 		const chat = mock<ChatInstance>();
-		chat.openDM.mockResolvedValue(thread as never);
+		chat.openDM.mockResolvedValue(dmThread as never);
+		chat.thread.mockReturnValue(sentThread as never);
 		const chatIntegrationService = mock<ChatIntegrationService>();
 		chatIntegrationService.getChatInstance.mockReturnValue(undefined);
 		chatIntegrationService.getChatInstanceForTools.mockResolvedValue(chat);
@@ -236,8 +245,9 @@ describe('ChatIntegrationActionExecutor', () => {
 		});
 
 		expect(chatIntegrationService.getChatInstanceForTools).toHaveBeenCalledWith('agent-1', slack);
-		expect(thread.post).toHaveBeenCalledWith('Hello');
-		expect(thread.subscribe).toHaveBeenCalled();
+		expect(dmThread.post).toHaveBeenCalledWith('Hello');
+		expect(chat.thread).toHaveBeenCalledWith('slack:D123:123.456');
+		expect(sentThread.subscribe).toHaveBeenCalled();
 		expect(result).toEqual({
 			ok: true,
 			messageContext: {
@@ -254,18 +264,22 @@ describe('ChatIntegrationActionExecutor', () => {
 		});
 	});
 
-	it('binds a Slack DM thread to the originating session', async () => {
+	it('binds the sent-message thread of a Slack DM to the originating session', async () => {
 		const sentMessage = {
 			id: '123.456',
-			threadId: 'slack:D123:123.456',
+			threadId: 'slack:D123:',
 		};
-		const thread = {
-			id: 'slack:D123:123.456',
+		const dmThread = {
+			id: 'slack:D123:',
 			post: vi.fn().mockResolvedValue(sentMessage),
+		};
+		const sentThread = {
+			id: 'slack:D123:123.456',
 			subscribe: vi.fn().mockResolvedValue(undefined),
 		};
 		const chat = mock<ChatInstance>();
-		chat.openDM.mockResolvedValue(thread as never);
+		chat.openDM.mockResolvedValue(dmThread as never);
+		chat.thread.mockReturnValue(sentThread as never);
 		const chatIntegrationService = mock<ChatIntegrationService>();
 		chatIntegrationService.getChatInstance.mockReturnValue(chat);
 		const messageContextService = mock<IntegrationMessageContextService>();
@@ -289,6 +303,54 @@ describe('ChatIntegrationActionExecutor', () => {
 			'agent-1:slack:D123:123.456',
 			persistence,
 		);
+	});
+
+	it('binds the sent-message thread of a Slack channel post to the originating session', async () => {
+		const sentMessage = {
+			id: '456.789',
+			threadId: 'slack:C123:',
+		};
+		const channel = {
+			post: vi.fn().mockResolvedValue(sentMessage),
+		};
+		const sentThread = {
+			id: 'slack:C123:456.789',
+			subscribe: vi.fn().mockResolvedValue(undefined),
+		};
+		const chat = mock<ChatInstance>();
+		chat.channel.mockReturnValue(channel as never);
+		chat.thread.mockReturnValue(sentThread as never);
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const messageContextService = mock<IntegrationMessageContextService>();
+		const executor = new ChatIntegrationActionExecutor(
+			chatIntegrationService,
+			buildRegistry(),
+			messageContextService,
+		);
+		const descriptor = getIntegrationToolConnectionDescriptors([slack], 'agent-1')[0];
+		const persistence = { threadId: 'task-task-1-uuid', resourceId: 'task:task-1' };
+
+		const result = await executor.execute({
+			descriptor,
+			action: 'send_channel_message',
+			input: { channelId: 'C123', message: { text: 'Scheduled update' } },
+			awaitResponse: false,
+			persistence,
+		});
+
+		expect(chat.thread).toHaveBeenCalledWith('slack:C123:456.789');
+		expect(sentThread.subscribe).toHaveBeenCalled();
+		expect(messageContextService.bindSession).toHaveBeenCalledWith(
+			'agent-1:slack:C123:456.789',
+			persistence,
+		);
+		expect(result).toMatchObject({
+			ok: true,
+			messageContext: {
+				target: { type: 'channel', channelId: 'slack:C123', threadId: 'slack:C123:456.789' },
+			},
+		});
 	});
 
 	it('posts generic message card buttons with their labels', async () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-action-executor.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-action-executor.test.ts
@@ -58,6 +58,7 @@ import { getIntegrationToolConnectionDescriptors } from '../integration-tools';
 import { LinearIntegration } from '../platforms/linear-integration';
 import { SlackIntegration } from '../platforms/slack/slack-integration';
 import type { ChatIntegrationService, ChatInstance } from '../chat-integration.service';
+import type { IntegrationMessageContextService } from '../integration-message-context.service';
 import type { AgentIntegrationConfig } from '@n8n/api-types';
 import type { RichCardComponentType } from '@n8n/api-types';
 
@@ -251,6 +252,43 @@ describe('ChatIntegrationActionExecutor', () => {
 				updatedAt: expect.any(String),
 			},
 		});
+	});
+
+	it('binds a Slack DM thread to the originating session', async () => {
+		const sentMessage = {
+			id: '123.456',
+			threadId: 'slack:D123:123.456',
+		};
+		const thread = {
+			id: 'slack:D123:123.456',
+			post: vi.fn().mockResolvedValue(sentMessage),
+			subscribe: vi.fn().mockResolvedValue(undefined),
+		};
+		const chat = mock<ChatInstance>();
+		chat.openDM.mockResolvedValue(thread as never);
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const messageContextService = mock<IntegrationMessageContextService>();
+		const executor = new ChatIntegrationActionExecutor(
+			chatIntegrationService,
+			buildRegistry(),
+			messageContextService,
+		);
+		const descriptor = getIntegrationToolConnectionDescriptors([slack], 'agent-1')[0];
+		const persistence = { threadId: 'task-task-1-uuid', resourceId: 'task:task-1' };
+
+		await executor.execute({
+			descriptor,
+			action: 'send_dm',
+			input: { userId: 'U123', message: { text: 'Hello' } },
+			awaitResponse: false,
+			persistence,
+		});
+
+		expect(messageContextService.bindSession).toHaveBeenCalledWith(
+			'agent-1:slack:D123:123.456',
+			persistence,
+		);
 	});
 
 	it('posts generic message card buttons with their labels', async () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-message-context.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-message-context.service.test.ts
@@ -1,0 +1,85 @@
+import { mock } from 'vitest-mock-extended';
+
+import type { AgentResourceRepository } from '../../repositories/agent-resource.repository';
+import type { AgentThreadRepository } from '../../repositories/agent-thread.repository';
+import type { AgentThreadEntity } from '../../entities/agent-thread.entity';
+import { IntegrationMessageContextService } from '../integration-message-context.service';
+
+describe('IntegrationMessageContextService session bind', () => {
+	const threadRepository = mock<AgentThreadRepository>();
+	const resourceRepository = mock<AgentResourceRepository>();
+	const service = new IntegrationMessageContextService(threadRepository, resourceRepository);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		threadRepository.create.mockImplementation((value) => value as AgentThreadEntity);
+		threadRepository.save.mockImplementation(async (value) => value as AgentThreadEntity);
+		resourceRepository.existsBy.mockResolvedValue(true);
+	});
+
+	it('does not write when the derived thread is already the origin', async () => {
+		await service.bindSession('task-1', { threadId: 'task-1', resourceId: 'task:task-1' });
+
+		expect(threadRepository.findOneBy).not.toHaveBeenCalled();
+		expect(threadRepository.save).not.toHaveBeenCalled();
+	});
+
+	it('stores continueAs on a new alias row', async () => {
+		threadRepository.findOneBy.mockResolvedValue(null);
+
+		await service.bindSession('agent-1:slack:D123', {
+			threadId: 'task-1',
+			resourceId: 'task:task-1',
+		});
+
+		expect(threadRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 'agent-1:slack:D123',
+				resourceId: 'task:task-1',
+				metadata: JSON.stringify({
+					continueAs: { threadId: 'task-1', resourceId: 'task:task-1' },
+				}),
+			}),
+		);
+	});
+
+	it('overwrites continueAs on a later bind', async () => {
+		threadRepository.findOneBy.mockResolvedValue({
+			id: 'agent-1:slack:D123',
+			resourceId: 'task:task-1',
+			title: null,
+			metadata: JSON.stringify({
+				continueAs: { threadId: 'task-1', resourceId: 'task:task-1' },
+			}),
+		} as AgentThreadEntity);
+
+		await service.bindSession('agent-1:slack:D123', {
+			threadId: 'task-2',
+			resourceId: 'task:task-2',
+		});
+
+		const saved = threadRepository.save.mock.calls[0][0] as AgentThreadEntity;
+		expect(JSON.parse(saved.metadata ?? '{}')).toEqual({
+			continueAs: { threadId: 'task-2', resourceId: 'task:task-2' },
+		});
+	});
+
+	it('resolves continueAs and returns null when none is stored', async () => {
+		threadRepository.findOneBy.mockResolvedValueOnce({
+			id: 'agent-1:slack:D123',
+			metadata: JSON.stringify({
+				continueAs: { threadId: 'task-1', resourceId: 'task:task-1' },
+			}),
+		} as AgentThreadEntity);
+		threadRepository.findOneBy.mockResolvedValueOnce({
+			id: 'agent-1:slack:D456',
+			metadata: JSON.stringify({ currentMessageContext: {} }),
+		} as AgentThreadEntity);
+
+		await expect(service.resolveSession('agent-1:slack:D123')).resolves.toEqual({
+			threadId: 'task-1',
+			resourceId: 'task:task-1',
+		});
+		await expect(service.resolveSession('agent-1:slack:D456')).resolves.toBeNull();
+	});
+});

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-message-context.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-message-context.service.test.ts
@@ -43,7 +43,7 @@ describe('IntegrationMessageContextService session bind', () => {
 		);
 	});
 
-	it('overwrites continueAs on a later bind', async () => {
+	it('does not overwrite an existing binding (first write wins)', async () => {
 		threadRepository.findOneBy.mockResolvedValue({
 			id: 'agent-1:slack:D123',
 			resourceId: 'task:task-1',
@@ -58,10 +58,44 @@ describe('IntegrationMessageContextService session bind', () => {
 			resourceId: 'task:task-2',
 		});
 
-		const saved = threadRepository.save.mock.calls[0][0] as AgentThreadEntity;
-		expect(JSON.parse(saved.metadata ?? '{}')).toEqual({
-			continueAs: { threadId: 'task-2', resourceId: 'task:task-2' },
+		expect(threadRepository.save).not.toHaveBeenCalled();
+		await expect(service.resolveSession('agent-1:slack:D123')).resolves.toEqual({
+			threadId: 'task-1',
+			resourceId: 'task:task-1',
 		});
+	});
+
+	it('binds two different threads to independent sessions', async () => {
+		threadRepository.findOneBy.mockResolvedValue(null);
+
+		await service.bindSession('agent-1:slack:D123', {
+			threadId: 'task-1',
+			resourceId: 'task:task-1',
+		});
+		await service.bindSession('agent-1:slack:D456', {
+			threadId: 'task-2',
+			resourceId: 'task:task-2',
+		});
+
+		expect(threadRepository.save).toHaveBeenCalledTimes(2);
+		expect(threadRepository.save).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				id: 'agent-1:slack:D123',
+				metadata: JSON.stringify({
+					continueAs: { threadId: 'task-1', resourceId: 'task:task-1' },
+				}),
+			}),
+		);
+		expect(threadRepository.save).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				id: 'agent-1:slack:D456',
+				metadata: JSON.stringify({
+					continueAs: { threadId: 'task-2', resourceId: 'task:task-2' },
+				}),
+			}),
+		);
 	});
 
 	it('resolves continueAs and returns null when none is stored', async () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-tools.test.ts
@@ -909,6 +909,7 @@ describe('integration tools', () => {
 			expect.objectContaining({
 				action: 'send_dm',
 				input: { userId: 'U123', message: { text: 'Hello' } },
+				persistence: { threadId: 'thread-1', resourceId: 'resource-1' },
 			}),
 		);
 	});

--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
@@ -156,6 +156,29 @@ describe('SlackIntegration', () => {
 		});
 	});
 
+	describe('messageThreadId', () => {
+		it('anchors a top-level post at the sent message ts', () => {
+			expect(integration.messageThreadId({ id: '123.456', threadId: 'slack:C123:' })).toBe(
+				'slack:C123:123.456',
+			);
+			expect(integration.messageThreadId({ id: '123.456', threadId: 'slack:D123:' })).toBe(
+				'slack:D123:123.456',
+			);
+		});
+
+		it('returns undefined when the message was posted into an anchored thread', () => {
+			expect(
+				integration.messageThreadId({ id: '123.457', threadId: 'slack:C123:123.456' }),
+			).toBeUndefined();
+		});
+
+		it('returns undefined for non-Slack thread ids', () => {
+			expect(
+				integration.messageThreadId({ id: 'msg-1', threadId: 'telegram:12345' }),
+			).toBeUndefined();
+		});
+	});
+
 	describe('handleUnauthenticatedWebhook', () => {
 		it('echoes the challenge for a url_verification event', () => {
 			const result = integration.handleUnauthenticatedWebhook({

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -35,11 +35,11 @@ import { buildSuspendCardPayload, isApprovalSuspendPayload } from './agent-chat-
 import { CallbackStore, type CallbackMetadata } from './callback-store';
 import type { ComponentMapper, ShortenCallback } from './component-mapper';
 import { IntegrationMessageContextService } from './integration-message-context.service';
-import type { ReplyExpectation } from './integration-tools';
+import type { AgentSessionOrigin, ReplyExpectation } from './integration-tools';
 import { downloadDiscordAttachment } from './platforms/discord-operations';
 import type { AgentIntegrationConfig } from '@n8n/api-types';
 
-import { type InternalThread, toInternalThreadId } from './types';
+import { type InternalThread, toChatSessionThreadId, toInternalThreadId } from './types';
 
 interface AgentExecutor {
 	executeForChatPublished(config: {
@@ -102,7 +102,7 @@ export class AgentChatBridge {
 		private readonly logger: Logger,
 		private readonly n8nProjectId: string,
 		private readonly integration: AgentIntegrationConfig,
-		messageContextStore?: IntegrationMessageContextService,
+		private readonly messageContextStore?: IntegrationMessageContextService,
 		private readonly attachmentService?: AgentChatAttachmentService,
 		private readonly discordHttpClient?: HttpRequestClient,
 	) {
@@ -145,8 +145,7 @@ export class AgentChatBridge {
 			formatActionDecisionMessage: (params) =>
 				this.integrationImpl?.formatActionDecisionMessage?.(params),
 			settleActionMessage: this.integrationImpl?.settleActionMessage?.bind(this.integrationImpl),
-			resolvePlatformThreadId: this.resolvePlatformThreadId.bind(this),
-			toAgentThreadId: this.toAgentThreadId.bind(this),
+			resolveAgentThread: this.resolveAgentThread.bind(this),
 			getPlatformAgentContext: this.getPlatformAgentContext.bind(this),
 			messageContextBridge: this.messageContextBridge,
 			streamConsumer: this.streamConsumer,
@@ -275,7 +274,18 @@ export class AgentChatBridge {
 	}
 
 	private toAgentThreadId(platformThreadId: string) {
-		return toInternalThreadId(`${this.agentId}:${platformThreadId}`);
+		return toInternalThreadId(toChatSessionThreadId(this.agentId, platformThreadId));
+	}
+
+	private async resolveAgentThread(
+		thread: Thread<unknown, unknown>,
+	): Promise<{ threadId: InternalThread; origin: AgentSessionOrigin | null }> {
+		const derived = this.toAgentThreadId(this.resolvePlatformThreadId(thread));
+		const origin = (await this.messageContextStore?.resolveSession?.(derived.id)) ?? null;
+		return {
+			threadId: origin ? toInternalThreadId(origin.threadId) : derived,
+			origin,
+		};
 	}
 
 	/**
@@ -310,9 +320,10 @@ export class AgentChatBridge {
 		const inboundAttachments = message.attachments ?? [];
 		if (!text && inboundAttachments.length === 0) return;
 
-		const platformThreadId = this.resolvePlatformThreadId(thread);
-		const threadId = this.toAgentThreadId(platformThreadId);
-		const resourceId = integrationMemoryResourceId(this.integration.type, message.author.userId);
+		const { threadId, origin } = await this.resolveAgentThread(thread);
+		const resourceId =
+			origin?.resourceId ??
+			integrationMemoryResourceId(this.integration.type, message.author.userId);
 		const { attachments, attachmentNotes } = await this.storeInboundAttachments(
 			inboundAttachments,
 			threadId.id,
@@ -343,13 +354,18 @@ export class AgentChatBridge {
 				this.messageContextBridge.resolveSubject(message),
 			]);
 			statusHandle = onceStatusHandle(bridgeExecutionContext.statusHandle);
-			await this.messageContextBridge.updateLatest(threadId.id, message.author.userId, thread, {
-				messageId: message.id,
-				interactingUserId: message.author.userId,
-				...bridgeExecutionContext.platformAgentContext,
-				subject,
-				replyExpectation,
-			});
+			await this.messageContextBridge.updateLatest(
+				threadId.id,
+				origin?.resourceId ?? message.author.userId,
+				thread,
+				{
+					messageId: message.id,
+					interactingUserId: message.author.userId,
+					...bridgeExecutionContext.platformAgentContext,
+					subject,
+					replyExpectation,
+				},
+			);
 			// threadId.id is agent-prefixed for observation storage; resourceId keeps
 			// the platform user identity so episodic recall works across threads for
 			// the same user while staying isolated between users.

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -231,12 +231,13 @@ export class AgentChatBridge {
 		this.chat.onNewMention(async (thread, message) => {
 			try {
 				if (!this.canUserAccess(message.author)) return;
+				const anchoredThread = this.anchorInboundThread(thread, message);
 				const shouldSubscribe =
 					this.integrationImpl?.shouldSubscribeToNewMention?.({ thread, message }) ?? true;
 				if (shouldSubscribe) {
-					await thread.subscribe();
+					await anchoredThread.subscribe();
 				}
-				await this.executeAndStream(thread, message, { isNewMention: true });
+				await this.executeAndStream(anchoredThread, message, { isNewMention: true });
 			} catch (error) {
 				await this.postErrorToThread(thread, error);
 			}
@@ -245,7 +246,8 @@ export class AgentChatBridge {
 		this.chat.onSubscribedMessage(async (thread, message) => {
 			try {
 				if (!this.canUserAccess(message.author)) return;
-				await this.executeAndStream(thread, message, { isNewMention: false });
+				const anchoredThread = this.anchorInboundThread(thread, message);
+				await this.executeAndStream(anchoredThread, message, { isNewMention: false });
 			} catch (error) {
 				await this.postErrorToThread(thread, error);
 			}
@@ -263,6 +265,21 @@ export class AgentChatBridge {
 
 	private canUserAccess(author: Author): boolean {
 		return this.integrationImpl?.isUserAllowed?.(author, this.integration) ?? true;
+	}
+
+	/**
+	 * Re-anchor an inbound conversation at the message's own thread on
+	 * platforms where a top-level message (e.g. a Slack DM) arrives through the
+	 * channel-level pseudo-thread. Replies then open a thread under that
+	 * message, and follow-ups resolve their session and context from that
+	 * thread only.
+	 */
+	private anchorInboundThread(thread: Thread, message: Message): Thread {
+		const anchored = this.integrationImpl?.messageThreadId?.({
+			id: message.id,
+			threadId: thread.id,
+		});
+		return anchored ? this.chat.thread(anchored) : thread;
 	}
 
 	// ---------------------------------------------------------------------------

--- a/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
@@ -13,6 +13,7 @@ import { onceStatusHandle } from './agent-chat-integration';
 import type { AgentChatMessageContextBridge } from './agent-chat-message-context';
 import type { AgentChatStreamConsumer } from './agent-chat-stream-consumer';
 import type { CallbackStore } from './callback-store';
+import type { AgentSessionOrigin } from './integration-tools';
 import type { InternalThread } from './types';
 
 interface ResumeExecutor {
@@ -36,8 +37,9 @@ interface AgentChatHitlResumeHandlerOptions {
 	deleteActionMessageBeforeResume: boolean;
 	formatActionDecisionMessage?: ActionDecisionMessageFormatter;
 	settleActionMessage?: SettleActionMessage;
-	resolvePlatformThreadId: (thread: Thread<unknown, unknown>) => string;
-	toAgentThreadId: (platformThreadId: string) => InternalThread;
+	resolveAgentThread: (
+		thread: Thread<unknown, unknown>,
+	) => Promise<{ threadId: InternalThread; origin: AgentSessionOrigin | null }>;
 	getPlatformAgentContext: () => PlatformAgentContext;
 	messageContextBridge: AgentChatMessageContextBridge;
 	streamConsumer: AgentChatStreamConsumer;
@@ -76,16 +78,20 @@ export class AgentChatHitlResumeHandler {
 		// Persist the interacting user / messageId into the thread's message
 		// context so tools running on resume can read it via the message
 		// context store — no need to bolt a duplicate copy onto resumeData.
-		const platformThreadId = this.options.resolvePlatformThreadId(thread);
-		const threadId = this.options.toAgentThreadId(platformThreadId);
-		await this.options.messageContextBridge.updateLatest(threadId.id, event.user.userId, thread, {
-			messageId: event.messageId,
-			interactingUserId: event.user.userId,
-			...this.options.getPlatformAgentContext(),
-			// The resume response streams back to this thread like any chat turn,
-			// so the same reply-delivery rules apply.
-			replyExpectation: 'required',
-		});
+		const { threadId, origin } = await this.options.resolveAgentThread(thread);
+		await this.options.messageContextBridge.updateLatest(
+			threadId.id,
+			origin?.resourceId ?? event.user.userId,
+			thread,
+			{
+				messageId: event.messageId,
+				interactingUserId: event.user.userId,
+				...this.options.getPlatformAgentContext(),
+				// The resume response streams back to this thread like any chat turn,
+				// so the same reply-delivery rules apply.
+				replyExpectation: 'required',
+			},
+		);
 
 		await this.cleanUpBeforeResume(event, parsed.resumeData, callbackData);
 		await this.executeResume(thread, parsed.runId, parsed.toolCallId, parsed.resumeData);

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -356,6 +356,16 @@ export abstract class AgentChatIntegration {
 	};
 
 	/**
+	 * Thread id anchored at a message, for platforms where a top-level message
+	 * starts its own thread (e.g. Slack). Outbound sends and inbound DM
+	 * messages travel through a channel-level pseudo-thread (empty thread_ts),
+	 * while replies arrive in the thread anchored at the message's own id — so
+	 * replies, subscription, and session context must attach there. Return
+	 * undefined when the message is already in an anchored thread.
+	 */
+	messageThreadId?(message: { id: string; threadId: string }): string | undefined;
+
+	/**
 	 * Optional per-user authorisation check called on every inbound mention,
 	 * subscribed message, and action before the bridge subscribes / executes.
 	 * Default (no implementation): allow. Telegram uses this to enforce the

--- a/packages/cli/src/modules/agents/integrations/integration-action-executor.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-action-executor.ts
@@ -274,15 +274,16 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 	): Promise<IntegrationActionResult> {
 		const input = sendDmInputSchema.parse(params.input);
 		const thread = await chat.openDM(input.userId);
-		await this.prepareSentThread(params.descriptor, thread, params.persistence);
 		const sent = await thread.post(await this.toPostable(params.descriptor, input.message, params));
+		const threadId = this.sentThreadId(params.descriptor, sent) ?? thread.id;
+		await this.prepareSentThread(params.descriptor, chat.thread(threadId), params.persistence);
 
 		return {
 			ok: true,
 			messageContext: buildMessageContextFromSentMessage({
 				descriptor: params.descriptor,
 				sent,
-				target: { type: 'dm', userId: input.userId, threadId: thread.id },
+				target: { type: 'dm', userId: input.userId, threadId },
 			}),
 		};
 	}
@@ -335,12 +336,9 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 		const sent = await channel.post(
 			await this.toPostable(params.descriptor, input.message, params),
 		);
-		if (sent.threadId) {
-			await this.prepareSentThread(
-				params.descriptor,
-				chat.thread(sent.threadId),
-				params.persistence,
-			);
+		const threadId = this.sentThreadId(params.descriptor, sent);
+		if (threadId) {
+			await this.prepareSentThread(params.descriptor, chat.thread(threadId), params.persistence);
 		}
 
 		return {
@@ -348,7 +346,7 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 			messageContext: buildMessageContextFromSentMessage({
 				descriptor: params.descriptor,
 				sent,
-				target: { type: 'channel', channelId, threadId: sent.threadId },
+				target: { type: 'channel', channelId, threadId },
 			}),
 		};
 	}
@@ -398,6 +396,22 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 			agentId,
 			{ type: integration.type, credentialId },
 			metadata,
+		);
+	}
+
+	/**
+	 * Thread id where follow-ups to an outbound sent message will arrive.
+	 * Platforms where a top-level post starts its own thread (Slack) re-anchor
+	 * the id at the sent message; others keep the posting thread.
+	 */
+	private sentThreadId(
+		descriptor: IntegrationToolConnectionDescriptor,
+		sent: SentMessage,
+	): string | undefined {
+		if (!sent.threadId) return undefined;
+		const integration = this.integrationRegistry.get(descriptor.integration.type);
+		return (
+			integration?.messageThreadId?.({ id: sent.id, threadId: sent.threadId }) ?? sent.threadId
 		);
 	}
 

--- a/packages/cli/src/modules/agents/integrations/integration-action-executor.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-action-executor.ts
@@ -19,13 +19,16 @@ import {
 	normalizePlatformId,
 	unsupportedAction,
 } from './integration-helpers';
+import { IntegrationMessageContextService } from './integration-message-context.service';
 import type {
+	AgentSessionOrigin,
 	IntegrationAction,
 	IntegrationActionExecutor,
 	IntegrationActionResult,
 	IntegrationMessageContext,
 	IntegrationToolConnectionDescriptor,
 } from './integration-tools';
+import { toChatSessionThreadId } from './types';
 
 // The shared wire schema from @n8n/api-types — the same definition the tool
 // boundary validates against and the editor-ui renderer parses with.
@@ -67,17 +70,10 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 	constructor(
 		private readonly chatIntegrationService: ChatIntegrationService,
 		private readonly integrationRegistry: ChatIntegrationRegistry,
+		private readonly messageContextService?: IntegrationMessageContextService,
 	) {}
 
-	async execute(params: {
-		descriptor: IntegrationToolConnectionDescriptor;
-		action: IntegrationAction;
-		input: Record<string, unknown>;
-		awaitResponse: boolean;
-		runId?: string;
-		toolCallId?: string;
-		currentMessageContext?: IntegrationMessageContext;
-	}): Promise<IntegrationActionResult> {
+	async execute(params: ExecuteParams): Promise<IntegrationActionResult> {
 		if (!params.descriptor.agentId) return connectionUnavailable();
 
 		if (params.action === 'do_not_respond') {
@@ -259,7 +255,7 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 		}
 
 		const thread = chat.thread(threadId);
-		await this.prepareSentThread(params.descriptor, thread);
+		await this.prepareSentThread(params.descriptor, thread, params.persistence);
 		const sent = await thread.post(await this.toPostable(params.descriptor, input.message, params));
 
 		return {
@@ -278,7 +274,7 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 	): Promise<IntegrationActionResult> {
 		const input = sendDmInputSchema.parse(params.input);
 		const thread = await chat.openDM(input.userId);
-		await this.prepareSentThread(params.descriptor, thread);
+		await this.prepareSentThread(params.descriptor, thread, params.persistence);
 		const sent = await thread.post(await this.toPostable(params.descriptor, input.message, params));
 
 		return {
@@ -340,7 +336,11 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 			await this.toPostable(params.descriptor, input.message, params),
 		);
 		if (sent.threadId) {
-			await this.prepareSentThread(params.descriptor, chat.thread(sent.threadId));
+			await this.prepareSentThread(
+				params.descriptor,
+				chat.thread(sent.threadId),
+				params.persistence,
+			);
 		}
 
 		return {
@@ -404,8 +404,16 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 	private async prepareSentThread(
 		descriptor: IntegrationToolConnectionDescriptor,
 		thread: Parameters<NonNullable<AgentChatIntegration['prepareSentThread']>>[0],
+		persistence?: AgentSessionOrigin,
 	): Promise<void> {
-		await this.integrationRegistry.get(descriptor.integration.type)?.prepareSentThread?.(thread);
+		const integration = this.integrationRegistry.get(descriptor.integration.type);
+		await integration?.prepareSentThread?.(thread);
+		if (!persistence || !this.messageContextService || !descriptor.agentId) return;
+		const platformThreadId = integration?.formatThreadId?.fromSdk(thread) ?? thread.id;
+		await this.messageContextService.bindSession(
+			toChatSessionThreadId(descriptor.agentId, platformThreadId),
+			persistence,
+		);
 	}
 }
 
@@ -425,6 +433,7 @@ interface ExecuteParams {
 	runId?: string;
 	toolCallId?: string;
 	currentMessageContext?: IntegrationMessageContext;
+	persistence?: AgentSessionOrigin;
 }
 
 function buildMessageContextFromSentMessage(params: {

--- a/packages/cli/src/modules/agents/integrations/integration-context-query-executor.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-context-query-executor.ts
@@ -5,6 +5,7 @@ import { ChatIntegrationService } from './chat-integration.service';
 import { INTEGRATION_ERROR_CODES } from './integration-error-codes';
 import { connectionUnavailable, integrationError } from './integration-helpers';
 import type {
+	AgentSessionOrigin,
 	IntegrationContextQuery,
 	IntegrationContextQueryExecutor,
 	IntegrationToolConnectionDescriptor,
@@ -26,7 +27,7 @@ export class ChatIntegrationContextQueryExecutor implements IntegrationContextQu
 		descriptor: IntegrationToolConnectionDescriptor;
 		query: IntegrationContextQuery;
 		input: Record<string, unknown>;
-		persistence?: { threadId: string; resourceId: string };
+		persistence?: AgentSessionOrigin;
 	}): Promise<unknown> {
 		if (!params.descriptor.agentId) return connectionUnavailable();
 

--- a/packages/cli/src/modules/agents/integrations/integration-message-context.service.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-message-context.service.ts
@@ -42,10 +42,12 @@ export class IntegrationMessageContextService implements IntegrationMessageConte
 	/**
 	 * Point a derived chat-session thread id at the run that sent the outbound
 	 * message, so inbound follow-ups continue that session. No-op when the
-	 * derived id already is the origin. Last write wins.
+	 * derived id already is the origin or a binding exists — a thread's session
+	 * never changes once established (first write wins).
 	 */
 	async bindSession(derivedThreadId: string, origin: AgentSessionOrigin): Promise<void> {
 		if (derivedThreadId === origin.threadId) return;
+		if (await this.resolveSession(derivedThreadId)) return;
 		await this.writeMetadata(derivedThreadId, origin.resourceId, {
 			[CONTINUE_AS_METADATA_KEY]: origin,
 		});

--- a/packages/cli/src/modules/agents/integrations/integration-message-context.service.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-message-context.service.ts
@@ -3,6 +3,7 @@ import { isRecord } from '@n8n/utils/is-record';
 import { jsonParse } from 'n8n-workflow';
 
 import type {
+	AgentSessionOrigin,
 	IntegrationMessageContext,
 	IntegrationMessageSubject,
 	IntegrationSubjectPerson,
@@ -13,6 +14,7 @@ import { AgentResourceRepository } from '../repositories/agent-resource.reposito
 import { AgentThreadRepository } from '../repositories/agent-thread.repository';
 
 const MESSAGE_CONTEXT_METADATA_KEY = 'currentMessageContext';
+const CONTINUE_AS_METADATA_KEY = 'continueAs';
 
 @Service()
 export class IntegrationMessageContextService implements IntegrationMessageContextStore {
@@ -32,10 +34,38 @@ export class IntegrationMessageContextService implements IntegrationMessageConte
 		resourceId: string,
 		context: IntegrationMessageContext,
 	): Promise<void> {
+		await this.writeMetadata(threadId, resourceId, {
+			[MESSAGE_CONTEXT_METADATA_KEY]: context,
+		});
+	}
+
+	/**
+	 * Point a derived chat-session thread id at the run that sent the outbound
+	 * message, so inbound follow-ups continue that session. No-op when the
+	 * derived id already is the origin. Last write wins.
+	 */
+	async bindSession(derivedThreadId: string, origin: AgentSessionOrigin): Promise<void> {
+		if (derivedThreadId === origin.threadId) return;
+		await this.writeMetadata(derivedThreadId, origin.resourceId, {
+			[CONTINUE_AS_METADATA_KEY]: origin,
+		});
+	}
+
+	async resolveSession(derivedThreadId: string): Promise<AgentSessionOrigin | null> {
+		const thread = await this.threadRepository.findOneBy({ id: derivedThreadId });
+		const value = this.parseMetadata(thread?.metadata)[CONTINUE_AS_METADATA_KEY];
+		return isAgentSessionOrigin(value) ? value : null;
+	}
+
+	private async writeMetadata(
+		threadId: string,
+		resourceId: string,
+		patch: Record<string, unknown>,
+	): Promise<void> {
 		const existing = await this.threadRepository.findOneBy({ id: threadId });
 		const metadata = {
 			...this.parseMetadata(existing?.metadata),
-			[MESSAGE_CONTEXT_METADATA_KEY]: context,
+			...patch,
 		};
 
 		if (existing) {
@@ -73,6 +103,12 @@ export class IntegrationMessageContextService implements IntegrationMessageConte
 			return {};
 		}
 	}
+}
+
+function isAgentSessionOrigin(value: unknown): value is AgentSessionOrigin {
+	return (
+		isRecord(value) && typeof value.threadId === 'string' && typeof value.resourceId === 'string'
+	);
 }
 
 export function isIntegrationMessageContext(value: unknown): value is IntegrationMessageContext {

--- a/packages/cli/src/modules/agents/integrations/integration-tool-execution.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-tool-execution.ts
@@ -203,6 +203,7 @@ export async function executeActionToolOperation(params: {
 		runId: ctx.runId,
 		toolCallId: ctx.toolCallId,
 		currentMessageContext,
+		persistence,
 	});
 
 	if (!result.ok) return result;

--- a/packages/cli/src/modules/agents/integrations/integration-tool-types.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-tool-types.ts
@@ -3,6 +3,11 @@ import type { z } from 'zod';
 
 import type { IntegrationErrorCode } from './integration-error-codes';
 
+export interface AgentSessionOrigin {
+	threadId: string;
+	resourceId: string;
+}
+
 export type IntegrationMessageTarget =
 	| {
 			type: 'thread';
@@ -138,7 +143,7 @@ export interface IntegrationContextQueryExecutor {
 		descriptor: IntegrationToolConnectionDescriptor;
 		query: IntegrationContextQuery;
 		input: Record<string, unknown>;
-		persistence?: { threadId: string; resourceId: string };
+		persistence?: AgentSessionOrigin;
 	}): Promise<unknown>;
 }
 
@@ -151,6 +156,7 @@ export interface IntegrationActionExecutor {
 		runId?: string;
 		toolCallId?: string;
 		currentMessageContext?: IntegrationMessageContext;
+		persistence?: AgentSessionOrigin;
 	}): Promise<IntegrationActionResult>;
 }
 

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/recorded-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/recorded-integration.test.ts
@@ -131,17 +131,20 @@ describe('Slack recorded integration replay', () => {
 					integrationType: 'slack',
 				}),
 			);
+			// The conversation anchors at the DM message's own ts: the reply posts
+			// inside that message's thread and the context targets it.
 			expect(ctx.latestContext()).toMatchObject({
 				platform: 'slack',
 				messageId: '1782379185.654229',
 				interactingUserId: 'U_USER',
 				target: {
-					threadId: 'slack:D_DM:',
+					threadId: 'slack:D_DM:1782379185.654229',
 					channelId: 'slack:D_DM',
 				},
 			});
 			expect(ctx.lastPost()?.body).toMatchObject({
 				channel: 'D_DM',
+				thread_ts: '1782379185.654229',
 				markdown_text: "I'm Assistant.",
 			});
 		} finally {

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/synthetic-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/synthetic-integration.test.ts
@@ -44,16 +44,19 @@ describe('Slack channel integration scenarios', () => {
 					integrationType: 'slack',
 				}),
 			);
+			// The conversation anchors at the DM message's own ts: the reply posts
+			// inside that message's thread and the context targets it.
 			expect(ctx.latestContext()).toMatchObject({
 				messageId: '1719000100.000100',
 				interactingUserId: 'U_DM_USER',
 				target: {
-					threadId: 'slack:D_DM:',
+					threadId: 'slack:D_DM:1719000100.000100',
 					channelId: 'slack:D_DM',
 				},
 			});
 			expect(ctx.lastPost()?.body).toMatchObject({
 				channel: 'D_DM',
+				thread_ts: '1719000100.000100',
 				markdown_text: 'Got it',
 			});
 		} finally {

--- a/packages/cli/src/modules/agents/integrations/platforms/slack/slack-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack/slack-integration.ts
@@ -115,6 +115,18 @@ export class SlackIntegration extends AgentChatIntegration {
 		await subscribeSlackThread(thread);
 	}
 
+	/**
+	 * A top-level Slack message (outbound post or inbound DM) travels through a
+	 * channel-level thread id with an empty thread_ts (`slack:C123:`). The
+	 * message's own ts anchors the thread where replies belong, so re-anchor
+	 * there.
+	 */
+	messageThreadId(message: { id: string; threadId: string }): string | undefined {
+		const [platform, channel, threadTs] = message.threadId.split(':');
+		if (platform !== 'slack' || !channel || threadTs) return undefined;
+		return `slack:${channel}:${message.id}`;
+	}
+
 	getPlatformAgentContext(chat: ChatInstance): PlatformAgentContext {
 		return getSlackPlatformAgentContext(chat);
 	}

--- a/packages/cli/src/modules/agents/integrations/types.ts
+++ b/packages/cli/src/modules/agents/integrations/types.ts
@@ -19,3 +19,7 @@ export const toInternalThreadId = (id: string): InternalThread => {
 		id,
 	};
 };
+
+/** Agent-prefixed chat session id the bridge derives from a platform thread. */
+export const toChatSessionThreadId = (agentId: string, platformThreadId: string): string =>
+	`${agentId}:${platformThreadId}`;


### PR DESCRIPTION
## Summary

Fixes agent session continuity when a task-initiated run sends messages into chat channels/DMs and receives follow-ups there.

- Bind outbound chat threads back to the originating agent session using `agents_threads.metadata`
- Resolve that binding on inbound follow-ups and HITL resumes so replies continue the original task session

## How to test
- Start an agent from a task
- Have it send a message into a Slack/Telegram thread or DM
- Reply in that same conversation
- Confirm the follow-up continues the original task session instead of starting a new context

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-547

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

