### PR TITLE
feat(core): Add folder filtering to the MCP workflow search tool

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -1,15 +1,18 @@
 import type { Mock } from 'vitest';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { User } from '@n8n/db';
-import type { WorkflowEntity } from '@n8n/db';
+import type { Folder, WorkflowEntity } from '@n8n/db';
 import type { INode } from 'n8n-workflow';
 import {
 	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
 	MANUAL_TRIGGER_NODE_TYPE,
+	PROJECT_ROOT,
 	SCHEDULE_TRIGGER_NODE_TYPE,
 } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
+import { FolderNotFoundError } from '@/errors/folder-not-found.error';
+import { FolderFinderService } from '@/services/folder-finder.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowService } from '@/workflows/workflow.service';
 
@@ -19,6 +22,20 @@ import { searchWorkflows, createSearchWorkflowsTool } from '../tools/search-work
 
 describe('search-workflows MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
+
+	const folderFixture = (id: string) => ({ id, name: `folder-${id}` }) as Folder;
+
+	/**
+	 * Resolves the given folders for any lookup; an empty list stands in for a
+	 * folder that does not exist or that the user cannot reach.
+	 */
+	const mockFolderFinder = (folders: Folder[] = []) =>
+		mockInstance(FolderFinderService, {
+			findFoldersByIdsForUser: vi.fn().mockResolvedValue(folders),
+			findFolderSubtreesForUser: vi.fn().mockResolvedValue(folders),
+		});
+
+	const folderFinderService = mockFolderFinder();
 
 	describe('smoke tests', () => {
 		test('it creates tool correctly', () => {
@@ -42,6 +59,7 @@ describe('search-workflows MCP tool', () => {
 			const tool = createSearchWorkflowsTool(
 				user,
 				workflowService as unknown as WorkflowService,
+				folderFinderService,
 				telemetry,
 			);
 
@@ -93,7 +111,12 @@ describe('search-workflows MCP tool', () => {
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: vi.fn().mockResolvedValue({ workflows, count: 2 }),
 			});
-			const result = await searchWorkflows(user, workflowService as unknown as WorkflowService, {});
+			const result = await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{},
+			);
 
 			expect(result.count).toBe(2);
 			expect(result.data).toEqual([
@@ -106,6 +129,7 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					availableInMCP: true,
+					parentFolderId: null,
 					tags: [],
 				},
 				{
@@ -117,6 +141,7 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					availableInMCP: true,
+					parentFolderId: null,
 					tags: [],
 				},
 			]);
@@ -138,9 +163,14 @@ describe('search-workflows MCP tool', () => {
 				getMany: vi.fn().mockResolvedValue({ workflows, count: 1 }),
 			});
 
-			const result = await searchWorkflows(user, workflowService as unknown as WorkflowService, {
-				tags: ['production', 'critical'],
-			});
+			const result = await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{
+					tags: ['production', 'critical'],
+				},
+			);
 
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter).toMatchObject({ tags: ['production', 'critical'] });
@@ -156,9 +186,14 @@ describe('search-workflows MCP tool', () => {
 				getMany: vi.fn().mockResolvedValue({ workflows: [], count: 0 }),
 			});
 
-			await searchWorkflows(user, workflowService as unknown as WorkflowService, {
-				tags: ['', ''],
-			});
+			await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{
+					tags: ['', ''],
+				},
+			);
 
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter.tags).toBeUndefined();
@@ -169,9 +204,14 @@ describe('search-workflows MCP tool', () => {
 				getMany: vi.fn().mockResolvedValue({ workflows: [], count: 0 }),
 			});
 
-			await searchWorkflows(user, workflowService as unknown as WorkflowService, {
-				tags: ['production', 'production', 'critical', 'production'],
-			});
+			await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{
+					tags: ['production', 'production', 'critical', 'production'],
+				},
+			);
 
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter.tags).toEqual(['production', 'critical']);
@@ -182,11 +222,16 @@ describe('search-workflows MCP tool', () => {
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: vi.fn().mockResolvedValue({ workflows, count: 1 }),
 			});
-			await searchWorkflows(user, workflowService as unknown as WorkflowService, {
-				limit: 500,
-				query: 'foo',
-				projectId: 'proj-1',
-			});
+			await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{
+					limit: 500,
+					query: 'foo',
+					projectId: 'proj-1',
+				},
+			);
 
 			const [_userArg, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.take).toBe(200);
@@ -201,7 +246,12 @@ describe('search-workflows MCP tool', () => {
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: vi.fn().mockResolvedValue({ workflows: [], count: 0 }),
 			});
-			await searchWorkflows(user, workflowService as unknown as WorkflowService, {});
+			await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{},
+			);
 
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.sortBy).toBe('updatedAt:desc');
@@ -211,9 +261,14 @@ describe('search-workflows MCP tool', () => {
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: vi.fn().mockResolvedValue({ workflows: [], count: 0 }),
 			});
-			await searchWorkflows(user, workflowService as unknown as WorkflowService, {
-				sortBy: 'name:asc',
-			});
+			await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{
+					sortBy: 'name:asc',
+				},
+			);
 
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.sortBy).toBe('name:asc');
@@ -223,9 +278,14 @@ describe('search-workflows MCP tool', () => {
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: vi.fn().mockResolvedValue({ workflows: [], count: 0 }),
 			});
-			await searchWorkflows(user, workflowService as unknown as WorkflowService, {
-				limit: 0,
-			});
+			await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{
+					limit: 0,
+				},
+			);
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.take).toBe(1);
 		});
@@ -242,11 +302,155 @@ describe('search-workflows MCP tool', () => {
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: vi.fn().mockResolvedValue({ workflows, count: 1 }),
 			});
-			const result = await searchWorkflows(user, workflowService as unknown as WorkflowService, {});
+			const result = await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{},
+			);
 			expect(result.data[0]).toMatchObject({
 				id: 'no-nodes',
 				availableInMCP: true,
 			});
+		});
+	});
+
+	describe('folder filtering', () => {
+		const emptyResult = () =>
+			mockInstance(WorkflowService, {
+				getMany: vi.fn().mockResolvedValue({ workflows: [], count: 0 }),
+			});
+
+		test('searches the folder and its subfolders by default', async () => {
+			const workflowService = emptyResult();
+			const folderFinder = mockFolderFinder([
+				folderFixture('folder-1'),
+				folderFixture('folder-1-child'),
+			]);
+
+			await searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
+				folderId: 'folder-1',
+			});
+
+			expect(folderFinder.findFolderSubtreesForUser).toHaveBeenCalledWith(['folder-1'], user, [
+				'folder:read',
+			]);
+			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
+			expect(optionsArg.filter.parentFolderIds).toEqual(['folder-1', 'folder-1-child']);
+			expect(optionsArg.filter.parentFolderId).toBeUndefined();
+		});
+
+		test('searches only the folder itself when includeSubfolders is false', async () => {
+			const workflowService = emptyResult();
+			const folderFinder = mockFolderFinder([folderFixture('folder-1')]);
+
+			await searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
+				folderId: 'folder-1',
+				includeSubfolders: false,
+			});
+
+			expect(folderFinder.findFoldersByIdsForUser).toHaveBeenCalledWith(['folder-1'], user, [
+				'folder:read',
+			]);
+			expect(folderFinder.findFolderSubtreesForUser).not.toHaveBeenCalled();
+			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
+			expect(optionsArg.filter.parentFolderId).toBe('folder-1');
+			expect(optionsArg.filter.parentFolderIds).toBeUndefined();
+		});
+
+		test('matches the project root without resolving a folder', async () => {
+			const workflowService = emptyResult();
+			const folderFinder = mockFolderFinder();
+
+			await searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
+				folderId: PROJECT_ROOT,
+			});
+
+			expect(folderFinder.findFolderSubtreesForUser).not.toHaveBeenCalled();
+			expect(folderFinder.findFoldersByIdsForUser).not.toHaveBeenCalled();
+			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
+			expect(optionsArg.filter.parentFolderId).toBe(PROJECT_ROOT);
+		});
+
+		test('combines the folder filter with the other filters', async () => {
+			const workflowService = emptyResult();
+			const folderFinder = mockFolderFinder([folderFixture('folder-1')]);
+
+			await searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
+				folderId: 'folder-1',
+				projectId: 'proj-1',
+				query: 'slack',
+			});
+
+			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
+			expect(optionsArg.filter).toMatchObject({
+				isArchived: false,
+				query: 'slack',
+				projectId: 'proj-1',
+				parentFolderIds: ['folder-1'],
+			});
+		});
+
+		test('reports the folder holding each workflow so it can be searched next', async () => {
+			const workflows = [
+				createWorkflow({
+					id: 'in-folder',
+					activeVersionId: uuid(),
+					parentFolder: folderFixture('folder-1'),
+				}),
+				createWorkflow({ id: 'at-root', activeVersionId: uuid() }),
+			];
+			const workflowService = mockInstance(WorkflowService, {
+				getMany: vi.fn().mockResolvedValue({ workflows, count: 2 }),
+			});
+
+			const result = await searchWorkflows(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				{},
+			);
+
+			expect(result.data[0].parentFolderId).toBe('folder-1');
+			expect(result.data[1].parentFolderId).toBeNull();
+			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
+			expect(optionsArg.select).toMatchObject({ parentFolder: true });
+		});
+
+		test('treats an empty folderId as a folder that cannot be resolved', async () => {
+			const workflowService = emptyResult();
+			const folderFinder = mockFolderFinder([]);
+
+			await expect(
+				searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
+					folderId: '',
+				}),
+			).rejects.toThrow(FolderNotFoundError);
+			expect(workflowService.getMany).not.toHaveBeenCalled();
+		});
+
+		// A folder the user cannot see must fail loudly: dropping the filter would
+		// quietly hand back every workflow on the instance instead.
+		test('fails with a recoverable error instead of widening the search', async () => {
+			const workflowService = emptyResult();
+			const folderFinder = mockFolderFinder([]);
+			const telemetry = mockInstance(Telemetry, { track: vi.fn() });
+			const tool = createSearchWorkflowsTool(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinder,
+				telemetry,
+			);
+
+			const result = await tool.handler({ folderId: 'nope' });
+
+			expect(result.isError).toBe(true);
+			expect(result.structuredContent).toEqual({
+				data: [],
+				count: 0,
+				error: expect.stringContaining('search_folders'),
+			});
+			expect(workflowService.getMany).not.toHaveBeenCalled();
 		});
 	});
 
@@ -262,6 +466,7 @@ describe('search-workflows MCP tool', () => {
 			const tool = createSearchWorkflowsTool(
 				user,
 				workflowService as unknown as WorkflowService,
+				folderFinderService,
 				telemetry,
 			);
 
@@ -276,6 +481,7 @@ describe('search-workflows MCP tool', () => {
 				updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 				triggerCount: 0,
 				availableInMCP: true,
+				parentFolderId: null,
 				tags: [],
 				resource: 'workflow', // unknown field surfaced by the data layer
 			};

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -31,7 +31,7 @@ describe('search-workflows MCP tool', () => {
 	 */
 	const mockFolderFinder = (folderIds: string[] = []) =>
 		mockInstance(FolderFinderService, {
-			findFolderFilterIds: vi.fn().mockResolvedValue(folderIds),
+			findFolderFilterIdsWithoutAccessCheck: vi.fn().mockResolvedValue(folderIds),
 		});
 
 	const folderFinderService = mockFolderFinder();
@@ -326,7 +326,10 @@ describe('search-workflows MCP tool', () => {
 				folderId: 'folder-1',
 			});
 
-			expect(folderFinder.findFolderFilterIds).toHaveBeenCalledWith('folder-1', true);
+			expect(folderFinder.findFolderFilterIdsWithoutAccessCheck).toHaveBeenCalledWith(
+				'folder-1',
+				true,
+			);
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter.parentFolderIds).toEqual(['folder-1', 'folder-1-child']);
 			expect(optionsArg.filter.parentFolderId).toBeUndefined();
@@ -341,7 +344,10 @@ describe('search-workflows MCP tool', () => {
 				includeSubfolders: false,
 			});
 
-			expect(folderFinder.findFolderFilterIds).toHaveBeenCalledWith('folder-1', false);
+			expect(folderFinder.findFolderFilterIdsWithoutAccessCheck).toHaveBeenCalledWith(
+				'folder-1',
+				false,
+			);
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter.parentFolderIds).toEqual(['folder-1']);
 			expect(optionsArg.filter.parentFolderId).toBeUndefined();
@@ -355,7 +361,7 @@ describe('search-workflows MCP tool', () => {
 				folderId: PROJECT_ROOT,
 			});
 
-			expect(folderFinder.findFolderFilterIds).not.toHaveBeenCalled();
+			expect(folderFinder.findFolderFilterIdsWithoutAccessCheck).not.toHaveBeenCalled();
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter.parentFolderId).toBe(PROJECT_ROOT);
 		});

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -128,6 +128,7 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					availableInMCP: true,
+					parentFolderId: null,
 					tags: [],
 				},
 				{
@@ -139,6 +140,7 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					availableInMCP: true,
+					parentFolderId: null,
 					tags: [],
 				},
 			]);
@@ -406,7 +408,8 @@ describe('search-workflows MCP tool', () => {
 			);
 
 			expect(result.data[0].parentFolderId).toBe('folder-1');
-			expect(result.data[1]).not.toHaveProperty('parentFolderId');
+			// null rather than absent, matching what get_workflow_details reports.
+			expect(result.data[1].parentFolderId).toBeNull();
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.select).toMatchObject({ parentFolder: true });
 		});
@@ -448,6 +451,40 @@ describe('search-workflows MCP tool', () => {
 		});
 	});
 
+	describe('input schema', () => {
+		const folderIdSchemaOf = () => {
+			const workflowService = mockInstance(WorkflowService, { getMany: vi.fn() });
+			const telemetry = mockInstance(Telemetry, { track: vi.fn() });
+			const tool = createSearchWorkflowsTool(
+				user,
+				workflowService as unknown as WorkflowService,
+				folderFinderService,
+				telemetry,
+			);
+			return z.object(tool.config.inputSchema as z.ZodRawShape).shape.folderId;
+		};
+
+		// Rejecting these at the schema saves a database lookup for a value that
+		// could never be an id — an LLM sending a folder name, most likely.
+		test.each([
+			['an empty string', ''],
+			['a blank string', ' '],
+			['a folder name', 'My folder'],
+			['a folder path', 'Triggers/Nested'],
+		])('rejects %s', (_label, value) => {
+			expect(folderIdSchemaOf().safeParse(value).success).toBe(false);
+		});
+
+		test.each([
+			['a folder id', 'uCTsB9uJaYgN4RYF'],
+			['an id minted elsewhere', '0195b8d6-7c3f-7a1e-9f2b-3d4e5f6a7b8c'],
+			['the project root sentinel', PROJECT_ROOT],
+			['nothing at all', undefined],
+		])('accepts %s', (_label, value) => {
+			expect(folderIdSchemaOf().safeParse(value).success).toBe(true);
+		});
+	});
+
 	describe('output schema', () => {
 		// Regression: the advertised output schema for each workflow item must allow
 		// extra properties. The data layer (workflowService.getMany) can surface fields
@@ -475,6 +512,7 @@ describe('search-workflows MCP tool', () => {
 				updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 				triggerCount: 0,
 				availableInMCP: true,
+				parentFolderId: null,
 				tags: [],
 				resource: 'workflow', // unknown field surfaced by the data layer
 			};

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -26,13 +26,12 @@ describe('search-workflows MCP tool', () => {
 	const folderFixture = (id: string) => ({ id, name: `folder-${id}` }) as Folder;
 
 	/**
-	 * Resolves the given folders for any lookup; an empty list stands in for a
-	 * folder that does not exist or that the user cannot reach.
+	 * Resolves the given folder ids for a filter lookup; an empty list stands in
+	 * for a folderId that matches no folder.
 	 */
-	const mockFolderFinder = (folders: Folder[] = []) =>
+	const mockFolderFinder = (folderIds: string[] = []) =>
 		mockInstance(FolderFinderService, {
-			findFoldersByIdsForUser: vi.fn().mockResolvedValue(folders),
-			findFolderSubtreesForUser: vi.fn().mockResolvedValue(folders),
+			findFolderFilterIds: vi.fn().mockResolvedValue(folderIds),
 		});
 
 	const folderFinderService = mockFolderFinder();
@@ -129,7 +128,6 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					availableInMCP: true,
-					parentFolderId: null,
 					tags: [],
 				},
 				{
@@ -141,7 +139,6 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					availableInMCP: true,
-					parentFolderId: null,
 					tags: [],
 				},
 			]);
@@ -323,18 +320,13 @@ describe('search-workflows MCP tool', () => {
 
 		test('searches the folder and its subfolders by default', async () => {
 			const workflowService = emptyResult();
-			const folderFinder = mockFolderFinder([
-				folderFixture('folder-1'),
-				folderFixture('folder-1-child'),
-			]);
+			const folderFinder = mockFolderFinder(['folder-1', 'folder-1-child']);
 
 			await searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
 				folderId: 'folder-1',
 			});
 
-			expect(folderFinder.findFolderSubtreesForUser).toHaveBeenCalledWith(['folder-1'], user, [
-				'folder:read',
-			]);
+			expect(folderFinder.findFolderFilterIds).toHaveBeenCalledWith('folder-1', true);
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter.parentFolderIds).toEqual(['folder-1', 'folder-1-child']);
 			expect(optionsArg.filter.parentFolderId).toBeUndefined();
@@ -342,20 +334,17 @@ describe('search-workflows MCP tool', () => {
 
 		test('searches only the folder itself when includeSubfolders is false', async () => {
 			const workflowService = emptyResult();
-			const folderFinder = mockFolderFinder([folderFixture('folder-1')]);
+			const folderFinder = mockFolderFinder(['folder-1']);
 
 			await searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
 				folderId: 'folder-1',
 				includeSubfolders: false,
 			});
 
-			expect(folderFinder.findFoldersByIdsForUser).toHaveBeenCalledWith(['folder-1'], user, [
-				'folder:read',
-			]);
-			expect(folderFinder.findFolderSubtreesForUser).not.toHaveBeenCalled();
+			expect(folderFinder.findFolderFilterIds).toHaveBeenCalledWith('folder-1', false);
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
-			expect(optionsArg.filter.parentFolderId).toBe('folder-1');
-			expect(optionsArg.filter.parentFolderIds).toBeUndefined();
+			expect(optionsArg.filter.parentFolderIds).toEqual(['folder-1']);
+			expect(optionsArg.filter.parentFolderId).toBeUndefined();
 		});
 
 		test('matches the project root without resolving a folder', async () => {
@@ -366,15 +355,14 @@ describe('search-workflows MCP tool', () => {
 				folderId: PROJECT_ROOT,
 			});
 
-			expect(folderFinder.findFolderSubtreesForUser).not.toHaveBeenCalled();
-			expect(folderFinder.findFoldersByIdsForUser).not.toHaveBeenCalled();
+			expect(folderFinder.findFolderFilterIds).not.toHaveBeenCalled();
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.filter.parentFolderId).toBe(PROJECT_ROOT);
 		});
 
 		test('combines the folder filter with the other filters', async () => {
 			const workflowService = emptyResult();
-			const folderFinder = mockFolderFinder([folderFixture('folder-1')]);
+			const folderFinder = mockFolderFinder(['folder-1']);
 
 			await searchWorkflows(user, workflowService as unknown as WorkflowService, folderFinder, {
 				folderId: 'folder-1',
@@ -412,7 +400,7 @@ describe('search-workflows MCP tool', () => {
 			);
 
 			expect(result.data[0].parentFolderId).toBe('folder-1');
-			expect(result.data[1].parentFolderId).toBeNull();
+			expect(result.data[1]).not.toHaveProperty('parentFolderId');
 			const [, optionsArg] = (workflowService.getMany as Mock).mock.calls[0];
 			expect(optionsArg.select).toMatchObject({ parentFolder: true });
 		});
@@ -429,7 +417,7 @@ describe('search-workflows MCP tool', () => {
 			expect(workflowService.getMany).not.toHaveBeenCalled();
 		});
 
-		// A folder the user cannot see must fail loudly: dropping the filter would
+		// An id matching no folder must fail loudly: dropping the filter would
 		// quietly hand back every workflow on the instance instead.
 		test('fails with a recoverable error instead of widening the search', async () => {
 			const workflowService = emptyResult();
@@ -481,7 +469,6 @@ describe('search-workflows MCP tool', () => {
 				updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 				triggerCount: 0,
 				availableInMCP: true,
-				parentFolderId: null,
 				tags: [],
 				resource: 'workflow', // unknown field surfaced by the data layer
 			};

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -429,6 +429,7 @@ export class McpService {
 		const workflowSearchTool = createSearchWorkflowsTool(
 			user,
 			this.workflowService,
+			this.folderFinderService,
 			this.telemetry,
 		);
 		registerIfAllowed(workflowSearchTool);

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -92,6 +92,8 @@ export type SearchWorkflowsParams = {
 	projectId?: string;
 	tags?: string[];
 	sortBy?: SearchWorkflowsSortBy;
+	folderId?: string;
+	includeSubfolders?: boolean;
 };
 
 export type SearchWorkflowsItem = {
@@ -103,12 +105,14 @@ export type SearchWorkflowsItem = {
 	updatedAt: string | null;
 	triggerCount: number | null;
 	availableInMCP: boolean;
+	parentFolderId: string | null;
 	tags: Array<{ id: string; name: string }>;
 };
 
 export type SearchWorkflowsResult = {
 	data: SearchWorkflowsItem[];
 	count: number;
+	error?: string;
 };
 
 export type WorkflowDetailsResult = z.infer<WorkflowDetailsOutputSchema>;

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -105,7 +105,7 @@ export type SearchWorkflowsItem = {
 	updatedAt: string | null;
 	triggerCount: number | null;
 	availableInMCP: boolean;
-	parentFolderId: string | null;
+	parentFolderId?: string;
 	tags: Array<{ id: string; name: string }>;
 };
 

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -105,7 +105,7 @@ export type SearchWorkflowsItem = {
 	updatedAt: string | null;
 	triggerCount: number | null;
 	availableInMCP: boolean;
-	parentFolderId?: string;
+	parentFolderId: string | null;
 	tags: Array<{ id: string; name: string }>;
 };
 

--- a/packages/cli/src/modules/mcp/tools/search-folders.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-folders.tool.ts
@@ -51,7 +51,7 @@ export const createSearchFoldersTool = (
 	name: 'search_folders',
 	config: {
 		description:
-			"Search for folders within a project. Use this to resolve a folder name to an ID before creating a workflow in a folder, creating or updating a folder, or moving workflows into a folder. Each result includes the folder's full name path — when multiple folders match a name, use the paths to ask the user which one they meant. Requires a projectId — use search_projects first if needed.",
+			"Search for folders within a project. Use this to resolve a folder name to an ID before searching workflows inside a folder, creating a workflow in a folder, creating or updating a folder, or moving workflows into a folder. Each result includes the folder's full name path — when multiple folders match a name, use the paths to ask the user which one they meant. Requires a projectId — use search_projects first if needed.",
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -24,6 +24,12 @@ import { createLimitSchema, tagSchema, toTagSummary } from './schemas';
 
 const MAX_RESULTS = 200;
 
+// Folder ids are nanoids, but imported folders can carry an id minted elsewhere,
+// which is why `folderIdSchema` allows up to 36 characters. Match that tolerance
+// and only reject shapes no id can take — an empty string, or the folder *name*
+// an LLM may send instead of an id.
+const FOLDER_ID_PATTERN = /^[A-Za-z0-9-]+$/;
+
 const DEFAULT_SORT_BY: SearchWorkflowsSortBy = 'updatedAt:desc';
 
 const inputSchema = {
@@ -41,6 +47,9 @@ const inputSchema = {
 			`Sort order for results (default: ${DEFAULT_SORT_BY}). Use updatedAt:desc to find the most recently edited workflows first.`,
 		),
 	folderId: folderIdSchema
+		.refine((id) => id === PROJECT_ROOT || FOLDER_ID_PATTERN.test(id), {
+			message: `Must be a folder id, or "${PROJECT_ROOT}" for the project root`,
+		})
 		.optional()
 		.describe(
 			`Filter by folder. Pass a parentFolderId from an earlier result to find a workflow's siblings, or — when search_folders is available — use it to resolve a folder name to an id first. Pass "${PROJECT_ROOT}" for workflows that sit at the project root rather than in a folder.`,
@@ -79,9 +88,9 @@ const outputSchema = {
 					availableInMCP: z.boolean().describe('Whether the workflow is visible to MCP tools'),
 					parentFolderId: z
 						.string()
-						.optional()
+						.nullable()
 						.describe(
-							'The id of the folder holding the workflow, omitted when it sits at the project root. Pass it back as folderId to find related workflows.',
+							'The id of the folder holding the workflow, or null when it sits at the project root. Pass it back as folderId to find related workflows.',
 						),
 					tags: z.array(tagSchema).describe('Tags assigned to the workflow'),
 				})
@@ -313,9 +322,7 @@ export async function searchWorkflows(
 			updatedAt: updatedAt.toISOString(),
 			triggerCount,
 			availableInMCP: settings?.availableInMCP ?? false,
-			// Omitted rather than null: most workflows on a folder-less instance would
-			// otherwise carry a dead field on every row of every search.
-			...(parentFolder ? { parentFolderId: parentFolder.id } : {}),
+			parentFolderId: parentFolder?.id ?? null,
 			tags: toTagSummary(workflowTags),
 		};
 	});

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -43,7 +43,7 @@ const inputSchema = {
 	folderId: folderIdSchema
 		.optional()
 		.describe(
-			`Filter by folder. Use search_folders to resolve a folder name to an id, or pass a workflow's own parentFolderId to find its siblings. Pass "${PROJECT_ROOT}" for workflows that sit at the project root rather than in a folder.`,
+			`Filter by folder. Pass a parentFolderId from an earlier result to find a workflow's siblings, or — when search_folders is available — use it to resolve a folder name to an id first. Pass "${PROJECT_ROOT}" for workflows that sit at the project root rather than in a folder.`,
 		),
 	includeSubfolders: z
 		.boolean()
@@ -79,9 +79,9 @@ const outputSchema = {
 					availableInMCP: z.boolean().describe('Whether the workflow is visible to MCP tools'),
 					parentFolderId: z
 						.string()
-						.nullable()
+						.optional()
 						.describe(
-							'The id of the folder holding the workflow, or null when it sits at the project root. Pass it back as folderId to find related workflows.',
+							'The id of the folder holding the workflow, omitted when it sits at the project root. Pass it back as folderId to find related workflows.',
 						),
 					tags: z.array(tagSchema).describe('Tags assigned to the workflow'),
 				})
@@ -109,7 +109,7 @@ export const createSearchWorkflowsTool = (
 		name: 'search_workflows',
 		config: {
 			description:
-				'Search for workflows with optional filters. Returns a preview of each workflow. On instances that organise workflows into folders, narrow the search with folderId instead of scanning everything — resolve the folder by name with search_folders first.',
+				'Search for workflows with optional filters. Returns a preview of each workflow. Where workflows are organised into folders, narrow the search with folderId instead of scanning everything: reuse a parentFolderId from an earlier result, or resolve a folder name with search_folders when that tool is available.',
 			inputSchema,
 			outputSchema,
 			annotations: {
@@ -208,11 +208,12 @@ export const createSearchWorkflowsTool = (
  * the plain workflow list query — unlike the workflows-and-folders union the UI
  * uses — matches `parentFolderId` literally and never walks the hierarchy.
  *
- * Resolution goes through the folder finder so folders the user cannot reach are
- * dropped, and an empty resolution raises instead of returning no filter.
+ * The resolved ids only narrow a query that already filters to the workflows the
+ * user may read, so they need no folder-level permission check of their own —
+ * the same split the workflow list endpoint makes. An id that matches no folder
+ * raises, so a wrong id can never be mistaken for an empty folder.
  */
 async function resolveFolderFilter(
-	user: User,
 	folderFinderService: FolderFinderService,
 	folderId: string,
 	includeSubfolders: boolean,
@@ -221,20 +222,10 @@ async function resolveFolderFilter(
 	// matches workflows with no parent folder.
 	if (folderId === PROJECT_ROOT) return { parentFolderId: PROJECT_ROOT };
 
-	if (!includeSubfolders) {
-		const [folder] = await folderFinderService.findFoldersByIdsForUser([folderId], user, [
-			'folder:read',
-		]);
-		if (!folder) throw new FolderNotFoundError(folderId);
-		return { parentFolderId: folder.id };
-	}
+	const folderIds = await folderFinderService.findFolderFilterIds(folderId, includeSubfolders);
+	if (folderIds.length === 0) throw new FolderNotFoundError(folderId);
 
-	const subtree = await folderFinderService.findFolderSubtreesForUser([folderId], user, [
-		'folder:read',
-	]);
-	if (!subtree.some((folder) => folder.id === folderId)) throw new FolderNotFoundError(folderId);
-
-	return { parentFolderIds: subtree.map((folder) => folder.id) };
+	return { parentFolderIds: folderIds };
 }
 
 export async function searchWorkflows(
@@ -258,7 +249,7 @@ export async function searchWorkflows(
 	const folderFilter =
 		folderId === undefined
 			? {}
-			: await resolveFolderFilter(user, folderFinderService, folderId, includeSubfolders);
+			: await resolveFolderFilter(folderFinderService, folderId, includeSubfolders);
 
 	const options: ListQuery.Options = {
 		take: safeLimit,
@@ -315,7 +306,9 @@ export async function searchWorkflows(
 			updatedAt: updatedAt.toISOString(),
 			triggerCount,
 			availableInMCP: settings?.availableInMCP ?? false,
-			parentFolderId: parentFolder?.id ?? null,
+			// Omitted rather than null: most workflows on a folder-less instance would
+			// otherwise carry a dead field on every row of every search.
+			...(parentFolder ? { parentFolderId: parentFolder.id } : {}),
 			tags: toTagSummary(workflowTags),
 		};
 	});

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -1,4 +1,6 @@
+import { folderIdSchema } from '@n8n/api-types';
 import { type User, type WorkflowEntity } from '@n8n/db';
+import { PROJECT_ROOT } from 'n8n-workflow';
 import z from 'zod';
 
 import { USER_CALLED_MCP_TOOL_EVENT } from '../mcp.constants';
@@ -12,9 +14,12 @@ import type {
 	UserCalledMCPToolEventPayload,
 } from '../mcp.types';
 
+import { FolderNotFoundError } from '@/errors/folder-not-found.error';
 import type { ListQuery } from '@/requests';
+import type { FolderFinderService } from '@/services/folder-finder.service';
 import type { Telemetry } from '@/telemetry';
 import type { WorkflowService } from '@/workflows/workflow.service';
+import { describeFolderError } from './folder-error.utils';
 import { createLimitSchema, tagSchema, toTagSummary } from './schemas';
 
 const MAX_RESULTS = 200;
@@ -34,6 +39,17 @@ const inputSchema = {
 		.optional()
 		.describe(
 			`Sort order for results (default: ${DEFAULT_SORT_BY}). Use updatedAt:desc to find the most recently edited workflows first.`,
+		),
+	folderId: folderIdSchema
+		.optional()
+		.describe(
+			`Filter by folder. Use search_folders to resolve a folder name to an id, or pass a workflow's own parentFolderId to find its siblings. Pass "${PROJECT_ROOT}" for workflows that sit at the project root rather than in a folder.`,
+		),
+	includeSubfolders: z
+		.boolean()
+		.optional()
+		.describe(
+			`Whether a folderId search also covers that folder's subfolders (default: true). Set false to match only workflows directly inside the folder. Ignored when folderId is "${PROJECT_ROOT}", which always matches the project root only.`,
 		),
 } satisfies z.ZodRawShape;
 
@@ -61,28 +77,39 @@ const outputSchema = {
 						.nullable()
 						.describe('The number of triggers associated with the workflow'),
 					availableInMCP: z.boolean().describe('Whether the workflow is visible to MCP tools'),
+					parentFolderId: z
+						.string()
+						.nullable()
+						.describe(
+							'The id of the folder holding the workflow, or null when it sits at the project root. Pass it back as folderId to find related workflows.',
+						),
 					tags: z.array(tagSchema).describe('Tags assigned to the workflow'),
 				})
 				.passthrough(),
 		)
 		.describe('List of workflows matching the query'),
 	count: z.number().int().min(0).describe('Total number of workflows that match the filters'),
+	error: z
+		.string()
+		.optional()
+		.describe('Error message explaining why the search failed. Present only on failure.'),
 } satisfies z.ZodRawShape;
 
 /**
- * 	Creates mcp tool definition for searching workflows with optional filters. Workflows can be filtered by name, project ID, and tags.
- * Returns a preview of each workflow including id, name, active status, creation and update timestamps, trigger count, and tags.
+ * 	Creates mcp tool definition for searching workflows with optional filters. Workflows can be filtered by name, project ID, folder, and tags.
+ * Returns a preview of each workflow including id, name, active status, creation and update timestamps, trigger count, folder and tags.
  */
 export const createSearchWorkflowsTool = (
 	user: User,
 	workflowService: WorkflowService,
+	folderFinderService: FolderFinderService,
 	telemetry: Telemetry,
 ): ToolDefinition<typeof inputSchema> => {
 	return {
 		name: 'search_workflows',
 		config: {
 			description:
-				'Search for workflows with optional filters. Returns a preview of each workflow.',
+				'Search for workflows with optional filters. Returns a preview of each workflow. On instances that organise workflows into folders, narrow the search with folderId instead of scanning everything — resolve the folder by name with search_folders first.',
 			inputSchema,
 			outputSchema,
 			annotations: {
@@ -99,8 +126,10 @@ export const createSearchWorkflowsTool = (
 			projectId,
 			tags,
 			sortBy,
+			folderId,
+			includeSubfolders,
 		}: SearchWorkflowsParams) => {
-			const parameters = { limit, query, projectId, tags, sortBy };
+			const parameters = { limit, query, projectId, tags, sortBy, folderId, includeSubfolders };
 			const telemetryPayload: UserCalledMCPToolEventPayload = {
 				user_id: user.id,
 				tool_name: 'search_workflows',
@@ -108,13 +137,20 @@ export const createSearchWorkflowsTool = (
 			};
 
 			try {
-				const payload: SearchWorkflowsResult = await searchWorkflows(user, workflowService, {
-					limit,
-					query,
-					projectId,
-					tags,
-					sortBy,
-				});
+				const payload: SearchWorkflowsResult = await searchWorkflows(
+					user,
+					workflowService,
+					folderFinderService,
+					{
+						limit,
+						query,
+						projectId,
+						tags,
+						sortBy,
+						folderId,
+						includeSubfolders,
+					},
+				);
 
 				// Track successful execution
 				telemetryPayload.results = {
@@ -142,19 +178,87 @@ export const createSearchWorkflowsTool = (
 					error: error instanceof Error ? error.message : String(error),
 				};
 				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+				// An unresolvable folderId is a recoverable mistake: hand the client a
+				// structured error pointing at search_folders rather than throwing, so it
+				// can retry with a valid id. Never fall back to an unfiltered search —
+				// silently widening the scope is worse than failing.
+				if (error instanceof FolderNotFoundError) {
+					const output: SearchWorkflowsResult = {
+						data: [],
+						count: 0,
+						error: describeFolderError(error),
+					};
+					return {
+						structuredContent: output,
+						content: [{ type: 'text', text: JSON.stringify(output) }],
+						isError: true,
+					};
+				}
+
 				throw error;
 			}
 		},
 	};
 };
 
+/**
+ * Turns a requested `folderId` into the folder filter the workflow query
+ * understands. A subfolder search resolves the whole subtree up front because
+ * the plain workflow list query — unlike the workflows-and-folders union the UI
+ * uses — matches `parentFolderId` literally and never walks the hierarchy.
+ *
+ * Resolution goes through the folder finder so folders the user cannot reach are
+ * dropped, and an empty resolution raises instead of returning no filter.
+ */
+async function resolveFolderFilter(
+	user: User,
+	folderFinderService: FolderFinderService,
+	folderId: string,
+	includeSubfolders: boolean,
+): Promise<{ parentFolderId: string } | { parentFolderIds: string[] }> {
+	// The project root is not a folder, so there is no subtree to expand: it
+	// matches workflows with no parent folder.
+	if (folderId === PROJECT_ROOT) return { parentFolderId: PROJECT_ROOT };
+
+	if (!includeSubfolders) {
+		const [folder] = await folderFinderService.findFoldersByIdsForUser([folderId], user, [
+			'folder:read',
+		]);
+		if (!folder) throw new FolderNotFoundError(folderId);
+		return { parentFolderId: folder.id };
+	}
+
+	const subtree = await folderFinderService.findFolderSubtreesForUser([folderId], user, [
+		'folder:read',
+	]);
+	if (!subtree.some((folder) => folder.id === folderId)) throw new FolderNotFoundError(folderId);
+
+	return { parentFolderIds: subtree.map((folder) => folder.id) };
+}
+
 export async function searchWorkflows(
 	user: User,
 	workflowService: WorkflowService,
-	{ limit = MAX_RESULTS, query, projectId, tags, sortBy = DEFAULT_SORT_BY }: SearchWorkflowsParams,
+	folderFinderService: FolderFinderService,
+	{
+		limit = MAX_RESULTS,
+		query,
+		projectId,
+		tags,
+		sortBy = DEFAULT_SORT_BY,
+		folderId,
+		includeSubfolders = true,
+	}: SearchWorkflowsParams,
 ): Promise<SearchWorkflowsResult> {
 	const safeLimit = Math.min(Math.max(1, limit), MAX_RESULTS);
 	const filterTags = tags && Array.from(new Set(tags.filter((tag) => tag.length > 0)));
+	// Any folderId the caller sent is resolved, including an empty one: skipping
+	// it would turn a malformed folder search into a search of everything.
+	const folderFilter =
+		folderId === undefined
+			? {}
+			: await resolveFolderFilter(user, folderFinderService, folderId, includeSubfolders);
 
 	const options: ListQuery.Options = {
 		take: safeLimit,
@@ -164,6 +268,7 @@ export async function searchWorkflows(
 			...(query ? { query } : {}),
 			...(projectId ? { projectId } : {}),
 			...(filterTags && filterTags.length > 0 ? { tags: filterTags } : {}),
+			...folderFilter,
 		},
 		select: {
 			id: true,
@@ -174,6 +279,7 @@ export async function searchWorkflows(
 			updatedAt: true,
 			triggerCount: true,
 			settings: true,
+			parentFolder: true,
 			tags: true,
 		},
 	};
@@ -196,6 +302,7 @@ export async function searchWorkflows(
 			updatedAt,
 			triggerCount,
 			settings,
+			parentFolder,
 			tags: workflowTags,
 		} = workflow as WorkflowEntity;
 
@@ -208,6 +315,7 @@ export async function searchWorkflows(
 			updatedAt: updatedAt.toISOString(),
 			triggerCount,
 			availableInMCP: settings?.availableInMCP ?? false,
+			parentFolderId: parentFolder?.id ?? null,
 			tags: toTagSummary(workflowTags),
 		};
 	});

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -222,7 +222,14 @@ async function resolveFolderFilter(
 	// matches workflows with no parent folder.
 	if (folderId === PROJECT_ROOT) return { parentFolderId: PROJECT_ROOT };
 
-	const folderIds = await folderFinderService.findFolderFilterIds(folderId, includeSubfolders);
+	// Resolved without a folder permission check on purpose: these ids only narrow
+	// the workflow query below, which keeps enforcing workflow access on its own, so
+	// a member can still filter by the parentFolderId this tool reported for a
+	// workflow shared out of a project they do not belong to.
+	const folderIds = await folderFinderService.findFolderFilterIdsWithoutAccessCheck(
+		folderId,
+		includeSubfolders,
+	);
 	if (folderIds.length === 0) throw new FolderNotFoundError(folderId);
 
 	return { parentFolderIds: folderIds };

--- a/packages/cli/src/services/__tests__/folder-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/folder-finder.service.test.ts
@@ -193,11 +193,11 @@ describe('FolderFinderService', () => {
 		});
 	});
 
-	describe('findFolderFilterIds', () => {
+	describe('findFolderFilterIdsWithoutAccessCheck', () => {
 		it('returns an empty list for a folder that does not exist', async () => {
 			const { finder, folderRepository } = makeFinder([]);
 
-			const result = await finder.findFolderFilterIds('fld-missing', true);
+			const result = await finder.findFolderFilterIdsWithoutAccessCheck('fld-missing', true);
 
 			expect(result).toEqual([]);
 			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls).toHaveLength(0);
@@ -206,7 +206,7 @@ describe('FolderFinderService', () => {
 		it('returns only the folder itself when descendants are not requested', async () => {
 			const { finder, folderRepository } = makeFinder([makeFolder({ id: 'fld-1' })]);
 
-			const result = await finder.findFolderFilterIds('fld-1', false);
+			const result = await finder.findFolderFilterIdsWithoutAccessCheck('fld-1', false);
 
 			expect(result).toEqual(['fld-1']);
 			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls).toHaveLength(0);
@@ -216,7 +216,7 @@ describe('FolderFinderService', () => {
 			const { finder, folderRepository, roleService } = makeFinder([makeFolder({ id: 'fld-1' })]);
 			folderRepository.getAllFolderIdsInSubtrees.mockResolvedValue(['fld-2', 'fld-3']);
 
-			const result = await finder.findFolderFilterIds('fld-1', true);
+			const result = await finder.findFolderFilterIdsWithoutAccessCheck('fld-1', true);
 
 			expect(result).toEqual(['fld-1', 'fld-2', 'fld-3']);
 			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls[0]).toEqual([['fld-1']]);

--- a/packages/cli/src/services/__tests__/folder-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/folder-finder.service.test.ts
@@ -192,4 +192,37 @@ describe('FolderFinderService', () => {
 			expect(result).toEqual(new Set(['fld-1']));
 		});
 	});
+
+	describe('findFolderFilterIds', () => {
+		it('returns an empty list for a folder that does not exist', async () => {
+			const { finder, folderRepository } = makeFinder([]);
+
+			const result = await finder.findFolderFilterIds('fld-missing', true);
+
+			expect(result).toEqual([]);
+			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls).toHaveLength(0);
+		});
+
+		it('returns only the folder itself when descendants are not requested', async () => {
+			const { finder, folderRepository } = makeFinder([makeFolder({ id: 'fld-1' })]);
+
+			const result = await finder.findFolderFilterIds('fld-1', false);
+
+			expect(result).toEqual(['fld-1']);
+			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls).toHaveLength(0);
+		});
+
+		it('returns the folder with its descendants, without an access check', async () => {
+			const { finder, folderRepository, roleService } = makeFinder([makeFolder({ id: 'fld-1' })]);
+			folderRepository.getAllFolderIdsInSubtrees.mockResolvedValue(['fld-2', 'fld-3']);
+
+			const result = await finder.findFolderFilterIds('fld-1', true);
+
+			expect(result).toEqual(['fld-1', 'fld-2', 'fld-3']);
+			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls[0]).toEqual([['fld-1']]);
+			// No project roles are resolved: these ids only narrow a query that
+			// enforces access on its own.
+			expect(roleService.rolesWithScope.mock.calls).toHaveLength(0);
+		});
+	});
 });

--- a/packages/cli/src/services/folder-finder.service.ts
+++ b/packages/cli/src/services/folder-finder.service.ts
@@ -29,6 +29,29 @@ export class FolderFinderService {
 		return new Set(folders.map(({ id }) => id));
 	}
 
+	/**
+	 * Resolves a folder id to itself plus, optionally, its descendant ids —
+	 * deliberately without the project-level access check the `*ForUser` methods
+	 * apply.
+	 *
+	 * Only for narrowing a query that enforces its own access control: the ids go
+	 * into a `WHERE` clause and are never returned, so the caller's ACL still
+	 * decides what the user sees. This mirrors the workflow list endpoint, which
+	 * filters by `parentFolderId` with no folder permission check and gates only
+	 * the *returning* of folder rows behind `folder:list`.
+	 *
+	 * Returns an empty array for a folder that does not exist, so callers can tell
+	 * an unknown id apart from a folder holding nothing.
+	 */
+	async findFolderFilterIds(folderId: string, includeDescendants: boolean): Promise<string[]> {
+		const existing = await this.findExistingFolderIds([folderId]);
+		if (!existing.has(folderId)) return [];
+		if (!includeDescendants) return [folderId];
+
+		const descendantIds = await this.folderRepository.getAllFolderIdsInSubtrees([folderId]);
+		return [folderId, ...descendantIds];
+	}
+
 	async findFoldersByIdsForUser(
 		folderIds: string[],
 		user: User,

--- a/packages/cli/src/services/folder-finder.service.ts
+++ b/packages/cli/src/services/folder-finder.service.ts
@@ -30,20 +30,33 @@ export class FolderFinderService {
 	}
 
 	/**
-	 * Resolves a folder id to itself plus, optionally, its descendant ids —
-	 * deliberately without the project-level access check the `*ForUser` methods
-	 * apply.
+	 * Resolves a folder id to itself plus, optionally, its descendant ids, with
+	 * **no access check** — unlike every `*ForUser` method on this class.
 	 *
-	 * Only for narrowing a query that enforces its own access control: the ids go
-	 * into a `WHERE` clause and are never returned, so the caller's ACL still
-	 * decides what the user sees. This mirrors the workflow list endpoint, which
-	 * filters by `parentFolderId` with no folder permission check and gates only
-	 * the *returning* of folder rows behind `folder:list`.
+	 * Contract for callers: the returned ids may only be used to *narrow* a query
+	 * that already restricts rows to what the user may read, and must never be
+	 * returned to the caller or used to decide whether a folder may be touched.
+	 * Under that contract the absent check discloses nothing, because the calling
+	 * query still decides every visible row. Anything that hands folder data back
+	 * belongs on {@link findFoldersByIdsForUser} or
+	 * {@link findFolderSubtreesForUser} instead.
+	 *
+	 * The absent check is required, not merely tolerated. It mirrors the workflow
+	 * list endpoint, which filters by `parentFolderId` with no folder permission at
+	 * all and gates only the *returning* of folder rows behind `folder:list`. A
+	 * per-user check here would also break the round trip the filter exists for: a
+	 * workflow shared into someone's personal project keeps the parent folder of
+	 * its *home* project, so a member who may read the workflow — and who was just
+	 * handed its `parentFolderId` — usually has no relation to the project holding
+	 * that folder.
 	 *
 	 * Returns an empty array for a folder that does not exist, so callers can tell
 	 * an unknown id apart from a folder holding nothing.
 	 */
-	async findFolderFilterIds(folderId: string, includeDescendants: boolean): Promise<string[]> {
+	async findFolderFilterIdsWithoutAccessCheck(
+		folderId: string,
+		includeDescendants: boolean,
+	): Promise<string[]> {
 		const existing = await this.findExistingFolderIds([folderId]);
 		if (!existing.has(folderId)) return [];
 		if (!includeDescendants) return [folderId];

--- a/packages/cli/test/integration/mcp/search-workflows.tool.test.ts
+++ b/packages/cli/test/integration/mcp/search-workflows.tool.test.ts
@@ -1,0 +1,134 @@
+import { LicenseState } from '@n8n/backend-common';
+import { createWorkflow, getPersonalProject, mockInstance, testDb } from '@n8n/backend-test-utils';
+import type { Folder, Project, User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { PROJECT_ROOT } from 'n8n-workflow';
+
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { FolderNotFoundError } from '@/errors/folder-not-found.error';
+import { License } from '@/license';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { searchWorkflows } from '@/modules/mcp/tools/search-workflows.tool';
+import { FolderFinderService } from '@/services/folder-finder.service';
+import { WorkflowService } from '@/workflows/workflow.service';
+import { createFolder } from '@test-integration/db/folders';
+import { LicenseMocker } from '@test-integration/license';
+
+import { createMember, createOwner } from '../shared/db/users';
+
+mockInstance(LoadNodesAndCredentials);
+mockInstance(ActiveWorkflowManager);
+
+/**
+ * Exercises the folder filter against a real database: the folder subtree is
+ * resolved with a recursive query and fed into the workflow list query, so a
+ * mocked workflow service would assert the wiring while telling us nothing about
+ * which workflows actually come back.
+ */
+describe('searchWorkflows folder filter', () => {
+	let workflowService: WorkflowService;
+	let folderFinderService: FolderFinderService;
+	let owner: User;
+	let ownerProject: Project;
+	let triggers: Folder;
+	let nested: Folder;
+
+	const names = async (params: Parameters<typeof searchWorkflows>[3], user: User = owner) => {
+		const result = await searchWorkflows(user, workflowService, folderFinderService, params);
+		return { names: result.data.map((workflow) => workflow.name).sort(), count: result.count };
+	};
+
+	beforeAll(async () => {
+		await testDb.init();
+
+		const license = new LicenseMocker();
+		license.mock(Container.get(License));
+		license.mockLicenseState(Container.get(LicenseState));
+
+		workflowService = Container.get(WorkflowService);
+		folderFinderService = Container.get(FolderFinderService);
+
+		owner = await createOwner();
+		ownerProject = await getPersonalProject(owner);
+
+		// Triggers/ ── Nested/
+		//   plus one workflow at the project root and one in an unrelated folder.
+		triggers = await createFolder(ownerProject, { name: 'Triggers' });
+		nested = await createFolder(ownerProject, { name: 'Nested', parentFolder: triggers });
+		const other = await createFolder(ownerProject, { name: 'Other' });
+
+		await createWorkflow({ name: 'Root flow' }, ownerProject);
+		await createWorkflow({ name: 'Slack trigger', parentFolder: triggers }, ownerProject);
+		await createWorkflow({ name: 'Nested slack trigger', parentFolder: nested }, ownerProject);
+		await createWorkflow({ name: 'Other flow', parentFolder: other }, ownerProject);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	test('returns every workflow when no folder is given', async () => {
+		expect(await names({})).toEqual({
+			names: ['Nested slack trigger', 'Other flow', 'Root flow', 'Slack trigger'],
+			count: 4,
+		});
+	});
+
+	test('returns the folder and its subfolders by default', async () => {
+		expect(await names({ folderId: triggers.id })).toEqual({
+			names: ['Nested slack trigger', 'Slack trigger'],
+			count: 2,
+		});
+	});
+
+	test('returns only the folder itself when includeSubfolders is false', async () => {
+		expect(await names({ folderId: triggers.id, includeSubfolders: false })).toEqual({
+			names: ['Slack trigger'],
+			count: 1,
+		});
+	});
+
+	test('returns the workflows of a subfolder when it is the search target', async () => {
+		expect(await names({ folderId: nested.id })).toEqual({
+			names: ['Nested slack trigger'],
+			count: 1,
+		});
+	});
+
+	test('returns only project-root workflows for the root sentinel', async () => {
+		expect(await names({ folderId: PROJECT_ROOT })).toEqual({
+			names: ['Root flow'],
+			count: 1,
+		});
+	});
+
+	test('narrows a name query to the folder subtree', async () => {
+		expect(await names({ folderId: triggers.id, query: 'Nested' })).toEqual({
+			names: ['Nested slack trigger'],
+			count: 1,
+		});
+	});
+
+	test('reports the folder each workflow lives in', async () => {
+		const result = await searchWorkflows(owner, workflowService, folderFinderService, {});
+		const byName = new Map(result.data.map((workflow) => [workflow.name, workflow.parentFolderId]));
+
+		expect(byName.get('Slack trigger')).toBe(triggers.id);
+		expect(byName.get('Nested slack trigger')).toBe(nested.id);
+		expect(byName.get('Root flow')).toBeNull();
+	});
+
+	test('rejects a folder the user cannot reach rather than searching everything', async () => {
+		const member = await createMember();
+
+		await expect(
+			searchWorkflows(member, workflowService, folderFinderService, { folderId: triggers.id }),
+		).rejects.toThrow(FolderNotFoundError);
+	});
+
+	test('rejects an unknown folder id', async () => {
+		await expect(
+			searchWorkflows(owner, workflowService, folderFinderService, { folderId: 'does-not-exist' }),
+		).rejects.toThrow(FolderNotFoundError);
+	});
+});

--- a/packages/cli/test/integration/mcp/search-workflows.tool.test.ts
+++ b/packages/cli/test/integration/mcp/search-workflows.tool.test.ts
@@ -122,9 +122,7 @@ describe('searchWorkflows folder filter', () => {
 
 		expect(byName.get('Slack trigger')).toBe(triggers.id);
 		expect(byName.get('Nested slack trigger')).toBe(nested.id);
-		expect(result.data.find((workflow) => workflow.name === 'Root flow')).not.toHaveProperty(
-			'parentFolderId',
-		);
+		expect(byName.get('Root flow')).toBeNull();
 	});
 
 	// A workflow shared into a member's personal project keeps the parent folder of
@@ -148,6 +146,8 @@ describe('searchWorkflows folder filter', () => {
 		expect(found.data.map((workflow) => workflow.name)).toEqual(['Shared team flow']);
 		const reportedFolderId = found.data[0].parentFolderId;
 		expect(reportedFolderId).toBe(teamFolder.id);
+		// Narrow for the round trip below; the assertion above is the real check.
+		if (reportedFolderId === null) throw new Error('expected a folder id to feed back');
 
 		// The id the tool just reported must be usable as a filter, and must not
 		// widen the member's view to the workflow they cannot read.

--- a/packages/cli/test/integration/mcp/search-workflows.tool.test.ts
+++ b/packages/cli/test/integration/mcp/search-workflows.tool.test.ts
@@ -1,5 +1,12 @@
 import { LicenseState } from '@n8n/backend-common';
-import { createWorkflow, getPersonalProject, mockInstance, testDb } from '@n8n/backend-test-utils';
+import {
+	createTeamProject,
+	createWorkflow,
+	getPersonalProject,
+	mockInstance,
+	shareWorkflowWithProjects,
+	testDb,
+} from '@n8n/backend-test-utils';
 import type { Folder, Project, User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { PROJECT_ROOT } from 'n8n-workflow';
@@ -115,15 +122,40 @@ describe('searchWorkflows folder filter', () => {
 
 		expect(byName.get('Slack trigger')).toBe(triggers.id);
 		expect(byName.get('Nested slack trigger')).toBe(nested.id);
-		expect(byName.get('Root flow')).toBeNull();
+		expect(result.data.find((workflow) => workflow.name === 'Root flow')).not.toHaveProperty(
+			'parentFolderId',
+		);
 	});
 
-	test('rejects a folder the user cannot reach rather than searching everything', async () => {
+	// A workflow shared into a member's personal project keeps the parent folder of
+	// its *home* project, which the member has no relation to. Filtering by the
+	// parentFolderId the search just handed them has to keep working: the folder ids
+	// only narrow a result set the workflow ACL already gates.
+	test('filters by a folder in a project the user is not a member of', async () => {
 		const member = await createMember();
+		const memberProject = await getPersonalProject(member);
+		const teamProject = await createTeamProject('Team', owner);
+		const teamFolder = await createFolder(teamProject, { name: 'Team triggers' });
 
-		await expect(
-			searchWorkflows(member, workflowService, folderFinderService, { folderId: triggers.id }),
-		).rejects.toThrow(FolderNotFoundError);
+		const shared = await createWorkflow(
+			{ name: 'Shared team flow', parentFolder: teamFolder },
+			teamProject,
+		);
+		await createWorkflow({ name: 'Unshared team flow', parentFolder: teamFolder }, teamProject);
+		await shareWorkflowWithProjects(shared, [{ project: memberProject }]);
+
+		const found = await searchWorkflows(member, workflowService, folderFinderService, {});
+		expect(found.data.map((workflow) => workflow.name)).toEqual(['Shared team flow']);
+		const reportedFolderId = found.data[0].parentFolderId;
+		expect(reportedFolderId).toBe(teamFolder.id);
+
+		// The id the tool just reported must be usable as a filter, and must not
+		// widen the member's view to the workflow they cannot read.
+		const filtered = await searchWorkflows(member, workflowService, folderFinderService, {
+			folderId: reportedFolderId,
+		});
+		expect(filtered.data.map((workflow) => workflow.name)).toEqual(['Shared team flow']);
+		expect(filtered.count).toBe(1);
 	});
 
 	test('rejects an unknown folder id', async () => {

--- a/packages/testing/playwright/services/mcp-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-api-helper.ts
@@ -78,6 +78,18 @@ export interface InternalMcpToolsListResult {
 	tools: McpToolDefinition[];
 }
 
+/**
+ * Arguments accepted by the search_workflows tool. A type alias rather than an
+ * interface so it still satisfies the `Record<string, unknown>` tool-call payload.
+ */
+export type SearchWorkflowsArgs = {
+	limit?: number;
+	query?: string;
+	projectId?: string;
+	folderId?: string;
+	includeSubfolders?: boolean;
+};
+
 /** Response from search_workflows tool */
 export interface SearchWorkflowsResult {
 	data: Array<{
@@ -89,9 +101,11 @@ export interface SearchWorkflowsResult {
 		updatedAt: string | null;
 		triggerCount: number | null;
 		availableInMCP: boolean;
+		parentFolderId: string | null;
 		tags: Array<{ id: string; name: string }>;
 	}>;
 	count: number;
+	error?: string;
 }
 
 /** Response from get_workflow_details tool */
@@ -950,7 +964,7 @@ export class McpApiHelper {
 	 */
 	async internalMcpSearchWorkflows(
 		apiKey: string,
-		args: { limit?: number; query?: string; projectId?: string } = {},
+		args: SearchWorkflowsArgs = {},
 	): Promise<SearchWorkflowsResult> {
 		return await this.callInternalMcpTool<SearchWorkflowsResult>(apiKey, 'search_workflows', args);
 	}


### PR DESCRIPTION
## Summary

Large instances organise workflows into folders, but the MCP `search_workflows` tool reached across every workflow and ignored folders entirely — so a folder-scoped request turned into a scan of the whole instance, with the latency and token cost that implies.

`search_workflows` now takes a folder filter:

- **`folderId`** — narrows the search to a folder. Pass a `parentFolderId` from an earlier result to find a workflow's siblings, or resolve a folder name with `search_folders` where that tool is available. `"0"` (`PROJECT_ROOT`) matches workflows that sit outside any folder.
- **`includeSubfolders`** — `true` by default, so a folder search covers its whole subtree; set `false` to match only workflows directly inside the folder. Ignored for the project root, which has no subtree to expand.
- Results now carry **`parentFolderId`** (omitted for workflows at the project root), so the model can go from a workflow it just found to the folder that holds it and search there.

### Notes for reviewers

**The subtree is resolved up front.** The plain workflow list query the MCP uses matches `parentFolderId` literally — only the workflows-and-folders union query behind the UI walks the hierarchy, and only when a `query` is present. So the tool expands the subtree itself and passes `parentFolderIds`.

**Folder resolution is deliberately not access-checked, matching the REST endpoint.** `GET /workflows` gates `folder:list` on whether folder *rows* are returned (`includeFolders`) and applies the `parentFolderId` filter with no folder permission at all; the repository's own hierarchy expansion likewise runs with no per-user folder ACL. n8n draws the line at *enumerating* folders, not at *filtering* by one, so the new `FolderFinderService.findFolderFilterIds` resolves ids without an access check. This matters for correctness, not just consistency: a workflow shared into someone's personal project keeps the parent folder of its **home** project, so a per-user folder lookup rejected the very `parentFolderId` the search had just reported. There is a regression test for that round trip.

The ids only narrow a query whose own ACL still decides what the user sees, and they are never returned — so nothing is disclosed that an unfiltered search doesn't already show. The one new signal is that an unknown id errors while an empty folder returns no results, i.e. a folder-id existence oracle on unguessable ids; REST already lets any member filter by any folder id, silently. Flagging it explicitly in case you'd rather it were silent too.

**An unresolvable folder fails loudly.** An id matching no folder returns `{ data: [], count: 0, error }` with `isError: true` and a message pointing at `search_folders`, so the client can retry. It never falls back to an unfiltered search — silently widening the scope would be worse than failing. A provided-but-empty `folderId` is resolved (and rejected) for the same reason rather than being skipped.

The new parameter is **not** license-gated, matching `GET /workflows`. The four folder *tools* stay gated exactly as they are today. No MCP scope change either: `search_workflows` stays under `workflow:read`, the filter only narrows results, and `get_workflow_details` — same scope — already returns `parentFolderId`. Because `search_folders` is license-gated *and* sits in a different scope bucket (`project:read`/`project:write`), the tool descriptions present it as optional rather than as a required first step, so a `workflow:read`-only grant is never pointed at a tool it cannot call.

## How to test

Requires MCP access enabled (`N8N_MCP_MANAGED_BY_ENV=true` + `N8N_MCP_ACCESS_ENABLED=true`, or the toggle in Settings → MCP). Creating folders needs the `feat:folders` licence; the new `folderId` parameter itself does not.

1. In a project, build a nested layout — `Triggers/` with a `Nested/` subfolder — and put a workflow in each, plus one at the project root and one in an unrelated folder.
2. Connect an MCP client and call `search_folders` to get the `Triggers` folder id.
3. `search_workflows { folderId: "<Triggers id>" }` → returns the workflows in `Triggers` **and** `Nested`, and nothing from the root or the unrelated folder.
4. `search_workflows { folderId: "<Triggers id>", includeSubfolders: false }` → only the workflow directly in `Triggers`.
5. `search_workflows { folderId: "0" }` → only the project-root workflow.
6. `search_workflows { folderId: "<Triggers id>", query: "<name of the nested workflow>" }` → the query is scoped to the subtree.
7. `search_workflows { folderId: "does-not-exist" }` → an error result naming `search_folders`, not a full unfiltered listing.
8. Note the `parentFolderId` on any result and pass it straight back as `folderId` to find that workflow's neighbours. Worth trying as a member with a workflow shared from a project they don't belong to: the round trip should return that workflow, and must not reveal others in the same folder.

Automated coverage: 18 unit tests in `packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts`, 3 new service tests in `packages/cli/src/services/__tests__/folder-finder.service.test.ts`, and a real-database suite at `packages/cli/test/integration/mcp/search-workflows.tool.test.ts` (9 tests) that builds the layout above and asserts through the real `WorkflowService` and `FolderFinderService`. The counts discriminate no-expansion, over-expansion, and dropped-filter, so it fails if the feature regresses rather than just checking the wiring; the shared-workflow case was verified to fail against the previous access-checked implementation.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/MCP-23

Not covered here: the ticket's first bullet ("searches folders as well as workflows … find the `Triggers` folder first, and then search within that") is model tool-selection behaviour. This PR supplies the mechanism and nudges it via the tool descriptions, but nothing measures it — that belongs in the module's eval harness (`--tier mcp`) as a follow-up.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)