### PR TITLE
fix(core): Wrap a trigger's closeFunction in an expression isolate at creation time

### DIFF
--- a/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
@@ -62,6 +62,54 @@ describe('TriggersAndPollers', () => {
 			expect(result).toEqual({ test: true });
 		});
 
+		describe('closeFunction isolate wrapping', () => {
+			const originalClose = vi.fn(async () => {});
+			const withIsolate = vi.fn(async (fn: () => Promise<void>) => await fn());
+
+			beforeEach(() => {
+				nodeType.trigger = triggerFn;
+				workflow.expression = { withIsolate } as unknown as Workflow['expression'];
+			});
+
+			it('wraps closeFunction so teardown runs inside workflow.expression.withIsolate', async () => {
+				triggerFn.mockResolvedValue({ closeFunction: originalClose });
+
+				const response = await runTriggerHelper();
+
+				expect(response?.closeFunction).not.toBe(originalClose);
+				expect(originalClose).not.toHaveBeenCalled();
+
+				await response!.closeFunction!();
+
+				expect(withIsolate).toHaveBeenCalledTimes(1);
+				expect(originalClose).toHaveBeenCalledTimes(1);
+				const [isolateOrder] = withIsolate.mock.invocationCallOrder;
+				const [closeOrder] = originalClose.mock.invocationCallOrder;
+				expect(isolateOrder).toBeLessThan(closeOrder);
+			});
+
+			it('wraps closeFunction in manual mode too', async () => {
+				triggerFn.mockResolvedValue({ closeFunction: originalClose });
+
+				const response = await runTriggerHelper('manual');
+
+				expect(response?.closeFunction).not.toBe(originalClose);
+				await response!.closeFunction!();
+				expect(withIsolate).toHaveBeenCalledTimes(1);
+				expect(originalClose).toHaveBeenCalledTimes(1);
+			});
+
+			it('propagates a closeFunction rejection through the wrapper', async () => {
+				const closeError = new Error('close failed');
+				originalClose.mockRejectedValueOnce(closeError);
+				triggerFn.mockResolvedValue({ closeFunction: originalClose });
+
+				const response = await runTriggerHelper();
+
+				await expect(response!.closeFunction!()).rejects.toThrow(closeError);
+			});
+		});
+
 		describe('manual mode', () => {
 			const getMockTriggerFunctions = () => getTriggerFunctions.mock.results[0]?.value;
 

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1562,8 +1562,9 @@ describe('WorkflowExecute', () => {
 	describe('runNode', () => {
 		const nodeTypes = mock<INodeTypes>();
 		const triggerNode = mock<INode>();
+		const closeFunctionSpy = vi.fn();
 		const triggerResponse = mock<ITriggerResponse>({
-			closeFunction: vi.fn(),
+			closeFunction: closeFunctionSpy,
 			// This node should never trigger, or return
 			manualTriggerFunction: async () => await new Promise(() => {}),
 		});
@@ -1618,10 +1619,11 @@ describe('WorkflowExecute', () => {
 			});
 			expect(isSettled).toBe(false);
 			expect(abortController.signal.aborted).toBe(false);
-			expect(triggerResponse.closeFunction).not.toHaveBeenCalled();
+			expect(closeFunctionSpy).not.toHaveBeenCalled();
 
 			abortController.abort();
-			expect(triggerResponse.closeFunction).toHaveBeenCalled();
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(closeFunctionSpy).toHaveBeenCalled();
 		});
 	});
 

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -136,10 +136,27 @@ export class TriggersAndPollers {
 				};
 			});
 
-			return triggerResponse;
+			return this.wrapCloseFunctionInIsolate(workflow, triggerResponse);
 		}
 		// In all other modes simply start the trigger
-		return await nodeType.trigger.call(triggerFunctions);
+		return this.wrapCloseFunctionInIsolate(workflow, await nodeType.trigger.call(triggerFunctions));
+	}
+
+	/**
+	 * Wraps a trigger's `closeFunction` so teardown holds an expression isolate:
+	 * the closure evaluates expressions through this workflow's expression
+	 * instance, which is no longer in scope at the eventual close call sites.
+	 */
+	private wrapCloseFunctionInIsolate(
+		workflow: Workflow,
+		response: ITriggerResponse | undefined,
+	): ITriggerResponse | undefined {
+		const closeFunction = response?.closeFunction;
+		if (response && closeFunction) {
+			response.closeFunction = async () =>
+				await workflow.expression.withIsolate(async () => await closeFunction.call(response));
+		}
+		return response;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Alternative approach to #36606, opened for discussion — not meant to be merged as-is without alignment.

Same bug (CAT-4125): a trigger's `closeFunction` can evaluate expressions during teardown, but by then no expression isolate is held, so the evaluation fails under the vm engine.

Instead of storing the workflow's expression handle in the trigger registry and threading it through every close call site, this wraps `closeFunction` with `workflow.expression.withIsolate` at the single point where trigger responses are created (`TriggersAndPollers.runTriggerFunction`) — the `workflow` instance is still in scope there, so nothing needs to be carried to the close sites.

What this buys compared to #36606:

- No new registry state, no widened signatures — the whole change is one wrapper in one file.
- Every close call site is correct by construction, including future ones. With the registry approach, a close site that forgets to pass the expression handle compiles fine and silently closes without an isolate again.
- The manual-execution path (`workflow-execute.ts` mints trigger responses through the same function and calls `closeFunction` on abort) is covered for free; the registry approach doesn't reach it.
- `withIsolate` already handles the edge cases the hand-rolled acquire/release bracket in #36606 has to get right: a failing acquire doesn't skip the close, and a failing release doesn't mask the close error.

Nesting is safe: if the caller already holds the isolate, the inner acquire returns `false` and the wrapper won't release it.

## How to test

Unit tests in `packages/core`:

```
pnpm --filter n8n-core test src/execution-engine/__tests__/triggers-and-pollers.test.ts
```

Manual repro (same as #36606): with `N8N_EXPRESSION_ENGINE=vm`, activate a workflow whose trigger evaluates an expression in its teardown (e.g. a trigger node with an expression in a parameter read during close), then deactivate it — teardown must not fail with an isolate error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4125

Alternative to https://github.com/n8n-io/n8n/pull/36606

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

