### PR TITLE
feat(core): Run policy checks and combine their decisions (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -54,6 +54,7 @@ export const LOG_SCOPES = [
 	'scheduler',
 	'enqueued-execution-recovery',
 	'engine-v2',
+	'policy',
 ] as const;
 
 export type LogScope = (typeof LOG_SCOPES)[number];

--- a/packages/@n8n/decorators/src/policy-check/policy-check.ts
+++ b/packages/@n8n/decorators/src/policy-check/policy-check.ts
@@ -177,6 +177,10 @@ export type PolicyDecision = {
  *   action.
  * - Only read state, never write it. That's what makes `evaluate` safe to call.
  * - Implement only the points you care about.
+ * - Pass `signal` to anything that accepts one, and check it around long steps. Every check
+ *   runs under a deadline; the signal is how a check gets to stop its own work instead of
+ *   being abandoned mid-query. Ignoring it is safe — the deadline still holds — but the work
+ *   carries on in the background.
  *
  * There's no `priority`, because every check has to pass — the order they run in can't
  * change the answer.
@@ -187,8 +191,8 @@ export type PolicyDecision = {
  * export class NodeTypePolicyCheck implements RegisteredPolicyCheck {
  *   readonly id = 'node-type-availability';
  *
- *   async onWorkflowStart({ workflow, projectId }: WorkflowStartContext) {
- *     return { violations: await this.violationsFor(workflow, projectId) };
+ *   async onWorkflowStart({ workflow, projectId }: WorkflowStartContext, signal: AbortSignal) {
+ *     return { violations: await this.violationsFor(workflow, projectId, signal) };
  *   }
  * }
  * ```
@@ -197,12 +201,18 @@ export interface RegisteredPolicyCheck {
 	/** Stable id, shown on every violation and on the audit log. */
 	id: string;
 
-	onWorkflowSave?(ctx: WorkflowSaveContext): Promise<PolicyCheckResult>;
-	onWorkflowPublish?(ctx: WorkflowPublishContext): Promise<PolicyCheckResult>;
-	onWorkflowStart?(ctx: WorkflowStartContext): Promise<PolicyCheckResult>;
-	onWorkflowTransfer?(ctx: WorkflowTransferContext): Promise<PolicyCheckResult>;
-	onCredentialDecrypt?(ctx: CredentialDecryptContext): Promise<PolicyCheckResult>;
-	onContentImport?(ctx: ContentImportContext): Promise<PolicyCheckResult>;
+	onWorkflowSave?(ctx: WorkflowSaveContext, signal: AbortSignal): Promise<PolicyCheckResult>;
+	onWorkflowPublish?(ctx: WorkflowPublishContext, signal: AbortSignal): Promise<PolicyCheckResult>;
+	onWorkflowStart?(ctx: WorkflowStartContext, signal: AbortSignal): Promise<PolicyCheckResult>;
+	onWorkflowTransfer?(
+		ctx: WorkflowTransferContext,
+		signal: AbortSignal,
+	): Promise<PolicyCheckResult>;
+	onCredentialDecrypt?(
+		ctx: CredentialDecryptContext,
+		signal: AbortSignal,
+	): Promise<PolicyCheckResult>;
+	onContentImport?(ctx: ContentImportContext, signal: AbortSignal): Promise<PolicyCheckResult>;
 }
 
 /** The {@link RegisteredPolicyCheck} method for a point, e.g. `'onWorkflowSave'`. */

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
@@ -1,0 +1,256 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type {
+	PolicyCheckClass,
+	PolicyCheckMetadata,
+	PolicyCheckResult,
+	RegisteredPolicyCheck,
+	WorkflowSaveContext,
+	WorkflowStartContext,
+} from '@n8n/decorators';
+import { Container, Service } from '@n8n/di';
+import { mock } from 'vitest-mock-extended';
+
+import { classifyHttpError } from '@/errors/http-error-classifier';
+import { serializeInternalRestError } from '@/errors/http-error-serializers';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
+
+import { PolicyCheckFailedError } from '../policy-check-failed.error';
+import { PolicyDecisionService } from '../policy-decision.service';
+
+const slackBlocked = {
+	kind: 'node-type-unavailable',
+	checkId: 'node-types',
+	message: 'n8n-nodes-base.slack is not available',
+};
+
+const codeBlocked = {
+	kind: 'node-type-unavailable',
+	checkId: 'other',
+	message: 'n8n-nodes-base.code is not available',
+};
+
+const saveContext: WorkflowSaveContext = {
+	workflow: { id: 'wf-1', name: 'My workflow', nodes: [] },
+	storedWorkflow: null,
+	projectId: 'proj-1',
+};
+
+const startContext: WorkflowStartContext = {
+	workflow: { id: 'wf-1', name: 'My workflow', nodes: [] },
+	projectId: 'proj-1',
+};
+
+@Service()
+class SilentCheck implements RegisteredPolicyCheck {
+	readonly id = 'silent';
+
+	async onWorkflowSave(): Promise<PolicyCheckResult> {
+		return { violations: [] };
+	}
+}
+
+@Service()
+class SlackCheck implements RegisteredPolicyCheck {
+	readonly id = 'node-types';
+
+	async onWorkflowSave(): Promise<PolicyCheckResult> {
+		return { violations: [slackBlocked], policyVersions: [{ scope: 'instance', version: 4 }] };
+	}
+}
+
+@Service()
+class CodeCheck implements RegisteredPolicyCheck {
+	readonly id = 'other';
+
+	async onWorkflowSave(): Promise<PolicyCheckResult> {
+		return { violations: [codeBlocked], policyVersions: [{ scope: 'instance', version: 4 }] };
+	}
+}
+
+@Service()
+class BrokenCheck implements RegisteredPolicyCheck {
+	readonly id = 'broken';
+
+	async onWorkflowSave(): Promise<PolicyCheckResult> {
+		throw new Error('the policy store connection dropped');
+	}
+}
+
+@Service()
+class HangingCheck implements RegisteredPolicyCheck {
+	readonly id = 'hanging';
+
+	async onWorkflowStart(): Promise<PolicyCheckResult> {
+		return await new Promise(() => {});
+	}
+}
+
+/** Only implements `onWorkflowStart`, so it must not be called at other points. */
+@Service()
+class StartOnlyCheck implements RegisteredPolicyCheck {
+	readonly id = 'start-only';
+
+	onWorkflowStart = vi.fn(async (): Promise<PolicyCheckResult> => ({ violations: [] }));
+}
+
+const serviceWith = (...classes: PolicyCheckClass[]) => {
+	const metadata = mock<PolicyCheckMetadata>({ getClasses: () => classes });
+
+	return new PolicyDecisionService(mockLogger(), metadata);
+};
+
+describe('PolicyDecisionService', () => {
+	describe('enforce', () => {
+		it('allows when no checks are registered', async () => {
+			const decision = await serviceWith().enforce('workflowSave', saveContext);
+
+			expect(decision).toEqual({ violations: [] });
+		});
+
+		it('allows when every registered check is silent', async () => {
+			const decision = await serviceWith(SilentCheck).enforce('workflowSave', saveContext);
+
+			expect(decision).toEqual({ violations: [] });
+		});
+
+		it('reports every violation, not just the first', async () => {
+			const decision = await serviceWith(SlackCheck, CodeCheck).enforce(
+				'workflowSave',
+				saveContext,
+			);
+
+			expect(decision.violations).toEqual([slackBlocked, codeBlocked]);
+		});
+
+		it('merges the policy versions the checks read, without duplicates', async () => {
+			const decision = await serviceWith(SlackCheck, CodeCheck).enforce(
+				'workflowSave',
+				saveContext,
+			);
+
+			expect(decision.policyVersions).toEqual([{ scope: 'instance', version: 4 }]);
+		});
+
+		it('blocks when a check throws, without leaking why', async () => {
+			const error = await serviceWith(SilentCheck, BrokenCheck)
+				.enforce('workflowSave', saveContext)
+				.catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(PolicyCheckFailedError);
+			const failure = error as PolicyCheckFailedError;
+			expect(failure.message).not.toContain('policy store');
+			expect(JSON.stringify(failure.meta)).not.toContain('policy store');
+			expect(failure.meta.correlationIds).toHaveLength(1);
+			expect(failure.httpStatusCode).toBe(503);
+		});
+
+		it('treats a check that overruns its deadline like one that threw', async () => {
+			vi.useFakeTimers();
+
+			try {
+				const pending = serviceWith(HangingCheck)
+					.enforce('workflowStart', startContext)
+					.catch((e: unknown) => e);
+
+				await vi.advanceTimersByTimeAsync(250);
+
+				expect(await pending).toBeInstanceOf(PolicyCheckFailedError);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('only runs checks that implement the point', async () => {
+			const service = serviceWith(StartOnlyCheck);
+
+			await service.enforce('workflowSave', saveContext);
+
+			expect(Container.get(StartOnlyCheck).onWorkflowStart).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('evaluate', () => {
+		it('returns an empty decision when no checks are registered', async () => {
+			expect(await serviceWith().evaluate('workflowSave', saveContext)).toEqual({
+				violations: [],
+			});
+		});
+
+		it('returns violations rather than throwing', async () => {
+			const decision = await serviceWith(SlackCheck).evaluate('workflowSave', saveContext);
+
+			expect(decision.violations).toEqual([slackBlocked]);
+			expect(decision.checkErrors).toBeUndefined();
+		});
+
+		it('keeps the surviving checks when one breaks', async () => {
+			const decision = await serviceWith(SlackCheck, BrokenCheck).evaluate(
+				'workflowSave',
+				saveContext,
+			);
+
+			expect(decision.violations).toEqual([slackBlocked]);
+			expect(decision.checkErrors).toHaveLength(1);
+			expect(decision.checkErrors?.[0].checkId).toBe('broken');
+			expect(decision.checkErrors?.[0].correlationId).toMatch(/^[0-9a-f-]{36}$/);
+		});
+	});
+
+	describe('check resolution', () => {
+		it('reads the registry per decision, so a check registered later still runs', async () => {
+			const classes: PolicyCheckClass[] = [];
+			const metadata = mock<PolicyCheckMetadata>({ getClasses: () => classes });
+			const service = new PolicyDecisionService(mockLogger(), metadata);
+
+			expect(await service.enforce('workflowSave', saveContext)).toEqual({ violations: [] });
+
+			classes.push(SlackCheck);
+
+			const decision = await service.enforce('workflowSave', saveContext);
+			expect(decision.violations).toEqual([slackBlocked]);
+		});
+	});
+
+	describe('through the enforcement proxy', () => {
+		it('turns violations into a PolicyViolationError', async () => {
+			const proxy = new PolicyEnforcementService();
+			proxy.setImplementation(serviceWith(SlackCheck));
+
+			const error = await proxy.enforceWorkflowSave(saveContext).catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(PolicyViolationError);
+			expect((error as PolicyViolationError).violations).toEqual([slackBlocked]);
+		});
+
+		it('clears when the checks are silent', async () => {
+			const proxy = new PolicyEnforcementService();
+			proxy.setImplementation(serviceWith(SilentCheck));
+
+			const token = await proxy.enforceWorkflowSave(saveContext);
+
+			expect(token.subject).toEqual({ type: 'workflow', id: 'wf-1' });
+		});
+
+		it('lets a check failure through as-is, so the action is blocked', async () => {
+			const proxy = new PolicyEnforcementService();
+			proxy.setImplementation(serviceWith(BrokenCheck));
+
+			await expect(proxy.enforceWorkflowSave(saveContext)).rejects.toBeInstanceOf(
+				PolicyCheckFailedError,
+			);
+		});
+
+		it('keeps the check failure out of the REST response body', async () => {
+			const proxy = new PolicyEnforcementService();
+			proxy.setImplementation(serviceWith(BrokenCheck));
+
+			const error = await proxy.enforceWorkflowSave(saveContext).catch((e: unknown) => e);
+			const { status, body } = serializeInternalRestError(classifyHttpError(error as Error));
+
+			expect(status).toBe(503);
+			expect(JSON.stringify(body)).not.toContain('policy store');
+			expect(body.meta).toEqual({ correlationIds: [expect.any(String)] });
+		});
+	});
+});

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
@@ -17,7 +17,7 @@ import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { PolicyViolationError } from '@/policy/policy-violation.error';
 
 import { PolicyCheckFailedError } from '../policy-check-failed.error';
-import { PolicyDecisionService } from '../policy-decision.service';
+import { PolicyDecisionService, withDeadline } from '../policy-decision.service';
 
 const slackBlocked = {
 	kind: 'node-type-unavailable',
@@ -290,5 +290,37 @@ describe('PolicyDecisionService', () => {
 			expect(JSON.stringify(body)).not.toContain('policy store');
 			expect(body.meta).toEqual({ correlationIds: [expect.any(String)] });
 		});
+	});
+});
+
+describe('withDeadline', () => {
+	const afterDeadline = async (work: (signal: AbortSignal) => Promise<unknown>) => {
+		vi.useFakeTimers();
+
+		try {
+			const pending = withDeadline(work, 250).catch((e: unknown) => e);
+			await vi.advanceTimersByTimeAsync(250);
+
+			return await pending;
+		} finally {
+			vi.useRealTimers();
+		}
+	};
+
+	it('rejects when a check resolves from its abort handler', async () => {
+		const resolvesOnAbort = async (signal: AbortSignal) =>
+			await new Promise((resolve) => signal.addEventListener('abort', () => resolve('too late')));
+
+		expect(await afterDeadline(resolvesOnAbort)).toBeInstanceOf(OperationalError);
+	});
+
+	it('rejects when a check ignores the signal entirely', async () => {
+		const ignoresSignal = async () => await new Promise(() => {});
+
+		expect(await afterDeadline(ignoresSignal)).toBeInstanceOf(OperationalError);
+	});
+
+	it('returns the answer when the check beats the deadline', async () => {
+		expect(await withDeadline(async () => 'in time', 250)).toBe('in time');
 	});
 });

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
@@ -8,6 +8,7 @@ import type {
 	WorkflowStartContext,
 } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
+import { OperationalError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { classifyHttpError } from '@/errors/http-error-classifier';
@@ -86,6 +87,26 @@ class HangingCheck implements RegisteredPolicyCheck {
 	}
 }
 
+/** Honours the signal, the way a check talking to a store with an abortable client would. */
+@Service()
+class AbortAwareCheck implements RegisteredPolicyCheck {
+	readonly id = 'abort-aware';
+
+	aborted: unknown = null;
+
+	async onWorkflowStart(
+		_ctx: WorkflowStartContext,
+		signal: AbortSignal,
+	): Promise<PolicyCheckResult> {
+		return await new Promise((_resolve, reject) => {
+			signal.addEventListener('abort', () => {
+				this.aborted = signal.reason;
+				reject(new Error('aborted by signal'));
+			});
+		});
+	}
+}
+
 /** Only implements `onWorkflowStart`, so it must not be called at other points. */
 @Service()
 class StartOnlyCheck implements RegisteredPolicyCheck {
@@ -156,6 +177,23 @@ describe('PolicyDecisionService', () => {
 				await vi.advanceTimersByTimeAsync(250);
 
 				expect(await pending).toBeInstanceOf(PolicyCheckFailedError);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('signals a check that overruns, so it can stop its own work', async () => {
+			vi.useFakeTimers();
+
+			try {
+				const pending = serviceWith(AbortAwareCheck)
+					.enforce('workflowStart', startContext)
+					.catch((e: unknown) => e);
+
+				await vi.advanceTimersByTimeAsync(250);
+
+				expect(await pending).toBeInstanceOf(PolicyCheckFailedError);
+				expect(Container.get(AbortAwareCheck).aborted).toBeInstanceOf(OperationalError);
 			} finally {
 				vi.useRealTimers();
 			}

--- a/packages/cli/src/modules/policy-infrastructure/policy-check-failed.error.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-check-failed.error.ts
@@ -1,0 +1,24 @@
+import type { EnforcementPoint } from '@n8n/decorators';
+import { OperationalError } from 'n8n-workflow';
+
+/**
+ * A check broke, so the action is blocked. Not knowing whether a policy allows something is not
+ * the same as it being allowed.
+ *
+ * Deliberately opaque: check internals never reach `violations` or a response body, since an
+ * infrastructure fault rendered as a policy rule is something a user would try to satisfy. The
+ * correlation ids tie the response back to the server logs holding the real errors.
+ */
+export class PolicyCheckFailedError extends OperationalError {
+	readonly httpStatusCode = 503;
+
+	readonly errorCode = 503;
+
+	readonly meta: { correlationIds: string[] };
+
+	constructor(point: EnforcementPoint, correlationIds: string[]) {
+		super(`Could not verify policy for ${point}, so the action was blocked`);
+
+		this.meta = { correlationIds };
+	}
+}

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
@@ -30,21 +30,31 @@ const DEADLINES_MS = {
 
 type CheckRunner<Point extends EnforcementPoint> = (
 	context: PolicyContext<Point>,
+	signal: AbortSignal,
 ) => Promise<PolicyCheckResult>;
 
 type CheckOutcome =
 	| { answered: true; result: PolicyCheckResult }
 	| { answered: false; failure: PolicyCheckFailure };
 
-/** Stops waiting after `ms`. The work itself keeps running — a promise can't be cancelled. */
-async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T> {
+/**
+ * Bounds `start` to `ms`, two ways. The signal lets a check that honours it stop its own work
+ * — abort the query, drop the request — and the race covers the ones that don't, which would
+ * otherwise carry on in the background while we've stopped waiting.
+ */
+async function withDeadline<T>(start: (signal: AbortSignal) => Promise<T>, ms: number) {
+	const controller = new AbortController();
 	let timer: NodeJS.Timeout | undefined;
 
 	try {
 		return await Promise.race([
-			work,
+			start(controller.signal),
 			new Promise<never>((_, reject) => {
-				timer = setTimeout(() => reject(new OperationalError(`Deadline of ${ms}ms exceeded`)), ms);
+				timer = setTimeout(() => {
+					const expired = new OperationalError(`Deadline of ${ms}ms exceeded`);
+					controller.abort(expired);
+					reject(expired);
+				}, ms);
 			}),
 		]);
 	} finally {
@@ -128,7 +138,12 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 		const outcomes = await Promise.all(
 			this.runnersFor(point).map(async ({ checkId, run }): Promise<CheckOutcome> => {
 				try {
-					return { answered: true, result: await withDeadline(run(context), DEADLINES_MS[point]) };
+					const result = await withDeadline(
+						async (signal) => await run(context, signal),
+						DEADLINES_MS[point],
+					);
+
+					return { answered: true, result };
 				} catch (error) {
 					const correlationId = randomUUID();
 

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
@@ -1,0 +1,171 @@
+import { Logger } from '@n8n/backend-common';
+import type {
+	EnforcementPoint,
+	PolicyCheckFailure,
+	PolicyCheckResult,
+	PolicyDecision,
+	PolicyVersionRef,
+} from '@n8n/decorators';
+import { ENFORCEMENT_POINT_METHODS, PolicyCheckMetadata } from '@n8n/decorators';
+import { Container, Service } from '@n8n/di';
+import { OperationalError } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
+
+import type { PolicyContext, PolicyEnforcementBackend } from '@/policy/policy-enforcement-backend';
+
+import { PolicyCheckFailedError } from './policy-check-failed.error';
+
+/**
+ * How long one check gets. Tight on the two points that sit inside a running execution: a wedged
+ * policy store there pins worker slots rather than failing a single request.
+ */
+const DEADLINES_MS = {
+	workflowSave: 1_000,
+	workflowPublish: 1_000,
+	workflowStart: 250,
+	workflowTransfer: 1_000,
+	credentialDecrypt: 250,
+	contentImport: 1_000,
+} as const satisfies Record<EnforcementPoint, number>;
+
+type CheckRunner<Point extends EnforcementPoint> = (
+	context: PolicyContext<Point>,
+) => Promise<PolicyCheckResult>;
+
+type CheckOutcome =
+	| { answered: true; result: PolicyCheckResult }
+	| { answered: false; failure: PolicyCheckFailure };
+
+/** Stops waiting after `ms`. The work itself keeps running — a promise can't be cancelled. */
+async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+
+	try {
+		return await Promise.race([
+			work,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new OperationalError(`Deadline of ${ms}ms exceeded`)), ms);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function mergeVersions(results: PolicyCheckResult[]): PolicyVersionRef[] {
+	const byScope = new Map<string, PolicyVersionRef>();
+
+	for (const { policyVersions = [] } of results) {
+		for (const version of policyVersions)
+			byScope.set(`${version.scope}:${version.version}`, version);
+	}
+
+	return [...byScope.values()];
+}
+
+function decisionFrom(results: PolicyCheckResult[]): PolicyDecision {
+	const violations = results.flatMap((result) => result.violations);
+	const policyVersions = mergeVersions(results);
+
+	return policyVersions.length > 0 ? { violations, policyVersions } : { violations };
+}
+
+/**
+ * Runs the registered `@PolicyCheck`s and combines what they say. Registered into
+ * `PolicyEnforcementService` by the module, which is what turns the proxy's no-ops into real
+ * decisions.
+ *
+ * Three outcomes, three answers:
+ *
+ * - **No checks** — allow. A feature that isn't installed isn't a security failure.
+ * - **A check breaks or overruns its deadline** — `enforce` blocks with `PolicyCheckFailedError`,
+ *   because a check that didn't answer hasn't said yes.
+ * - **Same, under `evaluate`** — report it in `checkErrors` and keep what the other checks said.
+ *   An advisory surface must never show a crashed check as "no violations".
+ *
+ * Checks are combined by conjunction: all of them have to pass and every violation is reported,
+ * so a user fixing a workflow sees the whole list rather than one at a time.
+ */
+@Service()
+export class PolicyDecisionService implements PolicyEnforcementBackend {
+	constructor(
+		private readonly logger: Logger,
+		private readonly checkMetadata: PolicyCheckMetadata,
+	) {
+		this.logger = this.logger.scoped('policy');
+	}
+
+	async enforce<Point extends EnforcementPoint>(
+		point: Point,
+		context: PolicyContext<Point>,
+	): Promise<PolicyDecision> {
+		const { results, failures } = await this.runChecks(point, context);
+
+		if (failures.length > 0) {
+			throw new PolicyCheckFailedError(
+				point,
+				failures.map((failure) => failure.correlationId),
+			);
+		}
+
+		return decisionFrom(results);
+	}
+
+	async evaluate<Point extends EnforcementPoint>(
+		point: Point,
+		context: PolicyContext<Point>,
+	): Promise<PolicyDecision> {
+		const { results, failures } = await this.runChecks(point, context);
+		const decision = decisionFrom(results);
+
+		return failures.length > 0 ? { ...decision, checkErrors: failures } : decision;
+	}
+
+	private async runChecks<Point extends EnforcementPoint>(
+		point: Point,
+		context: PolicyContext<Point>,
+	) {
+		const outcomes = await Promise.all(
+			this.runnersFor(point).map(async ({ checkId, run }): Promise<CheckOutcome> => {
+				try {
+					return { answered: true, result: await withDeadline(run(context), DEADLINES_MS[point]) };
+				} catch (error) {
+					const correlationId = randomUUID();
+
+					this.logger.error(`Policy check "${checkId}" failed at ${point}`, {
+						correlationId,
+						error,
+					});
+
+					return { answered: false, failure: { checkId, correlationId } };
+				}
+			}),
+		);
+
+		const results: PolicyCheckResult[] = [];
+		const failures: PolicyCheckFailure[] = [];
+
+		for (const outcome of outcomes) {
+			if (outcome.answered) results.push(outcome.result);
+			else failures.push(outcome.failure);
+		}
+
+		return { results, failures };
+	}
+
+	/**
+	 * Read the registry per decision rather than once at startup, so module load order can't
+	 * decide whether a check runs. Order follows registration order, which affects the sequence
+	 * of reported violations but never the verdict.
+	 */
+	private runnersFor<Point extends EnforcementPoint>(point: Point) {
+		return this.checkMetadata.getClasses().flatMap((checkClass) => {
+			const check = Container.get(checkClass);
+			// `ENFORCEMENT_POINT_METHODS` pins each point to exactly its own method, but TS can't
+			// correlate the two through a generic `Point`, so the pairing is asserted here.
+			const run = check[ENFORCEMENT_POINT_METHODS[point]] as CheckRunner<Point> | undefined;
+
+			return run ? [{ checkId: check.id, run: run.bind(check) }] : [];
+		});
+	}
+}

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
@@ -42,18 +42,25 @@ type CheckOutcome =
  * — abort the query, drop the request — and the race covers the ones that don't, which would
  * otherwise carry on in the background while we've stopped waiting.
  */
-async function withDeadline<T>(start: (signal: AbortSignal) => Promise<T>, ms: number) {
+export async function withDeadline<T>(start: (signal: AbortSignal) => Promise<T>, ms: number) {
 	const controller = new AbortController();
+	let expired: OperationalError | undefined;
 	let timer: NodeJS.Timeout | undefined;
 
 	try {
 		return await Promise.race([
-			start(controller.signal),
+			// Aborting can make a check answer, so re-check after it settles: an answer that
+			// arrives once the deadline has passed is not an answer.
+			start(controller.signal).then((result) => {
+				if (expired) throw expired;
+
+				return result;
+			}),
 			new Promise<never>((_, reject) => {
 				timer = setTimeout(() => {
-					const expired = new OperationalError(`Deadline of ${ms}ms exceeded`);
-					controller.abort(expired);
+					expired = new OperationalError(`Deadline of ${ms}ms exceeded`);
 					reject(expired);
+					controller.abort(expired);
 				}, ms);
 			}),
 		]);

--- a/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
@@ -1,19 +1,25 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 
 /**
- * Shared layer every policy feature is built on: it will register the policy
+ * Shared layer every policy feature is built on: it registers the policy
  * enforcement implementation that runs the registered `@PolicyCheck`s.
  *
  * Runs on all instance types — enforcement points sit on execution paths that
  * also run on workers and webhook processes.
  *
  * Opt-in via `N8N_ENABLED_MODULES=policy-infrastructure` while it is being
- * built out; becomes a default module at GA.
+ * built out; becomes a default module at GA. Disabling it is the documented
+ * break-glass lever: no checks run and everything is allowed.
  */
 @BackendModule({ name: 'policy-infrastructure' })
 export class PolicyInfrastructureModule implements ModuleInterface {
 	async init() {
-		// Later tickets register the enforcement implementation here.
+		const { PolicyDecisionService } = await import('./policy-decision.service.js');
+
+		Container.get(PolicyEnforcementService).setImplementation(Container.get(PolicyDecisionService));
 	}
 }


### PR DESCRIPTION
## Summary

Fills in the `policy-infrastructure` module so the enforcement proxy stops no-opping. This is
where the fail posture actually gets built — every check that any tenant registers later inherits
it, so nobody re-implements aggregation or timeouts per feature.

`PolicyDecisionService` runs the registered `@PolicyCheck`s for a point and combines what they
say. Three situations, three answers:

| Situation | `enforce` | `evaluate` |
| --- | --- | --- |
| No checks registered | allow | empty decision |
| Checks report violations | throws `PolicyViolationError` with all of them | returns them |
| A check throws or hangs | blocks with `PolicyCheckFailedError` | reports it in `checkErrors`, keeps the other checks' results |

Checks run in parallel and are combined by conjunction: everything has to pass, and every
violation is reported so a user fixing a workflow sees the whole list instead of one at a time.

### Deadlines

Each check runs under a per-point deadline, and a timeout is treated exactly like a throw.
Without it, one wedged store connection turns the execution gate into an instance-wide outage,
pinning worker slots forever rather than failing one request.

The RFC left the values open ("defaults proposed in code review"), so these are a proposal:

- **250ms** for `workflowStart` and `credentialDecrypt` — inside a running execution, where a
  check should be a cache hit or one indexed query
- **1000ms** for `workflowSave`, `workflowPublish`, `workflowTransfer`, `contentImport` —
  interactive but not on the execution hot path

Happy to move these. They're constants rather than config for now; worth an env var if operators
turn out to need one.

Bounded two ways, per Andi's review. Each check gets an `AbortSignal` as a second argument, so a
check that honours it can stop its own work — abort the query, drop the request — instead of
being abandoned mid-flight. The race still covers checks that ignore the signal, which is what
protects the request either way. Ignoring it stays safe; the deadline holds regardless.

This adds a parameter to the six `RegisteredPolicyCheck` methods in `@n8n/decorators`. Additive,
and no tenant check exists yet, so now is the cheap moment.

### Keeping check failures opaque

`PolicyCheckFailedError` is 5xx-class and carries only correlation ids. The underlying error goes
to the log (`N8N_LOG_SCOPES=policy`) and never into `violations` or a response body — an
infrastructure fault rendered as a policy rule is something a user would try to satisfy, and
driver errors shouldn't leak into HTTP responses. There's a test asserting the store error's text
is absent from the serialized REST body, not just from the error message.

A buggy check blocking work is an incident; a buggy check silently passing is a potential breach.
This takes the incident.

### Two decisions worth a look

- **A check failure beats reported violations.** If one check objects and another breaks,
  `enforce` throws `PolicyCheckFailedError` and the known violations are dropped. Reporting a
  partial list would be worse: the user fixes those, retries, and gets blocked again by the check
  that never ran.
- **The registry is read per decision**, not cached at startup, so module load order can't decide
  whether a check runs. That's a `getClasses()` call plus a DI lookup per check per decision —
  cheap at this scale, and worth revisiting only if the check count grows.

Not in here: the decision audit line (its own ticket), and the startup check manifest the RFC
describes as an integrity rule — neither is in this ticket's scope.

## How to test

```bash
cd packages/cli
pnpm test src/policy src/modules/policy-infrastructure
pnpm typecheck
```

To see it end to end, run with `N8N_ENABLED_MODULES=policy-infrastructure`. With no tenant
checks registered nothing changes, which is the point.

The tests cover each row of the table above, plus: violations from two checks arriving in
registration order; policy versions merged and deduplicated; only checks that implement a point
being called; a check registered after the service exists still running; and the whole thing
driven through the real proxy, so violations come out as `PolicyViolationError` and a check
failure passes through untouched.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1117

Follows #36586, which is now on `master`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
