### PR TITLE
build: Install Kafka binding on fresh clone

### DIFF
--- a/.github/scripts/docker/kafka-native-smoke-check.mjs
+++ b/.github/scripts/docker/kafka-native-smoke-check.mjs
@@ -14,7 +14,9 @@ const REQUIRED_FEATURES = ['ssl', 'sasl_scram'];
 const COMPRESSION_CODECS = ['gzip', 'snappy', 'lz4', 'zstd'];
 
 const n8nInstallDir = process.env.N8N_INSTALL_DIR || '/usr/local/lib/node_modules/n8n';
-const nodesBasePackageJson = path.join(n8nInstallDir, 'node_modules/n8n-nodes-base/package.json');
+const nodesBasePackageJson =
+	process.env.NODES_BASE_PACKAGE_JSON ||
+	path.join(n8nInstallDir, 'node_modules/n8n-nodes-base/package.json');
 // n8n-nodes-base is a pnpm symlink; resolve it so require() walks up from its real
 // location in the pnpm virtual store, where its dependencies actually live.
 const require = createRequire(realpathSync(nodesBasePackageJson));

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -54,6 +54,13 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      # Confluent publishes prebuilds up to Node 24 only.
+      - name: Verify Kafka native binding installed
+        if: startsWith(inputs.nodeVersion, '24.')
+        env:
+          NODES_BASE_PACKAGE_JSON: packages/nodes-base/package.json
+        run: node .github/scripts/docker/kafka-native-smoke-check.mjs
+
       # cli is the only backend package wired into janitor scoping today, so
       # the workspace bulk run excludes it and a dedicated step invokes the
       # scoped variant. This avoids turbo silently no-op'ing `test:unit:changed`

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@confluentinc/kafka-javascript",
       "@vscode/ripgrep",
       "isolated-vm",
       "sqlite3"

--- a/package.json
+++ b/package.json
@@ -236,7 +236,8 @@
       "assert@2.1.0": "patches/assert@2.1.0.patch",
       "lodash@4.18.1": "patches/lodash@4.18.1.patch",
       "@langchain/openai@1.4.4": "patches/@langchain__openai@1.4.4.patch",
-      "@langchain/google-common@2.1.24": "patches/@langchain__google-common@2.1.24.patch"
+      "@langchain/google-common@2.1.24": "patches/@langchain__google-common@2.1.24.patch",
+      "@confluentinc/kafka-javascript@1.9.1": "patches/@confluentinc__kafka-javascript@1.9.1.patch"
     }
   }
 }

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -940,7 +940,6 @@
     "@smithy/signature-v4": "5.3.5",
     "@smithy/types": "4.13.1",
     "@n8n/backend-network": "workspace:*",
-    "@confluentinc/kafka-javascript": "catalog:",
     "@kafkajs/confluent-schema-registry": "3.8.0",
     "@langchain/core": "catalog:",
     "@mozilla/readability": "catalog:",
@@ -1025,6 +1024,9 @@
     "xml2js": "catalog:",
     "xmlhttprequest-ssl": "3.1.0",
     "zod": "catalog:"
+  },
+  "optionalDependencies": {
+    "@confluentinc/kafka-javascript": "catalog:"
   },
   "license": "LicenseRef-n8n-sustainable-use"
 }

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -940,6 +940,7 @@
     "@smithy/signature-v4": "5.3.5",
     "@smithy/types": "4.13.1",
     "@n8n/backend-network": "workspace:*",
+    "@confluentinc/kafka-javascript": "catalog:",
     "@kafkajs/confluent-schema-registry": "3.8.0",
     "@langchain/core": "catalog:",
     "@mozilla/readability": "catalog:",
@@ -1024,9 +1025,6 @@
     "xml2js": "catalog:",
     "xmlhttprequest-ssl": "3.1.0",
     "zod": "catalog:"
-  },
-  "optionalDependencies": {
-    "@confluentinc/kafka-javascript": "catalog:"
   },
   "license": "LicenseRef-n8n-sustainable-use"
 }

--- a/patches/@confluentinc__kafka-javascript@1.9.1.patch
+++ b/patches/@confluentinc__kafka-javascript@1.9.1.patch
@@ -1,5 +1,5 @@
 diff --git a/package.json b/package.json
-index ed972a91dca9ad78b47f1d8d295df58cdef269ff..700f05450431d7cb743a96594a1a521898645f83 100644
+index ed972a91dca9ad78b47f1d8d295df58cdef269ff..d8f7499f85c1432cbf62bdbbe01fc12680e8e31c 100644
 --- a/package.json
 +++ b/package.json
 @@ -10,7 +10,7 @@
@@ -7,7 +7,7 @@ index ed972a91dca9ad78b47f1d8d295df58cdef269ff..700f05450431d7cb743a96594a1a5218
      "build": "node-gyp build",
      "test": "make test",
 -    "install": "node-pre-gyp install --fallback-to-build",
-+    "install": "node-pre-gyp install || true",
++    "install": "node-pre-gyp install || echo '[@confluentinc/kafka-javascript] no prebuilt binding for this Node version or platform (see the node-pre-gyp error above), so the Kafka node will not run. Use Node 24 for local Kafka work.'",
      "install-from-source": "npm ci && node-pre-gyp install --build-from-source=@confluentinc/kafka-javascript --fallback-to-build",
      "prepack": "node ./ci/prepublish.js",
      "test:types": "tsc -p ."

--- a/patches/@confluentinc__kafka-javascript@1.9.1.patch
+++ b/patches/@confluentinc__kafka-javascript@1.9.1.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index ed972a91dca9ad78b47f1d8d295df58cdef269ff..700f05450431d7cb743a96594a1a521898645f83 100644
+--- a/package.json
++++ b/package.json
+@@ -10,7 +10,7 @@
+     "configure": "node-gyp configure",
+     "build": "node-gyp build",
+     "test": "make test",
+-    "install": "node-pre-gyp install --fallback-to-build",
++    "install": "node-pre-gyp install || true",
+     "install-from-source": "npm ci && node-pre-gyp install --build-from-source=@confluentinc/kafka-javascript --fallback-to-build",
+     "prepack": "node ./ci/prepublish.js",
+     "test:types": "tsc -p ."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6350,9 +6350,6 @@ importers:
       '@aws-sdk/credential-providers':
         specifier: 3.808.0
         version: 3.808.0
-      '@confluentinc/kafka-javascript':
-        specifier: 'catalog:'
-        version: 1.9.1(encoding@0.1.13)
       '@e965/xlsx':
         specifier: 'catalog:'
         version: 0.20.3
@@ -6750,6 +6747,10 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@7.0.2)(vitest@4.1.9)
+    optionalDependencies:
+      '@confluentinc/kafka-javascript':
+        specifier: 'catalog:'
+        version: 1.9.1(encoding@0.1.13)
 
   packages/testing/code-health:
     dependencies:
@@ -22766,8 +22767,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.9:
-    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
+  vue-component-type-helpers@3.3.10:
+    resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -25962,6 +25963,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -27486,6 +27488,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
 
   '@marijn/find-cluster-break@1.0.2': {}
 
@@ -29876,7 +29879,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@6.0.2)
-      vue-component-type-helpers: 3.3.9
+      vue-component-type-helpers: 3.3.10
 
   '@stryker-mutator/api@9.6.1':
     dependencies:
@@ -32010,7 +32013,8 @@ snapshots:
 
   abbrev@1.1.1: {}
 
-  abbrev@3.0.1: {}
+  abbrev@3.0.1:
+    optional: true
 
   abbrev@4.0.0: {}
 
@@ -33337,7 +33341,8 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
-  consola@3.4.2: {}
+  consola@3.4.2:
+    optional: true
 
   console-browserify@1.2.0: {}
 
@@ -38579,6 +38584,7 @@ snapshots:
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
+    optional: true
 
   nopt@9.0.0:
     dependencies:
@@ -42611,7 +42617,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.9: {}
+  vue-component-type-helpers@3.3.10: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@6.0.2)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,6 +814,9 @@ overrides:
   '@zone-eu/mailsplit@<5.4.15': 5.4.15
 
 patchedDependencies:
+  '@confluentinc/kafka-javascript@1.9.1':
+    hash: 8d79f013c55004abe2831fb0275eeb2f17e3c916ebbaee63080f939c7396a998
+    path: patches/@confluentinc__kafka-javascript@1.9.1.patch
   '@langchain/google-common@2.1.24':
     hash: b50436a6c7b0a82d54472dff331ba1b42ab8b816995f83295eef2ee4b482a87d
     path: patches/@langchain__google-common@2.1.24.patch
@@ -6350,6 +6353,9 @@ importers:
       '@aws-sdk/credential-providers':
         specifier: 3.808.0
         version: 3.808.0
+      '@confluentinc/kafka-javascript':
+        specifier: 'catalog:'
+        version: 1.9.1(patch_hash=8d79f013c55004abe2831fb0275eeb2f17e3c916ebbaee63080f939c7396a998)(encoding@0.1.13)
       '@e965/xlsx':
         specifier: 'catalog:'
         version: 0.20.3
@@ -6747,10 +6753,6 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@7.0.2)(vitest@4.1.9)
-    optionalDependencies:
-      '@confluentinc/kafka-javascript':
-        specifier: 'catalog:'
-        version: 1.9.1(encoding@0.1.13)
 
   packages/testing/code-health:
     dependencies:
@@ -25955,7 +25957,7 @@ snapshots:
     dependencies:
       commander: 13.1.0
 
-  '@confluentinc/kafka-javascript@1.9.1(encoding@0.1.13)':
+  '@confluentinc/kafka-javascript@1.9.1(patch_hash=8d79f013c55004abe2831fb0275eeb2f17e3c916ebbaee63080f939c7396a998)(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       bindings: 1.5.0
@@ -25963,7 +25965,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -27488,7 +27489,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   '@marijn/find-cluster-break@1.0.2': {}
 
@@ -32013,8 +32013,7 @@ snapshots:
 
   abbrev@1.1.1: {}
 
-  abbrev@3.0.1:
-    optional: true
+  abbrev@3.0.1: {}
 
   abbrev@4.0.0: {}
 
@@ -33341,8 +33340,7 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
-  consola@3.4.2:
-    optional: true
+  consola@3.4.2: {}
 
   console-browserify@1.2.0: {}
 
@@ -38584,7 +38582,6 @@ snapshots:
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
-    optional: true
 
   nopt@9.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,7 +815,7 @@ overrides:
 
 patchedDependencies:
   '@confluentinc/kafka-javascript@1.9.1':
-    hash: 8d79f013c55004abe2831fb0275eeb2f17e3c916ebbaee63080f939c7396a998
+    hash: c597d3e3d9d6d0d33588b7dc1e88d55f270ba155721aad464bd7fb03e28f5003
     path: patches/@confluentinc__kafka-javascript@1.9.1.patch
   '@langchain/google-common@2.1.24':
     hash: b50436a6c7b0a82d54472dff331ba1b42ab8b816995f83295eef2ee4b482a87d
@@ -6355,7 +6355,7 @@ importers:
         version: 3.808.0
       '@confluentinc/kafka-javascript':
         specifier: 'catalog:'
-        version: 1.9.1(patch_hash=8d79f013c55004abe2831fb0275eeb2f17e3c916ebbaee63080f939c7396a998)(encoding@0.1.13)
+        version: 1.9.1(patch_hash=c597d3e3d9d6d0d33588b7dc1e88d55f270ba155721aad464bd7fb03e28f5003)(encoding@0.1.13)
       '@e965/xlsx':
         specifier: 'catalog:'
         version: 0.20.3
@@ -25957,7 +25957,7 @@ snapshots:
     dependencies:
       commander: 13.1.0
 
-  '@confluentinc/kafka-javascript@1.9.1(patch_hash=8d79f013c55004abe2831fb0275eeb2f17e3c916ebbaee63080f939c7396a998)(encoding@0.1.13)':
+  '@confluentinc/kafka-javascript@1.9.1(patch_hash=c597d3e3d9d6d0d33588b7dc1e88d55f270ba155721aad464bd7fb03e28f5003)(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       bindings: 1.5.0

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -35,7 +35,12 @@ const config = {
 };
 
 // Define backend patches to keep during deployment
-const PATCHES_TO_KEEP = ['pdfjs-dist', 'pkce-challenge', 'bull'];
+const PATCHES_TO_KEEP = [
+	'pdfjs-dist',
+	'pkce-challenge',
+	'bull',
+	'@confluentinc/kafka-javascript',
+];
 
 // #endregion ===== Configuration =====
 


### PR DESCRIPTION
## Summary

A fresh clone produces no Kafka native binding, so the Kafka node fails locally with `Could not locate the bindings file`. pnpm 10 runs a dependency's install script only if the package is listed in `pnpm.onlyBuiltDependencies`. `@confluentinc/kafka-javascript` was on that list until the bot PR #36381, which swept up the install-time removal that the Node 26 CI migration relied on. Re-adding the entry on its own would break CI, because on Node 26 the install script fails, as Confluent publishes no Node 26 prebuild and the vendored `librdkafka` cannot build inside `node_modules`.

So this PR re-adds the entry and moves the dependency to `optionalDependencies`, where a failing install script is not fatal. Docker images are unaffected, since they compile the binding themselves.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/confluentinc/confluent-kafka-javascript/issues/397

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Install-time configuration, not covered by unit tests. The Kafka smoke check in docker-build-push covers the image path. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)