### PR TITLE
fix(core): Avoid restarting task runners that are only slow

### DIFF
--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -1718,20 +1718,6 @@ describe('TaskBroker', () => {
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
 
-		it('should report a runner that reached the threshold after deregistering', async () => {
-			// the transport deregistered the runner, but a process that outlived its
-			// transport still needs restarting
-			taskBroker.deregisterRunner('runner1', new Error('connection lost'));
-
-			await timeOutAcceptance();
-			await timeOutAcceptance();
-			await timeOutAcceptance();
-
-			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
-				runnerId: 'runner1',
-			});
-		});
-
 		it('should count acknowledgment timeouts per runner', async () => {
 			taskBroker.registerRunner(mock<TaskRunner>({ id: 'runner2' }), vi.fn());
 

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -1612,6 +1612,33 @@ describe('TaskBroker', () => {
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
 
+		it('should report on the next timeout once the in-flight tasks are gone', async () => {
+			taskBroker.setTasks({
+				task1: {
+					id: 'task1',
+					runnerId: 'runner1',
+					requesterId: 'requester1',
+					taskType: 'taskType1',
+				},
+			});
+
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+
+			taskBroker.setTasks({});
+
+			// the threshold was already reached, so no further timeouts need to be re-earned
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledTimes(1);
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
+		});
+
 		it('should reset the count when the runner acknowledges an acceptance', async () => {
 			await timeOutAcceptance();
 			await timeOutAcceptance();

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -1595,6 +1595,39 @@ describe('TaskBroker', () => {
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
 
+		it('should reset the count when the runner reports a task error', async () => {
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			await taskBroker.onRunnerMessage('runner1', {
+				type: 'runner:taskerror',
+				taskId: 'task1',
+				error: new Error('some error'),
+			});
+
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+		});
+
+		it('should not reset the count when the runner only keeps sending offers', async () => {
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			await taskBroker.onRunnerMessage('runner1', {
+				type: 'runner:taskoffer',
+				taskType: 'taskType1',
+				offerId: 'offer2',
+				validFor: 10_000,
+			});
+
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledTimes(1);
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
+		});
+
 		it('should not report a runner that still has tasks in flight', async () => {
 			taskBroker.setTasks({
 				task1: {

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -1560,6 +1560,58 @@ describe('TaskBroker', () => {
 			expect(lifecycleEvents.emit).toHaveBeenCalledTimes(1);
 		});
 
+		it('should count acknowledgment timeouts firing within the same stall as a single timeout', async () => {
+			const acceptances = Array.from(
+				{ length: 3 },
+				async () => await taskBroker.acceptOffer(offerFrom('runner1'), requestFor()),
+			);
+			vi.advanceTimersByTime(ACCEPT_TIMEOUT_MS);
+			await Promise.all(acceptances);
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+
+			// the coalesced burst counted as one strike, so two spaced timeouts reach the threshold
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledTimes(1);
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
+		});
+
+		it('should reset the count when the runner completes a task', async () => {
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			await taskBroker.onRunnerMessage('runner1', {
+				type: 'runner:taskdone',
+				taskId: 'task1',
+				data: mock<TaskResultData>(),
+			});
+
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+		});
+
+		it('should not report a runner that still has tasks in flight', async () => {
+			taskBroker.setTasks({
+				task1: {
+					id: 'task1',
+					runnerId: 'runner1',
+					requesterId: 'requester1',
+					taskType: 'taskType1',
+				},
+			});
+
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+		});
+
 		it('should reset the count when the runner acknowledges an acceptance', async () => {
 			await timeOutAcceptance();
 			await timeOutAcceptance();
@@ -1607,16 +1659,13 @@ describe('TaskBroker', () => {
 		});
 
 		it('should report a runner that reached the threshold after deregistering', async () => {
-			const acceptances = Array.from(
-				{ length: 3 },
-				async () => await taskBroker.acceptOffer(offerFrom('runner1'), requestFor()),
-			);
-
-			// the transport deregisters the runner while the acceptances are still settling,
-			// so their timeouts are all counted against a runner no longer known
-			vi.advanceTimersByTime(ACCEPT_TIMEOUT_MS);
+			// the transport deregistered the runner, but a process that outlived its
+			// transport still needs restarting
 			taskBroker.deregisterRunner('runner1', new Error('connection lost'));
-			await Promise.all(acceptances);
+
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			await timeOutAcceptance();
 
 			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
 				runnerId: 'runner1',
@@ -1671,20 +1720,25 @@ describe('TaskBroker', () => {
 			);
 		};
 
-		const letRequestExpire = () => {
+		const enqueueRequest = (requestId: string) => {
 			taskBroker.taskRequested({
-				requestId: 'request1',
+				requestId,
 				requesterId: 'requester1',
 				taskType: 'taskType1',
-				timeout: taskBroker['createRequestTimeout']('request1'),
+				timeout: taskBroker['createRequestTimeout'](requestId),
 			});
+		};
+
+		const letRequestExpire = (requestId = 'request1') => {
+			enqueueRequest(requestId);
 			vi.advanceTimersByTime(REQUEST_TIMEOUT_MS);
 		};
 
-		it('should report a reachable runner that sent no offers while a request expired', () => {
+		it('should report a reachable runner that stayed silent across two request expiries', () => {
 			registerRunner();
 
-			letRequestExpire();
+			letRequestExpire('request1');
+			letRequestExpire('request2');
 
 			expect(lifecycleEvents.emit).toHaveBeenCalledTimes(1);
 			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
@@ -1695,6 +1749,38 @@ describe('TaskBroker', () => {
 				requestId: 'request1',
 				reason: 'timeout',
 			});
+		});
+
+		it('should not report a runner observed silent at a single request expiry', () => {
+			registerRunner();
+
+			letRequestExpire('request1');
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+		});
+
+		it('should not report a runner when the expiries observing it are too close together', () => {
+			registerRunner();
+
+			enqueueRequest('request1');
+			enqueueRequest('request2');
+			vi.advanceTimersByTime(REQUEST_TIMEOUT_MS);
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+		});
+
+		it('should not report a runner that sent a message between expiries', async () => {
+			registerRunner();
+
+			letRequestExpire('request1');
+			await taskBroker.onRunnerMessage('runner1', {
+				type: 'runner:taskdone',
+				taskId: 'task1',
+				data: mock<TaskResultData>(),
+			});
+			letRequestExpire('request2');
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
 
 		it('should not report a runner with an in-flight task', () => {
@@ -1708,7 +1794,8 @@ describe('TaskBroker', () => {
 				},
 			});
 
-			letRequestExpire();
+			letRequestExpire('request1');
+			letRequestExpire('request2');
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
@@ -1725,7 +1812,8 @@ describe('TaskBroker', () => {
 				},
 			]);
 
-			letRequestExpire();
+			letRequestExpire('request1');
+			letRequestExpire('request2');
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
@@ -1742,7 +1830,8 @@ describe('TaskBroker', () => {
 				},
 			]);
 
-			letRequestExpire();
+			letRequestExpire('request1');
+			letRequestExpire('request2');
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
@@ -1753,7 +1842,8 @@ describe('TaskBroker', () => {
 				task1: { accept: vi.fn(), reject: vi.fn(), runnerId: 'runner1' },
 			});
 
-			letRequestExpire();
+			letRequestExpire('request1');
+			letRequestExpire('request2');
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
@@ -1761,7 +1851,8 @@ describe('TaskBroker', () => {
 		it('should not report an unreachable runner', () => {
 			registerRunner(() => false);
 
-			letRequestExpire();
+			letRequestExpire('request1');
+			letRequestExpire('request2');
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
@@ -1769,13 +1860,14 @@ describe('TaskBroker', () => {
 		it('should not report a runner that does not support the task type', () => {
 			taskBroker.registerRunner(mock<TaskRunner>({ id: 'runner1', taskTypes: ['other'] }), vi.fn());
 
-			letRequestExpire();
+			letRequestExpire('request1');
+			letRequestExpire('request2');
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
 
 		it('should expire the request without reporting when no runner is registered', () => {
-			letRequestExpire();
+			letRequestExpire('request1');
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 			expect(requesterCallback).toHaveBeenCalledWith({

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -1538,6 +1538,12 @@ describe('TaskBroker', () => {
 			await acceptPromise;
 		};
 
+		const trackTaskFor = (runnerId: string) => {
+			taskBroker.setTasks({
+				task1: { id: 'task1', runnerId, requesterId: 'requester1', taskType: 'taskType1' },
+			});
+		};
+
 		const answerAcceptance = async (respond: (taskId: string) => void) => {
 			const acceptPromise = taskBroker.acceptOffer(offerFrom('runner1'), requestFor());
 			const [taskId] = taskBroker.getRunnerAcceptRejects().keys();
@@ -1583,6 +1589,7 @@ describe('TaskBroker', () => {
 		it('should reset the count when the runner completes a task', async () => {
 			await timeOutAcceptance();
 			await timeOutAcceptance();
+			trackTaskFor('runner1');
 			await taskBroker.onRunnerMessage('runner1', {
 				type: 'runner:taskdone',
 				taskId: 'task1',
@@ -1595,9 +1602,43 @@ describe('TaskBroker', () => {
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
 
+		it('should not reset the count on a result for a task the runner was not given', async () => {
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			trackTaskFor('runner2');
+			await taskBroker.onRunnerMessage('runner1', {
+				type: 'runner:taskdone',
+				taskId: 'task1',
+				data: mock<TaskResultData>(),
+			});
+
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
+		});
+
+		it('should not reset the count on a result for an untracked task', async () => {
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+			await taskBroker.onRunnerMessage('runner1', {
+				type: 'runner:taskdone',
+				taskId: 'unknown-task',
+				data: mock<TaskResultData>(),
+			});
+
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
+		});
+
 		it('should reset the count when the runner reports a task error', async () => {
 			await timeOutAcceptance();
 			await timeOutAcceptance();
+			trackTaskFor('runner1');
 			await taskBroker.onRunnerMessage('runner1', {
 				type: 'runner:taskerror',
 				taskId: 'task1',
@@ -1718,6 +1759,43 @@ describe('TaskBroker', () => {
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
 		});
 
+		it('should keep counting timeouts across a backward system clock jump', async () => {
+			await timeOutAcceptance();
+			await timeOutAcceptance();
+
+			// a clock correction must not make the next timeout look like part of the last burst
+			vi.setSystemTime(Date.now() - 60_000);
+			await timeOutAcceptance();
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
+		});
+
+		it('should report a runner that keeps offering but never acknowledges', async () => {
+			taskBroker.registerRequester('requester1', vi.fn());
+			taskBroker.taskRequested({
+				requestId: 'request1',
+				requesterId: 'requester1',
+				taskType: 'taskType1',
+				timeout: taskBroker['createRequestTimeout']('request1'),
+			});
+
+			for (let n = 0; n < 3; n++) {
+				await taskBroker.onRunnerMessage('runner1', {
+					type: 'runner:taskoffer',
+					taskType: 'taskType1',
+					offerId: `offer${n}`,
+					validFor: 10_000,
+				});
+				await vi.advanceTimersByTimeAsync(ACCEPT_TIMEOUT_MS);
+			}
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
+		});
+
 		it('should count acknowledgment timeouts per runner', async () => {
 			taskBroker.registerRunner(mock<TaskRunner>({ id: 'runner2' }), vi.fn());
 
@@ -1737,6 +1815,7 @@ describe('TaskBroker', () => {
 
 	describe('silent runner detection', () => {
 		const REQUEST_TIMEOUT_MS = 60_000;
+		const MIN_SILENCE_DURATION_MS = 2_000;
 
 		let lifecycleEvents: MockProxy<TaskRunnerLifecycleEvents>;
 		let requesterCallback: ReturnType<typeof vi.fn<RequesterMessageCallback>>;
@@ -1813,6 +1892,30 @@ describe('TaskBroker', () => {
 			vi.advanceTimersByTime(REQUEST_TIMEOUT_MS);
 
 			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+		});
+
+		it('should not report a runner when the expiries are just under the silence floor', () => {
+			registerRunner();
+
+			enqueueRequest('request1');
+			vi.advanceTimersByTime(MIN_SILENCE_DURATION_MS - 1);
+			enqueueRequest('request2');
+			vi.advanceTimersByTime(REQUEST_TIMEOUT_MS);
+
+			expect(lifecycleEvents.emit).not.toHaveBeenCalled();
+		});
+
+		it('should report a runner when the expiries are exactly the silence floor apart', () => {
+			registerRunner();
+
+			enqueueRequest('request1');
+			vi.advanceTimersByTime(MIN_SILENCE_DURATION_MS);
+			enqueueRequest('request2');
+			vi.advanceTimersByTime(REQUEST_TIMEOUT_MS);
+
+			expect(lifecycleEvents.emit).toHaveBeenCalledWith('runner:unresponsive', {
+				runnerId: 'runner1',
+			});
 		});
 
 		it('should not report a runner that sent a message between expiries', async () => {

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -279,6 +279,7 @@ export class TaskBroker {
 			return;
 		}
 
+		// Any message from the runner disproves the silence a report would be based on.
 		this.silentRunnersSince.delete(runnerId);
 
 		switch (message.type) {
@@ -304,6 +305,7 @@ export class TaskBroker {
 				});
 				break;
 			case 'runner:taskdone':
+				// A task result proves the channel is alive, like an acknowledgement does.
 				this.consecutiveAcceptTimeouts.delete(runnerId);
 				await this.taskDoneHandler(message.taskId, message.data);
 				break;

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -860,9 +860,6 @@ export class TaskBroker {
 	 * execution timeout, which force-restarts the process in internal mode and, in external
 	 * mode, untracks the tasks so the next report is no longer skipped.
 	 *
-	 * Reports a runner that is no longer registered too, since a process that outlived
-	 * its transport is exactly what still needs restarting.
-	 *
 	 * @returns whether the runner was reported.
 	 */
 	private reportUnresponsive(runnerId: TaskRunner['id'], cause: string): boolean {

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -303,11 +303,11 @@ export class TaskBroker {
 				});
 				break;
 			case 'runner:taskdone':
-				// A completed task proves the channel is alive, like an acknowledgement does.
 				this.consecutiveAcceptTimeouts.delete(runnerId);
 				await this.taskDoneHandler(message.taskId, message.data);
 				break;
 			case 'runner:taskerror':
+				this.consecutiveAcceptTimeouts.delete(runnerId);
 				await this.taskErrorHandler(message.taskId, message.error);
 				break;
 			case 'runner:taskdatarequest':
@@ -788,7 +788,9 @@ export class TaskBroker {
 	/**
 	 * Counts consecutive acknowledgement timeouts per runner and reports it unresponsive
 	 * once the threshold is reached. Timeouts within one acceptance window of the previous
-	 * one count as a single timeout, and any reply from the runner resets the count.
+	 * one count as a single timeout, and any reply to a broker request resets the count.
+	 * Task offers do not reset it, since an alive offer loop with a dead accept path is
+	 * the state this detects.
 	 */
 	private flagRunnerIfUnresponsive(runnerId: TaskRunner['id']) {
 		const now = Date.now();

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -305,12 +305,11 @@ export class TaskBroker {
 				});
 				break;
 			case 'runner:taskdone':
-				// A task result proves the channel is alive, like an acknowledgement does.
-				this.consecutiveAcceptTimeouts.delete(runnerId);
+				this.resetAcceptTimeoutsOnOwnTask(runnerId, message.taskId);
 				await this.taskDoneHandler(message.taskId, message.data);
 				break;
 			case 'runner:taskerror':
-				this.consecutiveAcceptTimeouts.delete(runnerId);
+				this.resetAcceptTimeoutsOnOwnTask(runnerId, message.taskId);
 				await this.taskErrorHandler(message.taskId, message.error);
 				break;
 			case 'runner:taskdatarequest':
@@ -789,14 +788,25 @@ export class TaskBroker {
 	}
 
 	/**
+	 * Clears acknowledgement strikes when a runner reports on a task the broker tracks for
+	 * it, which proves its accept path is alive. A result for a task the broker no longer
+	 * tracks, or never assigned to this runner, proves nothing and is ignored.
+	 */
+	private resetAcceptTimeoutsOnOwnTask(runnerId: TaskRunner['id'], taskId: Task['id']) {
+		if (this.tasks.get(taskId)?.runnerId === runnerId) {
+			this.consecutiveAcceptTimeouts.delete(runnerId);
+		}
+	}
+
+	/**
 	 * Counts consecutive acknowledgement timeouts per runner and reports it unresponsive
 	 * once the threshold is reached. Timeouts within one acceptance window of the previous
-	 * one count as a single timeout, and any reply to a broker request resets the count.
-	 * Task offers do not reset it, since an alive offer loop with a dead accept path is
-	 * the state this detects.
+	 * one count as a single timeout, and any acknowledgement or task result resets the
+	 * count. Task offers do not reset it, since an alive offer loop with a dead accept path
+	 * is the state this detects.
 	 */
 	private flagRunnerIfUnresponsive(runnerId: TaskRunner['id']) {
-		const now = Date.now();
+		const now = this.monotonicNowMs();
 		const previous = this.consecutiveAcceptTimeouts.get(runnerId);
 		const acceptWindowMs = this.taskRunnersConfig.taskAcceptTimeout * Time.seconds.toMilliseconds;
 
@@ -829,7 +839,7 @@ export class TaskBroker {
 	private flagSilentRunners(taskType: string) {
 		this.expireTasks();
 
-		const now = Date.now();
+		const now = this.monotonicNowMs();
 
 		[...this.knownRunners.values()]
 			.filter(({ runner }) => runner.taskTypes.includes(taskType))
@@ -845,8 +855,14 @@ export class TaskBroker {
 				if (silentSince === undefined) {
 					this.silentRunnersSince.set(runner.id, now);
 				} else if (now - silentSince >= MIN_SILENCE_DURATION_MS) {
-					this.silentRunnersSince.delete(runner.id);
-					this.reportUnresponsive(runner.id, 'sent no task offers while task requests expired');
+					const reported = this.reportUnresponsive(
+						runner.id,
+						'sent no task offers while task requests expired',
+					);
+
+					if (reported) {
+						this.silentRunnersSince.delete(runner.id);
+					}
 				}
 			});
 	}
@@ -864,7 +880,7 @@ export class TaskBroker {
 	 */
 	private reportUnresponsive(runnerId: TaskRunner['id'], cause: string): boolean {
 		if (this.getInFlightTaskIds(runnerId).length > 0) {
-			this.logger.warn(
+			this.logger.debug(
 				`Runner (${runnerId}) ${cause}, but it still has tasks in flight, so not reporting it as unresponsive`,
 			);
 			return false;
@@ -874,6 +890,14 @@ export class TaskBroker {
 		this.taskRunnerLifecycleEvents.emit('runner:unresponsive', { runnerId });
 
 		return true;
+	}
+
+	/**
+	 * Milliseconds from a monotonic clock, so a system clock adjustment cannot make two
+	 * observations look closer together or further apart than they were.
+	 */
+	private monotonicNowMs() {
+		return Number(process.hrtime.bigint() / 1_000_000n);
 	}
 
 	private isSilent(runnerId: TaskRunner['id']) {

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -48,6 +48,13 @@ const MAX_REQUEST_TIMEOUT_REFRESHES = 3;
 
 const MAX_CONSECUTIVE_ACCEPT_TIMEOUTS = 3;
 
+/**
+ * How long a runner must have been silent before it may be reported unresponsive.
+ * Well above the runner's 250ms offer refresh interval, so the short gap between
+ * a task completing and the next offer does not count as silence.
+ */
+const MIN_SILENCE_DURATION_MS = 2_000;
+
 export interface TaskRequest {
 	requestId: string;
 	requesterId: string;
@@ -100,7 +107,13 @@ export class TaskBroker {
 		{ accept: RequesterAcceptCallback; reject: TaskRejectCallback }
 	> = new Map();
 
-	private consecutiveAcceptTimeouts: Map<TaskRunner['id'], number> = new Map();
+	private consecutiveAcceptTimeouts: Map<
+		TaskRunner['id'],
+		{ count: number; lastTimeoutAt: number }
+	> = new Map();
+
+	/** When each runner was first observed silent, cleared on any message from it. */
+	private silentRunnersSince: Map<TaskRunner['id'], number> = new Map();
 
 	private pendingTaskOffers: TaskOffer[] = [];
 
@@ -215,6 +228,7 @@ export class TaskBroker {
 	deregisterRunner(runnerId: string, error: Error) {
 		this.knownRunners.delete(runnerId);
 		this.consecutiveAcceptTimeouts.delete(runnerId);
+		this.silentRunnersSince.delete(runnerId);
 
 		this.discardOffersFrom(runnerId);
 
@@ -263,6 +277,10 @@ export class TaskBroker {
 		if (!runner) {
 			return;
 		}
+
+		// Any message from the runner disproves the silence a report would be based on.
+		this.silentRunnersSince.delete(runnerId);
+
 		switch (message.type) {
 			case 'runner:taskaccepted':
 				this.handleRunnerAccept(message.taskId);
@@ -286,6 +304,8 @@ export class TaskBroker {
 				});
 				break;
 			case 'runner:taskdone':
+				// A completed task proves the channel is alive, like an acknowledgement does.
+				this.consecutiveAcceptTimeouts.delete(runnerId);
 				await this.taskDoneHandler(message.taskId, message.data);
 				break;
 			case 'runner:taskerror':
@@ -768,15 +788,25 @@ export class TaskBroker {
 
 	/**
 	 * Counts consecutive acknowledgement timeouts per runner.
-	 * Any application-level reply (accept, reject, defer) proves the channel is alive and resets the count.
+	 * Timeouts firing within one acceptance window of the previous one are counted as a
+	 * single timeout, since acceptances pending during the same stall prove only one
+	 * missed acknowledgement.
+	 * Any application-level reply (accept, reject, defer, task completion) proves the
+	 * channel is alive and resets the count.
 	 * At the threshold, the runner is reported unresponsive exactly once,
 	 * so its transport can be torn down and the runner restarted.
 	 */
 	private flagRunnerIfUnresponsive(runnerId: TaskRunner['id']) {
-		const failures = (this.consecutiveAcceptTimeouts.get(runnerId) ?? 0) + 1;
+		const now = Date.now();
+		const previous = this.consecutiveAcceptTimeouts.get(runnerId);
+		const acceptWindowMs = this.taskRunnersConfig.taskAcceptTimeout * Time.seconds.toMilliseconds;
+
+		if (previous && now - previous.lastTimeoutAt < acceptWindowMs) return;
+
+		const failures = (previous?.count ?? 0) + 1;
 
 		if (failures < MAX_CONSECUTIVE_ACCEPT_TIMEOUTS) {
-			this.consecutiveAcceptTimeouts.set(runnerId, failures);
+			this.consecutiveAcceptTimeouts.set(runnerId, { count: failures, lastTimeoutAt: now });
 		} else {
 			this.consecutiveAcceptTimeouts.delete(runnerId);
 			this.reportUnresponsive(
@@ -788,23 +818,38 @@ export class TaskBroker {
 
 	/**
 	 * Reports as unresponsive every reachable runner for `taskType` with no sign of life:
-	 * no pending offer, no in-flight task, no acceptance in progress.
+	 * no pending offer, no in-flight task, no acceptance in progress, no message received.
 	 *
-	 * A healthy runner with spare capacity keeps offers pending,
-	 * so a request expiring next to a silent runner means the runner's offer loop has stalled
-	 * and its transport should be torn down so the runner can be restarted.
+	 * A healthy runner with spare capacity keeps offers pending, but is briefly offerless
+	 * between a task completing and the next offer, so one instantaneous sample can catch
+	 * a healthy runner. A runner is only reported once observed silent at two request
+	 * expiries spanning at least the minimum silence duration, which only a runner whose
+	 * offer loop has stalled can reach.
 	 *
 	 * A no-op when no runner is registered, which is normal while a runner is still starting up.
 	 */
 	private flagSilentRunners(taskType: string) {
 		this.expireTasks();
 
+		const now = Date.now();
+
 		[...this.knownRunners.values()]
 			.filter(({ runner }) => runner.taskTypes.includes(taskType))
 			.filter(({ isRunnerReachable }) => isRunnerReachable())
-			.filter(({ runner }) => this.isSilent(runner.id))
 			.forEach(({ runner }) => {
-				this.reportUnresponsive(runner.id, 'sent no task offers while a task request expired');
+				if (!this.isSilent(runner.id)) {
+					this.silentRunnersSince.delete(runner.id);
+					return;
+				}
+
+				const silentSince = this.silentRunnersSince.get(runner.id);
+
+				if (silentSince === undefined) {
+					this.silentRunnersSince.set(runner.id, now);
+				} else if (now - silentSince >= MIN_SILENCE_DURATION_MS) {
+					this.silentRunnersSince.delete(runner.id);
+					this.reportUnresponsive(runner.id, 'sent no task offers while task requests expired');
+				}
 			});
 	}
 
@@ -812,11 +857,21 @@ export class TaskBroker {
 	 * Reports a runner as unresponsive, so its transport can be torn down and, in internal
 	 * mode, its process force-restarted.
 	 *
-	 * Reports a runner that is no longer registered too: concurrent acceptances can reach the
-	 * timeout threshold after the transport deregistered the runner, and a process that
-	 * outlived its transport is exactly what still needs restarting.
+	 * Skipped while the runner has in-flight tasks: tearing it down would fail tasks that
+	 * may still complete, and a runner that is truly stuck is still recovered once those
+	 * tasks hit their own execution timeout.
+	 *
+	 * Reports a runner that is no longer registered too, since a process that outlived
+	 * its transport is exactly what still needs restarting.
 	 */
 	private reportUnresponsive(runnerId: TaskRunner['id'], cause: string) {
+		if (this.getInFlightTaskIds(runnerId).length > 0) {
+			this.logger.warn(
+				`Runner (${runnerId}) ${cause}, but it still has tasks in flight, so not reporting it as unresponsive`,
+			);
+			return;
+		}
+
 		this.logger.warn(`Runner (${runnerId}) ${cause}, reporting it as unresponsive`);
 		this.taskRunnerLifecycleEvents.emit('runner:unresponsive', { runnerId });
 	}

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -799,16 +799,19 @@ export class TaskBroker {
 			return;
 		}
 
-		const failures = (previous?.count ?? 0) + 1;
+		const failures = Math.min((previous?.count ?? 0) + 1, MAX_CONSECUTIVE_ACCEPT_TIMEOUTS);
 
-		if (failures < MAX_CONSECUTIVE_ACCEPT_TIMEOUTS) {
-			this.consecutiveAcceptTimeouts.set(runnerId, { count: failures, lastTimeoutAt: now });
-		} else {
+		this.consecutiveAcceptTimeouts.set(runnerId, { count: failures, lastTimeoutAt: now });
+
+		if (failures < MAX_CONSECUTIVE_ACCEPT_TIMEOUTS) return;
+
+		const reported = this.reportUnresponsive(
+			runnerId,
+			`failed to acknowledge ${MAX_CONSECUTIVE_ACCEPT_TIMEOUTS} consecutive task acceptances`,
+		);
+
+		if (reported) {
 			this.consecutiveAcceptTimeouts.delete(runnerId);
-			this.reportUnresponsive(
-				runnerId,
-				`failed to acknowledge ${MAX_CONSECUTIVE_ACCEPT_TIMEOUTS} consecutive task acceptances`,
-			);
 		}
 	}
 
@@ -853,17 +856,21 @@ export class TaskBroker {
 	 *
 	 * Reports a runner that is no longer registered too, since a process that outlived
 	 * its transport is exactly what still needs restarting.
+	 *
+	 * @returns whether the runner was reported.
 	 */
-	private reportUnresponsive(runnerId: TaskRunner['id'], cause: string) {
+	private reportUnresponsive(runnerId: TaskRunner['id'], cause: string): boolean {
 		if (this.getInFlightTaskIds(runnerId).length > 0) {
 			this.logger.warn(
 				`Runner (${runnerId}) ${cause}, but it still has tasks in flight, so not reporting it as unresponsive`,
 			);
-			return;
+			return false;
 		}
 
 		this.logger.warn(`Runner (${runnerId}) ${cause}, reporting it as unresponsive`);
 		this.taskRunnerLifecycleEvents.emit('runner:unresponsive', { runnerId });
+
+		return true;
 	}
 
 	private isSilent(runnerId: TaskRunner['id']) {

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -854,8 +854,9 @@ export class TaskBroker {
 	 * mode, its process force-restarted.
 	 *
 	 * Skipped while the runner has in-flight tasks: tearing it down would fail tasks that
-	 * may still complete, and a runner that is truly stuck is still recovered once those
-	 * tasks hit their own execution timeout.
+	 * may still complete. A stuck runner is still recovered once those tasks hit their own
+	 * execution timeout, which force-restarts the process in internal mode and, in external
+	 * mode, untracks the tasks so the next report is no longer skipped.
 	 *
 	 * Reports a runner that is no longer registered too, since a process that outlived
 	 * its transport is exactly what still needs restarting.

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -278,7 +278,6 @@ export class TaskBroker {
 			return;
 		}
 
-		// Any message from the runner disproves the silence a report would be based on.
 		this.silentRunnersSince.delete(runnerId);
 
 		switch (message.type) {
@@ -787,21 +786,18 @@ export class TaskBroker {
 	}
 
 	/**
-	 * Counts consecutive acknowledgement timeouts per runner.
-	 * Timeouts firing within one acceptance window of the previous one are counted as a
-	 * single timeout, since acceptances pending during the same stall prove only one
-	 * missed acknowledgement.
-	 * Any application-level reply (accept, reject, defer, task completion) proves the
-	 * channel is alive and resets the count.
-	 * At the threshold, the runner is reported unresponsive exactly once,
-	 * so its transport can be torn down and the runner restarted.
+	 * Counts consecutive acknowledgement timeouts per runner and reports it unresponsive
+	 * once the threshold is reached. Timeouts within one acceptance window of the previous
+	 * one count as a single timeout, and any reply from the runner resets the count.
 	 */
 	private flagRunnerIfUnresponsive(runnerId: TaskRunner['id']) {
 		const now = Date.now();
 		const previous = this.consecutiveAcceptTimeouts.get(runnerId);
 		const acceptWindowMs = this.taskRunnersConfig.taskAcceptTimeout * Time.seconds.toMilliseconds;
 
-		if (previous && now - previous.lastTimeoutAt < acceptWindowMs) return;
+		if (previous && now - previous.lastTimeoutAt < acceptWindowMs) {
+			return;
+		}
 
 		const failures = (previous?.count ?? 0) + 1;
 
@@ -819,14 +815,8 @@ export class TaskBroker {
 	/**
 	 * Reports as unresponsive every reachable runner for `taskType` with no sign of life:
 	 * no pending offer, no in-flight task, no acceptance in progress, no message received.
-	 *
-	 * A healthy runner with spare capacity keeps offers pending, but is briefly offerless
-	 * between a task completing and the next offer, so one instantaneous sample can catch
-	 * a healthy runner. A runner is only reported once observed silent at two request
-	 * expiries spanning at least the minimum silence duration, which only a runner whose
-	 * offer loop has stalled can reach.
-	 *
-	 * A no-op when no runner is registered, which is normal while a runner is still starting up.
+	 * Since a healthy runner is briefly offerless between tasks, a runner is only reported
+	 * once observed silent at two request expiries at least the minimum silence duration apart.
 	 */
 	private flagSilentRunners(taskType: string) {
 		this.expireTasks();

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -49,9 +49,10 @@ const MAX_REQUEST_TIMEOUT_REFRESHES = 3;
 const MAX_CONSECUTIVE_ACCEPT_TIMEOUTS = 3;
 
 /**
- * How long a runner must have been silent before it may be reported unresponsive.
- * Well above the runner's 250ms offer refresh interval, so the short gap between
- * a task completing and the next offer does not count as silence.
+ * How far apart two silence observations must be to count as two.
+ * Requests pending together expire in the same tick, so without this floor a single
+ * instant of silence would satisfy the two-observation rule and could catch a runner
+ * that is only briefly offerless between tasks.
  */
 const MIN_SILENCE_DURATION_MS = 2_000;
 


### PR DESCRIPTION
## Summary

A task runner that is busy or slow can currently be mistaken for a dead one and torn down. That fails all of its in-flight tasks, and under a backlog it can turn one slow moment into a kill-and-respawn loop that amplifies "task runner not available" errors.

This PR makes the three checks in `task-broker.service.ts` require stronger evidence before reporting a runner as unresponsive:

- **Acceptance timeouts**: timeouts within one accept window now count as a single strike, so several acceptances stalling together no longer look like several missed acknowledgements. A task result (done or error) resets the count, and strikes are kept until a report actually goes out.
- **Silence**: a runner must be observed silent at two request expiries at least 2 seconds apart, instead of one instantaneous sample. Any message from the runner clears the mark, and a healthy runner refreshes its offers every 250 ms.
- **In-flight tasks**: no teardown while the runner still has tasks in flight, since those tasks may still complete. A runner that is truly stuck is still recovered by the task execution timeout and by the heartbeat check.

The fix is broker-side on purpose: `runner:unresponsive` makes the WebSocket server close the connection and fail every in-flight task immediately, so a drain on the runner process could not save those tasks.

No timeouts or defaults change.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4128

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
