### PR TITLE
fix(editor): Restore Edit Fields type selector styles

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/TypeSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/TypeSelect.vue
@@ -97,9 +97,9 @@ const onSelect = (type: string): void => {
 	border-bottom-left-radius: var(--input--radius--bottom-left, var(--input--radius, 0));
 	border-top-right-radius: var(--input-triple--radius--top-right, var(--input--radius, 0));
 	border-bottom-right-radius: var(--input-triple--radius--bottom-right, var(--input--radius, 0));
-	background-color: var(--color--background--light-2);
+	background-color: var(--input--color--background);
 	color: var(--color--text);
-	font-size: var(--font-size--2xs);
+	font-size: var(--font-size--xs);
 	font-family: var(--font-family);
 	cursor: pointer;
 


### PR DESCRIPTION
## Summary

Fixes [DS-616](https://linear.app/n8n/issue/DS-616/bug-edit-fields-node-component-visual-degradations)

Restore the Edit Fields type selector background color and font size. This regression happened in [#24592](<https://github.com/n8n-io/n8n/issues/24592>) , drifting the background color and font-size away.

The selector now uses the input background token and the standard extra-small font size. No regression test added as purely visual change.

<!-- linear:table-colwidths:403,403 -->
| Before | After |
| -- | -- |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/6c655517-1665-484d-9578-8ca69576e96e/7e6884d0-268a-45ce-a238-e07d40a7a09c?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi82YzY1NTUxNy0xNjY1LTQ4NGQtOTU3OC04Y2E2OTU3NmU5NmUvN2U2ODg0ZDAtMjY4YS00NWNlLWEyMzgtZTA3ZDQwYTdhMDljIiwiaWF0IjoxNzg2OTU3NjcxLCJleHAiOjE4MTg1MjgyMzF9.gxampPv0OrICGlgTNVarp-IsWGFkoOt1EXQ9Ni-mdLk " alt="CleanShot 2026-08-17 at 09.55.35@2x.png" width="818" data-linear-height="448" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/ef07d689-a586-4117-9b91-bf0734885f5a/fa0131fe-50a7-4bb6-89d2-dd82040d3bd0?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9lZjA3ZDY4OS1hNTg2LTQxMTctOWI5MS1iZjA3MzQ4ODVmNWEvZmEwMTMxZmUtNTBhNy00YmI2LTg5ZDItZGQ4MjA0MGQzYmQwIiwiaWF0IjoxNzg2OTU3NjcxLCJleHAiOjE4MTg1MjgyMzF9.p1GyGgkjF_nsl3SEAI-5flAVRxQcx4WrvuW2CKIOUfY " alt="CleanShot 2026-08-17 at 10.07.00@2x.png" width="826" data-linear-height="434" /> |

## How to test

1. Add an Edit Fields node to a workflow.
2. Add a field in Manual Mapping mode.
3. Open the field type selector.
4. Confirm that the selector background matches the input background.
5. Confirm that the selector text matches the input text size.
6. Check the result in light mode and dark mode.

## Related Linear tickets, Github issues, and Community forum posts

[DS-616](https://linear.app/n8n/issue/DS-616)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)