### PR TITLE
fix(core): Respect the editor write lock when Instance AI writes workflows

### DIFF
--- a/packages/@n8n/instance-ai/src/errors/workflow-editor-locked.error.ts
+++ b/packages/@n8n/instance-ai/src/errors/workflow-editor-locked.error.ts
@@ -1,0 +1,21 @@
+import { OperationalError } from 'n8n-workflow';
+
+/**
+ * Thrown when an Instance AI workflow write is refused because a user holds the
+ * editor write lock — someone has the workflow open on the canvas and is
+ * actively editing it, so writing would overwrite work in progress.
+ */
+export class WorkflowEditorLockedError extends OperationalError {
+	constructor(readonly workflowId: string) {
+		super(
+			`Workflow ${workflowId} is being edited by a user in the n8n editor right now, so it cannot be modified. ` +
+				'Tell the user to finish or close their editing session, then retry.',
+			{ level: 'warning' },
+		);
+	}
+}
+
+export function isWorkflowEditorLockedError(error: unknown): boolean {
+	if (error instanceof WorkflowEditorLockedError) return true;
+	return error instanceof Error && error.cause instanceof WorkflowEditorLockedError;
+}

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -186,6 +186,7 @@ export { parseModelHeadersJson } from './utils/parse-model-headers';
 export { resolveCustomModelExperimentDefaultsFromEnv } from './utils/custom-model-defaults';
 export { WorkflowSaveConflictError } from './errors/workflow-save-conflict.error';
 export { WorkflowNotFoundError } from './errors/workflow-not-found.error';
+export { WorkflowEditorLockedError } from './errors/workflow-editor-locked.error';
 export {
 	LEGACY_PLANNED_TASK_KINDS,
 	PLANNED_TASK_KINDS,

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -3,6 +3,8 @@ import { generateWorkflowCode } from '@n8n/workflow-sdk';
 import type { Mock } from 'vitest';
 
 import { executeTool } from '../../__tests__/tool-test-utils';
+import { WorkflowEditorLockedError } from '../../errors/workflow-editor-locked.error';
+import { WorkflowSaveConflictError } from '../../errors/workflow-save-conflict.error';
 import type { InstanceAiContext } from '../../types';
 import {
 	analyzeWorkflow,
@@ -12,6 +14,7 @@ import {
 import { STRUCTURE_ONLY_NOTE } from '../workflows/summarize-workflow';
 import {
 	getWorkflowSourceFileBinding,
+	refreshWorkflowSourceFileBindingFromSave,
 	saveWorkflowSourceFileBinding,
 } from '../workflows/workflow-file-bindings';
 import { createWorkflowsTool, type WorkflowAction } from '../workflows.tool';
@@ -787,6 +790,181 @@ describe('workflows tool', () => {
 				}),
 			);
 			expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+		});
+
+		describe('stale-save detection', () => {
+			const workflowDetail = (checksum: string) => ({
+				id: 'wf1',
+				name: 'Test WF',
+				versionId: 'v1',
+				checksum,
+				activeVersionId: null,
+				isArchived: false,
+				createdAt: '2024-01-01',
+				updatedAt: '2024-01-01',
+				nodes: [],
+				connections: {},
+			});
+
+			it('expects the checksum the agent last read, so a concurrent save is caught', async () => {
+				const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
+				(context.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue(
+					workflowDetail('checksum-saved'),
+				);
+				const tool = createWorkflowsTool(context, 'full');
+
+				await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
+				await executeTool(
+					tool,
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+
+				expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledWith(
+					'wf1',
+					workflowPayload,
+					{ expectedChecksum: 'checksum-read' },
+				);
+			});
+
+			it('expects the checksum current when the agent read the workflow JSON to edit', async () => {
+				const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
+				(context.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue(
+					workflowDetail('checksum-saved'),
+				);
+				const tool = createWorkflowsTool(context, 'full');
+
+				await executeTool(tool, { action: 'get-json', workflowId: 'wf1' }, {} as never);
+				await executeTool(
+					tool,
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+
+				expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledWith(
+					'wf1',
+					workflowPayload,
+					{ expectedChecksum: 'checksum-read' },
+				);
+			});
+
+			it('does not expect a checksum after reading a past version', async () => {
+				const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
+				(context.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue(
+					workflowDetail('checksum-saved'),
+				);
+				const tool = createWorkflowsTool(context, 'full');
+
+				await executeTool(
+					tool,
+					{ action: 'get-json', workflowId: 'wf1', versionId: 'v-old' },
+					{} as never,
+				);
+				await executeTool(
+					tool,
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+
+				expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledWith(
+					'wf1',
+					workflowPayload,
+				);
+			});
+
+			it('advances the expectation to the checksum of its own save', async () => {
+				const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
+				(context.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue(
+					workflowDetail('checksum-saved'),
+				);
+				const tool = createWorkflowsTool(context, 'full');
+
+				await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
+				await executeTool(
+					tool,
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+				await executeTool(
+					tool,
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+
+				expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenLastCalledWith(
+					'wf1',
+					workflowPayload,
+					{ expectedChecksum: 'checksum-saved' },
+				);
+			});
+
+			it('tracks saves made by other Instance AI paths, so they do not look stale', async () => {
+				const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
+				(context.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue(
+					workflowDetail('checksum-saved'),
+				);
+				const tool = createWorkflowsTool(context, 'full');
+
+				await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
+				// e.g. the setup or apply-credentials flow saving in between
+				await refreshWorkflowSourceFileBindingFromSave(context, 'wf1', {
+					versionId: 'v-setup',
+					checksum: 'checksum-setup',
+				});
+				await executeTool(
+					tool,
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+
+				expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledWith(
+					'wf1',
+					workflowPayload,
+					{ expectedChecksum: 'checksum-setup' },
+				);
+			});
+
+			it('tells the agent to re-read the workflow when its save is stale', async () => {
+				const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
+				(context.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				(context.workflowService.updateFromWorkflowJSON as Mock).mockRejectedValue(
+					new WorkflowSaveConflictError('wf1'),
+				);
+				const tool = createWorkflowsTool(context, 'full');
+
+				await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
+				const result = await executeTool(
+					tool,
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+
+				expect(result).toMatchObject({ success: false });
+				expect((result as { error: string }).error).toMatch(/modified outside this conversation/);
+				expect((result as { error: string }).error).toMatch(/action="get"/);
+			});
+		});
+
+		it('tells the agent what to do when a user is editing the workflow in the editor', async () => {
+			const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
+			(context.workflowService.updateFromWorkflowJSON as Mock).mockRejectedValue(
+				new WorkflowEditorLockedError('wf1'),
+			);
+
+			const result = await executeTool(
+				createWorkflowsTool(context, 'full'),
+				{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+				{} as never,
+			);
+
+			expect(result).toMatchObject({ success: false });
+			expect((result as { error: string }).error).toMatch(/being edited by a user/);
+			expect((result as { error: string }).error).toMatch(/retry/i);
 		});
 
 		it('should update without approval when the workflow was created in this run', async () => {

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -875,6 +875,65 @@ describe('workflows tool', () => {
 				);
 			});
 
+			it('expects the checksum read in an earlier turn of the same conversation', async () => {
+				// Each run builds its own context, so the expectation has to live on the thread.
+				const threads = new Map<string, { metadata: Record<string, unknown> }>();
+				const threadMemory = {
+					getThread: vi.fn(
+						async (threadId: string) => await Promise.resolve(threads.get(threadId) ?? null),
+					),
+					patchThread: vi.fn(
+						async ({
+							threadId,
+							update,
+						}: {
+							threadId: string;
+							update: (current: { metadata: Record<string, unknown> }) => {
+								metadata?: Record<string, unknown>;
+							} | null;
+						}) => {
+							const current = threads.get(threadId) ?? { metadata: {} };
+							const patch = update(current);
+							if (!patch) return null;
+							const next = { ...current, metadata: patch.metadata ?? current.metadata };
+							threads.set(threadId, next);
+							return await Promise.resolve(next);
+						},
+					),
+				};
+				const contextForTurn = () =>
+					createMockContext({
+						permissions: { updateWorkflow: 'always_allow' },
+						threadId: 'thread-1',
+						threadMemory,
+					});
+
+				const readTurn = contextForTurn();
+				(readTurn.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				await executeTool(
+					createWorkflowsTool(readTurn, 'full'),
+					{ action: 'get', workflowId: 'wf1' },
+					{} as never,
+				);
+
+				const updateTurn = contextForTurn();
+				(updateTurn.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));
+				(updateTurn.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue(
+					workflowDetail('checksum-saved'),
+				);
+				await executeTool(
+					createWorkflowsTool(updateTurn, 'full'),
+					{ action: 'update', workflowId: 'wf1', workflow: workflowPayload },
+					{} as never,
+				);
+
+				expect(updateTurn.workflowService.updateFromWorkflowJSON).toHaveBeenCalledWith(
+					'wf1',
+					workflowPayload,
+					{ expectedChecksum: 'checksum-read' },
+				);
+			});
+
 			it('advances the expectation to the checksum of its own save', async () => {
 				const context = createMockContext({ permissions: { updateWorkflow: 'always_allow' } });
 				(context.workflowService.get as Mock).mockResolvedValue(workflowDetail('checksum-read'));

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/eval-setup-agent.tools.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/eval-setup-agent.tools.test.ts
@@ -20,7 +20,9 @@ function makeContext(
 	domainContext.workflowService.get = vi
 		.fn()
 		.mockResolvedValue({ id: 'w1', name: 'Test', nodes: [], connections: {}, active: false });
-	domainContext.workflowService.updateFromWorkflowJSON = vi.fn().mockResolvedValue(undefined);
+	domainContext.workflowService.updateFromWorkflowJSON = vi
+		.fn()
+		.mockResolvedValue({ id: 'w1', name: 'Test', versionId: 'v1', nodes: [], connections: {} });
 	domainContext.workflowService.updateVersion = vi.fn().mockResolvedValue(undefined);
 
 	const ctx = mock<OrchestrationContext>();

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -10,6 +10,7 @@ import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
+import { WorkflowSaveConflictError } from '../errors/workflow-save-conflict.error';
 import type { InstanceAiContext } from '../types';
 import {
 	findSetupHintProblems,
@@ -18,6 +19,11 @@ import {
 	TEMPLATABLE_PLAIN_AUTH_TYPES,
 } from './credentials.tool';
 import { formatTimestamp } from '../utils/format-timestamp';
+import {
+	getObservedWorkflowChecksum,
+	rememberCurrentWorkflowChecksum,
+	rememberObservedWorkflowChecksum,
+} from './workflows/observed-workflow-checksums';
 import { setupSuspendSchema, setupResumeSchema } from './workflows/setup-workflow.schema';
 import {
 	analyzeWorkflow,
@@ -435,6 +441,7 @@ async function handleGet(context: InstanceAiContext, input: Extract<Input, { act
 			};
 		}
 		const detail = await context.workflowService.get(input.workflowId);
+		rememberObservedWorkflowChecksum(context, input.workflowId, detail.checksum);
 		if (input.full || isSmallPayload(detail)) return detail;
 		const { nodes, connections, ...meta } = detail;
 		return {
@@ -466,7 +473,13 @@ async function handleGetJson(
 	input: Extract<Input, { action: 'get-json' }>,
 ) {
 	try {
-		return await context.workflowService.getAsWorkflowJSON(input.workflowId, input.versionId);
+		const json = await context.workflowService.getAsWorkflowJSON(input.workflowId, input.versionId);
+		// This is the graph the agent edits before `update`, so pin the state it
+		// saw. Historical reads must not advance the optimistic-concurrency lock.
+		if (!input.versionId) {
+			await rememberCurrentWorkflowChecksum(context, input.workflowId);
+		}
+		return json;
 	} catch (error) {
 		return {
 			workflowId: input.workflowId,
@@ -936,11 +949,32 @@ async function handleUpdate(
 		};
 	}
 
+	// Guard against overwriting a save this conversation never saw (canvas
+	// autosave, another user, another thread). Absent when the agent never read
+	// the workflow here — then there is nothing to pin the save to.
+	const expectedChecksum = getObservedWorkflowChecksum(context, input.workflowId);
+
 	try {
-		await context.workflowService.updateFromWorkflowJSON(input.workflowId, input.workflow);
+		const saved = expectedChecksum
+			? await context.workflowService.updateFromWorkflowJSON(input.workflowId, input.workflow, {
+					expectedChecksum,
+				})
+			: await context.workflowService.updateFromWorkflowJSON(input.workflowId, input.workflow);
 		await refreshWorkflowSourceFileBindingFromWorkflow(context, input.workflowId);
+		// Pin to what this save wrote, not to the re-read above: if another writer
+		// landed in between, the next update should conflict rather than clobber.
+		if (saved.checksum) {
+			rememberObservedWorkflowChecksum(context, input.workflowId, saved.checksum);
+		}
 		return { success: true, workflowId: input.workflowId };
 	} catch (error) {
+		if (error instanceof WorkflowSaveConflictError) {
+			return {
+				success: false,
+				error: `${error.message} Call workflows(action="get", workflowId="${input.workflowId}") to read the current state, re-apply your change, then update again.`,
+			};
+		}
+
 		return {
 			success: false,
 			error: error instanceof Error ? error.message : String(error),

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -441,7 +441,7 @@ async function handleGet(context: InstanceAiContext, input: Extract<Input, { act
 			};
 		}
 		const detail = await context.workflowService.get(input.workflowId);
-		rememberObservedWorkflowChecksum(context, input.workflowId, detail.checksum);
+		await rememberObservedWorkflowChecksum(context, input.workflowId, detail.checksum);
 		if (input.full || isSmallPayload(detail)) return detail;
 		const { nodes, connections, ...meta } = detail;
 		return {
@@ -952,7 +952,7 @@ async function handleUpdate(
 	// Guard against overwriting a save this conversation never saw (canvas
 	// autosave, another user, another thread). Absent when the agent never read
 	// the workflow here — then there is nothing to pin the save to.
-	const expectedChecksum = getObservedWorkflowChecksum(context, input.workflowId);
+	const expectedChecksum = await getObservedWorkflowChecksum(context, input.workflowId);
 
 	try {
 		const saved = expectedChecksum
@@ -964,7 +964,7 @@ async function handleUpdate(
 		// Pin to what this save wrote, not to the re-read above: if another writer
 		// landed in between, the next update should conflict rather than clobber.
 		if (saved.checksum) {
-			rememberObservedWorkflowChecksum(context, input.workflowId, saved.checksum);
+			await rememberObservedWorkflowChecksum(context, input.workflowId, saved.checksum);
 		}
 		return { success: true, workflowId: input.workflowId };
 	} catch (error) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/observed-workflow-checksums.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/observed-workflow-checksums.test.ts
@@ -1,0 +1,109 @@
+import type { ThreadPatch, ThreadRecord } from '../../../storage/thread-patch';
+import type { InstanceAiContext } from '../../../types';
+import {
+	getObservedWorkflowChecksum,
+	rememberObservedWorkflowChecksum,
+} from '../observed-workflow-checksums';
+
+/** Thread store shared across contexts, the way one conversation spans several runs. */
+function createThreadMemory() {
+	const threads = new Map<string, ThreadRecord>();
+
+	return {
+		getThread: vi.fn(
+			async (threadId: string) => await Promise.resolve(threads.get(threadId) ?? null),
+		),
+		patchThread: vi.fn(
+			async ({
+				threadId,
+				update,
+			}: {
+				threadId: string;
+				update: (current: ThreadRecord) => ThreadPatch | null | undefined;
+			}) => {
+				const current: ThreadRecord = threads.get(threadId) ?? {
+					id: threadId,
+					metadata: {},
+					resourceId: 'resource-1',
+					createdAt: new Date('2026-01-01'),
+					updatedAt: new Date('2026-01-01'),
+				};
+				const patch = update(current);
+				if (!patch) return null;
+				const next = { ...current, metadata: patch.metadata ?? current.metadata };
+				threads.set(threadId, next);
+				return await Promise.resolve(next);
+			},
+		),
+	};
+}
+
+/** Each Instance AI run builds a fresh context, so a turn is a new context object. */
+function createContextForRun(threadMemory: ReturnType<typeof createThreadMemory>) {
+	return {
+		threadId: 'thread-1',
+		threadMemory,
+		logger: { debug: vi.fn(), warn: vi.fn() },
+	} as unknown as InstanceAiContext;
+}
+
+describe('observed workflow checksums', () => {
+	it('carries the observed checksum into later turns of the same conversation', async () => {
+		const threadMemory = createThreadMemory();
+
+		await rememberObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1', 'checksum-1');
+
+		await expect(
+			getObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1'),
+		).resolves.toBe('checksum-1');
+	});
+
+	it('keeps checksums separate per workflow', async () => {
+		const threadMemory = createThreadMemory();
+		const context = createContextForRun(threadMemory);
+
+		await rememberObservedWorkflowChecksum(context, 'wf-1', 'checksum-1');
+		await rememberObservedWorkflowChecksum(context, 'wf-2', 'checksum-2');
+
+		await expect(
+			getObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-2'),
+		).resolves.toBe('checksum-2');
+	});
+
+	it('forgets the checksum in later turns when a save reports none', async () => {
+		const threadMemory = createThreadMemory();
+
+		await rememberObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1', 'checksum-1');
+		await rememberObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1', undefined);
+
+		await expect(
+			getObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1'),
+		).resolves.toBeUndefined();
+	});
+
+	it('has no expectation for a workflow this conversation never observed', async () => {
+		const threadMemory = createThreadMemory();
+
+		await expect(
+			getObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-unknown'),
+		).resolves.toBeUndefined();
+	});
+
+	it('still remembers within a run when the conversation has no thread memory', async () => {
+		const context = { logger: { debug: vi.fn(), warn: vi.fn() } } as unknown as InstanceAiContext;
+
+		await rememberObservedWorkflowChecksum(context, 'wf-1', 'checksum-1');
+
+		await expect(getObservedWorkflowChecksum(context, 'wf-1')).resolves.toBe('checksum-1');
+	});
+
+	it('keeps the run-local checksum when persisting to the thread fails', async () => {
+		const threadMemory = createThreadMemory();
+		threadMemory.patchThread.mockRejectedValue(new Error('thread store is down'));
+		const context = createContextForRun(threadMemory);
+
+		await rememberObservedWorkflowChecksum(context, 'wf-1', 'checksum-1');
+
+		await expect(getObservedWorkflowChecksum(context, 'wf-1')).resolves.toBe('checksum-1');
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/observed-workflow-checksums.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/observed-workflow-checksums.test.ts
@@ -97,6 +97,29 @@ describe('observed workflow checksums', () => {
 		await expect(getObservedWorkflowChecksum(context, 'wf-1')).resolves.toBe('checksum-1');
 	});
 
+	it('prefers what this run observed over a stale thread copy', async () => {
+		const threadMemory = createThreadMemory();
+		await rememberObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1', 'checksum-1');
+
+		// A later run re-reads the workflow, but the thread write does not land.
+		const laterRun = createContextForRun(threadMemory);
+		threadMemory.patchThread.mockRejectedValue(new Error('thread store is down'));
+		await rememberObservedWorkflowChecksum(laterRun, 'wf-1', 'checksum-2');
+
+		await expect(getObservedWorkflowChecksum(laterRun, 'wf-1')).resolves.toBe('checksum-2');
+	});
+
+	it('does not fall back to a stale thread copy after a failed clear', async () => {
+		const threadMemory = createThreadMemory();
+		await rememberObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1', 'checksum-1');
+
+		const laterRun = createContextForRun(threadMemory);
+		threadMemory.patchThread.mockRejectedValue(new Error('thread store is down'));
+		await rememberObservedWorkflowChecksum(laterRun, 'wf-1', undefined);
+
+		await expect(getObservedWorkflowChecksum(laterRun, 'wf-1')).resolves.toBeUndefined();
+	});
+
 	it('keeps the run-local checksum when persisting to the thread fails', async () => {
 		const threadMemory = createThreadMemory();
 		threadMemory.patchThread.mockRejectedValue(new Error('thread store is down'));

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/observed-workflow-checksums.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/observed-workflow-checksums.test.ts
@@ -2,6 +2,7 @@ import type { ThreadPatch, ThreadRecord } from '../../../storage/thread-patch';
 import type { InstanceAiContext } from '../../../types';
 import {
 	getObservedWorkflowChecksum,
+	rememberCurrentWorkflowChecksum,
 	rememberObservedWorkflowChecksum,
 } from '../observed-workflow-checksums';
 
@@ -95,6 +96,29 @@ describe('observed workflow checksums', () => {
 		await rememberObservedWorkflowChecksum(context, 'wf-1', 'checksum-1');
 
 		await expect(getObservedWorkflowChecksum(context, 'wf-1')).resolves.toBe('checksum-1');
+	});
+
+	it('has no expectation when the thread copy cannot be read', async () => {
+		const threadMemory = createThreadMemory();
+		await rememberObservedWorkflowChecksum(createContextForRun(threadMemory), 'wf-1', 'checksum-1');
+
+		const laterRun = createContextForRun(threadMemory);
+		threadMemory.getThread.mockRejectedValue(new Error('thread store is down'));
+
+		// An unguarded save beats blocking the agent on unreadable bookkeeping.
+		await expect(getObservedWorkflowChecksum(laterRun, 'wf-1')).resolves.toBeUndefined();
+	});
+
+	it('records no expectation when the workflow itself cannot be read', async () => {
+		const context = {
+			threadId: 'thread-1',
+			threadMemory: createThreadMemory(),
+			logger: { debug: vi.fn(), warn: vi.fn() },
+			workflowService: { get: vi.fn().mockRejectedValue(new Error('workflow is gone')) },
+		} as unknown as InstanceAiContext;
+
+		await expect(rememberCurrentWorkflowChecksum(context, 'wf-1')).resolves.toBeUndefined();
+		await expect(getObservedWorkflowChecksum(context, 'wf-1')).resolves.toBeUndefined();
 	});
 
 	it('prefers what this run observed over a stale thread copy', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-remediation.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-remediation.test.ts
@@ -1,3 +1,4 @@
+import { WorkflowEditorLockedError } from '../../../errors/workflow-editor-locked.error';
 import { WorkflowNotFoundError } from '../../../errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../../errors/workflow-save-conflict.error';
 import { createSaveFailureRemediation } from '../workflow-build-remediation';
@@ -12,6 +13,30 @@ describe('createSaveFailureRemediation', () => {
 			reason: 'workflow_modified_externally',
 		});
 		expect(remediation.guidance).toContain('get-as-code');
+	});
+
+	it('blocks source edits when a user holds the editor write lock', () => {
+		const remediation = createSaveFailureRemediation(new WorkflowEditorLockedError('wf-1'), true);
+
+		expect(remediation).toMatchObject({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'workflow_locked_by_editor',
+		});
+		expect(remediation.guidance).toContain('editing');
+	});
+
+	it('blocks source edits when the editor lock error is nested as cause', () => {
+		const remediation = createSaveFailureRemediation(
+			new Error('Failed to save workflow', { cause: new WorkflowEditorLockedError('wf-1') }),
+			true,
+		);
+
+		expect(remediation).toMatchObject({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'workflow_locked_by_editor',
+		});
 	});
 
 	it('returns bound_workflow_not_found for WorkflowNotFoundError', () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/observed-workflow-checksums.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/observed-workflow-checksums.ts
@@ -18,9 +18,10 @@ const observedChecksumsSchema = z.record(z.string(), z.string());
  * Persisted on the thread, because every run builds a fresh context: a workflow
  * read in one turn is often only saved in a later one.
  */
-const runLocalChecksums = new WeakMap<InstanceAiContext, Map<string, string>>();
+/** `null` is a tombstone: observed in this run as having no checksum to pin to. */
+const runLocalChecksums = new WeakMap<InstanceAiContext, Map<string, string | null>>();
 
-function runLocalFor(context: InstanceAiContext): Map<string, string> {
+function runLocalFor(context: InstanceAiContext): Map<string, string | null> {
 	let checksums = runLocalChecksums.get(context);
 	if (!checksums) {
 		checksums = new Map();
@@ -53,20 +54,16 @@ async function readThreadChecksums(
 
 /**
  * Records the workflow state this conversation has seen — a read or its own
- * save. `undefined` clears the entry: with no checksum to pin to, an unguarded
- * save beats one guarded against a stale expectation.
+ * save. `undefined` clears the entry, and is remembered as a tombstone for the
+ * rest of the run: with no checksum to pin to, an unguarded save beats one
+ * guarded against an expectation we already know is stale.
  */
 export async function rememberObservedWorkflowChecksum(
 	context: InstanceAiContext,
 	workflowId: string,
 	checksum: string | undefined,
 ): Promise<void> {
-	const runLocal = runLocalFor(context);
-	if (checksum === undefined) {
-		runLocal.delete(workflowId);
-	} else {
-		runLocal.set(workflowId, checksum);
-	}
+	runLocalFor(context).set(workflowId, checksum ?? null);
 
 	if (!context.threadMemory || !context.threadId) return;
 
@@ -116,9 +113,12 @@ export async function getObservedWorkflowChecksum(
 	context: InstanceAiContext,
 	workflowId: string,
 ): Promise<string | undefined> {
+	// What this run observed wins: it is at least as fresh as the thread copy, and
+	// strictly fresher when the thread write failed. A later run starts with an
+	// empty run-local map and falls through to the thread.
+	const runLocal = runLocalFor(context);
+	if (runLocal.has(workflowId)) return runLocal.get(workflowId) ?? undefined;
+
 	const threadChecksums = await readThreadChecksums(context);
-	// Falling back to this run's copy only matters when the thread write failed:
-	// a cleared entry is dropped from both at once, and a later run starts with
-	// an empty run-local map.
-	return threadChecksums?.[workflowId] ?? runLocalFor(context).get(workflowId);
+	return threadChecksums?.[workflowId];
 }

--- a/packages/@n8n/instance-ai/src/tools/workflows/observed-workflow-checksums.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/observed-workflow-checksums.ts
@@ -1,4 +1,11 @@
+import { z } from 'zod';
+
+import { getThread, patchThread } from '../../storage/thread-patch';
 import type { InstanceAiContext } from '../../types';
+
+const METADATA_KEY = 'instanceAiObservedWorkflowChecksums';
+
+const observedChecksumsSchema = z.record(z.string(), z.string());
 
 /**
  * Checksum of the workflow state this conversation last observed, per workflow.
@@ -7,33 +14,82 @@ import type { InstanceAiContext } from '../../types';
  * file binding, but the plain `workflows(action="update")` path has no source
  * file to bind to. Without an expectation the agent overwrites whatever landed
  * in the meantime — a canvas autosave, another user's edit, another thread.
+ *
+ * Persisted on the thread, because every run builds a fresh context: a workflow
+ * read in one turn is often only saved in a later one.
  */
-const observedChecksums = new WeakMap<InstanceAiContext, Map<string, string>>();
+const runLocalChecksums = new WeakMap<InstanceAiContext, Map<string, string>>();
 
-function checksumsFor(context: InstanceAiContext): Map<string, string> {
-	let checksums = observedChecksums.get(context);
+function runLocalFor(context: InstanceAiContext): Map<string, string> {
+	let checksums = runLocalChecksums.get(context);
 	if (!checksums) {
 		checksums = new Map();
-		observedChecksums.set(context, checksums);
+		runLocalChecksums.set(context, checksums);
 	}
 
 	return checksums;
 }
 
-/** Records the workflow state this conversation has seen — a read or its own save. */
-export function rememberObservedWorkflowChecksum(
+function parseChecksums(raw: unknown): Record<string, string> {
+	const parsed = observedChecksumsSchema.safeParse(raw);
+	return parsed.success ? parsed.data : {};
+}
+
+async function readThreadChecksums(
+	context: InstanceAiContext,
+): Promise<Record<string, string> | undefined> {
+	if (!context.threadMemory || !context.threadId) return undefined;
+
+	try {
+		const thread = await getThread(context.threadMemory, context.threadId);
+		return parseChecksums(thread?.metadata?.[METADATA_KEY]);
+	} catch (error) {
+		context.logger?.debug('Failed to read observed workflow checksums from thread metadata', {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
+}
+
+/**
+ * Records the workflow state this conversation has seen — a read or its own
+ * save. `undefined` clears the entry: with no checksum to pin to, an unguarded
+ * save beats one guarded against a stale expectation.
+ */
+export async function rememberObservedWorkflowChecksum(
 	context: InstanceAiContext,
 	workflowId: string,
 	checksum: string | undefined,
-): void {
-	const checksums = checksumsFor(context);
+): Promise<void> {
+	const runLocal = runLocalFor(context);
 	if (checksum === undefined) {
-		// No checksum to pin to — drop the stale one rather than guarding against it.
-		checksums.delete(workflowId);
-		return;
+		runLocal.delete(workflowId);
+	} else {
+		runLocal.set(workflowId, checksum);
 	}
 
-	checksums.set(workflowId, checksum);
+	if (!context.threadMemory || !context.threadId) return;
+
+	try {
+		await patchThread(context.threadMemory, {
+			threadId: context.threadId,
+			update: ({ metadata = {} }) => {
+				const checksums = parseChecksums(metadata[METADATA_KEY]);
+				if (checksum === undefined) {
+					delete checksums[workflowId];
+				} else {
+					checksums[workflowId] = checksum;
+				}
+				return { metadata: { ...metadata, [METADATA_KEY]: checksums } };
+			},
+		});
+	} catch (error) {
+		// The run-local copy still guards saves made in this run.
+		context.logger?.warn('Failed to persist the observed workflow checksum to thread metadata', {
+			workflowId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
 }
 
 /**
@@ -47,7 +103,7 @@ export async function rememberCurrentWorkflowChecksum(
 ): Promise<void> {
 	try {
 		const detail = await context.workflowService.get(workflowId);
-		rememberObservedWorkflowChecksum(context, workflowId, detail.checksum);
+		await rememberObservedWorkflowChecksum(context, workflowId, detail.checksum);
 	} catch (error) {
 		context.logger?.debug('Failed to record the observed workflow checksum', {
 			workflowId,
@@ -56,9 +112,13 @@ export async function rememberCurrentWorkflowChecksum(
 	}
 }
 
-export function getObservedWorkflowChecksum(
+export async function getObservedWorkflowChecksum(
 	context: InstanceAiContext,
 	workflowId: string,
-): string | undefined {
-	return observedChecksums.get(context)?.get(workflowId);
+): Promise<string | undefined> {
+	const threadChecksums = await readThreadChecksums(context);
+	// Falling back to this run's copy only matters when the thread write failed:
+	// a cleared entry is dropped from both at once, and a later run starts with
+	// an empty run-local map.
+	return threadChecksums?.[workflowId] ?? runLocalFor(context).get(workflowId);
 }

--- a/packages/@n8n/instance-ai/src/tools/workflows/observed-workflow-checksums.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/observed-workflow-checksums.ts
@@ -1,0 +1,64 @@
+import type { InstanceAiContext } from '../../types';
+
+/**
+ * Checksum of the workflow state this conversation last observed, per workflow.
+ *
+ * `build-workflow` gets its optimistic-concurrency expectation from the source
+ * file binding, but the plain `workflows(action="update")` path has no source
+ * file to bind to. Without an expectation the agent overwrites whatever landed
+ * in the meantime — a canvas autosave, another user's edit, another thread.
+ */
+const observedChecksums = new WeakMap<InstanceAiContext, Map<string, string>>();
+
+function checksumsFor(context: InstanceAiContext): Map<string, string> {
+	let checksums = observedChecksums.get(context);
+	if (!checksums) {
+		checksums = new Map();
+		observedChecksums.set(context, checksums);
+	}
+
+	return checksums;
+}
+
+/** Records the workflow state this conversation has seen — a read or its own save. */
+export function rememberObservedWorkflowChecksum(
+	context: InstanceAiContext,
+	workflowId: string,
+	checksum: string | undefined,
+): void {
+	const checksums = checksumsFor(context);
+	if (checksum === undefined) {
+		// No checksum to pin to — drop the stale one rather than guarding against it.
+		checksums.delete(workflowId);
+		return;
+	}
+
+	checksums.set(workflowId, checksum);
+}
+
+/**
+ * Records the workflow's current state for reads that hand the agent a graph to
+ * edit but no checksum of their own (`get-json`). Best-effort: bookkeeping must
+ * never fail the read it is attached to.
+ */
+export async function rememberCurrentWorkflowChecksum(
+	context: InstanceAiContext,
+	workflowId: string,
+): Promise<void> {
+	try {
+		const detail = await context.workflowService.get(workflowId);
+		rememberObservedWorkflowChecksum(context, workflowId, detail.checksum);
+	} catch (error) {
+		context.logger?.debug('Failed to record the observed workflow checksum', {
+			workflowId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+export function getObservedWorkflowChecksum(
+	context: InstanceAiContext,
+	workflowId: string,
+): string | undefined {
+	return observedChecksums.get(context)?.get(workflowId);
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-remediation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-remediation.ts
@@ -1,4 +1,5 @@
 import type { WorkflowSourceCompileFailureReason } from './workflow-source-compiler';
+import { isWorkflowEditorLockedError } from '../../errors/workflow-editor-locked.error';
 import { isWorkflowNotFoundError } from '../../errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../errors/workflow-save-conflict.error';
 import { createRemediation } from '../../workflow-loop/remediation';
@@ -58,12 +59,26 @@ export function createWorkflowModifiedExternallyRemediation(): RemediationMetada
 	});
 }
 
+export function createWorkflowLockedByEditorRemediation(): RemediationMetadata {
+	return createRemediation({
+		category: 'blocked',
+		shouldEdit: false,
+		reason: 'workflow_locked_by_editor',
+		guidance:
+			'The workflow could not be saved because someone is editing it in the n8n editor right now — saving would overwrite their work. Stop editing the source and tell the user to finish or close their editing session, then retry.',
+	});
+}
+
 export function createSaveFailureRemediation(
 	error: unknown,
 	hasBoundWorkflowId: boolean,
 ): RemediationMetadata {
 	if (error instanceof WorkflowSaveConflictError) {
 		return createWorkflowModifiedExternallyRemediation();
+	}
+
+	if (isWorkflowEditorLockedError(error)) {
+		return createWorkflowLockedByEditorRemediation();
 	}
 
 	const text = getFailureText(error);

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-file-bindings.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-file-bindings.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
 
+import { rememberObservedWorkflowChecksum } from './observed-workflow-checksums';
 import { getThread, patchThread } from '../../storage/thread-patch';
 import type { InstanceAiContext } from '../../types';
 import { readWorkspaceFile } from '../../workspace/workspace-files';
@@ -147,6 +148,11 @@ export async function refreshWorkflowSourceFileBindingFromSave(
 	workflowId: string,
 	saved: { versionId: string; checksum?: string },
 ): Promise<void> {
+	// Every agent-side save routes through here, so this is also where the
+	// conversation's view of the workflow (used by `workflows(action="update")`)
+	// stays in step with the DB.
+	rememberObservedWorkflowChecksum(context, workflowId, saved.checksum);
+
 	const threadBindings = await readThreadBindings(context);
 	const fallback = getFallbackBindings(context);
 	const entries: WorkflowSourceFileBinding[] = [];

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-file-bindings.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-file-bindings.ts
@@ -151,7 +151,7 @@ export async function refreshWorkflowSourceFileBindingFromSave(
 	// Every agent-side save routes through here, so this is also where the
 	// conversation's view of the workflow (used by `workflows(action="update")`)
 	// stays in step with the DB.
-	rememberObservedWorkflowChecksum(context, workflowId, saved.checksum);
+	await rememberObservedWorkflowChecksum(context, workflowId, saved.checksum);
 
 	const threadBindings = await readThreadBindings(context);
 	const fallback = getFallbackBindings(context);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-workflow-writes.integration.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-workflow-writes.integration.test.ts
@@ -1,0 +1,168 @@
+import { LicenseState } from '@n8n/backend-common';
+import {
+	createWorkflow,
+	mockInstance,
+	shareWorkflowWithUsers,
+	testDb,
+} from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { WorkflowRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import type { IWorkflowBase } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { CollaborationService } from '@/collaboration/collaboration.service';
+import { License } from '@/license';
+import { Push } from '@/push';
+import { CacheService } from '@/services/cache/cache.service';
+import { Telemetry } from '@/telemetry';
+import { createMember, createOwner } from '@test-integration/db/users';
+
+import { InstanceAiAdapterService } from '../instance-ai.adapter.service';
+
+/**
+ * Instance AI writes bypass the REST controller, so the editor write lock and
+ * the `workflowUpdated` broadcast have to be enforced by the adapter itself.
+ */
+describe('Instance AI workflow writes (integration)', () => {
+	mockInstance(ActiveWorkflowManager);
+	mockInstance(Telemetry);
+	mockInstance(Push, new Push(mock(), mock(), mock(), mock(), mock()));
+
+	const EDITOR_CLIENT_ID = 'editor-client-id';
+
+	let pushService: Push;
+	let collaborationService: CollaborationService;
+	let cacheService: CacheService;
+	let workflowRepository: WorkflowRepository;
+	let adapterService: InstanceAiAdapterService;
+
+	/** The user chatting with Instance AI. */
+	let agentUser: User;
+	/** A collaborator with the workflow open on the canvas. */
+	let editingUser: User;
+	let workflow: IWorkflowBase;
+
+	const workflowJson = (name: string) =>
+		({ name, nodes: [], connections: {} }) as unknown as WorkflowJSON;
+
+	const instanceAiWorkflows = () =>
+		adapterService.createContext(agentUser, { threadId: 'thread-1' }).workflowService;
+
+	const openInEditor = async (user: User, clientId: string) =>
+		await collaborationService.handleUserMessage(user.id, clientId, {
+			type: 'workflowOpened',
+			workflowId: workflow.id,
+		});
+
+	const acquireWriteLock = async (user: User, clientId: string) =>
+		await collaborationService.handleUserMessage(user.id, clientId, {
+			type: 'writeAccessRequested',
+			workflowId: workflow.id,
+		});
+
+	const releaseWriteLock = async (user: User, clientId: string) =>
+		await collaborationService.handleUserMessage(user.id, clientId, {
+			type: 'writeAccessReleaseRequested',
+			workflowId: workflow.id,
+		});
+
+	const storedWorkflow = async () => await workflowRepository.findOneByOrFail({ id: workflow.id });
+
+	beforeAll(async () => {
+		await testDb.init();
+		Container.get(LicenseState).setLicenseProvider(Container.get(License));
+
+		pushService = Container.get(Push);
+		collaborationService = Container.get(CollaborationService);
+		cacheService = Container.get(CacheService);
+		workflowRepository = Container.get(WorkflowRepository);
+		adapterService = Container.get(InstanceAiAdapterService);
+
+		await cacheService.init();
+
+		[agentUser, editingUser] = await Promise.all([createOwner(), createMember()]);
+	});
+
+	beforeEach(async () => {
+		workflow = await createWorkflow({ name: 'Original name' }, agentUser);
+		await shareWorkflowWithUsers(workflow, [editingUser]);
+	});
+
+	afterEach(async () => {
+		vi.resetAllMocks();
+		await cacheService.reset();
+		await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'WorkflowHistory']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('while another user holds the editor write lock', () => {
+		beforeEach(async () => {
+			await openInEditor(editingUser, EDITOR_CLIENT_ID);
+			await acquireWriteLock(editingUser, EDITOR_CLIENT_ID);
+		});
+
+		it('rejects an update and leaves the stored workflow untouched', async () => {
+			await expect(
+				instanceAiWorkflows().updateFromWorkflowJSON(workflow.id, workflowJson('Renamed by AI')),
+			).rejects.toThrow(/being edited/);
+
+			expect((await storedWorkflow()).name).toBe('Original name');
+		});
+
+		it('rejects a publish', async () => {
+			await expect(instanceAiWorkflows().publish(workflow.id)).rejects.toThrow(/being edited/);
+
+			expect((await storedWorkflow()).activeVersionId).toBeNull();
+		});
+
+		it('rejects an archive', async () => {
+			await expect(instanceAiWorkflows().archive(workflow.id)).rejects.toThrow(/being edited/);
+
+			expect((await storedWorkflow()).isArchived).toBe(false);
+		});
+
+		it('allows the update once the lock is released', async () => {
+			await releaseWriteLock(editingUser, EDITOR_CLIENT_ID);
+
+			await instanceAiWorkflows().updateFromWorkflowJSON(
+				workflow.id,
+				workflowJson('Renamed by AI'),
+			);
+
+			expect((await storedWorkflow()).name).toBe('Renamed by AI');
+		});
+	});
+
+	describe('when nobody holds the editor write lock', () => {
+		it('notifies open editors that the workflow changed', async () => {
+			await openInEditor(editingUser, EDITOR_CLIENT_ID);
+			vi.mocked(pushService.sendToUsers).mockClear();
+
+			await instanceAiWorkflows().updateFromWorkflowJSON(
+				workflow.id,
+				workflowJson('Renamed by AI'),
+			);
+
+			expect((await storedWorkflow()).name).toBe('Renamed by AI');
+			expect(pushService.sendToUsers).toHaveBeenCalledWith(
+				{ type: 'workflowUpdated', data: { workflowId: workflow.id, userId: agentUser.id } },
+				expect.arrayContaining([editingUser.id]),
+			);
+		});
+
+		it('does not notify anyone when the workflow is not open in an editor', async () => {
+			await instanceAiWorkflows().updateFromWorkflowJSON(
+				workflow.id,
+				workflowJson('Renamed by AI'),
+			);
+
+			expect(pushService.sendToUsers).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
@@ -57,6 +57,7 @@ import type { InstanceAiSettingsService } from '../instance-ai-settings.service'
 
 import type { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 import type { ExecutionPersistence } from '@/executions/execution-persistence';
+import type { CollaborationService } from '@/collaboration/collaboration.service';
 import type { EventService } from '@/events/event.service';
 import type { License } from '@/license';
 import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
@@ -166,6 +167,7 @@ const service = new InstanceAiAdapterService(
 	mock<OutboundHttp>(),
 	mock<AiGatewayService>(),
 	mock<WorkflowTemplatesService>(),
+	mock<CollaborationService>(),
 );
 
 const user = mock<User>({

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2721,6 +2721,19 @@ describe('createWorkflowAdapter', () => {
 			expect(mockWorkflowService.update).not.toHaveBeenCalled();
 		});
 
+		it('refuses to write when the lock cannot be checked, without claiming a lock', async () => {
+			// Fail closed: an unreadable lock is no proof that nobody is editing.
+			const { adapter, mockCollaborationService, mockWorkflowService } =
+				createWorkflowAdapterForTests();
+			const lookupFailure = new Error('collaboration cache is unreachable');
+			mockCollaborationService.ensureWorkflowEditable.mockRejectedValue(lookupFailure);
+
+			await expect(adapter.updateFromWorkflowJSON('wf-existing', minimalWorkflowJSON)).rejects.toBe(
+				lookupFailure,
+			);
+			expect(mockWorkflowService.update).not.toHaveBeenCalled();
+		});
+
 		it('refuses to unpublish a locked workflow', async () => {
 			const { adapter, mockCollaborationService, mockWorkflowService } =
 				createWorkflowAdapterForTests();

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -6,9 +6,13 @@ vi.mock('@n8n/instance-ai', async () => {
 	const { WorkflowNotFoundError } = await import(
 		'../../../../../@n8n/instance-ai/src/errors/workflow-not-found.error.js'
 	);
+	const { WorkflowEditorLockedError } = await import(
+		'../../../../../@n8n/instance-ai/src/errors/workflow-editor-locked.error.js'
+	);
 	return {
 		WorkflowSaveConflictError,
 		WorkflowNotFoundError,
+		WorkflowEditorLockedError,
 		wrapUntrustedData(content: string, source: string, label?: string): string {
 			const esc = (s: string) =>
 				s
@@ -83,6 +87,14 @@ import { LlmJudgeProviderRegistry } from '@/evaluation.ee/llm-judge-provider-reg
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Collaboration stub that reports no editor write lock and records broadcasts. */
+function createMockCollaborationService() {
+	return {
+		ensureWorkflowEditable: vi.fn().mockResolvedValue(undefined),
+		broadcastWorkflowUpdate: vi.fn().mockResolvedValue(undefined),
+	};
+}
 
 function createMockExecutionRepository(
 	execution?: ReturnType<typeof makeExecution>,
@@ -1237,10 +1249,12 @@ import type { DataTableRepository } from '@/modules/data-table/data-table.reposi
 import type { DataTableService } from '@/modules/data-table/data-table.service';
 import type { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import { WorkflowEditorLockedError } from '../../../../../@n8n/instance-ai/src/errors/workflow-editor-locked.error';
 import { WorkflowNotFoundError } from '../../../../../@n8n/instance-ai/src/errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../../../../@n8n/instance-ai/src/errors/workflow-save-conflict.error';
 import type { WorkflowService } from '@/workflows/workflow.service';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { LockedError } from '@/errors/response-errors/locked.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { License } from '@/license';
 import type { RoleService } from '@/services/role.service';
@@ -1323,6 +1337,9 @@ function createNodeAdapterServiceForTests(
 			typeof InstanceAiAdapterService
 		>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		createMockCollaborationService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 		nodeCatalogService,
 	);
 
@@ -1681,6 +1698,9 @@ function createDataTableAdapterForTests(overrides?: {
 			typeof InstanceAiAdapterService
 		>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		createMockCollaborationService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const adapter = service.createContext(mockUser, {
@@ -1931,6 +1951,7 @@ function createWorkflowAdapterForTests(overrides?: {
 		archive: vi.fn().mockResolvedValue(savedWorkflow),
 		unarchive: vi.fn().mockResolvedValue(savedWorkflow),
 		activateWorkflow: vi.fn().mockResolvedValue({ activeVersionId: 'version-1' }),
+		deactivateWorkflow: vi.fn().mockResolvedValue(savedWorkflow),
 		update: vi.fn().mockResolvedValue(savedWorkflow),
 	};
 	const mockWorkflowHistoryService = {
@@ -1946,6 +1967,7 @@ function createWorkflowAdapterForTests(overrides?: {
 		scoped: vi.fn(),
 	};
 	mockLogger.scoped.mockReturnValue(mockLogger);
+	const mockCollaborationService = createMockCollaborationService();
 
 	const mockUser = { id: 'user-1', role: { slug: 'global:member' } } as unknown as User;
 
@@ -2009,6 +2031,9 @@ function createWorkflowAdapterForTests(overrides?: {
 			typeof InstanceAiAdapterService
 		>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		mockCollaborationService as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const boundProjectId =
@@ -2030,6 +2055,7 @@ function createWorkflowAdapterForTests(overrides?: {
 		mockWorkflowService,
 		mockWorkflowHistoryService,
 		mockEnterpriseWorkflowService,
+		mockCollaborationService,
 		mockTelemetry,
 		mockLogger,
 		mockUser,
@@ -2674,6 +2700,113 @@ describe('createWorkflowAdapter', () => {
 			);
 		});
 	});
+
+	describe('editor write lock', () => {
+		const lockWorkflow = (
+			mockCollaborationService: ReturnType<typeof createMockCollaborationService>,
+		) => {
+			mockCollaborationService.ensureWorkflowEditable.mockRejectedValue(
+				new LockedError('Cannot modify workflow while it is being edited by a user in the editor.'),
+			);
+		};
+
+		it('reports a locked workflow as a WorkflowEditorLockedError instead of a response error', async () => {
+			const { adapter, mockCollaborationService, mockWorkflowService } =
+				createWorkflowAdapterForTests();
+			lockWorkflow(mockCollaborationService);
+
+			await expect(
+				adapter.updateFromWorkflowJSON('wf-existing', minimalWorkflowJSON),
+			).rejects.toThrow(WorkflowEditorLockedError);
+			expect(mockWorkflowService.update).not.toHaveBeenCalled();
+		});
+
+		it('refuses to unpublish a locked workflow', async () => {
+			const { adapter, mockCollaborationService, mockWorkflowService } =
+				createWorkflowAdapterForTests();
+			lockWorkflow(mockCollaborationService);
+
+			await expect(adapter.unpublish('wf-1')).rejects.toThrow(WorkflowEditorLockedError);
+			expect(mockWorkflowService.deactivateWorkflow).not.toHaveBeenCalled();
+		});
+
+		it('refuses to restore a version of a locked workflow', async () => {
+			const { adapter, mockCollaborationService, mockWorkflowService } =
+				createWorkflowAdapterForTests();
+			lockWorkflow(mockCollaborationService);
+
+			await expect(adapter.restoreVersion?.('wf-1', 'v-1')).rejects.toThrow(
+				WorkflowEditorLockedError,
+			);
+			expect(mockWorkflowService.update).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('notifying open editors', () => {
+		it('notifies after publishing', async () => {
+			const { adapter, mockCollaborationService } = createWorkflowAdapterForTests();
+
+			await adapter.publish('wf-1');
+
+			expect(mockCollaborationService.broadcastWorkflowUpdate).toHaveBeenCalledWith(
+				'wf-1',
+				'user-1',
+			);
+		});
+
+		it('notifies after unpublishing', async () => {
+			const { adapter, mockCollaborationService } = createWorkflowAdapterForTests();
+
+			await adapter.unpublish('wf-1');
+
+			expect(mockCollaborationService.broadcastWorkflowUpdate).toHaveBeenCalledWith(
+				'wf-1',
+				'user-1',
+			);
+		});
+
+		it('notifies after archiving', async () => {
+			const { adapter, mockCollaborationService } = createWorkflowAdapterForTests();
+
+			await adapter.archive('wf-1');
+
+			expect(mockCollaborationService.broadcastWorkflowUpdate).toHaveBeenCalledWith(
+				'wf-1',
+				'user-1',
+			);
+		});
+
+		it('notifies after restoring a version', async () => {
+			const { adapter, mockCollaborationService, mockWorkflowHistoryService } =
+				createWorkflowAdapterForTests();
+			mockWorkflowHistoryService.getVersion.mockResolvedValue({
+				versionId: 'v-1',
+				nodes: [],
+				connections: {},
+				nodeGroups: [],
+			});
+
+			await adapter.restoreVersion?.('wf-1', 'v-1');
+
+			expect(mockCollaborationService.broadcastWorkflowUpdate).toHaveBeenCalledWith(
+				'wf-1',
+				'user-1',
+			);
+		});
+
+		it('keeps a committed update when notifying open editors fails', async () => {
+			const { adapter, mockCollaborationService, mockLogger } = createWorkflowAdapterForTests();
+			mockCollaborationService.broadcastWorkflowUpdate.mockRejectedValue(new Error('push is down'));
+
+			await expect(
+				adapter.updateFromWorkflowJSON('wf-existing', minimalWorkflowJSON),
+			).resolves.toMatchObject({ id: 'wf-new' });
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Failed to notify open editors of an AI workflow update',
+				expect.objectContaining({ workflowId: 'wf-existing', error: 'push is down' }),
+			);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -2830,6 +2963,9 @@ function createExecutionAdapterForTests(overrides?: { sharingEnabled?: boolean }
 			typeof InstanceAiAdapterService
 		>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		createMockCollaborationService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const adapter = service.createContext(mockUser).executionService;
@@ -3094,6 +3230,9 @@ function createRunAdapterForTests(
 			typeof InstanceAiAdapterService
 		>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		createMockCollaborationService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const adapter = service.createContext(mockUser, { threadId: options?.threadId }).executionService;

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -54,6 +54,7 @@ import {
 	deriveCredentialHosts,
 	WorkflowSaveConflictError,
 	WorkflowNotFoundError,
+	WorkflowEditorLockedError,
 } from '@n8n/instance-ai';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
 import {
@@ -126,7 +127,9 @@ import {
 } from 'n8n-workflow';
 
 import { ActiveExecutions } from '@/active-executions';
+import { CollaborationService } from '@/collaboration/collaboration.service';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { LockedError } from '@/errors/response-errors/locked.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
@@ -277,6 +280,7 @@ export class InstanceAiAdapterService {
 		private readonly outboundHttp: OutboundHttp,
 		private readonly aiGatewayService: AiGatewayService,
 		private readonly workflowTemplatesService: WorkflowTemplatesService,
+		private readonly collaborationService: CollaborationService,
 		private readonly nodeCatalogService?: NodeCatalogService,
 		// Optional: absent only in package/test contexts constructed without DI.
 		// DI (by type, not position) always provides it in a running instance.
@@ -607,11 +611,40 @@ export class InstanceAiAdapterService {
 			license,
 			allowSendingParameterValues,
 			telemetry,
+			collaborationService,
 		} = this;
 		const logger = this.logger;
 		const assertNotReadOnly = () => this.assertInstanceNotReadOnly('workflows');
 		const { resolveBoundProjectId } = this.createProjectScopeHelpers(user, boundProjectId);
 		const redactParameters = !allowSendingParameterValues;
+
+		/**
+		 * Instance AI writes bypass the REST controller, so the editor write lock
+		 * has to be honoured here — otherwise the agent silently overwrites the
+		 * work of whoever is editing the workflow on the canvas right now.
+		 */
+		const assertNotLockedByEditor = async (workflowId: string) => {
+			try {
+				await collaborationService.ensureWorkflowEditable(workflowId);
+			} catch (error) {
+				if (error instanceof LockedError) throw new WorkflowEditorLockedError(workflowId);
+				throw error;
+			}
+		};
+
+		/** Tells open editors to reload, mirroring what the REST controller does after a write. */
+		const notifyWorkflowUpdated = async (workflowId: string) => {
+			try {
+				await collaborationService.broadcastWorkflowUpdate(workflowId, user.id);
+			} catch (error) {
+				// The write is already committed — a failed notification must not fail it.
+				logger.warn('Failed to notify open editors of an AI workflow update', {
+					threadId,
+					workflowId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		};
 
 		return {
 			async list(options) {
@@ -655,10 +688,12 @@ export class InstanceAiAdapterService {
 
 			async archive(workflowId: string) {
 				assertNotReadOnly();
+				await assertNotLockedByEditor(workflowId);
 				const result = await workflowService.archive(user, workflowId, { skipArchived: true });
 				if (!result) {
 					throw new WorkflowNotFoundError(workflowId);
 				}
+				await notifyWorkflowUpdated(workflowId);
 			},
 
 			async unarchive(workflowId: string) {
@@ -703,6 +738,7 @@ export class InstanceAiAdapterService {
 				workflowId: string,
 				options?: { versionId?: string; name?: string; description?: string },
 			) {
+				await assertNotLockedByEditor(workflowId);
 				const wf = await workflowService.activateWorkflow(user, workflowId, {
 					versionId: options?.versionId,
 					name: options?.name,
@@ -722,13 +758,17 @@ export class InstanceAiAdapterService {
 					});
 				}
 
+				await notifyWorkflowUpdated(workflowId);
+
 				return { activeVersionId: wf.activeVersionId };
 			},
 
 			async unpublish(workflowId: string) {
+				await assertNotLockedByEditor(workflowId);
 				await workflowService.deactivateWorkflow(user, workflowId, {
 					source: 'n8n-ai',
 				});
+				await notifyWorkflowUpdated(workflowId);
 			},
 
 			async getAsWorkflowJSON(workflowId: string, versionId?: string) {
@@ -910,6 +950,7 @@ export class InstanceAiAdapterService {
 				options?: { projectId?: string; expectedChecksum?: string },
 			) {
 				assertNotReadOnly();
+				await assertNotLockedByEditor(workflowId);
 				// Strip redactionPolicy if the user lacks the required directional scope —
 				// mirrors the check in WorkflowService.update().
 				const settings = (json.settings ?? {}) as IWorkflowSettings;
@@ -986,6 +1027,8 @@ export class InstanceAiAdapterService {
 					});
 				}
 
+				await notifyWorkflowUpdated(workflowId);
+
 				return await toWorkflowDetailWithChecksum(updated, { redactParameters });
 			},
 
@@ -1048,6 +1091,7 @@ export class InstanceAiAdapterService {
 			},
 
 			async restoreVersion(workflowId, versionId) {
+				await assertNotLockedByEditor(workflowId);
 				const version = await workflowHistoryService.getVersion(user, workflowId, versionId);
 
 				const updateData = workflowRepository.create({
@@ -1061,6 +1105,8 @@ export class InstanceAiAdapterService {
 				await workflowService.update(user, updateData, workflowId, {
 					source: 'n8n-ai',
 				});
+
+				await notifyWorkflowUpdated(workflowId);
 			},
 
 			...(this.license.isLicensed('feat:namedVersions')


### PR DESCRIPTION
## Summary

Instance AI writes workflows through `InstanceAiAdapterService`, not through the REST controller, so they skipped two things the controller does:

- **The editor write lock.** `CollaborationService.validateWriteLock` is only called from the `workflows` REST routes, so the agent could save, publish, unpublish, archive or restore a workflow while another user was actively editing it on the canvas.
- **The `workflowUpdated` broadcast.** Nothing told open editors the workflow had changed, so collaborators kept a stale canvas and only discovered the divergence as a 409 on their next save.

This PR closes both, following the pattern the MCP workflow-builder tools already use (`ensureWorkflowEditable` before the write, `broadcastWorkflowUpdate` after it):

- `update`, `publish`, `unpublish`, `archive` and `restore-version` now refuse to write while any user holds the editor write lock, and notify open editors after a successful write. Broadcast failures are logged, not propagated — the write is already committed.
- A refused write reaches the agent as `WorkflowEditorLockedError`, which maps to a **blocked** (`shouldEdit: false`) build remediation, so `build-workflow` reports the blocker to the user instead of rewriting its source and retrying.
- `clearAiTemporary` / `archiveIfAiTemporary` are deliberately left unguarded so the run-finish reap of temporary workflows can never be blocked by a lock. Creating a workflow is unguarded too — no lock can exist on a workflow that doesn't exist yet.

The lock is only held while someone is *actively* editing (it's released after 20s of inactivity), so this doesn't add friction to the common case of a workflow merely being open somewhere.

Separately, the plain `workflows(action="update")` path had no stale-save detection at all — unlike `build-workflow`, which pins its save to the checksum on its source-file binding. It now pins each save to the workflow state the conversation last observed (`get` / `get-json`), and on conflict tells the agent to re-read and re-apply. Saves made by the other Instance AI paths (setup, credential apply, build) refresh that expectation through the existing `refreshWorkflowSourceFileBindingFromSave` hook, so they don't show up as stale. Reads of a past version don't advance the expectation.

## How to test

Instance AI requires the `instance-ai` module and a model credential, so start the instance with it enabled (`N8N_ENABLED_MODULES=instance-ai`) and configure a model under Settings → AI.

Manual check of the reported scenario:

1. As user A, open a workflow in the editor and start editing (a click that dirties the canvas is enough to take the write lock).
2. As user B, in an Instance AI conversation, ask the assistant to modify that same workflow.
3. The assistant now reports that the workflow is being edited and stops, instead of saving over user A's work.
4. Release the lock (leave user A's canvas idle for ~20s, or close the tab) and retry — the save succeeds, and user A's open canvas reloads with the change instead of silently drifting.

Automated:

```bash
cd packages/cli
pnpm test:integration src/modules/instance-ai/__tests__/instance-ai-workflow-writes.integration.test.ts
pnpm test src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts

cd ../@n8n/instance-ai
pnpm test src/tools/__tests__/workflows.tool.test.ts src/tools/workflows/__tests__/workflow-build-remediation.test.ts
```

The integration test is the reported bug: it takes the write lock as a second user through the real push messages, then asserts each Instance AI write is refused and the stored workflow is untouched — and that a permitted write reaches open editors.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-897

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

