### PR TITLE
test: Stabilize Instance AI execute-step e2e against in-progress builds (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/InstanceAiPage.ts
+++ b/packages/testing/playwright/pages/InstanceAiPage.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
 import { BasePage } from './BasePage';
+import { hoverToReveal } from '../utils/retry-utils';
 import { CredentialModal } from './components/CredentialModal';
 import { InstanceAiSidebar } from './components/InstanceAiSidebar';
 import { InstanceAiWorkflowSetup } from './components/InstanceAiWorkflowSetup';
@@ -417,21 +418,12 @@ export class InstanceAiPage extends BasePage {
 
 	/**
 	 * The "Execute step" toolbar button only renders once the AI build has
-	 * finished, and mid-stream canvas re-renders can dismiss an open toolbar.
-	 * Poll with a re-hover on every attempt instead of a single hover + wait.
+	 * finished, and mid-stream canvas re-renders can dismiss an open toolbar,
+	 * so reveal it with a re-hovering poll.
 	 */
 	async executePreviewNodeByName(nodeName: string): Promise<void> {
-		const node = this.getPreviewNodeByName(nodeName);
 		const executeNodeButton = this.getPreviewExecuteNodeButton(nodeName);
-		await expect
-			.poll(
-				async () => {
-					await node.hover();
-					return await executeNodeButton.isVisible().catch(() => false);
-				},
-				{ intervals: [500, 1_000, 2_000], timeout: 10_000 },
-			)
-			.toBe(true);
+		await hoverToReveal(this.getPreviewNodeByName(nodeName), executeNodeButton);
 		await executeNodeButton.dispatchEvent('click');
 	}
 

--- a/packages/testing/playwright/pages/InstanceAiPage.ts
+++ b/packages/testing/playwright/pages/InstanceAiPage.ts
@@ -429,7 +429,7 @@ export class InstanceAiPage extends BasePage {
 					await node.hover();
 					return await executeNodeButton.isVisible().catch(() => false);
 				},
-				{ intervals: [500, 1_000, 2_000], timeout: 30_000 },
+				{ intervals: [500, 1_000, 2_000], timeout: 10_000 },
 			)
 			.toBe(true);
 		await executeNodeButton.dispatchEvent('click');

--- a/packages/testing/playwright/pages/InstanceAiPage.ts
+++ b/packages/testing/playwright/pages/InstanceAiPage.ts
@@ -415,9 +415,23 @@ export class InstanceAiPage extends BasePage {
 		return this.getPreviewNodeByName(nodeName).getByRole('button', { name: 'Execute step' });
 	}
 
+	/**
+	 * The "Execute step" toolbar button only renders once the AI build has
+	 * finished, and mid-stream canvas re-renders can dismiss an open toolbar.
+	 * Poll with a re-hover on every attempt instead of a single hover + wait.
+	 */
 	async executePreviewNodeByName(nodeName: string): Promise<void> {
+		const node = this.getPreviewNodeByName(nodeName);
 		const executeNodeButton = this.getPreviewExecuteNodeButton(nodeName);
-		await executeNodeButton.waitFor({ state: 'visible', timeout: 5_000 });
+		await expect
+			.poll(
+				async () => {
+					await node.hover();
+					return await executeNodeButton.isVisible().catch(() => false);
+				},
+				{ intervals: [500, 1_000, 2_000], timeout: 30_000 },
+			)
+			.toBe(true);
 		await executeNodeButton.dispatchEvent('click');
 	}
 

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-sidebar.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-sidebar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, instanceAiTestConfig } from './fixtures';
+import { hoverToReveal } from '../../../utils/retry-utils';
 
 test.use(instanceAiTestConfig);
 test.describe(
@@ -100,9 +101,8 @@ test.describe(
 			const threadCountBefore = await n8n.instanceAi.sidebar.getThreadItems().count();
 
 			// Hover the target thread to reveal the three-dots button, then click it
-			await targetThread.hover();
 			const actionButton = n8n.instanceAi.sidebar.getThreadActionsTrigger(targetThread);
-			await expect(actionButton).toBeVisible({ timeout: 5_000 });
+			await hoverToReveal(targetThread, actionButton);
 			await actionButton.click();
 
 			// Click delete option in the dropdown

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
@@ -159,12 +159,13 @@ test.describe(
 
 				await n8n.instanceAi.waitForPreviewCanvasNode(setNodeName);
 
-				// Hover over the Set node to show its toolbar
-				const setNode = n8n.instanceAi.getPreviewNodeByName(setNodeName);
-				await expect(setNode).toBeVisible({ timeout: 10_000 });
-				await setNode.hover();
+				// The node streams onto the canvas while the AI is still building; wait
+				// for the run button to enable (build finished) before using the toolbar.
+				await expect(n8n.instanceAi.getPreviewRunWorkflowButton()).toBeEnabled({
+					timeout: 60_000,
+				});
 
-				// Click the execute node button on the toolbar
+				// Hover the node and click the execute step button on its toolbar
 				await n8n.instanceAi.executePreviewNodeByName(setNodeName);
 
 				// The node should show a success indicator after execution

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
@@ -161,9 +161,16 @@ test.describe(
 
 				// The node streams onto the canvas while the AI is still building; wait
 				// for the run button to enable (build finished) before using the toolbar.
-				await expect(n8n.instanceAi.getPreviewRunWorkflowButton()).toBeEnabled({
-					timeout: 60_000,
-				});
+				await expect
+					.poll(
+						async () =>
+							await n8n.instanceAi
+								.getPreviewRunWorkflowButton()
+								.isEnabled()
+								.catch(() => false),
+						{ intervals: [500, 1_000, 2_000], timeout: 60_000 },
+					)
+					.toBe(true);
 
 				// Hover the node and click the execute step button on its toolbar
 				await n8n.instanceAi.executePreviewNodeByName(setNodeName);

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
@@ -168,7 +168,7 @@ test.describe(
 								.getPreviewRunWorkflowButton()
 								.isEnabled()
 								.catch(() => false),
-						{ intervals: [500, 1_000, 2_000], timeout: 60_000 },
+						{ intervals: [500, 1_000, 2_000], timeout: 10_000 },
 					)
 					.toBe(true);
 

--- a/packages/testing/playwright/utils/retry-utils.ts
+++ b/packages/testing/playwright/utils/retry-utils.ts
@@ -1,3 +1,27 @@
+import { expect, type Locator } from '@playwright/test';
+
+/**
+ * Hovers `trigger` until `target` becomes visible, re-hovering on every
+ * attempt. Use for hover-revealed UI (node toolbars, list item actions):
+ * re-renders can dismiss the hover state, so a single hover followed by a
+ * flat wait is flaky.
+ */
+export const hoverToReveal = async (
+	trigger: Locator,
+	target: Locator,
+	{ intervals = [500, 1_000, 2_000], timeout = 10_000 } = {},
+): Promise<void> => {
+	await expect
+		.poll(
+			async () => {
+				await trigger.hover();
+				return await target.isVisible().catch(() => false);
+			},
+			{ intervals, timeout },
+		)
+		.toBe(true);
+};
+
 /**
  * Retries the given assertion until it passes or the timeout is reached
  *


### PR DESCRIPTION
## Summary

Fixes a flaky Playwright test: `Instance AI workflow execution › should execute individual node from node toolbar`.

The node streams onto the preview canvas while the AI is still generating the workflow. The test hovered the node at that point and gave the "Execute step" toolbar button a flat 5 s to appear. The button only renders after generation completes, so the test timed out on slow CI runners (example: all 3 attempts of [this E2E Shard 1 run](https://github.com/n8n-io/n8n/actions/runs/32255296887/job/96077569753) failed with the chat still at "Generating workflow · 11–12 s").

Changes:
- The spec now waits for the preview run button to become enabled before it uses the node toolbar. This is the same build-finished signal that `runPreviewWorkflow` polls.
- `InstanceAiPage.executePreviewNodeByName` now polls with a re-hover on each attempt and a 30 s overall timeout. Mid-stream canvas re-renders can dismiss an open toolbar, so a single hover was not reliable.

Test-stability fix only. No product code changes.

## How to test

Run the affected spec against the containers setup:

```
pnpm --filter=n8n-playwright test:container:multi-main:e2e tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
```

The test also runs in E2E Shard 1 on this PR.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1225

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

