### PR TITLE
fix(Agent Node): Show disabled reason on prompt-source option

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -1255,7 +1255,12 @@ describe('ParameterInputList', () => {
 				type: 'options',
 				default: 'auto',
 				options: [
-					{ name: 'Connected Chat Trigger Node', value: 'auto' },
+					{
+						name: 'Connected Chat Trigger Node',
+						value: 'auto',
+						description:
+							"Looks for an input field called 'chatInput' that is coming from a directly connected Chat Trigger",
+					},
 					{ name: 'Define below', value: 'define' },
 				],
 			},

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -454,9 +454,7 @@ function updateAgentParameters(parameters: INodeProperties[], nodeName: string) 
 				return {
 					...option,
 					disabled: true,
-					description:
-						option.description ??
-						i18n.baseText('parameterInputList.autoRequiresChatTriggerDescription'),
+					description: i18n.baseText('parameterInputList.autoRequiresChatTriggerDescription'),
 				};
 			}),
 		};


### PR DESCRIPTION
## Summary

The AI Agent's "Source for Prompt (User Message)" option "Connected Chat Trigger Node" shows as disabled when no Chat Trigger is upstream. The tooltip did not explain why. It showed the option's normal functional description instead.

The code already had a fallback string for this case. The fallback used `??`, and the option always ships with a non-null functional description. So the fallback never activated.

This PR makes the disabled reason always show when the option is disabled. The functional description still shows when the option is enabled.

## How to test

1. Create a new workflow.
2. Add a Manual Trigger.
3. Connect it to an AI Agent node.
4. Open the AI Agent node.
5. Open the "Source for Prompt (User Message)" dropdown.
6. Hover the "Connected Chat Trigger Node" option.
7. Confirm the tooltip reads "Available when connected to a Chat Trigger node."
8. Replace the Manual Trigger with "On chat message" (Chat Trigger).
9. Confirm the option is enabled and shows its original functional description.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5769

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

