### PR TITLE
feat(editor): Warn about self-escalation via Manage project roles scope

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2960,6 +2960,7 @@
 	"instanceRoles.description.insights.view": "View instance-level insights",
 	"instanceRoles.warning.manageMembers": "A user with this permission can give themselves or an account they invite permissions they don't currently hold. {link}",
 	"instanceRoles.warning.manageRoles": "A user with this permission can edit their own custom role to add permissions they weren't originally granted. {link}",
+	"instanceRoles.warning.manageProjectRoles": "A user with this permission can edit a custom project role they hold themselves to grant themselves permissions they weren't originally granted in that project. {link}",
 	"instanceRoles.warning.viewDocs": "View docs",
 	"roles.instance.newRole": "New instance role",
 	"roles.instance.editRole": "Custom instance role",

--- a/packages/frontend/editor-ui/src/features/roles/instance/components/ScopeGroupSelector.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/components/ScopeGroupSelector.test.ts
@@ -117,6 +117,13 @@ describe('ScopeGroupSelector', () => {
 			expect(getByTestId('scope-escalation-warning-role')).toBeTruthy();
 		});
 
+		it('renders the project-roles warning when only role:manageProject is selected', () => {
+			const { getByTestId } = renderComponent(ScopeGroupSelector, {
+				props: { modelValue: ['role:read', 'role:manageProject'] },
+			});
+			expect(getByTestId('scope-escalation-warning-role')).toBeTruthy();
+		});
+
 		it('does not render a warning for a non-escalating scope', () => {
 			const { queryByTestId } = renderComponent(ScopeGroupSelector, {
 				props: { modelValue: ['tag:read'] },

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.test.ts
@@ -212,8 +212,16 @@ describe('getEscalationWarningKey', () => {
 		);
 	});
 
-	it('does not warn for "Manage project roles" alone (role:manageProject without role:manage)', () => {
-		expect(getEscalationWarningKey('role', ['role:read', 'role:manageProject'])).toBeUndefined();
+	it('returns the project-roles warning for "Manage project roles" alone (role:manageProject without role:manage)', () => {
+		expect(getEscalationWarningKey('role', ['role:read', 'role:manageProject'])).toBe(
+			'instanceRoles.warning.manageProjectRoles',
+		);
+	});
+
+	it('prefers the roles warning over the project-roles warning when both scopes are present', () => {
+		expect(
+			getEscalationWarningKey('role', ['role:read', 'role:manage', 'role:manageProject']),
+		).toBe('instanceRoles.warning.manageRoles');
 	});
 
 	it('returns undefined for a non-escalating resource', () => {

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
@@ -266,20 +266,32 @@ export function toggleOptionInGroup(
 	return [...next];
 }
 
-/** Resource groups whose scopes enable privilege escalation, with the warning to show. */
+/**
+ * Resource groups whose scopes enable privilege escalation, with the warning to show.
+ * Entries are checked in order; the first matching scope's message wins.
+ */
 export const ESCALATION_WARNING_SCOPES: Partial<
-	Record<InstanceResource, { scopes: Scope[]; messageKey: BaseTextKey }>
+	Record<InstanceResource, Array<{ scopes: Scope[]; messageKey: BaseTextKey }>>
 > = {
-	user: {
-		scopes: [...GLOBAL_CUSTOM_ROLE_SCOPE_GROUPS.user.Manage],
-		messageKey: 'instanceRoles.warning.manageMembers',
-	},
-	role: {
-		// Only full instance-role management ("Manage all roles") enables self-escalation;
-		// managing project roles alone cannot edit the holder's own instance role.
-		scopes: ['role:manage'],
-		messageKey: 'instanceRoles.warning.manageRoles',
-	},
+	user: [
+		{
+			scopes: [...GLOBAL_CUSTOM_ROLE_SCOPE_GROUPS.user.Manage],
+			messageKey: 'instanceRoles.warning.manageMembers',
+		},
+	],
+	role: [
+		{
+			// Full instance-role management: can edit the holder's own instance role.
+			scopes: ['role:manage'],
+			messageKey: 'instanceRoles.warning.manageRoles',
+		},
+		{
+			// Project-role management alone: can edit the scopes of any custom
+			// project role, including one the holder is themselves assigned in a project.
+			scopes: ['role:manageProject'],
+			messageKey: 'instanceRoles.warning.manageProjectRoles',
+		},
+	],
 };
 
 /** Warning i18n key for a resource group given the current scopes, or undefined. */
@@ -287,8 +299,8 @@ export function getEscalationWarningKey(
 	resource: InstanceResource,
 	scopes: readonly string[],
 ): BaseTextKey | undefined {
-	const cfg = ESCALATION_WARNING_SCOPES[resource];
-	return cfg?.scopes.some((s) => scopes.includes(s)) ? cfg.messageKey : undefined;
+	const cfgs = ESCALATION_WARNING_SCOPES[resource];
+	return cfgs?.find((cfg) => cfg.scopes.some((s) => scopes.includes(s)))?.messageKey;
 }
 
 /** Total number of permission options shown in the instance role editor. */


### PR DESCRIPTION
## Summary

Adds a third case to the existing "privilege escalation" warning callout shown in the custom instance role editor (Roles group). A user holding only the **Manage project roles** permission (`role:manageProject`) can already edit the scopes of any project-type custom role, including one they hold themselves in a project — this surfaces that risk in the UI instead of leaving it unflagged, matching the two escalation warnings already shown for **Manage all roles** and **Members: Manage**.

No authorization behavior changes — `role:manageProject` continues to work as designed (an instance-wide delegation intentionally granted by an owner/admin). This is a UI/documentation clarity change only; a companion docs.n8n.io PR adds the same bullet to the public docs page.

## How to test

1. Enable the `CUSTOM_ROLES` enterprise license feature.
2. Go to **Settings > Roles > Instance roles > Create role**.
3. Under **Roles**, check only **Manage project roles** (not **Manage all roles**).
4. Confirm the warning callout now appears under the Roles group, explaining that this permission can edit the scopes of any project-type custom role, including one the holder is themselves assigned.
5. Check only **Manage all roles** instead — confirm the existing (unchanged) warning for that case still shows, and takes priority if both scopes happen to be present.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1237

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

