### PR TITLE
refactor(core): Add breaking change rule for AI Agent versions below 2

### DIFF
--- a/packages/cli/src/modules/breaking-changes/rules/index.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/index.ts
@@ -21,6 +21,7 @@ import './v2/workflow-hooks-deprecated.rule';
 
 // v3 rules
 import './v3/agent-node-version.rule';
+import './v3/agent-removed-modes.rule';
 import './v3/ai-transform-deprecated.rule';
 import './v3/always-output-data-multi-output.rule';
 import './v3/chat-trigger-embedded-json.rule';

--- a/packages/cli/src/modules/breaking-changes/rules/index.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/index.ts
@@ -20,6 +20,7 @@ import './v2/wait-node-subworkflow.rule';
 import './v2/workflow-hooks-deprecated.rule';
 
 // v3 rules
+import './v3/agent-node-version.rule';
 import './v3/ai-transform-deprecated.rule';
 import './v3/always-output-data-multi-output.rule';
 import './v3/chat-trigger-embedded-json.rule';

--- a/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/agent-node-version.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/agent-node-version.rule.test.ts
@@ -1,0 +1,104 @@
+import { createNode, createWorkflow } from '../../../__tests__/test-helpers';
+import { AgentNodeVersionRule } from '../agent-node-version.rule';
+
+const AGENT_NODE_TYPE = '@n8n/n8n-nodes-langchain.agent';
+
+describe('AgentNodeVersionRule', () => {
+	let rule: AgentNodeVersionRule;
+
+	beforeEach(() => {
+		rule = new AgentNodeVersionRule();
+	});
+
+	describe('detectWorkflow()', () => {
+		it('should not be affected when there is no AI Agent node', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('HTTP', 'n8n-nodes-base.httpRequest'),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should not be affected when the AI Agent is on version 2 or above', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				{ ...createNode('AI Agent', AGENT_NODE_TYPE), typeVersion: 2.2 },
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should warn about an AI Agent below version 2 that uses the tools agent', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				{
+					...createNode('AI Agent', AGENT_NODE_TYPE, { agent: 'toolsAgent' }),
+					typeVersion: 1.9,
+				},
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].title).toContain('1.9');
+			expect(result.issues[0].level).toBe('warning');
+			expect(result.issues[0].nodeName).toBe('AI Agent');
+		});
+
+		it('should report an error for a node that uses a removed agent mode', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				{
+					...createNode('SQL Agent', AGENT_NODE_TYPE, { agent: 'sqlAgent' }),
+					typeVersion: 1.5,
+				},
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].level).toBe('error');
+			expect(result.issues[0].description).toContain('SQL Agent');
+		});
+
+		it('should report an error for a node up to 1.5 that has no agent parameter', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				{ ...createNode('AI Agent', AGENT_NODE_TYPE), typeVersion: 1.4 },
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].level).toBe('error');
+			expect(result.issues[0].description).toContain('Conversational Agent');
+		});
+
+		it('should flag only the nodes below version 2 when multiple AI Agents exist', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				{ ...createNode('Old Agent', AGENT_NODE_TYPE), typeVersion: 1 },
+				{ ...createNode('New Agent', AGENT_NODE_TYPE), typeVersion: 3.1 },
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].nodeName).toBe('Old Agent');
+		});
+	});
+
+	describe('getRecommendations()', () => {
+		it('should explain how to migrate the removed agent modes', async () => {
+			const recommendations = await rule.getRecommendations([]);
+
+			expect(recommendations).toHaveLength(1);
+			expect(recommendations[0].description).toContain('Tools Agent');
+			expect(recommendations[0].description).toContain('SQL Agent');
+		});
+	});
+});

--- a/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/agent-removed-modes.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/agent-removed-modes.rule.test.ts
@@ -1,13 +1,13 @@
 import { createNode, createWorkflow } from '../../../__tests__/test-helpers';
-import { AgentNodeVersionRule } from '../agent-node-version.rule';
+import { AgentRemovedModesRule } from '../agent-removed-modes.rule';
 
 const AGENT_NODE_TYPE = '@n8n/n8n-nodes-langchain.agent';
 
-describe('AgentNodeVersionRule', () => {
-	let rule: AgentNodeVersionRule;
+describe('AgentRemovedModesRule', () => {
+	let rule: AgentRemovedModesRule;
 
 	beforeEach(() => {
-		rule = new AgentNodeVersionRule();
+		rule = new AgentRemovedModesRule();
 	});
 
 	describe('detectWorkflow()', () => {
@@ -24,7 +24,10 @@ describe('AgentNodeVersionRule', () => {
 
 		it('should not be affected when the AI Agent is on version 2 or above', async () => {
 			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
-				{ ...createNode('AI Agent', AGENT_NODE_TYPE), typeVersion: 2.2 },
+				{
+					...createNode('AI Agent', AGENT_NODE_TYPE, { agent: 'conversationalAgent' }),
+					typeVersion: 2,
+				},
 			]);
 
 			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
@@ -33,7 +36,7 @@ describe('AgentNodeVersionRule', () => {
 			expect(result.issues).toHaveLength(0);
 		});
 
-		it('should warn about an AI Agent below version 2 that uses the tools agent', async () => {
+		it('should not be affected when the node below version 2 uses the tools agent', async () => {
 			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
 				{
 					...createNode('AI Agent', AGENT_NODE_TYPE, { agent: 'toolsAgent' }),
@@ -43,65 +46,74 @@ describe('AgentNodeVersionRule', () => {
 
 			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
 
-			expect(result.isAffected).toBe(true);
-			expect(result.issues).toHaveLength(1);
-			expect(result.issues[0].title).toContain('1.9');
-			expect(result.issues[0].level).toBe('warning');
-			expect(result.issues[0].nodeName).toBe('AI Agent');
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
 		});
 
-		it('should warn about a node from 1.6 onwards that has no agent parameter', async () => {
-			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
-				{ ...createNode('AI Agent', AGENT_NODE_TYPE), typeVersion: 1.7 },
-			]);
-
-			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
-
-			expect(result.issues).toHaveLength(1);
-			expect(result.issues[0].level).toBe('warning');
-		});
-
-		it('should leave nodes on a removed agent mode to the removed modes rule', async () => {
+		it('should report an error for a node that uses a removed agent mode', async () => {
 			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
 				{
 					...createNode('SQL Agent', AGENT_NODE_TYPE, { agent: 'sqlAgent' }),
 					typeVersion: 1.5,
 				},
-				{ ...createNode('Conversational Agent', AGENT_NODE_TYPE), typeVersion: 1.4 },
-			]);
-
-			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
-
-			expect(result.isAffected).toBe(false);
-			expect(result.issues).toHaveLength(0);
-		});
-
-		it('should flag only the nodes below version 2 when multiple AI Agents exist', async () => {
-			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
-				{ ...createNode('Old Agent', AGENT_NODE_TYPE, { agent: 'toolsAgent' }), typeVersion: 1.8 },
-				{ ...createNode('New Agent', AGENT_NODE_TYPE), typeVersion: 3.1 },
 			]);
 
 			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
 
 			expect(result.isAffected).toBe(true);
 			expect(result.issues).toHaveLength(1);
-			expect(result.issues[0].nodeName).toBe('Old Agent');
+			expect(result.issues[0].level).toBe('error');
+			expect(result.issues[0].title).toContain('SQL Agent');
+			expect(result.issues[0].description).toContain('SQL Agent');
+			expect(result.issues[0].nodeName).toBe('SQL Agent');
+		});
+
+		it('should report an error for a node up to 1.5 that has no agent parameter', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				{ ...createNode('AI Agent', AGENT_NODE_TYPE), typeVersion: 1.4 },
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].level).toBe('error');
+			expect(result.issues[0].description).toContain('Conversational Agent');
+		});
+
+		it('should flag only the nodes on a removed mode when multiple AI Agents exist', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				{
+					...createNode('ReAct Agent', AGENT_NODE_TYPE, { agent: 'reActAgent' }),
+					typeVersion: 1.6,
+				},
+				{
+					...createNode('Tools Agent', AGENT_NODE_TYPE, { agent: 'toolsAgent' }),
+					typeVersion: 1.6,
+				},
+				{ ...createNode('New Agent', AGENT_NODE_TYPE), typeVersion: 2.2 },
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].nodeName).toBe('ReAct Agent');
 		});
 	});
 
 	describe('getMetadata()', () => {
-		it('should report a medium severity for nodes that keep working', () => {
-			expect(rule.getMetadata().severity).toBe('medium');
+		it('should report a critical severity for nodes that stop working', () => {
+			expect(rule.getMetadata().severity).toBe('critical');
 		});
 	});
 
 	describe('getRecommendations()', () => {
-		it('should explain how to move the nodes to the latest version', async () => {
+		it('should explain how to rebuild the affected nodes', async () => {
 			const recommendations = await rule.getRecommendations([]);
 
 			expect(recommendations).toHaveLength(1);
 			expect(recommendations[0].description).toContain('latest version');
+			expect(recommendations[0].description).toContain('SQL Agent');
 		});
 	});
 });

--- a/packages/cli/src/modules/breaking-changes/rules/v3/agent-node-mode.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/agent-node-mode.ts
@@ -1,0 +1,36 @@
+import type { INode } from 'n8n-workflow';
+
+export const AGENT_NODE_TYPE = '@n8n/n8n-nodes-langchain.agent';
+const FIRST_SUPPORTED_VERSION = 2;
+
+/** Agent modes that only versions below 2 offered, mapped to their display name. */
+const REMOVED_AGENT_MODES: Record<string, string> = {
+	conversationalAgent: 'Conversational Agent',
+	openAiFunctionsAgent: 'OpenAI Functions Agent',
+	planAndExecuteAgent: 'Plan and Execute Agent',
+	reActAgent: 'ReAct Agent',
+	sqlAgent: 'SQL Agent',
+};
+
+/**
+ * Up to version 1.5 the `agent` parameter defaulted to the Conversational Agent, so an unset
+ * parameter means Tools Agent only from 1.6 onwards.
+ */
+function resolveAgentMode(node: INode) {
+	if (typeof node.parameters?.agent === 'string') return node.parameters.agent;
+
+	return node.typeVersion <= 1.5 ? 'conversationalAgent' : 'toolsAgent';
+}
+
+export function getAgentNodesBelowFirstSupportedVersion(
+	nodesGroupedByType: Map<string, INode[]>,
+): INode[] {
+	return (nodesGroupedByType.get(AGENT_NODE_TYPE) ?? []).filter(
+		(node) => node.typeVersion < FIRST_SUPPORTED_VERSION,
+	);
+}
+
+/** Display name of the removed mode the node runs in, or `undefined` if its mode still exists. */
+export function getRemovedAgentMode(node: INode): string | undefined {
+	return REMOVED_AGENT_MODES[resolveAgentMode(node)];
+}

--- a/packages/cli/src/modules/breaking-changes/rules/v3/agent-node-version.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/agent-node-version.rule.ts
@@ -1,0 +1,91 @@
+import type { BreakingChangeAffectedWorkflow, BreakingChangeRecommendation } from '@n8n/api-types';
+import type { WorkflowEntity } from '@n8n/db';
+import { BreakingChangeRule } from '@n8n/decorators';
+import type { INode } from 'n8n-workflow';
+
+import type {
+	BreakingChangeRuleMetadata,
+	IBreakingChangeWorkflowRule,
+	WorkflowDetectionReport,
+} from '../../types';
+import { BreakingChangeCategory } from '../../types';
+
+const AGENT_NODE_TYPE = '@n8n/n8n-nodes-langchain.agent';
+const FIRST_SUPPORTED_VERSION = 2;
+
+/** Agent modes that only versions below 2 offered. */
+const REMOVED_AGENT_MODES: Record<string, string> = {
+	conversationalAgent: 'Conversational Agent',
+	openAiFunctionsAgent: 'OpenAI Functions Agent',
+	planAndExecuteAgent: 'Plan and Execute Agent',
+	reActAgent: 'ReAct Agent',
+	sqlAgent: 'SQL Agent',
+};
+
+/**
+ * Up to version 1.5 the `agent` parameter defaulted to the Conversational Agent, so an unset
+ * parameter means Tools Agent only from 1.6 onwards.
+ */
+function resolveAgentMode(node: INode) {
+	if (typeof node.parameters?.agent === 'string') return node.parameters.agent;
+
+	return node.typeVersion <= 1.5 ? 'conversationalAgent' : 'toolsAgent';
+}
+
+@BreakingChangeRule({ version: 'v3' })
+export class AgentNodeVersionRule implements IBreakingChangeWorkflowRule {
+	id = 'agent-node-version-v3';
+
+	getMetadata(): BreakingChangeRuleMetadata {
+		return {
+			version: 'v3',
+			title: 'AI Agent versions below 2 run with version 2 behavior',
+			description:
+				'AI Agent versions below 2 are removed and every AI Agent node runs with version 2 behavior, which only supports the Tools Agent. Nodes set to the Conversational, OpenAI Functions, Plan and Execute, ReAct or SQL Agent mode stop working and fail with an error when executed.',
+			category: BreakingChangeCategory.workflow,
+			severity: 'critical',
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async getRecommendations(
+		_workflowResults: BreakingChangeAffectedWorkflow[],
+	): Promise<BreakingChangeRecommendation[]> {
+		return [
+			{
+				action: 'Move AI Agent nodes on versions below 2 to the latest version',
+				description:
+					'Replace each affected AI Agent node with an AI Agent on the latest version and reconnect its model, memory and tools. Nodes set to the Conversational, OpenAI Functions, Plan and Execute or ReAct Agent mode need to be rebuilt as a Tools Agent. Nodes set to the SQL Agent mode need to be rebuilt as a Tools Agent with a database tool.',
+			},
+		];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async detectWorkflow(
+		_workflow: WorkflowEntity,
+		nodesGroupedByType: Map<string, INode[]>,
+	): Promise<WorkflowDetectionReport> {
+		const affectedNodes = (nodesGroupedByType.get(AGENT_NODE_TYPE) ?? []).filter(
+			(node) => node.typeVersion < FIRST_SUPPORTED_VERSION,
+		);
+
+		if (affectedNodes.length === 0) return { isAffected: false, issues: [] };
+
+		return {
+			isAffected: true,
+			issues: affectedNodes.map((node) => {
+				const removedMode = REMOVED_AGENT_MODES[resolveAgentMode(node)];
+
+				return {
+					title: `Node '${node.name}' uses AI Agent version ${node.typeVersion}`,
+					description: removedMode
+						? `This node uses the "${removedMode}" mode, which is no longer available. It will fail when executed until it is rebuilt as a Tools Agent on the latest version.`
+						: 'This node will run with version 2 behavior of the Tools Agent.',
+					level: removedMode ? 'error' : 'warning',
+					nodeId: node.id,
+					nodeName: node.name,
+				};
+			}),
+		};
+	}
+}

--- a/packages/cli/src/modules/breaking-changes/rules/v3/agent-node-version.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/agent-node-version.rule.ts
@@ -3,6 +3,7 @@ import type { WorkflowEntity } from '@n8n/db';
 import { BreakingChangeRule } from '@n8n/decorators';
 import type { INode } from 'n8n-workflow';
 
+import { getAgentNodesBelowFirstSupportedVersion, getRemovedAgentMode } from './agent-node-mode';
 import type {
 	BreakingChangeRuleMetadata,
 	IBreakingChangeWorkflowRule,
@@ -10,28 +11,10 @@ import type {
 } from '../../types';
 import { BreakingChangeCategory } from '../../types';
 
-const AGENT_NODE_TYPE = '@n8n/n8n-nodes-langchain.agent';
-const FIRST_SUPPORTED_VERSION = 2;
-
-/** Agent modes that only versions below 2 offered. */
-const REMOVED_AGENT_MODES: Record<string, string> = {
-	conversationalAgent: 'Conversational Agent',
-	openAiFunctionsAgent: 'OpenAI Functions Agent',
-	planAndExecuteAgent: 'Plan and Execute Agent',
-	reActAgent: 'ReAct Agent',
-	sqlAgent: 'SQL Agent',
-};
-
 /**
- * Up to version 1.5 the `agent` parameter defaulted to the Conversational Agent, so an unset
- * parameter means Tools Agent only from 1.6 onwards.
+ * Covers the nodes that keep working after the update. Nodes on a mode that version 2 never
+ * offered are reported by the AgentRemovedModesRule instead, which is critical rather than medium.
  */
-function resolveAgentMode(node: INode) {
-	if (typeof node.parameters?.agent === 'string') return node.parameters.agent;
-
-	return node.typeVersion <= 1.5 ? 'conversationalAgent' : 'toolsAgent';
-}
-
 @BreakingChangeRule({ version: 'v3' })
 export class AgentNodeVersionRule implements IBreakingChangeWorkflowRule {
 	id = 'agent-node-version-v3';
@@ -39,11 +22,11 @@ export class AgentNodeVersionRule implements IBreakingChangeWorkflowRule {
 	getMetadata(): BreakingChangeRuleMetadata {
 		return {
 			version: 'v3',
-			title: 'AI Agent versions below 2 run with version 2 behavior',
+			title: 'AI Agent versions below 2 are removed',
 			description:
-				'AI Agent versions below 2 are removed and every AI Agent node runs with version 2 behavior, which only supports the Tools Agent. Nodes set to the Conversational, OpenAI Functions, Plan and Execute, ReAct or SQL Agent mode stop working and fail with an error when executed.',
+				'AI Agent versions below 2 are removed. After the update, AI Agent nodes that are currently on a version below 2 will run with version 2 behavior, which only supports the Tools Agent.',
 			category: BreakingChangeCategory.workflow,
-			severity: 'critical',
+			severity: 'medium',
 		};
 	}
 
@@ -55,7 +38,7 @@ export class AgentNodeVersionRule implements IBreakingChangeWorkflowRule {
 			{
 				action: 'Move AI Agent nodes on versions below 2 to the latest version',
 				description:
-					'Replace each affected AI Agent node with an AI Agent on the latest version and reconnect its model, memory and tools. Nodes set to the Conversational, OpenAI Functions, Plan and Execute or ReAct Agent mode need to be rebuilt as a Tools Agent. Nodes set to the SQL Agent mode need to be rebuilt as a Tools Agent with a database tool.',
+					'Replace each affected AI Agent node with an AI Agent on the latest version and reconnect its model, memory and tools, then run the workflow to confirm it still behaves as expected.',
 			},
 		];
 	}
@@ -65,27 +48,21 @@ export class AgentNodeVersionRule implements IBreakingChangeWorkflowRule {
 		_workflow: WorkflowEntity,
 		nodesGroupedByType: Map<string, INode[]>,
 	): Promise<WorkflowDetectionReport> {
-		const affectedNodes = (nodesGroupedByType.get(AGENT_NODE_TYPE) ?? []).filter(
-			(node) => node.typeVersion < FIRST_SUPPORTED_VERSION,
+		const affectedNodes = getAgentNodesBelowFirstSupportedVersion(nodesGroupedByType).filter(
+			(node) => !getRemovedAgentMode(node),
 		);
 
 		if (affectedNodes.length === 0) return { isAffected: false, issues: [] };
 
 		return {
 			isAffected: true,
-			issues: affectedNodes.map((node) => {
-				const removedMode = REMOVED_AGENT_MODES[resolveAgentMode(node)];
-
-				return {
-					title: `Node '${node.name}' uses AI Agent version ${node.typeVersion}`,
-					description: removedMode
-						? `This node uses the "${removedMode}" mode, which is no longer available. It will fail when executed until it is rebuilt as a Tools Agent on the latest version.`
-						: 'This node will run with version 2 behavior of the Tools Agent.',
-					level: removedMode ? 'error' : 'warning',
-					nodeId: node.id,
-					nodeName: node.name,
-				};
-			}),
+			issues: affectedNodes.map((node) => ({
+				title: `Node '${node.name}' uses AI Agent version ${node.typeVersion}`,
+				description: 'After the update, this node will run with version 2 behavior.',
+				level: 'warning',
+				nodeId: node.id,
+				nodeName: node.name,
+			})),
 		};
 	}
 }

--- a/packages/cli/src/modules/breaking-changes/rules/v3/agent-removed-modes.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/agent-removed-modes.rule.ts
@@ -1,0 +1,72 @@
+import type { BreakingChangeAffectedWorkflow, BreakingChangeRecommendation } from '@n8n/api-types';
+import type { WorkflowEntity } from '@n8n/db';
+import { BreakingChangeRule } from '@n8n/decorators';
+import type { INode } from 'n8n-workflow';
+
+import { getAgentNodesBelowFirstSupportedVersion, getRemovedAgentMode } from './agent-node-mode';
+import type {
+	BreakingChangeRuleMetadata,
+	IBreakingChangeWorkflowRule,
+	WorkflowDetectionReport,
+} from '../../types';
+import { BreakingChangeCategory } from '../../types';
+
+/**
+ * Covers the nodes that stop working after the update. Nodes below version 2 that keep working
+ * are reported by the AgentNodeVersionRule instead.
+ */
+@BreakingChangeRule({ version: 'v3' })
+export class AgentRemovedModesRule implements IBreakingChangeWorkflowRule {
+	id = 'agent-removed-modes-v3';
+
+	getMetadata(): BreakingChangeRuleMetadata {
+		return {
+			version: 'v3',
+			title: 'Deprecated AI Agent modes removed',
+			description:
+				'AI Agent versions below 2 are removed, and with them the Conversational, OpenAI Functions, Plan and Execute, ReAct and SQL Agent modes, which version 2 does not offer. After the update, nodes set to one of these modes will fail when executed.',
+			category: BreakingChangeCategory.workflow,
+			severity: 'critical',
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async getRecommendations(
+		_workflowResults: BreakingChangeAffectedWorkflow[],
+	): Promise<BreakingChangeRecommendation[]> {
+		return [
+			{
+				action: 'Rebuild AI Agent nodes that use a removed mode',
+				description:
+					'Replace each affected AI Agent node with an AI Agent on the latest version and reconnect its model, memory and tools. Nodes that used the SQL Agent mode also need a database tool connected to keep querying their database.',
+			},
+		];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async detectWorkflow(
+		_workflow: WorkflowEntity,
+		nodesGroupedByType: Map<string, INode[]>,
+	): Promise<WorkflowDetectionReport> {
+		const affectedNodes = getAgentNodesBelowFirstSupportedVersion(nodesGroupedByType).flatMap(
+			(node) => {
+				const removedMode = getRemovedAgentMode(node);
+
+				return removedMode ? [{ node, removedMode }] : [];
+			},
+		);
+
+		if (affectedNodes.length === 0) return { isAffected: false, issues: [] };
+
+		return {
+			isAffected: true,
+			issues: affectedNodes.map(({ node, removedMode }) => ({
+				title: `Node '${node.name}' uses the "${removedMode}" mode of AI Agent version ${node.typeVersion}`,
+				description: `The "${removedMode}" mode is no longer available. After the update, this node will fail when executed until it is replaced with an AI Agent on the latest version.`,
+				level: 'error',
+				nodeId: node.id,
+				nodeName: node.name,
+			})),
+		};
+	}
+}


### PR DESCRIPTION
## Summary

Adds a v3 breaking-change rule (`agent-node-version-v3`) that reports AI Agent nodes on a version below 2, so affected workflows can be found before upgrading.

- Flags every `@n8n/n8n-nodes-langchain.agent` node with `typeVersion < 2`.
- Resolves the node's agent mode from the `agent` parameter, falling back to the version default when it is unset (Conversational up to 1.5, Tools from 1.6).
- Reports `error` for nodes resolving to a mode that version 2 does not offer (Conversational, OpenAI Functions, Plan and Execute, ReAct, SQL), and `warning` for nodes that will simply run with version 2 behavior.
- Recommends replacing affected nodes with an AI Agent on the latest version and rebuilding them as a Tools Agent.

<img width="913" height="353" alt="image" src="https://github.com/user-attachments/assets/417c7ac7-9c37-4831-a979-8d4e7d3aa80c" />


## How to test

1. Temporarily set `MIGRATION_REPORT_TARGET_VERSION = 'v3'` in `packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts` (it gates both the backend module and the settings route), then rebuild api-types.
2. Start n8n and sign in as owner/admin (`breakingChanges:list` scope).
3. Create and **save** a workflow from the JSON below.
4. Open **Settings → Migration report → Workflow issues**. The rule appears as "AI Agent versions below 2 run with version 2 behavior"; its detail page lists the workflow. Use the Refresh button if a cached report is served.

Expected on the example workflow: 9 flagged nodes — 7 `error` (the five explicit removed modes, the v1 node, and the v1.5 node with no `agent` parameter) and 2 `warning` (the v1.7 node with no `agent` parameter and the explicit Tools Agent on v1.9). The two version 2 nodes are not flagged.

<details>
<summary>Example workflow</summary>

```json
{
  "nodes": [
    {
      "parameters": {},
      "id": "aaaaaaaa-0000-4000-8000-000000000001",
      "name": "Manual Trigger",
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [-260, 220]
    },
    {
      "parameters": { "agent": "conversationalAgent" },
      "id": "aaaaaaaa-0000-4000-8000-000000000002",
      "name": "Conversational v1.7 (explicit)",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.7,
      "position": [0, 0]
    },
    {
      "parameters": { "agent": "openAiFunctionsAgent" },
      "id": "aaaaaaaa-0000-4000-8000-000000000003",
      "name": "OpenAI Functions v1.6",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.6,
      "position": [240, 0]
    },
    {
      "parameters": { "agent": "planAndExecuteAgent" },
      "id": "aaaaaaaa-0000-4000-8000-000000000004",
      "name": "Plan and Execute v1.6",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.6,
      "position": [480, 0]
    },
    {
      "parameters": { "agent": "reActAgent" },
      "id": "aaaaaaaa-0000-4000-8000-000000000005",
      "name": "ReAct v1.4",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.4,
      "position": [720, 0]
    },
    {
      "parameters": { "agent": "sqlAgent" },
      "id": "aaaaaaaa-0000-4000-8000-000000000006",
      "name": "SQL Agent v1.4",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.4,
      "position": [960, 0]
    },
    {
      "parameters": { "agent": "conversationalAgent" },
      "id": "aaaaaaaa-0000-4000-8000-000000000007",
      "name": "Conversational v1 (oldest)",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1,
      "position": [0, 220]
    },
    {
      "parameters": {},
      "id": "aaaaaaaa-0000-4000-8000-000000000008",
      "name": "Unset agent param v1.5",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.5,
      "position": [240, 220]
    },
    {
      "parameters": {},
      "id": "aaaaaaaa-0000-4000-8000-000000000009",
      "name": "Unset agent param v1.7",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.7,
      "position": [480, 220]
    },
    {
      "parameters": { "agent": "toolsAgent" },
      "id": "aaaaaaaa-0000-4000-8000-00000000000a",
      "name": "Tools Agent v1.9",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 1.9,
      "position": [720, 220]
    },
    {
      "parameters": {},
      "id": "aaaaaaaa-0000-4000-8000-00000000000b",
      "name": "Agent v2 (control)",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 2,
      "position": [0, 440]
    },
    {
      "parameters": {},
      "id": "aaaaaaaa-0000-4000-8000-00000000000c",
      "name": "Agent v2.2 (control)",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 2.2,
      "position": [240, 440]
    }
  ],
  "connections": {
    "Manual Trigger": {
      "main": [[{ "node": "Conversational v1.7 (explicit)", "type": "main", "index": 0 }]]
    }
  },
  "pinData": {}
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-660

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

