### PR TITLE
chore: Update skills marketplace name to n8n-agent-skills

### DIFF
--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -131,8 +131,7 @@ the tools assume.
 
 Claude sessions can also load the private quality skills from the
 `n8n-io/n8n-agent-skills` repository (bug insights, defect attribution,
-mutation testing, and more). Its Claude marketplace remains named
-`n8n-claude-skills`. `post-start.mjs` installs the `quality` plugin on each
+mutation testing, and more). `post-start.mjs` installs the `quality` plugin on each
 container start, so every session gets the skills with no per-session step.
 
 The private marketplace uses the codespace's own GitHub auth — no extra token.

--- a/.devcontainer/codespaces/post-start.mjs
+++ b/.devcontainer/codespaces/post-start.mjs
@@ -3,7 +3,7 @@
 import { execFileSync } from 'node:child_process';
 
 const MARKETPLACE = 'n8n-io/n8n-agent-skills';
-const PLUGIN = 'quality@n8n-claude-skills';
+const PLUGIN = 'quality@n8n-agent-skills';
 
 // The codespace clones over HTTPS and has no SSH key. The loader defaults to SSH
 // for "owner/repo", so it must prefer HTTPS or the private clone fails.

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -81,7 +81,7 @@ const CACHE = 'export TURBO_CACHE_DIR=/workspaces/.turbo-cache; [ -d "$TURBO_CAC
 // no-op once cached). Mirrors the env vars post-start.mjs sets for the private
 // HTTPS clone; failures are tolerated so a plugin hiccup never blocks the session.
 const MARKETPLACE = 'n8n-io/n8n-agent-skills';
-const PLUGIN = 'quality@n8n-claude-skills';
+const PLUGIN = 'quality@n8n-agent-skills';
 const ENSURE_PLUGIN = `export CLAUDE_CODE_PLUGIN_PREFER_HTTPS=1 CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE=1; claude plugin marketplace add ${MARKETPLACE} >/dev/null 2>&1 || true; claude plugin install ${PLUGIN} >/dev/null 2>&1 || true`;
 
 function remoteCommand(session, extraArgs) {


### PR DESCRIPTION
## Summary

Follow-up to #36332, which updated the repo slug but kept the plugin identifier `quality@n8n-claude-skills` — correct at the time, because the skills repo had deliberately kept its Claude marketplace named `n8n-claude-skills`. That changed today: [n8n-agent-skills#65](https://github.com/n8n-io/n8n-agent-skills/pull/65) renamed the Claude marketplace identity to `n8n-agent-skills` (shipped in `quality-v1.14.1`), so the old identifier no longer resolves.

Both call sites tolerate install failures by design (`|| true` / try-catch), which means the `quality` plugin has been **silently failing to install** in codespaces and cloud sessions since the rename landed:

- `scripts/cloud-session.mjs` — `PLUGIN` → `quality@n8n-agent-skills`
- `.devcontainer/codespaces/post-start.mjs` — same
- `.devcontainer/codespaces/README.md` — drops the now-outdated "marketplace remains named `n8n-claude-skills`" note

## Review notes

Name-only change; the marketplace slug (`n8n-io/n8n-agent-skills`) was already correct in both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

