### PR TITLE
ci: Resolve the npm-install graph without downloading it

### DIFF
--- a/.github/workflows/test-single-instance-npm.yml
+++ b/.github/workflows/test-single-instance-npm.yml
@@ -80,10 +80,30 @@ jobs:
           BASE_BRANCH: ${{ inputs.base-branch }}
         run: git checkout "$BASE_BRANCH"
 
+      # A `base-branch` can point at a release line that predates this tooling (the v1 patch track
+      # is the live case), where there is simply nothing to verify. Without a base-branch the ref is
+      # the caller's own revision, on which the package must exist — a move or rename has to fail
+      # loudly rather than quietly turn this into a green job that verified nothing.
+      - name: Check the verifier is present on this ref
+        id: verifier
+        env:
+          BASE_BRANCH: ${{ inputs.base-branch }}
+        run: |
+          if [ -f packages/testing/code-health/package.json ]; then
+            echo 'present=true' >> "$GITHUB_OUTPUT"
+          elif [ -n "$BASE_BRANCH" ]; then
+            echo 'present=false' >> "$GITHUB_OUTPUT"
+            echo "::notice::packages/testing/code-health is absent on \"$BASE_BRANCH\"; nothing to verify."
+          else
+            echo '::error::packages/testing/code-health is missing (moved or renamed?).'
+            exit 1
+          fi
+
       # Only the verifier's own closure needs compiling. The check reads package.json out of the
       # npm-install graph, so the packed tarballs' contents don't matter, and the two packages with
       # a prepack hook build themselves.
       - name: Setup and Build
+        if: steps.verifier.outputs.present == 'true'
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: pnpm turbo run build --filter=@n8n/code-health...
@@ -91,7 +111,7 @@ jobs:
       # `--dir` rather than `--filter`: a filter matching nothing exits 0, so a renamed or moved
       # package would turn this into a green job that verified nothing.
       - name: Verify npm-install closure (changed packages)
-        if: inputs.scope == 'changed'
+        if: steps.verifier.outputs.present == 'true' && inputs.scope == 'changed'
         env:
           BASE_REF: ${{ inputs.base-ref }}
         run: |
@@ -101,7 +121,7 @@ jobs:
           pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --changed="$BASE_REF" $REPORT_ONLY
 
       - name: Verify npm-install closure (all packages)
-        if: inputs.scope == 'all'
+        if: steps.verifier.outputs.present == 'true' && inputs.scope == 'all'
         run: |
           # shellcheck disable=SC2086 # see the scoped step above
           pnpm --dir packages/testing/code-health exec tsx src/cli.ts verify-npm-install --all $REPORT_ONLY

--- a/.github/workflows/test-single-instance-npm.yml
+++ b/.github/workflows/test-single-instance-npm.yml
@@ -69,16 +69,17 @@ jobs:
               ;;
           esac
 
+      # Checking out `base-branch` directly (rather than fetching everything and switching
+      # afterwards) keeps that case to a single-commit fetch. scope=changed does need history back
+      # to `base-ref`, but only to diff it: `git diff --name-only --no-renames` reads trees, so the
+      # blobs can stay on the server. Nothing after this step reads an object outside the working
+      # tree, which the checkout materializes in full.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          ref: ${{ inputs.base-branch }}
+          fetch-depth: ${{ inputs.base-branch != '' && 1 || 0 }}
+          filter: blob:none
           persist-credentials: false
-
-      - name: Switch to base branch
-        if: inputs.base-branch != ''
-        env:
-          BASE_BRANCH: ${{ inputs.base-branch }}
-        run: git checkout "$BASE_BRANCH"
 
       # A `base-branch` can point at a release line that predates this tooling (the v1 patch track
       # is the live case), where there is simply nothing to verify. Without a base-branch the ref is
@@ -100,8 +101,8 @@ jobs:
           fi
 
       # Only the verifier's own closure needs compiling. The check reads package.json out of the
-      # npm-install graph, so the packed tarballs' contents don't matter, and the two packages with
-      # a prepack hook build themselves.
+      # npm-install graph, so the packed tarballs' contents don't matter — packing skips lifecycle
+      # scripts, and the workspace install exists so `pnpm pack` can resolve `workspace:` specs.
       - name: Setup and Build
         if: steps.verifier.outputs.present == 'true'
         uses: ./.github/actions/setup-nodejs

--- a/packages/testing/code-health/src/single-instance/lock-graph.test.ts
+++ b/packages/testing/code-health/src/single-instance/lock-graph.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { copiesFromLockfile } from './lock-graph.js';
+
+/** An npm lockfile with the given `packages` map. */
+function lockfile(packages: Record<string, unknown>): string {
+	return JSON.stringify({ name: 'scratch', lockfileVersion: 3, packages });
+}
+
+describe('copiesFromLockfile', () => {
+	it('records one copy per install path', () => {
+		const found = copiesFromLockfile(
+			lockfile({
+				'': { name: 'scratch' },
+				'node_modules/a': { version: '1.0.0' },
+				'node_modules/a/node_modules/zod': { version: '3.0.0' },
+				'node_modules/zod': { version: '4.0.0' },
+			}),
+		);
+		expect(found.get('a')).toEqual([{ realPath: 'node_modules/a', version: '1.0.0' }]);
+		expect(found.get('zod')).toEqual([
+			{ realPath: 'node_modules/a/node_modules/zod', version: '3.0.0' },
+			{ realPath: 'node_modules/zod', version: '4.0.0' },
+		]);
+	});
+
+	it('keys a scoped package on its full name', () => {
+		const found = copiesFromLockfile(
+			lockfile({ 'node_modules/@langchain/core': { version: '1.0.0' } }),
+		);
+		expect([...found.keys()]).toEqual(['@langchain/core']);
+	});
+
+	// `"zod-v3": "npm:zod@^3"` installs a real second copy of zod, which the directory name hides.
+	it('attributes an aliased install to the manifest name', () => {
+		const found = copiesFromLockfile(
+			lockfile({
+				'node_modules/zod': { version: '4.0.0' },
+				'node_modules/zod-v3': { name: 'zod', version: '3.0.0' },
+			}),
+		);
+		expect(found.get('zod')).toHaveLength(2);
+		expect(found.has('zod-v3')).toBe(false);
+	});
+
+	it('ignores the root project and symlinked entries', () => {
+		const found = copiesFromLockfile(
+			lockfile({
+				'': { name: 'scratch' },
+				'packages/local': { version: '1.0.0' },
+				'node_modules/local': { resolved: 'packages/local', link: true },
+			}),
+		);
+		expect(found.size).toBe(0);
+	});
+
+	// A lockfile lists every platform's build of an optional native dep; an install unpacks one.
+	it('drops entries this platform would not install', () => {
+		const found = copiesFromLockfile(
+			lockfile({
+				'node_modules/native': { version: '1.0.0', os: [process.platform] },
+				'node_modules/a/node_modules/native': { version: '2.0.0', os: ['someotheros'] },
+				'node_modules/wrong-arch': { version: '1.0.0', cpu: ['someotherarch'] },
+				'node_modules/forbidden': { version: '1.0.0', os: [`!${process.platform}`] },
+			}),
+		);
+		expect(found.get('native')).toEqual([{ realPath: 'node_modules/native', version: '1.0.0' }]);
+		expect(found.has('wrong-arch')).toBe(false);
+		expect(found.has('forbidden')).toBe(false);
+	});
+
+	// Throwing is the contract for "the check did not run" — returning an empty map would report a
+	// clean closure for a tree that was never resolved.
+	it('throws on a lockfile it cannot read', () => {
+		expect(() => copiesFromLockfile('not json')).toThrow(/Could not parse/);
+		expect(() => copiesFromLockfile(lockfile({}))).toThrow(/Unusable npm lockfile/);
+		expect(() => copiesFromLockfile(JSON.stringify({ lockfileVersion: 1 }))).toThrow(/version 1/);
+	});
+});

--- a/packages/testing/code-health/src/single-instance/lock-graph.ts
+++ b/packages/testing/code-health/src/single-instance/lock-graph.ts
@@ -1,0 +1,74 @@
+import type { Copy } from './collect-copies.js';
+
+/** One `packages` entry of an npm lockfile. The lockfile keys these by install path. */
+interface LockEntry {
+	name?: string;
+	version?: string;
+	link?: boolean;
+	os?: string[];
+	cpu?: string[];
+}
+
+interface Lockfile {
+	lockfileVersion?: number;
+	packages?: Record<string, LockEntry>;
+}
+
+const NODE_MODULES = 'node_modules/';
+
+/** npm's `os` / `cpu` matching: a bare value allows, a `!`-prefixed value forbids. */
+function matches(list: string[] | undefined, actual: string): boolean {
+	if (!list || list.length === 0) return true;
+	if (list.some((value) => value.startsWith('!') && value.slice(1) === actual)) return false;
+	const allowed = list.filter((value) => !value.startsWith('!'));
+	return allowed.length === 0 || allowed.includes(actual);
+}
+
+/**
+ * True when npm would place this entry on the machine running the check.
+ *
+ * A lockfile lists every platform's build of an optional native dependency, but an install only
+ * unpacks the one that matches. Counting them all invents copies that never coexist in a process.
+ */
+function installsHere(entry: LockEntry): boolean {
+	return matches(entry.os, process.platform) && matches(entry.cpu, process.arch);
+}
+
+/**
+ * Read an npm lockfile as the copy map `analyze()` expects.
+ *
+ * The keys of `packages` are the paths npm materializes, so one key is one physical copy — the same
+ * ground truth `collectCopies` reads off disk, without downloading anything.
+ */
+export function copiesFromLockfile(contents: string): Map<string, Copy[]> {
+	let lock: Lockfile;
+	try {
+		lock = JSON.parse(contents) as Lockfile;
+	} catch {
+		throw new Error('Could not parse the npm lockfile, so nothing was verified.');
+	}
+	const packages = lock.packages ?? {};
+	// A v1 lockfile has no `packages` map at all, and an empty one means npm resolved no tree.
+	// Callers treat a throw as "the check did not run", not as "no duplicates found".
+	if (Object.keys(packages).length === 0) {
+		throw new Error(
+			`Unusable npm lockfile (version ${lock.lockfileVersion ?? 'unknown'}), so nothing was verified.`,
+		);
+	}
+
+	const found = new Map<string, Copy[]>();
+	for (const [path, entry] of Object.entries(packages)) {
+		if (path === '') continue; // the scratch project itself
+		if (entry.link) continue; // a symlink; whatever it points at has its own entry
+		if (!installsHere(entry)) continue;
+		const index = path.lastIndexOf(NODE_MODULES);
+		if (index === -1) continue; // a workspace project, not an installed copy
+		// Key on the manifest name rather than the directory: npm records `name` when the two differ,
+		// which is what keeps an alias (`"zod-v3": "npm:zod@^3"`) a copy of zod.
+		const name = entry.name ?? path.slice(index + NODE_MODULES.length);
+		const copies = found.get(name) ?? [];
+		copies.push({ realPath: path, version: entry.version ?? '' });
+		found.set(name, copies);
+	}
+	return found;
+}

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
@@ -10,7 +10,6 @@ import {
 /** Build a WorkspacePkg fixture from `[depName, section]` pairs (only names + sections matter). */
 function ws(name: string, deps: Array<[string, string]>) {
 	return {
-		dir: `/x/${name}`,
 		relDir: `packages/${name}`,
 		info: {
 			filePath: `/x/${name}/package.json`,

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.ts
@@ -1,10 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
-import { analyze, collectCopies } from './collect-copies.js';
+import { analyze } from './collect-copies.js';
+import { copiesFromLockfile } from './lock-graph.js';
 import type { PackageJsonInfo } from '../utils/package-json-scanner.js';
 import {
 	findPackageJsonFiles,
@@ -33,20 +34,28 @@ function annotate(message: string): void {
 }
 
 /**
- * The scratch install is the one network-bound step, and a registry blip must not read as a
- * dependency finding. Retries only the install; a persistent failure still throws.
+ * Resolve the scratch project's dependency graph and write it to `package-lock.json`.
+ *
+ * `--package-lock-only` reports the tree npm *would* install without fetching a single tarball.
+ * The lockfile records the path of every copy, which is all this check reads — so the ~2500
+ * downloads and unpacks that dominated the step buy nothing.
+ *
+ * This is the one network-bound step, and a registry blip must not read as a dependency finding.
+ * Retries only the resolve; a persistent failure still throws.
  */
-async function installWithRetry(scratch: string, attempts = 3): Promise<void> {
+async function resolveGraphWithRetry(scratch: string, attempts = 3): Promise<void> {
 	for (let attempt = 1; ; attempt++) {
 		try {
 			execFileSync(
 				'npm',
 				[
 					'install',
+					'--package-lock-only',
 					'--no-audit',
 					'--no-fund',
+					// Nothing is unpacked, so no script can run — kept so that stays true if a future
+					// npm resolves `file:` dependencies by preparing them.
 					'--ignore-scripts',
-					'--no-package-lock',
 					// Third-party deprecation notices run to ~2000 lines and bury the report this step
 					// exists to print. Errors still come through.
 					'--loglevel=error',
@@ -56,7 +65,7 @@ async function installWithRetry(scratch: string, attempts = 3): Promise<void> {
 			return;
 		} catch (error) {
 			if (attempt >= attempts) throw error;
-			console.error(`npm install failed (attempt ${attempt}/${attempts}); retrying...`);
+			console.error(`npm resolve failed (attempt ${attempt}/${attempts}); retrying...`);
 			await setTimeout(attempt * 5_000);
 		}
 	}
@@ -248,7 +257,8 @@ function packWorkspacePackages(
  * verifier against it. Local pnpm dev and the `pnpm deploy` closure both apply root
  * `pnpm.overrides`, which hide duplication; those don't travel in published tarballs, so
  * `npm install` can resolve a second copy. Packs with `pnpm pack` (resolving `catalog:`/
- * `workspace:` like publishing does), installs into a scratch dir with npm, then verifies.
+ * `workspace:` like publishing does), has npm resolve the graph those tarballs produce, then
+ * verifies the resolved tree.
  */
 export async function runVerifyNpmInstall(args: string[], rootDir: string): Promise<number> {
 	const reportOnly = args.includes('--report-only');
@@ -276,9 +286,9 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 	mkdirSync(tarballs, { recursive: true });
 	mkdirSync(scratch, { recursive: true });
 
-	// An enforcing-mode finding is the only reason to keep the tree. A report-only run exits 0 so
-	// nothing downstream reads it, and a throw (pack failure, registry outage) leaves nothing worth
-	// inspecting — either way, keeping it just leaks a full node_modules into tmpdir per run.
+	// An enforcing-mode finding is the only reason to keep the resolved lockfile. A report-only run
+	// exits 0 so nothing downstream reads it, and a throw (pack failure, registry outage) leaves
+	// nothing worth inspecting.
 	let keepScratch = false;
 	try {
 		console.log(`Packing ${toPack.length} workspace package(s) (targets: ${targets.length})...`);
@@ -298,12 +308,13 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 			),
 		);
 
-		console.log('Installing into scratch dir with npm...');
-		await installWithRetry(scratch);
+		console.log('Resolving the npm-install graph...');
+		await resolveGraphWithRetry(scratch);
 
-		const { duplicates, failures } = analyze(collectCopies(scratch));
+		const lockfile = join(scratch, 'package-lock.json');
+		const { duplicates, failures } = analyze(copiesFromLockfile(readFileSync(lockfile, 'utf8')));
 
-		console.log(`\nnpm-install closure — scratch: ${scratch}\n`);
+		console.log(`\nnpm-install closure — lockfile: ${lockfile}\n`);
 		const curatedTag = reportOnly ? 'CURATED DUP (report)' : 'FAIL';
 		for (const d of duplicates) {
 			const tag = d.isCurated ? (d.allowed ? 'ALLOWED DUP' : curatedTag) : 'dup (report)';
@@ -327,7 +338,7 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 		console.log('\nOK: no curated duplicates in the npm-install graph.');
 		return 0;
 	} finally {
-		if (keepScratch) console.log(`\nScratch install kept for inspection: ${scratch}`);
+		if (keepScratch) console.log(`\nResolved lockfile kept for inspection: ${scratch}`);
 		else rmSync(work, { recursive: true, force: true });
 	}
 }

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { analyze, collectCopies } from './collect-copies.js';
@@ -41,7 +41,16 @@ async function installWithRetry(scratch: string, attempts = 3): Promise<void> {
 		try {
 			execFileSync(
 				'npm',
-				['install', '--no-audit', '--no-fund', '--ignore-scripts', '--no-package-lock'],
+				[
+					'install',
+					'--no-audit',
+					'--no-fund',
+					'--ignore-scripts',
+					'--no-package-lock',
+					// Third-party deprecation notices run to ~2000 lines and bury the report this step
+					// exists to print. Errors still come through.
+					'--loglevel=error',
+				],
 				{ cwd: scratch, stdio: ['ignore', 'inherit', 'inherit'] },
 			);
 			return;
@@ -53,8 +62,13 @@ async function installWithRetry(scratch: string, attempts = 3): Promise<void> {
 	}
 }
 
+/** One entry of `pnpm pack --json`. */
+interface Packed {
+	name: string;
+	filename: string;
+}
+
 interface WorkspacePkg {
-	dir: string;
 	relDir: string;
 	info: PackageJsonInfo;
 }
@@ -65,7 +79,7 @@ async function loadWorkspace(rootDir: string): Promise<Map<string, WorkspacePkg>
 	for (const file of await findPackageJsonFiles(rootDir)) {
 		const info = parsePackageJson(file);
 		if (info.private) continue;
-		byName.set(info.packageName, { dir: dirname(file), relDir: relativeDir(rootDir, file), info });
+		byName.set(info.packageName, { relDir: relativeDir(rootDir, file), info });
 	}
 	return byName;
 }
@@ -109,7 +123,10 @@ function changedPackages(
 	}
 	let out: string;
 	try {
-		out = execFileSync('git', ['diff', '--name-only', baseRef, 'HEAD'], {
+		// `--no-renames`: a moved file has to count against both the old and the new package, and
+		// rename detection would also read blob contents — which the CI checkout deliberately
+		// leaves on the server.
+		out = execFileSync('git', ['diff', '--name-only', '--no-renames', baseRef, 'HEAD'], {
 			cwd: rootDir,
 			encoding: 'utf8',
 		});
@@ -165,6 +182,68 @@ export function resolveTargets(
 }
 
 /**
+ * Pack the named packages in one recursive pnpm run, and return name -> tarball path.
+ *
+ * One invocation rather than one per package: packing these tarballs is quick, so ~50 pnpm startups
+ * dominate the step. `--json` reports the tarball each project produced, which also removes the
+ * need to diff the destination directory — that mis-attributes a tarball whose name is already
+ * present, and reads as "pack produced nothing".
+ *
+ * Scripts are off. The only `prepack` hook among publishable packages rebuilds `dist`, and this
+ * check reads package.json out of the installed graph, so nothing here needs compiling.
+ */
+function packWorkspacePackages(
+	names: string[],
+	destination: string,
+	rootDir: string,
+): Record<string, string> {
+	let stdout: string;
+	try {
+		stdout = execFileSync(
+			'pnpm',
+			[
+				'pack',
+				'--recursive',
+				...names.flatMap((name) => ['--filter', name]),
+				'--config.ignore-scripts=true',
+				'--pack-destination',
+				destination,
+				'--json',
+			],
+			{
+				cwd: rootDir,
+				encoding: 'utf8',
+				// The report lists every packed file, so it runs to several MB. The default 1MB cap
+				// would kill pnpm mid-pack.
+				maxBuffer: 256 * 1024 * 1024,
+				stdio: ['ignore', 'pipe', 'inherit'],
+			},
+		);
+	} catch (error) {
+		// `--json` puts the failure on stdout, which is captured rather than inherited — print it or
+		// the throw reads as a bare "Command failed" with the cause nowhere in the log.
+		const captured = (error as { stdout?: string }).stdout;
+		if (captured) console.error(captured);
+		throw error;
+	}
+	// pnpm reports a bare object for a single project and an array for several.
+	let packed: Packed | Packed[];
+	try {
+		packed = JSON.parse(stdout) as Packed | Packed[];
+	} catch {
+		throw new Error(`Could not read the pnpm pack report: ${stdout.slice(0, 500)}`);
+	}
+	const tarballByName = Object.fromEntries(
+		[packed].flat().map(({ name, filename }) => [name, filename]),
+	);
+	const missing = names.filter((name) => !tarballByName[name]);
+	if (missing.length > 0) {
+		throw new Error(`pnpm pack produced no tarball for: ${missing.join(', ')}`);
+	}
+	return tarballByName;
+}
+
+/**
  * Reproduce the `npm install` graph for the targeted publishable packages and run the closure
  * verifier against it. Local pnpm dev and the `pnpm deploy` closure both apply root
  * `pnpm.overrides`, which hide duplication; those don't travel in published tarballs, so
@@ -203,19 +282,7 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 	let keepScratch = false;
 	try {
 		console.log(`Packing ${toPack.length} workspace package(s) (targets: ${targets.length})...`);
-		const tarballByName: Record<string, string> = {};
-		for (const name of toPack) {
-			const entry = byName.get(name);
-			if (!entry) continue;
-			const before = new Set(readdirSync(tarballs));
-			execFileSync('pnpm', ['pack', '--pack-destination', tarballs], {
-				cwd: entry.dir,
-				stdio: ['ignore', 'ignore', 'inherit'],
-			});
-			const produced = readdirSync(tarballs).find((f) => !before.has(f) && f.endsWith('.tgz'));
-			if (!produced) throw new Error(`pnpm pack produced no tarball for ${name}`);
-			tarballByName[name] = join(tarballs, produced);
-		}
+		const tarballByName = packWorkspacePackages(toPack, tarballs, rootDir);
 
 		// Scratch project: install targets as file: deps, force ALL packed workspace deps to their
 		// local tarballs. Third-party deps resolve from the real npm registry.


### PR DESCRIPTION
## Summary

Third layer of stack #36689, on top of #36687.

The scratch step installed about 2500 packages so the check could read their `package.json` files. `npm install --package-lock-only` reports the tree npm would install without fetching a tarball, and the lockfile's `packages` keys are the paths npm materializes — one key is one physical copy, the same ground truth the on-disk walk reads.

`copiesFromLockfile` maps the lockfile to the shape `analyze()` already takes. Two details the on-disk walk got for free:

- **Aliases.** `"zod-v3": "npm:zod@^3"` installs a real second copy of zod. npm records `name` on the entry when it differs from the directory, so the copy is keyed on the manifest name. Confirmed against a real lockfile.
- **Platform-specific optional dependencies.** A lockfile lists *every* platform's build of an optional native dependency; an install unpacks only the matching one. Entries whose `os`/`cpu` rule out the current machine are dropped, or the report invents copies that never coexist in a process. Confirmed against a real lockfile: `esbuild` contributes 25 such entries.

An unreadable or v1 lockfile throws, matching `collectCopies`. Callers must read that as "the check did not run", never as "no duplicates found".

`collectCopies` stays — `verify-closure` still walks a built closure on disk.

### Evidence

**Equivalence is verified.** On a 17-package closure (413 resolved packages), the duplicate report is byte-identical to the real install's: 15 groups, same copy counts, same versions. Reproduced twice — once against a fully built repo, once in a worktree built exactly the way CI builds it.

**The expected saving is smaller than it first appears, and is not yet proven.** Two measurements changed the cost model:

- With a cold cache, resolving a full closure downloads about **853MB of registry metadata** and essentially no tarball bodies (11 cache entries, 0MiB). A 413-package closure costs 149MB.
- The real install fetches the *same* packuments and then also downloads and unpacks the tarballs. `--package-lock-only` therefore removes the tarball bodies and the unpack, but **not** the metadata fetch, which is the larger remaining cost.

So this should be read as removing one of two costs, not as making the step nearly free.

**The full-scale comparison has to happen on CI.** Locally the full closure does not resolve within 10 minutes in *either* mode. Four configurations were tried — warm and cold npm cache, tarballs with and without `dist` — and the stall is mode-independent, so it is an artifact of this machine rather than a property of the change. That is what this PR is for: the run on this branch reports the real number.

**Kill criterion.** If the scoped job on this branch does not beat the roughly 2m20s scratch step it replaces, close this PR and keep #36579 and #36687. The layer above (#36688) targets the metadata cost and does not depend on this change landing.

## How to test

The verifier runs from source, so a full build is not needed.

```bash
pnpm install --frozen-lockfile
pnpm turbo run build --filter=@n8n/code-health...

pnpm --dir packages/testing/code-health exec tsx src/cli.ts \
  verify-npm-install n8n-core n8n-workflow --report-only
```

Expect `Resolving the npm-install graph...`, then 15 duplicate groups and `OK: no curated duplicates`. No `node_modules` tree is created; the artifact is the `package-lock.json` the run prints the path to.

To reproduce the equivalence check, run the same command on `master` and diff the duplicate lines.

Unit tests cover the parser, including the alias and platform cases:

```bash
cd packages/testing/code-health && pnpm test
```

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket. Part of stack #36689. Follows #34681 (added the check) and #36437 (made advisory runs advisory).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No user-facing docs. -->
- [x] Tests included. <!-- 6 unit tests for copiesFromLockfile, covering aliases, platform filtering, symlinks and unreadable lockfiles. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

