### PR TITLE
feat(editor): Update brand colors and component styles

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -145,7 +145,8 @@ const handleClick = (event: MouseEvent) => {
 
 	height: var(--button--height);
 	padding: var(--button--padding);
-	border-radius: var(--button--radius);
+	border-radius: var(--radius--full);
+	// border-radius: var(--button--radius);
 	font-size: var(--button--font-size);
 
 	--button--color--background: transparent;
@@ -201,35 +202,35 @@ const handleClick = (event: MouseEvent) => {
 	&.xsmall {
 		--button--height: var(--height--xs);
 		--button--padding: 0 var(--spacing--2xs);
-		--button--radius: var(--radius--3xs);
+		--button--radius: var(--radius--xs);
 		--button--font-size: var(--font-size--2xs);
 	}
 
 	&.small {
 		--button--height: var(--height--sm);
 		--button--padding: 0 var(--spacing--xs);
-		--button--radius: var(--radius--3xs);
+		--button--radius: var(--radius--xs);
 		--button--font-size: var(--font-size--xs);
 	}
 
 	&.medium {
 		--button--height: var(--height--md);
 		--button--padding: 0 var(--spacing--xs);
-		--button--radius: var(--radius--3xs);
+		--button--radius: var(--radius--xs);
 		--button--font-size: var(--font-size--sm);
 	}
 
 	&.large {
 		--button--height: var(--height--lg);
 		--button--padding: 0 var(--spacing--sm);
-		--button--radius: var(--radius--2xs);
+		--button--radius: var(--radius--sm);
 		--button--font-size: var(--font-size--sm);
 	}
 
 	&.xlarge {
 		--button--height: var(--height--xl);
 		--button--padding: 0 var(--spacing--sm);
-		--button--radius: var(--radius--xs);
+		--button--radius: var(--radius--sm);
 		--button--font-size: var(--font-size--md);
 	}
 
@@ -237,7 +238,7 @@ const handleClick = (event: MouseEvent) => {
 		--button--color--background: var(--background--brand);
 		--button--color--background-hover: var(--background--brand--hover);
 		--button--color--background-active: var(--background--brand--active);
-		--button--color: var(--color--neutral-white);
+		--button--color: var(--color--neutral-black);
 		--button--shadow: var(--shadow--xs);
 		--button--shadow--hover: var(--shadow--xs);
 		--button--shadow--active: var(--shadow--xs);

--- a/packages/frontend/@n8n/design-system/src/components/N8nCard/Card.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCard/Card.vue
@@ -46,7 +46,7 @@ const classes = computed(() => ({
 
 <style lang="scss" module>
 .card {
-	border-radius: var(--radius--lg);
+	border-radius: var(--radius);
 	border: 1px solid var(--border-color);
 	background-color: var(--color--background--light-3);
 	padding: var(--card--padding, var(--spacing--sm));

--- a/packages/frontend/@n8n/design-system/src/components/N8nTabs/Tabs.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTabs/Tabs.vue
@@ -198,7 +198,7 @@ const scrollRight = () => scroll(50);
 }
 
 .tabs {
-	color: var(--color--text);
+	color: var(--text-color--subtle);
 	font-weight: var(--font-weight--medium);
 	display: flex;
 	align-items: center;
@@ -231,7 +231,7 @@ const scrollRight = () => scroll(50);
 
 	cursor: pointer;
 	white-space: nowrap;
-	color: var(--color--text);
+	color: var(--text-color--subtle);
 	&:hover {
 		color: var(--color--primary);
 	}
@@ -315,7 +315,7 @@ const scrollRight = () => scroll(50);
 
 .link {
 	cursor: pointer;
-	color: var(--color--text);
+	color: var(--text-color--subtle);
 
 	&:hover {
 		color: var(--color--primary);
@@ -355,11 +355,11 @@ const scrollRight = () => scroll(50);
 }
 
 .disabledTab {
-	color: var(--color--text--tint-1);
+	color: var(--text-color--subtle--tint-1);
 	cursor: not-allowed;
 
 	&:hover {
-		color: var(--color--text--tint-1);
+		color: var(--text-color--subtle--tint-1);
 	}
 }
 

--- a/packages/frontend/@n8n/design-system/src/css/_primitives.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_primitives.scss
@@ -1,18 +1,18 @@
 @mixin primitives {
 	/* pink */
-	--color--pink-50: oklch(97.14% 0.0141 343.2);
-	--color--pink-100: oklch(94.82% 0.0276 342.26);
-	--color--pink-150: oklch(92.3% 0.0423 343.08);
-	--color--pink-200: oklch(89.85% 0.0615 343.45);
-	--color--pink-250: oklch(86.04% 0.0898 343.69);
-	--color--pink-300: oklch(82.25% 0.119 346.16);
-	--color--pink-400: oklch(71.76% 0.2017 349.7);
-	--color--pink-500: oklch(65.58% 0.2404 354.32);
-	--color--pink-600: oklch(59.79% 0.2417 1.37);
-	--color--pink-700: oklch(53.17% 0.2137 4.81);
-	--color--pink-800: oklch(46.07% 0.1853 4.1);
-	--color--pink-900: oklch(40.82% 0.1533 2.23);
-	--color--pink-950: oklch(28.41% 0.1089 3.59);
+	--color--pink-50: oklch(97.53% 0.0128 5.65);
+	--color--pink-100: oklch(95.06% 0.0256 5.65);
+	--color--pink-150: oklch(92.56% 0.0398 5.49);
+	--color--pink-200: oklch(90.05% 0.0541 5.33);
+	--color--pink-250: oklch(88.05% 0.0666 5.18);
+	--color--pink-300: oklch(86.04% 0.0791 5.02);
+	--color--pink-400: oklch(82.05% 0.1071 4.98);
+	--color--pink-500: oklch(78.07% 0.136 5);
+	--color--pink-600: oklch(59.08% 0.148 5.02);
+	--color--pink-700: oklch(40.09% 0.1611 5.09);
+	--color--pink-800: oklch(30.08% 0.1209 4.81);
+	--color--pink-900: oklch(24.87% 0.1 4.8);
+	--color--pink-950: oklch(18% 0.075 4.8);
 
 	/* white */
 	--color--white-alpha-50: oklch(100% 0 89.88 / 0.05);
@@ -274,6 +274,7 @@
 	--radius--xl: 1.5rem; /** 24px **/
 	--radius--2xl: 2rem; /** 32px **/
 	--radius--full: 9999px;
+	--radius: var(--radius--xs);
 
 	--height--5xs: 0.5rem; /** 8px **/
 	--height--4xs: 0.75rem; /** 12px **/

--- a/packages/frontend/@n8n/design-system/src/css/_primitives.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_primitives.scss
@@ -7,10 +7,10 @@
 	--color--pink-250: oklch(88.05% 0.0666 5.18);
 	--color--pink-300: oklch(86.04% 0.0791 5.02);
 	--color--pink-400: oklch(82.05% 0.1071 4.98);
-	--color--pink-500: oklch(78.07% 0.136 5);
-	--color--pink-600: oklch(59.08% 0.148 5.02);
-	--color--pink-700: oklch(40.09% 0.1611 5.09);
-	--color--pink-800: oklch(30.08% 0.1209 4.81);
+	--color--pink-500: oklch(78.07% 0.136 5.02);
+	--color--pink-600: oklch(68.08% 0.148 5.02);
+	--color--pink-700: oklch(59.09% 0.1611 5.09);
+	--color--pink-800: oklch(40.08% 0.1209 4.81);
 	--color--pink-900: oklch(24.87% 0.1 4.8);
 	--color--pink-950: oklch(18% 0.075 4.8);
 

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.legacy.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.legacy.scss
@@ -104,10 +104,10 @@
 	--shadow--light: var(--box-shadow-light, 0 2px 12px 0 var(--color--black-alpha-100));
 	--shadow--card-hover: 0 2px 8px rgba(68, 28, 23, 0.1);
 
-	--radius--xl: var(--border-radius-xlarge, 12px);
-	--radius--lg: var(--border-radius-large, 8px);
-	--radius: var(--border-radius-base, 4px);
-	--radius--sm: var(--border-radius-small, 2px);
+	// --radius--xl: var(--border-radius-xlarge, 12px);
+	// --radius--lg: var(--border-radius-large, 8px);
+	// --radius: var(--border-radius-base, 4px);
+	// --radius--sm: var(--border-radius-small, 2px);
 	--border-color--light: var(--border-color-light, var(--color--foreground--tint-1));
 
 	--border-style: var(--border-style-base, solid);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -715,6 +715,10 @@
 	--text-color--inverse: var(--color--neutral-800);
 	--icon-color--inverse: var(--color--neutral-800);
 
+	--focus--border-width: 2px;
+	--focus--outline-color: var(--color--white-alpha-200);
+	--focus--border-color: var(--color--neutral-white);
+
 	// AI Assistant
 	--assistant--color--highlight-1: #8c90f2;
 	--assistant--color--highlight-2: #a977f0;

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -16,11 +16,6 @@
 	--background--focus: var(--color--black-alpha-100);
 	--background--disabled: var(--color--neutral-200);
 
-	--color--primary: var(--color--neutral-900);
-	--color--primary--tint-1: var(--color--neutral-600);
-	--color--primary--tint-2: var(--color--neutral-400);
-	--color--primary--tint-3: var(--color--neutral-300);
-
 	/* stylelint-disable @n8n/css-var-naming */
 	--border-color: var(--border-color-base, var(--color--black-alpha-100));
 	/* stylelint-enable @n8n/css-var-naming */
@@ -38,6 +33,11 @@
 	--text-color--subtle: var(--color--neutral-600);
 	--text-color--subtler: var(--color--neutral-500);
 	--text-color--disabled: var(--color--neutral-400);
+
+	--color--primary: var(--color--neutral-900);
+	--color--primary--tint-1: var(--color--neutral-600);
+	--color--primary--tint-2: var(--color--neutral-400);
+	--color--primary--tint-3: var(--color--neutral-300);
 
 	--background--success: var(--color--green-50);
 	--border-color--success: var(--color--green-200);
@@ -684,6 +684,11 @@
 	--text-color--subtle: var(--color--neutral-200);
 	--text-color--subtler: var(--color--neutral-400);
 	--text-color--disabled: var(--color--neutral-600);
+
+	--color--primary: var(--color--neutral-white);
+	--color--primary--tint-1: var(--color--neutral-200);
+	--color--primary--tint-2: var(--color--neutral-500);
+	--color--primary--tint-3: var(--color--neutral-700);
 
 	--background--success: var(--color--green-950);
 	--border-color--success: var(--color--green-800);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -3,10 +3,10 @@
 
 @mixin theme {
 	@include tokens-legacy.theme-legacy;
-	--background--brand: var(--color--orange-500);
-	--background--brand--hover: var(--color--orange-600);
-	--background--brand--active: var(--color--orange-700);
-	--background--brand--focus: var(--color--orange-400);
+	--background--brand: var(--color--pink-500);
+	--background--brand--hover: var(--color--pink-600);
+	--background--brand--active: var(--color--pink-700);
+	--background--brand--focus: var(--color--pink-400);
 	--background--brand--disabled: var(--color--neutral-200);
 
 	--background--surface: var(--color--neutral-white);
@@ -15,6 +15,11 @@
 	--background--active: var(--color--black-alpha-100);
 	--background--focus: var(--color--black-alpha-100);
 	--background--disabled: var(--color--neutral-200);
+
+	--color--primary: var(--color--neutral-900);
+	--color--primary--tint-1: var(--color--neutral-600);
+	--color--primary--tint-2: var(--color--neutral-400);
+	--color--primary--tint-3: var(--color--neutral-300);
 
 	/* stylelint-disable @n8n/css-var-naming */
 	--border-color: var(--border-color-base, var(--color--black-alpha-100));
@@ -30,7 +35,7 @@
 	--icon-color--strong: var(--color--neutral-800);
 
 	--text-color: var(--color--neutral-900);
-	--text-color--subtle: var(--color--neutral-700);
+	--text-color--subtle: var(--color--neutral-600);
 	--text-color--subtler: var(--color--neutral-500);
 	--text-color--disabled: var(--color--neutral-400);
 
@@ -60,8 +65,8 @@
 	--icon-color--inverse: var(--color--neutral-100);
 
 	--focus--border-width: 2px;
-	--focus--outline-color: var(--color--purple-alpha-200);
-	--focus--border-color: var(--color--purple-500);
+	--focus--outline-color: var(--color--black-alpha-200);
+	--focus--border-color: var(--color--neutral-black);
 
 	// LangChain
 	--lm-chat--messages--color--background: var(--color--background);
@@ -261,8 +266,8 @@
 
 	// Button primary
 	--button--color--text--primary: var(--color--neutral-white);
-	--button--border-color--primary: var(--color--orange-500);
-	--button--color--background--primary: var(--color--orange-500);
+	--button--border-color--primary: var(--background--brand);
+	--button--color--background--primary: var(--background--brand);
 	--button--border-color--primary--hover-active: var(--color--primary);
 	--button--color--background--primary--hover-active-focus: var(--color--primary);
 	--button--outline-color--primary--focus: var(--color--orange-alpha-300);
@@ -274,10 +279,10 @@
 	--button--color--text--secondary: var(--color--neutral-700);
 	--button--border-color--secondary: var(--color--neutral-300);
 	--button--color--background--secondary: var(--color--neutral-white);
-	--button--color--text--secondary--hover-active-focus: var(--color--orange-500);
-	--button--border-color--secondary--hover-active-focus: var(--color--orange-600);
-	--button--color--background--secondary--hover: var(--color--orange-50);
-	--button--color--background--secondary--active-focus: var(--color--orange-100);
+	--button--color--text--secondary--hover-active-focus: var(--color--pink-500);
+	--button--border-color--secondary--hover-active-focus: var(--color--pink-600);
+	--button--color--background--secondary--hover: var(--color--pink-50);
+	--button--color--background--secondary--active-focus: var(--color--pink-100);
 	--button--outline-color--secondary--focus: var(--color--neutral-200);
 	--button--color--text--secondary--disabled: var(--color--neutral-250);
 	--button--border-color--secondary--disabled: var(--color--neutral-250);
@@ -325,8 +330,8 @@
 
 	// Node Creator Button
 	--node-creator--button--color--text: var(--color--neutral-600);
-	--node-creator--button--color--text--hover: var(--color--orange-500);
-	--node-creator--button--border-color--hover: var(--color--orange-500);
+	--node-creator--button--color--text--hover: var(--color--pink-500);
+	--node-creator--button--border-color--hover: var(--color--pink-500);
 	--node-creator--button--color--background: var(--color--neutral-white);
 
 	// Table
@@ -651,10 +656,10 @@
 @mixin theme-dark {
 	@include tokens-legacy.theme-dark-legacy;
 
-	--background--brand: var(--color--orange-500);
-	--background--brand--hover: var(--color--orange-600);
-	--background--brand--active: var(--color--orange-700);
-	--background--brand--focus: var(--color--orange-400);
+	--background--brand: var(--color--pink-500);
+	--background--brand--hover: var(--color--pink-600);
+	--background--brand--active: var(--color--pink-700);
+	--background--brand--focus: var(--color--pink-400);
 	--background--brand--disabled: var(--color--neutral-800);
 
 	--background--surface: var(--color--neutral-900);
@@ -942,7 +947,7 @@
 	--node-creator--button--color--text--hover: var(
 		--button--color--text--secondary--hover-active-focus
 	);
-	--node-creator--button--border-color--hover: var(--color--orange-500);
+	--node-creator--button--border-color--hover: var(--color--pink-500);
 	--node-creator--button--color--background: var(--color--orange-alpha-100);
 
 	// Table
@@ -1224,7 +1229,7 @@
 	--link--color--secondary--hover: var(--color--purple-500);
 	// Params
 	--icon--color: var(--color--text--tint-1);
-	--icon--color--hover: var(--color--orange-500);
+	--icon--color--hover: var(--color--pink-500);
 
 	--menu--color--background: var(--color--neutral-900);
 	--menu--color--background--hover: var(--color--neutral-700);

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -960,7 +960,7 @@ defineExpose({
 .buttonGroup {
 	display: inline-flex;
 	border: var(--border);
-	border-radius: var(--radius--3xs);
+	border-radius: var(--radius--full);
 }
 
 .groupButtonLeft,

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentPublishButton.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentPublishButton.vue
@@ -204,7 +204,7 @@ async function onDropdownSelect(action: string) {
 .buttonGroup {
 	display: inline-flex;
 	border: var(--border);
-	border-radius: var(--radius--3xs);
+	border-radius: var(--radius--full);
 }
 
 .groupButtonLeft,


### PR DESCRIPTION
## Summary

- Add the new brand color primitives and semantic tokens.
- Update buttons, cards, and tabs to use the new visual language.
- Update the workflow publish action shape and colors.

Screenshots are not included.

## How to test

1. Start the Editor UI.
2. Open views that contain buttons, cards, and tabs.
3. Confirm that each component uses the new colors, borders, and corner shapes.
4. Open a workflow.
5. Confirm that the draft and publish actions use the new visual style.
6. Check light and dark themes.

Automated tests were not run for this visual-only change.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)