### PR TITLE
fix(core): Scope AI Assistant credential setup cards to the thread's project

### DIFF
--- a/packages/@n8n/api-types/src/agents/agent-interaction.schema.ts
+++ b/packages/@n8n/api-types/src/agents/agent-interaction.schema.ts
@@ -101,6 +101,9 @@ export const credentialSuspendPayloadSchema = z.object({
 	severity: z.literal('info'),
 	credentialRequests: z.array(credentialRequestSchema).min(1),
 	credentialFlow: z.object({ stage: z.literal('generic') }),
+	// Scopes the FE credential picker to the builder's project — without it the
+	// picker falls back to the user's personal project.
+	projectId: z.string().optional(),
 });
 export type CredentialSuspendPayload = z.infer<typeof credentialSuspendPayloadSchema>;
 

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -1616,6 +1616,27 @@ describe('workflows tool', () => {
 			});
 		});
 
+		it('should scope the setup suspend to the thread-bound project even when the model omits projectId', async () => {
+			(analyzeWorkflow as Mock).mockResolvedValue([
+				{
+					node: { name: 'Slack', type: 'n8n-nodes-base.slack' },
+					credentialType: 'slackApi',
+					needsAction: true,
+				},
+			]);
+
+			const context = createMockContext({ projectId: 'project-team-1' });
+			const suspend = vi.fn();
+
+			const tool = createWorkflowsTool(context, 'full');
+			await executeTool(tool, { action: 'setup', workflowId: 'wf1' }, {
+				suspend,
+				resumeData: undefined,
+			} as never);
+
+			expect(suspend.mock.calls[0][0]).toMatchObject({ projectId: 'project-team-1' });
+		});
+
 		it('should scope setup requests to nodes changed by the latest build', async () => {
 			(analyzeWorkflow as Mock).mockResolvedValue([
 				{

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -669,13 +669,18 @@ async function handleSetupTestTrigger(
 	// as already-resolved from the previous suspend cycle
 	state.currentRequestId = nanoid();
 
+	// The thread-bound project is authoritative for credential scoping; without
+	// it the frontend falls back to the user's personal project and offers
+	// credentials from outside the conversation's project.
+	const projectId = context.projectId ?? input.projectId;
+
 	return await ctx.suspend({
 		requestId: state.currentRequestId,
 		message: 'Configure credentials for your workflow',
 		severity: 'info' as const,
 		setupRequests: refreshedRequests,
 		workflowId: input.workflowId,
-		...(input.projectId ? { projectId: input.projectId } : {}),
+		...(projectId ? { projectId } : {}),
 	});
 }
 
@@ -898,13 +903,18 @@ async function handleSetup(
 
 		state.currentRequestId = nanoid();
 
+		// The thread-bound project is authoritative for credential scoping; without
+		// it the frontend falls back to the user's personal project and offers
+		// credentials from outside the conversation's project.
+		const projectId = context.projectId ?? input.projectId;
+
 		return await ctx.suspend({
 			requestId: state.currentRequestId,
 			message: 'Configure credentials for your workflow',
 			severity: 'info' as const,
 			setupRequests,
 			workflowId: input.workflowId,
-			...(input.projectId ? { projectId: input.projectId } : {}),
+			...(projectId ? { projectId } : {}),
 		});
 	}
 

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -853,6 +853,7 @@ export class AgentsBuilderToolsService {
 			}),
 			buildAskCredentialTool({
 				credentialProvider,
+				projectId,
 				isCredentialTypeKnown: (credentialType) => this.credentialTypes.recognizes(credentialType),
 				listIntegrationCredentialIds: async () => {
 					const agent = await this.agentsService.findById(agentId, projectId);
@@ -864,6 +865,7 @@ export class AgentsBuilderToolsService {
 			}),
 			buildAskEmbeddingCredentialTool({
 				credentialProvider,
+				projectId,
 				isCredentialTypeKnown: (credentialType) => this.credentialTypes.recognizes(credentialType),
 				isAssistantProxyEnabled: () => this.aiService.isProxyEnabled(),
 				track,

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/ask-credential.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/ask-credential.tool.test.ts
@@ -27,13 +27,15 @@ function makeProvider(creds: CredentialListItem[]): CredentialProvider {
 
 let track: Mock;
 
-function askCredentialTool(deps: Omit<AskCredentialToolDeps, 'track'>) {
-	const merged: AskCredentialToolDeps = { ...deps, track };
+function askCredentialTool(deps: Omit<AskCredentialToolDeps, 'track' | 'projectId'>) {
+	const merged: AskCredentialToolDeps = { projectId: 'project-1', ...deps, track };
 	return buildAskCredentialTool(merged);
 }
 
-function askEmbeddingCredentialTool(deps: Omit<AskEmbeddingCredentialToolDeps, 'track'>) {
-	const merged: AskEmbeddingCredentialToolDeps = { ...deps, track };
+function askEmbeddingCredentialTool(
+	deps: Omit<AskEmbeddingCredentialToolDeps, 'track' | 'projectId'>,
+) {
+	const merged: AskEmbeddingCredentialToolDeps = { projectId: 'project-1', ...deps, track };
 	return buildAskEmbeddingCredentialTool(merged);
 }
 
@@ -189,6 +191,7 @@ describe('ask_credential tool', () => {
 					},
 				],
 				credentialFlow: { stage: 'generic' },
+				projectId: 'project-1',
 			}),
 		);
 		expect(track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.BUILDER_REQUESTED_CREDENTIAL, {

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/finish-setup.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/finish-setup.tool.test.ts
@@ -73,6 +73,7 @@ describe('finish_setup tool', () => {
 				],
 			},
 		]);
+		expect(payload.projectId).toBe('project-1');
 		expect(
 			(payload.finishSetupChain as { collected: { credentials: unknown } }).collected.credentials,
 		).toEqual({

--- a/packages/cli/src/modules/agents/builder/interactive/ask-credential.tool.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/ask-credential.tool.ts
@@ -19,6 +19,8 @@ import type { BuilderTrackFn } from '../builder-config-telemetry';
 
 export interface AskCredentialToolDeps {
 	credentialProvider: CredentialProvider;
+	/** Project the agent lives in — scopes the FE credential picker. */
+	projectId: string;
 	isCredentialTypeKnown?: (credentialType: string) => boolean;
 	/**
 	 * Credential ids of the agent's configured chat channel integrations. When
@@ -159,6 +161,7 @@ async function resolveCredentialSelection(
 			},
 		],
 		credentialFlow: { stage: 'generic' as const },
+		projectId: deps.projectId,
 	});
 }
 

--- a/packages/cli/src/modules/agents/builder/interactive/finish-setup.tool.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/finish-setup.tool.ts
@@ -374,6 +374,7 @@ async function suspendForPhase(params: {
 		severity: 'info' as const,
 		credentialRequests,
 		credentialFlow: { stage: 'generic' as const },
+		projectId: deps.projectId,
 		finishSetupChain,
 	});
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -184,6 +184,7 @@ describe('InstanceAiCredentialSetup', () => {
 
 		const credentialsStore = useCredentialsStore();
 		vi.spyOn(credentialsStore, 'fetchAllCredentials').mockResolvedValue([]);
+		vi.spyOn(credentialsStore, 'fetchAllCredentialsForWorkflow').mockResolvedValue([]);
 		vi.spyOn(credentialsStore, 'fetchCredentialTypes').mockResolvedValue(undefined);
 		// The card renders the NodeCredentials picker when the store has a usable
 		// credential of the type; default to one so the picker-based tests render it.
@@ -232,6 +233,25 @@ describe('InstanceAiCredentialSetup', () => {
 
 			await userEvent.click(getByTestId('instance-ai-credential-next'));
 			expect(getAllByTestId('credential-picker')).toHaveLength(1);
+		});
+
+		it('preloads only project-scoped credentials when a projectId is provided', async () => {
+			const credentialsStore = useCredentialsStore();
+			const requests = makeCredentialRequestsWithExisting(1);
+			renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: requests,
+					message: 'Set up credentials',
+					projectId: 'project-team-1',
+				},
+			});
+			await nextTick();
+
+			expect(credentialsStore.fetchAllCredentialsForWorkflow).toHaveBeenCalledWith({
+				projectId: 'project-team-1',
+			});
+			expect(credentialsStore.fetchAllCredentials).not.toHaveBeenCalled();
 		});
 
 		it('renders the setup button (modal path) for a plain type with no usable credentials', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
@@ -431,12 +431,14 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 			<!-- ============ Standalone items (no approval wrapper) ============ -->
 			<template v-if="chunk.type === 'standalone'">
 				<!-- Workflow setup -->
+				<!-- Threads are project-bound: fall back to the thread's project so a
+				     payload without projectId never degrades to the personal project. -->
 				<InstanceAiWorkflowSetup
 					v-if="chunk.item.toolCall.confirmation.setupRequests?.length"
 					:key="'setup-' + chunk.item.toolCall.confirmation.requestId"
 					:request-id="chunk.item.toolCall.confirmation.requestId"
 					:setup-requests="chunk.item.toolCall.confirmation.setupRequests!"
-					:project-id="chunk.item.toolCall.confirmation.projectId"
+					:project-id="chunk.item.toolCall.confirmation.projectId ?? thread.projectId"
 					:credential-flow="chunk.item.toolCall.confirmation.credentialFlow"
 					:workflow-id="chunk.item.toolCall.confirmation.workflowId"
 				/>
@@ -448,7 +450,7 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 					:request-id="chunk.item.toolCall.confirmation.requestId"
 					:credential-requests="chunk.item.toolCall.confirmation.credentialRequests!"
 					:message="chunk.item.toolCall.confirmation.message"
-					:project-id="chunk.item.toolCall.confirmation.projectId"
+					:project-id="chunk.item.toolCall.confirmation.projectId ?? thread.projectId"
 					:credential-flow="chunk.item.toolCall.confirmation.credentialFlow"
 				/>
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -226,10 +226,14 @@ onMounted(async () => {
 
 	// Ensure the credentials store is populated so NodeCredentials can show
 	// existing credentials in the dropdown. The Instance AI page may not have
-	// fetched them yet.
+	// fetched them yet. Scope to the thread's project — an unscoped fetch fills
+	// the store with credentials from other projects (e.g. personal) that the
+	// picker would then offer.
 	try {
 		await Promise.all([
-			credentialsStore.fetchAllCredentials(),
+			props.projectId
+				? credentialsStore.fetchAllCredentialsForWorkflow({ projectId: props.projectId })
+				: credentialsStore.fetchAllCredentials(),
 			credentialsStore.fetchCredentialTypes(false),
 		]);
 	} catch (error) {


### PR DESCRIPTION
## Summary

Credential setup cards in the AI Assistant could offer (and auto-select) credentials from the user's personal project when the conversation belongs to a team project — most visibly after reopening a conversation in a new tab.

The suspend payloads behind the cards didn't carry the thread's project, so the frontend credential picker fell back to the personal project. Fixed by:

- Sending the thread-bound `projectId` on the workflow setup and agent-builder credential suspends.
- Falling back to the thread's project in the confirmation panel for payloads without one.
- Making the credential setup card preload project-scoped credentials instead of all of the user's credentials.

## How to test

1. Create a team project with no credentials; keep a credential of some type (e.g. Linear) in your personal project.
2. Start an AI Assistant conversation in the team project and ask it to build a workflow using that service.
3. When the "Set up …" card appears, open the conversation URL in a new tab: the card must not offer the personal-project credential, and the picker should fetch `GET /rest/credentials/for-workflow?projectId=<team project id>`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1129

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

