### PR TITLE
fix(core): Correct MCP trigger resolution errors and reason codes

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -344,6 +344,44 @@ describe('execute-workflow MCP tool', () => {
 				).rejects.toThrow(/no trigger that can be executed in production mode/);
 			});
 
+			test('names the supported trigger types when inputs are passed and no trigger is eligible', async () => {
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'Error Trigger',
+							type: 'n8n-nodes-base.errorTrigger',
+							typeVersion: 1,
+							position: [0, 0],
+							disabled: false,
+							parameters: {},
+						} as INode,
+					],
+				});
+				(workflowFinderService.findWorkflowForUser as Mock).mockResolvedValue(workflow);
+
+				// Without the eligibility check inside the guard this reports
+				// "Available triggers: none.", which the caller cannot act on.
+				await expect(
+					executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRunner,
+						mcpService,
+						workflowsConfig,
+						workflowPublishedDataService,
+						'unsupported-trigger',
+						{ webhookData: { method: 'POST', body: { hello: 'world' } } },
+						'production',
+					),
+				).rejects.toMatchObject({
+					reason: 'unsupported_trigger',
+					message: expect.stringContaining('no trigger that can be executed in production mode'),
+				});
+				expect(workflowRunner.run).not.toHaveBeenCalled();
+			});
+
 			test('throws error with correct reason when workflow has unsupported trigger', async () => {
 				const workflow = createWorkflow({
 					activeVersionId: uuid(),
@@ -713,7 +751,7 @@ describe('execute-workflow MCP tool', () => {
 						'production',
 					),
 				).rejects.toMatchObject({
-					reason: 'unsupported_trigger',
+					reason: 'invalid_inputs',
 					message: expect.stringContaining('Provide triggerNodeName and inputs'),
 				});
 				expect(workflowRunner.run).not.toHaveBeenCalled();
@@ -950,7 +988,7 @@ describe('execute-workflow MCP tool', () => {
 						'production',
 					),
 				).rejects.toMatchObject({
-					reason: 'unsupported_trigger',
+					reason: 'invalid_inputs',
 					message: expect.stringContaining('Provide triggerNodeName and inputs'),
 				});
 				expect(workflowRunner.run).not.toHaveBeenCalled();
@@ -1142,7 +1180,7 @@ describe('execute-workflow MCP tool', () => {
 					'production',
 				),
 			).rejects.toMatchObject({
-				reason: 'unsupported_trigger',
+				reason: 'invalid_inputs',
 				message: expect.stringContaining('Provide triggerNodeName when passing inputs'),
 			});
 			expect(workflowRunner.run).not.toHaveBeenCalled();

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -344,9 +344,12 @@ const resolveExecuteWorkflowTrigger = (
 	const available = formatTriggerNames(eligible);
 
 	if (inputs && !triggerNodeName) {
+		// Checked here too: with no eligible trigger, `available` is "none", so asking
+		// for a name would leave the caller nothing to act on.
+		if (eligible.length === 0) throw noEligibleTriggerError(executionMode);
 		throw new WorkflowAccessError(
 			`Provide triggerNodeName when passing inputs. Available triggers: ${available}.`,
-			'unsupported_trigger',
+			'invalid_inputs',
 		);
 	}
 
@@ -386,17 +389,12 @@ const resolveExecuteWorkflowTrigger = (
 		return noPayloadTriggers[0];
 	}
 
-	if (eligible.length === 0) {
-		throw new WorkflowAccessError(
-			`This workflow has no trigger that can be executed in ${executionMode} mode. Supported triggers: ${getSupportedTriggerNamesForMode(executionMode).join(', ')}.`,
-			'unsupported_trigger',
-		);
-	}
+	if (eligible.length === 0) throw noEligibleTriggerError(executionMode);
 
 	if (eligible.every((node) => triggerRequiresInputs(node.type))) {
 		throw new WorkflowAccessError(
 			`Provide triggerNodeName and inputs to execute this workflow. Available triggers: ${available}.`,
-			'unsupported_trigger',
+			'invalid_inputs',
 		);
 	}
 
@@ -440,6 +438,16 @@ const inputsMatchTrigger = (nodeType: string, inputs: WorkflowInputs): boolean =
 
 const formatTriggerNames = (nodes: INode[]): string =>
 	nodes.length > 0 ? nodes.map((node) => node.name).join(', ') : 'none';
+
+/**
+ * Raised when the workflow holds no trigger this mode can drive. Names the supported
+ * types rather than the workflow's own triggers, since there are none to list.
+ */
+const noEligibleTriggerError = (executionMode: ExecutionMode): WorkflowAccessError =>
+	new WorkflowAccessError(
+		`This workflow has no trigger that can be executed in ${executionMode} mode. Supported triggers: ${getSupportedTriggerNamesForMode(executionMode).join(', ')}.`,
+		'unsupported_trigger',
+	);
 
 /**
  * Gets the execution mode based on the trigger node type.


### PR DESCRIPTION
## Summary

Two follow-ups on top of #36341, targeting that branch so they land with it.

**1. The guard hid the useful error.** `inputs && !triggerNodeName` was checked before `eligible.length === 0`, and `formatTriggerNames` returns `"none"` for an empty list. So a workflow whose only trigger MCP cannot drive (a Gmail Trigger, say) called with `inputs` got:

> Provide triggerNodeName when passing inputs. Available triggers: none.

There is no name to provide and no list to pick from. The empty-list check now runs inside the guard as well.

Worth noting why it is nested rather than hoisted: the named-trigger branch is only reachable when a name was given, and its best message, "cannot be used in production mode. Use a webhook, form, chat, or schedule trigger, or execute in manual mode", only fires when `eligible` is empty, since a Manual Trigger is not production-eligible. Hoisting the check would make that message unreachable for a manual-trigger-only workflow and fail the existing test at `execute-workflow.tool.test.ts:1312`.

**2. Argument-shape errors claimed the trigger was unsupported.** Both "Provide triggerNodeName when passing inputs" and "Provide triggerNodeName and inputs" carried `reason: 'unsupported_trigger'` while the triggers were perfectly supported. The effect was that the same user mistake split across two buckets depending on which argument was left out:

| Call | Reason before | Reason now |
|---|---|---|
| `triggerNodeName: "Webhook"` + `{ chatInput }` | `invalid_inputs` | `invalid_inputs` |
| no name + `{ chatInput }` | `unsupported_trigger` | `invalid_inputs` |

Since `unsupported_trigger` is what tells us a workflow cannot be MCP-executed at all, letting ordinary client argument mistakes into it costs us that signal. `invalid_inputs`, added in #36341, already covers this case in `validateInputsForTrigger`.

Three assertions that pinned the old reason are updated (`:716`, `:953`, `:1145`). They asserted the code's behaviour rather than specifying it.

Also extracts the duplicated no-eligible-trigger error into `noEligibleTriggerError`.

## Related

Follow-up to #36341 / https://linear.app/n8n/issue/ADO-5795

## How to test

```bash
pushd packages/cli
pnpm test src/modules/mcp
pnpm typecheck
popd
```

Added test covers the path that had none: inputs passed when no trigger is eligible. Reverting the one-line guard change makes it fail with the old message, which is how I confirmed it tests something.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

