### PR TITLE
docs: Add engine scope to PR title conventions (no-changelog)

### DIFF
--- a/.github/pull_request_title_conventions.md
+++ b/.github/pull_request_title_conventions.md
@@ -11,7 +11,7 @@ A PR title consists of these elements:
   |       |                        Capitalized
   |       |                        No period at the end.
   │       │
-  │       └─⫸ Scope: API | benchmark | core | editor | * Node
+  │       └─⫸ Scope: API | benchmark | core | editor | engine | * Node
   │
   └─⫸ Type: build | ci | chore | docs | feat | fix | perf | refactor | test
 ```
@@ -53,6 +53,7 @@ The scope should specify the place of the commit change as long as the commit cl
 - `benchmark` - changes to the benchmark cli
 - `core` - changes to the core / private API / backend of n8n
 - `editor` - changes to the Editor UI
+- `engine` - changes to the new workflow execution engine v2
 - `* Node` - changes to a specific node or trigger node (”`*`” to be replaced with the node name, not its display name), e.g.
   - mattermost → Mattermost Node
   - microsoftToDo → Microsoft To Do Node

--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -27,10 +27,12 @@ const changelogStream = new ConventionalChangelog()
 		releaseCount: 1,
 		transformCommit(commit) {
 			const hasNoChangelogInHeader = commit.header?.includes('(no-changelog)');
-			const isBenchmarkScope = commit.scope === 'benchmark';
+			// 'engine' is ignored for now. We will show it in the changelog when the engine is stable.
+			const ignoredScopes = ['benchmark', 'engine'];
+			const hasIgnoredScope = ignoredScopes.includes(commit.scope);
 
-			// Ignore commits that have 'benchmark' scope or '(no-changelog)' in the header
-			if (hasNoChangelogInHeader || isBenchmarkScope) return null;
+			// Ignore commits that have an ignored scope or '(no-changelog)' in the header
+			if (hasNoChangelogInHeader || hasIgnoredScope) return null;
 
 			// Strip backport information from commit subject, e.g.:
 			// "Fix something (backport to release-candidate/2.12.x) (#123)" → "Fix something (#123)"


### PR DESCRIPTION
## Summary

Add an `engine` scope to the PR title conventions. Use this scope for
changes to the new workflow execution engine v2.

The changelog generator ignores the `engine` scope for now, the same
way it ignores `benchmark`. We will show `engine` PRs in the changelog
when the engine is stable.

Related PR: https://github.com/n8n-io/validate-n8n-pull-request-title/pull/15

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

