### PR TITLE
feat: Let nodes declare why an operation failed (no-changelog)

### DIFF
--- a/packages/@n8n/backend-network/src/http/retryability.ts
+++ b/packages/@n8n/backend-network/src/http/retryability.ts
@@ -1,3 +1,5 @@
+import { errorChain, isObjectLike, type UnknownRecord } from '@n8n/utils/errors/error-chain';
+
 import { isDnsFailure, isTransportFailure } from './client-request-error';
 
 /**
@@ -84,46 +86,8 @@ function isRetryableStatus(status: number): boolean {
 	return status === 408 || status === 429 || status >= 500;
 }
 
-type UnknownRecord = Readonly<Record<string, unknown>>;
-
-const isRecord = (value: unknown): value is UnknownRecord =>
-	typeof value === 'object' && value !== null;
-
-const MAX_CHAIN_DEPTH = 5;
-
-/** The keys errors wrap each other under. */
-const WRAPPING_KEYS = ['cause', 'errorResponse', 'reason'] as const;
-
-/** The error and the errors it wraps, shallowest first, each visited once. */
-function errorChain(error: unknown): UnknownRecord[] {
-	if (!isRecord(error)) {
-		return [];
-	}
-
-	const seen = new Set<UnknownRecord>([error]);
-	const chain: UnknownRecord[] = [error];
-	let generation: UnknownRecord[] = [error];
-
-	for (let depth = 0; depth < MAX_CHAIN_DEPTH && generation.length > 0; depth++) {
-		const next: UnknownRecord[] = [];
-		for (const level of generation) {
-			for (const key of WRAPPING_KEYS) {
-				const wrapped = level[key];
-				if (isRecord(wrapped) && !seen.has(wrapped)) {
-					seen.add(wrapped);
-					next.push(wrapped);
-				}
-			}
-		}
-		chain.push(...next);
-		generation = next;
-	}
-
-	return chain;
-}
-
 const responseOf = (level: UnknownRecord): UnknownRecord | undefined =>
-	isRecord(level.response) ? level.response : undefined;
+	isObjectLike(level.response) ? level.response : undefined;
 
 /**
  * The HTTP status of the failing response, if any. An `httpCode` anywhere in
@@ -176,7 +140,7 @@ function findRetryAfterMs(chain: UnknownRecord[], now: Date): number | undefined
 
 /** The `Retry-After` value from a `get()` style or plain headers object. */
 function readRetryAfterHeader(headers: unknown): string | undefined {
-	if (!isRecord(headers)) {
+	if (!isObjectLike(headers)) {
 		return undefined;
 	}
 

--- a/packages/@n8n/utils/src/errors/error-chain.test.ts
+++ b/packages/@n8n/utils/src/errors/error-chain.test.ts
@@ -1,0 +1,59 @@
+import { errorChain } from './error-chain';
+
+describe('errorChain', () => {
+	it('returns the error itself first', () => {
+		const error = new Error('boom');
+
+		expect(errorChain(error)).toEqual([error]);
+	});
+
+	it('walks cause, errorResponse and reason, shallowest first', () => {
+		const cause = new Error('cause');
+		const errorResponse = { message: 'response' };
+		const reason = new Error('reason');
+		const error = Object.assign(new Error('outer'), { cause, errorResponse, reason });
+
+		expect(errorChain(error)).toEqual([error, cause, errorResponse, reason]);
+	});
+
+	it('visits a shared wrapped error once', () => {
+		const shared = new Error('shared');
+		const error = Object.assign(new Error('outer'), { cause: shared, errorResponse: shared });
+
+		expect(errorChain(error)).toEqual([error, shared]);
+	});
+
+	it('stops at the depth cap', () => {
+		let deepest: Record<string, unknown> = { message: 'level 7' };
+		let current = deepest;
+		for (let level = 6; level >= 0; level--) {
+			current = { message: `level ${level}`, cause: current };
+		}
+		deepest = current;
+
+		const chain = errorChain(deepest);
+
+		expect(chain).toHaveLength(6);
+		expect(chain[5]).toMatchObject({ message: 'level 5' });
+	});
+
+	it('survives a self-referential cause chain', () => {
+		const error = new Error('loop') as Error & { cause: unknown };
+		error.cause = error;
+
+		expect(errorChain(error)).toEqual([error]);
+	});
+
+	it('keeps a wrapped array in the chain', () => {
+		const wrappedArray = [{ message: 'entry' }];
+		const error = Object.assign(new Error('outer'), { cause: wrappedArray });
+
+		expect(errorChain(error)).toEqual([error, wrappedArray]);
+	});
+
+	it('returns an empty chain for a non-object value', () => {
+		expect(errorChain('not an object')).toEqual([]);
+		expect(errorChain(null)).toEqual([]);
+		expect(errorChain(undefined)).toEqual([]);
+	});
+});

--- a/packages/@n8n/utils/src/errors/error-chain.ts
+++ b/packages/@n8n/utils/src/errors/error-chain.ts
@@ -1,0 +1,38 @@
+export type UnknownRecord = Readonly<Record<string, unknown>>;
+
+/** Any non-null object. Unlike is-record.ts this accepts arrays, so a wrapped array stays in the chain. */
+export const isObjectLike = (value: unknown): value is UnknownRecord =>
+	typeof value === 'object' && value !== null;
+
+const MAX_CHAIN_DEPTH = 5;
+
+/** The keys errors wrap each other under. */
+const WRAPPING_KEYS = ['cause', 'errorResponse', 'reason'] as const;
+
+/** The error and the errors it wraps, shallowest first, each visited once. */
+export function errorChain(error: unknown): UnknownRecord[] {
+	if (!isObjectLike(error)) {
+		return [];
+	}
+
+	const seen = new Set<UnknownRecord>([error]);
+	const chain: UnknownRecord[] = [error];
+	let generation: UnknownRecord[] = [error];
+
+	for (let depth = 0; depth < MAX_CHAIN_DEPTH && generation.length > 0; depth++) {
+		const next: UnknownRecord[] = [];
+		for (const level of generation) {
+			for (const key of WRAPPING_KEYS) {
+				const wrapped = level[key];
+				if (isObjectLike(wrapped) && !seen.has(wrapped)) {
+					seen.add(wrapped);
+					next.push(wrapped);
+				}
+			}
+		}
+		chain.push(...next);
+		generation = next;
+	}
+
+	return chain;
+}

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
@@ -390,8 +390,10 @@ describe('refreshOAuth2Token', () => {
 			'The credential "test-credentials-name" needs to be reconnected.',
 		);
 		await expect(promise).rejects.toMatchObject({
+			name: 'NodeOperationError',
 			description: expect.stringContaining('reconnect'),
 			level: 'warning',
+			failure: { cause: 'credential-invalid' },
 		});
 		expect(
 			mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
@@ -139,6 +139,7 @@ function buildOAuth2ReconnectError(node: INode, credentialsType: string): NodeOp
 			description:
 				'Access could not be refreshed because the connected account has revoked access, the refresh token expired, or the account password or permissions changed. Open the credential and reconnect it to continue.',
 			level: 'warning',
+			failure: { cause: 'credential-invalid' },
 		},
 	);
 }

--- a/packages/nodes-base/nodes/Google/Drive/GoogleDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDriveTrigger.node.ts
@@ -7,6 +7,7 @@ import type {
 	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
+	Failure,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeApiError } from 'n8n-workflow';
 
@@ -443,7 +444,10 @@ export class GoogleDriveTrigger implements INodeType {
 
 		const query = ['trashed = false'];
 
-		if (triggerOn === 'specificFolder' && event !== 'watchFolderUpdated') {
+		const queryTargetsWatchedFolder =
+			triggerOn === 'specificFolder' && event !== 'watchFolderUpdated';
+
+		if (queryTargetsWatchedFolder) {
 			const folderToWatch = extractId(
 				this.getNodeParameter('folderToWatch', '', { extractValue: true }) as string,
 			);
@@ -479,12 +483,36 @@ export class GoogleDriveTrigger implements INodeType {
 
 		let files;
 
-		if (this.getMode() === 'manual') {
-			qs.pageSize = 1;
-			files = await googleApiRequest.call(this, 'GET', '/drive/v3/files', {}, qs);
-			files = files.files;
-		} else {
-			files = await googleApiRequestAllItems.call(this, 'files', 'GET', '/drive/v3/files', {}, qs);
+		try {
+			if (this.getMode() === 'manual') {
+				qs.pageSize = 1;
+				files = await googleApiRequest.call(this, 'GET', '/drive/v3/files', {}, qs);
+				files = files.files;
+			} else {
+				files = await googleApiRequestAllItems.call(
+					this,
+					'files',
+					'GET',
+					'/drive/v3/files',
+					{},
+					qs,
+				);
+			}
+		} catch (error) {
+			if (!(error instanceof NodeApiError)) {
+				throw error;
+			}
+
+			const failure = driveFailureFromError(error, queryTargetsWatchedFolder);
+			if (failure) {
+				error.failure = failure;
+				// A 404 is only classified when the query filters on the watched folder.
+				if (error.httpCode === '404') {
+					error.message =
+						'The folder this node watches no longer exists. Please update it in the workflow.';
+				}
+			}
+			throw error;
 		}
 
 		if (triggerOn === 'specificFile' && this.getMode() !== 'manual') {
@@ -519,4 +547,82 @@ export class GoogleDriveTrigger implements INodeType {
 
 		return null;
 	}
+}
+
+const DAILY_QUOTA_TIMEZONE = 'America/Los_Angeles';
+
+const RATE_LIMIT_REASONS = [
+	'rateLimitExceeded',
+	'userRateLimitExceeded',
+	'sharingRateLimitExceeded',
+];
+
+const NESTED_ERROR_KEYS = ['cause', 'errorResponse', 'error', 'errors', 'response', 'body', 'data'];
+
+function collectGoogleErrorReasons(
+	value: unknown,
+	reasons = new Set<string>(),
+	seen = new WeakSet<object>(),
+	depth = 0,
+): Set<string> {
+	if (depth > 6 || typeof value !== 'object' || value === null || seen.has(value)) {
+		return reasons;
+	}
+	seen.add(value);
+
+	if (Array.isArray(value)) {
+		for (const entry of value) {
+			collectGoogleErrorReasons(entry, reasons, seen, depth + 1);
+		}
+		return reasons;
+	}
+
+	const record = value as IDataObject;
+	if (typeof record.reason === 'string') {
+		reasons.add(record.reason);
+	}
+	for (const key of NESTED_ERROR_KEYS) {
+		collectGoogleErrorReasons(record[key], reasons, seen, depth + 1);
+	}
+
+	return reasons;
+}
+
+/**
+ * Why a failed Drive API call failed, or `null` for anything this node cannot
+ * classify with confidence.
+ */
+function driveFailureFromError(
+	error: NodeApiError,
+	queryTargetsWatchedFolder: boolean,
+): Failure | null {
+	if (error.httpCode === '401') {
+		return { cause: 'credential-invalid' };
+	}
+
+	if (error.httpCode === '429') {
+		return { cause: 'rate-limited' };
+	}
+
+	if (error.httpCode === '403') {
+		const reasons = collectGoogleErrorReasons(error);
+		if (RATE_LIMIT_REASONS.some((reason) => reasons.has(reason))) {
+			return { cause: 'rate-limited' };
+		}
+		if (reasons.has('dailyLimitExceeded')) {
+			return { cause: 'quota-exhausted', resetsAtEpochMs: nextDailyQuotaReset() };
+		}
+		return null;
+	}
+
+	if (error.httpCode === '404' && queryTargetsWatchedFolder) {
+		return { cause: 'configuration-invalid' };
+	}
+
+	return null;
+}
+
+/** Google Drive daily quotas reset at midnight Pacific Time. Unix epoch ms. */
+function nextDailyQuotaReset(): number {
+	return moment.tz(DAILY_QUOTA_TIMEZONE).add(1, 'day').startOf('day').valueOf();
 }

--- a/packages/nodes-base/nodes/Google/Drive/test/GoogleDriveTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/GoogleDriveTrigger.node.test.ts
@@ -463,6 +463,160 @@ describe('GoogleDriveTrigger', () => {
 		});
 	});
 
+	describe('Poll Function - Declared Failures', () => {
+		const setParameters = (params: Record<string, unknown>) => {
+			mockPollFunctions.getNodeParameter.mockImplementation(
+				(paramName: string) => params[paramName] ?? '',
+			);
+		};
+
+		const driveApiError = (statusCode: number, reason?: string) => {
+			const requestError = Object.assign(new Error(`${statusCode} - request failed`), {
+				statusCode,
+				error: {
+					error: {
+						code: statusCode,
+						message: 'request failed',
+						...(reason ? { errors: [{ domain: 'usageLimits', reason }] } : {}),
+					},
+				},
+			});
+			return new NodeApiError(mockNode, requestError as never);
+		};
+
+		beforeEach(() => {
+			setParameters({
+				triggerOn: 'specificFile',
+				event: 'fileUpdated',
+				fileToWatch: 'test-file-id',
+				options: {},
+			});
+		});
+
+		it.each(['rateLimitExceeded', 'userRateLimitExceeded', 'sharingRateLimitExceeded'])(
+			'should declare a 403 with reason %s as rate-limited',
+			async (reason) => {
+				const apiError = driveApiError(403, reason);
+				googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+				await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(apiError);
+				expect(apiError.failure).toEqual({ cause: 'rate-limited' });
+				expect(apiError.httpCode).toBe('403');
+			},
+		);
+
+		it('should declare a 403 with reason dailyLimitExceeded as quota-exhausted, resetting at the next Pacific midnight', async () => {
+			const apiError = driveApiError(403, 'dailyLimitExceeded');
+			googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+			await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(apiError);
+			expect(apiError.failure?.cause).toBe('quota-exhausted');
+
+			const { resetsAtEpochMs } = apiError.failure as { resetsAtEpochMs?: number };
+			expect(resetsAtEpochMs).toBeGreaterThan(Date.now());
+			expect(moment(resetsAtEpochMs).tz('America/Los_Angeles').format('HH:mm:ss')).toBe('00:00:00');
+		});
+
+		it('should declare a 429 as rate-limited', async () => {
+			const apiError = driveApiError(429);
+			googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+			await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(apiError);
+			expect(apiError.failure).toEqual({ cause: 'rate-limited' });
+			expect(apiError.httpCode).toBe('429');
+		});
+
+		it('should declare a 403 whose payload is a plain object stored under errorResponse', async () => {
+			const apiError = new NodeApiError(mockNode, {
+				statusCode: 403,
+				error: {
+					error: {
+						code: 403,
+						message: 'request failed',
+						errors: [{ domain: 'usageLimits', reason: 'userRateLimitExceeded' }],
+					},
+				},
+			} as never);
+			googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+			await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(apiError);
+			expect(apiError.failure).toEqual({ cause: 'rate-limited' });
+		});
+
+		it('should declare a 401 as credential-invalid', async () => {
+			const apiError = driveApiError(401);
+			googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+			await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(apiError);
+			expect(apiError.failure).toEqual({ cause: 'credential-invalid' });
+			expect(apiError.httpCode).toBe('401');
+		});
+
+		it('should declare a 404 as configuration-invalid when the query filters on the watched folder', async () => {
+			setParameters({
+				triggerOn: 'specificFolder',
+				event: 'fileCreated',
+				folderToWatch: 'test-folder-id',
+				options: {},
+			});
+			const apiError = driveApiError(404);
+			googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+			await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(apiError);
+			expect(apiError.failure).toEqual({ cause: 'configuration-invalid' });
+			expect(apiError.message).toBe(
+				'The folder this node watches no longer exists. Please update it in the workflow.',
+			);
+		});
+
+		it.each([
+			['any file or folder', { triggerOn: 'anyFileFolder', event: 'fileUpdated', options: {} }],
+			[
+				'a specific file, whose id never reaches the API',
+				{
+					triggerOn: 'specificFile',
+					event: 'fileUpdated',
+					fileToWatch: 'test-file-id',
+					options: {},
+				},
+			],
+			[
+				'a specific folder for updates, whose id never reaches the API',
+				{
+					triggerOn: 'specificFolder',
+					event: 'watchFolderUpdated',
+					folderToWatch: 'test-folder-id',
+					options: {},
+				},
+			],
+		])('should not declare a 404 when watching %s', async (_name, params) => {
+			setParameters(params);
+			const apiError = driveApiError(404);
+			googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+			const promise = trigger.poll.call(mockPollFunctions);
+
+			await expect(promise).rejects.toBe(apiError);
+			expect(apiError.failure).toBeUndefined();
+		});
+
+		it('should rethrow a 403 with an unrecognized reason unannotated', async () => {
+			const apiError = driveApiError(403, 'domainPolicy');
+			googleApiRequestAllItemsSpy.mockRejectedValue(apiError);
+
+			await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(apiError);
+			expect(apiError.failure).toBeUndefined();
+		});
+
+		it('should rethrow an error that is not a NodeApiError unannotated', async () => {
+			const plainError = new Error('socket hang up');
+			googleApiRequestAllItemsSpy.mockRejectedValue(plainError);
+
+			await expect(trigger.poll.call(mockPollFunctions)).rejects.toBe(plainError);
+			expect(plainError).not.toHaveProperty('failure');
+		});
+	});
+
 	describe('Poll Function - Edge Cases', () => {
 		it('should return null when no files found in trigger mode', async () => {
 			mockPollFunctions.getNodeParameter.mockImplementation((paramName: string) => {

--- a/packages/workflow/src/errors/abstract/node.error.ts
+++ b/packages/workflow/src/errors/abstract/node.error.ts
@@ -1,4 +1,5 @@
 import { ExecutionBaseError } from './execution-base.error';
+import type { Failure } from '../failure';
 import type { IDataObject, INode, JsonObject } from '../../interfaces';
 import { isTraversableObject, jsonParse } from '../../utils';
 
@@ -37,6 +38,9 @@ const COMMON_ERRORS: IDataObject = {
 export abstract class NodeError extends ExecutionBaseError {
 	messages: string[] = [];
 
+	/** Why the operation failed, when the node declared it. */
+	failure?: Failure;
+
 	constructor(
 		readonly node: INode,
 		error: Error | JsonObject,
@@ -48,6 +52,7 @@ export abstract class NodeError extends ExecutionBaseError {
 
 		if (error instanceof NodeError) {
 			this.tags.reWrapped = true;
+			this.failure = error.failure;
 		}
 	}
 

--- a/packages/workflow/src/errors/failure.ts
+++ b/packages/workflow/src/errors/failure.ts
@@ -1,0 +1,39 @@
+/** Causes where the source comes back on its own, so a wait can help. */
+export const TIMED_CAUSES = [
+	/** The source is throttling requests. */
+	'rate-limited',
+	/** A usage quota is used up until it resets. */
+	'quota-exhausted',
+	/** The source is down or degraded right now. */
+	'temporarily-unavailable',
+] as const;
+
+/** Causes where someone has to act before the operation can succeed. */
+export const ACTIONABLE_CAUSES = [
+	/** The credential is dead and the user has to reconnect it. */
+	'credential-invalid',
+	/** The node points at something that no longer exists or is no longer allowed. */
+	'configuration-invalid',
+	/** A bug in the node itself, neither the credential nor the configuration is to blame. */
+	'node-defect',
+] as const;
+
+export type TimedCause = (typeof TIMED_CAUSES)[number];
+export type ActionableCause = (typeof ACTIONABLE_CAUSES)[number];
+
+/**
+ * Why an operation failed, declared by the node that ran it. Carried as plain data on the
+ * error's `failure`, so a reader needs neither `instanceof` nor this exact copy of the
+ * package. It says why the operation failed, never what to do about it.
+ *
+ * Wait hints only exist on the causes a wait can help. Nothing to wait for on the others.
+ */
+export type Failure =
+	| {
+			cause: TimedCause;
+			/** Minimum wait the source asked for, in ms. */
+			retryAfterMs?: number;
+			/** When the source says the operation will work again, as Unix epoch ms. */
+			resetsAtEpochMs?: number;
+	  }
+	| { cause: ActionableCause };

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -14,6 +14,13 @@ export {
 } from './execution-cancelled.error';
 export { NodeApiError } from './node-api.error';
 export { NodeOperationError } from './node-operation.error';
+export {
+	TIMED_CAUSES,
+	ACTIONABLE_CAUSES,
+	type Failure,
+	type TimedCause,
+	type ActionableCause,
+} from './failure';
 export { WorkflowConfigurationError } from './workflow-configuration.error';
 export { NodeSslError } from './node-ssl.error';
 export { WebhookPathTakenError } from './webhook-taken.error';

--- a/packages/workflow/src/errors/node-api.error.ts
+++ b/packages/workflow/src/errors/node-api.error.ts
@@ -5,6 +5,7 @@ import { parseString } from 'xml2js';
 
 import { removeCircularRefs, sanitizeXmlName } from '../utils';
 import { NodeError } from './abstract/node.error';
+import type { Failure } from './failure';
 import type { ErrorLevel } from '@n8n/errors';
 import {
 	NO_OP_NODE_TYPE,
@@ -34,6 +35,8 @@ export interface NodeOperationErrorOptions {
 		subExecution?: RelatedExecution;
 		parentExecution?: RelatedExecution;
 	};
+	/** Why the operation failed, when the node knows. */
+	failure?: Failure;
 }
 
 interface NodeApiErrorOptions extends NodeOperationErrorOptions {
@@ -134,9 +137,13 @@ export class NodeApiError extends NodeError {
 			level,
 			functionality,
 			messageMapping,
+			failure,
 		}: NodeApiErrorOptions = {},
 	) {
 		if (errorResponse instanceof NodeApiError) {
+			// Re-wrapping hands back the original, so the declaration has to land on it:
+			// nodes routinely rethrow an error a shared request helper already wrapped.
+			if (failure) errorResponse.failure = failure;
 			return errorResponse;
 		}
 
@@ -272,6 +279,9 @@ export class NodeApiError extends NodeError {
 		if (functionality !== undefined) this.functionality = functionality;
 		if (runIndex !== undefined) this.context.runIndex = runIndex;
 		if (itemIndex !== undefined) this.context.itemIndex = itemIndex;
+		if (failure) {
+			this.failure = failure;
+		}
 	}
 
 	private setDescriptionFromXml(xml: string) {

--- a/packages/workflow/src/errors/node-operation.error.ts
+++ b/packages/workflow/src/errors/node-operation.error.ts
@@ -15,6 +15,9 @@ export class NodeOperationError extends NodeError {
 		options: NodeOperationErrorOptions = {},
 	) {
 		if (error instanceof NodeOperationError) {
+			if (options.failure) {
+				error.failure = options.failure;
+			}
 			return error;
 		}
 
@@ -35,6 +38,7 @@ export class NodeOperationError extends NodeError {
 		this.level = options.level ?? 'warning';
 		if (options.functionality) this.functionality = options.functionality;
 		if (options.type) this.type = options.type;
+		if (options.failure) this.failure = options.failure;
 
 		if (options.description) this.description = options.description;
 		else if ('description' in error && typeof error.description === 'string')

--- a/packages/workflow/test/errors/failure.test.ts
+++ b/packages/workflow/test/errors/failure.test.ts
@@ -1,0 +1,132 @@
+import { NodeApiError, NodeOperationError } from '../../src/errors';
+import type { Failure } from '../../src/errors';
+import type { INode } from '../../src/interfaces';
+
+// @ts-expect-error A wait hint only exists on the causes a wait can help.
+const hintOnActionableCause: Failure = { cause: 'credential-invalid', retryAfterMs: 5_000 };
+void hintOnActionableCause;
+
+const node: INode = {
+	id: '1',
+	name: 'Test Node',
+	typeVersion: 1,
+	type: 'n8n-nodes-base.test',
+	position: [0, 0],
+	parameters: {},
+};
+
+describe('the failure option', () => {
+	it('declares a cause on a NodeApiError', () => {
+		const error = new NodeApiError(
+			node,
+			{ message: 'unauthorized' },
+			{ failure: { cause: 'credential-invalid' } },
+		);
+
+		expect(error.failure).toEqual({ cause: 'credential-invalid' });
+	});
+
+	it('declares a cause with hints on a NodeApiError', () => {
+		const resetsAtEpochMs = Date.parse('2026-08-19T00:00:00.000Z');
+		const error = new NodeApiError(
+			node,
+			{ message: 'slow down' },
+			{ failure: { cause: 'quota-exhausted', retryAfterMs: 1_000, resetsAtEpochMs } },
+		);
+
+		expect(error.failure).toEqual({
+			cause: 'quota-exhausted',
+			retryAfterMs: 1_000,
+			resetsAtEpochMs,
+		});
+	});
+
+	it('declares a cause on a NodeOperationError', () => {
+		const error = new NodeOperationError(node, 'bad folder', {
+			failure: { cause: 'configuration-invalid' },
+		});
+
+		expect(error.failure).toEqual({ cause: 'configuration-invalid' });
+	});
+
+	it('carries a wait hint on any timed cause', () => {
+		const error = new NodeApiError(
+			node,
+			{ message: 'maintenance' },
+			{ failure: { cause: 'temporarily-unavailable', retryAfterMs: 5_000 } },
+		);
+
+		expect(error.failure).toEqual({
+			cause: 'temporarily-unavailable',
+			retryAfterMs: 5_000,
+		});
+	});
+
+	it('leaves the rest of the error untouched', () => {
+		const error = new NodeApiError(
+			node,
+			{ message: 'api failure', httpCode: '401' },
+			{ failure: { cause: 'credential-invalid' } },
+		);
+
+		expect(error.name).toBe('NodeApiError');
+		expect(error.httpCode).toBe('401');
+		expect(error.message).toBe('Authorization failed - please check your credentials');
+	});
+
+	it('declares on the original error when re-wrapping hands it back', () => {
+		const original = new NodeApiError(node, { message: 'unauthorized' });
+		const rewrapped = new NodeApiError(node, original as never, {
+			failure: { cause: 'credential-invalid' },
+		});
+
+		expect(rewrapped).toBe(original);
+		expect(original.failure).toEqual({ cause: 'credential-invalid' });
+	});
+
+	it('replaces an earlier declaration when re-wrapping declares again', () => {
+		const original = new NodeApiError(
+			node,
+			{ message: 'boom' },
+			{ failure: { cause: 'temporarily-unavailable' } },
+		);
+		const rewrapped = new NodeApiError(node, original as never, {
+			failure: { cause: 'credential-invalid' },
+		});
+
+		expect(rewrapped).toBe(original);
+		expect(original.failure).toEqual({ cause: 'credential-invalid' });
+	});
+
+	it('declares on the original NodeOperationError when re-wrapping hands it back', () => {
+		const original = new NodeOperationError(node, 'boom');
+		const rewrapped = new NodeOperationError(node, original, { failure: { cause: 'node-defect' } });
+
+		expect(rewrapped).toBe(original);
+		expect(original.failure).toEqual({ cause: 'node-defect' });
+	});
+
+	it('carries the declaration over when re-wrapping builds a new error', () => {
+		const original = new NodeOperationError(node, 'reconnect', {
+			failure: { cause: 'credential-invalid' },
+		});
+		const rewrapped = new NodeApiError(node, original as never);
+
+		expect(rewrapped).not.toBe(original);
+		expect(rewrapped.failure).toEqual({ cause: 'credential-invalid' });
+	});
+
+	it('prefers the declared cause over the one it re-wraps', () => {
+		const original = new NodeOperationError(node, 'boom', { failure: { cause: 'node-defect' } });
+		const rewrapped = new NodeApiError(node, original as never, {
+			failure: { cause: 'credential-invalid' },
+		});
+
+		expect(rewrapped.failure).toEqual({ cause: 'credential-invalid' });
+	});
+
+	it('leaves an error without the option unannotated', () => {
+		expect(new NodeApiError(node, { message: 'boom' }).failure).toBeUndefined();
+		expect(new NodeOperationError(node, 'boom').failure).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

A node can now say why an operation failed, as an option on the error it throws:

```ts
throw new NodeApiError(node, error, {
	failure: { cause: 'quota-exhausted', resetsAt },
});
```

The declaration lands on `error.failure` as plain data, so a reader needs neither `instanceof` nor this exact copy of `n8n-workflow`.

| `cause` | Meaning |
| -- | -- |
| `rate-limited` | The source is throttling requests. |
| `quota-exhausted` | A usage quota is used up until it resets. |
| `temporarily-unavailable` | The source is down or degraded right now. |
| `credential-invalid` | The credential is dead, the user has to reconnect it. |
| `configuration-invalid` | The node points at something gone or no longer allowed. |
| `node-defect` | A bug in the node itself. |

`retryAfterMs` and `resetsAt` are optional hints, valid on any cause.

Three properties worth defending:

- **`cause` says why the operation failed, never what to do about it.** No retry vocabulary reaches the node author.
- **One shape to write.** No bare-string shorthand, no post-hoc stamping helper: the declaration is set at construction, on a typed field.
- **Nothing here interprets it.** Whoever reads it owns the derivation and can fix it without touching the contract.

The API lives in `n8n-workflow` because community nodes only depend on that package, and they are the ones declaring.

## First adopters

- **OAuth2 token refresh** (`packages/core`): a refresh answering `invalid_grant` declares `credential-invalid`. Every OAuth2 node gets it for free.
- **Google Drive Trigger**: 401, the 403 rate and quota reasons, and a 404 on the watched folder. The daily quota carries `resetsAt`, Google's documented midnight Pacific reset. Everything else is rethrown untouched.

Also included: the wrapped-error traversal in `retryabilityFromError` moves into `@n8n/utils` as an `errorChain` primitive, where the future reader can use it too.

## Not in this PR

Reading the declaration back, and every policy built on it: `retryOnFail` in `workflow-execute.ts`, poll backoff in #35707, `markNonRetryable` in `@n8n/backend-network`.

The declaration is inert until a consumer reads it, hence `(no-changelog)`.

## How to test manually

1. Create a workflow with a Google Drive Trigger that watches a specific folder.
2. Activate the workflow, then delete the folder in Google Drive.
3. The next poll fails with "The folder this node watches no longer exists. Please update it in the workflow." instead of a raw 404.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-4122
- Groundwork for #35707, sibling of #36527.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
