### PR TITLE
feat(editor): Add stop execution button to the NDV

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
@@ -865,6 +865,18 @@ describe('useNodeExecution', () => {
 			expect(mockWorkflowsStore.removeTestWebhook).toHaveBeenCalledWith('123');
 		});
 
+		it('should stop webhook wait from a non-trigger node', async () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(false);
+			mockWorkflowExecutionStateStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ name: 'Edit Fields' }));
+
+			const { stopExecution } = useNodeExecution(node);
+			await stopExecution();
+
+			expect(mockWorkflowsStore.removeTestWebhook).toHaveBeenCalledWith('123');
+			expect(mockRunWorkflow.stopCurrentExecution).not.toHaveBeenCalled();
+		});
+
 		it('should stop current execution when listening for workflow events', async () => {
 			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
 			mockNodeTypesStore.getNodeType.mockReturnValue({

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -439,9 +439,10 @@ export function useNodeExecution(
 	}
 
 	async function stopExecution(): Promise<void> {
-		if (isListening.value) {
+		// While the run waits for a test webhook there is no execution to stop.
+		if (workflowExecutionStateStore.value.executionWaitingForWebhook) {
 			await stopWaitingForWebhook();
-		} else if (isListeningForWorkflowEvents.value) {
+		} else {
 			await stopCurrentExecution();
 		}
 	}

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -17,7 +17,10 @@ import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { chatEventBus } from '@n8n/chat/event-buses';
 import { useChat } from '@n8n/chat/composables';
 import type { INodeUi, IStartRunData } from '@/Interface';
-import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import type {
+	IExecutionResponse,
+	IExecutionsStopData,
+} from '@/features/execution/executions/executions.types';
 import type { WorkflowData } from '@n8n/rest-api-client/api/workflows';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
@@ -1430,6 +1433,31 @@ describe('useRunWorkflow({ router })', () => {
 	});
 
 	describe('stopCurrentExecution()', () => {
+		it('waits for the pending execution id instead of dropping the stop request', async () => {
+			const runWorkflowComposable = useRunWorkflow({ router });
+			const { useExecutionsStore } = await import(
+				'@/features/execution/executions/executions.store'
+			);
+			const executionsStore = useExecutionsStore();
+			const stopSpy = vi
+				.spyOn(executionsStore, 'stopCurrentExecution')
+				.mockResolvedValue({ mode: 'manual', status: 'canceled' } as IExecutionsStopData);
+			vi.spyOn(workflowsStore, 'getExecution').mockResolvedValue({
+				status: 'canceled',
+			} as IExecutionResponse);
+
+			// Run accepted, backend id not yet known.
+			executionStateStore.setActiveExecutionId(null);
+
+			const stopPromise = runWorkflowComposable.stopCurrentExecution();
+			expect(stopSpy).not.toHaveBeenCalled();
+
+			executionStateStore.setActiveExecutionId('exec-late');
+			await stopPromise;
+
+			expect(stopSpy).toHaveBeenCalledWith('exec-late');
+		});
+
 		it('stamps id and clears activeExecutionId before setWorkflowExecutionData when execution finished before stop', async () => {
 			const runWorkflowComposable = useRunWorkflow({ router });
 			const finishedExecution: IExecutionResponse = {

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -22,6 +22,7 @@ import {
 	BINARY_MODE_COMBINED,
 } from 'n8n-workflow';
 import { retry } from '@n8n/utils/retry';
+import { until } from '@vueuse/core';
 import { computed, getCurrentInstance, type Ref } from 'vue';
 
 import { useToast } from '@n8n/composables/useToast';
@@ -561,8 +562,17 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	}
 
 	async function stopCurrentExecution() {
-		const executionId = workflowExecutionState.value.activeExecutionId;
+		let executionId = workflowExecutionState.value.activeExecutionId;
 		let stopData: IExecutionsStopData | undefined;
+
+		// null means the run started but the backend id is not yet known.
+		// Wait for it instead of dropping the click.
+		if (executionId === null) {
+			executionId = await until(() => workflowExecutionState.value.activeExecutionId).toMatch(
+				(id) => id !== null,
+				{ timeout: 10_000 },
+			);
+		}
 
 		if (!executionId) {
 			return;

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1291,13 +1291,6 @@ function removeExecutionOpenedEventBindings() {
 }
 
 async function onStopExecution() {
-	// The NDV stop button routes here in every running state. While the run
-	// waits for a test webhook there is no execution to stop yet — cancel
-	// the webhook wait instead.
-	if (isExecutionWaitingForWebhook.value) {
-		await stopWaitingForWebhook();
-		return;
-	}
 	isStoppingExecution.value = true;
 	await stopCurrentExecution();
 	isStoppingExecution.value = false;

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1291,6 +1291,13 @@ function removeExecutionOpenedEventBindings() {
 }
 
 async function onStopExecution() {
+	// The NDV stop button routes here in every running state. While the run
+	// waits for a test webhook there is no execution to stop yet — cancel
+	// the webhook wait instead.
+	if (isExecutionWaitingForWebhook.value) {
+		await stopWaitingForWebhook();
+		return;
+	}
 	isStoppingExecution.value = true;
 	await stopCurrentExecution();
 	isStoppingExecution.value = false;

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsHeader.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from '@n8n/i18n';
+import { N8nIconButton } from '@n8n/design-system';
 import type { IUpdateInformation } from '@/Interface';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import NodeSettingsTabs from './NodeSettingsTabs.vue';
 import NodeExecuteButton from '@/app/components/NodeExecuteButton.vue';
 import type { NodeSettingsTab } from '@/app/types/nodeSettings';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useNodeExecution } from '@/app/composables/useNodeExecution';
 
 type Props = {
 	nodeName: string;
@@ -17,7 +22,12 @@ type Props = {
 	pushRef: string;
 };
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+const i18n = useI18n();
+const workflowDocumentStore = injectWorkflowDocumentStore();
+const node = computed(() => workflowDocumentStore.value.getNodeByName(props.nodeName) ?? null);
+const { isExecuting } = useNodeExecution(node);
 
 const emit = defineEmits<{
 	execute: [];
@@ -37,6 +47,16 @@ const emit = defineEmits<{
 			:push-ref="pushRef"
 			:class="$style.tabs"
 			@update:model-value="emit('tab-changed', $event)"
+		/>
+		<N8nIconButton
+			v-if="!hideExecute && isExecuting"
+			data-test-id="ndv-stop-execution-button"
+			variant="subtle"
+			icon="square"
+			size="small"
+			:class="$style.stop"
+			:title="i18n.baseText('nodeView.stopCurrentExecution')"
+			@click="emit('stop-execution')"
 		/>
 		<NodeExecuteButton
 			v-if="!hideExecute"
@@ -72,5 +92,9 @@ const emit = defineEmits<{
 
 .tabs :global(#communityNode) {
 	padding-right: var(--spacing--2xs);
+}
+
+.stop {
+	margin-right: var(--spacing--2xs);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsHeader.vue
@@ -27,7 +27,7 @@ const props = defineProps<Props>();
 const i18n = useI18n();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const node = computed(() => workflowDocumentStore.value.getNodeByName(props.nodeName) ?? null);
-const { isExecuting } = useNodeExecution(node);
+const { isExecuting, stopExecution } = useNodeExecution(node);
 
 const emit = defineEmits<{
 	execute: [];
@@ -56,7 +56,7 @@ const emit = defineEmits<{
 			size="small"
 			:class="$style.stop"
 			:title="i18n.baseText('nodeView.stopCurrentExecution')"
-			@click="emit('stop-execution')"
+			@click="stopExecution"
 		/>
 		<NodeExecuteButton
 			v-if="!hideExecute"


### PR DESCRIPTION
## Summary

Adds a stop button next to 'Execute step' in the NDV header, so a test-step run can be canceled without closing the NDV. The button shows while the node executes and calls `useNodeExecution.stopExecution()`, which picks the correct stop action for the current state:

- When the run waits for a test webhook (e.g. 'Execute step' on a child of a Webhook trigger), there is no execution to stop — it cancels the webhook wait, the same action the canvas webhook-wait button uses.
- Otherwise it stops the current execution. `stopCurrentExecution` also no longer drops a stop click that lands before the backend returns the execution id (it now waits for the pending id, 10s cap) — this race also affected the canvas stop button.

## How to test

1. Workflow A: Manual Trigger → Code node with `await new Promise((r) => setTimeout(r, 120000)); return [];`. Open the Code node, click **Execute step**, then the stop button next to it — the execution cancels, even when clicked immediately.
2. Workflow B: Webhook → Edit Fields. Open Edit Fields, click **Execute step** (the run waits for the test webhook), then the stop button — the webhook wait is canceled and the UI resets.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-252

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)