### PR TITLE
test(core): Cover deleteWorkflowCursors in the poller-state repository suite (no-changelog)

### DIFF
--- a/packages/cli/test/integration/database/repositories/poller-state.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/poller-state.repository.test.ts
@@ -12,12 +12,14 @@ describe('PollerStateRepository', () => {
 	let workflowRepository: WorkflowRepository;
 	let txRunner: TransactionRunner;
 	let workflowId: string;
+	let otherWorkflowId: string;
 
 	beforeAll(async () => {
 		await testDb.init();
 		repository = Container.get(PollerStateRepository);
 		workflowRepository = Container.get(WorkflowRepository);
 		({ id: workflowId } = await createWorkflow());
+		({ id: otherWorkflowId } = await createWorkflow());
 		txRunner = Container.get(TransactionRunner);
 	});
 
@@ -104,6 +106,27 @@ describe('PollerStateRepository', () => {
 
 			expect(await repository.findCursor(doomedWorkflowId, 'node-1')).toBeNull();
 			expect(await repository.findCursor(doomedWorkflowId, 'node-2')).toBeNull();
+		});
+	});
+
+	describe('deleteWorkflowCursors', () => {
+		it('deletes all rows of the given workflows and reports how many', async () => {
+			await seed('node-1', { lastItemId: 'a' });
+			await seed('node-2', { lastItemId: 'b' });
+			await seed('node-1', { lastItemId: 'c' }, otherWorkflowId);
+
+			expect(await repository.deleteWorkflowCursors([workflowId])).toBe(2);
+
+			expect(await repository.findCursor(workflowId, 'node-1')).toBeNull();
+			expect(await repository.findCursor(workflowId, 'node-2')).toBeNull();
+			expect(await repository.findCursor(otherWorkflowId, 'node-1')).toEqual({ lastItemId: 'c' });
+		});
+
+		it('deletes nothing and reports zero rows for an empty workflow list', async () => {
+			await seed('node-1', { lastItemId: 'a' });
+
+			expect(await repository.deleteWorkflowCursors([])).toBe(0);
+			expect(await repository.findCursor(workflowId, 'node-1')).toEqual({ lastItemId: 'a' });
 		});
 	});
 

--- a/packages/cli/test/integration/workflows/durable-poller-gate.test.ts
+++ b/packages/cli/test/integration/workflows/durable-poller-gate.test.ts
@@ -163,8 +163,4 @@ describe('DurablePollerGateService (integration)', () => {
 			{ workflow_ids: [offender.id], deleted_cursor_rows: 1 },
 		);
 	});
-
-	test('deleting cursors for no workflows touches nothing and reports zero rows', async () => {
-		await expect(pollerStateRepository.deleteWorkflowCursors([])).resolves.toBe(0);
-	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #36340 (currently in the merge queue), from [this review thread](https://github.com/n8n-io/n8n/pull/36340#discussion_r3796143916).

`PollerStateRepository.deleteWorkflowCursors` gets its own describe in the existing DB-backed repository suite, pinning the method's contract: it deletes all rows of the given workflows, returns the real deleted-row count, leaves other workflows' rows alone, and does nothing for an empty list. The empty-list test moves here from the durable-poller gate integration suite, where it was off-topic. The gate suite keeps its behavioral assertions (offender rows deleted, clean rows kept, count reaching telemetry).


## How to test

```
pnpm --filter n8n test:integration test/integration/database/repositories/poller-state.repository.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4057

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->