### PR TITLE
ci: Bump PR title action to v2.5.0 and document engine scope

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -34,6 +34,7 @@ Creates GitHub PRs with titles that pass n8n's `check-pr-title` CI validation.
 - `benchmark` - Benchmark CLI changes
 - `core` - Core/backend/private API
 - `editor` - Editor UI changes
+- `engine` - New workflow execution engine v2 (@n8n/engine package)
 - `* Node` - Specific node (e.g., `Slack Node`, `GitHub Node`)
 
 ### Summary Rules

--- a/.github/workflows/ci-check-pr-title.yml
+++ b/.github/workflows/ci-check-pr-title.yml
@@ -16,6 +16,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Validate PR title
-        uses: n8n-io/validate-n8n-pull-request-title@c3b6fd06bda12eebd57a592c0cf3b747d5b73569 # v2.4.0
+        uses: n8n-io/validate-n8n-pull-request-title@8aad0456a34b6f487c421539210529304ae8042c # v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR bumps the `n8n-io/validate-n8n-pull-request-title` action pin in `.github/workflows/ci-check-pr-title.yml` from v2.4.0 to v2.5.0. This release adds the `engine` scope for the new workflow execution engine v2.
It also adds the `engine` scope to the `create-pr` skill's scope list, so the skill stays in sync with the action.

## How to test

Open a PR with a title using the `engine` scope (e.g. `feat(engine): Add example`) and confirm the `check-pr-title` CI check passes.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

