### PR TITLE
chore: Replace n8n-claude-skills usages with n8n-agent-skills

### DIFF
--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -130,13 +130,14 @@ the tools assume.
 ## Quality skills (Claude plugin)
 
 Claude sessions can also load the private quality skills from the
-`n8n-io/n8n-claude-skills` plugin marketplace (bug insights, defect attribution,
-mutation testing, and more). `post-start.mjs` installs the `quality` plugin on
-each container start, so every session gets the skills with no per-session step.
+`n8n-io/n8n-agent-skills` repository (bug insights, defect attribution,
+mutation testing, and more). Its Claude marketplace remains named
+`n8n-claude-skills`. `post-start.mjs` installs the `quality` plugin on each
+container start, so every session gets the skills with no per-session step.
 
 The private marketplace uses the codespace's own GitHub auth — no extra token.
 `devcontainer.json` grants the codespace read access to
-`n8n-io/n8n-claude-skills` via `customizations.codespaces.repositories`, and
+`n8n-io/n8n-agent-skills` via `customizations.codespaces.repositories`, and
 **each user authorizes that access once when they create the codespace** (GitHub
 prompts for it, then remembers). Both repos are in the same org, which is what
 lets this work.

--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -24,7 +24,7 @@
 	"customizations": {
 		"codespaces": {
 			"repositories": {
-				"n8n-io/n8n-claude-skills": { "permissions": { "contents": "read" } }
+				"n8n-io/n8n-agent-skills": { "permissions": { "contents": "read" } }
 			}
 		}
 	},

--- a/.devcontainer/codespaces/post-start.mjs
+++ b/.devcontainer/codespaces/post-start.mjs
@@ -2,7 +2,7 @@
 // Runs on each codespace start. Installs the skills marketplace, starts the worker.
 import { execFileSync } from 'node:child_process';
 
-const MARKETPLACE = 'n8n-io/n8n-claude-skills';
+const MARKETPLACE = 'n8n-io/n8n-agent-skills';
 const PLUGIN = 'quality@n8n-claude-skills';
 
 // The codespace clones over HTTPS and has no SSH key. The loader defaults to SSH

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -80,7 +80,7 @@ const CACHE = 'export TURBO_CACHE_DIR=/workspaces/.turbo-cache; [ -d "$TURBO_CAC
 // Run the idempotent install here to block until the plugin is on disk (a fast
 // no-op once cached). Mirrors the env vars post-start.mjs sets for the private
 // HTTPS clone; failures are tolerated so a plugin hiccup never blocks the session.
-const MARKETPLACE = 'n8n-io/n8n-claude-skills';
+const MARKETPLACE = 'n8n-io/n8n-agent-skills';
 const PLUGIN = 'quality@n8n-claude-skills';
 const ENSURE_PLUGIN = `export CLAUDE_CODE_PLUGIN_PREFER_HTTPS=1 CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE=1; claude plugin marketplace add ${MARKETPLACE} >/dev/null 2>&1 || true; claude plugin install ${PLUGIN} >/dev/null 2>&1 || true`;
 


### PR DESCRIPTION
## Summary

This PR replaces repository name, as it's going to be renamed soon. The claude plugin name stays the same for compatibility reasons

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

