### PR TITLE
feat(core): Add retryabilityFromError to @n8n/backend-network (no-changelog)

### DIFF
--- a/packages/@n8n/backend-network/src/http/__tests__/retryability.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/retryability.test.ts
@@ -103,6 +103,21 @@ describe('retryabilityFromError', () => {
 			expect(retryabilityFromError(withCode(code))).toEqual({ retryable: 'yes' });
 		});
 
+		it('is retryable for an undici terminated error hidden inside a wrapper', () => {
+			const terminated = new TypeError('terminated');
+			expect(retryabilityFromError(new Error('node failed', { cause: terminated }))).toEqual({
+				retryable: 'yes',
+			});
+		});
+
+		it('is retryable for a network error wrapped under errorResponse', () => {
+			expect(
+				retryabilityFromError(
+					Object.assign(new Error('node failed'), { errorResponse: withCode('ECONNRESET') }),
+				),
+			).toEqual({ retryable: 'yes' });
+		});
+
 		it('is unknown for an error that never went through an HTTP client', () => {
 			expect(retryabilityFromError(new Error('some logic bug'))).toEqual({
 				retryable: 'unknown',

--- a/packages/@n8n/backend-network/src/http/__tests__/retryability.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/retryability.test.ts
@@ -1,0 +1,284 @@
+import nock from 'nock';
+
+import { SsrfBlockedHostnameError, SsrfBlockedIpError } from '../../ssrf';
+import { httpRequest } from '../axios/request';
+import { markNonRetryable, retryabilityFromError } from '../retryability';
+
+const withStatus = (status: number, headers?: Record<string, string | string[]>) =>
+	Object.assign(new Error('request failed'), { response: { status, headers } });
+
+const withCode = (code: string) => Object.assign(new Error('socket failure'), { code });
+
+const NOW = new Date('2026-08-18T12:00:00.000Z');
+
+describe('retryabilityFromError', () => {
+	describe('from a response status', () => {
+		it.each([408, 429, 500, 502, 503, 504, 599])('is retryable for %s', (status) => {
+			expect(retryabilityFromError(withStatus(status))).toEqual({ retryable: 'yes', status });
+		});
+
+		it.each([400, 401, 402, 403, 404, 410, 422])(
+			'is unknown, never no, for the ambiguous %s',
+			(status) => {
+				expect(retryabilityFromError(withStatus(status))).toEqual({
+					retryable: 'unknown',
+					status,
+				});
+			},
+		);
+
+		it('reads SDK conventions that carry the status outside `response`', () => {
+			expect(retryabilityFromError(Object.assign(new Error('boom'), { statusCode: 503 }))).toEqual({
+				retryable: 'yes',
+				status: 503,
+			});
+			expect(retryabilityFromError(Object.assign(new Error('boom'), { status: 429 }))).toEqual({
+				retryable: 'yes',
+				status: 429,
+			});
+			expect(
+				retryabilityFromError(Object.assign(new Error('boom'), { response: { statusCode: 500 } })),
+			).toEqual({ retryable: 'yes', status: 500 });
+		});
+
+		it('reads httpCode, as node errors carry it: a numeric string', () => {
+			expect(retryabilityFromError(Object.assign(new Error('boom'), { httpCode: '429' }))).toEqual({
+				retryable: 'yes',
+				status: 429,
+			});
+			expect(retryabilityFromError(Object.assign(new Error('boom'), { httpCode: '403' }))).toEqual({
+				retryable: 'unknown',
+				status: 403,
+			});
+		});
+
+		it('prefers httpCode over the other status fields, anywhere in the chain', () => {
+			const wrapped = Object.assign(new Error('outer'), {
+				response: { status: 500 },
+				cause: Object.assign(new Error('api'), { httpCode: '429' }),
+			});
+			expect(retryabilityFromError(wrapped)).toEqual({ retryable: 'yes', status: 429 });
+		});
+
+		it('reads the status off the cause chain', () => {
+			const wrapped = new Error('outer', { cause: withStatus(503) });
+			expect(retryabilityFromError(wrapped)).toEqual({ retryable: 'yes', status: 503 });
+		});
+
+		it.each(['errorResponse', 'reason'])(
+			'follows the %s key node errors wrap with',
+			(wrappingKey) => {
+				const error = Object.assign(new Error('outer'), {
+					[wrappingKey]: { response: { status: 502 } },
+				});
+				expect(retryabilityFromError(error)).toEqual({ retryable: 'yes', status: 502 });
+			},
+		);
+
+		it('ignores fields that cannot be an HTTP status', () => {
+			expect(retryabilityFromError(Object.assign(new Error('boom'), { status: 0 }))).toEqual({
+				retryable: 'unknown',
+			});
+			expect(
+				retryabilityFromError(Object.assign(new Error('boom'), { statusCode: 1503.5 })),
+			).toEqual({ retryable: 'unknown' });
+			expect(
+				retryabilityFromError(Object.assign(new Error('boom'), { httpCode: 'ENOTFOUND' })),
+			).toEqual({ retryable: 'unknown' });
+			expect(
+				retryabilityFromError(Object.assign(new Error('boom'), { response: { status: '9000' } })),
+			).toEqual({ retryable: 'unknown' });
+		});
+	});
+
+	describe('from connection errors', () => {
+		it.each(['ECONNRESET', 'ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT'])(
+			'is retryable for a network error (%s)',
+			(code) => {
+				expect(retryabilityFromError(withCode(code))).toEqual({ retryable: 'yes' });
+			},
+		);
+
+		it.each(['ENOTFOUND', 'EAI_AGAIN'])('is retryable for a DNS error (%s)', (code) => {
+			expect(retryabilityFromError(withCode(code))).toEqual({ retryable: 'yes' });
+		});
+
+		it('is unknown for an error that never went through an HTTP client', () => {
+			expect(retryabilityFromError(new Error('some logic bug'))).toEqual({
+				retryable: 'unknown',
+			});
+			expect(retryabilityFromError(withCode('EACCES'))).toEqual({ retryable: 'unknown' });
+		});
+	});
+
+	describe('Retry-After', () => {
+		it('parses the delay-seconds form', () => {
+			expect(retryabilityFromError(withStatus(429, { 'Retry-After': '30' }), NOW)).toEqual({
+				retryable: 'yes',
+				status: 429,
+				retryAfterMs: 30_000,
+			});
+		});
+
+		it('parses the HTTP-date form against the supplied now', () => {
+			const inTwoMinutes = new Date(NOW.getTime() + 120_000).toUTCString();
+			expect(retryabilityFromError(withStatus(503, { 'retry-after': inTwoMinutes }), NOW)).toEqual({
+				retryable: 'yes',
+				status: 503,
+				retryAfterMs: 120_000,
+			});
+		});
+
+		it('clamps a past HTTP-date to zero instead of going negative', () => {
+			const twoMinutesAgo = new Date(NOW.getTime() - 120_000).toUTCString();
+			expect(
+				retryabilityFromError(withStatus(503, { 'retry-after': twoMinutesAgo }), NOW),
+			).toMatchObject({ retryAfterMs: 0 });
+		});
+
+		it('is set even when the status itself is not retryable, as some APIs throttle with 403', () => {
+			expect(retryabilityFromError(withStatus(403, { 'retry-after': '60' }), NOW)).toEqual({
+				retryable: 'unknown',
+				status: 403,
+				retryAfterMs: 60_000,
+			});
+		});
+
+		it('is found on the wrapped response when the node error carries only the status', () => {
+			const nodeError = Object.assign(new Error('api failed'), {
+				httpCode: '403',
+				errorResponse: { response: { status: 403, headers: { 'retry-after': '60' } } },
+			});
+			expect(retryabilityFromError(nodeError, NOW)).toEqual({
+				retryable: 'unknown',
+				status: 403,
+				retryAfterMs: 60_000,
+			});
+		});
+
+		it('omits retryAfterMs when the header is absent or invalid', () => {
+			expect(retryabilityFromError(withStatus(429), NOW).retryAfterMs).toBeUndefined();
+			expect(
+				retryabilityFromError(withStatus(429, { 'retry-after': 'soon' }), NOW).retryAfterMs,
+			).toBeUndefined();
+			expect(
+				retryabilityFromError(withStatus(429, { 'retry-after': '-5' }), NOW).retryAfterMs,
+			).toBeUndefined();
+			expect(
+				retryabilityFromError(withStatus(429, { 'retry-after': '5.5' }), NOW).retryAfterMs,
+			).toBeUndefined();
+		});
+
+		it('reads a headers object with a get() method (fetch Headers)', () => {
+			const error = Object.assign(new Error('boom'), {
+				status: 429,
+				headers: new Headers({ 'Retry-After': '7' }),
+			});
+			expect(retryabilityFromError(error, NOW)).toEqual({
+				retryable: 'yes',
+				status: 429,
+				retryAfterMs: 7000,
+			});
+		});
+
+		it('takes the first value of a multi-valued header', () => {
+			expect(
+				retryabilityFromError(withStatus(429, { 'retry-after': ['12', '99'] }), NOW),
+			).toMatchObject({ retryAfterMs: 12_000 });
+		});
+	});
+
+	describe('marked non-retryable', () => {
+		it('is no for an error marked with markNonRetryable', () => {
+			expect(retryabilityFromError(markNonRetryable(new Error('give up')))).toEqual({
+				retryable: 'no',
+			});
+		});
+
+		it('is no for SSRF blocked errors', () => {
+			expect(retryabilityFromError(new SsrfBlockedIpError('127.0.0.1'))).toEqual({
+				retryable: 'no',
+			});
+			expect(retryabilityFromError(new SsrfBlockedHostnameError('internal.test'))).toEqual({
+				retryable: 'no',
+			});
+		});
+
+		it('is no for a wrapped SSRF error, as undici and nodes re-wrap them', () => {
+			const wrapped = new TypeError('fetch failed', {
+				cause: new SsrfBlockedIpError('127.0.0.1'),
+			});
+			expect(retryabilityFromError(wrapped)).toEqual({ retryable: 'no' });
+		});
+
+		it('wins over a retryable status found on the same chain', () => {
+			const marked = markNonRetryable(Object.assign(new Error('boom'), { statusCode: 503 }));
+			expect(retryabilityFromError(marked)).toEqual({ retryable: 'no', status: 503 });
+		});
+
+		it('does not leak the mark into logs or serialization', () => {
+			const error = markNonRetryable(Object.assign(new Error('boom'), { code: 'X' }));
+			expect(Object.keys(error)).toEqual(['code']);
+			expect(JSON.stringify(error)).not.toContain('non-retryable');
+		});
+	});
+
+	describe('never throws', () => {
+		it.each([undefined, null, 'ECONNRESET', 42, Symbol('x'), () => {}])(
+			'handles non-error value %p',
+			(value) => {
+				expect(retryabilityFromError(value)).toEqual({ retryable: 'unknown' });
+			},
+		);
+
+		it('terminates on a self-referential cause chain', () => {
+			const selfReferential: Error & { cause?: unknown } = new Error('loop');
+			selfReferential.cause = selfReferential;
+			expect(retryabilityFromError(selfReferential)).toEqual({ retryable: 'unknown' });
+		});
+
+		it('keeps the status when the headers get() throws', () => {
+			const error = Object.assign(new Error('boom'), {
+				status: 503,
+				headers: {
+					get() {
+						throw new Error('broken');
+					},
+				},
+			});
+			expect(retryabilityFromError(error)).toEqual({ retryable: 'yes', status: 503 });
+		});
+	});
+
+	describe('node HTTP path (httpRequest)', () => {
+		beforeEach(() => {
+			nock.cleanAll();
+		});
+
+		it('handles a non-2xx rejection from the unmarked httpRequest export', async () => {
+			nock('https://api.test').get('/data').reply(503, 'unavailable', { 'Retry-After': '2' });
+
+			const error: unknown = await httpRequest({ url: 'https://api.test/data', method: 'GET' })
+				.then(() => undefined)
+				.catch((thrown: unknown) => thrown);
+
+			expect(retryabilityFromError(error, NOW)).toEqual({
+				retryable: 'yes',
+				status: 503,
+				retryAfterMs: 2000,
+			});
+		});
+
+		it('handles a connection error from the unmarked httpRequest export', async () => {
+			nock('https://api.test')
+				.get('/data')
+				.replyWithError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }));
+
+			const error: unknown = await httpRequest({ url: 'https://api.test/data', method: 'GET' })
+				.then(() => undefined)
+				.catch((thrown: unknown) => thrown);
+
+			expect(retryabilityFromError(error)).toEqual({ retryable: 'yes' });
+		});
+	});
+});

--- a/packages/@n8n/backend-network/src/http/index.ts
+++ b/packages/@n8n/backend-network/src/http/index.ts
@@ -19,6 +19,7 @@ export {
 	type HttpTransportOptions,
 	type TypedHttpFullResponse,
 } from './outbound-http';
+export { markNonRetryable, retryabilityFromError, type Retryability } from './retryability';
 export {
 	httpStatusFromError,
 	isAxiosError,

--- a/packages/@n8n/backend-network/src/http/retryability.ts
+++ b/packages/@n8n/backend-network/src/http/retryability.ts
@@ -1,0 +1,220 @@
+import { isDnsFailure, isTransportFailure } from './client-request-error';
+
+/**
+ * Retry information extracted from a failed outbound HTTP request.
+ * Plain data only, so any caller can map it onto its own retry policy.
+ */
+export type Retryability = {
+	/**
+	 * `yes` when the failure is proven worth retrying: a 429, 5xx or 408
+	 * response, a network error or a DNS error. `no` only for errors marked
+	 * with {@link markNonRetryable}, never derived from a status alone.
+	 * `unknown` is everything else and the caller decides what to do with it.
+	 */
+	retryable: 'yes' | 'no' | 'unknown';
+	/** HTTP status of the failed request, when one was found on the error. */
+	status?: number;
+	/** Wait requested by a `Retry-After` header, in ms. Absent when the header is missing or invalid. */
+	retryAfterMs?: number;
+};
+
+// Symbol.for so the mark survives the package being loaded twice (src and dist).
+const NON_RETRYABLE = Symbol.for('n8n.backend-network.non-retryable-error');
+
+/**
+ * Marks an error as proven not worth retrying. {@link retryabilityFromError}
+ * then returns `no` for it, even when it is wrapped in another error.
+ */
+export function markNonRetryable<E>(error: E): E {
+	if (typeof error === 'object' && error !== null) {
+		Object.defineProperty(error, NON_RETRYABLE, {
+			value: true,
+			enumerable: false,
+			configurable: true,
+		});
+	}
+	return error;
+}
+
+/**
+ * Extracts retry information from anything a failed outbound HTTP call may
+ * have thrown, whichever client or wrapper threw it, n8n node errors
+ * included. Never throws.
+ *
+ * @param now Reference time for resolving an HTTP-date `Retry-After` header.
+ *   Defaults to the current time.
+ */
+export function retryabilityFromError(error: unknown, now: Date = new Date()): Retryability {
+	try {
+		const chain = errorChain(error);
+		const status = findStatus(chain);
+
+		let retryAfterMs: number | undefined;
+		try {
+			retryAfterMs = findRetryAfterMs(chain, now);
+		} catch {
+			// A broken headers object only costs the delay hint, not the status.
+		}
+
+		let retryable: Retryability['retryable'] = 'unknown';
+		if (isMarkedNonRetryable(chain)) {
+			retryable = 'no';
+		} else if (
+			(status !== undefined && isRetryableStatus(status)) ||
+			isTransportFailure(error) ||
+			isDnsFailure(error)
+		) {
+			retryable = 'yes';
+		}
+
+		return {
+			retryable,
+			...(status !== undefined ? { status } : {}),
+			...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+		};
+	} catch {
+		return { retryable: 'unknown' };
+	}
+}
+
+function isMarkedNonRetryable(chain: UnknownRecord[]): boolean {
+	return chain.some((level) => (level as Record<symbol, unknown>)[NON_RETRYABLE] === true);
+}
+
+function isRetryableStatus(status: number): boolean {
+	return status === 408 || status === 429 || status >= 500;
+}
+
+type UnknownRecord = Readonly<Record<string, unknown>>;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+	typeof value === 'object' && value !== null;
+
+const MAX_CHAIN_DEPTH = 5;
+
+/** The keys errors wrap each other under. */
+const WRAPPING_KEYS = ['cause', 'errorResponse', 'reason'] as const;
+
+/** The error and the errors it wraps, shallowest first, each visited once. */
+function errorChain(error: unknown): UnknownRecord[] {
+	if (!isRecord(error)) {
+		return [];
+	}
+
+	const seen = new Set<UnknownRecord>([error]);
+	const chain: UnknownRecord[] = [error];
+	let generation: UnknownRecord[] = [error];
+
+	for (let depth = 0; depth < MAX_CHAIN_DEPTH && generation.length > 0; depth++) {
+		const next: UnknownRecord[] = [];
+		for (const level of generation) {
+			for (const key of WRAPPING_KEYS) {
+				const wrapped = level[key];
+				if (isRecord(wrapped) && !seen.has(wrapped)) {
+					seen.add(wrapped);
+					next.push(wrapped);
+				}
+			}
+		}
+		chain.push(...next);
+		generation = next;
+	}
+
+	return chain;
+}
+
+const responseOf = (level: UnknownRecord): UnknownRecord | undefined =>
+	isRecord(level.response) ? level.response : undefined;
+
+/**
+ * The HTTP status of the failing response, if any. An `httpCode` anywhere in
+ * the chain wins over the other status fields.
+ */
+function findStatus(chain: UnknownRecord[]): number | undefined {
+	let fallback: number | undefined;
+
+	for (const level of chain) {
+		const httpCode = toHttpStatus(level.httpCode);
+		if (httpCode !== undefined) {
+			return httpCode;
+		}
+
+		fallback ??=
+			toHttpStatus(responseOf(level)?.status) ??
+			toHttpStatus(responseOf(level)?.statusCode) ??
+			toHttpStatus(level.status) ??
+			toHttpStatus(level.statusCode);
+	}
+
+	return fallback;
+}
+
+/** The value as an HTTP status, or undefined when it cannot be one. */
+function toHttpStatus(value: unknown): number | undefined {
+	const status =
+		typeof value === 'number'
+			? value
+			: typeof value === 'string' && /^\d+$/.test(value.trim())
+				? Number(value.trim())
+				: undefined;
+
+	return status !== undefined && Number.isInteger(status) && status >= 100 && status <= 599
+		? status
+		: undefined;
+}
+
+/** The first parseable `Retry-After` in the chain, in ms. */
+function findRetryAfterMs(chain: UnknownRecord[], now: Date): number | undefined {
+	for (const level of chain) {
+		const headers = responseOf(level)?.headers ?? level.headers;
+		const parsed = parseRetryAfter(readRetryAfterHeader(headers), now);
+		if (parsed !== undefined) {
+			return parsed;
+		}
+	}
+	return undefined;
+}
+
+/** The `Retry-After` value from a `get()` style or plain headers object. */
+function readRetryAfterHeader(headers: unknown): string | undefined {
+	if (typeof headers !== 'object' || headers === null) {
+		return undefined;
+	}
+
+	const get = (headers as { get?: unknown }).get;
+	if (typeof get === 'function') {
+		const value: unknown = (get as (name: string) => unknown).call(headers, 'retry-after');
+		return typeof value === 'string' ? value : undefined;
+	}
+
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.toLowerCase() === 'retry-after') {
+			const first: unknown = Array.isArray(value) ? value[0] : value;
+			return typeof first === 'string' ? first : undefined;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * A `Retry-After` value in ms, from the delay-seconds form or the HTTP-date
+ * form resolved against `now` and never negative. Undefined for anything else.
+ */
+function parseRetryAfter(value: string | undefined, now: Date): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	const trimmed = value.trim();
+
+	if (/^\d+$/.test(trimmed)) {
+		const ms = Number(trimmed) * 1000;
+		return Number.isSafeInteger(ms) ? ms : undefined;
+	}
+
+	// HTTP-dates contain letters. This keeps Date.parse from reading numeric garbage as a date.
+	if (!/[a-z]/i.test(trimmed)) {
+		return undefined;
+	}
+	const dateMs = Date.parse(trimmed);
+	return Number.isNaN(dateMs) ? undefined : Math.max(0, dateMs - now.getTime());
+}

--- a/packages/@n8n/backend-network/src/http/retryability.ts
+++ b/packages/@n8n/backend-network/src/http/retryability.ts
@@ -61,8 +61,7 @@ export function retryabilityFromError(error: unknown, now: Date = new Date()): R
 			retryable = 'no';
 		} else if (
 			(status !== undefined && isRetryableStatus(status)) ||
-			isTransportFailure(error) ||
-			isDnsFailure(error)
+			chain.some((level) => isTransportFailure(level) || isDnsFailure(level))
 		) {
 			retryable = 'yes';
 		}

--- a/packages/@n8n/backend-network/src/http/retryability.ts
+++ b/packages/@n8n/backend-network/src/http/retryability.ts
@@ -177,13 +177,13 @@ function findRetryAfterMs(chain: UnknownRecord[], now: Date): number | undefined
 
 /** The `Retry-After` value from a `get()` style or plain headers object. */
 function readRetryAfterHeader(headers: unknown): string | undefined {
-	if (typeof headers !== 'object' || headers === null) {
+	if (!isRecord(headers)) {
 		return undefined;
 	}
 
-	const get = (headers as { get?: unknown }).get;
+	const get = headers.get;
 	if (typeof get === 'function') {
-		const value: unknown = (get as (name: string) => unknown).call(headers, 'retry-after');
+		const value: unknown = get.call(headers, 'retry-after');
 		return typeof value === 'string' ? value : undefined;
 	}
 

--- a/packages/@n8n/backend-network/src/ssrf/ssrf-blocked-hostname.error.ts
+++ b/packages/@n8n/backend-network/src/ssrf/ssrf-blocked-hostname.error.ts
@@ -1,5 +1,7 @@
 import { UserError } from 'n8n-workflow';
 
+import { markNonRetryable } from '../http/retryability';
+
 /**
  * Error thrown when a destination hostname is denied by SSRF hostname policy.
  *
@@ -20,5 +22,6 @@ export class SsrfBlockedHostnameError extends UserError {
 
 		this.name = 'SsrfBlockedHostnameError';
 		this.hostname = hostname;
+		markNonRetryable(this);
 	}
 }

--- a/packages/@n8n/backend-network/src/ssrf/ssrf-blocked-ip.error.ts
+++ b/packages/@n8n/backend-network/src/ssrf/ssrf-blocked-ip.error.ts
@@ -1,5 +1,7 @@
 import { UserError } from 'n8n-workflow';
 
+import { markNonRetryable } from '../http/retryability';
+
 /**
  * Error thrown when a resolved address is denied by SSRF IP policy.
  */
@@ -21,5 +23,6 @@ export class SsrfBlockedIpError extends UserError {
 		this.name = 'SsrfBlockedIpError';
 		this.ip = ip;
 		this.hostname = hostname;
+		markNonRetryable(this);
 	}
 }

--- a/packages/cli/src/utils/__tests__/ai-service-retry.test.ts
+++ b/packages/cli/src/utils/__tests__/ai-service-retry.test.ts
@@ -65,6 +65,30 @@ describe('callAiServiceWithRetry', () => {
 		expect(errorReporter.warn).toHaveBeenCalledTimes(1);
 	});
 
+	it('retries transient upstream statuses', async () => {
+		vi.useFakeTimers();
+		const unavailable = Object.assign(new Error('Service Unavailable'), { statusCode: 503 });
+		const call = vi.fn().mockRejectedValueOnce(unavailable).mockResolvedValue('ok');
+
+		const promise = callAiServiceWithRetry('Test call', call);
+		await vi.runAllTimersAsync();
+
+		await expect(promise).resolves.toBe('ok');
+		expect(call).toHaveBeenCalledTimes(2);
+	});
+
+	it('retries failures that carry no upstream status', async () => {
+		vi.useFakeTimers();
+		const gatewayFailure = new Error('<html>Bad Gateway</html>');
+		const call = vi.fn().mockRejectedValueOnce(gatewayFailure).mockResolvedValue('ok');
+
+		const promise = callAiServiceWithRetry('Test call', call);
+		await vi.runAllTimersAsync();
+
+		await expect(promise).resolves.toBe('ok');
+		expect(call).toHaveBeenCalledTimes(2);
+	});
+
 	it('does not retry definite client errors', async () => {
 		const unauthorized = Object.assign(new Error('Unauthorized'), { statusCode: 401 });
 		const call = vi.fn(async () => await Promise.reject(unauthorized));

--- a/packages/cli/src/utils/ai-service-retry.ts
+++ b/packages/cli/src/utils/ai-service-retry.ts
@@ -1,3 +1,4 @@
+import { retryabilityFromError } from '@n8n/backend-network';
 import { sleep } from '@n8n/utils/sleep';
 import { OperationalError } from 'n8n-workflow';
 
@@ -51,13 +52,12 @@ async function callWithTimeout<T>(call: () => Promise<T>, label: string): Promis
 	}
 }
 
-// The AI assistant service SDK carries upstream HTTP status as numeric statusCode;
-// gateway HTML bodies and network failures are re-wrapped without one.
+// The AI service SDK re-wraps gateway bodies and network failures without a status.
+// Those status-less failures are treated as transient here.
 function isTransientAiServiceError(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false;
-	const status = 'statusCode' in error ? error.statusCode : undefined;
-	if (typeof status !== 'number') return true;
-	return status >= 500 || status === 408 || status === 429;
+	const { retryable, status } = retryabilityFromError(error);
+	return retryable === 'yes' || (retryable === 'unknown' && status === undefined);
 }
 
 export async function callAiServiceWithRetry<T>(


### PR DESCRIPTION
## Summary

Add one shared function that decides if an outbound HTTP failure is worth retrying.

The open PR #35707 can drop its local status and `Retry-After` parsing and keep only its backoff policy.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4120

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

