### PR TITLE
fix(core): Resolve $execution.mode as test inside sub-workflows of manual executions

### DIFF
--- a/packages/cli/test/integration/execution-mode-in-subworkflow.test.ts
+++ b/packages/cli/test/integration/execution-mode-in-subworkflow.test.ts
@@ -44,7 +44,7 @@ function modeReporterNode(name: string, position: [number, number]) {
 	};
 }
 
-/** Filter node reproducing the reported condition: keep items only on a manual run. */
+/** Filter node that keeps an item only when `$execution.mode` resolves to 'test'. */
 function testModeFilterNode(name: string, position: [number, number]) {
 	return {
 		parameters: {
@@ -282,6 +282,7 @@ describe('$execution.mode inside a manually started run', () => {
 
 		const grandchildExecution = await getExecutionWithData(grandchildExecutionSummary.id);
 
+		expect(grandchildExecution.status).toBe('success');
 		expect(outputItems(grandchildExecution, 'Report Mode')[0].json.executionMode).toBe('test');
 		expect(outputItems(grandchildExecution, 'Only Test')).toHaveLength(1);
 	});

--- a/packages/cli/test/integration/execution-mode-in-subworkflow.test.ts
+++ b/packages/cli/test/integration/execution-mode-in-subworkflow.test.ts
@@ -1,0 +1,315 @@
+/**
+ * `$execution.mode` is documented as 'test' whenever the run was started by hand and
+ * 'production' otherwise. A sub-workflow of a manual run executes as 'integrated', so
+ * these tests pin down what expressions inside it actually observe.
+ */
+
+import { testDb, createWorkflow, createActiveWorkflow } from '@n8n/backend-test-utils';
+import { ExecutionRepository, type IWorkflowDb } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { NodeConnectionTypes } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
+
+import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+
+import { createOwner } from './shared/db/users';
+import * as utils from './shared/utils';
+import { loadNodesFromDist } from './shared/utils/node-types-data';
+import {
+	createParentWorkflowFixture,
+	createMiddleWorkflowFixture,
+} from './shared/workflow-fixtures';
+
+/** Set node that records the resolved `$execution.mode` so it can be asserted on. */
+function modeReporterNode(name: string, position: [number, number]) {
+	return {
+		parameters: {
+			assignments: {
+				assignments: [
+					{
+						id: uuid(),
+						name: 'executionMode',
+						value: '={{ $execution.mode }}',
+						type: 'string',
+					},
+				],
+			},
+			options: {},
+		},
+		type: 'n8n-nodes-base.set',
+		typeVersion: 3.4,
+		position,
+		id: uuid(),
+		name,
+	};
+}
+
+/** Filter node reproducing the reported condition: keep items only on a manual run. */
+function testModeFilterNode(name: string, position: [number, number]) {
+	return {
+		parameters: {
+			conditions: {
+				options: {
+					caseSensitive: true,
+					leftValue: '',
+					typeValidation: 'strict',
+				},
+				conditions: [
+					{
+						id: uuid(),
+						leftValue: '={{ $execution.mode }}',
+						rightValue: 'test',
+						operator: {
+							type: 'string',
+							operation: 'equals',
+						},
+					},
+				],
+				combinator: 'and',
+			},
+			options: {},
+		},
+		type: 'n8n-nodes-base.filter',
+		typeVersion: 2.2,
+		position,
+		id: uuid(),
+		name,
+	};
+}
+
+function chain(first: string, second: string, third: string) {
+	const link = (node: string) => ({
+		main: [[{ node, type: NodeConnectionTypes.Main, index: 0 }]],
+	});
+	return { [first]: link(second), [second]: link(third) };
+}
+
+/** Sub-workflow that reports and filters on `$execution.mode`. */
+function createModeProbeSubWorkflowFixture() {
+	return {
+		nodes: [
+			{
+				parameters: { workflowInputs: { values: [{ name: 'test' }] } },
+				type: 'n8n-nodes-base.executeWorkflowTrigger',
+				typeVersion: 1.1,
+				position: [0, 0] as [number, number],
+				id: uuid(),
+				name: 'Trigger',
+			},
+			modeReporterNode('Report Mode', [208, 0]),
+			testModeFilterNode('Only Test', [416, 0]),
+		],
+		connections: chain('Trigger', 'Report Mode', 'Only Test'),
+		pinData: {},
+	};
+}
+
+/** Same probe, but at the top level of a manually executed workflow. */
+function createModeProbeWorkflowFixture() {
+	return {
+		nodes: [
+			{
+				parameters: {},
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0] as [number, number],
+				id: uuid(),
+				name: 'Trigger',
+			},
+			modeReporterNode('Report Mode', [208, 0]),
+			testModeFilterNode('Only Test', [416, 0]),
+		],
+		connections: chain('Trigger', 'Report Mode', 'Only Test'),
+		pinData: {},
+	};
+}
+
+describe('$execution.mode inside a manually started run', () => {
+	let owner: Awaited<ReturnType<typeof createOwner>>;
+	let workflowExecutionService: WorkflowExecutionService;
+	let executionRepository: ExecutionRepository;
+
+	beforeAll(async () => {
+		await testDb.init();
+
+		owner = await createOwner();
+
+		const nodeTypes = loadNodesFromDist([
+			'n8n-nodes-base.manualTrigger',
+			'n8n-nodes-base.executeWorkflow',
+			'n8n-nodes-base.executeWorkflowTrigger',
+			'n8n-nodes-base.set',
+			'n8n-nodes-base.filter',
+		]);
+
+		await utils.initNodeTypes(nodeTypes);
+		await utils.initBinaryDataService();
+
+		workflowExecutionService = Container.get(WorkflowExecutionService);
+		executionRepository = Container.get(ExecutionRepository);
+	});
+
+	afterEach(async () => {
+		await testDb.truncate(['ExecutionEntity', 'WorkflowEntity']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	async function waitForExecution(executionId: string, timeout = 10000) {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const execution = await executionRepository.findOneBy({ id: executionId });
+			if (execution?.finished) return;
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		throw new Error(`Execution ${executionId} did not complete within ${timeout}ms`);
+	}
+
+	async function getExecutionWithData(executionId: string) {
+		const execution = await executionRepository.findSingleExecution(executionId, {
+			includeData: true,
+			unflattenData: true,
+		});
+		if (!execution) throw new Error(`Execution ${executionId} not found`);
+		return execution;
+	}
+
+	/** Items a node emitted on its first (and here only) run, on the given output branch. */
+	function outputItems(
+		execution: Awaited<ReturnType<typeof getExecutionWithData>>,
+		nodeName: string,
+		branch = 0,
+	) {
+		const runData = execution.data.resultData.runData[nodeName];
+		expect(runData).toBeDefined();
+		return runData[0].data?.main[branch] ?? [];
+	}
+
+	async function runManually(workflow: IWorkflowDb) {
+		const result = await workflowExecutionService.executeManually(
+			workflow,
+			{ triggerToStartFrom: { name: 'Trigger' } },
+			owner,
+		);
+
+		if (!('executionId' in result) || !result.executionId) {
+			throw new Error(`Expected an executionId, instead got ${JSON.stringify(result)}`);
+		}
+
+		await waitForExecution(result.executionId);
+		return await getExecutionWithData(result.executionId);
+	}
+
+	it('resolves to test at the top level of a manual execution', async () => {
+		const workflow = await createWorkflow(
+			{ name: 'Mode Probe', ...createModeProbeWorkflowFixture() } as unknown as IWorkflowDb,
+			owner,
+		);
+
+		const execution = await runManually(workflow);
+
+		expect(execution.status).toBe('success');
+		expect(outputItems(execution, 'Report Mode')[0].json.executionMode).toBe('test');
+		expect(outputItems(execution, 'Only Test')).toHaveLength(1);
+	});
+
+	it('resolves to test inside a sub-workflow of a manual execution', async () => {
+		const childWorkflow = await createActiveWorkflow(
+			{
+				name: 'Mode Probe Sub-workflow',
+				...createModeProbeSubWorkflowFixture(),
+			} as unknown as IWorkflowDb,
+			owner,
+		);
+
+		const parentWorkflow = await createWorkflow(
+			{
+				name: 'Parent Workflow',
+				...createParentWorkflowFixture(childWorkflow.id),
+			} as unknown as IWorkflowDb,
+			owner,
+		);
+
+		await runManually(parentWorkflow);
+
+		const [childExecutionSummary] = await executionRepository.find({
+			where: { workflowId: childWorkflow.id },
+			order: { createdAt: 'DESC' },
+		});
+		expect(childExecutionSummary).toBeDefined();
+
+		const childExecution = await getExecutionWithData(childExecutionSummary.id);
+
+		expect(childExecution.status).toBe('success');
+		expect(outputItems(childExecution, 'Report Mode')[0].json.executionMode).toBe('test');
+	});
+
+	it('resolves to test two sub-workflow levels below a manual execution', async () => {
+		const grandchildWorkflow = await createActiveWorkflow(
+			{
+				name: 'Mode Probe Sub-workflow',
+				...createModeProbeSubWorkflowFixture(),
+			} as unknown as IWorkflowDb,
+			owner,
+		);
+
+		const childWorkflow = await createActiveWorkflow(
+			{
+				name: 'Middle Workflow',
+				...createMiddleWorkflowFixture(grandchildWorkflow.id),
+			} as unknown as IWorkflowDb,
+			owner,
+		);
+
+		const parentWorkflow = await createWorkflow(
+			{
+				name: 'Parent Workflow',
+				...createParentWorkflowFixture(childWorkflow.id),
+			} as unknown as IWorkflowDb,
+			owner,
+		);
+
+		await runManually(parentWorkflow);
+
+		const [grandchildExecutionSummary] = await executionRepository.find({
+			where: { workflowId: grandchildWorkflow.id },
+			order: { createdAt: 'DESC' },
+		});
+		expect(grandchildExecutionSummary).toBeDefined();
+
+		const grandchildExecution = await getExecutionWithData(grandchildExecutionSummary.id);
+
+		expect(outputItems(grandchildExecution, 'Report Mode')[0].json.executionMode).toBe('test');
+		expect(outputItems(grandchildExecution, 'Only Test')).toHaveLength(1);
+	});
+
+	it('keeps items in a sub-workflow filter that tests for a manual run', async () => {
+		const childWorkflow = await createActiveWorkflow(
+			{
+				name: 'Mode Probe Sub-workflow',
+				...createModeProbeSubWorkflowFixture(),
+			} as unknown as IWorkflowDb,
+			owner,
+		);
+
+		const parentWorkflow = await createWorkflow(
+			{
+				name: 'Parent Workflow',
+				...createParentWorkflowFixture(childWorkflow.id),
+			} as unknown as IWorkflowDb,
+			owner,
+		);
+
+		await runManually(parentWorkflow);
+
+		const [childExecutionSummary] = await executionRepository.find({
+			where: { workflowId: childWorkflow.id },
+			order: { createdAt: 'DESC' },
+		});
+		const childExecution = await getExecutionWithData(childExecutionSummary.id);
+
+		expect(outputItems(childExecution, 'Only Test')).toHaveLength(1);
+	});
+});

--- a/packages/cli/test/integration/execution-mode-in-subworkflow.test.ts
+++ b/packages/cli/test/integration/execution-mode-in-subworkflow.test.ts
@@ -215,7 +215,7 @@ describe('$execution.mode inside a manually started run', () => {
 		expect(outputItems(execution, 'Only Test')).toHaveLength(1);
 	});
 
-	it('resolves to test inside a sub-workflow of a manual execution', async () => {
+	it('resolves to test and keeps filtered items inside a sub-workflow of a manual execution', async () => {
 		const childWorkflow = await createActiveWorkflow(
 			{
 				name: 'Mode Probe Sub-workflow',
@@ -244,6 +244,7 @@ describe('$execution.mode inside a manually started run', () => {
 
 		expect(childExecution.status).toBe('success');
 		expect(outputItems(childExecution, 'Report Mode')[0].json.executionMode).toBe('test');
+		expect(outputItems(childExecution, 'Only Test')).toHaveLength(1);
 	});
 
 	it('resolves to test two sub-workflow levels below a manual execution', async () => {
@@ -283,33 +284,5 @@ describe('$execution.mode inside a manually started run', () => {
 
 		expect(outputItems(grandchildExecution, 'Report Mode')[0].json.executionMode).toBe('test');
 		expect(outputItems(grandchildExecution, 'Only Test')).toHaveLength(1);
-	});
-
-	it('keeps items in a sub-workflow filter that tests for a manual run', async () => {
-		const childWorkflow = await createActiveWorkflow(
-			{
-				name: 'Mode Probe Sub-workflow',
-				...createModeProbeSubWorkflowFixture(),
-			} as unknown as IWorkflowDb,
-			owner,
-		);
-
-		const parentWorkflow = await createWorkflow(
-			{
-				name: 'Parent Workflow',
-				...createParentWorkflowFixture(childWorkflow.id),
-			} as unknown as IWorkflowDb,
-			owner,
-		);
-
-		await runManually(parentWorkflow);
-
-		const [childExecutionSummary] = await executionRepository.find({
-			where: { workflowId: childWorkflow.id },
-			order: { createdAt: 'DESC' },
-		});
-		const childExecution = await getExecutionWithData(childExecutionSummary.id);
-
-		expect(outputItems(childExecution, 'Only Test')).toHaveLength(1);
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
@@ -151,9 +151,9 @@ describe('getAdditionalKeys', () => {
 		expect(result.$execution?.mode).toBe('production');
 	});
 
-	it('should honour the root mode for any non-manual execution mode', () => {
-		const nodeToolData = { ...additionalData, rootExecutionMode: 'manual' as const };
-		const result = getAdditionalKeys(nodeToolData, 'internal', null);
+	it('should return test mode for an internal execution whose root execution is manual', () => {
+		const subWorkflowData = { ...additionalData, rootExecutionMode: 'manual' as const };
+		const result = getAdditionalKeys(subWorkflowData, 'internal', null);
 
 		expect(result.$execution?.mode).toBe('test');
 	});

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
@@ -15,6 +15,7 @@ describe('getAdditionalKeys', () => {
 		formWaitingBaseUrl: 'https://form.test',
 		variables: { testVar: 'value' },
 		externalSecretsProxy,
+		rootExecutionMode: undefined,
 	});
 	additionalData.externalSecretProviderKeysAccessibleByCredential =
 		providerKeysAccessibleByCredential;

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
@@ -136,6 +136,27 @@ describe('getAdditionalKeys', () => {
 		expect(result.$execution?.mode).toBe('test');
 	});
 
+	it('should return test mode for a sub-workflow whose root execution is manual', () => {
+		const subWorkflowData = { ...additionalData, rootExecutionMode: 'manual' as const };
+		const result = getAdditionalKeys(subWorkflowData, 'integrated', null);
+
+		expect(result.$execution?.mode).toBe('test');
+	});
+
+	it('should return production mode for a sub-workflow whose root execution is production', () => {
+		const subWorkflowData = { ...additionalData, rootExecutionMode: 'trigger' as const };
+		const result = getAdditionalKeys(subWorkflowData, 'integrated', null);
+
+		expect(result.$execution?.mode).toBe('production');
+	});
+
+	it('should honour the root mode for any non-manual execution mode', () => {
+		const nodeToolData = { ...additionalData, rootExecutionMode: 'manual' as const };
+		const result = getAdditionalKeys(nodeToolData, 'internal', null);
+
+		expect(result.$execution?.mode).toBe('test');
+	});
+
 	it('should return variables from additionalData', () => {
 		const result = getAdditionalKeys(additionalData, 'manual', null);
 		expect(result.$vars?.testVar).toEqual('value');

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
@@ -24,6 +24,8 @@ export function getAdditionalKeys(
 	options: { isCredential: boolean } = { isCredential: false },
 ): IWorkflowDataProxyAdditionalKeys {
 	const executionId = additionalData.executionId ?? PLACEHOLDER_EMPTY_EXECUTION_ID;
+	// Sub-workflows always execute as 'integrated' regardless of what started the root run,
+	// so fall back to the root mode to keep $execution.mode accurate there too.
 	const effectiveMode = additionalData.rootExecutionMode ?? mode;
 
 	let resumeUrl = `${additionalData.webhookWaitingBaseUrl}/${executionId}`;

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
@@ -24,6 +24,7 @@ export function getAdditionalKeys(
 	options: { isCredential: boolean } = { isCredential: false },
 ): IWorkflowDataProxyAdditionalKeys {
 	const executionId = additionalData.executionId ?? PLACEHOLDER_EMPTY_EXECUTION_ID;
+	const effectiveMode = additionalData.rootExecutionMode ?? mode;
 
 	let resumeUrl = `${additionalData.webhookWaitingBaseUrl}/${executionId}`;
 	let resumeFormUrl = `${additionalData.formWaitingBaseUrl}/${executionId}`;
@@ -34,7 +35,7 @@ export function getAdditionalKeys(
 	return {
 		$execution: {
 			id: executionId,
-			mode: mode === 'manual' ? 'test' : 'production',
+			mode: effectiveMode === 'manual' ? 'test' : 'production',
 			resumeUrl,
 			resumeFormUrl,
 			customData: runExecutionData


### PR DESCRIPTION

## Summary

A sub-workflow runs under its own execution mode, `integrated`, whatever started the top-level run. `$execution.mode` only produced `'test'` for `manual`, so it returned `'production'` inside every sub-workflow.

A Filter on `{{ $execution.mode }} == 'test'` therefore discarded all its items. No error, and the execution reported success.

The engine already carries the root mode as `additionalData.rootExecutionMode`, and credential resolution already reads it. This change reads it for `$execution.mode` too.

```ts
const effectiveMode = additionalData.rootExecutionMode ?? mode;
```

The field is unset for top-level runs, so they are unchanged.

## Behaviour change

Sub-workflows of a manual run now report `'test'` instead of `'production'`. This matches the UI's own description of `test`: triggered by clicking a button in n8n.

| Case | Before | After |
|---|---|---|
| Sub-workflow, no wait | `production` | `test` |
| Sub-workflow, before a wait | `production` | `test` |
| Sub-workflow, after a resume | `production` | `production` |
| Top-level manual | `test` | `test` |
| Production trigger | `production` | `production` |

## Pre-existing bug this does not cover

`rootExecutionMode` is not restored when an execution resumes. That bug is on master today, independent of this change. It already affects credential resolution and agent dispatch. Tracked as CAT-4095, which is not a prerequisite for merging this.

Here it means a sub-workflow with a Wait node reports `'test'` before the wait and `'production'` after.

## How to test

1. Create a sub-workflow: Execute Workflow Trigger into a Filter with the condition `{{ $execution.mode }}` equals `test`
2. Create a parent: Manual Trigger into an Execute Workflow node calling it
3. Run the parent by hand

The Filter discards every item before this change, and keeps them after.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4018

Follow-up: https://linear.app/n8n/issue/CAT-4095

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

