### PR TITLE
fix(editor): Trim the doc comments in `@n8n/frontend-vite-config` (no-changelog)

### DIFF
--- a/packages/@n8n/frontend-vite-config/aliases.ts
+++ b/packages/@n8n/frontend-vite-config/aliases.ts
@@ -4,8 +4,8 @@ import type { Alias } from 'vite';
 import { frontendModuleAliases, frontendSourceAliases } from './source-packages.js';
 
 /**
- * Workspace-resolution exceptions: packages reached *transitively*, so they are not declared
- * dependencies of anyone and cannot sit in the source-packages table.
+ * Packages reached *transitively*: they are not a declared dependency of anyone, so they cannot sit
+ * in the source-packages table.
  *
  * `n8n-workflow`'s expression-sandboxing imports `astVisit` from `@n8n/tournament`, whose dist is
  * CJS. Linked workspace packages skip optimizeDeps, so the dev server serves that file verbatim and
@@ -17,12 +17,11 @@ export const transitiveWorkspaceAliases = (packagesDir: string): Alias[] => [
 ];
 
 /**
- * Rewrites for third-party specifiers, unrelated to how workspace packages resolve.
- *
- * **Shell-only, deliberately out of `frontendAliases`:** these replacements are bare specifiers
+ * Shell-only, deliberately out of `frontendAliases`: these replacements are bare specifiers
  * resolved from the consumer's own `node_modules`, and only editor-ui declares `lodash` and
  * `stream-browserify`. Shared with a module's vitest, a value import of `stream` anywhere in its
- * graph fails to resolve — latent today only because `n8n-workflow` imports `stream` as a type.
+ * graph would fail to resolve — latent today only because `n8n-workflow` imports `stream` as a
+ * type.
  */
 export const vendorAliases = (): Alias[] => [
 	...['orderBy', 'camelCase', 'cloneDeep', 'startCase'].map((name) => ({
@@ -35,14 +34,8 @@ export const vendorAliases = (): Alias[] => [
 ];
 
 /**
- * Everything a frontend Vite or vitest config needs that is *not* specific to one package: the
- * platform source mapping plus the transitive workspace exceptions. Every entry here rewrites to an
- * absolute path under `packages/`, which is what makes the set safe to share from any directory —
- * `aliases.test.ts` holds that line.
- *
- * Sibling modules are deliberately absent — `frontendModuleAliases` is exported separately because
- * only the shell may resolve them. A module aliasing its siblings would let an accidental
- * cross-module import resolve at test time, which is the boundary the module tsconfig base holds.
+ * Every entry rewrites to an absolute path under `packages/`, which is what makes the set safe to
+ * share from any directory — `aliases.test.ts` holds that line.
  */
 export const frontendAliases = (packagesDir: string): Alias[] => [
 	...frontendSourceAliases(packagesDir),
@@ -50,9 +43,7 @@ export const frontendAliases = (packagesDir: string): Alias[] => [
 ];
 
 /**
- * The shell's full set: the shared aliases, the module mapping only it may resolve, and the vendor
- * rewrites only it can resolve. Vendor rewrites stay last, where they sat before this package
- * existed, so the shell's resolution order is unchanged by the move.
+ * Order is resolution order: vendor rewrites stay last, where they sat before this package existed.
  */
 export const shellAliases = (packagesDir: string): Alias[] => [
 	...frontendAliases(packagesDir),

--- a/packages/@n8n/frontend-vite-config/source-packages.ts
+++ b/packages/@n8n/frontend-vite-config/source-packages.ts
@@ -3,19 +3,14 @@ import type { Alias } from 'vite';
 
 /**
  * Workspace packages the frontend consumes from source rather than from `dist`, so that an edit in
- * one of them hot-reloads the editor without a rebuild.
+ * one of them hot-reloads the editor without a rebuild. `dir` is relative to `packages/`.
  *
- * Hand-maintained — a list you read and edit, not one derived from the filesystem. It has to stay
- * in step with editor-ui's tsconfig `paths` and with `tsconfig.frontend-module.json`: when those
- * disagreed, vue-tsc typechecked a package from `src` while the bundle was built from its `dist`.
- * `editor-ui/vite/aliases.test.ts` fails when they diverge; add a package here and it will tell you
- * what else to update. `dir` is relative to `packages/`.
+ * Must stay in step with editor-ui's tsconfig `paths` and with `tsconfig.frontend-module.json`:
+ * when those disagreed, vue-tsc typechecked a package from `src` while the bundle was built from
+ * its `dist`. `editor-ui/vite/aliases.test.ts` fails when they diverge and names what to update.
  *
- * It lives in this package rather than in editor-ui because editor-ui is not its only consumer:
- * every `packages/modules/<name>/frontend` needs the same mapping for its own vitest run, and a
- * module cannot import from the shell it plugs into. The cost is one declared dependency per
- * consumer — accepted deliberately over the earlier home inside `@n8n/vitest-config`, which needed
- * no new edge but put frontend Vite resolution inside a test-config package.
+ * It lives here rather than in editor-ui because every `packages/modules/<name>/frontend` needs the
+ * same mapping for its own vitest run, and a module cannot import from the shell it plugs into.
  *
  * `entry: false` marks packages with no `src/index.ts`. Their `exports` map has no `.`, so a bare
  * import of them does not resolve at all and must not be aliased.
@@ -38,12 +33,9 @@ export const sourcePackages = [
 ];
 
 /**
- * Feature module packages, appended by `n8n-module-sdk create`. Kept separate from the table
- * above because only the shell resolves them: a module aliasing its siblings would let an
- * accidental cross-module import resolve at test time, which is the boundary the module tsconfig
- * base is there to hold.
- *
- * Empty until the first module lands under `packages/modules/`.
+ * Feature module packages, appended by `n8n-module-sdk create`. Kept separate from the table above
+ * because only the shell may resolve them: a module aliasing its siblings would let an accidental
+ * cross-module import resolve at test time, which is the boundary the module tsconfig base holds.
  */
 export const modulePackages: Array<{ name: string; dir: string; entry?: boolean }> = [];
 
@@ -52,11 +44,8 @@ const escapeForRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, 
 /**
  * Each package gets a slash-delimited, anchored pair — `^@n8n/chat$` and `^@n8n/chat/(.+)$`. One
  * open-ended `^@n8n/chat(.+)$` would match `@n8n/chat-hub/…` as well, and would leave the bare
- * `@n8n/chat` unmatched: `(.+)` needs a character after the package name, which is how 115 bare
- * `@n8n/stores` imports used to fall through to `dist`.
- *
- * Shared for the same reason the table is: twenty-eight regexes hand-written per consumer is
- * twenty-eight chances to reintroduce that hole.
+ * `@n8n/chat` unmatched — `(.+)` needs a character after the package name — falling through to
+ * `dist`.
  */
 const expand = (packagesDir: string, packages: typeof modulePackages): Alias[] =>
 	packages.flatMap(({ name, dir, entry = true }) => {
@@ -71,10 +60,9 @@ const expand = (packagesDir: string, packages: typeof modulePackages): Alias[] =
 		];
 	});
 
-/** The platform mapping. Every frontend consumer needs this one, modules included. */
 export const frontendSourceAliases = (packagesDir: string): Alias[] =>
 	expand(packagesDir, sourcePackages);
 
-/** The module mapping. Only the shell needs this one. */
+/** Shell-only — see `modulePackages`. */
 export const frontendModuleAliases = (packagesDir: string): Alias[] =>
 	expand(packagesDir, modulePackages);


### PR DESCRIPTION
## Summary

Comments only. No code, no exports, no behaviour — `git diff` has zero non-comment lines. The two files landed in #36043 and are the last ones not held to the comment bar applied to the rest of that chain.

The test each comment had to pass: **it survives only if it encodes a constraint or a non-obvious why.** Narration and restatement of the code below it go. 41 comment lines out, 20 in.

### What was cut

`source-packages.ts`

- "Hand-maintained — a list you read and edit, not one derived from the filesystem." The code is a hand-written array; nothing added.
- The rejected-alternative history: "The cost is one declared dependency per consumer — accepted deliberately over the earlier home inside `@n8n/vitest-config`…". That is PR-description material, not a rule a reader of this file must obey. The constraint that *does* force the placement — a module cannot import from the shell — stays.
- "Empty until the first module lands under `packages/modules/`." Restates `= []`.
- "115 bare `@n8n/stores` imports used to fall through to `dist`." A war story; the rule it illustrates stays.
- "twenty-eight regexes hand-written per consumer is twenty-eight chances to reintroduce that hole." Justifies sharing a helper. Sharing is visible.
- `/** The platform mapping. Every frontend consumer needs this one, modules included. */` Restates the name.

`aliases.ts`

- `frontendAliases`: "the platform source mapping plus the transitive workspace exceptions" — the two-line body says exactly that. The absolute-path constraint stays.
- `frontendAliases`: the sibling-modules paragraph, duplicated near-verbatim on `modulePackages`. Kept at the table, where the rule belongs.
- `shellAliases`: "the shared aliases, the module mapping only it may resolve, and the vendor rewrites only it can resolve" — reads the three spread lines back. The ordering constraint stays.
- `vendorAliases`: "Rewrites for third-party specifiers" — restates `vendorAliases`.

### What was kept, and why

- The tsconfig-sync constraint, including the failure it prevents (vue-tsc on `src`, bundle from `dist`) — you cannot see it from here, and `aliases.test.ts` enforces it.
- `dir` is relative to `packages/`, and what `entry: false` means. Field semantics the types do not carry.
- Why the pair of anchored regexes, not one open-ended one. The bug is silent.
- The `@n8n/tournament` CJS paragraph with its ~397 kB. The single least-guessable fact in the package.
- Why `vendorAliases` is shell-only and must not join the shared set.
- Vendor rewrites last: order is resolution order.

## How to test

Nothing to test at runtime. `git diff -U0 <sha> | grep -vE '^[+-]\s*(\*|/\*|//)'` returns no changed lines outside comments. `biome ci` clean on both files.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #36043.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- Comments only; no behaviour to test. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

