### PR TITLE
fix(editor): Keep module registration silent when it re-runs after a re-login (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/commandRegistry.test.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/commandRegistry.test.ts
@@ -30,16 +30,29 @@ describe('commandRegistry', () => {
 		expect(commandRegistry.getAll()).toEqual([commandA, commandB]);
 	});
 
-	it('should warn and skip when an id is registered twice', () => {
+	it('should warn and skip when a different command claims the id', () => {
+		const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		commandRegistry.register(commandA);
+		commandRegistry.register({ ...commandA, title: 'Impostor' });
+
+		expect(consoleSpy).toHaveBeenCalledWith(
+			'Command with id "cmd-a" is already registered. Skipping.',
+		);
+		expect(commandRegistry.getAll()).toEqual([commandA]);
+
+		consoleSpy.mockRestore();
+	});
+
+	// A re-login replays the manifest, so the same definitions arrive twice.
+	it('should re-register the same command silently', () => {
 		const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		commandRegistry.register(commandA);
 		commandRegistry.register(commandA);
 
-		expect(consoleSpy).toHaveBeenCalledWith(
-			'Command with id "cmd-a" is already registered. Skipping.',
-		);
-		expect(commandRegistry.getAll()).toHaveLength(1);
+		expect(consoleSpy).not.toHaveBeenCalled();
+		expect(commandRegistry.getAll()).toEqual([commandA]);
 
 		consoleSpy.mockRestore();
 	});

--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/commandRegistry.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/commandRegistry.ts
@@ -13,8 +13,13 @@ function notifyListeners(): void {
 }
 
 export function register(command: CommandBarEntry): void {
-	if (commands.has(command.id)) {
-		console.warn(`Command with id "${command.id}" is already registered. Skipping.`);
+	const existing = commands.get(command.id);
+	if (existing) {
+		// Same definition replayed by a re-login is a no-op; a different one
+		// claiming a taken id is the real collision.
+		if (existing !== command) {
+			console.warn(`Command with id "${command.id}" is already registered. Skipping.`);
+		}
 		return;
 	}
 	commands.set(command.id, command);

--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.test.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.test.ts
@@ -49,18 +49,43 @@ describe('modalRegistry', () => {
 			expect(modalRegistry.getKeys()).toHaveLength(2);
 		});
 
-		it('should warn and skip registration if modal key already exists', () => {
+		it('should warn and skip registration if a different modal claims the key', () => {
 			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 			modalRegistry.register(mockModal1);
-			modalRegistry.register(mockModal1);
+			modalRegistry.register({ ...mockModal1, component: mockComponent2 });
 
 			expect(consoleSpy).toHaveBeenCalledWith(
 				'Modal with key "test-modal-1" is already registered. Skipping.',
 			);
 			expect(modalRegistry.getKeys()).toHaveLength(1);
+			expect(modalRegistry.get('test-modal-1')?.component).toBe(mockComponent1);
 
 			consoleSpy.mockRestore();
+		});
+
+		// A re-login replays the manifest, so the same definitions arrive twice.
+		it('should re-register the same definition silently', () => {
+			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			modalRegistry.register(mockModal1);
+			modalRegistry.register(mockModal1);
+
+			expect(consoleSpy).not.toHaveBeenCalled();
+			expect(modalRegistry.get('test-modal-1')).toBe(mockModal1);
+			expect(modalRegistry.getKeys()).toHaveLength(1);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('should not notify listeners when the same definition is re-registered', () => {
+			modalRegistry.register(mockModal1);
+			const listener = vi.fn();
+			modalRegistry.subscribe(listener);
+
+			modalRegistry.register(mockModal1);
+
+			expect(listener).not.toHaveBeenCalled();
 		});
 
 		it('should notify listeners when a modal is registered', () => {

--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.ts
@@ -22,8 +22,14 @@ function notifyListeners(): void {
 }
 
 export function register(modal: ModalDefinition): void {
-	if (modals.has(modal.key)) {
-		console.warn(`Modal with key "${modal.key}" is already registered. Skipping.`);
+	const existing = modals.get(modal.key);
+	if (existing) {
+		// Replaying the same definition is how a re-login re-runs registration —
+		// a no-op, not a collision. Only a different definition claiming a taken
+		// key is worth warning about.
+		if (existing !== modal) {
+			console.warn(`Modal with key "${modal.key}" is already registered. Skipping.`);
+		}
 		return;
 	}
 

--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/pushHandlerRegistry.test.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/pushHandlerRegistry.test.ts
@@ -50,6 +50,21 @@ describe('pushHandlerRegistry', () => {
 		consoleSpy.mockRestore();
 	});
 
+	// A re-login replays the manifest, so the same handlers arrive twice.
+	it('should re-register the same handler silently', () => {
+		const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const handler = vi.fn();
+		const handlers: ModulePushHandlers = { workflowActivated: handler };
+
+		pushHandlerRegistry.registerAll(handlers);
+		pushHandlerRegistry.registerAll(handlers);
+
+		expect(consoleSpy).not.toHaveBeenCalled();
+		expect(pushHandlerRegistry.get('workflowActivated')).toBe(handler);
+
+		consoleSpy.mockRestore();
+	});
+
 	it('should register every entry in a module pushHandlers map', () => {
 		const activated = vi.fn();
 		const deactivated = vi.fn();

--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/pushHandlerRegistry.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/pushHandlerRegistry.ts
@@ -7,8 +7,13 @@ import type { ModulePushHandler, ModulePushHandlers } from '../types/push';
 const handlers = new Map<PushType, ModulePushHandler>();
 
 export function register(type: PushType, handler: ModulePushHandler): void {
-	if (handlers.has(type)) {
-		console.warn(`Push handler for type "${type}" is already registered. Skipping.`);
+	const existing = handlers.get(type);
+	if (existing) {
+		// Same handler replayed by a re-login is a no-op; a different one
+		// claiming a taken type is the real collision.
+		if (existing !== handler) {
+			console.warn(`Push handler for type "${type}" is already registered. Skipping.`);
+		}
 		return;
 	}
 	handlers.set(type, handler);

--- a/packages/frontend/editor-ui/src/app/init/index.test.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.test.ts
@@ -22,9 +22,35 @@ import { setActivePinia } from 'pinia';
 import { mock } from 'vitest-mock-extended';
 import { telemetry } from '@/app/plugins/telemetry';
 import { registerToastNotifier } from '@/app/init/toastNotifier';
+import * as moduleInitializer from '@/app/moduleInitializer/moduleInitializer';
 
 const showMessage = vi.fn();
 const showToast = vi.fn();
+
+// Spied, not stubbed: the real registration must run so a replay that warns is
+// caught by the test that asserts the console stays quiet.
+vi.mock('@/app/moduleInitializer/moduleInitializer', async (importOriginal) => {
+	const actual = await importOriginal<typeof moduleInitializer>();
+
+	return {
+		...actual,
+		registerModuleResources: vi.fn(actual.registerModuleResources),
+		registerModuleProjectTabs: vi.fn(actual.registerModuleProjectTabs),
+		registerModuleModals: vi.fn(actual.registerModuleModals),
+		registerModuleSettingsPages: vi.fn(actual.registerModuleSettingsPages),
+		registerModulePushHandlers: vi.fn(actual.registerModulePushHandlers),
+		registerModuleCommands: vi.fn(actual.registerModuleCommands),
+	};
+});
+
+const moduleRegistrations = [
+	moduleInitializer.registerModuleResources,
+	moduleInitializer.registerModuleProjectTabs,
+	moduleInitializer.registerModuleModals,
+	moduleInitializer.registerModuleSettingsPages,
+	moduleInitializer.registerModulePushHandlers,
+	moduleInitializer.registerModuleCommands,
+];
 
 vi.mock('@n8n/composables/useToast', () => ({
 	useToast: () => ({ showMessage, showToast }),
@@ -303,6 +329,31 @@ describe('Init', () => {
 
 			await initializeAuthenticatedFeatures();
 			expect(cloudStoreSpy).toHaveBeenCalledTimes(2);
+		});
+
+		it('re-runs module registration on the next login, without a duplicate-registration warning', async () => {
+			// Force registerAuthenticationHooks() (only runs once) to run again.
+			state.initialized = false;
+			const registerLogoutHookSpy = vi.spyOn(usersStore, 'registerLogoutHook');
+			await initializeCore();
+			const registeredLogoutHook = registerLogoutHookSpy.mock.calls[0][0];
+
+			vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValue();
+			usersStore.currentUser = mock<IUser>({ id: '123', globalScopes: ['user:list'] });
+			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			await initializeAuthenticatedFeatures(false);
+			await registeredLogoutHook();
+			await initializeAuthenticatedFeatures();
+
+			for (const register of moduleRegistrations) {
+				expect(register).toHaveBeenCalledTimes(2);
+			}
+			// Matched on the shared registry wording, so unrelated Vue warnings in
+			// this graph do not decide the result.
+			expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('is already registered'));
+
+			consoleSpy.mockRestore();
 		});
 
 		it('should handle cloud plan initialization error', async () => {

--- a/packages/frontend/editor-ui/src/app/moduleInitializer/moduleInitializer.test.ts
+++ b/packages/frontend/editor-ui/src/app/moduleInitializer/moduleInitializer.test.ts
@@ -34,4 +34,20 @@ describe('registerModuleModals', () => {
 
 		expect(modalRegistry.isAdHocKey('aModalNobodyRegistered')).toBe(false);
 	});
+
+	// Post-login registration runs again after a re-login in the same page
+	// session, so replaying it must stay silent and lossless.
+	it('replays registration without warning and keeps every modal', () => {
+		const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		registerModuleModals();
+		const keysAfterFirstRun = modalRegistry.getKeys();
+
+		registerModuleModals();
+
+		expect(consoleSpy).not.toHaveBeenCalled();
+		expect(modalRegistry.getKeys()).toEqual(keysAfterFirstRun);
+
+		consoleSpy.mockRestore();
+	});
 });


### PR DESCRIPTION
## Summary

Post-login module registration runs again when a user logs in a second time inside one page session. `authenticatedFeaturesInitialized` is reset by the logout hook (added in #35507), so `initializeAuthenticatedFeatures` re-runs and calls the six `registerModule*` functions a second time.

Three SDK registries treated that replay as a collision and logged a warning per entry:

```
Modal with key "toolSettingsModal" is already registered. Skipping.
```

Registration is now idempotent by identity. Re-registering the **same** definition is a silent no-op. A **different** definition claiming a taken key still warns and still keeps the first one — the collision guard is unchanged.

Touched: `modalRegistry.register`, `commandRegistry.register`, `pushHandlerRegistry.register`. `resourceRegistry`, `uiStore.registerCustomTabs` and `uiStore.registerSettingsPages` are keyed assignments and were already idempotent.

No production behaviour changes beyond the console output: the retained definition is the same object either way.

## How to test

Reachable path today, no code change needed:

1. Enable MFA enforcement on the instance.
2. Open the editor and complete MFA setup. `MfaSetupModal.vue` calls `usersStore.logout()` and then `router.push({ name: VIEWS.SIGNIN })` — a route change, not a page reload.
3. Sign in again in the same tab.
4. Watch the console. On `master` you get one `is already registered` warning per module modal. With this branch the console stays quiet and every modal stays registered.

The other two logout paths (`handleSessionExpired`, `SignoutView`) set `window.location.href`, so they reload the page and never reach this.

Automated coverage:

- `packages/frontend/@n8n/frontend-module-sdk` — one "re-register the same X silently" test per registry; the existing collision tests now register a *different* definition under the taken key.
- `editor-ui/src/app/moduleInitializer/moduleInitializer.test.ts` — replaying `registerModuleModals()` warns nothing and keeps every key.
- `editor-ui/src/app/init/index.test.ts` — a logout followed by a second `initializeAuthenticatedFeatures()` runs all six registration functions twice with no duplicate-registration warning.

All five new tests fail on `master` and pass here.

## Related Linear tickets, Github issues, and Community forum posts

Follows #34422 (push and command registry wiring) and #35507 (the logout reset).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

