### PR TITLE
fix(core): safely handle null and undefined args in sendMessageToUI

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -526,4 +526,19 @@ export const describeCommonTests = (
 			});
 		});
 	});
+
+	describe('sendMessageToUI', () => {
+		it('should handle null and undefined arguments without throwing', () => {
+			additionalData.sendDataToUI = vi.fn();
+
+			expect(() => {
+				context.sendMessageToUI(null, undefined, 'hello', 123);
+			}).not.toThrow();
+
+			expect(additionalData.sendDataToUI).toHaveBeenCalledWith('sendConsoleMessage', {
+				source: `[Node: "${node.name}"]`,
+				messages: [null, undefined, 'hello', 123],
+			});
+		});
+	});
 };

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -336,11 +336,11 @@ export class BaseExecuteContext extends NodeExecutionContext {
 				args = args.map((arg) => {
 					// prevent invalid dates from being logged as null
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-					if (arg.isLuxonDateTime && arg.invalidReason) return { ...arg };
+					if (arg?.isLuxonDateTime && arg.invalidReason) return { ...arg };
 
 					// log valid dates in human readable format, as in browser
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-					if (arg.isLuxonDateTime) return new Date(arg.ts).toString();
+					if (arg?.isLuxonDateTime) return new Date(arg.ts).toString();
 					if (arg instanceof Date) return arg.toString();
 
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-return


### PR DESCRIPTION
## Summary

Fixes #36174 by using optional chaining on `arg?.isLuxonDateTime` inside `BaseExecuteContext.sendMessageToUI()`.

## Problem

When a Code node calls `console.log(null)` or `console.log(undefined)` during manual workflow execution:
1. `sendMessageToUI()` iterated through arguments and evaluated `arg.isLuxonDateTime`.
2. This threw `TypeError: Cannot read properties of null (reading 'isLuxonDateTime')`.
3. In workflows with loops or nullable fields, this flooded logs and prevented messages from reaching the UI console.

## Solution

1. Use optional chaining (`arg?.isLuxonDateTime`) when inspecting arguments in `sendMessageToUI()`.
2. Added unit tests in `packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts` to ensure `null` and `undefined` arguments are safely forwarded to `sendDataToUI` without throwing.

## Validation

- `pnpm --filter n8n-core test src/execution-engine/node-execution-context/__tests__/` ? **300 passed** across 11 test suites.
- `eslint` and `biome format` ? clean.

Fixes #36174


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

