### PR TITLE
fix(Webhook Node): clarify the error message when a request is rejected by the Ignore Bots option

### DIFF
--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -243,7 +243,10 @@ export class Webhook extends Node {
 		let validationData: IDataObject | undefined;
 		try {
 			if (options.ignoreBots && isbot(req.headers['user-agent']))
-				throw new WebhookAuthorizationError(403);
+				throw new WebhookAuthorizationError(
+					403,
+					'Request rejected: the user agent was detected as a bot and the "Ignore Bots" option is enabled on this webhook',
+				);
 			if (context.getNodeParameter('authentication', 'none') === 'n8nOAuth2') {
 				// Two-step n8n user-auth flow: (1) validate the bearer token and resolve
 				// the caller to an n8n user, then (2) seed the execution context so the

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -62,6 +62,44 @@ describe('Test Webhook Node', () => {
 		});
 	});
 
+	describe('bot rejection (ignoreBots)', () => {
+		const node = new Webhook();
+
+		const buildContext = (userAgent: string) => {
+			const context = mock<IWebhookFunctions>({ nodeHelpers: mock() });
+			context.getNode.calledWith().mockReturnValue({
+				type: 'n8n-nodes-base.webhook',
+				typeVersion: 1.1,
+			} as any);
+			context.getNodeParameter.mockImplementation((parameterName: string) => {
+				if (parameterName === 'responseMode') return 'onReceived';
+				if (parameterName === 'options') return { ignoreBots: true };
+				if (parameterName === 'authentication') return 'none';
+				return undefined;
+			});
+			const req = mock<Request>();
+			req.headers = { 'user-agent': userAgent };
+			(req as any).ips = [];
+			(req as any).ip = '127.0.0.1';
+			context.getRequestObject.mockReturnValue(req);
+			const resp = mock<Response>();
+			context.getResponseObject.mockReturnValue(resp);
+			return { context, resp };
+		};
+
+		it('should reject bot user agents with a message that names the Ignore Bots option', async () => {
+			const { context, resp } = buildContext('curl/8.5.0');
+
+			const result = await node.webhook(context);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(resp.writeHead).toHaveBeenCalledWith(403, expect.anything());
+			expect(resp.end).toHaveBeenCalledWith(
+				'Request rejected: the user agent was detected as a bot and the "Ignore Bots" option is enabled on this webhook',
+			);
+		});
+	});
+
 	describe('handleFormData', () => {
 		const node = new Webhook();
 		const context = mock<IWebhookFunctions>({


### PR DESCRIPTION
## Summary

When a webhook has the **Ignore Bots** option enabled and a request is
rejected by bot detection, the response body is currently:

```
Authorization data is wrong!
```

This is the generic default message of `WebhookAuthorizationError(403)` and is
misleading: the webhook has no authentication configured, so users debugging
the 403 look for credential problems instead of the actual cause (their
client's user agent being classified as a bot — e.g. plain `curl`, or even a
bare `Mozilla/5.0`).

This PR passes an explicit message at the only bot-rejection call site in the
Webhook node (also used by the Wait node's webhook resume):

```
Request rejected: the user agent was detected as a bot and the "Ignore Bots" option is enabled on this webhook
```

## How I ran into this

While testing a Wait-node approval flow with `curl`, the resume URL returned
403 "Authorization data is wrong!". The webhook had no auth configured, so I
spent time checking credentials before finding the `ignoreBots` check via the
source. A message that names the option makes this self-diagnosable.

## Changes

- `Webhook.node.ts`: pass an explicit message to `WebhookAuthorizationError`
  for the bot-rejection case (no behavioural change otherwise; status stays 403)
- `Webhook.test.ts`: add a unit test asserting the 403 and the new message

## Review notes

- The `WWW-Authenticate: Basic realm="Webhook"` header is still sent for this
  error path (unchanged); happy to drop it for the bot case too if preferred,
  but I kept the diff minimal.
- The Form trigger has a separate bot-rejection path (401 with empty body in
  `Form/utils/utils.ts`); left untouched to keep this PR focused.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

