### PR TITLE
fix(core): CAT-3451 (backport to 1.x)

### DIFF
--- a/packages/@n8n/expression-runtime/package.json
+++ b/packages/@n8n/expression-runtime/package.json
@@ -32,7 +32,7 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "dependencies": {
     "@n8n/errors": "workspace:*",
-    "@n8n/tournament": "1.2.0",
+    "@n8n/tournament": "1.9.1",
     "isolated-vm": "catalog:",
     "jmespath": "0.16.0",
     "js-base64": "catalog:",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@n8n/errors": "workspace:*",
     "@n8n/expression-runtime": "workspace:*",
-    "@n8n/tournament": "1.0.6",
+    "@n8n/tournament": "1.9.1",
     "ast-types": "0.16.1",
     "callsites": "catalog:",
     "esprima-next": "5.8.4",

--- a/packages/workflow/src/expression-evaluator-proxy.ts
+++ b/packages/workflow/src/expression-evaluator-proxy.ts
@@ -1,15 +1,17 @@
 import { Tournament } from '@n8n/tournament';
 
-import { DollarSignValidator, ThisSanitizer, PrototypeSanitizer } from './expression-sandboxing';
+import { expressionSandboxHooks } from './expression-sandboxing';
 
 type Evaluator = (expr: string, data: unknown) => string | null | (() => unknown);
 type ErrorHandler = (error: Error) => void;
 
 const errorHandler: ErrorHandler = () => {};
-const tournamentEvaluator = new Tournament(errorHandler, undefined, undefined, {
-	before: [ThisSanitizer],
-	after: [PrototypeSanitizer, DollarSignValidator],
-});
+const tournamentEvaluator = new Tournament(
+	errorHandler,
+	undefined,
+	undefined,
+	expressionSandboxHooks,
+);
 const evaluator: Evaluator = tournamentEvaluator.execute.bind(tournamentEvaluator);
 
 export const setErrorHandler = (handler: ErrorHandler) => {

--- a/packages/workflow/src/expression-sandboxing.ts
+++ b/packages/workflow/src/expression-sandboxing.ts
@@ -1,4 +1,10 @@
-import { type ASTAfterHook, type ASTBeforeHook, astBuilders as b, astVisit } from '@n8n/tournament';
+import {
+	type ASTAfterHook,
+	type ASTBeforeHook,
+	type TournamentHooks,
+	astBuilders as b,
+	astVisit,
+} from '@n8n/tournament';
 
 import {
 	ExpressionClassExtensionError,
@@ -129,7 +135,51 @@ const isValidDollarPropertyAccess = (expr: unknown): boolean => {
 
 const GLOBAL_IDENTIFIERS = new Set(['globalThis']);
 
-const BLOCKED_SPREAD_GLOBALS = new Set(['process', 'global', 'globalThis', 'Buffer']);
+/**
+ * Backstop, not the containment: the polyfill already resolves a free base class
+ * identifier through the data context. Listed here because a subclass inherits
+ * the static side of its base, so these are the costliest to ever let through.
+ */
+const blockedBaseClasses = new Set([
+	'Function',
+	'GeneratorFunction',
+	'AsyncFunction',
+	'AsyncGeneratorFunction',
+	'Buffer',
+]);
+
+/**
+ * Rejects `class X extends <expr>` unless the base class is a plain identifier
+ * that is not one of {@link blockedBaseClasses}.
+ *
+ * Must stay a before hook: the polyfill rewrites a free base class identifier
+ * into a data-context lookup, after which the two cases are indistinguishable.
+ */
+export const ClassExtensionValidator: ASTBeforeHook = (ast, _dataNode) => {
+	const validate = (superClass: unknown) => {
+		if (isAstNode(superClass)) {
+			if (superClass.type !== 'Identifier') {
+				throw new ExpressionError('Cannot use dynamic class extension due to security concerns');
+			}
+
+			if (typeof superClass.name === 'string' && blockedBaseClasses.has(superClass.name)) {
+				throw new ExpressionClassExtensionError(superClass.name);
+			}
+		}
+	};
+
+	astVisit(ast, {
+		visitClassDeclaration(path) {
+			this.traverse(path);
+			validate(path.node.superClass);
+		},
+
+		visitClassExpression(path) {
+			this.traverse(path);
+			validate(path.node.superClass);
+		},
+	});
+};
 
 /**
  * Prevents regular functions from binding their `this` to the Node.js global.
@@ -301,58 +351,6 @@ export const DollarSignValidator: ASTAfterHook = (ast, _dataNode) => {
 	});
 };
 
-const blockedBaseClasses = new Set([
-	'Function',
-	'GeneratorFunction',
-	'AsyncFunction',
-	'AsyncGeneratorFunction',
-]);
-
-/**
- * Builds an AST node that safely resolves a spread argument like `...process`.
- *
- * Tournament's VariablePolyfill rewrites plain identifiers (e.g. `process`)
- * to look them up from the data context, but it does NOT handle identifiers
- * inside SpreadElement / SpreadProperty nodes. Without this fix, `{...process}`
- * would resolve to the real Node.js `process` object.
- *
- * The generated code checks the data context first, falling back to a throw:
- *
- *   ("process" in data) ? data.process : (() => { throw new Error("...") })()
- *
- * - If the workflow has a variable called "process" → spread that (safe, user-defined)
- * - Otherwise → throw at runtime, blocking access to the real global
- */
-const buildSafeSpreadArg = (name: string, dataNode: Parameters<ASTAfterHook>[1]) => {
-	// "process" in ___n8n_data
-	const isInDataContext = b.binaryExpression('in', b.literal(name), dataNode);
-
-	// ___n8n_data.process
-	const readFromDataContext = b.memberExpression(dataNode, b.identifier(name));
-
-	// (() => { throw new Error('Cannot spread "process" ...') })()
-	//
-	// This is an IIFE because `throw` is a statement, not an expression,
-	// so it cannot appear directly inside a ternary's falsy branch.
-	const throwSecurityError = b.callExpression(
-		b.arrowFunctionExpression(
-			[],
-			b.blockStatement([
-				b.throwStatement(
-					b.newExpression(b.identifier('Error'), [
-						b.literal(`Cannot spread "${name}" due to security concerns`),
-					]),
-				),
-			]),
-		),
-		[],
-	);
-
-	// Full result:
-	//   ("process" in ___n8n_data) ? ___n8n_data.process : (() => { throw ... })()
-	return b.conditionalExpression(isInDataContext, readFromDataContext, throwSecurityError);
-};
-
 export const PrototypeSanitizer: ASTAfterHook = (ast, dataNode) => {
 	astVisit(ast, {
 		visitVariableDeclarator(path) {
@@ -392,41 +390,18 @@ export const PrototypeSanitizer: ASTAfterHook = (ast, dataNode) => {
 
 		visitClassDeclaration(path) {
 			this.traverse(path);
-			const node = path.node;
 
-			const className = getReservedIdentifier(node.id);
-			if (className !== undefined) {
-				throw new ExpressionReservedVariableError(className);
-			}
-
-			if (node.superClass) {
-				if (node.superClass.type === 'Identifier') {
-					if (blockedBaseClasses.has(node.superClass.name)) {
-						throw new ExpressionClassExtensionError(node.superClass.name);
-					}
-				} else {
-					throw new ExpressionError('Cannot use dynamic class extension due to security concerns');
-				}
-			}
+			const className = getReservedIdentifier(path.node.id);
+			if (className === undefined) return;
+			throw new ExpressionReservedVariableError(className);
 		},
 
 		visitClassExpression(path) {
 			this.traverse(path);
-			const node = path.node;
 
-			const className = getReservedIdentifier(node.id);
+			const className = getReservedIdentifier(path.node.id);
 			if (className !== undefined) {
 				throw new ExpressionReservedVariableError(className);
-			}
-
-			if (node.superClass) {
-				if (node.superClass.type === 'Identifier') {
-					if (blockedBaseClasses.has(node.superClass.name)) {
-						throw new ExpressionClassExtensionError(node.superClass.name);
-					}
-				} else {
-					throw new ExpressionError('Cannot use dynamic class extension due to security concerns');
-				}
 			}
 		},
 
@@ -530,28 +505,20 @@ export const PrototypeSanitizer: ASTAfterHook = (ast, dataNode) => {
 			}
 		},
 
-		visitSpreadElement(path) {
-			this.traverse(path);
-			const { argument } = path.node;
-			if (argument.type === 'Identifier' && BLOCKED_SPREAD_GLOBALS.has(argument.name)) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-				(path.node as any).argument = buildSafeSpreadArg(argument.name, dataNode);
-			}
-		},
-
-		visitSpreadProperty(path) {
-			this.traverse(path);
-			const { argument } = path.node;
-			if (argument.type === 'Identifier' && BLOCKED_SPREAD_GLOBALS.has(argument.name)) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-				(path.node as any).argument = buildSafeSpreadArg(argument.name, dataNode);
-			}
-		},
-
 		visitWithStatement() {
 			throw new ExpressionWithStatementError();
 		},
 	});
+};
+
+/**
+ * The complete set of AST hooks an expression evaluator must run. Evaluators take
+ * this object rather than assembling their own, so a hook added here cannot be
+ * missed by one of them.
+ */
+export const expressionSandboxHooks: TournamentHooks = {
+	before: [ClassExtensionValidator, ThisSanitizer],
+	after: [PrototypeSanitizer, DollarSignValidator],
 };
 
 export const sanitizer = (value: unknown): unknown => {

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -6,13 +6,7 @@ import { MemoryLimitError, SecurityViolationError, TimeoutError } from '@n8n/exp
 import { ExpressionExtensionError } from './errors/expression-extension.error';
 import { ExpressionError } from './errors/expression.error';
 import { evaluateExpression, setErrorHandler } from './expression-evaluator-proxy';
-import {
-	DollarSignValidator,
-	PrototypeSanitizer,
-	ThisSanitizer,
-	sanitizer,
-	sanitizerName,
-} from './expression-sandboxing';
+import { expressionSandboxHooks, sanitizer, sanitizerName } from './expression-sandboxing';
 import { isExpression } from './expressions/expression-helpers';
 import * as LoggerProxy from './logger-proxy';
 import { extend, extendOptional } from './extensions';
@@ -281,10 +275,7 @@ export class Expression {
 				maxCodeCacheSize: options.maxCodeCacheSize,
 				poolSize: options.poolSize,
 				idleTimeoutMs: options.idleTimeoutMs,
-				hooks: {
-					before: [ThisSanitizer],
-					after: [PrototypeSanitizer, DollarSignValidator],
-				},
+				hooks: expressionSandboxHooks,
 				logger: LoggerProxy,
 				observability: options.observability,
 			});

--- a/packages/workflow/test/expression-sandboxing.test.ts
+++ b/packages/workflow/test/expression-sandboxing.test.ts
@@ -10,13 +10,7 @@ import {
 	ExpressionError,
 	ExpressionWithStatementError,
 } from '../src/errors';
-import {
-	DollarSignValidator,
-	ThisSanitizer,
-	PrototypeSanitizer,
-	sanitizer,
-	DOLLAR_SIGN_ERROR,
-} from '../src/expression-sandboxing';
+import { expressionSandboxHooks, sanitizer, DOLLAR_SIGN_ERROR } from '../src/expression-sandboxing';
 
 const tournament = new Tournament(
 	(e) => {
@@ -24,10 +18,7 @@ const tournament = new Tournament(
 	},
 	undefined,
 	undefined,
-	{
-		before: [ThisSanitizer],
-		after: [PrototypeSanitizer, DollarSignValidator],
-	},
+	expressionSandboxHooks,
 );
 
 const errorRegex = /^Cannot access ".*" due to security concerns$/;
@@ -477,6 +468,15 @@ describe('PrototypeSanitizer', () => {
 			}).toThrowError(ExpressionClassExtensionError);
 		});
 
+		it('should not allow class extending Buffer', () => {
+			expect(() => {
+				tournament.execute(
+					'{{ (() => { class Z extends Buffer {} return Z.allocUnsafe(32).length; })() }}',
+					{ __sanitize: sanitizer },
+				);
+			}).toThrow(ExpressionClassExtensionError);
+		});
+
 		it('should allow class extending safe classes', () => {
 			expect(() => {
 				tournament.execute(
@@ -647,98 +647,179 @@ describe('PrototypeSanitizer', () => {
 		});
 	});
 
-	describe('Spread-based global access', () => {
-		it('should not allow spreading process', () => {
+	describe('Spread of host globals', () => {
+		it.each([
+			'process',
+			'global',
+			'globalThis',
+			'Buffer',
+			'console',
+			'Error',
+			'crypto',
+			'navigator',
+			'performance',
+			'Intl',
+			'Atomics',
+			'URL',
+			'TextEncoder',
+			'TextDecoder',
+			'fetch',
+			'Headers',
+			'Request',
+			'Response',
+			'Blob',
+			'File',
+			'FormData',
+			'AbortController',
+			'Event',
+			'EventTarget',
+			'MessageChannel',
+			'SharedArrayBuffer',
+			'ReadableStream',
+			'WritableStream',
+			'WeakRef',
+			'FinalizationRegistry',
+			'AggregateError',
+		])('should not expose the host %s through a spread', (name) => {
+			expect(tournament.execute(`{{ ({...${name}}) }}`, { __sanitize: sanitizer })).toEqual({});
+		});
+
+		it.each([
+			['nested spread', '{{ ({...({...process})}) }}'],
+			['spread inside an arrow function', '{{ (() => ({...process}))() }}'],
+			['spread among other spreads', '{{ ({...{}, ...process}) }}'],
+		])('should not expose a host global through a %s', (_, expression) => {
+			expect(tournament.execute(expression, { __sanitize: sanitizer })).toEqual({});
+		});
+
+		it.each([
+			['process.env', '{{ typeof ({...process}).env }}'],
+			['process.pid', '{{ typeof ({...process}).pid }}'],
+			['Buffer.allocUnsafe', '{{ typeof ({...Buffer}).allocUnsafe }}'],
+			['console.log', '{{ typeof ({...console}).log }}'],
+		])('should not expose the host %s through a spread', (_, expression) => {
+			expect(tournament.execute(expression, { __sanitize: sanitizer })).toBe('undefined');
+		});
+
+		it.each([
+			['an array literal', '{{ [...process] }}'],
+			['call arguments', '{{ ((a) => a)(...process) }}'],
+		])('should not iterate the host process in %s', (_, expression) => {
+			expect(() => tournament.execute(expression, { __sanitize: sanitizer })).toThrow(
+				/is not iterable/,
+			);
+		});
+
+		it('should not hand out a reference to a host function', () => {
 			expect(() => {
-				tournament.execute('{{ ((g) => g.getBuiltinModule)(({...process})) }}', {
+				tournament.execute('{{ ({...console}).log.toString() }}', { __sanitize: sanitizer });
+			}).toThrow(/Cannot read properties of undefined/);
+		});
+
+		it('should not write to a host function', () => {
+			expect(() => {
+				tournament.execute('{{ Object.assign(({...console}).log, {written: 1}).name }}', {
 					__sanitize: sanitizer,
+					Object,
 				});
-			}).toThrowError(/due to security concerns/);
+			}).toThrow(/Cannot convert undefined or null to object/);
+
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+			expect((console.log as any).written).toBeUndefined();
 		});
 
-		it('should not allow spreading process in object literal', () => {
-			expect(() => {
-				tournament.execute('{{ ({...process}) }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "process" due to security concerns/);
+		it.each([
+			['an array literal', '{{ [...arguments][0] }}'],
+			['an object literal', '{{ ({...arguments}) }}'],
+			['a function body', '{{ (() => [...arguments][0])() }}'],
+		])("should not expose the evaluator's own arguments in %s", (_, expression) => {
+			expect(() => tournament.execute(expression, { __sanitize: sanitizer })).toThrow(errorRegex);
 		});
 
-		it('should not allow spreading process in array', () => {
-			expect(() => {
-				tournament.execute('{{ [...process] }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "process" due to security concerns/);
-		});
-
-		it('should not allow spreading global', () => {
-			expect(() => {
-				tournament.execute('{{ ({...global}) }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "global" due to security concerns/);
-		});
-
-		it('should not allow spreading Buffer', () => {
-			expect(() => {
-				tournament.execute('{{ ({...Buffer}) }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "Buffer" due to security concerns/);
-		});
-
-		it('should not allow the exact RCE PoC payload', () => {
+		it('should not reach a built-in module through a spread', () => {
 			expect(() => {
 				tournament.execute(
 					"{{ ((g) => g.getBuiltinModule('child_process').execSync('id').toString())({...process}) }}",
 					{ __sanitize: sanitizer },
 				);
-			}).toThrowError(/due to security concerns/);
+			}).toThrow(errorRegex);
 		});
 
-		it('should not allow spreading process in function call arguments', () => {
-			expect(() => {
-				tournament.execute('{{ ((a, b) => a)(...process) }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "process" due to security concerns/);
-		});
-
-		it('should not allow spreading process inside arrow function', () => {
-			expect(() => {
-				tournament.execute('{{ (() => ({...process}))() }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "process" due to security concerns/);
-		});
-
-		it('should not allow spreading process in nested spread', () => {
-			expect(() => {
-				tournament.execute('{{ ({...({...process})}) }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "process" due to security concerns/);
-		});
-
-		it('should not allow spreading process in template expression', () => {
-			expect(() => {
-				// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
-				tournament.execute('{{ `${JSON.stringify({...process})}` }}', {
-					__sanitize: sanitizer,
-				});
-			}).toThrow();
-		});
-
-		it('should not allow spreading process among other spreads', () => {
-			expect(() => {
-				tournament.execute('{{ ({...{a:1}, ...process}) }}', { __sanitize: sanitizer });
-			}).toThrowError(/Cannot spread "process" due to security concerns/);
-		});
-
-		it('should resolve spread from data context process, not the real one', () => {
-			const result = tournament.execute('{{ ({...process}).safe }}', {
+		it('should not expose the host process through a template expression', () => {
+			// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
+			const result = tournament.execute('{{ `${JSON.stringify({...process})}` }}', {
 				__sanitize: sanitizer,
-				process: { safe: true },
+				JSON,
 			});
-			expect(result).toBe(true);
+			expect(result).toBe('{}');
 		});
 
-		it('should not expose real process.version via spread', () => {
-			const result = tournament.execute('{{ typeof ({...process}).version }}', {
+		it('should not expose the host process as a computed key', () => {
+			const result = tournament.execute('{{ Object.keys({[process]: 1})[0] }}', {
 				__sanitize: sanitizer,
-				process: {},
+				Object,
 			});
 			expect(result).toBe('undefined');
 		});
 
-		it('should use data context pid via spread, not real pid', () => {
+		/**
+		 * `Buffer` is additionally named in `blockedBaseClasses`, so these use a
+		 * global that is not, to show that containment comes from the polyfill
+		 * rather than from that list.
+		 */
+		it.each([
+			['Error', '{{ (() => { class X extends Error {} return X.captureStackTrace; })() }}'],
+			['Array', '{{ (() => { class X extends Array {} return X.from; })() }}'],
+		])('should not expose the host %s as a base class', (_, expression) => {
+			expect(() => tournament.execute(expression, { __sanitize: sanitizer })).toThrow(
+				/is not a constructor or null/,
+			);
+		});
+
+		it('should not expose the host process as a switch case', () => {
+			const result = tournament.execute(
+				'{{ (() => { switch (1) { case process: return "host"; } return "safe"; })() }}',
+				{ __sanitize: sanitizer },
+			);
+			expect(result).toBe('safe');
+		});
+	});
+
+	describe('Spread of data context values', () => {
+		it('should spread an object from the data context', () => {
+			const result = tournament.execute('{{ ({...$json}).greeting }}', {
+				__sanitize: sanitizer,
+				$json: { greeting: 'hello' },
+			});
+			expect(result).toBe('hello');
+		});
+
+		it('should merge a spread data context object with additional properties', () => {
+			const result = tournament.execute('{{ JSON.stringify({...$json, b: 2}) }}', {
+				__sanitize: sanitizer,
+				$json: { a: 1 },
+				JSON,
+			});
+			expect(result).toBe('{"a":1,"b":2}');
+		});
+
+		it('should spread an array from the data context', () => {
+			const result = tournament.execute('{{ [...$arr].length }}', {
+				__sanitize: sanitizer,
+				$arr: [1, 2, 3],
+			});
+			expect(result).toBe(3);
+		});
+
+		it('should spread a data context value into call arguments', () => {
+			const result = tournament.execute('{{ Math.max(...$arr) }}', {
+				__sanitize: sanitizer,
+				$arr: [1, 5, 3],
+			});
+			expect(result).toBe(5);
+		});
+
+		it('should prefer a data context value over the host global of the same name', () => {
 			const result = tournament.execute('{{ ({...process}).pid }}', {
 				__sanitize: sanitizer,
 				process: { pid: -1 },
@@ -746,42 +827,42 @@ describe('PrototypeSanitizer', () => {
 			expect(result).toBe(-1);
 		});
 
-		it('should use data context when spread is wrapped in arrow function', () => {
-			const result = tournament.execute('{{ ((g) => g.pid)({...process}) }}', {
-				__sanitize: sanitizer,
-				process: { pid: -1 },
-			});
-			expect(result).toBe(-1);
+		it.each([
+			['const', '{{ (() => { const process = { a: 1 }; return {...process}.a; })() }}'],
+			['function scope', '{{ (function(){ const Buffer = { a: 1 }; return {...Buffer}.a; })() }}'],
+			['parameter', '{{ ((process) => ({...process}).a)({ a: 1 }) }}'],
+		])('should spread a local variable declared in %s scope', (_, expression) => {
+			expect(tournament.execute(expression, { __sanitize: sanitizer })).toBe(1);
 		});
 
-		it('should not give access to real process.exit via spread', () => {
-			const result = tournament.execute('{{ typeof ({...process}).exit }}', {
+		it('should resolve a computed key from the data context', () => {
+			const result = tournament.execute('{{ ({[$key]: 1}).dynamic }}', {
 				__sanitize: sanitizer,
-				process: {},
+				$key: 'dynamic',
 			});
-			expect(result).not.toBe('function');
+			expect(result).toBe(1);
 		});
 
-		it('should not give access to real process.env via spread', () => {
-			const result = tournament.execute('{{ typeof ({...process}).env }}', {
-				__sanitize: sanitizer,
-				process: {},
-			});
-			expect(result).not.toBe('object');
-		});
-
-		it('should not give access to getBuiltinModule via spread', () => {
-			let result: unknown;
-			try {
-				result = tournament.execute('{{ typeof ({...process}).getBuiltinModule }}', {
-					__sanitize: sanitizer,
-					process: {},
-				});
-			} catch {
-				// Blocked by PrototypeSanitizer — also a valid outcome
-				return;
+		it('should resolve a base class from the data context', () => {
+			class Base {
+				greet() {
+					return 'hello';
+				}
 			}
-			expect(result).not.toBe('function');
+
+			const result = tournament.execute(
+				'{{ (() => { class X extends Base {} return new X().greet(); })() }}',
+				{ __sanitize: sanitizer, Base },
+			);
+			expect(result).toBe('hello');
+		});
+
+		it('should resolve a switch case from the data context', () => {
+			const result = tournament.execute(
+				'{{ (() => { switch ($key) { case $key: return "matched"; } return "unmatched"; })() }}',
+				{ __sanitize: sanitizer, $key: 'a' },
+			);
+			expect(result).toBe('matched');
 		});
 	});
 
@@ -1054,6 +1135,47 @@ describe('ThisSanitizer', () => {
 				__sanitize: sanitizer,
 			});
 			expect(result).toEqual({});
+		});
+	});
+
+	describe('global access via concise arrow bodies', () => {
+		it('should resolve a concise arrow body identifier from the data context', () => {
+			const result = tournament.execute('{{ (() => safeVar)() }}', {
+				__sanitize: sanitizer,
+				safeVar: 'ok',
+			});
+			expect(result).toBe('ok');
+		});
+
+		it('should not expose real process members via a concise arrow body', () => {
+			const result = tournament.execute('{{ typeof (() => process)().arch }}', {
+				__sanitize: sanitizer,
+				process: {},
+			});
+			expect(result).toBe('undefined');
+		});
+
+		it('should not expose real Reflect via a concise arrow body', () => {
+			const result = tournament.execute('{{ typeof (() => Reflect)().get }}', {
+				__sanitize: sanitizer,
+				Reflect: {},
+			});
+			expect(result).toBe('undefined');
+		});
+
+		it('should not resolve host globals through arrow-captured identifiers', () => {
+			expect(() => {
+				tournament.execute(
+					// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
+					"{{ ((R,p)=>R.get(p,'getBuiltinModule'))((()=>Reflect)(),(()=>process)())('child_process').execSync('id').toString() }}",
+					{ __sanitize: sanitizer },
+				);
+			}).toThrow();
+		});
+
+		it('should not rewrite arrow parameters used in a concise body', () => {
+			const result = tournament.execute('{{ ((x) => x)(42) }}', { __sanitize: sanitizer });
+			expect(result).toBe(42);
 		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17743,8 +17743,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.10:
-    resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
+  vue-component-type-helpers@3.3.9:
+    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -24612,7 +24612,7 @@ snapshots:
       storybook: 9.1.7(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.0.0(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.9.2)
-      vue-component-type-helpers: 3.3.10
+      vue-component-type-helpers: 3.3.9
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@2.6.1))':
     dependencies:
@@ -26398,16 +26398,6 @@ snapshots:
   axios@1.18.0(debug@4.4.1):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.1)
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  axios@1.18.0(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -29866,7 +29856,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.21
       '@types/tough-cookie': 4.0.5
-      axios: 1.18.0(debug@4.4.3)
+      axios: 1.18.0(debug@4.4.1)
       camelcase: 6.3.0
       debug: 4.4.3
       dotenv: 16.6.1
@@ -29876,7 +29866,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0)
+      retry-axios: 2.6.0(axios@1.18.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -34241,7 +34231,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.18.0):
+  retry-axios@2.6.0(axios@1.18.0(debug@4.4.3)):
     dependencies:
       axios: 1.18.0(debug@4.4.1)
 
@@ -36532,7 +36522,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.10: {}
+  vue-component-type-helpers@3.3.9: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.9.2)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -948,8 +948,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       '@n8n/tournament':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.9.1
+        version: 1.9.1
       isolated-vm:
         specifier: 'catalog:'
         version: 6.2.0
@@ -3411,8 +3411,8 @@ importers:
         specifier: workspace:*
         version: link:../@n8n/expression-runtime
       '@n8n/tournament':
-        specifier: 1.0.6
-        version: 1.0.6
+        specifier: 1.9.1
+        version: 1.9.1
       ast-types:
         specifier: 0.16.1
         version: 0.16.1
@@ -6365,13 +6365,8 @@ packages:
     resolution: {integrity: sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==}
     engines: {node: '>=18'}
 
-  '@n8n/tournament@1.0.6':
-    resolution: {integrity: sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==}
-    engines: {node: '>=20.15', pnpm: '>=9.5'}
-
-  '@n8n/tournament@1.2.0':
-    resolution: {integrity: sha512-EY/vqijjYi2LhnKeShNXNtVBJW7lSRGFe5D2ikv5AfDZiLOqneRnNdfwZbv1bTLByRYyzY708KiXF8P66Gr1dg==}
-    engines: {node: '>=20.15', pnpm: '>=9.5'}
+  '@n8n/tournament@1.9.1':
+    resolution: {integrity: sha512-cqlvqs1mrIsU4FyVvzLz9n8tFNfglHXwTfRNoZ/upDMahoNE2faitj/eB5HFS72gCNoS7M1/HuoA1qfv4zpt+Q==}
 
   '@n8n/typeorm@0.3.20-15':
     resolution: {integrity: sha512-qTksdwNypUElt3gYwPejy5Nl3MZGmex1/5BXE8AqZZXjjapCfw6xu0mwJ9JkO+WR0BhvA6DQWni4RCc6t9HN2Q==}
@@ -6404,9 +6399,6 @@ packages:
   '@n8n_io/license-sdk@2.24.1':
     resolution: {integrity: sha512-nrITEzOmFonFXD5XtzHjpY/s1kpKksYQoY5HBqhzRkGq3ldEO3nLKDl6RG9AEtkKKlKkid3lzviZJCIDINZlQw==}
     engines: {node: '>=18.12.1'}
-
-  '@n8n_io/riot-tmpl@4.0.1':
-    resolution: {integrity: sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==}
 
   '@napi-rs/canvas-android-arm64@0.1.70':
     resolution: {integrity: sha512-I/YOuQ0wbkVYxVaYtCgN42WKTYxNqFA0gTcTrHIGG1jfpDSyZWII/uHcjOo4nzd19io6Y4+/BqP8E5hJgf9OmQ==}
@@ -11321,9 +11313,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
-
-  eslint-config-riot@1.0.0:
-    resolution: {integrity: sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==}
 
   eslint-doc-generator@2.2.2:
     resolution: {integrity: sha512-LBr0Nz1AZnkifkOMyE0sfx+IvS/V+TK1Sp8fCYDdk4Eb5gZCpEcK4t/ImT23oJAwso26rkHzBCRMrd/bc7bddQ==}
@@ -17754,8 +17743,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.9:
-    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
+  vue-component-type-helpers@3.3.10:
+    resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -22517,14 +22506,7 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@n8n/tournament@1.0.6':
-    dependencies:
-      '@n8n_io/riot-tmpl': 4.0.1
-      ast-types: 0.16.1
-      esprima-next: 5.8.4
-      recast: 0.22.0
-
-  '@n8n/tournament@1.2.0':
+  '@n8n/tournament@1.9.1':
     dependencies:
       ast-types: 0.16.1
       esprima-next: 5.8.4
@@ -22561,10 +22543,6 @@ snapshots:
       node-machine-id: 1.1.12
       node-rsa: 1.1.1
       undici: 7.29.0
-
-  '@n8n_io/riot-tmpl@4.0.1':
-    dependencies:
-      eslint-config-riot: 1.0.0
 
   '@napi-rs/canvas-android-arm64@0.1.70':
     optional: true
@@ -24634,7 +24612,7 @@ snapshots:
       storybook: 9.1.7(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.0.0(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.9.2)
-      vue-component-type-helpers: 3.3.9
+      vue-component-type-helpers: 3.3.10
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@2.6.1))':
     dependencies:
@@ -26420,6 +26398,16 @@ snapshots:
   axios@1.18.0(debug@4.4.1):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.1)
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  axios@1.18.0(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -28462,8 +28450,6 @@ snapshots:
     dependencies:
       eslint: 9.29.0(jiti@2.6.1)
 
-  eslint-config-riot@1.0.0: {}
-
   eslint-doc-generator@2.2.2(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/utils': 8.35.0(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.2)
@@ -29880,7 +29866,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.21
       '@types/tough-cookie': 4.0.5
-      axios: 1.18.0(debug@4.4.1)
+      axios: 1.18.0(debug@4.4.3)
       camelcase: 6.3.0
       debug: 4.4.3
       dotenv: 16.6.1
@@ -29890,7 +29876,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.18.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -34255,7 +34241,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.18.0(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.18.0):
     dependencies:
       axios: 1.18.0(debug@4.4.1)
 
@@ -36546,7 +36532,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.9: {}
+  vue-component-type-helpers@3.3.10: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.9.2)):
     dependencies:


### PR DESCRIPTION
## Summary

This PR bumps `@n8n/tournament` to `1.9.1` and adapts the expression sandbox to it.

## Related Linear tickets, Github issues, and Community forum posts

Tracked internally. No public issue link.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.