### PR TITLE
ci: Pin benchmark job to Node 24 (no-changelog)

### DIFF
--- a/.github/workflows/test-bench-reusable.yml
+++ b/.github/workflows/test-bench-reusable.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
+        with:
+          # @codspeed/core prebuilds do not load on Node 26 (removed V8 symbol).
+          node-version: '24.18.1'
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # v4.11.1


### PR DESCRIPTION
## Summary

The `Performance / Benchmarks` job on master fails since the CI pipeline moved to Node 26 (#34032, [CAT-4069](https://linear.app/n8n/issue/CAT-4069)). The `@codspeed/core` prebuilt binding references `v8::String::Utf8Length(v8::Isolate*)`, a V8 symbol that Node 26 removed, so each Vitest worker crashes on startup:

```
node: symbol lookup error: .../@codspeed/core/prebuilds/linux-x64/node.napi.node: undefined symbol: _ZNK2v86String10Utf8LengthEPNS_7IsolateE
```

Failing run: https://github.com/n8n-io/n8n/actions/runs/31811655772/job/94803472400

An upgrade of `@codspeed` does not help: the latest release (5.7.1) has the same symbol in its prebuild. This PR pins the benchmark job to Node 24.18.1 (the previous CI default) until CodSpeed ships Node 26-compatible prebuilds.

## Review notes

- Other workflows use the same pin pattern (for example `docker-build-smoke.yml`, `release-push-to-channel.yml`).
- The benchmark results stay comparable with the pre-Node-26 baseline because the runtime does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

