### PR TITLE
perf(core): Skip reading run data when saving execution progress

### DIFF
--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -747,7 +747,7 @@ describe('ExecutionPersistence', () => {
 			it('should preserve fields not supplied in a partial payload', async () => {
 				const executionPersistence = createPersistenceService('db');
 				mockEntity('db');
-				dbStore.read.mockResolvedValue(existingBundle);
+				dbStore.readWorkflowData.mockResolvedValue(existingBundle);
 
 				const mockTx = createMockTransaction();
 				executionRepository.manager.transaction = createMockTx(mockTx);
@@ -763,6 +763,22 @@ describe('ExecutionPersistence', () => {
 					}),
 					mockTx,
 				);
+			});
+
+			it('should not read the run data it is about to overwrite', async () => {
+				const executionPersistence = createPersistenceService('db');
+				mockEntity('db');
+				dbStore.readWorkflowData.mockResolvedValue(existingBundle);
+
+				const mockTx = createMockTransaction();
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				await executionPersistence.updateExistingExecution(executionId, { data: runData });
+
+				// The merge only needs the workflow snapshot, so the (often far larger) `data` column
+				// stays unread - it would otherwise be loaded while the transaction holds the write lock.
+				expect(dbStore.readWorkflowData).toHaveBeenCalledWith({ workflowId, executionId }, mockTx);
+				expect(dbStore.read).not.toHaveBeenCalled();
 			});
 
 			it('should apply requireStatus condition and skip the db write when no rows match', async () => {
@@ -787,7 +803,7 @@ describe('ExecutionPersistence', () => {
 			it('should throw MissingExecutionDataError when the db row is missing', async () => {
 				const executionPersistence = createPersistenceService('db');
 				mockEntity('db');
-				dbStore.read.mockResolvedValue(null);
+				dbStore.readWorkflowData.mockResolvedValue(null);
 
 				const mockTx = createMockTransaction();
 				executionRepository.manager.transaction = createMockTx(mockTx);
@@ -2201,7 +2217,7 @@ describe('ExecutionPersistence', () => {
 			const executionPersistence = createPersistenceService('db');
 			executionRepository.findOne.mockResolvedValue(entity('db'));
 			executionRepository.manager.transaction = createMockTx(createMockTransaction());
-			dbStore.read.mockResolvedValue(null);
+			dbStore.readWorkflowData.mockResolvedValue(null);
 
 			await expect(
 				executionPersistence.updateExistingExecution('exec-1', { data: runData }),
@@ -2284,7 +2300,7 @@ describe('ExecutionPersistence', () => {
 			const executionPersistence = createPersistenceService('db');
 			executionRepository.findOne.mockResolvedValue(entity('db'));
 			executionRepository.manager.transaction = createMockTx(createMockTransaction());
-			dbStore.read.mockRejectedValueOnce(
+			dbStore.readWorkflowData.mockRejectedValueOnce(
 				new CorruptedExecutionDataError(
 					{ workflowId: 'wf-1', executionId: 'exec-1' },
 					new Error('x'),

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -23,6 +23,7 @@ import type { DbStore } from '@/executions/execution-data/db-store';
 import type { ExecutionDataJsonStore } from '@/executions/execution-data/execution-data-json-store';
 import { MissingExecutionDataError } from '@/executions/execution-data/missing-execution-data.error';
 import type { ExecutionDataPayload } from '@/executions/execution-data/types';
+import { UnreadableRunDataError } from '@/executions/execution-data/unreadable-run-data.error';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 describe('ExecutionPersistence', () => {
@@ -832,7 +833,7 @@ describe('ExecutionPersistence', () => {
 				expect(dbStore.write).not.toHaveBeenCalled();
 			});
 
-			it('should throw MissingExecutionDataError when the db row carries no run data', async () => {
+			it('should throw UnreadableRunDataError when the db row carries no run data', async () => {
 				const executionPersistence = createPersistenceService('db');
 				mockEntity('db');
 				// The row exists, so the read returns it, but its `data` column holds nothing usable.
@@ -847,7 +848,7 @@ describe('ExecutionPersistence', () => {
 
 				await expect(
 					executionPersistence.updateExistingExecution(executionId, { workflowData }),
-				).rejects.toBeInstanceOf(MissingExecutionDataError);
+				).rejects.toBeInstanceOf(UnreadableRunDataError);
 
 				expect(dbStore.write).not.toHaveBeenCalled();
 			});

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -22,6 +22,7 @@ import { CorruptedExecutionDataError } from '@/executions/execution-data/corrupt
 import type { DbStore } from '@/executions/execution-data/db-store';
 import type { ExecutionDataJsonStore } from '@/executions/execution-data/execution-data-json-store';
 import { MissingExecutionDataError } from '@/executions/execution-data/missing-execution-data.error';
+import type { ExecutionDataPayload } from '@/executions/execution-data/types';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 describe('ExecutionPersistence', () => {
@@ -781,6 +782,22 @@ describe('ExecutionPersistence', () => {
 				expect(dbStore.read).not.toHaveBeenCalled();
 			});
 
+			it('should read the full bundle on a workflowData-only update', async () => {
+				const executionPersistence = createPersistenceService('db');
+				mockEntity('db');
+				dbStore.read.mockResolvedValue(existingBundle);
+
+				const mockTx = createMockTransaction();
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				await executionPersistence.updateExistingExecution(executionId, { workflowData });
+
+				// No `data` was supplied, so the stored run data has to be carried over. The snapshot
+				// read would not return it, so this update reads the whole bundle.
+				expect(dbStore.read).toHaveBeenCalledWith({ workflowId, executionId }, mockTx);
+				expect(dbStore.readWorkflowData).not.toHaveBeenCalled();
+			});
+
 			it('should apply requireStatus condition and skip the db write when no rows match', async () => {
 				const executionPersistence = createPersistenceService('db');
 				mockEntity('db');
@@ -810,6 +827,26 @@ describe('ExecutionPersistence', () => {
 
 				await expect(
 					executionPersistence.updateExistingExecution(executionId, { data: runData }),
+				).rejects.toBeInstanceOf(MissingExecutionDataError);
+
+				expect(dbStore.write).not.toHaveBeenCalled();
+			});
+
+			it('should throw MissingExecutionDataError when the db row carries no run data', async () => {
+				const executionPersistence = createPersistenceService('db');
+				mockEntity('db');
+				// The row exists, so the read returns it, but its `data` column holds nothing usable.
+				// Distinct from the case above, where there is no row at all.
+				dbStore.read.mockResolvedValue({
+					workflowData: existingBundle.workflowData,
+					workflowVersionId: existingBundle.workflowVersionId,
+				} as unknown as ExecutionDataPayload);
+
+				const mockTx = createMockTransaction();
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				await expect(
+					executionPersistence.updateExistingExecution(executionId, { workflowData }),
 				).rejects.toBeInstanceOf(MissingExecutionDataError);
 
 				expect(dbStore.write).not.toHaveBeenCalled();
@@ -941,6 +978,22 @@ describe('ExecutionPersistence', () => {
 					}),
 					'fs',
 				);
+			});
+
+			it('should read the full bundle on a data-only update', async () => {
+				const executionPersistence = createPersistenceService('fs');
+				mockEntity('fs');
+				jsonStore.read.mockResolvedValue(existingBundle);
+
+				const mockTx = createMockTransaction();
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				await executionPersistence.updateExistingExecution(executionId, { data: runData });
+
+				// Only db mode can select a subset of columns. A blob store fetches whole bundles, so
+				// there is no narrower read to route this to.
+				expect(jsonStore.read).toHaveBeenCalledWith({ workflowId, executionId }, 'fs');
+				expect(dbStore.readWorkflowData).not.toHaveBeenCalled();
 			});
 
 			it('should apply requireStatus condition and skip the fs write when no rows match', async () => {

--- a/packages/cli/src/executions/execution-data/db-store.ts
+++ b/packages/cli/src/executions/execution-data/db-store.ts
@@ -68,8 +68,17 @@ export class DbStore {
 		return result;
 	}
 
-	async readWorkflowData({ executionId }: ExecutionRef): Promise<BundleWorkflowSnapshot | null> {
-		const result = await this.repository.findOne({
+	/**
+	 * Read only the workflow-snapshot columns of a row, leaving the `data` column unread. Callers
+	 * that are about to overwrite the run data use this to avoid loading it, which matters inside a
+	 * transaction: on SQLite that transaction holds the process-wide write connection.
+	 */
+	async readWorkflowData(
+		{ executionId }: ExecutionRef,
+		tx?: EntityManager,
+	): Promise<BundleWorkflowSnapshot | null> {
+		const repo = tx ? tx.getRepository(ExecutionData) : this.repository;
+		const result = await repo.findOne({
 			where: { executionId },
 			select: ['workflowData', 'workflowVersionId'],
 		});

--- a/packages/cli/src/executions/execution-data/types.ts
+++ b/packages/cli/src/executions/execution-data/types.ts
@@ -18,14 +18,16 @@ export type WorkflowSnapshot = Pick<
 	'id' | 'name' | 'nodes' | 'connections' | 'settings' | 'nodeGroups'
 >;
 
-export type ExecutionDataPayload = {
+export type ExecutionDataPayload = BundleWorkflowSnapshot & {
 	data: string;
+};
+
+export function isExecutionDataPayload(x: BundleWorkflowSnapshot): x is ExecutionDataPayload {
+	return 'data' in x && typeof x.data === 'string';
+}
+
+/** The workflow-snapshot part of a payload, without the run data. */
+export type BundleWorkflowSnapshot = {
 	workflowData: WorkflowSnapshot;
 	workflowVersionId: string | null;
 };
-
-/** The workflow-snapshot part of a payload, without the run data. */
-export type BundleWorkflowSnapshot = Pick<
-	ExecutionDataPayload,
-	'workflowData' | 'workflowVersionId'
->;

--- a/packages/cli/src/executions/execution-data/unreadable-run-data.error.ts
+++ b/packages/cli/src/executions/execution-data/unreadable-run-data.error.ts
@@ -1,0 +1,15 @@
+import { UnexpectedError } from 'n8n-workflow';
+
+import type { ExecutionRef } from './types';
+
+/**
+ * Thrown when a merge needs the stored run data but the bundle read back does not
+ * carry it as a string. Reaching this means the read was narrowed to the workflow
+ * snapshot for an update that has to carry the run data over, or the `data` column
+ * holds something other than a serialized bundle.
+ */
+export class UnreadableRunDataError extends UnexpectedError {
+	constructor(ref: ExecutionRef) {
+		super('Execution data bundle carries no readable run data', { extra: { ...ref } });
+	}
+}

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -37,6 +37,7 @@ import {
 	type ExecutionRef,
 	type WorkflowSnapshot,
 } from './execution-data/types';
+import { UnreadableRunDataError } from './execution-data/unreadable-run-data.error';
 import { sumBinaryDataBytes } from './sum-binary-data-bytes';
 import { DuplicateExecutionError } from '../errors/duplicate-execution.error';
 import { EventService } from '../events/event.service';
@@ -843,7 +844,7 @@ export class ExecutionPersistence {
 					serializedData = stored.data;
 				} else {
 					// should not happen, ensures serializedData type safety
-					throw new MissingExecutionDataError(ref);
+					throw new UnreadableRunDataError(ref);
 				}
 
 				const bundle: ExecutionDataPayload = {

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -29,12 +29,13 @@ import { CorruptedExecutionDataError } from './execution-data/corrupted-executio
 import { DbStore } from './execution-data/db-store';
 import { ExecutionDataJsonStore } from './execution-data/execution-data-json-store';
 import { MissingExecutionDataError } from './execution-data/missing-execution-data.error';
-import type {
-	BlobStorageLocation,
-	BundleWorkflowSnapshot,
-	ExecutionDataPayload,
-	ExecutionRef,
-	WorkflowSnapshot,
+import {
+	isExecutionDataPayload,
+	type BlobStorageLocation,
+	type BundleWorkflowSnapshot,
+	type ExecutionDataPayload,
+	type ExecutionRef,
+	type WorkflowSnapshot,
 } from './execution-data/types';
 import { sumBinaryDataBytes } from './sum-binary-data-bytes';
 import { DuplicateExecutionError } from '../errors/duplicate-execution.error';
@@ -775,6 +776,13 @@ export class ExecutionPersistence {
 		const { data, workflowData } = execution;
 		const updatableColumns = this.pickUpdatableEntityColumns(execution);
 
+		// Skip the read on a full overwrite. Safe only with a known version id, except in db mode:
+		// the DB overwrite leaves that column untouched, whereas a blob write would clobber it with null.
+		const isFullOverwrite =
+			data !== undefined &&
+			workflowData !== undefined &&
+			(workflowVersionId !== null || mode === 'db');
+
 		return await this.executionRepository.manager.transaction(async (tx) => {
 			const whereCondition = this.buildEntityWhereCondition(ref.executionId, conditions);
 
@@ -795,13 +803,7 @@ export class ExecutionPersistence {
 				if (!matchingRow) return false;
 			}
 
-			// Skip the read on a full overwrite. Safe only with a known version id, except in db mode:
-			// the DB overwrite leaves that column untouched, whereas a blob write would clobber it with null.
-			if (
-				data !== undefined &&
-				workflowData !== undefined &&
-				(workflowVersionId !== null || mode === 'db')
-			) {
+			if (isFullOverwrite) {
 				const binaryDataSizeBytes = sumBinaryDataBytes(data);
 				const jsonSizeBytes = await this.trackWrite(mode, ref.workflowId, async () => {
 					const bundle: ExecutionDataPayload = {
@@ -823,22 +825,40 @@ export class ExecutionPersistence {
 				return true;
 			}
 
-			// Read the existing bundle to merge the field the caller didn't supply (or to recover the
-			// version id when the entity row doesn't have it).
-			const existing = await this.trackRead(mode, async () => await this.readData(mode, ref, tx));
-			if (!existing) throw new MissingExecutionDataError(ref);
+			// The merge carries over whatever the caller left out. With `data` supplied the run data is
+			// replaced wholesale, so only the workflow snapshot has to be read: in db mode that leaves the
+			// (often far larger) `data` column unread, which matters because this read runs while the
+			// transaction holds the write connection. Otherwise the stored run data is carried over, so
+			// the whole bundle is read.
+			const stored = await this.trackRead(mode, async () =>
+				data !== undefined && mode === 'db'
+					? await this.dbStore.readWorkflowData(ref, tx)
+					: await this.readData(mode, ref, tx),
+			);
+			if (!stored) throw new MissingExecutionDataError(ref);
+
+			// A function rather than a value, so `stringify` runs inside the `trackWrite` callback
+			// below. That metric counts serialization together with the write, so resolving the run
+			// data here would leave the serialization out of the reported duration.
+			// The guard restates what the read above already decided: the read is narrowed to the
+			// workflow snapshot exactly when the caller supplied `data`, so the stored run data is
+			// there whenever this needs it. The type system cannot correlate the two on its own.
+			const storedData = () => {
+				if (data !== undefined) return stringify(data); // this may take some time...
+				if (!isExecutionDataPayload(stored)) throw new MissingExecutionDataError(ref);
+				return stored.data;
+			};
 
 			const jsonSizeBytes = await this.trackWrite(mode, ref.workflowId, async () => {
 				const bundle: ExecutionDataPayload = {
-					data: data !== undefined ? stringify(data) : existing.data,
-					workflowData: workflowData
-						? this.toWorkflowSnapshot(workflowData)
-						: existing.workflowData,
-					workflowVersionId: existing.workflowVersionId,
+					data: storedData(),
+					workflowData: workflowData ? this.toWorkflowSnapshot(workflowData) : stored.workflowData,
+					workflowVersionId: stored.workflowVersionId,
 				};
 
 				return await this.writeData(mode, ref, bundle, tx);
 			});
+
 			// Binary size is derived from the in-memory run data, so only recompute it when the
 			// caller supplied `data`. A workflowData-only update leaves the column untouched (and
 			// doesn't affect binary anyway), mirroring when `jsonSizeBytes` would have changed.

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -825,33 +825,29 @@ export class ExecutionPersistence {
 				return true;
 			}
 
-			// The merge carries over whatever the caller left out. With `data` supplied the run data is
-			// replaced wholesale, so only the workflow snapshot has to be read: in db mode that leaves the
-			// (often far larger) `data` column unread, which matters because this read runs while the
-			// transaction holds the write connection. Otherwise the stored run data is carried over, so
-			// the whole bundle is read.
 			const stored = await this.trackRead(mode, async () =>
 				data !== undefined && mode === 'db'
-					? await this.dbStore.readWorkflowData(ref, tx)
+					? await this.dbStore.readWorkflowData(ref, tx) // do not load .data, it will be overwritten
 					: await this.readData(mode, ref, tx),
 			);
 			if (!stored) throw new MissingExecutionDataError(ref);
 
-			// A function rather than a value, so `stringify` runs inside the `trackWrite` callback
-			// below. That metric counts serialization together with the write, so resolving the run
-			// data here would leave the serialization out of the reported duration.
-			// The guard restates what the read above already decided: the read is narrowed to the
-			// workflow snapshot exactly when the caller supplied `data`, so the stored run data is
-			// there whenever this needs it. The type system cannot correlate the two on its own.
-			const storedData = () => {
-				if (data !== undefined) return stringify(data); // this may take some time...
-				if (!isExecutionDataPayload(stored)) throw new MissingExecutionDataError(ref);
-				return stored.data;
-			};
-
 			const jsonSizeBytes = await this.trackWrite(mode, ref.workflowId, async () => {
+				let serializedData: string;
+
+				if (data !== undefined) {
+					// the caller replaces it, the stored one was not read
+					serializedData = stringify(data);
+				} else if (isExecutionDataPayload(stored)) {
+					// carried over from the full read
+					serializedData = stored.data;
+				} else {
+					// should not happen, ensures serializedData type safety
+					throw new MissingExecutionDataError(ref);
+				}
+
 				const bundle: ExecutionDataPayload = {
-					data: storedData(),
+					data: serializedData,
 					workflowData: workflowData ? this.toWorkflowSnapshot(workflowData) : stored.workflowData,
 					workflowVersionId: stored.workflowVersionId,
 				};


### PR DESCRIPTION
## Summary

On SQLite, `LockAcquireTimeoutError: Timeout waiting for lock SqliteWriteConnectionMutex to become available` has been reported when starting a workflow. The pooled SQLite driver guards its single write connection with one mutex, held for the **whole** transaction rather than per statement, with a 60s acquire timeout. Every write transaction in the process queues on it, and execution creation (`ExecutionPersistence.create`) is the caller that reports the timeout.

### The mitigation the ticket proposed is already in the code

CAT-2301 suggests re-adding a cheap read guard so a progress save for an already finished or canceled execution bails out before entering the write transaction. That guard exists today, and it arrived after 2.7.0 in #30447 as a side effect of that refactor rather than as a response to this ticket:

- `updateExistingExecution` reads the entity first and returns `false` when nothing matches, before `applyDataUpdate` opens any transaction.
- The `finished` / `canceled` filtering happens in that query's `WHERE` clause via `buildEntityWhereCondition` (`requireNotFinished` → `finished = false`, `requireNotCanceled` → `status != 'canceled'`), which is why it is easy to miss when looking for the pre-2.7.0 shape of an application-level check.
- Being a `SELECT`, it routes to the read pool and never contends for the write connection.

So no change was needed there.

### What this PR changes instead: it stops handling data it does not need

A progress save supplies `data` and no `workflowData`, so it took the merge path, which read the **entire** stored bundle inside the write transaction only to carry over the workflow snapshot. The `data` column it also loaded is the largest part of that record and is overwritten by the very same save, so loading it was pure waste, paid for while holding the process-wide write connection.

The merge read is now narrowed to the columns the merge actually consumes:

- `DbStore.readWorkflowData` accepts an optional `EntityManager`, so the existing snapshot-only read (`workflowData`, `workflowVersionId`) can run on the transaction's connection.
- In `db` mode, a data-carrying update reads through it instead of `DbStore.read`, leaving the `data` column unread.
- The two merge cases are now one flow, with the conditionals selecting the read, the run data, and the size columns.

The persisted result is unchanged: the same bundle is written, so `jsonSizeBytes` and `binaryDataSizeBytes` are byte-identical. Blob modes (`fs`, `s3`, `az`) are untouched, since those stores can only fetch whole bundles.

`N8N_EXECUTION_DATA_STORAGE_MODE` defaults to `database`, so this targets the configuration the reported instances actually run.

### Why

Each progress save now holds the single SQLite write connection for less time, because it no longer loads and discards the largest column while holding it. The queue drains faster, so a starting execution is less likely to reach the 60s cutoff.

This is a mitigation, not a fix, and the ticket should stay open. It does not change that SQLite allows one writer, that the mutex is held across a whole transaction, or that waiters are unbounded until the timeout. Under enough concurrency the error can still occur. Deliberately out of scope here:

1. The write half. Each progress save still upserts the whole record, including the workflow snapshot that never changes. Narrowing that would cut more; `DbStore.overwrite` is the precedent.
2. Progress-save frequency. Throttling or coalescing them would reduce contention proportionally.
3. Starvation itself. Only giving execution creation a retry or queue priority, or not holding the connection across a whole transaction, would remove this error class, and the first merely shifts the timeout onto progress saves.

I have not benchmarked the improvement. The tests prove the behaviour is unchanged, not the size of the effect. A load test with concurrent executions on SQLite measuring write-connection hold time would give a real number.

## How to test

No behaviour change to verify by hand; this is an I/O reduction on an existing path. Automated coverage:

```bash
cd packages/cli
pnpm test src/executions src/execution-lifecycle       # 396 pass
pnpm test:integration src/executions                   # 45 pass, real SQLite
```

The added unit test, *should not read the run data it is about to overwrite*, asserts `DbStore.read` is never called for a data-only `db`-mode update, and that the snapshot read receives the transaction. The integration suites exercise the same path against a real database, so the byte-identical persisted result is covered there.

Four existing tests were updated to mock `readWorkflowData` instead of `read`, since that is the method the `db`-mode merge read now uses.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2301

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
