### PR TITLE
fix(core): Offer to clean up test data left by live test runs in AI Assistant

### DIFF
--- a/packages/@n8n/instance-ai/skills/one-off-operations/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/one-off-operations/SKILL.md
@@ -79,10 +79,13 @@ flow*, not the anchor.
    and shapes you actually read. If the target system is cheap to read (e.g. a
    read operation of the same node type), offer a read-back of the destination
    as final confirmation.
-5. **Offer cleanup.** When the operation succeeded, ask whether to keep the
-   workflow for future reuse or delete it now that the job is done. Never
-   delete without asking. If the user keeps it, mention it stays unpublished
-   unless they say otherwise.
+5. **Offer to clean up the workflow.** When the operation succeeded, ask whether
+   to keep the workflow for future reuse or delete it now that the job is done.
+   Never delete without asking. If the user keeps it, mention it stays
+   unpublished unless they say otherwise. This step is about the *workflow*: the
+   data a one-off wrote is the deliverable the user asked for, so never offer to
+   undo that. Test data left behind by a *test* run is the opposite case — see
+   "Cleaning up after a live test" in `post-build-flow`.
 
 ## Optional pre-flight verification
 

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -65,7 +65,7 @@ Pick in this order:
 2. **Simplified Custom Auth** (`httpTemplatedCustomAuth`) for any service
    without a dedicated type whose auth is expressible as header/query/body
    values — which covers API keys and bearer tokens (`Authorization: Bearer
-   <token>` becomes `{"headers":{"Authorization":"Bearer {{api_key}}"}}`, not
+<token>` becomes `{"headers":{"Authorization":"Bearer {{api_key}}"}}`, not
    `httpBearerAuth`). Always provide a recipe (below) so the user only pastes
    their secret.
 3. **Plain generic types** (`httpBasicAuth`, `httpDigestAuth`, `oAuth2Api`, …)
@@ -118,26 +118,26 @@ key-check endpoint):
 
 ```json
 {
-  "action": "setup",
-  "workflowId": "...",
-  "credentialHints": [
-    {
-      "suggestedName": "fal.ai API Key",
-      "template": {
-        "headers": { "Authorization": "Key {{api_key}}" }
-      },
-      "placeholders": [
-        {
-          "name": "api_key",
-          "title": "fal.ai API key",
-          "info": "Key ID and secret, separated by a colon",
-          "type": "password"
-        }
-      ],
-      "docsUrl": "https://fal.ai/dashboard/keys",
-      "testUrl": "https://api.fal.ai/v1/models/usage"
-    }
-  ]
+	"action": "setup",
+	"workflowId": "...",
+	"credentialHints": [
+		{
+			"suggestedName": "fal.ai API Key",
+			"template": {
+				"headers": { "Authorization": "Key {{api_key}}" }
+			},
+			"placeholders": [
+				{
+					"name": "api_key",
+					"title": "fal.ai API key",
+					"info": "Key ID and secret, separated by a colon",
+					"type": "password"
+				}
+			],
+			"docsUrl": "https://fal.ai/dashboard/keys",
+			"testUrl": "https://api.fal.ai/v1/models/usage"
+		}
+	]
 }
 ```
 
@@ -220,16 +220,18 @@ again.
      again.
    - If `verificationReadiness.status === "already_verified"`, treat the
      workflow as verified and do **not** call `verify-built-workflow` again.
-  - If `verificationReadiness.status === "ready"`, call
-    `verify-built-workflow` with the `workflowId`, the `workItemId` when you
-    have it, and the trigger-appropriate `inputData` shape.
-   - If `verificationReadiness.status === "needs_setup"`, call
-     `workflows(action="setup")` with the workflowId so the user can configure it
-     through the inline setup card in the AI Assistant panel.
-   - If `verificationReadiness.status === "not_verifiable"`, do not infer
-     lower-level verification conditions; use the readiness guidance to give a
-     clear warning or manual-test note. This is a warning completion state, not
-     a verified state and not an infinite blocker.
+
+- If `verificationReadiness.status === "ready"`, call
+  `verify-built-workflow` with the `workflowId`, the `workItemId` when you
+  have it, and the trigger-appropriate `inputData` shape.
+- If `verificationReadiness.status === "needs_setup"`, call
+  `workflows(action="setup")` with the workflowId so the user can configure it
+  through the inline setup card in the AI Assistant panel.
+- If `verificationReadiness.status === "not_verifiable"`, do not infer
+  lower-level verification conditions; use the readiness guidance to give a
+  clear warning or manual-test note. This is a warning completion state, not
+  a verified state and not an infinite blocker.
+
 2. Judge coverage, not just status. A `verify-built-workflow` result with
    `success: true` but a non-empty `nodesNotReached` is **partial** evidence:
    the execution ended early (see `lastNodeExecuted` and `coverageNote`) and
@@ -268,16 +270,24 @@ again.
    when the latest verification evidence used mocks or simulations. If this
    follow-up is due, ask only whether the user wants the live test. Do not
    mention publishing or ask about the error workflow in the same response.
-7. If testing has not already been offered or completed, ask whether the user
+7. Before your final summary, scan the **whole conversation** for live runs that
+   already wrote test data into an external system — earlier turns included, not
+   just this one. For each such record still sitting there, follow
+   [Cleaning up after a live test](#cleaning-up-after-a-live-test): name it and
+   offer to remove it. This is about data that **already exists** — a promise to
+   clean up after some future run does not discharge it, and neither does the
+   user's silence. If a later run failed, that says nothing about records an
+   earlier successful run left behind; they are still there.
+8. If testing has not already been offered or completed, ask whether the user
    wants to test the workflow. Skip this if `verify-built-workflow` already
    proved it works end-to-end with full coverage.
-8. Only call `workflows(action="publish")` when the user explicitly asks to
+9. Only call `workflows(action="publish")` when the user explicitly asks to
    publish. Never publish automatically or proactively offer publishing before
    the publish-readiness requirement above is met.
-9. After a direct new primary workflow is successfully published, follow
-   [Error workflow follow-up](#error-workflow-follow-up).
-   Do not replace this explicit opt-in with a generic "add
-   anything else?", publish, or test question.
+10. After a direct new primary workflow is successfully published, follow
+    [Error workflow follow-up](#error-workflow-follow-up).
+    Do not replace this explicit opt-in with a generic "add
+    anything else?", publish, or test question.
 
 ## Error workflow follow-up
 
@@ -356,11 +366,19 @@ A live run against real credentials leaves **real artifacts** — a row in their
 sheet, a message in their channel, a block on their page. Test data you created
 is your mess, not theirs.
 
+This applies to any live run in the conversation, **not only one from this
+turn**. A test record written three turns ago is still on the user's page now,
+and the debt is still yours — carry it forward until it is cleared or the user
+declines. Undertaking to clean up after some _future_ run does not settle a
+record that already exists, and a run that failed afterwards does not remove
+what an earlier successful run wrote.
+
 When a live test, or a verification you seeded data for, wrote/sent/changed
 anything in an external system:
 
-1. **Name what it left behind**, in the same message that reports the run: which
-   record, where, and how to recognise it ("a `[Test] …` to-do at the bottom of
+1. **Name what it left behind**, in the message that reports the run — or, for a
+   record from an earlier turn, in your next response: which record, where, and
+   how to recognise it ("a `[Test] …` to-do at the bottom of
    the toggle"). Read it back from the effect node's output rather than guessing.
 2. **Offer to remove it yourself.** You can delete it the same way you wrote it —
    the target has an API and you can reach it with a workflow. When no node or
@@ -368,7 +386,7 @@ anything in an external system:
    what `one-off-operations` is for. Never present manual deletion as how this
    gets resolved, and never claim you have no way to delete it — "I don't have a
    delete tool for X" is false whenever X has a write API you just used. Noting
-   that the user *could* also remove it by hand is fine only alongside your own
+   that the user _could_ also remove it by hand is fine only alongside your own
    offer.
 3. **Ask before deleting.** Removal is destructive, so it goes through the usual
    approval gate. Never clean up silently — something labelled "test" may still
@@ -380,9 +398,9 @@ anything in an external system:
 If the user declines, note that the item is still there and move on — don't
 re-ask.
 
-**Not every write is test data.** When the live run *was* the point — a one-off
+**Not every write is test data.** When the live run _was_ the point — a one-off
 operation whose whole purpose is the effect (see `one-off-operations`) — what it
-wrote is the deliverable. There you offer to clean up the *workflow*, never the
+wrote is the deliverable. There you offer to clean up the _workflow_, never the
 result.
 
 ## Claiming success
@@ -399,8 +417,8 @@ complete; do not infer correctness from the fact that a node ran. The same
 applies to rows or records written to an external system: never make quantitative
 claims ("22 rows written", "columns matched") that you did not read back from
 the effect node's actual output (`executions(action="get-node-output")`) or from
-the target system itself — a successful run status does not prove the *right
-data* was written, only that nodes ran. If you could not run the
+the target system itself — a successful run status does not prove the _right
+data_ was written, only that nodes ran. If you could not run the
 failing path or inspect the artifact, say so plainly — "I couldn't verify X
 because Y" — and name what is unconfirmed. An honest "could not verify" beats an
 unverified success claim.

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -237,7 +237,9 @@ again.
    - Most common cause: a lookup/query node returned zero items (n8n stops
      downstream nodes on empty item lists). If the dead-end is a Data Table
      lookup, insert a matching test row with `data-tables(action="insert-rows")`,
-     re-run `verify-built-workflow`, and delete the test row afterwards.
+     re-run `verify-built-workflow`, and delete the test row afterwards. The same
+     holds for data you seed anywhere else to unblock a run — it is yours to
+     remove once the run is done (see "Cleaning up after a live test").
    - If you cannot seed the data source, report honestly: name which nodes
      were verified and which were not, and tell the user the unreached part
      needs a manual test. Do not start a live `executions(action="run")`
@@ -347,6 +349,41 @@ verification. If the live test fails, treat the workflow as unresolved and do
 not offer publishing. If the user declines or defers, state what remains
 untested, do not claim live end-to-end verification, and do not offer
 publishing.
+
+## Cleaning up after a live test
+
+A live run against real credentials leaves **real artifacts** — a row in their
+sheet, a message in their channel, a block on their page. Test data you created
+is your mess, not theirs.
+
+When a live test, or a verification you seeded data for, wrote/sent/changed
+anything in an external system:
+
+1. **Name what it left behind**, in the same message that reports the run: which
+   record, where, and how to recognise it ("a `[Test] …` to-do at the bottom of
+   the toggle"). Read it back from the effect node's output rather than guessing.
+2. **Offer to remove it yourself.** You can delete it the same way you wrote it —
+   the target has an API and you can reach it with a workflow. When no node or
+   tool does it directly, build a **one-off cleanup workflow**; that is exactly
+   what `one-off-operations` is for. Never present manual deletion as how this
+   gets resolved, and never claim you have no way to delete it — "I don't have a
+   delete tool for X" is false whenever X has a write API you just used. Noting
+   that the user *could* also remove it by hand is fine only alongside your own
+   offer.
+3. **Ask before deleting.** Removal is destructive, so it goes through the usual
+   approval gate. Never clean up silently — something labelled "test" may still
+   be data the user wants.
+4. **Don't stack test data.** Do not offer another live run against the same
+   target while an earlier test artifact is still sitting there. Clear it first,
+   or say plainly that the next run will add a second one.
+
+If the user declines, note that the item is still there and move on — don't
+re-ask.
+
+**Not every write is test data.** When the live run *was* the point — a one-off
+operation whose whole purpose is the effect (see `one-off-operations`) — what it
+wrote is the deliverable. There you offer to clean up the *workflow*, never the
+result.
 
 ## Claiming success
 


### PR DESCRIPTION
## Summary

When the assistant runs a live test of a workflow, that run writes real records into the user's external systems — a row in a sheet, a message in a channel, a block on a Notion page. The assistant left that test data behind and made it the user's problem.

Two examples from real threads:

> One cleanup note: the earlier buggy run left a stray `[Test] (auto-added)` at the very end of the toggle. **You'll probably want to delete that one manually — this workflow won't touch it.**

> **I don't have an ad-hoc Notion delete tool**, so the quickest fix is for you to delete that one toggle block directly in Notion.

The second statement is not true. The assistant had just built an HTTP Request node that calls the Notion API, so it could reach the delete endpoint the same way. The `one-off-operations` skill exists to build a throwaway workflow for exactly this kind of one-time effect.

The cause is a gap in the prompt. Only one cleanup rule existed, and it applied to Data Table rows during verification. The `Offer cleanup` step in `one-off-operations` refers to deleting the workflow, not the data the workflow wrote. Nothing told the assistant to clean up what a live run left behind.

This PR adds a `Cleaning up after a live test` section to `post-build-flow` and puts cleanup into the enumerated follow-up checklist as step 7. The rules are:

1. Name what the run left behind.
2. Offer to remove it yourself. Build a one-off cleanup workflow if no tool does it directly. Do not present manual deletion as the resolution. Do not claim you cannot delete it.
3. Ask before deleting. Removal is destructive.
4. Do not offer another live run against the same target while an earlier test artifact is still there.

The rule is written around data that **already exists**. A first version of this change phrased it inside a forward-looking flow, and the assistant then applied it prospectively — promising to clean up after a hypothetical future run while the record already on the page went unmentioned. The wording now says to scan the whole conversation, that a promise about a future run does not discharge an existing record, and that a later failed run does not remove what an earlier successful run wrote.

There is a carve-out. For a one-off operation the written data is the deliverable, so the assistant must not offer to undo it. Step 5 of `one-off-operations` is retitled to `Offer to clean up the workflow` to make that clear.

Rule 4 is not in the ticket. It was added after a calibration run showed the assistant offering a second live run against the same page while the first test item was still unmentioned.

The change is prompt text only. No code changes.

## How to test

The behaviour is measured by lang-tracer case **602** (`offers-to-clean-up-test-data-it-left`) in the `baseline` suite, filed as `capability_gap`. The case seeds a thread where a workflow was built, a live test ran against a real Notion page, and a `[Test] Topic from n8n` to-do is now sitting on it. The live turn reports only a placement bug and never mentions the test item, so the assistant has to raise it unprompted.

```bash
cd packages/@n8n/instance-ai
pnpm eval:instance-ai --source langtracer --suite baseline \
  --filter offers-to-clean-up-test-data-it-left --iterations 5
```

Requires `N8N_ENABLED_MODULES=instance-ai`, a configured sandbox, and `LANGTRACER_URL` + `LANGTRACER_API_KEY` in the environment.

**Paired measurement**, two instances, same case, same model, N=5 per arm:

| | clean runs | expectation trials |
|---|---|---|
| before (`origin/master`) | **0/5** | 5/15 |
| after (this PR) | **4/5** | 13/15 |

The before arm is deterministic: both cleanup expectations fail in all five runs. The `after` anchor outcome expectation passes in every run of **both** arms, so the build is correct throughout and the delta is behavioural rather than a build-quality artifact.

**This is an improvement, not a guarantee.** One run in five still misses, and N=5 is a single sample of a stochastic behaviour. The honest claim is that a behaviour which was reliably absent is now usually present. Case 602 should stay `capability_gap` and accumulate real pass-rate data in nightly before anyone considers promoting it to a gated tier.

To check it by hand, ask the assistant to build a workflow that writes to an external system, ask it to run a live test, and then ask for an unrelated change. It should raise the test record it created and offer to remove it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-874

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI