### PR TITLE
feat(core): Add policy infrastructure module scaffold (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -31,6 +31,7 @@ describe('eligibleModules', () => {
 	it('should not include opt-in modules by default', () => {
 		const eligible = Container.get(ModuleRegistry).eligibleModules;
 		expect(eligible).not.toContain('agents');
+		expect(eligible).not.toContain('policy-infrastructure');
 	});
 
 	it('should include instance-ai by default', () => {

--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -35,6 +35,7 @@ export const MODULE_NAMES = [
 	'runtime-credentials',
 	'n8n-packages',
 	'workflow-reviews',
+	'policy-infrastructure',
 ] as const;
 
 export type ModuleName = (typeof MODULE_NAMES)[number];

--- a/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
@@ -1,0 +1,19 @@
+import type { ModuleInterface } from '@n8n/decorators';
+import { BackendModule } from '@n8n/decorators';
+
+/**
+ * Shared layer every policy feature is built on: it will register the policy
+ * enforcement implementation that runs the registered `@PolicyCheck`s.
+ *
+ * Runs on all instance types — enforcement points sit on execution paths that
+ * also run on workers and webhook processes.
+ *
+ * Opt-in via `N8N_ENABLED_MODULES=policy-infrastructure` while it is being
+ * built out; becomes a default module at GA.
+ */
+@BackendModule({ name: 'policy-infrastructure' })
+export class PolicyInfrastructureModule implements ModuleInterface {
+	async init() {
+		// Later tickets register the enforcement implementation here.
+	}
+}


### PR DESCRIPTION
## Summary

Registers a new `policy-infrastructure` backend module. This is the shared layer that later tickets in the milestone build the policy enforcement implementation on. The module is empty for now: it declares itself and does nothing else.

It is opt-in via `N8N_ENABLED_MODULES=policy-infrastructure` and is deliberately **not** in `defaultModules`, so a half-built enforcement layer is unreachable by default. Moving it into `defaultModules` and dropping the flag happens at GA, tracked separately.

Two design points taken from the [RFC](https://www.notion.so/n8n/Policy-infrastructure-39e5b6e0c94f8013a1b1c80c15433b27) rather than the ticket text:

- **No license flag.** The infrastructure layer is license-free. Only the per-feature tenant modules (node type availability and friends) are license-gated.
- **No `instanceTypes` filter.** Enforcement points sit on execution paths that also run on workers and webhook processes, so the module must init on every instance type.

## How to test

The module is off in a default instance. Enable it with the env var.

1. Start n8n with `N8N_ENABLED_MODULES=policy-infrastructure` and `N8N_LOG_LEVEL=debug`.
2. Confirm the log contains `Initialized module "policy-infrastructure"`.
3. Confirm the instance starts normally and no request path behaves differently.
4. Start n8n again without the env var.
5. Confirm the log does not mention `policy-infrastructure`, and the instance starts normally.

Both cases were verified against a real boot on this branch.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1113

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

