### PR TITLE
ci: Skip the npm-install closure check when the verifier is absent

### DIFF
--- a/.github/workflows/test-single-instance-npm.yml
+++ b/.github/workflows/test-single-instance-npm.yml
@@ -80,10 +80,30 @@ jobs:
           BASE_BRANCH: ${{ inputs.base-branch }}
         run: git checkout "$BASE_BRANCH"
 
+      # A `base-branch` can point at a release line that predates this tooling (the v1 patch track
+      # is the live case), where there is simply nothing to verify. Without a base-branch the ref is
+      # the caller's own revision, on which the package must exist — a move or rename has to fail
+      # loudly rather than quietly turn this into a green job that verified nothing.
+      - name: Check the verifier is present on this ref
+        id: verifier
+        env:
+          BASE_BRANCH: ${{ inputs.base-branch }}
+        run: |
+          if [ -f packages/testing/code-health/package.json ]; then
+            echo 'present=true' >> "$GITHUB_OUTPUT"
+          elif [ -n "$BASE_BRANCH" ]; then
+            echo 'present=false' >> "$GITHUB_OUTPUT"
+            echo "::notice::packages/testing/code-health is absent on \"$BASE_BRANCH\"; nothing to verify."
+          else
+            echo '::error::packages/testing/code-health is missing (moved or renamed?).'
+            exit 1
+          fi
+
       # Only the verifier's own closure needs compiling. The check reads package.json out of the
       # npm-install graph, so the packed tarballs' contents don't matter, and the two packages with
       # a prepack hook build themselves.
       - name: Setup and Build
+        if: steps.verifier.outputs.present == 'true'
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: pnpm turbo run build --filter=@n8n/code-health...
@@ -91,7 +111,7 @@ jobs:
       # `--dir` rather than `--filter`: a filter matching nothing exits 0, so a renamed or moved
       # package would turn this into a green job that verified nothing.
       - name: Verify npm-install closure (changed packages)
-        if: inputs.scope == 'changed'
+        if: steps.verifier.outputs.present == 'true' && inputs.scope == 'changed'
         env:
           BASE_REF: ${{ inputs.base-ref }}
         run: |
@@ -101,7 +121,7 @@ jobs:
           pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --changed="$BASE_REF" $REPORT_ONLY
 
       - name: Verify npm-install closure (all packages)
-        if: inputs.scope == 'all'
+        if: steps.verifier.outputs.present == 'true' && inputs.scope == 'all'
         run: |
           # shellcheck disable=SC2086 # see the scoped step above
           pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --all $REPORT_ONLY


### PR DESCRIPTION
## Summary

Bottom layer of stack

`release-create-pr.yml` passes the release line it prepares as `base-branch`, and `release-schedule-patch-prs.yml` runs a `v1` track that resolves to `1.x` — where `packages/testing/code-health` does not exist. The job checked that ref out and then failed on the missing directory, which reads as a dependency finding rather than as "this ref predates the check". The full-scope job landed on 2026-08-17, so that path has not run yet.

A new step reports whether the package is present, and the steps below it are gated on it:

```yaml
- name: Check the verifier is present on this ref
  id: verifier
```

**The skip applies only when the caller passed `base-branch`.** Without one, the ref is the caller's own revision, where the package must exist, so a move or a rename still fails the job. This keeps the guarantee the rest of the file is built around: the job must not go green after verifying nothing.

This PR is the fix on its own. The speed-up work that used to sit here is now #36687 and above.

## How to test

Run the workflow with `scope: all` and `base-branch: 1.x`. The job passes, emits a `::notice::`, and skips setup, build and both verify steps.

With no `base-branch`, delete `packages/testing/code-health/package.json` and confirm the job fails instead of skipping.

`actionlint` passes on the workflow.

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket. Part of stack #36689. Follows #34681 (added the check) and #36437 (made advisory runs advisory).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No user-facing docs; WORKFLOWS.md documents this workflow's inputs, which are unchanged. -->
- [ ] Tests included. <!-- Workflow-only change with no unit-testable surface; verified by running the workflow against `1.x` as described above. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
