### PR TITLE
feat(core): Make IAI drop invalid node groups

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -603,9 +603,10 @@ first.
 
 `.group(name, members, { description })` on the workflow builder; members are the node handles.
 Read `knowledge-base/reference/node-groups.md` for the exact rules (trigger nodes excluded,
-one connected section, AI sub-nodes stay with their Agent) before creating groups — an invalid
-group is rejected on save. When editing an existing workflow, keep existing `.group(...)` calls
-and their descriptions intact unless the change is about grouping.
+one connected section, AI sub-nodes stay with their Agent) before creating groups. Agent save
+tools drop an invalid group and report a warning, so fix the source rather than re-emitting the
+same invalid group. When editing an existing workflow, keep existing `.group(...)` calls and
+their descriptions intact unless the change is about grouping.
 
 ## Workflow Rules
 

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -1,5 +1,6 @@
 import type { InstanceAiPermissions } from '@n8n/api-types';
-import { generateWorkflowCode } from '@n8n/workflow-sdk';
+import { generateWorkflowCode, type WorkflowJSON } from '@n8n/workflow-sdk';
+import { NodeConnectionTypes, type INodeTypeDescription, type INodeTypes } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 
 import { executeTool } from '../../__tests__/tool-test-utils';
@@ -104,6 +105,57 @@ function createMockContext(
 		permissions: {},
 		...overrides,
 	} as unknown as InstanceAiContext;
+}
+
+function makeWorkflowNode(
+	id: string,
+	name: string,
+	type = 'n8n-nodes-base.set',
+): WorkflowJSON['nodes'][number] {
+	return {
+		id,
+		name,
+		type,
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+}
+
+function makeNodeType(overrides: Partial<INodeTypeDescription> = {}): INodeTypeDescription {
+	return {
+		displayName: overrides.displayName ?? 'Set',
+		name: overrides.name ?? 'n8n-nodes-base.set',
+		group: overrides.group ?? ['transform'],
+		version: overrides.version ?? 1,
+		description: overrides.description ?? '',
+		defaults: overrides.defaults ?? { name: 'Set' },
+		inputs: overrides.inputs ?? [NodeConnectionTypes.Main],
+		outputs: overrides.outputs ?? [NodeConnectionTypes.Main],
+		properties: overrides.properties ?? [],
+		...overrides,
+	};
+}
+
+function makeNodeTypesProvider(): INodeTypes {
+	const descriptions: Record<string, INodeTypeDescription> = {
+		'n8n-nodes-base.set': makeNodeType(),
+		'n8n-nodes-base.manualTrigger': makeNodeType({
+			name: 'n8n-nodes-base.manualTrigger',
+			group: ['trigger'],
+		}),
+	};
+	const getByNameAndVersion = (nodeType: string) => {
+		const description = descriptions[nodeType];
+		if (!description) throw new Error('Unknown node type');
+		return { description };
+	};
+
+	return {
+		getByName: getByNameAndVersion,
+		getByNameAndVersion,
+		getKnownTypes: () => ({}),
+	};
 }
 
 function getInputSchema(tool: unknown): { safeParse: (input: unknown) => { success: boolean } } {
@@ -979,6 +1031,107 @@ describe('workflows tool', () => {
 				}),
 			);
 			expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+		});
+
+		it('drops an invalid node group, saves the workflow, and returns a coded warning', async () => {
+			const invalidGroupWorkflow: WorkflowJSON = {
+				name: 'Updated WF',
+				nodes: [makeWorkflowNode('trigger', 'Manual Trigger', 'n8n-nodes-base.manualTrigger')],
+				connections: {},
+				nodeGroups: [{ id: 'g1', name: 'Trigger group', nodeIds: ['trigger'] }],
+			};
+			const context = createMockContext({
+				permissions: { updateWorkflow: 'always_allow' },
+				nodeTypesProvider: makeNodeTypesProvider(),
+			});
+			(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue({
+				id: 'wf1',
+				versionId: 'v-updated',
+				checksum: 'checksum-updated',
+			});
+
+			const result = await executeTool<{ success: boolean; warnings?: string[] }>(
+				createWorkflowsTool(context, 'full'),
+				{ action: 'update', workflowId: 'wf1', workflow: invalidGroupWorkflow },
+				{} as never,
+			);
+
+			const savedWorkflow = (context.workflowService.updateFromWorkflowJSON as Mock).mock
+				.calls[0][1] as WorkflowJSON;
+			expect(result.success).toBe(true);
+			expect(savedWorkflow.nodeGroups).toEqual([]);
+			expect(result.warnings?.join('\n')).toContain('[NODE_GROUP_DROPPED]');
+			expect(result.warnings?.join('\n')).toContain('Trigger group');
+		});
+
+		it('saves a valid node group unchanged without returning warnings', async () => {
+			const validGroupWorkflow: WorkflowJSON = {
+				name: 'Updated WF',
+				nodes: [makeWorkflowNode('a', 'A'), makeWorkflowNode('b', 'B')],
+				connections: {
+					A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+				},
+				nodeGroups: [{ id: 'g1', name: 'Valid group', nodeIds: ['a', 'b'] }],
+			};
+			const context = createMockContext({
+				permissions: { updateWorkflow: 'always_allow' },
+				nodeTypesProvider: makeNodeTypesProvider(),
+			});
+			(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue({
+				id: 'wf1',
+				versionId: 'v-updated',
+				checksum: 'checksum-updated',
+			});
+
+			const result = await executeTool<{ success: boolean; warnings?: string[] }>(
+				createWorkflowsTool(context, 'full'),
+				{ action: 'update', workflowId: 'wf1', workflow: validGroupWorkflow },
+				{} as never,
+			);
+
+			const savedWorkflow = (context.workflowService.updateFromWorkflowJSON as Mock).mock
+				.calls[0][1] as WorkflowJSON;
+			expect(result.success).toBe(true);
+			expect(savedWorkflow.nodeGroups).toEqual([
+				{ id: 'g1', name: 'Valid group', nodeIds: ['a', 'b'] },
+			]);
+			expect(result.warnings).toBeUndefined();
+		});
+
+		it('normalizes blank and duplicate node IDs before validating node groups', async () => {
+			const workflowWithUnstableIds: WorkflowJSON = {
+				name: 'Updated WF',
+				nodes: [makeWorkflowNode('', 'A'), makeWorkflowNode('', 'B')],
+				connections: {
+					A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+				},
+				nodeGroups: [{ id: 'g1', name: 'Healed group', nodeIds: ['', ''] }],
+			};
+			const context = createMockContext({
+				permissions: { updateWorkflow: 'always_allow' },
+				nodeTypesProvider: makeNodeTypesProvider(),
+			});
+			(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue({
+				id: 'wf1',
+				versionId: 'v-updated',
+				checksum: 'checksum-updated',
+			});
+
+			const result = await executeTool<{ success: boolean; warnings?: string[] }>(
+				createWorkflowsTool(context, 'full'),
+				{ action: 'update', workflowId: 'wf1', workflow: workflowWithUnstableIds },
+				{} as never,
+			);
+
+			const savedWorkflow = (context.workflowService.updateFromWorkflowJSON as Mock).mock
+				.calls[0][1] as WorkflowJSON;
+			expect(result.success).toBe(true);
+			expect(savedWorkflow.nodeGroups).toHaveLength(1);
+			expect(savedWorkflow.nodeGroups?.[0]?.nodeIds).toEqual(
+				savedWorkflow.nodes.map((node) => node.id),
+			);
+			expect(savedWorkflow.nodeGroups?.[0]?.nodeIds).not.toContain('');
+			expect(result.warnings).toBeUndefined();
 		});
 
 		describe('stale-save detection', () => {

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -1064,6 +1064,27 @@ describe('workflows tool', () => {
 			expect(result.warnings?.join('\n')).toContain('Trigger group');
 		});
 
+		it('returns an error instead of throwing when raw update nodes are malformed', async () => {
+			const context = createMockContext({
+				permissions: { updateWorkflow: 'always_allow' },
+				nodeTypesProvider: makeNodeTypesProvider(),
+			});
+
+			const result = await executeTool<{ success: boolean; error?: string }>(
+				createWorkflowsTool(context, 'full'),
+				{
+					action: 'update',
+					workflowId: 'wf1',
+					workflow: { name: 'Updated WF', nodes: [null], connections: {} },
+				},
+				{} as never,
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Cannot read');
+			expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+		});
+
 		it('saves a valid node group unchanged without returning warnings', async () => {
 			const validGroupWorkflow: WorkflowJSON = {
 				name: 'Updated WF',

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -19,6 +19,7 @@ import {
 	TEMPLATABLE_PLAIN_AUTH_TYPES,
 } from './credentials.tool';
 import { formatTimestamp } from '../utils/format-timestamp';
+import { dropInvalidNodeGroups } from './workflows/node-group-validation';
 import {
 	getObservedWorkflowChecksum,
 	rememberCurrentWorkflowChecksum,
@@ -52,9 +53,10 @@ import { validateWorkflowConfig } from './workflows/validate-workflow.service';
 import {
 	grantSessionWorkflowUpdate,
 	canSkipWorkflowUpdateHitl,
+	formatWarning,
 } from './workflows/workflow-build-context';
 import { refreshWorkflowSourceFileBindingFromWorkflow } from './workflows/workflow-file-bindings';
-import { getReferencedWorkflowIds } from './workflows/workflow-json-utils';
+import { ensureUniqueNodeIds, getReferencedWorkflowIds } from './workflows/workflow-json-utils';
 
 // ── Action schemas ──────────────────────────────────────────────────────────
 
@@ -1278,6 +1280,9 @@ async function handleUpdate(
 		};
 	}
 
+	ensureUniqueNodeIds(input.workflow);
+	const droppedGroups = dropInvalidNodeGroups(input.workflow, context);
+
 	// Guard against overwriting a save this conversation never saw (canvas
 	// autosave, another user, another thread). Absent when the agent never read
 	// the workflow here — then there is nothing to pin the save to.
@@ -1295,7 +1300,13 @@ async function handleUpdate(
 		if (saved.checksum) {
 			await rememberObservedWorkflowChecksum(context, input.workflowId, saved.checksum);
 		}
-		return { success: true, workflowId: input.workflowId };
+		return {
+			success: true,
+			workflowId: input.workflowId,
+			...(droppedGroups.length > 0
+				? { warnings: droppedGroups.map((w) => formatWarning(w.code, w.message)) }
+				: {}),
+		};
 	} catch (error) {
 		if (error instanceof WorkflowSaveConflictError) {
 			return {

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -1280,15 +1280,14 @@ async function handleUpdate(
 		};
 	}
 
-	ensureUniqueNodeIds(input.workflow);
-	const droppedGroups = dropInvalidNodeGroups(input.workflow, context);
-
 	// Guard against overwriting a save this conversation never saw (canvas
 	// autosave, another user, another thread). Absent when the agent never read
 	// the workflow here — then there is nothing to pin the save to.
 	const expectedChecksum = await getObservedWorkflowChecksum(context, input.workflowId);
 
 	try {
+		ensureUniqueNodeIds(input.workflow);
+		const droppedGroups = dropInvalidNodeGroups(input.workflow, context);
 		const saved = expectedChecksum
 			? await context.workflowService.updateFromWorkflowJSON(input.workflowId, input.workflow, {
 					expectedChecksum,

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -1,3 +1,6 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import { NodeConnectionTypes, type INodeTypeDescription, type INodeTypes } from 'n8n-workflow';
+
 import { executeTool } from '../../../__tests__/tool-test-utils';
 import { WorkflowNotFoundError } from '../../../errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../../errors/workflow-save-conflict.error';
@@ -46,6 +49,57 @@ const generatedWorkflow = {
 	],
 	connections: {},
 };
+
+function makeWorkflowNode(
+	id: string,
+	name: string,
+	type = 'n8n-nodes-base.set',
+): WorkflowJSON['nodes'][number] {
+	return {
+		id,
+		name,
+		type,
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+}
+
+function makeNodeType(overrides: Partial<INodeTypeDescription> = {}): INodeTypeDescription {
+	return {
+		displayName: overrides.displayName ?? 'Set',
+		name: overrides.name ?? 'n8n-nodes-base.set',
+		group: overrides.group ?? ['transform'],
+		version: overrides.version ?? 1,
+		description: overrides.description ?? '',
+		defaults: overrides.defaults ?? { name: 'Set' },
+		inputs: overrides.inputs ?? [NodeConnectionTypes.Main],
+		outputs: overrides.outputs ?? [NodeConnectionTypes.Main],
+		properties: overrides.properties ?? [],
+		...overrides,
+	};
+}
+
+function makeNodeTypesProvider(): INodeTypes {
+	const descriptions: Record<string, INodeTypeDescription> = {
+		'n8n-nodes-base.set': makeNodeType(),
+		'n8n-nodes-base.manualTrigger': makeNodeType({
+			name: 'n8n-nodes-base.manualTrigger',
+			group: ['trigger'],
+		}),
+	};
+	const getByNameAndVersion = (nodeType: string) => {
+		const description = descriptions[nodeType];
+		if (!description) throw new Error('Unknown node type');
+		return { description };
+	};
+
+	return {
+		getByName: getByNameAndVersion,
+		getByNameAndVersion,
+		getKnownTypes: () => ({}),
+	};
+}
 
 vi.mock('../workflow-source-compiler', () => ({
 	compileWorkflowSource: vi.fn(),
@@ -288,6 +342,73 @@ describe('createBuildWorkflowTool', () => {
 			workflowVersionId: 'v-1',
 			sourceHash: hashWorkflowSource(source),
 		});
+	});
+
+	it('drops an invalid node group and still saves the workflow', async () => {
+		const workflow: WorkflowJSON = {
+			name: 'Grouped workflow',
+			nodes: [makeWorkflowNode('trigger', 'Manual Trigger', 'n8n-nodes-base.manualTrigger')],
+			connections: {},
+			nodeGroups: [{ id: 'g1', name: 'Trigger group', nodeIds: ['trigger'] }],
+		};
+		vi.mocked(compileWorkflowSource).mockResolvedValueOnce({
+			success: true,
+			workflow,
+			warnings: [],
+			compiler: 'sandbox-tsx',
+		});
+		const { context, filePath } = makeContext({
+			source: 'workflow source with groups',
+			overrides: { nodeTypesProvider: makeNodeTypesProvider() },
+		});
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			name: 'Grouped workflow',
+		});
+
+		const savedWorkflow = vi.mocked(context.workflowService.createFromWorkflowJSON).mock
+			.calls[0][0];
+		expect(result.success).toBe(true);
+		expect(savedWorkflow.nodeGroups).toEqual([]);
+		expect(result.warnings?.join('\n')).toContain('[NODE_GROUP_DROPPED]');
+		expect(result.warnings?.join('\n')).toContain('Trigger group');
+	});
+
+	it('validates node groups after blank node IDs are normalized', async () => {
+		const workflow: WorkflowJSON = {
+			name: 'Grouped workflow',
+			nodes: [makeWorkflowNode('', 'A'), makeWorkflowNode('', 'B')],
+			connections: {
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			},
+			nodeGroups: [{ id: 'g1', name: 'Healed group', nodeIds: ['', ''] }],
+		};
+		vi.mocked(compileWorkflowSource).mockResolvedValueOnce({
+			success: true,
+			workflow,
+			warnings: [],
+			compiler: 'sandbox-tsx',
+		});
+		const { context, filePath } = makeContext({
+			source: 'workflow source with blank ids',
+			overrides: { nodeTypesProvider: makeNodeTypesProvider() },
+		});
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			name: 'Grouped workflow',
+		});
+
+		const savedWorkflow = vi.mocked(context.workflowService.createFromWorkflowJSON).mock
+			.calls[0][0];
+		expect(result.success).toBe(true);
+		expect(savedWorkflow.nodeGroups).toHaveLength(1);
+		expect(savedWorkflow.nodeGroups?.[0]?.nodeIds).toEqual(
+			savedWorkflow.nodes.map((node) => node.id),
+		);
+		expect(savedWorkflow.nodeGroups?.[0]?.nodeIds).not.toContain('');
+		expect(result.warnings?.join('\n') ?? '').not.toContain('NODE_GROUP_DROPPED');
 	});
 
 	it('hands one-off builds to the one-off-operations skill with optional verification', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/node-group-validation.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/node-group-validation.test.ts
@@ -1,0 +1,278 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import {
+	jsonParse,
+	NodeConnectionTypes,
+	type INodeTypeDescription,
+	type INodeTypes,
+} from 'n8n-workflow';
+
+import type { InstanceAiContext } from '../../../types';
+import { dropInvalidNodeGroups } from '../node-group-validation';
+import { partitionWarnings } from '../workflow-validation-warnings';
+
+function makeNodeType(overrides: Partial<INodeTypeDescription> = {}): INodeTypeDescription {
+	return {
+		displayName: overrides.displayName ?? 'Set',
+		name: overrides.name ?? 'n8n-nodes-base.set',
+		group: overrides.group ?? ['transform'],
+		version: overrides.version ?? 1,
+		description: overrides.description ?? '',
+		defaults: overrides.defaults ?? { name: 'Set' },
+		inputs: overrides.inputs ?? [NodeConnectionTypes.Main],
+		outputs: overrides.outputs ?? [NodeConnectionTypes.Main],
+		properties: overrides.properties ?? [],
+		...overrides,
+	};
+}
+
+function makeNode(
+	id: string,
+	name: string,
+	type = 'n8n-nodes-base.set',
+): WorkflowJSON['nodes'][number] {
+	return {
+		id,
+		name,
+		type,
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+}
+
+function makeWorkflow(
+	nodes: WorkflowJSON['nodes'],
+	connections: WorkflowJSON['connections'] = {},
+	nodeGroups?: WorkflowJSON['nodeGroups'],
+): WorkflowJSON {
+	return {
+		name: 'Test workflow',
+		nodes,
+		connections,
+		...(nodeGroups ? { nodeGroups } : {}),
+	};
+}
+
+function makeNodeTypesProvider(): INodeTypes {
+	const descriptions: Record<string, INodeTypeDescription> = {
+		'n8n-nodes-base.set': makeNodeType(),
+		'n8n-nodes-base.manualTrigger': makeNodeType({
+			name: 'n8n-nodes-base.manualTrigger',
+			group: ['trigger'],
+		}),
+		'@n8n/n8n-nodes-langchain.agent': makeNodeType({
+			name: '@n8n/n8n-nodes-langchain.agent',
+		}),
+		'@n8n/n8n-nodes-langchain.lmChatOpenAi': makeNodeType({
+			name: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+		}),
+	};
+
+	const getByNameAndVersion = (nodeType: string) => {
+		const description = descriptions[nodeType];
+		if (!description) throw new Error('Unknown node type');
+		return { description };
+	};
+
+	return {
+		getByName: getByNameAndVersion,
+		getByNameAndVersion,
+		getKnownTypes: () => ({}),
+	};
+}
+
+function makeContext(nodeTypesProvider?: INodeTypes): InstanceAiContext {
+	return { nodeTypesProvider } as InstanceAiContext;
+}
+
+const context = makeContext(makeNodeTypesProvider());
+
+describe('dropInvalidNodeGroups', () => {
+	it('returns no warnings and leaves the workflow untouched when nodeGroups is missing', () => {
+		const json = makeWorkflow([makeNode('a', 'A')]);
+		const before = structuredClone(json);
+
+		expect(dropInvalidNodeGroups(json, context)).toEqual([]);
+		expect(json).toEqual(before);
+	});
+
+	it('returns no warnings and keeps valid groups untouched', () => {
+		const nodeGroups = [{ id: 'g1', name: 'Valid group', nodeIds: ['a', 'b'] }];
+		const json = makeWorkflow(
+			[makeNode('a', 'A'), makeNode('b', 'B')],
+			{
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			},
+			nodeGroups,
+		);
+
+		expect(dropInvalidNodeGroups(json, context)).toEqual([]);
+		expect(json.nodeGroups).toBe(nodeGroups);
+		expect(json.nodeGroups).toEqual([{ id: 'g1', name: 'Valid group', nodeIds: ['a', 'b'] }]);
+	});
+
+	it('drops a group containing a trigger node', () => {
+		const json = makeWorkflow(
+			[makeNode('trigger', 'Manual Trigger', 'n8n-nodes-base.manualTrigger')],
+			{},
+			[{ id: 'g1', name: 'Trigger group', nodeIds: ['trigger'] }],
+		);
+
+		const warnings = dropInvalidNodeGroups(json, context);
+
+		expect(json.nodeGroups).toEqual([]);
+		expect(warnings).toEqual([
+			expect.objectContaining({
+				code: 'NODE_GROUP_DROPPED',
+				severity: 'informational',
+			}),
+		]);
+		expect(warnings[0]?.message).toContain('cannot contain trigger nodes: Manual Trigger.');
+	});
+
+	it('drops a group spanning disconnected graph islands', () => {
+		const json = makeWorkflow(
+			[makeNode('a', 'A'), makeNode('b', 'B'), makeNode('c', 'C')],
+			{
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			},
+			[{ id: 'g1', name: 'Disconnected group', nodeIds: ['a', 'c'] }],
+		);
+
+		const warnings = dropInvalidNodeGroups(json, context);
+
+		expect(json.nodeGroups).toEqual([]);
+		expect(warnings[0]?.message).toContain(
+			'must form a single connected subgraph with a single entry and exit',
+		);
+	});
+
+	it('drops a group that splits an AI Agent from its sub-node', () => {
+		const json = makeWorkflow(
+			[
+				makeNode('agent', 'Agent', '@n8n/n8n-nodes-langchain.agent'),
+				makeNode('model', 'Model', '@n8n/n8n-nodes-langchain.lmChatOpenAi'),
+			],
+			{
+				Agent: {
+					[NodeConnectionTypes.AiLanguageModel]: [
+						[{ node: 'Model', type: NodeConnectionTypes.AiLanguageModel, index: 0 }],
+					],
+				},
+			},
+			[{ id: 'g1', name: 'Agent group', nodeIds: ['agent'] }],
+		);
+
+		const warnings = dropInvalidNodeGroups(json, context);
+
+		expect(json.nodeGroups).toEqual([]);
+		expect(warnings[0]?.message).toContain(
+			'cannot cross the "ai_languageModel" connection between "Agent" and "Model"',
+		);
+	});
+
+	it('drops only invalid groups when valid and invalid groups are present', () => {
+		const json = makeWorkflow(
+			[
+				makeNode('a', 'A'),
+				makeNode('b', 'B'),
+				makeNode('trigger', 'Manual Trigger', 'n8n-nodes-base.manualTrigger'),
+			],
+			{
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			},
+			[
+				{ id: 'valid', name: 'Valid group', nodeIds: ['a', 'b'] },
+				{ id: 'invalid', name: 'Trigger group', nodeIds: ['trigger'] },
+			],
+		);
+
+		const warnings = dropInvalidNodeGroups(json, context);
+
+		expect(json.nodeGroups).toEqual([{ id: 'valid', name: 'Valid group', nodeIds: ['a', 'b'] }]);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]?.message).toContain('Trigger group');
+	});
+
+	it('runs basic checks without a nodeTypesProvider but skips trigger checks', () => {
+		const basicInvalid = makeWorkflow([makeNode('a', 'A')], {}, [
+			{ id: 'g1', name: 'Unknown node group', nodeIds: ['missing'] },
+		]);
+		const triggerGroup = makeWorkflow(
+			[makeNode('trigger', 'Manual Trigger', 'n8n-nodes-base.manualTrigger')],
+			{},
+			[{ id: 'g1', name: 'Trigger group', nodeIds: ['trigger'] }],
+		);
+
+		expect(dropInvalidNodeGroups(basicInvalid, makeContext())).toHaveLength(1);
+		expect(basicInvalid.nodeGroups).toEqual([]);
+		expect(dropInvalidNodeGroups(triggerGroup, makeContext())).toEqual([]);
+		expect(triggerGroup.nodeGroups).toEqual([
+			{ id: 'g1', name: 'Trigger group', nodeIds: ['trigger'] },
+		]);
+	});
+
+	it('returns informational warnings that partition as non-blocking', () => {
+		const json = makeWorkflow(
+			[makeNode('trigger', 'Manual Trigger', 'n8n-nodes-base.manualTrigger')],
+			{},
+			[{ id: 'g1', name: 'Trigger group', nodeIds: ['trigger'] }],
+		);
+
+		const warnings = dropInvalidNodeGroups(json, context);
+
+		expect(warnings).toEqual([expect.objectContaining({ severity: 'informational' })]);
+		expect(partitionWarnings(warnings)).toEqual({ blocking: [], informational: warnings });
+	});
+
+	it('detects a non-main boundary connection through the SDK connection bridge', () => {
+		const json = makeWorkflow(
+			[makeNode('a', 'A'), makeNode('b', 'B')],
+			{
+				A: {
+					[NodeConnectionTypes.AiTool]: [
+						[{ node: 'B', type: NodeConnectionTypes.AiTool, index: 0 }],
+					],
+				},
+			},
+			[{ id: 'g1', name: 'Tool boundary group', nodeIds: ['a'] }],
+		);
+
+		const warnings = dropInvalidNodeGroups(json, context);
+
+		expect(json.nodeGroups).toEqual([]);
+		expect(warnings[0]?.message).toContain(
+			'cannot cross the "ai_tool" connection between "A" and "B"',
+		);
+	});
+
+	it('skips unknown connection types instead of throwing', () => {
+		const json = makeWorkflow(
+			[makeNode('a', 'A'), makeNode('b', 'B')],
+			{
+				A: {
+					unknown: [[{ node: 'B', type: 'unknown', index: 0 }]],
+				},
+			},
+			[{ id: 'g1', name: 'Unknown connection group', nodeIds: ['a'] }],
+		);
+
+		expect(dropInvalidNodeGroups(json, context)).toEqual([]);
+		expect(json.nodeGroups).toEqual([
+			{ id: 'g1', name: 'Unknown connection group', nodeIds: ['a'] },
+		]);
+	});
+
+	it('skips __proto__ connection keys without polluting plain objects', () => {
+		const connections = jsonParse<WorkflowJSON['connections']>(
+			'{"A":{"__proto__":[[{"node":"B","type":"ai_tool","index":0}]]},"__proto__":{"main":[[{"node":"B","type":"main","index":0}]]}}',
+		);
+		const json = makeWorkflow([makeNode('a', 'A'), makeNode('b', 'B')], connections, [
+			{ id: 'g1', name: 'Unsafe key group', nodeIds: ['a'] },
+		]);
+
+		expect(dropInvalidNodeGroups(json, context)).toEqual([]);
+		expect({}).not.toHaveProperty(NodeConnectionTypes.Main);
+		expect(json.nodeGroups).toEqual([{ id: 'g1', name: 'Unsafe key group', nodeIds: ['a'] }]);
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/node-group-validation.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/node-group-validation.test.ts
@@ -194,6 +194,18 @@ describe('dropInvalidNodeGroups', () => {
 		expect(warnings[0]?.message).toContain('Trigger group');
 	});
 
+	it('returns one warning per dropped group when a group has multiple violations', () => {
+		const json = makeWorkflow([makeNode('a', 'A')], {}, [
+			{ id: 'g1', name: 'Missing nodes group', nodeIds: ['missing-1', 'missing-2'] },
+		]);
+
+		const warnings = dropInvalidNodeGroups(json, context);
+
+		expect(json.nodeGroups).toEqual([]);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]?.message).toContain('missing-1');
+	});
+
 	it('runs basic checks without a nodeTypesProvider but skips trigger checks', () => {
 		const basicInvalid = makeWorkflow([makeNode('a', 'A')], {}, [
 			{ id: 'g1', name: 'Unknown node group', nodeIds: ['missing'] },

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 
 import { computeChatModelValidationIssues } from './chat-model-validation';
+import { dropInvalidNodeGroups } from './node-group-validation';
 import { planVerificationSimulation } from './plan-verification-simulation';
 import { preserveExistingNodePositions } from './preserve-node-positions';
 import {
@@ -1021,6 +1022,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				await ensureWebhookIds(json, targetWorkflowId, context);
 				await preserveExistingNodeGroupIds(json, targetWorkflowId, context);
 				await preserveExistingNodePositions(json, targetWorkflowId, context);
+				informational.push(...dropInvalidNodeGroups(json, context));
 
 				if (await hasLostAllSavedNodeIds(json, targetWorkflowId, context)) {
 					context.logger.debug('Build kept none of the saved node ids', {

--- a/packages/@n8n/instance-ai/src/tools/workflows/node-group-validation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/node-group-validation.ts
@@ -1,0 +1,81 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import {
+	isNodeConnectionType,
+	isSafeObjectProperty,
+	makeGetNodeTypeForGrouping,
+	validateWorkflowGroups,
+	type IConnections,
+	type INode,
+	type INodeConnections,
+} from 'n8n-workflow';
+
+import type { ValidationWarning } from './workflow-validation-warnings';
+import type { InstanceAiContext } from '../../types';
+
+export const NODE_GROUP_DROPPED_CODE = 'NODE_GROUP_DROPPED';
+
+function toValidationNodes(nodes: WorkflowJSON['nodes']): INode[] {
+	return nodes.map((node) => ({
+		id: node.id,
+		name: node.name ?? '',
+		type: node.type,
+		typeVersion: node.typeVersion,
+		position: node.position,
+		parameters: {},
+	}));
+}
+
+function toWorkflowConnections(connections: WorkflowJSON['connections']): IConnections {
+	const bySourceNode: IConnections = {};
+
+	for (const [sourceNode, byType] of Object.entries(connections ?? {})) {
+		if (!isSafeObjectProperty(sourceNode)) continue;
+
+		const nodeConnections: INodeConnections = {};
+		for (const [connectionType, outputs] of Object.entries(byType)) {
+			if (!isSafeObjectProperty(connectionType)) continue;
+
+			nodeConnections[connectionType] = outputs.map(
+				(outputConnections) =>
+					outputConnections?.flatMap((connection) =>
+						isNodeConnectionType(connection.type) ? [{ ...connection, type: connection.type }] : [],
+					) ?? null,
+			);
+		}
+
+		bySourceNode[sourceNode] = nodeConnections;
+	}
+
+	return bySourceNode;
+}
+
+/**
+ * Drops every group that breaks the structural grouping rules, mutating
+ * `json.nodeGroups`, and returns one informational warning per dropped group.
+ */
+export function dropInvalidNodeGroups(
+	json: WorkflowJSON,
+	context: InstanceAiContext,
+): ValidationWarning[] {
+	if (!json.nodeGroups?.length) return [];
+
+	const result = validateWorkflowGroups({
+		nodes: toValidationNodes(json.nodes ?? []),
+		connectionsBySourceNode: toWorkflowConnections(json.connections),
+		nodeGroups: json.nodeGroups,
+		getNodeType: context.nodeTypesProvider
+			? makeGetNodeTypeForGrouping(context.nodeTypesProvider)
+			: null,
+	});
+
+	if (result.valid) return [];
+
+	const droppedGroupIds = new Set(result.violations.map((violation) => violation.groupId));
+	json.nodeGroups = json.nodeGroups.filter((group) => !droppedGroupIds.has(group.id));
+
+	return result.violations.map((violation) => ({
+		code: NODE_GROUP_DROPPED_CODE,
+		severity: 'informational',
+		message: `Node group "${violation.groupName}" was removed from the saved workflow: ${violation.message}`,
+	}));
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/node-group-validation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/node-group-validation.ts
@@ -35,6 +35,8 @@ function toWorkflowConnections(connections: WorkflowJSON['connections']): IConne
 		for (const [connectionType, outputs] of Object.entries(byType)) {
 			if (!isSafeObjectProperty(connectionType)) continue;
 
+			// SDK connection types are plain strings. Re-key known values into
+			// n8n-workflow's type union and skip unsafe object keys from raw JSON.
 			nodeConnections[connectionType] = outputs.map(
 				(outputConnections) =>
 					outputConnections?.flatMap((connection) =>
@@ -70,10 +72,17 @@ export function dropInvalidNodeGroups(
 
 	if (result.valid) return [];
 
-	const droppedGroupIds = new Set(result.violations.map((violation) => violation.groupId));
+	const firstViolationByGroupId = new Map<string, (typeof result.violations)[number]>();
+	for (const violation of result.violations) {
+		if (!firstViolationByGroupId.has(violation.groupId)) {
+			firstViolationByGroupId.set(violation.groupId, violation);
+		}
+	}
+
+	const droppedGroupIds = new Set(firstViolationByGroupId.keys());
 	json.nodeGroups = json.nodeGroups.filter((group) => !droppedGroupIds.has(group.id));
 
-	return result.violations.map((violation) => ({
+	return Array.from(firstViolationByGroupId.values()).map((violation) => ({
 		code: NODE_GROUP_DROPPED_CODE,
 		severity: 'informational',
 		message: `Node group "${violation.groupName}" was removed from the saved workflow: ${violation.message}`,

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -114,6 +114,12 @@ describe('NODE_GROUPS_REFERENCE', () => {
 		expect(NODE_GROUPS_REFERENCE).toMatch(/keep the .+ and their descriptions\s+intact/is);
 	});
 
+	it('tells agents invalid groups are dropped with warnings and source should be fixed', () => {
+		expect(NODE_GROUPS_REFERENCE).toMatch(/drop an invalid group.+report a warning/is);
+		expect(NODE_GROUPS_REFERENCE).toMatch(/fix the source.+not re-emitted/is);
+		expect(NODE_GROUPS_REFERENCE).not.toContain('rejected on save');
+	});
+
 	it('states the single entry/exit boundary rule that grouping enforces', () => {
 		// reason: 'invalid-subgraph' — grouping rejects a group with more than one
 		// incoming or outgoing main connection (single entry/exit *boundary*).

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -106,8 +106,9 @@ sentence — anything past ${GROUP_DESCRIPTION_MAX_LENGTH} characters is cut off
 When editing an existing workflow, **keep the \`.group(...)\` calls and their descriptions
 intact** unless the change is specifically about grouping.
 
-An invalid group is rejected on save, so these following rules MUST be followed when
-creating or editing groups.
+Agent save tools drop an invalid group from the saved workflow and report a warning.
+Fix the source so the invalid group is not re-emitted. These rules MUST be followed
+when creating or editing groups.
 
 Rules:
 ${renderRulesLines()}

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -13,9 +13,8 @@ import {
 	summarizeDynamicCredentialsUsage,
 	validateWorkflowGroups,
 	type IDataObject,
-	type INode,
+	type GetNodeTypeForGrouping,
 	type INodeCredentialsDetails,
-	type INodeTypeDescription,
 	type INodeTypes,
 	type IRun,
 	type ITaskData,
@@ -32,6 +31,8 @@ import { VariablesService } from '@/environments.ee/variables/variables.service.
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 import { OwnershipService } from './services/ownership.service';
+
+export { makeGetNodeTypeForGrouping } from 'n8n-workflow';
 
 /**
  * Validates that pinned data does not exceed size limits.
@@ -144,27 +145,6 @@ export function resolveNodeWebhookIds(workflow: IWorkflowBase, nodeTypes: INodeT
 			// node type not found, skip
 		}
 	}
-}
-
-/**
- * Resolves a node to its type description, or `null` for unknown node types.
- * Used by the grouping validator to detect trigger nodes.
- */
-type GetNodeTypeForGrouping = (node: INode) => INodeTypeDescription | null;
-
-/**
- * Builds the `getNodeType` callback that the grouping validator needs to resolve
- * a node to its type description (used to detect trigger nodes). Returns `null`
- * for unknown node types so validation degrades gracefully rather than throwing.
- */
-export function makeGetNodeTypeForGrouping(nodeTypes: INodeTypes): GetNodeTypeForGrouping {
-	return (node: INode) => {
-		try {
-			return nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
-		} catch {
-			return null;
-		}
-	};
 }
 
 /**

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -13,6 +13,7 @@ import {
 	type INodeInputConfiguration,
 	type INodeOutputConfiguration,
 	type INodeTypeDescription,
+	type INodeTypes,
 	type IWorkflowGroup,
 	type NodeConnectionType,
 } from './interfaces';
@@ -20,6 +21,8 @@ import { isTriggerNode } from './node-helpers';
 
 type NodeIo = NodeConnectionType | INodeInputConfiguration | INodeOutputConfiguration;
 type IODirection = 'inputs' | 'outputs';
+
+export type GetNodeTypeForGrouping = (node: INode) => INodeTypeDescription | null;
 
 /** Character cap on a node group description; keeps it within 3 lines in the collapsed panel. */
 export const GROUP_DESCRIPTION_MAX_LENGTH = 145;
@@ -102,6 +105,20 @@ export const NODE_GROUPING_RULES = {
 		violation: 'contains nodes that already belong to another group',
 	},
 } as const;
+
+/**
+ * Builds the `getNodeType` callback that the grouping validator needs. Returns
+ * `null` for unknown node types so validation degrades gracefully.
+ */
+export function makeGetNodeTypeForGrouping(nodeTypes: INodeTypes): GetNodeTypeForGrouping {
+	return (node: INode) => {
+		try {
+			return nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+		} catch {
+			return null;
+		}
+	};
+}
 
 export function validateNodeSelectionForExtraction<TNode extends INode>(
 	input: NodeGroupingValidationInput<TNode>,

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -1,5 +1,6 @@
 import {
 	GROUP_DESCRIPTION_MAX_LENGTH,
+	makeGetNodeTypeForGrouping,
 	normalizeGroupDescription,
 	validateNodeSelectionForExtraction,
 	validateNodeSelectionForGrouping,
@@ -10,6 +11,7 @@ import {
 	STICKY_NODE_TYPE,
 	type IConnections,
 	type INode,
+	type INodeTypes,
 	type INodeTypeDescription,
 } from '../src';
 
@@ -579,6 +581,26 @@ describe('normalizeGroupDescription', () => {
 		['null', null],
 	])('drops a non-string value (%s)', (_label, value) => {
 		expect(normalizeGroupDescription(value)).toBeUndefined();
+	});
+});
+
+describe('makeGetNodeTypeForGrouping', () => {
+	it('returns a node type description for known node types and null for unknown ones', () => {
+		const description = makeNodeType();
+		const nodeTypes: INodeTypes = {
+			getByName: () => {
+				throw new Error('Unknown node type');
+			},
+			getByNameAndVersion: (nodeType) => {
+				if (nodeType === description.name) return { description };
+				throw new Error('Unknown node type');
+			},
+			getKnownTypes: () => ({}),
+		};
+		const getNodeType = makeGetNodeTypeForGrouping(nodeTypes);
+
+		expect(getNodeType(makeNode({ type: description.name }))).toBe(description);
+		expect(getNodeType(makeNode({ type: 'n8n-nodes-base.unknown' }))).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary

This PR validates Instance AI `nodeGroups` before workflow saves.

- Reuse the shared node group validator from `n8n-workflow`. Instance AI now drops groups that break grouping rules and returns an informational warning instead of failing the whole build.
- Move the `INodeTypes` adapter for group validation into `n8n-workflow`, so Instance AI and CLI/MCP can use the same helper.
- Update the builder guidance to tell agents that invalid groups are dropped with warnings, and that they should fix the source instead of re-emitting the same group.

Before:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/1c3a82ab-5953-4522-8b63-3f19052ac7ac" />

After:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/c2b69d1e-5fc8-4c97-9574-0988fc9bddb3" />

## How to test

Use this prompt:

```
Build a workflow that starts with a Manual Trigger and then fans out into two parallel branches.

  Branch 1 prepares a customer record with a Set node, then formats it with another Set node.
  Branch 2 prepares an invoice record with a Set node, then formats it with another Set node.
  Then merge the branches and create a final summary Set node.

  Please make the canvas readable with node groups by business function:
  - "Prepare records" should contain the two prepare Set nodes from both branches.
  - "Format records" should contain the two format Set nodes from both branches.
  - "Final summary" should contain the merge and summary nodes.
 ```

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/ADO-5806

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

