### PR TITLE
fix(editor): Move the trust checkbox out of the MCP consent redirect callout

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
@@ -167,13 +167,22 @@ describe('OAuthConsentView', () => {
 		expect(allowButton).not.toBeDisabled();
 	});
 
-	it('should show the redirect URL inside the warning callout', async () => {
+	it('should show the redirect URL inside the redirect callout', async () => {
 		const { getByTestId } = renderComponent();
 		await waitAllPromises();
 
 		expect(getByTestId('consent-redirect-warning')).toBeVisible();
 		expect(getByTestId('consent-redirect-uri')).toHaveTextContent(
 			'https://legitimate-client.com/callback',
+		);
+	});
+
+	it('should render the trust checkbox outside the redirect callout', async () => {
+		const { getByTestId } = renderComponent();
+		await waitAllPromises();
+
+		expect(getByTestId('consent-redirect-warning')).not.toContainElement(
+			getByTestId('consent-redirect-confirm'),
 		);
 	});
 
@@ -204,7 +213,7 @@ describe('OAuthConsentView', () => {
 			expect(getByTestId('consent-allow-button')).not.toBeDisabled();
 		});
 
-		it('should not show the redirect URL or the warning callout', async () => {
+		it('should not show the redirect URL or the redirect callout', async () => {
 			const { queryByTestId } = renderComponent();
 			await waitAllPromises();
 
@@ -288,6 +297,20 @@ describe('OAuthConsentView', () => {
 				'workflow:write',
 				'execution:read',
 			]);
+		});
+
+		it('should keep a custom scope selection when the trust checkbox is toggled', async () => {
+			const { getByTestId, getByLabelText } = renderComponent();
+			await waitAllPromises();
+
+			await userEvent.click(getByTestId('scopes-mode-custom'));
+			await userEvent.click(getByTestId('scope-group-executions'));
+			expect(getByTestId('scopes-count')).toHaveTextContent('1 of 3 scopes selected');
+
+			await userEvent.click(getByLabelText('I recognize and trust this URL'));
+
+			expect(getByTestId('scopes-count')).toHaveTextContent('1 of 3 scopes selected');
+			expect(getByTestId('scopes-mode-custom')).toBeChecked();
 		});
 
 		it('should show a tool count pill per scope group when scope tools are provided', async () => {

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -286,30 +286,34 @@ onMounted(async () => {
 				</div>
 			</div>
 			<footer v-if="!waitingForRedirect" :class="$style.footer">
-				<!-- Third-party clients: the trust acknowledgment lives inside the warning itself so it
-				     can't be missed: one block that says where access goes, shows the URL, asks for the check.
-				     First-party clients skip this entirely — their redirect URI is the form itself. -->
-				<N8nCallout
-					v-if="!error && !clientDetails?.isFirstParty && clientDetails?.redirectUri"
-					theme="warning"
-					data-test-id="consent-redirect-warning"
-				>
-					<div :class="$style['redirect-warning-content']">
-						<N8nText :bold="true" size="small">
+				<!-- Third-party clients: the redirect destination, with the trust acknowledgment
+				     below it in the action row so it reads as a step rather than banner small
+				     print. Both are gated on the same `trustRequired` as the Allow button, so the
+				     screen can never ask for a confirmation it doesn't show. First-party clients
+				     skip both — their redirect URI is the form itself. -->
+				<div v-if="!error && trustRequired" :class="$style.divided">
+					<N8nCallout
+						theme="secondary"
+						:iconless="true"
+						:class="$style['redirect-note']"
+						data-test-id="consent-redirect-warning"
+					>
+						<span :class="$style['redirect-note-title']">
 							{{ i18n.baseText('oauth.consentView.redirectWarning.title') }}
-						</N8nText>
-						<code :class="$style['redirect-warning-url']" data-test-id="consent-redirect-uri">
-							{{ clientDetails.redirectUri }}
+						</span>
+						<code :class="$style['redirect-url']" data-test-id="consent-redirect-uri">
+							{{ clientDetails?.redirectUri }}
 						</code>
-						<N8nCheckbox
-							v-model="redirectUriTrusted"
-							:class="$style['redirect-warning-confirm']"
-							:label="i18n.baseText('oauth.consentView.redirectWarning.confirm')"
-							data-test-id="consent-redirect-confirm"
-						/>
-					</div>
-				</N8nCallout>
-				<div :class="$style['footer-actions']">
+					</N8nCallout>
+				</div>
+				<div :class="[$style['footer-actions'], $style.divided]">
+					<N8nCheckbox
+						v-if="!error && trustRequired"
+						v-model="redirectUriTrusted"
+						:class="$style['trust-confirm']"
+						:label="i18n.baseText('oauth.consentView.redirectWarning.confirm')"
+						data-test-id="consent-redirect-confirm"
+					/>
 					<div :class="$style['button-group']">
 						<N8nButton
 							v-if="error"
@@ -508,6 +512,8 @@ onMounted(async () => {
 	}
 }
 
+/* The gap gives each separator the same breathing room above the line as the
+   `.divided` padding gives below it. */
 .footer {
 	width: 100%;
 	display: flex;
@@ -515,34 +521,60 @@ onMounted(async () => {
 	gap: var(--spacing--sm);
 }
 
-.redirect-warning-content {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--3xs);
+/* Hairline separators keep the redirect note and the action row as distinct steps
+   without adding more nested boxes. */
+.divided {
+	padding-block-start: var(--spacing--sm);
+	border-block-start: var(--border-width, 1px) solid var(--border-color--subtle);
 }
 
-.redirect-warning-url {
-	font-size: var(--font-size--2xs);
-	word-break: break-all;
+/* The `secondary` callout theme is purple; retint it to a neutral grey so the note
+   reads as information rather than as a banner users learn to skip. Retinting the
+   theme's own custom properties rather than the resolved colors keeps this working
+   regardless of whether the callout's CSS is bundled before or after this file. */
+.redirect-note {
+	--callout--border-color--secondary: var(--border-color--subtle);
+	--callout--color--background--secondary: var(--background--subtle);
+	--callout--color--text--secondary: var(--text-color--subtle);
 }
 
-.redirect-warning-confirm {
-	margin-top: var(--spacing--3xs);
-	margin-bottom: 0;
+/* Both lines size themselves rather than restyling the callout's inner N8nText,
+   which is an implementation detail of the component. */
+.redirect-note-title,
+.redirect-url {
+	display: block;
+	font-size: var(--font-size--sm);
+	line-height: var(--line-height--lg);
 }
 
-/* CTAs sit at the right; the trust checkbox anchors the left edge of the row. */
+.redirect-url {
+	margin-block-start: var(--spacing--4xs);
+	font-family: var(--font-family--monospace);
+	overflow-wrap: anywhere;
+}
+
+/* The trust checkbox anchors the left edge of the row and keeps its full label
+   width, so the button group is what drops to a second line when space runs out. */
 .footer-actions {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	justify-content: flex-end;
-	gap: var(--spacing--sm);
+	flex-wrap: wrap;
+	gap: var(--spacing--2xs) var(--spacing--sm);
 
+	/* The auto margin is what right-aligns the buttons, on both a shared line and a
+	   wrapped one, and when there is no checkbox at all (first-party, error). */
 	.button-group {
 		display: flex;
-		justify-content: flex-end;
+		align-items: center;
+		margin-inline-start: auto;
 		gap: var(--spacing--2xs);
 	}
+}
+
+/* Tone the label down to match the note it refers to; the checkbox's own default is
+   the darker body color. */
+.trust-confirm label {
+	color: var(--text-color--subtle);
 }
 </style>


### PR DESCRIPTION
## Summary

On the MCP consent screen the "I recognize and trust this URL" checkbox sat inside a yellow warning callout, where session replays showed people missing it and getting stuck with a disabled Allow button.

The checkbox now sits in the action row next to Deny / Allow access, and the redirect destination is a neutral grey callout. Layout follows the design in the ticket:

- grey callout holding the destination URL in monospace
- checkbox below it, left-aligned in the button row
- hairline separators between the description, the callout and the actions

The callout wording is deliberately left as it was ("After you allow, access to this instance is sent to:") rather than switching to the mockup's "You will be redirected to the following location:". This is the only anti-phishing control on the screen, and DCR is unauthenticated by spec, so a self-registered client can pick its own redirect URI. Dropping the warning colour and the statement of consequence in the same change felt like one step too many. Happy to take the mockup wording if design prefers it.

Allow is still gated on the checkbox, and a scope selection (including a custom set) survives toggling it. The callout and the checkbox are now gated on the same `trustRequired` expression that disables Allow, so the screen cannot ask for a confirmation it does not render. First-party consents such as forms are unchanged: they show neither the callout nor the checkbox, and the buttons stay right-aligned.

Test IDs are unchanged, so the Playwright page object needed no update.

## How to test

1. Connect an MCP client (Claude or ChatGPT) through either the one-click or the manual setup so the consent screen appears.
2. The redirect destination shows in a grey callout with the checkbox below it.
3. Allow access is disabled until the checkbox is ticked.
4. Pick Custom in the scope picker, select a few scopes, then tick the checkbox. The selection stays as it was.

Unit tests: `pnpm --filter n8n-editor-ui test src/app/views/OAuthConsentView.test.ts`

Verified in a local instance through a real DCR + authorize flow, plus unit tests, typecheck, eslint and stylelint.

## Known follow-up

`N8nCallout` hardcodes `role="alert"` for every theme, so a screen reader announces the redirect line assertively on load. That was reasonable for a warning banner and is less so for a neutral note, but fixing it means adding a `role` passthrough to the shared component, which belongs in its own PR.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5653

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
