### PR TITLE
fix(core): Acquire expression isolate for dynamic node parameter requests (backport to 1.x)

### DIFF
--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -93,6 +93,132 @@ describe('DynamicNodeParametersService', () => {
 		});
 	});
 
+	describe('expression isolate lifecycle', () => {
+		let acquireSpy: jest.SpyInstance;
+		let releaseSpy: jest.SpyInstance;
+
+		beforeEach(() => {
+			acquireSpy = jest.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(true);
+			releaseSpy = jest.spyOn(Expression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should acquire and release isolate around getOptionsViaMethodName', async () => {
+			const loadOptionsMethod = jest.fn().mockResolvedValue([{ name: 'opt', value: 'v' }]);
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { loadOptions: { getOptions: loadOptionsMethod } },
+				}),
+			);
+
+			await service.getOptionsViaMethodName(
+				'getOptions',
+				'',
+				mock<IWorkflowExecuteAdditionalData>(),
+				{ name: 'TestNode', version: 1 },
+				mock<INodeParameters>(),
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should release isolate even when the inner method throws', async () => {
+			const loadOptionsMethod = jest.fn().mockRejectedValue(new Error('boom'));
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { loadOptions: { getOptions: loadOptionsMethod } },
+				}),
+			);
+
+			await expect(
+				service.getOptionsViaMethodName(
+					'getOptions',
+					'',
+					mock<IWorkflowExecuteAdditionalData>(),
+					{ name: 'TestNode', version: 1 },
+					mock<INodeParameters>(),
+				),
+			).rejects.toThrow('boom');
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should acquire and release isolate around getResourceLocatorResults', async () => {
+			const listSearchMethod = jest
+				.fn()
+				.mockResolvedValue({ results: [{ name: 'r', value: 'v' }] });
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { listSearch: { searchModels: listSearchMethod } },
+				}),
+			);
+
+			await service.getResourceLocatorResults(
+				'searchModels',
+				'',
+				mock<IWorkflowExecuteAdditionalData>(),
+				{ name: 'TestNode', version: 1 },
+				mock<INodeParameters>(),
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should acquire and release isolate around getResourceMappingFields', async () => {
+			const resourceMappingMethod = jest.fn().mockResolvedValue({
+				fields: [{ id: '1', displayName: 'F', defaultMatch: false, required: true, display: true }],
+			});
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { resourceMapping: { getFields: resourceMappingMethod } },
+				}),
+			);
+
+			await service.getResourceMappingFields(
+				'getFields',
+				'',
+				mock<IWorkflowExecuteAdditionalData>(),
+				{ name: 'TestNode', version: 1 },
+				mock<INodeParameters>(),
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should acquire and release isolate around getActionResult', async () => {
+			const actionHandler = jest.fn().mockResolvedValue({ key: 'value' });
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { actionHandler: { handle: actionHandler } },
+				}),
+			);
+
+			await service.getActionResult(
+				'handle',
+				'',
+				mock<IWorkflowExecuteAdditionalData>(),
+				{ name: 'TestNode', version: 1 },
+				mock<INodeParameters>(),
+				undefined,
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	describe('getOptionsViaLoadOptionsByPath', () => {
 		it('should throw BadRequestError when no loadOptions routing exists at the parameter path', async () => {
 			nodeTypes.getByNameAndVersion.mockReturnValue(

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -32,6 +32,8 @@ import { CredentialsFinderService } from '@/credentials/credentials-finder.servi
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
+import { withExpressionIsolate } from '@/utils';
+
 import { WorkflowLoaderService } from './workflow-loader.service';
 import { SharedWorkflowRepository, User } from '@n8n/db';
 import { userHasScopes } from '@/permissions.ee/check-access';
@@ -136,10 +138,13 @@ export class DynamicNodeParametersService {
 		const method = this.getMethod('loadOptions', methodName, nodeType);
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
-		// Need to use untyped call since `this` usage is widespread and we don't have `strictBindCallApply`
-		// enabled in `tsconfig.json`
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return method.call(thisArgs);
+		return await withExpressionIsolate(workflow, async () => {
+			// Need to use untyped call since `this` usage is widespread and we don't have `strictBindCallApply`
+			// enabled in `tsconfig.json`
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+			return await method.call(thisArgs);
+		});
 	}
 
 	/**
@@ -243,17 +248,19 @@ export class DynamicNodeParametersService {
 			[],
 		);
 		const routingNode = new RoutingNode(executeFunctions, tempNodeType);
-		const optionsData = await routingNode.runNode();
+		return await withExpressionIsolate(workflow, async () => {
+			const optionsData = await routingNode.runNode();
 
-		if (optionsData?.length === 0) {
-			return [];
-		}
+			if (optionsData?.length === 0) {
+				return [];
+			}
 
-		if (!Array.isArray(optionsData)) {
-			throw new UnexpectedError('The returned data is not an array');
-		}
+			if (!Array.isArray(optionsData)) {
+				throw new UnexpectedError('The returned data is not an array');
+			}
 
-		return optionsData[0].map((item) => item.json) as unknown as INodePropertyOptions[];
+			return optionsData[0].map((item) => item.json) as unknown as INodePropertyOptions[];
+		});
 	}
 
 	async getResourceLocatorResults(
@@ -271,7 +278,10 @@ export class DynamicNodeParametersService {
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return method.call(thisArgs, filter, paginationToken);
+		return await withExpressionIsolate(workflow, async () => {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+			return await method.call(thisArgs, filter, paginationToken);
+		});
 	}
 
 	/** Returns the available mapping fields for the ResourceMapper component */
@@ -287,8 +297,10 @@ export class DynamicNodeParametersService {
 		const method = this.getMethod('resourceMapping', methodName, nodeType);
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
-		return this.removeDuplicateResourceMappingFields(
-			(await method.call(thisArgs)) as ResourceMapperFields,
+		return await withExpressionIsolate(workflow, async () =>
+			this.removeDuplicateResourceMappingFields(
+				(await method.call(thisArgs)) as ResourceMapperFields,
+			),
 		);
 	}
 
@@ -322,7 +334,10 @@ export class DynamicNodeParametersService {
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return method.call(thisArgs, payload);
+		return await withExpressionIsolate(workflow, async () => {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+			return await method.call(thisArgs, payload);
+		});
 	}
 
 	private getMethod(


### PR DESCRIPTION
## Summary

Backport of #29671 to 1.x, in its post-#30892 shape (uses the shared `withExpressionIsolate` helper from `@/utils`, which #35934 already brought to 1.x with the ownership guard).

With `N8N_EXPRESSION_ENGINE=vm`, editor-time dynamic-parameter requests (`loadOptions`, `listSearch`, `resourceMapping`, `actionHandler`) never acquired an expression isolate. Any expression resolved during the request then threw `IsolateError: No bridge acquired for this context. Call acquire() first.` The most common path is a credential's generic auth template, e.g. Airtable's `Authorization: '=Bearer {{$credentials.accessToken}}'` — so "From list" resource locators failed with the bridge error, and resource-mapper columns silently showed "No columns found".

This wraps the five entry points in `DynamicNodeParametersService` with `withExpressionIsolate`, byte-identical to master's current state, and ports master's isolate-lifecycle tests to Jest.

**How to test:** run 1.x with `N8N_EXPRESSION_ENGINE=vm`, add an Airtable node with a PAT credential, set Base to "From list". Without this fix the dropdown fails with the bridge error; with it, bases load.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-4028
- Forum: https://community.n8n.io/t/airtable-node-resource-locator-fails-with-no-bridge-acquired-for-this-context-cloud-1-123-69/306956/1

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A — bug fix, no behavior change beyond removing the error)
- [x] Tests included.
- [ ] PR Labeled with backport label (N/A — this PR targets 1.x directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

