### PR TITLE
fix(editor): Close the demo-route workflow document store null window (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -28,6 +28,7 @@ if (window !== window.parent) {
 const workflowId = useWorkflowId();
 
 const {
+	isLoading,
 	initializeData,
 	initializeWorkflow,
 	currentWorkflowDocumentStore,
@@ -84,7 +85,12 @@ onBeforeUnmount(() => {
 
 <template>
 	<BaseLayout>
-		<RouterView v-if="currentWorkflowDocumentStore" />
+		<!-- Gate on isLoading as well as on the store: WorkflowDocumentStoreKey is shared by
+		every layout, so on a layout swap the store is still the outgoing layout's one, which
+		its cleanup() then nulls. isLoading is this layout's own and starts true, so NodeView
+		never mounts before this layout owns the store. Deliberately no LoadingView here —
+		an embedded preview must not paint a spinner the host page did not ask for. -->
+		<RouterView v-if="!isLoading && currentWorkflowDocumentStore" />
 		<template #footer>
 			<DemoFooter />
 		</template>

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -85,11 +85,6 @@ onBeforeUnmount(() => {
 
 <template>
 	<BaseLayout>
-		<!-- Gate on isLoading as well as on the store: WorkflowDocumentStoreKey is shared by
-		every layout, so on a layout swap the store is still the outgoing layout's one, which
-		its cleanup() then nulls. isLoading is this layout's own and starts true, so NodeView
-		never mounts before this layout owns the store. Deliberately no LoadingView here —
-		an embedded preview must not paint a spinner the host page did not ask for. -->
 		<RouterView v-if="!isLoading && currentWorkflowDocumentStore" />
 		<template #footer>
 			<DemoFooter />

--- a/packages/frontend/editor-ui/src/app/layouts/documentStoreNullWindow.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/documentStoreNullWindow.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `WorkflowDocumentStoreKey` is provided once, by App.vue, and shared by every
+ * layout. A layout that renders its `RouterView` before its own initialization
+ * has produced a document store therefore renders it against whatever store the
+ * *outgoing* layout left in that ref — a store the outgoing layout's `cleanup()`
+ * is about to null (`useWorkflowInitialization.ts:89`).
+ *
+ * `NodeView` reads that ref strictly, through `injectNDVStore()`, from a watcher
+ * getter that re-runs on every invalidation. So "store nulled while NodeView is
+ * mounted" is an illegal state: the read throws
+ * `injectNDVStore() was accessed without an active workflow document store`.
+ *
+ * These tests assert the state, not the throw. In the browser the throw is masked
+ * because the parent render effect happens to unmount `NodeView` before the child
+ * watcher job runs — flush order, not a guard, is what holds the invariant today.
+ *
+ * `WorkflowLayout` is here as the control. It gates on `isLoading` as well as on
+ * the store, so it never mounts `NodeView` in that window. `DemoLayout` gates on
+ * the store alone and does.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { computed, defineComponent, ref, shallowRef, type ShallowRef } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+import { renderComponent } from '@/__tests__/render';
+import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { injectStrict } from '@/app/utils/injectStrict';
+import type { WorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import DemoLayout from './DemoLayout.vue';
+import WorkflowLayout from './WorkflowLayout.vue';
+
+/** The single App.vue-provided ref, under the test's control. */
+let providedDocumentStore: ShallowRef<WorkflowDocumentStore | null>;
+
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = (await importOriginal()) as object;
+	return {
+		...actual,
+		useRoute: () => ({ params: {}, query: {}, meta: {}, name: 'demo' }),
+		useRouter: () => ({ replace: vi.fn(), push: vi.fn(), afterEach: vi.fn() }),
+	};
+});
+
+vi.mock('@/app/composables/useWorkflowInitialization', () => ({
+	useWorkflowInitialization: () => {
+		// Models the three things about the real composable that this window depends on:
+		// it injects the shared ref (line 63), starts with isLoading true (line 76), and
+		// nulls the shared ref from cleanup() (line 89). Initialization is left in flight
+		// on purpose — the window under test is the one before it resolves.
+		const currentWorkflowDocumentStore = injectStrict(WorkflowDocumentStoreKey);
+		const stillInFlight = () => new Promise<void>(() => {});
+
+		return {
+			isLoading: ref(true),
+			workflowId: computed(() => 'demo'),
+			currentWorkflowDocumentStore,
+			isNewWorkflowRoute: computed(() => false),
+			isDemoRoute: computed(() => true),
+			isTemplateRoute: computed(() => false),
+			isOnboardingRoute: computed(() => false),
+			isDebugRoute: computed(() => false),
+			initializeData: stillInFlight,
+			initializeWorkflow: stillInFlight,
+			handleDebugModeRoute: stillInFlight,
+			cleanup: () => {
+				currentWorkflowDocumentStore.value = null;
+			},
+		};
+	},
+}));
+
+vi.mock('@/app/composables/usePostMessageHandler', () => ({
+	usePostMessageHandler: () => ({ setup: vi.fn(), cleanup: vi.fn() }),
+}));
+
+vi.mock('@/app/composables/usePushConnection/usePushConnection', () => ({
+	usePushConnection: () => ({ initialize: vi.fn(), terminate: vi.fn() }),
+}));
+
+vi.mock('@/app/stores/pushConnection.store', () => ({
+	usePushConnectionStore: () => ({ pushConnect: vi.fn(), pushDisconnect: vi.fn() }),
+}));
+
+vi.mock('@/app/composables/useLayoutProps', () => ({
+	useLayoutProps: () => ({ layoutProps: computed(() => ({ logs: false })) }),
+}));
+
+vi.mock('@/features/ai/assistant/assistant.store', () => ({
+	useAssistantStore: () => ({ isFloatingButtonShown: false }),
+}));
+
+/**
+ * Stands in for NodeView: strict-injects the shared document store ref, exactly as
+ * `injectNDVStore()` does. Its presence in the DOM is the fact under test.
+ */
+const NodeViewStub = defineComponent({
+	setup() {
+		injectStrict(WorkflowDocumentStoreKey);
+	},
+	template: '<div data-test-id="node-view" />',
+});
+
+const stubs = {
+	AppHeader: { template: '<div />' },
+	AppSidebar: { template: '<div />' },
+	LogsPanel: { template: '<div />' },
+	AskAssistantFloatingButton: { template: '<div />' },
+	CanvasChatOverlay: { template: '<div />' },
+	DemoFooter: { template: '<div />' },
+	LoadingView: { template: '<div data-test-id="loading-view" />' },
+	RouterView: NodeViewStub,
+	Suspense: { template: '<div><slot /></div>' },
+};
+
+function renderLayout(layout: typeof DemoLayout) {
+	return renderComponent(layout, {
+		global: {
+			provide: { [WorkflowDocumentStoreKey as symbol]: providedDocumentStore },
+			stubs,
+		},
+	});
+}
+
+/** The document store the layout being navigated away from still has provided. */
+function outgoingDocumentStore() {
+	return {
+		documentId: 'workflow:outgoing',
+		workflowId: 'outgoing',
+	} as unknown as WorkflowDocumentStore;
+}
+
+describe('layouts: workflow document store null window', () => {
+	beforeEach(() => {
+		createTestingPinia();
+		vi.clearAllMocks();
+		providedDocumentStore = shallowRef(outgoingDocumentStore());
+	});
+
+	describe('DemoLayout', () => {
+		it('does not mount NodeView against the outgoing layout document store', () => {
+			const { queryByTestId } = renderLayout(DemoLayout);
+
+			expect(queryByTestId('node-view')).not.toBeInTheDocument();
+		});
+
+		it('does not keep NodeView mounted once the provided document store is null', () => {
+			const { queryByTestId } = renderLayout(DemoLayout);
+
+			// The outgoing layout's cleanup(), which nulls the shared ref.
+			providedDocumentStore.value = null;
+
+			// Read the DOM in the same frame, with no flush in between. This is the frame
+			// NodeView's watcher getters re-run in and injectNDVStore() throws in. Awaiting
+			// nextTick first would let the v-if unmount NodeView and hide the window.
+			expect(queryByTestId('node-view')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('WorkflowLayout', () => {
+		it('does not mount NodeView against the outgoing layout document store', () => {
+			const { queryByTestId } = renderLayout(WorkflowLayout);
+
+			expect(queryByTestId('node-view')).not.toBeInTheDocument();
+			expect(queryByTestId('loading-view')).toBeInTheDocument();
+		});
+
+		it('does not keep NodeView mounted once the provided document store is null', () => {
+			const { queryByTestId } = renderLayout(WorkflowLayout);
+
+			providedDocumentStore.value = null;
+
+			expect(queryByTestId('node-view')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/layouts/documentStoreNullWindow.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/documentStoreNullWindow.test.ts
@@ -3,7 +3,7 @@
  * layout. A layout that renders its `RouterView` before its own initialization
  * has produced a document store therefore renders it against whatever store the
  * *outgoing* layout left in that ref — a store the outgoing layout's `cleanup()`
- * is about to null (`useWorkflowInitialization.ts:89`).
+ * is about to null.
  *
  * `NodeView` reads that ref strictly, through `injectNDVStore()`, from a watcher
  * getter that re-runs on every invalidation. So "store nulled while NodeView is
@@ -13,10 +13,6 @@
  * These tests assert the state, not the throw. In the browser the throw is masked
  * because the parent render effect happens to unmount `NodeView` before the child
  * watcher job runs — flush order, not a guard, is what holds the invariant today.
- *
- * `WorkflowLayout` is here as the control. It gates on `isLoading` as well as on
- * the store, so it never mounts `NodeView` in that window. `DemoLayout` gates on
- * the store alone and does.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { computed, defineComponent, ref, shallowRef, type ShallowRef } from 'vue';


### PR DESCRIPTION
## Summary

`/workflows/demo` reaches an illegal state on every layout swap: `WorkflowDocumentStoreKey` is null while `DemoLayout` keeps `NodeView` mounted. This PR pins that state with a test, then closes it. Both commits ship together — the test fails on the first commit and passes on the second.

`WorkflowDocumentStoreKey` is provided once, by `App.vue`, and shared by every layout. `DemoLayout` gated its `RouterView` on that store alone:

```vue
<RouterView v-if="currentWorkflowDocumentStore" />
```

So on a layout swap the store is still the **outgoing** layout's one, and `DemoLayout` mounted `NodeView` against it. The outgoing layout's `cleanup()` then nulled that ref (`useWorkflowInitialization.ts:89`) while `NodeView` was mounted. `NodeView` reads the ref strictly through `injectNDVStore()`, from a watcher getter that re-runs on every invalidation, so the read in that frame throws:

```
injectNDVStore() was accessed without an active workflow document store
```

Nothing guarded that. Vue's flush order masked it: `NodeView`'s watcher is a default `pre` watcher, so the parent render effect ran first and the `v-if` unmounted `NodeView` before the getter re-ran.

## The fix

`DemoLayout` now gates on `isLoading` as well:

```vue
<RouterView v-if="!isLoading && currentWorkflowDocumentStore" />
```

`isLoading` comes from this layout's own `useWorkflowInitialization()` instance and starts `true` (`useWorkflowInitialization.ts:76`), so `NodeView` cannot mount before this layout owns the store. This is the same invariant `WorkflowLayout.vue:98` already holds.

**No `LoadingView` on this route**, on purpose. `WorkflowLayout` renders one because it is the standalone editor; the demo route is an embed, and painting an n8n-branded spinner the host page did not ask for is a regression, not a fix. The window the guard covers already rendered nothing, so the DOM in it is unchanged.

## Scope

Deliberately **only the demo-route window**. Once `NodeView` is mounted, *any* layout has this frame — `WorkflowLayout` included. What both layouts now avoid is *entering* it on a swap. "Shared ref nulled under a mounted consumer" stays unsafe as a general shape; that residual is tracked separately and is not this PR.

No console allowlist entry for `injectNDVStore()` — the error names a state the app really reaches.

## How to test

```bash
cd packages/frontend/editor-ui
pnpm test src/app/layouts/documentStoreNullWindow.test.ts
```

| Case | Before the fix | After |
| --- | --- | --- |
| `DemoLayout` does not mount NodeView against the outgoing layout document store | ❌ | ✅ |
| `DemoLayout` does not keep NodeView mounted once the provided document store is null | ❌ | ✅ |
| `WorkflowLayout` — same two cases | ✅ ✅ | ✅ ✅ |

The four cases assert the state, in the same frame, with no flush — not the throw, which flush order hides.

`src/app/layouts` is green (9 files, 87 cases, including the 14 existing `DemoLayout.test.ts` cases). `pnpm typecheck` clean. `pnpm lint` 0 errors.

## Browser verification

Demo route in an iframe embed, preview mode, unauthenticated (`N8N_PREVIEW_MODE=true`), workflow imported by `openWorkflow` postMessage, Chromium at 1280×800, 3 runs each.

| | Spinner ever painted | CLS | Canvas visible | Nodes visible |
| --- | --- | --- | --- | --- |
| Before the fix | no | 0 (0 shift entries) | 1029 / 1058 / 1106 ms | 1051 / 1080 / 1129 ms |
| After the fix | no | 0 (0 shift entries) | 956 / 1098 / 1100 ms | 975 / 1121 / 1121 ms |

Overlapping ranges, no new visible state, no layout shift. NDV opens correctly on the demo route and shows Parameters/Settings with input and output panels. The only console errors on the route are the unrelated 401 pair (`/rest/workflows/new`, `/rest/license`), which #36403 fixes; no `injectNDVStore()` error.

## Related Linear tickets, Github issues, and Community forum posts

None. Tracked in Multica as N8N-271, split out of N8N-262. The general-class residual is N8N-272.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
