### PR TITLE
fix(core): Harden agent HTTP Request tool configuration

### DIFF
--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -132,6 +132,10 @@ function buildOpenAiCompatible(
 
 type OpenAiCompatibleProviderId = 'nvidia' | 'moonshotai';
 
+function isOfficialOpenAiBaseUrl(baseURL: string | undefined): boolean {
+	return baseURL?.replace(/\/+$/, '') === 'https://api.openai.com/v1';
+}
+
 function openAiCompatibleEntry<P extends OpenAiCompatibleProviderId>(
 	name: P,
 	defaultBaseURL: string,
@@ -157,9 +161,13 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 			// A custom baseURL usually means an OpenAI-COMPATIBLE server (LM Studio,
 			// vLLM, Ollama), which speaks /chat/completions; the provider's default
 			// model targets OpenAI's own Responses API (/responses) that those
-			// servers do not implement. A proxy in front of real OpenAI also sets a
-			// baseURL but does serve /responses, so `apiStyle` overrides the guess.
-			const useChat = apiStyle ? apiStyle === 'chat' : Boolean(providerCreds.baseURL);
+			// servers do not implement. OpenAI credentials also carry the official
+			// baseURL, so keep those on /responses. `apiStyle` handles proxies that
+			// explicitly support one API or the other.
+			const useChat =
+				apiStyle === 'chat' ||
+				(apiStyle === undefined &&
+					Boolean(providerCreds.baseURL && !isOfficialOpenAiBaseUrl(providerCreds.baseURL)));
 			return useChat ? provider.chat(model) : provider(model);
 		},
 	},

--- a/packages/@n8n/api-types/src/agent-builder-tool-node-types.ts
+++ b/packages/@n8n/api-types/src/agent-builder-tool-node-types.ts
@@ -19,6 +19,8 @@ const AGENT_BUILDER_AI_UTILITY_TOOL_NODE_TYPES = [
 export const AGENT_BUILDER_HIDDEN_AVAILABLE_TOOL_NODE_TYPES: readonly string[] = [
 	...AI_VENDOR_NODE_TYPES.map((nodeType) => `${nodeType}Tool`),
 	CHAT_TOOL_NODE_TYPE,
+	// Replaced by the standard HTTP Request node's usable-as-tool variant
+	'@n8n/n8n-nodes-langchain.toolHttpRequest',
 	// Agents call workflows via native workflow tools, not the sub-workflow node
 	WORKFLOW_TOOL_LANGCHAIN_NODE_TYPE,
 	// Reasoning helpers an agent does not need

--- a/packages/cli/src/modules/agents/__tests__/agent-config.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-config.service.test.ts
@@ -220,6 +220,41 @@ describe('AgentConfigService', () => {
 	});
 
 	describe('updateConfig', () => {
+		it('rejects saving an HTTP Request URL controlled by $fromAI', async () => {
+			const { service, agentRepository } = makeService();
+			const agent = makeAgent();
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+
+			await expect(
+				service.updateConfig(
+					agentId,
+					projectId,
+					{
+						...baseConfig,
+						tools: [
+							{
+								type: 'node',
+								name: 'Fetch page',
+								node: {
+									nodeType: 'n8n-nodes-base.httpRequestTool',
+									nodeTypeVersion: 4.5,
+									nodeParameters: {
+										url: "={{ $fromAI('url', 'The URL to inspect', 'string') }}",
+									},
+								},
+							},
+						],
+					},
+					user,
+					byUser,
+				),
+			).rejects.toThrow(
+				'HTTP Request tool "Fetch page" cannot use $fromAI in tools.0.node.nodeParameters.url. Enter a fixed URL.',
+			);
+			expect(agent.schema).toBe(baseConfig);
+			expect(agentRepository.save).not.toHaveBeenCalled();
+		});
+
 		it('persists an explicit web-search disable and clears native provider tools', async () => {
 			// Regression: previously the disable was stripped on write and resurrected
 			// on read, so the config hash never changed and the builder looped.

--- a/packages/cli/src/modules/agents/__tests__/agent-validation.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-validation.service.test.ts
@@ -878,6 +878,63 @@ describe('AgentValidationService — structured issues', () => {
 		);
 	});
 
+	it('blocks an HTTP Request URL using $fromAI for publishing but not runtime validation', async () => {
+		const { service, agentRepository, nodeTypes } = makeService();
+		nodeTypes.getByNameAndVersion.mockReturnValue({
+			description: { properties: [] },
+		} as never);
+		const config: AgentJsonConfig = {
+			...runnableConfig,
+			tools: [
+				{
+					type: 'node',
+					name: 'Fetch page',
+					node: {
+						nodeType: 'n8n-nodes-base.httpRequestTool',
+						nodeTypeVersion: 4.5,
+						nodeParameters: { url: "={{ $fromAI('url') }}" },
+					},
+				},
+			],
+		};
+		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent(config));
+		const credentials = makeCredentialProvider([{ id: 'openai-main', type: 'openAiApi' }]);
+
+		const publishResult = await service.validateAgentConfiguration(
+			agentId,
+			projectId,
+			credentials,
+			'publish',
+		);
+		const runtimeResult = await service.validateAgentIsRunnable(agentId, projectId, credentials);
+		const historyResult = await service.validateAgentHistoryConfiguration(
+			agentId,
+			projectId,
+			{
+				versionId: 'version-1',
+				schema: config,
+				skills: null,
+				tools: null,
+			} as never,
+			[],
+			credentials,
+		);
+
+		const expectedResult = {
+			status: 'invalid',
+			issues: [
+				{
+					code: 'invalid_value',
+					path: 'tools.0.node.nodeParameters.url',
+					capability: { kind: 'tool', id: 'Fetch page', index: 0, toolType: 'node' },
+				},
+			],
+		} as const;
+		expect(publishResult).toEqual(expectedResult);
+		expect(historyResult).toEqual(expectedResult);
+		expect(runtimeResult).toEqual({ missing: [] });
+	});
+
 	it('runtime validation ignores channel and task issues but still reports execution-relevant tool and sub-agent issues', async () => {
 		const { service, agentRepository, agentTaskRepository } = makeService();
 		agentRepository.findByIdAndProjectId.mockResolvedValue(

--- a/packages/cli/src/modules/agents/agent-config.service.ts
+++ b/packages/cli/src/modules/agents/agent-config.service.ts
@@ -35,7 +35,11 @@ import { AgentRepository } from './repositories/agent.repository';
 import { normalizeWorkflowToolRefs } from './tools/workflow-tool-workflow-resolver';
 import { createAgentCredentialProvider } from './utils/agent-credential-provider';
 import { markAgentDraftDirty } from './utils/agent-draft.utils';
-import { validateNodeToolConfigs, validateNodeToolExpressions } from './utils/node-tool-validation';
+import {
+	findHttpRequestToolUrlFromAiViolations,
+	validateNodeToolConfigs,
+	validateNodeToolExpressions,
+} from './utils/node-tool-validation';
 import { resolveUniqueSubAgents, type ResolvedSubAgentRef } from './utils/sub-agent-resolver';
 
 @Service()
@@ -100,6 +104,19 @@ export class AgentConfigService {
 			return {
 				valid: false,
 				error: `Invalid $fromAI expression in node tool config: ${message}`,
+			};
+		}
+
+		const urlViolations = findHttpRequestToolUrlFromAiViolations(config.tools);
+		if (urlViolations.length > 0) {
+			return {
+				valid: false,
+				error: urlViolations
+					.map(
+						({ toolName, path }) =>
+							`HTTP Request tool "${toolName}" cannot use $fromAI in ${path}. Enter a fixed URL.`,
+					)
+					.join('\n'),
 			};
 		}
 

--- a/packages/cli/src/modules/agents/agent-validation.service.ts
+++ b/packages/cli/src/modules/agents/agent-validation.service.ts
@@ -36,6 +36,7 @@ import { AgentTaskRepository } from './repositories/agent-task.repository';
 import { AgentRepository } from './repositories/agent.repository';
 import { detectTriggerNode, validateCompatibility } from './tools/workflow-tool-factory';
 import { findWorkflowToolWorkflows } from './tools/workflow-tool-workflow-resolver';
+import { findHttpRequestToolUrlFromAiViolations } from './utils/node-tool-validation';
 
 type AgentValidationScope = 'runtime' | 'publish';
 
@@ -274,6 +275,16 @@ export class AgentValidationService {
 		this.collectSubAgentRefIssues(ctx, agentsById, issues);
 		this.collectSkillIssues(config, ctx.skills, issues);
 		if (scope === 'publish') {
+			for (const violation of findHttpRequestToolUrlFromAiViolations(config.tools)) {
+				issues.push(
+					issue('invalid_value', violation.path, {
+						kind: 'tool',
+						id: violation.toolName,
+						index: violation.toolIndex,
+						toolType: 'node',
+					}),
+				);
+			}
 			this.collectTaskIssues(config, ctx.tasks, issues);
 			await this.collectChannelIssues(ctx.integrations, findCredential, issues);
 		}

--- a/packages/cli/src/modules/agents/builder/__tests__/agents-builder-model-recommendations.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/agents-builder-model-recommendations.test.ts
@@ -1,7 +1,7 @@
 import type { ProviderCatalog } from '@n8n/agents';
 
 import { buildModelRecommendationsSection } from '../agents-builder-model-recommendations';
-import { PREREQUISITES_SECTION, buildBuilderPrompt } from '../agents-builder-prompts';
+import { buildBuilderPrompt } from '../agents-builder-prompts';
 import { getBuilderRuntimeSkills } from '../skills';
 
 const catalog: ProviderCatalog = {
@@ -106,37 +106,6 @@ describe('builder model recommendations', () => {
 		expect(section).not.toContain('text-embedding-3-large');
 	});
 
-	it('injects always-needed builder guidance into the base builder prompt', () => {
-		const prompt = buildPrompt(null);
-
-		expect(prompt).toContain('## Config Mutation Guidance');
-		expect(prompt).toContain('## Prerequisites you cannot create');
-		expect(PREREQUISITES_SECTION).toContain('cannot create n8n workflows or data tables');
-		expect(PREREQUISITES_SECTION).toContain('Do not ask the user to create them in this chat');
-		expect(prompt.indexOf('## Prerequisites you cannot create')).toBeLessThan(
-			prompt.indexOf('## When To Build vs When To Converse'),
-		);
-		expect(prompt).toContain('## LLM Selection Guidance');
-		expect(prompt).toContain('## Memory Guidance');
-		expect(prompt).toContain('## Tool Guidance');
-		expect(prompt).toContain('## Interactive tools');
-		expect(prompt).toContain('## Config Freshness');
-		expect(prompt).toContain('## Workflow');
-		expect(prompt).toContain('## Example flows');
-		expect(prompt).toContain('## Response Style');
-		expect(prompt).not.toContain('## Builder runtime skills');
-		expect(prompt).toContain('agent-builder-external-services');
-		expect(prompt).toContain('agent-builder-memory');
-		expect(prompt).toContain('agent-builder-custom-tools');
-		expect(prompt).not.toContain('agent-builder-config-mutation');
-		expect(prompt).not.toContain('agent-builder-llm-selection');
-
-		const externalServicesSkill = getBuilderRuntimeSkills().find(
-			(s) => s.id === 'agent-builder-external-services',
-		);
-		expect(externalServicesSkill?.instructions).toContain('agent-builder-resource-locators');
-	});
-
 	it('routes subagent delegation to the sub-agent builder skill', () => {
 		const prompt = buildPrompt(null);
 		const skill = getBuilderRuntimeSkills().find((s) => s.id === 'agent-builder-sub-agents');
@@ -225,50 +194,6 @@ describe('builder model recommendations', () => {
 		expect(buildPrompt(section)).toContain('`openai/gpt-5` GPT-5');
 		expect(buildPrompt(null)).not.toContain('### Recommended LLM Models');
 		expect(buildPrompt(null)).toContain('do not recommend or name');
-	});
-
-	it('keeps always-on interaction and workflow guidance in the main prompt, deferring expressions to a skill', () => {
-		const prompt = buildPrompt('### Recommended LLM Models\n\n- OpenAI: `openai/gpt-5` GPT-5');
-		const skill = getBuilderRuntimeSkills().find((s) => s.id === 'agent-builder-external-services');
-
-		expect(prompt).toContain('### Recommended LLM Models');
-		expect(prompt).toContain('Never call two interactive tools in parallel');
-		expect(prompt).not.toContain('$now.toISO()');
-		expect(prompt).not.toContain('$today');
-		expect(prompt).toContain('## Workflow');
-		expect(prompt).toContain(
-			'Always call `read_config` first whenever a request touches the config',
-		);
-		expect(prompt).toContain('## Example flows');
-
-		expect(skill).toBeDefined();
-		expect(skill?.instructions).toContain('$fromAI');
-		expect(skill?.instructions).toContain('$now.toISO()');
-		expect(skill?.instructions).toContain('$today');
-		expect(skill?.instructions).toContain('sendAndWait');
-		expect(skill?.instructions).toContain('dispatchAndWait');
-		expect(skill?.instructions).toContain('requireApproval: true');
-	});
-
-	it('registers only optional builder runtime skills', () => {
-		const skills = getBuilderRuntimeSkills();
-		const skillsById = new Map(skills.map((skill) => [skill.id, skill]));
-
-		expect(skills.map((skill) => skill.id)).toEqual([
-			'agent-builder-custom-tools',
-			'agent-builder-external-services',
-			'agent-builder-memory',
-			'agent-builder-resource-locators',
-			'agent-builder-sub-agents',
-			'agent-builder-target-skills',
-			'agent-builder-target-tasks',
-		]);
-		expect(skillsById.has('agent-builder-research')).toBe(false);
-
-		const resourceLocators = skillsById.get('agent-builder-resource-locators');
-		expect(resourceLocators?.description).toContain('stable dynamic selector fields');
-		expect(resourceLocators?.instructions).toContain('Linear `teamId`');
-		expect(resourceLocators?.instructions).toContain('Do not use `$fromAI`');
 	});
 
 	it('does not tell the builder to prefer Slack OAuth credentials for chat integrations', () => {

--- a/packages/cli/src/modules/agents/builder/__tests__/agents-builder.service.session.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/agents-builder.service.session.test.ts
@@ -29,7 +29,6 @@ const agentsSdkMocks = vi.hoisted(() => {
 	const modelCalls: unknown[] = [];
 	const promptCachingCalls: unknown[] = [];
 	const reasoningCalls: string[] = [];
-	const skillsCalls: unknown[] = [];
 	const telemetryCalls: unknown[] = [];
 	const memoryTaskObserverCalls: unknown[] = [];
 	const observationalMemoryCalls: Array<{
@@ -63,8 +62,7 @@ const agentsSdkMocks = vi.hoisted(() => {
 			instructionsCalls.push(text);
 			return this;
 		}
-		skills(skills: unknown) {
-			skillsCalls.push(skills);
+		skills(_skills: unknown) {
 			return this;
 		}
 		memory() {
@@ -130,7 +128,6 @@ const agentsSdkMocks = vi.hoisted(() => {
 		modelCalls,
 		promptCachingCalls,
 		reasoningCalls,
-		skillsCalls,
 		telemetryCalls,
 		memoryTaskObserverCalls,
 		observationalMemoryCalls,
@@ -239,7 +236,6 @@ describe('AgentsBuilderService session isolation', () => {
 		agentsSdkMocks.modelCalls.length = 0;
 		agentsSdkMocks.promptCachingCalls.length = 0;
 		agentsSdkMocks.reasoningCalls.length = 0;
-		agentsSdkMocks.skillsCalls.length = 0;
 		agentsSdkMocks.telemetryCalls.length = 0;
 		agentsSdkMocks.memoryTaskObserverCalls.length = 0;
 		agentsSdkMocks.observationalMemoryCalls.length = 0;
@@ -333,17 +329,6 @@ describe('AgentsBuilderService session isolation', () => {
 		await service.cancelCheckpoint('agent-1', 'run-1');
 
 		expect(n8nCheckpointStorage.delete).toHaveBeenCalledWith('run-1', 'agent-1');
-	});
-
-	it('includes the external services skill', async () => {
-		const { service, user, credentialProvider } = setup();
-
-		await drain(
-			service.buildAgent('agent-1', 'project-1', 'hi', credentialProvider, user, baseSession),
-		);
-
-		const skills = agentsSdkMocks.skillsCalls[0] as Array<{ id: string }>;
-		expect(skills.some((skill) => skill.id === 'agent-builder-external-services')).toBe(true);
 	});
 
 	it('uses session.modelConfig directly for the builder model', async () => {

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -241,7 +241,7 @@ export const FEW_SHOT_FLOWS_SECTION = `\
 4. \`patch_config(...)\` replacing \`/model\` and \`/credential\`.
 
 ### Add an explicitly requested n8n node tool to an existing agent
-1. Load \`agent-builder-external-services\`, then call \`search_nodes\` and
+1. Load \`agent-builder-node-tools\`, then call \`search_nodes\` and
    \`get_node_types\`; the explicit n8n-node request does not need
    \`resolve_integration\`.
 2. \`ask_credential\` for every required slot.
@@ -249,7 +249,7 @@ export const FEW_SHOT_FLOWS_SECTION = `\
 4. \`patch_config(...)\` adding the node tool to \`/tools/-\`.
 
 ### Add an explicitly requested n8n node tool when credential setup is skipped
-1. Load \`agent-builder-external-services\`, then call \`search_nodes\` and
+1. Load \`agent-builder-node-tools\`, then call \`search_nodes\` and
    \`get_node_types\`.
 2. \`ask_credential(...)\` -> \`{ skipped: true }\`.
 3. \`read_config()\`.
@@ -296,8 +296,8 @@ follow-up for the credential.
    and follow the returned kind:
    - \`kind: "mcp"\`: follow the skill's MCP Servers section — verify and wire
      the MCP server.
-   - \`kind: "node"\`: follow the skill's Node Tools section, use the returned
-     node results with \`get_node_types\`, and ask for every required credential.
+   - \`kind: "node"\`: load \`agent-builder-node-tools\`, use the returned node
+     results with \`get_node_types\`, and ask for every required credential.
 5. In this non-chat branch only, \`read_config()\`, then \`patch_config(...)\` or
    \`write_config(...)\` with the resolved capability.
 

--- a/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
+++ b/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
@@ -14,7 +14,8 @@ changing, or removing entries in \`tools[]\` / \`mcpServers\` / \`providerTools\
 
 For an external product, load \`agent-builder-external-services\` once and
 follow it. It covers the chat-integration-versus-callable-tool decision, chat
-integration setup, MCP servers, and node tools.
+integration setup, and MCP servers. Load \`agent-builder-node-tools\` before
+configuring a node tool.
 
 - Chat/trigger integration: call \`list_integration_types\`, then
   \`configure_channel\` with a returned type. Do not call \`resolve_integration\`
@@ -26,8 +27,8 @@ integration setup, MCP servers, and node tools.
   from memory.
   - \`kind: "mcp"\`: follow the skill's MCP Servers section — credential,
     verification, and config workflow.
-  - \`kind: "node"\`: follow the skill's Node Tools section, use the returned
-    node results, and continue with \`get_node_types\`.
+  - \`kind: "node"\`: load \`agent-builder-node-tools\`, use the returned node
+    results, and continue with \`get_node_types\`.
 
 Use \`search_nodes\` directly only when the user explicitly asks for an n8n node,
 when refining node results, or when a verified MCP server lacks the requested
@@ -49,10 +50,13 @@ they cannot perform live network, filesystem, process, timer, or host I/O.
 
 #### Node Tools
 
-Load \`agent-builder-external-services\` when the user explicitly requests an
-n8n node, and follow its Node Tools section before adding, changing, or
-removing node-backed tools, \`nodeParameters\`, \`$fromAI\` usage, or n8n
-expressions.
+Load \`agent-builder-node-tools\` before adding, changing, or removing
+node-backed tools, \`nodeParameters\`, \`$fromAI\` usage, or n8n expressions.
+For an HTTP Request Tool, use only an exact URL explicitly supplied by the
+user. If the user has not supplied one during an initial build, you MUST ask
+for it through the trailing \`finish_setup\` call, then configure the tool with
+the answer. On later turns, use \`ask_questions\` before mutating the config.
+Never infer or invent a URL.
 
 #### MCP Servers
 

--- a/packages/cli/src/modules/agents/builder/resolve-integration.tool.ts
+++ b/packages/cli/src/modules/agents/builder/resolve-integration.tool.ts
@@ -22,7 +22,7 @@ const resolveIntegrationInputSchema = z.object({
 export function buildResolveIntegrationTool(deps: ResolveIntegrationDeps): BuiltTool {
 	return new Tool(BUILDER_TOOLS.RESOLVE_INTEGRATION)
 		.description(
-			'Resolve external services to MCP servers or n8n node tools. Searches the MCP registry first and returns kind: "mcp" when a match exists; only searches agent-eligible n8n node tools and returns kind: "node" when no MCP server matches. For either kind, load agent-builder-external-services and follow its matching section, using the returned results.',
+			'Resolve external services to MCP servers or n8n node tools. Searches the MCP registry first and returns kind: "mcp" when a match exists; only searches agent-eligible n8n node tools and returns kind: "node" when no MCP server matches. For kind "mcp", load agent-builder-external-services. For kind "node", load agent-builder-node-tools. Follow the loaded skill using the returned results.',
 		)
 		.input(resolveIntegrationInputSchema)
 		.handler(async ({ queries }: { queries: string[] }) => {

--- a/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
@@ -15,13 +15,11 @@ export function externalServicesSkill(): RuntimeSkill {
 		id: 'agent-builder-external-services',
 		name: 'Agent Builder External Services',
 		description:
-			'Use when connecting the target agent to any external product: deciding whether Slack, Discord, Linear, Telegram, or another platform is a chat integration/trigger versus an MCP, node, or workflow tool; adding, removing, or updating chat integrations or MCP servers; and wiring n8n node-backed tools (search_nodes/get_node_types discovery, nodeParameters, node credential slots, $fromAI usage, n8n expressions).',
+			'Use when connecting the target agent to an external product: deciding whether Slack, Discord, Linear, Telegram, or another platform is a chat integration/trigger versus a callable service, and adding, removing, or updating chat integrations or MCP servers.',
 		recommendedTools: [
 			'resolve_integration',
 			'list_integration_types',
 			'configure_channel',
-			'search_nodes',
-			'get_node_types',
 			'ask_credential',
 			'verify_mcp_server',
 			'read_config',
@@ -32,11 +30,8 @@ export function externalServicesSkill(): RuntimeSkill {
 			'list_integration_types',
 			'configure_channel',
 			'search_mcp_servers',
-			'search_nodes',
-			'get_node_types',
 			'ask_credential',
 			'verify_mcp_server',
-			'get_resource_locator_options',
 			'ask_questions',
 			'read_config',
 			'patch_config',
@@ -46,11 +41,10 @@ export function externalServicesSkill(): RuntimeSkill {
 		instructions: `\
 ## Purpose
 
-Use this to connect the target agent to external products across all three
-surfaces: chat integrations (the \`integrations\` array), MCP servers
-(\`mcpServers\`), and n8n node tools (entries in \`tools[]\` with
-\`nodeParameters\`). Decide the right surface first, then follow that
-section.
+Use this to connect the target agent to external products across chat
+integrations (the \`integrations\` array), MCP servers (\`mcpServers\`), and
+n8n node tools. Decide the right surface first. For a node tool, load
+\`agent-builder-node-tools\` and follow that skill.
 
 ## Integration vs Callable Tool Decision
 
@@ -86,18 +80,7 @@ Examples:
 
 For callable (non-chat) services, call \`resolve_integration\` separately per
 service and follow the returned \`kind\`: \`"mcp"\` -> MCP Servers section
-below, \`"node"\` -> Node Tools section below.
-
-## Web Search vs Direct HTTP Requests
-
-Generic web search, browsing, research, current-information, and source-finding
-requests must use \`config.webSearch\` according to the system prompt's
-web-search rules. Do not call \`resolve_integration\` or \`search_nodes\` for
-these requests.
-
-Never add \`n8n-nodes-base.httpRequestTool\` or
-\`@n8n/n8n-nodes-langchain.toolHttpRequest\` unless the user explicitly
-requests the HTTP Request Tool or direct HTTP, API, or specific-page fetching.
+below, \`"node"\` -> load \`agent-builder-node-tools\`.
 
 ## Chat Integrations
 
@@ -162,8 +145,9 @@ call \`resolve_integration\` with queries matching the requested service.
 Resolve one requested service per call; use \`queries\` only for alternative
 search terms for that service.
 
-- If it returns \`kind: "node"\` for a generic service request, follow the Node
-  Tools section with the returned node results. Stop this MCP workflow.
+- If it returns \`kind: "node"\` for a generic service request, load
+  \`agent-builder-node-tools\` and follow it with the returned node results.
+  Stop this MCP workflow.
 - If it returns \`kind: "node"\` but the user explicitly requested an MCP server,
   do not silently substitute a node tool. Continue with manual MCP setup by
   asking for the URL and transport/authentication decision through
@@ -211,9 +195,9 @@ credential into the matching entry itself (\`credentialApplied: true\`); no
 additions keep the immediate ask + verify flow above unchanged.
 
 If verification succeeds but the tools do not cover the requested capability
-for a generic service request, switch to the Node Tools section, call
-\`search_nodes\` with the same service queries, and continue with node setup. Do
-not add the MCP server merely because its registry entry matched.
+for a generic service request, load \`agent-builder-node-tools\`, call
+\`search_nodes\` with the same service queries, and follow that skill. Do not
+add the MCP server merely because its registry entry matched.
 
 Full schema reference:
 
@@ -307,70 +291,6 @@ Auth, or None) via \`${ASK_QUESTIONS_TOOL_NAME}\`. Then map to:
 - A registry match proves server availability, not support for the requested
   capability; use the verified live tool list for that decision.
 
-## Node Tools
-
-Use this section to discover, configure, and wire node tools into the target
-agent's \`tools[]\`, including \`nodeParameters\` and n8n expressions.
-
-### Workflow
-
-- For a generic external-service request, call \`resolve_integration\` before
-  node discovery unless a resolver result is already available.
-- If it returns \`kind: "mcp"\`, follow the MCP Servers section instead and stop
-  this node-tool workflow.
-- If it returns \`kind: "node"\`, use its returned node results and call
-  \`get_node_types\`; do not repeat the same search with \`search_nodes\`.
-- Call \`search_nodes\` directly only when the user explicitly requests an n8n
-  node, when refining node results, or when a verified MCP server lacks the
-  requested capability.
-- Never guess node type names.
-- Use the tool node id from discovery, usually ending in \`Tool\`.
-- Put fixed values in \`nodeParameters\`; use complete n8n expressions for values the agent should decide at runtime:
-  \`={{ $fromAI('url', 'The URL to inspect', 'string') }}\`.
-- For stable dynamic selectors, load \`agent-builder-resource-locators\` and
-  follow it.
-- Never write literal \`"$fromAI"\` or bare \`$fromAI\`; the node will treat it as the actual value.
-- Do not pipe AI-chosen fields through \`$json\`.
-- Do not include \`inputSchema\` or \`toolDescription\` for node tools.
-- n8n Connect (\`n8n credits\`) covers many services, including some community nodes. Adding a node tool with its credential slot omitted triggers server-side assignment: for a covered service the server attaches the managed \`n8n credits\` credential (\`{ id: null, name: "n8n credits", __aiGatewayManaged: true }\`) to each required, eligible slot on write — but only when the project has no credential of that type; an existing credential of the type wins and the slot stays empty for the normal credential flow below. Add the tool with the credential slot omitted, then \`read_config\`.
-- Exception — when the user explicitly asks to run a tool on n8n credits, write \`{ "id": null, "name": "n8n credits", "__aiGatewayManaged": true }\` into that credential slot yourself: the server keeps it when the service is covered (even if the user has their own credential of the type) and removes it when not covered — check \`read_config\` after the write and resolve a real credential if it was removed.
-- The \`n8n credits\` managed credential IS the real, working credential — the tool executes through n8n's gateway on n8n credits, so NO separate API key is needed. It is NOT a placeholder and NOT "invalid for the service", even for a community node. For a slot \`read_config\` shows populated with it: the slot is fully connected and the tool WILL run. Do NOT call \`ask_credential\` for it; do NOT include it in \`finish_setup\`; NEVER clear, remove, or replace it via \`patch_config\`; and NEVER seek a "real" API key to swap in for it. Report the tool as ready, running on n8n credits — exactly like a managed model. Never tell the user the credential is "not connected"/"not set up" or that the tool "won't run until a credential is added".
-- Only for a required slot that \`read_config\` shows still empty after the write (a service n8n Connect does not cover) do you resolve a real credential: call \`ask_credential\` once before the config mutation for an addition to an existing agent. ${INITIAL_BUILD_NOTE} After the trailing \`finish_setup\` resolves the credential, copy the returned credentials into \`node.credentials\` via \`patch_config\`; for resource-locator resolution follow \`agent-builder-resource-locators\` then. Pass the node's credential key as \`credentialSlot\`. On success, copy the returned \`credentials\` object directly to \`node.credentials\`. If skipped, still add the tool and omit only that credential slot.
-- When the agent already has a chat channel configured and the tool needs the same
-  credential type, \`ask_credential\` reuses the channel's credential automatically —
-  do not ask the user to pick a different one.
-
-### n8n Expressions
-
-Node tool parameters inside \`nodeParameters\` can use n8n expressions.
-Prefer \`$fromAI\` whenever the target agent should decide a value at runtime.
-Do not use \`$fromAI\` for stable resource IDs that the target agent cannot know
-at runtime, such as Linear \`teamId\`, project IDs, channel IDs, calendar IDs,
-database IDs, table IDs, or other dynamic "Name or ID" selectors. Resolve those
-with the \`agent-builder-resource-locators\` skill, \`ask_credential\`, and
-\`get_resource_locator_options\`; write the returned \`parameterValue\` into
-\`nodeParameters\`.
-
-- \`={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('fieldName', 'What value to provide', 'string') }}\`
-- \`={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('count', 'How many items', 'number') }}\`
-- \`={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('enabled', 'Whether to enable this option', 'boolean') }}\`
-- \`={{ $now.toISO() }}\` for current date/time.
-- \`={{ $today }}\` for the start of today.
-
-Always wrap expressions in \`={{ }}\`. Never pipe AI-chosen node-tool fields
-through \`$json\`; use \`$fromAI\` for those fields instead.
-
-### Gotchas
-
-- Do not include \`inputSchema\` or \`toolDescription\` for node tools.
-- \`$fromAI(...)\` placeholders define the node tool input schema; do not add it manually.
-- Follow \`agent-builder-resource-locators\` for dynamic selector lookup,
-  credentials, and \`parameterValue\` handling.
-- If a required node-tool credential is skipped, add the tool and omit only that credential slot.
-- Node tools execute inline, so never use waiting operations such as \`sendAndWait\`
-  or \`dispatchAndWait\`. When the user requests human approval, configure the
-  intended non-waiting operation and set \`requireApproval: true\` on the tool.
-
 ## Verify
 
 - Configured chat integrations were set up through \`configure_channel\` or the
@@ -382,7 +302,6 @@ through \`$json\`; use \`$fromAI\` for those fields instead.
 - Generic non-chat external services were routed through \`resolve_integration\`
   before MCP or node setup.
 - The final \`integrations\` array keeps unrelated integrations intact and
-  removes only the requested channel entries.
-- Node tools use discovered tool node ids and valid node parameters.`,
+  removes only the requested channel entries.`,
 	};
 }

--- a/packages/cli/src/modules/agents/builder/skills/index.ts
+++ b/packages/cli/src/modules/agents/builder/skills/index.ts
@@ -3,6 +3,7 @@ import type { RuntimeSkill } from '@n8n/agents';
 import { customToolsSkill } from './custom-tools.skill';
 import { externalServicesSkill } from './external-services.skill';
 import { memorySkill } from './memory.skill';
+import { nodeToolsSkill } from './node-tools.skill';
 import { resourceLocatorsSkill } from './resource-locators.skill';
 import { subAgentsSkill } from './sub-agents.skill';
 import { targetSkillsSkill } from './target-skills.skill';
@@ -13,6 +14,7 @@ export function getBuilderRuntimeSkills(): RuntimeSkill[] {
 		customToolsSkill(),
 		externalServicesSkill(),
 		memorySkill(),
+		nodeToolsSkill(),
 		resourceLocatorsSkill(),
 		subAgentsSkill(),
 		targetSkillsSkill(),

--- a/packages/cli/src/modules/agents/builder/skills/node-tools.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/node-tools.skill.ts
@@ -1,0 +1,132 @@
+import type { RuntimeSkill } from '@n8n/agents';
+import { ASK_QUESTIONS_TOOL_NAME } from '@n8n/api-types';
+
+import { INITIAL_BUILD_NOTE } from '../prompts/initial-build.prompt';
+
+export function nodeToolsSkill(): RuntimeSkill {
+	return {
+		id: 'agent-builder-node-tools',
+		name: 'Agent Builder Node Tools',
+		description:
+			'Use whenever adding, removing, or updating an n8n node-backed tool, including search_nodes/get_node_types discovery, nodeParameters, node credential slots, $fromAI usage, n8n expressions, and HTTP Request Tool configuration.',
+		recommendedTools: [
+			'resolve_integration',
+			'search_nodes',
+			'get_node_types',
+			'ask_credential',
+			'read_config',
+			'patch_config',
+		],
+		allowedTools: [
+			'resolve_integration',
+			'search_nodes',
+			'get_node_types',
+			'ask_credential',
+			'get_resource_locator_options',
+			'ask_questions',
+			'read_config',
+			'patch_config',
+			'write_config',
+			'load_skill',
+		],
+		instructions: `\
+## Purpose
+
+Use this to discover, configure, and wire node tools into the target agent's
+\`tools[]\`, including \`nodeParameters\`, credentials, and n8n expressions.
+
+## Web Search vs Direct HTTP Requests
+
+Generic web search, browsing, research, current-information, and source-finding
+requests must use \`config.webSearch\` according to the system prompt's
+web-search rules. Do not call \`resolve_integration\` or \`search_nodes\` for
+these requests.
+
+Never add the retired \`@n8n/n8n-nodes-langchain.toolHttpRequest\`. When the
+user explicitly requests the HTTP Request Tool or direct HTTP, API, or
+specific-page fetching, use only \`n8n-nodes-base.httpRequestTool\`.
+
+### Mandatory HTTP Request URL Gate
+
+Use only an exact URL explicitly supplied by the user for
+\`n8n-nodes-base.httpRequestTool\`. If the user has not supplied one, you MUST
+ask which URL the tool should fetch. During an initial build, mark this setup
+as blocked and include the URL question in the single trailing \`finish_setup\`
+call; add the tool with the returned URL after the user answers. On later
+turns, call \`${ASK_QUESTIONS_TOOL_NAME}\` and wait for the answer before
+mutating the config. Do not search for, derive, infer, guess, or invent a URL
+from a service name, requested action, documentation, or common API
+conventions. Never add an incomplete tool or use a placeholder URL.
+
+## Workflow
+
+- For a generic external-service request, call \`resolve_integration\` before
+  node discovery unless a resolver result is already available.
+- If it returns \`kind: "mcp"\`, load \`agent-builder-external-services\`,
+  follow its MCP Servers section, and stop this node-tool workflow.
+- If it returns \`kind: "node"\`, use its returned node results and call
+  \`get_node_types\`; do not repeat the same search with \`search_nodes\`.
+- Call \`search_nodes\` directly only when the user explicitly requests an n8n
+  node, when refining node results, or when a verified MCP server lacks the
+  requested capability.
+- Never guess node type names.
+- Use the tool node id from discovery, usually ending in \`Tool\`.
+- Put fixed values in \`nodeParameters\`; use complete n8n expressions for values the agent should decide at runtime:
+  \`={{ $fromAI('message', 'The message to send', 'string') }}\`.
+- \`n8n-nodes-base.httpRequestTool\` requires a fixed \`nodeParameters.url\`; it
+  does not work with a dynamic or model-selected URL. Never use \`$fromAI\` in
+  the URL; use it only in other request fields.
+- For stable dynamic selectors, load \`agent-builder-resource-locators\` and
+  follow it.
+- Never write literal \`"$fromAI"\` or bare \`$fromAI\`; the node will treat it as the actual value.
+- Do not pipe AI-chosen fields through \`$json\`.
+- Do not include \`inputSchema\` or \`toolDescription\` for node tools.
+- n8n Connect (\`n8n credits\`) covers many services, including some community nodes. Adding a node tool with its credential slot omitted triggers server-side assignment: for a covered service the server attaches the managed \`n8n credits\` credential (\`{ id: null, name: "n8n credits", __aiGatewayManaged: true }\`) to each required, eligible slot on write — but only when the project has no credential of that type; an existing credential of the type wins and the slot stays empty for the normal credential flow below. Add the tool with the credential slot omitted, then \`read_config\`.
+- Exception — when the user explicitly asks to run a tool on n8n credits, write \`{ "id": null, "name": "n8n credits", "__aiGatewayManaged": true }\` into that credential slot yourself: the server keeps it when the service is covered (even if the user has their own credential of the type) and removes it when not covered — check \`read_config\` after the write and resolve a real credential if it was removed.
+- The \`n8n credits\` managed credential IS the real, working credential — the tool executes through n8n's gateway on n8n credits, so NO separate API key is needed. It is NOT a placeholder and NOT "invalid for the service", even for a community node. For a slot \`read_config\` shows populated with it: the slot is fully connected and the tool WILL run. Do NOT call \`ask_credential\` for it; do NOT include it in \`finish_setup\`; NEVER clear, remove, or replace it via \`patch_config\`; and NEVER seek a "real" API key to swap in for it. Report the tool as ready, running on n8n credits — exactly like a managed model. Never tell the user the credential is "not connected"/"not set up" or that the tool "won't run until a credential is added".
+- Only for a required slot that \`read_config\` shows still empty after the write (a service n8n Connect does not cover) do you resolve a real credential: call \`ask_credential\` once before the config mutation for an addition to an existing agent. ${INITIAL_BUILD_NOTE} After the trailing \`finish_setup\` resolves the credential, copy the returned credentials into \`node.credentials\` via \`patch_config\`; for resource-locator resolution follow \`agent-builder-resource-locators\` then. Pass the node's credential key as \`credentialSlot\`. On success, copy the returned \`credentials\` object directly to \`node.credentials\`. If skipped, still add the tool and omit only that credential slot.
+- When the agent already has a chat channel configured and the tool needs the same
+  credential type, \`ask_credential\` reuses the channel's credential automatically —
+  do not ask the user to pick a different one.
+
+## n8n Expressions
+
+Node tool parameters inside \`nodeParameters\` can use n8n expressions.
+Prefer \`$fromAI\` whenever the target agent should decide a value at runtime,
+except where this skill requires a fixed value, especially the HTTP Request
+Tool URL.
+Do not use \`$fromAI\` for stable resource IDs that the target agent cannot know
+at runtime, such as Linear \`teamId\`, project IDs, channel IDs, calendar IDs,
+database IDs, table IDs, or other dynamic "Name or ID" selectors. Resolve those
+with the \`agent-builder-resource-locators\` skill, \`ask_credential\`, and
+\`get_resource_locator_options\`; write the returned \`parameterValue\` into
+\`nodeParameters\`.
+
+- \`={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('fieldName', 'What value to provide', 'string') }}\`
+- \`={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('count', 'How many items', 'number') }}\`
+- \`={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('enabled', 'Whether to enable this option', 'boolean') }}\`
+- \`={{ $now.toISO() }}\` for current date/time.
+- \`={{ $today }}\` for the start of today.
+
+Always wrap expressions in \`={{ }}\`. Never pipe AI-chosen node-tool fields
+through \`$json\`; use \`$fromAI\` for those fields instead.
+
+## Gotchas
+
+- Do not include \`inputSchema\` or \`toolDescription\` for node tools.
+- \`$fromAI(...)\` placeholders define the node tool input schema; do not add it manually.
+- Follow \`agent-builder-resource-locators\` for dynamic selector lookup,
+  credentials, and \`parameterValue\` handling.
+- If a required node-tool credential is skipped, add the tool and omit only that credential slot.
+- Node tools execute inline, so never use waiting operations such as \`sendAndWait\`
+  or \`dispatchAndWait\`. When the user requests human approval, configure the
+  intended non-waiting operation and set \`requireApproval: true\` on the tool.
+
+## Verify
+
+- Generic external-service requests were routed through \`resolve_integration\`
+  before node setup.
+- Node tools use discovered tool node ids and valid node parameters.
+- HTTP Request Tools use a fixed URL supplied by the user.`,
+	};
+}

--- a/packages/cli/src/modules/agents/utils/__tests__/node-tool-validation.test.ts
+++ b/packages/cli/src/modules/agents/utils/__tests__/node-tool-validation.test.ts
@@ -45,6 +45,9 @@ describe('HTTP Request URL validation', () => {
 				configuredNodeTool('HTTP Request', 'n8n-nodes-base.httpRequest', {
 					url: "={{ $FromAI ('url') }}",
 				}),
+				configuredNodeTool('Malformed HTTP Request', 'n8n-nodes-base.httpRequestTool', {
+					url: "={{ $fromAI('url' }}",
+				}),
 			]),
 		).toEqual([
 			{
@@ -56,6 +59,11 @@ describe('HTTP Request URL validation', () => {
 				toolIndex: 1,
 				toolName: 'HTTP Request',
 				path: 'tools.1.node.nodeParameters.url',
+			},
+			{
+				toolIndex: 2,
+				toolName: 'Malformed HTTP Request',
+				path: 'tools.2.node.nodeParameters.url',
 			},
 		]);
 

--- a/packages/cli/src/modules/agents/utils/__tests__/node-tool-validation.test.ts
+++ b/packages/cli/src/modules/agents/utils/__tests__/node-tool-validation.test.ts
@@ -1,6 +1,9 @@
 import type { AgentJsonToolConfig } from '@n8n/api-types';
 
-import { validateNodeToolConfigs } from '../node-tool-validation';
+import {
+	findHttpRequestToolUrlFromAiViolations,
+	validateNodeToolConfigs,
+} from '../node-tool-validation';
 
 const { mockValidateNodeConfig } = vi.hoisted(() => ({
 	mockValidateNodeConfig: vi.fn(),
@@ -20,6 +23,57 @@ const nodeTool = (operation: string): AgentJsonToolConfig => ({
 		nodeTypeVersion: 2.2,
 		nodeParameters: { resource: 'message', operation },
 	},
+});
+
+const configuredNodeTool = (
+	name: string,
+	nodeType: string,
+	nodeParameters: Record<string, unknown>,
+): AgentJsonToolConfig => ({
+	type: 'node',
+	name,
+	node: { nodeType, nodeTypeVersion: 4.5, nodeParameters },
+});
+
+describe('HTTP Request URL validation', () => {
+	it('finds $fromAI only in modern HTTP Request URL fields', () => {
+		expect(
+			findHttpRequestToolUrlFromAiViolations([
+				configuredNodeTool('HTTP Request Tool', 'n8n-nodes-base.httpRequestTool', {
+					url: "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('url') }}",
+				}),
+				configuredNodeTool('HTTP Request', 'n8n-nodes-base.httpRequest', {
+					url: "={{ $FromAI ('url') }}",
+				}),
+			]),
+		).toEqual([
+			{
+				toolIndex: 0,
+				toolName: 'HTTP Request Tool',
+				path: 'tools.0.node.nodeParameters.url',
+			},
+			{
+				toolIndex: 1,
+				toolName: 'HTTP Request',
+				path: 'tools.1.node.nodeParameters.url',
+			},
+		]);
+
+		expect(
+			findHttpRequestToolUrlFromAiViolations([
+				configuredNodeTool('Fixed HTTP Request', 'n8n-nodes-base.httpRequestTool', {
+					url: '={{ $json.url }}',
+					body: "={{ $fromAI('body') }}",
+				}),
+				configuredNodeTool('Legacy HTTP Request', '@n8n/n8n-nodes-langchain.toolHttpRequest', {
+					url: "={{ $fromAI('url') }}",
+				}),
+				configuredNodeTool('Other Node', 'n8n-nodes-base.slackTool', {
+					url: "={{ $fromAI('url') }}",
+				}),
+			]),
+		).toEqual([]);
+	});
 });
 
 describe('validateNodeToolConfigs', () => {

--- a/packages/cli/src/modules/agents/utils/node-tool-validation.ts
+++ b/packages/cli/src/modules/agents/utils/node-tool-validation.ts
@@ -1,6 +1,6 @@
 import { extractFromAIParameters } from '@n8n/ai-utilities/fromai-helpers';
 import type { AgentJsonToolConfig } from '@n8n/api-types';
-import type { INodeParameters } from 'n8n-workflow';
+import { extractFromAICalls, HTTP_REQUEST_NODE_TYPE, type INodeParameters } from 'n8n-workflow';
 
 import {
 	isUnsupportedEphemeralNodeOperation,
@@ -9,6 +9,44 @@ import {
 import { resolveBuiltinNodeDefinitionDirs } from '@/utils/node-definition-dirs';
 
 type NodeToolConfig = Extract<AgentJsonToolConfig, { type: 'node' }>;
+const HTTP_REQUEST_TOOL_NODE_TYPE = `${HTTP_REQUEST_NODE_TYPE}Tool`;
+
+export interface HttpRequestToolUrlFromAiViolation {
+	toolIndex: number;
+	toolName: string;
+	path: `tools.${number}.node.nodeParameters.url`;
+}
+
+export function findHttpRequestToolUrlFromAiViolations(
+	tools: AgentJsonToolConfig[] | undefined,
+): HttpRequestToolUrlFromAiViolation[] {
+	return (tools ?? []).flatMap((tool, toolIndex) => {
+		if (
+			tool.type !== 'node' ||
+			(tool.node.nodeType !== HTTP_REQUEST_NODE_TYPE &&
+				tool.node.nodeType !== HTTP_REQUEST_TOOL_NODE_TYPE)
+		) {
+			return [];
+		}
+
+		const url = tool.node.nodeParameters?.url;
+		if (typeof url !== 'string') return [];
+
+		try {
+			if (extractFromAICalls(url).length === 0) return [];
+		} catch {
+			return [];
+		}
+
+		return [
+			{
+				toolIndex,
+				toolName: tool.name,
+				path: `tools.${toolIndex}.node.nodeParameters.url` as const,
+			},
+		];
+	});
+}
 
 /**
  * Throws when a node tool's parameters contain a malformed `$fromAI`

--- a/packages/cli/src/modules/agents/utils/node-tool-validation.ts
+++ b/packages/cli/src/modules/agents/utils/node-tool-validation.ts
@@ -35,7 +35,7 @@ export function findHttpRequestToolUrlFromAiViolations(
 		try {
 			if (extractFromAICalls(url).length === 0) return [];
 		} catch {
-			return [];
+			// A malformed $fromAI call is still unsafe in this field.
 		}
 
 		return [

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7832,6 +7832,7 @@
 	"agents.builder.preview.disabledTooltip": "This agent's configuration has errors. Resolve them before previewing.",
 	"agents.builder.validation.issue.missingRequired": "A required field is missing",
 	"agents.builder.validation.issue.invalidValue": "A field has an invalid value",
+	"agents.builder.validation.issue.httpRequestUrlFromAi": "The model can't set the URL. Enter a fixed URL.",
 	"agents.builder.validation.issue.missingCredential": "Credential is missing",
 	"agents.builder.validation.issue.invalidCredential": "Credential isn't valid or isn't accessible",
 	"agents.builder.validation.issue.incompatibleCredential": "Credential type doesn't match",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -2621,6 +2621,20 @@ describe('AgentBuilderView — three-column shell', () => {
 	});
 
 	it('opens the tool config modal with the custom tool source', async () => {
+		const validationIssue = {
+			code: 'missing_reference' as const,
+			path: 'tools.0.id',
+			capability: {
+				kind: 'tool' as const,
+				id: 'custom_tool',
+				index: 0,
+				toolType: 'custom' as const,
+			},
+		};
+		getAgentConfigValidationMock.mockResolvedValue({
+			status: 'invalid',
+			issues: [validationIssue],
+		});
 		const customTool: CustomToolEntry = {
 			code: 'export async function run() {\n\treturn "ok";\n}',
 			descriptor: {
@@ -2665,6 +2679,7 @@ describe('AgentBuilderView — three-column shell', () => {
 				data: expect.objectContaining({
 					toolRef,
 					customTool,
+					validationIssues: [validationIssue],
 				}),
 			}),
 		);

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolConfigModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolConfigModal.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
+import type { AgentConfigValidationIssue } from '@n8n/api-types';
 import { mockedStore } from '@/__tests__/utils';
 import { useUIStore } from '@/app/stores/ui.store';
 import { fireEvent, waitFor } from '@testing-library/vue';
@@ -56,7 +57,13 @@ vi.mock('@n8n/design-system', async () => {
 
 function createToolSettingsStub(emitValid: boolean) {
 	return defineComponent({
-		props: ['initialNode', 'existingToolNames', 'projectId'],
+		props: [
+			'initialNode',
+			'existingToolNames',
+			'projectId',
+			'parameterIssues',
+			'fromAiDisabledParameters',
+		],
 		emits: ['update:valid', 'update:node-name', 'update:node'],
 		setup(props, { emit, expose }) {
 			// Expose what the modal reads from ref(...). The stub carries through
@@ -66,7 +73,7 @@ function createToolSettingsStub(emitValid: boolean) {
 				name: props.initialNode?.name ?? '',
 				type: props.initialNode?.type ?? '',
 				typeVersion: props.initialNode?.typeVersion ?? 1,
-				parameters: { edited: true },
+				parameters: { ...props.initialNode?.parameters, edited: true },
 				credentials: props.initialNode?.credentials,
 				position: [0, 0],
 			};
@@ -83,7 +90,15 @@ function createToolSettingsStub(emitValid: boolean) {
 			return {};
 		},
 		template: `
-			<div data-test-id="node-tool-settings-content" :data-project-id="projectId" />
+			<div data-test-id="node-tool-settings-content" :data-project-id="projectId">
+				<button
+					v-if="!fromAiDisabledParameters?.includes('url')"
+					data-test-id="from-ai-override-button"
+				/>
+				<div v-if="parameterIssues?.url?.length" data-test-id="agent-tool-http-url-error">
+					{{ parameterIssues.url[0] }}
+				</div>
+			</div>
 		`,
 	});
 }
@@ -123,7 +138,7 @@ function createWorkflowToolConfigStub(emitValid: boolean) {
 const MODAL_NAME = 'AgentToolConfigModal';
 
 function toolRef(
-	overrides: Partial<Extract<AgentJsonToolRef, { type: 'node' }>> = {},
+	overrides: Partial<Extract<AgentJsonToolRef, { type: 'node' }>['node']> = {},
 ): Extract<AgentJsonToolRef, { type: 'node' }> {
 	return {
 		type: 'node',
@@ -146,6 +161,7 @@ function renderModal({
 	customTool,
 	projectId,
 	agentId,
+	validationIssues,
 }: {
 	valid?: boolean;
 	onConfirm?: (updated: AgentJsonToolRef) => void;
@@ -153,6 +169,7 @@ function renderModal({
 	customTool?: CustomToolEntry;
 	projectId?: string;
 	agentId?: string;
+	validationIssues?: AgentConfigValidationIssue[];
 } = {}) {
 	const renderComponent = createComponentRenderer(AgentToolConfigModal, {
 		global: {
@@ -179,7 +196,15 @@ function renderModal({
 	return renderComponent({
 		props: {
 			modalName: MODAL_NAME,
-			data: { toolRef: ref, customTool, existingToolNames: [], projectId, agentId, onConfirm },
+			data: {
+				toolRef: ref,
+				customTool,
+				existingToolNames: [],
+				projectId,
+				agentId,
+				validationIssues,
+				onConfirm,
+			},
 		},
 	});
 }
@@ -258,8 +283,34 @@ describe('AgentToolConfigModal', () => {
 		expect(updated.description).toBe(initial.description);
 		expect(updated).not.toHaveProperty('inputSchema');
 		// Fields merged from the edited INode
-		expect(updated.node.nodeParameters).toEqual({ edited: true });
+		expect(updated.node.nodeParameters).toEqual({ channel: 'general', edited: true });
 		expect(updated.node.credentials).toEqual({ slackApi: { id: 'cred-1', name: 'Prod Slack' } });
+	});
+
+	it('shows the HTTP Request URL error and blocks Save for a model override', async () => {
+		const { getByTestId, queryByTestId } = renderModal({
+			valid: true,
+			ref: toolRef({
+				nodeType: 'n8n-nodes-base.httpRequestTool',
+				nodeParameters: {
+					url: "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('URL', ``, 'string') }}",
+				},
+			}),
+			validationIssues: [
+				{
+					code: 'invalid_value',
+					path: 'tools.0.node.nodeParameters.url',
+					capability: { kind: 'tool', id: 'HTTP Request', index: 0, toolType: 'node' },
+				},
+			],
+		});
+		await nextTick();
+
+		expect(getByTestId('agent-tool-http-url-error')).toHaveTextContent(
+			'agents.builder.validation.issue.httpRequestUrlFromAi',
+		);
+		expect(queryByTestId('from-ai-override-button')).not.toBeInTheDocument();
+		expect(getByTestId('agent-tool-config-save')).toBeDisabled();
 	});
 
 	it('saves the approval requirement on node tool refs', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigModal.vue
@@ -11,10 +11,12 @@ import {
 	N8nDialogHeader,
 	N8nIcon,
 } from '@n8n/design-system';
-import { useI18n } from '@n8n/i18n';
-import type { INode } from 'n8n-workflow';
+import type { AgentConfigValidationIssue } from '@n8n/api-types';
+import { useI18n, type BaseTextKey } from '@n8n/i18n';
+import { extractFromAICalls, type INode } from 'n8n-workflow';
 import { FocusScope } from 'reka-ui';
 
+import { HTTP_REQUEST_NODE_TYPE, HTTP_REQUEST_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import type {
 	AgentJsonMcpServerConfig,
@@ -41,6 +43,7 @@ interface ToolModalData {
 	existingToolNames?: string[];
 	projectId?: string;
 	agentId?: string;
+	validationIssues?: AgentConfigValidationIssue[];
 	/** Inline agents pass false: approval needs suspend/resume, which workflow executions don't support. */
 	supportsToolApproval?: boolean;
 	onConfirm: (updatedRef: AgentJsonToolRef) => void;
@@ -74,6 +77,8 @@ const props = defineProps<{
 }>();
 
 const i18n = useI18n();
+const httpRequestUrlErrorKey =
+	'agents.builder.validation.issue.httpRequestUrlFromAi' as BaseTextKey;
 const uiStore = useUIStore();
 const isCredentialModalOpen = computed(
 	() => uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY]?.open === true,
@@ -88,6 +93,15 @@ const isOpen = computed({
 
 function isMcpServerModalData(data: AgentToolConfigModalData): data is McpServerModalData {
 	return data.kind === 'mcpServer';
+}
+
+function containsFromAiCall(value: unknown): boolean {
+	if (typeof value !== 'string') return false;
+	try {
+		return extractFromAICalls(value).length > 0;
+	} catch {
+		return false;
+	}
 }
 
 const isMcpTool = computed(() => isMcpServerModalData(props.data));
@@ -149,11 +163,6 @@ const customToolTitle = computed(() => {
 const canRender = computed(
 	() => isCustomTool.value || isWorkflowTool.value || initialNode.value !== null,
 );
-const canSave = computed(() => {
-	if (isCustomTool.value) return true;
-	if (isMcpTool.value) return isValid.value && mcpApprovalValid.value;
-	return isValid.value;
-});
 const supportsApproval = computed(() => props.data.supportsToolApproval !== false);
 const showApprovalSetting = computed(
 	() => supportsApproval.value && !isMcpTool.value && toolModalData.value !== null,
@@ -184,6 +193,43 @@ watch(
 );
 
 const currentNode = computed(() => draftNode.value ?? initialNode.value);
+const hasHttpRequestUrlIssue = computed(() => {
+	const data = toolModalData.value;
+	if (data?.toolRef.type !== 'node') return false;
+	if (
+		!data.validationIssues?.some(
+			(issue) => issue.code === 'invalid_value' && issue.path.endsWith('.node.nodeParameters.url'),
+		)
+	) {
+		return false;
+	}
+
+	const url = currentNode.value?.parameters.url;
+	return containsFromAiCall(url);
+});
+const canSave = computed(() => {
+	if (isCustomTool.value) return true;
+	if (isMcpTool.value) return isValid.value && mcpApprovalValid.value;
+	return isValid.value && !hasHttpRequestUrlIssue.value;
+});
+const fromAiDisabledParameters = computed(() => {
+	const toolRef = toolModalData.value?.toolRef;
+	if (
+		toolRef?.type === 'node' &&
+		(toolRef.node.nodeType === HTTP_REQUEST_NODE_TYPE ||
+			toolRef.node.nodeType === HTTP_REQUEST_TOOL_NODE_TYPE)
+	) {
+		return ['url'];
+	}
+	return [];
+});
+const nodeParameterIssues = computed<Record<string, string[]>>(() => {
+	const issues: Record<string, string[]> = {};
+	if (hasHttpRequestUrlIssue.value) {
+		issues.url = [i18n.baseText(httpRequestUrlErrorKey)];
+	}
+	return issues;
+});
 
 const headerKind = computed<'node' | 'workflow' | 'custom' | 'mcp'>(() => {
 	if (isCustomTool.value) return 'custom';
@@ -386,6 +432,8 @@ function handleNodeUpdate(node: INode) {
 							:initial-node="initialNode"
 							:existing-tool-names="data.existingToolNames"
 							:project-id="data.projectId"
+							:from-ai-disabled-parameters="fromAiDisabledParameters"
+							:parameter-issues="nodeParameterIssues"
 							content-test-id="node-tool-settings-content"
 							@update:valid="handleValidUpdate"
 							@update:node-name="handleNodeNameUpdate"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigNodeContent.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigNodeContent.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
 	existingToolNames?: string[];
 	projectId?: string;
 	contentTestId?: string;
+	parameterIssues?: Record<string, string[]>;
+	fromAiDisabledParameters?: string[];
 }>();
 
 const emit = defineEmits<{
@@ -49,6 +51,8 @@ defineExpose({
 		:existing-tool-names="props.existingToolNames"
 		:project-id="props.projectId"
 		:hidden-operations="UNSUPPORTED_AGENT_NODE_TOOL_OPERATIONS"
+		:parameter-issues="props.parameterIssues"
+		:from-ai-disabled-parameters="props.fromAiDisabledParameters"
 		:data-test-id="props.contentTestId"
 		@update:valid="emit('update:valid', $event)"
 		@update:node-name="emit('update:node-name', $event)"

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
@@ -2,6 +2,7 @@ import { computed, type ComputedRef, type Ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useToast } from '@n8n/composables/useToast';
+import type { AgentConfigValidationIssue } from '@n8n/api-types';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { AI_MCP_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
@@ -84,6 +85,7 @@ export interface UseAgentCapabilitiesActionsDeps {
 	 * Hosts whose agent always exists omit it.
 	 */
 	ensureAgentPersisted?: () => Promise<void>;
+	validationIssues?: Ref<AgentConfigValidationIssue[]> | ComputedRef<AgentConfigValidationIssue[]>;
 	telemetry?: AgentCapabilitiesTelemetry;
 }
 
@@ -105,6 +107,7 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 		localSkills,
 		supportsToolApproval,
 		ensureAgentPersisted,
+		validationIssues,
 		telemetry,
 	} = deps;
 
@@ -173,6 +176,9 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 					projectId: projectId.value,
 					agentId: agentId.value,
 					supportsToolApproval,
+					validationIssues: validationIssues?.value.filter(
+						(issue) => issue.capability.kind === 'tool' && issue.capability.index === toolIndex,
+					),
 					existingToolNames: tools
 						.map((toolRef, i) =>
 							i === toolIndex || toolRef.type === 'custom' ? null : toolRef.name,

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -1045,6 +1045,7 @@ const caps = useAgentCapabilitiesActions({
 	agentId,
 	connectedTriggers,
 	ensureAgentPersisted,
+	validationIssues: computed(() => configValidation.value?.issues ?? []),
 	scheduleConfigUpdate: onConfigFieldUpdate,
 	scheduleSkillSave: ({ skillId, skill }) => {
 		// The persisted validation result no longer reflects the working copy —

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -148,6 +148,7 @@ type Props = {
 	errorHighlight?: boolean;
 	isForCredential?: boolean;
 	canBeOverridden?: boolean;
+	externalIssues?: string[];
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -161,6 +162,7 @@ const props = withDefaults(defineProps<Props>(), {
 	eventBus: () => createEventBus(),
 	additionalExpressionData: () => ({}),
 	label: () => ({ size: 'small' }),
+	externalIssues: () => [],
 });
 
 const emit = defineEmits<{
@@ -579,7 +581,7 @@ const getIssues = computed<string[]>(() => {
 	const validationError = jsonValidationError.value;
 
 	if (validationError) {
-		return [validationError];
+		return [validationError, ...props.externalIssues];
 	}
 
 	if (props.hideIssues || !node.value) {
@@ -659,10 +661,10 @@ const getIssues = computed<string[]>(() => {
 	}
 
 	if (issues?.parameters?.[props.parameter.name] !== undefined) {
-		return issues.parameters[props.parameter.name];
+		return [...issues.parameters[props.parameter.name], ...props.externalIssues];
 	}
 
-	return [];
+	return props.externalIssues;
 });
 
 const displayTitle = computed<string>(() => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
@@ -116,6 +116,18 @@ describe('ParameterInputFull.vue', () => {
 		expect(getByTestId('from-ai-override-button')).toBeInTheDocument();
 	});
 
+	it('does not offer a model override when disabled', () => {
+		mockNodeTypesState.getNodeType = vi.fn().mockReturnValue({
+			codex: {
+				categories: ['AI'],
+				subcategories: { AI: ['Tools'] },
+			},
+		});
+		const { queryByTestId } = renderComponent({ props: { disableFromAi: true } });
+
+		expect(queryByTestId('from-ai-override-button')).not.toBeInTheDocument();
+	});
+
 	it('should render parameter with override button in options', async () => {
 		mockNodeTypesState.getNodeType = vi.fn().mockReturnValue({
 			codex: {
@@ -146,10 +158,30 @@ describe('ParameterInputFull.vue', () => {
 		const { queryByTestId, getByTestId } = renderComponent({
 			props: {
 				value: `={{ ${FROM_AI_AUTO_GENERATED_MARKER} $fromAI('myParam') }}`,
+				disableFromAi: true,
 			},
 		});
 		expect(getByTestId('fromAI-override-field')).toBeInTheDocument();
 		expect(queryByTestId('override-button')).not.toBeInTheDocument();
+	});
+
+	it('shows external validation issues in the parameter row', () => {
+		mockNodeTypesState.getNodeType = vi.fn().mockReturnValue({
+			codex: {
+				categories: ['AI'],
+				subcategories: { AI: ['Tools'] },
+			},
+		});
+		const { getByTestId } = renderComponent({
+			props: {
+				value: `={{ ${FROM_AI_AUTO_GENERATED_MARKER} $fromAI('myParam') }}`,
+				disableFromAi: true,
+				externalIssues: ["The model can't set the URL. Enter a fixed URL."],
+			},
+		});
+
+		expect(getByTestId('fromAI-override-field')).toBeInTheDocument();
+		expect(getByTestId('parameter-issues')).toBeInTheDocument();
 	});
 
 	it('should render an existing fromAI override for static options parameters', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.vue
@@ -58,6 +58,8 @@ type Props = {
 	showDelete?: boolean;
 	onDelete?: () => void;
 	optionsOverrides?: ParameterOptionsOverrides;
+	externalIssues?: string[];
+	disableFromAi?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -70,6 +72,8 @@ const props = withDefaults(defineProps<Props>(), {
 	label: () => ({ size: 'small' }),
 	showDelete: false,
 	onDelete: undefined,
+	externalIssues: () => [],
+	disableFromAi: false,
 });
 const emit = defineEmits<{
 	blur: [];
@@ -107,7 +111,7 @@ const fromAIOverride = ref<FromAIOverride | null>(makeOverrideValue(props, activ
 
 const canCreateContentOverride = computed(() => {
 	// The resourceLocator handles overrides separately
-	if (!activeNode.value || isResourceLocator.value) return false;
+	if (props.disableFromAi || !activeNode.value || isResourceLocator.value) return false;
 
 	return canBeContentOverride(props, activeNode.value);
 });
@@ -381,6 +385,7 @@ function removeOverride(clearField = false) {
 					:active-drop="activeDrop"
 					:force-show-expression="forceShowExpression"
 					:hide-issues="hideIssues"
+					:external-issues="externalIssues"
 					:label="label"
 					:event-bus="eventBus"
 					input-size="small"
@@ -478,6 +483,7 @@ function removeOverride(clearField = false) {
 				<FromAiOverrideField
 					v-if="fromAIOverride && isContentOverride"
 					:is-read-only="isReadOnly"
+					:issues="externalIssues"
 					@close="removeOverride(!canCreateContentOverride)"
 				/>
 				<div v-else>
@@ -495,6 +501,7 @@ function removeOverride(clearField = false) {
 						:hint="hint"
 						:hide-hint="hideHint"
 						:hide-issues="hideIssues"
+						:external-issues="externalIssues"
 						:label="label"
 						:event-bus="eventBus"
 						:can-be-overridden="canCreateContentOverride"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -91,6 +91,8 @@ type Props = {
 	optionsOverrides?: ParameterOptionsOverrides;
 	assignmentCollectionEditableValueIndices?: Record<string, number[]>;
 	layout?: 'inline';
+	parameterIssues?: Record<string, string[]>;
+	fromAiDisabledParameters?: string[];
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -1027,6 +1029,8 @@ watch(
 					:key="node?.name"
 					:parameter="item.parameter"
 					:hide-issues="hiddenIssuesInputs.includes(item.parameter.name)"
+					:external-issues="parameterIssues?.[item.parameter.name]"
+					:disable-from-ai="fromAiDisabledParameters?.includes(item.parameter.name)"
 					:value="getParameterValue(item.parameter.name)"
 					:display-options="item.showOptions"
 					:options-overrides="optionsOverrides"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputOverrides/FromAiOverrideField.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputOverrides/FromAiOverrideField.vue
@@ -3,8 +3,10 @@ import { i18n } from '@n8n/i18n';
 
 import { N8nIcon, N8nText } from '@n8n/design-system';
 import AiStarsIcon from '@/app/components/AiStarsIcon.vue';
+import ParameterIssues from '../ParameterIssues.vue';
 defineProps<{
 	isReadOnly?: boolean;
+	issues?: string[];
 }>();
 
 const emit = defineEmits<{
@@ -24,8 +26,11 @@ const emit = defineEmits<{
 				size="small"
 			/>
 		</div>
-		<div v-if="!isReadOnly" :class="[$style.overrideCloseButton]" @click="emit('close')">
-			<N8nIcon v-if="!isReadOnly" icon="x" size="small" />
+		<div v-if="issues?.length || !isReadOnly" :class="$style.actions">
+			<ParameterIssues v-if="issues?.length" :issues="issues" />
+			<div v-if="!isReadOnly" :class="$style.overrideCloseButton" @click="emit('close')">
+				<N8nIcon icon="x" size="small" />
+			</div>
 		</div>
 	</div>
 </template>
@@ -56,7 +61,6 @@ const emit = defineEmits<{
 .overrideCloseButton {
 	border: 0;
 	color: var(--color--text--tint-1);
-	margin-left: auto;
 	padding: 0 var(--spacing--2xs);
 	align-self: stretch;
 	display: flex;
@@ -66,6 +70,13 @@ const emit = defineEmits<{
 	&:hover {
 		color: var(--color--text);
 	}
+}
+
+.actions {
+	align-self: stretch;
+	display: flex;
+	align-items: center;
+	margin-left: auto;
 }
 
 .contentOverrideContainer {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.vue
@@ -45,6 +45,7 @@ type Props = {
 	eventBus?: EventBus;
 	canBeOverridden?: boolean;
 	hideLabel?: boolean;
+	externalIssues?: string[];
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -199,6 +200,7 @@ defineExpose({
 				:data-test-id="`parameter-input-${parsedParameterName}`"
 				:event-bus="eventBus"
 				:can-be-overridden="canBeOverridden"
+				:external-issues="externalIssues"
 				@focus="onFocus"
 				@blur="onBlur"
 				@drop="onDrop"

--- a/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
@@ -50,6 +50,8 @@ const props = defineProps<{
 	projectId?: string;
 	/** Operation option values to hide from the form (e.g. operations the hosting runtime cannot execute). */
 	hiddenOperations?: readonly string[];
+	parameterIssues?: Record<string, string[]>;
+	fromAiDisabledParameters?: string[];
 }>();
 
 const emit = defineEmits<{
@@ -427,6 +429,8 @@ defineExpose({ node, isValid, nodeTypeDescription, handleChangeName });
 					:node-values="node.parameters"
 					:is-read-only="false"
 					:node="node"
+					:parameter-issues="props.parameterIssues"
+					:from-ai-disabled-parameters="props.fromAiDisabledParameters"
 					@value-changed="handleChangeParameter"
 				>
 					<NodeCredentials


### PR DESCRIPTION
## Summary

- Reject model-controlled URLs in Agent HTTP Request tools when a draft is saved or published. Keep existing published agents runnable until they are edited or republished.
- Show the URL validation error on the affected field and remove the model-override action from that field.
- Split node-tool setup into a dedicated builder skill. Require initial builds to collect a missing URL through `finish_setup` and never infer a URL.
- Use the Responses API for official OpenAI credentials so reasoning models can use function tools.

## How to test

1. Enable the Agents module with `N8N_ENABLED_MODULES=agents`.
2. Add an HTTP Request tool to an Agent and set its URL through the model-override action in an existing configuration.
3. Confirm that the URL field shows an actionable error and that saving is blocked until a fixed URL is entered.
4. Ask the Agent Builder to add an HTTP Request tool without giving it a URL. Confirm that the initial build requests the URL through the trailing `finish_setup` step.
5. Configure an official OpenAI credential and confirm that a reasoning model can use function tools.

Automated verification:
- `pnpm build`
- `pnpm test src/runtime/__tests__/model-factory.test.ts` in `packages/@n8n/agents`
- Focused Agent validation tests in `packages/cli`
- Focused Agent editor tests in `packages/frontend/editor-ui`
- Package lint and typecheck for all affected packages

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-530

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

