### PR TITLE
fix(workflow): preserve trailing elements in array .merge() when lengths differ

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/array-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/array-extensions.ts
@@ -254,13 +254,19 @@ function merge(value: unknown[], extraArgs: unknown[][]): unknown {
 	const listLength = value.length > others.length ? value.length : others.length;
 	let merged = {};
 	for (let i = 0; i < listLength; i++) {
-		if (value[i] !== undefined) {
-			if (typeof value[i] === 'object' && typeof others[i] === 'object') {
-				merged = Object.assign(
-					merged,
-					mergeObjects(value[i] as Record<string, unknown>, [others[i]]),
-				);
-			}
+		const valueItem = value[i];
+		const otherItem = others[i];
+
+		if (valueItem !== undefined && typeof valueItem === 'object') {
+			// mergeObjects() returns valueItem unchanged when otherItem is missing,
+			// so elements unique to `value` are kept even if `others` is shorter
+			merged = Object.assign(
+				merged,
+				mergeObjects(valueItem as Record<string, unknown>, [otherItem]),
+			);
+		} else if (otherItem !== undefined && typeof otherItem === 'object') {
+			// Elements unique to `others` (past the end of `value`) are merged directly
+			merged = Object.assign(merged, otherItem as Record<string, unknown>);
 		}
 	}
 	return merged;

--- a/packages/@n8n/expression-runtime/src/extensions/array-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/array-extensions.ts
@@ -257,7 +257,11 @@ function merge(value: unknown[], extraArgs: unknown[][]): unknown {
 		const valueItem = value[i];
 		const otherItem = others[i];
 
-		if (valueItem !== undefined && typeof valueItem === 'object') {
+		if (
+			valueItem !== undefined &&
+			typeof valueItem === 'object' &&
+			(otherItem === undefined || typeof otherItem === 'object')
+		) {
 			// mergeObjects() returns valueItem unchanged when otherItem is missing,
 			// so elements unique to `value` are kept even if `others` is shorter
 			merged = Object.assign(
@@ -265,8 +269,9 @@ function merge(value: unknown[], extraArgs: unknown[][]): unknown {
 				mergeObjects(valueItem as Record<string, unknown>, [otherItem]),
 			);
 		} else if (otherItem !== undefined && typeof otherItem === 'object') {
-			// Elements unique to `others` (past the end of `value`) are merged directly
-			merged = Object.assign(merged, otherItem as Record<string, unknown>);
+			// Elements unique to `others` (past the end of `value`) are merged with
+			// first-value-wins so existing keys aren't overwritten
+			merged = Object.assign(merged, mergeObjects(merged, [otherItem]));
 		}
 	}
 	return merged;

--- a/packages/workflow/src/extensions/array-extensions.ts
+++ b/packages/workflow/src/extensions/array-extensions.ts
@@ -259,7 +259,11 @@ function merge(value: unknown[], extraArgs: unknown[][]): unknown {
 		const valueItem = value[i];
 		const otherItem = others[i];
 
-		if (valueItem !== undefined && typeof valueItem === 'object') {
+		if (
+			valueItem !== undefined &&
+			typeof valueItem === 'object' &&
+			(otherItem === undefined || typeof otherItem === 'object')
+		) {
 			// mergeObjects() returns valueItem unchanged when otherItem is missing,
 			// so elements unique to `value` are kept even if `others` is shorter
 			merged = Object.assign(
@@ -267,8 +271,9 @@ function merge(value: unknown[], extraArgs: unknown[][]): unknown {
 				mergeObjects(valueItem as Record<string, unknown>, [otherItem]),
 			);
 		} else if (otherItem !== undefined && typeof otherItem === 'object') {
-			// Elements unique to `others` (past the end of `value`) are merged directly
-			merged = Object.assign(merged, otherItem as Record<string, unknown>);
+			// Elements unique to `others` (past the end of `value`) are merged with
+			// first-value-wins so existing keys aren't overwritten
+			merged = Object.assign(merged, mergeObjects(merged, [otherItem]));
 		}
 	}
 	return merged;

--- a/packages/workflow/src/extensions/array-extensions.ts
+++ b/packages/workflow/src/extensions/array-extensions.ts
@@ -256,13 +256,19 @@ function merge(value: unknown[], extraArgs: unknown[][]): unknown {
 	const listLength = value.length > others.length ? value.length : others.length;
 	let merged = {};
 	for (let i = 0; i < listLength; i++) {
-		if (value[i] !== undefined) {
-			if (typeof value[i] === 'object' && typeof others[i] === 'object') {
-				merged = Object.assign(
-					merged,
-					mergeObjects(value[i] as Record<string, unknown>, [others[i]]),
-				);
-			}
+		const valueItem = value[i];
+		const otherItem = others[i];
+
+		if (valueItem !== undefined && typeof valueItem === 'object') {
+			// mergeObjects() returns valueItem unchanged when otherItem is missing,
+			// so elements unique to `value` are kept even if `others` is shorter
+			merged = Object.assign(
+				merged,
+				mergeObjects(valueItem as Record<string, unknown>, [otherItem]),
+			);
+		} else if (otherItem !== undefined && typeof otherItem === 'object') {
+			// Elements unique to `others` (past the end of `value`) are merged directly
+			merged = Object.assign(merged, otherItem as Record<string, unknown>);
 		}
 	}
 	return merged;

--- a/packages/workflow/test/ExpressionExtensions/array-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/array-extensions.test.ts
@@ -133,6 +133,22 @@ describe('Data Transformation Functions', () => {
 			).toEqual({ a: 1, some: null, c: 'something', b: 23 });
 		});
 
+		test('.merge() should preserve elements when the base array is longer', () => {
+			expect(evaluate('={{ [{ a: 1 }, { b: 2 }].merge([{ c: 3 }]) }}')).toEqual({
+				a: 1,
+				b: 2,
+				c: 3,
+			});
+		});
+
+		test('.merge() should preserve elements when the argument array is longer', () => {
+			expect(evaluate('={{ [{ a: 1 }].merge([{ b: 2 }, { c: 3 }]) }}')).toEqual({
+				a: 1,
+				b: 2,
+				c: 3,
+			});
+		});
+
 		test('.smartJoin() should work correctly on an array of objects', () => {
 			expect(
 				evaluate(

--- a/packages/workflow/test/ExpressionExtensions/array-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/array-extensions.test.ts
@@ -149,6 +149,24 @@ describe('Data Transformation Functions', () => {
 			});
 		});
 
+		test('.merge() should not overwrite existing keys with a trailing object in the argument array', () => {
+			expect(evaluate('={{ [{ a: 1 }].merge([{ b: 2 }, { a: 99 }]) }}')).toEqual({
+				a: 1,
+				b: 2,
+			});
+		});
+
+		test('.merge() should skip truthy primitives in the argument array without throwing', () => {
+			expect(evaluate('={{ [{ a: 1 }].merge([1]) }}')).toEqual({});
+		});
+
+		test('.merge() should merge objects while skipping truthy primitives', () => {
+			expect(evaluate('={{ [{ a: 1 }, { b: 2 }].merge([1, { c: 3 }]) }}')).toEqual({
+				b: 2,
+				c: 3,
+			});
+		});
+
 		test('.smartJoin() should work correctly on an array of objects', () => {
 			expect(
 				evaluate(


### PR DESCRIPTION
##Summary
Fixes an issue where array .merge() silently dropped trailing elements when merging arrays of different lengths (addressing index checks where missing counterparts evaluated as undefined).
 * Updated both packages/workflow/src/extensions/array-extensions.ts and its mirrored copy in packages/@n8n/expression-runtime/src/extensions/array-extensions.ts.
 * Added regression test cases covering base array longer vs argument array longer scenarios.
How to test
Run the workflow expression extension tests:
pnpm test test/ExpressionExtensions/array-extensions.test.ts

Or execute an expression in a workflow:
{{ [{ a: 1 }, { b: 2 }].merge([{ c: 3 }]) }} -> returns { a: 1, b: 2, c: 3 }
Related Linear tickets, Github issues, and Community forum posts
Fixes #36160
Review / Merge checklist
 * [x] I have seen this code, I have run this code, and I take responsibility for this code.
 * [x] PR title and summary are descriptive.
 * [ ] Docs updated or follow-up ticket created.
 * [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

