### PR TITLE
fix: Keep Kafka patch in Docker image build (no-changelog)

### DIFF
--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -39,7 +39,8 @@ const PATCHES_TO_KEEP = [
 	'pdfjs-dist',
 	'pkce-challenge',
 	'bull',
-	'lodash'
+	'lodash',
+	'@confluentinc/kafka-javascript',
 ];
 
 // #endregion ===== Configuration =====


### PR DESCRIPTION
## Summary

During the `Bundle/2.x` merge (#36558), `@confluentinc/kafka-javascript` was accidentally removed from `PATCHES_TO_KEEP` in `scripts/build-n8n.mjs`.

As a result, the pre-deploy step in `scripts/build-n8n.mjs` stripped the Kafka patch before running `pnpm deploy`, causing `node-pre-gyp` to attempt compiling `librdkafka` from source on runners lacking a prebuilt binary. This caused `Prepare Docker / Build & publish image` CI jobs to hang and fail after ~7 minutes.

This fix restores `'@confluentinc/kafka-javascript'` to `PATCHES_TO_KEEP` so the patch is preserved during deployment.

## How to test

Verify CI job `Prepare Docker / Build & publish image` succeeds.

## Related Linear tickets, Github issues, and Community forum posts

- Linear ticket: https://linear.app/n8n/issue/N8N-10869

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

