### PR TITLE
ci: Surface errors on bump-versions and similiar scripts

### DIFF
--- a/.github/scripts/bump-versions.mjs
+++ b/.github/scripts/bump-versions.mjs
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 import child_process from 'child_process';
 import { promisify } from 'util';
 import assert from 'assert';
+import { getMonorepoProjects } from './pnpm-utils.mjs';
 
 const exec = promisify(child_process.exec);
 
@@ -184,13 +185,7 @@ async function bumpVersions() {
 		releaseType === 'experimental'
 			? (await exec('git rev-parse --short=8 HEAD')).stdout.trim()
 			: undefined;
-	const packages = JSON.parse(
-		(
-			await exec(
-				`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
-			)
-		).stdout,
-	);
+	const packages = await getMonorepoProjects();
 
 	/** @type {Record<string, { path: string, isDirty: boolean, version: string, nextVersion?: string }>} */
 	const packageMap = {};
@@ -290,5 +285,10 @@ async function bumpVersions() {
 
 // only run when executed directly, not when imported by tests
 if (import.meta.url === `file://${process.argv[1]}`) {
-	bumpVersions();
+	try {
+		await bumpVersions();
+	} catch (error) {
+		console.error(error);
+		process.exit(1);
+	}
 }

--- a/.github/scripts/detect-new-packages.mjs
+++ b/.github/scripts/detect-new-packages.mjs
@@ -14,19 +14,10 @@
  *   1 – One or more public packages have never been published
  */
 
-import child_process from 'child_process';
-import { promisify } from 'util';
 import { writeGithubOutput } from './github-helpers.mjs';
+import { getMonorepoProjects } from './pnpm-utils.mjs';
 
-const exec = promisify(child_process.exec);
-
-const packages = JSON.parse(
-	(
-		await exec(
-			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name:.name, private: .private}]'`,
-		)
-	).stdout,
-);
+const packages = await getMonorepoProjects();
 
 const newPackages = [];
 

--- a/.github/scripts/ensure-provenance-fields.mjs
+++ b/.github/scripts/ensure-provenance-fields.mjs
@@ -1,21 +1,12 @@
 import { writeFile, readFile, copyFile } from 'fs/promises';
 import { resolve, dirname } from 'path';
-import child_process from 'child_process';
 import { fileURLToPath } from 'url';
-import { promisify } from 'util';
-
-const exec = promisify(child_process.exec);
+import { getMonorepoProjects } from './pnpm-utils.mjs';
 
 const commonFiles = ['LICENSE.md', 'LICENSE_EE.md'];
 
 const baseDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
-const packages = JSON.parse(
-	(
-		await exec(
-			`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
-		)
-	).stdout,
-);
+const packages = await getMonorepoProjects();
 
 for (let { name, path, version, private: isPrivate } of packages) {
 	if (isPrivate) continue;

--- a/.github/scripts/pnpm-utils.mjs
+++ b/.github/scripts/pnpm-utils.mjs
@@ -1,7 +1,7 @@
 import child_process from 'child_process';
 import { promisify } from 'node:util';
 
-const exec = promisify(child_process.exec);
+const execFile = promisify(child_process.execFile);
 
 /**
  * @typedef PnpmPackage
@@ -15,11 +15,28 @@ const exec = promisify(child_process.exec);
  * @returns { Promise<PnpmPackage[]> }
  * */
 export async function getMonorepoProjects() {
-	return JSON.parse(
-		(
-			await exec(
-				`pnpm ls -r --only-projects --json | jq -r '[.[] | { name: .name, version: .version, path: .path,  private: .private}]'`,
-			)
-		).stdout,
-	);
+	let stdout;
+
+	// No shell and no `| jq`: a pipeline hides pnpm's exit code (jq exits 0 on
+	// empty input), which turns a failing pnpm into an empty package list.
+	try {
+		({ stdout } = await execFile('pnpm', ['ls', '-r', '--only-projects', '--json'], {
+			// Unprojected output is ~600KB and grows with the workspace.
+			maxBuffer: 64 * 1024 * 1024,
+		}));
+	} catch (error) {
+		const details = error.stderr?.trim() || error.message;
+		throw new Error(`\`pnpm ls -r --only-projects --json\` failed: ${details}`);
+	}
+
+	if (!stdout.trim()) {
+		throw new Error('`pnpm ls -r --only-projects --json` produced no output');
+	}
+
+	return JSON.parse(stdout).map(({ name, version, path, private: isPrivate }) => ({
+		name,
+		version,
+		path,
+		private: Boolean(isPrivate),
+	}));
 }

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -89,8 +89,16 @@ jobs:
           corepack enable
 
       - name: Bump package versions
+        # Assign first: a command substitution nested in another command's
+        # arguments (e.g. `echo "X=$(node …)"`) discards the script's exit code.
+        shell: bash
         run: |
-          echo "NEXT_RELEASE=$(node .github/scripts/bump-versions.mjs)" >> "$GITHUB_ENV"
+          NEXT_RELEASE="$(node .github/scripts/bump-versions.mjs)"
+          if [ -z "$NEXT_RELEASE" ]; then
+            echo "::error::bump-versions.mjs produced no version"
+            exit 1
+          fi
+          echo "NEXT_RELEASE=$NEXT_RELEASE" >> "$GITHUB_ENV"
         env:
           RELEASE_TYPE: ${{ inputs.release-type }}
 


### PR DESCRIPTION
## Summary

CI was failing on a release due to bump versions not outputting the next version for the rest of the pipeline to use. This change refactors how we handle some of the commands inside of the script and similiar scripts to surface errors instead of silently failing and causing issues down in the pipeline.

## How to test

```bash
export RELEASE_TYPE=minor && node .github/scripts/bump-versions.mjs
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

