### PR TITLE
fix(core): Release test-webhook isolate only after teardown completes

### DIFF
--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -446,7 +446,7 @@ describe('TestWebhooks', () => {
 
 			vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValue(workflow);
 			vi.spyOn(testWebhooks, 'getActiveWebhook').mockResolvedValue(webhook);
-			registrations.get.mockResolvedValue({
+			registrations.get.mockResolvedValueOnce({
 				version: 1,
 				workflowEntity,
 				webhook,

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -475,6 +475,47 @@ describe('TestWebhooks', () => {
 			expect(acquireOrder).toBeLessThan(deactivateOrder);
 			expect(deactivateOrder).toBeLessThan(releaseOrder);
 		});
+
+		test('logs when isolate release fails after teardown', async () => {
+			const expression = mock<WorkflowExpression>();
+			const workflowStartNode = mock<ReturnType<Workflow['getNode']>>({
+				type: 'n8n-nodes-base.noOp',
+			});
+			const workflow = mock<Workflow>({
+				id: workflowEntity.id,
+				expression,
+				getNode: vi.fn().mockReturnValue(workflowStartNode),
+			});
+
+			vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValue(workflow);
+			vi.spyOn(testWebhooks, 'getActiveWebhook').mockResolvedValue(webhook);
+			registrations.get.mockResolvedValueOnce({
+				version: 1,
+				workflowEntity,
+				webhook,
+			} as TestWebhookRegistration);
+			vi.spyOn(testWebhooks, 'deactivateWebhooks').mockResolvedValue(undefined);
+
+			vi.spyOn(WebhookHelpers, 'executeWebhook').mockImplementation(async (...args: unknown[]) => {
+				const onDone = args[10] as (error: Error | null, data: unknown) => void;
+				onDone(null, { noWebhookResponse: true });
+				return 'execution-id';
+			});
+
+			const error = new Error('release failed');
+			expression.releaseIsolate.mockRejectedValueOnce(error);
+
+			await testWebhooks.executeWebhook(
+				mock<WebhookRequest>({ params: { path }, method: httpMethod }),
+				mock<express.Response>(),
+			);
+			await flushMicrotasks();
+
+			expect(logger.error).toHaveBeenCalledWith(
+				'Failed to release expression isolate for test webhook',
+				expect.objectContaining({ error }),
+			);
+		});
 	});
 
 	describe('deactivateWebhooks()', () => {

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -44,6 +44,12 @@ const webhook = mock<IWebhookData>({
 	userId,
 });
 
+const flushMicrotasks = async () => {
+	const { setImmediate: realSetImmediate } =
+		await vi.importActual<typeof import('timers')>('timers');
+	await new Promise((resolve) => realSetImmediate(resolve));
+};
+
 describe('TestWebhooks', () => {
 	const logger = mock<Logger>();
 	const registrations = mock<TestWebhookRegistrationsService>();
@@ -428,12 +434,6 @@ describe('TestWebhooks', () => {
 		});
 
 		test('releases isolate only after deactivateWebhooks completes on successful execution', async () => {
-			const flushMicrotasks = async () => {
-				const { setImmediate: realSetImmediate } =
-					await vi.importActual<typeof import('timers')>('timers');
-				await new Promise((resolve) => realSetImmediate(resolve));
-			};
-
 			const expression = mock<WorkflowExpression>();
 			const workflowStartNode = mock<ReturnType<Workflow['getNode']>>({
 				type: 'n8n-nodes-base.noOp',
@@ -495,12 +495,6 @@ describe('TestWebhooks', () => {
 	});
 
 	describe('cancelWebhook()', () => {
-		const flushMicrotasks = async () => {
-			const { setImmediate: realSetImmediate } =
-				await vi.importActual<typeof import('timers')>('timers');
-			await new Promise((resolve) => realSetImmediate(resolve));
-		};
-
 		test('acquires and releases isolate around deactivateWebhooks', async () => {
 			const expression = mock<WorkflowExpression>();
 			const workflow = mock<Workflow>({ id: workflowEntity.id, expression });

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -468,6 +468,7 @@ describe('TestWebhooks', () => {
 			await flushMicrotasks();
 
 			expect(deactivateSpy).toHaveBeenCalledWith(workflow);
+			expect(expression.acquireIsolate).toHaveBeenCalledTimes(1);
 			expect(expression.releaseIsolate).toHaveBeenCalledTimes(1);
 			const [acquireOrder] = (expression.acquireIsolate as Mock).mock.invocationCallOrder;
 			const [deactivateOrder] = deactivateSpy.mock.invocationCallOrder;

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -426,6 +426,55 @@ describe('TestWebhooks', () => {
 
 			await expect(promise).rejects.toThrowError(WebhookNotFoundError);
 		});
+
+		test('releases isolate only after deactivateWebhooks completes on successful execution', async () => {
+			const flushMicrotasks = async () => {
+				const { setImmediate: realSetImmediate } =
+					await vi.importActual<typeof import('timers')>('timers');
+				await new Promise((resolve) => realSetImmediate(resolve));
+			};
+
+			const expression = mock<WorkflowExpression>();
+			const workflowStartNode = mock<ReturnType<Workflow['getNode']>>({
+				type: 'n8n-nodes-base.noOp',
+			});
+			const workflow = mock<Workflow>({
+				id: workflowEntity.id,
+				expression,
+				getNode: vi.fn().mockReturnValue(workflowStartNode),
+			});
+
+			vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValue(workflow);
+			vi.spyOn(testWebhooks, 'getActiveWebhook').mockResolvedValue(webhook);
+			registrations.get.mockResolvedValue({
+				version: 1,
+				workflowEntity,
+				webhook,
+			} as TestWebhookRegistration);
+			const deactivateSpy = vi
+				.spyOn(testWebhooks, 'deactivateWebhooks')
+				.mockResolvedValue(undefined);
+
+			vi.spyOn(WebhookHelpers, 'executeWebhook').mockImplementation(async (..._args: unknown[]) => {
+				const onDone = _args[10] as (error: Error | null, data: unknown) => void;
+				onDone(null, { noWebhookResponse: true });
+				return 'execution-id';
+			});
+
+			await testWebhooks.executeWebhook(
+				mock<WebhookRequest>({ params: { path }, method: httpMethod }),
+				mock<express.Response>(),
+			);
+			await flushMicrotasks();
+
+			expect(deactivateSpy).toHaveBeenCalledWith(workflow);
+			expect(expression.releaseIsolate).toHaveBeenCalledTimes(1);
+			const [acquireOrder] = (expression.acquireIsolate as Mock).mock.invocationCallOrder;
+			const [deactivateOrder] = deactivateSpy.mock.invocationCallOrder;
+			const [releaseOrder] = (expression.releaseIsolate as Mock).mock.invocationCallOrder;
+			expect(acquireOrder).toBeLessThan(deactivateOrder);
+			expect(deactivateOrder).toBeLessThan(releaseOrder);
+		});
 	});
 
 	describe('deactivateWebhooks()', () => {

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -455,8 +455,8 @@ describe('TestWebhooks', () => {
 				.spyOn(testWebhooks, 'deactivateWebhooks')
 				.mockResolvedValue(undefined);
 
-			vi.spyOn(WebhookHelpers, 'executeWebhook').mockImplementation(async (..._args: unknown[]) => {
-				const onDone = _args[10] as (error: Error | null, data: unknown) => void;
+			vi.spyOn(WebhookHelpers, 'executeWebhook').mockImplementation(async (...args: unknown[]) => {
+				const onDone = args[10] as (error: Error | null, data: unknown) => void;
 				onDone(null, { noWebhookResponse: true });
 				return 'execution-id';
 			});

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -513,7 +513,7 @@ describe('TestWebhooks', () => {
 
 			expect(logger.error).toHaveBeenCalledWith(
 				'Failed to release expression isolate for test webhook',
-				expect.objectContaining({ error }),
+				expect.objectContaining({ error, workflowId: workflowEntity.id }),
 			);
 		});
 	});

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -146,8 +146,10 @@ export class TestWebhooks implements IWebhookManager {
 		}
 
 		await workflow.expression.acquireIsolate();
-		try {
-			return await new Promise(async (resolve, reject) => {
+		// Release only after teardown below runs, not when resolve() settles the
+		// promise early — teardown still needs the isolate held.
+		return await new Promise(async (resolve, reject) => {
+			try {
 				try {
 					const executionMode = 'manual';
 					const executionId = await WebhookHelpers.executeWebhook(
@@ -172,7 +174,6 @@ export class TestWebhooks implements IWebhookManager {
 					// or a ping so do not resolve the promise and wait for the real webhook
 					// request instead.
 					if (executionId === undefined) {
-						await workflow.expression.releaseIsolate();
 						return;
 					}
 
@@ -212,10 +213,10 @@ export class TestWebhooks implements IWebhookManager {
 				this.clearTimeout(key);
 
 				await this.deactivateWebhooks(workflow);
-			});
-		} finally {
-			await workflow.expression.releaseIsolate();
-		}
+			} finally {
+				await workflow.expression.releaseIsolate();
+			}
+		});
 	}
 
 	@OnPubSubEvent('clear-test-webhooks', { instanceType: 'main' })

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -212,13 +212,9 @@ export class TestWebhooks implements IWebhookManager {
 
 				this.clearTimeout(key);
 
-				try {
-					await this.deactivateWebhooks(workflow);
-				} catch (error) {
-					// Response (if any) was already sent, so this can only be logged.
-					this.logger.error('Failed to deactivate test webhooks after execution', { error });
-				}
+				await this.deactivateWebhooks(workflow);
 			} finally {
+				// Response (if any) was already sent, so a release failure here can only be logged.
 				try {
 					await workflow.expression.releaseIsolate();
 				} catch (error) {

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -219,9 +219,9 @@ export class TestWebhooks implements IWebhookManager {
 					await workflow.expression.releaseIsolate();
 				} catch (error) {
 					this.logger.error('Failed to release expression isolate for test webhook', {
-					error,
-					workflowId: workflow.id,
-				});
+						error,
+						workflowId: workflow.id,
+					});
 				}
 			}
 		});

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -212,9 +212,18 @@ export class TestWebhooks implements IWebhookManager {
 
 				this.clearTimeout(key);
 
-				await this.deactivateWebhooks(workflow);
+				try {
+					await this.deactivateWebhooks(workflow);
+				} catch (error) {
+					// Response (if any) was already sent, so this can only be logged.
+					this.logger.error('Failed to deactivate test webhooks after execution', { error });
+				}
 			} finally {
-				await workflow.expression.releaseIsolate();
+				try {
+					await workflow.expression.releaseIsolate();
+				} catch (error) {
+					this.logger.error('Failed to release expression isolate for test webhook', { error });
+				}
 			}
 		});
 	}

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -218,7 +218,10 @@ export class TestWebhooks implements IWebhookManager {
 				try {
 					await workflow.expression.releaseIsolate();
 				} catch (error) {
-					this.logger.error('Failed to release expression isolate for test webhook', { error });
+					this.logger.error('Failed to release expression isolate for test webhook', {
+					error,
+					workflowId: workflow.id,
+				});
 				}
 			}
 		});


### PR DESCRIPTION
## Summary

- `TestWebhooks.executeWebhook` released the expression isolate as soon as the response promise settled, but `deactivateWebhooks` (provider-side webhook teardown, e.g. GitHub `DELETE` hook, and registration deregistration) ran afterward and still needed it.
- Under the vm expression engine, this raised an `IsolateError` inside the promise executor after `resolve()` had already fired, so it went unhandled and teardown silently never completed: the provider-side subscription leaked and the stale registration could interfere with the next test run.
- Fix: release the isolate in a `finally` around the whole executor body, so it only happens once `deactivateWebhooks` (or the multi-main early-return) has actually completed, not when the returned promise settles.

## How to test

- Added a unit test asserting `acquireIsolate` → `deactivateWebhooks` → `releaseIsolate` ordering on the successful-execution path in `test-webhooks.test.ts`.
- Manual repro (vm engine default): register a webhook-trigger node whose provider `delete`/deactivation hook resolves an expression parameter, call the test webhook, then deactivate — before the fix, teardown throws `IsolateError` (swallowed) and the provider-side hook never fires; after the fix it completes normally.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4124

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

