### PR TITLE
feat(core): Add engine v2 workflow setting (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/engine.config.ts
+++ b/packages/@n8n/config/src/configs/engine.config.ts
@@ -2,10 +2,6 @@ import { Config, Env } from '../decorators';
 
 @Config
 export class EngineConfig {
-	/** Whether the EXPERIMENTAL engine 2.0 is enabled. When enabled, workflows with `engineType: 'v2'` are dispatched to the new engine. */
-	@Env('N8N_ENGINE_V2_ENABLED')
-	v2Enabled: boolean = false;
-
 	/** Port the engine HTTP server listens on. */
 	@Env('N8N_ENGINE_PORT')
 	port: number = 3000;

--- a/packages/@n8n/config/src/configs/engine.config.ts
+++ b/packages/@n8n/config/src/configs/engine.config.ts
@@ -2,6 +2,10 @@ import { Config, Env } from '../decorators';
 
 @Config
 export class EngineConfig {
+	/** Whether the EXPERIMENTAL engine 2.0 is enabled. When enabled, workflows with `engineType: 'v2'` are dispatched to the new engine. */
+	@Env('N8N_ENGINE_V2_ENABLED')
+	v2Enabled: boolean = false;
+
 	/** Port the engine HTTP server listens on. */
 	@Env('N8N_ENGINE_PORT')
 	port: number = 3000;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3808,6 +3808,7 @@ export interface IWorkflowSettings {
 	saveExecutionProgress?: 'DEFAULT' | boolean;
 	executionTimeout?: number;
 	executionOrder?: 'v0' | 'v1';
+	engineType?: 'v1' | 'v2';
 	binaryMode?: WorkflowSettingsBinaryMode;
 	timeSavedPerExecution?: number;
 	timeSavedMode?: 'fixed' | 'dynamic';


### PR DESCRIPTION
## Summary

This PR adds the groundwork for opting a workflow into engine 2.0.

- Add `engineType: 'v1' | 'v2'` to `IWorkflowSettings`. Optional, defaults to `v1`

FE changes are a followup in CAT-4109.

Nothing reads this yet. That is also followup.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2876

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

