### PR TITLE
fix(core): Build AI proxy dispatchers on undici v7 (no-changelog)

### DIFF
--- a/packages/@n8n/ai-utilities/package.json
+++ b/packages/@n8n/ai-utilities/package.json
@@ -144,7 +144,7 @@
     "js-tiktoken": "catalog:",
     "@thednp/dommatrix": "^2.0.12",
     "pdf-parse": "catalog:",
-    "undici": "catalog:undici-v6"
+    "undici": "catalog:undici-v7"
   },
   "license": "LicenseRef-n8n-sustainable-use"
 }

--- a/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
+++ b/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
@@ -2,25 +2,24 @@
  * Proxy/transport helpers for the AI model suppliers.
  *
  * These are the last AI proxy-fetch helpers not yet consolidated onto `@n8n/backend-network`.
- * They are kept here because their consumers (the langchain providers, e.g. `@langchain/openai` / `@langchain/anthropic`) pin
- * undici v6 and inject the proxy via `fetchOptions: { dispatcher }`,
- * while `@n8n/backend-network` builds undici v7 dispatchers.
  *
- * A v7 `Dispatcher` is not interoperable with a v6 `fetch` (the dispatch-handler protocol differs),
- * so the dispatcher produced here cannot simply come from backend-network.
+ * The dispatchers built here are handed to AI SDK clients via
+ * `fetchOptions: { dispatcher }` and dispatched by the global `fetch`. They
+ * must come from undici v7: a v7 dispatcher accepts the dispatch handlers of
+ * every supported Node's fetch, while a v6 dispatcher rejects the v7 handlers
+ * of Node >= 26 (`invalid onError method`).
  *
  * Proxy URL resolution and the Node `http(s).Agent` (both version-agnostic) do come from `@n8n/backend-network/proxy`,
  * so this module no longer depends on `proxy-from-env` / `https-proxy-agent` directly.
  *
- * TODO: once these consumers move to undici v7, drop these helpers and route
- * their calls through `@n8n/backend-network/transport` (use `asCustomFetch()`,
- * a self-contained `fetch` that is version-agnostic, rather than handing out a
- * raw dispatcher). See CAT-3377 for the consolidation this completes.
+ * TODO: drop these helpers and route their calls through
+ * `@n8n/backend-network/transport` (CAT-3377 consolidated the backend callers
+ * and left these runner-side ones in place).
  */
 import { createHttpsProxyAgent, resolveProxyUrl } from '@n8n/backend-network/proxy'; // `@n8n/backend-network/proxy` is a DI-free subpath: it pulls in only the proxy-agent libs
 import type { AgentOptions } from 'node:https';
 import type { LookupFunction } from 'node:net';
-/* eslint-disable n8n-local-rules/no-uncentralized-http -- langchain consumers pin undici v6, incompatible with backend-network's v7 dispatchers; see block comment below */
+/* eslint-disable n8n-local-rules/no-uncentralized-http -- raw dispatchers for AI SDK `fetchOptions`; see block comment above */
 import { Agent, ProxyAgent, fetch as undiciFetch } from 'undici';
 
 /**

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -576,13 +576,12 @@ export class LmChatAnthropic implements INodeType {
 			};
 		};
 
-		const clientOptions: {
-			fetchOptions?: { dispatcher: ReturnType<typeof getProxyAgent> };
-			defaultHeaders?: Record<string, string>;
-		} = {
+		const clientOptions: NonNullable<ChatAnthropicInput['clientOptions']> = {
+			// undici v7 and the SDK's bundled fetch types disagree structurally
+			// (FormData iterators), so the dispatcher cannot carry its own type here.
 			fetchOptions: {
 				dispatcher: getProxyAgent(baseURL),
-			},
+			} as NonNullable<ChatAnthropicInput['clientOptions']>['fetchOptions'],
 		};
 
 		const customHeader = getCustomCredentialHeader(credentials);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1176,8 +1176,8 @@ importers:
         specifier: 3.0.3
         version: 3.0.3
       undici:
-        specifier: catalog:undici-v6
-        version: 6.28.0
+        specifier: catalog:undici-v7
+        version: 7.29.0
       zod:
         specifier: 3.25.76
         version: 3.25.76


### PR DESCRIPTION
## Summary

The AI proxy helpers in `@n8n/ai-utilities` build undici v6 dispatchers that AI SDK clients hand to the global `fetch` via `fetchOptions: { dispatcher }`. Node 26's global fetch is undici v7 and its dispatch-handler protocol rejects v6 , so on the upcoming Node 26 image (#36291) every such AI call fails. #36318 fixed the `proxyFetch` path. This covers the remaining ~18 `fetchOptions` call sites by bumping to v7. 

Verified end to end: the chat-hub e2e specs that fail deterministically on the upcoming Node 26 image (#36291) pass on a local Node 26 image with this fix.

## Related Linear tickets, Github issues, and Community forum posts

https://app.notion.com/p/n8n/Halving-memory-usage-via-pointer-compression-3ac5b6e0c94f8005af87e93a9f837b53

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)