### PR TITLE
fix(core): Resolve AI Assistant sticky note placement after layout

### DIFF
--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -661,6 +661,27 @@ export function isNodeInstance(value: unknown): value is NodeInstance<string, st
 	return typeof toProp === 'function';
 }
 
+/**
+ * A sticky note that was asked to wrap a set of nodes.
+ *
+ * Only the anchor node IDs are recorded at construction time: node positions do not
+ * exist yet when `sticky()` runs, so the box is resolved during serialization from
+ * wherever the anchors ended up. IDs rather than names, because a node can be
+ * auto-renamed on its way into the workflow.
+ */
+export interface AnchoredStickyNote {
+	readonly stickyAnchorIds: readonly string[];
+}
+
+/** Type guard for {@link AnchoredStickyNote}. */
+export function isAnchoredStickyNote(value: object): value is AnchoredStickyNote {
+	return (
+		'stickyAnchorIds' in value &&
+		Array.isArray(value.stickyAnchorIds) &&
+		value.stickyAnchorIds.every((id) => typeof id === 'string')
+	);
+}
+
 // =============================================================================
 // Subnode instance types (with category markers)
 // =============================================================================

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/constants.ts
@@ -27,6 +27,18 @@ export const STICKY_BOTTOM_PADDING = GRID_SIZE * 4; // 64
 
 export const STICKY_NODE_TYPE = 'n8n-nodes-base.stickyNote';
 
+/** Matches the StickyNote node's own width/height defaults. */
+export const DEFAULT_STICKY_SIZE: [number, number] = [240, 160];
+
+/** Gap between a sticky's edge and the nodes it wraps. */
+export const STICKY_PADDING = GRID_SIZE * 2; // 32
+
+/** Headroom above wrapped nodes so the sticky's text does not sit on top of them. */
+export const STICKY_HEADER_HEIGHT = GRID_SIZE * 4; // 64
+
+/** Bound on the sticky de-overlap walk so a pathological graph can't spin. */
+export const MAX_STICKY_SEPARATION_STEPS = 50;
+
 // BFS layout constants (used by calculateNodePositions for basic positioning)
 export const NODE_SPACING_X = 200;
 export const DEFAULT_Y = 300;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -2,7 +2,14 @@
  * Tests for layout utility functions (BFS and Dagre)
  */
 
-import { GRID_SIZE, STICKY_NODE_TYPE, NODE_SPACING_X, START_X, DEFAULT_Y } from './constants';
+import {
+	GRID_SIZE,
+	STICKY_NODE_TYPE,
+	NODE_SPACING_X,
+	START_X,
+	DEFAULT_Y,
+	DEFAULT_NODE_SIZE,
+} from './constants';
 import { calculateNodePositions, calculateNodePositionsDagre } from './layout-utils';
 import type { GraphNode, ConnectionTarget } from '../types/base';
 
@@ -19,13 +26,17 @@ function createGraphNode(
 		['main', new Map<number, ConnectionTarget[]>()],
 	]),
 	position?: [number, number],
+	parameters?: Record<string, unknown>,
 ): GraphNode {
 	return {
 		instance: {
 			type,
 			name,
 			version: 1,
-			config: position ? { position } : {},
+			config: {
+				...(position ? { position } : {}),
+				...(parameters ? { parameters } : {}),
+			},
 		} as unknown as GraphNode['instance'],
 		connections,
 	};
@@ -416,8 +427,41 @@ describe('calculateNodePositionsDagre', () => {
 
 			const positions = calculateNodePositionsDagre(nodes);
 
-			// Sticky is reanchored relative to trigger's explicit position, not dagre's guess
-			expect(positions.get('note')).toEqual([496, 672]);
+			// Sticky is reanchored relative to trigger's explicit position, not dagre's guess.
+			// Bottom-aligned against the covered node using the sticky's own 240x160 default
+			// size — not the node-sized box the layout used to assume for stickies.
+			expect(positions.get('note')).toEqual([432, 608]);
+		});
+
+		it('measures coverage using the sticky note declared size', () => {
+			const nodes = new Map<string, GraphNode>();
+			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
+
+			nodes.set(
+				'trigger',
+				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns, [500, 600]),
+			);
+			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+			// A wide sticky whose declared box covers the trigger, but whose top-left
+			// corner alone does not — only its real width/height reveal the coverage.
+			nodes.set(
+				'note',
+				createGraphNode('note', STICKY_NODE_TYPE, undefined, [480, 560], {
+					width: 400,
+					height: 300,
+				}),
+			);
+
+			const positions = calculateNodePositionsDagre(nodes);
+
+			// The sticky covers the trigger, so it follows it instead of being left behind
+			const notePosition = positions.get('note');
+			expect(notePosition).toBeDefined();
+			const [x, y] = notePosition!;
+			expect(x).toBeLessThanOrEqual(500);
+			expect(x + 400).toBeGreaterThanOrEqual(500 + DEFAULT_NODE_SIZE[0]);
+			expect(y).toBeLessThanOrEqual(600);
+			expect(y + 300).toBeGreaterThanOrEqual(600 + DEFAULT_NODE_SIZE[1]);
 		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -201,10 +201,14 @@ function calculateNodeHeight(mainInputCount: number, mainOutputCount: number): n
 	return DEFAULT_NODE_SIZE[1] + Math.max(0, maxVerticalHandles - 2) * GRID_SIZE * 2;
 }
 
-/** Whether a sticky carries its own width/height, rather than relying on defaults. */
-function declaresOwnSize(graphNode: GraphNode): boolean {
-	const parameters = graphNode.instance.config?.parameters;
-	return typeof parameters?.width === 'number' || typeof parameters?.height === 'number';
+/** Whether a sticky carries its own width, rather than relying on the default. */
+function declaresOwnWidth(graphNode: GraphNode): boolean {
+	return typeof graphNode.instance.config?.parameters?.width === 'number';
+}
+
+/** Whether a sticky carries its own height, rather than relying on the default. */
+function declaresOwnHeight(graphNode: GraphNode): boolean {
+	return typeof graphNode.instance.config?.parameters?.height === 'number';
 }
 
 /**
@@ -532,11 +536,9 @@ export function resolveStickyGeometry(
 		return { x: position[0], y: position[1], width, height };
 	};
 
-	const placed: BoundingBox[] = [];
-
-	for (const name of stickyNames) {
+	const resolved = stickyNames.flatMap((name) => {
 		const graphNode = nodes.get(name);
-		if (!graphNode) continue;
+		if (!graphNode) return [];
 
 		const { instance } = graphNode;
 		const explicitPosition = instance.config?.position;
@@ -550,28 +552,48 @@ export function resolveStickyGeometry(
 			: [];
 
 		const wrappingBox = wrappingBoxFor(anchorBoxes);
-		const sizedByAnchors = wrappingBox !== undefined && !declaresOwnSize(graphNode);
 
-		// Whatever the caller declared wins; the anchors only fill in what is missing.
+		// Whatever the caller declared wins, dimension by dimension; the anchors only
+		// fill in what is missing, so a declared width still gets a wrapping height.
+		const declared = declaredStickySize(graphNode);
+		const ownWidth = declaresOwnWidth(graphNode);
+		const ownHeight = declaresOwnHeight(graphNode);
+		const size = {
+			width: !ownWidth && wrappingBox ? wrappingBox.width : declared.width,
+			height: !ownHeight && wrappingBox ? wrappingBox.height : declared.height,
+		};
+		const sizedByAnchors = wrappingBox !== undefined && !(ownWidth && ownHeight);
+
 		const origin = toPoint(explicitPosition) ??
 			(wrappingBox && { x: wrappingBox.x, y: wrappingBox.y }) ??
 			toPoint(positions.get(name)) ?? { x: START_X, y: DEFAULT_Y };
-		const size =
-			sizedByAnchors && wrappingBox
-				? { width: wrappingBox.width, height: wrappingBox.height }
-				: declaredStickySize(graphNode);
 
-		let box: BoundingBox = { ...origin, ...size };
+		// A sticky is pinned when the author placed it or when it wraps anchors — moving
+		// either one would take it away from the thing it is meant to sit on.
+		const pinned = explicitPosition !== undefined || wrappingBox !== undefined;
 
-		// An explicitly placed sticky is where the author wanted it; everything else
-		// gets pushed clear of the stickies already placed so none of them stack.
-		if (!explicitPosition) box = separateFrom(placed, box);
+		return [{ name, box: { ...origin, ...size }, sizedByAnchors, pinned }];
+	});
 
-		placed.push(box);
+	const record = (name: string, box: BoundingBox, sizedByAnchors: boolean): void => {
 		geometryByName.set(name, {
 			position: [box.x, box.y],
 			...(sizedByAnchors && { size: { width: box.width, height: box.height } }),
 		});
+	};
+
+	const placed = resolved.filter((sticky) => sticky.pinned).map(({ box }) => box);
+	for (const { name, box, sizedByAnchors, pinned } of resolved) {
+		if (pinned) {
+			record(name, box, sizedByAnchors);
+			continue;
+		}
+
+		// Free-floating notes have nowhere they need to be, so they give way to
+		// everything already placed rather than stacking on it.
+		const separated = separateFrom(placed, box);
+		placed.push(separated);
+		record(name, separated, sizedByAnchors);
 	}
 
 	return geometryByName;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -26,8 +26,12 @@ import {
 	NODE_SPACING_X,
 	DEFAULT_Y,
 	START_X,
+	DEFAULT_STICKY_SIZE,
+	STICKY_PADDING,
+	STICKY_HEADER_HEIGHT,
+	MAX_STICKY_SEPARATION_STEPS,
 } from './constants';
-import type { GraphNode } from '../types/base';
+import { isAnchoredStickyNote, type GraphNode } from '../types/base';
 
 // ===========================================================================
 // BFS Layout (default)
@@ -197,12 +201,37 @@ function calculateNodeHeight(mainInputCount: number, mainOutputCount: number): n
 	return DEFAULT_NODE_SIZE[1] + Math.max(0, maxVerticalHandles - 2) * GRID_SIZE * 2;
 }
 
+/** Whether a sticky carries its own width/height, rather than relying on defaults. */
+function declaresOwnSize(graphNode: GraphNode): boolean {
+	const parameters = graphNode.instance.config?.parameters;
+	return typeof parameters?.width === 'number' || typeof parameters?.height === 'number';
+}
+
+/**
+ * A sticky's own width/height parameters, falling back to the StickyNote node defaults.
+ * Sticky notes are sized by their parameters, not by the node-canvas defaults.
+ */
+function declaredStickySize(graphNode: GraphNode): { width: number; height: number } {
+	const parameters = graphNode.instance.config?.parameters;
+	const width = parameters?.width;
+	const height = parameters?.height;
+	return {
+		width: typeof width === 'number' ? width : DEFAULT_STICKY_SIZE[0],
+		height: typeof height === 'number' ? height : DEFAULT_STICKY_SIZE[1],
+	};
+}
+
 export function getNodeDimensions(
 	nodeName: string,
 	aiParentNames: Set<string>,
 	aiConfigNames: Set<string>,
 	nodes: ReadonlyMap<string, GraphNode>,
 ): { width: number; height: number } {
+	const graphNode = nodes.get(nodeName);
+	if (graphNode?.instance.type === STICKY_NODE_TYPE) {
+		return declaredStickySize(graphNode);
+	}
+
 	if (aiConfigNames.has(nodeName)) {
 		return { width: CONFIGURATION_NODE_SIZE[0], height: CONFIGURATION_NODE_SIZE[1] };
 	}
@@ -414,6 +443,138 @@ function repositionStickyNotes(
 
 		result.set(stickyName, [snapToGrid(newX), snapToGrid(newY)]);
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Sticky note geometry
+// ---------------------------------------------------------------------------
+
+export interface StickyGeometry {
+	position: [number, number];
+	/**
+	 * Only set when this resolver sized the sticky (i.e. it wraps anchors). Stickies that
+	 * carry their own size keep it — overwriting would break workflow round-trips.
+	 */
+	size?: { width: number; height: number };
+}
+
+function boxesOverlap(a: BoundingBox, b: BoundingBox): boolean {
+	return a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height;
+}
+
+function toPoint(position?: [number, number]): { x: number; y: number } | undefined {
+	return position && { x: position[0], y: position[1] };
+}
+
+/** The box that wraps a sticky's anchors, with room above for the note's own text. */
+function wrappingBoxFor(anchorBoxes: BoundingBox[]): BoundingBox | undefined {
+	if (anchorBoxes.length === 0) return undefined;
+	const wrapped = compositeBoundingBox(anchorBoxes);
+	return {
+		x: snapToGrid(wrapped.x - STICKY_PADDING),
+		y: snapToGrid(wrapped.y - STICKY_PADDING - STICKY_HEADER_HEIGHT),
+		width: snapToGrid(wrapped.width + STICKY_PADDING * 2),
+		height: snapToGrid(wrapped.height + STICKY_PADDING * 2 + STICKY_HEADER_HEIGHT),
+	};
+}
+
+/** Push a box down until it clears every box already placed. */
+function separateFrom(placed: BoundingBox[], box: BoundingBox): BoundingBox {
+	let separated = box;
+	for (let step = 0; step < MAX_STICKY_SEPARATION_STEPS; step++) {
+		const collision = placed.find((placedBox) => boxesOverlap(placedBox, separated));
+		if (!collision) break;
+		separated = {
+			...separated,
+			y: snapToGrid(collision.y + collision.height + NODE_Y_SPACING),
+		};
+	}
+	return separated;
+}
+
+/**
+ * Resolve the final position and size of every sticky note.
+ *
+ * `sticky(content, [nodes])` can only record which nodes it wraps — when it runs,
+ * layout has not happened and the anchors have no positions yet. So the box is
+ * computed here, from wherever the anchors actually landed. Stickies that were given
+ * an explicit position keep it; the rest are nudged apart so they never stack.
+ *
+ * @param nodes - the workflow graph, keyed by the name each node is serialized under
+ * @param positions - positions chosen by the active layout, keyed the same way
+ */
+export function resolveStickyGeometry(
+	nodes: ReadonlyMap<string, GraphNode>,
+	positions: ReadonlyMap<string, [number, number]>,
+): Map<string, StickyGeometry> {
+	const geometryByName = new Map<string, StickyGeometry>();
+
+	const stickyNames = [...nodes.keys()].filter(
+		(name) => nodes.get(name)?.instance.type === STICKY_NODE_TYPE,
+	);
+	if (stickyNames.length === 0) return geometryByName;
+
+	const aiParentNames = getAiParentNames(nodes);
+	const aiConfigNames = getAiConfigNames(nodes);
+
+	// Anchors are recorded by node ID, since a node can be renamed on its way in.
+	const nameById = new Map<string, string>();
+	for (const [name, graphNode] of nodes) {
+		nameById.set(graphNode.instance.id, name);
+	}
+
+	const boxOfNode = (name: string): BoundingBox | undefined => {
+		const graphNode = nodes.get(name);
+		if (!graphNode) return undefined;
+		const position = graphNode.instance.config?.position ?? positions.get(name);
+		if (!position) return undefined;
+		const { width, height } = getNodeDimensions(name, aiParentNames, aiConfigNames, nodes);
+		return { x: position[0], y: position[1], width, height };
+	};
+
+	const placed: BoundingBox[] = [];
+
+	for (const name of stickyNames) {
+		const graphNode = nodes.get(name);
+		if (!graphNode) continue;
+
+		const { instance } = graphNode;
+		const explicitPosition = instance.config?.position;
+
+		const anchorBoxes = isAnchoredStickyNote(instance)
+			? instance.stickyAnchorIds
+					.map((id) => nameById.get(id))
+					.filter((anchorName): anchorName is string => anchorName !== undefined)
+					.map(boxOfNode)
+					.filter((box): box is BoundingBox => box !== undefined)
+			: [];
+
+		const wrappingBox = wrappingBoxFor(anchorBoxes);
+		const sizedByAnchors = wrappingBox !== undefined && !declaresOwnSize(graphNode);
+
+		// Whatever the caller declared wins; the anchors only fill in what is missing.
+		const origin = toPoint(explicitPosition) ??
+			(wrappingBox && { x: wrappingBox.x, y: wrappingBox.y }) ??
+			toPoint(positions.get(name)) ?? { x: START_X, y: DEFAULT_Y };
+		const size =
+			sizedByAnchors && wrappingBox
+				? { width: wrappingBox.width, height: wrappingBox.height }
+				: declaredStickySize(graphNode);
+
+		let box: BoundingBox = { ...origin, ...size };
+
+		// An explicitly placed sticky is where the author wanted it; everything else
+		// gets pushed clear of the stickies already placed so none of them stack.
+		if (!explicitPosition) box = separateFrom(placed, box);
+
+		placed.push(box);
+		geometryByName.set(name, {
+			position: [box.x, box.y],
+			...(sizedByAnchors && { size: { width: box.width, height: box.height } }),
+		});
+	}
+
+	return geometryByName;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.test.ts
@@ -11,7 +11,13 @@ import {
 	switchCase,
 } from './node-builder';
 import { languageModel, memory, tool, outputParser } from './subnode-builders';
+import { isAnchoredStickyNote, type NodeInstance } from '../../types/base';
 import { splitInBatches } from '../control-flow-builders/split-in-batches';
+
+/** The nodes a sticky was asked to wrap, by ID. */
+function anchorsOf(instance: NodeInstance<string, string, unknown>): readonly string[] {
+	return isAnchoredStickyNote(instance) ? instance.stickyAnchorIds : [];
+}
 
 describe('Node Builder', () => {
 	describe('node()', () => {
@@ -214,7 +220,7 @@ describe('Node Builder', () => {
 			expect(s.config.parameters?.height).toBe(200);
 		});
 
-		it('should auto-position around nodes when nodes array is provided as second parameter', () => {
+		it('should record the nodes it wraps as anchors', () => {
 			const n1 = node({
 				type: 'n8n-nodes-base.httpRequest',
 				version: 4.2,
@@ -229,13 +235,10 @@ describe('Node Builder', () => {
 			// New signature: sticky(content, nodes?, config?)
 			const s = sticky('## API Section', [n1, n2], { color: 2 });
 
-			// Should calculate bounding box around nodes with padding (50px)
-			// minX = 400, maxX = 700 + 200 = 900, minY = 300, maxY = 300 + 100 = 400
-			// position = [400-50, 300-50] = [350, 250]
-			// width = (900-400) + 100 = 600, height = (400-300) + 100 = 200
-			expect(s.config.position).toEqual([350, 250]);
-			expect(s.config.parameters?.width).toBe(600);
-			expect(s.config.parameters?.height).toBe(200);
+			// The box itself is resolved during serialization, once layout has placed
+			// the anchors — see sticky-placement.test.ts
+			expect(anchorsOf(s)).toEqual([n1.id, n2.id]);
+			expect(s.config.position).toBeUndefined();
 			expect(s.config.parameters?.color).toBe(2);
 		});
 
@@ -312,8 +315,8 @@ describe('Node Builder', () => {
 
 			expect(s.type).toBe('n8n-nodes-base.stickyNote');
 			expect(s.config.parameters?.content).toBe('## Batch Processing');
-			// Should use the sibNode's position for bounding box
-			expect(s.config.position).toEqual([450, 350]);
+			// Anchors on the underlying node, not the builder wrapper
+			expect(anchorsOf(s)).toEqual([sibNode.id]);
 		});
 
 		it('should not crash when nodes array contains an IfElseBuilder', () => {
@@ -330,8 +333,8 @@ describe('Node Builder', () => {
 
 			expect(s.type).toBe('n8n-nodes-base.stickyNote');
 			expect(s.config.parameters?.content).toBe('## Conditional Logic');
-			// Should use ifNode's position for bounding box
-			expect(s.config.position).toEqual([250, 150]);
+			// Anchors on the IF node, not the builder wrapper
+			expect(anchorsOf(s)).toEqual([ifNode.id]);
 		});
 
 		it('should not crash when nodes array contains a SwitchCaseBuilder', () => {
@@ -348,8 +351,8 @@ describe('Node Builder', () => {
 
 			expect(s.type).toBe('n8n-nodes-base.stickyNote');
 			expect(s.config.parameters?.content).toBe('## Routing');
-			// Should use switchNode's position for bounding box
-			expect(s.config.position).toEqual([350, 250]);
+			// Anchors on the Switch node, not the builder wrapper
+			expect(anchorsOf(s)).toEqual([sw.id]);
 		});
 	});
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { NODE_TYPES, isIfNodeType, isSwitchNodeType } from '../../constants/node-types';
 import {
 	isNodeChain,
+	type AnchoredStickyNote,
 	type NodeInstance,
 	type TriggerInstance,
 	type NodeConfig,
@@ -1034,23 +1035,14 @@ export function trigger<TTrigger extends TriggerInput>(
 	);
 }
 
-// Default node dimensions for bounding box calculation
-const DEFAULT_NODE_WIDTH = 200;
-const DEFAULT_NODE_HEIGHT = 100;
-const STICKY_PADDING = 50;
-
 /**
- * Calculate bounding box around a set of nodes
+ * Resolve the IDs of the nodes a sticky was asked to wrap.
+ *
+ * Only IDs are captured — the sticky's box is computed during serialization, once
+ * layout has decided where the anchors actually sit.
  */
-function calculateNodesBoundingBox(nodes: Array<NodeInstance<string, string, unknown>>): {
-	position: [number, number];
-	width: number;
-	height: number;
-} | null {
-	if (nodes.length === 0) return null;
-
-	// Normalize builder objects to their underlying NodeInstance
-	const normalizedNodes = nodes
+function resolveAnchorIds(nodes: Array<NodeInstance<string, string, unknown>>): string[] {
+	return nodes
 		.map((item): NodeInstance<string, string, unknown> | null => {
 			if (isSplitInBatchesBuilder(item)) {
 				return extractSplitInBatchesBuilder(item).sibNode;
@@ -1066,68 +1058,43 @@ function calculateNodesBoundingBox(nodes: Array<NodeInstance<string, string, unk
 			}
 			return null;
 		})
-		.filter((n): n is NodeInstance<string, string, unknown> => n !== null);
-
-	if (normalizedNodes.length === 0) return null;
-
-	let minX = Infinity;
-	let minY = Infinity;
-	let maxX = -Infinity;
-	let maxY = -Infinity;
-
-	for (const node of normalizedNodes) {
-		const pos = node.config.position ?? [0, 0];
-		const x = pos[0];
-		const y = pos[1];
-
-		minX = Math.min(minX, x);
-		minY = Math.min(minY, y);
-		maxX = Math.max(maxX, x + DEFAULT_NODE_WIDTH);
-		maxY = Math.max(maxY, y + DEFAULT_NODE_HEIGHT);
-	}
-
-	return {
-		position: [minX - STICKY_PADDING, minY - STICKY_PADDING],
-		width: maxX - minX + STICKY_PADDING * 2,
-		height: maxY - minY + STICKY_PADDING * 2,
-	};
+		.filter((n): n is NodeInstance<string, string, unknown> => n !== null)
+		.map((n) => n.id);
 }
 
 /**
  * Sticky note node instance
  */
-class StickyNoteInstance implements NodeInstance<'n8n-nodes-base.stickyNote', 'v1', void> {
+class StickyNoteInstance
+	implements NodeInstance<'n8n-nodes-base.stickyNote', 'v1', void>, AnchoredStickyNote
+{
 	readonly type = 'n8n-nodes-base.stickyNote' as const;
 	readonly version = 'v1' as const;
 	readonly config: NodeConfig;
 	readonly id: string;
 	readonly name: string;
+	readonly stickyAnchorIds: readonly string[];
 
 	constructor(
 		content: string,
 		nodes: Array<NodeInstance<string, string, unknown>> = [],
 		stickyConfig: StickyNoteConfig = {},
+		anchorIds?: readonly string[],
 	) {
 		this.id = uuid();
 		// Use a unique default name to prevent multiple stickies from overwriting each other
 		// when added to a workflow (Map uses name as key)
 		this.name = stickyConfig.name ?? `Sticky Note ${this.id.slice(0, 8)}`;
-
-		// If nodes are provided, calculate bounding box to wrap around them
-		const boundingBox = nodes.length > 0 ? calculateNodesBoundingBox(nodes) : null;
+		this.stickyAnchorIds = anchorIds ?? resolveAnchorIds(nodes);
 
 		this.config = {
 			name: this.name,
-			position: stickyConfig.position ?? boundingBox?.position,
+			position: stickyConfig.position,
 			parameters: {
 				content,
 				...(stickyConfig.color !== undefined && { color: stickyConfig.color }),
-				...((stickyConfig.width ?? boundingBox?.width) !== undefined && {
-					width: stickyConfig.width ?? boundingBox?.width,
-				}),
-				...((stickyConfig.height ?? boundingBox?.height) !== undefined && {
-					height: stickyConfig.height ?? boundingBox?.height,
-				}),
+				...(stickyConfig.width !== undefined && { width: stickyConfig.width }),
+				...(stickyConfig.height !== undefined && { height: stickyConfig.height }),
 			},
 		};
 	}
@@ -1141,8 +1108,8 @@ class StickyNoteInstance implements NodeInstance<'n8n-nodes-base.stickyNote', 'v
 			height: (config.parameters?.height as number) ?? (this.config.parameters?.height as number),
 			name: config.name ?? this.name,
 		};
-		// Pass empty nodes array since update doesn't recalculate bounding box
-		return new StickyNoteInstance(newContent, [], newConfig);
+		// Anchors carry over: update() changes config, not what the sticky wraps
+		return new StickyNoteInstance(newContent, [], newConfig, this.stickyAnchorIds);
 	}
 
 	input(_index: number): InputTarget {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -16,7 +16,12 @@ import type {
 	GraphNode,
 } from '../../../types/base';
 import { START_X, DEFAULT_Y } from '../../constants';
-import { calculateNodePositions, calculateNodePositionsDagre } from '../../layout-utils';
+import {
+	calculateNodePositions,
+	calculateNodePositionsDagre,
+	resolveStickyGeometry,
+	type StickyGeometry,
+} from '../../layout-utils';
 import {
 	normalizeResourceLocators,
 	escapeNewlinesInExpressionStrings,
@@ -42,6 +47,7 @@ function serializeNode(
 	mapKey: string,
 	graphNode: GraphNode,
 	nodePositions: Map<string, [number, number]>,
+	stickyGeometry: Map<string, StickyGeometry>,
 ): NodeJSON | undefined {
 	const instance = graphNode.instance;
 
@@ -51,7 +57,11 @@ function serializeNode(
 	}
 
 	const config = instance.config ?? {};
-	const position = config.position ?? nodePositions.get(mapKey) ?? [START_X, DEFAULT_Y];
+	// Sticky notes are placed and sized after layout, from the nodes they wrap.
+	const sticky = stickyGeometry.get(mapKey);
+	const position = sticky?.position ??
+		config.position ??
+		nodePositions.get(mapKey) ?? [START_X, DEFAULT_Y];
 
 	// Determine node name:
 	// - If config has _originalName, use that (preserves undefined for sticky notes from fromJSON)
@@ -84,6 +94,11 @@ function serializeNode(
 	} else {
 		const normalized = normalizeResourceLocators(parsedParams);
 		serializedParams = escapeNewlinesInExpressionStrings(normalized) as IDataObject;
+	}
+
+	if (sticky?.size) {
+		serializedParams.width = sticky.size.width;
+		serializedParams.height = sticky.size.height;
 	}
 
 	const n8nNode: NodeJSON = {
@@ -229,10 +244,13 @@ export const jsonSerializer: SerializerPlugin<WorkflowJSON> = {
 			? calculateNodePositionsDagre(ctx.nodes)
 			: calculateNodePositions(ctx.nodes);
 
+		// Sticky notes are placed last: their box depends on where their anchors landed
+		const stickyGeometry = resolveStickyGeometry(ctx.nodes, nodePositions);
+
 		// Convert nodes and connections
 		for (const [mapKey, graphNode] of ctx.nodes) {
 			// Serialize node
-			const serializedNode = serializeNode(mapKey, graphNode, nodePositions);
+			const serializedNode = serializeNode(mapKey, graphNode, nodePositions, stickyGeometry);
 			if (!serializedNode) continue;
 
 			nodes.push(serializedNode);

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/sticky-placement.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/sticky-placement.test.ts
@@ -7,7 +7,7 @@
 
 import type { NodeJSON, WorkflowJSON } from '../types/base';
 import { workflow } from '../workflow-builder';
-import { DEFAULT_NODE_SIZE, STICKY_NODE_TYPE } from './constants';
+import { DEFAULT_NODE_SIZE, DEFAULT_STICKY_SIZE, STICKY_NODE_TYPE } from './constants';
 import { node, sticky, trigger } from './node-builders/node-builder';
 
 interface Box {
@@ -32,9 +32,6 @@ function nodeBox(json: WorkflowJSON, name: string): Box {
 		height: DEFAULT_NODE_SIZE[1],
 	};
 }
-
-/** Matches the StickyNote node's own width/height defaults, used when the sticky declares none. */
-const DEFAULT_STICKY_SIZE: [number, number] = [240, 160];
 
 function stickyBox(json: WorkflowJSON, name: string): Box {
 	const found = findNode(json, name);
@@ -165,6 +162,41 @@ describe('sticky note placement with tidyUp', () => {
 		expect(stickyBox(json, 'Large note').width).toBeGreaterThan(
 			stickyBox(json, 'Small note').width,
 		);
+	});
+
+	it('keeps wrapping its anchors when two anchored stickies overlap', () => {
+		const { start, fetch, compute, post, record } = buildChain();
+		// Overlapping anchor sets: both stickies want a box around "Compute week"
+		const first = sticky('## Ingest', [start, fetch, compute], { name: 'First note' });
+		const second = sticky('## Deliver', [compute, post, record], { name: 'Second note' });
+
+		const json = workflow('wf', 'Test')
+			.add(start.to(fetch).to(compute).to(post).to(record))
+			.add(first)
+			.add(second)
+			.toJSON({ tidyUp: true });
+
+		// Neither may be shoved off its anchors just because the two boxes intersect
+		const firstBox = stickyBox(json, 'First note');
+		expect(contains(firstBox, nodeBox(json, 'Every Friday'))).toBe(true);
+		expect(contains(firstBox, nodeBox(json, 'Compute week'))).toBe(true);
+
+		const secondBox = stickyBox(json, 'Second note');
+		expect(contains(secondBox, nodeBox(json, 'Compute week'))).toBe(true);
+		expect(contains(secondBox, nodeBox(json, 'Record run'))).toBe(true);
+	});
+
+	it('derives only the dimension the caller left out', () => {
+		const { start, fetch } = buildChain();
+		const note = sticky('## Wide', [start, fetch], { name: 'Wide note', width: 800 });
+
+		const json = workflow('wf', 'Test').add(start.to(fetch)).add(note).toJSON({ tidyUp: true });
+
+		const box = stickyBox(json, 'Wide note');
+		// Declared width is honoured, height still wraps the anchors
+		expect(box.width).toBe(800);
+		expect(contains(box, nodeBox(json, 'Every Friday'))).toBe(true);
+		expect(contains(box, nodeBox(json, 'Active teams'))).toBe(true);
 	});
 
 	it('emits every sticky as a sticky note node', () => {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/sticky-placement.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/sticky-placement.test.ts
@@ -5,10 +5,10 @@
  * at toJSON({ tidyUp: true }). These tests pin the placement contract for that case.
  */
 
-import { DEFAULT_NODE_SIZE, STICKY_NODE_TYPE } from './constants';
-import { node, sticky, trigger } from './node-builders/node-builder';
 import type { NodeJSON, WorkflowJSON } from '../types/base';
 import { workflow } from '../workflow-builder';
+import { DEFAULT_NODE_SIZE, STICKY_NODE_TYPE } from './constants';
+import { node, sticky, trigger } from './node-builders/node-builder';
 
 interface Box {
 	x: number;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/sticky-placement.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/sticky-placement.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Sticky note placement through the full builder -> tidyUp layout -> JSON path.
+ *
+ * Agent-generated SDK code never sets explicit node positions — layout runs later,
+ * at toJSON({ tidyUp: true }). These tests pin the placement contract for that case.
+ */
+
+import { DEFAULT_NODE_SIZE, STICKY_NODE_TYPE } from './constants';
+import { node, sticky, trigger } from './node-builders/node-builder';
+import type { NodeJSON, WorkflowJSON } from '../types/base';
+import { workflow } from '../workflow-builder';
+
+interface Box {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+function findNode(json: WorkflowJSON, name: string): NodeJSON {
+	const found = json.nodes.find((n) => n.name === name);
+	if (!found) throw new Error(`Node "${name}" not found in workflow JSON`);
+	return found;
+}
+
+function nodeBox(json: WorkflowJSON, name: string): Box {
+	const { position } = findNode(json, name);
+	return {
+		x: position[0],
+		y: position[1],
+		width: DEFAULT_NODE_SIZE[0],
+		height: DEFAULT_NODE_SIZE[1],
+	};
+}
+
+/** Matches the StickyNote node's own width/height defaults, used when the sticky declares none. */
+const DEFAULT_STICKY_SIZE: [number, number] = [240, 160];
+
+function stickyBox(json: WorkflowJSON, name: string): Box {
+	const found = findNode(json, name);
+	const { width, height } = found.parameters ?? {};
+	return {
+		x: found.position[0],
+		y: found.position[1],
+		width: typeof width === 'number' ? width : DEFAULT_STICKY_SIZE[0],
+		height: typeof height === 'number' ? height : DEFAULT_STICKY_SIZE[1],
+	};
+}
+
+function contains(outer: Box, inner: Box): boolean {
+	return (
+		inner.x >= outer.x &&
+		inner.y >= outer.y &&
+		inner.x + inner.width <= outer.x + outer.width &&
+		inner.y + inner.height <= outer.y + outer.height
+	);
+}
+
+function overlaps(a: Box, b: Box): boolean {
+	return a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height;
+}
+
+/** Five chained nodes with no explicit positions, mirroring real agent output. */
+function buildChain() {
+	return {
+		start: trigger({
+			type: 'n8n-nodes-base.scheduleTrigger',
+			version: 1.2,
+			config: { name: 'Every Friday' },
+		}),
+		fetch: node({ type: 'n8n-nodes-base.notion', version: 2.2, config: { name: 'Active teams' } }),
+		compute: node({ type: 'n8n-nodes-base.code', version: 2, config: { name: 'Compute week' } }),
+		post: node({ type: 'n8n-nodes-base.slack', version: 2.3, config: { name: 'DM pre-brief' } }),
+		record: node({
+			type: 'n8n-nodes-base.postgres',
+			version: 2.5,
+			config: { name: 'Record run' },
+		}),
+	};
+}
+
+describe('sticky note placement with tidyUp', () => {
+	it('wraps the nodes it is anchored to', () => {
+		const { start, fetch, compute, post, record } = buildChain();
+		const note = sticky('## Ingest', [start, fetch], { name: 'Ingest note' });
+
+		const json = workflow('wf', 'Test')
+			.add(start.to(fetch).to(compute).to(post).to(record))
+			.add(note)
+			.toJSON({ tidyUp: true });
+
+		const box = stickyBox(json, 'Ingest note');
+		expect(contains(box, nodeBox(json, 'Every Friday'))).toBe(true);
+		expect(contains(box, nodeBox(json, 'Active teams'))).toBe(true);
+	});
+
+	it('does not stack stickies anchored to different node groups', () => {
+		const { start, fetch, compute, post, record } = buildChain();
+		const ingest = sticky('## Ingest', [start, fetch], { name: 'Ingest note' });
+		const deliver = sticky('## Deliver', [post, record], { name: 'Deliver note' });
+
+		const json = workflow('wf', 'Test')
+			.add(start.to(fetch).to(compute).to(post).to(record))
+			.add(ingest)
+			.add(deliver)
+			.toJSON({ tidyUp: true });
+
+		const ingestBox = stickyBox(json, 'Ingest note');
+		const deliverBox = stickyBox(json, 'Deliver note');
+
+		expect(ingestBox).not.toEqual(deliverBox);
+		expect(overlaps(ingestBox, deliverBox)).toBe(false);
+		expect(contains(ingestBox, nodeBox(json, 'Every Friday'))).toBe(true);
+		expect(contains(deliverBox, nodeBox(json, 'Record run'))).toBe(true);
+	});
+
+	it('does not stack stickies that have neither anchors nor explicit positions', () => {
+		const { start, fetch, compute } = buildChain();
+
+		const json = workflow('wf', 'Test')
+			.add(start.to(fetch).to(compute))
+			.add(sticky('## One', { name: 'One' }))
+			.add(sticky('## Two', { name: 'Two' }))
+			.add(sticky('## Three', { name: 'Three' }))
+			.toJSON({ tidyUp: true });
+
+		const boxes = ['One', 'Two', 'Three'].map((name) => stickyBox(json, name));
+		for (const [i, a] of boxes.entries()) {
+			for (const b of boxes.slice(i + 1)) {
+				expect(overlaps(a, b)).toBe(false);
+			}
+		}
+	});
+
+	it('keeps an explicit position and size the caller passed', () => {
+		const { start, fetch } = buildChain();
+		const note = sticky('## Pinned', [start, fetch], {
+			name: 'Pinned note',
+			position: [-960, -480],
+			width: 400,
+			height: 300,
+		});
+
+		const json = workflow('wf', 'Test').add(start.to(fetch)).add(note).toJSON({ tidyUp: true });
+
+		expect(stickyBox(json, 'Pinned note')).toEqual({
+			x: -960,
+			y: -480,
+			width: 400,
+			height: 300,
+		});
+	});
+
+	it('sizes the sticky to its content group rather than a fixed box', () => {
+		const { start, fetch, compute, post, record } = buildChain();
+		const small = sticky('## Small', [start], { name: 'Small note' });
+		const large = sticky('## Large', [fetch, compute, post, record], { name: 'Large note' });
+
+		const json = workflow('wf', 'Test')
+			.add(start.to(fetch).to(compute).to(post).to(record))
+			.add(small)
+			.add(large)
+			.toJSON({ tidyUp: true });
+
+		expect(stickyBox(json, 'Large note').width).toBeGreaterThan(
+			stickyBox(json, 'Small note').width,
+		);
+	});
+
+	it('emits every sticky as a sticky note node', () => {
+		const { start, fetch } = buildChain();
+
+		const json = workflow('wf', 'Test')
+			.add(start.to(fetch))
+			.add(sticky('## A', [start], { name: 'A' }))
+			.add(sticky('## B', [fetch], { name: 'B' }))
+			.toJSON({ tidyUp: true });
+
+		expect(json.nodes.filter((n) => n.type === STICKY_NODE_TYPE)).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## Summary

The AI Assistant stacked sticky notes on top of each other, so their text rendered over one another and over the nodes.

`sticky(content, [nodes])` sized itself from the wrapped nodes' positions **at construction time**, but layout has not run yet at that point — agent-generated SDK code never sets explicit node positions, so every wrapped node read as `[0, 0]`. Every anchored sticky therefore computed the same box (`position: [-50,-50]`, `300x200`) and they stacked. That baked-in position then counted as "explicit", so Dagre skipped the sticky, and `repositionStickyNotes()` couldn't rescue it either: it measures a sticky as a default 96x96 node instead of using its own width/height, so the coverage check never matched.

Reproduced against the built SDK — two stickies wrapping disjoint node pairs:

```
before                                       after
stickyNote  [-50,-50]  Sticky A  300 200     stickyNote  [-32,-96]  Sticky A  384 224
stickyNote  [-50,-50]  Sticky B  300 200     stickyNote  [640,-96]  Sticky B  384 224
```

**The fix** moves sticky geometry from construction time to serialization time:

- `sticky()` now records only *which* nodes it wraps (by node ID, so auto-renaming on the way into the workflow can't break the link). No geometry is guessed up front.
- A new `resolveStickyGeometry()` computes each sticky's box from where its anchors actually landed, plus padding and headroom above so the note text doesn't sit on the nodes.
- Stickies with neither anchors nor an explicit position are nudged apart, so they never stack either (previously they all resolved to the same coordinates).
- `getNodeDimensions()` now measures a sticky by its declared width/height instead of treating it as a default-sized node.
- Anything the caller declared explicitly — position or size — still wins.

Applies to both layout strategies (`toJSON()` and `toJSON({ tidyUp: true })`; the assistant's sandbox runner uses the latter).

## How to test

Ask the AI Assistant to build a workflow and request sticky notes documenting different sections — previously the stickies landed on the same spot.

Or exercise the SDK directly:

```ts
const t = trigger({ type: 'n8n-nodes-base.scheduleTrigger', version: 1.2, config: { name: 'Every Friday' } });
const a = node({ type: 'n8n-nodes-base.notion', version: 2.2, config: { name: 'Active teams' } });
const b = node({ type: 'n8n-nodes-base.slack', version: 2.3, config: { name: 'DM pre-brief' } });

const json = workflow('wf', 'Test')
  .add(t.to(a).to(b))
  .add(sticky('## Ingest', [t, a], { name: 'Ingest note' }))
  .add(sticky('## Deliver', [b], { name: 'Deliver note' }))
  .toJSON({ tidyUp: true });
```

Each sticky should wrap its own nodes, with no two boxes overlapping.

Automated coverage: `pnpm --filter @n8n/workflow-sdk test src/workflow-builder` (956 pass), including the new `sticky-placement.test.ts` which exercises the full builder -> layout -> JSON path. That path had no test coverage before, which is why this shipped.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1115

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

### Notes for reviewers

- Four tests in `node-builder.test.ts` asserted construction-time geometry (`s.config.position === [350, 250]`). They only passed because they gave the wrapped nodes explicit positions — the one condition that never holds in real agent output. They now assert anchor recording; the geometry assertions moved to the integration level.
- One expectation in `layout-utils.test.ts` changed (`[496, 672]` -> `[432, 608]`) because a sticky is no longer measured as a 96x96 node.
- Sizes are only written for stickies this resolver actually sized, so imported workflows that declare no width/height round-trip unchanged.
- The 57 pre-existing `codegen-roundtrip` failures on master are unaffected — verified the failing set is byte-identical before and after.
- Found while working on this, not fixed here: codegen omits a sticky's `position` when it is exactly `[0, 0]` (`code-generator.ts:594`), so such a sticky loses its placement on a codegen round-trip. Happy to file a follow-up.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

