### PR TITLE
ci: Cache the npm registry metadata the closure check downloads

### DIFF
--- a/.github/workflows/test-single-instance-npm.yml
+++ b/.github/workflows/test-single-instance-npm.yml
@@ -109,6 +109,24 @@ jobs:
         with:
           build-command: pnpm turbo run build --filter=@n8n/code-health...
 
+      # Resolving the scratch graph downloads the registry metadata for every name in it — roughly
+      # 850MB for a full closure, measured, and the step's dominant cost now that the tarball bodies
+      # are gone. Keyed on the pnpm lockfile so an entry is written once per dependency change
+      # rather than once per run: this cache shares a 10GB repo-wide budget with the pnpm store
+      # caches, and a per-run key would evict them.
+      #
+      # A restored entry is revalidated rather than trusted (no `--prefer-offline`), so a
+      # third-party release published since the entry was written still changes the resolution.
+      # Conditional requests cost a fraction of the bodies.
+      - name: Restore npm registry metadata
+        if: steps.verifier.outputs.present == 'true'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm/_cacache
+          key: npm-metadata-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            npm-metadata-${{ runner.os }}-
+
       # `--dir` rather than `--filter`: a filter matching nothing exits 0, so a renamed or moved
       # package would turn this into a green job that verified nothing.
       - name: Verify npm-install closure (changed packages)


### PR DESCRIPTION
## Summary

Third layer of stack #36597, on top of #36595.

Resolving the scratch graph downloads a registry packument for every name in it. Measured with a cold npm cache:

| closure | resolved packages | registry metadata |
|---|---|---|
| `n8n-core` + `n8n-workflow` | 413 | 149MB |
| the 9 targets a typical master push produces | ~2500 | 853MB |

Tarball bodies are a rounding error next to this once #36595 removes them (11 cache entries, 0MiB), and the real install pays the same metadata cost on top of its downloads. So the metadata is the dominant remaining cost of the step, and it is what this PR caches.

Two deliberate choices:

- **Keyed on `pnpm-lock.yaml`, not the run id.** An entry is written once per dependency change rather than once per run. This cache shares a 10GB repo-wide budget with the pnpm store caches, and a per-run key would write a fresh few-hundred-MB entry every push and evict them. `restore-keys` falls back to the newest entry for the runner OS, so a lockfile change still starts from a warm cache.
- **No `--prefer-offline`.** A restored entry is revalidated rather than trusted, so a third-party release published since the entry was written still changes the resolution — which is the point of a check that looks for duplicate copies. Conditional requests cost a fraction of the bodies.

**Kill criterion.** If restoring and saving the cache costs more than the metadata fetch it replaces, drop this layer. The step timings in the job log show both sides directly. Note this layer does not depend on #36595 landing — the metadata cost exists either way — so it can be rebased onto #36579 if #36595 is dropped.

## How to test

Not reproducible locally; `actions/cache` needs the Actions cache service. On CI:

1. Run the workflow once to populate the cache. `Restore npm registry metadata` reports a miss, and the post-job step saves an entry.
2. Run it again without changing `pnpm-lock.yaml`. The step reports a hit, and the resolve step is faster by roughly the metadata transfer it no longer makes.
3. Compare the `Verify npm-install closure` step duration between the two runs.

To see the metadata volume the cache is standing in for, run the verifier against a throwaway npm cache and measure it:

```bash
rm -rf /tmp/nc
npm_config_cache=/tmp/nc pnpm --dir packages/testing/code-health exec tsx src/cli.ts \
  verify-npm-install n8n-core n8n-workflow --report-only
du -sh /tmp/nc/_cacache   # ~149MB
```

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket. Part of stack #36597. Follows #34681 (added the check) and #36437 (made advisory runs advisory).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No user-facing docs; WORKFLOWS.md documents this workflow's inputs, which are unchanged. -->
- [ ] Tests included. <!-- Workflow-only change; there is no unit-testable surface. Verified by comparing step durations across two CI runs, as described above. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
