### PR TITLE
chore(scripts): combine duplicate node:fs imports in check-workspace-deps.mjs

### DIFF
--- a/scripts/check-workspace-deps.mjs
+++ b/scripts/check-workspace-deps.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 const isPackageJson = (file) => file.endsWith('package.json');
 const files = process.argv.slice(2).filter((file) => file && isPackageJson(file) && existsSync(file));


### PR DESCRIPTION
### Summary
- In `scripts/check-workspace-deps.mjs`, combine duplicate import statements from `node:fs` into a single `import { existsSync, readFileSync } from 'node:fs';`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

