### PR TITLE
fix(editor): Respect reduced motion preferences (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogContent.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogContent.vue
@@ -133,6 +133,8 @@ function handleInteractOutside(e: Event) {
 </template>
 
 <style module lang="scss">
+@use '../../css/mixins/motion';
+
 @keyframes dialogFadeIn {
 	from {
 		opacity: 0;
@@ -184,10 +186,14 @@ function handleInteractOutside(e: Event) {
 
 .content[data-state='open'] {
 	animation: dialogFadeIn var(--animation--duration--snappy) ease-out;
+
+	@include motion.reduced-motion;
 }
 
 .content[data-state='closed'] {
 	animation: dialogFadeOut var(--animation--duration--snappy) ease-out;
+
+	@include motion.reduced-motion;
 }
 
 .small {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogOverlay.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogOverlay.vue
@@ -20,6 +20,8 @@ defineProps<DialogOverlayProps>();
 </template>
 
 <style module lang="scss">
+@use '../../css/mixins/motion';
+
 @keyframes overlayFadeIn {
 	from {
 		opacity: 0;
@@ -52,9 +54,13 @@ defineProps<DialogOverlayProps>();
 
 .overlay[data-state='open'] {
 	animation: overlayFadeIn var(--animation--duration--snappy) ease;
+
+	@include motion.reduced-motion;
 }
 
 .overlay[data-state='closed'] {
 	animation: overlayFadeOut var(--animation--duration--snappy) ease;
+
+	@include motion.reduced-motion;
 }
 </style>

--- a/packages/frontend/@n8n/design-system/src/css/dialog.scss
+++ b/packages/frontend/@n8n/design-system/src/css/dialog.scss
@@ -1,4 +1,5 @@
 @use 'mixins/mixins';
+@use 'mixins/motion';
 @use 'mixins/utils';
 @use './common/var';
 @use 'common/popup';
@@ -113,31 +114,15 @@
 }
 
 .dialog-fade-enter-active {
-	animation: dialog-fade-in 0.3s;
+	--animation--fade-in-down--duration: 0.3s;
+	--animation--fade-in-down--translate: 20px;
+
+	@include motion.fade-in-down;
 }
 
 .dialog-fade-leave-active {
-	animation: dialog-fade-out 0.3s;
-}
+	--animation--fade-out-up--duration: 0.3s;
+	--animation--fade-out-up--translate: 20px;
 
-@keyframes dialog-fade-in {
-	0% {
-		transform: translate3d(0, -20px, 0);
-		opacity: 0;
-	}
-	100% {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
-}
-
-@keyframes dialog-fade-out {
-	0% {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
-	100% {
-		transform: translate3d(0, -20px, 0);
-		opacity: 0;
-	}
+	@include motion.fade-out-up;
 }

--- a/packages/frontend/@n8n/design-system/src/css/loading.scss
+++ b/packages/frontend/@n8n/design-system/src/css/loading.scss
@@ -1,4 +1,5 @@
 @use 'mixins/mixins';
+@use 'mixins/motion';
 @use './common/var';
 
 @include mixins.b(loading-parent) {
@@ -21,6 +22,8 @@
 	bottom: 0;
 	left: 0;
 	transition: opacity 0.3s;
+
+	@include motion.reduced-motion;
 
 	@include mixins.when(fullscreen) {
 		position: fixed;
@@ -55,14 +58,19 @@
 	}
 
 	.circular {
+		--animation--spin--duration: 2s;
+
 		max-height: 100%;
 		height: var.$loading-spinner-size;
 		width: var.$loading-spinner-size;
-		animation: loading-rotate 2s linear infinite;
+
+		@include motion.spin;
 	}
 
 	.path {
 		animation: loading-dash 1.5s ease-in-out infinite;
+
+		@include motion.reduced-motion;
 		stroke-dasharray: 90, 150;
 		stroke-dashoffset: 0;
 		stroke-width: 2;
@@ -78,12 +86,6 @@
 .el-loading-fade-enter-from,
 .el-loading-fade-leave-active {
 	opacity: 0;
-}
-
-@keyframes loading-rotate {
-	100% {
-		transform: rotate(360deg);
-	}
 }
 
 @keyframes loading-dash {

--- a/packages/frontend/@n8n/design-system/src/css/message-box.scss
+++ b/packages/frontend/@n8n/design-system/src/css/message-box.scss
@@ -1,4 +1,5 @@
 @use 'mixins/mixins';
+@use 'mixins/motion';
 @use './common/var';
 @use 'common/popup';
 @use 'input';
@@ -323,31 +324,15 @@
 }
 
 .msgbox-fade-enter-active {
-	animation: msgbox-fade-in 0.3s;
+	--animation--fade-in-down--duration: 0.3s;
+	--animation--fade-in-down--translate: 20px;
+
+	@include motion.fade-in-down;
 }
 
 .msgbox-fade-leave-active {
-	animation: msgbox-fade-out 0.3s;
-}
+	--animation--fade-out-up--duration: 0.3s;
+	--animation--fade-out-up--translate: 20px;
 
-@keyframes msgbox-fade-in {
-	0% {
-		transform: translate3d(0, -20px, 0);
-		opacity: 0;
-	}
-	100% {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
-}
-
-@keyframes msgbox-fade-out {
-	0% {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
-	100% {
-		transform: translate3d(0, -20px, 0);
-		opacity: 0;
-	}
+	@include motion.fade-out-up;
 }

--- a/packages/frontend/@n8n/design-system/src/css/mixins/motion.scss
+++ b/packages/frontend/@n8n/design-system/src/css/mixins/motion.scss
@@ -1,3 +1,10 @@
+@mixin reduced-motion {
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+		transition: none;
+	}
+}
+
 // Shimmer - animated gradient for loading/skeleton states
 @mixin shimmer {
 	background: linear-gradient(

--- a/packages/frontend/@n8n/design-system/src/css/skeleton.scss
+++ b/packages/frontend/@n8n/design-system/src/css/skeleton.scss
@@ -1,3 +1,5 @@
+@use 'mixins/motion';
+
 .el-skeleton {
 	width: 100%;
 }
@@ -78,6 +80,8 @@
 	background-size: 400% 100%;
 	-webkit-animation: el-skeleton-loading 1.4s ease infinite;
 	animation: el-skeleton-loading 1.4s ease infinite;
+
+	@include motion.reduced-motion;
 }
 
 @-webkit-keyframes el-skeleton-loading {

--- a/packages/frontend/@n8n/design-system/src/styleguide/motion.mdx
+++ b/packages/frontend/@n8n/design-system/src/styleguide/motion.mdx
@@ -24,6 +24,7 @@ Motion utilities live in `@n8n/design-system/src/css/mixins/motion.scss`.
 
 | Mixin                           | Use for                             | Notes                                                      |
 | ------------------------------- | ----------------------------------- | ---------------------------------------------------------- |
+| `motion.reduced-motion`         | Existing custom motion              | Disables animation and transitions for reduced motion.     |
 | `motion.spin`                   | Loading indicators                  | Continuous rotation.                                       |
 | `motion.skeleton-pulse`         | Skeleton loading placeholders       | Use for placeholder surfaces, not interactive elements.    |
 | `motion.shimmer`                | Text or inline loading states       | Best for short-lived AI or thinking states.                |


### PR DESCRIPTION
## Summary

This PR adds a shared mixin for existing custom motion. Ideally animations use `motion.scss` which comes with `reduced-motion` but it's not always possible.

It disables nonessential animation and transitions when the operating system requests reduced motion. It applies this behavior to dialogs, message boxes, loading indicators, and skeleton loaders.

It also replaces duplicate dialog and message box keyframes with the existing motion mixins.

## How to test

1. Start Storybook for the design system.
2. Disable reduced motion in the operating system.
3. Open dialogs and message boxes. Confirm that their entrance and exit animations run.
4. View loading indicators and skeleton loaders. Confirm that their animations run.
5. Enable reduced motion in the operating system.
6. Repeat the checks. Confirm that the affected animations do not run.
7. Run `pnpm lint` in `packages/frontend/@n8n/design-system`.
8. Run `pnpm typecheck` in `packages/frontend/@n8n/design-system`.

## Related Linear tickets, Github issues, and Community forum posts

[DS-601](https://linear.app/n8n/issue/DS-601)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)