### PR TITLE
fix(core): Show a clear no-access message when SSO role mapping denies a login

### DIFF
--- a/packages/@n8n/api-types/src/constants/role-mapping.ts
+++ b/packages/@n8n/api-types/src/constants/role-mapping.ts
@@ -7,3 +7,12 @@
  * role type (`global:*`, `project:*`), including custom roles.
  */
 export const BLOCK_ACCESS_ASSIGNMENT = 'block:access';
+
+/**
+ * Query parameter the SSO callbacks add when redirecting a denied login back to
+ * the sign-in page, so the UI can explain the denial instead of surfacing it as
+ * a failed login.
+ */
+export const SSO_ERROR_QUERY_PARAM = 'ssoError';
+
+export const SSO_ERROR_ACCESS_DENIED = 'access-denied';

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -702,4 +702,8 @@ export {
 	MOONSHOTAI_KIMI_K3_PROVIDER,
 	isMoonshotaiKimiK3ModelId,
 } from './constants/instance-ai-models';
-export { BLOCK_ACCESS_ASSIGNMENT } from './constants/role-mapping';
+export {
+	BLOCK_ACCESS_ASSIGNMENT,
+	SSO_ERROR_ACCESS_DENIED,
+	SSO_ERROR_QUERY_PARAM,
+} from './constants/role-mapping';

--- a/packages/cli/src/__tests__/controller.registry.test.ts
+++ b/packages/cli/src/__tests__/controller.registry.test.ts
@@ -21,12 +21,14 @@ import {
 } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import express, { json } from 'express';
+import { ErrorReporter } from 'n8n-core';
 import request from 'supertest';
 import { mock } from 'vitest-mock-extended';
 import { z } from 'zod';
 
 import type { AuthService } from '@/auth/auth.service';
 import { ControllerRegistry } from '@/controller.registry';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { License } from '@/license';
 import type { LastActiveAtService } from '@/services/last-active-at.service';
 import { RateLimitService } from '@/services/rate-limit.service';
@@ -366,6 +368,49 @@ describe('ControllerRegistry', () => {
 			const { headers, body } = await request(app).get('/rest/test/args/1234').expect(200);
 			expect(headers.testing).toBe('true');
 			expect(body.data).toEqual({ url: '/args/1234', id: '1234' });
+		});
+	});
+
+	describe('Template routes', () => {
+		@RestController('/test')
+		// @ts-expect-error tsc complains about unused class
+		class TestController {
+			@Get('/template/forbidden', { usesTemplates: true })
+			forbidden() {
+				throw new ForbiddenError('Nope');
+			}
+
+			@Get('/template/unexpected', { usesTemplates: true })
+			unexpected() {
+				throw new Error('Something broke');
+			}
+
+			@Get('/template/rendered', { usesTemplates: true })
+			rendered(_req: express.Request, res: express.Response) {
+				res.send('<html lang="en"></html>');
+			}
+		}
+
+		beforeEach(() => {
+			Container.set(ErrorReporter, mock<ErrorReporter>());
+			authMiddleware.mockImplementation(async (_req, _res, next) => next());
+			lastActiveAtService.middleware.mockImplementation(async (_req, _res, next) => next());
+		});
+
+		it('should answer with the status of the thrown response error, not 500', async () => {
+			const { body } = await request(app).get('/rest/test/template/forbidden').expect(403);
+			expect(body).toEqual({ code: 403, message: 'Nope' });
+		});
+
+		it('should answer 500 for an unexpected error and report it', async () => {
+			const { body } = await request(app).get('/rest/test/template/unexpected').expect(500);
+			expect(body).toEqual({ code: 0, message: 'Something broke' });
+			expect(Container.get(ErrorReporter).error).toHaveBeenCalled();
+		});
+
+		it('should leave a successful response untouched', async () => {
+			const { text } = await request(app).get('/rest/test/template/rendered').expect(200);
+			expect(text).toBe('<html lang="en"></html>');
 		});
 	});
 

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -22,7 +22,8 @@ import assert from 'node:assert';
 import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
 import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
-import { send } from '@/response-helper';
+import { reportError, send, sendErrorResponse } from '@/response-helper';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
 
 import { AbstractServer } from './abstract-server';
 import { NotFoundError } from './errors/response-errors/not-found.error';
@@ -121,7 +122,18 @@ export class ControllerRegistry {
 			const middlewares = this.buildMiddlewares(route, controllerMiddlewares, bodyArgType);
 			const finalHandler = route.usesTemplates
 				? async (req: Request, res: Response) => {
-						await handler(req, res);
+						try {
+							await handler(req, res);
+						} catch (e) {
+							// Template routes skip `send()`, so without this a thrown error
+							// reaches Express's default handler, which cannot read
+							// `httpStatusCode` off a ResponseError and answers 500 — and in
+							// production with a body of just "Internal Server Error".
+							const error = ensureError(e);
+							reportError(error, { extra: { method: req.method, path: req.path } });
+							if (res.headersSent) throw error;
+							sendErrorResponse(res, error);
+						}
 					}
 				: send(handler);
 

--- a/packages/cli/src/modules/provisioning.ee/constants.ts
+++ b/packages/cli/src/modules/provisioning.ee/constants.ts
@@ -1,1 +1,9 @@
+import { SSO_ERROR_ACCESS_DENIED, SSO_ERROR_QUERY_PARAM } from '@n8n/api-types';
+
 export const PROVISIONING_PREFERENCES_DB_KEY = 'features.provisioning';
+
+/**
+ * Instance-relative path the SSO callbacks redirect a login denied by role
+ * mapping to, where the UI explains that the user has no access.
+ */
+export const SSO_ACCESS_DENIED_REDIRECT_PATH = `/signin?${SSO_ERROR_QUERY_PARAM}=${SSO_ERROR_ACCESS_DENIED}`;

--- a/packages/cli/src/modules/provisioning.ee/errors/sso-access-denied.error.ts
+++ b/packages/cli/src/modules/provisioning.ee/errors/sso-access-denied.error.ts
@@ -1,0 +1,14 @@
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+
+/**
+ * An SSO login denied because role mapping resolved to "Block access".
+ *
+ * Kept distinct from a generic authentication failure so the SSO callbacks can
+ * send the user somewhere that explains they have no access, instead of
+ * surfacing it as something that went wrong.
+ */
+export class SsoAccessDeniedError extends ForbiddenError {
+	constructor() {
+		super('Access denied by SSO role mapping configuration');
+	}
+}

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -25,13 +25,13 @@ import { jsonParse } from 'n8n-workflow';
 import { ZodError } from 'zod';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserService } from '@/services/user.service';
 
 import { PROVISIONING_PREFERENCES_DB_KEY } from './constants';
+import { SsoAccessDeniedError } from './errors/sso-access-denied.error';
 import { RoleMappingRuleService } from './role-mapping-rule.service.ee';
 import type { RoleMappingConfig, ResolvedRoles, RoleResolverContext } from './role-resolver-types';
 import { RoleResolverService } from './role-resolver.service.ee';
@@ -744,7 +744,7 @@ export class ProvisioningService {
 						matchedRuleId: null,
 						isFallback: true,
 					});
-					throw new ForbiddenError('Access denied by SSO role mapping configuration');
+					throw new SsoAccessDeniedError();
 				}
 				return;
 			}
@@ -761,7 +761,7 @@ export class ProvisioningService {
 					matchedRuleId: resolved.instanceRole.matchedRuleId,
 					isFallback: resolved.instanceRole.isFallback,
 				});
-				throw new ForbiddenError('Access denied by SSO role mapping configuration');
+				throw new SsoAccessDeniedError();
 			}
 			return;
 		}
@@ -774,7 +774,7 @@ export class ProvisioningService {
 			this.logger.warn('SSO login blocked: no recognised instance role claim', {
 				provider: context.$provider,
 			});
-			throw new ForbiddenError('Access denied by SSO role mapping configuration');
+			throw new SsoAccessDeniedError();
 		}
 	}
 

--- a/packages/cli/src/modules/sso-oidc/__tests__/oidc.controller.ee.test.ts
+++ b/packages/cli/src/modules/sso-oidc/__tests__/oidc.controller.ee.test.ts
@@ -8,6 +8,7 @@ import { mock } from 'vitest-mock-extended';
 import type { AuthService } from '@/auth/auth.service';
 import { OIDC_NONCE_COOKIE_NAME, OIDC_STATE_COOKIE_NAME } from '@/constants';
 import type { EventService } from '@/events/event.service';
+import { SsoAccessDeniedError } from '@/modules/provisioning.ee/errors/sso-access-denied.error';
 import type { AuthlessRequest } from '@/requests';
 import type { UrlService } from '@/services/url.service';
 
@@ -263,6 +264,31 @@ describe('OidcController', () => {
 				authenticationMethod: 'oidc',
 			});
 			expect(res.redirect).toHaveBeenCalledWith('/');
+		});
+
+		test('Should redirect a login denied by role mapping to the sign-in page', async () => {
+			const req = mock<AuthlessRequest>({
+				originalUrl: '/sso/oidc/callback?code=auth_code&state=state_value',
+				cookies: {
+					[OIDC_STATE_COOKIE_NAME]: 'state_value',
+					[OIDC_NONCE_COOKIE_NAME]: 'nonce_value',
+				},
+			});
+			const res = mock<Response>();
+
+			oidcService.loginUser.mockRejectedValueOnce(new SsoAccessDeniedError());
+
+			await controller.callbackHandler(req, res);
+
+			expect(res.redirect).toHaveBeenCalledWith(
+				'http://localhost:5678/signin?ssoError=access-denied',
+			);
+			expect(authService.issueCookie).not.toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith('user-login-failed', {
+				userEmail: 'unknown',
+				authenticationMethod: 'oidc',
+			});
+			expect(eventService.emit).not.toHaveBeenCalledWith('user-logged-in', expect.anything());
 		});
 
 		test('Should render success page in test mode without creating session', async () => {

--- a/packages/cli/src/modules/sso-oidc/oidc.controller.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.controller.ee.ts
@@ -2,7 +2,7 @@ import { OidcConfigDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig, InstanceSettingsLoaderConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
-import { AuthenticatedRequest } from '@n8n/db';
+import { AuthenticatedRequest, type User } from '@n8n/db';
 import { Body, Get, GlobalScope, Licensed, Post, RestController } from '@n8n/decorators';
 import { Request, Response } from 'express';
 
@@ -11,6 +11,8 @@ import { OIDC_NONCE_COOKIE_NAME, OIDC_STATE_COOKIE_NAME } from '@/constants';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
+import { SSO_ACCESS_DENIED_REDIRECT_PATH } from '@/modules/provisioning.ee/constants';
+import { SsoAccessDeniedError } from '@/modules/provisioning.ee/errors/sso-access-denied.error';
 import { AuthlessRequest } from '@/requests';
 import { UrlService } from '@/services/url.service';
 import { isOidcCurrentAuthenticationMethod } from '@/sso.ee/sso-helpers';
@@ -141,7 +143,20 @@ export class OidcController {
 			}
 		}
 
-		const { user, idToken } = await this.oidcService.loginUser(callbackUrl, state, nonce);
+		let user: User;
+		let idToken: string | undefined;
+		try {
+			({ user, idToken } = await this.oidcService.loginUser(callbackUrl, state, nonce));
+		} catch (error) {
+			if (error instanceof SsoAccessDeniedError) {
+				this.eventService.emit('user-login-failed', {
+					userEmail: 'unknown',
+					authenticationMethod: 'oidc',
+				});
+				return res.redirect(this.urlService.getInstanceBaseUrl() + SSO_ACCESS_DENIED_REDIRECT_PATH);
+			}
+			throw error;
+		}
 
 		this.authService.issueCookie(res, user, true, req.browserId);
 

--- a/packages/cli/src/modules/sso-saml/__tests__/saml.controller.ee.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml.controller.ee.test.ts
@@ -8,6 +8,7 @@ import { mock } from 'vitest-mock-extended';
 
 import type { AuthService } from '@/auth/auth.service';
 import type { EventService } from '@/events/event.service';
+import { SsoAccessDeniedError } from '@/modules/provisioning.ee/errors/sso-access-denied.error';
 import type { AuthlessRequest } from '@/requests';
 import type { UrlService } from '@/services/url.service';
 import { isSamlLicensedAndEnabled } from '@/sso.ee/sso-helpers';
@@ -302,6 +303,24 @@ describe('SAML Login Flow', () => {
 
 		expect(authService.issueCookie).toHaveBeenCalledWith(res, user, true, 'test-browser-id');
 		expect(res.redirect).toHaveBeenCalledWith('http://localhost:5678/custom/redirect');
+	});
+
+	test('Should redirect a login denied by role mapping to the sign-in page', async () => {
+		const req = mock<AuthlessRequest>({ browserId: 'test-browser-id' });
+		const res = mock<Response>();
+
+		samlService.handleSamlLogin.mockRejectedValueOnce(new SsoAccessDeniedError());
+
+		await controller.acsPost(req, res, { RelayState: '/' });
+
+		expect(res.redirect).toHaveBeenCalledWith(
+			'http://localhost:5678/signin?ssoError=access-denied',
+		);
+		expect(authService.issueCookie).not.toHaveBeenCalled();
+		expect(eventService.emit).toHaveBeenCalledWith('user-login-failed', {
+			userEmail: 'unknown',
+			authenticationMethod: 'saml',
+		});
 	});
 
 	describe('Redirect URL Validation', () => {

--- a/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
@@ -12,6 +12,8 @@ import { AuthService } from '@/auth/auth.service';
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
+import { SSO_ACCESS_DENIED_REDIRECT_PATH } from '@/modules/provisioning.ee/constants';
+import { SsoAccessDeniedError } from '@/modules/provisioning.ee/errors/sso-access-denied.error';
 import { AuthlessRequest } from '@/requests';
 import { sendErrorResponse } from '@/response-helper';
 import { UrlService } from '@/services/url.service';
@@ -190,6 +192,11 @@ export class SamlController {
 				userEmail: 'unknown',
 				authenticationMethod: 'saml',
 			});
+			// A login denied by role mapping is not a failure to authenticate: send the
+			// user to the sign-in page, which explains they have no access.
+			if (error instanceof SsoAccessDeniedError) {
+				return res.redirect(this.urlService.getInstanceBaseUrl() + SSO_ACCESS_DENIED_REDIRECT_PATH);
+			}
 			// Need to manually send the error response since we're using templates
 			return sendErrorResponse(
 				res,

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -1085,6 +1085,26 @@ describe('SAML SSO provisioning', () => {
 		expect(userFromDB.role.slug).toBe('global:admin');
 	});
 
+	it('should redirect a blocked login to the sign-in page instead of answering with an error', async () => {
+		const provisioningService = Container.get(ProvisioningService);
+		// @ts-expect-error - provisioningConfig is private
+		provisioningService.provisioningConfig.defaultInstanceRole = BLOCK_ACCESS_ASSIGNMENT;
+
+		vi.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+			mapped: {
+				email: 'saml-blocked-over-http@example.com',
+				firstName: 'SAML',
+				lastName: 'User',
+				userPrincipalName: 'saml-blocked-over-http',
+			},
+			raw: { email: 'saml-blocked-over-http@example.com', department: 'sales' },
+		});
+
+		const response = await authOwnerAgent.post('/sso/saml/acs').expect(302);
+
+		expect(response.headers.location).toContain('/signin?ssoError=access-denied');
+	});
+
 	it('should provision project role via expression mapping', async () => {
 		const project = await createTeamProject('saml-expr-project-role-test');
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -239,6 +239,8 @@
 	"auth.setup.setupOwner": "Set up owner account",
 	"auth.signin": "Sign in",
 	"auth.signin.error": "Problem logging in",
+	"auth.signin.accessDenied.title": "You don't have access to n8n",
+	"auth.signin.accessDenied": "Your role or permissions do not currently give you access to n8n. Please speak to your administrator if you think this is incorrect.",
 	"auth.signin.sessionExpired.title": "Session expired",
 	"auth.signin.sessionExpired": "Your session has expired. Please log in again to continue using n8n.",
 	"auth.signout": "Sign out",

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
@@ -126,6 +126,24 @@ describe('SigninView', () => {
 		expect(showMessage).not.toHaveBeenCalled();
 	});
 
+	it('should show a no-access toast when the SSO login was denied by role mapping', () => {
+		const route = useRoute();
+		vi.spyOn(route, 'query', 'get').mockReturnValue({
+			ssoError: 'access-denied',
+		});
+
+		renderComponent();
+
+		expect(showMessage).toHaveBeenCalledWith({
+			title: "You don't have access to n8n",
+			message:
+				'Your role or permissions do not currently give you access to n8n. Please speak to your administrator if you think this is incorrect.',
+			type: 'error',
+			duration: 0,
+		});
+		expect(notificationsStore.setNotificationsSuppressed.mock.calls).toEqual([[false], [true]]);
+	});
+
 	it('should show and submit email/password form (happy path)', async () => {
 		await signInWithValidUser();
 

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
@@ -17,6 +17,7 @@ import { useSSOStore } from '@/features/settings/sso/sso.store';
 import type { IFormBoxConfig } from '@/Interface';
 import { MFA_AUTHENTICATION_REQUIRED_ERROR_CODE, VIEWS, MFA_FORM } from '@/app/constants';
 import type { LoginRequestDto } from '@n8n/api-types';
+import { SSO_ERROR_ACCESS_DENIED, SSO_ERROR_QUERY_PARAM } from '@n8n/api-types';
 
 export type EmailOrLdapLoginIdAndPassword = Pick<
 	LoginRequestDto,
@@ -44,18 +45,36 @@ const reportError = ref(false);
 
 const notificationsStore = useNotificationsStore();
 
+// Notifications are suppressed on the auth views, so lift the suppression just
+// for this message.
+const showAuthViewMessage = (messageData: Parameters<typeof toast.showMessage>[0]) => {
+	notificationsStore.setNotificationsSuppressed(false);
+	toast.showMessage(messageData);
+	notificationsStore.setNotificationsSuppressed(true);
+};
+
 onMounted(() => {
+	// An SSO login denied by role mapping ("Block access"): the user authenticated
+	// fine at the IdP, they are simply not allowed in, so say exactly that.
+	if (route.query[SSO_ERROR_QUERY_PARAM] === SSO_ERROR_ACCESS_DENIED) {
+		showAuthViewMessage({
+			title: locale.baseText('auth.signin.accessDenied.title'),
+			message: locale.baseText('auth.signin.accessDenied'),
+			type: 'error',
+			duration: 0,
+		});
+		return;
+	}
+
 	if (route.query.sessionExpired !== 'true') {
 		return;
 	}
 
-	notificationsStore.setNotificationsSuppressed(false);
-	toast.showMessage({
+	showAuthViewMessage({
 		title: locale.baseText('auth.signin.sessionExpired.title'),
 		message: locale.baseText('auth.signin.sessionExpired'),
 		type: 'info',
 	});
-	notificationsStore.setNotificationsSuppressed(true);
 });
 
 // Covers leaving via e.g. "Forgot password", which login() below never sees.


### PR DESCRIPTION
## Summary

When the SSO role-mapping **default condition** is set to **Block access**, a denied login showed **"Internal Server Error"** instead of telling the user they have no access. The denial itself worked correctly (no account created, existing accounts untouched) — only the response was wrong: `usesTemplates` routes bypass `send()`, so the thrown error reached Express's default handler, which can't read `httpStatusCode` off a `ResponseError` and answers 500. This adds an error path for template routes (`reportError` → `sendErrorResponse`, so a response error keeps its status), introduces `SsoAccessDeniedError` so the SAML ACS and OIDC callback handlers can tell a denial apart from a failure to authenticate, and redirects a denied login to the sign-in page with a clear message: **"You don't have access to n8n — Your role or permissions do not currently give you access to n8n. Please speak to your administrator if you think this is incorrect."**

Worth noting for reviewers: the 500 is not specific to Block access. `usesTemplates: true` was added to `GET /sso/oidc/callback` in #27824 (2.16.0) for the test-login views, so since then *every* OIDC login failure — "Invalid state", "Invalid authorization code", "An email is required" — has surfaced as a bare 500; those now return their real status too. The same latent bug affected the OAuth server's six template routes, which had no `try`/`catch` at all.

## How to test

Requires an enterprise license with SSO enabled (SAML or OIDC) and instance-role provisioning.

1. Settings → SSO → set the **default condition** to **Block access**.
2. Log in with a user that matches no mapping rule. Instead of "Internal Server Error", you land on `/signin?ssoError=access-denied` with the no-access message, and no account is created.
3. Set the default condition back to a role — the login succeeds as before.
4. OIDC only: break the flow another way (e.g. tamper with the state cookie) — the response is now a proper 400 rather than a 500.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1223

Follow-up to #35023 (the configurable default condition) and #34825 (the Block access dropdown option).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

