### PR TITLE
build: Re-pin mailsplit license election to 5.4.15 (no-changelog)

### DIFF
--- a/scripts/licenses/license-overrides.json
+++ b/scripts/licenses/license-overrides.json
@@ -71,9 +71,9 @@
       "elected": "MIT",
       "source": "Dual-licensed (MIT OR GPL-3.0-or-later) per https://github.com/Stuk/jszip/blob/main/LICENSE.markdown. n8n elects MIT; recorded so a copyleft policy gate reads MIT rather than the GPL alternative."
     },
-    "pkg:npm/%40zone-eu/mailsplit@5.4.8": {
+    "pkg:npm/%40zone-eu/mailsplit@5.4.15": {
       "elected": "MIT",
-      "source": "Dual-licensed (MIT OR EUPL-1.1+) per https://github.com/zone-eu/mailsplit#license. n8n elects MIT; recorded so a copyleft policy gate reads MIT rather than the EUPL alternative."
+      "source": "Dual-licensed (MIT OR EUPL-1.1+) per https://github.com/zone-eu/mailsplit#license; re-verified for 5.4.15 (package.json license field unchanged). n8n elects MIT; recorded so a copyleft policy gate reads MIT rather than the EUPL alternative."
     }
   }
 }


### PR DESCRIPTION
## Summary

SBOM/license generation is failing on every branch with exit code 3:

```
Stale elections:
  pkg:npm/%40zone-eu/mailsplit@5.4.8
```

License elections in `scripts/licenses/license-overrides.json` are pinned to an exact version PURL so that any dependency bump forces re-verification of the license. #36362 bumped `@zone-eu/mailsplit` 5.4.8 → 5.4.15 without re-pinning the election, so the recorded PURL no longer matches any SBOM component and `enrich-sbom.mjs` fails loudly (by design).

mailsplit 5.4.15 still declares `(MIT OR EUPL-1.1+)` in its `package.json` — same dual license as 5.4.8 — so the MIT election remains valid. This PR re-pins the election to 5.4.15 and notes the re-verification in the `source` field.

## How to test

`node --test scripts/licenses/*.test.mjs` — 106 tests pass. The SBOM generation job on this PR's CI run is the end-to-end check.

Example failing run: https://github.com/n8n-io/n8n/actions/runs/32116265806/job/95667026299

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #36362.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. <!-- covered by existing license pipeline tests + SBOM CI job -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

