### PR TITLE
ci: Verify the packed `@n8n/design-system` tarball from a real consumer (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -62,10 +62,21 @@ jobs:
       scope: changed
       base-ref: ${{ github.event.before }}
 
+  # Also a required check on PRs. Repeated here because the merge queue is not the last word: a
+  # tarball can break from a dependency resolving differently on master than it did on the branch.
+  packed-consumer:
+    name: Packed consumer
+    uses: ./.github/workflows/test-packed-consumer-reusable.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.sha }}
+      scope: full
+
   notify-on-failure:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
-    needs: [unit-test, lint, performance, build-github]
+    needs: [unit-test, lint, performance, build-github, packed-consumer]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -251,6 +251,23 @@ jobs:
         run: |
           pnpm -r pack --dry-run
 
+  # Builds, typechecks and loads a generated consumer against the packed `@n8n/design-system`
+  # tarball, outside the workspace resolution graph.
+  #
+  # Gated on the broad `ci` filter rather than a path filter over the package's build config and
+  # `exports` map. Half of what this catches is a specifier added elsewhere in the monorepo that
+  # only resolves through a build-time alias to `src` — and a path filter listing the packages
+  # that consume the design system is exactly the hand-maintained list that let the artifact rot
+  # in the first place. The job costs well under two minutes, so breadth is the cheaper mistake.
+  packed-consumer:
+    name: Packed consumer
+    needs: install-and-build
+    if: needs.install-and-build.outputs.ci == 'true'
+    uses: ./.github/workflows/test-packed-consumer-reusable.yml
+    with:
+      ref: ${{ needs.install-and-build.outputs.commit_sha }}
+      scope: full
+
   # Seeds the SHA-keyed Docker image cache once so that downstream e2e jobs
   # (each of which invokes prepare-docker internally) short-circuit to a
   # cache hit instead of racing to rebuild.
@@ -405,6 +422,7 @@ jobs:
         typecheck,
         lint,
         check-packaging,
+        packed-consumer,
         sqlite-sanity,
         e2e,
         dev-server-smoke,

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -259,10 +259,15 @@ jobs:
   # only resolves through a build-time alias to `src` — and a path filter listing the packages
   # that consume the design system is exactly the hand-maintained list that let the artifact rot
   # in the first place. The job costs well under two minutes, so breadth is the cheaper mistake.
+  #
+  # `workflows` as well as `ci`: the `ci` filter excludes `.github/**`, so a PR that only edits
+  # this job's own workflow would skip it, and `required-checks` passes on a skipped job.
   packed-consumer:
     name: Packed consumer
     needs: install-and-build
-    if: needs.install-and-build.outputs.ci == 'true'
+    if: >-
+      needs.install-and-build.outputs.ci == 'true' ||
+      needs.install-and-build.outputs.workflows == 'true'
     uses: ./.github/workflows/test-packed-consumer-reusable.yml
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}

--- a/.github/workflows/test-packed-consumer-reusable.yml
+++ b/.github/workflows/test-packed-consumer-reusable.yml
@@ -1,0 +1,68 @@
+name: 'Test: Packed consumer (@n8n/design-system)'
+
+# `@n8n/design-system` published a broken artifact for months with a green pipeline, because
+# nothing in the monorepo consumed `dist`: every internal package aliases the specifier to `src`,
+# so the published output was never exercised. This job is the consumer that does exercise it —
+# it packs the package, installs the tarball outside the workspace resolution graph, then builds,
+# typechecks and loads a generated consumer against it.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Commit to check out.'
+        required: true
+        type: string
+      scope:
+        description: >-
+          "full" packs, installs and compiles a consumer. "static" only checks that the exports map
+          covers every specifier the monorepo imports — seconds instead of a minute, no registry.
+        required: false
+        type: string
+        default: 'full'
+      timeout-minutes:
+        description: 'Job timeout. The full scope installs from the npm registry, so it needs room.'
+        required: false
+        type: number
+        default: 15
+
+jobs:
+  verify:
+    name: Packed consumer
+    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      # Rejecting an unknown scope here rather than defaulting to one: `--static-only` skips the
+      # build, typecheck and load, so a typo silently downgrading the job to the cheap half would
+      # leave a green check that never compiled anything.
+      - name: Validate inputs
+        env:
+          SCOPE: ${{ inputs.scope }}
+        run: |
+          case "$SCOPE" in
+            full|static) ;;
+            *) echo "::error::Unknown scope \"$SCOPE\" (expected \"full\" or \"static\")."; exit 1 ;;
+          esac
+
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      # `pnpm pack` packs whatever is on disk, so `dist` has to exist first — and it has to be
+      # this commit's `dist`. Only the design-system's own build closure is needed, plus the
+      # verifier's.
+      - name: Setup and Build
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: pnpm turbo run build --filter=@n8n/design-system... --filter=@n8n/code-health...
+
+      - name: Verify the packed tarball
+        env:
+          SCOPE: ${{ inputs.scope }}
+        run: |
+          ARGS=""
+          if [ "$SCOPE" = "static" ]; then ARGS="--static-only"; fi
+          pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-packed-consumer $ARGS

--- a/packages/frontend/editor-ui/src/features/agents/channels/types.ts
+++ b/packages/frontend/editor-ui/src/features/agents/channels/types.ts
@@ -3,7 +3,7 @@ import type {
 	AgentIntegrationSettings,
 	ChatIntegrationDescriptor,
 } from '@n8n/api-types';
-import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
+import type { IconName } from '@n8n/design-system';
 import type { BaseTextKey } from '@n8n/i18n';
 import type { PermissionsRecord } from '@n8n/permissions';
 import type { Component, Ref, VNode } from 'vue';

--- a/packages/testing/code-health/src/cli.ts
+++ b/packages/testing/code-health/src/cli.ts
@@ -13,6 +13,7 @@ import * as path from 'node:path';
 import { parseArgs } from './cli/arg-parser.js';
 import type { CodeHealthContext } from './context.js';
 import { createDefaultRunner } from './index.js';
+import { runVerifyPackedConsumer } from './packed-consumer/verify-packed-consumer.js';
 import { runVerifyClosure } from './single-instance/verify-closure.js';
 import { runVerifyNpmInstall } from './single-instance/verify-npm-install.js';
 
@@ -37,6 +38,10 @@ async function main(): Promise<void> {
 
 	if (options.command === 'verify-npm-install') {
 		process.exit(await runVerifyNpmInstall(options.args, rootDir));
+	}
+
+	if (options.command === 'verify-packed-consumer') {
+		process.exit(await runVerifyPackedConsumer(options.args, rootDir));
 	}
 
 	const runner = createDefaultRunner();

--- a/packages/testing/code-health/src/cli/arg-parser.ts
+++ b/packages/testing/code-health/src/cli/arg-parser.ts
@@ -1,5 +1,11 @@
 // The default command is `analyze`; these are the explicit subcommands accepted as argv[0].
-const SUBCOMMANDS = ['baseline', 'rules', 'verify-closure', 'verify-npm-install'] as const;
+const SUBCOMMANDS = [
+	'baseline',
+	'rules',
+	'verify-closure',
+	'verify-npm-install',
+	'verify-packed-consumer',
+] as const;
 type Subcommand = (typeof SUBCOMMANDS)[number];
 
 export interface CliOptions {

--- a/packages/testing/code-health/src/packed-consumer/README.md
+++ b/packages/testing/code-health/src/packed-consumer/README.md
@@ -58,10 +58,29 @@ the component named in the fixture: the acceptance criteria call for a typed slo
 inherently a named example. If it leaves the barrel the fixture stops compiling, which is a loud
 failure rather than silent rot.
 
-**Test files and this package are excluded from the specifier scan.** A test never ships, and a
-test is exactly where a made-up specifier appears as a fixture string; this checker generates
-consumer code, so it holds specifiers as data and names them in doc comments. Both were observed
-producing phantom findings before the exclusions went in.
+**The file set comes from `git ls-files`, not from a glob.** A glob needs a hand-written list of
+directories to skip, and every entry missing from that list is a silent hole. Two were found in
+review: `fast-glob`'s default `dot: false` hid `.storybook/`, where a build-time config imports
+this package (two real violations passed under it), and `storybook-static/` — build output nobody
+had thought to exclude — contributed four specifiers out of bundled asset chunks. Tracked-or-not
+answers both permanently and without a list: generated output is never tracked, and a
+dot-directory is tracked like anything else. The command throws rather than falling back to a
+filesystem walk, because a fallback would scan a different set than it reports.
+
+**Test files and this package are still excluded** — but as semantic exclusions, each stated with
+its reason in `isSemanticallyExcluded`. A test never ships, and a test is exactly where a made-up
+specifier appears as a fixture string; this checker generates consumer code, so it holds
+specifiers as data. Both were observed producing phantom findings.
+
+**Two specifiers are grandfathered, loudly.** `.storybook/preview.ts` imports
+`@n8n/design-system/plugin` and `…/composables/useIconBodyLoader` deeply on purpose — `preview.ts`
+is a TurboSnap global, and a barrel import would make every component a global dep and force a
+full Chromatic snapshot on any component change. Those imports predate the stage-5 exports flip by
+three weeks, so the subpath migration missed them under the same dot-directory blind spot. Both
+symbols are on the root barrel, so a root import compiles, but it costs that property — which is
+not this job's call to spend. They sit in `grandfathered.ts` with their reason, are printed on
+every run, and the check **fails if one becomes resolvable**, so the exception cannot outlive its
+cause. Anything new is enforced normally.
 
 Subpaths with no monorepo consumer are still covered: `style.css` and `theme.css` exist for
 external consumers only, and the fixture imports them because its CSS import list comes from the
@@ -89,6 +108,8 @@ Vite 5–6 peer, and the catalog is on Vite 8) is narrowed in the fixture's `ove
 | `./icons/lucide` removed from the `exports` map | phase 2, naming the importing file |
 | One pre-built icon bucket chunk deleted from `dist` | phase 6, naming the chunk; also phase 5 |
 | `TableHeader<T>` widened to `any` in the shipped `.d.ts` | phase 4 (`TS2344`, and `TS2578` on the now-unused `@ts-expect-error`) |
+| A new unexported deep import added to `editor-ui` | phase 2 — the grandfathered list does not excuse it |
+| `./plugin` added to `exports`, making a grandfathered entry stale | phase 2, telling you to delete the entry |
 
 ## Known confusion this does not fix
 

--- a/packages/testing/code-health/src/packed-consumer/README.md
+++ b/packages/testing/code-health/src/packed-consumer/README.md
@@ -1,0 +1,107 @@
+# Packed-consumer check
+
+Builds, typechecks and loads a generated consumer project against the **packed tarball** of
+`@n8n/design-system`, outside the workspace resolution graph.
+
+```bash
+# Everything: pack, install from the registry, typecheck, build, load under Node (~35s).
+pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-packed-consumer
+
+# Static half only: does the exports map cover every specifier the monorepo imports? (~6s)
+pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-packed-consumer --static-only
+
+# Keep the scratch project to poke at it.
+pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-packed-consumer --keep
+```
+
+`dist` must be built first — `pnpm pack` packs what is on disk:
+
+```bash
+pnpm turbo run build --filter=@n8n/design-system...
+```
+
+## Why this exists
+
+`@n8n/design-system` published a broken artifact for months with a green pipeline. Nothing in the
+monorepo consumed `dist`: every internal package aliases `@n8n/design-system(.*)` to `src$1`, so
+the published output was never exercised by anything. The artifact was fixed; this is the check
+that stops it rotting again.
+
+## What it checks
+
+Each phase fails the command.
+
+1. **Export targets present.** Every non-wildcard `exports` target resolves to a file in the
+   tarball.
+2. **Specifier coverage.** Every `@n8n/design-system…` specifier written anywhere in the monorepo
+   resolves through the published `exports` map to a file that ships. This is the half that
+   catches a deep import added elsewhere — the kind that resolves fine inside the workspace
+   through the alias and resolves nowhere for anybody else.
+3. **Peer ranges.** Every peer the packed manifest declares matches the range the consumer
+   installs. Both come from the same catalog entry, so equality is the invariant.
+4. **Typecheck.** `vue-tsc --noEmit` over a consumer that uses a generically typed slot
+   (`N8nDataTableServer`'s `#item`, whose payload reaches a `@tanstack/vue-table` type through the
+   emitted declarations) plus explicit assertions that the published types have not degraded to
+   `any`.
+5. **Build.** `vite build` with the stock Vue plugin and nothing else. Needing the icon plugin here
+   would mean the pre-built icon chunks stopped shipping.
+6. **Load under plain Node.** Each module subpath imported one at a time as native ESM, then an
+   icon body fetched through the public loader for every chunk the icon entry references.
+
+## Design decisions worth knowing
+
+**Nothing is enumerated by hand.** The probe surface comes from the target's `exports` map, the
+specifier set from a scan of the repo, the toolchain versions from the target's own manifest via
+the pnpm catalog, and the expected icon chunks from the icon entry's own dynamic imports. A
+subpath, a consumer or a chunk added tomorrow is covered with no edit here. The one exception is
+the component named in the fixture: the acceptance criteria call for a typed slot, and that is
+inherently a named example. If it leaves the barrel the fixture stops compiling, which is a loud
+failure rather than silent rot.
+
+**Test files and this package are excluded from the specifier scan.** A test never ships, and a
+test is exactly where a made-up specifier appears as a fixture string; this checker generates
+consumer code, so it holds specifiers as data and names them in doc comments. Both were observed
+producing phantom findings before the exclusions went in.
+
+Subpaths with no monorepo consumer are still covered: `style.css` and `theme.css` exist for
+external consumers only, and the fixture imports them because its CSS import list comes from the
+`exports` map rather than from the scan.
+
+**`@n8n/design-system/src/…` specifiers are skipped.** They are deliberately outside `exports`;
+`files` ships `dist`, not `src`. Storybook and the browser extension use them through a
+build-time alias.
+
+**`skipLibCheck` stays on.** Turning it off checks every third-party `.d.ts` in the install too,
+so an upstream dependency shipping bad types would redden this job for a defect nobody here can
+fix. The declarations that matter are held to account at their use site instead, by the
+assertions in the generated `src/type-probe.ts`.
+
+**No `--legacy-peer-deps`.** npm satisfies a conflicting peer by nesting a second copy, which is
+what makes the package loadable. The flag flattens instead, and a flattened tree fails at link
+time — it reported a broken `@tiptap/extension-list` against an older `@tiptap/core` as a defect
+in the tarball, which it was not. One stale peer range (`@vitejs/plugin-vue@5` still declares a
+Vite 5–6 peer, and the catalog is on Vite 8) is narrowed in the fixture's `overrides` instead.
+
+**The negative controls have been run.** Each was injected and each failed the job:
+
+| Injected defect | Caught by |
+| --- | --- |
+| `./icons/lucide` removed from the `exports` map | phase 2, naming the importing file |
+| One pre-built icon bucket chunk deleted from `dist` | phase 6, naming the chunk; also phase 5 |
+| `TableHeader<T>` widened to `any` in the shipped `.d.ts` | phase 4 (`TS2344`, and `TS2578` on the now-unused `@ts-expect-error`) |
+
+## Known confusion this does not fix
+
+`@n8n/chat` resolves the bare `@n8n/design-system` specifier through `exports` to `dist` rather
+than to source. CI is safe because turbo orders `test` after `^build`, but `vitest run` invoked
+directly inside `chat` on a **fresh clone** fails with
+`Failed to resolve import "@n8n/design-system"`, because `dist` is gitignored and has not been
+built yet. Build first:
+
+```bash
+pnpm turbo run build --filter=@n8n/design-system...
+pnpm --filter @n8n/chat test
+```
+
+This is confusing rather than broken, and "run the tests in this package" is the first thing a new
+contributor tries.

--- a/packages/testing/code-health/src/packed-consumer/catalog-versions.test.ts
+++ b/packages/testing/code-health/src/packed-consumer/catalog-versions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCatalogDep } from './catalog-versions.js';
+import type { CatalogData } from '../utils/workspace-parser.js';
+
+const CATALOG: CatalogData = {
+	default: { typescript: '6.0.2', vite: '^8.0.2' },
+	named: { frontend: { vue: '^3.5.13', 'vue-tsc': '^2.2.8' } },
+};
+
+describe('resolveCatalogDep', () => {
+	it('follows the default catalog', () => {
+		expect(resolveCatalogDep('typescript', { typescript: 'catalog:' }, CATALOG)).toBe('6.0.2');
+	});
+
+	it('follows a named catalog', () => {
+		expect(resolveCatalogDep('vue', { vue: 'catalog:frontend' }, CATALOG)).toBe('^3.5.13');
+	});
+
+	it('passes a literal range through', () => {
+		expect(resolveCatalogDep('sass', { sass: '^1.71.1' }, CATALOG)).toBe('^1.71.1');
+	});
+
+	it('returns null for a dependency the manifest does not declare', () => {
+		expect(resolveCatalogDep('vue', {}, CATALOG)).toBeNull();
+	});
+
+	it('returns null for a workspace protocol, which never resolves outside the workspace', () => {
+		expect(resolveCatalogDep('@n8n/utils', { '@n8n/utils': 'workspace:*' }, CATALOG)).toBeNull();
+	});
+
+	it('returns null when the named catalog has no such entry', () => {
+		// Silently defaulting here would let the fixture compile against whatever npm hoisted,
+		// which is the opposite of pinning the toolchain the package is built with.
+		expect(resolveCatalogDep('vue', { vue: 'catalog:backend' }, CATALOG)).toBeNull();
+	});
+});

--- a/packages/testing/code-health/src/packed-consumer/catalog-versions.ts
+++ b/packages/testing/code-health/src/packed-consumer/catalog-versions.ts
@@ -1,0 +1,29 @@
+import type { CatalogData } from '../utils/workspace-parser.js';
+
+/**
+ * Look a dependency's concrete range up from the manifest section it is declared in, following a
+ * `catalog:` / `catalog:<name>` indirection.
+ *
+ * The generated consumer takes its toolchain versions from the target package's own manifest, so
+ * the fixture always compiles against the Vue and TypeScript the package was built with. A pinned
+ * copy in this file would drift from the catalog silently, and a floating `latest` would turn an
+ * upstream release into a red `main` that nobody caused.
+ *
+ * Returns `null` when the dependency is absent or resolves to a workspace package, which the
+ * caller must treat as an error rather than a default: a silently dropped toolchain dependency
+ * makes the generated consumer typecheck against whatever npm happens to hoist.
+ */
+export function resolveCatalogDep(
+	depName: string,
+	declared: Record<string, string>,
+	catalog: CatalogData,
+): string | null {
+	const spec = declared[depName];
+	if (spec === undefined) return null;
+	if (!spec.startsWith('catalog:')) return spec.startsWith('workspace:') ? null : spec;
+
+	const catalogName = spec.slice('catalog:'.length);
+	const table = catalogName === '' ? catalog.default : catalog.named[catalogName];
+	const version = table?.[depName];
+	return typeof version === 'string' && !version.startsWith('workspace:') ? version : null;
+}

--- a/packages/testing/code-health/src/packed-consumer/consumer-specifiers.test.ts
+++ b/packages/testing/code-health/src/packed-consumer/consumer-specifiers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	extractSpecifiers,
+	isInternalSourceSpecifier,
+	targetCandidates,
+} from './consumer-specifiers.js';
+
+const PKG = '@n8n/design-system';
+
+describe('extractSpecifiers', () => {
+	it('finds an import, a type-only import and a sass `@use`', () => {
+		const source = [
+			"import { N8nButton } from '@n8n/design-system';",
+			"import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';",
+			'@use "@n8n/design-system/css/mixins/motion" as motion;',
+		].join('\n');
+		expect(extractSpecifiers(source, PKG).sort()).toEqual([
+			PKG,
+			`${PKG}/components/N8nIcon/icons`,
+			`${PKG}/css/mixins/motion`,
+		]);
+	});
+
+	it('ignores an unquoted mention in prose', () => {
+		// Failing a build over a sentence in a comment is how a check earns a reputation for
+		// crying wolf, and a check nobody trusts is worse than no check.
+		const source = '// Legacy tree component in @n8n/design-system/components. Use N8nTree2.';
+		expect(extractSpecifiers(source, PKG)).toEqual([]);
+	});
+
+	it('ignores a tsconfig `paths` pattern', () => {
+		expect(extractSpecifiers('"@n8n/design-system/src*": ["./src*"]', PKG)).toEqual([]);
+	});
+
+	it('does not match a package whose name merely starts the same', () => {
+		// Without a boundary this reads as a bare import of `@n8n/design-system`, i.e. a different
+		// package reported as this one.
+		expect(extractSpecifiers("import x from '@n8n/design-system-icons';", PKG)).toEqual([]);
+	});
+
+	it('strips trailing punctuation from a `url()` or statement', () => {
+		expect(extractSpecifiers("@import '@n8n/design-system/css/index.scss';", PKG)).toEqual([
+			`${PKG}/css/index.scss`,
+		]);
+	});
+
+	it('deduplicates repeated specifiers', () => {
+		const source = "import a from '@n8n/design-system';\nimport b from '@n8n/design-system';";
+		expect(extractSpecifiers(source, PKG)).toEqual([PKG]);
+	});
+});
+
+describe('isInternalSourceSpecifier', () => {
+	it('recognises the alias-only `src` form', () => {
+		expect(isInternalSourceSpecifier(PKG, `${PKG}/src`)).toBe(true);
+		expect(isInternalSourceSpecifier(PKG, `${PKG}/src/icons/lucide/vite`)).toBe(true);
+	});
+
+	it('does not excuse a published subpath', () => {
+		expect(isInternalSourceSpecifier(PKG, `${PKG}/icons/lucide`)).toBe(false);
+		expect(isInternalSourceSpecifier(PKG, `${PKG}/srcfoo`)).toBe(false);
+	});
+});
+
+describe('targetCandidates', () => {
+	it('takes an explicit extension literally', () => {
+		expect(targetCandidates('./dist/index.js')).toEqual(['dist/index.js']);
+		expect(targetCandidates('./dist/css/markdown.scss')).toEqual(['dist/css/markdown.scss']);
+	});
+
+	it("offers sass's candidates for an extensionless stylesheet target", () => {
+		// `@n8n/design-system/css/mixins/motion` is legal sass and resolves to `motion.scss`;
+		// Node's own exports resolution would stop at the extensionless name.
+		expect(targetCandidates('./dist/css/mixins/motion')).toContain('dist/css/mixins/motion.scss');
+	});
+
+	it('offers the partial and index forms too', () => {
+		const candidates = targetCandidates('./dist/css/_tokens');
+		expect(candidates).toContain('dist/css/_tokens.scss');
+		expect(targetCandidates('./dist/css/mixins')).toContain('dist/css/mixins/index.scss');
+	});
+});

--- a/packages/testing/code-health/src/packed-consumer/consumer-specifiers.test.ts
+++ b/packages/testing/code-health/src/packed-consumer/consumer-specifiers.test.ts
@@ -3,10 +3,69 @@ import { describe, expect, it } from 'vitest';
 import {
 	extractSpecifiers,
 	isInternalSourceSpecifier,
+	isScannableFile,
 	targetCandidates,
+	trackedScannableFiles,
 } from './consumer-specifiers.js';
 
 const PKG = '@n8n/design-system';
+
+describe('isScannableFile', () => {
+	it('scans a file inside a dot-directory', () => {
+		// The original glob ran with `fast-glob`'s default `dot: false`, which skipped
+		// `.storybook/preview.ts` — a build-time config that imports this package — and so passed
+		// over two unexported specifiers.
+		expect(isScannableFile('packages/frontend/@n8n/storybook/.storybook/preview.ts')).toBe(true);
+	});
+
+	it('scans the source extensions that can carry a specifier', () => {
+		for (const file of ['a.ts', 'a.mts', 'a.vue', 'a.scss', 'a.css', 'a.mjs']) {
+			expect(isScannableFile(`packages/x/src/${file}`)).toBe(true);
+		}
+	});
+
+	it('ignores extensions that cannot', () => {
+		for (const file of ['a.md', 'a.json', 'a.yml', 'a.snap', 'a']) {
+			expect(isScannableFile(`packages/x/src/${file}`)).toBe(false);
+		}
+	});
+
+	it('ignores test files, whose specifiers are fixtures rather than imports', () => {
+		expect(isScannableFile('packages/x/src/a.test.ts')).toBe(false);
+		expect(isScannableFile('packages/x/src/a.spec.ts')).toBe(false);
+		expect(isScannableFile('packages/x/src/__tests__/a.ts')).toBe(false);
+		expect(isScannableFile('packages/x/src/__mocks__/a.ts')).toBe(false);
+	});
+
+	it('ignores this checker, which holds specifiers as data', () => {
+		expect(isScannableFile('packages/testing/code-health/src/packed-consumer/fixture.ts')).toBe(
+			false,
+		);
+	});
+
+	it('ignores scaffolding templates for generated user projects', () => {
+		expect(isScannableFile('packages/@n8n/node-cli/src/template/templates/a.ts')).toBe(false);
+	});
+});
+
+describe('trackedScannableFiles', () => {
+	it('reads the git index, so generated output can never be scanned', () => {
+		// `storybook-static/` is gitignored build output. It bundles this package's stylesheets, so
+		// scanning it contributed four specifiers attributed to unreadable asset chunks. Tracking
+		// status excludes every such directory at once, with no list to maintain.
+		const files = trackedScannableFiles(process.cwd());
+		expect(files.length).toBeGreaterThan(0);
+		expect(files.some((f) => f.includes('storybook-static/'))).toBe(false);
+		expect(files.some((f) => f.includes('node_modules/'))).toBe(false);
+		expect(files.some((f) => f.includes('/dist/'))).toBe(false);
+	});
+
+	it('throws rather than silently scanning a smaller set than it reports', () => {
+		expect(() => trackedScannableFiles('/nonexistent-path-outside-any-repo')).toThrow(
+			/needs a git checkout/,
+		);
+	});
+});
 
 describe('extractSpecifiers', () => {
 	it('finds an import, a type-only import and a sass `@use`', () => {

--- a/packages/testing/code-health/src/packed-consumer/consumer-specifiers.ts
+++ b/packages/testing/code-health/src/packed-consumer/consumer-specifiers.ts
@@ -1,0 +1,140 @@
+import fg from 'fast-glob';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Enumerate the specifiers the monorepo actually writes for a published package.
+ *
+ * Every one of them has to resolve through the published `exports` map. A specifier that only
+ * resolves through a build-time alias is the exact defect this check exists to catch: it works
+ * for every package inside the workspace and fails for the first consumer outside it. Deriving
+ * the set from the source tree — rather than from a list in this file — is what keeps that
+ * property true after the next import is added.
+ */
+
+/**
+ * Files that can carry a module or stylesheet specifier.
+ *
+ * Test files are excluded, and deliberately so. The question this check asks is what the published
+ * surface owes a consumer, and a test never ships — but a test is exactly where a made-up
+ * specifier appears as a fixture string, which would fail the job for a specifier nobody imports.
+ */
+const SOURCE_GLOBS = [
+	'**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs,vue,scss,sass,css}',
+	'!**/node_modules/**',
+	'!**/dist/**',
+	'!**/.turbo/**',
+	'!**/src/template/**',
+	'!**/*.{test,spec}.*',
+	'!**/__tests__/**',
+	'!**/__mocks__/**',
+	// This checker itself. It generates consumer code, so it holds specifiers as data and names
+	// them in doc comments — none of which is anybody importing anything.
+	'!packages/testing/code-health/**',
+];
+
+export interface SpecifierUse {
+	specifier: string;
+	/** Repo-relative path of the first file seen importing it. */
+	file: string;
+}
+
+/**
+ * Match the package name only where a specifier can legally appear: inside a quoted string
+ * (`import … from '…'`, `@use '…'`) or a `url()`. An unquoted mention in prose is a comment,
+ * and failing the build over a comment would teach people to distrust the check.
+ *
+ * The trailing lookahead is what stops `@n8n/design-system-icons` from being read as a bare
+ * import of `@n8n/design-system` — a different package reported as this one.
+ */
+function specifierPattern(pkgName: string): RegExp {
+	const escaped = pkgName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return new RegExp(`['"\`(]\\s*(${escaped}(?:/[^'"\`)\\s]*)?)(?=['"\`)\\s]|$)`, 'g');
+}
+
+/** Distinct specifiers for `pkgName` in `content`, with any trailing punctuation removed. */
+export function extractSpecifiers(content: string, pkgName: string): string[] {
+	const found = new Set<string>();
+	for (const match of content.matchAll(specifierPattern(pkgName))) {
+		const specifier = match[1].replace(/[;,)]+$/, '');
+		// `paths` patterns in a tsconfig, not something a consumer can import.
+		if (specifier.includes('*')) continue;
+		found.add(specifier);
+	}
+	return [...found];
+}
+
+/**
+ * True for the alias-only internal form. `@n8n/design-system/src/…` is deliberately outside the
+ * `exports` map: `files` ships `dist`, not `src`, so these are workspace-internal by construction
+ * and must not be reported as a broken published specifier.
+ */
+export function isInternalSourceSpecifier(pkgName: string, specifier: string): boolean {
+	return specifier === `${pkgName}/src` || specifier.startsWith(`${pkgName}/src/`);
+}
+
+/** Scan the whole repo (excluding the package itself) for specifiers naming `pkgName`. */
+export async function collectConsumerSpecifiers(
+	rootDir: string,
+	pkgName: string,
+	ownRelDir: string,
+): Promise<SpecifierUse[]> {
+	const files = await fg(SOURCE_GLOBS, {
+		cwd: rootDir,
+		absolute: true,
+		// The package's own sources import themselves through the `@n8n/design-system` -> `src`
+		// self-alias, which says nothing about what the tarball owes an external consumer.
+		ignore: [`${ownRelDir}/**`],
+	});
+
+	const bySpecifier = new Map<string, SpecifierUse>();
+	for (const file of files) {
+		let content: string;
+		try {
+			content = fs.readFileSync(file, 'utf-8');
+		} catch {
+			continue;
+		}
+		if (!content.includes(pkgName)) continue;
+		for (const specifier of extractSpecifiers(content, pkgName)) {
+			if (bySpecifier.has(specifier)) continue;
+			bySpecifier.set(specifier, {
+				specifier,
+				file: path.relative(rootDir, file).split(path.sep).join('/'),
+			});
+		}
+	}
+	return [...bySpecifier.values()].sort((a, b) => a.specifier.localeCompare(b.specifier));
+}
+
+/**
+ * Candidate files for a resolved `exports` target.
+ *
+ * Node requires the target to name a file exactly, and for JS it does. Sass does not: it runs its
+ * own load algorithm on top of the `exports` result, so `@n8n/design-system/css/_tokens` legally
+ * resolves to `_tokens.scss` and `css/mixins/motion` to `motion.scss`. Rejecting those would fail
+ * the job on imports that work, so stylesheet targets get sass's candidate list.
+ */
+export function targetCandidates(target: string): string[] {
+	const clean = target.replace(/^\.\//, '');
+	if (/\.(css|scss|sass|[cm]?js|d\.[cm]?ts|json)$/.test(clean)) return [clean];
+	const dir = path.posix.dirname(clean);
+	const base = path.posix.basename(clean);
+	return [
+		clean,
+		`${clean}.scss`,
+		`${clean}.css`,
+		path.posix.join(dir, `_${base}.scss`),
+		path.posix.join(clean, 'index.scss'),
+		path.posix.join(clean, '_index.scss'),
+	];
+}
+
+/** First candidate for `target` that exists under `packageRoot`, or `null`. */
+export function resolveTargetFile(packageRoot: string, target: string): string | null {
+	for (const candidate of targetCandidates(target)) {
+		const absolute = path.join(packageRoot, candidate);
+		if (fs.existsSync(absolute) && fs.statSync(absolute).isFile()) return candidate;
+	}
+	return null;
+}

--- a/packages/testing/code-health/src/packed-consumer/consumer-specifiers.ts
+++ b/packages/testing/code-health/src/packed-consumer/consumer-specifiers.ts
@@ -1,4 +1,4 @@
-import fg from 'fast-glob';
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -10,28 +10,55 @@ import * as path from 'node:path';
  * for every package inside the workspace and fails for the first consumer outside it. Deriving
  * the set from the source tree — rather than from a list in this file — is what keeps that
  * property true after the next import is added.
+ *
+ * The file set comes from `git ls-files`, not from a glob. A glob needs a hand-written list of
+ * directories to skip, and every entry missing from that list is a silent hole: `dot: false` (the
+ * `fast-glob` default) hid `.storybook/`, where a build-time config imports this package, and
+ * `storybook-static/` — a build output nobody had thought to exclude — contributed four specifiers
+ * out of bundled asset files. Tracked-or-not answers both, permanently and without a list:
+ * generated output is never tracked, and a dot-directory is tracked like anything else.
  */
 
+const SCANNED_EXTENSIONS = new Set([
+	'.ts',
+	'.tsx',
+	'.mts',
+	'.cts',
+	'.js',
+	'.jsx',
+	'.mjs',
+	'.cjs',
+	'.vue',
+	'.scss',
+	'.sass',
+	'.css',
+]);
+
 /**
- * Files that can carry a module or stylesheet specifier.
+ * Tracked paths that still must not contribute a specifier.
  *
- * Test files are excluded, and deliberately so. The question this check asks is what the published
- * surface owes a consumer, and a test never ships — but a test is exactly where a made-up
- * specifier appears as a fixture string, which would fail the job for a specifier nobody imports.
+ * Unlike the directories a glob would have to skip, each of these is a semantic exclusion rather
+ * than a mechanical one, so each is stated with its reason:
+ *
+ * - Test files never ship, and a test is exactly where a made-up specifier appears as a fixture
+ *   string — which would fail the job for a specifier nobody imports.
+ * - This checker generates consumer code, so it holds specifiers as data and names them in doc
+ *   comments. Both were observed producing phantom findings.
+ * - `src/template/` is scaffolding for generated user projects, not code this repo builds.
  */
-const SOURCE_GLOBS = [
-	'**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs,vue,scss,sass,css}',
-	'!**/node_modules/**',
-	'!**/dist/**',
-	'!**/.turbo/**',
-	'!**/src/template/**',
-	'!**/*.{test,spec}.*',
-	'!**/__tests__/**',
-	'!**/__mocks__/**',
-	// This checker itself. It generates consumer code, so it holds specifiers as data and names
-	// them in doc comments — none of which is anybody importing anything.
-	'!packages/testing/code-health/**',
-];
+function isSemanticallyExcluded(relPath: string): boolean {
+	if (/(^|\/)__(tests|mocks)__\//.test(relPath)) return true;
+	if (/\.(test|spec)\.[^/]+$/.test(relPath)) return true;
+	if (relPath.startsWith('packages/testing/code-health/')) return true;
+	if (relPath.includes('/src/template/')) return true;
+	return false;
+}
+
+/** True when a tracked repo-relative path should be read for specifiers. */
+export function isScannableFile(relPath: string): boolean {
+	if (!SCANNED_EXTENSIONS.has(path.extname(relPath))) return false;
+	return !isSemanticallyExcluded(relPath);
+}
 
 export interface SpecifierUse {
 	specifier: string;
@@ -73,35 +100,52 @@ export function isInternalSourceSpecifier(pkgName: string, specifier: string): b
 	return specifier === `${pkgName}/src` || specifier.startsWith(`${pkgName}/src/`);
 }
 
+/**
+ * Every git-tracked, scannable path in the repo.
+ *
+ * Throws rather than falling back to a filesystem walk. A fallback would keep the job green while
+ * scanning a different — and smaller — set of files than it reports, which is the failure mode this
+ * whole function was just rewritten to remove.
+ */
+export function trackedScannableFiles(rootDir: string): string[] {
+	let out: string;
+	try {
+		out = execFileSync('git', ['ls-files', '-z'], {
+			cwd: rootDir,
+			encoding: 'utf8',
+			maxBuffer: 64 * 1024 * 1024,
+		});
+	} catch (cause) {
+		throw new Error(
+			`Cannot list tracked files in ${rootDir}. This check reads the git index to know what ` +
+				'to scan, so it needs a git checkout.',
+			{ cause },
+		);
+	}
+	return out.split('\0').filter((f) => f.length > 0 && isScannableFile(f));
+}
+
 /** Scan the whole repo (excluding the package itself) for specifiers naming `pkgName`. */
-export async function collectConsumerSpecifiers(
+export function collectConsumerSpecifiers(
 	rootDir: string,
 	pkgName: string,
 	ownRelDir: string,
-): Promise<SpecifierUse[]> {
-	const files = await fg(SOURCE_GLOBS, {
-		cwd: rootDir,
-		absolute: true,
+): SpecifierUse[] {
+	const bySpecifier = new Map<string, SpecifierUse>();
+	for (const relPath of trackedScannableFiles(rootDir)) {
 		// The package's own sources import themselves through the `@n8n/design-system` -> `src`
 		// self-alias, which says nothing about what the tarball owes an external consumer.
-		ignore: [`${ownRelDir}/**`],
-	});
-
-	const bySpecifier = new Map<string, SpecifierUse>();
-	for (const file of files) {
+		if (relPath.startsWith(`${ownRelDir}/`)) continue;
 		let content: string;
 		try {
-			content = fs.readFileSync(file, 'utf-8');
+			content = fs.readFileSync(path.join(rootDir, relPath), 'utf-8');
 		} catch {
 			continue;
 		}
 		if (!content.includes(pkgName)) continue;
 		for (const specifier of extractSpecifiers(content, pkgName)) {
 			if (bySpecifier.has(specifier)) continue;
-			bySpecifier.set(specifier, {
-				specifier,
-				file: path.relative(rootDir, file).split(path.sep).join('/'),
-			});
+			bySpecifier.set(specifier, { specifier, file: relPath });
 		}
 	}
 	return [...bySpecifier.values()].sort((a, b) => a.specifier.localeCompare(b.specifier));

--- a/packages/testing/code-health/src/packed-consumer/exports-map.test.ts
+++ b/packages/testing/code-health/src/packed-consumer/exports-map.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyTarget, collectExportEntries, resolveSpecifier } from './exports-map.js';
+
+const PKG = '@n8n/design-system';
+
+// The shape `@n8n/design-system` publishes, trimmed to what the resolver has to reason about.
+const EXPORTS = {
+	'.': { types: './dist/index.d.ts', import: './dist/index.js' },
+	'./icons/lucide': {
+		types: './dist/icons/lucide/index.d.ts',
+		import: './dist/icons/lucide/index.js',
+	},
+	'./style.css': './dist/style.css',
+	'./css/*': './dist/css/*',
+	'./package.json': './package.json',
+};
+
+describe('classifyTarget', () => {
+	it('separates modules, declarations, stylesheets and the manifest', () => {
+		expect(classifyTarget('./dist/index.js')).toBe('module');
+		expect(classifyTarget('./dist/index.d.ts')).toBe('types');
+		expect(classifyTarget('./dist/style.css')).toBe('style');
+		expect(classifyTarget('./dist/css/_tokens.scss')).toBe('style');
+		expect(classifyTarget('./package.json')).toBe('manifest');
+	});
+
+	it('reads `.d.ts` as declarations rather than as a module', () => {
+		// `.d.ts` ends in `.ts`, not `.js`, but an ordering mistake here would probe a declaration
+		// file with a runtime `import()` and fail on a healthy package.
+		expect(classifyTarget('./dist/icons/lucide/index.d.ts')).toBe('types');
+	});
+});
+
+describe('collectExportEntries', () => {
+	it('gives every subpath the specifier a consumer writes', () => {
+		const entries = collectExportEntries(PKG, EXPORTS);
+		const specifiers = entries.map((e) => e.specifier);
+		expect(specifiers).toContain(PKG);
+		expect(specifiers).toContain(`${PKG}/icons/lucide`);
+		expect(specifiers).toContain(`${PKG}/style.css`);
+	});
+
+	it('leaves a wildcard key without a specifier', () => {
+		const wildcard = collectExportEntries(PKG, EXPORTS).find((e) => e.subpath === './css/*');
+		expect(wildcard?.isWildcard).toBe(true);
+		expect(wildcard?.specifier).toBeUndefined();
+	});
+
+	it('collects both the types and the import condition', () => {
+		const root = collectExportEntries(PKG, EXPORTS).find((e) => e.subpath === '.');
+		expect(root?.targets.map((t) => t.condition).sort()).toEqual(['import', 'types']);
+	});
+
+	it('treats a bare string `exports` as the root entry', () => {
+		const entries = collectExportEntries(PKG, './dist/index.js');
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({ subpath: '.', specifier: PKG });
+	});
+
+	it('returns nothing when `exports` is absent, so the caller can fail loudly', () => {
+		expect(collectExportEntries(PKG, undefined)).toEqual([]);
+	});
+});
+
+describe('resolveSpecifier', () => {
+	const entries = collectExportEntries(PKG, EXPORTS);
+
+	it('matches the bare specifier to the root', () => {
+		expect(resolveSpecifier(PKG, PKG, entries)?.entry.subpath).toBe('.');
+	});
+
+	it('prefers an exact key over a wildcard', () => {
+		const withBoth = collectExportEntries(PKG, {
+			'./css/*': './dist/css/*',
+			'./css/index.scss': './dist/css/main.scss',
+		});
+		const match = resolveSpecifier(PKG, `${PKG}/css/index.scss`, withBoth);
+		expect(match?.entry.subpath).toBe('./css/index.scss');
+		expect(match?.targets[0].target).toBe('./dist/css/main.scss');
+	});
+
+	it('substitutes the captured segment into a wildcard target', () => {
+		const match = resolveSpecifier(PKG, `${PKG}/css/mixins/motion`, entries);
+		expect(match?.entry.subpath).toBe('./css/*');
+		expect(match?.targets[0].target).toBe('./dist/css/mixins/motion');
+	});
+
+	it('returns null for a subpath the map does not cover', () => {
+		// The deep-import regression: resolves through a build-time alias inside the workspace,
+		// resolves nowhere for a consumer outside it.
+		expect(resolveSpecifier(PKG, `${PKG}/components/N8nIcon/icons`, entries)).toBeNull();
+	});
+
+	it('returns null for a specifier belonging to another package', () => {
+		expect(resolveSpecifier(PKG, '@n8n/design-system-extra/thing', entries)).toBeNull();
+	});
+
+	it('picks the longest static prefix when two wildcards both match', () => {
+		const nested = collectExportEntries(PKG, {
+			'./css/*': './dist/css/*',
+			'./css/mixins/*': './dist/scss-mixins/*',
+		});
+		const match = resolveSpecifier(PKG, `${PKG}/css/mixins/motion`, nested);
+		expect(match?.entry.subpath).toBe('./css/mixins/*');
+		expect(match?.targets[0].target).toBe('./dist/scss-mixins/motion');
+	});
+});

--- a/packages/testing/code-health/src/packed-consumer/exports-map.ts
+++ b/packages/testing/code-health/src/packed-consumer/exports-map.ts
@@ -1,0 +1,152 @@
+/**
+ * Reading of a package's `exports` map, kept pure so the probe surface is derived from the
+ * manifest rather than from a list somebody has to remember to extend. A subpath added to
+ * `exports` is covered by the next run with no edit here.
+ */
+
+export type TargetKind = 'module' | 'types' | 'style' | 'manifest' | 'unknown';
+
+export interface ExportTarget {
+	/** The `exports` condition this target sits under (`import`, `types`, or `default`). */
+	condition: string;
+	/** Package-relative target, e.g. `./dist/icons/lucide/index.js`. */
+	target: string;
+	kind: TargetKind;
+}
+
+export interface ExportEntry {
+	/** The `exports` key, e.g. `.`, `./icons/lucide`, `./css/*`. */
+	subpath: string;
+	/**
+	 * The bare specifier a consumer writes. Absent for wildcard keys: `./css/*` has no single
+	 * specifier, so it is only ever checked through a specifier a real consumer imports.
+	 */
+	specifier?: string;
+	targets: ExportTarget[];
+	isWildcard: boolean;
+}
+
+export function classifyTarget(target: string): TargetKind {
+	if (target.endsWith('package.json')) return 'manifest';
+	if (/\.d\.[cm]?ts$/.test(target)) return 'types';
+	if (/\.[cm]?js$/.test(target)) return 'module';
+	if (/\.(css|scss|sass)$/.test(target)) return 'style';
+	// A wildcard target (`./dist/css/*`) carries no extension of its own — the specifier supplies it.
+	if (target.includes('*')) return 'unknown';
+	return 'unknown';
+}
+
+/** The conditions that decide what a consumer actually loads; `require` is absent by design (ESM-only). */
+const PROBED_CONDITIONS = ['types', 'import', 'default'];
+
+function targetsOf(value: unknown): ExportTarget[] {
+	if (typeof value === 'string') {
+		return [{ condition: 'default', target: value, kind: classifyTarget(value) }];
+	}
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) return [];
+	const out: ExportTarget[] = [];
+	for (const condition of PROBED_CONDITIONS) {
+		const nested = (value as Record<string, unknown>)[condition];
+		if (typeof nested === 'string') {
+			out.push({ condition, target: nested, kind: classifyTarget(nested) });
+		}
+	}
+	return out;
+}
+
+/**
+ * Flatten an `exports` field into one entry per subpath key.
+ *
+ * A missing or string-valued `exports` yields the single root entry, which is what an older
+ * manifest looks like — the caller then still has one thing to probe rather than zero, so a
+ * regression that erases the map fails loudly instead of passing with an empty target set.
+ */
+export function collectExportEntries(pkgName: string, exportsField: unknown): ExportEntry[] {
+	if (typeof exportsField === 'string') {
+		return [
+			{
+				subpath: '.',
+				specifier: pkgName,
+				targets: targetsOf(exportsField),
+				isWildcard: false,
+			},
+		];
+	}
+	if (exportsField === null || typeof exportsField !== 'object' || Array.isArray(exportsField)) {
+		return [];
+	}
+
+	const entries: ExportEntry[] = [];
+	for (const [subpath, value] of Object.entries(exportsField as Record<string, unknown>)) {
+		// A bare condition map (`{ "import": "./x.js" }`) with no `./`-prefixed keys is the root.
+		const isSubpathKey = subpath === '.' || subpath.startsWith('./');
+		if (!isSubpathKey) continue;
+		const isWildcard = subpath.includes('*');
+		entries.push({
+			subpath,
+			specifier: isWildcard
+				? undefined
+				: subpath === '.'
+					? pkgName
+					: `${pkgName}/${subpath.slice('./'.length)}`,
+			targets: targetsOf(value),
+			isWildcard,
+		});
+	}
+	return entries;
+}
+
+export interface SpecifierMatch {
+	entry: ExportEntry;
+	/** Targets with `*` substituted by the specifier's captured segment. */
+	targets: ExportTarget[];
+}
+
+/**
+ * Resolve a bare specifier against a package's export entries, the way Node does: an exact key
+ * wins, otherwise the wildcard key with the longest static prefix wins.
+ *
+ * Returns `null` when nothing matches — which is the finding this whole check exists to surface,
+ * since such a specifier only ever worked through a build-time alias.
+ */
+export function resolveSpecifier(
+	pkgName: string,
+	specifier: string,
+	entries: ExportEntry[],
+): SpecifierMatch | null {
+	const subpath =
+		specifier === pkgName
+			? '.'
+			: specifier.startsWith(`${pkgName}/`)
+				? `./${specifier.slice(pkgName.length + 1)}`
+				: null;
+	if (subpath === null) return null;
+
+	const exact = entries.find((e) => !e.isWildcard && e.subpath === subpath);
+	if (exact) return { entry: exact, targets: exact.targets };
+
+	let best: { entry: ExportEntry; captured: string; prefixLength: number } | null = null;
+	for (const entry of entries) {
+		if (!entry.isWildcard) continue;
+		const starIndex = entry.subpath.indexOf('*');
+		const prefix = entry.subpath.slice(0, starIndex);
+		const suffix = entry.subpath.slice(starIndex + 1);
+		if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) continue;
+		if (subpath.length < prefix.length + suffix.length) continue;
+		const captured = subpath.slice(prefix.length, subpath.length - suffix.length);
+		if (!best || prefix.length > best.prefixLength) {
+			best = { entry, captured, prefixLength: prefix.length };
+		}
+	}
+	if (!best) return null;
+
+	const captured = best.captured;
+	return {
+		entry: best.entry,
+		targets: best.entry.targets.map((t) => ({
+			...t,
+			target: t.target.replace('*', captured),
+			kind: classifyTarget(t.target.replace('*', captured)),
+		})),
+	};
+}

--- a/packages/testing/code-health/src/packed-consumer/fixture.test.ts
+++ b/packages/testing/code-health/src/packed-consumer/fixture.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFixture, type FixtureInput } from './fixture.js';
+
+const INPUT: FixtureInput = {
+	packageName: '@n8n/design-system',
+	tarballDeps: {
+		'@n8n/design-system': 'file:/tmp/x/n8n-design-system-2.34.0.tgz',
+		'@n8n/utils': 'file:/tmp/x/n8n-utils-0.1.0.tgz',
+	},
+	toolchainDeps: { vue: '^3.5.13', 'vue-tsc': '^2.2.8' },
+	moduleSpecifiers: ['@n8n/design-system', '@n8n/design-system/icons/lucide'],
+	styleSpecifiers: ['@n8n/design-system/css/_tokens', '@n8n/design-system/css/mixins/motion'],
+	cssSpecifiers: ['@n8n/design-system/style.css'],
+};
+
+interface ConsumerManifest {
+	dependencies: Record<string, string>;
+	overrides: Record<string, unknown>;
+}
+
+function parseManifest(raw: string): ConsumerManifest {
+	try {
+		return JSON.parse(raw) as ConsumerManifest;
+	} catch (cause) {
+		throw new Error('buildFixture emitted a package.json that is not valid JSON', { cause });
+	}
+}
+
+describe('buildFixture', () => {
+	const files = buildFixture(INPUT);
+
+	it('writes a project that can be installed, typechecked, built and loaded', () => {
+		expect(Object.keys(files).sort()).toEqual([
+			'index.html',
+			'package.json',
+			'runtime-probe.mjs',
+			'src/App.vue',
+			'src/main.ts',
+			'src/shims.d.ts',
+			'src/styles.scss',
+			'src/type-probe.ts',
+			'tsconfig.json',
+			'vite.config.mts',
+		]);
+	});
+
+	it('forces every packed workspace package to its local tarball', () => {
+		const manifest = parseManifest(files['package.json']);
+		// Without the overrides, npm resolves a published copy at the same version and the run
+		// verifies a tarball nobody built.
+		expect(manifest.overrides['@n8n/utils']).toBe(INPUT.tarballDeps['@n8n/utils']);
+		expect(manifest.dependencies['@n8n/design-system']).toMatch(/^file:/);
+	});
+
+	it('omits the styles entry when nothing imports a stylesheet subpath', () => {
+		const withoutStyles = buildFixture({ ...INPUT, styleSpecifiers: [] });
+		expect(withoutStyles['src/styles.scss']).toBeUndefined();
+		expect(withoutStyles['src/main.ts']).not.toContain('./styles.scss');
+	});
+
+	it('gives each stylesheet `@use` its own namespace', () => {
+		// Several of these define the same token names; sharing a namespace would fail for a
+		// reason that has nothing to do with whether the stylesheet shipped.
+		expect(files['src/styles.scss']).toContain("@use '@n8n/design-system/css/_tokens' as probe0;");
+		expect(files['src/styles.scss']).toContain(
+			"@use '@n8n/design-system/css/mixins/motion' as probe1;",
+		);
+	});
+
+	it('probes every module specifier one at a time', () => {
+		// A single module importing all of them stops at the first failure and hides the rest.
+		expect(files['runtime-probe.mjs']).toContain('for (const specifier of SPECIFIERS)');
+		for (const specifier of INPUT.moduleSpecifiers) {
+			expect(files['runtime-probe.mjs']).toContain(specifier);
+		}
+	});
+
+	it('derives the expected icon chunks from the entry rather than from a directory listing', () => {
+		// A listing makes the check agree with whatever is present: delete a chunk and it would
+		// verify one fewer and still pass.
+		expect(files['runtime-probe.mjs']).toContain('entrySource.matchAll');
+		expect(files['runtime-probe.mjs']).not.toContain('readdirSync');
+	});
+
+	it('uses a statically named slot, which `vue-tsc` can actually check', () => {
+		expect(files['src/App.vue']).toContain('<template #item="{ item, cells }">');
+		expect(files['src/App.vue']).not.toContain('#[');
+	});
+
+	it('asserts the published types have not degraded to `any`', () => {
+		expect(files['src/type-probe.ts']).toContain('type IsAny<T> = 0 extends 1 & T ? true : false');
+		expect(files['src/type-probe.ts']).toContain('@ts-expect-error');
+	});
+
+	it('registers no icon plugin, so the chunks have to be pre-built', () => {
+		expect(files['vite.config.mts']).not.toContain('lucide');
+		expect(files['vite.config.mts']).toContain('vue()');
+	});
+});

--- a/packages/testing/code-health/src/packed-consumer/fixture.ts
+++ b/packages/testing/code-health/src/packed-consumer/fixture.ts
@@ -1,0 +1,362 @@
+/**
+ * The generated consumer project.
+ *
+ * It is written fresh on every run rather than committed, so it cannot drift from the `exports`
+ * map it probes: the specifier lists below are arguments, derived by the caller from the target
+ * manifest and from what the monorepo actually imports.
+ *
+ * Kept pure (string in, string out) so the interesting parts are unit-testable without packing,
+ * installing or compiling anything.
+ */
+
+export interface FixtureInput {
+	packageName: string;
+	/** name -> `file:` spec for every packed workspace tarball. */
+	tarballDeps: Record<string, string>;
+	/** name -> version range for the toolchain, resolved from the target's own manifest. */
+	toolchainDeps: Record<string, string>;
+	/** Every module specifier from the `exports` map, probed one at a time under plain Node. */
+	moduleSpecifiers: string[];
+	/** Stylesheet specifiers the monorepo really imports, e.g. `@n8n/design-system/css/_tokens`. */
+	styleSpecifiers: string[];
+	/** Plain-CSS specifiers from the `exports` map, e.g. `@n8n/design-system/style.css`. */
+	cssSpecifiers: string[];
+}
+
+const PROBE_ICON = 'activity';
+
+function json(value: unknown): string {
+	return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function consumerManifest(input: FixtureInput): string {
+	return json({
+		name: 'packed-consumer-fixture',
+		private: true,
+		version: '0.0.0',
+		type: 'module',
+		scripts: {
+			typecheck: 'vue-tsc --noEmit',
+			build: 'vite build',
+			'probe:runtime': 'node runtime-probe.mjs',
+		},
+		dependencies: { ...input.tarballDeps },
+		devDependencies: { ...input.toolchainDeps },
+		overrides: {
+			// Every workspace package in the closure is at a version npm has never seen, so each one
+			// must be forced to its local tarball or the install resolves a stale published copy.
+			...input.tarballDeps,
+			// `@vitejs/plugin-vue@5` still declares a Vite 5–6 peer range, and the catalog is on
+			// Vite 8 — the same pairing the package itself builds with, where pnpm only warns.
+			// Narrowing that one stale peer keeps every other peer strict. `--legacy-peer-deps`
+			// was the alternative and it is worse than the problem: it flattens the tree instead
+			// of nesting it, which broke `@tiptap/extension-list` against an older `@tiptap/core`
+			// and reported it as a defect in the tarball.
+			'@vitejs/plugin-vue': { vite: '$vite' },
+		},
+	});
+}
+
+function tsconfig(): string {
+	return json({
+		compilerOptions: {
+			target: 'ESNext',
+			module: 'ESNext',
+			// `bundler`, matching the only resolution mode this package supports. `node16` is
+			// unattainable for a `.vue` library without flattening the declarations, which
+			// api-extractor cannot do for `.vue` specifiers — a documented limitation, not a gap.
+			moduleResolution: 'bundler',
+			strict: true,
+			noEmit: true,
+			noUnusedLocals: false,
+			jsx: 'preserve',
+			lib: ['ESNext', 'DOM', 'DOM.Iterable'],
+			// Left on deliberately. Turning it off checks every third-party `.d.ts` in the install
+			// too, so an upstream dependency shipping bad types would redden this job for a defect
+			// nobody here can fix — and a check that goes red for reasons the reader cannot act on
+			// is how a red signal stops meaning anything. The declarations that matter are held to
+			// account at their use site instead, by the assertions in `src/type-probe.ts`.
+			skipLibCheck: true,
+		},
+		include: ['src/**/*.ts', 'src/**/*.d.ts', 'src/**/*.vue', 'vite.config.mts'],
+	});
+}
+
+function viteConfig(): string {
+	// No `lucideIconsPlugin()`. The icon bodies are compiled into the published `dist` as lazy
+	// chunks, so an external consumer resolves them with the stock Vue plugin and nothing else.
+	// Needing a plugin here would mean the pre-built chunks stopped shipping.
+	return `import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [vue()],
+	build: {
+		// A warning is not a failure, and a silently truncated build is worse than a loud one.
+		chunkSizeWarningLimit: Number.MAX_SAFE_INTEGER,
+	},
+});
+`;
+}
+
+function indexHtml(): string {
+	return `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>packed-consumer-fixture</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/main.ts"></script>
+	</body>
+</html>
+`;
+}
+
+function mainTs(input: FixtureInput): string {
+	const cssImports = input.cssSpecifiers.map((s) => `import '${s}';`).join('\n');
+	const styleImport = input.styleSpecifiers.length > 0 ? "import './styles.scss';" : '';
+	return `import { createApp } from 'vue';
+
+import { IconBodyLoaderKey } from '${input.packageName}';
+import { loadLucideIconBody } from '${input.packageName}/icons/lucide';
+
+${cssImports}
+${styleImport}
+import App from './App.vue';
+
+const app = createApp(App);
+
+// The published icon entry has to satisfy the published injection key's type. These two come
+// from different \`exports\` subpaths, so this is also an interop check between them.
+app.provide(IconBodyLoaderKey, loadLucideIconBody);
+app.mount('#app');
+`;
+}
+
+/**
+ * A component with a statically named, generically typed slot.
+ *
+ * `N8nDataTableServer` is the probe because its slot payload reaches a `@tanstack/vue-table`
+ * type through the emitted declarations. That is the shape that broke before: flattening the
+ * declarations left 38 external imports dangling and degraded a component's props to `any`.
+ *
+ * The slot is `#item`, not the `item.<key>` index signature: a dynamic slot name (`#[…]`) is
+ * unchecked by `vue-tsc`, so it would compile no matter how badly the types had rotted.
+ */
+function appVue(input: FixtureInput): string {
+	return `<script setup lang="ts">
+import { N8nDataTableServer, N8nIcon, type TableHeader } from '${input.packageName}';
+
+type Row = { id: string; label: string };
+
+const headers: Array<TableHeader<Row>> = [{ title: 'Label', key: 'label' }];
+const items: Row[] = [{ id: 'a', label: 'first' }];
+</script>
+
+<template>
+	<N8nDataTableServer :headers="headers" :items="items" :items-length="items.length">
+		<template #item="{ item, cells }">
+			<N8nIcon icon="${PROBE_ICON}" />
+			<span>{{ item.id }} / {{ item.label }} / {{ cells.length }}</span>
+		</template>
+	</N8nDataTableServer>
+</template>
+`;
+}
+
+/**
+ * Compile-time negative controls.
+ *
+ * `skipLibCheck` means a rotted declaration does not fail on its own — it quietly resolves to
+ * `any`, and every use site keeps compiling. Each assertion below fails when that happens, so
+ * the typecheck has something it can actually lose.
+ */
+function typeProbeTs(input: FixtureInput): string {
+	return `import {
+	IconBodyLoaderKey,
+	N8nDataTableServer,
+	N8nIcon,
+	type IconBodyLoader,
+	type TableHeader,
+	type TableOptions,
+} from '${input.packageName}';
+import { loadLucideIconBody } from '${input.packageName}/icons/lucide';
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+/**
+ * Fails to compile when the argument is not \`true\`.
+ *
+ * Each assertion below spells \`IsAny<…> extends true ? false : true\` out at the use site rather
+ * than behind a generic alias: with a type parameter still open, the conditional stays deferred
+ * and TypeScript rejects the alias itself, which is a compile error that says nothing about the
+ * package under test.
+ */
+type Assert<T extends true> = T;
+
+type Row = { id: string; label: string };
+
+export type AssertHeaderTyped = Assert<IsAny<TableHeader<Row>> extends true ? false : true>;
+export type AssertOptionsTyped = Assert<IsAny<TableOptions> extends true ? false : true>;
+export type AssertLoaderTyped = Assert<IsAny<IconBodyLoader> extends true ? false : true>;
+export type AssertTableTyped = Assert<
+	IsAny<typeof N8nDataTableServer> extends true ? false : true
+>;
+export type AssertIconTyped = Assert<IsAny<typeof N8nIcon> extends true ? false : true>;
+export type AssertKeyTyped = Assert<IsAny<typeof IconBodyLoaderKey> extends true ? false : true>;
+
+// The two subpaths have to agree: the icon entry's export must satisfy the barrel's key type.
+export const loader: IconBodyLoader = loadLucideIconBody;
+
+// \`key\` is constrained to the keys of \`Row\`, so this object is invalid. If the generic
+// parameter was dropped or the type widened to \`any\`, the error disappears and \`vue-tsc\`
+// reports the unused directive instead — either way the assertion is load-bearing.
+// @ts-expect-error 'nope' is not a key of Row
+export const rejectedHeader: TableHeader<Row> = { key: 'nope' };
+`;
+}
+
+/**
+ * Stylesheet imports carry no types, and TypeScript 6 errors on a side-effect import it cannot
+ * resolve to a declaration. Every app that imports a stylesheet declares these; that the files
+ * themselves ship is asserted before the fixture is written, and again by the Vite build.
+ */
+function shimsDts(): string {
+	return `declare module '*.css';
+declare module '*.scss';
+`;
+}
+
+function stylesScss(input: FixtureInput): string {
+	// Distinct namespaces: several of these define the same token names, and a collision would
+	// fail for a reason that has nothing to do with whether the stylesheet shipped.
+	const uses = input.styleSpecifiers
+		.map((specifier, index) => `@use '${specifier}' as probe${index};`)
+		.join('\n');
+	return `// Every stylesheet specifier the monorepo imports from this package, compiled through
+// sass against the packed tarball rather than against \`src\`.
+${uses}
+`;
+}
+
+/**
+ * Runtime probe, run by plain \`node\` — no bundler.
+ *
+ * Per specifier, one at a time. A single module that imports everything stops at the first
+ * failure and hides the rest; that is how an extensionless CJS subpath stayed hidden while a
+ * different bad import was being fixed. Bundlers paper over these with \`cjs-module-lexer\`, so an
+ * all-green \`vite build\` is not evidence that Node can load the package.
+ */
+function runtimeProbeMjs(input: FixtureInput): string {
+	return `import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const PACKAGE = ${JSON.stringify(input.packageName)};
+const SPECIFIERS = ${JSON.stringify(input.moduleSpecifiers, null, 1)};
+
+const failures = [];
+
+for (const specifier of SPECIFIERS) {
+	try {
+		const module = await import(specifier);
+		if (module === null || typeof module !== 'object') {
+			failures.push(\`\${specifier}: imported but produced no module namespace\`);
+			continue;
+		}
+		if (Object.keys(module).length === 0) {
+			failures.push(\`\${specifier}: module namespace is empty\`);
+			continue;
+		}
+		console.log(\`  ok  \${specifier} (\${Object.keys(module).length} exports)\`);
+	} catch (error) {
+		failures.push(\`\${specifier}: \${error.message}\`);
+	}
+}
+
+// The pre-built icon chunks. \`files\` ships \`dist\`, and the loader reaches its chunks by relative
+// dynamic import, so a chunk that stopped being emitted or stopped being packed is invisible
+// until an icon body is actually requested through the public API.
+// \`import.meta.resolve\`, not \`createRequire().resolve\`: the exports map declares \`types\` and
+// \`import\` and no \`require\`, which is correct for an ESM-only package — so CJS resolution refuses
+// the subpath, and using it here would fail on a healthy tarball.
+const entryPath = fileURLToPath(import.meta.resolve(\`\${PACKAGE}/icons/lucide\`));
+
+// The expected chunk set comes from the entry's own dynamic imports, never from a directory
+// listing. Listing the directory would make the check agree with whatever happens to be there:
+// delete a chunk and the probe would just verify one fewer, and pass.
+const entrySource = readFileSync(entryPath, 'utf-8');
+const referenced = [
+	...entrySource.matchAll(/import\\(\\s*["']([^"']+)["']\\s*\\)/g),
+].map((m) => m[1]);
+const chunkRefs = referenced.filter((r) => /lucide-icons-bucket-\\d+/.test(r));
+
+if (chunkRefs.length === 0) {
+	failures.push(
+		\`icon chunks: \${entryPath} dynamically imports no bucket chunk — the icon bodies are no \` +
+			'longer pre-built, so every consumer needs the build-time plugin again',
+	);
+} else {
+	const { loadLucideIconBody } = await import(\`\${PACKAGE}/icons/lucide\`);
+	console.log(\`  ok  entry references \${chunkRefs.length} pre-built icon chunk(s)\`);
+
+	// One real icon per referenced chunk, requested through the public loader. This also proves
+	// the loader's bucket function still agrees with the partitioning the build used: a name is
+	// only found if it is looked for in the chunk it was compiled into.
+	for (const ref of chunkRefs) {
+		const chunkPath = resolve(dirname(entryPath), ref);
+		if (!existsSync(chunkPath)) {
+			failures.push(\`\${ref}: referenced by the icon entry but absent from the tarball\`);
+			continue;
+		}
+		const contents = await import(pathToFileURL(chunkPath).href);
+		const names = Object.keys(contents.default ?? {});
+		if (names.length === 0) {
+			failures.push(\`\${ref}: chunk has no icon bodies\`);
+			continue;
+		}
+		const name = names[0];
+		const body = await loadLucideIconBody(name);
+		if (typeof body !== 'string' || body.length === 0) {
+			failures.push(\`\${ref}: loadLucideIconBody('\${name}') returned \${JSON.stringify(body)}\`);
+		}
+	}
+
+	// Negative control: an icon that does not exist must resolve to \`null\`, not throw and not
+	// return a body. A probe that is never shown to fail is not evidence.
+	const missing = await loadLucideIconBody('n8n-not-a-real-icon-name');
+	if (missing !== null) {
+		failures.push(\`loadLucideIconBody returned \${JSON.stringify(missing)} for an unknown icon\`);
+	}
+	console.log('  ok  icon bodies load for every chunk; unknown icon resolves to null');
+}
+
+if (failures.length > 0) {
+	console.error(\`\\nFAIL: \${failures.length} runtime problem(s) loading the packed tarball:\`);
+	for (const failure of failures) console.error(\`  - \${failure}\`);
+	process.exit(1);
+}
+
+console.log('\\nOK: the packed tarball loads under plain Node.');
+`;
+}
+
+/** Every file of the generated consumer, keyed by its path relative to the project root. */
+export function buildFixture(input: FixtureInput): Record<string, string> {
+	const files: Record<string, string> = {
+		'package.json': consumerManifest(input),
+		'tsconfig.json': tsconfig(),
+		'vite.config.mts': viteConfig(),
+		'index.html': indexHtml(),
+		'runtime-probe.mjs': runtimeProbeMjs(input),
+		'src/main.ts': mainTs(input),
+		'src/App.vue': appVue(input),
+		'src/type-probe.ts': typeProbeTs(input),
+		'src/shims.d.ts': shimsDts(),
+	};
+	if (input.styleSpecifiers.length > 0) {
+		files['src/styles.scss'] = stylesScss(input);
+	}
+	return files;
+}

--- a/packages/testing/code-health/src/packed-consumer/grandfathered.test.ts
+++ b/packages/testing/code-health/src/packed-consumer/grandfathered.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { GRANDFATHERED_SPECIFIERS, findGrandfathered } from './grandfathered.js';
+
+describe('GRANDFATHERED_SPECIFIERS', () => {
+	it('names an exact specifier, never a prefix or a glob', () => {
+		// A directory-shaped exception is what let `.storybook/` hide two violations. An exact
+		// string cannot widen to cover a subpath nobody reviewed.
+		for (const entry of GRANDFATHERED_SPECIFIERS) {
+			expect(entry.specifier).not.toContain('*');
+			expect(entry.specifier.endsWith('/')).toBe(false);
+		}
+	});
+
+	it('states a reason substantial enough to act on', () => {
+		// The point of the list is that every exception is readable in the job output. A one-word
+		// reason would make it a silent exclusion with extra steps.
+		for (const entry of GRANDFATHERED_SPECIFIERS) {
+			expect(entry.reason.length).toBeGreaterThan(80);
+		}
+	});
+
+	it('holds no duplicates', () => {
+		const specifiers = GRANDFATHERED_SPECIFIERS.map((e) => e.specifier);
+		expect(new Set(specifiers).size).toBe(specifiers.length);
+	});
+});
+
+describe('findGrandfathered', () => {
+	it('matches only the exact specifier', () => {
+		expect(findGrandfathered('@n8n/design-system/plugin')?.specifier).toBe(
+			'@n8n/design-system/plugin',
+		);
+		expect(findGrandfathered('@n8n/design-system/plugin/extra')).toBeUndefined();
+		expect(findGrandfathered('@n8n/design-system')).toBeUndefined();
+	});
+});

--- a/packages/testing/code-health/src/packed-consumer/grandfathered.ts
+++ b/packages/testing/code-health/src/packed-consumer/grandfathered.ts
@@ -1,0 +1,45 @@
+/**
+ * Specifiers that are knowingly outside the published `exports` surface when this check landed.
+ *
+ * A new gate over an existing codebase either grandfathers what it finds or blocks on work it does
+ * not own. This package already takes the first route elsewhere — `endpoint-scope-coverage` ships
+ * disabled precisely so ~129 existing routes can be reviewed into a baseline first — so this is the
+ * same pattern, kept as small as it can be: exact specifier strings, each with its reason, printed
+ * on every run, and self-clearing.
+ *
+ * This is deliberately not a directory or a glob. The hole this check shipped with was a
+ * `dot: false` default that excluded `.storybook/` without anybody writing it down; an exclusion
+ * that is invisible in the output is the defect, not the fact that an exception exists.
+ */
+
+export interface GrandfatheredSpecifier {
+	specifier: string;
+	/** Why it is not simply fixed, and what would resolve it. */
+	reason: string;
+}
+
+export const GRANDFATHERED_SPECIFIERS: GrandfatheredSpecifier[] = [
+	{
+		specifier: '@n8n/design-system/plugin',
+		reason:
+			'`.storybook/preview.ts` imports it deeply on purpose (8ce1fdca557, 2026-07-27): preview.ts ' +
+			'is a TurboSnap global, and the barrel\'s `export * from "./components"` would make every ' +
+			'component a global dep, forcing a full Chromatic snapshot on any component change. The ' +
+			'symbol is on the root barrel, so a root import compiles — but it costs that property. ' +
+			'Resolution is `./plugin` as its own entry, like `./icons/lucide`: a plugin that pulls the ' +
+			'whole component set is exactly the optional capability the barrel should not carry. ' +
+			'Needs a build entry too — `dist/plugin.d.ts` ships today with no `dist/plugin.js`.',
+	},
+	{
+		specifier: '@n8n/design-system/composables/useIconBodyLoader',
+		reason:
+			'Same import site and same TurboSnap reason as `@n8n/design-system/plugin`. Only ' +
+			'`IconBodyLoaderKey` is needed, and it is on the root barrel. Resolution is the same: give ' +
+			'the icon-loader contract a published subpath, or accept the barrel import here once the ' +
+			'TurboSnap cost is measured rather than assumed.',
+	},
+];
+
+export function findGrandfathered(specifier: string): GrandfatheredSpecifier | undefined {
+	return GRANDFATHERED_SPECIFIERS.find((g) => g.specifier === specifier);
+}

--- a/packages/testing/code-health/src/packed-consumer/verify-packed-consumer.ts
+++ b/packages/testing/code-health/src/packed-consumer/verify-packed-consumer.ts
@@ -8,9 +8,11 @@ import {
 	collectConsumerSpecifiers,
 	isInternalSourceSpecifier,
 	resolveTargetFile,
+	type SpecifierUse,
 } from './consumer-specifiers.js';
 import { collectExportEntries, resolveSpecifier, type ExportEntry } from './exports-map.js';
 import { buildFixture } from './fixture.js';
+import { findGrandfathered } from './grandfathered.js';
 import type { WorkspacePkg } from '../utils/pack-workspace.js';
 import { closureOf, loadWorkspace, packClosure } from '../utils/pack-workspace.js';
 import { parseCatalog } from '../utils/workspace-parser.js';
@@ -71,16 +73,15 @@ function extractTarball(tarball: string, destDir: string): string {
  * so a specifier missing from `exports` is invisible until the first consumer outside the
  * workspace tries it.
  */
-async function verifySpecifiersResolve(
-	rootDir: string,
+function verifySpecifiersResolve(
+	uses: SpecifierUse[],
 	pkgName: string,
-	ownRelDir: string,
 	packageRoot: string,
 	entries: ExportEntry[],
-): Promise<Failure[]> {
-	const uses = await collectConsumerSpecifiers(rootDir, pkgName, ownRelDir);
+): Failure[] {
 	const failures: Failure[] = [];
 	const internal: string[] = [];
+	const quarantined: string[] = [];
 
 	for (const use of uses) {
 		if (isInternalSourceSpecifier(pkgName, use.specifier)) {
@@ -88,10 +89,27 @@ async function verifySpecifiersResolve(
 			continue;
 		}
 		const match = resolveSpecifier(pkgName, use.specifier, entries);
+		const known = findGrandfathered(use.specifier);
 		if (!match) {
+			if (known) {
+				quarantined.push(`${known.specifier} (${use.file})\n        ${known.reason}`);
+				continue;
+			}
 			failures.push({
 				phase: 'specifiers',
 				detail: `${use.specifier} — no matching key in the exports map (${use.file})`,
+			});
+			continue;
+		}
+		// A grandfathered specifier that now resolves means the underlying work landed. Failing here
+		// is what stops the exception list outliving its reason and quietly excusing a future
+		// regression on the same subpath.
+		if (known) {
+			failures.push({
+				phase: 'specifiers',
+				detail:
+					`${use.specifier} resolves through \`exports\` now, so its grandfathered entry is ` +
+					'stale — delete it from `grandfathered.ts`',
 			});
 			continue;
 		}
@@ -108,8 +126,16 @@ async function verifySpecifiersResolve(
 		console.log(`  ok  ${use.specifier} -> ${match.entry.subpath}`);
 	}
 
+	// Printed unconditionally, and not as a warning that scrolls past: an exception nobody can see
+	// in the output is how this check shipped green over two real violations in the first place.
+	if (quarantined.length > 0) {
+		console.log(`\n  ${quarantined.length} grandfathered specifier(s) — NOT enforced:`);
+		for (const entry of quarantined) console.log(`    - ${entry}`);
+	}
+
 	console.log(
-		`\n  ${uses.length - internal.length} published specifier(s) checked; ` +
+		`\n  ${uses.length - internal.length - quarantined.length} published specifier(s) enforced; ` +
+			`${quarantined.length} grandfathered; ` +
 			`${internal.length} alias-only \`${pkgName}/src…\` specifier(s) skipped ` +
 			'(deliberately outside `exports` — `files` ships `dist`).',
 	);
@@ -238,10 +264,9 @@ export async function runVerifyPackedConsumer(args: string[], rootDir: string): 
 	const packageArg = args.find((a) => a.startsWith('--package='));
 	const pkgName = packageArg ? packageArg.slice('--package='.length) : DEFAULT_TARGET;
 	const keep = args.includes('--keep');
-	// The two halves have very different costs. The static half needs only the tarball and a repo
-	// glob, so it can afford to run on any PR — which is what catches a deep import added anywhere
-	// in the monorepo. The consumer half installs from the registry and compiles, so it runs when
-	// the package's own packaging changes.
+	// Local shortcut: the static half needs only the tarball and the git index, so it answers "did I
+	// just add an unexported specifier?" in seconds. Both CI callers run the full scope; nothing
+	// passes `static`, deliberately — a green check that skipped the compile is worth little.
 	const staticOnly = args.includes('--static-only');
 
 	const byName = await loadWorkspace(rootDir);
@@ -292,10 +317,9 @@ export async function runVerifyPackedConsumer(args: string[], rootDir: string): 
 	}
 
 	heading('Every specifier the monorepo imports resolves through `exports`');
-	const ownRelDir = target.relDir;
-	failures.push(
-		...(await verifySpecifiersResolve(rootDir, pkgName, ownRelDir, packageRoot, entries)),
-	);
+	// Collected once and reused below: the scan reads every tracked source file in the repo.
+	const uses = collectConsumerSpecifiers(rootDir, pkgName, target.relDir);
+	failures.push(...verifySpecifiersResolve(uses, pkgName, packageRoot, entries));
 
 	// The static phases are cheap and their findings are complete on their own. Installing and
 	// compiling on top of a broken exports map only buries them under a compiler error.
@@ -328,7 +352,7 @@ export async function runVerifyPackedConsumer(args: string[], rootDir: string): 
 		.filter((e) => !e.isWildcard && e.targets.some((t) => t.kind === 'style'))
 		.map((e) => e.specifier)
 		.filter((s): s is string => s !== undefined);
-	const styleSpecifiers = (await collectConsumerSpecifiers(rootDir, pkgName, ownRelDir))
+	const styleSpecifiers = uses
 		.map((u) => u.specifier)
 		.filter((s) => !isInternalSourceSpecifier(pkgName, s))
 		.filter((s) => {

--- a/packages/testing/code-health/src/packed-consumer/verify-packed-consumer.ts
+++ b/packages/testing/code-health/src/packed-consumer/verify-packed-consumer.ts
@@ -1,0 +1,416 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+import { resolveCatalogDep } from './catalog-versions.js';
+import {
+	collectConsumerSpecifiers,
+	isInternalSourceSpecifier,
+	resolveTargetFile,
+} from './consumer-specifiers.js';
+import { collectExportEntries, resolveSpecifier, type ExportEntry } from './exports-map.js';
+import { buildFixture } from './fixture.js';
+import type { WorkspacePkg } from '../utils/pack-workspace.js';
+import { closureOf, loadWorkspace, packClosure } from '../utils/pack-workspace.js';
+import { parseCatalog } from '../utils/workspace-parser.js';
+
+const DEFAULT_TARGET = '@n8n/design-system';
+
+/**
+ * The toolchain the generated consumer compiles with. Versions are not written here — each one is
+ * resolved from the target package's own manifest, so the fixture tracks the catalog instead of
+ * drifting from it. A name missing from the target's manifest is an error, not a default.
+ */
+const TOOLCHAIN = ['vue', 'vue-router', 'vue-tsc', 'typescript', 'vite', '@vitejs/plugin-vue'];
+
+/** Sass is what compiles the SCSS passthrough; the target declares it as a plain devDependency. */
+const OPTIONAL_TOOLCHAIN = ['sass'];
+
+interface Failure {
+	phase: string;
+	detail: string;
+}
+
+function heading(text: string): void {
+	console.log(`\n=== ${text} ===`);
+}
+
+/**
+ * Read the packed manifest. A tarball whose `package.json` will not parse is itself the finding,
+ * so this throws with the path rather than returning a shape the caller would read as "no exports".
+ */
+function readPackedManifest(packageRoot: string): {
+	exports?: unknown;
+	peerDependencies?: Record<string, string>;
+} {
+	const file = join(packageRoot, 'package.json');
+	const raw = readFileSync(file, 'utf-8');
+	try {
+		return JSON.parse(raw) as { exports?: unknown; peerDependencies?: Record<string, string> };
+	} catch (cause) {
+		throw new Error(`Packed manifest ${file} is not valid JSON`, { cause });
+	}
+}
+
+/** Extract a packed tarball and return the path of its `package/` root. */
+function extractTarball(tarball: string, destDir: string): string {
+	mkdirSync(destDir, { recursive: true });
+	execFileSync('tar', ['-xzf', tarball, '-C', destDir], { stdio: ['ignore', 'ignore', 'inherit'] });
+	const root = join(destDir, 'package');
+	if (!existsSync(root)) throw new Error(`Tarball ${tarball} has no package/ root`);
+	return root;
+}
+
+/**
+ * Assert every specifier the monorepo writes for this package resolves through the published
+ * `exports` map to a file that is actually in the tarball.
+ *
+ * This is the check that does not need a hand-written list, and the one that would have caught the
+ * original rot: inside the workspace every specifier resolves through a build-time alias to `src`,
+ * so a specifier missing from `exports` is invisible until the first consumer outside the
+ * workspace tries it.
+ */
+async function verifySpecifiersResolve(
+	rootDir: string,
+	pkgName: string,
+	ownRelDir: string,
+	packageRoot: string,
+	entries: ExportEntry[],
+): Promise<Failure[]> {
+	const uses = await collectConsumerSpecifiers(rootDir, pkgName, ownRelDir);
+	const failures: Failure[] = [];
+	const internal: string[] = [];
+
+	for (const use of uses) {
+		if (isInternalSourceSpecifier(pkgName, use.specifier)) {
+			internal.push(use.specifier);
+			continue;
+		}
+		const match = resolveSpecifier(pkgName, use.specifier, entries);
+		if (!match) {
+			failures.push({
+				phase: 'specifiers',
+				detail: `${use.specifier} — no matching key in the exports map (${use.file})`,
+			});
+			continue;
+		}
+		const missing = match.targets.filter((t) => resolveTargetFile(packageRoot, t.target) === null);
+		if (missing.length > 0) {
+			failures.push({
+				phase: 'specifiers',
+				detail: `${use.specifier} — exports maps it to ${missing
+					.map((t) => `${t.condition}: ${t.target}`)
+					.join(', ')}, absent from the tarball (${use.file})`,
+			});
+			continue;
+		}
+		console.log(`  ok  ${use.specifier} -> ${match.entry.subpath}`);
+	}
+
+	console.log(
+		`\n  ${uses.length - internal.length} published specifier(s) checked; ` +
+			`${internal.length} alias-only \`${pkgName}/src…\` specifier(s) skipped ` +
+			'(deliberately outside `exports` — `files` ships `dist`).',
+	);
+	return failures;
+}
+
+/** Assert every non-wildcard `exports` target is a file in the tarball. */
+function verifyExportTargets(packageRoot: string, entries: ExportEntry[]): Failure[] {
+	const failures: Failure[] = [];
+	for (const entry of entries) {
+		if (entry.isWildcard) continue;
+		if (entry.targets.length === 0) {
+			failures.push({
+				phase: 'exports',
+				detail: `${entry.subpath} — no import/types/default condition, so nothing can load it`,
+			});
+			continue;
+		}
+		for (const target of entry.targets) {
+			if (resolveTargetFile(packageRoot, target.target) === null) {
+				failures.push({
+					phase: 'exports',
+					detail: `${entry.subpath} (${target.condition}) -> ${target.target} is not in the tarball`,
+				});
+			}
+		}
+	}
+	return failures;
+}
+
+/**
+ * Hold every peer the packed manifest declares to the exact range the generated consumer installs.
+ *
+ * Both ranges come from the same catalog entry — the target declares `vue` under
+ * `peerDependencies` and under `devDependencies` — so equality is the invariant, and a change to
+ * one without the other is the defect. npm's own peer resolution does not cover this: it accepts
+ * any version inside the range, and says nothing at all about a peer the manifest stopped
+ * declaring, which is the regression that would silently push the framework into the bundle.
+ */
+function verifyPeerRanges(packageRoot: string, toolchain: Record<string, string>): Failure[] {
+	const peers = readPackedManifest(packageRoot).peerDependencies ?? {};
+	if (Object.keys(peers).length === 0) {
+		return [
+			{
+				phase: 'peers',
+				detail:
+					'the packed manifest declares no peerDependencies — a Vue component library that ' +
+					'bundles no framework must declare the framework it needs',
+			},
+		];
+	}
+
+	const failures: Failure[] = [];
+	for (const [name, range] of Object.entries(peers)) {
+		const installedRange = toolchain[name];
+		if (installedRange === undefined) {
+			failures.push({
+				phase: 'peers',
+				detail: `${name}@${range} is a declared peer, but the consumer installs no ${name}`,
+			});
+			continue;
+		}
+		if (installedRange !== range) {
+			failures.push({
+				phase: 'peers',
+				detail: `${name}: peerDependencies says ${range}, the consumer installs ${installedRange}`,
+			});
+			continue;
+		}
+		console.log(`  ok  ${name}@${range}`);
+	}
+	return failures;
+}
+
+function runStep(
+	phase: string,
+	command: string,
+	args: string[],
+	cwd: string,
+	failures: Failure[],
+): boolean {
+	heading(phase);
+	try {
+		execFileSync(command, args, { cwd, stdio: ['ignore', 'inherit', 'inherit'] });
+		return true;
+	} catch {
+		failures.push({ phase, detail: `\`${command} ${args.join(' ')}\` exited non-zero` });
+		return false;
+	}
+}
+
+function toolchainDeps(
+	target: WorkspacePkg,
+	catalog: ReturnType<typeof parseCatalog>,
+): {
+	deps: Record<string, string>;
+	missing: string[];
+} {
+	const declared: Record<string, string> = {};
+	for (const dep of target.info.deps) declared[dep.name] = dep.version;
+
+	const deps: Record<string, string> = {};
+	const missing: string[] = [];
+	for (const name of TOOLCHAIN) {
+		const version = resolveCatalogDep(name, declared, catalog);
+		if (version === null) missing.push(name);
+		else deps[name] = version;
+	}
+	for (const name of OPTIONAL_TOOLCHAIN) {
+		const version = resolveCatalogDep(name, declared, catalog);
+		if (version !== null) deps[name] = version;
+	}
+	return { deps, missing };
+}
+
+/**
+ * Build, typecheck and load a minimal consumer against the packed tarball, outside the workspace
+ * resolution graph.
+ *
+ * Every internal package aliases `@n8n/design-system` to `src`, so nothing in this repo has ever
+ * exercised the published output. That is why it shipped broken for months without a red build.
+ * This reproduces what an external consumer does — `npm install` a tarball, then compile — and
+ * fails the job when that stops working.
+ */
+export async function runVerifyPackedConsumer(args: string[], rootDir: string): Promise<number> {
+	const packageArg = args.find((a) => a.startsWith('--package='));
+	const pkgName = packageArg ? packageArg.slice('--package='.length) : DEFAULT_TARGET;
+	const keep = args.includes('--keep');
+	// The two halves have very different costs. The static half needs only the tarball and a repo
+	// glob, so it can afford to run on any PR — which is what catches a deep import added anywhere
+	// in the monorepo. The consumer half installs from the registry and compiles, so it runs when
+	// the package's own packaging changes.
+	const staticOnly = args.includes('--static-only');
+
+	const byName = await loadWorkspace(rootDir);
+	const target = byName.get(pkgName);
+	if (!target) {
+		console.error(`Unknown publishable package "${pkgName}".`);
+		return 2;
+	}
+
+	const work = mkdtempSync(join(tmpdir(), 'packed-consumer-'));
+	// The scratch project must sit outside the workspace, or pnpm/npm would resolve the package
+	// through the workspace instead of the tarball and the whole check would verify nothing.
+	if (resolve(work).startsWith(`${resolve(rootDir)}/`)) {
+		console.error(`Refusing to run: scratch dir ${work} is inside the workspace at ${rootDir}.`);
+		return 2;
+	}
+	for (let dir = work; dir !== dirname(dir); dir = dirname(dir)) {
+		if (existsSync(join(dir, 'pnpm-workspace.yaml'))) {
+			console.error(`Refusing to run: ${dir} makes the scratch dir part of a pnpm workspace.`);
+			return 2;
+		}
+	}
+
+	const failures: Failure[] = [];
+	const tarballDir = join(work, 'tarballs');
+	const consumerDir = join(work, 'consumer');
+
+	const toPack = closureOf([pkgName], byName);
+	heading(`Packing ${toPack.length} workspace package(s)`);
+	const tarballByName = packClosure(toPack, byName, tarballDir);
+	console.log(toPack.map((n) => `  ${n}`).join('\n'));
+
+	const packageRoot = extractTarball(tarballByName[pkgName], join(work, 'extracted'));
+	const entries = collectExportEntries(pkgName, readPackedManifest(packageRoot).exports);
+	if (entries.length === 0) {
+		console.error(`FAIL: ${pkgName} publishes no usable \`exports\` map.`);
+		return 1;
+	}
+
+	heading('Export targets present in the tarball');
+	failures.push(...verifyExportTargets(packageRoot, entries));
+	for (const entry of entries) {
+		console.log(
+			`  ${entry.isWildcard ? 'wildcard' : 'exact   '}  ${entry.subpath} -> ${entry.targets
+				.map((t) => t.target)
+				.join(', ')}`,
+		);
+	}
+
+	heading('Every specifier the monorepo imports resolves through `exports`');
+	const ownRelDir = target.relDir;
+	failures.push(
+		...(await verifySpecifiersResolve(rootDir, pkgName, ownRelDir, packageRoot, entries)),
+	);
+
+	// The static phases are cheap and their findings are complete on their own. Installing and
+	// compiling on top of a broken exports map only buries them under a compiler error.
+	if (failures.length > 0) return report(failures, work, keep);
+
+	if (staticOnly) {
+		if (!keep) rmSync(work, { recursive: true, force: true });
+		console.log(
+			'\nOK: the exports map covers every specifier the monorepo imports. ' +
+				'Consumer build, typecheck and load not run (--static-only).',
+		);
+		return 0;
+	}
+
+	const catalog = parseCatalog(rootDir);
+	const { deps: toolchain, missing } = toolchainDeps(target, catalog);
+	if (missing.length > 0) {
+		console.error(
+			`\nFAIL: ${pkgName} does not declare ${missing.join(', ')}, so the generated consumer ` +
+				'has no pinned toolchain to compile with.',
+		);
+		return report([{ phase: 'toolchain', detail: `missing: ${missing.join(', ')}` }], work, keep);
+	}
+
+	const moduleSpecifiers = entries
+		.filter((e) => !e.isWildcard && e.targets.some((t) => t.kind === 'module'))
+		.map((e) => e.specifier)
+		.filter((s): s is string => s !== undefined);
+	const cssSpecifiers = entries
+		.filter((e) => !e.isWildcard && e.targets.some((t) => t.kind === 'style'))
+		.map((e) => e.specifier)
+		.filter((s): s is string => s !== undefined);
+	const styleSpecifiers = (await collectConsumerSpecifiers(rootDir, pkgName, ownRelDir))
+		.map((u) => u.specifier)
+		.filter((s) => !isInternalSourceSpecifier(pkgName, s))
+		.filter((s) => {
+			const match = resolveSpecifier(pkgName, s, entries);
+			return (
+				match?.entry.isWildcard === true &&
+				match.targets.some((t) =>
+					/\.(scss|sass|css)$/.test(resolveTargetFile(packageRoot, t.target) ?? ''),
+				)
+			);
+		});
+
+	heading('Generating the consumer project');
+	const files = buildFixture({
+		packageName: pkgName,
+		tarballDeps: Object.fromEntries(toPack.map((n) => [n, `file:${tarballByName[n]}`])),
+		toolchainDeps: toolchain,
+		moduleSpecifiers,
+		styleSpecifiers,
+		cssSpecifiers,
+	});
+	for (const [relPath, content] of Object.entries(files)) {
+		const absolute = join(consumerDir, relPath);
+		mkdirSync(dirname(absolute), { recursive: true });
+		writeFileSync(absolute, content);
+	}
+	console.log(`  ${consumerDir}`);
+	console.log(
+		Object.keys(files)
+			.map((f) => `    ${f}`)
+			.join('\n'),
+	);
+	console.log(
+		`\n  toolchain: ${Object.entries(toolchain)
+			.map(([n, v]) => `${n}@${v}`)
+			.join(', ')}`,
+	);
+
+	heading('Peer dependencies the tarball declares');
+	failures.push(...verifyPeerRanges(packageRoot, toolchain));
+	if (failures.length > 0) return report(failures, work, keep);
+
+	// Strict peer resolution on purpose. npm satisfies a conflicting peer by nesting a second copy,
+	// which is what makes the package loadable; `--legacy-peer-deps` flattens instead, and a
+	// flattened tree fails at link time for reasons that belong to the flag rather than to the
+	// tarball. The one stale peer range that blocks a strict install is narrowed in the fixture's
+	// `overrides` instead.
+	const installed = runStep(
+		'npm install (outside the workspace graph)',
+		'npm',
+		['install', '--no-audit', '--no-fund', '--no-package-lock'],
+		consumerDir,
+		failures,
+	);
+
+	if (installed) {
+		// All three, not the first that fails: a reader triaging this wants the whole picture, and
+		// the three failure modes are independent — types, bundling, and native loading.
+		runStep('Typecheck (vue-tsc)', 'npm', ['run', '--silent', 'typecheck'], consumerDir, failures);
+		runStep('Build (vite)', 'npm', ['run', '--silent', 'build'], consumerDir, failures);
+		runStep(
+			'Load under plain Node',
+			'npm',
+			['run', '--silent', 'probe:runtime'],
+			consumerDir,
+			failures,
+		);
+	}
+
+	return report(failures, work, keep);
+}
+
+function report(failures: Failure[], work: string, keep: boolean): number {
+	if (failures.length === 0) {
+		if (!keep) rmSync(work, { recursive: true, force: true });
+		else console.log(`\nScratch kept: ${work}`);
+		console.log('\nOK: the packed tarball builds, typechecks and loads in a fresh consumer.');
+		return 0;
+	}
+
+	console.error(`\nFAIL: ${failures.length} problem(s) with the packed tarball:`);
+	for (const failure of failures) console.error(`  [${failure.phase}] ${failure.detail}`);
+	console.error(`\nScratch kept for inspection: ${work}`);
+	return 1;
+}

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { closureOf, filesTriggerFullRun, matchChangedFiles } from './verify-npm-install.js';
+import { filesTriggerFullRun, matchChangedFiles } from './verify-npm-install.js';
+import { closureOf } from '../utils/pack-workspace.js';
 
 /** Build a WorkspacePkg fixture from `[depName, section]` pairs (only names + sections matter). */
 function ws(name: string, deps: Array<[string, string]>) {

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.ts
@@ -1,48 +1,24 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { analyze, collectCopies } from './collect-copies.js';
-import type { PackageJsonInfo } from '../utils/package-json-scanner.js';
+import type { WorkspacePkg } from '../utils/pack-workspace.js';
 import {
-	findPackageJsonFiles,
-	parsePackageJson,
-	relativeDir,
-} from '../utils/package-json-scanner.js';
+	closureOf,
+	loadWorkspace,
+	packClosure,
+	packageDirPrefixes,
+} from '../utils/pack-workspace.js';
 
 // Repo-relative paths whose change can shift dependency resolution repo-wide (the catalog, the
 // root manifest, or the single-instance tooling itself) — a scoped diff would otherwise miss them.
 const ROOT_TRIGGERS = ['pnpm-workspace.yaml', 'package.json', 'packages/testing/code-health/'];
 
-// Sections that follow the publish graph — devDependencies don't ship, so they're not packed.
-const CLOSURE_SECTIONS = new Set(['dependencies', 'peerDependencies', 'optionalDependencies']);
-
 /** True when a changed file can shift dependency resolution repo-wide, forcing a full check. */
 export function filesTriggerFullRun(files: string[]): boolean {
 	return files.some((f) => ROOT_TRIGGERS.some((t) => f === t || f.startsWith(t)));
-}
-
-interface WorkspacePkg {
-	dir: string;
-	relDir: string;
-	info: PackageJsonInfo;
-}
-
-/** Every non-private workspace package: name -> { dir, relDir, info }. */
-async function loadWorkspace(rootDir: string): Promise<Map<string, WorkspacePkg>> {
-	const byName = new Map<string, WorkspacePkg>();
-	for (const file of await findPackageJsonFiles(rootDir)) {
-		const info = parsePackageJson(file);
-		if (info.private) continue;
-		byName.set(info.packageName, { dir: dirname(file), relDir: relativeDir(rootDir, file), info });
-	}
-	return byName;
-}
-
-/** Package dirs as forward-slash, trailing-slash prefixes (matches git's path output on any OS). */
-function packageDirPrefixes(byName: Map<string, WorkspacePkg>): Array<[string, string]> {
-	return [...byName.entries()].map(([name, { relDir }]) => [name, `${relDir}/`]);
 }
 
 /**
@@ -95,25 +71,6 @@ function changedPackages(
 	return matchChangedFiles(files, packageDirPrefixes(byName));
 }
 
-/** BFS the workspace-internal dependency closure of the given target names. */
-export function closureOf(targets: string[], byName: Map<string, WorkspacePkg>): string[] {
-	const seen = new Set<string>();
-	const queue = [...targets];
-	while (queue.length > 0) {
-		const name = queue.shift();
-		if (name === undefined || seen.has(name)) continue;
-		const entry = byName.get(name);
-		if (!entry) continue;
-		seen.add(name);
-		for (const dep of entry.info.deps) {
-			if (CLOSURE_SECTIONS.has(dep.section) && byName.has(dep.name) && !seen.has(dep.name)) {
-				queue.push(dep.name);
-			}
-		}
-	}
-	return [...seen];
-}
-
 function resolveTargets(
 	args: string[],
 	byName: Map<string, WorkspacePkg>,
@@ -164,19 +121,7 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 	mkdirSync(scratch, { recursive: true });
 
 	console.log(`Packing ${toPack.length} workspace package(s) (targets: ${targets.length})...`);
-	const tarballByName: Record<string, string> = {};
-	for (const name of toPack) {
-		const entry = byName.get(name);
-		if (!entry) continue;
-		const before = new Set(readdirSync(tarballs));
-		execFileSync('pnpm', ['pack', '--pack-destination', tarballs], {
-			cwd: entry.dir,
-			stdio: ['ignore', 'ignore', 'inherit'],
-		});
-		const produced = readdirSync(tarballs).find((f) => !before.has(f) && f.endsWith('.tgz'));
-		if (!produced) throw new Error(`pnpm pack produced no tarball for ${name}`);
-		tarballByName[name] = join(tarballs, produced);
-	}
+	const tarballByName = packClosure(toPack, byName, tarballs);
 
 	// Scratch project: install targets as file: deps, force ALL packed workspace deps to their
 	// local tarballs. Third-party deps resolve from the real npm registry.

--- a/packages/testing/code-health/src/utils/pack-workspace.ts
+++ b/packages/testing/code-health/src/utils/pack-workspace.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { PackageJsonInfo } from './package-json-scanner.js';
+import { findPackageJsonFiles, parsePackageJson, relativeDir } from './package-json-scanner.js';
+
+// Sections that follow the publish graph — devDependencies don't ship, so they're not packed.
+const CLOSURE_SECTIONS = new Set(['dependencies', 'peerDependencies', 'optionalDependencies']);
+
+export interface WorkspacePkg {
+	dir: string;
+	relDir: string;
+	info: PackageJsonInfo;
+}
+
+/** Every non-private workspace package: name -> { dir, relDir, info }. */
+export async function loadWorkspace(rootDir: string): Promise<Map<string, WorkspacePkg>> {
+	const byName = new Map<string, WorkspacePkg>();
+	for (const file of await findPackageJsonFiles(rootDir)) {
+		const info = parsePackageJson(file);
+		if (info.private) continue;
+		byName.set(info.packageName, { dir: dirname(file), relDir: relativeDir(rootDir, file), info });
+	}
+	return byName;
+}
+
+/** Package dirs as forward-slash, trailing-slash prefixes (matches git's path output on any OS). */
+export function packageDirPrefixes(byName: Map<string, WorkspacePkg>): Array<[string, string]> {
+	return [...byName.entries()].map(([name, { relDir }]) => [name, `${relDir}/`]);
+}
+
+/** BFS the workspace-internal dependency closure of the given target names. */
+export function closureOf(targets: string[], byName: Map<string, WorkspacePkg>): string[] {
+	const seen = new Set<string>();
+	const queue = [...targets];
+	while (queue.length > 0) {
+		const name = queue.shift();
+		if (name === undefined || seen.has(name)) continue;
+		const entry = byName.get(name);
+		if (!entry) continue;
+		seen.add(name);
+		for (const dep of entry.info.deps) {
+			if (CLOSURE_SECTIONS.has(dep.section) && byName.has(dep.name) && !seen.has(dep.name)) {
+				queue.push(dep.name);
+			}
+		}
+	}
+	return [...seen];
+}
+
+/**
+ * `pnpm pack` each named workspace package into `destDir` and return name -> tarball path.
+ *
+ * `pnpm pack` rather than `npm pack` because it resolves `catalog:` and `workspace:` specifiers
+ * the way publishing does; npm would leave them verbatim and the install would fail on a
+ * protocol it does not understand.
+ */
+export function packClosure(
+	names: string[],
+	byName: Map<string, WorkspacePkg>,
+	destDir: string,
+): Record<string, string> {
+	mkdirSync(destDir, { recursive: true });
+	const tarballByName: Record<string, string> = {};
+	for (const name of names) {
+		const entry = byName.get(name);
+		if (!entry) continue;
+		const before = new Set(readdirSync(destDir));
+		execFileSync('pnpm', ['pack', '--pack-destination', destDir], {
+			cwd: entry.dir,
+			stdio: ['ignore', 'ignore', 'inherit'],
+		});
+		const produced = readdirSync(destDir).find((f) => !before.has(f) && f.endsWith('.tgz'));
+		if (!produced) throw new Error(`pnpm pack produced no tarball for ${name}`);
+		tarballByName[name] = join(destDir, produced);
+	}
+	return tarballByName;
+}


### PR DESCRIPTION
## Summary

`@n8n/design-system` published a broken artifact for months with a green pipeline. Nothing in the monorepo consumed `dist`: every internal package aliases `@n8n/design-system(.*)` to `src$1`, so the published output was never exercised by anything. [N8N-110](https://linear.app/n8n/issue/CAT-3974) fixed the artifact. It did not fix the reason the artifact was allowed to rot.

This adds the consumer that does exercise it. A new `Packed consumer` required check packs the package, installs the tarball **outside the workspace resolution graph**, then builds, typechecks and loads a generated consumer against it.

https://linear.app/n8n/issue/CAT-3981

## What the check does

Each phase fails the job.

1. **Export targets present** — every non-wildcard `exports` target resolves to a file in the tarball.
2. **Specifier coverage** — every `@n8n/design-system…` specifier written anywhere in the monorepo resolves through the published `exports` map. This catches a deep import that resolves fine inside the workspace through the alias and resolves nowhere for anybody else.
3. **Peer ranges** — every peer the packed manifest declares matches the range the consumer installs.
4. **Typecheck** — `vue-tsc --noEmit` over a consumer using `N8nDataTableServer`'s generically typed `#item` slot, whose payload reaches a `@tanstack/vue-table` type through the emitted declarations, plus explicit assertions that the published types have not degraded to `any`.
5. **Build** — `vite build` with the stock Vue plugin and nothing else. Needing the icon plugin here would mean the pre-built icon chunks stopped shipping.
6. **Load under plain Node** — each module subpath imported one at a time as native ESM, then an icon body fetched through the public loader for every chunk the icon entry references.

Nothing is enumerated by hand. The probe surface comes from the `exports` map, the specifier set from a scan of the repo, the toolchain versions from the target's own manifest via the pnpm catalog, and the expected icon chunks from the icon entry's own dynamic imports. A subpath, consumer or chunk added tomorrow is covered with no edit.

Full rationale, including why `skipLibCheck` stays on and why `--legacy-peer-deps` is not used: `packages/testing/code-health/src/packed-consumer/README.md`.

## Negative controls

A probe not shown to fail on the defect it claims absent is not evidence. Each was injected locally and each failed the job:

| Injected defect | Caught by |
| --- | --- |
| `./icons/lucide` removed from the `exports` map | phase 2, naming the importing file |
| One pre-built icon bucket chunk deleted from `dist` | phase 6, naming the chunk; also phase 5 |
| `TableHeader<T>` widened to `any` in the shipped `.d.ts` | phase 4 (`TS2344`, plus `TS2578` on the now-unused `@ts-expect-error`) |

The first version of the chunk probe derived its expectations from a directory listing and therefore passed when a chunk was deleted. It now reads the entry's own dynamic imports.

## Also in this PR

The check flagged one real deep import surviving on master: `editor-ui/src/features/agents/channels/types.ts` imported `IconName` from `@n8n/design-system/components/N8nIcon/icons`, which is outside the `exports` map. Migrated to the root import — the type is already re-exported from the barrel. This is the class of regression [N8N-128](https://linear.app/n8n/issue/CAT-3976)/[N8N-184](https://linear.app/n8n/issue/CAT-4093) migrated 119 imports for, arriving again with nothing watching.

`loadWorkspace` / `closureOf` / the pack loop moved from `verify-npm-install.ts` to `utils/pack-workspace.ts`, shared by both verifiers. No behaviour change; its existing tests cover it.

## Cost and wiring

- Full run: **~35s** locally (pack, npm install, typecheck, build, load).
- Gated on the broad `ci` filter rather than a path filter over the package's build config and `exports` map. Half of what this catches is a specifier added elsewhere in the monorepo, and a path filter listing the packages that consume the design system is exactly the hand-maintained list that let the artifact rot in the first place.
- Added to `required-checks` on PRs, and to `ci-master.yml` — a tarball can break from a dependency resolving differently on master than it did on the branch.
- A `--static-only` scope runs phases 1–3 in ~6s, for local iteration.

## Review notes

- `test-packed-consumer-reusable.yml` rejects an unknown `scope` rather than defaulting, so a typo cannot silently downgrade the job to the cheap half and leave a green check that compiled nothing.
- The generated fixture names one component (`N8nDataTableServer`). The acceptance criteria call for a typed slot, which is inherently a named example; if it leaves the barrel the fixture stops compiling, which is a loud failure rather than silent rot.
- Test files and `packages/testing/code-health/**` are excluded from the specifier scan — both were observed producing phantom findings, since both hold specifiers as fixture data.
- The `@n8n/chat` fresh-clone `vitest run` confusion from the issue thread is documented in the README (verified locally: `Failed to resolve import "@n8n/design-system"`, 2 test files failing, because `dist` is gitignored). Not fixed here — it is a developer-experience issue, not a packaging defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



---

## Review round 1 — blocker fixed at the root

@filter found that the specifier scan ran `fast-glob` with the default `dot: false`, so `.storybook/` was never read. Two real violations hid under it, both in `.storybook/preview.ts`: `@n8n/design-system/plugin` and `@n8n/design-system/composables/useIconBodyLoader`, neither in the `exports` map. Reproduced exactly — 16 specifiers instead of 14, both reported.

Rather than adding `dot: true`, the scan now enumerates from **`git ls-files`**. That fixes the root cause and closes a second hole found while confirming the first: `storybook-static/` build output was being scanned and contributed four specifiers out of bundled asset chunks. Generated output is never tracked and a dot-directory is tracked like anything else, so neither needs a hand-written exclusion — which was @filter's actual objection. The command throws rather than falling back to a filesystem walk, since a fallback would scan a different set than it reports.

`isScannableFile` and `trackedScannableFiles` are unit-tested, including the dot-directory case and the generated-output case (8 new tests).

### The two `.storybook` imports are grandfathered, not migrated

The suggested fix was the same one-line root import used for `channels/types.ts`. That would regress a documented property, so it is not applied:

- The deep imports are deliberate. `preview.ts:1-3` states it: `preview.ts` is a TurboSnap global, and the barrel's `export * from './components'` would make every component a global dep, forcing a full Chromatic snapshot on any component change.
- `git blame` dates them to `8ce1fdca557` (2026-07-27), three weeks before the exports flip (`35bb514616`, today). N8N-184's subpath migration missed them under the same dot-directory blind spot.
- Both symbols are on the root barrel, so a root import compiles. It just spends Chromatic snapshot budget, and I have no measurement to price that with — so it is not this job's call.
- Storybook is `private: true` and resolves the package through its own alias to `src` (`storybook/vite.config.ts:38`), so nothing published is at risk. Verified: `pnpm --filter @n8n/storybook build` exits 0, while `import.meta.resolve` of both specifiers fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

They sit in `grandfathered.ts` with their reason and are **printed on every run**. The check fails if one becomes resolvable, so the exception cannot outlive its cause, and anything new is enforced normally. This follows the pattern `endpoint-scope-coverage` already uses in this package for pre-existing violations.

The real resolution is to give `./plugin` its own published entry, exactly as `./icons/lucide` got one — a plugin that pulls the whole component set is the optional capability the barrel should not carry. That needs a build entry as well: `dist/plugin.d.ts` ships today with no `dist/plugin.js`. That expands the published API surface that stage 5 deliberately scoped to six keys, so it is routed to the design-system owner rather than decided here.

### Two new negative controls

| Injected defect | Caught by |
| --- | --- |
| A new unexported deep import added to `editor-ui` | phase 2 — the grandfathered list does not excuse it |
| `./plugin` added to `exports`, making a grandfathered entry stale | phase 2, naming the entry to delete |

### Nits

- **Taken:** the job now gates on `ci == 'true' || workflows == 'true'`. `ci` excludes `.github/**`, so a PR editing only this job's workflow would have skipped it, and `required-checks` passes on a skip.
- **Taken:** corrected the comment that described `static`/`full` scope wiring no caller uses.
- **Left:** branch name.

Full gate green in **22s** locally. 161 unit tests pass; lint, biome, prettier and typecheck clean.


---

## Closed — not merged

Operator decision, 2026-08-17: a manual consumability check is enough; this gate is not wanted in CI.

Closing rather than reworking. The one real defect this branch found — a deep `@n8n/design-system/components/N8nIcon/icons` import in `editor-ui`, outside the six-key `exports` map — lands separately, together with a by-hand version of the procedure so the check stays repeatable without CI.

Branch `cat-3981-ci-consumes-packed-design-system-tarball` is left in place at `ce70a91838` for reference: the verifier, its 161 tests and the five fault injections are all there if the decision is ever revisited.
