### PR TITLE
fix(core): Support array indices in setNodeParameter JSON Pointer paths

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
@@ -332,23 +332,31 @@ describe('applyOperations', () => {
 		test('rejects an out-of-bounds array index', () => {
 			const wf = baseWorkflow();
 			wf.nodes[1].parameters = { values: [{ name: 'a' }] };
+
 			const result = applyOperations(wf, [
 				{ type: 'setNodeParameter', nodeName: 'B', path: '/values/1/name', value: 'b' },
 			]);
+
 			expect(result.success).toBe(false);
 			if (result.success) return;
-			expect(result.error).toContain('out of bounds');
+
+			expect(result.error).toContain('array index 1 out of bounds');
+			expect(result.error).toContain("at '/values'");
 		});
 
 		test('rejects a non-numeric segment used against an array', () => {
 			const wf = baseWorkflow();
 			wf.nodes[1].parameters = { values: [{ name: 'a' }] };
+
 			const result = applyOperations(wf, [
 				{ type: 'setNodeParameter', nodeName: 'B', path: '/values/foo/name', value: 'b' },
 			]);
+
 			expect(result.success).toBe(false);
 			if (result.success) return;
-			expect(result.error).toContain('array index');
+
+			expect(result.error).toContain("cannot use 'foo' as an array index");
+			expect(result.error).toContain("at '/values'");
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
@@ -358,6 +358,30 @@ describe('applyOperations', () => {
 			expect(result.error).toContain("cannot use 'foo' as an array index");
 			expect(result.error).toContain("at '/values'");
 		});
+
+		test('rejects creating an array via a numeric segment when the container does not exist', () => {
+			const wf = baseWorkflow();
+
+			// Empty node with no parameters, so updating an array value will error
+			wf.nodes[1].parameters = {};
+
+			const result = applyOperations(wf, [
+				{
+					type: 'setNodeParameter',
+					nodeName: 'B',
+					path: '/assignments/assignments/0/value',
+					value: 99,
+				},
+			]);
+
+			expect(result.success).toBe(false);
+			if (result.success) return;
+
+			expect(result.error).toContain("cannot create array at '/assignments/assignments'");
+			expect(result.error).toContain("for numeric segment '0'");
+			expect(result.error).toContain('updateNodeParameters');
+			expect(wf.nodes[1].parameters).toEqual({});
+		});
 	});
 
 	describe('addNode', () => {

--- a/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
@@ -303,15 +303,52 @@ describe('applyOperations', () => {
 			}
 		});
 
-		test('fails clearly when descending through an array (indices not supported)', () => {
+		test('descends into an array by numeric index and sets a nested field', () => {
 			const wf = baseWorkflow();
 			wf.nodes[1].parameters = { values: [{ name: 'Content-Type', value: 'application/json' }] };
 			const result = applyOperations(wf, [
 				{ type: 'setNodeParameter', nodeName: 'B', path: '/values/0/value', value: 'text/plain' },
 			]);
+			expect(result.success).toBe(true);
+			if (!result.success) return;
+			expect(result.workflow.nodes[1].parameters).toEqual({
+				values: [{ name: 'Content-Type', value: 'text/plain' }],
+			});
+		});
+
+		test('replaces an array element outright when the path ends at the index', () => {
+			const wf = baseWorkflow();
+			wf.nodes[1].parameters = { values: [{ name: 'a' }, { name: 'b' }] };
+			const result = applyOperations(wf, [
+				{ type: 'setNodeParameter', nodeName: 'B', path: '/values/1', value: { name: 'c' } },
+			]);
+			expect(result.success).toBe(true);
+			if (!result.success) return;
+			expect(result.workflow.nodes[1].parameters).toEqual({
+				values: [{ name: 'a' }, { name: 'c' }],
+			});
+		});
+
+		test('rejects an out-of-bounds array index', () => {
+			const wf = baseWorkflow();
+			wf.nodes[1].parameters = { values: [{ name: 'a' }] };
+			const result = applyOperations(wf, [
+				{ type: 'setNodeParameter', nodeName: 'B', path: '/values/1/name', value: 'b' },
+			]);
 			expect(result.success).toBe(false);
 			if (result.success) return;
-			expect(result.error).toContain('cannot descend');
+			expect(result.error).toContain('out of bounds');
+		});
+
+		test('rejects a non-numeric segment used against an array', () => {
+			const wf = baseWorkflow();
+			wf.nodes[1].parameters = { values: [{ name: 'a' }] };
+			const result = applyOperations(wf, [
+				{ type: 'setNodeParameter', nodeName: 'B', path: '/values/foo/name', value: 'b' },
+			]);
+			expect(result.success).toBe(false);
+			if (result.success) return;
+			expect(result.error).toContain('array index');
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -141,7 +141,7 @@ export const partialUpdateOperationSchema = z.discriminatedUnion('type', [
 			.string()
 			.min(2)
 			.describe(
-				'JSON Pointer (RFC 6901) path to the parameter to set, e.g. "/jsonSchema" or "/options/systemMessage". Must start with "/". Intermediate objects are created on demand. Array indices are NOT supported — to change a value inside an array, set the whole array. Use this instead of `updateNodeParameters` when you only need to set one nested key — the payload stays small regardless of the rest of the parameters object.',
+				'JSON Pointer (RFC 6901) path, e.g. "/options/systemMessage" or "/assignments/assignments/0/value". Numeric segments index into arrays (index must already exist). Prefer over `updateNodeParameters` for a single nested key.',
 			),
 		value: z
 			.unknown()
@@ -462,53 +462,128 @@ const sanitizeUnsafeKeys = (value: unknown): unknown => {
 };
 
 /**
- * Decode a JSON Pointer path (RFC 6901) into safe property segments.
- * Returns null if the path is malformed, empty, contains an empty segment,
- * or contains an unsafe segment. The leading "/" is required.
- * Array indices are not supported: numeric segments are treated as object keys,
- * and descent into an array (or any non-object) fails at apply time.
+ * Decode a JSON Pointer path (RFC 6901) into safe segments, or null if malformed/unsafe.
+ * A numeric segment indexes an array (must reference an existing element) or keys an object — see `setAtPointer`.
  */
 const parseJsonPointer = (path: string): string[] | null => {
-	if (!path.startsWith('/')) return null;
+	if (!path.startsWith('/')) {
+		return null;
+	}
+
 	const tail = path.slice(1);
-	if (tail.length === 0) return null;
+	if (tail.length === 0) {
+		return null;
+	}
+
 	const rawSegments = tail.split('/');
 	const segments: string[] = [];
+
+	// RFC 6901: every '~' must be followed by '0' or '1'. Bare '~' or '~2' is malformed.
+	const invalidEscapeSequenceRegex = /~(?:[^01]|$)/;
+
 	for (const raw of rawSegments) {
-		// RFC 6901: every '~' must be followed by '0' or '1'. Bare '~' or '~2' is malformed.
-		if (/~(?:[^01]|$)/.test(raw)) return null;
+		if (invalidEscapeSequenceRegex.test(raw)) {
+			return null;
+		}
+
+		// Unescape RFC 6901 JSON Pointer tokens: '~1' -> '/' and '~0' -> '~'.
+		// reject empty segments or segments that are not considered safe object property names
 		const seg = raw.replace(/~1/g, '/').replace(/~0/g, '~');
-		if (seg.length === 0 || !isSafeObjectProperty(seg)) return null;
+		if (seg.length === 0 || !isSafeObjectProperty(seg)) {
+			return null;
+		}
+
 		segments.push(seg);
 	}
 	return segments;
 };
 
+const isArrayIndexSegment = (segment: string): boolean => /^(0|[1-9]\d*)$/.test(segment);
+
+/**
+ * Read/write a single segment on a cursor that may be a plain object or an array.
+ * Returns an error message for an out-of-bounds or non-numeric array segment,
+ * otherwise returns `{ value }` (the current value at that segment, possibly
+ * undefined) — writing is done separately by the caller via `writeSegment`.
+ */
+const readSegment = (
+	cursor: Record<string, unknown> | unknown[],
+	key: string,
+	pathSoFar: string,
+): { value: unknown } | { error: string } => {
+	if (!Array.isArray(cursor)) {
+		return { value: cursor[key] };
+	}
+
+	if (!isArrayIndexSegment(key)) {
+		return { error: `cannot use '${key}' as an array index at '/${pathSoFar}'` };
+	}
+
+	const index = Number(key);
+	if (index >= cursor.length) {
+		return {
+			error: `array index ${index} out of bounds (length ${cursor.length}) at '/${pathSoFar}'`,
+		};
+	}
+
+	return { value: cursor[index] };
+};
+
+const writeSegment = (
+	cursor: Record<string, unknown> | unknown[],
+	key: string,
+	value: unknown,
+): void => {
+	if (Array.isArray(cursor)) {
+		cursor[Number(key)] = value;
+		return;
+	}
+	cursor[key] = value;
+};
+
 /**
  * Set `value` at `segments` inside `root`, creating intermediate objects on demand.
- * Returns an error message if an intermediate segment exists but is not a plain object,
- * otherwise mutates `root` in place and returns null.
+ * Numeric segments index into arrays (must reference an existing element, no auto-extension).
+ * Mutates `root` in place; returns an error message on failure, else null.
  */
 const setAtPointer = (
 	root: Record<string, unknown>,
 	segments: string[],
 	value: unknown,
 ): string | null => {
-	let cursor: Record<string, unknown> = root;
+	let cursor: Record<string, unknown> | unknown[] = root;
 	for (let i = 0; i < segments.length - 1; i++) {
 		const key = segments[i];
-		const next = cursor[key];
-		if (next === undefined) {
+		const pathSoFar = segments.slice(0, i + 1).join('/');
+		const read = readSegment(cursor, key, pathSoFar);
+		if ('error' in read) {
+			return read.error;
+		}
+
+		if (read.value === undefined && !Array.isArray(cursor)) {
 			const child: Record<string, unknown> = {};
-			cursor[key] = child;
+			writeSegment(cursor, key, child);
 			cursor = child;
-		} else if (isPlainObject(next)) {
-			cursor = next;
+		} else if (isPlainObject(read.value) || Array.isArray(read.value)) {
+			cursor = read.value;
 		} else {
-			return `cannot descend into non-object at '/${segments.slice(0, i + 1).join('/')}'`;
+			return `cannot descend into non-object at '/${pathSoFar}'`;
 		}
 	}
-	cursor[segments[segments.length - 1]] = sanitizeUnsafeKeys(value);
+
+	const lastKey = segments[segments.length - 1];
+	if (Array.isArray(cursor)) {
+		if (!isArrayIndexSegment(lastKey)) {
+			return `cannot use '${lastKey}' as an array index at '/${segments.join('/')}'`;
+		}
+
+		const index = Number(lastKey);
+		if (index >= cursor.length) {
+			return `array index ${index} out of bounds (length ${cursor.length}) at '/${segments.join('/')}'`;
+		}
+	}
+
+	writeSegment(cursor, lastKey, sanitizeUnsafeKeys(value));
 	return null;
 };
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -572,7 +572,13 @@ const setAtPointer = (
 		}
 
 		if (read.value === undefined && !Array.isArray(cursor)) {
-			// The intermediate container does not exist yet, must be created.
+			const nextKey = segments[i + 1];
+			if (isArrayIndexSegment(nextKey)) {
+				// Do not auto-create an array as in many if not all situations might result in a broken node and workflow
+				const containerPath = segments.slice(0, i + 1).join('/');
+				return `cannot create array at '/${containerPath}' for numeric segment '${nextKey}' — set the whole array via updateNodeParameters instead`;
+			}
+
 			const child: Record<string, unknown> = {};
 			writeSegment(cursor, key, child);
 			cursor = child;

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -509,20 +509,20 @@ const isArrayIndexSegment = (segment: string): boolean => /^(0|[1-9]\d*)$/.test(
 const readSegment = (
 	cursor: Record<string, unknown> | unknown[],
 	key: string,
-	pathSoFar: string,
+	failingPathForErrorMessage: string,
 ): { value: unknown } | { error: string } => {
 	if (!Array.isArray(cursor)) {
 		return { value: cursor[key] };
 	}
 
 	if (!isArrayIndexSegment(key)) {
-		return { error: `cannot use '${key}' as an array index at '/${pathSoFar}'` };
+		return { error: `cannot use '${key}' as an array index at '/${failingPathForErrorMessage}'` };
 	}
 
 	const index = Number(key);
 	if (index >= cursor.length) {
 		return {
-			error: `array index ${index} out of bounds (length ${cursor.length}) at '/${pathSoFar}'`,
+			error: `array index ${index} out of bounds (length ${cursor.length}) at '/${failingPathForErrorMessage}'`,
 		};
 	}
 
@@ -546,40 +546,58 @@ const writeSegment = (
  * Numeric segments index into arrays (must reference an existing element, no auto-extension).
  * Mutates `root` in place; returns an error message on failure, else null.
  */
+// PROVISIONAL — ejemplo:
+//   root     = { assignments: { assignments: [ { id: 'a', name: 'x', value: 1 } ] } }
+//   segments = ['assignments', 'assignments', '0', 'value']   // viene de parsear "/assignments/assignments/0/value"
+//   value    = 99
+// objetivo: dejar root.assignments.assignments[0].value = 99
 const setAtPointer = (
 	root: Record<string, unknown>,
 	segments: string[],
 	value: unknown,
 ): string | null => {
 	let cursor: Record<string, unknown> | unknown[] = root;
+
+	// Loop through all elements but the last one, since that is the one we want
+	// to write to, not read from. The previous segments are just for navigation
+	// to that point.
 	for (let i = 0; i < segments.length - 1; i++) {
-		const key = segments[i];
-		const pathSoFar = segments.slice(0, i + 1).join('/');
-		const read = readSegment(cursor, key, pathSoFar);
+		const key = segments[i]; // i=0 -> 'assignments'; i=1 -> 'assignments'; i=2 -> '0'
+
+		const failingPathSegmentReadingFailure = segments.slice(0, i).join('/');
+
+		const read = readSegment(cursor, key, failingPathSegmentReadingFailure);
 		if ('error' in read) {
 			return read.error;
 		}
 
 		if (read.value === undefined && !Array.isArray(cursor)) {
+			// The intermediate container does not exist yet, must be created.
 			const child: Record<string, unknown> = {};
 			writeSegment(cursor, key, child);
 			cursor = child;
 		} else if (isPlainObject(read.value) || Array.isArray(read.value)) {
+			// The intermediate container already exists and is valid (object or array)
+			// it is our cursor now, next iteration will read from it.
 			cursor = read.value;
 		} else {
-			return `cannot descend into non-object at '/${pathSoFar}'`;
+			const failingPath = segments.slice(0, i + 1).join('/');
+			return `cannot descend into non-object at '/${failingPath}'`;
 		}
 	}
 
+	// Here the cursor finally points to what we want to update
 	const lastKey = segments[segments.length - 1];
 	if (Array.isArray(cursor)) {
+		const failingPathWithoutIndex = segments.slice(0, -1).join('/');
+
 		if (!isArrayIndexSegment(lastKey)) {
-			return `cannot use '${lastKey}' as an array index at '/${segments.join('/')}'`;
+			return `cannot use '${lastKey}' as an array index at '/${failingPathWithoutIndex}'`;
 		}
 
 		const index = Number(lastKey);
 		if (index >= cursor.length) {
-			return `array index ${index} out of bounds (length ${cursor.length}) at '/${segments.join('/')}'`;
+			return `array index ${index} out of bounds (length ${cursor.length}) at '/${failingPathWithoutIndex}'`;
 		}
 	}
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -141,7 +141,7 @@ export const partialUpdateOperationSchema = z.discriminatedUnion('type', [
 			.string()
 			.min(2)
 			.describe(
-				'JSON Pointer (RFC 6901) path, e.g. "/options/systemMessage" or "/assignments/assignments/0/value". Numeric segments index into arrays (index must already exist). Prefer over `updateNodeParameters` for a single nested key.',
+				'JSON Pointer (RFC 6901) path, e.g. "/options/systemMessage" or "/assignments/assignments/0/value". Numeric segments index into an existing array element only — to add or remove elements, set the whole array (or its parent) instead. Prefer over `updateNodeParameters` for a single nested key — the payload stays small regardless of the rest of the parameters object.',
 			),
 		value: z
 			.unknown()


### PR DESCRIPTION
## Summary

`setNodeParameter`'s JSON Pointer engine (`setAtPointer` in `workflow-operations.ts`) only knew how to descend into plain objects. Any path segment that landed on an array — e.g. a Set/Edit Fields node's `assignments` collection, shaped `{ assignments: [...] }` — failed with a generic `cannot descend into non-object` error, regardless of whether the target index actually existed.

This meant an MCP agent could never edit a single item inside an array-backed parameter (e.g. one assignment's value) without falling back to `updateNodeParameters` and resending the whole array.

Numeric path segments now index into arrays, with specific errors instead of one generic message:
- valid index → descends/sets normally
- non-numeric segment against an array → `cannot use '<segment>' as an array index`
- out-of-bounds index → `array index <n> out of bounds (length <len>)`

Arrays are never auto-extended — an index must already exist. To add/remove elements, the whole array still needs to be replaced (`updateNodeParameters` or `setNodeParameter` targeting the array itself).

## How to test

Create (or use an existing) workflow with a Set/Edit Fields node (`n8n-nodes-base.set`, manual mode) that has a few assignments, then call `update_workflow` via the MCP `update_workflow` tool:

```json
{
  "type": "setNodeParameter",
  "nodeName": "Set Values",
  "path": "/assignments/assignments/1/value",
  "value": 99
}
```

- Valid index (e.g. `1` on a 4-item array) → succeeds, that assignment's value is updated.
- Out-of-range index (e.g. `6` on a 4-item array) → fails with `array index 6 out of bounds (length 4) at '/assignments/assignments'`.
- Non-numeric segment against an array (e.g. `/assignments/assignments/foo/value`) → fails with `cannot use 'foo' as an array index ...`.

Unit tests added in `workflow-operations.test.ts` cover all three cases plus whole-element replacement via a trailing index.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5752

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

