### PR TITLE
fix(editor): Treat agent persistence and channel setup as one in-flight action

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-app-setup.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-app-setup.service.test.ts
@@ -1,4 +1,5 @@
 import type { Mock, Mocked } from 'vitest';
+import type { Logger } from '@n8n/backend-common';
 import type { HttpRequestClient, OutboundHttp } from '@n8n/backend-network';
 import type { CredentialsEntity, User, UserRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
@@ -183,6 +184,7 @@ describe('Slack setup services', () => {
 			outboundHttp,
 			cacheService,
 			cipher,
+			mock<Logger>(),
 		);
 		const manualService = new SlackManualSetupService(
 			methods,

--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-methods.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-methods.service.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method -- mock-based tests intentionally reference unbound methods */
+import type { Logger } from '@n8n/backend-common';
 import type { OutboundHttp } from '@n8n/backend-network';
-import { mock } from 'vitest-mock-extended';
 import type { Cipher } from 'n8n-core';
+import { mock } from 'vitest-mock-extended';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
 import type { CacheService } from '@/services/cache/cache.service';
@@ -16,31 +17,46 @@ describe('SlackMethodsService', () => {
 	function makeService() {
 		const credentialsService = mock<CredentialsService>();
 		const managementService = mock<AgentIntegrationManagementService>();
+		const agentRepository = mock<AgentRepository>();
 		const urlService = mock<UrlService>();
 		urlService.getWebhookBaseUrl.mockReturnValue('https://hooks.example/');
 		return {
 			service: new SlackMethodsService(
 				credentialsService,
-				mock<AgentRepository>(),
+				agentRepository,
 				managementService,
 				urlService,
 				mock<OutboundHttp>(),
 				mock<CacheService>(),
 				mock<Cipher>(),
+				mock<Logger>(),
 			),
 			credentialsService,
 			managementService,
+			agentRepository,
 		};
 	}
 
+	const agent = {
+		id: 'agent-1',
+		projectId: 'project-1',
+		name: 'Support Agent',
+		activeVersionId: 'version-1',
+	} as unknown as Agent;
+
+	const session = {
+		projectId: 'project-1',
+		agentId: 'agent-1',
+		userId: 'user-1',
+		appId: 'app-1',
+		clientId: 'client-1',
+		clientSecret: 'client-secret',
+		signingSecret: 'signing-secret',
+		redirectUrl: 'https://n8n.example/callback',
+	};
+
 	it('creates a bot credential and delegates activation to integration management', async () => {
 		const { service, credentialsService, managementService } = makeService();
-		const agent = {
-			id: 'agent-1',
-			projectId: 'project-1',
-			name: 'Support Agent',
-			activeVersionId: 'version-1',
-		} as unknown as Agent;
 		const user = { id: 'user-1' };
 		credentialsService.createUnmanagedCredential.mockResolvedValue({
 			id: 'credential-1',
@@ -49,16 +65,7 @@ describe('SlackMethodsService', () => {
 			integration: { type: 'slack', credentialId: 'credential-1' },
 			savedAgent: agent,
 		});
-		await service.connectBotCredential(agent, user as never, 'xoxb-token', {
-			projectId: 'project-1',
-			agentId: 'agent-1',
-			userId: 'user-1',
-			appId: 'app-1',
-			clientId: 'client-1',
-			clientSecret: 'client-secret',
-			signingSecret: 'signing-secret',
-			redirectUrl: 'https://n8n.example/callback',
-		});
+		await service.connectBotCredential(agent, user as never, 'xoxb-token', session);
 
 		expect(credentialsService.createUnmanagedCredential).toHaveBeenCalledWith(
 			{
@@ -76,6 +83,64 @@ describe('SlackMethodsService', () => {
 			agent,
 			user,
 			integration: { type: 'slack', credentialId: 'credential-1' },
+		});
+		expect(credentialsService.delete).not.toHaveBeenCalled();
+	});
+
+	describe('when the connect fails', () => {
+		const user = { id: 'user-1' };
+
+		function arrangeFailedConnect() {
+			const context = makeService();
+			context.credentialsService.createUnmanagedCredential.mockResolvedValue({
+				id: 'credential-1',
+			} as never);
+			context.managementService.connect.mockRejectedValue(new Error('startup failed'));
+			return context;
+		}
+
+		it('deletes the credential it created when nothing references it', async () => {
+			const { service, credentialsService, agentRepository } = arrangeFailedConnect();
+			agentRepository.findIntegrationState.mockResolvedValue({
+				integrations: [],
+				versionId: 'version-1',
+				activeVersionId: 'version-1',
+			} as never);
+
+			await expect(
+				service.connectBotCredential(agent, user as never, 'xoxb-token', session),
+			).rejects.toThrow('startup failed');
+
+			expect(credentialsService.delete).toHaveBeenCalledWith(user, 'credential-1');
+		});
+
+		it('keeps the credential when the agent durably references it', async () => {
+			const { service, credentialsService, agentRepository } = arrangeFailedConnect();
+			agentRepository.findIntegrationState.mockResolvedValue({
+				integrations: [{ type: 'slack', credentialId: 'credential-1' }],
+				versionId: 'version-1',
+				activeVersionId: 'version-1',
+			} as never);
+
+			await expect(
+				service.connectBotCredential(agent, user as never, 'xoxb-token', session),
+			).rejects.toThrow('startup failed');
+
+			expect(credentialsService.delete).not.toHaveBeenCalled();
+		});
+
+		it('reports the setup failure even when the cleanup itself fails', async () => {
+			const { service, credentialsService, agentRepository } = arrangeFailedConnect();
+			agentRepository.findIntegrationState.mockResolvedValue({
+				integrations: [],
+				versionId: 'version-1',
+				activeVersionId: 'version-1',
+			} as never);
+			credentialsService.delete.mockRejectedValue(new Error('credential is in use'));
+
+			await expect(
+				service.connectBotCredential(agent, user as never, 'xoxb-token', session),
+			).rejects.toThrow('startup failed');
 		});
 	});
 

--- a/packages/cli/src/modules/agents/integrations/platforms/slack/slack-methods.service.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack/slack-methods.service.ts
@@ -3,6 +3,7 @@ import type {
 	SlackAgentAppManifest,
 	SlackApiErrorMeta,
 } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
 import { OutboundHttp } from '@n8n/backend-network';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -62,6 +63,7 @@ export class SlackMethodsService {
 		private readonly outboundHttp: OutboundHttp,
 		private readonly cacheService: CacheService,
 		private readonly cipher: Cipher,
+		private readonly logger: Logger,
 	) {}
 
 	async callSlackApi<T extends { [key: string]: unknown }>(
@@ -211,13 +213,51 @@ export class SlackMethodsService {
 			type: 'slack',
 			credentialId: credential.id,
 		} satisfies AgentIntegrationConfig;
-		await this.integrationManagementService.connect({
-			agent,
-			user,
-			integration,
-		});
+		try {
+			await this.integrationManagementService.connect({
+				agent,
+				user,
+				integration,
+			});
+		} catch (error) {
+			await this.deleteUnreferencedCredential(agent.id, credential.id, user);
+			throw error;
+		}
 		await this.clearManagedAppSession(session);
 		return credential.id;
+	}
+
+	/**
+	 * Undo the credential this setup attempt created, so a failed connect doesn't
+	 * leave one behind in the project.
+	 *
+	 * Keyed on whether the agent durably references it rather than on how the
+	 * connect failed: a startup failure can still leave the entry persisted, and
+	 * that entry is what the next publish or reconcile acts on. Only ever called
+	 * with a credential created moments earlier in the same call, so nothing the
+	 * user picked or already owned can be reached from here.
+	 */
+	private async deleteUnreferencedCredential(
+		agentId: string,
+		credentialId: string,
+		user: User,
+	): Promise<void> {
+		try {
+			const state = await this.agentRepository.findIntegrationState(agentId);
+			const referenced = (state?.integrations ?? []).some(
+				(entry) => entry.credentialId === credentialId,
+			);
+			if (referenced) return;
+
+			await this.credentialsService.delete(user, credentialId);
+		} catch (error) {
+			// Best-effort: the setup failure is what the caller reports.
+			this.logger.warn('[SlackMethodsService] Could not clean up the Slack credential', {
+				agentId,
+				credentialId,
+				error,
+			});
+		}
 	}
 
 	private async clearManagedAppSession(session: SlackAppSetupSession): Promise<void> {

--- a/packages/cli/src/modules/agents/integrations/platforms/slack/slack-methods.service.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack/slack-methods.service.ts
@@ -232,10 +232,15 @@ export class SlackMethodsService {
 	 * leave one behind in the project.
 	 *
 	 * Keyed on whether the agent durably references it rather than on how the
-	 * connect failed: a startup failure can still leave the entry persisted, and
-	 * that entry is what the next publish or reconcile acts on. Only ever called
-	 * with a credential created moments earlier in the same call, so nothing the
-	 * user picked or already owned can be reached from here.
+	 * connect failed: the integration write lands before the steps that settle
+	 * publication and release a replaced channel, so a failure there still leaves
+	 * the entry persisted, and that entry is what the next publish or reconcile
+	 * acts on.
+	 *
+	 * Only ever called with a credential created moments earlier in the same call
+	 * and never handed out on this path, so the agent row is the only place that
+	 * can reference it — nothing the user picked or already owned is reachable
+	 * from here.
 	 */
 	private async deleteUnreferencedCredential(
 		agentId: string,

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -8208,6 +8208,7 @@
 	"agents.channels.modal.configured": "Configured",
 	"agents.channels.modal.connected": "Connected",
 	"agents.channels.modal.removeChannel": "Remove channel",
+	"agents.channels.modal.saveChannelError": "Channel couldn't be saved. Try again.",
 	"agents.channels.modal.removeChannelError": "Channel couldn't be removed. Try again.",
 	"agents.channels.modal.slackAppNotDeleted.title": "Slack app wasn't removed",
 	"agents.channels.modal.slackAppNotDeleted.message": "The channel and credential were removed from n8n. Remove the app from Slack manually.",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
@@ -384,6 +384,20 @@ describe('AgentChannelModal', () => {
 		});
 	});
 
+	it('surfaces a failed pre-save step instead of connecting', async () => {
+		mocks.beforeSave.mockRejectedValue(new Error('settings could not be saved'));
+		selectedCredentials.value.example = 'credential-new';
+		const wrapper = mountModal('example_setup');
+		await flushPromises();
+
+		await wrapper.get('[data-testid="connect-channel"]').trigger('click');
+		await flushPromises();
+
+		expect(mocks.showError).toHaveBeenCalled();
+		expect(mocks.connect).not.toHaveBeenCalled();
+		expect(wrapper.emitted('update:open')).toBeUndefined();
+	});
+
 	it('closes when a platform reports connected from inside its own flow', async () => {
 		const wrapper = mountModal('example_setup');
 		await flushPromises();

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
@@ -45,12 +45,21 @@ vi.mock('../channels/registry', async () => {
 	const { ref, defineComponent } = await import('vue');
 	const platformView = {
 		props: ['modelValue', 'mode', 'isPublished', 'runtime'],
-		emits: ['update:modelValue', 'connect'],
-		setup: () => ({
-			currentSettings: { accessMode: 'all' },
-			validationError: null,
-			beforeSave: mocks.beforeSave,
-		}),
+		emits: ['update:modelValue', 'connect', 'connected'],
+		setup: () => {
+			// Platforms that drive their own flow (Slack) report `connected` while
+			// still reporting `loading`, so the two are controlled together here.
+			const loading = ref(false);
+			return {
+				currentSettings: { accessMode: 'all' },
+				validationError: null,
+				beforeSave: mocks.beforeSave,
+				loading,
+				startOwnFlow: () => {
+					loading.value = true;
+				},
+			};
+		},
 		template: `
 			<div
 				data-testid="platform-view"
@@ -60,6 +69,7 @@ vi.mock('../channels/registry', async () => {
 			>
 				<button data-testid="select-credential" @click="$emit('update:modelValue', 'credential-new')" />
 				<button data-testid="connect-channel" @click="$emit('connect')" />
+				<button data-testid="platform-own-flow" @click="startOwnFlow(); $emit('connected')" />
 			</div>
 		`,
 	};
@@ -298,6 +308,93 @@ describe('AgentChannelModal', () => {
 			mocks.connect.mock.invocationCallOrder[0],
 		);
 		expect(wrapper.emitted('agent-changed')).toHaveLength(1);
+	});
+
+	describe('while agent persistence is pending', () => {
+		function deferPersistence() {
+			let release: () => void = () => {};
+			mocks.ensureAgentPersisted.mockImplementation(
+				async () =>
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					}),
+			);
+			return () => release();
+		}
+
+		it('does not submit setup twice', async () => {
+			const release = deferPersistence();
+			selectedCredentials.value.example = 'credential-new';
+			const wrapper = mountModal('example_setup');
+			await flushPromises();
+
+			await wrapper.get('[data-testid="connect-channel"]').trigger('click');
+			await wrapper.get('[data-testid="connect-channel"]').trigger('click');
+			await flushPromises();
+
+			expect(mocks.ensureAgentPersisted).toHaveBeenCalledOnce();
+			expect(mocks.connect).not.toHaveBeenCalled();
+
+			release();
+			await flushPromises();
+
+			expect(mocks.connect).toHaveBeenCalledOnce();
+		});
+
+		it('keeps close, back and remove inert', async () => {
+			const release = deferPersistence();
+			statuses.value.example = 'configured';
+			connectedCredentials.value.example = 'credential-old';
+			selectedCredentials.value.example = 'credential-new';
+			const wrapper = mountModal('example_edit');
+			await flushPromises();
+
+			await wrapper.get('[data-testid="agent-channel-save-channel-config"]').trigger('click');
+			await flushPromises();
+
+			await wrapper.get('[data-testid="close-dialog"]').trigger('click');
+			expect(wrapper.emitted('update:open')).toBeUndefined();
+
+			expect(
+				wrapper.get('[data-testid="agent-channel-back"]').attributes('disabled'),
+			).toBeDefined();
+
+			await wrapper.get('[data-testid="agent-channel-remove-channel"]').trigger('click');
+			expect(mocks.disconnect).not.toHaveBeenCalled();
+
+			release();
+			await flushPromises();
+
+			expect(mocks.connect).toHaveBeenCalledOnce();
+			expect(wrapper.emitted('update:open')).toEqual([[false]]);
+		});
+
+		it('surfaces a failed persistence instead of connecting', async () => {
+			mocks.ensureAgentPersisted.mockRejectedValue(new Error('agent could not be saved'));
+			selectedCredentials.value.example = 'credential-new';
+			const wrapper = mountModal('example_setup');
+			await flushPromises();
+
+			await wrapper.get('[data-testid="connect-channel"]').trigger('click');
+			await flushPromises();
+
+			expect(mocks.showError).toHaveBeenCalled();
+			expect(mocks.connect).not.toHaveBeenCalled();
+			expect(wrapper.emitted('update:open')).toBeUndefined();
+		});
+	});
+
+	it('closes when a platform reports connected from inside its own flow', async () => {
+		const wrapper = mountModal('example_setup');
+		await flushPromises();
+
+		// The platform is still loading at this point — the in-flight guard covers
+		// user-initiated closes only, so it must not swallow this one.
+		await wrapper.get('[data-testid="platform-own-flow"]').trigger('click');
+		await flushPromises();
+
+		expect(wrapper.emitted('channel-connected')).toEqual([['example']]);
+		expect(wrapper.emitted('update:open')).toEqual([[false]]);
 	});
 
 	it('clears a stale integration error when the edit modal reopens', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
@@ -76,6 +76,7 @@ const {
 const currentView = ref<ChannelView>(props.view);
 const viewSession = ref(0);
 const credentialIdAtEditOpen = ref('');
+const channelActionInFlight = ref(false);
 const pendingDisconnect = ref<{
 	channelType: string;
 	credentialId: string;
@@ -177,8 +178,19 @@ const currentPlatform = computed(() =>
 const currentRuntime = computed(() => runtimeFor(selectedChannelType.value ?? 'unknown'));
 const channelViewRef = ref<AgentChannelViewExpose>();
 const channelViewLoading = computed(() => channelViewRef.value?.loading === true);
-const listLoading = computed(() =>
-	Object.values(runtimes).some((runtime) => runtime.loading.value),
+/**
+ * Persisting the Agent and setting the channel up are one action from here: the
+ * modal opens before the Agent row exists, so guarding on the connect request
+ * alone leaves the whole `ensureAgentPersisted` await open to a second submit.
+ */
+const actionInFlight = computed(
+	() =>
+		channelActionInFlight.value ||
+		channelViewLoading.value ||
+		(selectedChannelType.value ? isLoading(selectedChannelType.value) : false),
+);
+const listLoading = computed(
+	() => actionInFlight.value || Object.values(runtimes).some((runtime) => runtime.loading.value),
 );
 const disconnectConfirmationComponent = computed(() => {
 	const pending = pendingDisconnect.value;
@@ -192,7 +204,7 @@ const disconnectConfirmationLoading = computed(() => {
 });
 
 const headerContentDisabled = computed(
-	() => currentRuntime.value.loading.value || channelViewLoading.value,
+	() => currentRuntime.value.loading.value || actionInFlight.value,
 );
 const headerContentComponent = computed(() => {
 	if (isSetupMode.value) {
@@ -203,11 +215,7 @@ const headerContentComponent = computed(() => {
 	}
 	return undefined;
 });
-const canClose = computed(
-	() =>
-		!channelViewLoading.value &&
-		!(selectedChannelType.value ? isLoading(selectedChannelType.value) : false),
-);
+const canClose = computed(() => !actionInFlight.value);
 function prepareChannelEdit(channelType: string | null) {
 	captureConnectedCredential(channelType);
 	if (!channelType) return;
@@ -295,12 +303,7 @@ function goToEdit(channelType: string) {
 }
 
 function goBackToList() {
-	if (
-		channelViewLoading.value ||
-		(selectedChannelType.value ? isLoading(selectedChannelType.value) : false)
-	) {
-		return;
-	}
+	if (actionInFlight.value) return;
 	captureConnectedCredential(null);
 	currentView.value = 'list';
 }
@@ -309,29 +312,43 @@ function handleListDisconnect(channelType: string) {
 	requestDisconnect(channelType, connectedCredentials.value[channelType] ?? '', false);
 }
 
-function closeModal() {
-	if (selectedChannelType.value ? isLoading(selectedChannelType.value) : false) return;
+/**
+ * Close once a flow has finished its own work. Separate from `closeModal`
+ * because a platform reports `connected` from inside its setup flow, while that
+ * flow still counts as in flight — the user-facing guard would refuse to close.
+ */
+function completeAndClose() {
 	emit('update:open', false);
 }
 
+function closeModal() {
+	if (actionInFlight.value) return;
+	completeAndClose();
+}
+
 function handleModalOpenUpdate(isOpen: boolean) {
-	if (
-		!isOpen &&
-		(channelViewLoading.value ||
-			(selectedChannelType.value ? isLoading(selectedChannelType.value) : false))
-	) {
-		return;
-	}
+	if (!isOpen && actionInFlight.value) return;
 	emit('update:open', isOpen);
 }
 
+async function persistAgent(): Promise<boolean> {
+	try {
+		await props.ensureAgentPersisted?.();
+		return true;
+	} catch (error) {
+		// Only this step needs a toast — a failed `connect` is already rendered
+		// inline by the setup view.
+		toast.showError(error, i18n.baseText('agents.channels.modal.saveChannelError'));
+		return false;
+	}
+}
+
 async function saveChannelConfig() {
+	if (actionInFlight.value) return;
 	const channelType = selectedChannelType.value;
 	const credentialId = currentChannelCredentialId.value;
 	if (!channelType || !credentialId) return;
 	if (channelViewRef.value?.validationError) return;
-	await props.ensureAgentPersisted?.();
-	await channelViewRef.value?.beforeSave?.();
 
 	// Swapping the credential of a configured channel is one request: the
 	// backend brings the new channel up, swaps both entries in a single write,
@@ -343,12 +360,23 @@ async function saveChannelConfig() {
 			? credentialIdAtEditOpen.value
 			: undefined;
 
-	await connect(channelType, credentialId, channelViewRef.value?.currentSettings, {
-		...(credentialIdToReplace ? { replaces: { credentialId: credentialIdToReplace } } : {}),
-	});
+	channelActionInFlight.value = true;
+	try {
+		if (!(await persistAgent())) return;
+		await channelViewRef.value?.beforeSave?.();
+		await connect(channelType, credentialId, channelViewRef.value?.currentSettings, {
+			...(credentialIdToReplace ? { replaces: { credentialId: credentialIdToReplace } } : {}),
+		});
+	} catch {
+		// `useAgentIntegrationStatus` exposes the failure to the setup view.
+		return;
+	} finally {
+		channelActionInFlight.value = false;
+	}
+
 	emit('channel-connected', channelType);
 	emit('agent-changed');
-	closeModal();
+	completeAndClose();
 }
 
 function handlePlatformConnected() {
@@ -356,7 +384,7 @@ function handlePlatformConnected() {
 	if (!channelType) return;
 	emit('channel-connected', channelType);
 	emit('agent-changed');
-	closeModal();
+	completeAndClose();
 }
 
 async function handleDisconnected(
@@ -404,14 +432,16 @@ async function disconnectChannel(
 			}
 		}
 		pendingDisconnect.value = null;
-		if (closeAfter) closeModal();
+		if (closeAfter) completeAndClose();
 	} catch (error) {
 		toast.showError(error, i18n.baseText('agents.channels.modal.removeChannelError'));
 	}
 }
 
 function requestDisconnect(channelType: string, credentialId: string, closeAfter: boolean) {
-	if (isLoading(channelType)) return;
+	// The list view can target a channel other than the selected one, so its own
+	// loading state is checked on top of the modal-wide action.
+	if (actionInFlight.value || isLoading(channelType)) return;
 	const platform = getAgentChannelPlatform(channelType);
 	if (
 		platform.shouldConfirmDisconnect?.(runtimeFor(channelType), credentialId, {
@@ -503,10 +533,9 @@ watch(
 						size="small"
 						icon-size="medium"
 						icon="arrow-left"
-						:disabled="
-							channelViewLoading || (selectedChannelType ? isLoading(selectedChannelType) : false)
-						"
+						:disabled="actionInFlight"
 						:class="$style.backButton"
+						data-testid="agent-channel-back"
 						@click="goBackToList"
 					>
 						<template #icon>
@@ -609,7 +638,7 @@ watch(
 						variant="ghost"
 						size="medium"
 						:loading="selectedChannelType ? isLoading(selectedChannelType) : false"
-						:disabled="selectedChannelType ? isLoading(selectedChannelType) : true"
+						:disabled="actionInFlight || !selectedChannelType"
 						data-testid="agent-channel-remove-channel"
 						@click="removeCurrentChannel"
 					>
@@ -619,9 +648,7 @@ watch(
 						<N8nButton
 							variant="outline"
 							size="medium"
-							:disabled="
-								channelViewLoading || (selectedChannelType ? isLoading(selectedChannelType) : false)
-							"
+							:disabled="actionInFlight"
 							@click="closeModal"
 						>
 							{{ i18n.baseText('generic.cancel') }}
@@ -629,14 +656,8 @@ watch(
 						<N8nButton
 							variant="solid"
 							size="medium"
-							:loading="
-								(selectedChannelType ? isLoading(selectedChannelType) : false) ||
-								Boolean(channelViewRef?.loading)
-							"
-							:disabled="
-								!canSaveChannelConfig ||
-								(selectedChannelType ? isLoading(selectedChannelType) : true)
-							"
+							:loading="actionInFlight"
+							:disabled="!canSaveChannelConfig || actionInFlight"
 							data-testid="agent-channel-save-channel-config"
 							@click="saveChannelConfig"
 						>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
@@ -336,8 +336,22 @@ async function persistAgent(): Promise<boolean> {
 		await props.ensureAgentPersisted?.();
 		return true;
 	} catch (error) {
-		// Only this step needs a toast — a failed `connect` is already rendered
-		// inline by the setup view.
+		// Needs a toast — unlike `connect`, this step has no inline error surface.
+		toast.showError(error, i18n.baseText('agents.channels.modal.saveChannelError'));
+		return false;
+	}
+}
+
+/**
+ * The platform's own pre-save step (Slack managed settings). Only some of its
+ * failures render inline in the view, so a rejection is reported here rather
+ * than closing the modal on settings that were never saved.
+ */
+async function runBeforeSave(): Promise<boolean> {
+	try {
+		await channelViewRef.value?.beforeSave?.();
+		return true;
+	} catch (error) {
 		toast.showError(error, i18n.baseText('agents.channels.modal.saveChannelError'));
 		return false;
 	}
@@ -363,12 +377,13 @@ async function saveChannelConfig() {
 	channelActionInFlight.value = true;
 	try {
 		if (!(await persistAgent())) return;
-		await channelViewRef.value?.beforeSave?.();
+		if (!(await runBeforeSave())) return;
 		await connect(channelType, credentialId, channelViewRef.value?.currentSettings, {
 			...(credentialIdToReplace ? { replaces: { credentialId: credentialIdToReplace } } : {}),
 		});
 	} catch {
-		// `useAgentIntegrationStatus` exposes the failure to the setup view.
+		// Only `connect` is left to throw here, and `useAgentIntegrationStatus`
+		// exposes that failure to the setup view.
 		return;
 	} finally {
 		channelActionInFlight.value = false;


### PR DESCRIPTION
## Summary

Follow-up to AGENT-542. Two gaps remained after `ChannelSetupCard` was hardened: the channel modal itself, and Slack automatic setup.

**Editor — one in-flight action, end to end**

The channel modal opens before the Agent row exists, so setup is really `ensureAgentPersisted` followed by `connect`. Guarding only on the connect request left the whole persistence await open to a second submit. A single `actionInFlight` computed now covers both steps, and close, back, remove and cancel all read from it instead of the channel connection state alone.

Two details worth a look in review:

- `completeAndClose()` is split out from `closeModal()` because a platform that drives its own flow (Slack) reports `connected` while that flow still counts as in flight — the user-facing guard would otherwise refuse to close the modal it just finished with.
- `requestDisconnect` checks the per-channel loading state on top of the modal-wide one, since the list view can target a channel other than the selected one.

A failed `ensureAgentPersisted` now surfaces a toast; a failed `connect` stays inline in the setup view as before.

**Core — compensate a failed Slack automatic setup**

Slack automatic setup creates an unmanaged credential before connecting the integration. If the connect fails, the credential is now deleted — but only when no durable integration references it. That check is keyed on the persisted integration state rather than on how the connect failed, because a startup failure can still leave the entry persisted, and that entry is what the next publish or reconcile acts on. The helper is only ever reached with a credential created moments earlier in the same call, so an existing or user-selected credential can't be deleted by it. Cleanup is best-effort: if the delete itself fails, it is logged and the original setup error is what the caller sees.

## How to test

1. Open an Agent that has not been saved yet and add a Slack channel. Double-click **Connect** while the Agent is being created — only one setup request should go out, and close / back / remove should be inert until it settles.
2. Make agent persistence fail (e.g. throw from `ensureAgentPersisted`) — a toast appears, no connect request is sent, and the modal stays open.
3. Run Slack automatic setup with the integration startup failing. The credential created by that attempt should be gone from the project afterwards; a credential already referenced by the agent's integrations should survive.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-550

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

