### PR TITLE
ci: Close community GitHub issues when the linked Linear issue is resolved

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -397,6 +397,8 @@ Push to master/1.x
 | Daily 05:00               | `test-benchmark-destroy-nightly.yml`| Cleanup benchmark env  |
 | Daily 06:00               | `util-sync-master-to-3x.yml`      | Replay 3.x onto master (v3) |
 | Daily 08:00               | `build-v3-nightly.yml`            | Nightly v3 Docker images |
+| Weekdays 09:00            | `community-pr-close-stale.yml`    | Close community PRs awaiting a reply |
+| Weekdays 09:30            | `community-issue-close-resolved.yml` | Close GitHub issues whose Linear issue is done |
 | Monday 00:00              | `util-update-node-popularity.yml` | Node usage stats         |
 | Monday 02:00              | `test-e2e-coverage-weekly.yml`    | Weekly E2E coverage      |
 | Saturday 22:00            | `test-evals-ai.yml`               | AI workflow evals        |
@@ -506,6 +508,7 @@ Scripts in `.github/scripts/`:
 | `validate-docs-links.js`| Check doc URLs    | `util-check-docs-urls.yml`|
 | `send-build-stats.mjs`  | Build telemetry   | `setup-nodejs` action     |
 | `db-test-matrix.mjs`    | DB test matrix from `postgres-versions.json` | `ci-pull-requests.yml` |
+| `community/close-resolved-github-issues.mjs` | Close issues whose linked Linear issue is done | `community-issue-close-resolved.yml` |
 
 ### Branch Replay Scripts
 
@@ -808,6 +811,7 @@ Adding a new channel requires inviting the bot first; the first run otherwise fa
 | Error Tracking      | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_*_PROJECT`       |
 | Cloud/CDN           | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`             |
 | GitHub Automation   | `N8N_ASSISTANT_APP_ID`, `N8N_ASSISTANT_PRIVATE_KEY`         |
+| Issue Tracking      | `LINEAR_API_KEY` (read-only Linear key, used by `community-issue-close-resolved.yml`) |
 | Benchmarking        | `BENCHMARK_ARM_*`, `N8N_BENCHMARK_LICENSE_CERT`             |
 | AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENAI_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_XAI_KEY`, `EVALS_BASETEN_KEY`, `EVALS_FIREWORKS_KEY`, `EVALS_TOGETHER_KEY`, `EVALS_DATABRICKS_KEY`, `EVALS_MODAL_KEY`, `EVALS_LYCEUM_KEY`, `EVALS_AZURE_FOUNDRY_KEY`, `EVALS_VERTEX_KEY`, `EVALS_VERTEX_PROJECT_ID`, `EVALS_VERTEX_LOCATION`, `EVALS_LANGSMITH_*` |
 

--- a/.github/scripts/community/close-resolved-github-issues.mjs
+++ b/.github/scripts/community/close-resolved-github-issues.mjs
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+/**
+ * Close community GitHub issues whose linked Linear issue has been resolved.
+ *
+ * Community bug reports get mirrored into Linear (the mirrored issue keeps a
+ * `GH Link: https://github.com/n8n-io/n8n/issues/<n>` line in its description
+ * and/or a GitHub attachment). When the Linear issue is completed, nothing
+ * closes the GitHub side, so reporters never hear that their bug was fixed and
+ * the public backlog goes stale. This script walks the Linear issues completed
+ * in the lookback window, resolves the GitHub issues they point at, and closes
+ * the ones still open with a comment.
+ *
+ * Dry-run is the DEFAULT — nothing is commented or closed unless `--execute`.
+ *
+ * Only closes when *all* of these hold:
+ *   - the Linear issue's state is of type `completed` (canceled/duplicate never closes),
+ *   - it was completed within the lookback window,
+ *   - the link is an issue (not a PR) in this repository,
+ *   - the GitHub issue is still open.
+ *
+ * Auth: LINEAR_API_KEY (Linear personal API key) + GH_TOKEN / GITHUB_TOKEN.
+ * Repo: GITHUB_REPOSITORY env, defaults to n8n-io/n8n.
+ *
+ * Usage:
+ *   node .github/scripts/community/close-resolved-github-issues.mjs             # dry run
+ *   node .github/scripts/community/close-resolved-github-issues.mjs --days=30
+ *   node .github/scripts/community/close-resolved-github-issues.mjs --execute   # actually close
+ *
+ * Requires Node 18+ (global fetch).
+ */
+
+import { parseArgs } from 'node:util';
+
+const GITHUB_API = 'https://api.github.com';
+const LINEAR_API = 'https://api.linear.app/graphql';
+const DAY_MS = 86_400_000;
+const DEFAULT_REPO = 'n8n-io/n8n';
+
+// --- pure logic (exported for tests) ---------------------------------------
+
+/**
+ * Collect the GitHub issue numbers a Linear issue points at, from its
+ * description ("GH Link: …") and its attachment URLs. PR links, links to other
+ * repositories and `#123` shorthands are ignored: only fully-qualified issue
+ * URLs in this repo count, so a stray reference can never close the wrong thing.
+ *
+ * @param {{ description?: string | null, attachments?: Array<{ url?: string | null }> }} linearIssue
+ * @param {{ owner: string, repo: string }} target
+ * @returns {number[]} unique issue numbers, ascending
+ */
+export function extractGithubIssueNumbers(linearIssue, { owner, repo }) {
+	const haystack = [
+		linearIssue.description ?? '',
+		...(linearIssue.attachments ?? []).map((attachment) => attachment?.url ?? ''),
+	].join('\n');
+
+	const pattern = new RegExp(
+		`github\\.com/${escapeForRegExp(owner)}/${escapeForRegExp(repo)}/issues/(\\d+)`,
+		'gi',
+	);
+
+	const numbers = new Set();
+	for (const match of haystack.matchAll(pattern)) {
+		numbers.add(Number(match[1]));
+	}
+
+	return [...numbers].sort((a, b) => a - b);
+}
+
+function escapeForRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Pull request URLs attached to a Linear issue, used to point reporters at the fix.
+ *
+ * @param {{ attachments?: Array<{ url?: string | null }> }} linearIssue
+ * @param {{ owner: string, repo: string }} target
+ * @returns {number[]} unique PR numbers, ascending
+ */
+export function extractFixPullRequests(linearIssue, { owner, repo }) {
+	const pattern = new RegExp(
+		`^https?://github\\.com/${escapeForRegExp(owner)}/${escapeForRegExp(repo)}/pull/(\\d+)`,
+		'i',
+	);
+
+	const numbers = new Set();
+	for (const attachment of linearIssue.attachments ?? []) {
+		const match = (attachment?.url ?? '').match(pattern);
+		if (match) {
+			numbers.add(Number(match[1]));
+		}
+	}
+
+	return [...numbers].sort((a, b) => a - b);
+}
+
+/**
+ * Turn resolved Linear issues into GitHub-issue closure candidates.
+ * Pure: no network, no clock — `now` is injected so tests are deterministic.
+ *
+ * When several Linear issues point at the same GitHub issue, the first
+ * candidate wins and the rest are reported as duplicates: one GitHub issue is
+ * only ever closed (and commented on) once per run.
+ *
+ * @param {{
+ *   linearIssues: Array<{
+ *     identifier: string,
+ *     url?: string,
+ *     completedAt?: string | null,
+ *     state?: { name?: string, type?: string } | null,
+ *     description?: string | null,
+ *     attachments?: Array<{ url?: string | null }>,
+ *   }>,
+ *   owner: string,
+ *   repo: string,
+ *   lookbackDays: number,
+ *   now: number,
+ * }} input
+ * @returns {{
+ *   candidates: Array<{ number: number, linear: { identifier: string, url?: string, state: string, completedAt: string }, fixPullRequests: number[] }>,
+ *   skipped: Array<{ linear: string, reason: string }>,
+ * }}
+ */
+export function selectClosureCandidates({ linearIssues, owner, repo, lookbackDays, now }) {
+	const cutoff = now - lookbackDays * DAY_MS;
+	const candidates = [];
+	const skipped = [];
+	const claimedBy = new Map();
+
+	for (const issue of linearIssues) {
+		if (issue.state?.type !== 'completed') {
+			skipped.push({
+				linear: issue.identifier,
+				reason: `state "${issue.state?.name ?? '?'}" is not completed`,
+			});
+			continue;
+		}
+
+		const completedAt = issue.completedAt ? new Date(issue.completedAt).getTime() : NaN;
+		if (!Number.isFinite(completedAt)) {
+			skipped.push({ linear: issue.identifier, reason: 'missing completedAt' });
+			continue;
+		}
+		if (completedAt < cutoff) {
+			skipped.push({
+				linear: issue.identifier,
+				reason: `completed outside the ${lookbackDays}d lookback window`,
+			});
+			continue;
+		}
+
+		const numbers = extractGithubIssueNumbers(issue, { owner, repo });
+		if (numbers.length === 0) {
+			skipped.push({ linear: issue.identifier, reason: `no ${owner}/${repo} issue link` });
+			continue;
+		}
+
+		const fixPullRequests = extractFixPullRequests(issue, { owner, repo });
+		for (const number of numbers) {
+			const claimer = claimedBy.get(number);
+			if (claimer) {
+				skipped.push({
+					linear: issue.identifier,
+					reason: `#${number} already claimed by ${claimer}`,
+				});
+				continue;
+			}
+			claimedBy.set(number, issue.identifier);
+			candidates.push({
+				number,
+				linear: {
+					identifier: issue.identifier,
+					url: issue.url,
+					state: issue.state?.name ?? 'completed',
+					completedAt: issue.completedAt,
+				},
+				fixPullRequests,
+			});
+		}
+	}
+
+	candidates.sort((a, b) => a.number - b.number);
+
+	return { candidates, skipped };
+}
+
+/**
+ * Comment posted on the GitHub issue before closing it. Deliberately free of
+ * internal references (Linear identifiers and URLs stay in the run log) — the
+ * reporter only needs to know the fix landed and how to get the issue reopened.
+ *
+ * @param {{ fixPullRequests: number[] }} candidate
+ */
+export function buildCloseComment({ fixPullRequests }) {
+	const fixReference =
+		fixPullRequests.length > 0
+			? `The fix landed in ${fixPullRequests.map((number) => `#${number}`).join(', ')}.`
+			: 'The fix has been implemented and is on its way out with an upcoming release.';
+
+	return [
+		`Good news — this has been resolved, so we're closing the issue. 🎉`,
+		'',
+		fixReference,
+		'',
+		"If you still run into this on the latest version of n8n, please comment here and we'll take another look — closed issues can always be reopened. Thanks for reporting it! 🙏",
+	].join('\n');
+}
+
+// --- environment / auth -----------------------------------------------------
+
+function resolveGithubToken() {
+	const token = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim();
+	if (!token) {
+		throw new Error('No GitHub token found. Set GH_TOKEN or GITHUB_TOKEN.');
+	}
+	return token;
+}
+
+function resolveLinearApiKey() {
+	const key = process.env.LINEAR_API_KEY?.trim();
+	if (!key) {
+		throw new Error('No Linear API key found. Set the LINEAR_API_KEY secret.');
+	}
+	return key;
+}
+
+function resolveRepo() {
+	const [owner, repo] = (process.env.GITHUB_REPOSITORY || DEFAULT_REPO).split('/');
+	if (!owner || !repo) {
+		throw new Error(
+			`Cannot resolve repo from GITHUB_REPOSITORY="${process.env.GITHUB_REPOSITORY}".`,
+		);
+	}
+	return { owner, repo };
+}
+
+function resolveDryRun(values) {
+	// Dry run is the default; --execute (or DRY_RUN=false) opts into writes.
+	let dryRun = true;
+	if (values.execute) {
+		dryRun = false;
+	}
+	if (process.env.DRY_RUN === 'false' || process.env.DRY_RUN === '0') {
+		dryRun = false;
+	}
+	if (process.env.DRY_RUN === 'true' || process.env.DRY_RUN === '1') {
+		dryRun = true;
+	}
+	if (values['dry-run']) {
+		dryRun = true; // explicit override always wins toward safety
+	}
+	return dryRun;
+}
+
+// --- data fetching ----------------------------------------------------------
+
+const RESOLVED_ISSUES_QUERY = `
+	query ResolvedIssues($after: String, $since: DateTimeOrDuration!) {
+		issues(first: 100, after: $after, filter: { completedAt: { gt: $since } }) {
+			pageInfo { hasNextPage endCursor }
+			nodes {
+				identifier
+				url
+				completedAt
+				description
+				state { name type }
+				attachments(first: 25) { nodes { url } }
+			}
+		}
+	}`;
+
+async function fetchResolvedLinearIssues(ctx, since) {
+	console.log(`Fetching Linear issues completed since ${since}...`);
+
+	const issues = [];
+	let cursor = null;
+	do {
+		const res = await fetch(LINEAR_API, {
+			method: 'POST',
+			headers: {
+				Authorization: ctx.linearApiKey,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ query: RESOLVED_ISSUES_QUERY, variables: { after: cursor, since } }),
+		});
+		if (!res.ok) {
+			throw new Error(`Linear API -> ${res.status} ${await res.text()}`);
+		}
+		const json = await res.json();
+		if (json.errors) {
+			throw new Error(`Linear GraphQL error: ${JSON.stringify(json.errors)}`);
+		}
+
+		const page = json.data.issues;
+		for (const node of page.nodes) {
+			issues.push({ ...node, attachments: node.attachments?.nodes ?? [] });
+		}
+		cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+	} while (cursor);
+
+	console.log(`Found ${issues.length} completed Linear issue(s).`);
+
+	return issues;
+}
+
+async function githubRequest(ctx, method, path, body) {
+	const res = await fetch(`${GITHUB_API}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${ctx.githubToken}`,
+			Accept: 'application/vnd.github+json',
+			'X-GitHub-Api-Version': '2022-11-28',
+			...(body ? { 'Content-Type': 'application/json' } : {}),
+		},
+		...(body ? { body: JSON.stringify(body) } : {}),
+	});
+	if (!res.ok) {
+		throw new Error(`${method} ${path} -> ${res.status} ${await res.text()}`);
+	}
+	return res.json();
+}
+
+const issuePath = (ctx, number) => `/repos/${ctx.owner}/${ctx.repo}/issues/${number}`;
+
+const fetchGithubIssue = (ctx, number) => githubRequest(ctx, 'GET', issuePath(ctx, number));
+
+const commentOnGithubIssue = (ctx, number, body) =>
+	githubRequest(ctx, 'POST', `${issuePath(ctx, number)}/comments`, { body });
+
+const closeGithubIssue = (ctx, number) =>
+	githubRequest(ctx, 'PATCH', issuePath(ctx, number), {
+		state: 'closed',
+		state_reason: 'completed',
+	});
+
+// --- main -------------------------------------------------------------------
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			execute: { type: 'boolean', default: false },
+			'dry-run': { type: 'boolean' },
+			days: { type: 'string' },
+			max: { type: 'string' },
+			help: { type: 'boolean', default: false },
+		},
+	});
+
+	if (values.help) {
+		console.log(
+			'Usage: close-resolved-github-issues.mjs [--days=N] [--max=N] [--execute]\n' +
+				'  --days=N   Look back N days over Linear completions (default 7, or LOOKBACK_DAYS env)\n' +
+				'  --max=N    Cap how many GitHub issues a single run closes (default 50, or MAX_CLOSURES env)\n' +
+				'  --execute  Actually comment and close (default is dry run)\n' +
+				'Auth via LINEAR_API_KEY + GH_TOKEN/GITHUB_TOKEN. Repo via GITHUB_REPOSITORY.',
+		);
+		return;
+	}
+
+	const dryRun = resolveDryRun(values);
+	const lookbackDays = Number(values.days ?? process.env.LOOKBACK_DAYS ?? 7);
+	if (!Number.isFinite(lookbackDays) || lookbackDays <= 0) {
+		throw new Error(`Invalid --days value: ${values.days ?? process.env.LOOKBACK_DAYS}`);
+	}
+	// Blast-radius guard: a mistyped lookback shouldn't comment on hundreds of issues.
+	const maxClosures = Number(values.max ?? process.env.MAX_CLOSURES ?? 50);
+	if (!Number.isFinite(maxClosures) || maxClosures <= 0) {
+		throw new Error(`Invalid --max value: ${values.max ?? process.env.MAX_CLOSURES}`);
+	}
+
+	const { owner, repo } = resolveRepo();
+	const ctx = {
+		owner,
+		repo,
+		githubToken: resolveGithubToken(),
+		linearApiKey: resolveLinearApiKey(),
+	};
+
+	const now = Date.now();
+	const since = new Date(now - lookbackDays * DAY_MS).toISOString();
+
+	console.log(`Repository:  ${owner}/${repo}`);
+	console.log(`Lookback:    ${lookbackDays} days (since ${since})`);
+	console.log(`Max closes:  ${maxClosures}`);
+	console.log(
+		`Mode:        ${dryRun ? 'DRY RUN (no comments, no closes)' : 'EXECUTE (will close issues)'}`,
+	);
+	console.log('');
+
+	const linearIssues = await fetchResolvedLinearIssues(ctx, since);
+	const { candidates, skipped } = selectClosureCandidates({
+		linearIssues,
+		owner,
+		repo,
+		lookbackDays,
+		now,
+	});
+
+	console.log(`Skipped ${skipped.length} Linear issue(s) without an actionable link.`);
+	console.log(`Candidate GitHub issues: ${candidates.length}`);
+	console.log('');
+
+	let closed = 0;
+	for (const candidate of candidates) {
+		const label = `#${candidate.number} (${candidate.linear.identifier}, ${candidate.linear.state})`;
+
+		const githubIssue = await fetchGithubIssue(ctx, candidate.number);
+		if (githubIssue.pull_request) {
+			console.log(`  SKIP   ${label} — link points at a pull request`);
+			continue;
+		}
+		if (githubIssue.state !== 'open') {
+			console.log(`  SKIP   ${label} — already closed`);
+			continue;
+		}
+		if (closed >= maxClosures) {
+			console.log(`  SKIP   ${label} — reached the --max=${maxClosures} cap for this run`);
+			continue;
+		}
+
+		if (dryRun) {
+			console.log(`  WOULD CLOSE ${label}`);
+			closed++;
+			continue;
+		}
+
+		await commentOnGithubIssue(ctx, candidate.number, buildCloseComment(candidate));
+		await closeGithubIssue(ctx, candidate.number);
+		closed++;
+		console.log(`  CLOSED ${label}`);
+	}
+
+	console.log('');
+	console.log(`${dryRun ? 'Would close' : 'Closed'} ${closed} GitHub issue(s).`);
+}
+
+// only run when executed directly, not when imported by tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+	await main();
+}

--- a/.github/scripts/community/close-resolved-github-issues.test.mjs
+++ b/.github/scripts/community/close-resolved-github-issues.test.mjs
@@ -1,0 +1,192 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	extractGithubIssueNumbers,
+	extractFixPullRequests,
+	selectClosureCandidates,
+	buildCloseComment,
+} from './close-resolved-github-issues.mjs';
+
+/**
+ * Run these tests with:
+ *
+ * node --test ./.github/scripts/community/close-resolved-github-issues.test.mjs
+ * */
+
+const TARGET = { owner: 'n8n-io', repo: 'n8n' };
+const DAY_MS = 86_400_000;
+const NOW = new Date('2026-08-17T00:00:00Z').getTime();
+
+const daysAgo = (days) => new Date(NOW - days * DAY_MS).toISOString();
+
+const completed = (overrides = {}) => ({
+	identifier: 'AI-2422',
+	url: 'https://linear.app/n8n/issue/AI-2422/community-issue',
+	completedAt: daysAgo(1),
+	state: { name: 'Released/Done', type: 'completed' },
+	description: 'GH Link: https://github.com/n8n-io/n8n/issues/29119',
+	attachments: [],
+	...overrides,
+});
+
+describe('extractGithubIssueNumbers', () => {
+	it('reads the GH Link line out of a mirrored issue description', () => {
+		const issue = {
+			description: 'GH Link: https://github.com/n8n-io/n8n/issues/29119\nUser: someone',
+		};
+		assert.deepEqual(extractGithubIssueNumbers(issue, TARGET), [29119]);
+	});
+
+	it('reads markdown links and attachment URLs', () => {
+		const issue = {
+			description: '[link](https://github.com/n8n-io/n8n/issues/100)',
+			attachments: [{ url: 'https://github.com/n8n-io/n8n/issues/200' }, { url: null }],
+		};
+		assert.deepEqual(extractGithubIssueNumbers(issue, TARGET), [100, 200]);
+	});
+
+	it('deduplicates repeated references', () => {
+		const issue = {
+			description:
+				'https://github.com/n8n-io/n8n/issues/42 and again https://github.com/n8n-io/n8n/issues/42',
+		};
+		assert.deepEqual(extractGithubIssueNumbers(issue, TARGET), [42]);
+	});
+
+	it('ignores pull requests, other repos and bare #references', () => {
+		const issue = {
+			description: [
+				'https://github.com/n8n-io/n8n/pull/29141',
+				'https://github.com/n8n-io/n8n-docs/issues/7',
+				'https://github.com/someone/n8n/issues/8',
+				'fixes #9',
+			].join('\n'),
+		};
+		assert.deepEqual(extractGithubIssueNumbers(issue, TARGET), []);
+	});
+
+	it('tolerates a missing description and attachments', () => {
+		assert.deepEqual(extractGithubIssueNumbers({}, TARGET), []);
+		assert.deepEqual(extractGithubIssueNumbers({ description: null }, TARGET), []);
+	});
+});
+
+describe('extractFixPullRequests', () => {
+	it('collects PR attachments from this repo only', () => {
+		const issue = {
+			attachments: [
+				{ url: 'https://github.com/n8n-io/n8n/pull/29141' },
+				{ url: 'https://github.com/n8n-io/n8n-docs/pull/1' },
+				{ url: 'https://app.plain.com/workspace/w_1/thread/th_1' },
+			],
+		};
+		assert.deepEqual(extractFixPullRequests(issue, TARGET), [29141]);
+	});
+
+	it('returns an empty list when nothing is attached', () => {
+		assert.deepEqual(extractFixPullRequests({}, TARGET), []);
+	});
+});
+
+describe('selectClosureCandidates', () => {
+	const select = (linearIssues, lookbackDays = 7) =>
+		selectClosureCandidates({ linearIssues, ...TARGET, lookbackDays, now: NOW });
+
+	it('turns a recently completed mirrored issue into a candidate', () => {
+		const { candidates, skipped } = select([completed()]);
+
+		assert.equal(skipped.length, 0);
+		assert.deepEqual(candidates, [
+			{
+				number: 29119,
+				linear: {
+					identifier: 'AI-2422',
+					url: 'https://linear.app/n8n/issue/AI-2422/community-issue',
+					state: 'Released/Done',
+					completedAt: daysAgo(1),
+				},
+				fixPullRequests: [],
+			},
+		]);
+	});
+
+	it('carries the fix PR through to the candidate', () => {
+		const { candidates } = select([
+			completed({ attachments: [{ url: 'https://github.com/n8n-io/n8n/pull/29141' }] }),
+		]);
+
+		assert.deepEqual(candidates[0].fixPullRequests, [29141]);
+	});
+
+	it('skips issues that are not in a completed state', () => {
+		const { candidates, skipped } = select([
+			completed({ state: { name: 'Canceled', type: 'canceled' } }),
+			completed({ identifier: 'AI-1', state: { name: 'In Progress', type: 'started' } }),
+		]);
+
+		assert.equal(candidates.length, 0);
+		assert.equal(skipped.length, 2);
+		assert.match(skipped[0].reason, /not completed/);
+	});
+
+	it('skips issues completed before the lookback window', () => {
+		const { candidates, skipped } = select([completed({ completedAt: daysAgo(30) })]);
+
+		assert.equal(candidates.length, 0);
+		assert.match(skipped[0].reason, /lookback window/);
+	});
+
+	it('skips issues without a completion timestamp', () => {
+		const { candidates, skipped } = select([completed({ completedAt: null })]);
+
+		assert.equal(candidates.length, 0);
+		assert.match(skipped[0].reason, /completedAt/);
+	});
+
+	it('skips issues with no link to this repository', () => {
+		const { candidates, skipped } = select([completed({ description: 'internal-only work' })]);
+
+		assert.equal(candidates.length, 0);
+		assert.match(skipped[0].reason, /issue link/);
+	});
+
+	it('claims a GitHub issue only once when several Linear issues point at it', () => {
+		const { candidates, skipped } = select([completed(), completed({ identifier: 'AI-2423' })]);
+
+		assert.deepEqual(
+			candidates.map((c) => c.linear.identifier),
+			['AI-2422'],
+		);
+		assert.equal(skipped.length, 1);
+		assert.match(skipped[0].reason, /already claimed by AI-2422/);
+	});
+
+	it('returns candidates in ascending issue order', () => {
+		const { candidates } = select([
+			completed({ description: 'https://github.com/n8n-io/n8n/issues/300' }),
+			completed({ identifier: 'AI-2', description: 'https://github.com/n8n-io/n8n/issues/100' }),
+		]);
+
+		assert.deepEqual(
+			candidates.map((c) => c.number),
+			[100, 300],
+		);
+	});
+});
+
+describe('buildCloseComment', () => {
+	it('points at the fix PRs when they are known', () => {
+		const comment = buildCloseComment({ fixPullRequests: [29141, 29200] });
+		assert.match(comment, /The fix landed in #29141, #29200\./);
+	});
+
+	it('falls back to a generic message without a PR', () => {
+		const comment = buildCloseComment({ fixPullRequests: [] });
+		assert.match(comment, /upcoming release/);
+	});
+
+	it('never leaks internal references', () => {
+		const comment = buildCloseComment({ fixPullRequests: [29141] });
+		assert.doesNotMatch(comment, /linear/i);
+	});
+});

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-scripts",
   "scripts": {
-    "test": "node --test --experimental-test-module-mocks ./*.test.mjs ./quality/*.test.mjs ./slack/*.test.mjs ./stale/*.test.mjs ../../scripts/licenses/*.test.mjs ../../scripts/mutation-health/*.test.mjs",
+    "test": "node --test --experimental-test-module-mocks ./*.test.mjs ./community/*.test.mjs ./quality/*.test.mjs ./slack/*.test.mjs ./stale/*.test.mjs ../../scripts/licenses/*.test.mjs ../../scripts/mutation-health/*.test.mjs",
     "generate-sbom": "FETCH_LICENSE=true cdxgen -t pnpm --no-install-deps --profile license-compliance --spec-version 1.6 -o ../../sbom-source.cdx.json ../../compiled/",
     "enrich-sbom": "node ../../scripts/licenses/enrich-sbom.mjs ../../sbom-source.cdx.json",
     "render-licenses-md": "node ../../scripts/licenses/render-licenses-md.mjs ../../sbom-source.cdx.json ../../packages/cli/THIRD_PARTY_LICENSES.md ../../compiled/node_modules",

--- a/.github/workflows/community-issue-close-resolved.yml
+++ b/.github/workflows/community-issue-close-resolved.yml
@@ -1,0 +1,56 @@
+name: 'Community: Close Resolved Issues'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Community: Close Resolved Issues (dry-run={0}, days={1})', inputs['dry-run'], inputs.days) || '' }}"
+
+# Closes community GitHub issues whose mirrored Linear issue has been completed.
+# Without this, a fixed community bug stays open on GitHub: the reporter never
+# hears that it shipped and the public backlog goes stale.
+#
+# Requires the LINEAR_API_KEY secret (a read-only Linear API key is enough —
+# the workflow only writes to GitHub). Runs are dry by default on manual
+# dispatch; the scheduled run executes.
+
+on:
+  schedule:
+    - cron: '30 9 * * 1-5' # weekdays 9:30 UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run: log the issues that would be closed without commenting/closing.'
+        type: boolean
+        default: true
+      days:
+        description: 'Days of Linear completions to look back over.'
+        type: string
+        default: '7'
+      max:
+        description: 'Maximum number of GitHub issues to close in this run.'
+        type: string
+        default: '50'
+
+permissions:
+  contents: read # checkout
+  issues: write # comment on and close the resolved issues
+
+jobs:
+  close-resolved-community-issues:
+    name: Close resolved community issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # The script only needs Node builtins + global fetch, so no install step.
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.18.1
+
+      - name: Close resolved community issues
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LOOKBACK_DAYS: ${{ inputs.days || '7' }}
+          MAX_CLOSURES: ${{ inputs.max || '50' }}
+        # Scheduled runs have no inputs, so they execute; manual runs default to dry.
+        run: node .github/scripts/community/close-resolved-github-issues.mjs ${{ !inputs.dry-run && '--execute' || '--dry-run' }}


### PR DESCRIPTION
## Summary

Community bug reports get mirrored into Linear, but nothing closes the GitHub side when the Linear issue is completed — the reporter never hears the fix shipped and the public backlog goes stale (e.g. [#29119](https://github.com/n8n-io/n8n/issues/29119) is still open although its Linear issue was completed in July).

Adds a weekday-scheduled workflow (`community-issue-close-resolved.yml`) that walks the Linear issues completed in the lookback window, resolves the `n8n-io/n8n` issues they link to (the `GH Link:` line in the mirrored description, plus GitHub attachments), and comments + closes the ones still open. Fix PRs attached to the Linear issue are referenced in the comment; the comment carries no internal references.

Guardrails: only `completed`-type Linear states (never canceled/duplicate), only completions inside the lookback window, only issue URLs in this repo (PR links, other repos and bare `#123` are ignored), never touches an already-closed issue, one comment per GitHub issue per run, and a `--max` cap so a mistyped lookback can't mass-comment. Manual dispatch is dry-run by default.

**Before merging:** the repo needs a `LINEAR_API_KEY` secret (a read-only Linear key is enough — the workflow only writes to GitHub). Without it the run fails loudly rather than silently doing nothing.

## How to test

```bash
# unit tests for the pure selection/comment logic
node --test ./.github/scripts/community/close-resolved-github-issues.test.mjs
```

Then, once the secret exists, run the workflow manually with **dry-run** checked and `days` bumped (e.g. `90`) to review the issues it would close before letting the schedule execute.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-2262

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

