### PR TITLE
feat(Microsoft SharePoint Node): Register version 2 and make it the default

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/MicrosoftSharePoint.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/MicrosoftSharePoint.node.ts
@@ -2,8 +2,7 @@ import type { INodeTypeBaseDescription, IVersionedNodeType } from 'n8n-workflow'
 import { VersionedNodeType } from 'n8n-workflow';
 
 import { MicrosoftSharePointV1 } from './v1/MicrosoftSharePointV1.node';
-// Uncomment along with the v2 registration below to test v2 locally.
-// import { MicrosoftSharePointV2 } from './v2/MicrosoftSharePointV2.node';
+import { MicrosoftSharePointV2 } from './v2/MicrosoftSharePointV2.node';
 
 export class MicrosoftSharePoint extends VersionedNodeType {
 	constructor() {
@@ -16,16 +15,12 @@ export class MicrosoftSharePoint extends VersionedNodeType {
 			},
 			group: ['transform'],
 			description: 'Interact with Microsoft SharePoint API',
-			defaultVersion: 1,
+			defaultVersion: 2,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new MicrosoftSharePointV1(baseDescription),
-			// v2 is under construction. The editor and AI builder surface the
-			// highest registered version regardless of defaultVersion, so v2 must
-			// stay unregistered until the launch ticket flips the default.
-			// Uncomment locally to test v2 work.
-			// 2: new MicrosoftSharePointV2(baseDescription),
+			2: new MicrosoftSharePointV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/MicrosoftSharePoint.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/MicrosoftSharePoint.node.test.ts
@@ -2,11 +2,11 @@ import { MicrosoftSharePoint } from '../MicrosoftSharePoint.node';
 import { versionDescription } from '../v2/actions/versionDescription';
 
 describe('MicrosoftSharePoint (versioned root)', () => {
-	it('should register only version 1, with version 1 as the default', () => {
+	it('should register versions 1 and 2, with version 2 as the default', () => {
 		const node = new MicrosoftSharePoint();
 
-		expect(node.description.defaultVersion).toBe(1);
-		expect(Object.keys(node.nodeVersions)).toEqual(['1']);
+		expect(node.description.defaultVersion).toBe(2);
+		expect(Object.keys(node.nodeVersions)).toEqual(['1', '2']);
 
 		const v1 = node.nodeVersions[1];
 		expect(v1.description.version).toBe(1);
@@ -17,6 +17,16 @@ describe('MicrosoftSharePoint (versioned root)', () => {
 		expect(v1.description.usableAsTool).toBe(true);
 		expect(v1.methods?.listSearch).toBeDefined();
 		expect(v1.methods?.resourceMapping).toBeDefined();
+
+		const v2 = node.nodeVersions[2];
+		expect(v2.description.version).toBe(2);
+		expect(v2.description.properties).not.toHaveLength(0);
+		expect(v2.description.credentials?.map((credential) => credential.name)).toEqual([
+			'microsoftOAuth2Api',
+			'microsoftEntraServicePrincipalApi',
+		]);
+		expect(v2.methods?.listSearch).toBeDefined();
+		expect(v2.methods?.resourceMapping).toBeDefined();
 	});
 
 	it('should trim the subdomain in the declarative base URL', () => {
@@ -27,13 +37,10 @@ describe('MicrosoftSharePoint (versioned root)', () => {
 		);
 	});
 
-	it('should not register the under-construction version 2', () => {
+	it('should expose the registered version 2 as an AI tool', () => {
 		const node = new MicrosoftSharePoint();
 
-		expect(Object.keys(node.nodeVersions)).toEqual(['1']);
-	});
-
-	it('should expose version 2 as an AI tool once registered', () => {
+		expect(node.nodeVersions[2].description.usableAsTool).toBe(true);
 		expect(versionDescription.usableAsTool).toBe(true);
 	});
 


### PR DESCRIPTION
## Summary

Registers SharePoint node version 2 and flips `defaultVersion` from 1 to 2 in the same change — the launch step planned on the epic: the editor and AI builder surface the highest registered version regardless of `defaultVersion`, so v2 stayed unregistered during the build phase and becomes visible only now, when it also becomes the default.

From this change on, adding a Microsoft SharePoint node gives version 2 (Graph-based, with the OAuth2 / Entra service principal authentication selector). Every workflow saved on version 1 stays on version 1 and runs unchanged — v1, its credential, and its declarative base URL are untouched.

The root node test is updated in the same commit: it now asserts both versions are registered with 2 as the default, keeps every v1 assertion as-is (credential, subdomain base-URL trim), and adds the v2 assertions (version, the `microsoftOAuth2Api` + `microsoftEntraServicePrincipalApi` credential pair, listSearch/resourceMapping methods, exposed as an AI tool).

## Validation

Version 2 was validated against a real Microsoft 365 tenant before this flip, per the launch ticket's checklist: every v1 action verified in v2 under both sign-in methods with self-asserting workflows (locators, item CRUD across all column types, file upload/download/update with checksum verification, error surfaces, least-privilege `Sites.Selected`), plus the two deliberate behaviour changes re-tested end to end — an item update produces the same final state and output v1 produces, and a downloaded file byte-matches the original. Evidence and per-action minimum permissions are recorded on the ticket.

## How to test

1. On this branch, add a Microsoft SharePoint node — it is version 2 (Authentication selector, site/list resource locators).
2. Import a workflow saved with a version 1 SharePoint node — it loads and executes unchanged on v1.
3. The version selector on the node's settings shows 1 and 2.
4. `pushd packages/nodes-base && pnpm test MicrosoftSharePoint` — 13/13.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-190

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Docs updated or follow-up ticket created (ENT-189)
- [x] Tests included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

