### PR TITLE
feat(core): Add pure node-id heal function for published workflow versions (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
@@ -57,7 +57,21 @@ describe('healNodeIds', () => {
 			expect(healed.id).toMatch(/^[0-9a-f-]{36}$/);
 		}
 		expect(result.nodes[0].id).not.toBe(result.nodes[1].id);
-		expect(result.report.filled.map(({ name }) => name)).toEqual(['Empty', 'Missing']);
+		expect(result.report.filled).toEqual([
+			{ name: 'Empty', newId: result.nodes[0].id },
+			{ name: 'Missing', newId: result.nodes[1].id },
+		]);
+		expectStable(result.nodes);
+	});
+
+	it('fills same-named nodes without ids instead of collapsing them', () => {
+		const nodes = [node({ id: '', name: 'Twin' }), node({ id: '', name: 'Twin' })];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes).toHaveLength(2);
+		expect(result.nodes[0].id).not.toBe(result.nodes[1].id);
+		expect(result.report.dropped).toEqual([]);
 		expectStable(result.nodes);
 	});
 
@@ -88,7 +102,10 @@ describe('healNodeIds', () => {
 	});
 
 	it('keeps a shared id on the first sharer when several are trigger-like', () => {
+		// The non-trigger comes first so this is distinguishable from "any
+		// trigger-like sharer wins".
 		const nodes = [
+			node({ id: 'shared', name: 'Set' }),
 			trigger({ id: 'shared', name: 'Trigger A' }),
 			trigger({ id: 'shared', name: 'Trigger B' }),
 		];
@@ -97,6 +114,8 @@ describe('healNodeIds', () => {
 
 		expect(result.nodes[0]).toBe(nodes[0]);
 		expect(result.nodes[1].id).not.toBe('shared');
+		expect(result.nodes[2].id).not.toBe('shared');
+		expect(result.nodes[1].id).not.toBe(result.nodes[2].id);
 		expectStable(result.nodes);
 	});
 
@@ -138,18 +157,44 @@ describe('healNodeIds', () => {
 		expectStable(result.nodes);
 	});
 
-	it('never orphans an id that was referenced before healing', () => {
+	it('keeps a referenced id alive through combined drops and reassignments', () => {
 		// nodeGroups.nodeIds, poller_state rows and processed_data contexts key on
-		// the shared id: after healing it must still resolve to exactly one node.
+		// the shared id: after healing it must still resolve to exactly one node,
+		// even when the first occurrence is a dropped same-name duplicate.
 		const nodes = [
-			node({ id: 'shared', name: 'Set' }),
-			trigger({ id: 'shared', name: 'Trigger' }),
-			node({ id: '', name: 'Empty' }),
+			node({ id: 'shared', name: 'Twin', parameters: { generation: 1 } }),
+			node({ id: 'shared', name: 'Twin', parameters: { generation: 2 } }),
+			node({ id: 'shared', name: 'Twin', parameters: { generation: 3 } }),
+			node({ id: 'shared', name: 'Other A' }),
+			node({ id: 'shared', name: 'Other B' }),
 		];
+		const inputSnapshot = structuredClone(nodes);
 
 		const result = expectChanged(heal(nodes));
 
-		expect(result.nodes.filter(({ id }) => id === 'shared')).toHaveLength(1);
+		expect(result.nodes.map(({ name }) => name)).toEqual(['Twin', 'Other A', 'Other B']);
+		// No trigger-like sharer, so the first surviving occurrence keeps the id.
+		expect(result.nodes[0].parameters).toEqual({ generation: 3 });
+		expect(result.nodes[0].id).toBe('shared');
+		expect(result.nodes[1].id).not.toBe('shared');
+		expect(result.nodes[2].id).not.toBe('shared');
+		expect(result.nodes[1].id).not.toBe(result.nodes[2].id);
+		expect(result.report.dropped).toEqual([
+			{ name: 'Twin', id: 'shared' },
+			{ name: 'Twin', id: 'shared' },
+		]);
+		// The input array and its nodes are untouched.
+		expect(nodes).toEqual(inputSnapshot);
+		expectStable(result.nodes);
+	});
+
+	it('counts the same node object at two positions as two occurrences', () => {
+		const twin = node({ id: 'shared', name: 'Twin' });
+
+		const result = expectChanged(heal([twin, twin]));
+
+		expect(result.nodes).toEqual([twin]);
+		expect(result.report.dropped).toEqual([{ name: 'Twin', id: 'shared' }]);
 		expectStable(result.nodes);
 	});
 
@@ -164,7 +209,6 @@ describe('healNodeIds', () => {
 
 		const result = expectChanged(heal(nodes));
 
-		expect(result.nodes).toHaveLength(4);
 		expect(result.nodes.map(({ name }) => name)).toEqual([
 			'Trigger A',
 			'Set A',

--- a/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
@@ -1,0 +1,179 @@
+import type { INode } from 'n8n-workflow';
+
+import type { HealNodeIdsResult } from '../heal-node-ids';
+import { healNodeIds } from '../heal-node-ids';
+
+const node = (overrides: Partial<INode>): INode => ({
+	id: 'some-id',
+	name: 'Some Node',
+	type: 'n8n-nodes-base.set',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters: {},
+	...overrides,
+});
+
+const trigger = (overrides: Partial<INode>): INode =>
+	node({ type: 'n8n-nodes-base.scheduleTrigger', ...overrides });
+
+const sticky = (overrides: Partial<INode>): INode =>
+	node({ type: 'n8n-nodes-base.stickyNote', ...overrides });
+
+const isTriggerLike = (n: INode) => n.type.toLowerCase().includes('trigger');
+
+const heal = (nodes: INode[]) => healNodeIds(nodes, { isTriggerLike });
+
+const expectChanged = (result: HealNodeIdsResult) => {
+	expect(result.changed).toBe(true);
+	if (!result.changed) throw new Error('unreachable');
+	return result;
+};
+
+/** Healing a healed output must be a byte-identical no-op. */
+const expectStable = (healedNodes: INode[]) => {
+	expect(heal(healedNodes)).toEqual({ changed: false });
+};
+
+describe('healNodeIds', () => {
+	it('returns changed: false for nodes with unique, non-empty ids', () => {
+		const nodes = [trigger({ id: 'a', name: 'Trigger' }), node({ id: 'b', name: 'Set' })];
+
+		expect(heal(nodes)).toEqual({ changed: false });
+	});
+
+	it('leaves same-name nodes with distinct ids alone', () => {
+		const nodes = [node({ id: 'a', name: 'Twin' }), node({ id: 'b', name: 'Twin' })];
+
+		expect(heal(nodes)).toEqual({ changed: false });
+	});
+
+	it('fills missing and empty ids with fresh uuids', () => {
+		const nodes = [node({ id: '', name: 'Empty' }), node({ id: undefined, name: 'Missing' })];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes).toHaveLength(2);
+		for (const healed of result.nodes) {
+			expect(healed.id).toMatch(/^[0-9a-f-]{36}$/);
+		}
+		expect(result.nodes[0].id).not.toBe(result.nodes[1].id);
+		expect(result.report.filled.map(({ name }) => name)).toEqual(['Empty', 'Missing']);
+		expectStable(result.nodes);
+	});
+
+	it('keeps a shared id on the trigger-like node when exactly one sharer is trigger-like', () => {
+		const nodes = [node({ id: 'shared', name: 'Set' }), trigger({ id: 'shared', name: 'Trigger' })];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes[1]).toBe(nodes[1]);
+		expect(result.nodes[0].id).not.toBe('shared');
+		expect(result.report.reassigned).toEqual([
+			{ name: 'Set', oldId: 'shared', newId: result.nodes[0].id },
+		]);
+		expectStable(result.nodes);
+	});
+
+	it('keeps a shared id on the first sharer when none is trigger-like', () => {
+		const nodes = [
+			sticky({ id: 'shared', name: 'Note A' }),
+			sticky({ id: 'shared', name: 'Note B' }),
+		];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes[0]).toBe(nodes[0]);
+		expect(result.nodes[1].id).not.toBe('shared');
+		expectStable(result.nodes);
+	});
+
+	it('keeps a shared id on the first sharer when several are trigger-like', () => {
+		const nodes = [
+			trigger({ id: 'shared', name: 'Trigger A' }),
+			trigger({ id: 'shared', name: 'Trigger B' }),
+		];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes[0]).toBe(nodes[0]);
+		expect(result.nodes[1].id).not.toBe('shared');
+		expectStable(result.nodes);
+	});
+
+	it('drops exact same-name duplicates, keeping the last occurrence', () => {
+		// Last-write-wins matches the runtime's name-keyed node map, so the healed
+		// workflow executes the same node the unhealed one did.
+		const nodes = [
+			node({ id: 'shared', name: 'Twin', parameters: { generation: 1 } }),
+			node({ id: 'shared', name: 'Twin', parameters: { generation: 2 } }),
+		];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes).toEqual([nodes[1]]);
+		expect(result.report.dropped).toEqual([{ name: 'Twin', id: 'shared' }]);
+		expect(result.report.reassigned).toEqual([]);
+		expectStable(result.nodes);
+	});
+
+	it('handles a group of same-name and distinct-name sharers together', () => {
+		const nodes = [
+			node({ id: 'shared', name: 'Twin', parameters: { generation: 1 } }),
+			trigger({ id: 'shared', name: 'Trigger' }),
+			node({ id: 'shared', name: 'Twin', parameters: { generation: 2 } }),
+		];
+
+		const result = expectChanged(heal(nodes));
+
+		// Twin collapses to its last occurrence, the sole trigger keeps the id.
+		expect(result.nodes).toHaveLength(2);
+		expect(result.nodes[0]).toBe(nodes[1]);
+		expect(result.nodes[1].name).toBe('Twin');
+		expect(result.nodes[1].parameters).toEqual({ generation: 2 });
+		expect(result.nodes[1].id).not.toBe('shared');
+		expect(result.report.dropped).toEqual([{ name: 'Twin', id: 'shared' }]);
+		expect(result.report.reassigned).toEqual([
+			{ name: 'Twin', oldId: 'shared', newId: result.nodes[1].id },
+		]);
+		expectStable(result.nodes);
+	});
+
+	it('never orphans an id that was referenced before healing', () => {
+		// nodeGroups.nodeIds, poller_state rows and processed_data contexts key on
+		// the shared id: after healing it must still resolve to exactly one node.
+		const nodes = [
+			node({ id: 'shared', name: 'Set' }),
+			trigger({ id: 'shared', name: 'Trigger' }),
+			node({ id: '', name: 'Empty' }),
+		];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes.filter(({ id }) => id === 'shared')).toHaveLength(1);
+		expectStable(result.nodes);
+	});
+
+	it('heals multiple independent id groups in one pass', () => {
+		const nodes = [
+			trigger({ id: 'a', name: 'Trigger A' }),
+			node({ id: 'a', name: 'Set A' }),
+			sticky({ id: 'b', name: 'Note' }),
+			sticky({ id: 'b', name: 'Note' }),
+			node({ id: 'c', name: 'Untouched' }),
+		];
+
+		const result = expectChanged(heal(nodes));
+
+		expect(result.nodes).toHaveLength(4);
+		expect(result.nodes.map(({ name }) => name)).toEqual([
+			'Trigger A',
+			'Set A',
+			'Note',
+			'Untouched',
+		]);
+		expect(new Set(result.nodes.map(({ id }) => id)).size).toBe(4);
+		// Untouched nodes come through by reference, not as copies.
+		expect(result.nodes[3]).toBe(nodes[4]);
+		expectStable(result.nodes);
+	});
+});

--- a/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
@@ -76,6 +76,7 @@ describe('healNodeIds', () => {
 		expect(result.nodes.map(({ name }) => name)).toEqual(['Twin', 'Other']);
 		expect(result.nodes[0].parameters).toEqual({ generation: 2 });
 		expect(result.report.dropped).toEqual([{ name: 'Twin', id: '' }]);
+		expect(result.report.reassigned).toEqual([]);
 		expect(result.report.filled).toEqual([
 			{ name: 'Twin', newId: result.nodes[0].id },
 			{ name: 'Other', newId: result.nodes[1].id },

--- a/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/heal-node-ids.test.ts
@@ -64,14 +64,22 @@ describe('healNodeIds', () => {
 		expectStable(result.nodes);
 	});
 
-	it('fills same-named nodes without ids instead of collapsing them', () => {
-		const nodes = [node({ id: '', name: 'Twin' }), node({ id: '', name: 'Twin' })];
+	it('collapses same-named nodes without ids to the last occurrence, then fills it', () => {
+		const nodes = [
+			node({ id: '', name: 'Twin', parameters: { generation: 1 } }),
+			node({ id: '', name: 'Twin', parameters: { generation: 2 } }),
+			node({ id: undefined, name: 'Other' }),
+		];
 
 		const result = expectChanged(heal(nodes));
 
-		expect(result.nodes).toHaveLength(2);
-		expect(result.nodes[0].id).not.toBe(result.nodes[1].id);
-		expect(result.report.dropped).toEqual([]);
+		expect(result.nodes.map(({ name }) => name)).toEqual(['Twin', 'Other']);
+		expect(result.nodes[0].parameters).toEqual({ generation: 2 });
+		expect(result.report.dropped).toEqual([{ name: 'Twin', id: '' }]);
+		expect(result.report.filled).toEqual([
+			{ name: 'Twin', newId: result.nodes[0].id },
+			{ name: 'Other', newId: result.nodes[1].id },
+		]);
 		expectStable(result.nodes);
 	});
 

--- a/packages/cli/src/workflows/publication/heal-node-ids.ts
+++ b/packages/cli/src/workflows/publication/heal-node-ids.ts
@@ -18,21 +18,32 @@ export type HealNodeIdsResult =
  * Returns a corrected copy of `nodes` in which every node has a unique,
  * non-empty id, or `{ changed: false }` when the input needs no correction.
  *
- * - Nodes sharing a name and an id — or sharing a name and both lacking an id
- *   — are collapsed to the last occurrence: the one the runtime's name-keyed
- *   node map executes. Giving each its own id instead would leave the
- *   duplicate name in place, which structure validation rejects on the next
- *   save, while the extra node stays dead at runtime. Connections are
- *   name-keyed, so the survivor keeps them.
- * - After the collapse, a missing or empty id is filled with a fresh uuid.
- * - Nodes sharing an id under distinct names keep the id on one of them — the
- *   trigger-like node when exactly one sharer is trigger-like, else the first
- *   — and the rest get fresh uuids. Keeping the contested id alive preserves
- *   what is keyed on it elsewhere: `nodeGroups.nodeIds` references,
- *   `poller_state` rows, and `processed_data` dedup contexts.
+ * Case by case — letters are node names, brackets hold the id, `-` means no id:
  *
- * Same-name nodes with *distinct* ids are left alone: that is a name defect,
- * not an id defect, and it is owned by structure validation.
+ * 1. Missing or empty id:
+ *    `[A(-)]` → `[A(new)]`
+ *    Filled with a fresh uuid.
+ *
+ * 2. Same name, same id — or same name, both without an id:
+ *    `[A(x), A(x)]` → `[A(x)]`, `[A(-), A(-)]` → `[A(new)]`
+ *    Collapsed to the last occurrence: the runtime's node map is name-keyed
+ *    and last-write-wins, so that is the node that executed before healing —
+ *    behavior is unchanged, and connections (also name-keyed) stay on the
+ *    survivor. Giving each its own id instead would keep the duplicate name,
+ *    which structure validation rejects on the next save, while the extra
+ *    node stays dead at runtime.
+ *
+ * 3. Distinct names, same id:
+ *    `[A(x), B(x)]` → `[A(x), B(new)]`
+ *    `[A(x), T(x)]` → `[A(new), T(x)]` when T is the only trigger-like sharer
+ *    Exactly one node keeps the contested id — the trigger-like sharer if
+ *    there is exactly one, else the first — because other subsystems key on
+ *    it: `nodeGroups.nodeIds` references, `poller_state` rows, and
+ *    `processed_data` dedup contexts. The rest get fresh uuids.
+ *
+ * 4. Same name, distinct real ids:
+ *    `[A(x), A(y)]` → unchanged
+ *    A name defect, not an id defect — owned by structure validation.
  *
  * Healing a healed output is a no-op (`{ changed: false }`). This matters
  * because the caller publishes the corrected copy, and that publish enqueues

--- a/packages/cli/src/workflows/publication/heal-node-ids.ts
+++ b/packages/cli/src/workflows/publication/heal-node-ids.ts
@@ -1,0 +1,103 @@
+import type { INode } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
+
+export interface HealNodeIdsReport {
+	/** Nodes that had no id and received a fresh one. */
+	filled: Array<{ name: string; newId: string }>;
+	/** Nodes that shared their id with another node and received a fresh one. */
+	reassigned: Array<{ name: string; oldId: string; newId: string }>;
+	/** Exact same-name duplicates removed in favor of their last occurrence. */
+	dropped: Array<{ name: string; id: string }>;
+}
+
+export type HealNodeIdsResult =
+	| { changed: false }
+	| { changed: true; nodes: INode[]; report: HealNodeIdsReport };
+
+/**
+ * Returns a corrected copy of `nodes` in which every node has a unique,
+ * non-empty id, or `{ changed: false }` when the input needs no correction.
+ *
+ * - A missing or empty id is filled with a fresh uuid.
+ * - Nodes sharing an id *and* a name are collapsed to the last occurrence —
+ *   the one the runtime's name-keyed node map executes. Re-idding them instead
+ *   would leave the duplicate name in place, which structure validation
+ *   rejects on the next save. Connections are name-keyed, so the survivor
+ *   keeps them.
+ * - Nodes sharing an id under distinct names keep the id on one of them — the
+ *   trigger-like node when exactly one sharer is trigger-like, else the first
+ *   — and the rest get fresh uuids. Keeping the contested id alive preserves
+ *   what is keyed on it elsewhere: `nodeGroups.nodeIds` references,
+ *   `poller_state` rows, and `processed_data` dedup contexts.
+ *
+ * Same-name nodes with *distinct* ids are left alone: that is a name defect,
+ * not an id defect, and it is owned by structure validation.
+ *
+ * Healing a healed output is a no-op (`changed: false`). Callers publish the
+ * corrected copy and re-encounter it on the next activation, so a heal that
+ * kept minting ids would publish forever.
+ */
+export function healNodeIds(
+	nodes: INode[],
+	{ isTriggerLike }: { isTriggerLike: (node: INode) => boolean },
+): HealNodeIdsResult {
+	const report: HealNodeIdsReport = { filled: [], reassigned: [], dropped: [] };
+
+	const byId = new Map<string, INode[]>();
+	for (const node of nodes) {
+		if (!node.id) continue;
+		const group = byId.get(node.id);
+		if (group === undefined) {
+			byId.set(node.id, [node]);
+		} else {
+			group.push(node);
+		}
+	}
+
+	const dropped = new Set<INode>();
+	const newIds = new Map<INode, string>();
+
+	for (const [id, group] of byId) {
+		if (group.length < 2) continue;
+
+		const lastByName = new Map<string, INode>();
+		for (const node of group) lastByName.set(node.name, node);
+		for (const node of group) {
+			if (lastByName.get(node.name) !== node) {
+				dropped.add(node);
+				report.dropped.push({ name: node.name, id });
+			}
+		}
+
+		const sharers = group.filter((node) => !dropped.has(node));
+		if (sharers.length < 2) continue;
+
+		const triggerLike = sharers.filter(isTriggerLike);
+		const keeper = triggerLike.length === 1 ? triggerLike[0] : sharers[0];
+		for (const node of sharers) {
+			if (node === keeper) continue;
+			const newId = uuid();
+			newIds.set(node, newId);
+			report.reassigned.push({ name: node.name, oldId: id, newId });
+		}
+	}
+
+	for (const node of nodes) {
+		if (!node.id) {
+			const newId = uuid();
+			newIds.set(node, newId);
+			report.filled.push({ name: node.name, newId });
+		}
+	}
+
+	if (dropped.size === 0 && newIds.size === 0) return { changed: false };
+
+	const healed = nodes
+		.filter((node) => !dropped.has(node))
+		.map((node) => {
+			const newId = newIds.get(node);
+			return newId === undefined ? node : { ...node, id: newId };
+		});
+
+	return { changed: true, nodes: healed, report };
+}

--- a/packages/cli/src/workflows/publication/heal-node-ids.ts
+++ b/packages/cli/src/workflows/publication/heal-node-ids.ts
@@ -18,14 +18,13 @@ export type HealNodeIdsResult =
  * Returns a corrected copy of `nodes` in which every node has a unique,
  * non-empty id, or `{ changed: false }` when the input needs no correction.
  *
- * - A missing or empty id is filled with a fresh uuid. Two same-named nodes
- *   without ids both get fresh ids (they never shared one, so there is no
- *   occurrence to collapse) and land in the same-name/distinct-id bucket below.
- * - Nodes sharing an id *and* a name are collapsed to the last occurrence —
- *   the one the runtime's name-keyed node map executes. Re-idding them instead
- *   would leave the duplicate name in place, which structure validation
- *   rejects on the next save. Connections are name-keyed, so the survivor
- *   keeps them.
+ * - Nodes sharing a name and an id — or sharing a name and both lacking an id
+ *   — are collapsed to the last occurrence: the one the runtime's name-keyed
+ *   node map executes. Giving each its own id instead would leave the
+ *   duplicate name in place, which structure validation rejects on the next
+ *   save, while the extra node stays dead at runtime. Connections are
+ *   name-keyed, so the survivor keeps them.
+ * - After the collapse, a missing or empty id is filled with a fresh uuid.
  * - Nodes sharing an id under distinct names keep the id on one of them — the
  *   trigger-like node when exactly one sharer is trigger-like, else the first
  *   — and the rest get fresh uuids. Keeping the contested id alive preserves
@@ -35,9 +34,11 @@ export type HealNodeIdsResult =
  * Same-name nodes with *distinct* ids are left alone: that is a name defect,
  * not an id defect, and it is owned by structure validation.
  *
- * Healing a healed output is a no-op (`{ changed: false }`). Callers publish
- * the corrected copy and re-encounter it on the next activation, so a heal
- * that kept minting ids would publish forever.
+ * Healing a healed output is a no-op (`{ changed: false }`). This matters
+ * because the caller publishes the corrected copy, and that publish enqueues
+ * another activation — which runs the healer again, on its own output. If
+ * that second pass changed anything (say, because the healer minted fresh
+ * uuids on every call), every heal would trigger another publish, forever.
  */
 export function healNodeIds(
 	nodes: INode[],
@@ -46,13 +47,14 @@ export function healNodeIds(
 	const report: HealNodeIdsReport = { filled: [], reassigned: [], dropped: [] };
 
 	// All bookkeeping is by array index, not node reference: one object
-	// appearing at two positions must count as two occurrences.
+	// appearing at two positions must count as two occurrences. Nodes without
+	// an id are grouped under '' so the same-name collapse applies to them too.
 	const byId = new Map<string, number[]>();
 	nodes.forEach((node, index) => {
-		if (!node.id) return;
-		const group = byId.get(node.id);
+		const key = node.id || '';
+		const group = byId.get(key);
 		if (group === undefined) {
-			byId.set(node.id, [index]);
+			byId.set(key, [index]);
 		} else {
 			group.push(index);
 		}
@@ -73,6 +75,9 @@ export function healNodeIds(
 			}
 		}
 
+		// The id-less group has no shared id to keep; its survivors are filled below.
+		if (id === '') continue;
+
 		const sharers = group.filter((index) => !dropped.has(index));
 		if (sharers.length < 2) continue;
 
@@ -87,7 +92,7 @@ export function healNodeIds(
 	}
 
 	nodes.forEach((node, index) => {
-		if (!node.id) {
+		if (!node.id && !dropped.has(index)) {
 			const newId = uuid();
 			newIds.set(index, newId);
 			report.filled.push({ name: node.name, newId });

--- a/packages/cli/src/workflows/publication/heal-node-ids.ts
+++ b/packages/cli/src/workflows/publication/heal-node-ids.ts
@@ -18,7 +18,9 @@ export type HealNodeIdsResult =
  * Returns a corrected copy of `nodes` in which every node has a unique,
  * non-empty id, or `{ changed: false }` when the input needs no correction.
  *
- * - A missing or empty id is filled with a fresh uuid.
+ * - A missing or empty id is filled with a fresh uuid. Two same-named nodes
+ *   without ids both get fresh ids (they never shared one, so there is no
+ *   occurrence to collapse) and land in the same-name/distinct-id bucket below.
  * - Nodes sharing an id *and* a name are collapsed to the last occurrence —
  *   the one the runtime's name-keyed node map executes. Re-idding them instead
  *   would leave the duplicate name in place, which structure validation
@@ -33,9 +35,9 @@ export type HealNodeIdsResult =
  * Same-name nodes with *distinct* ids are left alone: that is a name defect,
  * not an id defect, and it is owned by structure validation.
  *
- * Healing a healed output is a no-op (`changed: false`). Callers publish the
- * corrected copy and re-encounter it on the next activation, so a heal that
- * kept minting ids would publish forever.
+ * Healing a healed output is a no-op (`{ changed: false }`). Callers publish
+ * the corrected copy and re-encounter it on the next activation, so a heal
+ * that kept minting ids would publish forever.
  */
 export function healNodeIds(
 	nodes: INode[],
@@ -43,61 +45,63 @@ export function healNodeIds(
 ): HealNodeIdsResult {
 	const report: HealNodeIdsReport = { filled: [], reassigned: [], dropped: [] };
 
-	const byId = new Map<string, INode[]>();
-	for (const node of nodes) {
-		if (!node.id) continue;
+	// All bookkeeping is by array index, not node reference: one object
+	// appearing at two positions must count as two occurrences.
+	const byId = new Map<string, number[]>();
+	nodes.forEach((node, index) => {
+		if (!node.id) return;
 		const group = byId.get(node.id);
 		if (group === undefined) {
-			byId.set(node.id, [node]);
+			byId.set(node.id, [index]);
 		} else {
-			group.push(node);
+			group.push(index);
 		}
-	}
+	});
 
-	const dropped = new Set<INode>();
-	const newIds = new Map<INode, string>();
+	const dropped = new Set<number>();
+	const newIds = new Map<number, string>();
 
 	for (const [id, group] of byId) {
 		if (group.length < 2) continue;
 
-		const lastByName = new Map<string, INode>();
-		for (const node of group) lastByName.set(node.name, node);
-		for (const node of group) {
-			if (lastByName.get(node.name) !== node) {
-				dropped.add(node);
-				report.dropped.push({ name: node.name, id });
+		const lastByName = new Map<string, number>();
+		for (const index of group) lastByName.set(nodes[index].name, index);
+		for (const index of group) {
+			if (lastByName.get(nodes[index].name) !== index) {
+				dropped.add(index);
+				report.dropped.push({ name: nodes[index].name, id });
 			}
 		}
 
-		const sharers = group.filter((node) => !dropped.has(node));
+		const sharers = group.filter((index) => !dropped.has(index));
 		if (sharers.length < 2) continue;
 
-		const triggerLike = sharers.filter(isTriggerLike);
+		const triggerLike = sharers.filter((index) => isTriggerLike(nodes[index]));
 		const keeper = triggerLike.length === 1 ? triggerLike[0] : sharers[0];
-		for (const node of sharers) {
-			if (node === keeper) continue;
+		for (const index of sharers) {
+			if (index === keeper) continue;
 			const newId = uuid();
-			newIds.set(node, newId);
-			report.reassigned.push({ name: node.name, oldId: id, newId });
+			newIds.set(index, newId);
+			report.reassigned.push({ name: nodes[index].name, oldId: id, newId });
 		}
 	}
 
-	for (const node of nodes) {
+	nodes.forEach((node, index) => {
 		if (!node.id) {
 			const newId = uuid();
-			newIds.set(node, newId);
+			newIds.set(index, newId);
 			report.filled.push({ name: node.name, newId });
 		}
-	}
+	});
 
 	if (dropped.size === 0 && newIds.size === 0) return { changed: false };
 
-	const healed = nodes
-		.filter((node) => !dropped.has(node))
-		.map((node) => {
-			const newId = newIds.get(node);
-			return newId === undefined ? node : { ...node, id: newId };
-		});
+	const healed: INode[] = [];
+	nodes.forEach((node, index) => {
+		if (dropped.has(index)) return;
+		const newId = newIds.get(index);
+		healed.push(newId === undefined ? node : { ...node, id: newId });
+	});
 
 	return { changed: true, nodes: healed, report };
 }


### PR DESCRIPTION
## Summary

Prep PR 1 of 3 for healing duplicate node ids before activation in the workflow publication service.

Workflows with duplicate or missing node ids exist in stored data (node ids were historically optional and unenforced). Under the publication service, per-node state is keyed on `(workflowId, nodeId)` — `workflow_publication_trigger_status`, `poller_state`, durable `scheduled_job` entries — so an active workflow with duplicate ids misbehaves silently.

This PR adds only the pure correction function, `healNodeIds(nodes, { isTriggerLike })`. No wiring, no DB access, nothing calls it yet:

- collapses nodes sharing a name and an id — or sharing a name and both lacking an id — to the last occurrence (what the runtime's name-keyed node map executes); giving each its own id instead would leave the duplicate name in place, which structure validation rejects
- fills missing/empty ids with fresh uuids after the collapse
- for nodes sharing an id under distinct names, keeps the id on one node (the trigger-like one when exactly one sharer is trigger-like, else the first) and re-ids the rest — keeping the contested id alive preserves `nodeGroups.nodeIds` references, `poller_state` rows, and `processed_data` dedup contexts
- healing a healed output is a no-op (`{ changed: false }`) — the caller will publish the corrected copy, and that publish enqueues another activation that runs the healer on its own output, so idempotence is load-bearing, not cosmetic

All bookkeeping is by array index, so the same node object appearing at two positions counts as two occurrences.

Follow-ups: a system-authored publish primitive (PR 2), then wiring into `WorkflowPublicationApplier` and retiring `DurablePollerGateService` (PR 3).

## How to test

```bash
cd packages/cli
pnpm test src/workflows/publication/__tests__/heal-node-ids.test.ts
```

Covers: clean input no-op, missing/empty ids, id-less same-name collapse, trigger-preference and first-sharer id keeping, same-name collapse (last occurrence survives), mixed groups, referenced-id survival under combined drops and reassignments, duplicate object references, input non-mutation, and the idempotence property on every case.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4056

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI