### PR TITLE
fix(core): Report activation mode 'activate' for a first publication via the outbox

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -328,6 +328,58 @@ describe('WorkflowPublicationApplier', () => {
 				abort,
 			);
 		});
+
+		describe('first publication (no published-version mapping)', () => {
+			beforeEach(() => {
+				workflowPublishedVersionRepository.findOne.mockResolvedValue(null);
+			});
+
+			test('reason publish activates with mode activate', async () => {
+				setTriggerSets([], [triggerNode('a')]);
+
+				await applier.apply(makeRecord({ reason: 'publish' }), abort);
+
+				expect(workflowTriggerActivator.activate).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'wf-1' }),
+					newVersion,
+					new Set(['a']),
+					'activate',
+					abort,
+				);
+			});
+
+			test('a record without a reason (pre-migration row) activates with mode activate', async () => {
+				setTriggerSets([], [triggerNode('a')]);
+
+				await applier.apply(makeRecord({ reason: undefined }), abort);
+
+				expect(workflowTriggerActivator.activate).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'wf-1' }),
+					newVersion,
+					new Set(['a']),
+					'activate',
+					abort,
+				);
+			});
+
+			test.each([
+				['startup', 'init'],
+				['leadership-takeover', 'leadershipChange'],
+				['reconcile', 'update'],
+			] as const)('reason %s still activates with mode %s', async (reason, expectedMode) => {
+				setTriggerSets([], [triggerNode('a')]);
+
+				await applier.apply(makeRecord({ reason }), abort);
+
+				expect(workflowTriggerActivator.activate).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'wf-1' }),
+					newVersion,
+					new Set(['a']),
+					expectedMode,
+					abort,
+				);
+			});
+		});
 	});
 
 	test('reconciles by registering desired non-webhook triggers missing from memory', async () => {
@@ -714,7 +766,7 @@ describe('WorkflowPublicationApplier', () => {
 			expect.objectContaining({ id: 'wf-1' }),
 			newVersion,
 			new Set(['a']),
-			'update',
+			'activate',
 			abort,
 		);
 	});

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -31,6 +31,8 @@ import { WorkflowPublishedDataService } from '@/workflows/workflow-published-dat
  * e.g. the n8n Trigger's "Instance Started" event fires exactly for the
  * leader's startup pass. Records from before the `reason` column existed
  * default to `publish` at the DB level, i.e. today's `update` behavior.
+ * A first publication overrides `publish` → `activate`; see
+ * {@link WorkflowPublicationApplier.resolveActivationMode}.
  */
 const ACTIVATION_MODE_BY_REASON: Record<WorkflowPublicationReason, WorkflowActivateMode> = {
 	[WorkflowPublicationReason.Publish]: 'update',
@@ -177,8 +179,7 @@ export class WorkflowPublicationApplier {
 		try {
 			abort.signal.throwIfAborted();
 			if (toAdd.size > 0) {
-				const activationMode =
-					ACTIVATION_MODE_BY_REASON[record.reason ?? WorkflowPublicationReason.Publish];
+				const activationMode = this.resolveActivationMode(record, oldVersion);
 				const outcome = await this.workflowTriggerActivator.activate(
 					workflow,
 					newVersion,
@@ -203,6 +204,19 @@ export class WorkflowPublicationApplier {
 				failures: [],
 			}),
 		};
+	}
+
+	/**
+	 * A first publication (no old version) reports `activate`, so the n8n Trigger's
+	 * "Workflow Published" event fires; otherwise the mode follows the record's reason.
+	 */
+	private resolveActivationMode(
+		record: WorkflowPublicationOutbox,
+		oldVersion: WorkflowHistory | null,
+	): WorkflowActivateMode {
+		const reason = record.reason ?? WorkflowPublicationReason.Publish;
+		if (reason === WorkflowPublicationReason.Publish && oldVersion === null) return 'activate';
+		return ACTIVATION_MODE_BY_REASON[reason];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Under the Workflow Publication Service, the n8n Trigger's "Workflow Published" event never fired. The publication applier mapped the `publish` outbox reason to activation mode `'update'` in all cases. The mode `'activate'` could not occur, and the event fires only for that mode.

The applier now checks for a first publication. A `publish` record with no currently published version reports `'activate'`. All other reasons keep their modes. This matches the legacy path in `workflow.service.ts`: `previousActiveVersionId ? 'update' : 'activate'`.

No schema change is needed. The `workflow_published_version` mapping already carries the signal: it is absent before the first publish and is removed on unpublish. A republish after an unpublish therefore also reports `'activate'`, which matches legacy behavior.

Known edge: if a first publish partially fails after the published version is advanced, the retry sees a mapping and reports `'update'`. The legacy path has an equivalent edge. Follow-up to #36123.

## How to test

Requires WPS: set `N8N_WORKFLOWS_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

1. Create a workflow with an **n8n Trigger** node set to the **Workflow Published** event.
2. Publish it for the first time. The workflow executes once. (Before the fix: no execution.)
3. Change and republish the workflow. It does not execute again.
4. Unpublish it, then publish it again. It executes once more.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4046

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

