### PR TITLE
fix(core): Hold an expression isolate while closing a trigger's teardown function

### DIFF
--- a/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
@@ -788,6 +788,29 @@ describe('ActiveWorkflowTriggers', () => {
 			expect(triggerResponse.closeFunction).toHaveBeenCalled();
 		});
 
+		it('should hold an expression isolate around closeFunction so an expression evaluated during teardown does not fail', async () => {
+			acquireIsolate.mockResolvedValueOnce(true);
+
+			await setupForRemoval();
+
+			expect(acquireIsolate).toHaveBeenCalledTimes(1);
+			expect(releaseIsolate).toHaveBeenCalledTimes(1);
+			const [acquireOrder] = acquireIsolate.mock.invocationCallOrder;
+			const [closeOrder] = (triggerResponse.closeFunction as Mock).mock.invocationCallOrder;
+			const [releaseOrder] = releaseIsolate.mock.invocationCallOrder;
+			expect(acquireOrder).toBeLessThan(closeOrder);
+			expect(closeOrder).toBeLessThan(releaseOrder);
+		});
+
+		it('should not release an isolate it never acquired', async () => {
+			acquireIsolate.mockResolvedValueOnce(false);
+
+			await setupForRemoval();
+
+			expect(acquireIsolate).toHaveBeenCalledTimes(1);
+			expect(releaseIsolate).not.toHaveBeenCalled();
+		});
+
 		it('should return false when removing non-existent workflow', async () => {
 			scheduledTaskManager.deregisterGroup.mockReturnValue(false);
 

--- a/packages/core/src/execution-engine/active-workflow-triggers.ts
+++ b/packages/core/src/execution-engine/active-workflow-triggers.ts
@@ -9,6 +9,7 @@ import type {
 	Workflow,
 	WorkflowActivateMode,
 	WorkflowExecuteMode,
+	WorkflowExpression,
 } from 'n8n-workflow';
 import {
 	isSubMinuteCron,
@@ -219,7 +220,7 @@ export class ActiveWorkflowTriggers {
 					activation,
 				);
 				if (triggerResponse !== undefined) {
-					triggers.addTriggerResponse(triggerNode.id, triggerResponse);
+					triggers.addTriggerResponse(triggerNode.id, triggerResponse, workflow.expression);
 					registeredNodeIds.add(triggerNode.id);
 
 					this.logTriggerActivation(workflow, triggerNode);
@@ -307,7 +308,7 @@ export class ActiveWorkflowTriggers {
 
 			const response = activeTriggers.get(nodeId);
 			if (response) {
-				await this.closeTrigger(response, workflowId);
+				await this.closeTrigger(response, workflowId, activeTriggers.getExpression(nodeId));
 			}
 			activeTriggers.delete(nodeId);
 
@@ -346,7 +347,7 @@ export class ActiveWorkflowTriggers {
 			}
 
 			try {
-				await this.closeTrigger(response, workflowId);
+				await this.closeTrigger(response, workflowId, triggers.getExpression(nodeId));
 			} catch (e) {
 				this.errorReporter.error(ensureError(e), { extra: { workflowId } });
 			} finally {
@@ -476,9 +477,9 @@ export class ActiveWorkflowTriggers {
 		// Best-effort: every close is attempted; a failing close keeps its node
 		// tracked (a possibly still-live trigger must stay visible to later
 		// teardown passes) while the rest of the cleanup proceeds.
-		for (const { nodeId, response } of triggers.closableTriggers()) {
+		for (const { nodeId, response, expression } of triggers.closableTriggers()) {
 			try {
-				await this.closeTrigger(response, workflowId);
+				await this.closeTrigger(response, workflowId, expression);
 				triggers.delete(nodeId);
 			} catch (error) {
 				errors.push(ensureError(error));
@@ -528,8 +529,14 @@ export class ActiveWorkflowTriggers {
 		});
 	}
 
-	private async closeTrigger(response: ITriggerResponse, workflowId: string) {
+	private async closeTrigger(
+		response: ITriggerResponse,
+		workflowId: string,
+		expression?: WorkflowExpression,
+	) {
 		if (!response.closeFunction) return;
+
+		const ownsIsolate = expression ? await expression.acquireIsolate() : false;
 
 		try {
 			await response.closeFunction();
@@ -548,6 +555,8 @@ export class ActiveWorkflowTriggers {
 				`Failed to deactivate trigger of workflow ID "${workflowId}": "${error.message}"`,
 				{ cause: error, workflowId },
 			);
+		} finally {
+			if (ownsIsolate) await expression?.releaseIsolate();
 		}
 	}
 

--- a/packages/core/src/execution-engine/workflow-active-triggers-state.ts
+++ b/packages/core/src/execution-engine/workflow-active-triggers-state.ts
@@ -1,10 +1,12 @@
-import type { ITriggerResponse } from 'n8n-workflow';
+import type { ITriggerResponse, WorkflowExpression } from 'n8n-workflow';
 
 export type TriggerRegistrationToken = symbol;
 
 type TriggerRegistration = {
 	token: TriggerRegistrationToken;
 	response?: ITriggerResponse;
+	/** The registering workflow's expression handle, needed to hold an isolate while closing the trigger. */
+	expression?: WorkflowExpression;
 };
 
 /**
@@ -31,10 +33,15 @@ export class WorkflowActiveTriggersState {
 		return this.pendingRegistrations > 0;
 	}
 
-	/** Records a trigger response for a registered node. */
-	addTriggerResponse(nodeId: string, response: ITriggerResponse): TriggerRegistrationToken {
+	/** Records a trigger response for a registered node, along with the workflow's expression handle used to close it under an isolate. */
+	addTriggerResponse(
+		nodeId: string,
+		response: ITriggerResponse,
+		expression: WorkflowExpression,
+	): TriggerRegistrationToken {
 		const registration = this.getOrCreateRegistration(nodeId);
 		registration.response = response;
+		registration.expression = expression;
 
 		return registration.token;
 	}
@@ -62,6 +69,11 @@ export class WorkflowActiveTriggersState {
 	/** The trigger response recorded for a node, if any. */
 	get(nodeId: string) {
 		return this.registrationsByNodeId.get(nodeId)?.response;
+	}
+
+	/** The expression handle recorded for a node's trigger response, if any. */
+	getExpression(nodeId: string) {
+		return this.registrationsByNodeId.get(nodeId)?.expression;
 	}
 
 	/** Whether the given node is registered in memory. */
@@ -96,7 +108,9 @@ export class WorkflowActiveTriggersState {
 	 */
 	*closableTriggers() {
 		for (const [nodeId, registration] of this.registrationsByNodeId.entries()) {
-			if (registration.response) yield { nodeId, response: registration.response };
+			if (registration.response) {
+				yield { nodeId, response: registration.response, expression: registration.expression };
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `closeTrigger()` in `ActiveWorkflowTriggers` called a trigger's `closeFunction` (e.g. Postgres Trigger's `DROP TRIGGER`/`UNLISTEN` teardown) without holding an expression isolate, so any expression evaluated during close threw and left remote resources (connections, subscriptions) undropped while n8n reported the workflow as deactivated.
- Deactivation call sites (`remove()`, `removeTriggers()`, `rollbackPartialActivation()`) only ever have a `workflowId` at that point, not a live `Workflow` instance to acquire an isolate from. So instead of threading one through, `WorkflowActiveTriggersState` now captures the registering workflow's `expression` handle alongside its `ITriggerResponse` at registration time (`startTriggers()` already has `workflow` in scope) and exposes it via `getExpression()`/`closableTriggers()`.
- `closeTrigger()` acquires that isolate before `closeFunction()` and releases it in a `finally`, following the same `ownsIsolate` acquire/release pattern already used in `poll-trigger-executor.ts` and `webhook-trigger-registrar.ts`.
- Pre-existing `TriggerCloseError` swallowing behavior is unchanged — out of scope for this ticket.

Linear: https://linear.app/n8n/issue/CAT-4125

## Test plan
- [x] 2 new regression tests: acquire → closeFunction → release ordering, and isolate not released when not owned
- [x] `pnpm test` in `packages/core` — 2037/2037 tests green
- [x] `pnpm lint` / `pnpm typecheck` in `packages/core` — clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

