### PR TITLE
fix(core): Restore AWS Secrets Manager connection reuse

### DIFF
--- a/packages/@n8n/backend-network/src/http/__tests__/outbound-http.node-agent.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/outbound-http.node-agent.test.ts
@@ -75,6 +75,40 @@ describe('getNodeAgent', () => {
 });
 
 // ---------------------------------------------------------------------------
+// getNodeAgent — connection-reuse options propagate across all routing paths
+//
+// The AWS Secrets Manager provider passes `{ keepAlive: true, maxSockets: 50 }`
+// to restore connection reuse. Regardless of how the request is routed, those
+// options must reach the constructed agent — otherwise a proxied deployment
+// would silently lose the fix.
+// ---------------------------------------------------------------------------
+
+describe('getNodeAgent connection-reuse options', () => {
+	// keep-alive/maxSockets are connection-management options, so Node's Agent (and
+	// the proxy agents that extend it) expose them as instance properties.
+	function getReuseOptions(agent: http.Agent | https.Agent): {
+		keepAlive: unknown;
+		maxSockets: unknown;
+	} {
+		const a = agent as { keepAlive?: unknown; maxSockets?: unknown };
+		return { keepAlive: a.keepAlive, maxSockets: a.maxSockets };
+	}
+
+	it.each([
+		['direct (proxy: false)', { proxy: false } as const],
+		['env proxy', { proxy: 'env' } as const],
+		['explicit proxy URL', { proxy: 'http://proxy.internal:3128' } as const],
+	])('forwards keepAlive/maxSockets on the %s path', (_label, transportOptions) => {
+		const { httpAgent, httpsAgent } = makeFacade()
+			.transport(transportOptions)
+			.getNodeAgent({ keepAlive: true, maxSockets: 50 });
+
+		expect(getReuseOptions(httpAgent)).toEqual({ keepAlive: true, maxSockets: 50 });
+		expect(getReuseOptions(httpsAgent)).toEqual({ keepAlive: true, maxSockets: 50 });
+	});
+});
+
+// ---------------------------------------------------------------------------
 // getNodeAgent — SSRF lookup injection
 // ---------------------------------------------------------------------------
 

--- a/packages/@n8n/backend-network/src/http/__tests__/outbound-http.node-agent.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/outbound-http.node-agent.test.ts
@@ -77,10 +77,10 @@ describe('getNodeAgent', () => {
 // ---------------------------------------------------------------------------
 // getNodeAgent — connection-reuse options propagate across all routing paths
 //
-// The AWS Secrets Manager provider passes `{ keepAlive: true, maxSockets: 50 }`
-// to restore connection reuse. Regardless of how the request is routed, those
-// options must reach the constructed agent — otherwise a proxied deployment
-// would silently lose the fix.
+// Callers may pass connection-management options (e.g. `keepAlive`,
+// `maxSockets`) to enable connection reuse. Regardless of how the request is
+// routed, those options must reach the constructed agent — otherwise a proxied
+// deployment would silently drop them.
 // ---------------------------------------------------------------------------
 
 describe('getNodeAgent connection-reuse options', () => {

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/aws-secrets-manager.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/aws-secrets-manager.test.ts
@@ -105,6 +105,11 @@ describe('AwsSecretsManager', () => {
 
 			expect(outboundHttp.transport).toHaveBeenCalledWith({ ssrf: 'disabled' });
 
+			// Request connection reuse from our agents. Smithy treats a supplied agent as
+			// external and skips its own keep-alive defaults, so we pass them explicitly to
+			// restore the AWS SDK-equivalent behavior (Smithy NodeHttpHandler defaults).
+			expect(transport.getNodeAgent).toHaveBeenCalledWith({ keepAlive: true, maxSockets: 50 });
+
 			// The SDK client is built with our agents as its requestHandler, while the
 			// region and credentials it was already given are left untouched.
 			const SecretsManagerMock = SecretsManager as unknown as Mock;

--- a/packages/cli/src/modules/external-secrets.ee/providers/aws-secrets-manager.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/aws-secrets-manager.ts
@@ -136,11 +136,15 @@ export class AwsSecretsManager extends SecretsProvider {
 			// Drive the AWS SDK's HTTP transport through n8n's outbound client,
 			// so its calls reuse our agents (proxy + TLS) like every other outbound request.
 			// SigV4 signing and the credential chain stay with the SDK.
+			//
+			// Keep connections pooled so the sequential ListSecrets/BatchGetSecretValue refresh
+			// reuses sockets instead of paying a fresh TLS handshake per request. `maxSockets`
+			// caps concurrent sockets, matching the AWS SDK's own defaults.
 			clientConfig.requestHandler = this.outboundHttp
 				.transport({
 					ssrf: 'disabled', // fixed AWS-resolved Secrets Manager host, not user-controlled
 				})
-				.getNodeAgent();
+				.getNodeAgent({ keepAlive: true, maxSockets: 50 });
 
 			const { SecretsManager } = await import('@aws-sdk/client-secrets-manager');
 			this.client = new SecretsManager(clientConfig);


### PR DESCRIPTION
## Summary

Routing the AWS Secrets Manager external-secrets provider through n8n's shared outbound transport (#32453) handed the SDK Node agents built from Node's defaults (`keepAlive: false`), so the sequential `ListSecrets`/`BatchGetSecretValue` refresh opened a brand-new TLS connection for every request instead of reusing one. This passes `{ keepAlive: true, maxSockets: 50 }` into `getNodeAgent()` so connections stay pooled across the refresh, matching the AWS SDK's own Smithy `NodeHttpHandler` defaults. A local benchmark over 6 sequential requests confirmed the effect: **6 connections without keep-alive vs 1 with it**. Auth, credential resolution, SigV4 signing, and response handling are unchanged; the options are set only at this call site, not as a shared agent default.

## How to test

Requires an enterprise license with the External Secrets feature enabled.

1. In **Settings → External Secrets**, connect an **AWS Secrets Manager** provider (IAM user or auto-detect) against an account holding several secrets.
2. Trigger a secrets refresh (reconnect the provider or wait for the periodic update) and confirm secrets still list and resolve correctly.
3. Optionally capture a packet trace (e.g. `tcpdump` to the Secrets Manager endpoint) and observe a single reused TLS connection across the refresh rather than one per request.
4. Unit coverage: `pnpm --filter n8n vitest run src/modules/external-secrets.ee/providers/__tests__/aws-secrets-manager.test.ts` and `pnpm --filter @n8n/backend-network vitest run src/http/__tests__/outbound-http.node-agent.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-909

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

