### PR TITLE
feat(API): Add startedAfter and startedBefore filters to GET /executions

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -3,7 +3,8 @@ import { GlobalConfig } from '@n8n/config';
 import type { SqliteConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import type { SelectQueryBuilder } from '@n8n/typeorm';
-import { In, LessThan, LessThanOrEqual, And, Not } from '@n8n/typeorm';
+import { In, LessThan, LessThanOrEqual, MoreThanOrEqual, And, Not } from '@n8n/typeorm';
+import { DateUtils } from '@n8n/typeorm/util/DateUtils';
 import { BinaryDataService } from 'n8n-core';
 import type { IRunExecutionData, IWorkflowBase } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
@@ -150,6 +151,81 @@ describe('ExecutionRepository', () => {
 					take: limit,
 				});
 
+				expect(result).toBe(mockCount);
+			});
+		});
+
+		describe('with startedAfter and startedBefore filters', () => {
+			const startedAfter = '2024-01-01T00:00:00.000Z';
+			const startedBefore = '2024-12-31T23:59:59.999Z';
+			const startedAfterCondition = MoreThanOrEqual(
+				DateUtils.mixedDateToUtcDatetimeString(new Date(startedAfter)),
+			);
+			const startedBeforeCondition = LessThanOrEqual(
+				DateUtils.mixedDateToUtcDatetimeString(new Date(startedBefore)),
+			);
+
+			test('should filter executions started after a given time', async () => {
+				const limit = 10;
+				const mockCount = 4;
+				const workflowIds = ['wf-1'];
+
+				entityManager.count.mockResolvedValueOnce(mockCount);
+				const result = await executionRepository.countInWorkflows(workflowIds, {
+					limit,
+					startedAfter,
+				});
+
+				expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+					where: {
+						workflowId: In(workflowIds),
+						startedAt: And(startedAfterCondition),
+					},
+					take: limit,
+				});
+				expect(result).toBe(mockCount);
+			});
+
+			test('should filter executions started before a given time', async () => {
+				const limit = 10;
+				const mockCount = 6;
+				const workflowIds = ['wf-1'];
+
+				entityManager.count.mockResolvedValueOnce(mockCount);
+				const result = await executionRepository.countInWorkflows(workflowIds, {
+					limit,
+					startedBefore,
+				});
+
+				expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+					where: {
+						workflowId: In(workflowIds),
+						startedAt: And(startedBeforeCondition),
+					},
+					take: limit,
+				});
+				expect(result).toBe(mockCount);
+			});
+
+			test('should filter executions started within a time range', async () => {
+				const limit = 10;
+				const mockCount = 3;
+				const workflowIds = ['wf-1'];
+
+				entityManager.count.mockResolvedValueOnce(mockCount);
+				const result = await executionRepository.countInWorkflows(workflowIds, {
+					limit,
+					startedAfter,
+					startedBefore,
+				});
+
+				expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+					where: {
+						workflowId: In(workflowIds),
+						startedAt: And(startedAfterCondition, startedBeforeCondition),
+					},
+					take: limit,
+				});
 				expect(result).toBe(mockCount);
 			});
 		});

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -118,20 +118,8 @@ function parseFiltersToQueryBuilder(
 			}
 		}
 	}
-	if (filters?.startedAfter) {
-		qb.andWhere({
-			startedAt: MoreThanOrEqual(
-				DateUtils.mixedDateToUtcDatetimeString(new Date(filters.startedAfter)),
-			),
-		});
-	}
-	if (filters?.startedBefore) {
-		qb.andWhere({
-			startedAt: LessThanOrEqual(
-				DateUtils.mixedDateToUtcDatetimeString(new Date(filters.startedBefore)),
-			),
-		});
-	}
+	const startedAt = startedAtCondition(filters ?? {});
+	if (startedAt) qb.andWhere({ startedAt });
 	if (filters?.workflowId) {
 		qb.andWhere({
 			workflowId: filters.workflowId,
@@ -139,12 +127,30 @@ function parseFiltersToQueryBuilder(
 	}
 }
 
-const lessThanOrEqual = (date: string): unknown => {
-	return LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(date)));
-};
+const startedAtCondition = ({
+	startedAfter,
+	startedBefore,
+}: {
+	startedAfter?: string;
+	startedBefore?: string;
+}) => {
+	const conditions = [];
 
-const moreThanOrEqual = (date: string): unknown => {
-	return MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(date)));
+	if (startedAfter) {
+		conditions.push(
+			MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedAfter))),
+		);
+	}
+
+	if (startedBefore) {
+		conditions.push(
+			LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedBefore))),
+		);
+	}
+
+	if (conditions.length === 0) return undefined;
+
+	return And(...conditions);
 };
 
 // This is the max number of elements in an IN-clause.
@@ -637,6 +643,8 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 			lastId?: string;
 			status?: ExecutionStatus;
 			excludedExecutionsIds?: string[];
+			startedAfter?: string;
+			startedBefore?: string;
 		},
 	): Promise<number> {
 		return await this.count({
@@ -675,6 +683,8 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 			lastId?: string;
 			status?: ExecutionStatus;
 			excludedExecutionsIds?: string[];
+			startedAfter?: string;
+			startedBefore?: string;
 		} = {},
 	) {
 		const where: FindOptionsWhere<IExecutionFlattedDb> = {
@@ -685,6 +695,9 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 			...this.getStatusCondition(options.status),
 			workflowId: In(workflowIds),
 		};
+
+		const startedAt = startedAtCondition(options);
+		if (startedAt) where.startedAt = startedAt;
 
 		return where;
 	}
@@ -968,8 +981,8 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 		if (status) qb.andWhere('execution.status IN (:...status)', { status });
 		if (finished) qb.andWhere({ finished });
 		if (workflowId) qb.andWhere({ workflowId });
-		if (startedBefore) qb.andWhere({ startedAt: lessThanOrEqual(startedBefore) });
-		if (startedAfter) qb.andWhere({ startedAt: moreThanOrEqual(startedAfter) });
+		const startedAt = startedAtCondition({ startedAfter, startedBefore });
+		if (startedAt) qb.andWhere({ startedAt });
 
 		if (metadata?.length === 1) {
 			const [{ key, value, exactMatch }] = metadata;
@@ -1176,21 +1189,8 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 			where.workflowId = query.workflowId;
 		}
 
-		const startedAtConditions = [];
-
-		if (query.startedAfter)
-			startedAtConditions.push(
-				MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(query.startedAfter))),
-			);
-
-		if (query.startedBefore)
-			startedAtConditions.push(
-				LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(query.startedBefore))),
-			);
-
-		if (startedAtConditions.length > 0) {
-			where.startedAt = And(...startedAtConditions);
-		}
+		const startedAt = startedAtCondition(query);
+		if (startedAt) where.startedAt = startedAt;
 
 		return await this.find({ select: ['id'], where });
 	}

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -906,6 +906,29 @@ describe('ExecutionService', () => {
 			);
 			expect(activeExecutions.getActiveExecutions).not.toHaveBeenCalled();
 		});
+
+		it('should forward startedAfter and startedBefore to the query', async () => {
+			executionPersistence.findManyInWorkflows.mockResolvedValue([]);
+			executionRepository.countInWorkflows.mockResolvedValue(0);
+			const startedAfter = '2024-01-01T00:00:00.000Z';
+			const startedBefore = '2024-12-31T23:59:59.999Z';
+
+			await executionService.findManyAndCount(['wf-1'], {
+				limit: 10,
+				startedAfter,
+				startedBefore,
+			});
+
+			expect(executionPersistence.findManyInWorkflows).toHaveBeenCalledWith(
+				['wf-1'],
+				expect.objectContaining({ startedAfter, startedBefore }),
+				undefined,
+			);
+			expect(executionRepository.countInWorkflows).toHaveBeenCalledWith(
+				['wf-1'],
+				expect.objectContaining({ startedAfter, startedBefore }),
+			);
+		});
 	});
 
 	describe('delete', () => {

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -601,6 +601,8 @@ export class ExecutionPersistence {
 			lastId?: string;
 			status?: ExecutionStatus;
 			excludedExecutionsIds?: string[];
+			startedAfter?: string;
+			startedBefore?: string;
 		},
 		maxDataSizeBytes?: number,
 	): Promise<IExecutionBase[]> {

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -807,6 +807,8 @@ export class ExecutionService {
 			status?: ExecutionStatus;
 			excludeRunning?: boolean;
 			maxDataSizeBytes?: number;
+			startedAfter?: string;
+			startedBefore?: string;
 		},
 	): Promise<{ executions: IExecutionBase[]; count: number }> {
 		const excludedExecutionsIds = options.excludeRunning
@@ -822,6 +824,8 @@ export class ExecutionService {
 			lastId: options.lastId,
 			status: options.status,
 			excludedExecutionsIds,
+			startedAfter: options.startedAfter,
+			startedBefore: options.startedBefore,
 		};
 
 		const executions = await this.executionPersistence.findManyInWorkflows(

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -49,6 +49,8 @@ export declare namespace ExecutionRequest {
 			workflowId?: string;
 			lastId?: string;
 			projectId?: string;
+			startedAfter?: string;
+			startedBefore?: string;
 		}
 	>;
 

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -135,6 +135,8 @@ const executionHandlers: ExecutionHandlers = {
 				ignoreDataSizeLimit = false,
 				workflowId = undefined,
 				projectId,
+				startedAfter,
+				startedBefore,
 			} = req.query;
 
 			const sharedWorkflowsIds = await Container.get(
@@ -152,6 +154,8 @@ const executionHandlers: ExecutionHandlers = {
 					limit,
 					lastId,
 					includeData,
+					startedAfter,
+					startedBefore,
 					// for backward compatibility `running` executions are always excluded
 					// unless the user explicitly filters by `running` status
 					excludeRunning: status !== 'running',

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -37,6 +37,22 @@ get:
       schema:
         type: string
         example: VmwOO9HeTEj20kxM
+    - name: startedAfter
+      in: query
+      description: Only return executions that started after this time.
+      required: false
+      schema:
+        type: string
+        format: date-time
+        example: '2024-01-01T00:00:00.000Z'
+    - name: startedBefore
+      in: query
+      description: Only return executions that started before this time.
+      required: false
+      schema:
+        type: string
+        format: date-time
+        example: '2024-12-31T23:59:59.999Z'
     - $ref: '../../../../shared/spec/parameters/limit.yml'
     - $ref: '../../../../shared/spec/parameters/cursor.yml'
   responses:
@@ -46,6 +62,8 @@ get:
         application/json:
           schema:
             $ref: '../schemas/executionList.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
     '403':

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -724,6 +724,135 @@ describe('GET /executions', () => {
 		);
 	});
 
+	describe('with startedAfter and startedBefore filters', () => {
+		test('should retrieve executions started after a given time', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const earlier = await createExecution(
+				{ startedAt: new Date('2020-06-01T00:00:00.000Z') },
+				workflow,
+			);
+			const later = await createExecution(
+				{ startedAt: new Date('2020-12-31T00:00:00.000Z') },
+				workflow,
+			);
+
+			const response = await authOwnerAgent.get('/executions').query({
+				startedAfter: '2020-07-01T00:00:00.000Z',
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.map((execution: ExecutionEntity) => execution.id)).toEqual([
+				later.id,
+			]);
+			expect(response.body.data.map((execution: ExecutionEntity) => execution.id)).not.toContain(
+				earlier.id,
+			);
+		});
+
+		test('should retrieve executions started before a given time', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const earlier = await createExecution(
+				{ startedAt: new Date('2020-06-01T00:00:00.000Z') },
+				workflow,
+			);
+			const later = await createExecution(
+				{ startedAt: new Date('2020-12-31T00:00:00.000Z') },
+				workflow,
+			);
+
+			const response = await authOwnerAgent.get('/executions').query({
+				startedBefore: '2020-07-01T00:00:00.000Z',
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.map((execution: ExecutionEntity) => execution.id)).toEqual([
+				earlier.id,
+			]);
+			expect(response.body.data.map((execution: ExecutionEntity) => execution.id)).not.toContain(
+				later.id,
+			);
+		});
+
+		test('should retrieve executions started within a time range', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const earlier = await createExecution(
+				{ startedAt: new Date('2020-01-01T00:00:00.000Z') },
+				workflow,
+			);
+			const inRange = await createExecution(
+				{ startedAt: new Date('2020-06-01T00:00:00.000Z') },
+				workflow,
+			);
+			const later = await createExecution(
+				{ startedAt: new Date('2020-12-31T00:00:00.000Z') },
+				workflow,
+			);
+
+			const response = await authOwnerAgent.get('/executions').query({
+				startedAfter: '2020-03-01T00:00:00.000Z',
+				startedBefore: '2020-09-01T00:00:00.000Z',
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.map((execution: ExecutionEntity) => execution.id)).toEqual([
+				inRange.id,
+			]);
+			expect(response.body.data.map((execution: ExecutionEntity) => execution.id)).not.toEqual(
+				expect.arrayContaining([earlier.id, later.id]),
+			);
+		});
+
+		test('should combine start-time filters with status and workflowId', async () => {
+			const [workflow, otherWorkflow] = await createManyWorkflows(2, {}, owner);
+			const matching = await createExecution(
+				{ startedAt: new Date('2020-06-01T00:00:00.000Z'), status: 'success' },
+				workflow,
+			);
+			await createExecution(
+				{ startedAt: new Date('2020-06-01T00:00:00.000Z'), status: 'error' },
+				workflow,
+			);
+			await createExecution(
+				{ startedAt: new Date('2020-12-31T00:00:00.000Z'), status: 'success' },
+				workflow,
+			);
+			await createExecution(
+				{ startedAt: new Date('2020-06-01T00:00:00.000Z'), status: 'success' },
+				otherWorkflow,
+			);
+
+			const response = await authOwnerAgent.get('/executions').query({
+				startedAfter: '2020-03-01T00:00:00.000Z',
+				startedBefore: '2020-09-01T00:00:00.000Z',
+				status: 'success',
+				workflowId: workflow.id,
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.map((execution: ExecutionEntity) => execution.id)).toEqual([
+				matching.id,
+			]);
+		});
+
+		test('should return 400 for a malformed startedAfter value', async () => {
+			const response = await authOwnerAgent.get('/executions').query({
+				startedAfter: 'not-a-date',
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(response.body.message).toContain('startedAfter');
+		});
+
+		test('should return 400 for a malformed startedBefore value', async () => {
+			const response = await authOwnerAgent.get('/executions').query({
+				startedBefore: 'not-a-date',
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(response.body.message).toContain('startedBefore');
+		});
+	});
+
 	test('owner should retrieve all executions regardless of ownership', async () => {
 		const [firstWorkflowForUser1, secondWorkflowForUser1] = await createManyWorkflows(2, {}, user1);
 		await createManyExecutions(2, firstWorkflowForUser1, createSuccessfulExecution);


### PR DESCRIPTION
## Summary

https://www.loom.com/share/9cdad121e15544cdb495586e5a789c20

Add optional `startedAfter` and `startedBefore` query parameters to `GET /api/v1/executions`.

Users can now filter executions by start time. They do not need to page through the full list and filter on the client.

Both parameters are independent. Use one bound or both as a range. They combine with the existing `status`, `workflowId`, and `projectId` filters.

The OpenAPI spec documents the new parameters as ISO 8601 date-times. Malformed values return `400`.

The public list path still uses cursor pagination and `id` sort order. A shared `startedAtCondition` helper applies the same inclusive start-time bounds in the public list, the internal range query, stop-many, and deletion filters.

## How to test

1. Create several executions with different `startedAt` values.
2. Call `GET /api/v1/executions?startedAfter=2024-01-01T00:00:00.000Z` with an API key that has `execution:list`. Confirm that only later executions are returned.
3. Call `GET /api/v1/executions?startedBefore=2024-12-31T23:59:59.999Z`. Confirm that only earlier executions are returned.
4. Combine both parameters as a range. Confirm that only executions in the window are returned.
5. Combine the date filters with `status` and `workflowId`. Confirm that all filters apply together.
6. Send a malformed value such as `startedAfter=not-a-date`. Confirm that the API returns `400`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-175

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

