### PR TITLE
feat(API): Add endpoint to list role-mapping rules

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -200,7 +200,11 @@ export {
 	RoleGetPublicDto,
 } from './roles/role-public.dto';
 export { CreateRoleMappingRuleDto } from './roles/create-role-mapping-rule.dto';
-export { RoleMappingRulePublicDto } from './roles/role-mapping-rule-public.dto';
+export {
+	RoleMappingRulePublicDto,
+	RoleMappingRuleListPublicDto,
+	RoleMappingRuleListQueryPublicDto,
+} from './roles/role-mapping-rule-public.dto';
 export {
 	PatchRoleMappingRuleDto,
 	type PatchRoleMappingRuleInput,

--- a/packages/@n8n/api-types/src/dto/roles/role-mapping-rule-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/role-mapping-rule-public.dto.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
 
 import { Z } from '../../zod-class';
+import { publicApiPaginationSchema } from '../pagination/pagination.dto';
 
-export class RoleMappingRulePublicDto extends Z.class({
+export const roleMappingRulePublicSchema = z.object({
 	id: z.string(),
 	expression: z.string(),
 	role: z.string(),
@@ -11,4 +12,17 @@ export class RoleMappingRulePublicDto extends Z.class({
 	projectIds: z.array(z.string()),
 	createdAt: z.string().datetime(),
 	updatedAt: z.string().datetime(),
+});
+
+export class RoleMappingRulePublicDto extends Z.class(roleMappingRulePublicSchema.shape) {}
+
+export class RoleMappingRuleListPublicDto extends Z.class({
+	data: z.array(roleMappingRulePublicSchema),
+	nextCursor: z.string().nullable(),
+}) {}
+
+export class RoleMappingRuleListQueryPublicDto extends Z.class({
+	limit: publicApiPaginationSchema.limit,
+	cursor: z.string().optional(),
+	type: z.enum(['instance', 'project']).optional(),
 }) {}

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -112,7 +112,7 @@ export const API_KEY_RESOURCES = {
 	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
 	role: ['manage', 'manageProject', 'list', 'read'] as const,
-	roleMappingRule: ['create'] as const,
+	roleMappingRule: ['create', 'list'] as const,
 } as const;
 
 export const GLOBAL_OWNER_ROLE_SLUG = 'global:owner';

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -92,6 +92,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'role:list',
 	'role:read',
 	'roleMappingRule:create',
+	'roleMappingRule:list',
 ];
 
 export const ADMIN_API_KEY_SCOPES: ApiKeyScope[] = OWNER_API_KEY_SCOPES;

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -21,11 +21,13 @@ import {
 } from '@n8n/decorators';
 import type { Response } from 'express';
 
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { RoleMappingRuleResponse } from '@/modules/provisioning.ee/role-mapping-rule.service.ee';
 import { RoleMappingRuleService } from '@/modules/provisioning.ee/role-mapping-rule.service.ee';
-import { decodeCursor, encodeNextCursor } from '@/public-api/v1/shared/services/pagination.service';
+import {
+	encodeNextCursor,
+	resolveOffsetPagination,
+} from '@/public-api/v1/shared/services/pagination.service';
 
 function toRoleMappingRulePublicDto(rule: RoleMappingRuleResponse): RoleMappingRulePublicDto {
 	return {
@@ -62,22 +64,7 @@ export class RoleMappingRulesPublicController {
 	): Promise<RoleMappingRuleListPublicDto> {
 		this.assertProvisioningLicensed();
 
-		let offset = 0;
-		let { limit } = query;
-
-		if (query.cursor) {
-			try {
-				const decoded = decodeCursor(query.cursor);
-				if (!('offset' in decoded)) {
-					throw new BadRequestError('An invalid cursor was provided');
-				}
-				offset = decoded.offset;
-				limit = decoded.limit;
-			} catch (error) {
-				if (error instanceof BadRequestError) throw error;
-				throw new BadRequestError('An invalid cursor was provided');
-			}
-		}
+		const { offset, limit } = resolveOffsetPagination(query);
 
 		const { count, items } = await this.roleMappingRuleService.list({
 			skip: offset,

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -1,4 +1,9 @@
-import { CreateRoleMappingRuleDto, RoleMappingRulePublicDto } from '@n8n/api-types';
+import {
+	CreateRoleMappingRuleDto,
+	RoleMappingRuleListPublicDto,
+	RoleMappingRuleListQueryPublicDto,
+	RoleMappingRulePublicDto,
+} from '@n8n/api-types';
 import { LicenseState } from '@n8n/backend-common';
 import { AuthenticatedRequest } from '@n8n/db';
 import {
@@ -9,13 +14,31 @@ import {
 	ApiSummary,
 	ApiTags,
 	Body,
+	Get,
 	Post,
 	PublicApiController,
+	Query,
 } from '@n8n/decorators';
 import type { Response } from 'express';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import type { RoleMappingRuleResponse } from '@/modules/provisioning.ee/role-mapping-rule.service.ee';
 import { RoleMappingRuleService } from '@/modules/provisioning.ee/role-mapping-rule.service.ee';
+import { decodeCursor, encodeNextCursor } from '@/public-api/v1/shared/services/pagination.service';
+
+function toRoleMappingRulePublicDto(rule: RoleMappingRuleResponse): RoleMappingRulePublicDto {
+	return {
+		id: rule.id,
+		expression: rule.expression,
+		role: rule.role,
+		type: rule.type,
+		order: rule.order,
+		projectIds: rule.projectIds,
+		createdAt: rule.createdAt,
+		updatedAt: rule.updatedAt,
+	};
+}
 
 @PublicApiController('/role-mapping-rules')
 export class RoleMappingRulesPublicController {
@@ -23,6 +46,54 @@ export class RoleMappingRulesPublicController {
 		private readonly roleMappingRuleService: RoleMappingRuleService,
 		private readonly licenseState: LicenseState,
 	) {}
+
+	@Get('/')
+	@ApiKeyScope('roleMappingRule:list')
+	@ApiSummary('Retrieve role-mapping rules')
+	@ApiDescription(
+		"Returns the configured role-mapping rules. `order` is the rule's evaluation position within its own `type`, so instance and project rules each have their own sequence starting at 0 — filter by `type` to retrieve a single evaluation order.",
+	)
+	@ApiTags(['RoleMappingRule'])
+	@ApiResponse(200, RoleMappingRuleListPublicDto)
+	async getRoleMappingRules(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Query query: RoleMappingRuleListQueryPublicDto,
+	): Promise<RoleMappingRuleListPublicDto> {
+		this.assertProvisioningLicensed();
+
+		let offset = 0;
+		let { limit } = query;
+
+		if (query.cursor) {
+			try {
+				const decoded = decodeCursor(query.cursor);
+				if (!('offset' in decoded)) {
+					throw new BadRequestError('An invalid cursor was provided');
+				}
+				offset = decoded.offset;
+				limit = decoded.limit;
+			} catch (error) {
+				if (error instanceof BadRequestError) throw error;
+				throw new BadRequestError('An invalid cursor was provided');
+			}
+		}
+
+		const { count, items } = await this.roleMappingRuleService.list({
+			skip: offset,
+			take: limit,
+			type: query.type,
+		});
+
+		return {
+			data: items.map(toRoleMappingRulePublicDto),
+			nextCursor: encodeNextCursor({
+				offset,
+				limit,
+				numberOfTotalRecords: count,
+			}),
+		};
+	}
 
 	@Post('/')
 	@ApiKeyScope('roleMappingRule:create')
@@ -38,21 +109,16 @@ export class RoleMappingRulesPublicController {
 		_res: Response,
 		@Body body: CreateRoleMappingRuleDto,
 	): Promise<RoleMappingRulePublicDto> {
-		if (!this.licenseState.isProvisioningLicensed()) {
-			throw new ForbiddenError('Provisioning is not licensed');
-		}
+		this.assertProvisioningLicensed();
 
 		const rule = await this.roleMappingRuleService.create(body, req.user);
 
-		return {
-			id: rule.id,
-			expression: rule.expression,
-			role: rule.role,
-			type: rule.type,
-			order: rule.order,
-			projectIds: rule.projectIds,
-			createdAt: rule.createdAt,
-			updatedAt: rule.updatedAt,
-		};
+		return toRoleMappingRulePublicDto(rule);
+	}
+
+	private assertProvisioningLicensed(): void {
+		if (!this.licenseState.isProvisioningLicensed()) {
+			throw new ForbiddenError('Provisioning is not licensed');
+		}
 	}
 }

--- a/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
@@ -12,8 +12,10 @@ import {
 } from '@n8n/decorators';
 import type { Response } from 'express';
 
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { decodeCursor, encodeNextCursor } from '@/public-api/v1/shared/services/pagination.service';
+import {
+	encodeNextCursor,
+	resolveOffsetPagination,
+} from '@/public-api/v1/shared/services/pagination.service';
 import { TagService } from '@/services/tag.service';
 
 @PublicApiController('/tags')
@@ -31,22 +33,7 @@ export class TagsPublicController {
 		_res: Response,
 		@Query query: ListTagsQueryDto,
 	): Promise<TagListPublicDto> {
-		let offset = 0;
-		let { limit } = query;
-
-		if (query.cursor) {
-			try {
-				const decoded = decodeCursor(query.cursor);
-				if (!('offset' in decoded)) {
-					throw new BadRequestError('An invalid cursor was provided');
-				}
-				offset = decoded.offset;
-				limit = decoded.limit;
-			} catch (error) {
-				if (error instanceof BadRequestError) throw error;
-				throw new BadRequestError('An invalid cursor was provided');
-			}
-		}
+		const { offset, limit } = resolveOffsetPagination(query);
 
 		const { data, count } = await this.tagService.getPaginated({ offset, limit });
 

--- a/packages/cli/src/public-api/v1/controllers/workflows.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/workflows.public.controller.ts
@@ -38,7 +38,11 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { SharedWorkflowNotFoundError } from '@/errors/shared-workflow-not-found.error';
 import { EventService } from '@/events/event.service';
-import { decodeCursor, encodeNextCursor } from '@/public-api/v1/shared/services/pagination.service';
+import {
+	decodeCursor,
+	encodeNextCursor,
+	resolveOffsetPagination,
+} from '@/public-api/v1/shared/services/pagination.service';
 import { TagService } from '@/services/tag.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -322,21 +326,7 @@ export class WorkflowsPublicController {
 		@Param('workflowId') workflowId: string,
 		@Query query: ListWorkflowHistoryQueryDto,
 	): Promise<WorkflowVersionHistoryListPublicDto> {
-		let { limit, offset } = query;
-
-		if (query.cursor) {
-			try {
-				const decoded = decodeCursor(query.cursor);
-				if (!('offset' in decoded)) {
-					throw new BadRequestError('An invalid cursor was provided');
-				}
-				offset = decoded.offset;
-				limit = decoded.limit;
-			} catch (error) {
-				if (error instanceof BadRequestError) throw error;
-				throw new BadRequestError('An invalid cursor was provided');
-			}
-		}
+		const { offset, limit } = resolveOffsetPagination(query);
 
 		try {
 			const versions = await this.workflowHistoryService.getList(

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/getRoleMappingRules.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/getRoleMappingRules.generated.yml
@@ -1,0 +1,77 @@
+operationId: getRoleMappingRules
+tags:
+  - RoleMappingRule
+summary: Retrieve role-mapping rules
+description: Returns the configured role-mapping rules. `order` is the rule's evaluation position within its own `type`, so instance and project rules each have their own sequence starting at 0 — filter by `type` to retrieve a single evaluation order.
+x-required-scope: roleMappingRule:list
+parameters:
+  - $ref: ../../../../shared/spec/parameters/limit.yml
+  - $ref: ../../../../shared/spec/parameters/cursor.yml
+  - schema:
+      type: string
+      enum:
+        - instance
+        - project
+    required: false
+    name: type
+    in: query
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+responses:
+  '200':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  expression:
+                    type: string
+                  role:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - instance
+                      - project
+                  order:
+                    type: integer
+                  projectIds:
+                    type: array
+                    items:
+                      type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                required:
+                  - id
+                  - expression
+                  - role
+                  - type
+                  - order
+                  - projectIds
+                  - createdAt
+                  - updatedAt
+            nextCursor:
+              type: string
+              nullable: true
+          required:
+            - data
+            - nextCursor
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -4,6 +4,8 @@ info:
   version: 0.0.0
 paths:
   /role-mapping-rules:
+    get:
+      $ref: ./handlers/role-mapping-rules/spec/paths/getRoleMappingRules.generated.yml
     post:
       $ref: ./handlers/role-mapping-rules/spec/paths/createRoleMappingRule.generated.yml
   /roles:

--- a/packages/cli/src/public-api/v1/shared/services/__tests__/pagination.service.test.ts
+++ b/packages/cli/src/public-api/v1/shared/services/__tests__/pagination.service.test.ts
@@ -1,0 +1,53 @@
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import { resolveOffsetPagination } from '../pagination.service';
+
+function encodeCursor(payload: object): string {
+	return Buffer.from(JSON.stringify(payload)).toString('base64');
+}
+
+describe('resolveOffsetPagination', () => {
+	it('defaults offset to 0 when no cursor or offset is given', () => {
+		expect(resolveOffsetPagination({ limit: 50 })).toEqual({ offset: 0, limit: 50 });
+	});
+
+	it('uses the query offset when no cursor is given', () => {
+		expect(resolveOffsetPagination({ limit: 50, offset: 20 })).toEqual({ offset: 20, limit: 50 });
+	});
+
+	it('treats an empty cursor string as no cursor', () => {
+		expect(resolveOffsetPagination({ limit: 50, offset: 10, cursor: '' })).toEqual({
+			offset: 10,
+			limit: 50,
+		});
+	});
+
+	it('overrides the query offset and limit with the decoded cursor', () => {
+		const cursor = encodeCursor({ offset: 40, limit: 25 });
+
+		expect(resolveOffsetPagination({ limit: 50, offset: 10, cursor })).toEqual({
+			offset: 40,
+			limit: 25,
+		});
+	});
+
+	it('throws BadRequestError for an undecodable cursor', () => {
+		expect(() => resolveOffsetPagination({ limit: 50, cursor: 'not-a-valid-cursor' })).toThrow(
+			BadRequestError,
+		);
+	});
+
+	it('throws BadRequestError for a cursor that decodes to valid but unexpected JSON', () => {
+		const cursor = Buffer.from('null').toString('base64');
+
+		expect(() => resolveOffsetPagination({ limit: 50, cursor })).toThrow(BadRequestError);
+	});
+
+	it('throws BadRequestError for a cursor without an offset (lastId-shaped)', () => {
+		const cursor = encodeCursor({ lastId: 'abc123', limit: 25 });
+
+		expect(() => resolveOffsetPagination({ limit: 50, cursor })).toThrow(
+			'An invalid cursor was provided',
+		);
+	});
+});

--- a/packages/cli/src/public-api/v1/shared/services/pagination.service.ts
+++ b/packages/cli/src/public-api/v1/shared/services/pagination.service.ts
@@ -33,8 +33,7 @@ export function resolveOffsetPagination(query: {
 			}
 			offset = decoded.offset;
 			limit = decoded.limit;
-		} catch (error) {
-			if (error instanceof BadRequestError) throw error;
+		} catch {
 			throw new BadRequestError('An invalid cursor was provided');
 		}
 	}

--- a/packages/cli/src/public-api/v1/shared/services/pagination.service.ts
+++ b/packages/cli/src/public-api/v1/shared/services/pagination.service.ts
@@ -1,5 +1,7 @@
 import { jsonParse } from 'n8n-workflow';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
 import type {
 	CursorPagination,
 	OffsetPagination,
@@ -10,6 +12,35 @@ import type {
 export const decodeCursor = (cursor: string): PaginationOffsetDecoded | PaginationCursorDecoded => {
 	return jsonParse(Buffer.from(cursor, 'base64').toString());
 };
+
+/**
+ * Resolves the offset and limit to query with for a list endpoint either from defaults
+ * or from a provided cursor.
+ */
+export function resolveOffsetPagination(query: {
+	cursor?: string;
+	limit: number;
+	offset?: number;
+}): { offset: number; limit: number } {
+	let { limit } = query;
+	let offset = query.offset ?? 0;
+
+	if (query.cursor) {
+		try {
+			const decoded = decodeCursor(query.cursor);
+			if (!('offset' in decoded)) {
+				throw new BadRequestError('An invalid cursor was provided');
+			}
+			offset = decoded.offset;
+			limit = decoded.limit;
+		} catch (error) {
+			if (error instanceof BadRequestError) throw error;
+			throw new BadRequestError('An invalid cursor was provided');
+		}
+	}
+
+	return { offset, limit };
+}
 
 const encodeOffSetPagination = (pagination: OffsetPagination): string | null => {
 	if (pagination.numberOfTotalRecords > pagination.offset + pagination.limit) {

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -1,3 +1,4 @@
+import type { CreateRoleMappingRuleDto } from '@n8n/api-types';
 import { createTeamProject, testDb } from '@n8n/backend-test-utils';
 import { RoleMappingRuleRepository, type Project, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -15,7 +16,7 @@ describe('Role mapping rules in Public API', () => {
 		enabledFeatures: ['feat:saml'],
 	});
 
-	const validInstancePayload = {
+	const validInstancePayload: CreateRoleMappingRuleDto = {
 		expression: 'claims.group === "admins"',
 		role: 'global:member',
 		type: 'instance' as const,
@@ -212,7 +213,8 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer.publicApiAgentFor(owner).get('/role-mapping-rules');
 
 			expect(response.status).toBe(200);
-			expect(response.body).toEqual({ data: [], nextCursor: null });
+			expect(response.body.nextCursor).toBeNull();
+			expect(response.body.data).toEqual([]);
 		});
 
 		it('returns the configured rules with the full public field set', async () => {
@@ -287,7 +289,7 @@ describe('Role mapping rules in Public API', () => {
 			expect(firstPage.status).toBe(200);
 			expect(firstPage.body.data).toHaveLength(1);
 			expect(firstPage.body.data[0].order).toBe(0);
-			expect(firstPage.body.nextCursor).toBeTruthy();
+			expect(firstPage.body.nextCursor).toEqual(expect.any(String));
 
 			const secondPage = await agent
 				.get('/role-mapping-rules')

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -206,4 +206,148 @@ describe('Role mapping rules in Public API', () => {
 			testServer.license.enable('feat:saml');
 		});
 	});
+
+	describe('GET /role-mapping-rules', () => {
+		it('returns an empty list with a null cursor when no rules exist', async () => {
+			const response = await testServer.publicApiAgentFor(owner).get('/role-mapping-rules');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ data: [], nextCursor: null });
+		});
+
+		it('returns the configured rules with the full public field set', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
+
+			const response = await agent.get('/role-mapping-rules');
+
+			expect(response.status).toBe(200);
+			expect(response.body.nextCursor).toBeNull();
+			expect(response.body.data).toEqual([
+				{
+					id: expect.any(String),
+					expression: validInstancePayload.expression,
+					role: 'global:member',
+					type: 'instance',
+					order: 0,
+					projectIds: [],
+					createdAt: expect.any(String),
+					updatedAt: expect.any(String),
+				},
+			]);
+		});
+
+		it('returns rules for a type in evaluation order', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			const { expression, role, type } = validInstancePayload;
+			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
+			await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type })
+				.expect(201);
+
+			const response = await agent.get('/role-mapping-rules').query({ type: 'instance' });
+
+			expect(response.status).toBe(200);
+			expect(response.body.data.map((rule: { order: number }) => rule.order)).toEqual([0, 1]);
+		});
+
+		it('filters by type', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
+			await agent
+				.post('/role-mapping-rules')
+				.send({
+					expression: 'claims.project === "alpha"',
+					role: 'project:editor',
+					type: 'project',
+					projectIds: [teamProject.id],
+				})
+				.expect(201);
+
+			const instanceOnly = await agent.get('/role-mapping-rules').query({ type: 'instance' });
+			expect(instanceOnly.body.data).toHaveLength(1);
+			expect(instanceOnly.body.data[0].type).toBe('instance');
+
+			const projectOnly = await agent.get('/role-mapping-rules').query({ type: 'project' });
+			expect(projectOnly.body.data).toHaveLength(1);
+			expect(projectOnly.body.data[0].type).toBe('project');
+		});
+
+		it('paginates with cursor and limit', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			const { expression, role, type } = validInstancePayload;
+			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
+			await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type })
+				.expect(201);
+
+			const firstPage = await agent.get('/role-mapping-rules').query({ limit: 1 });
+			expect(firstPage.status).toBe(200);
+			expect(firstPage.body.data).toHaveLength(1);
+			expect(firstPage.body.data[0].order).toBe(0);
+			expect(firstPage.body.nextCursor).toBeTruthy();
+
+			const secondPage = await agent
+				.get('/role-mapping-rules')
+				.query({ cursor: firstPage.body.nextCursor });
+			expect(secondPage.status).toBe(200);
+			expect(secondPage.body.data).toHaveLength(1);
+			expect(secondPage.body.data[0].order).toBe(1);
+			expect(secondPage.body.nextCursor).toBeNull();
+		});
+
+		it('rejects an undecodable cursor with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.get('/role-mapping-rules')
+				.query({ cursor: 'not-a-valid-cursor' });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects an invalid type filter with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.get('/role-mapping-rules')
+				.query({ type: 'bogus' });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects with 401 without an API key', async () => {
+			const response = await testServer.publicApiAgentWithoutApiKey().get('/role-mapping-rules');
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 401 with an invalid API key', async () => {
+			const response = await testServer
+				.publicApiAgentWithApiKey('invalid-key')
+				.get('/role-mapping-rules');
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when the key lacks roleMappingRule:list', async () => {
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
+
+			const response = await testServer.publicApiAgentFor(scopedOwner).get('/role-mapping-rules');
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects with 403 when provisioning is not licensed', async () => {
+			testServer.license.disable('feat:saml');
+			testServer.license.disable('feat:oidc');
+
+			const response = await testServer.publicApiAgentFor(owner).get('/role-mapping-rules');
+
+			expect(response.status).toBe(403);
+			expect(response.body.message).toBe('Provisioning is not licensed');
+
+			testServer.license.enable('feat:saml');
+		});
+	});
 });

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -20,6 +20,9 @@
 		"DELETE /roles/{slug}": {
 			"status": "gap"
 		},
+		"GET /role-mapping-rules": {
+			"status": "gap"
+		},
 		"POST /role-mapping-rules": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/role-mapping-rules` to the Public API, a thin `@PublicApiController` wrapper over the existing `RoleMappingRuleService.list` also used by the Internal API
- Cursor-paginated, with an optional `type` filter (`instance`/`project`); requires the provisioning licence (`feat:saml` or `feat:oidc`) as with the Internal API
- Adds `roleMappingRule:list` to `API_KEY_RESOURCES` and `OWNER_API_KEY_SCOPES`
- Extracts the duplicated cursor-decoding logic (shared with the `tags` and `workflow-history` list endpoints) into a `resolveOffsetPagination()` helper in `pagination.service.ts`

Demo:
https://www.loom.com/share/6990d2d6324048f7baff15c665ba5620

## How to test

With an API key that has the `roleMappingRule:list` scope and an instance with the provisioning licence enabled:

```bash
curl "http://localhost:5678/api/v1/role-mapping-rules?limit=1" \
  -H "X-N8N-API-KEY: $KEY"

curl "http://localhost:5678/api/v1/role-mapping-rules?type=instance" \
  -H "X-N8N-API-KEY: $KEY"
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-49

Follow-up filed separately: https://linear.app/n8n/issue/API-185 (deprecate the `offset` param on `GET /workflows/{id}/history`, the one remaining public list endpoint that doesn't follow cursor-only pagination).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

