### PR TITLE
ci: Remove unnecessary Kafka cleanup in setup-nodejs

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -145,19 +145,6 @@ runs:
       shell: bash
       run: node .github/scripts/verify-safechain.mjs
 
-    # Confluent ships no Node 26 prebuilt and its vendored librdkafka cannot build
-    # inside node_modules: https://github.com/confluentinc/confluent-kafka-javascript/issues/397
-    - name: Skip Kafka native build (no Node 26 prebuilds)
-      if: ${{ startsWith(inputs.node-version, '26.') }}
-      shell: bash
-      run: |
-        node -e "
-          const fs = require('fs');
-          const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-          p.pnpm.onlyBuiltDependencies = p.pnpm.onlyBuiltDependencies.filter(d => d !== '@confluentinc/kafka-javascript');
-          fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
-        "
-
     # `--loglevel` CLI flag does NOT override `.npmrc` for that path, but
     # `--config.loglevel` does — so the failing script's real output reaches us.
     # (Confirmed on CI across Blacksmith + GitHub-hosted, through the SafeChain


### PR DESCRIPTION
## Summary

A step in setup-nodejs caused the worktree to get dirty by rewriting our package.json.

The same step was to filter out the kafkajs entry from our `onlyBuiltDependencies`, which doesn't have an entry for said dependency, making this effectively an no-op while outputting a different format json file.

## How to test

Make sure CI passes.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

