### PR TITLE
fix(editor): Keep cursor position when clicking into an expression editor

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.test.ts
@@ -364,6 +364,25 @@ describe('useExpressionEditor', () => {
 			expect(toValue(editor)?.state.selection).toEqual(EditorSelection.single(3));
 		});
 
+		test('should keep the cursor position set by a click', async () => {
+			const editorValue = 'text here';
+			const {
+				expressionEditor: { editor },
+			} = await renderExpressionEditor({
+				editorValue,
+				initialCursorPosition: 'end',
+			});
+
+			const view = toValue(editor);
+			if (!view) throw new Error('editor not created');
+			await fireEvent.mouseDown(view.contentDOM);
+			view.dispatch({ selection: EditorSelection.cursor(2) });
+			view.focus();
+			await new Promise((resolve) => requestAnimationFrame(resolve));
+
+			expect(view.state.selection).toEqual(EditorSelection.single(2));
+		});
+
 		test('should default to position 0 when no option is provided', async () => {
 			const editorValue = 'Hello {{  }}';
 			const {

--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
@@ -304,6 +304,8 @@ export const useExpressionEditor = ({
 				EditorView.contentAttributes.of({ 'data-gramm': 'false' }), // disable grammarly
 				EditorView.domEventHandlers({
 					mousedown: () => {
+						// A click sets its own cursor; don't override it with the initial position
+						hasReceivedFocus = true;
 						dragging.value = true;
 					},
 				}),


### PR DESCRIPTION
## Summary

Clicking into an inline expression editor moved the cursor to the clicked position, then a deferred dispatch jumped it to the initial cursor position (end of the last expression). The dispatch was added in #30030 to place the caret inside `{{ }}` on auto-switch to expression mode, but it also fired when the first focus came from a mouse click. The editor's `mousedown` handler now disarms the initial-selection dispatch, so a click keeps its own cursor while programmatic focus (the auto-switch flow) keeps the initial placement.

## How to test

1. Open a node and set a parameter to an expression, e.g. `text {{ $json.foo }} more text`.
2. Close and reopen the NDV, then click into the middle of the expression value.
3. The cursor must stay at the clicked position instead of jumping to the end of the expression.
4. Type `{{` in a fixed-mode input: the caret must still land inside the brackets after the auto-switch.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5799

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

