### PR TITLE
fix(editor): Keep agent tool schemas aligned with saved configuration

### DIFF
--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -42,6 +42,10 @@ export const ResourceLocatorDropdownTeleportedKey: InjectionKey<boolean> = Symbo
 	'ResourceLocatorDropdownTeleported',
 );
 export const ChatHubToolContextKey: InjectionKey<boolean> = Symbol('ChatHubToolContext');
+/** Whether resource mappers may reconcile cached schemas without an explicit user action. */
+export const ResourceMapperSchemaAutoRefreshKey: InjectionKey<boolean> = Symbol(
+	'ResourceMapperSchemaAutoRefresh',
+);
 /**
  * Optional callback for hosts that keep a local node draft (e.g. tool-config
  * modals). ParameterInput invokes this when CredentialsSelect picks a

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolConfigNodeContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolConfigNodeContent.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import type { INode } from 'n8n-workflow';
+import { inject } from 'vue';
 
 import { createComponentRenderer } from '@/__tests__/render';
+import { ResourceMapperSchemaAutoRefreshKey } from '@/app/constants';
 import AgentToolConfigNodeContent from '../components/AgentToolConfigNodeContent.vue';
 
 const renderComponent = createComponentRenderer(AgentToolConfigNodeContent, {
@@ -9,8 +11,13 @@ const renderComponent = createComponentRenderer(AgentToolConfigNodeContent, {
 		stubs: {
 			NodeToolSettingsContent: {
 				template:
-					'<div data-test-id="node-tool-settings">{{ JSON.stringify(hiddenOperations) }}</div>',
+					'<div data-test-id="node-tool-settings" :data-schema-auto-refresh="schemaAutoRefreshEnabled">{{ JSON.stringify(hiddenOperations) }}</div>',
 				props: ['initialNode', 'existingToolNames', 'projectId', 'hiddenOperations'],
+				setup() {
+					return {
+						schemaAutoRefreshEnabled: inject(ResourceMapperSchemaAutoRefreshKey, true),
+					};
+				},
 			},
 		},
 	},
@@ -32,5 +39,14 @@ describe('AgentToolConfigNodeContent', () => {
 		const hiddenOperations = container.textContent ?? '';
 		expect(hiddenOperations).toContain('sendAndWait');
 		expect(hiddenOperations).toContain('dispatchAndWait');
+	});
+
+	it('disables automatic resource mapper schema refreshes', () => {
+		const { container } = renderComponent({ props: { initialNode: node } });
+
+		expect(container.querySelector('[data-schema-auto-refresh]')).toHaveAttribute(
+			'data-schema-auto-refresh',
+			'false',
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigNodeContent.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigNodeContent.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { provide, ref } from 'vue';
 import type { INode } from 'n8n-workflow';
 import { UNSUPPORTED_AGENT_NODE_TOOL_OPERATIONS } from '@n8n/api-types';
 
+import { ResourceMapperSchemaAutoRefreshKey } from '@/app/constants';
 import NodeToolSettingsContent from '@/features/shared/toolConfig/NodeToolSettingsContent.vue';
 
 const props = defineProps<{
@@ -19,6 +20,8 @@ const emit = defineEmits<{
 }>();
 
 const contentRef = ref<InstanceType<typeof NodeToolSettingsContent> | null>(null);
+
+provide(ResourceMapperSchemaAutoRefreshKey, false);
 
 function handleChangeName(name: string) {
 	contentRef.value?.handleChangeName(name);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.ts
@@ -21,6 +21,7 @@ import {
 	EXECUTE_WORKFLOW_NODE_TYPE_TEST,
 } from './ResourceMapper.test.constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { ResourceMapperSchemaAutoRefreshKey } from '@/app/constants';
 
 let nodeTypeStore: ReturnType<typeof useNodeTypesStore>;
 let projectsStore: MockedStore<typeof useProjectsStore>;
@@ -376,7 +377,7 @@ describe('ResourceMapper.vue', () => {
 		expect(fetchFieldsSpy).not.toHaveBeenCalled();
 	});
 
-	it('reconciles an incomplete cached schema with the live source when refreshIncompleteSchemaOnOpen is set', async () => {
+	it('reconciles an incomplete cached schema by default when refreshIncompleteSchemaOnOpen is set', async () => {
 		// A cached schema that is structurally incomplete (missing the
 		// loader-populated `readOnly`), as produced by an AI builder rather than
 		// a real load. After reconciling, the rendered fields should match the
@@ -425,6 +426,54 @@ describe('ResourceMapper.vue', () => {
 		const mappingContainer = getByTestId('mapping-fields-container');
 		expect(mappingContainer.textContent).not.toContain('cached_only_field');
 		expect(mappingContainer.textContent).toContain('First name');
+	});
+
+	it('keeps an incomplete cached schema when automatic refresh is disabled', async () => {
+		const incompleteCachedSchema = [
+			{
+				id: 'cached_only_field',
+				displayName: 'cached_only_field',
+				required: false,
+				defaultMatch: false,
+				display: true,
+				type: 'string',
+				canBeUsedToMatch: true,
+				removed: false,
+			},
+		];
+
+		const { getByTestId } = renderComponent({
+			props: {
+				node: createTestNode({
+					parameters: {
+						columns: {
+							schema: incompleteCachedSchema,
+						},
+					},
+				}),
+				parameter: createTestNodeProperties({
+					name: 'columns',
+					typeOptions: {
+						resourceMapper: {
+							mode: 'add',
+							resourceMapperMethod: 'getMappingColumns',
+							refreshIncompleteSchemaOnOpen: true,
+						} as ResourceMapperTypeOptions,
+					},
+				}),
+			},
+			global: {
+				provide: {
+					[ResourceMapperSchemaAutoRefreshKey as symbol]: false,
+				},
+			},
+		});
+		await waitAllPromises();
+
+		expect(fetchFieldsSpy).toHaveBeenCalledTimes(1);
+		const mappingContainer = getByTestId('mapping-fields-container');
+		expect(mappingContainer.textContent).toContain('cached_only_field');
+		expect(mappingContainer.textContent).not.toContain('First name');
 	});
 
 	it('does not reintroduce an incomplete field when reconciling a matching-id schema', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.vue
@@ -15,7 +15,10 @@ import type {
 } from 'n8n-workflow';
 import { deepCopy, NodeHelpers } from 'n8n-workflow';
 import { computed, inject, onMounted, reactive, watch } from 'vue';
-import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
+import {
+	ExpressionLocalResolveContextSymbol,
+	ResourceMapperSchemaAutoRefreshKey,
+} from '@/app/constants';
 import MappingModeSelect from './MappingModeSelect.vue';
 import MatchingColumnsSelect from './MatchingColumnsSelect.vue';
 import MappingFields from './MappingFields.vue';
@@ -53,6 +56,7 @@ const ndvStore = injectNDVStore();
 const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 const projectsStore = useProjectsStore();
 const expressionLocalResolveCtx = inject(ExpressionLocalResolveContextSymbol, undefined);
+const schemaAutoRefreshEnabled = inject(ResourceMapperSchemaAutoRefreshKey, true);
 const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const props = withDefaults(defineProps<Props>(), {
@@ -137,7 +141,11 @@ async function checkStaleFields(): Promise<void> {
 		state.paramValue.schema,
 		fetchedFields.fields,
 	);
-	if (isSchemaStale && props.parameter.typeOptions?.resourceMapper?.refreshStaleSchemaOnOpen) {
+	if (
+		isSchemaStale &&
+		schemaAutoRefreshEnabled &&
+		props.parameter.typeOptions?.resourceMapper?.refreshStaleSchemaOnOpen
+	) {
 		await initFetching(true, fetchedFields);
 		return;
 	}
@@ -216,6 +224,7 @@ onMounted(async () => {
 		// Only fetch a schema if it's not already set
 		await initFetching();
 	} else if (
+		schemaAutoRefreshEnabled &&
 		props.parameter.typeOptions?.resourceMapper?.refreshIncompleteSchemaOnOpen &&
 		isResourceMapperSchemaIncomplete(state.paramValue.schema)
 	) {


### PR DESCRIPTION
## Summary

Keep Agent tool resource-mapper schemas aligned with saved configuration by requiring an explicit refresh and save before replacing cached fields. Workflow node behavior remains unchanged.

Showing that the old columns haven't been removed and recognises as invalid:
<img width="773" height="660" alt="image" src="https://github.com/user-attachments/assets/8bf9ef18-63b8-48e2-b554-7cc93ec5863b" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-573

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

