### PR TITLE
fix(editor): Keep agent preview user messages right-aligned

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
@@ -645,6 +645,7 @@ onBeforeUnmount(() => {
 <style lang="scss" module>
 .messages {
 	flex: 1;
+	width: 100%;
 	min-height: 0;
 	overflow-y: auto;
 	padding: var(--spacing--lg) var(--spacing--md) var(--spacing--sm);


### PR DESCRIPTION
## Summary

Make the agent preview chat message column fill the available width.

Keep user message bubbles anchored to the right while the agent response starts and streams.

<img width="483" height="597" alt="image" src="https://github.com/user-attachments/assets/7100ec68-c352-4889-b90a-22b17446a3ac" />

## How to test

1. Start n8n with `N8N_ENABLED_MODULES=agents`.
2. Open the agent builder and its preview chat.
3. Start a new chat.
4. Send a short first message.
5. Verify that the user message is right-aligned immediately.
6. Verify that the message does not move when the agent starts to stream a response.

Automated checks:

- `pnpm test AgentChatMessageList.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec stylelint src/features/agents/components/AgentChatMessageList.vue --no-cache`

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

