### PR TITLE
ci: Set up Buildx builder for `node-pc` publish

### DIFF
--- a/.github/workflows/build-node-pc-image.yml
+++ b/.github/workflows/build-node-pc-image.yml
@@ -44,6 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Login to Docker registries (for pushing)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true)
         uses: ./.github/actions/docker-registry-login


### PR DESCRIPTION
## Summary

The `n8nio/node-pc` image has never been published! Runs of its workflow fail with `Attestation is not supported for the docker driver` ([Aug 11](https://github.com/n8n-io/n8n/actions/runs/31482351294), [Aug 14](https://github.com/n8n-io/n8n/actions/runs/31792891081)). Hence let's add the same `docker/setup-buildx-action` step that `docker-build-push.yml` already uses.

## Related Linear tickets, Github issues, and Community forum posts

https://app.notion.com/p/n8n/Halving-memory-usage-via-pointer-compression-3ac5b6e0c94f8005af87e93a9f837b53

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)