### PR TITLE
ci: Report single-instance dependency findings without failing advisory runs

### DIFF
--- a/.github/workflows/test-single-instance-npm.yml
+++ b/.github/workflows/test-single-instance-npm.yml
@@ -34,13 +34,19 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !inputs.blocking }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
+    env:
+      # Advisory runs downgrade findings to `::warning::` annotations and exit 0, so the known
+      # third-party splits don't leave a permanently red job that everyone learns to ignore.
+      # This deliberately replaces `continue-on-error`, which also swallowed the failures we do
+      # want — a usage error, a rejected input, or a crash that verified nothing.
+      REPORT_ONLY: ${{ !inputs.blocking && '--report-only' || '' }}
     steps:
       # Every rejected combination below otherwise degrades into a run that verifies nothing and
-      # still exits 0 — silently, since this job is advisory by default.
+      # still exits 0. These fail the job even in advisory mode — `--report-only` downgrades
+      # findings, not misconfiguration.
       - name: Validate inputs
         env:
           SCOPE: ${{ inputs.scope }}
@@ -88,8 +94,14 @@ jobs:
         if: inputs.scope == 'changed'
         env:
           BASE_REF: ${{ inputs.base-ref }}
-        run: pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --changed="$BASE_REF"
+        run: |
+          # REPORT_ONLY is a single flag or empty. Quoting it would pass an empty argument, which
+          # the CLI reads as an (unknown) package name and rejects.
+          # shellcheck disable=SC2086
+          pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --changed="$BASE_REF" $REPORT_ONLY
 
       - name: Verify npm-install closure (all packages)
         if: inputs.scope == 'all'
-        run: pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --all
+        run: |
+          # shellcheck disable=SC2086 # see the scoped step above
+          pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --all $REPORT_ONLY

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { closureOf, filesTriggerFullRun, matchChangedFiles } from './verify-npm-install.js';
+import {
+	closureOf,
+	filesTriggerFullRun,
+	matchChangedFiles,
+	resolveTargets,
+} from './verify-npm-install.js';
 
 /** Build a WorkspacePkg fixture from `[depName, section]` pairs (only names + sections matter). */
 function ws(name: string, deps: Array<[string, string]>) {
@@ -92,5 +97,27 @@ describe('filesTriggerFullRun', () => {
 
 	it('does not escalate on an ordinary package source change', () => {
 		expect(filesTriggerFullRun(['packages/core/src/index.ts'])).toBe(false);
+	});
+});
+
+describe('resolveTargets', () => {
+	it('does not mistake --report-only for a package name', () => {
+		expect(resolveTargets(['a', '--report-only'], byName, '/x')).toEqual(['a']);
+	});
+
+	// Flag-only args must reach the usage error rather than silently verifying nothing.
+	it('resolves no targets when only flags are passed', () => {
+		expect(resolveTargets(['--report-only'], byName, '/x')).toEqual([]);
+	});
+
+	it('still expands --all alongside the flag', () => {
+		expect(resolveTargets(['--all', '--report-only'], byName, '/x')?.sort()).toEqual([
+			'a',
+			'b',
+			'c',
+			'd',
+			'dev-only',
+			'solo',
+		]);
 	});
 });

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.ts
@@ -197,66 +197,70 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 	mkdirSync(tarballs, { recursive: true });
 	mkdirSync(scratch, { recursive: true });
 
-	console.log(`Packing ${toPack.length} workspace package(s) (targets: ${targets.length})...`);
-	const tarballByName: Record<string, string> = {};
-	for (const name of toPack) {
-		const entry = byName.get(name);
-		if (!entry) continue;
-		const before = new Set(readdirSync(tarballs));
-		execFileSync('pnpm', ['pack', '--pack-destination', tarballs], {
-			cwd: entry.dir,
-			stdio: ['ignore', 'ignore', 'inherit'],
-		});
-		const produced = readdirSync(tarballs).find((f) => !before.has(f) && f.endsWith('.tgz'));
-		if (!produced) throw new Error(`pnpm pack produced no tarball for ${name}`);
-		tarballByName[name] = join(tarballs, produced);
-	}
+	// An enforcing-mode finding is the only reason to keep the tree. A report-only run exits 0 so
+	// nothing downstream reads it, and a throw (pack failure, registry outage) leaves nothing worth
+	// inspecting — either way, keeping it just leaks a full node_modules into tmpdir per run.
+	let keepScratch = false;
+	try {
+		console.log(`Packing ${toPack.length} workspace package(s) (targets: ${targets.length})...`);
+		const tarballByName: Record<string, string> = {};
+		for (const name of toPack) {
+			const entry = byName.get(name);
+			if (!entry) continue;
+			const before = new Set(readdirSync(tarballs));
+			execFileSync('pnpm', ['pack', '--pack-destination', tarballs], {
+				cwd: entry.dir,
+				stdio: ['ignore', 'ignore', 'inherit'],
+			});
+			const produced = readdirSync(tarballs).find((f) => !before.has(f) && f.endsWith('.tgz'));
+			if (!produced) throw new Error(`pnpm pack produced no tarball for ${name}`);
+			tarballByName[name] = join(tarballs, produced);
+		}
 
-	// Scratch project: install targets as file: deps, force ALL packed workspace deps to their
-	// local tarballs. Third-party deps resolve from the real npm registry.
-	const fileDep = (n: string): [string, string] => [n, `file:${tarballByName[n]}`];
-	const overrides = Object.fromEntries(toPack.map(fileDep));
-	const deps = Object.fromEntries(targets.map(fileDep));
-	writeFileSync(
-		join(scratch, 'package.json'),
-		JSON.stringify(
-			{ name: 'single-instance-scratch', private: true, dependencies: deps, overrides },
-			null,
-			2,
-		),
-	);
-
-	console.log('Installing into scratch dir with npm...');
-	await installWithRetry(scratch);
-
-	const { duplicates, failures } = analyze(collectCopies(scratch));
-
-	console.log(`\nnpm-install closure — scratch: ${scratch}\n`);
-	const curatedTag = reportOnly ? 'CURATED DUP (report)' : 'FAIL';
-	for (const d of duplicates) {
-		const tag = d.isCurated ? (d.allowed ? 'ALLOWED DUP' : curatedTag) : 'dup (report)';
-		console.log(
-			`  ${d.name}: ${tag} — ${d.copies.length} copies (${d.copies.map((c) => `v${c.version}`).join(', ')})`,
+		// Scratch project: install targets as file: deps, force ALL packed workspace deps to their
+		// local tarballs. Third-party deps resolve from the real npm registry.
+		const fileDep = (n: string): [string, string] => [n, `file:${tarballByName[n]}`];
+		const overrides = Object.fromEntries(toPack.map(fileDep));
+		const deps = Object.fromEntries(targets.map(fileDep));
+		writeFileSync(
+			join(scratch, 'package.json'),
+			JSON.stringify(
+				{ name: 'single-instance-scratch', private: true, dependencies: deps, overrides },
+				null,
+				2,
+			),
 		);
-	}
 
-	// Report-only exits 0, so nothing downstream will look at the tree — keeping it would just
-	// leak a full node_modules into tmpdir on every run.
-	const keepScratch = failures.length > 0 && !reportOnly;
-	if (keepScratch) console.log(`\nScratch install kept for inspection: ${scratch}`);
-	else rmSync(work, { recursive: true, force: true });
+		console.log('Installing into scratch dir with npm...');
+		await installWithRetry(scratch);
 
-	if (failures.length > 0) {
-		for (const f of failures) {
-			annotate(
-				`${f.name}: ${f.copies.length} copies in the npm-install graph (${f.copies.map((c) => `v${c.version}`).join(', ')})`,
+		const { duplicates, failures } = analyze(collectCopies(scratch));
+
+		console.log(`\nnpm-install closure — scratch: ${scratch}\n`);
+		const curatedTag = reportOnly ? 'CURATED DUP (report)' : 'FAIL';
+		for (const d of duplicates) {
+			const tag = d.isCurated ? (d.allowed ? 'ALLOWED DUP' : curatedTag) : 'dup (report)';
+			console.log(
+				`  ${d.name}: ${tag} — ${d.copies.length} copies (${d.copies.map((c) => `v${c.version}`).join(', ')})`,
 			);
 		}
-		console.error(
-			`\n${reportOnly ? 'REPORT' : 'FAIL'}: ${failures.length} curated library duplicate(s) in the npm-install graph.`,
-		);
-		return reportOnly ? 0 : 1;
+
+		if (failures.length > 0) {
+			keepScratch = !reportOnly;
+			for (const f of failures) {
+				annotate(
+					`${f.name}: ${f.copies.length} copies in the npm-install graph (${f.copies.map((c) => `v${c.version}`).join(', ')})`,
+				);
+			}
+			console.error(
+				`\n${reportOnly ? 'REPORT' : 'FAIL'}: ${failures.length} curated library duplicate(s) in the npm-install graph.`,
+			);
+			return reportOnly ? 0 : 1;
+		}
+		console.log('\nOK: no curated duplicates in the npm-install graph.');
+		return 0;
+	} finally {
+		if (keepScratch) console.log(`\nScratch install kept for inspection: ${scratch}`);
+		else rmSync(work, { recursive: true, force: true });
 	}
-	console.log('\nOK: no curated duplicates in the npm-install graph.');
-	return 0;
 }

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 
 import { analyze, collectCopies } from './collect-copies.js';
 import type { PackageJsonInfo } from '../utils/package-json-scanner.js';
@@ -21,6 +22,35 @@ const CLOSURE_SECTIONS = new Set(['dependencies', 'peerDependencies', 'optionalD
 /** True when a changed file can shift dependency resolution repo-wide, forcing a full check. */
 export function filesTriggerFullRun(files: string[]): boolean {
 	return files.some((f) => ROOT_TRIGGERS.some((t) => f === t || f.startsWith(t)));
+}
+
+/**
+ * Surface a finding in the Actions UI. Report-only runs exit 0, and nobody opens the log of a
+ * green check — without an annotation the finding is indistinguishable from silence.
+ */
+function annotate(message: string): void {
+	if (process.env.GITHUB_ACTIONS) console.log(`::warning::${message}`);
+}
+
+/**
+ * The scratch install is the one network-bound step, and a registry blip must not read as a
+ * dependency finding. Retries only the install; a persistent failure still throws.
+ */
+async function installWithRetry(scratch: string, attempts = 3): Promise<void> {
+	for (let attempt = 1; ; attempt++) {
+		try {
+			execFileSync(
+				'npm',
+				['install', '--no-audit', '--no-fund', '--ignore-scripts', '--no-package-lock'],
+				{ cwd: scratch, stdio: ['ignore', 'inherit', 'inherit'] },
+			);
+			return;
+		} catch (error) {
+			if (attempt >= attempts) throw error;
+			console.error(`npm install failed (attempt ${attempt}/${attempts}); retrying...`);
+			await setTimeout(attempt * 5_000);
+		}
+	}
 }
 
 interface WorkspacePkg {
@@ -114,7 +144,8 @@ export function closureOf(targets: string[], byName: Map<string, WorkspacePkg>):
 	return [...seen];
 }
 
-function resolveTargets(
+/** Targets to verify: `null` means "nothing to do", `[]` means the args were unusable. */
+export function resolveTargets(
 	args: string[],
 	byName: Map<string, WorkspacePkg>,
 	rootDir: string,
@@ -141,11 +172,14 @@ function resolveTargets(
  * `workspace:` like publishing does), installs into a scratch dir with npm, then verifies.
  */
 export async function runVerifyNpmInstall(args: string[], rootDir: string): Promise<number> {
+	const reportOnly = args.includes('--report-only');
 	const byName = await loadWorkspace(rootDir);
 	const targets = resolveTargets(args, byName, rootDir);
 	if (targets === null) return 0;
 	if (targets.length === 0) {
-		console.error('Usage: verify-npm-install (--all | --changed=<ref> | <pkgName>...)');
+		console.error(
+			'Usage: verify-npm-install (--all | --changed=<ref> | <pkgName>...) [--report-only]',
+		);
 		return 2;
 	}
 	const unknown = targets.filter((t) => !byName.has(t));
@@ -193,33 +227,35 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 	);
 
 	console.log('Installing into scratch dir with npm...');
-	execFileSync(
-		'npm',
-		['install', '--no-audit', '--no-fund', '--ignore-scripts', '--no-package-lock'],
-		{
-			cwd: scratch,
-			stdio: ['ignore', 'inherit', 'inherit'],
-		},
-	);
+	await installWithRetry(scratch);
 
 	const { duplicates, failures } = analyze(collectCopies(scratch));
 
 	console.log(`\nnpm-install closure — scratch: ${scratch}\n`);
+	const curatedTag = reportOnly ? 'CURATED DUP (report)' : 'FAIL';
 	for (const d of duplicates) {
-		const tag = d.isCurated ? (d.allowed ? 'ALLOWED DUP' : 'FAIL') : 'dup (report)';
+		const tag = d.isCurated ? (d.allowed ? 'ALLOWED DUP' : curatedTag) : 'dup (report)';
 		console.log(
 			`  ${d.name}: ${tag} — ${d.copies.length} copies (${d.copies.map((c) => `v${c.version}`).join(', ')})`,
 		);
 	}
 
-	if (failures.length === 0) rmSync(work, { recursive: true, force: true });
-	else console.log(`\nScratch install kept for inspection: ${scratch}`);
+	// Report-only exits 0, so nothing downstream will look at the tree — keeping it would just
+	// leak a full node_modules into tmpdir on every run.
+	const keepScratch = failures.length > 0 && !reportOnly;
+	if (keepScratch) console.log(`\nScratch install kept for inspection: ${scratch}`);
+	else rmSync(work, { recursive: true, force: true });
 
 	if (failures.length > 0) {
+		for (const f of failures) {
+			annotate(
+				`${f.name}: ${f.copies.length} copies in the npm-install graph (${f.copies.map((c) => `v${c.version}`).join(', ')})`,
+			);
+		}
 		console.error(
-			`\nFAIL: ${failures.length} curated library duplicate(s) in the npm-install graph.`,
+			`\n${reportOnly ? 'REPORT' : 'FAIL'}: ${failures.length} curated library duplicate(s) in the npm-install graph.`,
 		);
-		return 1;
+		return reportOnly ? 0 : 1;
 	}
 	console.log('\nOK: no curated duplicates in the npm-install graph.');
 	return 0;


### PR DESCRIPTION
## Summary

Follow-up to #34681. The `Verify single-instance deps (npm-install)` job has been red on every master push since that PR landed:

```
FAIL: 1 curated library duplicate(s) in the npm-install graph.
  form-data: FAIL — 2 copies (v2.5.6, v4.0.6)
```

That finding is real and expected. `retry-request` → `@types/request@2.48.12` declares `form-data@^2.5.0` as a runtime dependency; our root `pnpm.overrides` pin `form-data: 4.0.6`, so pnpm shows one copy and a published tarball gets two. It is one of the three known third-party splits (`zod`, `@langchain/core`, `form-data`) documented in #34681 as not resolvable from a published tarball, and it is why the job ships advisory.

`continue-on-error: true` kept the *run* green, but the job still rendered a red ✗, which reads as a broken branch. This makes advisory mode actually advisory.

**Advisory runs now pass `--report-only`** — findings are printed, emitted as `::warning::` annotations, and the process exits 0. Enforcing runs (`blocking: true`) are unchanged.

**`continue-on-error` is removed rather than kept alongside it.** Stacking both made the job unfailable for *any* reason: usage errors, a rejected `Validate inputs` combination, a `pnpm pack` failure, or a crash that verified nothing would all have been swallowed. `--report-only` downgrades findings; it does not downgrade misconfiguration.

Two consequences of dropping that blanket net are handled here:

- The scratch `npm install` is the one network-bound step, so it gets a targeted retry (3 attempts, 5s/10s backoff). A registry blip should not read as a dependency finding; a persistent failure still fails the job.
- Report-only now cleans up its scratch dir. With findings permanent, the old "keep on failure" rule leaked a full `node_modules` tree into `tmpdir` on every run.

Note: with `continue-on-error` gone, the release-prep run (`release-create-pr.yml`) can now go red on a verifier crash. Nothing `needs:` that job and `approve-and-automerge` only depends on `create-release-pr`, so it cannot block a release — it just becomes visible.

This does **not** allowlist the known splits or flip the job to blocking. That still needs `EXPECTED_DUPLICATES` to become copy-aware (keyed by version set, not library name), as called out in #34681 — silencing `form-data` by name today would also stop the check ever failing on a split of our own making.

## How to test

Build the verifier once:

```bash
pnpm turbo run build --filter=@n8n/code-health...
cd packages/testing/code-health
```

**1. Advisory mode reports and passes.**

```bash
GITHUB_ACTIONS=true pnpm exec tsx src/cli.ts verify-npm-install n8n-nodes-base --report-only; echo "EXIT=$?"
```

Expect `EXIT=0`, and in the output:

```
  form-data: CURATED DUP (report) — 2 copies (v2.5.6, v4.0.6)
::warning::form-data: 2 copies in the npm-install graph (v2.5.6, v4.0.6)
REPORT: 1 curated library duplicate(s) in the npm-install graph.
```

**2. Enforcing mode still fails.** Same command without the flag:

```bash
pnpm exec tsx src/cli.ts verify-npm-install n8n-nodes-base; echo "EXIT=$?"
```

Expect `EXIT=1` and the `FAIL —` tag.

**3. Misconfiguration is not swallowed.** The flag must not be mistaken for a package name:

```bash
pnpm exec tsx src/cli.ts verify-npm-install --report-only; echo "EXIT=$?"
```

Expect `EXIT=2` and the usage line.

**4. No scratch leak.** Count before and after a report-only run — it should be unchanged, where enforcing mode leaves one behind for inspection:

```bash
find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'single-instance-npm-verify-*' | wc -l
```

**5. In CI.** On the merge commit, `Verify single-instance deps (npm-install)` should be ✅ with the `form-data` finding shown as a warning annotation on the run summary, rather than ✗.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #34681. No Linear ticket — that PR left the follow-up as "TBD".

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

