### PR TITLE
fix(core): Keep the account panel on hosted forms once every account is connected

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
@@ -709,6 +709,62 @@ describe('CredentialResolverWorkflowService', () => {
 				);
 			});
 
+			it('skips credentials on disabled nodes', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-active'),
+							nodeWithCredential('cred-disabled', { id: 'disabled-node', disabled: true }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([
+					createMockCredential({ id: 'cred-active' }),
+					createMockCredential({ id: 'cred-disabled' }),
+				]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId)).toEqual(['cred-active']);
+			});
+
+			it('returns no credentials when every account belongs to a disabled node', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [nodeWithCredential('cred-disabled', { id: 'disabled-node', disabled: true })],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-disabled' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result).toEqual([]);
+				expect(mockCredentialRepository.find).not.toHaveBeenCalled();
+			});
+
+			it('still includes a credential that also appears on an enabled node', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-shared', { id: 'enabled-node' }),
+							nodeWithCredential('cred-shared', { id: 'disabled-node', disabled: true }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-shared' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].credentialId).toBe('cred-shared');
+			});
+
 			it('skips disabled sub-workflow nodes', async () => {
 				mockWorkflowsById({
 					'workflow-1': createMockWorkflow({

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
@@ -79,10 +79,12 @@ export class CredentialResolverWorkflowService {
 	}
 
 	/**
-	 * Checks the status of all resolvable credentials in a workflow and its sub-workflows.
-	 * Traverses Execute Sub-workflow and AI Workflow Tool references recursively, deduplicating
-	 * both workflows (cycles / self-references / diamond references) and credentials, then tests
-	 * credential availability by attempting to retrieve secrets using the provided identity token.
+	 * Checks the status of all resolvable credentials on enabled nodes in a workflow and its
+	 * sub-workflows. Disabled nodes are skipped — they never run, so their accounts must not
+	 * gate form shells or submit. Traverses Execute Sub-workflow and AI Workflow Tool references
+	 * recursively, deduplicating both workflows (cycles / self-references / diamond references)
+	 * and credentials, then tests credential availability by attempting to retrieve secrets
+	 * using the provided identity token.
 	 *
 	 * @param workflowId - The (root) workflow ID to check
 	 * @param credentialContext - Identity context used for credential authorization
@@ -148,8 +150,10 @@ export class CredentialResolverWorkflowService {
 
 	/**
 	 * Recursively walks a workflow and its sub-workflows, recording every resolvable-credential id
-	 * mapped to the effective resolver of the workflow it was first found in. The `visited` set
-	 * prevents processing the same workflow twice (cycles, self-references, diamond references).
+	 * on an enabled node, mapped to the effective resolver of the workflow it was found in.
+	 * Disabled nodes are skipped so their accounts never appear in the status result. The
+	 * `visited` set prevents processing the same workflow twice (cycles, self-references,
+	 * diamond references).
 	 */
 	private async collectResolvableCredentials(
 		workflowId: string,
@@ -188,6 +192,9 @@ export class CredentialResolverWorkflowService {
 		const resolverId = this.dynamicCredentialsProxy.getEffectiveResolverId(workflow.settings);
 
 		for (const node of workflow.nodes ?? []) {
+			if (node.disabled) {
+				continue;
+			}
 			for (const credentialName in node.credentials ?? {}) {
 				const credentialId = node.credentials?.[credentialName]?.id;
 				if (!credentialId) {

--- a/packages/cli/templates/form-shell.handlebars
+++ b/packages/cli/templates/form-shell.handlebars
@@ -258,6 +258,8 @@
 				}
 			}
 
+			if (frame) frame.addEventListener('load', refresh);
+
 			var shellEl = document.querySelector('.shell');
 			var SUBMITTER_EMAIL = shellEl ? shellEl.getAttribute('data-submitter-email') || '' : '';
 			var CONNECTED_MENU_HTML =

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -1603,6 +1603,25 @@ describe('FormTrigger, formWebhook', () => {
 				);
 				expect(result).toEqual({ noWebhookResponse: true });
 			});
+
+			// A typed-in ?n8nShellInner=1 is a top-level document navigation, not the
+			// shell iframe. Honoring the flag there would skip the connect UI.
+			it('still renders the hosting shell for a hand-typed n8nShellInner URL', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupAuthedGet(ctx, {
+					query: { n8nShellInner: '1' },
+					headers: { 'sec-fetch-dest': 'document' },
+				});
+				ctx.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: true,
+					credentials: [configured],
+				});
+
+				const result = await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith('form-shell', expect.any(Object));
+				expect(result).toEqual({ noWebhookResponse: true });
+			});
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -24,6 +24,7 @@ import { DateTime } from 'luxon';
 import { InstanceSettings } from 'n8n-core';
 import type {
 	CredentialCheckResult,
+	CredentialCheckStatus,
 	FormFieldsParameter,
 	IDataObject,
 	INode,
@@ -1487,6 +1488,120 @@ describe('FormTrigger, formWebhook', () => {
 					webhookResponse: { status: 200 },
 					workflowData: [[expect.anything()]],
 				});
+			});
+		});
+
+		describe('hosting shell on GET', () => {
+			const missing: CredentialCheckStatus = {
+				credentialId: 'cred-missing',
+				credentialName: 'My Gmail',
+				credentialType: 'gmailOAuth2',
+				resolverId: 'resolver-1',
+				status: 'missing',
+				authorizationUrl: 'https://example.com/authorize',
+			};
+			const configured: CredentialCheckStatus = {
+				credentialId: 'cred-connected',
+				credentialName: 'My CRM',
+				credentialType: 'hubspotOAuth2',
+				resolverId: 'resolver-2',
+				status: 'configured',
+				revokeUrl: 'https://example.com/revoke?resolverId=resolver-2',
+			};
+
+			const setupAuthedGet = (
+				ctx: ReturnType<typeof mock<IWebhookFunctions>>,
+				overrides: { query?: IDataObject; headers?: Record<string, string> } = {},
+			) => {
+				const res = setupContext(ctx, {
+					method: 'GET',
+					query: overrides.query,
+					headers: { cookie: 'n8n-form-oauth=as-token', ...(overrides.headers ?? {}) },
+				});
+				ctx.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user: authedUser });
+				return res;
+			};
+
+			it('renders the shell while an account is still missing', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupAuthedGet(ctx);
+				ctx.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: false,
+					credentials: [missing, configured],
+				});
+
+				const result = await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith(
+					'form-shell',
+					expect.objectContaining({ total: 2, connectedCount: 1, allConnected: false }),
+				);
+				expect(result).toEqual({ noWebhookResponse: true });
+			});
+
+			// The panel must survive the reload right after connecting, or the submitter
+			// loses every way to see and revoke the accounts the form runs on.
+			it('keeps rendering the shell once every account is connected', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupAuthedGet(ctx);
+				ctx.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: true,
+					credentials: [configured],
+				});
+
+				const result = await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith(
+					'form-shell',
+					expect.objectContaining({
+						total: 1,
+						connectedCount: 1,
+						allConnected: true,
+						credentials: [
+							expect.objectContaining({
+								id: 'cred-connected',
+								connected: true,
+								account: authedUser.email,
+								revokeUrl: configured.revokeUrl,
+							}),
+						],
+					}),
+				);
+				expect(result).toEqual({ noWebhookResponse: true });
+			});
+
+			it('renders the plain form when the trigger needs no end-user accounts', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupAuthedGet(ctx);
+				ctx.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: true,
+					credentials: [],
+				});
+
+				const result = await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith('form-trigger', expect.any(Object));
+				expect(result).toEqual({ noWebhookResponse: true });
+			});
+
+			it('renders the plain form for the shell inner iframe GET', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupAuthedGet(ctx, {
+					query: { n8nShellInner: '1' },
+					headers: { 'sec-fetch-dest': 'iframe' },
+				});
+				ctx.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: true,
+					credentials: [configured],
+				});
+
+				const result = await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ shellInner: true }),
+				);
+				expect(result).toEqual({ noWebhookResponse: true });
 			});
 		});
 	});

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -1201,10 +1201,10 @@ export async function formWebhook(
 
 		// Connect-before-submit: when the workflow needs the submitter's own
 		// (private) credentials, establish their identity from the OAuth2 token and
-		// check readiness server-side. If anything is still missing — and we're not
-		// already rendering the inner iframe — wrap the form in the hosting shell
-		// (form + connect panel, submit disabled). No-op unless OAuth2 form auth and
-		// the dynamic-credentials module are both active.
+		// check readiness server-side. As long as the trigger requires any end-user
+		// account — and we're not already rendering the inner iframe — wrap the form
+		// in the hosting shell (form + connect panel). No-op unless OAuth2 form auth
+		// and the dynamic-credentials module are both active.
 		if (
 			authentication === 'n8nUserAuth' &&
 			authedUser &&
@@ -1218,7 +1218,12 @@ export async function formWebhook(
 			if (resourceUrl) {
 				await context.establishTriggerIdentity(oAuth2Token, resourceUrl);
 				const credentialStatus = await context.checkTriggerCredentialStatus();
-				if (credentialStatus && !credentialStatus.readyToExecute) {
+				// Gate on "needs end-user accounts", NOT on readiness: a fully connected
+				// submitter must keep the panel — which accounts the form uses, which
+				// identity, and Disconnect — otherwise it would vanish on the reload right
+				// after connecting. Forms with no end-user accounts fall through to the
+				// plain render below, unchanged.
+				if (credentialStatus?.credentials.length) {
 					// Hand the OAuth2 token to the same-site iframe GET via the one-hop
 					// cookie the OAuth2 flow already uses, so the inner form authenticates
 					// without re-running the provider redirect inside the frame.


### PR DESCRIPTION
## Summary

The account panel disappeared from a hosted form as soon as the submitter had
  connected everything. `formWebhook` decided whether to render the hosting shell
  by asking *"is everything ready?"*.

  Once every account was connected that condition went false, so the next GET
  rendered the plain form and the whole panel — the account list, Connected as …, and Disconnect — was gone. Hence the reported symptom: the panel survives
  the connect itself (the shell repaints in place, no reload) and vanishes on the
  next refresh. Disconnect was reachable only while something was still missing.

  The gate now asks "does this trigger need end-user accounts at all?", so the
  panel stays for the whole lifetime of the form and simply changes state — the
  all-connected summary line with Manage that the redesign already built,
  but that a fresh GET could never reach.

  Second change, in form-shell.handlebars: the inner form always renders with
  Submit disabled ({{#if shellInner}}disabled), and the shell only sent its
  readiness signal from markConnected / markDisconnected. A submitter who
  arrives already connected connects nothing, so no signal was ever sent and
  Submit stayed dead. The shell now posts its current state as soon as the iframe
  can listen.

  Forms with no end-user accounts fall through to the plain render, untouched. The
  server-side POST gate is unchanged and remains the only enforcement.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1213

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
