### PR TITLE
fix(core): Let Instance AI run a specific trigger's flow

### DIFF
--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -186,6 +186,19 @@ have the source file, load `workflow-builder`, declare representative `output`
 fixtures on the controlling upstream node, rebuild the same workflow, and verify
 again.
 
+**Never edit a saved workflow to reach a branch.** Disabling or deleting nodes to
+steer a test mutates the user's workflow and leaves it broken for as long as the
+test runs — if it is published, its triggers fire against the broken version.
+For a workflow with more than one trigger (`triggerNodes` has multiple entries):
+
+- When the user asked for a live run, pass `triggerNodeName` to
+  `executions(action="run")` — one run per trigger — and report each branch's
+  result. Naming no trigger runs only the auto-detected one.
+- `verify-built-workflow` always exercises the auto-detected trigger, so it
+  covers one branch. Say which trigger was verified and which branches were not,
+  and offer the user a live run for the rest. Do not force coverage by editing
+  the workflow.
+
 ## After build-workflow succeeds
 
 1. Read `workflowId`, `workItemId`, `triggerNodes`, `verificationReadiness`,

--- a/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
@@ -293,6 +293,30 @@ describe('executions tool', () => {
 			});
 		});
 
+		it('forwards the requested trigger node so a multi-trigger workflow runs the right branch', async () => {
+			const context = createMockContext({
+				permissions: { runWorkflow: 'always_allow' },
+				aiCreatedWorkflowIds: new Set(['wf-1']),
+			});
+			(context.executionService.run as Mock).mockResolvedValue({
+				executionId: 'exec-1',
+				status: 'success',
+			});
+
+			const tool = createExecutionsTool(context);
+			await executeTool(
+				tool,
+				{ action: 'run' as const, workflowId: 'wf-1', triggerNodeName: 'Weekly 5pm' },
+				createAgentCtx() as never,
+			);
+
+			expect(context.executionService.run).toHaveBeenCalledWith(
+				'wf-1',
+				undefined,
+				expect.objectContaining({ triggerNodeName: 'Weekly 5pm' }),
+			);
+		});
+
 		describe('session grant (always allow)', () => {
 			it('runs without HITL when the workflow has a session grant', async () => {
 				const context = createMockContext({

--- a/packages/@n8n/instance-ai/src/tools/executions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions.tool.ts
@@ -54,6 +54,17 @@ const runAction = z.object({
 				'For event-based triggers (e.g. Linear, GitHub, Slack), pass inputData matching ' +
 				'the shape the trigger would emit (e.g. { action: "create", data: { ... } }).',
 		),
+	triggerNodeName: z
+		.string()
+		.optional()
+		.describe(
+			'Name of the trigger node to start the run from. REQUIRED when the workflow has ' +
+				'more than one trigger: without it a single trigger is auto-detected and the other ' +
+				"triggers' branches never run. To run each branch, call run once per trigger. " +
+				"Trigger names come from build-workflow's `triggerNodes` or " +
+				'workflows(action="get-as-code"). Never disable, delete, or otherwise edit a saved ' +
+				'workflow to reach a branch — use this instead.',
+		),
 	timeout: z
 		.number()
 		.int()
@@ -290,6 +301,7 @@ async function handleRun(
 	// Approved or always_allow — execute
 	return await context.executionService.run(workflowId, input.inputData, {
 		timeout: input.timeout,
+		triggerNodeName: input.triggerNodeName,
 		abortSignal,
 	});
 }

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -3454,6 +3454,107 @@ describe('createExecutionAdapter run()', () => {
 		expect(firstStackItem?.data.main[0]?.[0]?.json).toEqual({});
 	});
 
+	describe('trigger selection', () => {
+		const triggerNode = (
+			name: string,
+			overrides?: { type?: string; disabled?: boolean },
+		): INode => ({
+			...makeNode(name, overrides?.type ?? 'n8n-nodes-base.scheduleTrigger'),
+			...(overrides?.disabled ? { disabled: true } : {}),
+		});
+
+		const startedFrom = (mockWorkflowRunner: { run: Mock }) =>
+			mockWorkflowRunner.run.mock.calls[0][0].triggerToStartFrom?.name;
+
+		it('starts from the named trigger instead of the first one', async () => {
+			const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+				id: 'wf-1',
+				nodes: [triggerNode('Daily 8am'), triggerNode('Weekly 5pm')],
+			});
+
+			await adapter.run('wf-1', undefined, { triggerNodeName: 'Weekly 5pm' });
+
+			expect(startedFrom(mockWorkflowRunner)).toBe('Weekly 5pm');
+		});
+
+		it('auto-detects the first trigger when none is named', async () => {
+			const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+				id: 'wf-1',
+				nodes: [triggerNode('Daily 8am'), triggerNode('Weekly 5pm')],
+			});
+
+			await adapter.run('wf-1');
+
+			expect(startedFrom(mockWorkflowRunner)).toBe('Daily 8am');
+		});
+
+		it('skips a disabled trigger when auto-detecting', async () => {
+			const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+				id: 'wf-1',
+				nodes: [triggerNode('Daily 8am', { disabled: true }), triggerNode('Weekly 5pm')],
+			});
+
+			await adapter.run('wf-1');
+
+			expect(startedFrom(mockWorkflowRunner)).toBe('Weekly 5pm');
+		});
+
+		it('falls back to a disabled trigger when every trigger is disabled', async () => {
+			const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+				id: 'wf-1',
+				nodes: [
+					triggerNode('Daily 8am', { disabled: true }),
+					triggerNode('Weekly 5pm', { disabled: true }),
+				],
+			});
+
+			await adapter.run('wf-1');
+
+			expect(startedFrom(mockWorkflowRunner)).toBe('Daily 8am');
+		});
+
+		it('prefers a known trigger type over an unknown one earlier in the node list', async () => {
+			const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+				id: 'wf-1',
+				nodes: [
+					triggerNode('On Interval', { type: 'n8n-nodes-base.cron' }),
+					triggerNode('On Chat Message', { type: '@n8n/n8n-nodes-langchain.chatTrigger' }),
+				],
+			});
+
+			await adapter.run('wf-1');
+
+			expect(startedFrom(mockWorkflowRunner)).toBe('On Chat Message');
+		});
+
+		it('rejects an unknown trigger name instead of running a different branch', async () => {
+			const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+				id: 'wf-1',
+				nodes: [triggerNode('Daily 8am'), triggerNode('Weekly 5pm')],
+			});
+
+			await expect(
+				adapter.run('wf-1', undefined, { triggerNodeName: 'Weekly 5PM' }),
+			).rejects.toThrow(/Weekly 5PM.*Daily 8am.*Weekly 5pm/s);
+			expect(mockWorkflowRunner.run).not.toHaveBeenCalled();
+		});
+
+		it('rejects a named node that is not a trigger', async () => {
+			const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+				id: 'wf-1',
+				nodes: [
+					triggerNode('Daily 8am'),
+					triggerNode('Compute Daily', { type: 'n8n-nodes-base.code' }),
+				],
+			});
+
+			await expect(
+				adapter.run('wf-1', undefined, { triggerNodeName: 'Compute Daily' }),
+			).rejects.toThrow(/Compute Daily/);
+			expect(mockWorkflowRunner.run).not.toHaveBeenCalled();
+		});
+	});
+
 	it('opts a verification run out of the error workflow, on the main process and on a worker', async () => {
 		const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
 			id: 'wf-1',

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1189,11 +1189,10 @@ export class InstanceAiAdapterService {
 
 				const nodes = workflow.nodes ?? [];
 
-				// Use the explicitly requested trigger node when provided,
-				// otherwise auto-detect using known trigger type constants
-				// then fall back to naive string matching for unknown trigger types
+				// Use the explicitly requested trigger node when provided — the only way to
+				// pick a branch in a multi-trigger workflow — otherwise auto-detect.
 				const triggerNode = options?.triggerNodeName
-					? (nodes.find((n) => n.name === options.triggerNodeName) ?? findTriggerNode(nodes))
+					? resolveRequestedTriggerNode(nodes, options.triggerNodeName)
 					: findTriggerNode(nodes);
 
 				const timeoutMs = Math.min(options?.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
@@ -3589,7 +3588,7 @@ export async function extractNodeOutput(
 	};
 }
 
-/** Known trigger node types in priority order. */
+/** Trigger node types we know how to make runnable, preferred over any other. */
 const KNOWN_TRIGGER_TYPES = new Set([
 	CHAT_TRIGGER_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,
@@ -3598,16 +3597,58 @@ const KNOWN_TRIGGER_TYPES = new Set([
 ]);
 
 /**
- * Find the trigger node: known types first (priority among multiple triggers),
- * then the canonical n8n-workflow detection — the same detection the
- * instance-ai simulation planner uses, so a trigger the planner simulates
- * (e.g. suffix-less cron/emailReadImap) is always found here too.
+ * Find the trigger node to start from: known types first, then the canonical
+ * n8n-workflow detection — the same detection the instance-ai simulation planner
+ * uses, so a trigger the planner simulates (e.g. suffix-less
+ * cron/emailReadImap) is always found here too.
+ *
+ * Among equally-eligible triggers, enabled ones win and then node order decides,
+ * so the pick stays predictable for the caller (a multi-trigger workflow should
+ * name its trigger explicitly rather than rely on this). Filtering out disabled
+ * triggers is what makes "disable the other trigger" a working way to choose a
+ * branch; without it, a disabled trigger was still selected and its branch ran.
  */
 function findTriggerNode(nodes: INode[]): INode | undefined {
-	const known = nodes.find((n) => KNOWN_TRIGGER_TYPES.has(n.type));
-	if (known) return known;
+	const byPreference = [
+		(n: INode) => KNOWN_TRIGGER_TYPES.has(n.type),
+		(n: INode) => isTriggerNodeType(n.type),
+	];
 
-	return nodes.find((n) => isTriggerNodeType(n.type));
+	for (const isEligible of byPreference) {
+		const enabled = nodes.find((n) => isEligible(n) && !n.disabled);
+		if (enabled) return enabled;
+	}
+
+	// Every trigger is disabled — still start from one rather than silently
+	// degrading to a manual whole-workflow run.
+	for (const isEligible of byPreference) {
+		const anyTrigger = nodes.find((n) => isEligible(n));
+		if (anyTrigger) return anyTrigger;
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolve the caller-requested trigger. Unlike auto-detection this must never
+ * fall through to a different node: silently running another branch is how a
+ * typo turns into "the agent ran the wrong flow".
+ */
+function resolveRequestedTriggerNode(nodes: INode[], triggerNodeName: string): INode {
+	const requested = nodes.find((n) => n.name === triggerNodeName);
+	if (requested && isTriggerNodeType(requested.type)) return requested;
+
+	const available = nodes.filter((n) => isTriggerNodeType(n.type)).map((n) => `"${n.name}"`);
+	const reason = requested
+		? `"${triggerNodeName}" is not a trigger node`
+		: `Trigger node "${triggerNodeName}" not found in the workflow`;
+	throw new UserError(
+		`${reason}. ${
+			available.length > 0
+				? `Available trigger nodes: ${available.join(', ')}.`
+				: 'This workflow has no trigger nodes.'
+		}`,
+	);
 }
 
 /** Copy of `connections` minus every listed source→target edge (any type). */


### PR DESCRIPTION
## Summary

In a workflow with more than one trigger, the assistant could not run one branch or
the other — `executions(action="run")` had no way to say which trigger to start from,
so every run started from the auto-detected one and the other branches were
unreachable.

The workaround it improvised was destructive. In the reported thread it disabled the
daily trigger (which didn't help — see below), then **deleted the daily branch from the
saved workflow**, ran the weekly branch, and restored it afterwards: four saves of the
user's live workflow, four approval prompts, and a window in which the saved workflow
was missing a branch. The workflow also wrote to a Data Table, so wrong-branch runs
mutated real state.

Three changes:

1. **`executions(action="run")` takes `triggerNodeName`.** The execution service and the
   n8n adapter already accepted it (`workflows(action="setup")` uses it for its trigger
   test) — the tool schema just never exposed it, and `handleRun` dropped it. The
   parameter description tells the agent it is required when a workflow has more than one
   trigger, and that editing a saved workflow to reach a branch is not the way.

2. **Trigger auto-detection skips disabled triggers.** It previously ignored `disabled`
   entirely, which is why disabling the other trigger — the one non-destructive thing the
   agent tried — still ran the disabled branch. If *every* trigger is disabled we still
   start from one, so nothing changes for that case.

3. **An unresolvable `triggerNodeName` now errors.** It used to fall back to
   auto-detection, so a typo silently ran a *different* branch. It now raises a
   `UserError` listing the workflow's actual trigger names, matching what the MCP
   `test_workflow` tool already does.

Plus a `post-build-flow` skill rule: never edit a saved workflow to reach a branch; on a
multi-trigger workflow pass `triggerNodeName` per branch for a live run, and since
`verify-built-workflow` still exercises only the auto-detected trigger, report which
branch was covered instead of forcing coverage.

### Deliberate behaviour changes

- Auto-detection now prefers enabled triggers. Single-trigger workflows are unaffected.
- An unresolvable `triggerNodeName` errors instead of silently running another branch.
  This also affects `workflows(action="setup")`, which previously could test the wrong
  trigger on a name mismatch.

### Known follow-up (not in this PR)

`verify-built-workflow` runs through the same auto-detection and does **not** take
`triggerNodeName`, so post-build verification still covers only one branch of a
multi-trigger workflow. The skill rule above makes the agent report that honestly rather
than work around it; threading the parameter through verification is the next step.

## How to test

Unit tests cover the whole matrix:

```bash
cd packages/cli && pnpm test src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
cd packages/@n8n/instance-ai && pnpm test src/tools/__tests__/executions.tool.test.ts
```

End to end: ask the assistant to build a workflow with two schedule triggers (e.g. a
daily 8am reminder and a Friday 5pm summary), then ask it to run both for real. Expect
two `executions(action="run")` calls carrying different `triggerNodeName` values, no
`build-workflow` call between them, and the saved workflow untouched at the end.

Calibrated against a live instance carrying this branch — the agent picked up the new
parameter unprompted and ran `triggerNodeName: 'Every Day 8am'` then
`'Every Friday 5pm'`, with no workflow edits in between.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1132

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

