### PR TITLE
fix(core): guard console.log(null/undefined) in sendMessageToUI

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -234,6 +234,14 @@ export const describeCommonTests = (
 				messages: ['Testing', 1, 2, {}],
 			});
 		});
+
+		it('should not throw and should pass through null and undefined args unchanged', () => {
+			expect(() => context.sendMessageToUI(null, undefined)).not.toThrow();
+			expect(additionalData.sendDataToUI).toHaveBeenCalledWith('sendConsoleMessage', {
+				source: '[Node: "Test Node"]',
+				messages: [null, undefined],
+			});
+		});
 	});
 
 	describe('logAiEvent', () => {

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -334,6 +334,9 @@ export class BaseExecuteContext extends NodeExecutionContext {
 		try {
 			if (this.additionalData.sendDataToUI) {
 				args = args.map((arg) => {
+					// console.log(null) / console.log(undefined) are valid and must pass through as-is
+					if (arg === null || arg === undefined) return arg;
+
 					// prevent invalid dates from being logged as null
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
 					if (arg.isLuxonDateTime && arg.invalidReason) return { ...arg };


### PR DESCRIPTION
## Summary

`console.log(null)` and `console.log(undefined)` inside a Code node running in manual mode threw:

```
Cannot read properties of null (reading 'isLuxonDateTime')
```

`sendMessageToUI()` in `packages/core/src/execution-engine/node-execution-context/base-execute-context.ts` maps over the console args to special-case Luxon `DateTime` instances and `Date` objects, but accessed `arg.isLuxonDateTime` without checking for `null`/`undefined` first. Since `console.log(null)` and `console.log(undefined)` are both valid JS, this threw on every such call instead of passing the value through.

This was reported to have caused a production incident: a single `console.log(null)` call flooded ~77k of these errors in 3 hours, exhausting heap.

The fix adds an early return for `null`/`undefined` args before any property access, leaving all other value handling (Luxon `DateTime`, `Date`, primitives, objects) unchanged.

## How to test

1. Create a workflow with a Code node.
2. In manual/test mode, add `console.log(null)` and `console.log(undefined)` to the code.
3. Execute the workflow.
4. Before the fix: execution fails/errors flood the console output. After the fix: the workflow executes normally and `null`/`undefined` are logged as-is in the UI console output.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #36174

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (not applicable — bug fix, no doc-facing behavior change)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

