### PR TITLE
feat(core): Add PolicyEnforcementService proxy (no-changelog)

### DIFF
--- a/packages/cli/src/policy/__tests__/policy-enforcement.service.test.ts
+++ b/packages/cli/src/policy/__tests__/policy-enforcement.service.test.ts
@@ -1,0 +1,222 @@
+import type { PolicedWorkflow, PolicyDecision, PolicyViolation } from '@n8n/decorators';
+import { UnexpectedError } from 'n8n-workflow';
+import { mock, type MockProxy } from 'vitest-mock-extended';
+
+import type { PolicyEnforcementBackend } from '../policy-enforcement-backend';
+import { PolicyEnforcementService } from '../policy-enforcement.service';
+import { PolicyViolationError } from '../policy-violation.error';
+
+const savedWorkflow: PolicedWorkflow = { id: 'wf-1', name: 'My workflow', nodes: [] };
+
+const violation: PolicyViolation = {
+	kind: 'node-type-unavailable',
+	checkId: 'node-type-availability',
+	message: 'The node type n8n-nodes-base.slack is not available on this instance',
+};
+
+const cleared: PolicyDecision = { violations: [] };
+
+/** One call per point, so a new point can't be left out of the no-op guarantee. */
+const enforceCalls = (service: PolicyEnforcementService) => ({
+	workflowSave: async () =>
+		await service.enforceWorkflowSave({
+			workflow: savedWorkflow,
+			storedWorkflow: null,
+			projectId: 'proj-1',
+		}),
+	workflowPublish: async () =>
+		await service.enforceWorkflowPublish({ workflow: savedWorkflow, projectId: 'proj-1' }),
+	workflowStart: async () =>
+		await service.enforceWorkflowStart({ workflow: savedWorkflow, projectId: 'proj-1' }),
+	workflowTransfer: async () =>
+		await service.enforceWorkflowTransfer({
+			workflow: savedWorkflow,
+			targetProjectId: 'proj-2',
+		}),
+	credentialDecrypt: async () =>
+		await service.enforceCredentialDecrypt({
+			credentialType: 'slackApi',
+			credentialId: 'cred-1',
+			consumer: null,
+			projectId: 'proj-1',
+		}),
+	contentImport: async () =>
+		await service.enforceContentImport({ workflow: savedWorkflow, projectId: 'proj-1' }),
+});
+
+const evaluateCalls = (service: PolicyEnforcementService) => ({
+	workflowSave: async () =>
+		await service.evaluateWorkflowSave({
+			workflow: savedWorkflow,
+			storedWorkflow: null,
+			projectId: 'proj-1',
+		}),
+	workflowPublish: async () =>
+		await service.evaluateWorkflowPublish({ workflow: savedWorkflow, projectId: 'proj-1' }),
+	workflowStart: async () =>
+		await service.evaluateWorkflowStart({ workflow: savedWorkflow, projectId: 'proj-1' }),
+	workflowTransfer: async () =>
+		await service.evaluateWorkflowTransfer({
+			workflow: savedWorkflow,
+			targetProjectId: 'proj-2',
+		}),
+	credentialDecrypt: async () =>
+		await service.evaluateCredentialDecrypt({
+			credentialType: 'slackApi',
+			credentialId: 'cred-1',
+			consumer: null,
+			projectId: 'proj-1',
+		}),
+	contentImport: async () =>
+		await service.evaluateContentImport({ workflow: savedWorkflow, projectId: 'proj-1' }),
+});
+
+describe('PolicyEnforcementService', () => {
+	describe('with no implementation registered', () => {
+		const service = new PolicyEnforcementService();
+
+		test.each(Object.entries(enforceCalls(service)))(
+			'%s clears without throwing',
+			async (point, call) => {
+				const token = await call();
+
+				expect(token.point).toBe(point);
+				expect(token.decision).toEqual(cleared);
+			},
+		);
+
+		test.each(Object.entries(evaluateCalls(service)))(
+			'%s evaluates to an empty decision',
+			async (_point, call) => {
+				expect(await call()).toEqual({ violations: [] });
+			},
+		);
+
+		it('hands out a fresh decision each call, so one caller cannot affect the next', async () => {
+			const first = await service.evaluateWorkflowStart({
+				workflow: savedWorkflow,
+				projectId: null,
+			});
+			first.violations.push(violation);
+
+			const second = await service.evaluateWorkflowStart({
+				workflow: savedWorkflow,
+				projectId: null,
+			});
+
+			expect(second.violations).toEqual([]);
+		});
+	});
+
+	describe('setImplementation', () => {
+		it('refuses a second implementation', () => {
+			const service = new PolicyEnforcementService();
+			service.setImplementation(mock<PolicyEnforcementBackend>());
+
+			expect(() => service.setImplementation(mock<PolicyEnforcementBackend>())).toThrow(
+				UnexpectedError,
+			);
+		});
+	});
+
+	describe('with an implementation registered', () => {
+		let service: PolicyEnforcementService;
+		let backend: MockProxy<PolicyEnforcementBackend>;
+
+		beforeEach(() => {
+			backend = mock<PolicyEnforcementBackend>();
+			service = new PolicyEnforcementService();
+			service.setImplementation(backend);
+		});
+
+		it('throws with every violation instead of minting', async () => {
+			const second = { ...violation, subject: 'n8n-nodes-base.code' };
+			backend.enforce.mockResolvedValue({ violations: [violation, second] });
+
+			const error = await service
+				.enforceWorkflowSave({ workflow: savedWorkflow, storedWorkflow: null, projectId: null })
+				.catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(PolicyViolationError);
+			expect((error as PolicyViolationError).violations).toEqual([violation, second]);
+		});
+
+		it('passes the point and context through and mints the decision it got back', async () => {
+			const decision: PolicyDecision = {
+				violations: [],
+				policyVersions: [{ scope: 'instance', version: 7 }],
+			};
+			backend.enforce.mockResolvedValue(decision);
+			const context = { workflow: savedWorkflow, storedWorkflow: null, projectId: 'proj-1' };
+
+			const token = await service.enforceWorkflowSave(context);
+
+			expect(backend.enforce).toHaveBeenCalledWith('workflowSave', context);
+			expect(token.decision).toBe(decision);
+			expect(token.policyVersions).toEqual([{ scope: 'instance', version: 7 }]);
+		});
+
+		it('returns the advisory decision as-is, violations and all', async () => {
+			const decision: PolicyDecision = {
+				violations: [violation],
+				checkErrors: [{ checkId: 'flaky', correlationId: 'abc' }],
+			};
+			backend.evaluate.mockResolvedValue(decision);
+			const context = { workflow: savedWorkflow, projectId: null };
+
+			expect(await service.evaluateContentImport(context)).toBe(decision);
+			expect(backend.evaluate).toHaveBeenCalledWith('contentImport', context);
+		});
+	});
+
+	describe('subject binding', () => {
+		const service = new PolicyEnforcementService();
+
+		it('binds a saved workflow to its id', async () => {
+			const token = await service.enforceWorkflowStart({
+				workflow: savedWorkflow,
+				projectId: null,
+			});
+
+			expect(token.subject).toEqual({ type: 'workflow', id: 'wf-1' });
+		});
+
+		it('binds an unsaved workflow to a hash of its nodes', async () => {
+			const unsaved: PolicedWorkflow = { id: null, name: 'New', nodes: [] };
+
+			const token = await service.enforceWorkflowSave({
+				workflow: unsaved,
+				storedWorkflow: null,
+				projectId: null,
+			});
+
+			expect(token.subject.type).toBe('workflow');
+			expect(token.subject.id).toMatch(/^[0-9a-f]{64}$/);
+		});
+
+		it('gives two unsaved workflows with different nodes different subjects', async () => {
+			const enforce = async (nodes: PolicedWorkflow['nodes']) =>
+				await service.enforceWorkflowSave({
+					workflow: { id: null, name: 'New', nodes },
+					storedWorkflow: null,
+					projectId: null,
+				});
+
+			const empty = await enforce([]);
+			const withNode = await enforce([mock<PolicedWorkflow['nodes'][number]>({ type: 'slack' })]);
+
+			expect(empty.subject.id).not.toBe(withNode.subject.id);
+		});
+
+		it('binds a credential decrypt to the credential', async () => {
+			const token = await service.enforceCredentialDecrypt({
+				credentialType: 'slackApi',
+				credentialId: 'cred-1',
+				consumer: { nodeType: 'n8n-nodes-base.slack' },
+				projectId: null,
+			});
+
+			expect(token.subject).toEqual({ type: 'credential', id: 'cred-1' });
+		});
+	});
+});

--- a/packages/cli/src/policy/policy-enforcement-backend.ts
+++ b/packages/cli/src/policy/policy-enforcement-backend.ts
@@ -1,0 +1,41 @@
+import type {
+	ContentImportContext,
+	CredentialDecryptContext,
+	EnforcementPoint,
+	PolicyDecision,
+	WorkflowPublishContext,
+	WorkflowSaveContext,
+	WorkflowStartContext,
+	WorkflowTransferContext,
+} from '@n8n/decorators';
+
+/** Which context each point is called with, mirroring `RegisteredPolicyCheck`. */
+type PolicyContexts = {
+	workflowSave: WorkflowSaveContext;
+	workflowPublish: WorkflowPublishContext;
+	workflowStart: WorkflowStartContext;
+	workflowTransfer: WorkflowTransferContext;
+	credentialDecrypt: CredentialDecryptContext;
+	contentImport: ContentImportContext;
+};
+
+export type PolicyContext<Point extends EnforcementPoint> = PolicyContexts[Point];
+
+/**
+ * What the policy infrastructure module registers into the proxy.
+ *
+ * Both modes return a decision; the proxy turns a non-empty one into a `PolicyViolationError`.
+ * Separate methods because the fail posture differs: `enforce` blocks on a check that breaks,
+ * `evaluate` reports it in `checkErrors` and keeps the rest.
+ */
+export interface PolicyEnforcementBackend {
+	enforce<Point extends EnforcementPoint>(
+		point: Point,
+		context: PolicyContext<Point>,
+	): Promise<PolicyDecision>;
+
+	evaluate<Point extends EnforcementPoint>(
+		point: Point,
+		context: PolicyContext<Point>,
+	): Promise<PolicyDecision>;
+}

--- a/packages/cli/src/policy/policy-enforcement.service.ts
+++ b/packages/cli/src/policy/policy-enforcement.service.ts
@@ -1,0 +1,140 @@
+import type {
+	ContentImportContext,
+	CredentialDecryptContext,
+	EnforcementPoint,
+	PolicedWorkflow,
+	PolicyDecision,
+	WorkflowPublishContext,
+	WorkflowSaveContext,
+	WorkflowStartContext,
+	WorkflowTransferContext,
+} from '@n8n/decorators';
+import { Service } from '@n8n/di';
+import { UnexpectedError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
+
+import { mintPolicyCleared, type PolicyCleared, type PolicySubject } from './policy-cleared';
+import type { PolicyContext, PolicyEnforcementBackend } from './policy-enforcement-backend';
+import { hasViolations, PolicyViolationError } from './policy-violation.error';
+
+/** Fresh each time — `violations` is mutable. */
+const emptyDecision = (): PolicyDecision => ({ violations: [] });
+
+/** A workflow being created has no id yet, so it binds to its nodes instead. */
+function workflowSubject(workflow: PolicedWorkflow): PolicySubject {
+	if (workflow.id !== null) return { type: 'workflow', id: workflow.id };
+
+	// Same object within one request, so key order is stable.
+	const nodes = createHash('sha256').update(JSON.stringify(workflow.nodes)).digest('hex');
+
+	return { type: 'workflow', id: nodes };
+}
+
+/**
+ * The policy enforcement point every host call site talks to.
+ *
+ * With nothing registered, `enforce*` clears and `evaluate*` returns an empty decision — the
+ * feature is *absent*, not failing closed, so a host can call this unconditionally.
+ *
+ * `enforce*` is the gate: it throws `PolicyViolationError` with every violation, or returns a
+ * `PolicyCleared`. `evaluate*` is the advisory: same checks, returns the decision, never mints.
+ */
+@Service()
+export class PolicyEnforcementService {
+	private implementation?: PolicyEnforcementBackend;
+
+	/** Single-shot: a second implementation would be silently ignored. */
+	setImplementation(implementation: PolicyEnforcementBackend) {
+		if (this.implementation) {
+			throw new UnexpectedError('A policy enforcement implementation is already registered');
+		}
+
+		this.implementation = implementation;
+	}
+
+	async enforceWorkflowSave(context: WorkflowSaveContext): Promise<PolicyCleared<'workflowSave'>> {
+		return await this.enforce('workflowSave', context, workflowSubject(context.workflow));
+	}
+
+	async evaluateWorkflowSave(context: WorkflowSaveContext): Promise<PolicyDecision> {
+		return await this.evaluate('workflowSave', context);
+	}
+
+	async enforceWorkflowPublish(
+		context: WorkflowPublishContext,
+	): Promise<PolicyCleared<'workflowPublish'>> {
+		return await this.enforce('workflowPublish', context, workflowSubject(context.workflow));
+	}
+
+	async evaluateWorkflowPublish(context: WorkflowPublishContext): Promise<PolicyDecision> {
+		return await this.evaluate('workflowPublish', context);
+	}
+
+	async enforceWorkflowStart(
+		context: WorkflowStartContext,
+	): Promise<PolicyCleared<'workflowStart'>> {
+		return await this.enforce('workflowStart', context, workflowSubject(context.workflow));
+	}
+
+	async evaluateWorkflowStart(context: WorkflowStartContext): Promise<PolicyDecision> {
+		return await this.evaluate('workflowStart', context);
+	}
+
+	async enforceWorkflowTransfer(
+		context: WorkflowTransferContext,
+	): Promise<PolicyCleared<'workflowTransfer'>> {
+		return await this.enforce('workflowTransfer', context, workflowSubject(context.workflow));
+	}
+
+	async evaluateWorkflowTransfer(context: WorkflowTransferContext): Promise<PolicyDecision> {
+		return await this.evaluate('workflowTransfer', context);
+	}
+
+	async enforceCredentialDecrypt(
+		context: CredentialDecryptContext,
+	): Promise<PolicyCleared<'credentialDecrypt'>> {
+		return await this.enforce('credentialDecrypt', context, {
+			type: 'credential',
+			id: context.credentialId,
+		});
+	}
+
+	async evaluateCredentialDecrypt(context: CredentialDecryptContext): Promise<PolicyDecision> {
+		return await this.evaluate('credentialDecrypt', context);
+	}
+
+	async enforceContentImport(
+		context: ContentImportContext,
+	): Promise<PolicyCleared<'contentImport'>> {
+		return await this.enforce('contentImport', context, workflowSubject(context.workflow));
+	}
+
+	async evaluateContentImport(context: ContentImportContext): Promise<PolicyDecision> {
+		return await this.evaluate('contentImport', context);
+	}
+
+	private async enforce<Point extends EnforcementPoint>(
+		point: Point,
+		context: PolicyContext<Point>,
+		subject: PolicySubject,
+	): Promise<PolicyCleared<Point>> {
+		const decision = this.implementation
+			? await this.implementation.enforce(point, context)
+			: emptyDecision();
+
+		if (hasViolations(decision.violations)) {
+			throw new PolicyViolationError(decision.violations);
+		}
+
+		return mintPolicyCleared({ point, subject, decision });
+	}
+
+	private async evaluate<Point extends EnforcementPoint>(
+		point: Point,
+		context: PolicyContext<Point>,
+	): Promise<PolicyDecision> {
+		if (!this.implementation) return emptyDecision();
+
+		return await this.implementation.evaluate(point, context);
+	}
+}

--- a/packages/cli/src/policy/policy-violation.error.ts
+++ b/packages/cli/src/policy/policy-violation.error.ts
@@ -4,6 +4,10 @@ import { UserError } from 'n8n-workflow';
 /** `enforce*` only throws when something objected, so an empty list is a bug, not a case. */
 export type NonEmptyViolations = [PolicyViolation, ...PolicyViolation[]];
 
+/** Narrows a decision's violations to something `PolicyViolationError` will accept. */
+export const hasViolations = (violations: PolicyViolation[]): violations is NonEmptyViolations =>
+	violations.length > 0;
+
 function summarize(violations: NonEmptyViolations): string {
 	if (violations.length === 1) return violations[0].message;
 


### PR DESCRIPTION
## Summary

Adds `PolicyEnforcementService` — the thing host code will call to ask "is this allowed?".

It has six pairs of methods, one pair per enforcement point:

- `enforceWorkflowSave(ctx)` blocks. It throws `PolicyViolationError` if anything objects,
  otherwise it hands back a `PolicyCleared` value for the action.
- `evaluateWorkflowSave(ctx)` just asks. It returns the decision, never throws, and never clears
  anything.

Same pair for `workflowPublish`, `workflowStart`, `workflowTransfer`, `credentialDecrypt` and
`contentImport`.

**The important part: with no policy implementation registered, everything passes.** `enforce*`
clears and `evaluate*` returns "no violations". Policy is a module that may never load, so host
code needs to call this without checking first, and a missing module must not start blocking
people. There's a test per point so it can't quietly regress.

### What gets registered into it

The policy module will register an object with two methods:

```ts
enforce(point, context) => Promise<PolicyDecision>
evaluate(point, context) => Promise<PolicyDecision>
```

Both just return a decision and the proxy decides what to do with it, which keeps the throwing
in one place. They're two methods rather than one because a check that breaks has to block under
`enforce`, but only gets reported under `evaluate`.

### Working out what was cleared

`PolicyCleared` records the thing it cleared, so `enforce*` reads that off the context: the
credential id for `credentialDecrypt`, the workflow id everywhere else. A workflow that's still
being created has no id, so it uses a hash of its nodes instead.

### Two decisions worth a look

- `setImplementation()` throws if you call it twice. Two implementations would mean one of them
  silently never runs.
- `evaluate*` doesn't catch errors from the implementation. "Never throws" means it doesn't throw
  because of violations, not that it swallows crashes. A broken check belongs in the decision's
  `checkErrors`; an implementation that blows up entirely is a bug worth seeing.

Nothing calls any of this yet. The implementation and the host wiring land separately.

## How to test

```bash
cd packages/cli
pnpm test src/policy
pnpm typecheck
```

The tests cover: every point clears and evaluates cleanly with nothing registered; each call gets
its own decision object, so one caller can't affect the next; a second `setImplementation` throws;
violations turn into a `PolicyViolationError` with all of them, not a clearance; the point and
context reach the implementation untouched; an advisory decision comes back as-is; and the
subject comes out as the workflow id, a node hash when unsaved, or the credential id.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1116

Follows #36580, which is now on `master`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
