### PR TITLE
fix(core): Surface agent failures with a useful message and original cause

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -136,7 +136,9 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 
 			returnData.push(itemResult);
 		} catch (error) {
-			const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex);
+			const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex, {
+				enrichNonParserErrors: true,
+			});
 			if (this.continueOnFail()) {
 				returnData.push({
 					json: { error: executionError.message },

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -21,7 +21,10 @@ import assert from 'node:assert';
 
 import { loadMemory } from '@utils/agent-execution';
 import { getPromptInputByType } from '@utils/helpers';
-import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
+import {
+	getFailureType,
+	wrapLangChainParserError,
+} from '@utils/output_parsers/langchainParserError';
 import {
 	getOptionalOutputParser,
 	type N8nOutputParser,
@@ -414,7 +417,9 @@ export async function toolsAgentExecute(
 			batchResults.forEach((result, index) => {
 				const itemIndex = i + index;
 				if (result.status === 'rejected') {
-					const error = wrapLangChainParserError(result.reason, this.getNode(), itemIndex);
+					const error = wrapLangChainParserError(result.reason, this.getNode(), itemIndex, {
+						enrichNonParserErrors: true,
+					});
 					failedItems++;
 					if (this.continueOnFail()) {
 						returnData.push({
@@ -459,8 +464,7 @@ export async function toolsAgentExecute(
 
 		return [returnData];
 	} catch (error) {
-		failureType =
-			error instanceof Error ? error.name || error.constructor.name || 'Error' : typeof error;
+		failureType = getFailureType(error);
 		throw error;
 	} finally {
 		applyAgentTracingMetadata(this, {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -8,6 +8,7 @@ import type {
 } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
 import { getHighlightedResponseKey } from 'n8n-workflow';
+import { getFailureType } from '@utils/output_parsers/langchainParserError';
 
 import { buildExecutionContext, executeBatch, resolveSubAgentRequest } from './helpers';
 import { isExecuteFunctions } from '../../utils';
@@ -147,8 +148,7 @@ export async function toolsAgentExecute(
 		// Otherwise return execution data
 		return [returnData];
 	} catch (error) {
-		failureType =
-			error instanceof Error ? error.name || error.constructor.name || 'Error' : typeof error;
+		failureType = getFailureType(error);
 		throw error;
 	} finally {
 		if (isExecuteFunctions(this)) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
@@ -107,7 +107,9 @@ export async function executeBatch(
 	batchResults.forEach((result, index) => {
 		const itemIndex = startIndex + index;
 		if (result.status === 'rejected') {
-			const error = wrapLangChainParserError(result.reason, ctx.getNode(), itemIndex);
+			const error = wrapLangChainParserError(result.reason, ctx.getNode(), itemIndex, {
+				enrichNonParserErrors: true,
+			});
 			if (ctx.continueOnFail()) {
 				returnData.push({
 					json: { error: error.message },

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/executeBatch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/executeBatch.test.ts
@@ -1,0 +1,145 @@
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+import { vi } from 'vitest';
+
+import type { ItemContext } from '../prepareItemContext';
+import { executeBatch } from '../executeBatch';
+
+const { runAgentMock, prepareItemContextMock } = vi.hoisted(() => ({
+	runAgentMock: vi.fn(),
+	prepareItemContextMock: vi.fn(),
+}));
+
+vi.mock('@utils/output_parsers/N8nOutputParser', () => ({
+	getOptionalOutputParser: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../runAgent', () => ({ runAgent: runAgentMock }));
+
+vi.mock('../prepareItemContext', () => ({ prepareItemContext: prepareItemContextMock }));
+
+vi.mock('../checkMaxIterations', () => ({ checkMaxIterations: vi.fn() }));
+
+vi.mock('../createAgentSequence', () => ({
+	createAgentSequence: vi.fn().mockReturnValue(mock()),
+}));
+
+vi.mock('../finalizeResult', () => ({ finalizeResult: vi.fn() }));
+
+const mockContext = mock<IExecuteFunctions>();
+const mockNode = mock<INode>();
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockContext.getNode.mockReturnValue(mockNode);
+	mockContext.getNodeParameter.mockReturnValue(10);
+});
+
+function buildItemContext(itemIndex: number): ItemContext {
+	return {
+		itemIndex,
+		input: 'test',
+		steps: [],
+		tools: [],
+		prompt: mock(),
+		options: {
+			maxIterations: 10,
+			returnIntermediateSteps: false,
+		},
+		outputParser: undefined,
+	};
+}
+
+describe('executeBatch — error enrichment (V3)', () => {
+	it('surfaces a useful message in the output item when a tool throws a plain Error("Error") and continueOnFail is on', async () => {
+		prepareItemContextMock.mockResolvedValue(buildItemContext(0));
+		runAgentMock.mockRejectedValue(new Error('Error'));
+		mockContext.continueOnFail.mockReturnValue(true);
+
+		const { returnData } = await executeBatch(
+			mockContext,
+			[{ json: { text: 'x' } }],
+			0,
+			mock<BaseChatModel>(),
+			null,
+			undefined,
+		);
+
+		expect(returnData).toHaveLength(1);
+		// The original message was the useless "Error"; the wrap must not pass it through verbatim.
+		expect(returnData[0].json.error).not.toBe('Error');
+		expect(returnData[0].json.error).toBe('Agent execution failed');
+	});
+
+	it('throws a NodeOperationError with a useful message when continueOnFail is off', async () => {
+		prepareItemContextMock.mockResolvedValue(buildItemContext(0));
+		runAgentMock.mockRejectedValue(new Error('Error'));
+		mockContext.continueOnFail.mockReturnValue(false);
+
+		await expect(
+			executeBatch(
+				mockContext,
+				[{ json: { text: 'x' } }],
+				0,
+				mock<BaseChatModel>(),
+				null,
+				undefined,
+			),
+		).rejects.toThrow('Agent execution failed');
+	});
+
+	it('preserves a real underlying message instead of falling back', async () => {
+		const real = new TypeError('not a function');
+		prepareItemContextMock.mockResolvedValue(buildItemContext(0));
+		runAgentMock.mockRejectedValue(real);
+		mockContext.continueOnFail.mockReturnValue(true);
+
+		const { returnData } = await executeBatch(
+			mockContext,
+			[{ json: { text: 'x' } }],
+			0,
+			mock<BaseChatModel>(),
+			null,
+			undefined,
+		);
+
+		expect(returnData[0].json.error).toBe('not a function');
+	});
+
+	it('still wraps parser errors with the dedicated parser message', async () => {
+		prepareItemContextMock.mockResolvedValue(buildItemContext(0));
+		runAgentMock.mockRejectedValue(new Error('Failed to parse. Text: "garbage"'));
+		mockContext.continueOnFail.mockReturnValue(false);
+
+		await expect(
+			executeBatch(
+				mockContext,
+				[{ json: { text: 'x' } }],
+				0,
+				mock<BaseChatModel>(),
+				null,
+				undefined,
+			),
+		).rejects.toThrow("Model output doesn't fit required format");
+	});
+
+	it('returns BaseError subclasses unchanged (no double-wrapping)', async () => {
+		const original = new NodeOperationError(mockNode, 'already enriched');
+		prepareItemContextMock.mockResolvedValue(buildItemContext(0));
+		runAgentMock.mockRejectedValue(original);
+		mockContext.continueOnFail.mockReturnValue(true);
+
+		const { returnData } = await executeBatch(
+			mockContext,
+			[{ json: { text: 'x' } }],
+			0,
+			mock<BaseChatModel>(),
+			null,
+			undefined,
+		);
+
+		expect(returnData[0].json.error).toBe('already enriched');
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/executeBatch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/executeBatch.test.ts
@@ -52,7 +52,7 @@ function buildItemContext(itemIndex: number): ItemContext {
 	};
 }
 
-describe('executeBatch — error enrichment (V3)', () => {
+describe('executeBatch — error enrichment', () => {
 	it('surfaces a useful message in the output item when a tool throws a plain Error("Error") and continueOnFail is on', async () => {
 		prepareItemContextMock.mockResolvedValue(buildItemContext(0));
 		runAgentMock.mockRejectedValue(new Error('Error'));

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV1.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV1.test.ts
@@ -216,6 +216,85 @@ describe('toolsAgentExecute', () => {
 		await expect(toolsAgentExecute.call(mockContext)).rejects.toThrow('Test error');
 	});
 
+	it('should surface a useful message when a tool throws a plain Error("Error") with continueOnFail', async () => {
+		const mockNode = mock<INode>();
+		mockContext.getNode.mockReturnValue(mockNode);
+		mockContext.getInputData.mockReturnValue([{ json: { text: 'test input' } }]);
+
+		const mockModel = mock<BaseChatModel>();
+		mockModel.bindTools = vi.fn();
+		mockModel.lc_namespace = ['chat_models'];
+		mockContext.getInputConnectionData.mockResolvedValue(mockModel);
+
+		const mockTools = [mock<Tool>()];
+		vi.spyOn(helpers, 'getConnectedTools').mockResolvedValue(mockTools);
+
+		mockContext.getNodeParameter.mockImplementation((param, _i, defaultValue) => {
+			if (param === 'text') return 'test input';
+			if (param === 'options')
+				return {
+					systemMessage: 'You are a helpful assistant',
+					maxIterations: 10,
+					returnIntermediateSteps: false,
+					passthroughBinaryImages: true,
+				};
+			return defaultValue;
+		});
+
+		mockContext.continueOnFail.mockReturnValue(true);
+
+		const mockExecutor = {
+			invoke: vi.fn().mockRejectedValue(new Error('Error')),
+		};
+
+		vi.spyOn(AgentExecutor, 'fromAgentAndTools').mockReturnValue(
+			ensureWithConfig(mockExecutor) as any,
+		);
+
+		const result = await toolsAgentExecute.call(mockContext);
+
+		expect(result[0][0].json.error).not.toBe('Error');
+		expect(result[0][0].json.error).toBe('Agent execution failed');
+	});
+
+	it('should throw a NodeOperationError with a useful message when a tool throws Error("Error") without continueOnFail', async () => {
+		const mockNode = mock<INode>();
+		mockContext.getNode.mockReturnValue(mockNode);
+		mockContext.getInputData.mockReturnValue([{ json: { text: 'test input' } }]);
+
+		const mockModel = mock<BaseChatModel>();
+		mockModel.bindTools = vi.fn();
+		mockModel.lc_namespace = ['chat_models'];
+		mockContext.getInputConnectionData.mockResolvedValue(mockModel);
+
+		const mockTools = [mock<Tool>()];
+		vi.spyOn(helpers, 'getConnectedTools').mockResolvedValue(mockTools);
+
+		mockContext.getNodeParameter.mockImplementation((param, _i, defaultValue) => {
+			if (param === 'text') return 'test input';
+			if (param === 'options')
+				return {
+					systemMessage: 'You are a helpful assistant',
+					maxIterations: 10,
+					returnIntermediateSteps: false,
+					passthroughBinaryImages: true,
+				};
+			return defaultValue;
+		});
+
+		mockContext.continueOnFail.mockReturnValue(false);
+
+		const mockExecutor = {
+			invoke: vi.fn().mockRejectedValue(new Error('Error')),
+		};
+
+		vi.spyOn(AgentExecutor, 'fromAgentAndTools').mockReturnValue(
+			ensureWithConfig(mockExecutor) as any,
+		);
+
+		await expect(toolsAgentExecute.call(mockContext)).rejects.toThrow('Agent execution failed');
+	});
+
 	it('should pass tracing metadata to tracing config', async () => {
 		const mockNode = mock<INode>();
 		mockContext.getNode.mockReturnValue(mockNode);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -373,6 +373,93 @@ describe('toolsAgentExecute', () => {
 		});
 	});
 
+	it('should surface a useful message when a tool throws a plain Error("Error") with continueOnFail', async () => {
+		const mockNode = mock<INode>();
+		mockNode.typeVersion = 2;
+		mockContext.getNode.mockReturnValue(mockNode);
+		mockContext.getInputData.mockReturnValue([{ json: { text: 'test input' } }]);
+
+		const mockModel = mock<BaseChatModel>();
+		mockModel.bindTools = vi.fn();
+		mockModel.lc_namespace = ['chat_models'];
+		mockContext.getInputConnectionData.mockResolvedValue(mockModel);
+
+		const mockTools = [mock<Tool>()];
+		vi.spyOn(helpers, 'getConnectedTools').mockResolvedValue(mockTools);
+
+		mockContext.getNodeParameter.mockImplementation((param, _i, defaultValue) => {
+			if (param === 'options.batching.batchSize') return 1;
+			if (param === 'options.batching.delayBetweenBatches') return 0;
+			if (param === 'text') return 'test input';
+			if (param === 'needsFallback') return false;
+			if (param === 'options')
+				return {
+					systemMessage: 'You are a helpful assistant',
+					maxIterations: 10,
+					returnIntermediateSteps: false,
+					passthroughBinaryImages: true,
+				};
+			return defaultValue;
+		});
+
+		mockContext.continueOnFail.mockReturnValue(true);
+
+		const mockExecutor = {
+			invoke: vi.fn().mockRejectedValue(new Error('Error')),
+		};
+
+		vi.spyOn(AgentExecutor, 'fromAgentAndTools').mockReturnValue(
+			ensureWithConfig(mockExecutor) as any,
+		);
+
+		const result = await toolsAgentExecute.call(mockContext);
+
+		expect(result[0][0].json.error).not.toBe('Error');
+		expect(result[0][0].json.error).toBe('Agent execution failed');
+	});
+
+	it('should throw a NodeOperationError with a useful message when a tool throws Error("Error") without continueOnFail', async () => {
+		const mockNode = mock<INode>();
+		mockNode.typeVersion = 2;
+		mockContext.getNode.mockReturnValue(mockNode);
+		mockContext.getInputData.mockReturnValue([{ json: { text: 'test input' } }]);
+
+		const mockModel = mock<BaseChatModel>();
+		mockModel.bindTools = vi.fn();
+		mockModel.lc_namespace = ['chat_models'];
+		mockContext.getInputConnectionData.mockResolvedValue(mockModel);
+
+		const mockTools = [mock<Tool>()];
+		vi.spyOn(helpers, 'getConnectedTools').mockResolvedValue(mockTools);
+
+		mockContext.getNodeParameter.mockImplementation((param, _i, defaultValue) => {
+			if (param === 'options.batching.batchSize') return 1;
+			if (param === 'options.batching.delayBetweenBatches') return 0;
+			if (param === 'text') return 'test input';
+			if (param === 'needsFallback') return false;
+			if (param === 'options')
+				return {
+					systemMessage: 'You are a helpful assistant',
+					maxIterations: 10,
+					returnIntermediateSteps: false,
+					passthroughBinaryImages: true,
+				};
+			return defaultValue;
+		});
+
+		mockContext.continueOnFail.mockReturnValue(false);
+
+		const mockExecutor = {
+			invoke: vi.fn().mockRejectedValue(new Error('Error')),
+		};
+
+		vi.spyOn(AgentExecutor, 'fromAgentAndTools').mockReturnValue(
+			ensureWithConfig(mockExecutor) as any,
+		);
+
+		await expect(toolsAgentExecute.call(mockContext)).rejects.toThrow('Agent execution failed');
+	});
+
 	it('should fetch output parser with correct item index', async () => {
 		const mockNode = mock<INode>();
 		mockNode.typeVersion = 2;

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
@@ -128,6 +128,16 @@ describe('wrapLangChainParserError', () => {
 			expect(wrapped.message).toBe('something broke');
 		});
 
+		it('uses the fallback when a non-Error throw has no string message', () => {
+			const wrapped = wrapLangChainParserError({ code: 500 }, node, undefined, {
+				enrichNonParserErrors: true,
+			});
+
+			expect(wrapped).toBeInstanceOf(NodeOperationError);
+			expect(wrapped.message).toBe('Agent execution failed');
+			expect(wrapped.message).not.toBe('[object Object]');
+		});
+
 		it('still wraps parser errors when the option is set', () => {
 			const error = new Error('Failed to parse. Text: "x"');
 
@@ -148,6 +158,23 @@ describe('getFailureType', () => {
 
 	it('returns the class name of a typed Error', () => {
 		expect(getFailureType(new TypeError('x'))).toBe('TypeError');
+	});
+
+	it('uses constructor.name for a custom subclass that inherits name "Error"', () => {
+		class CustomAgentError extends Error {}
+
+		expect(getFailureType(new CustomAgentError('boom'))).toBe('CustomAgentError');
+	});
+
+	it('keeps an explicitly set name over constructor.name', () => {
+		class CustomAgentError extends Error {
+			constructor(message?: string) {
+				super(message);
+				this.name = 'ExplicitFailure';
+			}
+		}
+
+		expect(getFailureType(new CustomAgentError('boom'))).toBe('ExplicitFailure');
 	});
 
 	it('walks the cause chain through a NodeOperationError to the underlying class', () => {

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
@@ -106,6 +106,18 @@ describe('wrapLangChainParserError', () => {
 			expect((wrapped as NodeOperationError).cause).toBe(original);
 		});
 
+		it('uses constructor.name in the description for a custom subclass that inherits name "Error"', () => {
+			class CustomAgentError extends Error {}
+			const original = new CustomAgentError('boom');
+
+			const wrapped = wrapLangChainParserError(original, node, undefined, {
+				enrichNonParserErrors: true,
+			});
+
+			expect((wrapped as NodeOperationError).description).toBe('Original error: CustomAgentError');
+			expect(getFailureType(wrapped)).toBe('CustomAgentError');
+		});
+
 		it('returns BaseError subclasses unchanged', () => {
 			class CustomBaseError extends BaseError {
 				constructor() {
@@ -126,6 +138,18 @@ describe('wrapLangChainParserError', () => {
 
 			expect(wrapped).toBeInstanceOf(NodeOperationError);
 			expect(wrapped.message).toBe('something broke');
+		});
+
+		it('keeps a named non-Error throw through the wrap instead of OperationalError', () => {
+			const wrapped = wrapLangChainParserError({ name: 'RateLimitError' }, node, undefined, {
+				enrichNonParserErrors: true,
+			}) as NodeOperationError;
+
+			expect(wrapped.message).toBe('Agent execution failed');
+			expect(wrapped.description).toBe('Original error: RateLimitError');
+			expect(wrapped.cause).toBeInstanceOf(Error);
+			expect((wrapped.cause as Error).name).toBe('RateLimitError');
+			expect(getFailureType(wrapped)).toBe('RateLimitError');
 		});
 
 		it('uses the fallback when a non-Error throw has no string message', () => {
@@ -194,9 +218,22 @@ describe('getFailureType', () => {
 		expect(getFailureType(top)).toBe('RangeError');
 	});
 
+	it('stops walking a cause chain that loops back on itself', () => {
+		const inner = new TypeError('inner');
+		const outer = new RangeError('outer');
+		inner.cause = outer;
+		outer.cause = inner;
+
+		expect(getFailureType(outer)).toBe('TypeError');
+	});
+
 	it('falls back to typeof for non-Error throws', () => {
 		expect(getFailureType('a string')).toBe('string');
 		expect(getFailureType(undefined)).toBe('undefined');
+	});
+
+	it('uses a name on a thrown plain object', () => {
+		expect(getFailureType({ name: 'RateLimitError' })).toBe('RateLimitError');
 	});
 
 	it('falls back to "Error" when the class name is empty', () => {

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
@@ -15,7 +15,7 @@ const node = {
 } as INode;
 
 describe('wrapLangChainParserError', () => {
-	describe('default (V1/V2) behaviour — non-parser errors unchanged', () => {
+	describe('default behaviour (no opt-in) — non-parser errors unchanged', () => {
 		it('leaves non-parser Error instances unchanged', () => {
 			const error = new Error('Connection failed');
 
@@ -54,7 +54,7 @@ describe('wrapLangChainParserError', () => {
 		});
 	});
 
-	describe('enrichNonParserErrors (V3) behaviour', () => {
+	describe('enrichNonParserErrors opt-in behaviour', () => {
 		it('wraps a plain Error with a useful message in NodeOperationError and chains the cause', () => {
 			const original = new Error('Connection failed');
 
@@ -68,6 +68,15 @@ describe('wrapLangChainParserError', () => {
 			expect((wrapped as NodeOperationError).cause).toBe(original);
 			expect((wrapped as NodeOperationError).description).toBe('Original error: Error');
 			expect((wrapped as NodeOperationError).context.itemIndex).toBe(3);
+		});
+
+		it('keeps the wrapped error reportable, since NodeOperationError defaults to a level the error reporter drops', () => {
+			const wrapped = wrapLangChainParserError(new Error('Error'), node, 0, {
+				enrichNonParserErrors: true,
+			}) as NodeOperationError;
+
+			expect(wrapped.level).toBe('error');
+			expect(wrapped.shouldReport).toBe(true);
 		});
 
 		it('uses a fallback message when the original message is empty or matches the class name', () => {

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
@@ -1,8 +1,9 @@
 import type { INode } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { BaseError, NodeOperationError } from 'n8n-workflow';
 
 import {
 	MODEL_OUTPUT_PARSER_ERROR_MESSAGE,
+	getFailureType,
 	wrapLangChainParserError,
 } from './langchainParserError';
 
@@ -14,31 +15,158 @@ const node = {
 } as INode;
 
 describe('wrapLangChainParserError', () => {
-	it('wraps parser errors without exposing raw model output', () => {
-		const rawModelOutput = 'customer secret in model output';
-		const error = new Error(`Failed to parse. Text: "${rawModelOutput}"`);
+	describe('default (V1/V2) behaviour — non-parser errors unchanged', () => {
+		it('leaves non-parser Error instances unchanged', () => {
+			const error = new Error('Connection failed');
 
-		const wrappedError = wrapLangChainParserError(error, node, 2);
+			expect(wrapLangChainParserError(error, node)).toBe(error);
+		});
 
-		expect(wrappedError).toBeInstanceOf(NodeOperationError);
-		expect(wrappedError.message).toBe(MODEL_OUTPUT_PARSER_ERROR_MESSAGE);
-		expect(wrappedError.message).not.toContain(rawModelOutput);
-		expect((wrappedError as NodeOperationError).description).not.toContain(rawModelOutput);
-		expect((wrappedError as NodeOperationError).context.itemIndex).toBe(2);
+		it('wraps non-Error throws in a plain Error with the message', () => {
+			const wrapped = wrapLangChainParserError({ message: 'something broke' }, node);
+
+			expect(wrapped).toBeInstanceOf(Error);
+			expect(wrapped.message).toBe('something broke');
+		});
 	});
 
-	it('wraps parser errors detected by name', () => {
-		const wrappedError = wrapLangChainParserError(
-			{ name: 'OutputParserException', message: 'Parser failed' },
-			node,
-		);
+	describe('parser errors', () => {
+		it('wraps parser errors without exposing raw model output', () => {
+			const rawModelOutput = 'customer secret in model output';
+			const error = new Error(`Failed to parse. Text: "${rawModelOutput}"`);
 
-		expect(wrappedError.message).toBe(MODEL_OUTPUT_PARSER_ERROR_MESSAGE);
+			const wrappedError = wrapLangChainParserError(error, node, 2);
+
+			expect(wrappedError).toBeInstanceOf(NodeOperationError);
+			expect(wrappedError.message).toBe(MODEL_OUTPUT_PARSER_ERROR_MESSAGE);
+			expect(wrappedError.message).not.toContain(rawModelOutput);
+			expect((wrappedError as NodeOperationError).description).not.toContain(rawModelOutput);
+			expect((wrappedError as NodeOperationError).context.itemIndex).toBe(2);
+		});
+
+		it('wraps parser errors detected by name', () => {
+			const wrappedError = wrapLangChainParserError(
+				{ name: 'OutputParserException', message: 'Parser failed' },
+				node,
+			);
+
+			expect(wrappedError.message).toBe(MODEL_OUTPUT_PARSER_ERROR_MESSAGE);
+		});
 	});
 
-	it('leaves non-parser errors unchanged', () => {
-		const error = new Error('Connection failed');
+	describe('enrichNonParserErrors (V3) behaviour', () => {
+		it('wraps a plain Error with a useful message in NodeOperationError and chains the cause', () => {
+			const original = new Error('Connection failed');
 
-		expect(wrapLangChainParserError(error, node)).toBe(error);
+			const wrapped = wrapLangChainParserError(original, node, 3, {
+				enrichNonParserErrors: true,
+			});
+
+			expect(wrapped).toBeInstanceOf(NodeOperationError);
+			expect(wrapped).not.toBe(original);
+			expect(wrapped.message).toBe('Connection failed');
+			expect((wrapped as NodeOperationError).cause).toBe(original);
+			expect((wrapped as NodeOperationError).description).toBe('Original error: Error');
+			expect((wrapped as NodeOperationError).context.itemIndex).toBe(3);
+		});
+
+		it('uses a fallback message when the original message is empty or matches the class name', () => {
+			const cases = [new Error('Error'), new Error(''), new Error()] as const;
+
+			for (const original of cases) {
+				const wrapped = wrapLangChainParserError(original, node, undefined, {
+					enrichNonParserErrors: true,
+				});
+
+				expect(wrapped).toBeInstanceOf(NodeOperationError);
+				expect(wrapped.message).toBe('Agent execution failed');
+				expect((wrapped as NodeOperationError).cause).toBe(original);
+				expect((wrapped as NodeOperationError).description).toBe('Original error: Error');
+			}
+		});
+
+		it('preserves the underlying class name in the description', () => {
+			const original = new TypeError('not a function');
+
+			const wrapped = wrapLangChainParserError(original, node, undefined, {
+				enrichNonParserErrors: true,
+			});
+
+			expect(wrapped.message).toBe('not a function');
+			expect((wrapped as NodeOperationError).description).toBe('Original error: TypeError');
+			expect((wrapped as NodeOperationError).cause).toBe(original);
+		});
+
+		it('returns BaseError subclasses unchanged', () => {
+			class CustomBaseError extends BaseError {
+				constructor() {
+					super('already enriched');
+				}
+			}
+			const original = new CustomBaseError();
+
+			expect(
+				wrapLangChainParserError(original, node, undefined, { enrichNonParserErrors: true }),
+			).toBe(original);
+		});
+
+		it('wraps non-Error throws with the extracted message', () => {
+			const wrapped = wrapLangChainParserError({ message: 'something broke' }, node, undefined, {
+				enrichNonParserErrors: true,
+			});
+
+			expect(wrapped).toBeInstanceOf(NodeOperationError);
+			expect(wrapped.message).toBe('something broke');
+		});
+
+		it('still wraps parser errors when the option is set', () => {
+			const error = new Error('Failed to parse. Text: "x"');
+
+			const wrapped = wrapLangChainParserError(error, node, undefined, {
+				enrichNonParserErrors: true,
+			});
+
+			expect(wrapped).toBeInstanceOf(NodeOperationError);
+			expect(wrapped.message).toBe(MODEL_OUTPUT_PARSER_ERROR_MESSAGE);
+		});
+	});
+});
+
+describe('getFailureType', () => {
+	it('returns the class name of a plain Error', () => {
+		expect(getFailureType(new Error('boom'))).toBe('Error');
+	});
+
+	it('returns the class name of a typed Error', () => {
+		expect(getFailureType(new TypeError('x'))).toBe('TypeError');
+	});
+
+	it('walks the cause chain through a NodeOperationError to the underlying class', () => {
+		const root = new TypeError('root cause');
+		const wrapped = new NodeOperationError(node, root, { message: 'wrapped' });
+
+		expect(getFailureType(wrapped)).toBe('TypeError');
+	});
+
+	it('walks a multi-level cause chain to the deepest class', () => {
+		const deepest = new RangeError('deepest');
+		const mid = new Error('mid');
+		(mid as Error & { cause: Error }).cause = deepest;
+		const top = new Error('top');
+		(top as Error & { cause: Error }).cause = mid;
+
+		expect(getFailureType(top)).toBe('RangeError');
+	});
+
+	it('falls back to typeof for non-Error throws', () => {
+		expect(getFailureType('a string')).toBe('string');
+		expect(getFailureType(undefined)).toBe('undefined');
+	});
+
+	it('falls back to "Error" when the class name is empty', () => {
+		const error = new Error();
+		Object.defineProperty(error, 'name', { value: '' });
+
+		expect(getFailureType(error)).toBe('Error');
 	});
 });

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
@@ -50,10 +50,14 @@ export function getFailureType(error: unknown): string {
 	while (current instanceof Error && current.cause instanceof Error) {
 		current = current.cause;
 	}
-	return (
-		(current instanceof Error ? current.name || current.constructor.name : typeof current) ||
-		'Error'
-	);
+	if (!(current instanceof Error)) {
+		return typeof current;
+	}
+	// Custom subclasses that do not set `this.name` inherit `'Error'`.
+	if (current.name && current.name !== 'Error') {
+		return current.name;
+	}
+	return current.constructor.name || 'Error';
 }
 
 function isUselessMessage(message: string | undefined, className: string | undefined): boolean {
@@ -69,7 +73,7 @@ function wrapAsNodeOperationError(
 ): Error {
 	const className = getErrorName(error);
 	const messageProperty = getErrorProperty(error, 'message');
-	const candidateMessage = messageProperty ?? (error instanceof Error ? undefined : String(error));
+	const candidateMessage = messageProperty ?? (typeof error === 'string' ? error : undefined);
 	const message = isUselessMessage(candidateMessage, className)
 		? AGENT_FAILURE_FALLBACK_MESSAGE
 		: (candidateMessage as string);

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
@@ -18,11 +18,12 @@ function getErrorProperty(error: unknown, property: 'message' | 'name') {
 	return typeof value === 'string' ? value : undefined;
 }
 
-function getErrorName(error: unknown) {
-	const errorName = getErrorProperty(error, 'name');
-	if (errorName) return errorName;
-
-	return error instanceof Error ? error.constructor.name : undefined;
+function resolveErrorName(error: unknown): string | undefined {
+	if (error instanceof Error) {
+		if (error.name && error.name !== 'Error') return error.name;
+		return error.constructor.name || undefined;
+	}
+	return getErrorProperty(error, 'name');
 }
 
 function hasLangChainParserMessage(error: unknown) {
@@ -35,7 +36,7 @@ function hasLangChainParserMessage(error: unknown) {
 export function isLangChainParserError(error: unknown) {
 	return (
 		error instanceof OutputParserException ||
-		getErrorName(error) === 'OutputParserException' ||
+		resolveErrorName(error) === 'OutputParserException' ||
 		hasLangChainParserMessage(error)
 	);
 }
@@ -47,17 +48,13 @@ export function isLangChainParserError(error: unknown) {
  */
 export function getFailureType(error: unknown): string {
 	let current: unknown = error;
+	const seen = new Set<Error>();
 	while (current instanceof Error && current.cause instanceof Error) {
+		seen.add(current);
+		if (seen.has(current.cause)) break;
 		current = current.cause;
 	}
-	if (!(current instanceof Error)) {
-		return typeof current;
-	}
-	// Custom subclasses that do not set `this.name` inherit `'Error'`.
-	if (current.name && current.name !== 'Error') {
-		return current.name;
-	}
-	return current.constructor.name || 'Error';
+	return resolveErrorName(current) ?? (current instanceof Error ? 'Error' : typeof current);
 }
 
 function isUselessMessage(message: string | undefined, className: string | undefined): boolean {
@@ -71,7 +68,7 @@ function wrapAsNodeOperationError(
 	node: INode,
 	itemIndex: number | undefined,
 ): Error {
-	const className = getErrorName(error);
+	const className = resolveErrorName(error);
 	const messageProperty = getErrorProperty(error, 'message');
 	const candidateMessage = messageProperty ?? (typeof error === 'string' ? error : undefined);
 	const message = isUselessMessage(candidateMessage, className)
@@ -84,10 +81,17 @@ function wrapAsNodeOperationError(
 		level: 'error' as const,
 		...(itemIndex !== undefined ? { itemIndex } : {}),
 	};
+
+	// Always pass an Error so NodeOperationError does not wrap a string in
+	// OperationalError and lose the original name.
+	let cause: Error;
 	if (error instanceof Error) {
-		return new NodeOperationError(node, error, options);
+		cause = error;
+	} else {
+		cause = new Error(message);
+		if (className) cause.name = className;
 	}
-	return new NodeOperationError(node, message, options);
+	return new NodeOperationError(node, cause, options);
 }
 
 export function wrapLangChainParserError(

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
@@ -77,6 +77,7 @@ function wrapAsNodeOperationError(
 	const options = {
 		message,
 		description: className ? `Original error: ${className}` : undefined,
+		level: 'error' as const,
 		...(itemIndex !== undefined ? { itemIndex } : {}),
 	};
 	if (error instanceof Error) {
@@ -92,14 +93,18 @@ export function wrapLangChainParserError(
 	options?: { enrichNonParserErrors?: boolean },
 ): Error {
 	if (!isLangChainParserError(error)) {
-		// V1/V2 path (default): preserve existing behaviour.
+		// Default: callers that have not opted in (the chain nodes, ReAct and
+		// Conversational agents) keep the error exactly as it was thrown.
 		if (!options?.enrichNonParserErrors) {
 			return error instanceof Error
 				? error
 				: new Error(getErrorProperty(error, 'message') ?? String(error));
 		}
 
-		// Agent V3 path
+		// Opt-in enrichment (Tools Agent, all versions): wrap plain errors so a
+		// useless message like "Error" never reaches the user, and the original
+		// error survives as `cause` for failure-type telemetry. Errors that are
+		// already ours carry a meaningful message, so leave them alone.
 		if (error instanceof BaseError) return error;
 		return wrapAsNodeOperationError(error, node, itemIndex);
 	}

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
@@ -1,12 +1,14 @@
 import { OutputParserException } from '@langchain/core/output_parsers';
 import type { INode } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { BaseError, NodeOperationError } from 'n8n-workflow';
 
 export const MODEL_OUTPUT_PARSER_ERROR_MESSAGE = "Model output doesn't fit required format";
 export const MODEL_OUTPUT_PARSER_ERROR_DESCRIPTION =
 	"To continue the execution when this happens, change the 'On Error' parameter in the root node's settings";
 
 const LANGCHAIN_PARSER_ERROR_MESSAGES = ['Failed to parse. Text:', 'Unable to parse JSON response'];
+
+const AGENT_FAILURE_FALLBACK_MESSAGE = 'Agent execution failed';
 
 function getErrorProperty(error: unknown, property: 'message' | 'name') {
 	if (error instanceof Error) return error[property];
@@ -38,19 +40,76 @@ export function isLangChainParserError(error: unknown) {
 	);
 }
 
-export function wrapLangChainParserError(error: unknown, node: INode, itemIndex?: number): Error {
-	if (!isLangChainParserError(error)) {
-		return error instanceof Error
-			? error
-			: new Error(getErrorProperty(error, 'message') ?? String(error));
+/**
+ * Walks the `root cause` chain to the deepest `Error` and returns its class name.
+ * Used for `ai.agent.failure.type` telemetry so the value reflects the
+ * underlying error class.
+ */
+export function getFailureType(error: unknown): string {
+	let current: unknown = error;
+	while (current instanceof Error && current.cause instanceof Error) {
+		current = current.cause;
 	}
+	return (
+		(current instanceof Error ? current.name || current.constructor.name : typeof current) ||
+		'Error'
+	);
+}
+
+function isUselessMessage(message: string | undefined, className: string | undefined): boolean {
+	if (!message) return true;
+	if (className && message === className) return true;
+	return message === 'Error';
+}
+
+function wrapAsNodeOperationError(
+	error: unknown,
+	node: INode,
+	itemIndex: number | undefined,
+): Error {
+	const className = getErrorName(error);
+	const messageProperty = getErrorProperty(error, 'message');
+	const candidateMessage = messageProperty ?? (error instanceof Error ? undefined : String(error));
+	const message = isUselessMessage(candidateMessage, className)
+		? AGENT_FAILURE_FALLBACK_MESSAGE
+		: (candidateMessage as string);
 
 	const options = {
+		message,
+		description: className ? `Original error: ${className}` : undefined,
+		...(itemIndex !== undefined ? { itemIndex } : {}),
+	};
+	if (error instanceof Error) {
+		return new NodeOperationError(node, error, options);
+	}
+	return new NodeOperationError(node, message, options);
+}
+
+export function wrapLangChainParserError(
+	error: unknown,
+	node: INode,
+	itemIndex?: number,
+	options?: { enrichNonParserErrors?: boolean },
+): Error {
+	if (!isLangChainParserError(error)) {
+		// V1/V2 path (default): preserve existing behaviour.
+		if (!options?.enrichNonParserErrors) {
+			return error instanceof Error
+				? error
+				: new Error(getErrorProperty(error, 'message') ?? String(error));
+		}
+
+		// Agent V3 path
+		if (error instanceof BaseError) return error;
+		return wrapAsNodeOperationError(error, node, itemIndex);
+	}
+
+	const parserOptions = {
 		description: MODEL_OUTPUT_PARSER_ERROR_DESCRIPTION,
 		...(itemIndex !== undefined ? { itemIndex } : {}),
 	};
 
-	const nodeError = new NodeOperationError(node, MODEL_OUTPUT_PARSER_ERROR_MESSAGE, options);
+	const nodeError = new NodeOperationError(node, MODEL_OUTPUT_PARSER_ERROR_MESSAGE, parserOptions);
 	nodeError.context.outputParserFailReason = 'Model output does not match the expected schema';
 
 	return nodeError;


### PR DESCRIPTION
## Summary

When the AI Agent failed on a plain `Error` (often from the model or executor), users saw an unhelpful message and Sentry recorded `Error: Error`. The execution engine sanitizes non-`BaseError` exceptions by replacing the message with the class name, so a generic `Error` became that string.
- Keep a useful original message when there is one.
- Fall back to `Agent execution failed` when the message is empty, `"Error"`, or matches the class name.
- Put the original class in the description (`Original error: <Class>`).
- Keep the original error as `cause` so Sentry `LinkedErrors` can attach it.
- Set `level: 'error'` so the reporter does not drop the event (`NodeOperationError` defaults to `warning`).
- Walk the cause chain for `ai.agent.failure.type` tracing metadata (`getFailureType`).

Applied to Tools Agent V1, V2, and V3 via an opt-in on `wrapLangChainParserError`. Chain nodes and ReAct / Conversational agents are unchanged.

**Note:** Built-in tools (Code Tool, Workflow Tool) still swallow their own errors and return a string to the LLM. Those runs stay green on the Agent node.

## How to test

1. Start a local HTTP server on port 9099 that returns HTTP 200 with an empty JSON body or use a mock service.
2. Create a workflow: Manual Trigger → AI Agent (v3.1), with an OpenAI Chat Model connected. On the model node, set Model to ID `gpt-4o-mini` and Base URL to `http://<mock-url>`. Attach any OpenAI credential (auth is not checked).
3. Execute the workflow.
4. Expected:
   - The **AI Agent** node is red (not only the model sub-node).
   - Description includes `Original error: SyntaxError` (or similar SDK parse error).
   - Message is the real parse/connection message, not `Error`.
Optional Sentry check: point `N8N_SENTRY_DSN` at a local Kent instance and confirm the event is `NodeOperationError` at level `error` with the original error as a linked exception, not `Error: Error`.

To hit a connection error instead of a parse error, replace the fake server with one that accepts TCP and immediately destroys the socket on the same port.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2719
https://linear.app/n8n/issue/AI-2716

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

