### PR TITLE
fix(editor): Exclude draft channels from telemetry (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/agentTelemetry.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/agentTelemetry.utils.test.ts
@@ -37,6 +37,10 @@ describe('buildAgentConfigFingerprint', () => {
 			},
 		],
 		memory: { enabled: true, storage: 'n8n' },
+		integrations: [
+			{ type: 'slack', credentialId: 'cred-slack' },
+			{ type: 'telegram', credentialId: 'cred-telegram' },
+		],
 	};
 
 	it('produces a 16-char hex config_version and includes the raw instructions', async () => {
@@ -58,6 +62,24 @@ describe('buildAgentConfigFingerprint', () => {
 		const a = await buildAgentConfigFingerprint(baseConfig, ['slack', 'telegram']);
 		const b = await buildAgentConfigFingerprint(baseConfig, ['telegram', 'slack']);
 		expect(a.config_version).toBe(b.config_version);
+	});
+
+	it('excludes draft trigger placeholders while including a newly configured trigger', async () => {
+		const config = {
+			...baseConfig,
+			integrations: [
+				{ type: 'slack' as const, credentialId: '' },
+				{ type: 'telegram' as const, credentialId: 'cred-telegram' },
+			],
+		};
+
+		const fingerprint = await buildAgentConfigFingerprint(
+			config,
+			['slack', 'telegram', 'linear'],
+			['linear'],
+		);
+
+		expect(fingerprint.triggers).toEqual(['linear', 'telegram']);
 	});
 
 	it('returns the same config_version for vector stores in different orders', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/composables/agentTelemetry.utils.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/agentTelemetry.utils.ts
@@ -1,3 +1,5 @@
+import { isDraftIntegration } from '@n8n/api-types';
+
 import type { AgentJsonConfig, AgentJsonToolRef, AgentResource } from '../types';
 
 export type AgentTelemetryStatus = 'draft' | 'production';
@@ -51,12 +53,19 @@ export function taskIdentifiersFromConfig(config: AgentJsonConfig | null): strin
 export async function buildAgentConfigFingerprint(
 	config: AgentJsonConfig | null,
 	connectedTriggers: string[],
+	additionalConfiguredTriggers: string[] = [],
 ): Promise<AgentConfigFingerprint> {
 	const instructions = config?.instructions ?? '';
 	const tools = toolIdentifiersFromConfig(config);
 	const skills = skillIdentifiersFromConfig(config);
 	const tasks = taskIdentifiersFromConfig(config);
-	const triggers = [...connectedTriggers].sort();
+	const configuredTriggers = new Set([
+		...(config?.integrations ?? [])
+			.filter((integration) => !isDraftIntegration(integration))
+			.map((integration) => integration.type),
+		...additionalConfiguredTriggers,
+	]);
+	const triggers = connectedTriggers.filter((trigger) => configuredTriggers.has(trigger)).sort();
 	const vectorStores = (config?.vectorStores ?? [])
 		.map((store) => `${store.provider}:${store.name}`)
 		.sort();

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderTelemetry.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderTelemetry.ts
@@ -67,12 +67,17 @@ export function useAgentBuilderTelemetry(deps: AgentBuilderTelemetryDeps) {
 	function withFingerprint(
 		config: AgentJsonConfig | null,
 		triggers: string[],
-		emit: (configVersion: string) => void,
+		emit: (configVersion: string, configuredTriggers: string[]) => void,
+		additionalConfiguredTriggers: string[] = [],
 	) {
 		void (async () => {
 			try {
-				const fp = await buildAgentConfigFingerprint(config, triggers);
-				emit(fp.config_version);
+				const fp = await buildAgentConfigFingerprint(
+					config,
+					triggers,
+					additionalConfiguredTriggers,
+				);
+				emit(fp.config_version, fp.triggers);
 			} catch {
 				// Swallow — telemetry is best-effort.
 			}
@@ -81,15 +86,20 @@ export function useAgentBuilderTelemetry(deps: AgentBuilderTelemetryDeps) {
 
 	function trackTriggerAdded(payload: { triggerType: string; triggers: string[] }) {
 		const s = snapshot();
-		withFingerprint(s.config, payload.triggers, (configVersion) => {
-			agentTelemetry.trackAddedTrigger({
-				agentId: s.agentId,
-				triggerType: payload.triggerType,
-				triggers: payload.triggers,
-				configVersion,
-				status: s.status,
-			});
-		});
+		withFingerprint(
+			s.config,
+			payload.triggers,
+			(configVersion, configuredTriggers) => {
+				agentTelemetry.trackAddedTrigger({
+					agentId: s.agentId,
+					triggerType: payload.triggerType,
+					triggers: configuredTriggers,
+					configVersion,
+					status: s.status,
+				});
+			},
+			[payload.triggerType],
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Exclude unfinished channel placeholders from agent telemetry trigger lists and config fingerprints.
- Keep configured unpublished channels and newly completed channel setup in telemetry without changing the editor's draft-channel display.

## How to test

Run:

```bash
pnpm test src/features/agents/__tests__/agentTelemetry.utils.test.ts
```

The focused regression test verifies that a draft Slack placeholder is excluded while configured Telegram and a newly completed Linear channel are included.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-556

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` if required.

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

