### PR TITLE
feat(core): Add policy check contract, decorator and registry

### DIFF
--- a/packages/@n8n/decorators/src/index.ts
+++ b/packages/@n8n/decorators/src/index.ts
@@ -10,6 +10,7 @@ export * from './context-establishment';
 export * from './credential-resolver';
 export * from './module';
 export * from './multi-main';
+export * from './policy-check';
 export * from './pubsub';
 export { Redactable } from './redactable';
 export * from './shutdown';

--- a/packages/@n8n/decorators/src/policy-check/__tests__/policy-check-metadata.test.ts
+++ b/packages/@n8n/decorators/src/policy-check/__tests__/policy-check-metadata.test.ts
@@ -1,0 +1,152 @@
+import { Container } from '@n8n/di';
+
+import {
+	pointsImplementedBy,
+	type PolicyCheckResult,
+	type RegisteredPolicyCheck,
+	type WorkflowSaveContext,
+	type WorkflowStartContext,
+} from '../policy-check';
+import {
+	PolicyCheck,
+	PolicyCheckMetadata,
+	UnknownEnforcementPointError,
+} from '../policy-check-metadata';
+
+const noViolations = async (): Promise<PolicyCheckResult> => ({ violations: [] });
+
+describe('PolicyCheckMetadata', () => {
+	let metadata: PolicyCheckMetadata;
+
+	beforeEach(() => {
+		metadata = new PolicyCheckMetadata();
+	});
+
+	it('should register check classes', () => {
+		class TestCheck implements RegisteredPolicyCheck {
+			id = 'test.check';
+			async onWorkflowSave(_ctx: WorkflowSaveContext) {
+				return await noViolations();
+			}
+		}
+
+		metadata.register({ class: TestCheck });
+
+		expect(metadata.getClasses()).toContain(TestCheck);
+	});
+
+	it('should return registered classes in registration order', () => {
+		class FirstCheck implements RegisteredPolicyCheck {
+			id = 'first.check';
+			async onWorkflowSave(_ctx: WorkflowSaveContext) {
+				return await noViolations();
+			}
+		}
+		class SecondCheck implements RegisteredPolicyCheck {
+			id = 'second.check';
+			async onWorkflowStart(_ctx: WorkflowStartContext) {
+				return await noViolations();
+			}
+		}
+
+		metadata.register({ class: FirstCheck });
+		metadata.register({ class: SecondCheck });
+
+		expect(metadata.getClasses()).toEqual([FirstCheck, SecondCheck]);
+	});
+});
+
+describe('@PolicyCheck decorator', () => {
+	let metadata: PolicyCheckMetadata;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+
+		metadata = new PolicyCheckMetadata();
+		Container.set(PolicyCheckMetadata, metadata);
+	});
+
+	it('should register the decorated class and make it DI-resolvable', () => {
+		@PolicyCheck()
+		class TestCheck implements RegisteredPolicyCheck {
+			id = 'policy.test';
+			async onWorkflowSave(_ctx: WorkflowSaveContext) {
+				return await noViolations();
+			}
+		}
+
+		const registered = metadata.getClasses();
+
+		expect(registered).toContain(TestCheck);
+		expect(registered).toHaveLength(1);
+		expect(Container.get(TestCheck)).toBeInstanceOf(TestCheck);
+	});
+
+	it('should register multiple decorated classes in registration order', () => {
+		@PolicyCheck()
+		class NodeTypeCheck implements RegisteredPolicyCheck {
+			id = 'node-type-availability';
+			async onWorkflowStart(_ctx: WorkflowStartContext) {
+				return await noViolations();
+			}
+		}
+
+		@PolicyCheck()
+		class QuotaCheck implements RegisteredPolicyCheck {
+			id = 'execution-quota';
+			async onWorkflowStart(_ctx: WorkflowStartContext) {
+				return await noViolations();
+			}
+		}
+
+		expect(metadata.getClasses()).toEqual([NodeTypeCheck, QuotaCheck]);
+	});
+
+	it('should reject an `on*` method that matches no enforcement point', () => {
+		class TypoCheck implements RegisteredPolicyCheck {
+			id = 'typo.check';
+			async onWorkflowSave(_ctx: WorkflowSaveContext) {
+				return await noViolations();
+			}
+			// Misspelled or removed point — shouldn't silently do nothing.
+			async onWorkflowDelete() {
+				return await noViolations();
+			}
+		}
+
+		const decorate = () => {
+			PolicyCheck()(TypoCheck);
+		};
+
+		expect(decorate).toThrow(UnknownEnforcementPointError);
+		expect(decorate).toThrow(/onWorkflowDelete/);
+		expect(metadata.getClasses()).toHaveLength(0);
+	});
+
+	it('should not treat non-point methods as enforcement points', () => {
+		@PolicyCheck()
+		class CheckWithHelpers implements RegisteredPolicyCheck {
+			id = 'helpers.check';
+			async onWorkflowSave(_ctx: WorkflowSaveContext) {
+				return await noViolations();
+			}
+			// Neither is `on` + a capital letter, so neither looks like a point.
+			once() {}
+			buildViolation() {}
+		}
+
+		expect(metadata.getClasses()).toContain(CheckWithHelpers);
+	});
+});
+
+describe('pointsImplementedBy', () => {
+	it('should derive only the points a check implements', () => {
+		const check: RegisteredPolicyCheck = {
+			id: 'partial.check',
+			onWorkflowSave: noViolations,
+			onCredentialDecrypt: noViolations,
+		};
+
+		expect(pointsImplementedBy(check)).toEqual(['workflowSave', 'credentialDecrypt']);
+	});
+});

--- a/packages/@n8n/decorators/src/policy-check/index.ts
+++ b/packages/@n8n/decorators/src/policy-check/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Policy check contract.
+ *
+ * Shared by every policy feature: the points where policies apply, what a check looks
+ * like, and the shape of a violation. Types only — the service that calls checks lives in
+ * cli core, and the code that runs and combines them lives in the policy-infrastructure
+ * module, so a policy feature never imports either.
+ */
+
+export {
+	PolicyCheck,
+	PolicyCheckMetadata,
+	UnknownEnforcementPointError,
+} from './policy-check-metadata';
+export * from './policy-check';

--- a/packages/@n8n/decorators/src/policy-check/policy-check-metadata.ts
+++ b/packages/@n8n/decorators/src/policy-check/policy-check-metadata.ts
@@ -1,0 +1,133 @@
+import { Container, Service } from '@n8n/di';
+import { UnexpectedError } from 'n8n-workflow';
+
+import {
+	ENFORCEMENT_POINT_METHODS,
+	ENFORCEMENT_POINTS,
+	type PolicyCheckClass,
+	type RegisteredPolicyCheck,
+} from './policy-check';
+
+/**
+ * One registered check.
+ *
+ * Wraps the class so we can attach more per-check data later without changing how
+ * registration is called.
+ *
+ * @internal
+ */
+type PolicyCheckEntry = {
+	class: PolicyCheckClass;
+};
+
+/**
+ * Thrown when a check has an `on*` method that isn't a known enforcement point.
+ *
+ * Without this, a misspelled or removed method name would simply never be called, and the
+ * author would think their check was working. Better to fail at startup.
+ */
+export class UnknownEnforcementPointError extends UnexpectedError {
+	constructor(checkClassName: string, unknownMethods: string[]) {
+		super(
+			`Policy check "${checkClassName}" declares ${unknownMethods.join(', ')}, which ` +
+				`match no known enforcement point. Known points: ${ENFORCEMENT_POINTS.join(', ')}.`,
+		);
+	}
+}
+
+/**
+ * Holds every class decorated with `@PolicyCheck()`.
+ *
+ * Filled in as modules load, so checks are found without any manual wiring.
+ *
+ * ```
+ * @PolicyCheck()   →   PolicyCheckMetadata   →   PEP implementation   →   host call site
+ *  (registration)        (collection)              (resolve & run)          (enforcement)
+ * ```
+ *
+ * Not this class's job: creating instances (DI does that), checking ids are unique, or
+ * running anything.
+ *
+ * Read this registry when you need it, not once during your own startup — module load
+ * order shouldn't decide whether a check gets found.
+ */
+@Service()
+export class PolicyCheckMetadata {
+	private readonly policyChecks: Set<PolicyCheckEntry> = new Set();
+
+	/**
+	 * Adds a check class.
+	 *
+	 * Called by the `@PolicyCheck()` decorator; not meant to be called directly.
+	 *
+	 * @internal Called by decorator only.
+	 */
+	register(entry: PolicyCheckEntry) {
+		this.policyChecks.add(entry);
+	}
+
+	/** Every registered check class, in the order they were registered. */
+	getClasses(): PolicyCheckClass[] {
+		return [...this.policyChecks.values()].map((entry) => entry.class);
+	}
+}
+
+/** A class as the decorator sees it: its prototype holds the check's methods. */
+type DecoratedPolicyCheckClass = PolicyCheckClass & {
+	readonly prototype: RegisteredPolicyCheck;
+};
+
+const KNOWN_POINT_METHODS = new Set<string>(Object.values(ENFORCEMENT_POINT_METHODS));
+
+/**
+ * Rejects `on*` methods that don't match a known point.
+ *
+ * Runs when the class is defined, so a mistake is a startup error instead of a check that
+ * silently does nothing.
+ *
+ * This only sees methods on the prototype, which is how checks are meant to be written. A
+ * point written as an arrow-function property won't be spotted here, and a check with no
+ * points at all shows up in the PEP's startup log instead.
+ */
+function assertPointsAreKnown(target: DecoratedPolicyCheckClass) {
+	const unknown = Object.getOwnPropertyNames(target.prototype).filter(
+		(name) => /^on[A-Z]/.test(name) && !KNOWN_POINT_METHODS.has(name),
+	);
+
+	if (unknown.length > 0) throw new UnknownEnforcementPointError(target.name, unknown);
+}
+
+/**
+ * Marks a class as a policy check, so it gets found and run automatically.
+ *
+ * When the class is defined it: checks that every `on*` method is a real point, adds the
+ * class to {@link PolicyCheckMetadata}, and applies `@Service()` so DI can build it.
+ *
+ * Takes no arguments — the check's id lives on the instance
+ * ({@link RegisteredPolicyCheck.id}), and there's no priority to set because every check
+ * has to pass anyway.
+ *
+ * @example
+ * ```typescript
+ * @PolicyCheck()
+ * export class NodeTypePolicyCheck implements RegisteredPolicyCheck {
+ *   readonly id = 'node-type-availability';
+ *
+ *   async onWorkflowStart({ workflow, projectId }: WorkflowStartContext) {
+ *     return { violations: [] };
+ *   }
+ * }
+ * ```
+ *
+ * @throws {UnknownEnforcementPointError} An `on*` method isn't a known point.
+ */
+export const PolicyCheck =
+	() =>
+	<T extends DecoratedPolicyCheckClass>(target: T) => {
+		assertPointsAreKnown(target);
+
+		Container.get(PolicyCheckMetadata).register({ class: target });
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return Service()(target);
+	};

--- a/packages/@n8n/decorators/src/policy-check/policy-check.ts
+++ b/packages/@n8n/decorators/src/policy-check/policy-check.ts
@@ -1,0 +1,240 @@
+import type { Constructable } from '@n8n/di';
+import type { INode } from 'n8n-workflow';
+
+/**
+ * The points in n8n where a policy can block an action.
+ *
+ * Adding a point here leaves existing checks untouched. Removing one isn't silent either:
+ * the registry rejects `on*` methods that aren't in this list, so a check can't keep
+ * pointing at a point that no longer exists.
+ */
+export const ENFORCEMENT_POINTS = [
+	'workflowSave',
+	'workflowPublish',
+	'workflowStart',
+	'workflowTransfer',
+	'credentialDecrypt',
+	'contentImport',
+] as const;
+
+export type EnforcementPoint = (typeof ENFORCEMENT_POINTS)[number];
+
+/**
+ * The workflow as a policy check sees it.
+ *
+ * Narrower than `IWorkflowBase` on purpose: a check only needs the nodes, and passing the
+ * whole entity invites checks to start depending on unrelated fields. `readonly` because
+ * checks only read — they never change anything.
+ *
+ * An `IWorkflowBase` fits this shape, so hosts can pass their entity straight through.
+ */
+export type PolicedWorkflow = {
+	/** `null` for a new workflow — it has no id until it's saved. */
+	readonly id: string | null;
+	readonly name: string;
+	readonly nodes: readonly INode[];
+};
+
+/**
+ * The node asking to decrypt a credential.
+ *
+ * Credentials are locked based on the node asking, not the credential type — the same
+ * credential can be fine for one node and blocked for another.
+ */
+export type CredentialConsumer = {
+	/** Full node type name, e.g. `n8n-nodes-base.slack`. */
+	readonly nodeType: string;
+};
+
+export type WorkflowSaveContext = {
+	readonly workflow: PolicedWorkflow;
+	/**
+	 * The saved workflow this save replaces, or `null` for a new one.
+	 *
+	 * Nullable rather than optional so it can't be left out by accident. The host must load
+	 * it from the database — never take it from the request, or a caller could fake an old
+	 * version to slip content past the check.
+	 */
+	readonly storedWorkflow: PolicedWorkflow | null;
+	readonly projectId: string | null;
+};
+
+export type WorkflowPublishContext = {
+	readonly workflow: PolicedWorkflow;
+	readonly projectId: string | null;
+};
+
+export type WorkflowStartContext = {
+	readonly workflow: PolicedWorkflow;
+	readonly projectId: string | null;
+};
+
+export type WorkflowTransferContext = {
+	readonly workflow: PolicedWorkflow;
+	/** The project the workflow is moving *into* — that's whose policy applies. */
+	readonly targetProjectId: string | null;
+};
+
+export type CredentialDecryptContext = {
+	readonly credentialType: string;
+	readonly credentialId: string;
+	/** `null` when no node is asking, e.g. a credential test. */
+	readonly consumer: CredentialConsumer | null;
+	readonly projectId: string | null;
+};
+
+export type ContentImportContext = {
+	readonly workflow: PolicedWorkflow;
+	readonly projectId: string | null;
+};
+
+/**
+ * One reason something was blocked.
+ *
+ * The same shape is used by the UI, API errors, import reports and the audit log.
+ * `kind`, `subjectType` and `scope` are plain strings rather than enums, so later policy
+ * features can add values without breaking existing readers — which also means readers
+ * must cope with values they don't recognise.
+ */
+export type PolicyViolation = {
+	/** e.g. `'node-type-unavailable'`. Don't assume you know every value. */
+	kind: string;
+
+	/** Id of the check that objected. */
+	checkId: string;
+
+	/** Readable on its own. Don't parse details out of it — use the fields below. */
+	message: string;
+
+	/** What was blocked: a node type name, a credential type name, … */
+	subject?: string;
+
+	/** What kind of name `subject` is — node and credential type names can look alike. */
+	subjectType?: string;
+
+	/** Which level objected. Usually `'instance'` or `'project'`, but treat it as open. */
+	scope?: string;
+
+	/** The rule that decided, if a rule did rather than a fallback default. */
+	matchedRuleId?: string;
+};
+
+/** A policy version a check read, recorded on the audit log. */
+export type PolicyVersionRef = {
+	/** Usually `'instance'` or `'project'`. Open, like {@link PolicyViolation.scope}. */
+	scope: string;
+	version: number;
+};
+
+/** A check that failed to run. Deliberately vague — error details stay server-side. */
+export type PolicyCheckFailure = {
+	checkId: string;
+	correlationId: string;
+};
+
+/**
+ * What one check returns.
+ *
+ * Everything in `violations` blocks. If we ever want warnings that don't block, they get
+ * their own field here rather than a severity flag on the violation — a flag would quietly
+ * change what every existing check means.
+ */
+export type PolicyCheckResult = {
+	violations: PolicyViolation[];
+
+	/** The policies this check read, for the audit log. */
+	policyVersions?: PolicyVersionRef[];
+};
+
+/**
+ * The combined result of every check at one point.
+ *
+ * Almost the same as {@link PolicyCheckResult} today, but kept separate so it's always
+ * clear who filled a field in: a single check, or the layer combining them.
+ */
+export type PolicyDecision = {
+	violations: PolicyViolation[];
+
+	policyVersions?: PolicyVersionRef[];
+
+	/**
+	 * `evaluate` only. A check that failed lands here while the rest keep their results, so
+	 * one broken check doesn't sink a whole report — and a crash never looks like "nothing
+	 * to report".
+	 */
+	checkErrors?: PolicyCheckFailure[];
+};
+
+/**
+ * What every policy check implements.
+ *
+ * One method per point, each with its own context type: mistakes are caught when compiling,
+ * and giving a check more context takes a visible signature change rather than happening
+ * by accident.
+ *
+ * Rules for writing one:
+ * - Report violations, don't throw for them. A throw means something broke, and blocks the
+ *   action.
+ * - Only read state, never write it. That's what makes `evaluate` safe to call.
+ * - Implement only the points you care about.
+ *
+ * There's no `priority`, because every check has to pass — the order they run in can't
+ * change the answer.
+ *
+ * @example
+ * ```typescript
+ * @PolicyCheck()
+ * export class NodeTypePolicyCheck implements RegisteredPolicyCheck {
+ *   readonly id = 'node-type-availability';
+ *
+ *   async onWorkflowStart({ workflow, projectId }: WorkflowStartContext) {
+ *     return { violations: await this.violationsFor(workflow, projectId) };
+ *   }
+ * }
+ * ```
+ */
+export interface RegisteredPolicyCheck {
+	/** Stable id, shown on every violation and on the audit log. */
+	id: string;
+
+	onWorkflowSave?(ctx: WorkflowSaveContext): Promise<PolicyCheckResult>;
+	onWorkflowPublish?(ctx: WorkflowPublishContext): Promise<PolicyCheckResult>;
+	onWorkflowStart?(ctx: WorkflowStartContext): Promise<PolicyCheckResult>;
+	onWorkflowTransfer?(ctx: WorkflowTransferContext): Promise<PolicyCheckResult>;
+	onCredentialDecrypt?(ctx: CredentialDecryptContext): Promise<PolicyCheckResult>;
+	onContentImport?(ctx: ContentImportContext): Promise<PolicyCheckResult>;
+}
+
+/** The {@link RegisteredPolicyCheck} method for a point, e.g. `'onWorkflowSave'`. */
+export type PolicyCheckMethod = `on${Capitalize<EnforcementPoint>}`;
+
+/**
+ * Which method belongs to which point.
+ *
+ * The type pins each point to exactly its own method name, so a missing entry, a stray
+ * entry, and a point wired to the wrong method all fail to compile. If a method is renamed
+ * on the interface without updating this list, {@link pointsImplementedBy} stops compiling.
+ */
+export const ENFORCEMENT_POINT_METHODS: {
+	readonly [P in EnforcementPoint]: `on${Capitalize<P>}`;
+} = {
+	workflowSave: 'onWorkflowSave',
+	workflowPublish: 'onWorkflowPublish',
+	workflowStart: 'onWorkflowStart',
+	workflowTransfer: 'onWorkflowTransfer',
+	credentialDecrypt: 'onCredentialDecrypt',
+	contentImport: 'onContentImport',
+};
+
+/** Constructor of a class implementing {@link RegisteredPolicyCheck}, for DI. */
+export type PolicyCheckClass = Constructable<RegisteredPolicyCheck>;
+
+/**
+ * Which points a check actually implements.
+ *
+ * Kept next to the mapping above so callers don't each work it out themselves.
+ */
+export const pointsImplementedBy = (check: RegisteredPolicyCheck): EnforcementPoint[] =>
+	ENFORCEMENT_POINTS.filter(
+		(point) => typeof check[ENFORCEMENT_POINT_METHODS[point]] === 'function',
+	);


### PR DESCRIPTION
## Summary

Adds the shared contract that policy features will be built on, per the [Policy infrastructure RFC](https://app.notion.com/p/n8n/Policy-infrastructure-39e5b6e0c94f8013a1b1c80c15433b27):

- the six enforcement points — `workflowSave`, `workflowPublish`, `workflowStart`, `workflowTransfer`, `credentialDecrypt`, `contentImport`
- `RegisteredPolicyCheck`, one method per point, each with its own closed context type
- one violation shape (`PolicyViolation`) plus the per-check (`PolicyCheckResult`) and aggregate (`PolicyDecision`) envelopes
- the `@PolicyCheck()` decorator and its `PolicyCheckMetadata` registry

Mirrors the existing `ClusterCheck` / `ClusterCheckMetadata` pattern in the same package.

**Contract only — nothing enforces anything yet.** The proxy that calls checks and the module that runs and combines them land in follow-up PRs, so this is additive and inert on its own.

Two things worth a reviewer's eye:

- **The decorator rejects `on*` methods that don't name a known enforcement point.** A misspelled or removed point would otherwise just never be called, and the author would think their check was working. This makes it a startup error instead. It sees prototype methods, which is how checks are meant to be written; a check with no points at all is left to the runtime startup log, since a point written as an arrow-function property is invisible at decoration time.
- **`ENFORCEMENT_POINT_METHODS` derives each value from its key** (`{ [P in EnforcementPoint]: `on${Capitalize<P>}` }`), so a missing entry, a stray entry, or a point wired to the *wrong* method all fail to compile. Verified against five drift cases, including renaming a method on the interface without updating the list.

A couple of small deviations from the RFC text, both deliberate:

- `PolicedWorkflow` rather than `IWorkflowBase` in the workflow contexts — a check only needs the nodes, and passing the whole entity invites checks to depend on unrelated fields. It also works for creates, where there's no `id`/`createdAt` yet. `IWorkflowBase` is structurally assignable, so hosts pass their entity straight through.
- `storedWorkflow: PolicedWorkflow | null` rather than optional, so it can't be omitted by accident.

## How to test

```bash
cd packages/@n8n/decorators
pnpm typecheck && pnpm lint && pnpm test
```

152/152 tests pass (8 new). The new tests cover registration and ordering, DI resolution, rejection of an unknown `on*` method, that a rejected class isn't registered, that non-point helpers (`once()`, `buildViolation()`) aren't mistaken for points, and `pointsImplementedBy`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1114

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- internal contract, no user-facing surface yet; module README is IAM-1121 -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

