### PR TITLE
build: Compile Kafka native binding in n8n image

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -29,6 +29,12 @@ COPY ./compiled /usr/local/lib/node_modules/n8n
 # version to the pinned image digest instead of fetching it at build time.
 RUN cd /usr/local/lib/node_modules/n8n/node_modules/sqlite3 && \
     node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js rebuild --release
+# The workspace install cannot build this binding, because CI installs on a Node version
+# Confluent ships no prebuild for, so `./compiled` arrives without one. Compile it here
+# and link against the runtime base's librdkafka. See: https://github.com/confluentinc/confluent-kafka-javascript/issues/397
+RUN apk add --no-cache librdkafka-dev && \
+    cd /usr/local/lib/node_modules/n8n/node_modules/.pnpm/@confluentinc+kafka-javascript@*/node_modules/@confluentinc/kafka-javascript && \
+    BUILD_LIBRDKAFKA=0 node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js rebuild --release
 COPY --from=native-builder /build/isolated-vm/build/Release/isolated_vm.node \
      /usr/local/lib/node_modules/n8n/node_modules/isolated-vm/build/Release/isolated_vm.node
 # node-gyp-build finds build/Release first. Delete the prebuilds to remove the glibc fallback.
@@ -36,7 +42,7 @@ RUN rm -rf /usr/local/lib/node_modules/n8n/node_modules/isolated-vm/prebuilds
 
 # The digest pins n8nio/base:24.18.1 for amd64 and arm64. A separate workflow builds that
 # image, so a new base reaches this image only when you change the digest here.
-FROM n8nio/base:24.18.1@sha256:f7a23e449f093b8b203467919e969ca35d12ba959442aadc1f69bb174b160ad2
+FROM n8nio/base:24.18.1@sha256:37248501401c48fed77ef8af4f14a244888d07081a299f2d5d50d270839f27db
 
 ARG N8N_VERSION
 ARG N8N_RELEASE_TYPE=dev


### PR DESCRIPTION
## Summary

#34032 moved CI to Node 26, where the Kafka binding cannot be installed, because Confluent ships no Node 26 prebuild, and the vendored `librdkafka` [cannot build](confluentinc/confluent-kafka-javascript#397) inside `node_modules`. My workaround stripped `@confluentinc/kafka-javascript` from `onlyBuiltDependencies` at install time for Node 26, but this turned out to leave the checkout dirty which downstream CI relies on, and this bot PR #36381 committed that removal to master because it runs the `peter-evans/create-pull-request` which commits _every modified file_ rather than just its own. Matsu's #36401 then dropped the workaround step, now dead after the bot PR.

So in end effect, no install produces the binding anymore, including the Node 24 image build, and every image since [fails](https://github.com/n8n-io/n8n/actions/runs/32016873734) the community-added Kafka smoke check.

Therefore this PR:

- Compiles the binding in the builder stage and links it against the runtime base's `librdkafka`.
- Bumps the `n8nio/base:24.18.1` digest. The pinned one predates `librdkafka` being added to the base in #34032, so it carries no `librdkafka.so`

#36291 will supersede this for Node 26.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/confluentinc/confluent-kafka-javascript/issues/397

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Covered by the existing Kafka smoke check in `docker-build-push`. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)