### PR TITLE
fix(editor): Stop repeating the caller policy label when the project is unknown

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/components/WorkflowSettings/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/components/WorkflowSettings/WorkflowSettings.test.ts
@@ -336,6 +336,19 @@ describe('WorkflowSettingsVue', () => {
 		});
 	});
 
+	// The labels are built in the same `Promise.all` as the workflow fetch, so the owning
+	// project can still be unknown when the same-owner option is labelled.
+	it('should label the same-owner option without a project name when the project is unknown', async () => {
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
+		const { getByTestId } = createComponent({ pinia });
+
+		await flushPromises();
+		const dropdownItems = await getDropdownItems(getByTestId('workflow-caller-policy'));
+
+		expect(dropdownItems[1]).toHaveTextContent('Only workflows in the same project');
+		expect(dropdownItems[1]).not.toHaveTextContent('Only workflows in Only workflows');
+	});
+
 	it('should render list of workflows field when policy is set to workflowsFromAList', async () => {
 		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
 		const { getByTestId } = createComponent({ pinia });

--- a/packages/frontend/editor-ui/src/features/workflows/components/WorkflowSettings/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/components/WorkflowSettings/WorkflowSettings.vue
@@ -229,11 +229,10 @@ const workflow = computed(() => workflowsListStore.getWorkflowById(workflowId.va
 const isSharingEnabled = computed(
 	() => settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing],
 );
-const workflowOwnerName = computed(() => {
-	const fallback = i18n.baseText('workflowSettings.callerPolicy.options.workflowsFromSameProject');
-
-	return workflowsEEStore.getWorkflowOwnerName(`${workflowId.value}`, fallback);
-});
+/** Empty when the owning project is not known yet, so callers can pick a label of their own. */
+const workflowOwnerName = computed(() =>
+	workflowsEEStore.getWorkflowOwnerName(`${workflowId.value}`, ''),
+);
 const workflowPermissions = computed(() => getResourcePermissions(workflow.value?.scopes).workflow);
 
 const projectPermissions = computed(() => {
@@ -445,16 +444,19 @@ const loadWorkflowCallerPolicyOptions = async () => {
 		},
 		{
 			key: 'workflowsFromSameOwner',
-			value: i18n.baseText(
-				workflow.value.homeProject?.type === ProjectTypes.Personal
-					? 'workflowSettings.callerPolicy.options.workflowsFromPersonalProject'
-					: 'workflowSettings.callerPolicy.options.workflowsFromTeamProject',
-				{
-					interpolate: {
-						projectName: workflowOwnerName.value,
-					},
-				},
-			),
+			// Without a project name to interpolate, use the label that names no project.
+			value: workflowOwnerName.value
+				? i18n.baseText(
+						workflow.value.homeProject?.type === ProjectTypes.Personal
+							? 'workflowSettings.callerPolicy.options.workflowsFromPersonalProject'
+							: 'workflowSettings.callerPolicy.options.workflowsFromTeamProject',
+						{
+							interpolate: {
+								projectName: workflowOwnerName.value,
+							},
+						},
+					)
+				: i18n.baseText('workflowSettings.callerPolicy.options.workflowsFromSameProject'),
 		},
 		{
 			key: 'workflowsFromAList',


### PR DESCRIPTION
## Summary

The `This workflow can be called by` dropdown labels the same-owner option `Only workflows in {projectName}`. When the owning project is unknown, the project name falls back to the string `Only workflows in the same project`, which is a whole sentence rather than a name. Interpolating one into the other gives:

> Only workflows in Only workflows in the same project

The owning project is unknown more often than it looks. `loadWorkflowCallerPolicyOptions()` builds the labels synchronously, and it sits in the same `Promise.all` as `workflowsListStore.fetchWorkflow(workflowId)`, so it runs before that fetch resolves. Any time the workflow is not already in the list store cache, `homeProject` is still undefined when the label is built.

The fix uses the label that names no project when there is no name to interpolate, rather than passing a sentence in as the name.

The added test reproduces it against the existing fixture, which has no `homeProject`. It fails on master with:

```
- Only workflows in Only workflows
+ Only workflows in Only workflows in the same project
```

## How to test

1. Open a workflow's settings on an instance with the Sharing feature, having loaded the page directly rather than from the workflow list.
2. Open the `This workflow can be called by` dropdown. The same-owner option reads `Only workflows in the same project`, not the doubled text.

## Related Linear tickets, Github issues, and Community forum posts

Found while working on https://linear.app/n8n/issue/ADO-4923. Split out because it is a pre-existing bug with its own cause, reproducible on master.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

