### PR TITLE
fix(core): Handle arrays and invalid input in jsonParse JS object recovery

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -120,17 +120,24 @@ function syntaxNodeToValue(expression?: SyntaxNode | null): unknown {
 }
 
 /**
- * Parse any JavaScript ObjectExpression, including:
+ * Parse any JavaScript object or array expression, including:
  * - single quoted keys
  * - unquoted keys
+ * - trailing commas
  */
 function parseJSObject(objectAsString: string): object {
 	const jsExpression = esprimaParse(`(${objectAsString})`).body.find(
 		(node): node is ExpressionStatement =>
-			node.type === Syntax.ExpressionStatement && node.expression.type === Syntax.ObjectExpression,
+			node.type === Syntax.ExpressionStatement &&
+			(node.expression.type === Syntax.ObjectExpression ||
+				node.expression.type === Syntax.ArrayExpression),
 	);
 
-	return syntaxNodeToValue(jsExpression?.expression) as object;
+	if (!jsExpression) {
+		throw new SyntaxError('Value is not an object or array expression');
+	}
+
+	return syntaxNodeToValue(jsExpression.expression) as object;
 }
 
 type MutuallyExclusive<T, U> =

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -157,6 +157,20 @@ describe('jsonParse', () => {
 				text: 'hello world',
 			});
 		});
+
+		it('should handle trailing commas', () => {
+			const result = jsonParse('{"a": [1, 2,],}', options);
+			expect(result).toEqual({ a: [1, 2] });
+		});
+
+		it('should handle top-level arrays', () => {
+			const result = jsonParse("[{name: 'John'},]", options);
+			expect(result).toEqual([{ name: 'John' }]);
+		});
+
+		it('should throw the original error for non-object input', () => {
+			expect(() => jsonParse('invalid_json', options)).toThrow(SyntaxError);
+		});
 	});
 
 	describe('JSON repair', () => {


### PR DESCRIPTION
## Summary

`jsonParse(value, { acceptJSObject: true })` recovers invalid strict JSON by parsing the value as a JavaScript expression. This recovery had two defects in `parseJSObject`:

- Only object expressions were matched. A top-level array (for example `[{name: 'John'},]`) was never recovered, although `syntaxNodeToValue` already supports arrays.
- When the input parsed as any other JS expression (for example a bare identifier like `invalid_json`), the function returned `undefined` instead of an error. `jsonParse` then returned `undefined` silently instead of falling back to `fallbackValue`, `errorMessage`, or the original `SyntaxError`.

The recovery now also accepts array expressions, and throws when the input is not an object or array expression. This makes `jsonParse` fall back to its normal error handling for garbage input.

This affects all `acceptJSObject` call sites (`validateFieldType`, AWS Cognito helpers, `N8nTool` AI argument parsing): garbage input now surfaces the configured error or fallback instead of a silent `undefined`, and top-level arrays with JS-object syntax now parse.

## How to test

Unit tests cover the new behavior:

```bash
cd packages/workflow && pnpm test utils.test.ts
```

- `should handle trailing commas`
- `should handle top-level arrays`
- `should throw the original error for non-object input`

## Related Linear tickets, Github issues, and Community forum posts

Extracted from a broader change that makes JSON parameters accept trailing commas; this fix stands alone.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

