### PR TITLE
feat(core): Load the workflow review inbox after signing in from a d…

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -851,6 +851,16 @@ describe('SecuritySettings', () => {
 			});
 		});
 
+		it('should show a Preview tag on the workflow reviews toggle', async () => {
+			const { getByTestId } = renderView();
+
+			await waitFor(() => {
+				expect(getByTestId('security-workflow-reviews-toggle')).toBeInTheDocument();
+			});
+
+			expect(getByTestId('security-workflow-reviews-preview-tag')).toHaveTextContent('Preview');
+		});
+
 		it('should persist workflow reviews toggle changes', async () => {
 			updateSecuritySettings.mockResolvedValue({
 				workflowReviews: { enabled: true },

--- a/packages/frontend/editor-ui/src/features/settings/security/WorkflowReviewsSection.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/WorkflowReviewsSection.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref, useCssModule } from 'vue';
 import { ElSwitch } from 'element-plus';
-import { N8nAlertDialog, N8nText } from '@n8n/design-system';
+import { N8nAlertDialog, N8nPreviewTag, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import * as securitySettingsApi from '@n8n/rest-api-client/api/security-settings';
@@ -72,9 +72,12 @@ function confirmDisable() {
 	<div>
 		<div :class="$style.settingsContainer">
 			<div :class="$style.settingsContainerInfo">
-				<N8nText :bold="true">
-					{{ i18n.baseText('settings.security.workflowReviews.enable.title') }}
-				</N8nText>
+				<div :class="$style.titleRow">
+					<N8nText :bold="true">
+						{{ i18n.baseText('settings.security.workflowReviews.enable.title') }}
+					</N8nText>
+					<N8nPreviewTag size="small" data-test-id="security-workflow-reviews-preview-tag" />
+				</div>
 				<N8nText size="small" color="text-light">
 					{{ i18n.baseText('settings.security.workflowReviews.enable.description') }}
 				</N8nText>
@@ -118,6 +121,12 @@ function confirmDisable() {
 	gap: var(--spacing--5xs);
 	flex: 1;
 	min-width: 0;
+}
+
+.titleRow {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
 }
 
 .settingsContainerAction {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewActivityFeed.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewActivityFeed.vue
@@ -180,7 +180,7 @@ onMounted(() => {
 
 /* The detail body stacks and takes over scrolling here, so the feed must bound itself or its
 	load-older sentinel never leaves the screen and drains every page. */
-@media (max-width: 60rem) {
+@container review-detail (max-width: 44rem) {
 	.feed {
 		max-height: 60vh;
 	}

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailMetadata.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailMetadata.vue
@@ -217,11 +217,12 @@ const statusSummary = computed(
 	}
 }
 
-@media (max-width: 60rem) {
+@container review-detail (max-width: 44rem) {
 	.metadata {
 		flex-basis: auto;
 		width: 100%;
 		min-width: 0;
+		padding-inline-end: var(--spacing--2xs);
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
@@ -235,11 +235,13 @@ const tabOptions = computed(() => [
 
 	.panel {
 		flex: 0 0 auto;
+		order: 1;
 		overflow: visible;
 	}
 
 	.activityPanel {
 		flex: 0 0 auto;
+		order: 1;
 		overflow: visible;
 		max-width: none;
 		margin-inline-end: 0;

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
@@ -165,6 +165,8 @@ const tabOptions = computed(() => [
 	flex-direction: column;
 	height: 100%;
 	min-height: 0;
+	container-name: review-detail;
+	container-type: inline-size;
 }
 
 .tabRow {
@@ -227,21 +229,19 @@ const tabOptions = computed(() => [
 	flex-shrink: 0;
 }
 
-@media (max-width: 60rem) {
+@container review-detail (max-width: 44rem) {
 	.detailBody {
 		flex-direction: column;
 		overflow: auto;
 	}
 
 	.panel {
-		flex: 0 0 auto;
-		order: 1;
+		flex: 1 0 auto;
 		overflow: visible;
 	}
 
 	.activityPanel {
-		flex: 0 0 auto;
-		order: 1;
+		flex: 1 1 0%;
 		overflow: visible;
 		max-width: none;
 		margin-inline-end: 0;

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.vue
@@ -306,7 +306,7 @@ function onListBackgroundClick() {
 
 <style lang="scss" module>
 .sidebar {
-	--review-sidebar--width: max(10rem, 25vw);
+	--review-sidebar--width: max(15rem, 25vw);
 
 	display: flex;
 	flex-direction: column;

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.vue
@@ -306,7 +306,7 @@ function onListBackgroundClick() {
 
 <style lang="scss" module>
 .sidebar {
-	--review-sidebar--width: max(15rem, 25vw);
+	--review-sidebar--width: clamp(15rem, 25vw, 25rem);
 
 	display: flex;
 	flex-direction: column;

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.vue
@@ -306,7 +306,7 @@ function onListBackgroundClick() {
 
 <style lang="scss" module>
 .sidebar {
-	--review-sidebar--width: 22rem;
+	--review-sidebar--width: max(10rem, 25vw);
 
 	display: flex;
 	flex-direction: column;

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/module.descriptor.ts
@@ -21,7 +21,7 @@ export const WorkflowReviewsModule: FrontendModuleDescription = {
 			beforeEnter() {
 				return (
 					useWorkflowReviewsFeature().isWorkflowReviewsEnabled.value || {
-						name: VIEWS.NOT_FOUND,
+						name: VIEWS.HOMEPAGE,
 					}
 				);
 			},

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/views/WorkflowReviewRequestsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/views/WorkflowReviewRequestsView.test.ts
@@ -874,12 +874,13 @@ describe('WorkflowReviewRequestsView', () => {
 		expect(showError).not.toHaveBeenCalled();
 	});
 
-	it('resets the store on unmount', async () => {
-		const { unmount } = renderComponent();
-		await waitAllPromises();
-		unmount();
+	it('clears the stores on entry, before probing', async () => {
+		renderComponent();
 
 		expect(store.reset).toHaveBeenCalledTimes(1);
+		expect(store.reset.mock.invocationCallOrder[0]).toBeLessThan(
+			store.probeInbox.mock.invocationCallOrder[0],
+		);
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/views/WorkflowReviewRequestsView.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/views/WorkflowReviewRequestsView.vue
@@ -77,6 +77,11 @@ function stateFromQuery(value: unknown): WorkflowReviewRequestState {
 	return value === 'closed' ? 'closed' : 'open';
 }
 
+// Clear on entry, not exit: a discarded layout-swap copy can unmount after the live
+// one has started probing, and a teardown clear would invalidate that probe.
+store.reset();
+activityStore.reset();
+
 // Hydrate the tab before probing so the first list fetch uses the URL state.
 store.activeTab = stateFromQuery(route.query[REVIEW_INBOX_QUERY_PARAM.state]);
 
@@ -265,8 +270,6 @@ onMounted(async () => {
 
 onUnmounted(() => {
 	isMounted = false;
-	store.reset();
-	activityStore.reset();
 });
 </script>
 


### PR DESCRIPTION

## Summary

The inbox cleared its stores when the view unmounted. Signing in from a review link redirects into the inbox and swaps the layout while its chunk still loads, so Vue keeps a second copy of the view and discards it after the live copy has started its probe. The teardown of the discarded copy invalidated that probe, so the inbox stayed on its loading skeleton until a reload.

The view now clears the stores when it is created, which its own fetches always follow, and leaves them alone on the way out.

Also add the Preview tag to the workflow reviews toggle in Security & policy, make the inbox sidebar width scale with the viewport, and send visitors to the homepage instead of the 404 catch-all when the feature is off.


## How to test

Log out and navigate to http://localhost:8080/workflow-review-requests/
-> Reviews should load correctly

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://linear.app/n8n/issue/LIGO-1009/polish-workflow-review-ui-and-fix-inbox-hang-on-unauthenticated-deep


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

