### PR TITLE
fix(core): Capture browser secrets independently of match boundaries

### DIFF
--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -125,6 +125,20 @@ describe('BUILTIN_PATTERNS coverage', () => {
 	});
 });
 
+describe('pattern cost', () => {
+	// Page text includes inline script/style, which is one long run with no
+	// delimiters. An unanchored pattern that backtracks over such a run turns
+	// every tool call into a stall.
+	it('scans a long undelimited run without backtracking', () => {
+		const blob = 'a1B2c3D4e5F6g7H8i9J0'.repeat(5000);
+
+		const started = performance.now();
+		findRegexSecretHits(blob);
+
+		expect(performance.now() - started).toBeLessThan(1000);
+	});
+});
+
 describe('capture safety', () => {
 	// Long secrets are exactly the ones worth capturing; a PEM match carries its
 	// own boundaries, so its length must not make it uncapturable.

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -139,13 +139,39 @@ describe('pattern cost', () => {
 	});
 });
 
+describe('variable-length provider shapes', () => {
+	// Google keys are not a fixed length. A pattern that matches a fixed count of
+	// one leaves the rest of the key in the text the model reads.
+	it('redacts an over-long google key completely', () => {
+		const key = `AIza${'SyC7mQ2xR9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1Bc'}`;
+
+		expect(redactString(`Your key is ${key} keep it`)).toBe(
+			'Your key is [REDACTED:google_api_key:1] keep it',
+		);
+	});
+
+	// A console that lists a key truncated beside the full one must not let the
+	// short rendering decide what gets stored.
+	it('keeps a truncated rendering separate from the full key', () => {
+		const truncated = `AIza${'B'.repeat(35)}`;
+		const full = `${truncated}EXTRA12`;
+
+		const hits = findRegexSecretHits(`Keys: ${truncated} Detail: ${full} end`);
+
+		expect(hits.map((hit) => (hit.captureValue ?? hit.value).length).sort()).toEqual([
+			truncated.length,
+			full.length,
+		]);
+	});
+});
+
 describe('capture safety', () => {
 	// Long secrets are exactly the ones worth capturing; a PEM match carries its
 	// own boundaries, so its length must not make it uncapturable.
 	// An occurrence inside an undelimitable run says nothing about the token's
 	// extent, so it must not overrule what a delimited occurrence established.
 	it('ignores an undelimited occurrence when a delimited one exists', () => {
-		const key = `AIza${'B'.repeat(35)}`;
+		const key = `ghp_${'B'.repeat(36)}`;
 		const run = 'x'.repeat(600);
 
 		const [hit] = findRegexSecretHits(`id.${key} and ${run}${key}${run}`);
@@ -155,7 +181,7 @@ describe('capture safety', () => {
 	});
 
 	it('blocks capture when every occurrence is undelimited', () => {
-		const key = `AIza${'B'.repeat(35)}`;
+		const key = `ghp_${'B'.repeat(36)}`;
 		const run = 'x'.repeat(600);
 
 		const [hit] = findRegexSecretHits(`${run}${key}${run} and ${run}${key}${run}`);

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -125,6 +125,40 @@ describe('BUILTIN_PATTERNS coverage', () => {
 	});
 });
 
+describe('capture safety', () => {
+	// Long secrets are exactly the ones worth capturing; a PEM match carries its
+	// own boundaries, so its length must not make it uncapturable.
+	// An occurrence inside an undelimitable run says nothing about the token's
+	// extent, so it must not overrule what a delimited occurrence established.
+	it('ignores an undelimited occurrence when a delimited one exists', () => {
+		const key = `AIza${'B'.repeat(35)}`;
+		const run = 'x'.repeat(600);
+
+		const [hit] = findRegexSecretHits(`id.${key} and ${run}${key}${run}`);
+
+		expect(hit.captureValue).toBe(`id.${key}`);
+		expect(hit.captureBlocked).toBeUndefined();
+	});
+
+	it('blocks capture when every occurrence is undelimited', () => {
+		const key = `AIza${'B'.repeat(35)}`;
+		const run = 'x'.repeat(600);
+
+		const [hit] = findRegexSecretHits(`${run}${key}${run} and ${run}${key}${run}`);
+
+		expect(hit.captureBlocked).toBeTruthy();
+	});
+
+	it('does not block capture of a PEM key longer than the span cap', () => {
+		const pem = `-----BEGIN RSA PRIVATE KEY-----\n${'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSj\n'.repeat(14)}-----END RSA PRIVATE KEY-----`;
+
+		const [hit] = findRegexSecretHits(`Here is the key:\n${pem}\nkeep it safe`);
+
+		expect(pem.length).toBeGreaterThan(512);
+		expect(hit.captureBlocked).toBeUndefined();
+	});
+});
+
 describe('redactString', () => {
 	it('redacts issuer-shaped secrets', () => {
 		expect(redactString(`key=${ANTHROPIC}`)).toBe('key=[REDACTED:anthropic_api_key:1]');

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -153,6 +153,11 @@ describe('redactString', () => {
 		);
 	});
 
+	it('redacts the dot-prefixed google key shape', () => {
+		const key = `AQ.${'Ab8RN6Jr7xQfP2mKdW9tZsLyVc4hEuNgT3iBoXaQwMzRkJvSpH'}`;
+		expect(redactString(`key=${key}`)).toBe('key=[REDACTED:google_api_key:1]');
+	});
+
 	it('does not redact common browser trace strings', () => {
 		const input = 'commit a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 by alice';
 		expect(redactString(input)).toBe(input);
@@ -176,6 +181,16 @@ describe('redactString', () => {
 });
 
 describe('findRegexSecretHits', () => {
+	// A console often shows the same key twice — bare, and inside a curl or env
+	// snippet. The bare one is the span that can be stored as a credential.
+	it('prefers the narrowest span when a key appears in more than one context', () => {
+		const key = `AIza${'B'.repeat(35)}`;
+
+		expect(findRegexSecretHits(`id.${key} and bare ${key}`)).toEqual([
+			{ type: 'google_api_key', value: key },
+		]);
+	});
+
 	it('dedupes matches by type and value', () => {
 		expect(findRegexSecretHits(`${ANTHROPIC} ${ANTHROPIC}`)).toEqual([
 			{ type: 'anthropic_api_key', value: ANTHROPIC },

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -150,6 +150,13 @@ describe('variable-length provider shapes', () => {
 		);
 	});
 
+	// Real legacy openai keys run past the 48 characters the pattern used to count.
+	it('redacts a real-length legacy openai key completely', () => {
+		const key = `sk-${'aB3xY9zQ7wE2rT5yU8iO1pL4kJ6hG0fDaB3xY9zQ7wE2rT5yU8i'}`;
+
+		expect(redactString(`key ${key} end`)).toBe('key [REDACTED:openai_legacy_api_key:1] end');
+	});
+
 	// A console that lists a key truncated beside the full one must not let the
 	// short rendering decide what gets stored.
 	it('keeps a truncated rendering separate from the full key', () => {

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
@@ -47,7 +47,7 @@ describe('expandToTokenSpan', () => {
 		expect(expand('https://api.test/v1?key=AQ.abc123&alt=json', 'abc123')).toBe('AQ.abc123');
 	});
 
-	it.each(['|', '*', '·'])('stops at %s used as an inline separator', (separator) => {
+	it.each(['|', '*', '·', '…'])('stops at %s used as an inline separator', (separator) => {
 		expect(expand(`AQ.abc123${separator}Copy`, 'abc123')).toBe('AQ.abc123');
 	});
 

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
@@ -66,6 +66,14 @@ describe('expandToTokenSpan', () => {
 		expect(expand(`${run}abc123${run}`, 'abc123')).toBe('abc123');
 	});
 
+	// A long match that expansion never extended is its own token — nothing was
+	// guessed, so it must not be treated as undelimited (e.g. a PEM key).
+	it('treats a match that is already the whole run as delimited', () => {
+		const long = 'a'.repeat(600);
+
+		expect(delimited(`before ${long} after`, long)).toBe(true);
+	});
+
 	// Callers must be able to tell a whole token from a match they fell back to.
 	it('reports whether the token was delimited', () => {
 		expect(delimited('key AQ.abc123 rest', 'abc123')).toBe(true);

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
@@ -1,7 +1,11 @@
 import { expandToTokenSpan } from '../token-span';
 
 function expand(text: string, match: string): string {
-	return expandToTokenSpan(text, text.indexOf(match), match.length);
+	return expandToTokenSpan(text, text.indexOf(match), match.length).span;
+}
+
+function delimited(text: string, match: string): boolean {
+	return expandToTokenSpan(text, text.indexOf(match), match.length).delimited;
 }
 
 describe('expandToTokenSpan', () => {
@@ -43,6 +47,15 @@ describe('expandToTokenSpan', () => {
 		expect(expand('https://api.test/v1?key=AQ.abc123&alt=json', 'abc123')).toBe('AQ.abc123');
 	});
 
+	it.each(['|', '*', '·'])('stops at %s used as an inline separator', (separator) => {
+		expect(expand(`AQ.abc123${separator}Copy`, 'abc123')).toBe('AQ.abc123');
+	});
+
+	// `+` is base64 and `~` is the Azure key shape, so both must keep crossing.
+	it.each(['+', '~'])('crosses %s, which occurs inside secrets', (inner) => {
+		expect(expand(`AQ.abc123${inner}def456 rest`, 'abc123')).toBe(`AQ.abc123${inner}def456`);
+	});
+
 	it('stops at a dash used as prose punctuation', () => {
 		expect(expand('Key—AQ.abc123 rest', 'abc123')).toBe('AQ.abc123');
 	});
@@ -51,5 +64,11 @@ describe('expandToTokenSpan', () => {
 		const run = 'x'.repeat(5000);
 
 		expect(expand(`${run}abc123${run}`, 'abc123')).toBe('abc123');
+	});
+
+	// Callers must be able to tell a whole token from a match they fell back to.
+	it('reports whether the token was delimited', () => {
+		expect(delimited('key AQ.abc123 rest', 'abc123')).toBe(true);
+		expect(delimited(`${'x'.repeat(5000)}abc123`, 'abc123')).toBe(false);
 	});
 });

--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/token-span.test.ts
@@ -1,0 +1,55 @@
+import { expandToTokenSpan } from '../token-span';
+
+function expand(text: string, match: string): string {
+	return expandToTokenSpan(text, text.indexOf(match), match.length);
+}
+
+describe('expandToTokenSpan', () => {
+	it('includes a prefix the match started after', () => {
+		expect(expand('key AQ.abc123 rest', 'abc123')).toBe('AQ.abc123');
+	});
+
+	it('includes a suffix the match stopped before', () => {
+		expect(expand('key abc123:tail rest', 'abc123')).toBe('abc123:tail');
+	});
+
+	it('returns the match unchanged when it already spans the whole run', () => {
+		expect(expand('abc123', 'abc123')).toBe('abc123');
+	});
+
+	it('drops quotes and separators a serialized value sits in', () => {
+		expect(expand('{"apiKey":"AQ.abc123",}', 'abc123')).toBe('AQ.abc123');
+	});
+
+	it('drops a sentence-ending dot but keeps dots inside the token', () => {
+		expect(expand('Use AQ.abc.123. Then continue', 'abc')).toBe('AQ.abc.123');
+	});
+
+	it('keeps base64 padding', () => {
+		expect(expand('value abc123== rest', 'abc123')).toBe('abc123==');
+	});
+
+	it('never trims into the match itself', () => {
+		expect(expand('leading (abc123) trailing', '(abc123)')).toBe('(abc123)');
+	});
+
+	// A console rendering `NAME=<key>`, a curl sample or a "use this URL" snippet
+	// must not become part of the captured credential.
+	it('stops at an assignment', () => {
+		expect(expand('GOOGLE_API_KEY=AQ.abc123 rest', 'abc123')).toBe('AQ.abc123');
+	});
+
+	it('stops at query-string punctuation', () => {
+		expect(expand('https://api.test/v1?key=AQ.abc123&alt=json', 'abc123')).toBe('AQ.abc123');
+	});
+
+	it('stops at a dash used as prose punctuation', () => {
+		expect(expand('Key—AQ.abc123 rest', 'abc123')).toBe('AQ.abc123');
+	});
+
+	it('gives up rather than return a whole unbroken run', () => {
+		const run = 'x'.repeat(5000);
+
+		expect(expand(`${run}abc123${run}`, 'abc123')).toBe('abc123');
+	});
+});

--- a/packages/@n8n/mcp-browser/src/redaction/patterns.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/patterns.ts
@@ -46,7 +46,12 @@ export const BUILTIN_PATTERNS: SecretPattern[] = [
 	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35}|AQ\.[0-9A-Za-z_-]{30,100}/ },
 	{ slug: 'google_oauth_client_secret', pattern: /GOCSPX-[A-Za-z0-9_-]{28,}/ },
 	{ slug: 'aws_access_key_id', pattern: /(?:AKIA|ASIA)[A-Z0-9]{16}/ },
-	{ slug: 'azure_ad_client_secret', pattern: /[A-Za-z0-9_-]{3,}~[A-Za-z0-9_-]{31,}/ },
+	// Anchored at a token boundary: without it the unbounded prefix backtracks over
+	// every offset of a long run, and inline script text is exactly that.
+	{
+		slug: 'azure_ad_client_secret',
+		pattern: /(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{3,}~[A-Za-z0-9_-]{31,}/,
+	},
 	{ slug: 'digitalocean_pat', pattern: /dop_v1_[a-f0-9]{64}/ },
 	{ slug: 'digitalocean_oauth_token', pattern: /doo_v1_[a-f0-9]{64}/ },
 	{ slug: 'digitalocean_refresh_token', pattern: /dor_v1_[a-f0-9]{64}/ },

--- a/packages/@n8n/mcp-browser/src/redaction/patterns.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/patterns.ts
@@ -31,7 +31,7 @@ export const BUILTIN_PATTERNS: SecretPattern[] = [
 	{ slug: 'anthropic_admin_key', pattern: /sk-ant-admin\d{2}-[A-Za-z0-9_-]{80,}/ },
 	{ slug: 'openai_api_key', pattern: /sk-proj-[A-Za-z0-9_-]{40,}/ },
 	{ slug: 'openai_service_account_key', pattern: /sk-svcacct-[A-Za-z0-9_-]{20,}/ },
-	{ slug: 'openai_legacy_api_key', pattern: /sk-[A-Za-z0-9]{48}/ },
+	{ slug: 'openai_legacy_api_key', pattern: /sk-[A-Za-z0-9]{48,}/ },
 	{ slug: 'huggingface_token', pattern: /hf_[A-Za-z0-9]{34,}/ },
 	{ slug: 'groq_api_key', pattern: /gsk_[A-Za-z0-9]{52}/ },
 	{ slug: 'perplexity_api_key', pattern: /pplx-[A-Za-z0-9]{48,}/ },
@@ -42,16 +42,12 @@ export const BUILTIN_PATTERNS: SecretPattern[] = [
 	{ slug: 'langsmith_api_key_v2', pattern: /lsv2_(?:pt|sk)_[a-f0-9]{40}_[a-f0-9]{16}/ },
 
 	// --- Cloud / infra ---
-	// `AIza…` is the legacy shape; AI Studio now issues `AQ.`-prefixed keys. Both
-	// are open-ended: a fixed count would leave the rest of a longer key in the
-	// text, and would make a truncated rendering match a prefix of the real one.
-	// Unanchored on purpose — a key concatenated into a run of text still has to be
-	// found, even though nothing there delimits it.
+	// Open-ended and unanchored: a fixed count leaves the tail of a longer key in
+	// the text, and an anchor misses a key concatenated into a run.
 	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35,}|AQ\.[0-9A-Za-z_-]{30,}/ },
 	{ slug: 'google_oauth_client_secret', pattern: /GOCSPX-[A-Za-z0-9_-]{28,}/ },
 	{ slug: 'aws_access_key_id', pattern: /(?:AKIA|ASIA)[A-Z0-9]{16}/ },
-	// Anchored at a token boundary: without it the unbounded prefix backtracks over
-	// every offset of a long run, and inline script text is exactly that.
+	// Anchored, or the unbounded prefix backtracks over every offset of a long run.
 	{
 		slug: 'azure_ad_client_secret',
 		pattern: /(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{3,}~[A-Za-z0-9_-]{31,}/,

--- a/packages/@n8n/mcp-browser/src/redaction/patterns.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/patterns.ts
@@ -42,8 +42,12 @@ export const BUILTIN_PATTERNS: SecretPattern[] = [
 	{ slug: 'langsmith_api_key_v2', pattern: /lsv2_(?:pt|sk)_[a-f0-9]{40}_[a-f0-9]{16}/ },
 
 	// --- Cloud / infra ---
-	// `AIza…` is the legacy shape; AI Studio now issues `AQ.`-prefixed keys.
-	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35}|AQ\.[0-9A-Za-z_-]{30,100}/ },
+	// `AIza…` is the legacy shape; AI Studio now issues `AQ.`-prefixed keys. Both
+	// are open-ended: a fixed count would leave the rest of a longer key in the
+	// text, and would make a truncated rendering match a prefix of the real one.
+	// Unanchored on purpose — a key concatenated into a run of text still has to be
+	// found, even though nothing there delimits it.
+	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35,}|AQ\.[0-9A-Za-z_-]{30,}/ },
 	{ slug: 'google_oauth_client_secret', pattern: /GOCSPX-[A-Za-z0-9_-]{28,}/ },
 	{ slug: 'aws_access_key_id', pattern: /(?:AKIA|ASIA)[A-Z0-9]{16}/ },
 	// Anchored at a token boundary: without it the unbounded prefix backtracks over

--- a/packages/@n8n/mcp-browser/src/redaction/patterns.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/patterns.ts
@@ -42,7 +42,8 @@ export const BUILTIN_PATTERNS: SecretPattern[] = [
 	{ slug: 'langsmith_api_key_v2', pattern: /lsv2_(?:pt|sk)_[a-f0-9]{40}_[a-f0-9]{16}/ },
 
 	// --- Cloud / infra ---
-	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35}/ },
+	// `AIza…` is the legacy shape; AI Studio now issues `AQ.`-prefixed keys.
+	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35}|AQ\.[0-9A-Za-z_-]{30,100}/ },
 	{ slug: 'google_oauth_client_secret', pattern: /GOCSPX-[A-Za-z0-9_-]{28,}/ },
 	{ slug: 'aws_access_key_id', pattern: /(?:AKIA|ASIA)[A-Z0-9]{16}/ },
 	{ slug: 'azure_ad_client_secret', pattern: /[A-Za-z0-9_-]{3,}~[A-Za-z0-9_-]{31,}/ },

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -64,8 +64,6 @@ export function findRegexSecretHits(input: string): SecretHit[] {
 			const value = match[0];
 			if (!value) continue;
 			const key = `${slug}:${value}`;
-			// Fixed-count patterns match only their first N characters of a longer
-			// token, so record the whole token for capturing.
 			const hit = hitForSpan(slug, value, expandToTokenSpan(input, match.index, value.length));
 			const existing = hits.get(key);
 			hits.set(key, existing ? narrowerCapture(existing, hit) : hit);
@@ -84,7 +82,7 @@ export function captureSpanOf(hit: SecretHit): string {
 }
 
 /** Fixed-count patterns match only part of a longer token, so record the span. */
-export function hitForSpan(type: string, value: string, { span, delimited }: TokenSpan): SecretHit {
+function hitForSpan(type: string, value: string, { span, delimited }: TokenSpan): SecretHit {
 	if (!delimited) return { type, value, captureBlocked: UNDELIMITED_TOKEN };
 	return span === value ? { type, value } : { type, value, captureValue: span };
 }
@@ -162,7 +160,6 @@ function replaceInValue(value: unknown, replacements: readonly Replacement[]): u
 	return value;
 }
 
-/** Replace every hit's value with its marker throughout a tool result, in place. */
 export function applyHitsToResult(
 	result: CallToolResult,
 	hits: readonly SecretHit[],

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -111,10 +111,24 @@ export function collectHit(hits: Map<string, SecretHit>, hit: SecretHit): void {
 	hits.set(key, existing ? narrowerCapture(existing, hit) : hit);
 }
 
+/**
+ * An occurrence inside an undelimitable run says nothing about how far the token
+ * reaches, so a delimited span always beats a blocked one.
+ *
+ * Two delimited sightings can still disagree, either because one is wrapped
+ * (`session.<key>`) or because two tokens share a fragment (`alpha.<key>` and
+ * `bravo.<key>`). Picking one span would leave the other sighting unreplaced, so
+ * fall back to the match: it is the only text common to both, and therefore the
+ * part that has to be replaced in every one of them.
+ */
 export function narrowerCapture(existing: SecretHit, incoming: SecretHit): SecretHit {
 	if (incoming.captureBlocked) return existing;
 	if (existing.captureBlocked) return incoming;
-	return captureSpanOf(incoming).length < captureSpanOf(existing).length ? incoming : existing;
+	if (captureSpanOf(existing) === captureSpanOf(incoming)) return existing;
+
+	const shared: SecretHit = { type: existing.type, value: existing.match ?? existing.value };
+	if (existing.ref) shared.ref = existing.ref;
+	return shared;
 }
 
 type Replacement = readonly [value: string, marker: string];

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -12,6 +12,8 @@ export interface SecretHit {
 	 * span is a guess, and markers are what the model has already seen.
 	 */
 	captureValue?: string;
+	/** Why this hit must not become a credential, when it must not. */
+	captureBlocked?: string;
 }
 
 type RedactionMarkerHit = Pick<SecretHit, 'type' | 'value' | 'ref'>;
@@ -64,11 +66,12 @@ export function findRegexSecretHits(input: string): SecretHit[] {
 			const key = `${slug}:${value}`;
 			// Fixed-count patterns match only their first N characters of a longer
 			// token, so record the whole token for capturing.
-			const span = expandToTokenSpan(input, match.index, value.length);
+			const { span, delimited } = expandToTokenSpan(input, match.index, value.length);
 			const existing = hits.get(key);
 			if (!existing) {
 				const hit: SecretHit = { type: slug, value };
 				if (span !== value) hit.captureValue = span;
+				if (!delimited) hit.captureBlocked = 'its surrounding text has no delimiter';
 				hits.set(key, hit);
 			} else if (span.length < (existing.captureValue ?? existing.value).length) {
 				// Narrowest wins: a wider span carries its neighbours into the value.

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -68,19 +68,34 @@ export function findRegexSecretHits(input: string): SecretHit[] {
 			// token, so record the whole token for capturing.
 			const { span, delimited } = expandToTokenSpan(input, match.index, value.length);
 			const existing = hits.get(key);
-			if (!existing) {
-				const hit: SecretHit = { type: slug, value };
-				if (span !== value) hit.captureValue = span;
-				if (!delimited) hit.captureBlocked = 'its surrounding text has no delimiter';
-				hits.set(key, hit);
-			} else if (span.length < (existing.captureValue ?? existing.value).length) {
-				// Narrowest wins: a wider span carries its neighbours into the value.
-				if (span === value) delete existing.captureValue;
-				else existing.captureValue = span;
-			}
+			if (existing) recordSpan(existing, span, delimited);
+			else hits.set(key, newHit(slug, value, span, delimited));
 		}
 	}
 	return [...hits.values()];
+}
+
+export const UNDELIMITED_TOKEN = 'its surrounding text has no delimiter';
+
+function newHit(slug: string, value: string, span: string, delimited: boolean): SecretHit {
+	const hit: SecretHit = { type: slug, value };
+	if (!delimited) hit.captureBlocked = UNDELIMITED_TOKEN;
+	else if (span !== value) hit.captureValue = span;
+	return hit;
+}
+
+/**
+ * An occurrence inside an undelimitable run says nothing about how far the token
+ * reaches, so only delimited ones count — and of those the narrowest wins, since
+ * a wider span carries its neighbours into the captured value.
+ */
+function recordSpan(hit: SecretHit, span: string, delimited: boolean): void {
+	if (!delimited) return;
+	const established = hit.captureBlocked ? undefined : (hit.captureValue ?? hit.value);
+	if (established !== undefined && span.length >= established.length) return;
+	delete hit.captureBlocked;
+	if (span === hit.value) delete hit.captureValue;
+	else hit.captureValue = span;
 }
 
 export type Replacement = readonly [value: string, marker: string];

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -1,10 +1,17 @@
 import type { CallToolResult } from '../types';
 import { BUILTIN_PATTERNS, type SecretPattern } from './patterns';
+import { expandToTokenSpan } from './token-span';
 
 export interface SecretHit {
 	type: string;
 	value: string;
 	ref?: string;
+	/**
+	 * The whole token the match sits in, read by capturing so a detector boundary
+	 * cannot truncate the stored value. Redaction keeps using `value`: a widened
+	 * span is a guess, and markers are what the model has already seen.
+	 */
+	captureValue?: string;
 }
 
 type RedactionMarkerHit = Pick<SecretHit, 'type' | 'value' | 'ref'>;
@@ -18,6 +25,12 @@ const GLOBAL_PATTERNS: ReadonlyArray<{ slug: string; regex: RegExp }> = BUILTIN_
 		),
 	}),
 );
+
+export const REDACTION_MARKER_PATTERN = /\[REDACTED:[^\]]+\](?:@[\w-]+)?/;
+
+export function containsRedactionMarker(value: string): boolean {
+	return REDACTION_MARKER_PATTERN.test(value);
+}
 
 export function formatRedactionMarker(
 	hit: Pick<SecretHit, 'type' | 'ref'> & { index?: number },
@@ -49,20 +62,49 @@ export function findRegexSecretHits(input: string): SecretHit[] {
 			const value = match[0];
 			if (!value) continue;
 			const key = `${slug}:${value}`;
-			if (!hits.has(key)) hits.set(key, { type: slug, value });
+			// Fixed-count patterns match only their first N characters of a longer
+			// token, so record the whole token for capturing.
+			const span = expandToTokenSpan(input, match.index, value.length);
+			const existing = hits.get(key);
+			if (!existing) {
+				const hit: SecretHit = { type: slug, value };
+				if (span !== value) hit.captureValue = span;
+				hits.set(key, hit);
+			} else if (span.length < (existing.captureValue ?? existing.value).length) {
+				// Narrowest wins: a wider span carries its neighbours into the value.
+				if (span === value) delete existing.captureValue;
+				else existing.captureValue = span;
+			}
 		}
 	}
 	return [...hits.values()];
 }
 
-export function redactString(input: string): string {
+export type Replacement = readonly [value: string, marker: string];
+
+/**
+ * Longest value first: where an entropy span contains a pattern's shorter match,
+ * replacing the short one first leaves the rest of the token visible. Build once
+ * per call, then apply to every string.
+ */
+export function buildReplacements(
+	hits: readonly SecretHit[],
+	marker: (hit: RedactionMarkerHit) => string,
+): Replacement[] {
+	return [...hits]
+		.sort((a, b) => b.value.length - a.value.length)
+		.map((hit) => [hit.value, marker(hit)] as const);
+}
+
+export function applyReplacements(input: string, replacements: readonly Replacement[]): string {
 	let output = input;
-	const hits = findRegexSecretHits(input);
-	const marker = createRedactionMarkerFormatter(hits);
-	for (const hit of hits) {
-		output = replaceLiteral(output, hit.value, marker(hit));
-	}
+	for (const [value, marker] of replacements) output = replaceLiteral(output, value, marker);
 	return output;
+}
+
+export function redactString(input: string): string {
+	const hits = findRegexSecretHits(input);
+	return applyReplacements(input, buildReplacements(hits, createRedactionMarkerFormatter(hits)));
 }
 
 export function replaceLiteral(input: string, value: string, replacement: string): string {
@@ -90,17 +132,17 @@ export function redactValue(
 	hits = findRegexSecretHits(collectStrings(value).join('\n')),
 	marker = createRedactionMarkerFormatter(hits),
 ): unknown {
+	return replaceInValue(value, buildReplacements(hits, marker));
+}
+
+export function replaceInValue(value: unknown, replacements: readonly Replacement[]): unknown {
 	if (value === null || value === undefined) return value;
-	if (typeof value === 'string') {
-		let output = value;
-		for (const hit of hits) output = replaceLiteral(output, hit.value, marker(hit));
-		return output;
-	}
-	if (Array.isArray(value)) return value.map((entry) => redactValue(entry, hits, marker));
+	if (typeof value === 'string') return applyReplacements(value, replacements);
+	if (Array.isArray(value)) return value.map((entry) => replaceInValue(entry, replacements));
 	if (isPlainObject(value)) {
 		const out: Record<string, unknown> = {};
 		for (const [k, v] of Object.entries(value)) {
-			out[k] = redactValue(v, hits, marker);
+			out[k] = replaceInValue(v, replacements);
 		}
 		return out;
 	}
@@ -116,15 +158,15 @@ export function redactCallToolResult(result: CallToolResult): CallToolResult {
 			...collectStrings(result.structuredContent),
 		].join('\n'),
 	);
-	const marker = createRedactionMarkerFormatter(hits);
+	const replacements = buildReplacements(hits, createRedactionMarkerFormatter(hits));
 
 	for (const item of result.content) {
 		if (item.type === 'text' && typeof item.text === 'string') {
-			for (const hit of hits) item.text = replaceLiteral(item.text, hit.value, marker(hit));
+			item.text = applyReplacements(item.text, replacements);
 		}
 	}
 	if (result.structuredContent !== undefined) {
-		const redacted = redactValue(result.structuredContent, hits, marker);
+		const redacted = replaceInValue(result.structuredContent, replacements);
 		if (isPlainObject(redacted)) result.structuredContent = redacted;
 	}
 	return result;

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -1,6 +1,6 @@
 import type { CallToolResult } from '../types';
 import { BUILTIN_PATTERNS, type SecretPattern } from './patterns';
-import { expandToTokenSpan } from './token-span';
+import { expandToTokenSpan, type TokenSpan } from './token-span';
 
 export interface SecretHit {
 	type: string;
@@ -66,10 +66,9 @@ export function findRegexSecretHits(input: string): SecretHit[] {
 			const key = `${slug}:${value}`;
 			// Fixed-count patterns match only their first N characters of a longer
 			// token, so record the whole token for capturing.
-			const { span, delimited } = expandToTokenSpan(input, match.index, value.length);
+			const hit = hitForSpan(slug, value, expandToTokenSpan(input, match.index, value.length));
 			const existing = hits.get(key);
-			if (existing) recordSpan(existing, span, delimited);
-			else hits.set(key, newHit(slug, value, span, delimited));
+			hits.set(key, existing ? narrowerCapture(existing, hit) : hit);
 		}
 	}
 	return [...hits.values()];
@@ -77,35 +76,39 @@ export function findRegexSecretHits(input: string): SecretHit[] {
 
 export const UNDELIMITED_TOKEN = 'its surrounding text has no delimiter';
 
-function newHit(slug: string, value: string, span: string, delimited: boolean): SecretHit {
-	const hit: SecretHit = { type: slug, value };
-	if (!delimited) hit.captureBlocked = UNDELIMITED_TOKEN;
-	else if (span !== value) hit.captureValue = span;
-	return hit;
+export const CONCATENATED_ONLY = 'it only appears where markup runs text together';
+
+/** The value capturing would store, which is the whole token when one was found. */
+export function captureSpanOf(hit: SecretHit): string {
+	return hit.captureValue ?? hit.value;
+}
+
+/** Fixed-count patterns match only part of a longer token, so record the span. */
+export function hitForSpan(type: string, value: string, { span, delimited }: TokenSpan): SecretHit {
+	if (!delimited) return { type, value, captureBlocked: UNDELIMITED_TOKEN };
+	return span === value ? { type, value } : { type, value, captureValue: span };
 }
 
 /**
- * An occurrence inside an undelimitable run says nothing about how far the token
- * reaches, so only delimited ones count — and of those the narrowest wins, since
- * a wider span carries its neighbours into the captured value.
+ * The same secret seen again — in another occurrence, pass, or document. An
+ * occurrence inside an undelimitable run says nothing about how far the token
+ * reaches, so a delimited span always beats a blocked one; among delimited spans
+ * the narrowest wins, since a wider one carries its neighbours into the value.
  */
-function recordSpan(hit: SecretHit, span: string, delimited: boolean): void {
-	if (!delimited) return;
-	const established = hit.captureBlocked ? undefined : (hit.captureValue ?? hit.value);
-	if (established !== undefined && span.length >= established.length) return;
-	delete hit.captureBlocked;
-	if (span === hit.value) delete hit.captureValue;
-	else hit.captureValue = span;
+export function narrowerCapture(existing: SecretHit, incoming: SecretHit): SecretHit {
+	if (incoming.captureBlocked) return existing;
+	if (existing.captureBlocked) return incoming;
+	return captureSpanOf(incoming).length < captureSpanOf(existing).length ? incoming : existing;
 }
 
-export type Replacement = readonly [value: string, marker: string];
+type Replacement = readonly [value: string, marker: string];
 
 /**
  * Longest value first: where an entropy span contains a pattern's shorter match,
  * replacing the short one first leaves the rest of the token visible. Build once
  * per call, then apply to every string.
  */
-export function buildReplacements(
+function buildReplacements(
 	hits: readonly SecretHit[],
 	marker: (hit: RedactionMarkerHit) => string,
 ): Replacement[] {
@@ -114,7 +117,7 @@ export function buildReplacements(
 		.map((hit) => [hit.value, marker(hit)] as const);
 }
 
-export function applyReplacements(input: string, replacements: readonly Replacement[]): string {
+function applyReplacements(input: string, replacements: readonly Replacement[]): string {
 	let output = input;
 	for (const [value, marker] of replacements) output = replaceLiteral(output, value, marker);
 	return output;
@@ -125,7 +128,7 @@ export function redactString(input: string): string {
 	return applyReplacements(input, buildReplacements(hits, createRedactionMarkerFormatter(hits)));
 }
 
-export function replaceLiteral(input: string, value: string, replacement: string): string {
+function replaceLiteral(input: string, value: string, replacement: string): string {
 	if (!value) return input;
 	return input.split(value).join(replacement);
 }
@@ -145,15 +148,7 @@ function collectStrings(value: unknown): string[] {
 	return [];
 }
 
-export function redactValue(
-	value: unknown,
-	hits = findRegexSecretHits(collectStrings(value).join('\n')),
-	marker = createRedactionMarkerFormatter(hits),
-): unknown {
-	return replaceInValue(value, buildReplacements(hits, marker));
-}
-
-export function replaceInValue(value: unknown, replacements: readonly Replacement[]): unknown {
+function replaceInValue(value: unknown, replacements: readonly Replacement[]): unknown {
 	if (value === null || value === undefined) return value;
 	if (typeof value === 'string') return applyReplacements(value, replacements);
 	if (Array.isArray(value)) return value.map((entry) => replaceInValue(entry, replacements));
@@ -167,16 +162,12 @@ export function replaceInValue(value: unknown, replacements: readonly Replacemen
 	return value;
 }
 
-export function redactCallToolResult(result: CallToolResult): CallToolResult {
-	const hits = findRegexSecretHits(
-		[
-			...result.content.flatMap((item) =>
-				item.type === 'text' && typeof item.text === 'string' ? [item.text] : [],
-			),
-			...collectStrings(result.structuredContent),
-		].join('\n'),
-	);
-	const replacements = buildReplacements(hits, createRedactionMarkerFormatter(hits));
+/** Replace every hit's value with its marker throughout a tool result, in place. */
+export function applyHitsToResult(
+	result: CallToolResult,
+	hits: readonly SecretHit[],
+): CallToolResult {
+	const replacements = buildReplacements(hits, createRedactionMarkerFormatter([...hits]));
 
 	for (const item of result.content) {
 		if (item.type === 'text' && typeof item.text === 'string') {
@@ -188,4 +179,14 @@ export function redactCallToolResult(result: CallToolResult): CallToolResult {
 		if (isPlainObject(redacted)) result.structuredContent = redacted;
 	}
 	return result;
+}
+
+export function redactCallToolResult(result: CallToolResult): CallToolResult {
+	const texts = [
+		...result.content.flatMap((item) =>
+			item.type === 'text' && typeof item.text === 'string' ? [item.text] : [],
+		),
+		...collectStrings(result.structuredContent),
+	];
+	return applyHitsToResult(result, findRegexSecretHits(texts.join('\n')));
 }

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -5,6 +5,12 @@ import { expandToTokenSpan, type TokenSpan } from './token-span';
 export interface SecretHit {
 	type: string;
 	value: string;
+	/**
+	 * What the detector matched, when `value` is wider than it. Two sightings of
+	 * one secret are the same hit even when their spans differ, so this — not the
+	 * span — identifies it.
+	 */
+	match?: string;
 	ref?: string;
 	/**
 	 * The whole token the match sits in, read by capturing so a detector boundary
@@ -63,10 +69,10 @@ export function findRegexSecretHits(input: string): SecretHit[] {
 		for (const match of input.matchAll(regex)) {
 			const value = match[0];
 			if (!value) continue;
-			const key = `${slug}:${value}`;
-			const hit = hitForSpan(slug, value, expandToTokenSpan(input, match.index, value.length));
-			const existing = hits.get(key);
-			hits.set(key, existing ? narrowerCapture(existing, hit) : hit);
+			collectHit(
+				hits,
+				hitForSpan(slug, value, expandToTokenSpan(input, match.index, value.length)),
+			);
 		}
 	}
 	return [...hits.values()];
@@ -93,6 +99,18 @@ function hitForSpan(type: string, value: string, { span, delimited }: TokenSpan)
  * reaches, so a delimited span always beats a blocked one; among delimited spans
  * the narrowest wins, since a wider one carries its neighbours into the value.
  */
+/**
+ * Record a hit, merging it with any earlier sighting of the same secret. Owning
+ * the identity here keeps every detector on one rule: callers that chose their
+ * own key drifted apart, and one of them stopped merging at all.
+ */
+export function collectHit(hits: Map<string, SecretHit>, hit: SecretHit): void {
+	if (!hit.value) return;
+	const key = `${hit.type}:${hit.match ?? hit.value}:${hit.ref ?? ''}`;
+	const existing = hits.get(key);
+	hits.set(key, existing ? narrowerCapture(existing, hit) : hit);
+}
+
 export function narrowerCapture(existing: SecretHit, incoming: SecretHit): SecretHit {
 	if (incoming.captureBlocked) return existing;
 	if (existing.captureBlocked) return incoming;

--- a/packages/@n8n/mcp-browser/src/redaction/redaction-applier.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redaction-applier.ts
@@ -1,55 +1,34 @@
 import type { CallToolResult } from '../types';
-import { createRedactionMarkerFormatter, replaceLiteral } from './redact';
+import {
+	applyReplacements,
+	buildReplacements,
+	createRedactionMarkerFormatter,
+	replaceInValue,
+} from './redact';
 import type { SensitivityOk } from '../sensitivity/analyze-html';
-
-function redactText(
-	input: string,
-	result: SensitivityOk,
-	marker: ReturnType<typeof createRedactionMarkerFormatter>,
-): string {
-	let output = input;
-	for (const hit of result.hits) {
-		output = replaceLiteral(output, hit.value, marker(hit));
-	}
-	return output;
-}
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	if (value === null || typeof value !== 'object') return false;
 	return Object.getPrototypeOf(value) === Object.prototype;
 }
 
-function redactValue(
-	value: unknown,
-	result: SensitivityOk,
-	marker: ReturnType<typeof createRedactionMarkerFormatter>,
-): unknown {
-	if (typeof value === 'string') return redactText(value, result, marker);
-	if (Array.isArray(value)) return value.map((entry) => redactValue(entry, result, marker));
-	if (isPlainObject(value)) {
-		const out: Record<string, unknown> = {};
-		for (const [key, entry] of Object.entries(value)) {
-			out[key] = redactValue(entry, result, marker);
-		}
-		return out;
-	}
-	return value;
-}
-
 export function applyRedactions(
 	result: CallToolResult,
 	sensitivity: SensitivityOk,
 ): CallToolResult {
-	const marker = createRedactionMarkerFormatter(sensitivity.hits);
+	const replacements = buildReplacements(
+		sensitivity.hits,
+		createRedactionMarkerFormatter(sensitivity.hits),
+	);
 
 	if (result.structuredContent !== undefined) {
-		const redacted = redactValue(result.structuredContent, sensitivity, marker);
+		const redacted = replaceInValue(result.structuredContent, replacements);
 		if (isPlainObject(redacted)) result.structuredContent = redacted;
 	}
 
 	for (const item of result.content) {
 		if (item.type === 'text' && typeof item.text === 'string') {
-			item.text = redactText(item.text, sensitivity, marker);
+			item.text = applyReplacements(item.text, replacements);
 		}
 	}
 

--- a/packages/@n8n/mcp-browser/src/redaction/redaction-applier.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redaction-applier.ts
@@ -1,36 +1,10 @@
 import type { CallToolResult } from '../types';
-import {
-	applyReplacements,
-	buildReplacements,
-	createRedactionMarkerFormatter,
-	replaceInValue,
-} from './redact';
+import { applyHitsToResult } from './redact';
 import type { SensitivityOk } from '../sensitivity/analyze-html';
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-	if (value === null || typeof value !== 'object') return false;
-	return Object.getPrototypeOf(value) === Object.prototype;
-}
 
 export function applyRedactions(
 	result: CallToolResult,
 	sensitivity: SensitivityOk,
 ): CallToolResult {
-	const replacements = buildReplacements(
-		sensitivity.hits,
-		createRedactionMarkerFormatter(sensitivity.hits),
-	);
-
-	if (result.structuredContent !== undefined) {
-		const redacted = replaceInValue(result.structuredContent, replacements);
-		if (isPlainObject(redacted)) result.structuredContent = redacted;
-	}
-
-	for (const item of result.content) {
-		if (item.type === 'text' && typeof item.text === 'string') {
-			item.text = applyReplacements(item.text, replacements);
-		}
-	}
-
-	return result;
+	return applyHitsToResult(result, sensitivity.hits);
 }

--- a/packages/@n8n/mcp-browser/src/redaction/token-span.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/token-span.ts
@@ -1,4 +1,4 @@
-const STOPS = /[\s"'`\\<>()[\]{},;?!&#%‘’“”—–]/;
+const STOPS = /[\s"'`\\<>()[\]{},;?!&#%|*·‘’“”—–]/;
 
 // `=` is padding after the match but an assignment before it, so `NAME=<key>`
 // must not widen into the field name.
@@ -12,18 +12,27 @@ const EDGES = /[.:]/;
 // and the match is the safer answer.
 const MAX_SPAN = 512;
 
+export interface TokenSpan {
+	span: string;
+	/** False when the run had no delimiter within `MAX_SPAN`, so `span` is only
+	 * the match and may be a fragment of the real token. */
+	delimited: boolean;
+}
+
 /**
  * Snap a match out to the whole token around it, so an unanticipated prefix or
  * suffix is covered without enumerating character classes. Only trims outside
  * the original match.
  */
-export function expandToTokenSpan(text: string, index: number, length: number): string {
+export function expandToTokenSpan(text: string, index: number, length: number): TokenSpan {
 	let start = index;
 	let end = index + length;
 	while (start > 0 && !STOPS.test(text[start - 1]) && !STOPS_LEFT.test(text[start - 1])) start--;
 	while (end < text.length && !STOPS.test(text[end])) end++;
 	while (start < index && EDGES.test(text[start])) start++;
 	while (end > index + length && EDGES.test(text[end - 1])) end--;
-	if (end - start > MAX_SPAN) return text.slice(index, index + length);
-	return text.slice(start, end);
+	if (end - start > MAX_SPAN) {
+		return { span: text.slice(index, index + length), delimited: false };
+	}
+	return { span: text.slice(start, end), delimited: true };
 }

--- a/packages/@n8n/mcp-browser/src/redaction/token-span.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/token-span.ts
@@ -1,22 +1,34 @@
-const STOPS = /[\s"'`\\<>()[\]{},;?!&#%|*·‘’“”—–]/;
+const STOPS = /[\s"'`\\<>()[\]{},;?!&#%|*·‘’“”—–…]/;
 
 // `=` is padding after the match but an assignment before it, so `NAME=<key>`
 // must not widen into the field name.
-const STOPS_LEFT = /[=]/;
+const STOPS_BEFORE = /[=]/;
 
 // Occur inside secrets (`AQ.`, JWTs, `<id>:<secret>`), so cross them but never
 // end on them.
 const EDGES = /[.:]/;
 
-// Past this, the token ran into something undelimitable (minified script text)
-// and the match is the safer answer.
-const MAX_SPAN = 512;
+// How far a span may reach past the match on either side. Bounds the scan, so a
+// long undelimited run (minified script text) costs the same for every match in
+// it instead of being walked end to end each time.
+const MAX_REACH = 256;
 
 export interface TokenSpan {
 	span: string;
-	/** False when the run had no delimiter within `MAX_SPAN`, so `span` is only
-	 * the match and may be a fragment of the real token. */
+	/**
+	 * False when no delimiter was found within reach, leaving `span` as just the
+	 * match — which may be a fragment of the real token, so it must not become a
+	 * credential.
+	 */
 	delimited: boolean;
+}
+
+function endsToken(char: string): boolean {
+	return STOPS.test(char);
+}
+
+function endsTokenBefore(char: string): boolean {
+	return endsToken(char) || STOPS_BEFORE.test(char);
 }
 
 /**
@@ -25,17 +37,19 @@ export interface TokenSpan {
  * the original match.
  */
 export function expandToTokenSpan(text: string, index: number, length: number): TokenSpan {
+	const matchEnd = index + length;
 	let start = index;
-	let end = index + length;
-	while (start > 0 && !STOPS.test(text[start - 1]) && !STOPS_LEFT.test(text[start - 1])) start--;
-	while (end < text.length && !STOPS.test(text[end])) end++;
+	let end = matchEnd;
+
+	while (start > 0 && index - start < MAX_REACH && !endsTokenBefore(text[start - 1])) start--;
+	while (end < text.length && end - matchEnd < MAX_REACH && !endsToken(text[end])) end++;
+
+	const delimited =
+		(start === 0 || endsTokenBefore(text[start - 1])) &&
+		(end === text.length || endsToken(text[end]));
+	if (!delimited) return { span: text.slice(index, matchEnd), delimited: false };
+
 	while (start < index && EDGES.test(text[start])) start++;
-	while (end > index + length && EDGES.test(text[end - 1])) end--;
-	if (end - start > MAX_SPAN) {
-		// A match expansion never extended carries its own boundaries (a PEM key),
-		// so nothing was guessed and it stays capturable.
-		const unextended = start === index && end === index + length;
-		return { span: text.slice(index, index + length), delimited: unextended };
-	}
+	while (end > matchEnd && EDGES.test(text[end - 1])) end--;
 	return { span: text.slice(start, end), delimited: true };
 }

--- a/packages/@n8n/mcp-browser/src/redaction/token-span.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/token-span.ts
@@ -32,7 +32,10 @@ export function expandToTokenSpan(text: string, index: number, length: number): 
 	while (start < index && EDGES.test(text[start])) start++;
 	while (end > index + length && EDGES.test(text[end - 1])) end--;
 	if (end - start > MAX_SPAN) {
-		return { span: text.slice(index, index + length), delimited: false };
+		// A match expansion never extended carries its own boundaries (a PEM key),
+		// so nothing was guessed and it stays capturable.
+		const unextended = start === index && end === index + length;
+		return { span: text.slice(index, index + length), delimited: unextended };
 	}
 	return { span: text.slice(start, end), delimited: true };
 }

--- a/packages/@n8n/mcp-browser/src/redaction/token-span.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/token-span.ts
@@ -1,0 +1,29 @@
+const STOPS = /[\s"'`\\<>()[\]{},;?!&#%‘’“”—–]/;
+
+// `=` is padding after the match but an assignment before it, so `NAME=<key>`
+// must not widen into the field name.
+const STOPS_LEFT = /[=]/;
+
+// Occur inside secrets (`AQ.`, JWTs, `<id>:<secret>`), so cross them but never
+// end on them.
+const EDGES = /[.:]/;
+
+// Past this, the token ran into something undelimitable (minified script text)
+// and the match is the safer answer.
+const MAX_SPAN = 512;
+
+/**
+ * Snap a match out to the whole token around it, so an unanticipated prefix or
+ * suffix is covered without enumerating character classes. Only trims outside
+ * the original match.
+ */
+export function expandToTokenSpan(text: string, index: number, length: number): string {
+	let start = index;
+	let end = index + length;
+	while (start > 0 && !STOPS.test(text[start - 1]) && !STOPS_LEFT.test(text[start - 1])) start--;
+	while (end < text.length && !STOPS.test(text[end])) end++;
+	while (start < index && EDGES.test(text[start])) start++;
+	while (end > index + length && EDGES.test(text[end - 1])) end--;
+	if (end - start > MAX_SPAN) return text.slice(index, index + length);
+	return text.slice(start, end);
+}

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
@@ -37,7 +37,7 @@ describe('analyzeHtmlSensitivity', () => {
 	// One document delimits the key unambiguously, another cannot. Whichever is
 	// merged last, the delimited occurrence is the one that knows the extent.
 	it('lets a delimited occurrence override a blocked one from another document', () => {
-		const key = `AIza${'B'.repeat(35)}`;
+		const key = `ghp_${'B'.repeat(36)}`;
 		const run = 'x'.repeat(600);
 		const result = analyzeHtmlSensitivity(
 			probe(`<p>${run}${key}${run}</p>`, [

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
@@ -34,6 +34,17 @@ describe('analyzeHtmlSensitivity', () => {
 		expect(result.ok && result.hits).toContainEqual({ type: 'google_api_key', value: key });
 	});
 
+	// A key split across siblings is only visible in concatenated `textContent`,
+	// and redaction cannot replace it there — but the page must still count as
+	// sensitive, which is what gates screenshots.
+	it('still flags a page whose key only appears in concatenated markup', () => {
+		const result = analyzeHtmlSensitivity(
+			probe(`<p><span>AQ.</span><span>${'AbCdEfGhIj'.repeat(3)}Ab</span></p>`),
+		);
+
+		expect(result.ok && result.sensitive).toBe(true);
+	});
+
 	it('finds regex hits in plain DOM text', () => {
 		const result = analyzeHtmlSensitivity(probe(`<p>${ANTHROPIC}</p>`));
 		expect(result.ok && result.sensitive).toBe(true);

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
@@ -46,6 +46,7 @@ describe('analyzeHtmlSensitivity', () => {
 		);
 		const hit = result.ok && result.hits.find((candidate) => candidate.value === key);
 
+		expect(hit).toBeTruthy();
 		expect(hit && hit.captureBlocked).toBeUndefined();
 	});
 

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
@@ -21,6 +21,19 @@ function probe(
 }
 
 describe('analyzeHtmlSensitivity', () => {
+	// The same key often appears in the page and again in an embedded frame; the
+	// bare occurrence is the span that can safely become a credential.
+	it('keeps the narrowest capture span when a key appears in several documents', () => {
+		const key = `AIza${'B'.repeat(35)}`;
+		const result = analyzeHtmlSensitivity(
+			probe(`<p>${key}</p>`, [
+				{ kind: 'iframe', html: `<p>id.${key}</p>`, children: [], errors: [] },
+			]),
+		);
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'google_api_key', value: key });
+	});
+
 	it('finds regex hits in plain DOM text', () => {
 		const result = analyzeHtmlSensitivity(probe(`<p>${ANTHROPIC}</p>`));
 		expect(result.ok && result.sensitive).toBe(true);

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
@@ -34,6 +34,20 @@ describe('analyzeHtmlSensitivity', () => {
 		expect(result.ok && result.hits).toContainEqual({ type: 'google_api_key', value: key });
 	});
 
+	// The entropy pass needs the same fail-closed rule as the pattern pass: inside
+	// an undelimitable run its candidate is a fragment of the real token.
+	it('blocks capture of an entropy candidate whose token could not be delimited', () => {
+		const blob = 'aB3xY9zQ7wE2rT5yU8iO1pL4kJ6hG0fD'.repeat(20);
+		const key = `AQ.${'Zt7vLpQ9mKdW4xR2bNfH3jEuXaGoT5wPqYs1Bc'}`;
+		const result = analyzeHtmlSensitivity(
+			probe(`<div data-testid="api-key">${blob}${key}${blob}</div>`),
+		);
+		const hit = result.ok && result.hits.find((candidate) => candidate.type === 'secret');
+
+		expect(hit).toBeTruthy();
+		expect(hit && hit.captureBlocked).toBeTruthy();
+	});
+
 	// A key split across siblings is only visible in concatenated `textContent`,
 	// and redaction cannot replace it there — but the page must still count as
 	// sensitive, which is what gates screenshots.

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
@@ -34,6 +34,21 @@ describe('analyzeHtmlSensitivity', () => {
 		expect(result.ok && result.hits).toContainEqual({ type: 'google_api_key', value: key });
 	});
 
+	// One document delimits the key unambiguously, another cannot. Whichever is
+	// merged last, the delimited occurrence is the one that knows the extent.
+	it('lets a delimited occurrence override a blocked one from another document', () => {
+		const key = `AIza${'B'.repeat(35)}`;
+		const run = 'x'.repeat(600);
+		const result = analyzeHtmlSensitivity(
+			probe(`<p>${run}${key}${run}</p>`, [
+				{ kind: 'iframe', html: `<p>${key}</p>`, children: [], errors: [] },
+			]),
+		);
+		const hit = result.ok && result.hits.find((candidate) => candidate.value === key);
+
+		expect(hit && hit.captureBlocked).toBeUndefined();
+	});
+
 	// The entropy pass needs the same fail-closed rule as the pattern pass: inside
 	// an undelimitable run its candidate is a fragment of the real token.
 	it('blocks capture of an entropy candidate whose token could not be delimited', () => {

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
@@ -56,13 +56,15 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 
 	// Markup with no whitespace between tags runs sibling text together in
 	// `textContent`, where a match can span text the model never sees as one
-	// token — and then nothing replaces it.
-	const texts = new Set([
-		document.documentElement.textContent ?? '',
-		elementText(document.documentElement),
-	]);
-	for (const text of texts) {
-		for (const hit of findRegexSecretHits(text)) addHit(hits, hit);
+	// token — and then nothing replaces it. Such a match still marks the page
+	// sensitive, but it cannot become a credential.
+	const rendered = elementText(document.documentElement);
+	for (const hit of findRegexSecretHits(rendered)) addHit(hits, hit);
+	for (const hit of findRegexSecretHits(document.documentElement.textContent ?? '')) {
+		if (!rendered.includes(hit.value)) {
+			hit.captureBlocked = 'it only appears where markup runs text together';
+		}
+		addHit(hits, hit);
 	}
 
 	// Inputs/textareas that are password-shaped or whose label reads as a secret

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
@@ -7,7 +7,6 @@ import {
 	elementText,
 	hasButtonMatching,
 	highEntropyCandidates,
-	type EntropyCandidate,
 	isSensitiveInput,
 	getLabelTextByControlIdMap,
 	REVEAL_BUTTON_PATTERN,
@@ -19,7 +18,7 @@ import {
 	getTestId,
 } from './dom-matchers';
 import type { SecretHit } from '../redaction/redact';
-import { findRegexSecretHits, UNDELIMITED_TOKEN } from '../redaction/redact';
+import { CONCATENATED_ONLY, findRegexSecretHits, narrowerCapture } from '../redaction/redact';
 import type { HtmlProbeNode, HtmlProbeResult } from '../types';
 
 export interface SensitivityOk {
@@ -41,20 +40,7 @@ function addHit(hits: Map<string, SecretHit>, hit: SecretHit): void {
 	// snapshot, and iframe/shadow copies during one probe.
 	const key = `${hit.type}:${hit.value}:${hit.ref ?? ''}`;
 	const existing = hits.get(key);
-	// Keep the narrowest capture span, not whichever copy came last.
-	if (existing && spanOf(existing).length <= spanOf(hit).length) return;
-	hits.set(key, hit);
-}
-
-/** Undelimited candidates still redact, but must not become a credential. */
-function secretHit({ value, delimited }: EntropyCandidate): SecretHit {
-	return delimited
-		? { type: 'secret', value }
-		: { type: 'secret', value, captureBlocked: UNDELIMITED_TOKEN };
-}
-
-function spanOf(hit: SecretHit): string {
-	return hit.captureValue ?? hit.value;
+	hits.set(key, existing ? narrowerCapture(existing, hit) : hit);
 }
 
 function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
@@ -69,9 +55,8 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	const rendered = elementText(document.documentElement);
 	for (const hit of findRegexSecretHits(rendered)) addHit(hits, hit);
 	for (const hit of findRegexSecretHits(document.documentElement.textContent ?? '')) {
-		if (!rendered.includes(hit.value)) {
-			hit.captureBlocked = 'it only appears where markup runs text together';
-		}
+		if (rendered.includes(hit.value)) continue; // the rendered pass has it, with a span we can trust
+		hit.captureBlocked = CONCATENATED_ONLY;
 		addHit(hits, hit);
 	}
 
@@ -98,9 +83,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		const hasRevealPhrase = REVEAL_PHRASE_PATTERNS.some((pattern) => pattern.test(text));
 		const hasCopyButton = hasButtonMatching(dialog, COPY_BUTTON_PATTERN);
 		if (!hasRevealPhrase && !hasCopyButton) continue;
-		for (const candidate of highEntropyCandidates(text)) {
-			addHit(hits, secretHit(candidate));
-		}
+		for (const hit of highEntropyCandidates(text)) addHit(hits, hit);
 	}
 
 	// Product UIs frequently label secret containers with test IDs even when the
@@ -111,9 +94,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		const testId = getTestId(el);
 		if (!testId || !SENSITIVE_TESTID_PATTERN.test(testId)) continue;
 		if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') continue;
-		for (const candidate of highEntropyCandidates(elementText(el))) {
-			addHit(hits, secretHit(candidate));
-		}
+		for (const hit of highEntropyCandidates(elementText(el))) addHit(hits, hit);
 	}
 
 	// aria-label/labelledby captures Stripe-style inline secret displays where
@@ -121,9 +102,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	for (const el of Array.from(document.querySelectorAll('[aria-label], [aria-labelledby]'))) {
 		if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') continue;
 		if (!SENSITIVE_ARIA_LABEL_PATTERN.test(elementLabel(el, document))) continue;
-		for (const candidate of highEntropyCandidates(elementText(el))) {
-			addHit(hits, secretHit(candidate));
-		}
+		for (const hit of highEntropyCandidates(elementText(el))) addHit(hits, hit);
 	}
 
 	// Non-dialog pages need both copy and reveal signals before we treat a
@@ -138,9 +117,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		}
 		if (!container || container.matches('[role="dialog"], dialog[open]')) continue;
 		if (!hasButtonMatching(container, REVEAL_BUTTON_PATTERN)) continue;
-		for (const candidate of highEntropyCandidates(elementText(container))) {
-			addHit(hits, secretHit(candidate));
-		}
+		for (const hit of highEntropyCandidates(elementText(container))) addHit(hits, hit);
 	}
 
 	// Monospace tokens inside a nearby sensitive ancestor are common in API-key
@@ -159,9 +136,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 			depth++;
 		}
 		if (!confident) continue;
-		for (const candidate of highEntropyCandidates(elementText(code))) {
-			addHit(hits, secretHit(candidate));
-		}
+		for (const hit of highEntropyCandidates(elementText(code))) addHit(hits, hit);
 	}
 }
 

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
@@ -7,6 +7,7 @@ import {
 	elementText,
 	hasButtonMatching,
 	highEntropyCandidates,
+	type EntropyCandidate,
 	isSensitiveInput,
 	getLabelTextByControlIdMap,
 	REVEAL_BUTTON_PATTERN,
@@ -18,7 +19,7 @@ import {
 	getTestId,
 } from './dom-matchers';
 import type { SecretHit } from '../redaction/redact';
-import { findRegexSecretHits } from '../redaction/redact';
+import { findRegexSecretHits, UNDELIMITED_TOKEN } from '../redaction/redact';
 import type { HtmlProbeNode, HtmlProbeResult } from '../types';
 
 export interface SensitivityOk {
@@ -43,6 +44,13 @@ function addHit(hits: Map<string, SecretHit>, hit: SecretHit): void {
 	// Keep the narrowest capture span, not whichever copy came last.
 	if (existing && spanOf(existing).length <= spanOf(hit).length) return;
 	hits.set(key, hit);
+}
+
+/** Undelimited candidates still redact, but must not become a credential. */
+function secretHit({ value, delimited }: EntropyCandidate): SecretHit {
+	return delimited
+		? { type: 'secret', value }
+		: { type: 'secret', value, captureBlocked: UNDELIMITED_TOKEN };
 }
 
 function spanOf(hit: SecretHit): string {
@@ -90,8 +98,8 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		const hasRevealPhrase = REVEAL_PHRASE_PATTERNS.some((pattern) => pattern.test(text));
 		const hasCopyButton = hasButtonMatching(dialog, COPY_BUTTON_PATTERN);
 		if (!hasRevealPhrase && !hasCopyButton) continue;
-		for (const value of highEntropyCandidates(text)) {
-			addHit(hits, { type: 'secret', value });
+		for (const candidate of highEntropyCandidates(text)) {
+			addHit(hits, secretHit(candidate));
 		}
 	}
 
@@ -103,8 +111,8 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		const testId = getTestId(el);
 		if (!testId || !SENSITIVE_TESTID_PATTERN.test(testId)) continue;
 		if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') continue;
-		for (const value of highEntropyCandidates(elementText(el))) {
-			addHit(hits, { type: 'secret', value });
+		for (const candidate of highEntropyCandidates(elementText(el))) {
+			addHit(hits, secretHit(candidate));
 		}
 	}
 
@@ -113,8 +121,8 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	for (const el of Array.from(document.querySelectorAll('[aria-label], [aria-labelledby]'))) {
 		if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') continue;
 		if (!SENSITIVE_ARIA_LABEL_PATTERN.test(elementLabel(el, document))) continue;
-		for (const value of highEntropyCandidates(elementText(el))) {
-			addHit(hits, { type: 'secret', value });
+		for (const candidate of highEntropyCandidates(elementText(el))) {
+			addHit(hits, secretHit(candidate));
 		}
 	}
 
@@ -130,8 +138,8 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		}
 		if (!container || container.matches('[role="dialog"], dialog[open]')) continue;
 		if (!hasButtonMatching(container, REVEAL_BUTTON_PATTERN)) continue;
-		for (const value of highEntropyCandidates(elementText(container))) {
-			addHit(hits, { type: 'secret', value });
+		for (const candidate of highEntropyCandidates(elementText(container))) {
+			addHit(hits, secretHit(candidate));
 		}
 	}
 
@@ -151,8 +159,8 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 			depth++;
 		}
 		if (!confident) continue;
-		for (const value of highEntropyCandidates(elementText(code))) {
-			addHit(hits, { type: 'secret', value });
+		for (const candidate of highEntropyCandidates(elementText(code))) {
+			addHit(hits, secretHit(candidate));
 		}
 	}
 }

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
@@ -38,7 +38,15 @@ function addHit(hits: Map<string, SecretHit>, hit: SecretHit): void {
 	if (!hit.value) return;
 	// Deduplicate by replacement target. The same secret can appear in text,
 	// snapshot, and iframe/shadow copies during one probe.
-	hits.set(`${hit.type}:${hit.value}:${hit.ref ?? ''}`, hit);
+	const key = `${hit.type}:${hit.value}:${hit.ref ?? ''}`;
+	const existing = hits.get(key);
+	// Keep the narrowest capture span, not whichever copy came last.
+	if (existing && spanOf(existing).length <= spanOf(hit).length) return;
+	hits.set(key, hit);
+}
+
+function spanOf(hit: SecretHit): string {
+	return hit.captureValue ?? hit.value;
 }
 
 function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
@@ -46,8 +54,16 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	const dom = new JSDOM(html, { virtualConsole });
 	const { document } = dom.window;
 
-	const bodyText = document.documentElement.textContent ?? '';
-	for (const hit of findRegexSecretHits(bodyText)) addHit(hits, hit);
+	// Markup with no whitespace between tags runs sibling text together in
+	// `textContent`, where a match can span text the model never sees as one
+	// token — and then nothing replaces it.
+	const texts = new Set([
+		document.documentElement.textContent ?? '',
+		elementText(document.documentElement),
+	]);
+	for (const text of texts) {
+		for (const hit of findRegexSecretHits(text)) addHit(hits, hit);
+	}
 
 	// Inputs/textareas that are password-shaped or whose label reads as a secret
 	// expose their values in the collected HTML; no entropy needed to flag them.

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
@@ -18,7 +18,7 @@ import {
 	getTestId,
 } from './dom-matchers';
 import type { SecretHit } from '../redaction/redact';
-import { CONCATENATED_ONLY, findRegexSecretHits, narrowerCapture } from '../redaction/redact';
+import { CONCATENATED_ONLY, collectHit, findRegexSecretHits } from '../redaction/redact';
 import type { HtmlProbeNode, HtmlProbeResult } from '../types';
 
 export interface SensitivityOk {
@@ -34,15 +34,6 @@ export interface SensitivityErr {
 
 export type SensitivityResult = SensitivityOk | SensitivityErr;
 
-function addHit(hits: Map<string, SecretHit>, hit: SecretHit): void {
-	if (!hit.value) return;
-	// Deduplicate by replacement target. The same secret can appear in text,
-	// snapshot, and iframe/shadow copies during one probe.
-	const key = `${hit.type}:${hit.value}:${hit.ref ?? ''}`;
-	const existing = hits.get(key);
-	hits.set(key, existing ? narrowerCapture(existing, hit) : hit);
-}
-
 function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	const virtualConsole = new VirtualConsole();
 	const dom = new JSDOM(html, { virtualConsole });
@@ -53,11 +44,11 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	// token — and then nothing replaces it. Such a match still marks the page
 	// sensitive, but it cannot become a credential.
 	const rendered = elementText(document.documentElement);
-	for (const hit of findRegexSecretHits(rendered)) addHit(hits, hit);
+	for (const hit of findRegexSecretHits(rendered)) collectHit(hits, hit);
 	for (const hit of findRegexSecretHits(document.documentElement.textContent ?? '')) {
 		if (rendered.includes(hit.value)) continue; // the rendered pass has it, with a span we can trust
 		hit.captureBlocked = CONCATENATED_ONLY;
-		addHit(hits, hit);
+		collectHit(hits, hit);
 	}
 
 	// Inputs/textareas that are password-shaped or whose label reads as a secret
@@ -71,7 +62,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 			);
 		if (!sensitive) continue;
 		for (const value of sensitiveInputValues(field)) {
-			addHit(hits, { type: 'password', value });
+			collectHit(hits, { type: 'password', value });
 		}
 	}
 
@@ -83,7 +74,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		const hasRevealPhrase = REVEAL_PHRASE_PATTERNS.some((pattern) => pattern.test(text));
 		const hasCopyButton = hasButtonMatching(dialog, COPY_BUTTON_PATTERN);
 		if (!hasRevealPhrase && !hasCopyButton) continue;
-		for (const hit of highEntropyCandidates(text)) addHit(hits, hit);
+		for (const hit of highEntropyCandidates(text)) collectHit(hits, hit);
 	}
 
 	// Product UIs frequently label secret containers with test IDs even when the
@@ -94,7 +85,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		const testId = getTestId(el);
 		if (!testId || !SENSITIVE_TESTID_PATTERN.test(testId)) continue;
 		if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') continue;
-		for (const hit of highEntropyCandidates(elementText(el))) addHit(hits, hit);
+		for (const hit of highEntropyCandidates(elementText(el))) collectHit(hits, hit);
 	}
 
 	// aria-label/labelledby captures Stripe-style inline secret displays where
@@ -102,7 +93,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	for (const el of Array.from(document.querySelectorAll('[aria-label], [aria-labelledby]'))) {
 		if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') continue;
 		if (!SENSITIVE_ARIA_LABEL_PATTERN.test(elementLabel(el, document))) continue;
-		for (const hit of highEntropyCandidates(elementText(el))) addHit(hits, hit);
+		for (const hit of highEntropyCandidates(elementText(el))) collectHit(hits, hit);
 	}
 
 	// Non-dialog pages need both copy and reveal signals before we treat a
@@ -117,7 +108,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 		}
 		if (!container || container.matches('[role="dialog"], dialog[open]')) continue;
 		if (!hasButtonMatching(container, REVEAL_BUTTON_PATTERN)) continue;
-		for (const hit of highEntropyCandidates(elementText(container))) addHit(hits, hit);
+		for (const hit of highEntropyCandidates(elementText(container))) collectHit(hits, hit);
 	}
 
 	// Monospace tokens inside a nearby sensitive ancestor are common in API-key
@@ -136,7 +127,7 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 			depth++;
 		}
 		if (!confident) continue;
-		for (const hit of highEntropyCandidates(elementText(code))) addHit(hits, hit);
+		for (const hit of highEntropyCandidates(elementText(code))) collectHit(hits, hit);
 	}
 }
 

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
@@ -10,6 +10,16 @@ import {
 } from './dom-matchers';
 
 describe('highEntropyCandidates', () => {
+	// Two tokens can share a high-entropy fragment. Picking one token's span would
+	// leave the other — and the shared fragment inside it — untouched.
+	it('falls back to the shared fragment when two tokens disagree', () => {
+		const fragment = 'Zt7vLpQ9mKdW4xR2bNfH3jEuXaGoT5wPqYs1BcRmZxQ';
+
+		const hits = highEntropyCandidates(`first alpha.${fragment} second bravo.${fragment} end`);
+
+		expect(hits.map((hit) => hit.value)).toEqual([fragment]);
+	});
+
 	// The same key shown bare and inside a wrapper is one secret. Keeping both
 	// spans would offer the model a marker that captures the wrapper text.
 	it('merges a bare key with a wrapped rendering of it', () => {

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
@@ -5,8 +5,22 @@ import {
 	SENSITIVE_ARIA_LABEL_PATTERN,
 	SENSITIVE_FIELD_LABEL_PATTERN,
 	SENSITIVE_TESTID_PATTERN,
+	highEntropyCandidates,
 	shannonEntropy,
 } from './dom-matchers';
+
+describe('highEntropyCandidates', () => {
+	// A large inline script is one long undelimited run. Expansion must not
+	// rescan it for every match, or sensitivity analysis stalls the tool call.
+	it('stays linear on a large run of high-entropy segments', () => {
+		const text = Array.from({ length: 3200 }, () => 'aB3xY9zQ7wE2rT5yU8iO1pL4kJ6hG0fD').join('.');
+
+		const started = performance.now();
+		highEntropyCandidates(text);
+
+		expect(performance.now() - started).toBeLessThan(1000);
+	});
+});
 
 describe('shannonEntropy', () => {
 	it('returns 0 for empty and repeated strings', () => {

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
@@ -10,6 +10,16 @@ import {
 } from './dom-matchers';
 
 describe('highEntropyCandidates', () => {
+	// The same key shown bare and inside a wrapper is one secret. Keeping both
+	// spans would offer the model a marker that captures the wrapper text.
+	it('merges a bare key with a wrapped rendering of it', () => {
+		const key = 'Zt7vLpQ9mKdW4xR2bNfH3jEuXaGoT5wPqYs1BcRmZxQ';
+
+		const hits = highEntropyCandidates(`bare ${key} and wrapped session.${key}`);
+
+		expect(hits.map((hit) => hit.value)).toEqual([key]);
+	});
+
 	// A large inline script is one long undelimited run. Expansion must not
 	// rescan it for every match, or sensitivity analysis stalls the tool call.
 	it('stays linear on a large run of high-entropy segments', () => {

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
@@ -1,3 +1,4 @@
+import { narrowerCapture, UNDELIMITED_TOKEN, type SecretHit } from '../redaction/redact';
 import { expandToTokenSpan } from '../redaction/token-span';
 
 export const TESTID_ATTRS = ['data-testid', 'data-test-id', 'data-test', 'data-qa'] as const;
@@ -148,20 +149,20 @@ export function shannonEntropy(value: string): number {
 	return entropy;
 }
 
-export interface EntropyCandidate {
-	value: string;
-	/** False when the span is only the inner match, so it may be a fragment. */
-	delimited: boolean;
-}
-
 // Scored on the inner match, reported as the whole token: a shape this class
 // misses must not be split into fragments.
-export function highEntropyCandidates(text: string): EntropyCandidate[] {
-	const candidates = new Map<string, boolean>();
+export function highEntropyCandidates(text: string): SecretHit[] {
+	const hits = new Map<string, SecretHit>();
 	for (const match of text.matchAll(/[A-Za-z0-9_/+=-]{20,}/g)) {
 		if (shannonEntropy(match[0]) < 4.5) continue;
 		const { span, delimited } = expandToTokenSpan(text, match.index, match[0].length);
-		candidates.set(span, delimited || (candidates.get(span) ?? false));
+		// Unlike a provider pattern, an entropy match is only ever a fragment of the
+		// token it sits in, so the span — not the match — is the redaction target.
+		const hit: SecretHit = delimited
+			? { type: 'secret', value: span }
+			: { type: 'secret', value: match[0], captureBlocked: UNDELIMITED_TOKEN };
+		const existing = hits.get(hit.value);
+		hits.set(hit.value, existing ? narrowerCapture(existing, hit) : hit);
 	}
-	return [...candidates].map(([value, delimited]) => ({ value, delimited }));
+	return [...hits.values()];
 }

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
@@ -154,7 +154,7 @@ export function highEntropyCandidates(text: string): string[] {
 	const spans = new Set<string>();
 	for (const match of text.matchAll(/[A-Za-z0-9_/+=-]{20,}/g)) {
 		if (shannonEntropy(match[0]) >= 4.5) {
-			spans.add(expandToTokenSpan(text, match.index, match[0].length));
+			spans.add(expandToTokenSpan(text, match.index, match[0].length).span);
 		}
 	}
 	return [...spans];

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
@@ -148,14 +148,20 @@ export function shannonEntropy(value: string): number {
 	return entropy;
 }
 
+export interface EntropyCandidate {
+	value: string;
+	/** False when the span is only the inner match, so it may be a fragment. */
+	delimited: boolean;
+}
+
 // Scored on the inner match, reported as the whole token: a shape this class
 // misses must not be split into fragments.
-export function highEntropyCandidates(text: string): string[] {
-	const spans = new Set<string>();
+export function highEntropyCandidates(text: string): EntropyCandidate[] {
+	const candidates = new Map<string, boolean>();
 	for (const match of text.matchAll(/[A-Za-z0-9_/+=-]{20,}/g)) {
-		if (shannonEntropy(match[0]) >= 4.5) {
-			spans.add(expandToTokenSpan(text, match.index, match[0].length).span);
-		}
+		if (shannonEntropy(match[0]) < 4.5) continue;
+		const { span, delimited } = expandToTokenSpan(text, match.index, match[0].length);
+		candidates.set(span, delimited || (candidates.get(span) ?? false));
 	}
-	return [...spans];
+	return [...candidates].map(([value, delimited]) => ({ value, delimited }));
 }

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
@@ -1,4 +1,4 @@
-import { narrowerCapture, UNDELIMITED_TOKEN, type SecretHit } from '../redaction/redact';
+import { collectHit, UNDELIMITED_TOKEN, type SecretHit } from '../redaction/redact';
 import { expandToTokenSpan } from '../redaction/token-span';
 
 export const TESTID_ATTRS = ['data-testid', 'data-test-id', 'data-test', 'data-qa'] as const;
@@ -161,8 +161,8 @@ export function highEntropyCandidates(text: string): SecretHit[] {
 		const hit: SecretHit = delimited
 			? { type: 'secret', value: span }
 			: { type: 'secret', value: match[0], captureBlocked: UNDELIMITED_TOKEN };
-		const existing = hits.get(hit.value);
-		hits.set(hit.value, existing ? narrowerCapture(existing, hit) : hit);
+		if (hit.value !== match[0]) hit.match = match[0];
+		collectHit(hits, hit);
 	}
 	return [...hits.values()];
 }

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
@@ -1,3 +1,5 @@
+import { expandToTokenSpan } from '../redaction/token-span';
+
 export const TESTID_ATTRS = ['data-testid', 'data-test-id', 'data-test', 'data-qa'] as const;
 
 export const SENSITIVE_TESTID_PATTERN =
@@ -146,7 +148,14 @@ export function shannonEntropy(value: string): number {
 	return entropy;
 }
 
+// Scored on the inner match, reported as the whole token: a shape this class
+// misses must not be split into fragments.
 export function highEntropyCandidates(text: string): string[] {
-	const candidates = text.match(/[A-Za-z0-9_/+=-]{20,}/g) ?? [];
-	return candidates.filter((candidate) => shannonEntropy(candidate) >= 4.5);
+	const spans = new Set<string>();
+	for (const match of text.matchAll(/[A-Za-z0-9_/+=-]{20,}/g)) {
+		if (shannonEntropy(match[0]) >= 4.5) {
+			spans.add(expandToTokenSpan(text, match.index, match[0].length));
+		}
+	}
+	return [...spans];
 }

--- a/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
@@ -5,8 +5,14 @@ import { elementText } from './dom-matchers';
 import { REDACTION_MARKER_PATTERN } from '../redaction/redact';
 import { applyRedactions } from '../redaction/redaction-applier';
 import { createCredentialTools } from '../tools/credential';
-import { createMockConnection, findTool, textOf, TOOL_CONTEXT } from '../tools/test-helpers';
-import type { CallToolResult, HtmlProbeResult } from '../types';
+import {
+	createMockConnection,
+	findTool,
+	htmlProbe,
+	textOf,
+	TOOL_CONTEXT,
+} from '../tools/test-helpers';
+import type { CallToolResult } from '../types';
 
 // Patterns go stale, so this corpus pins the shapes providers issue *today*:
 // every one must survive snapshot → marker → capture byte-exact and leave no
@@ -46,20 +52,7 @@ function revealPanel(key: string): string {
 // The same panel as a real console ships it: no whitespace between tags, so
 // `textContent` runs the sibling text together.
 function minifiedRevealPanel(key: string): string {
-	return `<html><body><section><span>Your API key</span><div>${key}</div><button aria-label="Copy API key">Copy</button><button aria-label="Show API key">Show</button></section></body></html>`;
-}
-
-function probe(html: string): HtmlProbeResult {
-	return {
-		ok: true,
-		root: {
-			kind: 'document',
-			html,
-			url: 'https://provider.test/keys',
-			children: [],
-			errors: [],
-		},
-	};
+	return revealPanel(key).replace(/>\s+</g, '><');
 }
 
 /**
@@ -70,22 +63,21 @@ function visibleText(html: string): string {
 	return elementText(new JSDOM(html).window.document.body);
 }
 
-function normalize(text: string): string {
-	return text.replace(/\s+/g, ' ').trim();
-}
-
 /** What must remain once every marker is stripped: the page without the key. */
 function textWithoutKey(render: (key: string) => string): string {
-	return normalize(visibleText(render('')));
+	return visibleText(render(''));
 }
 
 function residue(html: string): string {
-	return normalize(redactedSnapshot(html).replace(new RegExp(REDACTION_MARKER_PATTERN, 'g'), ''));
+	return redactedSnapshot(html)
+		.replace(new RegExp(REDACTION_MARKER_PATTERN, 'g'), '')
+		.replace(/\s+/g, ' ')
+		.trim();
 }
 
 /** The redacted page text the model reads for a page rendering a key. */
 function redactedSnapshot(html: string): string {
-	const sensitivity = analyzeHtmlSensitivity(probe(html));
+	const sensitivity = analyzeHtmlSensitivity(htmlProbe(html));
 	if (!sensitivity.ok) throw new Error(sensitivity.error);
 	const result: CallToolResult = { content: [{ type: 'text', text: visibleText(html) }] };
 	return textOf(applyRedactions(result, sensitivity));
@@ -101,7 +93,7 @@ function markerFor(html: string): string {
 async function capturedVia(marker: string, html: string): Promise<string | undefined> {
 	const capture = vi.fn();
 	const mockConn = createMockConnection();
-	mockConn.adapter.probePageHtml.mockResolvedValue(probe(html));
+	mockConn.adapter.probePageHtml.mockResolvedValue(htmlProbe(html));
 
 	await findTool(createCredentialTools(mockConn.connection), 'browser_capture_secret').execute(
 		{ credentialsKey: 'k1', field: 'apiKey', element: { redactedKey: marker } },
@@ -139,7 +131,7 @@ describe('current provider key shapes', () => {
 	// marker carries the generic type. Narrowing it back would re-expose the part
 	// of the key the pattern's fixed length does not cover.
 	it('labels an over-long key generically rather than leaving its tail visible', () => {
-		const key = `AIza${'SyC7mQ2xR9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1Bc'}`;
+		const { key } = KEY_SHAPES[1];
 		const snapshot = redactedSnapshot(revealPanel(key));
 
 		expect(snapshot).toContain('[REDACTED:secret:');

--- a/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
@@ -126,15 +126,13 @@ describe('current provider key shapes', () => {
 		expect(residue(minifiedRevealPanel(key))).toBe(textWithoutKey(minifiedRevealPanel));
 	});
 
-	// Coverage is chosen over labelling: where an entropy span reaches further
-	// than a provider pattern's match, the wider span replaces first and the
-	// marker carries the generic type. Narrowing it back would re-expose the part
-	// of the key the pattern's fixed length does not cover.
-	it('labels an over-long key generically rather than leaving its tail visible', () => {
+	// An open-ended provider pattern covers the whole key, so the marker keeps the
+	// specific type rather than being subsumed by a wider entropy span.
+	it('labels an over-long key with its provider type', () => {
 		const { key } = KEY_SHAPES[1];
 		const snapshot = redactedSnapshot(revealPanel(key));
 
-		expect(snapshot).toContain('[REDACTED:secret:');
+		expect(snapshot).toContain('[REDACTED:google_api_key:');
 		expect(snapshot).not.toContain(key.slice(-7));
 	});
 });

--- a/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
@@ -126,6 +126,14 @@ describe('current provider key shapes', () => {
 		expect(residue(minifiedRevealPanel(key))).toBe(textWithoutKey(minifiedRevealPanel));
 	});
 
+	// Both renderings must be masked, not just whichever the merge kept.
+	it('leaves nothing visible when two tokens share a fragment', () => {
+		const fragment = 'Zt7vLpQ9mKdW4xR2bNfH3jEuXaGoT5wPqYs1BcRmZxQ';
+		const panel = (key: string) => revealPanel(`alpha.${key}</div><div>bravo.${key}`);
+
+		expect(residue(panel(fragment))).not.toContain(fragment);
+	});
+
 	// An open-ended provider pattern covers the whole key, so the marker keeps the
 	// specific type rather than being subsumed by a wider entropy span.
 	it('labels an over-long key with its provider type', () => {

--- a/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
@@ -1,0 +1,142 @@
+import { JSDOM } from 'jsdom';
+
+import { analyzeHtmlSensitivity } from './analyze-html';
+import { elementText } from './dom-matchers';
+import { REDACTION_MARKER_PATTERN } from '../redaction/redact';
+import { applyRedactions } from '../redaction/redaction-applier';
+import { createCredentialTools } from '../tools/credential';
+import { createMockConnection, findTool, textOf, TOOL_CONTEXT } from '../tools/test-helpers';
+import type { CallToolResult, HtmlProbeResult } from '../types';
+
+// Patterns go stale, so this corpus pins the shapes providers issue *today*:
+// every one must survive snapshot → marker → capture byte-exact and leave no
+// fragment in what the model reads.
+const KEY_SHAPES: Array<{ name: string; key: string }> = [
+	{
+		name: 'google (dot-prefixed)',
+		key: `AQ.${'Ab8RN6Jr7xQfP2mKdW9tZsLyVc4hEuNgT3iBoXaQwMzRkJvSpH'}`,
+	},
+	// Longer than the fixed-count pattern matches, which covers only a prefix.
+	{
+		name: 'google (legacy, over-long)',
+		key: `AIza${'SyC7mQ2xR9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1Bc'}`,
+	},
+	{
+		name: 'jwt',
+		key: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0N2FjMzhkOWJmIiwiaWF0IjoxNzE2Mzk5MDIyfQ.9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1BcRmZxQ',
+	},
+	{ name: 'telegram (colon-separated)', key: '7845123096:AAHd9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1' },
+	{ name: 'azure (tilde-separated)', key: 'xY8~Q9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1Bc7mR2' },
+	{ name: 'sendgrid (two dots)', key: 'SG.9tKdW4vLpZ8bNfH.3jEuXaGoT5wPqYs1BcRmZxQ2vLp' },
+	// No pattern knows this shape — stands in for the next format change.
+	{ name: 'unknown dotted shape', key: 'Zt7.9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1BcRmZxQ' },
+];
+
+const VISIBLE_TEXT = 'Your API key Copy Show';
+
+// How a provider console renders a fresh key: a text node in a panel with
+// copy/reveal affordances, so there is no ref to capture from.
+function revealPanel(key: string): string {
+	return `<html><body><section>
+			<span>Your API key</span>
+			<div>${key}</div>
+			<button aria-label="Copy API key">Copy</button>
+			<button aria-label="Show API key">Show</button>
+		</section></body></html>`;
+}
+
+// The same panel as a real console ships it: no whitespace between tags, so
+// `textContent` runs the sibling text together.
+function minifiedRevealPanel(key: string): string {
+	return `<html><body><section><span>Your API key</span><div>${key}</div><button aria-label="Copy API key">Copy</button><button aria-label="Show API key">Show</button></section></body></html>`;
+}
+
+function probe(html: string): HtmlProbeResult {
+	return {
+		ok: true,
+		root: {
+			kind: 'document',
+			html,
+			url: 'https://provider.test/keys',
+			children: [],
+			errors: [],
+		},
+	};
+}
+
+/**
+ * Derived from the page, not hand-written: a value the detector reports but that
+ * never appears in what the model reads would otherwise pass unnoticed.
+ */
+function visibleText(html: string): string {
+	return elementText(new JSDOM(html).window.document.body);
+}
+
+/** The redacted page text the model reads for a page rendering a key. */
+function redactedSnapshot(html: string): string {
+	const sensitivity = analyzeHtmlSensitivity(probe(html));
+	if (!sensitivity.ok) throw new Error(sensitivity.error);
+	const result: CallToolResult = { content: [{ type: 'text', text: visibleText(html) }] };
+	return textOf(applyRedactions(result, sensitivity));
+}
+
+function markerFor(html: string): string {
+	const marker = REDACTION_MARKER_PATTERN.exec(redactedSnapshot(html))?.[0];
+	if (!marker) throw new Error('No redaction marker found');
+	return marker;
+}
+
+/** Run `browser_capture_secret` for a marker and return what it buffered. */
+async function capturedVia(marker: string, html: string): Promise<string | undefined> {
+	const capture = vi.fn();
+	const mockConn = createMockConnection();
+	mockConn.adapter.probePageHtml.mockResolvedValue(probe(html));
+
+	await findTool(createCredentialTools(mockConn.connection), 'browser_capture_secret').execute(
+		{ credentialsKey: 'k1', field: 'apiKey', element: { redactedKey: marker } },
+		{ ...TOOL_CONTEXT, secretsBuffer: { capture, getFields: vi.fn(), clear: vi.fn() } },
+	);
+
+	return capture.mock.calls[0]?.[2] as string | undefined;
+}
+
+describe('current provider key shapes', () => {
+	it.each(KEY_SHAPES)('leaves nothing of a $name key visible', ({ key }) => {
+		const withoutMarkers = redactedSnapshot(revealPanel(key)).replace(
+			new RegExp(REDACTION_MARKER_PATTERN, 'g'),
+			'',
+		);
+
+		expect(withoutMarkers.replace(/\s+/g, ' ').trim()).toBe(VISIBLE_TEXT);
+	});
+
+	it.each(KEY_SHAPES)('captures a $name key whole via its marker', async ({ key }) => {
+		const html = revealPanel(key);
+
+		expect(await capturedVia(markerFor(html), html)).toBe(key);
+	});
+
+	// A key with entropy below the 4.5 gate is found by its provider pattern
+	// alone, so the pattern's own span is all that stands between it and the model.
+	it('redacts a low-entropy key that only the provider pattern finds', () => {
+		const key = `AQ.${'AbCdEfGhIj'.repeat(3)}Ab`;
+
+		expect(redactedSnapshot(minifiedRevealPanel(key))).not.toContain(key);
+	});
+
+	it.each(KEY_SHAPES)('leaves nothing of a $name key visible in minified markup', ({ key }) => {
+		expect(redactedSnapshot(minifiedRevealPanel(key))).not.toContain(key);
+	});
+
+	// Coverage is chosen over labelling: where an entropy span reaches further
+	// than a provider pattern's match, the wider span replaces first and the
+	// marker carries the generic type. Narrowing it back would re-expose the part
+	// of the key the pattern's fixed length does not cover.
+	it('labels an over-long key generically rather than leaving its tail visible', () => {
+		const key = `AIza${'SyC7mQ2xR9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1Bc'}`;
+		const snapshot = redactedSnapshot(revealPanel(key));
+
+		expect(snapshot).toContain('[REDACTED:secret:');
+		expect(snapshot).not.toContain(key.slice(-7));
+	});
+});

--- a/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/key-shape-corpus.test.ts
@@ -32,8 +32,6 @@ const KEY_SHAPES: Array<{ name: string; key: string }> = [
 	{ name: 'unknown dotted shape', key: 'Zt7.9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1BcRmZxQ' },
 ];
 
-const VISIBLE_TEXT = 'Your API key Copy Show';
-
 // How a provider console renders a fresh key: a text node in a panel with
 // copy/reveal affordances, so there is no ref to capture from.
 function revealPanel(key: string): string {
@@ -72,6 +70,19 @@ function visibleText(html: string): string {
 	return elementText(new JSDOM(html).window.document.body);
 }
 
+function normalize(text: string): string {
+	return text.replace(/\s+/g, ' ').trim();
+}
+
+/** What must remain once every marker is stripped: the page without the key. */
+function textWithoutKey(render: (key: string) => string): string {
+	return normalize(visibleText(render('')));
+}
+
+function residue(html: string): string {
+	return normalize(redactedSnapshot(html).replace(new RegExp(REDACTION_MARKER_PATTERN, 'g'), ''));
+}
+
 /** The redacted page text the model reads for a page rendering a key. */
 function redactedSnapshot(html: string): string {
 	const sensitivity = analyzeHtmlSensitivity(probe(html));
@@ -102,12 +113,7 @@ async function capturedVia(marker: string, html: string): Promise<string | undef
 
 describe('current provider key shapes', () => {
 	it.each(KEY_SHAPES)('leaves nothing of a $name key visible', ({ key }) => {
-		const withoutMarkers = redactedSnapshot(revealPanel(key)).replace(
-			new RegExp(REDACTION_MARKER_PATTERN, 'g'),
-			'',
-		);
-
-		expect(withoutMarkers.replace(/\s+/g, ' ').trim()).toBe(VISIBLE_TEXT);
+		expect(residue(revealPanel(key))).toBe(textWithoutKey(revealPanel));
 	});
 
 	it.each(KEY_SHAPES)('captures a $name key whole via its marker', async ({ key }) => {
@@ -121,11 +127,11 @@ describe('current provider key shapes', () => {
 	it('redacts a low-entropy key that only the provider pattern finds', () => {
 		const key = `AQ.${'AbCdEfGhIj'.repeat(3)}Ab`;
 
-		expect(redactedSnapshot(minifiedRevealPanel(key))).not.toContain(key);
+		expect(residue(minifiedRevealPanel(key))).toBe(textWithoutKey(minifiedRevealPanel));
 	});
 
 	it.each(KEY_SHAPES)('leaves nothing of a $name key visible in minified markup', ({ key }) => {
-		expect(redactedSnapshot(minifiedRevealPanel(key))).not.toContain(key);
+		expect(residue(minifiedRevealPanel(key))).toBe(textWithoutKey(minifiedRevealPanel));
 	});
 
 	// Coverage is chosen over labelling: where an entropy span reaches further

--- a/packages/@n8n/mcp-browser/src/tools/credential.test.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.test.ts
@@ -298,6 +298,18 @@ describe('browser_capture_secret', () => {
 			expect(buffer.capture).not.toHaveBeenCalled();
 		});
 
+		it('refuses to buffer an empty value', async () => {
+			mockConn.adapter.getElementValue.mockResolvedValue('');
+
+			const result = await getTool().execute(
+				{ credentialsKey: 'k1', field: 'apiKey', element: { ref: 'e42' } },
+				makeContext({ secretsBuffer: buffer }),
+			);
+
+			expect(result.isError).toBe(true);
+			expect(buffer.capture).not.toHaveBeenCalled();
+		});
+
 		// Expansion gives up inside an undelimitable run, and the match it falls
 		// back to may be partial — that must fail, not be stored.
 		it('refuses to buffer a value whose token could not be delimited', async () => {

--- a/packages/@n8n/mcp-browser/src/tools/credential.test.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.test.ts
@@ -276,6 +276,48 @@ describe('browser_capture_secret', () => {
 			expect(buffer.capture).not.toHaveBeenCalled();
 		});
 
+		// A match that only exists once `textContent` runs sibling text together is
+		// never shown to the model, so its marker can only have been guessed.
+		it('refuses to buffer a value that only exists in concatenated markup', async () => {
+			// Split across siblings, so the key exists only once `textContent`
+			// concatenates them — never in the text the model reads.
+			mockProbe(
+				`<html><body><section><span>AQ.</span><span>${'AbCdEfGhIj'.repeat(3)}Ab</span></section></body></html>`,
+			);
+
+			const result = await getTool().execute(
+				{
+					credentialsKey: 'k1',
+					field: 'apiKey',
+					element: { redactedKey: '[REDACTED:google_api_key:1]' },
+				},
+				makeContext({ secretsBuffer: buffer }),
+			);
+
+			expect(result.isError).toBe(true);
+			expect(buffer.capture).not.toHaveBeenCalled();
+		});
+
+		// Expansion gives up inside an undelimitable run, and the match it falls
+		// back to may be partial — that must fail, not be stored.
+		it('refuses to buffer a value whose token could not be delimited', async () => {
+			const key = `AQ.${'Ab8RN6Jr7xQfP2mKdW9tZsLyVc4hEuNgT3iBoXaQwMzRkJvSpH'}`;
+			const run = 'x'.repeat(600);
+			mockProbe(`<html><body><p>${run}${key}${run}</p></body></html>`);
+
+			const result = await getTool().execute(
+				{
+					credentialsKey: 'k1',
+					field: 'apiKey',
+					element: { redactedKey: '[REDACTED:google_api_key:1]' },
+				},
+				makeContext({ secretsBuffer: buffer }),
+			);
+
+			expect(result.isError).toBe(true);
+			expect(buffer.capture).not.toHaveBeenCalled();
+		});
+
 		// A fixed-length pattern matches only the first N characters of a longer
 		// token; extraction must not inherit that boundary.
 		it('captures the whole token when a provider pattern matched only its prefix', async () => {

--- a/packages/@n8n/mcp-browser/src/tools/credential.test.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.test.ts
@@ -259,6 +259,40 @@ describe('browser_capture_secret', () => {
 
 			expect(result.isError).toBe(true);
 		});
+
+		it('refuses to buffer a value that is itself a redaction marker', async () => {
+			mockProbe(htmlWithPasswordInput('[REDACTED:secret:1] trailing'));
+
+			const result = await getTool().execute(
+				{
+					credentialsKey: 'k1',
+					field: 'apiKey',
+					element: { redactedKey: '[REDACTED:password:1]' },
+				},
+				makeContext({ secretsBuffer: buffer }),
+			);
+
+			expect(result.isError).toBe(true);
+			expect(buffer.capture).not.toHaveBeenCalled();
+		});
+
+		// A fixed-length pattern matches only the first N characters of a longer
+		// token; extraction must not inherit that boundary.
+		it('captures the whole token when a provider pattern matched only its prefix', async () => {
+			const key = `AIza${'SyC7mQ2xR9tKdW4vLpZ8bNfH3jEuXaGoT5wPqYs1Bc'}`;
+			mockProbe(`<html><body><p>Your key is ${key}</p></body></html>`);
+
+			await getTool().execute(
+				{
+					credentialsKey: 'k1',
+					field: 'apiKey',
+					element: { redactedKey: '[REDACTED:google_api_key:1]' },
+				},
+				makeContext({ secretsBuffer: buffer }),
+			);
+
+			expect(buffer.capture).toHaveBeenCalledWith('k1', 'apiKey', key);
+		});
 	});
 });
 

--- a/packages/@n8n/mcp-browser/src/tools/credential.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.ts
@@ -2,8 +2,11 @@ import { z } from 'zod';
 
 import type { BrowserConnection } from '../connection';
 import { createConnectedTool, pageIdField } from './helpers';
-import type { SecretHit } from '../redaction/redact';
-import { containsRedactionMarker, createRedactionMarkerFormatter } from '../redaction/redact';
+import {
+	captureSpanOf,
+	containsRedactionMarker,
+	createRedactionMarkerFormatter,
+} from '../redaction/redact';
 import { analyzeHtmlSensitivity } from '../sensitivity/analyze-html';
 import type {
 	AffectedResource,
@@ -69,12 +72,9 @@ function browserCaptureSecret(
 				const sensitivity = analyzeHtmlSensitivity(await state.adapter.probePageHtml(pageId));
 				if (sensitivity.ok) {
 					const formatMarker = createRedactionMarkerFormatter(sensitivity.hits);
-					const markerMap = sensitivity.hits.reduce((result, hit) => {
-						result.set(formatMarker(hit), hit);
-						return result;
-					}, new Map<string, SecretHit>());
+					const byMarker = new Map(sensitivity.hits.map((hit) => [formatMarker(hit), hit]));
 
-					const hit = markerMap.get(redactedKey);
+					const hit = byMarker.get(redactedKey);
 					if (!hit) {
 						throw new Error(`The marker "${redactedKey}" was not found.`);
 					}
@@ -85,7 +85,7 @@ function browserCaptureSecret(
 							`"${redactedKey}" cannot be captured because ${hit.captureBlocked}. Take a fresh snapshot and capture the element that holds the value.`,
 						);
 					}
-					value = hit.captureValue ?? hit.value;
+					value = captureSpanOf(hit);
 				} else {
 					throw new Error(`Secret capturing failed with error: ${sensitivity.error}`);
 				}

--- a/packages/@n8n/mcp-browser/src/tools/credential.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.ts
@@ -92,7 +92,12 @@ function browserCaptureSecret(
 			} else {
 				value = await state.adapter.getElementValue(pageId, { ref: args.element.ref });
 			}
-			// A stored marker would only fail once the provider is called.
+			// Both would only fail once the provider is called.
+			if (!value) {
+				throw new Error(
+					`The element for "${args.field}" holds no value. Take a fresh snapshot and capture the element that shows the secret.`,
+				);
+			}
 			if (containsRedactionMarker(value)) {
 				throw new Error(
 					`The value read for "${args.field}" is a redaction marker, not a secret. Take a fresh snapshot and capture the element that holds the value.`,

--- a/packages/@n8n/mcp-browser/src/tools/credential.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import type { BrowserConnection } from '../connection';
 import { createConnectedTool, pageIdField } from './helpers';
+import type { SecretHit } from '../redaction/redact';
 import { containsRedactionMarker, createRedactionMarkerFormatter } from '../redaction/redact';
 import { analyzeHtmlSensitivity } from '../sensitivity/analyze-html';
 import type {
@@ -69,14 +70,22 @@ function browserCaptureSecret(
 				if (sensitivity.ok) {
 					const formatMarker = createRedactionMarkerFormatter(sensitivity.hits);
 					const markerMap = sensitivity.hits.reduce((result, hit) => {
-						result.set(formatMarker(hit), hit.captureValue ?? hit.value);
+						result.set(formatMarker(hit), hit);
 						return result;
-					}, new Map<string, string>());
+					}, new Map<string, SecretHit>());
 
-					if (!markerMap.get(redactedKey)) {
+					const hit = markerMap.get(redactedKey);
+					if (!hit) {
 						throw new Error(`The marker "${redactedKey}" was not found.`);
 					}
-					value = markerMap.get(redactedKey)!;
+					// Better to send the agent back for a fresh snapshot than to store a
+					// value that may be a fragment of the real one.
+					if (hit.captureBlocked) {
+						throw new Error(
+							`"${redactedKey}" cannot be captured because ${hit.captureBlocked}. Take a fresh snapshot and capture the element that holds the value.`,
+						);
+					}
+					value = hit.captureValue ?? hit.value;
 				} else {
 					throw new Error(`Secret capturing failed with error: ${sensitivity.error}`);
 				}

--- a/packages/@n8n/mcp-browser/src/tools/credential.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import type { BrowserConnection } from '../connection';
 import { createConnectedTool, pageIdField } from './helpers';
-import { createRedactionMarkerFormatter } from '../redaction/redact';
+import { containsRedactionMarker, createRedactionMarkerFormatter } from '../redaction/redact';
 import { analyzeHtmlSensitivity } from '../sensitivity/analyze-html';
 import type {
 	AffectedResource,
@@ -69,7 +69,7 @@ function browserCaptureSecret(
 				if (sensitivity.ok) {
 					const formatMarker = createRedactionMarkerFormatter(sensitivity.hits);
 					const markerMap = sensitivity.hits.reduce((result, hit) => {
-						result.set(formatMarker(hit), hit.value);
+						result.set(formatMarker(hit), hit.captureValue ?? hit.value);
 						return result;
 					}, new Map<string, string>());
 
@@ -82,6 +82,12 @@ function browserCaptureSecret(
 				}
 			} else {
 				value = await state.adapter.getElementValue(pageId, { ref: args.element.ref });
+			}
+			// A stored marker would only fail once the provider is called.
+			if (containsRedactionMarker(value)) {
+				throw new Error(
+					`The value read for "${args.field}" is a redaction marker, not a secret. Take a fresh snapshot and capture the element that holds the value.`,
+				);
 			}
 			context.secretsBuffer.capture(args.credentialsKey, args.field, value);
 			return formatCallToolResult({ ok: true, fieldsCaptured: [args.field] });

--- a/packages/@n8n/mcp-browser/src/tools/test-helpers.ts
+++ b/packages/@n8n/mcp-browser/src/tools/test-helpers.ts
@@ -2,6 +2,8 @@ import type { BrowserConnection } from '../connection';
 import type {
 	CallToolResult,
 	ConnectionState,
+	HtmlProbeNode,
+	HtmlProbeResult,
 	PageInfo,
 	ToolContext,
 	ToolDefinition,
@@ -30,6 +32,14 @@ export function findTool(tools: ToolDefinition[], name: string): ToolDefinition 
 
 /** Default ToolContext for tests. */
 export const TOOL_CONTEXT: ToolContext = { dir: '/test' };
+
+/** An HTML probe result, as `probePageHtml` would return for one document. */
+export function htmlProbe(html: string, children: HtmlProbeNode[] = []): HtmlProbeResult {
+	return {
+		ok: true,
+		root: { kind: 'document', html, url: 'http://test.com', children, errors: [] },
+	};
+}
 
 /** Create a mock PlaywrightAdapter with all methods stubbed. */
 export function createMockAdapter() {


### PR DESCRIPTION
## Summary

`browser_capture_secret` could store a **partial** secret while reporting success, so n8n saved a broken credential that only failed later, when the provider was called.

Resolving a redaction marker returned exactly the span the detector matched, which made extraction fidelity equal to detection fidelity. Two ways that went wrong:

- `highEntropyCandidates` matches `[A-Za-z0-9_/+=-]{20,}`, which **excludes `.`** — so a Google AI Studio key (`AQ.` prefix) was captured without its prefix.
- Fixed-count provider patterns (`AIza[0-9A-Za-z_-]{35}`, `sk-[A-Za-z0-9]{48}`, …) match only their first N characters of a longer real token, and that prefix became the stored value.

The point of the change is that a detector miss can no longer corrupt a captured value, because key formats will keep changing:

- **Spans snap out to the whole surrounding token.** Entropy is scored on the inner match but the span reported covers the whole token, so an unanticipated prefix or suffix is included by construction rather than by enumerating character classes. Provider-pattern hits keep their anchored redaction span and carry the whole token for capturing.
- **Expansion is bounded.** Assignment, query-string and prose punctuation end a span; `=` only when it *precedes* the match, so base64 padding survives; a span past 512 characters falls back to the match. Without this, a console rendering `GOOGLE_API_KEY=<key>` or a request URL would widen the captured value into its neighbours.
- **Replacement runs longest-span-first**, so a wider span is not pre-empted by a shorter one nested inside it, which would leave the rest of the token visible.
- **Detection also runs over the rendered, space-joined page text.** Markup with no whitespace between tags runs sibling text together in `textContent`, where a match can span text the model never sees as one token — and then nothing replaces it.
- **Narrowest span wins** where the same key appears both bare and inside a snippet.
- Capturing refuses a value that is itself a redaction marker.
- `AQ.`-prefixed keys added to the `google_api_key` pattern — a footnote, not the fix.

A regression corpus pins the shapes providers issue *today* (dot-prefixed, over-long legacy, JWT, colon-separated, tilde-separated, two-dot, and an unknown shape), asserting each is captured byte-exact and leaves no fragment visible, in both normal and minified markup. Patterns go stale; the corpus is what catches the next format change.

## How to test

The mock console below mints an `AQ.`-prefixed key per run, renders it in each shape that used to break, and accepts **only that exact value** at `/verify` — so a captured credential is proven byte-exact instead of eyeballed.

1. Save the file below as `server.mjs` (no dependencies) and run it:

   ```bash
   node server.mjs        # walks up from :8791 to the first free port
   ```

   It prints the minted keys to *your terminal* — deliberately not into the page twice, so each case has exactly one occurrence.

2. Connect the Browser Use extension, then ask the AI Assistant:

   > Open http://localhost:8791/panel in the browser. That page displays a Google-style API key once. Capture it into the secure secret buffer — do not print it in the chat — and create a credential of type Header Auth (httpHeaderAuth) named "aq-panel", with header name "x-goog-api-key" and the header value set to the captured key.
   >
   > Then build and execute a one-node workflow: an HTTP Request node doing GET http://localhost:8791/verify using that credential. Show me the exact JSON response body.

3. Expect `{"ok": true, "verdict": "exact match", "which": "aq"}`. A 401 means the stored value was wrong, and the response plus the server log say how — `mismatch (got 68 chars, expected 53)` distinguishes truncation from pollution.

4. Repeat for the other cases, which cover the failure modes found in review:

   | path | what it exercises |
   |---|---|
   | `/panel` | the AI Studio shape — text node in a copy/reveal panel, no ref |
   | `/minified` | no whitespace between tags, so `textContent` concatenates siblings |
   | `/env` | `GOOGLE_API_KEY=<key>` — must not capture the field name |
   | `/url` | key inside a query string — must not capture the URL |
   | `/legacy` | `AIza…` key longer than the 39-char pattern |
   | `/input` | control: readonly input, so capture should use `{ ref }` |

   Also check the assistant transcript: the key must never appear in it, only `[REDACTED:…]` markers.


<details>
<summary>server.mjs — provider console stand-in</summary>

```js
// Stand-in for a provider console issuing `AQ.`-prefixed API keys. Mints one
// secret per run and accepts only that exact value at /verify, so a credential
// built from a captured value can be proven byte-exact.
//
//   node /tmp/aq-key-fixture/server.mjs [port]   (default: first free from 8791)
//
import { createServer } from 'node:http';
import { randomBytes } from 'node:crypto';

const REQUESTED_PORT = process.argv[2] ? Number(process.argv[2]) : undefined;

let PORT = REQUESTED_PORT ?? 8791;

const b64url = (n) => randomBytes(n).toString('base64url').slice(0, n);
const AQ_KEY = `AQ.${b64url(50)}`;
const LEGACY_KEY = `AIza${b64url(42)}`; // deliberately longer than the 39-char pattern

const CASES = {
	panel: {
		title: 'Reveal panel (the AI Studio shape)',
		note: 'Key is a text node in a panel with copy/reveal buttons — no ref to capture from.',
		key: AQ_KEY,
		render: (key) => `<div class="key">${key}</div>`,
	},
	minified: {
		title: 'Reveal panel, no whitespace between tags',
		note: 'textContent runs sibling text together, where a greedy pattern can match across it.',
		key: AQ_KEY,
		minify: true,
		render: (key) => `<div class="key">${key}</div>`,
	},
	env: {
		title: 'Env-var snippet',
		note: 'Renders NAME=<key>; the captured value must not include the field name.',
		key: AQ_KEY,
		render: (key) => `<pre class="key">GOOGLE_API_KEY=${key}</pre>`,
	},
	url: {
		title: 'Request URL',
		note: 'Key sits in a query string; the captured value must not include the URL.',
		key: AQ_KEY,
		render: (key) =>
			`<pre class="key">https://generativelanguage.googleapis.com/v1beta/models?key=${key}&alt=json</pre>`,
	},
	legacy: {
		title: 'Legacy AIza key, longer than the pattern',
		note: 'The provider pattern matches only its first 39 characters.',
		key: LEGACY_KEY,
		render: (key) => `<div class="key">${key}</div>`,
	},
	input: {
		title: 'Readonly input (control case)',
		note: 'Has a snapshot ref, so capture should use { ref } and never need a marker.',
		key: AQ_KEY,
		render: (key) =>
			`<input class="key" readonly spellcheck="false" aria-label="API key" value="${key}">`,
	},
};

const page = (id) => {
	const c = CASES[id];
	const body = `<section>
			<h2>${c.title}</h2>
			<p>Your API key is shown once. Copy it now — you won't be able to see it again.</p>
			${c.render(c.key)}
			<button aria-label="Copy API key">Copy</button>
			<button aria-label="Show API key">Show</button>
		</section>`;
	return `<!doctype html><html><head><meta charset="utf-8"><title>${c.title}</title>
<style>body{font:15px system-ui;margin:2rem;max-width:52rem}.key{font-family:ui-monospace,monospace;background:#f4f4f5;padding:.6rem;border-radius:6px;word-break:break-all;display:block;border:0;width:100%;box-sizing:border-box}nav a{margin-right:.75rem}button{margin-top:.75rem;margin-right:.5rem}</style>
</head><body>
<nav>${Object.keys(CASES)
		.map((k) => `<a href="/${k}">${k}</a>`)
		.join('')}</nav>
<p><small>${c.note}</small></p>
${c.minify ? body.replace(/>\s+</g, '><') : body}
</body></html>`;
};

const index = `<!doctype html><html><head><meta charset="utf-8"><title>AQ. key fixture</title>
<style>body{font:15px system-ui;margin:2rem;max-width:52rem}li{margin:.4rem 0}</style></head><body>
<h1>Provider console stand-in</h1>
<ul>${Object.entries(CASES)
	.map(([id, c]) => `<li><a href="/${id}">${id}</a> — ${c.title}<br><small>${c.note}</small></li>`)
	.join('')}</ul>
<p>Verify a captured value: <code>GET /verify</code> with header
<code>x-goog-api-key: &lt;value&gt;</code> — 200 only for the exact key.</p>
</body></html>`;

let verifyAttempts = 0;
let verifiedOk = 0;

const server = createServer((req, res) => {
	const url = new URL(req.url, `http://localhost:${PORT}`);
	const id = url.pathname.replace(/^\//, '');

	if (url.pathname === '/verify') {
		verifyAttempts++;
		const sent = req.headers['x-goog-api-key'] ?? url.searchParams.get('key') ?? '';
		const isAq = sent === AQ_KEY;
		const ok = isAq || sent === LEGACY_KEY;
		if (ok) verifiedOk++;
		const verdict = ok
			? 'exact match'
			: sent
				? `mismatch (got ${sent.length} chars, expected ${AQ_KEY.length} or ${LEGACY_KEY.length})`
				: 'no key sent';
		console.log(`  /verify → ${ok ? 'OK' : 'REJECTED'}: ${verdict}`);
		if (!ok && sent) console.log(`     sent: ${JSON.stringify(sent)}`);
		res.writeHead(ok ? 200 : 401, { 'content-type': 'application/json' });
		res.end(JSON.stringify({ ok, verdict, which: isAq ? 'aq' : ok ? 'legacy' : null }, null, 2));
		return;
	}

	if (url.pathname === '/status') {
		res.writeHead(200, { 'content-type': 'application/json' });
		res.end(JSON.stringify({ verifyAttempts, verifiedOk }, null, 2));
		return;
	}

	if (url.pathname === '/' || url.pathname === '') {
		res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
		res.end(index);
		return;
	}

	if (CASES[id]) {
		res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
		res.end(page(id));
		return;
	}

	res.writeHead(404, { 'content-type': 'text/plain' });
	res.end('not found');
});

// A stale instance or another dev server must not be a puzzle: walk up.
server.on('error', (error) => {
	if (error.code !== 'EADDRINUSE' || REQUESTED_PORT || PORT > 8891) throw error;
	server.listen(++PORT, '127.0.0.1');
});

server.listen(PORT, '127.0.0.1', () => {
	console.log(`\n  Provider stand-in on http://localhost:${PORT}\n`);
	console.log(`  minted AQ. key : ${AQ_KEY}`);
	console.log(`  minted AIza key: ${LEGACY_KEY}\n`);
	console.log(`  cases: ${Object.keys(CASES).join(', ')}`);
	console.log(`  verify: curl -s -H "x-goog-api-key: <value>" http://localhost:${PORT}/verify\n`);
});
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5768

Found by the credential-setup evals (https://linear.app/n8n/issue/NODE-5549) on their first live run against Google AI Studio. The hermetic `gemini` fixture that mints `AQ.`-prefixed keys lands with that ticket; the corpus in this PR covers the same shapes at unit level in the meantime.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

