### PR TITLE
fix(Message an Agent Node): Default the session to the connected Chat Trigger

### DIFF
--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -14,7 +14,7 @@ export const baseDescription: INodeTypeBaseDescription = {
 	icon: 'node:ai-agent',
 	group: ['transform'],
 	description: 'Send a message to a n8n agent',
-	defaultVersion: 3,
+	defaultVersion: 3.1,
 };
 
 export class MessageAnAgent extends VersionedNodeType {
@@ -22,11 +22,13 @@ export class MessageAnAgent extends VersionedNodeType {
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			// v1 keeps the original resourceLocator picker so existing workflows
 			// (typeVersion 1) are unaffected. v2 uses the agentSelector picker.
-			// v3 adds schema-from-example for structured output (same class as v2,
-			// gated via `@version`).
+			// v3 adds schema-from-example for structured output, and v3.1 the
+			// Session settings with a chat-trigger-aware default (same class as
+			// v2, gated via `@version`).
 			1: new MessageAnAgentV1(baseDescription),
 			2: new MessageAnAgentV2(baseDescription),
 			3: new MessageAnAgentV2(baseDescription),
+			3.1: new MessageAnAgentV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
@@ -1,5 +1,6 @@
 import type { IExecuteFunctions, ExecuteAgentData, NodeParameterValueType } from 'n8n-workflow';
 import { getNodeParameters, NodeOperationError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
 import type { Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
@@ -44,6 +45,7 @@ describe('MessageAnAgent Node', () => {
 				if (param === 'message') return 'Hello agent';
 				if (param === 'advanced.invokeMode') return 'perItem';
 				if (param === 'advanced') return fallback ?? {};
+				if (param === 'advanced.session.session') return fallback ?? {};
 				return undefined;
 			},
 		);
@@ -704,6 +706,220 @@ describe('MessageAnAgent Node', () => {
 		});
 	});
 
+	describe('v3.1 session resolution', () => {
+		const chatTriggerNode = {
+			id: 'chat-trigger-id',
+			name: 'When chat message received',
+			type: '@n8n/n8n-nodes-langchain.chatTrigger',
+			typeVersion: 1,
+			position: [0, 0] as [number, number],
+			parameters: {},
+		};
+
+		beforeEach(() => {
+			executeFunctions.getNode.mockReturnValue({
+				id: 'test-node-id',
+				name: 'Message an Agent',
+				type: 'n8n-nodes-base.messageAnAgent',
+				typeVersion: 3.1,
+				position: [0, 0],
+				parameters: {},
+			});
+			executeFunctions.getChatTrigger.mockReturnValue(null);
+			executeFunctions.evaluateExpression.mockReturnValue(undefined);
+		});
+
+		it('defaults to the sessionId from the input item without any configuration', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: { sessionId: 'chat-session-1' } }]);
+			mockParams();
+			executeFunctions.evaluateExpression.mockImplementation((expression: string) =>
+				expression === '{{ $json.sessionId }}' ? 'chat-session-1' : undefined,
+			);
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'chat-session-1' }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('falls back to the Chat Trigger output when the input has no sessionId', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams();
+			executeFunctions.getChatTrigger.mockReturnValue(chatTriggerNode);
+			executeFunctions.evaluateExpression.mockImplementation((expression: string) =>
+				expression === "{{ $('When chat message received').first().json.sessionId }}"
+					? 'chat-session-2'
+					: undefined,
+			);
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'chat-session-2' }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('falls back to a per-execution session when nothing resolves', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams();
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: undefined }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('ignores a disabled Chat Trigger', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams();
+			executeFunctions.getChatTrigger.mockReturnValue({ ...chatTriggerNode, disabled: true });
+			executeFunctions.evaluateExpression.mockImplementation((expression: string) =>
+				expression === '{{ $json.sessionId }}' ? undefined : 'unexpected-session',
+			);
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: undefined }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('ignores expression evaluation errors and falls back', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams();
+			executeFunctions.getChatTrigger.mockReturnValue(chatTriggerNode);
+			executeFunctions.evaluateExpression.mockImplementation(() => {
+				throw new Error('No data found');
+			});
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: undefined }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('hashes a chat-derived sessionId longer than the thread-key budget', async () => {
+			const longSessionId = 'x'.repeat(80);
+			const expectedHash = createHash('sha256').update(longSessionId).digest('hex');
+
+			executeFunctions.getInputData.mockReturnValue([{ json: { sessionId: longSessionId } }]);
+			mockParams();
+			executeFunctions.evaluateExpression.mockImplementation((expression: string) =>
+				expression === '{{ $json.sessionId }}' ? longSessionId : undefined,
+			);
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: expectedHash }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('uses the custom key when "Define below" is selected', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				'advanced.session.session': { sessionIdType: 'customKey', sessionKey: '  my-key  ' },
+			});
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'my-key' }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+			expect(executeFunctions.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('rejects a custom key longer than the thread-key budget', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				'advanced.session.session': { sessionIdType: 'customKey', sessionKey: 'x'.repeat(75) },
+			});
+			executeFunctions.continueOnFail.mockReturnValue(false);
+
+			await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+				'Session ID must be at most 74 characters',
+			);
+			expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+		});
+
+		it('treats an empty custom key as no override', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				'advanced.session.session': { sessionIdType: 'customKey', sessionKey: '   ' },
+			});
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: undefined }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('forwards the chat session for inline agents (thread memory persistence)', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: { sessionId: 'chat-session-3' } }]);
+			mockParams({
+				agentSource: 'inline',
+				inlineAgent: {
+					config: {
+						name: 'Inline Agent',
+						model: 'openai/gpt-5',
+						credential: 'cred-1',
+						instructions: 'Help users',
+						tools: [],
+					},
+				},
+			});
+			executeFunctions.evaluateExpression.mockImplementation((expression: string) =>
+				expression === '{{ $json.sessionId }}' ? 'chat-session-3' : undefined,
+			);
+			executeFunctions.executeAgent.mockResolvedValue({ ...mockAgentResult, session: null });
+
+			await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'chat-session-3' }),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+	});
+
 	it('invokes the agent once with all-items scope in "Once for All Items" mode', async () => {
 		executeFunctions.getInputData.mockReturnValue([{ json: { i: 0 } }, { json: { i: 1 } }]);
 		executeFunctions.getNodeParameter.mockImplementation(
@@ -820,11 +1036,11 @@ describe('MessageAnAgent versioning', () => {
 		);
 	});
 
-	it('exposes v1, v2, and v3 with v3 as the default', () => {
+	it('exposes v1, v2, v3, and v3.1 with v3.1 as the default', () => {
 		const versioned = new MessageAnAgent();
 
-		expect(versioned.description.defaultVersion).toBe(3);
-		expect(Object.keys(versioned.nodeVersions)).toEqual(['1', '2', '3']);
+		expect(versioned.description.defaultVersion).toBe(3.1);
+		expect(Object.keys(versioned.nodeVersions)).toEqual(['1', '2', '3', '3.1']);
 	});
 
 	it('keeps the original resourceLocator picker on v1 (non-breaking) with the listAgents method', () => {
@@ -864,12 +1080,12 @@ describe('MessageAnAgent versioning', () => {
 		});
 	});
 
-	it('serves v2 and v3 from the same class with the agentSelector picker', () => {
+	it('serves v2, v3, and v3.1 from the same class with the agentSelector picker', () => {
 		const v2 = new MessageAnAgentV2(baseDescription);
 		const agentId = v2.description.properties.find((p) => p.name === 'agentId');
 		const schemaType = v2.description.properties.find((p) => p.name === 'schemaType');
 
-		expect(v2.description.version).toEqual([2, 3]);
+		expect(v2.description.version).toEqual([2, 3, 3.1]);
 		expect(agentId?.type).toBe('agentSelector');
 		expect(schemaType?.default).toBe('fromJson');
 	});
@@ -916,6 +1132,30 @@ describe('MessageAnAgent versioning', () => {
 				false,
 				{ typeVersion: 3 },
 				v3.description,
+			),
+		).not.toThrow();
+	});
+
+	it('resolves parameters for a newly added v3.1 node', () => {
+		const v31 = new MessageAnAgentV2(baseDescription);
+
+		expect(() =>
+			getNodeParameters(
+				v31.description.properties,
+				{
+					agentSource: 'referenced',
+					agentId: { __rl: true, mode: 'list', value: '' },
+					inlineAgent: {},
+					message: '',
+					useStructuredOutput: false,
+					advanced: {
+						session: { session: { sessionIdType: 'customKey', sessionKey: 'thread-1' } },
+					},
+				},
+				false,
+				false,
+				{ typeVersion: 3.1 },
+				v31.description,
 			),
 		).not.toThrow();
 	});

--- a/packages/nodes-base/nodes/MessageAnAgent/shared.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/shared.ts
@@ -214,6 +214,7 @@ export const commonProperties: INodeProperties[] = [
 					},
 				],
 			},
+			// Free-text override for nodes below v3.1; v3.1+ uses the Session settings below.
 			{
 				displayName: 'Session ID',
 				name: 'sessionId',
@@ -221,6 +222,81 @@ export const commonProperties: INodeProperties[] = [
 				default: '',
 				description:
 					'Reuse an agent session to keep memory across runs. Leave empty to start a fresh session per execution.',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { lt: 3.1 } }],
+					},
+				},
+			},
+			{
+				displayName: 'Session',
+				name: 'session',
+				placeholder: 'Add session settings',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: false,
+				},
+				default: {
+					session: {},
+				},
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 3.1 } }],
+					},
+				},
+				options: [
+					{
+						displayName: 'Session',
+						name: 'session',
+						values: [
+							{
+								displayName: 'Session ID',
+								name: 'sessionIdType',
+								type: 'options',
+								options: [
+									{
+										name: 'Connected Chat Trigger Node',
+										value: 'fromInput',
+										description:
+											"Looks for an input field called 'sessionId' that is coming from a directly connected Chat Trigger",
+									},
+									{
+										// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+										name: 'Define below',
+										value: 'customKey',
+										description:
+											'Use an expression to reference data in previous nodes or enter static text',
+									},
+								],
+								default: 'fromInput',
+							},
+							{
+								displayName: 'Session Key From Previous Node',
+								name: 'sessionKey',
+								type: 'string',
+								default: '={{ $json.sessionId }}',
+								disabledOptions: { show: { sessionIdType: ['fromInput'] } },
+								displayOptions: {
+									show: {
+										sessionIdType: ['fromInput'],
+									},
+								},
+							},
+							{
+								displayName: 'Key',
+								name: 'sessionKey',
+								type: 'string',
+								default: '',
+								description: 'The key to use as the agent session ID',
+								displayOptions: {
+									show: {
+										sessionIdType: ['customKey'],
+									},
+								},
+							},
+						],
+					},
+				],
 			},
 			{
 				displayName: "Allow Agent to Access Other Nodes' Data",
@@ -413,6 +489,77 @@ function getAgentSource(ctx: IExecuteFunctions, itemIndex: number): ExecuteAgent
  */
 const SESSION_ID_MAX_LENGTH = 74;
 
+function validateSessionIdLength(ctx: IExecuteFunctions, sessionId: string, itemIndex: number) {
+	if (sessionId.length > SESSION_ID_MAX_LENGTH) {
+		throw new NodeOperationError(
+			ctx.getNode(),
+			`Session ID must be at most ${SESSION_ID_MAX_LENGTH} characters (got ${sessionId.length})`,
+			{ itemIndex },
+		);
+	}
+}
+
+/**
+ * Resolve the session ID the way the Simple Memory node does: read `sessionId`
+ * from the input item, falling back to the Chat Trigger node's output. Returns
+ * `undefined` when neither resolves (e.g. the workflow has no Chat Trigger),
+ * letting the engine fall back to a per-execution session.
+ */
+function getChatSessionId(ctx: IExecuteFunctions, itemIndex: number): string | undefined {
+	let sessionId: unknown;
+
+	try {
+		sessionId = ctx.evaluateExpression('{{ $json.sessionId }}', itemIndex);
+	} catch {}
+
+	if (typeof sessionId !== 'string' || !sessionId.trim()) {
+		try {
+			const chatTrigger = ctx.getChatTrigger();
+			if (chatTrigger && chatTrigger.disabled !== true) {
+				const triggerName = chatTrigger.name.replace(/'/g, "\\'");
+				sessionId = ctx.evaluateExpression(
+					`{{ $('${triggerName}').first().json.sessionId }}`,
+					itemIndex,
+				);
+			}
+		} catch {}
+	}
+
+	if (typeof sessionId !== 'string') return undefined;
+
+	const trimmed = sessionId.trim();
+	if (!trimmed) return undefined;
+
+	// Chat clients control this value, so an over-length id is not user-fixable;
+	// hash it to fit the thread-key budget.
+	if (trimmed.length > SESSION_ID_MAX_LENGTH) {
+		return crypto.createHash('sha256').update(trimmed).digest('hex');
+	}
+
+	return trimmed;
+}
+
+/**
+ * Session resolution for typeVersion >= 3.1, mirroring the Simple Memory node:
+ * a custom key when "Define below" is selected, otherwise the connected Chat
+ * Trigger's session. The Session settings default to `fromInput` even when the
+ * option was never added, so a Chat Trigger works out of the box.
+ */
+function resolveSessionId(ctx: IExecuteFunctions, itemIndex: number): string | undefined {
+	const session = ctx.getNodeParameter('advanced.session.session', itemIndex, {}) as {
+		sessionIdType?: string;
+		sessionKey?: unknown;
+	};
+
+	if (session.sessionIdType === 'customKey') {
+		const key = typeof session.sessionKey === 'string' ? session.sessionKey.trim() : '';
+		validateSessionIdLength(ctx, key, itemIndex);
+		return key || undefined;
+	}
+
+	return getChatSessionId(ctx, itemIndex);
+}
+
 /** Shared execution for every version. */
 export async function execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 	const items = this.getInputData();
@@ -439,16 +586,16 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				sessionId?: string;
 				allowOtherNodesData?: boolean;
 			};
-			const sessionIdOverride = advanced.sessionId?.trim();
 			const allowOtherNodesData =
 				agentSource === 'inline' ? false : (advanced.allowOtherNodesData ?? false);
 
-			if (sessionIdOverride && sessionIdOverride.length > SESSION_ID_MAX_LENGTH) {
-				throw new NodeOperationError(
-					this.getNode(),
-					`Session ID must be at most ${SESSION_ID_MAX_LENGTH} characters (got ${sessionIdOverride.length})`,
-					{ itemIndex: i },
-				);
+			let sessionId: string | undefined;
+			if (this.getNode().typeVersion >= 3.1) {
+				sessionId = resolveSessionId(this, i);
+			} else {
+				const sessionIdOverride = advanced.sessionId?.trim();
+				if (sessionIdOverride) validateSessionIdLength(this, sessionIdOverride, i);
+				sessionId = sessionIdOverride || undefined;
 			}
 
 			if (!prompt.trim()) {
@@ -462,7 +609,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			const result = await this.executeAgent(
 				{
 					...source,
-					sessionId: sessionIdOverride || undefined,
+					sessionId,
 					outputSchema,
 					inputDataScope: runOnceForAll ? 'all' : 'item',
 					exposeWorkflowData: allowOtherNodesData,

--- a/packages/nodes-base/nodes/MessageAnAgent/v2/MessageAnAgentV2.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/v2/MessageAnAgentV2.node.ts
@@ -15,10 +15,11 @@ export class MessageAnAgentV2 implements INodeType {
 		this.description = {
 			...thisBaseDescription,
 			...sharedVersionDescription,
-			// v3 adds schema-from-example for structured output; the differences
+			// v3 adds schema-from-example for structured output; v3.1 adds the
+			// Session settings with a chat-trigger-aware default. The differences
 			// are gated via `@version` displayOptions and typeVersion checks in
-			// the shared execute, so one class serves both versions.
-			version: [2, 3],
+			// the shared execute, so one class serves all versions.
+			version: [2, 3, 3.1],
 			properties: [
 				// Set by the node-creator agent picker ('referenced' | 'inline'), not
 				// editable in the NDV. Kept hidden with no displayOptions so saves


### PR DESCRIPTION
## Summary

The Message an Agent node defaulted its session/thread ID to the workflow execution ID. With a Chat Trigger, every chat message is a new execution, so the agent forgot the conversation — and inline agents ran with memory persistence disabled entirely (no caller session ID).

This PR adds node version **3.1** with Session settings that mirror the Simple Memory node:

- **Session ID** defaults to **Connected Chat Trigger Node** (`fromInput`): the session is read from the input item's `sessionId`, falling back to the Chat Trigger node's output. A Chat Trigger → agent workflow now keeps conversation memory out of the box, with zero configuration.
- **Define below** (`customKey`) lets the user set an explicit session key, with the existing 74-character thread-key validation.
- When nothing resolves (non-chat workflow), the node falls back to today's per-execution session. Chat-derived IDs over the 74-character thread-key budget are sha256-hashed to fit.
- The settings live under **Advanced → Session** as a nested fixedCollection (same pattern as HTTP Request's Pagination/Response options).

<img width="476" height="242" alt="image" src="https://github.com/user-attachments/assets/8d3216d8-0c75-40c4-a0e4-9ff8264b638c" />

Existing workflows (typeVersion ≤ 3) are unaffected: they keep the legacy free-text Session ID override and the per-execution default.

No engine or CLI changes — the resolved chat session flows through the existing `executeAgent` `sessionId` field, which also turns on inline-agent memory persistence (`hasCallerSessionId`).

## How to test

1. Create a workflow: **Chat Trigger → Message an Agent** (referenced or inline agent).
2. Open the chat and send two messages (e.g. "My name is Bob", then "What is my name?").
3. The second reply should remember the first — the agent output's `session.sessionId` matches the chat session across executions.
4. In the node's **Advanced → Add session settings**, switch **Session ID** to **Define below** with a custom key to pin or isolate a session; leave it on **Connected Chat Trigger Node** for the default behavior.
5. Requires the agents module (`N8N_ENABLED_MODULES=agents`).

Unit tests: `cd packages/nodes-base && pnpm test MessageAnAgent`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-666

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

