### PR TITLE
fix(core): Harden Daytona sandbox acquisition against transient failures and stuck sandboxes

### DIFF
--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -437,37 +437,93 @@ describe('DaytonaSandbox (creation strategies)', () => {
 	it.each([
 		['server error', new DaytonaError('Bad Gateway', 502)],
 		['rate limit', new DaytonaError('Too Many Requests', 429)],
-	])('fails without creating when the initial lookup returns a %s', async (_kind, error) => {
+	])('recovers the initial lookup from a transient %s without creating', async (_kind, error) => {
 		queuedGetErrors.push(error);
+		queuedGetResults.push(makeMockSandbox('remote-recovered'));
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
 			name: 'sandbox-name',
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
 		});
 
-		await expect(sandbox.start()).rejects.toThrow(error.message);
-		expect(clientLog[0].get).toHaveBeenCalledTimes(1);
+		await sandbox.start();
+
+		expect(clientLog[0].get).toHaveBeenCalledTimes(2);
+		expect(clientLog[0].create).not.toHaveBeenCalled();
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-recovered');
+	});
+
+	it('fails the initial lookup once transient retries are exhausted, without creating', async () => {
+		queuedGetErrors.push(
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+		);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await expect(sandbox.start()).rejects.toMatchObject({
+			name: 'SandboxAcquisitionError',
+			failureClass: 'DaytonaError:502',
+			message: expect.stringContaining('Bad Gateway'),
+		});
+		expect(clientLog[0].get).toHaveBeenCalledTimes(3);
 		expect(clientLog[0].create).not.toHaveBeenCalled();
 	});
 
-	it('fails without polling when the lookup after a name conflict errors', async () => {
+	it('recovers the lookup after a name conflict from a transient error', async () => {
 		queueNotFound('not found');
 		queuedCreateResults.push(
 			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
 		);
 		queuedGetErrors.push(new DaytonaError('Bad Gateway', 502));
+		queuedGetResults.push(makeMockSandbox('remote-existing'));
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
 			name: 'sandbox-name',
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await sandbox.start();
+
+		expect(clientLog[0].get).toHaveBeenCalledTimes(3);
+		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-existing');
+	});
+
+	it('fails the lookup after a name conflict once transient retries are exhausted', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queuedGetErrors.push(
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+		);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
 		});
 
 		await expect(sandbox.start()).rejects.toThrow('Bad Gateway');
-		expect(clientLog[0].get).toHaveBeenCalledTimes(2);
+		expect(clientLog[0].get).toHaveBeenCalledTimes(4);
 		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
 	});
 
@@ -520,37 +576,47 @@ describe('DaytonaSandbox (creation strategies)', () => {
 	it.each([
 		['server', new DaytonaError('Bad Gateway', 502)],
 		['rate-limit', new DaytonaError('Too Many Requests', 429)],
-	])('does not retry a %s create failure', async (_kind, error) => {
+		['connection', new DaytonaConnectionError('socket hang up')],
+		['timeout', new DaytonaTimeoutError('request timed out')],
+	])('retries a transient %s create failure', async (_kind, error) => {
 		queueNotFound('not found');
-		queuedCreateResults.push(error);
+		queuedCreateResults.push(error, makeMockSandbox('remote-after-retry'));
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
 			name: 'sandbox-name',
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
 		});
 
-		await expect(sandbox.start()).rejects.toThrow(error.message);
-		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+		await sandbox.start();
+
+		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-after-retry');
 	});
 
-	it.each([
-		['connection', DaytonaConnectionError],
-		['timeout', DaytonaTimeoutError],
-	])('does not retry a transient %s create failure', async (_kind, ErrorType) => {
+	it('fails once transient create retries are exhausted', async () => {
 		queueNotFound('not found');
-		queuedCreateResults.push(new ErrorType('transient create failure'));
+		queuedCreateResults.push(
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+		);
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
 			name: 'sandbox-name',
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
 		});
 
-		await expect(sandbox.start()).rejects.toThrow('transient create failure');
-		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+		await expect(sandbox.start()).rejects.toMatchObject({
+			name: 'SandboxAcquisitionError',
+			failureClass: 'DaytonaError:502',
+		});
+		expect(clientLog[0].create).toHaveBeenCalledTimes(3);
 	});
 
 	it('does not retry non-transient create failures', async () => {
@@ -617,6 +683,145 @@ describe('DaytonaSandbox (creation strategies)', () => {
 
 		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-replacement');
+	});
+
+	it('deletes a sandbox stuck in a transitional state and creates a fresh one', async () => {
+		const logger = makeLogger();
+		const wedged = makeMockSandbox('remote-wedged', 'starting');
+		wedged.waitUntilStarted.mockRejectedValue(
+			new DaytonaTimeoutError('Sandbox failed to become ready within the timeout period'),
+		);
+		queuedGetResults.push(wedged);
+		queuedCreateResults.push(makeMockSandbox('remote-fresh'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			timeout: 200_000,
+			logger,
+		});
+
+		await sandbox.start();
+
+		// The wait gets half the remaining acquisition budget, not all of it.
+		const waitSeconds = wedged.waitUntilStarted.mock.calls[0][0] as number;
+		expect(waitSeconds).toBeLessThanOrEqual(100);
+		expect(waitSeconds).toBeGreaterThanOrEqual(60);
+		expect(wedged.delete).toHaveBeenCalled();
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-fresh');
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Daytona sandbox is stuck in a transitional state; deleting it so a fresh one can be created',
+			expect.objectContaining({ sandboxName: 'sandbox-name', state: 'starting' }),
+		);
+	});
+
+	it('keeps a stopped sandbox whose resume times out and reconciles via the conflict path', async () => {
+		const stopped = makeMockSandbox('remote-stopped', 'stopped');
+		stopped.start.mockRejectedValue(new DaytonaTimeoutError('resume timed out'));
+		queuedGetResults.push(stopped);
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queuedGetResults.push(makeMockSandbox('remote-started-later'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await sandbox.start();
+
+		expect(stopped.delete).not.toHaveBeenCalled();
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-started-later');
+	});
+
+	it('fails fast with a distinct error when the conflicting sandbox is never visible', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queueNotFound('invisible');
+		queueNotFound('invisible');
+		queueNotFound('invisible');
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await expect(sandbox.start()).rejects.toMatchObject({
+			name: 'SandboxNameConflictError',
+			failureClass: 'unresolved-name-conflict',
+		});
+		expect(clientLog[0].create).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe('DaytonaSandbox (destroy ownership)', () => {
+	it('does not delete a sandbox by name when start() never acquired one', async () => {
+		queuedGetErrors.push(
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+			new DaytonaError('Bad Gateway', 502),
+		);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await expect(sandbox.start()).rejects.toThrow('Bad Gateway');
+		const getCallsAfterStart = clientLog[0].get.mock.calls.length;
+
+		await expect(sandbox.destroy()).resolves.toBeUndefined();
+
+		// No by-name resolve (and thus no delete) for a remote this instance never acquired.
+		expect(clientLog[0].get).toHaveBeenCalledTimes(getCallsAfterStart);
+	});
+
+	it('destroy() after stop() still deletes the acquired remote by name', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(makeMockSandbox('remote-created'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+		});
+
+		await sandbox.start();
+		await sandbox.stop();
+
+		const byName = makeMockSandbox('remote-created');
+		queuedGetResults.push(byName);
+		await sandbox.destroy();
+
+		expect(byName.delete).toHaveBeenCalled();
+	});
+
+	it('deleteRemote() deletes by name even when this instance never started the sandbox', async () => {
+		const foreign = makeMockSandbox('remote-foreign');
+		queuedGetResults.push(foreign);
+
+		const sandbox = new DaytonaSandbox({ name: 'sandbox-name', apiKey: 'api-key' });
+		await sandbox.deleteRemote();
+
+		expect(clientLog[0].get).toHaveBeenCalledWith('sandbox-name');
+		expect(foreign.delete).toHaveBeenCalled();
 	});
 });
 

--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -685,9 +685,9 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-replacement');
 	});
 
-	it('deletes a sandbox stuck in a transitional state and creates a fresh one', async () => {
+	it('deletes a sandbox stuck provisioning and creates a fresh one', async () => {
 		const logger = makeLogger();
-		const wedged = makeMockSandbox('remote-wedged', 'starting');
+		const wedged = makeMockSandbox('remote-wedged', 'building_snapshot');
 		wedged.waitUntilStarted.mockRejectedValue(
 			new DaytonaTimeoutError('Sandbox failed to become ready within the timeout period'),
 		);
@@ -713,31 +713,68 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-fresh');
 		expect(logger.warn).toHaveBeenCalledWith(
 			'Daytona sandbox is stuck in a transitional state; deleting it so a fresh one can be created',
-			expect.objectContaining({ sandboxName: 'sandbox-name', state: 'starting' }),
+			expect.objectContaining({ sandboxName: 'sandbox-name', state: 'building_snapshot' }),
 		);
 	});
 
-	it('keeps a stopped sandbox whose resume times out and reconciles via the conflict path', async () => {
+	it.each(['restoring', 'starting', 'resizing'])(
+		'keeps a %s sandbox whose wait times out and fails with a classified error',
+		async (state) => {
+			const stateful = makeMockSandbox(`remote-${state}`, state);
+			stateful.waitUntilStarted.mockRejectedValue(new DaytonaTimeoutError('never became ready'));
+			queuedGetResults.push(stateful);
+
+			const sandbox = new DaytonaSandbox({
+				id: 'sandbox-id',
+				name: 'sandbox-name',
+				apiKey: 'api-key',
+				snapshot: 'n8n/instance-ai:1.123.0',
+			});
+
+			await expect(sandbox.start()).rejects.toMatchObject({
+				name: 'SandboxNotReadyError',
+				failureClass: 'sandbox-not-ready',
+			});
+			expect(stateful.delete).not.toHaveBeenCalled();
+			expect(clientLog[0].create).not.toHaveBeenCalled();
+		},
+	);
+
+	it('keeps a stopped sandbox whose resume times out and fails with a classified error', async () => {
 		const stopped = makeMockSandbox('remote-stopped', 'stopped');
 		stopped.start.mockRejectedValue(new DaytonaTimeoutError('resume timed out'));
 		queuedGetResults.push(stopped);
-		queuedCreateResults.push(
-			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
-		);
-		queuedGetResults.push(makeMockSandbox('remote-started-later'));
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
 			name: 'sandbox-name',
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
-			createRetryBackoffBaseMs: 1,
+		});
+
+		await expect(sandbox.start()).rejects.toMatchObject({ name: 'SandboxNotReadyError' });
+		expect(stopped.delete).not.toHaveBeenCalled();
+		expect(clientLog[0].create).not.toHaveBeenCalled();
+	});
+
+	it('caps the create timeout at the remaining acquisition budget', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(makeMockSandbox('remote-created'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			timeout: 100_000,
+			createTimeoutSeconds: 300,
 		});
 
 		await sandbox.start();
 
-		expect(stopped.delete).not.toHaveBeenCalled();
-		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-started-later');
+		const createOptions = clientLog[0].create.mock.calls[0][1] as { timeout: number };
+		expect(createOptions.timeout).toBeLessThanOrEqual(100);
+		expect(createOptions.timeout).toBeGreaterThan(90);
 	});
 
 	it('fails fast with a distinct error when the conflicting sandbox is never visible', async () => {

--- a/packages/@n8n/agents/src/workspace/sandbox/base-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/base-sandbox.ts
@@ -47,6 +47,15 @@ export abstract class BaseSandbox implements WorkspaceSandbox {
 	abstract stop(): Promise<void>;
 	abstract destroy(): Promise<void>;
 
+	/**
+	 * Delete the provider-side sandbox this instance names, regardless of whether this
+	 * instance created it. For explicit teardown paths; defaults to destroy(). Providers
+	 * whose destroy() is scoped to remotes the instance acquired override this.
+	 */
+	async deleteRemote(): Promise<void> {
+		await this.destroy();
+	}
+
 	async _start(): Promise<void> {
 		if (this.status === 'running') return;
 

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -20,7 +20,7 @@ import type {
 } from '../types';
 import { BaseSandbox } from './base-sandbox';
 import { DaytonaAuthManager } from './daytona-auth-manager';
-import { SandboxAcquisitionError, SandboxNameConflictError } from './errors';
+import { SandboxAcquisitionError, SandboxNameConflictError, SandboxNotReadyError } from './errors';
 import { loadDaytona } from './lazy-daytona';
 import type { ErrorReporter, Logger } from './logger';
 
@@ -69,16 +69,28 @@ const RECOVERABLE_SANDBOX_STATES = new Set<SandboxState>([
 	SANDBOX_STATE_ARCHIVED,
 ]);
 
-const WAIT_FOR_STARTED_SANDBOX_STATES = new Set<SandboxState>([
+/**
+ * Transitional states of a sandbox being provisioned for the first time. No user workspace
+ * state exists yet, so one that never becomes ready can be safely deleted and recreated.
+ */
+const PROVISIONING_SANDBOX_STATES = new Set<SandboxState>([
 	SANDBOX_STATE_CREATING,
-	SANDBOX_STATE_RESTORING,
-	SANDBOX_STATE_STARTING,
 	SANDBOX_STATE_PENDING_BUILD,
 	SANDBOX_STATE_PULLING_SNAPSHOT,
+	SANDBOX_STATE_BUILDING_SNAPSHOT,
+]);
+
+/**
+ * Transitional states of a sandbox that already carries workspace state (resuming from
+ * stopped, restoring from archive, resizing, snapshotting, forking). Never deleted on a
+ * wait timeout — losing the wait must not lose the thread's files.
+ */
+const STATEFUL_TRANSITION_SANDBOX_STATES = new Set<SandboxState>([
+	SANDBOX_STATE_RESTORING,
+	SANDBOX_STATE_STARTING,
 	SANDBOX_STATE_FORKING,
 	SANDBOX_STATE_RESIZING,
 	SANDBOX_STATE_SNAPSHOTTING,
-	SANDBOX_STATE_BUILDING_SNAPSHOT,
 ]);
 
 const WAIT_FOR_RECOVERABLE_SANDBOX_STATES = new Set<SandboxState>([
@@ -593,7 +605,11 @@ export class DaytonaSandbox extends BaseSandbox {
 				return { status: 'pending' };
 			}
 			if (REMOVING_SANDBOX_STATES.has(state)) return { status: 'pending' };
-			if (RECOVERABLE_SANDBOX_STATES.has(state) || WAIT_FOR_STARTED_SANDBOX_STATES.has(state)) {
+			if (
+				RECOVERABLE_SANDBOX_STATES.has(state) ||
+				PROVISIONING_SANDBOX_STATES.has(state) ||
+				STATEFUL_TRANSITION_SANDBOX_STATES.has(state)
+			) {
 				if (!(await this.bringToStarted(sandbox, state, deadline))) return { status: 'pending' };
 			} else if (
 				WAIT_FOR_RECOVERABLE_SANDBOX_STATES.has(state) ||
@@ -612,10 +628,13 @@ export class DaytonaSandbox extends BaseSandbox {
 	/**
 	 * Drive an existing sandbox toward 'started': resume a stopped/archived one, or wait out a
 	 * transitional state. A single wait is capped at half the remaining acquisition budget so a
-	 * sandbox that never becomes ready can't consume the whole timeout — the rest of the budget
-	 * is left for replacing it. On a wait timeout the sandbox is treated as wedged and deleted
-	 * so the caller can create a fresh one; a resume timeout keeps the sandbox (its disk state
-	 * is intact and the conflict-reconcile path keeps waiting on the now-transitional state).
+	 * sandbox that never becomes ready can't consume the whole timeout. On a wait timeout:
+	 *  - a provisioning sandbox ({@link PROVISIONING_SANDBOX_STATES}: no workspace state yet)
+	 *    is treated as wedged and deleted so the caller can create a fresh one with the rest
+	 *    of the budget;
+	 *  - a sandbox that carries workspace state (resuming, or one of
+	 *    {@link STATEFUL_TRANSITION_SANDBOX_STATES}) is kept and the acquisition fails with a
+	 *    classified error instead — deleting it would lose the thread's files.
 	 */
 	private async bringToStarted(
 		sandbox: Sandbox,
@@ -638,20 +657,22 @@ export class DaytonaSandbox extends BaseSandbox {
 		} catch (error) {
 			const { DaytonaTimeoutError } = loadDaytona();
 			if (!(error instanceof DaytonaTimeoutError)) throw error;
-			if (resuming) {
-				this.options.logger?.warn('Daytona sandbox did not resume in time; still reconciling', {
-					sandboxName: this.sandboxName,
-					state,
-					waitSeconds,
-				});
+			if (PROVISIONING_SANDBOX_STATES.has(state)) {
+				this.options.logger?.warn(
+					'Daytona sandbox is stuck in a transitional state; deleting it so a fresh one can be created',
+					{ sandboxName: this.sandboxName, state, waitSeconds },
+				);
+				await sandbox.delete(this.operationTimeoutSeconds(deadline));
 				return false;
 			}
 			this.options.logger?.warn(
-				'Daytona sandbox is stuck in a transitional state; deleting it so a fresh one can be created',
+				'Daytona sandbox did not become ready in time; keeping it and failing the acquisition',
 				{ sandboxName: this.sandboxName, state, waitSeconds },
 			);
-			await sandbox.delete(this.operationTimeoutSeconds(deadline));
-			return false;
+			throw new SandboxNotReadyError(
+				`Daytona sandbox "${this.sandboxName}" did not become ready within the acquisition budget (state: ${state})`,
+				{ cause: error },
+			);
 		}
 	}
 
@@ -691,6 +712,8 @@ export class DaytonaSandbox extends BaseSandbox {
 					attempt: attempt + 1,
 				});
 				await this.waitBeforeAcquisitionRetry(attempt, deadline);
+				// Backoff may have consumed the budget — don't start an attempt we can't finish.
+				if (Date.now() >= deadline) throw error;
 			}
 		}
 	}
@@ -701,10 +724,13 @@ export class DaytonaSandbox extends BaseSandbox {
 
 		for (const candidate of candidates) {
 			try {
-				return await this.withTransientRetry('create', deadline, async () =>
-					this.options.createTimeoutSeconds
-						? await client.create(candidate.params, { timeout: this.options.createTimeoutSeconds })
-						: await client.create(candidate.params),
+				return await this.withTransientRetry(
+					'create',
+					deadline,
+					async () =>
+						await client.create(candidate.params, {
+							timeout: this.createTimeoutSeconds(deadline),
+						}),
 				);
 			} catch (error) {
 				// A name conflict is strategy-independent; let the caller reattach by name.
@@ -742,6 +768,13 @@ export class DaytonaSandbox extends BaseSandbox {
 	private operationTimeoutSeconds(deadline?: number): number {
 		if (deadline === undefined) return Math.ceil(this.timeout / 1000);
 		return Math.max(0.001, (deadline - Date.now()) / 1000);
+	}
+
+	/** Configured create timeout, capped by the remaining acquisition budget. */
+	private createTimeoutSeconds(deadline: number): number {
+		const remaining = this.operationTimeoutSeconds(deadline);
+		const configured = this.options.createTimeoutSeconds;
+		return configured ? Math.min(configured, remaining) : remaining;
 	}
 
 	private createSandboxParams(): Array<{

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -20,6 +20,7 @@ import type {
 } from '../types';
 import { BaseSandbox } from './base-sandbox';
 import { DaytonaAuthManager } from './daytona-auth-manager';
+import { SandboxAcquisitionError, SandboxNameConflictError } from './errors';
 import { loadDaytona } from './lazy-daytona';
 import type { ErrorReporter, Logger } from './logger';
 
@@ -42,6 +43,16 @@ const SANDBOX_STATE_DESTROYING = 'destroying';
 const SANDBOX_STATE_ERROR = 'error';
 const SANDBOX_STATE_BUILD_FAILED = 'build_failed';
 const MAX_ACQUISITION_RETRY_BACKOFF_MS = 5_000;
+/** Extra attempts (beyond the first) for a control-plane call that failed transiently. */
+const MAX_TRANSIENT_ACQUISITION_RETRIES = 2;
+/**
+ * Consecutive create-conflict → lookup-absent cycles tolerated before concluding the
+ * conflicting sandbox is invisible to this client and no amount of retrying will help.
+ */
+const MAX_CONSECUTIVE_ABSENT_CONFLICTS = 3;
+/** Floor for a single wait on a sandbox state transition, regardless of remaining budget. */
+const MIN_STATE_WAIT_SECONDS = 30;
+const TRANSIENT_HTTP_STATUS_CODES = new Set([408, 429]);
 
 /**
  * States a failed operation may recover from by resuming the sandbox: an idle sandbox that
@@ -88,6 +99,8 @@ const REMOVING_SANDBOX_STATES = new Set<SandboxState>([
 type ExistingSandboxLookup =
 	| { status: 'ready'; sandbox: Sandbox }
 	| { status: 'absent' | 'pending' };
+
+type ConflictLookupResult = ExistingSandboxLookup | { status: 'timeout' };
 
 export interface DaytonaSandboxOptions {
 	id?: string;
@@ -152,6 +165,34 @@ function isSandboxNameConflictError(error: unknown): boolean {
 	if (error instanceof DaytonaError && error.statusCode === 409) return true;
 	return /sandbox with name .+ already exists/i.test(error.message);
 }
+
+/**
+ * Whether a Daytona control-plane failure is worth retrying during acquisition: server/gateway
+ * errors, request timeouts, rate limits, and dropped connections. Auth (401/403), validation
+ * (400), not-found (404), and conflict (409) are deterministic — retrying can't change them.
+ */
+function isTransientAcquisitionError(error: unknown): boolean {
+	const { DaytonaError, DaytonaNotFoundError, DaytonaConnectionError, DaytonaTimeoutError } =
+		loadDaytona();
+	if (!(error instanceof DaytonaError)) return false;
+	if (error instanceof DaytonaNotFoundError) return false;
+	if (error instanceof DaytonaConnectionError || error instanceof DaytonaTimeoutError) {
+		return true;
+	}
+	return (
+		error.statusCode !== undefined &&
+		(error.statusCode >= 500 || TRANSIENT_HTTP_STATUS_CODES.has(error.statusCode))
+	);
+}
+
+function acquisitionFailureClass(error: unknown): string {
+	if (!(error instanceof Error)) return typeof error;
+	const { DaytonaError } = loadDaytona();
+	if (error instanceof DaytonaError && error.statusCode !== undefined) {
+		return `${error.constructor.name}:${error.statusCode}`;
+	}
+	return error.constructor.name;
+}
 export class DaytonaSandbox extends BaseSandbox {
 	readonly id: string;
 	readonly name = 'DaytonaSandbox';
@@ -167,6 +208,12 @@ export class DaytonaSandbox extends BaseSandbox {
 	private sandbox?: Sandbox;
 	private workingDirectory?: string;
 	private recoveryPromise?: Promise<void>;
+	/**
+	 * Whether this instance ever successfully created or attached to the remote sandbox.
+	 * Gates the by-name delete in {@link destroy}: a failed start() must not delete a
+	 * same-named sandbox another process owns.
+	 */
+	private remoteAcquired = false;
 
 	constructor(private readonly options: DaytonaSandboxOptions = {}) {
 		super();
@@ -195,16 +242,39 @@ export class DaytonaSandbox extends BaseSandbox {
 	override async start(): Promise<void> {
 		if (this.sandbox) return;
 
-		const client = await this.getDaytona();
-		const existing = await this.findExistingSandbox(client);
-		if (existing) {
-			this.sandbox = existing;
-			await this.detectWorkingDirectory();
-			return;
+		// One budget for the entire acquisition (lookup, waits, creates, conflict reconcile),
+		// so no single stuck operation can consume the whole turn.
+		const deadline = Date.now() + this.timeout;
+		try {
+			const client = await this.getDaytona();
+			const existing = await this.findExistingSandbox(client, deadline);
+			this.sandbox = existing ?? (await this.createSandboxOrReattach(client, deadline));
+			this.remoteAcquired = true;
+		} catch (error) {
+			throw this.toAcquisitionError(error);
 		}
-
-		this.sandbox = await this.createSandboxOrReattach(client);
 		await this.detectWorkingDirectory();
+	}
+
+	/**
+	 * Wrap Daytona SDK failures so acquisition surfaces one classified error type instead of
+	 * raw SDK errors. Aborts, already-classified errors, and non-SDK errors pass through.
+	 */
+	private toAcquisitionError(error: unknown): unknown {
+		if (isAbortError(error) || error instanceof SandboxAcquisitionError) return error;
+		const { DaytonaError } = loadDaytona();
+		if (!(error instanceof DaytonaError)) return error;
+		const failureClass = acquisitionFailureClass(error);
+		this.options.logger?.warn('Daytona sandbox acquisition failed', {
+			sandboxName: this.sandboxName,
+			failureClass,
+			error: error.message,
+		});
+		return new SandboxAcquisitionError(
+			`Failed to acquire Daytona sandbox: ${error.message}`,
+			failureClass,
+			{ cause: error },
+		);
 	}
 
 	/**
@@ -212,32 +282,45 @@ export class DaytonaSandbox extends BaseSandbox {
 	 * exists even though the initial lookup missed it due to a concurrent create from
 	 * another main. Deterministic names make reattach safe.
 	 */
-	private async createSandboxOrReattach(client: Daytona): Promise<Sandbox> {
-		let conflictDeadline: number | undefined;
+	private async createSandboxOrReattach(client: Daytona, deadline: number): Promise<Sandbox> {
 		let conflictError: unknown;
 		let attempt = 0;
+		let consecutiveAbsent = 0;
 
-		while (conflictDeadline === undefined || Date.now() < conflictDeadline) {
+		do {
 			try {
-				return await this.createSandbox(client);
+				return await this.createSandbox(client, deadline);
 			} catch (error) {
 				if (!isSandboxNameConflictError(error)) throw error;
 				conflictError = error;
-				conflictDeadline ??= Date.now() + this.timeout;
 
-				const existing = await this.findExistingSandboxAfterConflict(client, conflictDeadline);
-				if (existing) {
+				const existing = await this.findExistingSandboxAfterConflict(client, deadline);
+				if (existing.status === 'ready') {
 					this.options.logger?.info('Sandbox name already exists; reattached to existing sandbox', {
 						sandboxName: this.sandboxName,
-						remoteSandboxId: existing.id,
+						remoteSandboxId: existing.sandbox.id,
 					});
-					return existing;
+					return existing.sandbox;
+				}
+				if (existing.status === 'absent') {
+					// Create keeps conflicting while the lookup keeps missing: the conflicting
+					// sandbox is invisible to this client (e.g. ownership-scoped in proxy mode).
+					// That cannot resolve itself, so fail fast instead of burning the budget.
+					consecutiveAbsent++;
+					if (consecutiveAbsent >= MAX_CONSECUTIVE_ABSENT_CONFLICTS) {
+						throw new SandboxNameConflictError(
+							`Sandbox name "${this.sandboxName}" conflicts with a sandbox this client cannot see (${consecutiveAbsent} consecutive attempts)`,
+							{ cause: conflictError },
+						);
+					}
+				} else {
+					consecutiveAbsent = 0;
 				}
 
-				if (Date.now() >= conflictDeadline) break;
-				await this.waitBeforeAcquisitionRetry(attempt++, conflictDeadline);
+				if (Date.now() >= deadline) break;
+				await this.waitBeforeAcquisitionRetry(attempt++, deadline);
 			}
-		}
+		} while (Date.now() < deadline);
 
 		throw conflictError instanceof Error
 			? conflictError
@@ -261,16 +344,43 @@ export class DaytonaSandbox extends BaseSandbox {
 			if (this.sandbox) {
 				await this.ensureAuthFresh();
 				await this.sandbox.delete(Math.ceil(this.timeout / 1000));
-			} else {
-				const client = await this.getDaytona();
-				const existing = await client.get(this.sandboxName);
-				await existing.delete(Math.ceil(this.timeout / 1000));
+			} else if (this.remoteAcquired) {
+				// Handle lost after a stop()/recovery reset, but the remote was acquired by
+				// this instance — resolve by name and delete it.
+				await this.deleteRemoteByName();
 			}
+			// Never acquired: skip the by-name delete. Cleanup after a failed start() must
+			// not destroy a live sandbox this instance never owned but shares a name with.
 		} catch (error) {
 			if (!isSandboxGone(error)) throw error;
 			// Remote already gone — destroy is idempotent.
 		}
 		this.sandbox = undefined;
+	}
+
+	/**
+	 * Delete the remote sandbox carrying this instance's name, whether or not this instance
+	 * created it. For explicit teardown paths (thread/agent deletion); lifecycle cleanup goes
+	 * through {@link destroy}, which only deletes a remote this instance acquired.
+	 */
+	override async deleteRemote(): Promise<void> {
+		try {
+			if (this.sandbox) {
+				await this.ensureAuthFresh();
+				await this.sandbox.delete(Math.ceil(this.timeout / 1000));
+			} else {
+				await this.deleteRemoteByName();
+			}
+		} catch (error) {
+			if (!isSandboxGone(error)) throw error;
+		}
+		this.sandbox = undefined;
+	}
+
+	private async deleteRemoteByName(): Promise<void> {
+		const client = await this.getDaytona();
+		const existing = await client.get(this.sandboxName);
+		await existing.delete(Math.ceil(this.timeout / 1000));
 	}
 
 	override async executeCommand(
@@ -461,17 +571,21 @@ export class DaytonaSandbox extends BaseSandbox {
 		await this.recoveryPromise;
 	}
 
-	private async findExistingSandbox(client: Daytona): Promise<Sandbox | null> {
-		const result = await this.lookupExistingSandbox(client);
+	private async findExistingSandbox(client: Daytona, deadline: number): Promise<Sandbox | null> {
+		const result = await this.lookupExistingSandbox(client, deadline);
 		return result.status === 'ready' ? result.sandbox : null;
 	}
 
 	private async lookupExistingSandbox(
 		client: Daytona,
-		deadline?: number,
+		deadline: number,
 	): Promise<ExistingSandboxLookup> {
 		try {
-			const sandbox = await client.get(this.sandboxName);
+			const sandbox = await this.withTransientRetry(
+				'lookup',
+				deadline,
+				async () => await client.get(this.sandboxName),
+			);
 			const state = sandbox.state;
 			if (state === undefined) return { status: 'pending' };
 			if (FAILED_SANDBOX_STATES.has(state)) {
@@ -479,10 +593,8 @@ export class DaytonaSandbox extends BaseSandbox {
 				return { status: 'pending' };
 			}
 			if (REMOVING_SANDBOX_STATES.has(state)) return { status: 'pending' };
-			if (RECOVERABLE_SANDBOX_STATES.has(state)) {
-				await sandbox.start(this.operationTimeoutSeconds(deadline));
-			} else if (WAIT_FOR_STARTED_SANDBOX_STATES.has(state)) {
-				await sandbox.waitUntilStarted(this.operationTimeoutSeconds(deadline));
+			if (RECOVERABLE_SANDBOX_STATES.has(state) || WAIT_FOR_STARTED_SANDBOX_STATES.has(state)) {
+				if (!(await this.bringToStarted(sandbox, state, deadline))) return { status: 'pending' };
 			} else if (
 				WAIT_FOR_RECOVERABLE_SANDBOX_STATES.has(state) ||
 				state !== SANDBOX_STATE_STARTED
@@ -497,28 +609,103 @@ export class DaytonaSandbox extends BaseSandbox {
 		}
 	}
 
+	/**
+	 * Drive an existing sandbox toward 'started': resume a stopped/archived one, or wait out a
+	 * transitional state. A single wait is capped at half the remaining acquisition budget so a
+	 * sandbox that never becomes ready can't consume the whole timeout — the rest of the budget
+	 * is left for replacing it. On a wait timeout the sandbox is treated as wedged and deleted
+	 * so the caller can create a fresh one; a resume timeout keeps the sandbox (its disk state
+	 * is intact and the conflict-reconcile path keeps waiting on the now-transitional state).
+	 */
+	private async bringToStarted(
+		sandbox: Sandbox,
+		state: SandboxState,
+		deadline: number,
+	): Promise<boolean> {
+		const remainingSeconds = this.operationTimeoutSeconds(deadline);
+		const waitSeconds = Math.max(
+			remainingSeconds / 2,
+			Math.min(remainingSeconds, MIN_STATE_WAIT_SECONDS),
+		);
+		const resuming = RECOVERABLE_SANDBOX_STATES.has(state);
+		try {
+			if (resuming) {
+				await sandbox.start(waitSeconds);
+			} else {
+				await sandbox.waitUntilStarted(waitSeconds);
+			}
+			return true;
+		} catch (error) {
+			const { DaytonaTimeoutError } = loadDaytona();
+			if (!(error instanceof DaytonaTimeoutError)) throw error;
+			if (resuming) {
+				this.options.logger?.warn('Daytona sandbox did not resume in time; still reconciling', {
+					sandboxName: this.sandboxName,
+					state,
+					waitSeconds,
+				});
+				return false;
+			}
+			this.options.logger?.warn(
+				'Daytona sandbox is stuck in a transitional state; deleting it so a fresh one can be created',
+				{ sandboxName: this.sandboxName, state, waitSeconds },
+			);
+			await sandbox.delete(this.operationTimeoutSeconds(deadline));
+			return false;
+		}
+	}
+
 	private async findExistingSandboxAfterConflict(
 		client: Daytona,
 		deadline: number,
-	): Promise<Sandbox | null> {
+	): Promise<ConflictLookupResult> {
 		for (let attempt = 0; Date.now() < deadline; attempt++) {
 			const result = await this.lookupExistingSandbox(client, deadline);
-			if (result.status === 'ready') return result.sandbox;
-			if (result.status === 'absent') return null;
+			if (result.status !== 'pending') return result;
 			await this.waitBeforeAcquisitionRetry(attempt, deadline);
 		}
-		return null;
+		return { status: 'timeout' };
 	}
 
-	private async createSandbox(client: Daytona): Promise<Sandbox> {
+	/**
+	 * Run a Daytona control-plane call, retrying a bounded number of times on transient
+	 * failures (5xx, 408, 429, connection drops, request timeouts) with capped backoff.
+	 */
+	private async withTransientRetry<T>(
+		opName: 'lookup' | 'create',
+		deadline: number,
+		op: () => Promise<T>,
+	): Promise<T> {
+		for (let attempt = 0; ; attempt++) {
+			try {
+				return await op();
+			} catch (error) {
+				const retriable =
+					attempt < MAX_TRANSIENT_ACQUISITION_RETRIES &&
+					isTransientAcquisitionError(error) &&
+					Date.now() < deadline;
+				if (!retriable) throw error;
+				this.options.logger?.warn(`Retrying Daytona sandbox ${opName} after a transient error`, {
+					sandboxName: this.sandboxName,
+					failureClass: acquisitionFailureClass(error),
+					attempt: attempt + 1,
+				});
+				await this.waitBeforeAcquisitionRetry(attempt, deadline);
+			}
+		}
+	}
+
+	private async createSandbox(client: Daytona, deadline: number): Promise<Sandbox> {
 		const candidates = this.createSandboxParams();
 		let lastError: unknown;
 
 		for (const candidate of candidates) {
 			try {
-				return this.options.createTimeoutSeconds
-					? await client.create(candidate.params, { timeout: this.options.createTimeoutSeconds })
-					: await client.create(candidate.params);
+				return await this.withTransientRetry('create', deadline, async () =>
+					this.options.createTimeoutSeconds
+						? await client.create(candidate.params, { timeout: this.options.createTimeoutSeconds })
+						: await client.create(candidate.params),
+				);
 			} catch (error) {
 				// A name conflict is strategy-independent; let the caller reattach by name.
 				if (isSandboxNameConflictError(error)) throw error;

--- a/packages/@n8n/agents/src/workspace/sandbox/errors.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/errors.ts
@@ -25,3 +25,14 @@ export class SandboxNameConflictError extends SandboxAcquisitionError {
 		super(message, 'unresolved-name-conflict', options);
 	}
 }
+
+/**
+ * An existing sandbox that carries workspace state did not reach 'started' within the
+ * acquisition budget. The sandbox is kept — deleting it would lose the thread's files —
+ * and the turn fails; a later attempt reattaches once the sandbox recovers.
+ */
+export class SandboxNotReadyError extends SandboxAcquisitionError {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, 'sandbox-not-ready', options);
+	}
+}

--- a/packages/@n8n/agents/src/workspace/sandbox/errors.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Raised when a workspace sandbox could not be acquired — looked up, resumed, created, or
+ * reattached — after bounded retries. Wraps the provider SDK error so callers can classify
+ * acquisition failures without pattern-matching raw SDK error types.
+ */
+export class SandboxAcquisitionError extends Error {
+	constructor(
+		message: string,
+		/** Coarse failure category (e.g. `DaytonaError:502`) for logging and error tracking. */
+		readonly failureClass: string,
+		options?: { cause?: unknown },
+	) {
+		super(message, options);
+		this.name = new.target.name;
+	}
+}
+
+/**
+ * A create kept returning a name conflict while the conflicting sandbox stayed invisible to
+ * this client (e.g. owned by another account in proxy mode). Progress is impossible, so this
+ * is raised instead of retrying until the acquisition budget is exhausted.
+ */
+export class SandboxNameConflictError extends SandboxAcquisitionError {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, 'unresolved-name-conflict', options);
+	}
+}

--- a/packages/@n8n/agents/src/workspace/sandbox/index.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/index.ts
@@ -18,6 +18,7 @@ export {
 	type SandboxCommandTarget,
 } from './run-in-sandbox';
 export { loadDaytona } from './lazy-daytona';
+export { SandboxAcquisitionError, SandboxNameConflictError } from './errors';
 export { createFilesystem, createSandbox } from './create-workspace';
 export type {
 	CommandResult,

--- a/packages/@n8n/agents/src/workspace/sandbox/index.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/index.ts
@@ -18,7 +18,7 @@ export {
 	type SandboxCommandTarget,
 } from './run-in-sandbox';
 export { loadDaytona } from './lazy-daytona';
-export { SandboxAcquisitionError, SandboxNameConflictError } from './errors';
+export { SandboxAcquisitionError, SandboxNameConflictError, SandboxNotReadyError } from './errors';
 export { createFilesystem, createSandbox } from './create-workspace';
 export type {
 	CommandResult,

--- a/packages/@n8n/agents/src/workspace/types.ts
+++ b/packages/@n8n/agents/src/workspace/types.ts
@@ -149,6 +149,8 @@ export interface WorkspaceSandbox {
 	start?(): Promise<void>;
 	stop?(): Promise<void>;
 	destroy?(): Promise<void>;
+	/** Delete the provider-side sandbox by identity, regardless of local ownership. */
+	deleteRemote?(): Promise<void>;
 	_start?(): Promise<void>;
 	_stop?(): Promise<void>;
 	_destroy?(): Promise<void>;

--- a/packages/cli/src/modules/agents/__tests__/agent-sandbox-runtime.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-sandbox-runtime.service.test.ts
@@ -47,7 +47,7 @@ const otherWorkspaceSandboxId = '4197eecc-3092-54b8-9196-a4fecccea156';
 const knowledgeSandboxId = 'a54b9053-9f50-51e5-b971-e02942ff7b6b';
 
 type TestWorkspaceSandbox = WorkspaceSandbox &
-	Required<Pick<WorkspaceSandbox, '_start' | 'destroy' | 'executeCommand'>>;
+	Required<Pick<WorkspaceSandbox, '_start' | 'destroy' | 'deleteRemote' | 'executeCommand'>>;
 
 function makeAiService(overrides: Partial<AiService> = {}): AiService {
 	const aiService = mock<AiService>();
@@ -369,7 +369,8 @@ describe('AgentSandboxRuntimeService', () => {
 		const destroyedIds: string[] = [];
 		createSandboxMock.mockImplementation(async (config) => {
 			const target = makeSandbox(config.provider, config.id);
-			target.destroy.mockImplementation(async () => {
+			// Teardown must delete by identity even though these instances never started.
+			target.deleteRemote.mockImplementation(async () => {
 				destroyedIds.push(config.id);
 				if (config.id === `agent-kb-${knowledgeSandboxId}`) {
 					throw new Error('remote unavailable');

--- a/packages/cli/src/modules/agents/agent-sandbox-runtime.service.ts
+++ b/packages/cli/src/modules/agents/agent-sandbox-runtime.service.ts
@@ -302,10 +302,12 @@ export class AgentSandboxRuntimeService {
 					? await this.resolveDaytonaSandboxConfig(projectId, sandboxId, labels)
 					: await this.resolveN8nSandboxConfig(sandboxId);
 			const sandbox = await createSandbox(config, { logger: this.logger });
-			if (!sandbox?.destroy) {
+			// deleteRemote deletes by sandbox identity even though this instance never
+			// started it; destroy() is scoped to remotes the instance acquired.
+			if (!sandbox?.deleteRemote) {
 				throw new OperationalError('Agent knowledge sandbox does not support provider destroy');
 			}
-			await sandbox.destroy();
+			await sandbox.deleteRemote();
 		} catch (error) {
 			this.logger.warn('Failed to destroy agent knowledge sandbox', {
 				projectId,

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
@@ -1,5 +1,5 @@
 import type { Mock } from 'vitest';
-import { SandboxAcquisitionError } from '@n8n/agents/sandbox';
+import { SandboxAcquisitionError, SandboxNotReadyError } from '@n8n/agents/sandbox';
 import type { InstanceAiConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import type { ErrorReporter } from 'n8n-core';
@@ -433,6 +433,26 @@ describe('InstanceAiSandboxService', () => {
 				(error: unknown) => error instanceof OperationalError && error.cause === acquisitionError,
 			);
 			expect(workspace.destroy).toHaveBeenCalledTimes(1);
+		});
+
+		it('rethrows classified acquisition errors unwrapped so they stay reportable', async () => {
+			const { service } = createSandboxService({
+				config: { sandboxEnabled: true, sandboxProvider: 'daytona' },
+			});
+
+			const notReady = new SandboxNotReadyError('sandbox did not become ready (state: restoring)');
+			const workspace = {
+				init: vi.fn(async () => {
+					throw notReady;
+				}),
+				destroy: vi.fn(async () => {}),
+			};
+			(createSandbox as Mock).mockResolvedValue({ id: 'sandbox-1' });
+			(createWorkspace as Mock).mockReturnValue(workspace);
+
+			await expect(
+				service.getOrCreateWorkspace('thread-1', fakeUser, {} as InstanceAiContext),
+			).rejects.toBe(notReady);
 		});
 
 		it('serializes workspace creation for concurrent calls on the same thread', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
@@ -1,4 +1,5 @@
 import type { Mock } from 'vitest';
+import { SandboxAcquisitionError } from '@n8n/agents/sandbox';
 import type { InstanceAiConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import type { ErrorReporter } from 'n8n-core';
@@ -408,6 +409,32 @@ describe('InstanceAiSandboxService', () => {
 	});
 
 	describe('workspace lifecycle', () => {
+		it('wraps sandbox acquisition failures in OperationalError after cleanup', async () => {
+			const { service } = createSandboxService({
+				config: { sandboxEnabled: true, sandboxProvider: 'daytona' },
+			});
+
+			const acquisitionError = new SandboxAcquisitionError(
+				'Failed to acquire Daytona sandbox: Bad Gateway',
+				'DaytonaError:502',
+			);
+			const workspace = {
+				init: vi.fn(async () => {
+					throw acquisitionError;
+				}),
+				destroy: vi.fn(async () => {}),
+			};
+			(createSandbox as Mock).mockResolvedValue({ id: 'sandbox-1' });
+			(createWorkspace as Mock).mockReturnValue(workspace);
+
+			await expect(
+				service.getOrCreateWorkspace('thread-1', fakeUser, {} as InstanceAiContext),
+			).rejects.toSatisfy(
+				(error: unknown) => error instanceof OperationalError && error.cause === acquisitionError,
+			);
+			expect(workspace.destroy).toHaveBeenCalledTimes(1);
+		});
+
 		it('serializes workspace creation for concurrent calls on the same thread', async () => {
 			const { service } = createSandboxService({
 				config: { sandboxEnabled: true, sandboxProvider: 'daytona' },

--- a/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
+++ b/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 
+import { SandboxAcquisitionError } from '@n8n/agents/sandbox';
 import type { InstanceAiConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import {
@@ -417,6 +418,10 @@ export class InstanceAiSandboxService {
 				await workspace.destroy();
 			} catch {
 				// Best-effort cleanup when the sandbox cannot start
+			}
+			if (error instanceof SandboxAcquisitionError) {
+				// Acquisition failures are transient infra conditions, not code bugs.
+				throw new OperationalError(error.message, { cause: error });
 			}
 			throw error;
 		}

--- a/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
+++ b/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
@@ -419,8 +419,13 @@ export class InstanceAiSandboxService {
 			} catch {
 				// Best-effort cleanup when the sandbox cannot start
 			}
-			if (error instanceof SandboxAcquisitionError) {
-				// Acquisition failures are transient infra conditions, not code bugs.
+			// Only the generic transient wrap is downgraded to a non-reported warning.
+			// Classified subclasses (name conflict, sandbox not ready) keep their identity
+			// so they stay visible in Sentry as distinct issues.
+			if (
+				error instanceof SandboxAcquisitionError &&
+				error.constructor === SandboxAcquisitionError
+			) {
 				throw new OperationalError(error.message, { cause: error });
 			}
 			throw error;


### PR DESCRIPTION
## Summary

This PR fixes the root causes behind four related Daytona sandbox acquisition failures in one coherent change to the acquisition path in `@n8n/agents`.

**One budget for the whole acquisition.** `start()` now sets a single deadline (default 300s) that the lookup, state waits, creates, and conflict reconciliation all share. No single stuck call can consume the whole turn.

**Transient errors are retried.** `client.get` and `client.create` retry up to 3 attempts with capped backoff on 5xx, 408, 429, connection, and timeout errors. Auth (401/403), validation (400), not-found (404), and conflict (409) errors are never retried. A single gateway 502 no longer kills the user's turn.

**Stuck sandboxes are handled by kind.** A single `waitUntilStarted` is capped at half the remaining budget (min 30s). When the wait times out on a *provisioning* sandbox (`creating`, `pending_build`, `pulling_snapshot`, `building_snapshot` — no workspace state exists yet), the sandbox is treated as wedged: it is deleted and a fresh one is created within the same turn. When the wait times out on a sandbox that *carries workspace state* (`restoring`, `starting`, `resizing`, `snapshotting`, `forking`, or a stopped/archived resume), the sandbox is **kept** and the acquisition fails with a classified `SandboxNotReadyError` — a later turn reattaches once it recovers. Before this change, the turn waited the full 5 minutes and then failed hard (Sentry [INSTANCE-BACKEND-27H4](https://n8nio.sentry.io/issues/INSTANCE-BACKEND-27H4), 60 events / 54 users in one week).

**Creation is bounded by the same budget.** `client.create` receives the configured create timeout capped at the remaining acquisition budget, and a transient retry never starts once backoff has consumed the deadline — the total acquisition cannot exceed the configured timeout.

**The name-conflict loop is bounded.** After 3 consecutive create-409 → lookup-absent cycles, acquisition fails fast with a distinct `SandboxNameConflictError` instead of retrying for the full 5 minutes. This case means the conflicting sandbox is invisible to this client (e.g. ownership-scoped in proxy mode) and cannot resolve itself.

**Failed init no longer deletes a healthy sandbox.** `destroy()` now only deletes the remote by name when this instance actually created or attached to it. Cleanup after a failed `start()` can no longer destroy a live sandbox that merely shares the thread name. Explicit teardown paths (Agent Knowledge deletion) use the new `deleteRemote()`, which deletes by identity unconditionally.

**Acquisition failures are classified.** Raw Daytona SDK errors are wrapped in `SandboxAcquisitionError` (with a `failureClass` such as `DaytonaError:502`). The Instance AI service maps it to `OperationalError` (level `warning`), so these transient infra conditions stop surfacing as unhandled SDK errors in Sentry.


## How to test

Unit tests cover all new behavior:

- `packages/@n8n/agents`: `pnpm vitest run src/__tests__/workspace/sandbox/daytona-sandbox.test.ts` (52 tests, ~10 new: transient retry and exhaustion for lookup and create, wedged-sandbox delete + recreate, wait-budget capping, conflict fail-fast, destroy ownership, `deleteRemote`)
- `packages/cli`: `pnpm test src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts src/modules/agents/__tests__/agent-sandbox-runtime.service.test.ts`

Manual test (requires a Daytona-enabled instance: `N8N_INSTANCE_AI_SANDBOX_ENABLED=true`, `N8N_INSTANCE_AI_SANDBOX_PROVIDER=daytona` with API key, or proxy mode via `N8N_AI_ASSISTANT_BASE_URL`):

1. Start a thread in the AI Assistant and trigger a sandbox-backed action (e.g. build a workflow). The sandbox starts as before.
2. Kill the thread's Daytona sandbox in the Daytona dashboard mid-conversation, then continue the thread. The turn recovers by recreating the sandbox instead of failing.
3. Observe logs: transient control-plane failures now log `Retrying Daytona sandbox lookup/create after a transient error` with a `failureClass` instead of failing the turn.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-1202
- https://linear.app/n8n/issue/INS-1111
- https://linear.app/n8n/issue/INS-1112
- https://linear.app/n8n/issue/INS-1113
- Sentry: [INSTANCE-BACKEND-27H4](https://n8nio.sentry.io/issues/INSTANCE-BACKEND-27H4)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


