### PR TITLE
chore: Remove mention of N8N_INSTANCE_AI_MODEL_API_KEY from the install script

### DIFF
--- a/docker/get-n8n.sh
+++ b/docker/get-n8n.sh
@@ -212,11 +212,6 @@ N8N_RUNNERS_MODE=external
 N8N_RUNNERS_BROKER_LISTEN_ADDRESS=0.0.0.0
 N8N_RUNNERS_AUTH_TOKEN=$(gen_secret)
 
-# Instance AI (optional): fill this in to enable the AI assistant in n8n.
-# n8n works fine without it. Setup guide:
-# https://docs.n8n.io/deploy/host-n8n/configure-n8n/set-up-ai-assistant
-N8N_INSTANCE_AI_MODEL_API_KEY=
-
 # Web search for the AI assistant runs through the bundled SearXNG service.
 # Optionally set a Brave Search API key instead — it takes priority.
 INSTANCE_AI_BRAVE_SEARCH_API_KEY=
@@ -376,9 +371,6 @@ To uninstall: docker compose -f ${N8N_DIR}/compose.yml down -v   # -v DELETES al
 Security notes:
   - Only port ${N8N_PORT} (n8n) should ever be reachable from the internet.
   - The sandbox runner is privileged Docker-in-Docker — never publish its ports.
-  - The AI assistant stays disabled until you set N8N_INSTANCE_AI_MODEL_API_KEY
-    in ${N8N_DIR}/.env — see
-    https://docs.n8n.io/deploy/host-n8n/configure-n8n/set-up-ai-assistant
 
 This setup is meant to try n8n locally. For production (TLS, Postgres, queue
 mode) see ${DOCS_HOSTING_URL}


### PR DESCRIPTION
## Summary

Setting this env is optional, simplify the setup by dropping it.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1211/bug-remove-mention-of-the-env-that-must-be-set-for-aia-from-n8n

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

