### PR TITLE
feat: Create workflow tools from the agent builder

### DIFF
--- a/packages/@n8n/telemetry/src/events/agents.ts
+++ b/packages/@n8n/telemetry/src/events/agents.ts
@@ -533,7 +533,7 @@ export const AGENTS_TELEMETRY = defineTelemetryEvents({
 	USER_STARTED_ADDING_AGENT_TOOL: {
 		name: 'User started adding agent tool',
 		description:
-			'The user clicked Connect on an available row in the tools modal, starting a new tool flow.',
+			'The user started adding an available tool manually by connecting it or creating a workflow.',
 		properties: z.object({
 			tool_type: z.enum(['custom', 'workflow', 'node']),
 			source: z.literal('manual'),

--- a/packages/cli/src/modules/agents/__tests__/workflow-tool-factory.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/workflow-tool-factory.test.ts
@@ -92,7 +92,7 @@ function makeContext(foundWorkflow: WorkflowEntity | null): WorkflowToolContext 
 	const activeExecutions = mock<ActiveExecutions>();
 	const workflowLoader = mock<WorkflowToolWorkflowLoader>();
 
-	workflowLoader.loadPublishedWorkflow.mockResolvedValue(foundWorkflow);
+	workflowLoader.loadWorkflow.mockResolvedValue(foundWorkflow);
 
 	return {
 		workflowLoader,
@@ -181,7 +181,7 @@ describe('resolveWorkflowTool() — metadata attachment', () => {
 
 		await resolveWorkflowTool({ type: 'workflow', workflow: 'Scoped Workflow' }, context);
 
-		expect(context.workflowLoader.loadPublishedWorkflow).toHaveBeenCalledWith('project-1', {
+		expect(context.workflowLoader.loadWorkflow).toHaveBeenCalledWith('project-1', {
 			workflowName: 'Scoped Workflow',
 		});
 	});
@@ -196,7 +196,7 @@ describe('resolveWorkflowTool() — metadata attachment', () => {
 			),
 		).rejects.toThrow('Workflow "Existing Workflow" not found');
 
-		expect(context.workflowLoader.loadPublishedWorkflow).toHaveBeenCalledWith('project-1', {
+		expect(context.workflowLoader.loadWorkflow).toHaveBeenCalledWith('project-1', {
 			workflowId: 'missing-id',
 			workflowName: 'Existing Workflow',
 		});
@@ -210,7 +210,7 @@ describe('resolveWorkflowTool() — metadata attachment', () => {
 		).rejects.toThrow('Workflow "Missing Workflow" not found');
 	});
 
-	it('loads the current published workflow for every invocation', async () => {
+	it('loads the current workflow for every invocation', async () => {
 		const initial = makeWorkflow({ id: 'wf-current', name: 'Current Workflow' });
 		const secondVersion = makeWorkflow({
 			id: 'wf-current',
@@ -225,13 +225,13 @@ describe('resolveWorkflowTool() — metadata attachment', () => {
 			nodes: [makeManualTriggerNode(), { ...makeRespondToWebhookNode(), name: 'Version 3' }],
 		});
 		const context = makeContext(initial);
-		const loadPublishedWorkflow = vi
+		const loadWorkflow = vi
 			.fn()
 			.mockResolvedValueOnce(initial)
 			.mockResolvedValueOnce(secondVersion)
 			.mockResolvedValueOnce(thirdVersion);
 		Object.assign(context, {
-			workflowLoader: { loadPublishedWorkflow },
+			workflowLoader: { loadWorkflow },
 			executionMode: 'integrated',
 		});
 		context.workflowRunner.run = vi
@@ -252,15 +252,15 @@ describe('resolveWorkflowTool() — metadata attachment', () => {
 		await tool.handler?.({}, {});
 		await tool.handler?.({}, {});
 
-		expect(loadPublishedWorkflow).toHaveBeenNthCalledWith(1, 'project-1', {
+		expect(loadWorkflow).toHaveBeenNthCalledWith(1, 'project-1', {
 			workflowId: 'wf-current',
 			workflowName: 'Current Workflow',
 		});
-		expect(loadPublishedWorkflow).toHaveBeenNthCalledWith(2, 'project-1', {
+		expect(loadWorkflow).toHaveBeenNthCalledWith(2, 'project-1', {
 			workflowId: 'wf-current',
 			workflowName: 'Current Workflow',
 		});
-		expect(loadPublishedWorkflow).toHaveBeenNthCalledWith(3, 'project-1', {
+		expect(loadWorkflow).toHaveBeenNthCalledWith(3, 'project-1', {
 			workflowId: 'wf-current',
 			workflowName: 'Current Workflow',
 		});

--- a/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-workflow-loader.service.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-workflow-loader.service.test.ts
@@ -1,12 +1,5 @@
-import type { WorkflowsConfig } from '@n8n/config';
-import type {
-	PublishedWorkflowDataForExecution,
-	WorkflowEntity,
-	WorkflowRepository,
-} from '@n8n/db';
+import type { WorkflowEntity, WorkflowRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
-
-import type { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 
 import { WorkflowToolWorkflowLoader } from '../workflow-tool-workflow-loader.service';
 
@@ -20,90 +13,44 @@ function makeWorkflow(overrides: Partial<WorkflowEntity> = {}) {
 		nodes: [{ id: 'draft-node' }],
 		connections: {},
 		pinData: { Draft: [{ json: { pinned: true } }] },
-		activeVersion: null,
 		...overrides,
 	} as unknown as WorkflowEntity;
 }
 
-function makeService(useWorkflowPublicationService: boolean) {
-	const workflowsConfig = mock<WorkflowsConfig>({ useWorkflowPublicationService });
+function makeService() {
 	const workflowRepository = mock<WorkflowRepository>();
-	const workflowPublishedDataService = mock<WorkflowPublishedDataService>();
-	const service = new WorkflowToolWorkflowLoader(
-		workflowsConfig,
-		workflowRepository,
-		workflowPublishedDataService,
-	);
+	const service = new WorkflowToolWorkflowLoader(workflowRepository);
 
-	return { service, workflowRepository, workflowPublishedDataService };
+	return { service, workflowRepository };
 }
 
 describe('WorkflowToolWorkflowLoader', () => {
-	it('loads the current publication directly from the database when publication service is enabled', async () => {
-		const { service, workflowRepository, workflowPublishedDataService } = makeService(true);
-		workflowRepository.findOneByAgentToolReference.mockResolvedValue(makeWorkflow());
-		workflowPublishedDataService.getPublishedWorkflowDataForExecution.mockResolvedValue({
-			...makeWorkflow(),
-			versionId: 'published-version-2',
-			nodes: [{ id: 'published-node' }],
-		} as unknown as PublishedWorkflowDataForExecution);
+	it('loads the current draft without requiring a published version', async () => {
+		const { service, workflowRepository } = makeService();
+		workflowRepository.findOneByAgentToolReference.mockResolvedValue(
+			makeWorkflow({ versionId: 'draft-version' }),
+		);
 
-		const workflow = await service.loadPublishedWorkflow('project-1', reference);
+		const workflow = await service.loadWorkflow('project-1', reference);
 
 		expect(workflowRepository.findOneByAgentToolReference).toHaveBeenCalledWith(
 			'project-1',
 			reference,
 		);
-		expect(workflowPublishedDataService.getPublishedWorkflowDataForExecution).toHaveBeenCalledWith(
-			'workflow-1',
-		);
-		expect(
-			workflowPublishedDataService.getCachedPublishedWorkflowDataForExecution,
-		).not.toHaveBeenCalled();
 		expect(workflow).toMatchObject({
-			versionId: 'published-version-2',
-			nodes: [{ id: 'published-node' }],
-		});
-		expect(workflow?.pinData).toBeUndefined();
-	});
-
-	it('loads activeVersion when publication service is disabled', async () => {
-		const { service, workflowRepository, workflowPublishedDataService } = makeService(false);
-		workflowRepository.findOneByAgentToolReference.mockResolvedValue(makeWorkflow());
-		workflowRepository.findById.mockResolvedValue(
-			makeWorkflow({
-				activeVersion: {
-					versionId: 'active-version-3',
-					nodes: [{ id: 'active-node' }],
-					connections: { Trigger: { main: [[]] } },
-					nodeGroups: [],
-				} as unknown as NonNullable<WorkflowEntity['activeVersion']>,
-			}),
-		);
-
-		const workflow = await service.loadPublishedWorkflow('project-1', reference);
-
-		expect(
-			workflowPublishedDataService.getPublishedWorkflowDataForExecution,
-		).not.toHaveBeenCalled();
-		expect(workflow).toMatchObject({
-			versionId: 'active-version-3',
-			nodes: [{ id: 'active-node' }],
-			connections: { Trigger: { main: [[]] } },
+			versionId: 'draft-version',
+			nodes: [{ id: 'draft-node' }],
 		});
 		expect(workflow?.pinData).toBeUndefined();
 	});
 
 	it.each([
-		['unshared', null, makeWorkflow()],
-		['unpublished', makeWorkflow(), null],
-	] as const)('returns null when the workflow is %s', async (_label, accessible, published) => {
-		const { service, workflowRepository, workflowPublishedDataService } = makeService(true);
-		workflowRepository.findOneByAgentToolReference.mockResolvedValue(accessible);
-		workflowPublishedDataService.getPublishedWorkflowDataForExecution.mockResolvedValue(
-			published as PublishedWorkflowDataForExecution | null,
-		);
+		['unshared', null],
+		['archived', makeWorkflow({ isArchived: true })],
+	] as const)('returns null when the workflow is %s', async (_label, workflow) => {
+		const { service, workflowRepository } = makeService();
+		workflowRepository.findOneByAgentToolReference.mockResolvedValue(workflow);
 
-		await expect(service.loadPublishedWorkflow('project-1', reference)).resolves.toBeNull();
+		await expect(service.loadWorkflow('project-1', reference)).resolves.toBeNull();
 	});
 });

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -540,10 +540,7 @@ async function buildWorkflowTool(
 		workflowName,
 		...(descriptor.workflowId !== undefined ? { workflowId: descriptor.workflowId } : {}),
 	};
-	const workflow = await context.workflowLoader.loadPublishedWorkflow(
-		context.projectId,
-		initialReference,
-	);
+	const workflow = await context.workflowLoader.loadWorkflow(context.projectId, initialReference);
 	if (!workflow) {
 		throw new Error(`Workflow "${workflowName}" not found`);
 	}
@@ -595,7 +592,7 @@ async function buildWorkflowTool(
 					}) as never,
 			)
 			.handler(async (input: Record<string, unknown>) => {
-				const current = await loadCurrentPublishedWorkflow(context, reference, triggerType);
+				const current = await loadCurrentWorkflow(context, reference, triggerType);
 				const parsedInput = inferInputSchema(current.triggerNode, current.triggerType).parse(input);
 				const formUrl = getFormUrl(current.workflow, current.triggerNode, context.webhookBaseUrl);
 				const reason = parsedInput.reason;
@@ -634,7 +631,7 @@ async function buildWorkflowTool(
 			}),
 		)
 		.handler(async (input: Record<string, unknown>) => {
-			const current = await loadCurrentPublishedWorkflow(context, reference, triggerType);
+			const current = await loadCurrentWorkflow(context, reference, triggerType);
 			const parsedInput = inferInputSchema(current.triggerNode, current.triggerType).parse(input);
 			return await executeWorkflow(
 				current.workflow,
@@ -659,14 +656,14 @@ async function buildWorkflowTool(
 	};
 }
 
-async function loadCurrentPublishedWorkflow(
+async function loadCurrentWorkflow(
 	context: WorkflowToolContext,
 	reference: WorkflowToolWorkflowReference,
 	expectedTriggerType: string,
 ) {
-	const workflow = await context.workflowLoader.loadPublishedWorkflow(context.projectId, reference);
+	const workflow = await context.workflowLoader.loadWorkflow(context.projectId, reference);
 	if (!workflow) {
-		throw new Error(`Workflow "${reference.workflowName}" is no longer published or accessible`);
+		throw new Error(`Workflow "${reference.workflowName}" is no longer accessible`);
 	}
 
 	validateCompatibility(workflow);

--- a/packages/cli/src/modules/agents/tools/workflow-tool-workflow-loader.service.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-workflow-loader.service.ts
@@ -1,8 +1,5 @@
-import { WorkflowsConfig } from '@n8n/config';
 import { type WorkflowEntity, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-
-import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 
 export interface WorkflowToolWorkflowReference {
 	workflowId?: string;
@@ -11,41 +8,18 @@ export interface WorkflowToolWorkflowReference {
 
 @Service()
 export class WorkflowToolWorkflowLoader {
-	constructor(
-		private readonly workflowsConfig: WorkflowsConfig,
-		private readonly workflowRepository: WorkflowRepository,
-		private readonly workflowPublishedDataService: WorkflowPublishedDataService,
-	) {}
+	constructor(private readonly workflowRepository: WorkflowRepository) {}
 
-	async loadPublishedWorkflow(
+	async loadWorkflow(
 		projectId: string,
 		reference: WorkflowToolWorkflowReference,
 	): Promise<WorkflowEntity | null> {
-		const accessibleWorkflow = await this.workflowRepository.findOneByAgentToolReference(
+		const workflow = await this.workflowRepository.findOneByAgentToolReference(
 			projectId,
 			reference,
 		);
-		if (!accessibleWorkflow || accessibleWorkflow.isArchived) return null;
+		if (!workflow || workflow.isArchived) return null;
 
-		if (this.workflowsConfig.useWorkflowPublicationService) {
-			const publishedWorkflow =
-				await this.workflowPublishedDataService.getPublishedWorkflowDataForExecution(
-					accessibleWorkflow.id,
-				);
-			if (!publishedWorkflow || publishedWorkflow.isArchived) return null;
-
-			return Object.assign(accessibleWorkflow, publishedWorkflow, { pinData: undefined });
-		}
-
-		const workflow = await this.workflowRepository.findById(accessibleWorkflow.id);
-		if (!workflow || workflow.isArchived || !workflow.activeVersion) return null;
-
-		return Object.assign(workflow, {
-			versionId: workflow.activeVersion.versionId,
-			nodes: workflow.activeVersion.nodes,
-			connections: workflow.activeVersion.connections,
-			nodeGroups: workflow.activeVersion.nodeGroups,
-			pinData: undefined,
-		});
+		return Object.assign(workflow, { pinData: undefined });
 	}
 }

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7474,6 +7474,8 @@
 	"agents.tools.added": "Tool added",
 	"agents.tools.workflow.incompatible.title": "Workflow is not compatible",
 	"agents.tools.workflow.incompatible.message": "Workflow \"{name}\" contains nodes that can't be used as an agent tool: {nodes}.",
+	"agents.tools.workflow.createFailed.title": "Couldn't create workflow",
+	"agents.tools.workflow.createFailed.message": "Try creating the workflow again.",
 	"agents.tools.workflow.fetchFailed.title": "Couldn't check workflow compatibility",
 	"agents.tools.workflow.fetchFailed.message": "Try connecting the workflow again.",
 	"agents.tools.install.unresolved.title": "Couldn't add the installed tool",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
@@ -7,10 +7,15 @@ import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore } from '@/__tests__/utils';
 import { getWorkflow } from '@/app/api/workflows';
+import { VIEWS } from '@/app/constants';
 import { AI_MCP_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
+import { SAMPLE_SUBWORKFLOW_TRIGGER_ID } from '@/app/constants/samples';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useUsersStore } from '@n8n/stores/users.store';
 import type { ToolConnectionItem } from '@/features/shared/toolsConnection/types';
 import type { IWorkflowDb } from '@/Interface';
@@ -20,12 +25,18 @@ import type { AgentJsonMcpServerConfig, AgentJsonToolRef } from '../types';
 
 const showMessageMock = vi.fn();
 const showErrorMock = vi.fn();
+const routerResolveMock = vi.hoisted(() => vi.fn(() => ({ href: '/workflow/new-workflow-id' })));
 vi.mock('@n8n/composables/useToast', () => ({
 	useToast: () => ({
 		showError: showErrorMock,
 		showMessage: showMessageMock,
 		showToast: vi.fn(),
 	}),
+}));
+
+vi.mock('vue-router', async (importOriginal) => ({
+	...(await importOriginal<typeof import('vue-router')>()),
+	useRouter: () => ({ resolve: routerResolveMock }),
 }));
 
 vi.mock('@/app/api/workflows', () => ({
@@ -146,7 +157,14 @@ function emitSearch(query: string) {
 	(listener as (value: string) => void)(query);
 }
 
+function emitCreateWorkflow() {
+	const listener = modalAttrs.onCreateWorkflow;
+	if (typeof listener !== 'function') throw new Error('Missing onCreateWorkflow');
+	(listener as () => void)();
+}
+
 const MODAL_NAME = 'agentToolsModal';
+const PROJECT_ID = 'project-1';
 
 const renderComponent = createComponentRenderer(AgentToolsConnectionModalWrapper, {
 	global: {
@@ -160,6 +178,8 @@ describe('AgentToolsConnectionModalWrapper', () => {
 	let nodeTypesStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 	let uiStore: ReturnType<typeof mockedStore<typeof useUIStore>>;
 	let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;
+	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let windowOpenMock: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -170,6 +190,14 @@ describe('AgentToolsConnectionModalWrapper', () => {
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		uiStore = mockedStore(useUIStore);
 		workflowsListStore = mockedStore(useWorkflowsListStore);
+		workflowsStore = mockedStore(useWorkflowsStore);
+		mockedStore(useProjectsStore).myProjects = [
+			{
+				id: PROJECT_ID,
+				scopes: ['workflow:create'],
+			},
+		] as never;
+		mockedStore(useSourceControlStore).preferences = { branchReadOnly: false } as never;
 
 		nodeTypesStore.getNodeType = vi.fn().mockImplementation((name: string) => {
 			if (name === SLACK.name) return SLACK;
@@ -180,6 +208,7 @@ describe('AgentToolsConnectionModalWrapper', () => {
 			[NodeConnectionTypes.AiTool]: [SLACK.name, WIKIPEDIA.name],
 		};
 		workflowsListStore.searchWorkflows = vi.fn().mockResolvedValue([]);
+		workflowsStore.createNewWorkflow.mockReset();
 		mockedStore(useUsersStore).isAdminOrOwner = true;
 
 		uiStore.modalStateById = {
@@ -189,6 +218,9 @@ describe('AgentToolsConnectionModalWrapper', () => {
 		uiStore.closeModal = vi.fn();
 		uiStore.openModalWithData = vi.fn();
 		showMessageMock.mockReset();
+		showErrorMock.mockReset();
+		routerResolveMock.mockReset().mockReturnValue({ href: '/workflow/new-workflow-id' });
+		windowOpenMock = vi.spyOn(window, 'open').mockImplementation(() => null);
 		installNodeMock.mockReset().mockResolvedValue({ success: true });
 		filterAndSearchNodesMock.mockReset().mockReturnValue([]);
 	});
@@ -210,11 +242,12 @@ describe('AgentToolsConnectionModalWrapper', () => {
 		tools: AgentJsonToolRef[] = [],
 		onConfirm = vi.fn(),
 		mcpServers: AgentJsonMcpServerConfig[] = [],
+		projectId?: string,
 	) {
 		return renderComponent({
 			props: {
 				modalName: MODAL_NAME,
-				data: { tools, mcpServers, onConfirm },
+				data: { tools, mcpServers, onConfirm, projectId },
 			},
 		});
 	}
@@ -547,6 +580,88 @@ describe('AgentToolsConnectionModalWrapper', () => {
 			await flushPromises();
 			return getItems().find((item) => item.id === `workflow:${WORKFLOW.id}`)!;
 		}
+
+		it('creates a compatible workflow and attaches it after configuration is saved', async () => {
+			const existingTool = toolRef(WIKIPEDIA.name);
+			const onConfirm = vi.fn();
+			workflowsStore.createNewWorkflow.mockResolvedValueOnce({
+				...WORKFLOW,
+				id: 'new-workflow-id',
+				name: 'My workflow 1',
+			} as unknown as IWorkflowDb);
+
+			render([existingTool], onConfirm, [], PROJECT_ID);
+			await flushPromises();
+
+			emitCreateWorkflow();
+			await flushPromises();
+
+			expect(workflowsStore.createNewWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'My workflow 1',
+					projectId: PROJECT_ID,
+					nodes: expect.arrayContaining([
+						expect.objectContaining({
+							type: 'n8n-nodes-base.executeWorkflowTrigger',
+						}),
+					]),
+				}),
+			);
+			expect(onConfirm).not.toHaveBeenCalled();
+			expect(uiStore.closeModal).not.toHaveBeenCalled();
+			const [payload] = (uiStore.openModalWithData as ReturnType<typeof vi.fn>).mock.calls[0];
+			expect(payload).toMatchObject({
+				name: 'agentToolConfigModal',
+				data: {
+					projectId: PROJECT_ID,
+					toolRef: {
+						type: 'workflow',
+						workflowId: 'new-workflow-id',
+						workflow: 'My workflow 1',
+						name: 'My workflow 1',
+						description: '',
+						allOutputs: false,
+					},
+				},
+			});
+
+			const configuredRef: AgentJsonToolRef = {
+				...payload.data.toolRef,
+				description: 'Create the daily sales digest',
+			};
+			payload.data.onConfirm(configuredRef);
+
+			expect(onConfirm).toHaveBeenCalledWith({
+				tools: [existingTool, configuredRef],
+				mcpServers: [],
+			});
+			expect(uiStore.closeModal).toHaveBeenCalledWith(MODAL_NAME);
+			expect(routerResolveMock).toHaveBeenCalledWith({
+				name: VIEWS.WORKFLOW,
+				params: {
+					workflowId: 'new-workflow-id',
+					nodeId: SAMPLE_SUBWORKFLOW_TRIGGER_ID,
+				},
+			});
+			expect(windowOpenMock).toHaveBeenCalledWith('/workflow/new-workflow-id', '_blank');
+		});
+
+		it('does not attach or open a workflow when creation fails', async () => {
+			const error = new Error('network down');
+			const onConfirm = vi.fn();
+			workflowsStore.createNewWorkflow.mockRejectedValueOnce(error);
+
+			render([], onConfirm, [], PROJECT_ID);
+			await flushPromises();
+			emitCreateWorkflow();
+			await flushPromises();
+
+			expect(onConfirm).not.toHaveBeenCalled();
+			expect(windowOpenMock).not.toHaveBeenCalled();
+			expect(showErrorMock).toHaveBeenCalledWith(error, expect.any(String), {
+				message: expect.any(String),
+			});
+		});
 
 		it('refuses a workflow whose body contains an incompatible node', async () => {
 			const onConfirm = vi.fn();

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
@@ -2,17 +2,28 @@
 import { computed, onMounted, ref, watch } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
 import { useI18n } from '@n8n/i18n';
+import { getResourcePermissions } from '@n8n/permissions';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { INCOMPATIBLE_WORKFLOW_TOOL_BODY_NODE_TYPES } from '@n8n/api-types';
 import { NodeConnectionTypes, isCommunityPackageName } from 'n8n-workflow';
 import type { INode, INodeProperties, INodeTypeDescription } from 'n8n-workflow';
+import { useRouter } from 'vue-router';
 
 import { getWorkflow } from '@/app/api/workflows';
+import { VIEWS } from '@/app/constants';
+import {
+	SAMPLE_SUBWORKFLOW_TRIGGER_ID,
+	SAMPLE_SUBWORKFLOW_WORKFLOW,
+} from '@/app/constants/samples';
+import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants/workflows';
 import { AI_MCP_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { useToast } from '@n8n/composables/useToast';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { stripToolSuffix } from '@/app/stores/aiGateway.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useInstallNode } from '@/features/settings/communityNodes/composables/useInstallNode';
 import { useUsersStore } from '@n8n/stores/users.store';
 import {
@@ -81,7 +92,11 @@ const i18n = useI18n();
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
 const rootStore = useRootStore();
+const router = useRouter();
 const toast = useToast();
+const workflowsStore = useWorkflowsStore();
+const projectsStore = useProjectsStore();
+const sourceControlStore = useSourceControlStore();
 const toolTelemetry = useAgentToolTelemetry(props.data.agentId);
 const { availableToolTypes, availableWorkflows, loadWorkflows, resolveToolNodeType } =
 	useAgentToolCatalog();
@@ -90,6 +105,20 @@ const usersStore = useUsersStore();
 
 const searchQuery = ref('');
 const installingToolName = ref<string | null>(null);
+const isCreatingWorkflow = ref(false);
+
+const canCreateWorkflow = computed(() => {
+	if (!props.data.projectId || sourceControlStore.preferences.branchReadOnly) return false;
+
+	const projectScopes = projectsStore.myProjects.find(
+		(project) => project.id === props.data.projectId,
+	)?.scopes;
+	const projectPermission = getResourcePermissions(projectScopes).workflow.create;
+	const globalPermission = getResourcePermissions(usersStore.currentUser?.globalScopes).workflow
+		.create;
+
+	return Boolean(globalPermission ?? projectPermission);
+});
 
 interface WorkingToolEntry {
 	localId: string;
@@ -404,6 +433,50 @@ async function handleAddWorkflow(workflow: IWorkflowDb) {
 	openConfigForNewRef(workflowToNewToolRef(workflow));
 }
 
+async function handleCreateWorkflow() {
+	const projectId = props.data.projectId;
+	if (!projectId || !canCreateWorkflow.value || isCreatingWorkflow.value) return;
+
+	isCreatingWorkflow.value = true;
+	toolTelemetry.trackAddStarted('workflow');
+
+	try {
+		const sampleName = DEFAULT_NEW_WORKFLOW_NAME;
+		const matchingWorkflows = availableWorkflows.value.filter((workflow) =>
+			workflow.name?.startsWith(sampleName),
+		);
+		const newWorkflow = await workflowsStore.createNewWorkflow({
+			...SAMPLE_SUBWORKFLOW_WORKFLOW,
+			name: `${sampleName} ${matchingWorkflows.length + 1}`,
+			projectId,
+		});
+		const newRef = workflowToNewToolRef(newWorkflow);
+
+		openConfigForNewRef({
+			...newRef,
+			name: makeUniqueName(
+				newRef.name ?? newWorkflow.name,
+				getExistingToolNames(workingTools.value),
+			),
+		});
+
+		const { href } = router.resolve({
+			name: VIEWS.WORKFLOW,
+			params: {
+				workflowId: newWorkflow.id,
+				nodeId: SAMPLE_SUBWORKFLOW_TRIGGER_ID,
+			},
+		});
+		window.open(href, '_blank');
+	} catch (error) {
+		toast.showError(error, i18n.baseText('agents.tools.workflow.createFailed.title'), {
+			message: i18n.baseText('agents.tools.workflow.createFailed.message'),
+		});
+	} finally {
+		isCreatingWorkflow.value = false;
+	}
+}
+
 function openConfigForToolEntry(entry: WorkingToolEntry) {
 	const toolRef = entry.ref;
 	openConfigModal({
@@ -655,8 +728,11 @@ function handleRowActivate(item: ToolConnectionItem) {
 		:items="items"
 		:categories="CATEGORIES"
 		:detail-item="null"
+		:allow-workflow-creation="canCreateWorkflow"
+		:workflow-creation-loading="isCreatingWorkflow"
 		@update:search-query="searchQuery = $event"
 		@connect="handleRowActivate"
 		@open-detail="handleRowActivate"
+		@create-workflow="handleCreateWorkflow"
 	/>
 </template>

--- a/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolsConnectionModal.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolsConnectionModal.vue
@@ -34,11 +34,15 @@ const props = withDefaults(
 		detailItem?: ToolConnectionItem | null;
 		detailMode?: 'detail' | 'settings';
 		hideBackButton?: boolean;
+		allowWorkflowCreation?: boolean;
+		workflowCreationLoading?: boolean;
 	}>(),
 	{
 		open: false,
 		detailItem: null,
 		detailMode: 'detail',
+		allowWorkflowCreation: false,
+		workflowCreationLoading: false,
 	},
 );
 
@@ -54,6 +58,7 @@ const emit = defineEmits<{
 	'new-credential-connect': [item: ToolConnectionItem];
 	'open-detail': [item: ToolConnectionItem];
 	connect: [item: ToolConnectionItem];
+	'create-workflow': [];
 }>();
 
 const i18n = useI18n();
@@ -324,6 +329,32 @@ function handleOpenChange(value: boolean) {
 					@update:model-value="selectCategory"
 				/>
 
+				<button
+					v-if="activeCategory === 'workflows' && allowWorkflowCreation"
+					type="button"
+					:class="$style.createWorkflowRow"
+					:disabled="workflowCreationLoading"
+					:aria-busy="workflowCreationLoading"
+					data-test-id="tools-connection-create-workflow"
+					@click="emit('create-workflow')"
+				>
+					<span :class="$style.createWorkflowIcon" aria-hidden="true">
+						<N8nIcon
+							:icon="workflowCreationLoading ? 'loader-circle' : 'plus'"
+							:size="20"
+							:spin="workflowCreationLoading"
+						/>
+					</span>
+					<span :class="$style.createWorkflowText">
+						<N8nText tag="span" bold>
+							{{ i18n.baseText('generic.create.workflow') }}
+						</N8nText>
+						<N8nText tag="span" size="small" color="text-light">
+							{{ i18n.baseText('projectRoles.workflow:create.tooltip') }}
+						</N8nText>
+					</span>
+				</button>
+
 				<div v-if="isListEmpty" :class="$style.empty" data-test-id="tools-connection-empty">
 					<N8nText color="text-light">{{ emptyMessage }}</N8nText>
 				</div>
@@ -377,6 +408,52 @@ function handleOpenChange(value: boolean) {
 .tabs {
 	border-bottom: 1px solid var(--border-color);
 	flex-shrink: 0;
+}
+
+.createWorkflowRow {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--xs);
+	width: 100%;
+	min-height: 58px;
+	padding: var(--spacing--2xs);
+	border: 0;
+	border-radius: var(--radius--2xs);
+	background: none;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
+	flex-shrink: 0;
+
+	&:hover:not(:disabled) {
+		background: var(--color--background--light-1);
+	}
+
+	&:focus-visible {
+		outline: var(--focus--border-width) solid var(--focus--border-color);
+		outline-offset: 2px;
+	}
+
+	&:disabled {
+		cursor: default;
+	}
+}
+
+.createWorkflowIcon {
+	flex-shrink: 0;
+	width: 32px;
+	height: 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--color--primary);
+}
+
+.createWorkflowText {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+	min-width: 0;
 }
 
 // Runs past the dialog's own bottom padding so the list ends at the dialog

--- a/packages/frontend/editor-ui/src/features/shared/toolsConnection/__tests__/ToolsConnectionModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/toolsConnection/__tests__/ToolsConnectionModal.test.ts
@@ -91,6 +91,7 @@ function renderWith(
 		categories: ToolCategoryKey[];
 		detailItem: ToolConnectionItem | null;
 		detailMode: 'detail' | 'settings';
+		allowWorkflowCreation: boolean;
 	}>,
 ) {
 	return renderModal({
@@ -100,6 +101,7 @@ function renderWith(
 			categories: props.categories ?? ALL_CATEGORIES,
 			detailItem: props.detailItem ?? null,
 			detailMode: props.detailMode,
+			allowWorkflowCreation: props.allowWorkflowCreation,
 		},
 		pinia: createTestingPinia(),
 	});
@@ -173,6 +175,22 @@ describe('ToolsConnectionModal', () => {
 	it('shows the empty state when items is empty', () => {
 		const { getByTestId } = renderWith({ items: [] });
 		expect(getByTestId('tools-connection-empty')).toBeTruthy();
+	});
+
+	it('offers workflow creation when the workflows category is empty', async () => {
+		const { emitted, getByTestId, queryByTestId } = renderWith({
+			items: [],
+			categories: ['mcp', 'workflows'],
+			allowWorkflowCreation: true,
+		});
+
+		expect(queryByTestId('tools-connection-create-workflow')).toBeNull();
+
+		await fireEvent.click(getByTestId('tab-workflows'));
+		expect(getByTestId('tools-connection-empty')).toBeTruthy();
+
+		await fireEvent.click(getByTestId('tools-connection-create-workflow'));
+		expect(emitted()['create-workflow']).toEqual([[]]);
 	});
 
 	it('renders the detail view when a detailItem is set', () => {


### PR DESCRIPTION
## Summary

- Add a Create workflow action to the agent tools modal.
- Create a callable workflow, open its editor, and keep tool configuration open before attachment.
- Let agent workflow tools execute the current saved workflow, including unpublished drafts.

## How to test

1. Start n8n with `N8N_ENABLED_MODULES=agents`.
2. Open an agent and select **Add tool**.
3. Open the **Workflows** tab and select **Create workflow**.
4. Confirm that the workflow editor opens in a new tab and the workflow-tool configuration stays open.
5. Save the tool without publishing the workflow.
6. Run the agent and confirm that it executes the workflow's current saved draft.

Automated checks:
- `pnpm test src/features/shared/toolsConnection/__tests__/ToolsConnectionModal.test.ts src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts`
- `pnpm test src/modules/agents/tools/__tests__/workflow-tool-workflow-loader.service.test.ts src/modules/agents/__tests__/workflow-tool-factory.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-495

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

