### PR TITLE
feat(Perplexity Node): Add v3 Agent-only, keep v2 with deprecation notice

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+# 2.37.0
+
+### What changed?
+
+The default resource for new Perplexity node instances at typeVersion 2 changed from `chat` to `agent`. New nodes added to a workflow will land on the Agent resource, which routes to the Agent API. Existing saved workflows persist the resource value chosen at edit time and are not affected.
+
+### When is action necessary?
+
+If you programmatically create Perplexity nodes at typeVersion 2 and rely on the resource defaulting to `chat`. Set `parameters.resource` explicitly to `'chat'` in that case, and plan to migrate to the Agent resource before 2026-09-27, when the underlying Chat Completions API stops responding.
+
 # 2.0.0
 
 ### What changed?

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,16 +2,6 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
-# 2.37.0
-
-### What changed?
-
-The default resource for new Perplexity node instances at typeVersion 2 changed from `chat` to `agent`. New nodes added to a workflow will land on the Agent resource, which routes to the Agent API. Existing saved workflows persist the resource value chosen at edit time and are not affected.
-
-### When is action necessary?
-
-If you programmatically create Perplexity nodes at typeVersion 2 and rely on the resource defaulting to `chat`. Set `parameters.resource` explicitly to `'chat'` in that case, and plan to migrate to the Agent resource before 2026-09-27, when the underlying Chat Completions API stops responding.
-
 # 2.0.0
 
 ### What changed?

--- a/packages/nodes-base/nodes/Perplexity/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Perplexity/GenericFunctions.ts
@@ -28,7 +28,7 @@ export async function sendErrorPostReceive(
 			throw new NodeApiError(this.getNode(), errorBody, {
 				message: 'Invalid model',
 				description:
-					'The model is not valid. Permitted models can be found in the documentation at https://docs.perplexity.ai/guides/model-cards.',
+					'The model is not valid. Permitted models can be found in the documentation at https://docs.perplexity.ai/docs/agent-api/models.',
 			});
 		}
 
@@ -36,7 +36,7 @@ export async function sendErrorPostReceive(
 		throw new NodeApiError(this.getNode(), response as unknown as JsonObject, {
 			message: `${errorMessage}${itemIndex ? ' ' + itemIndex : ''}.`,
 			description:
-				'Any optional system messages must be sent first, followed by alternating user and assistant messages. For more details, refer to the API documentation: https://docs.perplexity.ai/api-reference/chat-completions',
+				'Any optional system messages must be sent first, followed by alternating user and assistant messages. For more details, refer to the API documentation: https://docs.perplexity.ai/api-reference/agent-post',
 		});
 	}
 	return data;

--- a/packages/nodes-base/nodes/Perplexity/Perplexity.node.ts
+++ b/packages/nodes-base/nodes/Perplexity/Perplexity.node.ts
@@ -65,12 +65,13 @@ export class Perplexity implements INodeType {
 						name: 'Agent',
 						value: 'agent',
 						description:
-							'Create responses using the Agent API with third-party models, presets, tools, and structured outputs',
+							'Recommended. Create responses using the Agent API with third-party models, presets, tools, and structured outputs',
 					},
 					{
 						name: 'Chat',
 						value: 'chat',
-						description: 'Send messages using Sonar models with built-in web search',
+						description:
+							'Send messages using Sonar models with built-in web search. Support ends on 2026-09-27; switch to the Agent resource',
 					},
 					{
 						name: 'Embedding',
@@ -83,10 +84,24 @@ export class Perplexity implements INodeType {
 						description: 'Get raw, ranked web search results',
 					},
 				],
-				default: 'chat',
+				default: 'agent',
 				displayOptions: {
 					show: {
 						'@version': [2],
+					},
+				},
+			},
+			// V2: deprecation notice shown when Chat resource is selected
+			{
+				displayName:
+					'The Chat resource is being upgraded to Agent and its support ends on 2026-09-27. Switch Resource to Agent. See the migration guide at https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview.',
+				name: 'chatDeprecationNotice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						'@version': [2],
+						resource: ['chat'],
 					},
 				},
 			},

--- a/packages/nodes-base/nodes/Perplexity/Perplexity.node.ts
+++ b/packages/nodes-base/nodes/Perplexity/Perplexity.node.ts
@@ -1,120 +1,34 @@
-import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
-import { NodeConnectionTypes } from 'n8n-workflow';
+import type { INodeTypeBaseDescription, IVersionedNodeType } from 'n8n-workflow';
+import { VersionedNodeType } from 'n8n-workflow';
 
-import { agent, chat, embeddings, search } from './descriptions';
-import { getAgentModels } from './GenericFunctions';
+import { PerplexityV2 } from './v2/PerplexityV2.node';
+import { PerplexityV3 } from './v3/PerplexityV3.node';
 
-export class Perplexity implements INodeType {
-	description: INodeTypeDescription = {
-		displayName: 'Perplexity',
-		name: 'perplexity',
-		icon: {
-			light: 'file:perplexity.svg',
-			dark: 'file:perplexity.dark.svg',
-		},
-		group: ['transform'],
-		version: [1, 2],
-		defaultVersion: 2,
-		subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
-		description:
-			'AI-powered answer engine that provides accurate, trusted, and real-time answers to any question. Supports chat completions, agent responses, web search, and embeddings.',
-		defaults: {
-			name: 'Perplexity',
-		},
-		inputs: [NodeConnectionTypes.Main],
-		outputs: [NodeConnectionTypes.Main],
-		usableAsTool: true,
-		credentials: [
-			{
-				name: 'perplexityApi',
-				required: true,
+export class Perplexity extends VersionedNodeType {
+	constructor() {
+		const baseDescription: INodeTypeBaseDescription = {
+			displayName: 'Perplexity',
+			name: 'perplexity',
+			icon: {
+				light: 'file:perplexity.svg',
+				dark: 'file:perplexity.dark.svg',
 			},
-		],
-		requestDefaults: {
-			baseURL: 'https://api.perplexity.ai',
-			ignoreHttpStatusErrors: true,
-		},
-		properties: [
-			// V1: hidden resource selector (only chat)
-			{
-				displayName: 'Resource',
-				name: 'resource',
-				type: 'hidden',
-				noDataExpression: true,
-				options: [
-					{
-						name: 'Chat',
-						value: 'chat',
-					},
-				],
-				default: 'chat',
-				displayOptions: {
-					show: {
-						'@version': [1],
-					},
-				},
-			},
-			// V2: visible resource selector (all resources)
-			{
-				displayName: 'Resource',
-				name: 'resource',
-				type: 'options',
-				noDataExpression: true,
-				options: [
-					{
-						name: 'Agent',
-						value: 'agent',
-						description:
-							'Recommended. Create responses using the Agent API with third-party models, presets, tools, and structured outputs',
-					},
-					{
-						name: 'Chat',
-						value: 'chat',
-						description:
-							'Send messages using Sonar models with built-in web search. Support ends on 2026-09-27; switch to the Agent resource',
-					},
-					{
-						name: 'Embedding',
-						value: 'embedding',
-						description: 'Generate vector embeddings for text',
-					},
-					{
-						name: 'Search',
-						value: 'search',
-						description: 'Get raw, ranked web search results',
-					},
-				],
-				default: 'agent',
-				displayOptions: {
-					show: {
-						'@version': [2],
-					},
-				},
-			},
-			// V2: deprecation notice shown when Chat resource is selected
-			{
-				displayName:
-					'The Chat resource is being upgraded to Agent and its support ends on 2026-09-27. Switch Resource to Agent. See the migration guide at https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview.',
-				name: 'chatDeprecationNotice',
-				type: 'notice',
-				default: '',
-				displayOptions: {
-					show: {
-						'@version': [2],
-						resource: ['chat'],
-					},
-				},
-			},
-			...agent.description,
-			...chat.description,
-			...embeddings.description,
-			...search.description,
-		],
-	};
+			group: ['transform'],
+			subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
+			description:
+				'AI-powered answer engine that provides accurate, trusted, and real-time answers to any question. Supports agent responses, web search, and embeddings.',
+			defaultVersion: 3,
+		};
 
-	methods = {
-		listSearch: {
-			getAgentModels,
-		},
-	};
+		const v2 = new PerplexityV2(baseDescription);
+		const v3 = new PerplexityV3(baseDescription);
+
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
+			1: v2,
+			2: v2,
+			3: v3,
+		};
+
+		super(nodeVersions, baseDescription);
+	}
 }

--- a/packages/nodes-base/nodes/Perplexity/test/Perplexity.node.test.ts
+++ b/packages/nodes-base/nodes/Perplexity/test/Perplexity.node.test.ts
@@ -40,7 +40,9 @@ describe('Perplexity Node', () => {
 			expect(v2.description.properties).toEqual(expect.arrayContaining(description));
 		});
 
-		it('should default the v2 Resource selector to agent', () => {
+		// Flipping this default would reroute saved workflows that omit the
+		// parameter because it matched the default at save time
+		it('should keep the v2 Resource selector defaulted to chat', () => {
 			const v2Resource = v2.description.properties.find(
 				(p) =>
 					p.name === 'resource' &&
@@ -49,7 +51,7 @@ describe('Perplexity Node', () => {
 			);
 
 			expect(v2Resource).toBeDefined();
-			expect(v2Resource?.default).toBe('agent');
+			expect(v2Resource?.default).toBe('chat');
 		});
 
 		it('should keep the v1 Resource selector defaulted to chat', () => {
@@ -64,14 +66,14 @@ describe('Perplexity Node', () => {
 			expect(v1Resource?.default).toBe('chat');
 		});
 
-		it('should include a Chat deprecation notice on v2', () => {
+		it('should include a Chat deprecation notice on v1 and v2', () => {
 			const chatDeprecationNotice = v2.description.properties.find(
 				(p) => p.name === 'chatDeprecationNotice' && p.type === 'notice',
 			);
 
 			expect(chatDeprecationNotice).toBeDefined();
 			expect(chatDeprecationNotice?.displayOptions?.show?.resource).toEqual(['chat']);
-			expect(chatDeprecationNotice?.displayOptions?.show?.['@version']).toEqual([2]);
+			expect(chatDeprecationNotice?.displayOptions?.show?.['@version']).toEqual([1, 2]);
 			expect(chatDeprecationNotice?.displayName).toMatch(/September 27, 2026/);
 			expect(chatDeprecationNotice?.displayName).toMatch(
 				/docs\.perplexity\.ai\/docs\/agent-api\/migrate-from-sonar/,
@@ -111,6 +113,14 @@ describe('Perplexity Node', () => {
 			);
 
 			expect(chatDeprecationNotice).toBeUndefined();
+		});
+
+		it('should not carry over any Chat properties', () => {
+			const chatProperties = v3.description.properties.filter((p) =>
+				p.displayOptions?.show?.resource?.includes('chat'),
+			);
+
+			expect(chatProperties).toEqual([]);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Perplexity/test/Perplexity.node.test.ts
+++ b/packages/nodes-base/nodes/Perplexity/test/Perplexity.node.test.ts
@@ -1,28 +1,47 @@
-import { Perplexity } from '../../Perplexity/Perplexity.node';
-import { description } from '../descriptions/chat/complete.operation';
-import type * as _importType0 from '../../Perplexity/GenericFunctions';
+import type { INodeTypeBaseDescription } from 'n8n-workflow';
 
-vi.mock('../../Perplexity/GenericFunctions', async () => ({
-	...(await vi.importActual<typeof _importType0>('../../Perplexity/GenericFunctions')),
+import { description } from '../descriptions/chat/complete.operation';
+import type * as _importType0 from '../GenericFunctions';
+import { Perplexity } from '../Perplexity.node';
+import { PerplexityV2 } from '../v2/PerplexityV2.node';
+import { PerplexityV3 } from '../v3/PerplexityV3.node';
+
+vi.mock('../GenericFunctions', async () => ({
+	...(await vi.importActual<typeof _importType0>('../GenericFunctions')),
 	getAgentModels: vi.fn(),
 }));
 
-describe('Perplexity Node', () => {
-	let node: Perplexity;
+const baseDescription: INodeTypeBaseDescription = {
+	displayName: 'Perplexity',
+	name: 'perplexity',
+	group: ['transform'],
+	description: 'test',
+	defaultVersion: 3,
+};
 
-	beforeEach(() => {
-		node = new Perplexity();
+describe('Perplexity Node', () => {
+	describe('VersionedNodeType shell', () => {
+		it('should expose v1, v2, and v3 with defaultVersion 3', () => {
+			const node = new Perplexity();
+
+			expect(node.currentVersion).toBe(3);
+			expect(Object.keys(node.nodeVersions).map(Number).sort()).toEqual([1, 2, 3]);
+		});
 	});
 
-	describe('Node Description', () => {
-		it('should correctly include chat completion properties', () => {
-			const properties = node.description.properties;
+	describe('PerplexityV2', () => {
+		let v2: PerplexityV2;
 
-			expect(properties).toEqual(expect.arrayContaining(description));
+		beforeEach(() => {
+			v2 = new PerplexityV2(baseDescription);
+		});
+
+		it('should correctly include chat completion properties', () => {
+			expect(v2.description.properties).toEqual(expect.arrayContaining(description));
 		});
 
 		it('should default the v2 Resource selector to agent', () => {
-			const v2Resource = node.description.properties.find(
+			const v2Resource = v2.description.properties.find(
 				(p) =>
 					p.name === 'resource' &&
 					p.type === 'options' &&
@@ -34,7 +53,7 @@ describe('Perplexity Node', () => {
 		});
 
 		it('should keep the v1 Resource selector defaulted to chat', () => {
-			const v1Resource = node.description.properties.find(
+			const v1Resource = v2.description.properties.find(
 				(p) =>
 					p.name === 'resource' &&
 					p.type === 'hidden' &&
@@ -46,17 +65,52 @@ describe('Perplexity Node', () => {
 		});
 
 		it('should include a Chat deprecation notice on v2', () => {
-			const chatDeprecationNotice = node.description.properties.find(
+			const chatDeprecationNotice = v2.description.properties.find(
 				(p) => p.name === 'chatDeprecationNotice' && p.type === 'notice',
 			);
 
 			expect(chatDeprecationNotice).toBeDefined();
 			expect(chatDeprecationNotice?.displayOptions?.show?.resource).toEqual(['chat']);
 			expect(chatDeprecationNotice?.displayOptions?.show?.['@version']).toEqual([2]);
-			expect(chatDeprecationNotice?.displayName).toMatch(/2026-09-27/);
+			expect(chatDeprecationNotice?.displayName).toMatch(/September 27, 2026/);
 			expect(chatDeprecationNotice?.displayName).toMatch(
 				/docs\.perplexity\.ai\/docs\/agent-api\/migrate-from-sonar/,
 			);
+		});
+	});
+
+	describe('PerplexityV3', () => {
+		let v3: PerplexityV3;
+
+		beforeEach(() => {
+			v3 = new PerplexityV3(baseDescription);
+		});
+
+		it('should default the Resource selector to agent', () => {
+			const resource = v3.description.properties.find(
+				(p) => p.name === 'resource' && p.type === 'options',
+			);
+
+			expect(resource).toBeDefined();
+			expect(resource?.default).toBe('agent');
+		});
+
+		it('should not include the Chat resource', () => {
+			const resource = v3.description.properties.find(
+				(p) => p.name === 'resource' && p.type === 'options',
+			);
+			const values = (resource?.options ?? []).map((o) => (o as { value: string }).value);
+
+			expect(values).toEqual(expect.arrayContaining(['agent', 'embedding', 'search']));
+			expect(values).not.toContain('chat');
+		});
+
+		it('should not include a Chat deprecation notice', () => {
+			const chatDeprecationNotice = v3.description.properties.find(
+				(p) => p.name === 'chatDeprecationNotice',
+			);
+
+			expect(chatDeprecationNotice).toBeUndefined();
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Perplexity/test/Perplexity.node.test.ts
+++ b/packages/nodes-base/nodes/Perplexity/test/Perplexity.node.test.ts
@@ -20,5 +20,43 @@ describe('Perplexity Node', () => {
 
 			expect(properties).toEqual(expect.arrayContaining(description));
 		});
+
+		it('should default the v2 Resource selector to agent', () => {
+			const v2Resource = node.description.properties.find(
+				(p) =>
+					p.name === 'resource' &&
+					p.type === 'options' &&
+					p.displayOptions?.show?.['@version']?.includes(2),
+			);
+
+			expect(v2Resource).toBeDefined();
+			expect(v2Resource?.default).toBe('agent');
+		});
+
+		it('should keep the v1 Resource selector defaulted to chat', () => {
+			const v1Resource = node.description.properties.find(
+				(p) =>
+					p.name === 'resource' &&
+					p.type === 'hidden' &&
+					p.displayOptions?.show?.['@version']?.includes(1),
+			);
+
+			expect(v1Resource).toBeDefined();
+			expect(v1Resource?.default).toBe('chat');
+		});
+
+		it('should include a Chat deprecation notice on v2', () => {
+			const chatDeprecationNotice = node.description.properties.find(
+				(p) => p.name === 'chatDeprecationNotice' && p.type === 'notice',
+			);
+
+			expect(chatDeprecationNotice).toBeDefined();
+			expect(chatDeprecationNotice?.displayOptions?.show?.resource).toEqual(['chat']);
+			expect(chatDeprecationNotice?.displayOptions?.show?.['@version']).toEqual([2]);
+			expect(chatDeprecationNotice?.displayName).toMatch(/2026-09-27/);
+			expect(chatDeprecationNotice?.displayName).toMatch(
+				/docs\.perplexity\.ai\/docs\/agent-api\/migrate-from-sonar/,
+			);
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Perplexity/test/v3/createResponse.test.ts
+++ b/packages/nodes-base/nodes/Perplexity/test/v3/createResponse.test.ts
@@ -1,0 +1,39 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+const credentials = {
+	perplexityApi: {
+		apiKey: 'test-api-key',
+		baseUrl: 'https://api.perplexity.ai',
+	},
+};
+
+describe('Perplexity Node V3 - Agent Create Response', () => {
+	beforeEach(() => {
+		nock.disableNetConnect();
+		nock('https://api.perplexity.ai')
+			.post('/v1/agent', (body) => {
+				return typeof body?.input === 'string';
+			})
+			.reply(200, {
+				id: 'resp_test123',
+				model: 'openai/gpt-5.2',
+				object: 'response',
+				status: 'completed',
+				output: [
+					{
+						type: 'message',
+						role: 'assistant',
+						content: [{ type: 'output_text', text: '2+2 equals 4.' }],
+					},
+				],
+			});
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	new NodeTestHarness().setupTests({ credentials });
+});

--- a/packages/nodes-base/nodes/Perplexity/test/v3/createResponse.workflow.json
+++ b/packages/nodes-base/nodes/Perplexity/test/v3/createResponse.workflow.json
@@ -1,0 +1,73 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-80, -680],
+			"id": "a9105e3d-172b-411e-8c06-767a3ce1003a",
+			"name": "When clicking 'Test workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "agent",
+				"operation": "createResponse",
+				"model": {
+					"__rl": true,
+					"value": "openai/gpt-5.2",
+					"mode": "id"
+				},
+				"input": "What is 2+2?",
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.perplexity",
+			"typeVersion": 3,
+			"position": [-40, -380],
+			"id": "agent-node-v3",
+			"name": "Agent Response",
+			"credentials": {
+				"perplexityApi": {
+					"id": "test",
+					"name": "Perplexity account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking 'Test workflow'": {
+			"main": [
+				[
+					{
+						"node": "Agent Response",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Agent Response": [
+			{
+				"json": {
+					"id": "resp_test123",
+					"model": "openai/gpt-5.2",
+					"object": "response",
+					"status": "completed",
+					"output": [
+						{
+							"type": "message",
+							"role": "assistant",
+							"content": [
+								{
+									"type": "output_text",
+									"text": "2+2 equals 4."
+								}
+							]
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Perplexity/v2/PerplexityV2.node.ts
+++ b/packages/nodes-base/nodes/Perplexity/v2/PerplexityV2.node.ts
@@ -64,7 +64,7 @@ export class PerplexityV2 implements INodeType {
 							name: 'Chat',
 							value: 'chat',
 							description:
-								'Send messages using Sonar models with built-in web search. Sonar service ends 2026-09-27; switch to the Agent resource.',
+								'Send messages using Sonar models with built-in web search. Perplexity ends Sonar support on September 27, 2026; switch to the Agent resource.',
 						},
 						{
 							name: 'Embedding',
@@ -77,23 +77,23 @@ export class PerplexityV2 implements INodeType {
 							description: 'Get raw, ranked web search results',
 						},
 					],
-					default: 'agent',
+					default: 'chat',
 					displayOptions: {
 						show: {
 							'@version': [2],
 						},
 					},
 				},
-				// V2: deprecation notice shown when Chat resource is selected
+				// Deprecation notice shown when the Chat resource is in use
 				{
 					displayName:
-						'Sonar Chat Completions is now <a href="https://docs.perplexity.ai/docs/agent-api/quickstart" target="_blank">Agent API</a>. Sonar service ends September 27, 2026. Please migrate by then. See the <a href="https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview" target="_blank">Migration Guide</a>.',
+						'Sonar Chat Completions is now the <a href="https://docs.perplexity.ai/docs/agent-api/quickstart" target="_blank">Agent API</a>. Perplexity ends Sonar support on September 27, 2026, after which this resource stops working. Switch to the Agent resource before then, following the <a href="https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview" target="_blank">migration guide</a>.',
 					name: 'chatDeprecationNotice',
 					type: 'notice',
 					default: '',
 					displayOptions: {
 						show: {
-							'@version': [2],
+							'@version': [1, 2],
 							resource: ['chat'],
 						},
 					},

--- a/packages/nodes-base/nodes/Perplexity/v2/PerplexityV2.node.ts
+++ b/packages/nodes-base/nodes/Perplexity/v2/PerplexityV2.node.ts
@@ -58,13 +58,13 @@ export class PerplexityV2 implements INodeType {
 							name: 'Agent',
 							value: 'agent',
 							description:
-								'Recommended. Create responses using the Agent API with third-party models, presets, tools, and structured outputs',
+								'Recommended. Create responses using the Agent API with third-party models, presets, tools, and structured outputs.',
 						},
 						{
 							name: 'Chat',
 							value: 'chat',
 							description:
-								'Send messages using Sonar models with built-in web search. Sonar service ends 2026-09-27; switch to the Agent resource',
+								'Send messages using Sonar models with built-in web search. Sonar service ends 2026-09-27; switch to the Agent resource.',
 						},
 						{
 							name: 'Embedding',

--- a/packages/nodes-base/nodes/Perplexity/v2/PerplexityV2.node.ts
+++ b/packages/nodes-base/nodes/Perplexity/v2/PerplexityV2.node.ts
@@ -1,0 +1,114 @@
+import type { INodeType, INodeTypeBaseDescription, INodeTypeDescription } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+
+import { agent, chat, embeddings, search } from '../descriptions';
+import { getAgentModels } from '../GenericFunctions';
+
+export class PerplexityV2 implements INodeType {
+	description: INodeTypeDescription;
+
+	constructor(baseDescription: INodeTypeBaseDescription) {
+		this.description = {
+			...baseDescription,
+			version: [1, 2],
+			defaults: {
+				name: 'Perplexity',
+			},
+			inputs: [NodeConnectionTypes.Main],
+			outputs: [NodeConnectionTypes.Main],
+			usableAsTool: true,
+			credentials: [
+				{
+					name: 'perplexityApi',
+					required: true,
+				},
+			],
+			requestDefaults: {
+				baseURL: 'https://api.perplexity.ai',
+				ignoreHttpStatusErrors: true,
+			},
+			properties: [
+				// V1: hidden resource selector (only chat)
+				{
+					displayName: 'Resource',
+					name: 'resource',
+					type: 'hidden',
+					noDataExpression: true,
+					options: [
+						{
+							name: 'Chat',
+							value: 'chat',
+						},
+					],
+					default: 'chat',
+					displayOptions: {
+						show: {
+							'@version': [1],
+						},
+					},
+				},
+				// V2: visible resource selector (all resources)
+				{
+					displayName: 'Resource',
+					name: 'resource',
+					type: 'options',
+					noDataExpression: true,
+					options: [
+						{
+							name: 'Agent',
+							value: 'agent',
+							description:
+								'Recommended. Create responses using the Agent API with third-party models, presets, tools, and structured outputs',
+						},
+						{
+							name: 'Chat',
+							value: 'chat',
+							description:
+								'Send messages using Sonar models with built-in web search. Sonar service ends 2026-09-27; switch to the Agent resource',
+						},
+						{
+							name: 'Embedding',
+							value: 'embedding',
+							description: 'Generate vector embeddings for text',
+						},
+						{
+							name: 'Search',
+							value: 'search',
+							description: 'Get raw, ranked web search results',
+						},
+					],
+					default: 'agent',
+					displayOptions: {
+						show: {
+							'@version': [2],
+						},
+					},
+				},
+				// V2: deprecation notice shown when Chat resource is selected
+				{
+					displayName:
+						'Sonar Chat Completions is now <a href="https://docs.perplexity.ai/docs/agent-api/quickstart" target="_blank">Agent API</a>. Sonar service ends September 27, 2026. Please migrate by then. See the <a href="https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview" target="_blank">Migration Guide</a>.',
+					name: 'chatDeprecationNotice',
+					type: 'notice',
+					default: '',
+					displayOptions: {
+						show: {
+							'@version': [2],
+							resource: ['chat'],
+						},
+					},
+				},
+				...agent.description,
+				...chat.description,
+				...embeddings.description,
+				...search.description,
+			],
+		};
+	}
+
+	methods = {
+		listSearch: {
+			getAgentModels,
+		},
+	};
+}

--- a/packages/nodes-base/nodes/Perplexity/v3/PerplexityV3.node.ts
+++ b/packages/nodes-base/nodes/Perplexity/v3/PerplexityV3.node.ts
@@ -1,0 +1,68 @@
+import type { INodeType, INodeTypeBaseDescription, INodeTypeDescription } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+
+import { agent, embeddings, search } from '../descriptions';
+import { getAgentModels } from '../GenericFunctions';
+
+export class PerplexityV3 implements INodeType {
+	description: INodeTypeDescription;
+
+	constructor(baseDescription: INodeTypeBaseDescription) {
+		this.description = {
+			...baseDescription,
+			version: [3],
+			defaults: {
+				name: 'Perplexity',
+			},
+			inputs: [NodeConnectionTypes.Main],
+			outputs: [NodeConnectionTypes.Main],
+			usableAsTool: true,
+			credentials: [
+				{
+					name: 'perplexityApi',
+					required: true,
+				},
+			],
+			requestDefaults: {
+				baseURL: 'https://api.perplexity.ai',
+				ignoreHttpStatusErrors: true,
+			},
+			properties: [
+				{
+					displayName: 'Resource',
+					name: 'resource',
+					type: 'options',
+					noDataExpression: true,
+					options: [
+						{
+							name: 'Agent',
+							value: 'agent',
+							description:
+								'Create responses using the Agent API with third-party models, presets, tools, and structured outputs',
+						},
+						{
+							name: 'Embedding',
+							value: 'embedding',
+							description: 'Generate vector embeddings for text',
+						},
+						{
+							name: 'Search',
+							value: 'search',
+							description: 'Get raw, ranked web search results',
+						},
+					],
+					default: 'agent',
+				},
+				...agent.description,
+				...embeddings.description,
+				...search.description,
+			],
+		};
+	}
+
+	methods = {
+		listSearch: {
+			getAgentModels,
+		},
+	};
+}


### PR DESCRIPTION
Summary
Perplexity's Sonar Chat Completions service ends on September 27, 2026. After that date, existing n8n workflows using the Chat resource will stop working at runtime. This PR adds a proper major version bump so users get a clear migration path without breaking any workflows that exist today.

Changes
New: typeVersion: 3. Agent-only. Resource selector shows Agent, Embedding, and Search. No Chat resource. Default Resource: Agent.

defaultVersion: 3. New Perplexity nodes dragged from the picker use v3.

typeVersion: 2 unchanged behaviorally. Existing workflows keep running until the Sonar service ends. Selecting the Chat resource in v2 now renders an in-node deprecation notice linking to the migration guide.

File split to match the VersionedNodeType pattern used by HTTP Request, Google Drive, Slack, and Postgres: Perplexity.node.ts is a thin shell, v2/PerplexityV2.node.ts holds existing behavior, v3/PerplexityV3.node.ts holds the new Agent-only shape.

Notice text (v2, Chat resource)
Sonar Chat Completions is now Agent API. Sonar service ends September 27, 2026. Please migrate by then. See the Migration Guide.

Both "Agent API" and "Migration Guide" render as clickable links.

Migration for users
The Perplexity migration guide covers the mapping from Chat resource fields to Agent equivalents: https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview

Testing done locally
v3 loads in the editor; Resource selector shows Agent / Embedding / Search only.

v3 Agent request against api.perplexity.ai returns 200 with expected response shape.

v2 still loads with all four resources; Chat renders the new notice with live clickable links.

v2 Chat request against api.perplexity.ai still returns 200.

pnpm --filter n8n-nodes-base build passes; 421 nodes generate.

Related
Related: #36553 (issue, tracked in Linear)
Related: https://community.n8n.io/t/perplexity-node-default-v2-resource-to-agent-chat-completions-sunsets-2026-09-27/308492 (forum topic)
Precursor: #26970 (Agent resource added)
