### PR TITLE
feat(core): Redesign the account connect panel on hosted forms

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-check-proxy.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-check-proxy.service.test.ts
@@ -2,11 +2,16 @@ import type { Mocked } from 'vitest';
 import type { GlobalConfig } from '@n8n/config';
 import type {
 	ICredentialContext,
+	ICredentialType,
 	IExecutionContext,
+	INodeType,
 	PlaintextExecutionContext,
+	Themed,
 } from 'n8n-workflow';
 
+import type { CredentialTypes } from '@/credential-types';
 import type { EnterpriseCredentialsService } from '@/credentials/credentials.service.ee';
+import type { NodeTypes } from '@/node-types';
 import type { UrlService } from '@/services/url.service';
 import type { ExecutionContextService } from 'n8n-core';
 import { CredentialsEntity } from '@n8n/db';
@@ -44,6 +49,8 @@ describe('CredentialCheckProxyService', () => {
 	let mockAuthorizeIntentService: Mocked<AuthorizeIntentService>;
 	let mockDynamicCredentialService: Mocked<DynamicCredentialService>;
 	let mockUrlService: Mocked<UrlService>;
+	let mockCredentialTypes: Mocked<CredentialTypes>;
+	let mockNodeTypes: Mocked<NodeTypes>;
 
 	const executionContext: IExecutionContext = {
 		version: 1,
@@ -90,6 +97,19 @@ describe('CredentialCheckProxyService', () => {
 			getInstanceBaseUrl: vi.fn().mockReturnValue('http://localhost:5678'),
 		} as unknown as Mocked<UrlService>;
 
+		// Unknown types throw in the real registry, which is the no-icon path.
+		mockCredentialTypes = {
+			getByName: vi.fn().mockImplementation(() => {
+				throw new Error('Unrecognized credential type');
+			}),
+		} as unknown as Mocked<CredentialTypes>;
+
+		mockNodeTypes = {
+			getByName: vi.fn().mockImplementation(() => {
+				throw new Error('Unrecognized node type');
+			}),
+		} as unknown as Mocked<NodeTypes>;
+
 		const globalConfig = { endpoints: { rest: 'rest' } } as unknown as GlobalConfig;
 
 		service = new CredentialCheckProxyService(
@@ -100,6 +120,8 @@ describe('CredentialCheckProxyService', () => {
 			mockDynamicCredentialService,
 			mockUrlService,
 			globalConfig,
+			mockCredentialTypes,
+			mockNodeTypes,
 		);
 	});
 
@@ -372,6 +394,104 @@ describe('CredentialCheckProxyService', () => {
 
 			expect(result.readyToExecute).toBe(true);
 			expect(result.credentials).toHaveLength(0);
+		});
+	});
+
+	describe('iconUrl', () => {
+		const credentialType = (overrides: Partial<ICredentialType>): ICredentialType => ({
+			name: 'someApi',
+			displayName: 'Some API',
+			properties: [],
+			...overrides,
+		});
+
+		// Only the description's icon is read, so that's all the stand-in carries.
+		const nodeType = (iconUrl: Themed<string>) => ({ description: { iconUrl } }) as INodeType;
+
+		const iconUrlFor = async (type: string) => {
+			mockCredentialResolverWorkflowService.getWorkflowStatus.mockResolvedValue([
+				{
+					credentialId: 'cred-1',
+					credentialName: 'Google Sheets account',
+					credentialType: type,
+					resolverId: 'resolver-1',
+					status: 'configured',
+				},
+			]);
+			const result = await service.checkCredentialStatus('workflow-1', executionContext);
+			return result.credentials[0].iconUrl;
+		};
+
+		it("should use the credential type's own iconUrl, made absolute", async () => {
+			mockCredentialTypes.getByName.mockReturnValue(
+				credentialType({ iconUrl: 'icons/n8n-nodes-base/dist/nodes/Slack/slack.svg' }),
+			);
+
+			await expect(iconUrlFor('slackOAuth2Api')).resolves.toBe(
+				'http://localhost:5678/icons/n8n-nodes-base/dist/nodes/Slack/slack.svg',
+			);
+		});
+
+		it('should use the light variant of a themed iconUrl', async () => {
+			mockCredentialTypes.getByName.mockReturnValue(
+				credentialType({ iconUrl: { light: 'icons/pkg/light.svg', dark: 'icons/pkg/dark.svg' } }),
+			);
+
+			await expect(iconUrlFor('themedApi')).resolves.toBe(
+				'http://localhost:5678/icons/pkg/light.svg',
+			);
+		});
+
+		it("should resolve a node: icon reference to that node type's icon", async () => {
+			mockCredentialTypes.getByName.mockReturnValue(
+				credentialType({ icon: 'node:n8n-nodes-base.googleSheets' }),
+			);
+			mockNodeTypes.getByName.mockReturnValue(
+				nodeType('icons/n8n-nodes-base/dist/nodes/Google/Sheet/googleSheets.svg'),
+			);
+
+			await expect(iconUrlFor('googleSheetsOAuth2Api')).resolves.toBe(
+				'http://localhost:5678/icons/n8n-nodes-base/dist/nodes/Google/Sheet/googleSheets.svg',
+			);
+			expect(mockNodeTypes.getByName).toHaveBeenCalledWith('n8n-nodes-base.googleSheets');
+		});
+
+		it('should fall back to the extends chain when the type has no icon of its own', async () => {
+			mockCredentialTypes.getByName.mockImplementation((name) =>
+				name === 'childApi'
+					? credentialType({ name, extends: ['parentApi'] })
+					: credentialType({ name, iconUrl: 'icons/pkg/parent.svg' }),
+			);
+
+			await expect(iconUrlFor('childApi')).resolves.toBe(
+				'http://localhost:5678/icons/pkg/parent.svg',
+			);
+		});
+
+		it('should not loop on a circular extends chain', async () => {
+			mockCredentialTypes.getByName.mockImplementation((name) =>
+				credentialType({ name, extends: [name === 'aApi' ? 'bApi' : 'aApi'] }),
+			);
+
+			await expect(iconUrlFor('aApi')).resolves.toBeUndefined();
+		});
+
+		it('should leave iconUrl undefined when nothing resolves', async () => {
+			await expect(iconUrlFor('unknownApi')).resolves.toBeUndefined();
+		});
+
+		it('should leave an already-absolute iconUrl untouched', async () => {
+			mockCredentialTypes.getByName.mockReturnValue(
+				credentialType({ iconUrl: 'https://cdn.example.com/icon.svg' }),
+			);
+
+			await expect(iconUrlFor('remoteApi')).resolves.toBe('https://cdn.example.com/icon.svg');
+		});
+
+		it('should ignore fa: icons, which the shell cannot render', async () => {
+			mockCredentialTypes.getByName.mockReturnValue(credentialType({ icon: 'fa:key' }));
+
+			await expect(iconUrlFor('faApi')).resolves.toBeUndefined();
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
@@ -5,15 +5,23 @@ import type {
 	CredentialCheckStatus,
 	DynamicCredentialCheckProxyProvider,
 	ICredentialContext,
+	ICredentialType,
+	Themed,
 } from 'n8n-workflow';
 
+import { CredentialTypes } from '@/credential-types';
 import { EnterpriseCredentialsService } from '@/credentials/credentials.service.ee';
+import { NodeTypes } from '@/node-types';
 import { UrlService } from '@/services/url.service';
 
 import { ExecutionContextService } from 'n8n-core';
 import { AuthorizeIntentService } from './authorize-intent.service';
 import { CredentialResolverWorkflowService } from './credential-resolver-workflow.service';
 import { DynamicCredentialService } from './dynamic-credential.service';
+
+/** The shell is light-theme only, so themed icons collapse to their light variant. */
+const lightVariant = (value: Themed<string> | undefined): string | undefined =>
+	typeof value === 'string' ? value : value?.light;
 
 @Service()
 export class CredentialCheckProxyService implements DynamicCredentialCheckProxyProvider {
@@ -25,6 +33,8 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 		private readonly dynamicCredentialService: DynamicCredentialService,
 		private readonly urlService: UrlService,
 		private readonly globalConfig: GlobalConfig,
+		private readonly credentialTypes: CredentialTypes,
+		private readonly nodeTypes: NodeTypes,
 	) {}
 
 	async checkCredentialStatus(
@@ -61,6 +71,7 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 					credentialType: status.credentialType,
 					resolverId: status.resolverId,
 					status: status.status,
+					iconUrl: this.resolveCredentialIconUrl(status.credentialType),
 				};
 
 				if (status.status === 'missing' && status.resolverId) {
@@ -91,6 +102,62 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 	 * fast and small. The caller identity is captured in a server-side intent so the
 	 * connection binds to the right subject regardless of who opens the link.
 	 */
+	/**
+	 * Absolute URL of the credential type's provider icon, so consumers that render
+	 * outside the editor — the form hosting shell, rendered from nodes-base — can
+	 * show it without reaching into the credential registry. Mirrors the editor's
+	 * `CredentialIcon.vue`: the type's own `iconUrl` first, then an
+	 * `icon: 'node:<nodeType>'` reference resolved to that node's icon, then the
+	 * `extends` chain. Types with neither already inherit an icon from a supported
+	 * node at load time.
+	 */
+	private resolveCredentialIconUrl(
+		credentialType: string,
+		seen = new Set<string>(),
+	): string | undefined {
+		if (!credentialType || seen.has(credentialType)) return undefined;
+		seen.add(credentialType);
+
+		let type: ICredentialType;
+		try {
+			type = this.credentialTypes.getByName(credentialType);
+		} catch {
+			return undefined;
+		}
+
+		const ownIconUrl = lightVariant(type.iconUrl);
+		if (ownIconUrl) return this.toAbsoluteIconUrl(ownIconUrl);
+
+		const icon = lightVariant(type.icon);
+		if (icon?.startsWith('node:')) {
+			const nodeIconUrl = this.resolveNodeIconUrl(icon.slice('node:'.length));
+			if (nodeIconUrl) return this.toAbsoluteIconUrl(nodeIconUrl);
+		}
+
+		for (const parentType of type.extends ?? []) {
+			const inherited = this.resolveCredentialIconUrl(parentType, seen);
+			if (inherited) return inherited;
+		}
+
+		return undefined;
+	}
+
+	private resolveNodeIconUrl(nodeTypeName: string): string | undefined {
+		try {
+			const { description } = this.nodeTypes.getByName(nodeTypeName);
+			return lightVariant(description.iconUrl);
+		} catch {
+			return undefined;
+		}
+	}
+
+	/** Loader-generated icon paths are instance-relative (`icons/<package>/…`), and the
+	 * shell renders on a webhook path where that wouldn't resolve. */
+	private toAbsoluteIconUrl(iconUrl: string): string {
+		if (/^https?:\/\//i.test(iconUrl)) return iconUrl;
+		return `${this.urlService.getInstanceBaseUrl()}/${iconUrl.replace(/^\/+/, '')}`;
+	}
+
 	/** Deletes the caller's own connection; mirrors `workflow-status.controller.ts`. */
 	private generateRevokeUrl(credentialId: string, resolverId: string): string {
 		const basePath = this.urlService.getInstanceBaseUrl();

--- a/packages/cli/templates/form-shell.handlebars
+++ b/packages/cli/templates/form-shell.handlebars
@@ -29,136 +29,158 @@
 			--color-icon-text: #6a5bdd;
 			--border-radius-card: 8px;
 			--border-radius-input: 6px;
-			--container-width: 480px;
+			/* Matches the form card's own --container-width so the panel and the card
+			   line up edge to edge; the narrow-viewport rule below mirrors the form's. */
+			--container-width: 448px;
 			--box-shadow-card: 0px 4px 16px 0px var(--color-card-shadow);
 			--box-shadow-dialog: 0px 12px 48px rgba(0, 0, 0, 0.18);
 		}
 		*, ::before, ::after { box-sizing: border-box; margin: 0; padding: 0; }
 		body { font-family: var(--font-family); background: var(--color-background); min-height: 100vh; }
 		.shell { width: 100%; padding-top: 24px; }
-		/* Aligned to the form card's width, which centers itself in the iframe below. */
-		.req-card, .req-strip { width: var(--container-width); max-width: calc(100vw - 32px); margin: 0 auto 16px; }
+		.req-card, .req-summary { width: var(--container-width); margin: 0 auto 16px; }
 
-		/* --- Required-credentials card (1–2 credentials, inline) --- */
+		/* --- Single-account panel: the credential row connects directly --- */
 		.req-card {
 			background: var(--color-card-bg);
 			border: 1px solid var(--color-card-border);
 			border-radius: var(--border-radius-card);
 			box-shadow: var(--box-shadow-card);
-			padding: 20px;
+			padding: 8px 20px;
 		}
-		.req-title { font-size: 15px; font-weight: 600; color: var(--color-header); }
-		.req-sub { font-size: 13px; color: var(--color-muted); margin-top: 4px; margin-bottom: 14px; }
 
-		/* --- Compact strip (3+ credentials) --- */
-		.req-strip {
+		/* --- Summary line (two or more accounts, details behind the dialog) --- */
+		.req-summary {
 			display: flex;
 			align-items: center;
-			gap: 14px;
+			gap: 12px;
 			background: var(--color-card-bg);
 			border: 1px solid var(--color-card-border);
 			border-radius: var(--border-radius-card);
 			box-shadow: var(--box-shadow-card);
-			padding: 16px 18px;
+			padding: 14px 18px;
 		}
-		.stack { display: flex; align-items: center; }
-		.stack .cred-icon { margin-right: -8px; border: 2px solid var(--color-card-bg); }
-		.stack .more {
-			width: 28px; height: 28px; border-radius: 6px; border: 2px solid var(--color-card-bg);
-			background: #eceafd; color: var(--color-icon-text);
-			font-size: 11px; font-weight: 600; display: flex; align-items: center; justify-content: center;
-		}
-		.strip-meta { flex: 1; min-width: 0; }
-		.strip-title { font-size: 14px; font-weight: 600; color: var(--color-header); }
-		.strip-count { font-size: 13px; color: var(--color-muted); margin-top: 2px; }
+		.summary-icon { display: flex; flex-shrink: 0; color: var(--color-icon-text); }
+		.summary-icon svg { display: block; }
+		.summary-icon .icon-ok, .req-summary.all-connected .summary-icon .icon-pending { display: none; }
+		.req-summary.all-connected .summary-icon { color: var(--color-ok); }
+		.req-summary.all-connected .summary-icon .icon-ok { display: block; }
+		.summary-text { flex: 1; min-width: 0; font-size: 13px; color: var(--color-header); }
 
-		/* --- Credential row (shared by card + dialog) --- */
+		/* --- Credential row (shared by the single-account panel + dialog) --- */
 		.cred-row { display: flex; align-items: center; gap: 12px; padding: 10px 0; }
-		.req-card .cred-row + .cred-row,
-		.dialog .cred-row + .cred-row { border-top: 1px solid #f0f1f4; }
 		.cred-icon {
 			width: 28px; height: 28px; border-radius: 6px; flex-shrink: 0;
 			background: var(--color-icon-bg); color: var(--color-icon-text);
 			font-size: 13px; font-weight: 600; display: flex; align-items: center; justify-content: center;
 		}
+		/* Provider icon, served unauthenticated from /icons/** on this same origin. */
+		img.cred-icon { background: none; object-fit: contain; }
 		.cred-meta { flex: 1; min-width: 0; }
 		.cred-name { display: block; font-size: 14px; font-weight: 600; color: var(--color-label); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+		/* Stays muted when connected — the green lives on the row's control, not the copy. */
 		.cred-sub { display: block; font-size: 12px; color: var(--color-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-		.cred-sub.connected { color: var(--color-ok); }
 
 		/* --- Buttons --- */
 		.btn {
 			font-family: var(--font-family); font-size: 13px; font-weight: 600;
 			padding: 8px 16px; border-radius: var(--border-radius-input); border: 1px solid transparent; cursor: pointer;
+			flex-shrink: 0;
 		}
 		.btn-primary { background: var(--color-primary); color: var(--color-primary-text); }
 		.btn-primary:hover { opacity: 0.88; }
 		.btn-secondary { background: var(--color-card-bg); color: var(--color-label); border-color: var(--color-card-border); }
 		.btn-secondary:hover { border-color: var(--color-muted); }
+		/* Connect (primary) while accounts are outstanding; Manage (quiet) once they're all in. */
+		#open-dialog { display: inline-flex; align-items: center; gap: 6px; }
+		#open-dialog .dot { display: none; width: 7px; height: 7px; border-radius: 50%; background: var(--color-ok); }
+		.req-summary.all-connected #open-dialog { background: var(--color-card-bg); color: var(--color-label); border-color: var(--color-card-border); }
+		.req-summary.all-connected #open-dialog:hover { opacity: 1; border-color: var(--color-muted); }
+		.req-summary.all-connected #open-dialog .dot { display: block; }
 		.cred-connected { position: relative; }
-		.btn-connected { display: inline-flex; align-items: center; gap: 6px; background: none; border: 0; color: var(--color-ok); font-family: var(--font-family); font-size: 13px; font-weight: 600; cursor: pointer; padding: 6px 4px; }
+		/* Bordered like the Connect button it replaces, so the row's control keeps its shape. */
+		.btn-connected {
+			display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+			background: var(--color-card-bg); border: 1px solid var(--color-card-border); border-radius: var(--border-radius-input);
+			color: var(--color-label); font-family: var(--font-family); font-size: 13px; font-weight: 600; padding: 8px 12px;
+		}
+		.btn-connected:hover { border-color: var(--color-muted); }
+		.btn-connected .caret { color: var(--color-muted); }
 		.btn-connected .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--color-ok); }
 		/* Fixed so the menu escapes the dialog's overflow clipping; positioned by JS. */
 		.cred-menu { display: none; position: fixed; min-width: 150px; background: var(--color-card-bg); border: 1px solid var(--color-card-border); border-radius: 6px; box-shadow: var(--box-shadow-dialog); z-index: 30; }
 		.cred-menu.open { display: block; }
 		.btn-disconnect { display: block; width: 100%; text-align: left; white-space: nowrap; background: none; border: 0; padding: 8px 14px; font-family: var(--font-family); font-size: 13px; color: #a02f28; cursor: pointer; }
 		.btn-disconnect:hover { background: #fdeceb; }
-		.cred-status-ok { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 600; color: var(--color-ok); white-space: nowrap; }
-		.cred-status-ok .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--color-ok); }
 		.cred-blocked { font-size: 13px; color: var(--color-muted); }
 
 		/* --- Dialog --- */
 		.overlay { display: none; position: fixed; inset: 0; background: rgba(20, 20, 30, 0.28); backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px); align-items: center; justify-content: center; z-index: 10; padding: 16px; }
 		.overlay.open { display: flex; }
-		.dialog { width: 480px; max-width: 100%; max-height: calc(100vh - 48px); display: flex; flex-direction: column; background: var(--color-card-bg); border-radius: 12px; box-shadow: var(--box-shadow-dialog); overflow: hidden; }
+		.dialog { width: 448px; max-width: 100%; max-height: calc(100vh - 48px); display: flex; flex-direction: column; background: var(--color-card-bg); border-radius: 12px; box-shadow: var(--box-shadow-dialog); overflow: hidden; }
 		.dialog-head { display: flex; align-items: center; justify-content: space-between; padding: 18px 20px 8px; }
 		.dialog-title { font-size: 16px; font-weight: 600; color: var(--color-header); }
 		.dialog-close { background: none; border: 0; font-size: 20px; line-height: 1; color: var(--color-muted); cursor: pointer; }
-		.dialog-sub { padding: 0 20px 8px; font-size: 13px; color: var(--color-muted); }
+		.dialog-sub { padding: 0 20px 16px; font-size: 13px; color: var(--color-muted); }
 		.dialog-list { padding: 0 20px; overflow-y: auto; }
 		.dialog-foot { display: flex; align-items: center; justify-content: space-between; padding: 14px 20px; border-top: 1px solid #f0f1f4; }
 		.dialog-count { font-size: 13px; color: var(--color-muted); }
 
 		/* --- The form itself, unchanged, in a null-origin sandboxed iframe --- */
 		#form-frame { display: block; width: 100%; height: calc(100vh - 40px); border: 0; background: transparent; }
+
+		/* Mirrors the form card's own narrow-viewport width so the edges stay aligned. */
+		@media only screen and (max-width: 500px) {
+			.req-card, .req-summary { width: 95%; }
+		}
 	</style>
 </head>
 
 <body>
+	{{#*inline "credRow"}}
+		<div
+			class='cred-row'
+			data-cred-id='{{id}}'
+			data-status='{{status}}'
+			data-resolver-id='{{resolverId}}'
+			data-not-connected-text='{{notConnectedText}}'
+			{{#if connected}} data-connected='true'{{/if}}
+			{{#if revokeUrl}} data-revoke-url='{{revokeUrl}}'{{/if}}
+		>
+			{{!-- The provider icon when it resolved server-side, else the letter tile. --}}
+			{{#if iconUrl}}
+				<img class='cred-icon cred-icon-img' src='{{iconUrl}}' alt='' data-initial='{{initial}}' />
+			{{else}}
+				<span class='cred-icon'>{{initial}}</span>
+			{{/if}}
+			<span class='cred-meta'>
+				<span class='cred-name'>{{name}}</span>
+				<span class='cred-sub'>{{#if connected}}{{#if account}}Connected as {{account}}{{else}}Connected{{/if}}{{else}}{{notConnectedText}}{{/if}}{{#if usedBy}} · used by {{usedBy}}{{/if}}</span>
+			</span>
+			{{#if connected}}
+				<span class='cred-connected'><button type='button' class='btn-connected'><span class='dot'></span> Connected <span class='caret'>&#9662;</span></button><div class='cred-menu'><button type='button' class='btn-disconnect'>Disconnect</button></div></span>
+			{{else if authorizationUrl}}
+				<button class='btn btn-secondary connect' data-url='{{authorizationUrl}}'>{{#if (eq status 'expired')}}Reconnect{{else}}Connect{{/if}}</button>
+			{{else}}
+				<span class='cred-blocked'>Ask the form owner</span>
+			{{/if}}
+		</div>
+	{{/inline}}
+
 	<div class='shell' data-submitter-email='{{submitterEmail}}'>
 		{{#if useDialog}}
-			<div class='req-strip'>
-				<div class='stack'>
-					{{#each iconStack}}
-						<span class='cred-icon'>{{this}}</span>
-					{{/each}}
-					{{#if moreCount}}<span class='more'>+{{moreCount}}</span>{{/if}}
-				</div>
-				<div class='strip-meta'>
-					<div class='strip-title'>Required credentials</div>
-					<div class='strip-count'>{{connectedCount}} of {{total}} credentials connected</div>
-				</div>
-				<button class='btn btn-primary' id='open-dialog'>Connect</button>
+			<div class='req-summary{{#if allConnected}} all-connected{{/if}}' id='req-summary'>
+				<span class='summary-icon'>
+					<svg class='icon-pending' width='17' height='17' viewBox='0 0 16 16' fill='none' stroke='currentColor' stroke-width='1.3' aria-hidden='true'><circle cx='8' cy='8' r='6.7' /><path d='M8 7.3v3.5' stroke-linecap='round' /><circle cx='8' cy='5.1' r='.8' fill='currentColor' stroke='none' /></svg>
+					<svg class='icon-ok' width='17' height='17' viewBox='0 0 16 16' fill='none' stroke='currentColor' stroke-width='1.3' aria-hidden='true'><circle cx='8' cy='8' r='6.7' /><path d='m5.2 8.2 1.9 1.9 3.7-4' stroke-linecap='round' stroke-linejoin='round' /></svg>
+				</span>
+				<span class='summary-text' id='summary-text'>{{summaryText}}</span>
+				<button class='btn btn-primary' id='open-dialog'><span class='dot'></span><span class='label'>{{#if allConnected}}Manage{{else}}Connect{{/if}}</span></button>
 			</div>
 		{{else}}
 			<div class='req-card'>
-				<div class='req-title'>Required credentials</div>
-				<div class='req-sub'>Connect required credentials to run this form using your data.</div>
 				{{#each credentials}}
-					<div class='cred-row' data-cred-id='{{id}}' data-status='{{status}}' data-resolver-id='{{resolverId}}'{{#if connected}} data-connected='true'{{/if}}{{#if revokeUrl}} data-revoke-url='{{revokeUrl}}'{{/if}}>
-						<span class='cred-icon'>{{initial}}</span>
-						<span class='cred-meta'>
-							<span class='cred-name'>{{name}}</span>
-							<span class='cred-sub {{#if connected}}connected{{/if}}'>{{#if connected}}{{#if account}}Connected as {{account}}{{else}}Connected{{/if}}{{else}}Not connected{{/if}}{{#if usedBy}} · used by {{usedBy}}{{/if}}</span>
-						</span>
-						{{#if connected}}
-							<span class='cred-connected'><button type='button' class='btn-connected'><span class='dot'></span> Connected <span class='caret'>&#9662;</span></button><div class='cred-menu'><button type='button' class='btn-disconnect'>Disconnect</button></div></span>
-						{{else if authorizationUrl}}
-							<button class='btn btn-secondary connect' data-url='{{authorizationUrl}}'>{{#if (eq status 'expired')}}Reconnect{{else}}Connect{{/if}}</button>
-						{{else}}
-							<span class='cred-blocked'>Ask the form owner</span>
-						{{/if}}
-					</div>
+					{{> credRow notConnectedText='Not connected · needed to submit this form'}}
 				{{/each}}
 			</div>
 		{{/if}}
@@ -174,30 +196,17 @@
 		<div class='overlay' id='overlay'>
 			<div class='dialog' role='dialog' aria-modal='true' aria-labelledby='dialog-title'>
 				<div class='dialog-head'>
-					<span class='dialog-title' id='dialog-title'>Required credentials</span>
+					<span class='dialog-title' id='dialog-title'>Connect your accounts</span>
 					<button class='dialog-close' id='close-dialog' aria-label='Close'>&times;</button>
 				</div>
-				<div class='dialog-sub'>Connect required credentials to run this form using your data.</div>
+				<div class='dialog-sub'>Submitting this form uses these accounts on your behalf.</div>
 				<div class='dialog-list'>
 					{{#each credentials}}
-						<div class='cred-row' data-cred-id='{{id}}' data-status='{{status}}' data-resolver-id='{{resolverId}}'{{#if connected}} data-connected='true'{{/if}}{{#if revokeUrl}} data-revoke-url='{{revokeUrl}}'{{/if}}>
-							<span class='cred-icon'>{{initial}}</span>
-							<span class='cred-meta'>
-								<span class='cred-name'>{{name}}</span>
-								<span class='cred-sub {{#if connected}}connected{{/if}}'>{{#if connected}}{{#if account}}Connected as {{account}}{{else}}Connected{{/if}}{{else}}Not connected{{/if}}{{#if usedBy}} · used by {{usedBy}}{{/if}}</span>
-							</span>
-							{{#if connected}}
-								<span class='cred-connected'><button type='button' class='btn-connected'><span class='dot'></span> Connected <span class='caret'>&#9662;</span></button><div class='cred-menu'><button type='button' class='btn-disconnect'>Disconnect</button></div></span>
-							{{else if authorizationUrl}}
-								<button class='btn btn-secondary connect' data-url='{{authorizationUrl}}'>{{#if (eq status 'expired')}}Reconnect{{else}}Connect{{/if}}</button>
-							{{else}}
-								<span class='cred-blocked'>Ask the form owner</span>
-							{{/if}}
-						</div>
+						{{> credRow notConnectedText='Not connected'}}
 					{{/each}}
 				</div>
 				<div class='dialog-foot'>
-					<span class='dialog-count'>{{connectedCount}} of {{total}} credentials connected</span>
+					<span class='dialog-count' id='dialog-count'>{{footerText}}</span>
 					<button class='btn btn-primary' id='done-dialog'>Done</button>
 				</div>
 			</div>
@@ -217,16 +226,33 @@
 			});
 			var total = Object.keys(ids).length;
 
+			function accountsLabel(count) { return count === 1 ? 'account' : 'accounts'; }
+
+			// Mirrors `formShellSummaryText` in nodes-base/nodes/Form/utils/utils.ts,
+			// which renders the same line server-side and is what the unit tests cover.
+			function summaryText(count) {
+				var remaining = total - count;
+				if (remaining <= 0) return 'All ' + total + ' accounts connected · ready to submit';
+				if (count === 0) return total + ' accounts needed to submit this form';
+				return remaining + ' more ' + accountsLabel(remaining) + ' needed to submit this form';
+			}
+
+			var summaryEl = document.getElementById('summary-text');
+			var summaryRow = document.getElementById('req-summary');
+			var countEl = document.getElementById('dialog-count');
+			var openBtnLabel = document.querySelector('#open-dialog .label');
+
 			function refresh() {
 				var count = Object.keys(connected).length;
-				var txt = count + ' of ' + total + ' credentials connected';
-				document.querySelectorAll('.strip-count, .dialog-count').forEach(function (el) {
-					el.textContent = txt;
-				});
+				var allConnected = count >= total;
+				if (summaryEl) summaryEl.textContent = summaryText(count);
+				if (summaryRow) summaryRow.classList.toggle('all-connected', allConnected);
+				if (openBtnLabel) openBtnLabel.textContent = allConnected ? 'Manage' : 'Connect';
+				if (countEl) countEl.textContent = count + ' of ' + total + ' ' + accountsLabel(total) + ' connected';
 				// UX-only signal to the form iframe; the server-side POST gate is the guarantee.
 				if (frame && frame.contentWindow) {
 					frame.contentWindow.postMessage(
-						{ type: count >= total ? 'n8n-shell-credentials-ready' : 'n8n-shell-credentials-not-ready' },
+						{ type: allConnected ? 'n8n-shell-credentials-ready' : 'n8n-shell-credentials-not-ready' },
 						'*',
 					);
 				}
@@ -238,16 +264,32 @@
 				'<button type="button" class="btn-connected"><span class="dot"></span> Connected <span class="caret">&#9662;</span></button>' +
 				'<div class="cred-menu"><button type="button" class="btn-disconnect">Disconnect</button></div>';
 
+			// A provider icon that 404s (renamed node package, stale path) falls back to
+			// the letter tile the row also carries.
+			function fallBackToLetterTile(img) {
+				if (!img || !img.classList || !img.classList.contains('cred-icon-img')) return;
+				var tile = document.createElement('span');
+				tile.className = 'cred-icon';
+				tile.textContent = img.getAttribute('data-initial') || '?';
+				img.replaceWith(tile);
+			}
+			// Capture phase because `error` doesn't bubble.
+			document.addEventListener('error', function (e) { fallBackToLetterTile(e.target); }, true);
+			// Images load in parallel with this script, so some may have already failed
+			// by the time the listener above attaches — sweep those up.
+			document.querySelectorAll('.cred-icon-img').forEach(function (img) {
+				if (img.complete && img.naturalWidth === 0) fallBackToLetterTile(img);
+			});
+
 			function markConnected(id) {
 				if (!id || connected[id]) return;
 				connected[id] = true;
-				// Card and dialog share the same data-cred-id; update both.
+				// The single-account panel and the dialog share the same data-cred-id.
 				document.querySelectorAll('.cred-row[data-cred-id="' + id + '"]').forEach(function (row) {
 					row.setAttribute('data-connected', 'true');
 					var sub = row.querySelector('.cred-sub');
 					if (sub) {
 						sub.textContent = SUBMITTER_EMAIL ? 'Connected as ' + SUBMITTER_EMAIL : 'Connected';
-						sub.classList.add('connected');
 					}
 					var btn = row.querySelector('.connect');
 					if (btn) {
@@ -307,7 +349,11 @@
 				document.querySelectorAll('.cred-row[data-cred-id="' + id + '"]').forEach(function (row) {
 					row.removeAttribute('data-connected');
 					var sub = row.querySelector('.cred-sub');
-					if (sub) { sub.textContent = 'Not connected'; sub.classList.remove('connected'); }
+					if (sub) {
+						// The single-account row spells out why the account is needed; the
+						// dialog's rows sit under copy that already says it.
+						sub.textContent = row.getAttribute('data-not-connected-text') || 'Not connected';
+					}
 					var wrap = row.querySelector('.cred-connected');
 					if (wrap) {
 						var btn = document.createElement('button');
@@ -407,7 +453,7 @@
 				document.querySelectorAll('.cred-menu.open').forEach(function (m) { m.classList.remove('open'); });
 			});
 
-			// Dialog (3+ credentials)
+			// Dialog (two or more accounts)
 			var overlay = document.getElementById('overlay');
 			var open = document.getElementById('open-dialog');
 			if (open && overlay) {
@@ -419,9 +465,10 @@
 
 			// The form's POST was refused by the server-side gate. Rows rendered at page load
 			// can be stale (revoked since, or disconnected in another tab), so flip the ones
-			// the server no longer considers connected and surface the panel — the 3+ layout
-			// otherwise keeps every row behind the strip. Declared after the dialog wiring so
-			// `overlay` is assigned; hoisting keeps it callable from the listener above.
+			// the server no longer considers connected and surface the panel — the 2+ layout
+			// otherwise keeps every row behind the summary line. Declared after the dialog
+			// wiring so `overlay` is assigned; hoisting keeps it callable from the listener
+			// above.
 			function handleGateRejection(data) {
 				if (!data || data.type !== 'n8n-form-credentials-rejected' || !Array.isArray(data.ids)) return;
 				data.ids.forEach(function (id) {

--- a/packages/cli/templates/form-shell.handlebars
+++ b/packages/cli/templates/form-shell.handlebars
@@ -60,7 +60,7 @@
 			box-shadow: var(--box-shadow-card);
 			padding: 14px 18px;
 		}
-		.summary-icon { display: flex; flex-shrink: 0; color: var(--color-icon-text); }
+		.summary-icon { display: flex; flex-shrink: 0; color: var(--color-muted); }
 		.summary-icon svg { display: block; }
 		.summary-icon .icon-ok, .req-summary.all-connected .summary-icon .icon-pending { display: none; }
 		.req-summary.all-connected .summary-icon { color: var(--color-ok); }

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -261,6 +261,12 @@
 				cursor: not-allowed;
 			}
 
+			#submit-hint {
+				margin-top: 8px;
+				font-size: var(--font-size-link);
+				color: var(--color-link);
+			}
+
 			#submit-btn:disabled:hover {
 				opacity: 1;
 			}
@@ -650,7 +656,7 @@
 
 					{{#if hasAuthenticatedSubmitter}}<p id='submit-error'></p>{{/if}}
 
-					<button id='submit-btn' type='submit' {{#if shellInner}}disabled title='Connect the required credentials first'{{/if}}>
+					<button id='submit-btn' type='submit' {{#if shellInner}}disabled title='Connect the required accounts first'{{/if}}>
 						<span><svg
 								xmlns='http://www.w3.org/2000/svg'
 								height='18px'
@@ -662,6 +668,11 @@
 							</svg></span>
 						{{ buttonLabel }}
 					</button>
+
+					{{#if shellInner}}
+						{{!-- Only inside the hosting shell, where the connect panel above supplies the accounts. --}}
+						<p id='submit-hint'>This form will run using your connected accounts.</p>
+					{{/if}}
 				</form>
 
 				<div class='card' id='submitted-form' style='display: none;'>
@@ -740,13 +751,13 @@
 				const isShellInner = {{#if shellInner}}true{{else}}false{{/if}};
 
 				// The submit-time credential gate refused this submission. Explain it and hand the
-				// form back with the answers intact. The panel names the credentials, so the banner
+				// form back with the answers intact. The panel names the accounts, so the banner
 				// only has to say what to do next.
 				function handleCredentialGate(credentials) {
 					updateError(
 						document.querySelector('#submit-error'),
 						'add',
-						'Not all required credentials are connected. ' +
+						'Not all required accounts are connected. ' +
 							(isShellInner
 								? 'Connect them above, then submit again.'
 								: 'Open this form in a new tab to connect them, then come back here and submit again.'),
@@ -1218,7 +1229,7 @@
 					{{/if}}
 				} else if (event.data.type === 'n8n-shell-credentials-not-ready') {
 					btn.disabled = true;
-					btn.setAttribute('title', 'Connect the required credentials first');
+					btn.setAttribute('title', 'Connect the required accounts first');
 				}
 			});
 		</script>

--- a/packages/nodes-base/nodes/Form/test/formShellViewModel.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formShellViewModel.test.ts
@@ -1,0 +1,170 @@
+import type { CredentialCheckStatus } from 'n8n-workflow';
+
+import { buildFormShellViewModel, formShellSummaryText } from '../utils/utils';
+
+const credential = (overrides: Partial<CredentialCheckStatus> = {}): CredentialCheckStatus => ({
+	credentialId: 'cred-1',
+	credentialName: 'Google Sheets account',
+	credentialType: 'googleSheetsOAuth2Api',
+	resolverId: 'resolver-1',
+	status: 'missing',
+	...overrides,
+});
+
+const missing = (n: number) =>
+	Array.from({ length: n }, (_, i) =>
+		credential({ credentialId: `missing-${i}`, credentialName: `Account ${i}` }),
+	);
+
+const configured = (n: number) =>
+	Array.from({ length: n }, (_, i) =>
+		credential({
+			credentialId: `configured-${i}`,
+			credentialName: `Account ${i}`,
+			status: 'configured',
+		}),
+	);
+
+describe('formShellSummaryText', () => {
+	it('should ask for every account when none are connected', () => {
+		expect(formShellSummaryText(2, 0)).toBe('2 accounts needed to submit this form');
+		expect(formShellSummaryText(5, 0)).toBe('5 accounts needed to submit this form');
+	});
+
+	it('should count down the remaining accounts, singular for the last one', () => {
+		expect(formShellSummaryText(2, 1)).toBe('1 more account needed to submit this form');
+		expect(formShellSummaryText(5, 4)).toBe('1 more account needed to submit this form');
+	});
+
+	it('should pluralise the remaining accounts', () => {
+		expect(formShellSummaryText(5, 1)).toBe('4 more accounts needed to submit this form');
+		expect(formShellSummaryText(3, 1)).toBe('2 more accounts needed to submit this form');
+	});
+
+	it('should report readiness once every account is connected', () => {
+		expect(formShellSummaryText(2, 2)).toBe('All 2 accounts connected · ready to submit');
+		expect(formShellSummaryText(4, 4)).toBe('All 4 accounts connected · ready to submit');
+	});
+
+	it('should never render "account(s)"', () => {
+		for (let total = 1; total <= 6; total++) {
+			for (let connectedCount = 0; connectedCount <= total; connectedCount++) {
+				expect(formShellSummaryText(total, connectedCount)).not.toContain('(s)');
+			}
+		}
+	});
+});
+
+describe('buildFormShellViewModel', () => {
+	describe('the 1-vs-2+ threshold', () => {
+		it('should connect a single account directly from its row, without the dialog', () => {
+			expect(buildFormShellViewModel(missing(1)).useDialog).toBe(false);
+			expect(buildFormShellViewModel(configured(1)).useDialog).toBe(false);
+		});
+
+		it('should collapse two or more accounts behind the dialog', () => {
+			expect(buildFormShellViewModel(missing(2)).useDialog).toBe(true);
+			expect(buildFormShellViewModel(missing(3)).useDialog).toBe(true);
+			expect(buildFormShellViewModel([...configured(2), ...missing(1)]).useDialog).toBe(true);
+		});
+	});
+
+	describe('counts', () => {
+		it('should count connected accounts from the configured status', () => {
+			const vm = buildFormShellViewModel([...configured(2), ...missing(3)]);
+
+			expect(vm.total).toBe(5);
+			expect(vm.connectedCount).toBe(2);
+			expect(vm.allConnected).toBe(false);
+			expect(vm.credentials.filter((c) => c.connected)).toHaveLength(2);
+		});
+
+		it('should not treat a resolver_missing account as connected', () => {
+			const vm = buildFormShellViewModel([
+				...configured(1),
+				credential({ credentialId: 'blocked', status: 'resolver_missing' }),
+			]);
+
+			expect(vm.connectedCount).toBe(1);
+			expect(vm.allConnected).toBe(false);
+		});
+
+		it('should mark everything connected only when no account is outstanding', () => {
+			expect(buildFormShellViewModel(configured(2)).allConnected).toBe(true);
+			expect(buildFormShellViewModel([]).allConnected).toBe(false);
+		});
+
+		it('should pluralise the dialog footer counter', () => {
+			expect(buildFormShellViewModel(missing(1)).footerText).toBe('0 of 1 account connected');
+			expect(buildFormShellViewModel([...configured(1), ...missing(1)]).footerText).toBe(
+				'1 of 2 accounts connected',
+			);
+			expect(buildFormShellViewModel(configured(3)).footerText).toBe('3 of 3 accounts connected');
+		});
+
+		it('should carry the summary line for the rendered state', () => {
+			expect(buildFormShellViewModel([...configured(1), ...missing(2)]).summaryText).toBe(
+				'2 more accounts needed to submit this form',
+			);
+		});
+	});
+
+	describe('icons', () => {
+		it("should pass through the credential type's resolved icon", () => {
+			const vm = buildFormShellViewModel([
+				credential({ iconUrl: 'http://localhost:5678/icons/pkg/googleSheets.svg' }),
+			]);
+
+			expect(vm.credentials[0].iconUrl).toBe('http://localhost:5678/icons/pkg/googleSheets.svg');
+		});
+
+		it('should always provide a letter tile as the fallback', () => {
+			const vm = buildFormShellViewModel([
+				credential({ credentialName: 'Google Sheets account' }),
+				credential({ credentialId: 'cred-2', credentialName: 'slack account', iconUrl: 'i.svg' }),
+			]);
+
+			expect(vm.credentials[0].iconUrl).toBeUndefined();
+			expect(vm.credentials[0].initial).toBe('G');
+			// The tile is still there behind a resolved icon, for a failed image load.
+			expect(vm.credentials[1].initial).toBe('S');
+		});
+
+		it('should fall back to "?" when the name yields no letter', () => {
+			const vm = buildFormShellViewModel([credential({ credentialName: '   ' })]);
+
+			expect(vm.credentials[0].initial).toBe('?');
+		});
+	});
+
+	describe('rows', () => {
+		it('should show the submitter as the connected account, and only once connected', () => {
+			const vm = buildFormShellViewModel([...configured(1), ...missing(1)], 'jan@company.com');
+
+			expect(vm.credentials[0].account).toBe('jan@company.com');
+			expect(vm.credentials[1].account).toBeUndefined();
+			expect(vm.submitterEmail).toBe('jan@company.com');
+		});
+
+		it('should carry the per-row connect and revoke links through', () => {
+			const vm = buildFormShellViewModel([
+				credential({
+					authorizationUrl: 'http://localhost:5678/rest/credentials/cred-1/authorize?token=t',
+				}),
+				credential({
+					credentialId: 'cred-2',
+					status: 'configured',
+					revokeUrl: 'http://localhost:5678/rest/credentials/cred-2/revoke?resolverId=resolver-1',
+				}),
+			]);
+
+			expect(vm.credentials[0].authorizationUrl).toBe(
+				'http://localhost:5678/rest/credentials/cred-1/authorize?token=t',
+			);
+			expect(vm.credentials[0].revokeUrl).toBeUndefined();
+			expect(vm.credentials[1].revokeUrl).toBe(
+				'http://localhost:5678/rest/credentials/cred-2/revoke?resolverId=resolver-1',
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -972,14 +972,76 @@ function renderFormShell({
 	const inner = new URL(buildAbsoluteFormUrl(req));
 	inner.searchParams.set('n8nShellInner', '1');
 
+	res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
+	res.render('form-shell', {
+		formTitle,
+		iframeSrc: `${inner.pathname}${inner.search}`,
+		resourceUrl,
+		...buildFormShellViewModel(credentials, submitterEmail),
+	});
+}
+
+export type FormShellCredentialRow = {
+	id: string;
+	name: string;
+	type: string;
+	status: CredentialCheckStatus['status'];
+	connected: boolean;
+	/** Letter tile, used whenever the provider icon doesn't resolve. */
+	initial: string;
+	iconUrl?: string;
+	authorizationUrl?: string;
+	revokeUrl?: string;
+	resolverId?: string;
+	account?: string;
+	usedBy?: string;
+};
+
+export type FormShellViewModel = {
+	credentials: FormShellCredentialRow[];
+	total: number;
+	connectedCount: number;
+	useDialog: boolean;
+	allConnected: boolean;
+	summaryText: string;
+	footerText: string;
+	submitterEmail?: string;
+};
+
+/** Submitter-facing copy talks about accounts, never credentials — and never `account(s)`. */
+const accountsLabel = (count: number) => (count === 1 ? 'account' : 'accounts');
+
+/**
+ * The one-line state of the connect panel for two or more accounts. Mirrored by
+ * the shell's client-side `summaryText()`, which re-renders it in place as rows
+ * connect (a reload would bounce the submitter back through consent).
+ */
+export function formShellSummaryText(total: number, connectedCount: number): string {
+	const remaining = total - connectedCount;
+	if (remaining <= 0) return `All ${total} accounts connected · ready to submit`;
+	if (connectedCount === 0) return `${total} accounts needed to submit this form`;
+	return `${remaining} more ${accountsLabel(remaining)} needed to submit this form`;
+}
+
+/**
+ * View model for `form-shell.handlebars`. Two shapes: a single required account
+ * gets its own row with a Connect button that opens the OAuth popup directly;
+ * two or more collapse behind a summary line plus the "Connect your accounts"
+ * dialog.
+ */
+export function buildFormShellViewModel(
+	credentials: CredentialCheckStatus[],
+	submitterEmail?: string,
+): FormShellViewModel {
 	const initialOf = (name: string) => (name.trim().charAt(0) || '?').toUpperCase();
-	const rows = credentials.map((c) => ({
+	const rows: FormShellCredentialRow[] = credentials.map((c) => ({
 		id: c.credentialId,
 		name: c.credentialName,
 		type: c.credentialType,
 		status: c.status,
 		connected: c.status === 'configured',
 		initial: initialOf(c.credentialName),
+		iconUrl: c.iconUrl,
 		authorizationUrl: c.authorizationUrl,
 		revokeUrl: c.revokeUrl,
 		resolverId: c.resolverId,
@@ -988,27 +1050,23 @@ function renderFormShell({
 		// provider account (when it differs) is a backend-enrichment follow-up.
 		account: c.status === 'configured' ? submitterEmail : undefined,
 		// `usedBy` (owning node) comes from the backend-enrichment follow-up.
-		usedBy: undefined as string | undefined,
+		usedBy: undefined,
 	}));
 
 	const total = rows.length;
 	const connectedCount = rows.filter((r) => r.connected).length;
-	// Design: 1–2 credentials render inline; 3+ collapse into a strip + dialog.
-	const useDialog = total >= 3;
 
-	res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
-	res.render('form-shell', {
-		formTitle,
-		iframeSrc: `${inner.pathname}${inner.search}`,
-		resourceUrl,
+	return {
 		credentials: rows,
 		total,
 		connectedCount,
-		useDialog,
+		// Design: one account connects directly from its row; two or more collapse.
+		useDialog: total >= 2,
+		allConnected: total > 0 && connectedCount === total,
+		summaryText: formShellSummaryText(total, connectedCount),
+		footerText: `${connectedCount} of ${total} ${accountsLabel(total)} connected`,
 		submitterEmail,
-		iconStack: rows.slice(0, 3).map((r) => r.initial),
-		moreCount: total > 3 ? total - 3 : 0,
-	});
+	};
 }
 
 export async function formWebhook(

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
@@ -24,7 +24,7 @@ const FIELD_LABEL = 'What is your first name?';
 
 /** The banner a plain form (no hosting shell above it) shows on a rejection. */
 const BANNER =
-	'Not all required credentials are connected. Open this form in a new tab to connect them, then come back here and submit again.';
+	'Not all required accounts are connected. Open this form in a new tab to connect them, then come back here and submit again.';
 
 const GATE_BODY = {
 	status: 'credential_connections_required',

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1160,6 +1160,12 @@ export type CredentialCheckStatus = {
 	status: 'missing' | 'configured' | 'resolver_missing';
 	authorizationUrl?: string;
 	revokeUrl?: string;
+	/**
+	 * Absolute URL of the credential type's provider icon. Resolved server-side
+	 * because consumers (e.g. the form hosting shell, rendered from nodes-base)
+	 * have no access to the credential registry.
+	 */
+	iconUrl?: string;
 };
 
 export type CredentialCheckResult = {


### PR DESCRIPTION
## Summary

Design-review pass over the credential-connect panel in the form hosting shell
(`form-shell.handlebars`). The shell was a first pass built ahead of the review; this
refines it. Behaviour only moves between panel shapes — the server-side submit gate and
the authorize/revoke flows are untouched.

**One panel, two shapes**

- **1 required account** → its own row with the provider icon and a `Connect` button that
  opens the OAuth popup directly. No panel title, no modal.
- **2+ required accounts** → an icon-less summary line whose `Connect` / `● Manage` button
  opens a **Connect your accounts** modal listing every account. Rows and the footer
  counter update in place as each connects.

The collapse threshold moves from `total >= 3` to `total >= 2`, so two accounts no longer
render as an inline two-row card. The icon stack and its `+N` badge are gone — the summary
line carries copy only, so `iconStack` / `moreCount` were removed from the view model.

**Copy** — counters give way to account-centric sentences, pluralised properly (never
`account(s)`):

| State | String |
| --- | --- |
| 1 account, not connected | `Not connected · needed to submit this form` |
| 1 account, connected | `Connected as {email}` |
| N ≥ 2, none connected | `{N} accounts needed to submit this form` |
| N ≥ 2, some connected | `{remaining} more account(s) needed to submit this form` |
| N ≥ 2, all connected | `All {N} accounts connected · ready to submit` |
| Modal footer | `{connected} of {N} accounts connected` |

"Accounts" now also replaces "credentials" in the disabled-submit tooltip
(`Connect the required accounts first`) and the submit-gate rejection banner. A
`This form will run using your connected accounts.` hint sits under Submit, `shellInner`
only.

**Width** — `--container-width` drops 480px → **448px** to match the form card, and the
narrow-viewport rule mirrors the form's own (`width: 95%` under 500px) in place of
`max-width: calc(100vw - 32px)`. Panel and card edges line up at every width.

**Real provider icons** — this is the one change outside the shell, and the part worth a
close look. `CredentialCheckStatus` gains `iconUrl?: string`, resolved server-side in
`CredentialCheckProxyService` because the shell renders from `nodes-base` and has no access
to the credential registry. The resolution mirrors the editor's `CredentialIcon.vue`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1220

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

