### PR TITLE
fix(editor): Open node details links in a new tab in canvas-only mode

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOnlyExternalLinks.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOnlyExternalLinks.test.ts
@@ -1,0 +1,105 @@
+import { effectScope, reactive } from 'vue';
+
+import { openSafeUrl } from '@/app/utils/htmlUtils';
+
+import { useCanvasOnlyExternalLinks } from './useCanvasOnlyExternalLinks';
+
+const settingsStore = reactive({ isCanvasOnly: false });
+
+vi.mock('@n8n/stores/settings.store', () => ({
+	useSettingsStore: () => settingsStore,
+}));
+
+vi.mock('@/app/utils/htmlUtils', () => ({
+	openSafeUrl: vi.fn(),
+}));
+
+describe('useCanvasOnlyExternalLinks', () => {
+	let scope: ReturnType<typeof effectScope>;
+	let root: HTMLDivElement;
+
+	const mountComposable = (canvasOnly: boolean) => {
+		settingsStore.isCanvasOnly = canvasOnly;
+		scope = effectScope();
+		scope.run(() => {
+			useCanvasOnlyExternalLinks(root);
+		});
+	};
+
+	beforeEach(() => {
+		root = document.createElement('div');
+		document.body.append(root);
+	});
+
+	afterEach(() => {
+		scope?.stop();
+		root.remove();
+		settingsStore.isCanvasOnly = false;
+		vi.clearAllMocks();
+	});
+
+	it('opens docs links in the node details view in a new tab when canvas-only is on', () => {
+		mountComposable(true);
+
+		const link = document.createElement('a');
+		link.href = 'https://docs.n8n.io/advanced-ai/intro-tutorial/';
+		link.textContent = 'tutorial';
+		root.append(link);
+		link.click();
+
+		expect(openSafeUrl).toHaveBeenCalledWith(link.href);
+	});
+
+	it('opens relative template links in the node details view in a new tab when canvas-only is on', () => {
+		mountComposable(true);
+
+		const link = document.createElement('a');
+		link.href = '/workflows/templates/1954';
+		link.textContent = 'example';
+		link.addEventListener('click', (event) => event.preventDefault());
+		root.append(link);
+		link.click();
+
+		expect(openSafeUrl).toHaveBeenCalledWith(link.href);
+	});
+
+	it('does not intercept clicks when canvas-only is off', () => {
+		mountComposable(false);
+
+		const link = document.createElement('a');
+		link.href = 'https://docs.n8n.io/advanced-ai/intro-tutorial/';
+		link.textContent = 'tutorial';
+		link.addEventListener('click', (event) => event.preventDefault());
+		root.append(link);
+		link.click();
+
+		expect(openSafeUrl).not.toHaveBeenCalled();
+	});
+
+	it('does not intercept notice action links', () => {
+		mountComposable(true);
+
+		const link = document.createElement('a');
+		link.dataset.key = 'toggle-expand';
+		link.textContent = 'Show more';
+		root.append(link);
+		link.click();
+
+		expect(openSafeUrl).not.toHaveBeenCalled();
+	});
+
+	it('does not intercept clicks outside the node details view', () => {
+		mountComposable(true);
+
+		const link = document.createElement('a');
+		link.href = '/projects/abc123';
+		link.textContent = 'Project';
+		link.addEventListener('click', (event) => event.preventDefault());
+		document.body.append(link);
+		link.click();
+
+		expect(openSafeUrl).not.toHaveBeenCalled();
+
+		link.remove();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOnlyExternalLinks.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOnlyExternalLinks.ts
@@ -1,25 +1,22 @@
+import { useEventListener } from '@vueuse/core';
 import { useSettingsStore } from '@n8n/stores/settings.store';
-import { toValue, watch, type MaybeRefOrGetter } from 'vue';
+import { toValue, type MaybeRefOrGetter } from 'vue';
 
 import { openSafeUrl } from '@/app/utils/htmlUtils';
-
-function isActionLink(anchor: HTMLAnchorElement): boolean {
-	return Boolean(anchor.dataset.key || anchor.dataset.action);
-}
 
 function shouldOpenInNewTab(href: string | null): boolean {
 	return href !== null && href !== '' && !href.startsWith('#') && !href.startsWith('javascript:');
 }
 
 /**
- * In canvas-only embeds, open tutorial/documentation links inside the node
- * details view in a new tab so they do not navigate the iframe.
+ * Makes any link clicked inside the Node Details View open in a new tab, if
+ * N8N_CANVAS_ONLY is enabled.
  */
 export function useCanvasOnlyExternalLinks(root: MaybeRefOrGetter<HTMLElement | null | undefined>) {
 	const settingsStore = useSettingsStore();
 
 	const onClick = (event: MouseEvent) => {
-		if (!settingsStore.isCanvasOnly || event.defaultPrevented) {
+		if (event.defaultPrevented) {
 			return;
 		}
 
@@ -33,7 +30,7 @@ export function useCanvasOnlyExternalLinks(root: MaybeRefOrGetter<HTMLElement | 
 		}
 
 		const anchor = target.closest('a');
-		if (!anchor || isActionLink(anchor) || !shouldOpenInNewTab(anchor.getAttribute('href'))) {
+		if (!anchor || !shouldOpenInNewTab(anchor.getAttribute('href'))) {
 			return;
 		}
 
@@ -41,16 +38,10 @@ export function useCanvasOnlyExternalLinks(root: MaybeRefOrGetter<HTMLElement | 
 		openSafeUrl(anchor.href);
 	};
 
-	watch(
-		[() => settingsStore.isCanvasOnly, () => toValue(root)],
-		([canvasOnly, el], _, onCleanup) => {
-			if (!canvasOnly || !el) {
-				return;
-			}
-
-			el.addEventListener('click', onClick, true);
-			onCleanup(() => el.removeEventListener('click', onClick, true));
-		},
-		{ immediate: true },
+	useEventListener(
+		() => (settingsStore.isCanvasOnly ? toValue(root) : undefined),
+		'click',
+		onClick,
+		{ capture: true },
 	);
 }

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOnlyExternalLinks.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOnlyExternalLinks.ts
@@ -1,0 +1,56 @@
+import { useSettingsStore } from '@n8n/stores/settings.store';
+import { toValue, watch, type MaybeRefOrGetter } from 'vue';
+
+import { openSafeUrl } from '@/app/utils/htmlUtils';
+
+function isActionLink(anchor: HTMLAnchorElement): boolean {
+	return Boolean(anchor.dataset.key || anchor.dataset.action);
+}
+
+function shouldOpenInNewTab(href: string | null): boolean {
+	return href !== null && href !== '' && !href.startsWith('#') && !href.startsWith('javascript:');
+}
+
+/**
+ * In canvas-only embeds, open tutorial/documentation links inside the node
+ * details view in a new tab so they do not navigate the iframe.
+ */
+export function useCanvasOnlyExternalLinks(root: MaybeRefOrGetter<HTMLElement | null | undefined>) {
+	const settingsStore = useSettingsStore();
+
+	const onClick = (event: MouseEvent) => {
+		if (!settingsStore.isCanvasOnly || event.defaultPrevented) {
+			return;
+		}
+
+		if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+			return;
+		}
+
+		const target = event.target;
+		if (!(target instanceof Element)) {
+			return;
+		}
+
+		const anchor = target.closest('a');
+		if (!anchor || isActionLink(anchor) || !shouldOpenInNewTab(anchor.getAttribute('href'))) {
+			return;
+		}
+
+		event.preventDefault();
+		openSafeUrl(anchor.href);
+	};
+
+	watch(
+		[() => settingsStore.isCanvasOnly, () => toValue(root)],
+		([canvasOnly, el], _, onCleanup) => {
+			if (!canvasOnly || !el) {
+				return;
+			}
+
+			el.addEventListener('click', onClick, true);
+			onCleanup(() => el.removeEventListener('click', onClick, true));
+		},
+		{ immediate: true },
+	);
+}

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -43,6 +43,7 @@ import InputPanel from '../../panel/components/InputPanel.vue';
 import OutputPanel from '../../panel/components/OutputPanel.vue';
 import PanelDragButton from '../../panel/components/PanelDragButton.vue';
 import TriggerPanel from '../../panel/components/TriggerPanel.vue';
+import { useCanvasOnlyExternalLinks } from '@/app/composables/useCanvasOnlyExternalLinks';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
 import { nodeViewEventBus } from '@/app/event-bus';
 import { N8nResizeWrapper } from '@n8n/design-system';
@@ -105,6 +106,8 @@ const isPairedItemHoveringEnabled = ref(true);
 const dialogRef = ref<HTMLDialogElement>();
 const containerRef = useTemplateRef('containerRef');
 const mainPanelRef = useTemplateRef('mainPanelRef');
+
+useCanvasOnlyExternalLinks(dialogRef);
 
 // computed
 const pushRef = computed(() => ndvStore.value.pushRef);


### PR DESCRIPTION
## Summary

https://www.loom.com/share/946ecb396b49402abb5420a76e39c431

In canvas-only embeds, docs and tutorial links in the node details view that omit `target="_blank"` can navigate the iframe away from the editor.

This intercepts those clicks only inside the node details dialog, and only when `canvasOnly` is true, so they open in a new tab. In-app navigation (for example project selection) is unchanged.

Links that already include `target="_blank"` (AI Agent tutorial/example, NDV Docs header) already opened in a new tab; this covers remaining notices such as Simple Vector Store **More info**.

## How to test

1. Start n8n with canvas-only mode:
   ```bash
   N8N_CANVAS_ONLY=true pnpm dev
   ```
2. Confirm `GET /rest/settings` has `"canvasOnly": true` and the sidebar is hidden.
3. Open a workflow, add **Simple Vector Store**, switch to **Insert Documents**, and click **More info** in the yellow notice (not the header Docs link). It should open in a new browser tab and leave the editor on the canvas.
4. Open **AI Agent** and click **tutorial** / **example**. They should still open in a new tab.
5. Select a project from the header. It should stay in the same tab.
6. Restart without `N8N_CANVAS_ONLY` and confirm default n8n link behavior is unchanged.

Optional iframe check: serve a page that embeds `http://localhost:5678` and repeat steps 3–5 so the iframe does not navigate.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-162

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)