### PR TITLE
ci: Force broad E2E selection for boot-time default changes (no-changelog)

### DIFF
--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -23,6 +23,8 @@ import {
 	selectTests,
 	changedRuntimeDepsFromManifests,
 	changedOverrideTargets,
+	isBackendConfig,
+	isTsconfig,
 } from '@n8n/test-impact';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -80,7 +82,7 @@ import {
 } from './core/method-usage-analyzer.js';
 import { createProject } from './core/project-loader.js';
 import { readLockfileImporters, readRuntimeClosure } from './core/read-lockfile-importers.js';
-import { readManifestDiffs, readTsconfigDiffs } from './core/read-manifest-diffs.js';
+import { isManifest, readFileDiffs } from './core/read-manifest-diffs.js';
 import { toJSON, toConsole } from './core/reporter.js';
 import { filterToFailedSpecs } from './core/retry-filter.js';
 import { computeScope, formatScope } from './core/scope-analyzer.js';
@@ -718,12 +720,13 @@ function runMergeCoverage(options: CliOptions): void {
  *  around {@link selectTests}, where the fail-open safety contract lives. */
 function runSelect(options: CliOptions): void {
 	const changedFiles = readChangedFiles(options) ?? [];
-	// With a base ref, read each changed package.json before/after so the
-	// devDependency-only classifier can drop a devDep-only lockfile change.
-	// No base (local dev) → omit manifests → conservative (keep lockfile broad).
-	const manifests = options.baseRef ? readManifestDiffs(changedFiles, options.baseRef) : undefined;
-	// Same for tsconfig diffs, feeding the resolution-key classifier.
-	const tsconfigs = options.baseRef ? readTsconfigDiffs(changedFiles, options.baseRef) : undefined;
+	// Content diffs feed the classifiers that need before/after to decide: the
+	// devDependency-only one (manifests), the resolution-key one (tsconfigs) and
+	// the changed-default one (configs). No base ref (local dev) → omit them all,
+	// which each classifier reads as "unproven" and keeps broad.
+	const diffs = (predicate: (file: string) => boolean) =>
+		options.baseRef ? readFileDiffs(changedFiles, options.baseRef, predicate) : undefined;
+	const manifests = diffs(isManifest);
 	// Only parse the (large) lockfile when a RUNTIME dependency actually changed —
 	// the only case the dep-graph selector (389) acts on. A devDep-only manifest
 	// change would parse it for nothing.
@@ -744,7 +747,8 @@ function runSelect(options: CliOptions): void {
 		mapFile: options.mapFile,
 		allSpecsFile: options.allSpecsFile,
 		manifests,
-		tsconfigs,
+		tsconfigs: diffs(isTsconfig),
+		configs: diffs(isBackendConfig),
 		lockfileImporters,
 		runtimeClosure: overridesChanged ? readRuntimeClosure() : undefined,
 	});

--- a/packages/testing/janitor/src/core/read-manifest-diffs.ts
+++ b/packages/testing/janitor/src/core/read-manifest-diffs.ts
@@ -1,15 +1,15 @@
 /**
- * before/after content of changed package.json / tsconfig files, for the
- * `@n8n/test-impact` classifiers. Any read failure → '' so a classifier stays
- * conservative (an unreadable file is treated as impactful).
+ * before/after content of changed files, for the `@n8n/test-impact` content-aware
+ * classifiers. Any read failure → '' so a classifier stays conservative (an
+ * unreadable file is treated as impactful).
  */
+import { type FileDiffs } from '@n8n/test-impact';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { getFileAtRef, getGitRoot } from '../utils/git-operations.js';
 
-const isManifest = (file: string): boolean => /(^|\/)package\.json$/.test(file);
-const isTsconfig = (file: string): boolean => /(^|\/)tsconfig([.\w-]*)\.json$/.test(file);
+export const isManifest = (file: string): boolean => /(^|\/)package\.json$/.test(file);
 
 /** Read the working-tree file, or '' on any failure (missing, unreadable, or a
  *  TOCTOU delete between the existsSync check and the read). */
@@ -22,15 +22,15 @@ function readWorkingTree(abs: string): string {
 }
 
 /** before/after content of each changed file matching `predicate`. */
-function readFileDiffs(
+export function readFileDiffs(
 	changedFiles: string[],
 	baseRef: string,
 	predicate: (file: string) => boolean,
-): Record<string, { before: string; after: string }> {
+): FileDiffs {
 	const matched = changedFiles.filter(predicate);
 	if (matched.length === 0) return {};
 	const root = getGitRoot(process.cwd());
-	const out: Record<string, { before: string; after: string }> = {};
+	const out: FileDiffs = {};
 	for (const file of matched) {
 		out[file] = {
 			before: getFileAtRef(file, baseRef) ?? '',
@@ -38,18 +38,4 @@ function readFileDiffs(
 		};
 	}
 	return out;
-}
-
-export function readManifestDiffs(
-	changedFiles: string[],
-	baseRef: string,
-): Record<string, { before: string; after: string }> {
-	return readFileDiffs(changedFiles, baseRef, isManifest);
-}
-
-export function readTsconfigDiffs(
-	changedFiles: string[],
-	baseRef: string,
-): Record<string, { before: string; after: string }> {
-	return readFileDiffs(changedFiles, baseRef, isTsconfig);
 }

--- a/packages/testing/playwright/scripts/distribute-tests.mjs
+++ b/packages/testing/playwright/scripts/distribute-tests.mjs
@@ -112,7 +112,10 @@ function selectV8Specs(externalFiles, base) {
 		if (parsed.mode === 'broad') {
 			return {
 				broad: true,
-				reason: parsed.failOpen ?? `unmapped: ${(parsed.unmapped ?? []).join(', ')}`,
+				// Not "unmapped": every non-fail-open broad reason is a file the map
+				// can't be trusted for (runtime-defining, resolution-changing, or an
+				// unscoped dependency change), which may well have a map entry.
+				reason: parsed.failOpen ?? `forced broad by: ${(parsed.unmapped ?? []).join(', ')}`,
 			};
 		}
 		// Coverage-gap alarm: changes with no E2E that verifies them aren't run

--- a/packages/testing/test-impact/src/changes.test.ts
+++ b/packages/testing/test-impact/src/changes.test.ts
@@ -6,6 +6,8 @@ import {
 	forcesBroad,
 	isTsconfig,
 	tsconfigForcesBroad,
+	isBackendConfig,
+	configForcesBroad,
 	classifyManifestChange,
 	dropDevDepOnlyDeps,
 	overrideTargetName,
@@ -88,6 +90,10 @@ describe('forcesBroad', () => {
 		'Dockerfile.dev',
 		'packages/cli/worker.Dockerfile',
 		'packages/nodes-base/credentials/MicrosoftOAuth2Api.credentials.ts',
+		// Module registry: decides which modules load at boot, so a default flip
+		// changes behaviour in specs that never execute this file.
+		'packages/@n8n/backend-common/src/modules/module-registry.ts',
+		'packages/@n8n/backend-common/src/modules/modules.config.ts',
 	])('treats %s as runtime-defining (force broad)', (file) => {
 		expect(forcesBroad(file)).toBe(true);
 	});
@@ -96,6 +102,11 @@ describe('forcesBroad', () => {
 		'packages/cli/src/server.ts',
 		'packages/testing/playwright/tests/e2e/x.spec.ts',
 		'packages/nodes-base/nodes/If/If.node.ts',
+		// A unit test beside the registry can't change the runtime — stays scoped.
+		'packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts',
+		// Per-module descriptors are NOT the registry: high churn, and they can't
+		// change which modules are enabled by default.
+		'packages/cli/src/modules/instance-ai/instance-ai.module.ts',
 	])('does not force broad for %s', (file) => {
 		expect(forcesBroad(file)).toBe(false);
 	});
@@ -348,5 +359,65 @@ describe('dropDevDepOnlyDeps — overrides (safety-critical)', () => {
 			'package.json': { before: ovr({}), after: ovr({ '>=2.0.0': '2.0.0' }) },
 		};
 		expect(dropDevDepOnlyDeps(files, manifests, closure)).toEqual(files);
+	});
+});
+
+describe('isBackendConfig', () => {
+	it.each([
+		'packages/@n8n/config/src/configs/ai.config.ts',
+		'packages/@n8n/config/src/configs/logging.config.ts',
+	])('matches %s', (file) => {
+		expect(isBackendConfig(file)).toBe(true);
+	});
+
+	it.each([
+		'packages/@n8n/config/src/configs/__tests__/ai.config.test.ts',
+		'packages/@n8n/config/src/decorators.ts',
+		'packages/cli/src/config/index.ts',
+	])('does not match %s', (file) => {
+		expect(isBackendConfig(file)).toBe(false);
+	});
+});
+
+describe('configForcesBroad', () => {
+	const cfg = (body: string) =>
+		`import { Config, Env } from '../decorators';\n@Config\nexport class C {\n${body}\n}`;
+	const enabled = "\t@Env('N8N_AI_ENABLED')\n\tenabled: boolean = false;";
+
+	it('forces broad when a default value changes', () => {
+		const after = cfg(enabled.replace('= false', '= true'));
+		expect(configForcesBroad(cfg(enabled), after)).toBe(true);
+	});
+
+	it('forces broad when an env var is renamed', () => {
+		const after = cfg(enabled.replace('N8N_AI_ENABLED', 'N8N_AI_ON'));
+		expect(configForcesBroad(cfg(enabled), after)).toBe(true);
+	});
+
+	it('forces broad when a field is removed', () => {
+		expect(configForcesBroad(cfg(enabled), cfg(''))).toBe(true);
+	});
+
+	it('forces broad when an optional field gains a default', () => {
+		const before = cfg('\tthreshold?: number;');
+		const after = cfg('\tthreshold?: number = 5;');
+		expect(configForcesBroad(before, after)).toBe(true);
+	});
+
+	it('does NOT force broad for a new field (additive)', () => {
+		const after = cfg(`${enabled}\n\n\t@Env('N8N_AI_TIMEOUT')\n\ttimeout: number = 60;`);
+		expect(configForcesBroad(cfg(enabled), after)).toBe(false);
+	});
+
+	it('does NOT force broad for a comment-only edit', () => {
+		const before = cfg(`\t/** Old wording. */\n${enabled}`);
+		const after = cfg(`\t/** New wording, same default. */\n${enabled}`);
+		expect(configForcesBroad(before, after)).toBe(false);
+	});
+
+	it('does NOT force broad for reformatted whitespace', () => {
+		const before = cfg('\tmaxSize: number = 50 * 1024 * 1024;');
+		const after = cfg('\tmaxSize: number =\t50 *  1024 * 1024;');
+		expect(configForcesBroad(before, after)).toBe(false);
 	});
 });

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -64,12 +64,20 @@ export function filterImpactfulChanges(files: string[]): string[] {
  * attributably to a spec and the runtime coverage map never records them. Absent
  * from the map, a credential change would be declared uncovered and skip its
  * covering specs, so we force broad instead.
+ *
+ * The module registry is the same boot-time class, but worse: it IS in the map,
+ * so a scoped result looks correct. Boot code is attributed only to specs that
+ * start their own container — i.e. the specs that already enable the module via
+ * `N8N_ENABLED_MODULES` and so can't observe a default flip. The specs that
+ * break assert the off-branch, and no hit-coverage map reaches a branch that
+ * stopped executing. Churn is low, so broad is cheap here too.
  */
 const FORCES_BROAD: Array<(f: string) => boolean> = [
 	(f) => f.startsWith('docker/'),
 	(f) => /(^|\/)Dockerfile(\.|$)|\.Dockerfile$/.test(f),
 	(f) => f.startsWith('packages/testing/containers/'),
 	(f) => f.startsWith('packages/nodes-base/credentials/'),
+	(f) => /^packages\/@n8n\/backend-common\/src\/modules\/[^/]+\.ts$/.test(f),
 ];
 
 /** True if a changed file defines the E2E runtime → the whole suite must run. */
@@ -235,6 +243,12 @@ const TSCONFIG_RESOLUTION_KEYS = [
 	'customConditions',
 ] as const;
 
+/** Remove block and line comments. A comment-only edit must not look like a
+ *  change. The `[^:]` guard keeps `http://` intact. */
+function stripComments(raw: string): string {
+	return raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
 /** Tolerant parse for tsconfig (allows comments + trailing commas). Null when
  *  unparseable, which the caller treats as "force broad". */
 function parseTsconfig(raw: string): Record<string, unknown> | null {
@@ -243,10 +257,7 @@ function parseTsconfig(raw: string): Record<string, unknown> | null {
 		return JSON.parse(raw) as Record<string, unknown>;
 	} catch {
 		try {
-			const stripped = raw
-				.replace(/\/\*[\s\S]*?\*\//g, '')
-				.replace(/(^|[^:])\/\/.*$/gm, '$1')
-				.replace(/,(\s*[}\]])/g, '$1');
+			const stripped = stripComments(raw).replace(/,(\s*[}\]])/g, '$1');
 			return JSON.parse(stripped) as Record<string, unknown>;
 		} catch {
 			return null;
@@ -269,6 +280,38 @@ export function tsconfigForcesBroad(before: string, after: string): boolean {
 	const bco = (b.compilerOptions ?? {}) as Record<string, unknown>;
 	const aco = (a.compilerOptions ?? {}) as Record<string, unknown>;
 	return TSCONFIG_RESOLUTION_KEYS.some((k) => JSON.stringify(bco[k]) !== JSON.stringify(aco[k]));
+}
+
+export const isBackendConfig = (f: string): boolean =>
+	/^packages\/@n8n\/config\/src\/configs\/[^/]+\.ts$/.test(f);
+
+/** Every field default (`name=initializer`, empty when the field has none) and
+ *  every `@Env` binding — the two inputs that decide a config's runtime value. */
+function configDefaults(source: string): Set<string> {
+	const src = stripComments(source);
+	const defaults = new Set<string>();
+	for (const [, env] of src.matchAll(/@Env\(\s*['"]([^'"]+)['"]/g)) {
+		defaults.add(`env:${env}`);
+	}
+	for (const [, field, init] of src.matchAll(
+		/^\s*(?:readonly\s+)?([\w$]+)[?!]?\s*:\s*[^=;\n]+?(?:=\s*([^;\n]+))?;/gm,
+	)) {
+		defaults.add(`${field}=${(init ?? '').trim().replace(/\s+/g, ' ')}`);
+	}
+	return defaults;
+}
+
+/**
+ * True when a config change alters an EXISTING default — a field's fallback
+ * value, or the env var it reads. Config classes are built once with the DI
+ * container, so their defaults are unattributable (1 of ~57 files is in the
+ * map) and a changed default moves behaviour in specs that never touch the
+ * file. A purely additive change can't: the code reading the new field is in
+ * the same PR and IS mapped. That split matters at ~130 commits/90d.
+ */
+export function configForcesBroad(before: string, after: string): boolean {
+	const next = configDefaults(after);
+	return [...configDefaults(before)].some((d) => !next.has(d));
 }
 
 /** Remove the lockfile + every package.json from a changed-file set. */

--- a/packages/testing/test-impact/src/index.ts
+++ b/packages/testing/test-impact/src/index.ts
@@ -13,6 +13,8 @@ export {
 	isNonImpactful,
 	filterImpactfulChanges,
 	forcesBroad,
+	isBackendConfig,
+	isTsconfig,
 	classifyManifestChange,
 	dropDevDepOnlyDeps,
 	changedRuntimeDeps,

--- a/packages/testing/test-impact/src/select.test.ts
+++ b/packages/testing/test-impact/src/select.test.ts
@@ -163,6 +163,66 @@ describe('selectTests — fail-open contract', () => {
 		expect(result.uncovered).toBeUndefined();
 	});
 
+	// Regression (#35670): enabling a module by default broke the specs asserting
+	// its off-branch, which the map can't reach. A scoped answer looks legitimate
+	// here because the registry HAS an entry — just a partial one.
+	it('module-registry change → broad, even though the map has a (partial) entry', () => {
+		const map: ImpactMap = {
+			'packages/@n8n/backend-common/src/modules/module-registry.ts': {
+				'17': ['tests/e2e/a.spec.ts'],
+			},
+		};
+		const mapPath = path.join(tempDir, 'map-registry.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: [
+				'packages/@n8n/backend-common/src/modules/module-registry.ts',
+				'packages/cli/src/modules/instance-ai/instance-ai.module.ts',
+			],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+		});
+		expect(result.mode).toBe('broad');
+		// b.spec.ts — the off-branch spec with no coverage link to the registry — runs.
+		expect(result.specs).toEqual([...ALL_SPECS].sort());
+		expect(result.uncovered).toBeUndefined();
+	});
+
+	describe('config default change', () => {
+		const CONFIG = 'packages/@n8n/config/src/configs/ai.config.ts';
+		const cfg = (init: string) =>
+			`@Config\nexport class C {\n\t@Env('N8N_AI')\n\ta: boolean = ${init};\n}`;
+
+		const select = (configs?: Record<string, { before: string; after: string }>) => {
+			const map: ImpactMap = { [CONFIG]: { '5': ['tests/e2e/a.spec.ts'] } };
+			const mapPath = path.join(tempDir, `map-cfg-${configs ? 'diff' : 'none'}.json`);
+			fs.writeFileSync(mapPath, JSON.stringify(map));
+			return selectTests({
+				changedFiles: [CONFIG],
+				mapFile: mapPath,
+				allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+				configs,
+			});
+		};
+
+		it('changed default → broad', () => {
+			const result = select({ [CONFIG]: { before: cfg('false'), after: cfg('true') } });
+			expect(result.mode).toBe('broad');
+			expect(result.specs).toEqual([...ALL_SPECS].sort());
+		});
+
+		it('new field (additive) → falls through to the map, stays scoped', () => {
+			const after = cfg('false').replace('\n}', "\n\t@Env('N8N_NEW')\n\tb: number = 1;\n}");
+			const result = select({ [CONFIG]: { before: cfg('false'), after } });
+			expect(result.mode).toBe('scoped');
+			expect(result.specs).toEqual(['tests/e2e/a.spec.ts']);
+		});
+
+		it('no diff metadata (local dev) → conservative broad', () => {
+			expect(select().mode).toBe('broad');
+		});
+	});
+
 	it('package.json change with NO dependency change (version) → uncovered, not broad', () => {
 		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
 		const mapPath = path.join(tempDir, 'map-ver.json');

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -15,9 +15,11 @@ import * as fs from 'node:fs';
 import {
 	changedRuntimeDepsFromManifests,
 	classifyManifestChange,
+	configForcesBroad,
 	dropDevDepOnlyDeps,
 	filterImpactfulChanges,
 	forcesBroad,
+	isBackendConfig,
 	isTsconfig,
 	stripDependencyFiles,
 	tsconfigForcesBroad,
@@ -34,6 +36,10 @@ import { DependencyGraphStrategy } from './select/dep-graph-strategy.js';
 import { selectImpactedTests } from './select/pipeline.js';
 import type { SelectionStrategy } from './select/strategy.js';
 
+/** before/after content of changed files, keyed by path — the caller reads these
+ *  from git. A file absent here can't be classified, so it stays broad. */
+export type FileDiffs = Record<string, { before: string; after: string }>;
+
 export interface SelectTestsInput {
 	/** Changed files (file paths). */
 	changedFiles: string[];
@@ -41,14 +47,14 @@ export interface SelectTestsInput {
 	mapFile?: string;
 	/** Path to a newline/comma separated list of every known spec. */
 	allSpecsFile?: string;
-	/** before/after content of each changed package.json (caller reads from git),
-	 *  keyed by path. When supplied, a devDependencies-only manifest change drops
-	 *  the lockfile + manifests from selection — a devDep can't reach the runtime
-	 *  bundle the E2E suite exercises. */
-	manifests?: Record<string, { before: string; after: string }>;
-	/** before/after content of each changed tsconfig (caller reads from git).
-	 *  Fed to {@link tsconfigForcesBroad}; omitted (local dev) → conservative broad. */
-	tsconfigs?: Record<string, { before: string; after: string }>;
+	/** Changed package.json diffs. When supplied, a devDependencies-only manifest
+	 *  change drops the lockfile + manifests from selection — a devDep can't reach
+	 *  the runtime bundle the E2E suite exercises. */
+	manifests?: FileDiffs;
+	/** Changed tsconfig diffs, fed to {@link tsconfigForcesBroad}. */
+	tsconfigs?: FileDiffs;
+	/** Changed `@n8n/config` diffs, fed to {@link configForcesBroad}. */
+	configs?: FileDiffs;
 	/** Workspace package dir → runtime dependency names it declares (parsed from
 	 *  pnpm-lock.yaml's `importers`). With `manifests`, a changed runtime dep is
 	 *  walked to its declaring packages and scoped via the map instead
@@ -119,17 +125,29 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	const forcing = impactful.filter(forcesBroad);
 	if (forcing.length > 0) return broad(forcing);
 
-	// A resolution-changing tsconfig edit forces broad; a resolution-neutral one
-	// is dropped (see tsconfigForcesBroad). No diff metadata → conservative broad.
-	const tsconfigChanges = impactful.filter(isTsconfig);
-	if (tsconfigChanges.length > 0) {
-		const forcingTsconfig = tsconfigChanges.filter((f) => {
-			const diff = input.tsconfigs?.[f];
-			return !diff || tsconfigForcesBroad(diff.before, diff.after);
+	// Content-aware classifiers: a change of this kind forces broad only when the
+	// diff proves it can move behaviour. An unsupplied diff (local dev, no base
+	// ref) can't prove anything, so it forces broad.
+	const forcingByContent = (
+		matches: (f: string) => boolean,
+		diffs: FileDiffs | undefined,
+		classify: (before: string, after: string) => boolean,
+	): string[] =>
+		impactful.filter((f) => {
+			if (!matches(f)) return false;
+			const diff = diffs?.[f];
+			return !diff || classify(diff.before, diff.after);
 		});
-		if (forcingTsconfig.length > 0) return broad(forcingTsconfig);
-		impactful = impactful.filter((f) => !isTsconfig(f));
-	}
+
+	const forcingTsconfig = forcingByContent(isTsconfig, input.tsconfigs, tsconfigForcesBroad);
+	if (forcingTsconfig.length > 0) return broad(forcingTsconfig);
+	// A resolution-neutral tsconfig resolves to the same modules → drop it.
+	impactful = impactful.filter((f) => !isTsconfig(f));
+
+	// A changed config default moves behaviour in specs that never execute the
+	// file; an additive one can't, and falls through to the map.
+	const forcingConfig = forcingByContent(isBackendConfig, input.configs, configForcesBroad);
+	if (forcingConfig.length > 0) return broad(forcingConfig);
 
 	// devDependency-only change can't reach the runtime bundle → dropped. Same for
 	// a `pnpm.overrides` pin whose target is outside the runtime closure.


### PR DESCRIPTION
## Summary

The coverage-based E2E selector attributes boot-time code only to the specs that **start their own container**. Those are exactly the specs that opt a module in via `N8N_ENABLED_MODULES`, so a change to the **default** module set resolves to the specs that cannot observe it — and never to the specs asserting the off-branch, since a hit-coverage map can't reach a branch that stopped executing. The selector returns a plausible-looking scoped answer with a real regression in the gap.

This is the shape that broke three `tests/e2e/ai/*` specs on master after #35670. That PR's selection was:

```
⚠ 2 changed file(s) have no E2E coverage — not run, relying on unit + sanity:
   .../modules/__tests__/module-registry.test.ts, .../instance-ai/instance-ai.module.ts
🎯 mode: scoped   v8: 9 specs   ast: 3 specs   union: 11/196
```

All 9 coverage-selected specs were instance-ai / chat-hub / mcp specs — the ones that already ran with the module on.

Two classifiers close the gap:

**1. Module registry → force broad.** `packages/@n8n/backend-common/src/modules/*.ts` joins `FORCES_BROAD`, on the rationale the `nodes-base/credentials/` entry already documents (boot-time registry data the runtime coverage map can't attribute). Top-level only, so `__tests__/` and `errors/` stay scoped. Cost: 9 commits/90d touch these files, 2 of which already forced broad for another reason → **7 net additional broad runs per 90 days**.

Deliberately excluded: `packages/cli/src/modules/*/*.module.ts`. 82 commits/90d, and a descriptor can't change which modules are on by default, so it wouldn't have caught this.

**2. `@n8n/config` → content-aware.** Blanket-broad would be too expensive here (131 commits/90d), so this mirrors the existing `tsconfigForcesBroad` classifier instead. A change that alters an **existing** default — a field's fallback value, or the env var it reads — forces broad. A purely additive change stays scoped, because the code reading the new field lands in the same PR and *is* in the map.

One rule expresses all of it: build the set of default bindings per side (`field=initializer` for every declared field, `env:NAME` for every `@Env`) and force broad if any binding present before is missing after. That covers changed values, renamed env vars, removed fields, and an optional field gaining a default. Comments are stripped and whitespace normalised first, so rewording or reformatting is a no-op.

Worth stating: only **1 of ~57** config files appears in the coverage map at all, so a change here was previously *declared uncovered* and ran nothing.

**Also in this PR**

- Broad reasons now print as `forced broad by:` rather than `unmapped:`. Every non-fail-open broad reason is a file the map can't be *trusted* for, which may well have an entry — the module registry does. This log line is the selector's main diagnostic surface, so the wording mattered.
- Cleanup: `stripComments` shared between the two content-aware classifiers; `forcingByContent` shares their selection blocks; a `FileDiffs` type replaces three inline copies of its shape. The janitor's three near-identical diff readers collapse to one taking a predicate, and its re-declared `isTsconfig` now imports from `@n8n/test-impact` instead of drifting from it.

## How to test

Unit tests cover both classifiers (`changes.test.ts`, `select.test.ts` — including a `#35670` regression case pinning that a *partial* map entry still resolves broad). 224 tests pass in `@n8n/test-impact`.

End-to-end through the real selector CLI:

```bash
# 1. #35670's change set → was scoped 11/196, now broad
node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate --impact \
  "--files=packages/@n8n/backend-common/src/modules/module-registry.ts,packages/cli/src/modules/instance-ai/instance-ai.module.ts" \
  "--base=249e5a839635fd3022402a27b77443375e84b227"
#   mode: broad (forced broad by: .../module-registry.ts) → 16 shards, 201 specs
#   includes ai/assistant-basic, ai/builder-setup-wizard, ai/assistant-credential-help

# 2. a real config default flip → broad
node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate --impact \
  "--files=packages/@n8n/config/src/configs/expression-engine.config.ts" "--base=98e0952c3~1"

# 3. a real additive config change → stays scoped
node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate --impact \
  "--files=packages/@n8n/config/src/configs/instance-ai.config.ts" "--base=cc5f1cb37~1"
```

Calibration on real history — every `@n8n/config/src/configs` commit of the last 90 days replayed against its own parent:

```
config commits (90d): 131  →  broad: 34   scoped: 97
```

74% cheaper than a blanket rule for the same catch, and the broad bucket reads like the dangerous shape it's meant to find (*"Make the vm expression engine the default"*, *"Flip the Instance AI durable event log on by default"*, *"Remove feature flag 070_empty_screen_layout"*). Cross-checked against an independent crude oracle (a removed line assigning a default, comment lines excluded): **0 disagreements across all 131**.

Combined cost of both classifiers: ~41 broad runs per 90 days, about one every 2.2 days.

## Related Linear tickets, Github issues, and Community forum posts

No ticket — happy to file one if you'd like it tracked.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

