### PR TITLE
perf(core): Index Instance AI events by thread write time (no-changelog)

### DIFF
--- a/docs/generated/postgres-schema/public.instance_ai_events.md
+++ b/docs/generated/postgres-schema/public.instance_ai_events.md
@@ -31,6 +31,7 @@
 | Name | Definition |
 | ---- | ---------- |
 | IDX_32cdd799675715fb1d2a8683e9 | CREATE INDEX "IDX_32cdd799675715fb1d2a8683e9" ON public.instance_ai_events USING btree ("threadId", "runId") |
+| IDX_instance_ai_events_threadId_createdAt | CREATE INDEX "IDX_instance_ai_events_threadId_createdAt" ON public.instance_ai_events USING btree ("threadId", "createdAt") |
 | PK_12489cd6197feeac2089acc7ef6 | CREATE UNIQUE INDEX "PK_12489cd6197feeac2089acc7ef6" ON public.instance_ai_events USING btree ("threadId", seq) |
 
 ## Relations

--- a/docs/generated/sqlite-schema/instance_ai_events.md
+++ b/docs/generated/sqlite-schema/instance_ai_events.md
@@ -37,6 +37,7 @@ CREATE TABLE "instance_ai_events" ("threadId" varchar NOT NULL, "seq" integer NO
 | Name | Definition |
 | ---- | ---------- |
 | IDX_32cdd799675715fb1d2a8683e9 | CREATE INDEX "IDX_32cdd799675715fb1d2a8683e9" ON "instance_ai_events" ("threadId", "runId")  |
+| IDX_instance_ai_events_threadId_createdAt | CREATE INDEX "IDX_instance_ai_events_threadId_createdAt" ON "instance_ai_events" ("threadId", "createdAt")  |
 | sqlite_autoindex_instance_ai_events_1 | PRIMARY KEY (threadId, seq) |
 
 ## Relations

--- a/packages/@n8n/db/src/migrations/common/1787141394735-AddInstanceAiEventsCreatedAtIndex.ts
+++ b/packages/@n8n/db/src/migrations/common/1787141394735-AddInstanceAiEventsCreatedAtIndex.ts
@@ -1,0 +1,23 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const table = 'instance_ai_events';
+
+/**
+ * A paged Instance AI history read resolves which runs the page needs by
+ * filtering the thread's facts on a `createdAt` range. The table's other access
+ * paths — the `(threadId, seq)` primary key and the `(threadId, runId)` index —
+ * narrow to the thread but leave the range predicate to a scan of every event
+ * row it holds, so the read cost tracked thread length rather than page size.
+ *
+ * Mirrors the index `instance_ai_run_snapshots` already carries for the same
+ * windowed read on the snapshot side.
+ */
+export class AddInstanceAiEventsCreatedAtIndex1787141394735 implements ReversibleMigration {
+	async up({ schemaBuilder: { createIndex } }: MigrationContext) {
+		await createIndex(table, ['threadId', 'createdAt']);
+	}
+
+	async down({ schemaBuilder: { dropIndex } }: MigrationContext) {
+		await dropIndex(table, ['threadId', 'createdAt']);
+	}
+}

--- a/packages/cli/src/modules/instance-ai/entities/instance-ai-event-log-entry.entity.ts
+++ b/packages/cli/src/modules/instance-ai/entities/instance-ai-event-log-entry.entity.ts
@@ -16,6 +16,7 @@ import { InstanceAiThread } from './instance-ai-thread.entity';
  */
 @Entity({ name: 'instance_ai_events' })
 @Index(['threadId', 'runId'])
+@Index(['threadId', 'createdAt'])
 export class InstanceAiEventLogEntry extends WithTimestamps {
 	@ManyToOne(() => InstanceAiThread, { onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'threadId' })


### PR DESCRIPTION
## Summary

Adds a `(threadId, createdAt)` index to `instance_ai_events`, plus the matching `@Index` on the entity.

A paged Instance AI history read resolves which runs the page needs by filtering the thread's facts on a `createdAt` range:

```sql
SELECT DISTINCT "runId" FROM instance_ai_events
WHERE "threadId" = ? AND "createdAt" >= ? AND "createdAt" < ?
```

The table's other access paths do not serve that predicate. The `(threadId, seq)` primary key and the `(threadId, runId)` index both narrow to the thread, but neither carries `createdAt`, so the engine visits every event row the thread holds to evaluate the range. The read cost therefore tracked thread length rather than page size.

This mirrors the index `instance_ai_run_snapshots` already carries for the same windowed read on the snapshot side.

This is a deferred follow-up to #36513. Before it, a paged read loaded every event row of the thread *with its `payload` text* and JSON-parsed all of them. What remains is a payload-less scan. `instance_ai_events` is the hottest write path in the module, so INS-1220 asks for a number before the index is carried. 

## How to test

The migration is schema-only, so the behaviour to confirm is that it applies and reverts cleanly on both engines.

**SQLite**

```bash
pnpm start                 # applies AddInstanceAiEventsCreatedAtIndex1787141394735
pnpm start -- db:revert    # drops the index again
pnpm start                 # re-applies cleanly
```

**Postgres** — same three commands with `DB_TYPE=postgresdb` and the usual connection env vars.

Inspect the result:

```sql
-- Postgres
SELECT indexdef FROM pg_indexes WHERE tablename = 'instance_ai_events';
-- SQLite
SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'instance_ai_events';
```

Both should list `("threadId", "createdAt")` alongside the existing `("threadId", "runId")`. The regenerated files under `docs/generated/` show the expected output for each engine.

**Before this merges**, the measurement INS-1220 asks for: on a thread with a large event count on Postgres, compare paged history read latency with and without the index, and check the event-drain insert throughput delta. If the scan does not show up in a profile, this should be closed rather than merged - I'll test this.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-1220
- Parent: https://linear.app/n8n/issue/INS-693
- Follow-up to #36513

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Schema-only migration: no data transformation to assert. Verified by running up/down on SQLite and Postgres; the regenerated docs/generated/ diffs pin the resulting index on both engines. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

