### PR TITLE
fix(editor): Restore theme outline shadows (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_primitives.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_primitives.scss
@@ -309,9 +309,9 @@
 	--easing--ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
 
 	--shadow-color: var(--color--black-alpha-100);
+	--shadow-color--outline: var(--color--black-alpha-100);
 
-	/* box-shadow: var(--shadow--xs), inset var(--shadow--outline); */
-	--shadow--outline: 0 0 0 1px light-dark(var(--shadow-color), var(--color--white-alpha-100));
+	--shadow--outline: 0 0 0 1px var(--shadow-color--outline);
 	--shadow--2xs: 0 1px var(--shadow-color);
 	--shadow--xs: 0 1px 3px -1px var(--shadow-color);
 	--shadow--sm: 0 4px 6px -1px var(--shadow-color), 0 2px 4px -2px var(--shadow-color);
@@ -319,6 +319,20 @@
 	--shadow--xl: 0 20px 25px -5px var(--shadow-color), 0 8px 10px -6px var(--shadow-color);
 }
 
+/** Redefine this primitive overrides here because Lightning CSS doesnt like light-dark in .scss files **/
+@mixin dark-theme-overrides {
+	--shadow-color: var(--color--black-alpha-250);
+	--shadow-color--outline: var(--color--white-alpha-100);
+}
+
 :root {
 	@include primitives;
+
+	[data-theme='dark'] {
+		@include dark-theme-overrides;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		@include dark-theme-overrides;
+	}
 }

--- a/packages/frontend/@n8n/design-system/src/css/_primitives.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_primitives.scss
@@ -328,11 +328,14 @@
 :root {
 	@include primitives;
 
-	[data-theme='dark'] {
-		@include dark-theme-overrides;
+	/** Make sure that media query preceeds [data-theme] as MacOS theme can override attribute specificity **/
+	@media (prefers-color-scheme: dark) {
+		body:not([data-theme]) {
+			@include dark-theme-overrides;
+		}
 	}
 
-	@media (prefers-color-scheme: dark) {
+	[data-theme='dark'] {
 		@include dark-theme-overrides;
 	}
 }

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -1236,8 +1236,6 @@
 	--command-bar-item--color--background--hover: var(--color--background--light-1);
 	--command-bar--shadow:
 		0 15px 45px 0 var(--color--black-alpha-400), 0 5px 10px 0 var(--color--black-alpha-200);
-
-	--shadow-color: var(--color--black-alpha-250);
 }
 
 :root {


### PR DESCRIPTION
## Summary

Restore visible outline shadows in that failed to render. As `shadow--outline` used `light-dark()` it was processed by `lightning-css` poorly.

Lightning CSS sets these properties approximately like this:

```css
  :root {
    --lightningcss-light: initial;
    --lightningcss-dark: ;
  }

  @media (prefers-color-scheme: dark) {
    :root {
      --lightningcss-light: ;
      --lightningcss-dark: initial;
    }
  }
```

This meant that there was a fail case where the `initial` didn't fallback to the correct value, making the outline looks transparent. This also affected dedicated theme `[data-theme='light']` attributes that didn't rely on media queries for theming.

Also `@media (prefers-color-scheme: dark)` was overriding the `[data-theme]` specificity so if you had n8n on light theme and MacOS on dark, you'd get some dark CSS variables.

Instead of using `light-dark()` we override a new `--shadow-color--outline` variable in dark mode.

<!-- linear:table-colwidths:403,403 -->
| **Before** | **After** |
| -- | -- |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/893254fa-3092-4687-96ec-147ef8e5464f/9376ced9-4203-4cf8-b47a-5df12e27441b?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi84OTMyNTRmYS0zMDkyLTQ2ODctOTZlYy0xNDdlZjhlNTQ2NGYvOTM3NmNlZDktNDIwMy00Y2Y4LWI0N2EtNWRmMTJlMjc0NDFiIiwiaWF0IjoxNzg3MTMxNjU1LCJleHAiOjE4MTg3MDIyMTV9.jZ7U--Z3j1JHYdwfIFUrXPbPF6WguFH-xchNcBUdrSM " alt="CleanShot 2026-08-19 at 09.55.29@2x.png" width="1588" data-linear-height="464" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/603fbb61-cbe9-4a35-877b-3d710e8e4f69/24e80727-51f2-4d5d-b253-cc3e783256ff?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi82MDNmYmI2MS1jYmU5LTRhMzUtODc3Yi0zZDcxMGU4ZTRmNjkvMjRlODA3MjctNTFmMi00ZDVkLWIyNTMtY2MzZTc4MzI1NmZmIiwiaWF0IjoxNzg3MTMxNjU1LCJleHAiOjE4MTg3MDIyMTV9.fazrr7ZyYHTAn1emB9Ck2mum1EiA6wVk95zRSk5yjVs " alt="CleanShot 2026-08-19 at 09.55.49@2x.png" width="1546" data-linear-height="382" /> |

## How to test

1. Open the AI agent preview in light mode.
2. Confirm that the text input has a visible outline.
3. Open the AI agent preview in dark mode.
4. Confirm that the text input has a visible outline.
5. Set the system theme to dark mode without an explicit n8n theme.
6. Confirm that the text input has a visible outline.

## Related Linear tickets, Github issues, and Community forum posts

[AGENT-584](https://linear.app/n8n/issue/AGENT-584)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [X] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)