### PR TITLE
feat(core): Add generic feature flag overrides via environment variable

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/feature-flags.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/feature-flags.config.test.ts
@@ -1,0 +1,54 @@
+import { Container } from '@n8n/di';
+
+import { FeatureFlagConfig } from '../feature-flags.config';
+
+describe('FeatureFlagConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+		vi.resetAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	test('defaults override to an empty map', () => {
+		expect(Container.get(FeatureFlagConfig).override).toEqual({});
+	});
+
+	test('parses a JSON map of string and boolean overrides', () => {
+		vi.stubEnv('N8N_FEATURE_FLAG_OVERRIDES', '{"my_flag":true,"multivariate_flag":"variant"}');
+
+		expect(Container.get(FeatureFlagConfig).override).toEqual({
+			my_flag: true,
+			multivariate_flag: 'variant',
+		});
+	});
+
+	test('parses a false value, so a flag can be forced off', () => {
+		vi.stubEnv('N8N_FEATURE_FLAG_OVERRIDES', '{"my_flag":false}');
+
+		expect(Container.get(FeatureFlagConfig).override).toEqual({ my_flag: false });
+	});
+
+	test('falls back to default on JSON that is not an object', () => {
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		vi.stubEnv('N8N_FEATURE_FLAG_OVERRIDES', '["my_flag"]');
+
+		expect(Container.get(FeatureFlagConfig).override).toEqual({});
+		expect(consoleWarnSpy).toHaveBeenCalled();
+	});
+
+	test('falls back to default on invalid JSON', () => {
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		vi.stubEnv('N8N_FEATURE_FLAG_OVERRIDES', 'not-json');
+
+		expect(Container.get(FeatureFlagConfig).override).toEqual({});
+		expect(consoleWarnSpy).toHaveBeenCalled();
+	});
+
+	test('falls back to default on non-string/boolean values', () => {
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		vi.stubEnv('N8N_FEATURE_FLAG_OVERRIDES', '{"my_flag":42}');
+
+		expect(Container.get(FeatureFlagConfig).override).toEqual({});
+		expect(consoleWarnSpy).toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/config/src/configs/feature-flags.config.ts
+++ b/packages/@n8n/config/src/configs/feature-flags.config.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+import { Config, Env } from '../decorators';
+
+const flagOverridesSchema = z
+	.string()
+	.transform((value, ctx): unknown => {
+		try {
+			return JSON.parse(value);
+		} catch {
+			ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'must be valid JSON' });
+			return z.NEVER;
+		}
+	})
+	.pipe(z.record(z.string(), z.union([z.string(), z.boolean()])));
+
+type FlagOverridesSchema = z.infer<typeof flagOverridesSchema>;
+
+@Config
+export class FeatureFlagConfig {
+	/**
+	 * JSON object mapping feature flag names to override values, applied on top
+	 * of the values resolved from the feature-flag provider. Boolean flags take
+	 * `true`/`false`; multivariate flags take their variant string. Because an
+	 * override sets the value outright, `false` also works as a kill switch for
+	 * a flag the provider enabled.
+	 *
+	 * Invalid JSON, or a value that is neither a string nor a boolean, is
+	 * rejected with a warning and leaves all flags untouched.
+	 *
+	 * @example '{"042_some_experiment":"variant","043_other_feature":false}'
+	 */
+	@Env('N8N_FEATURE_FLAG_OVERRIDES', flagOverridesSchema)
+	override: FlagOverridesSchema = {};
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -23,6 +23,7 @@ import { EventBusConfig } from './configs/event-bus.config';
 import { ExecutionsConfig } from './configs/executions.config';
 import { ExpressionEngineConfig } from './configs/expression-engine.config';
 import { ExternalHooksConfig } from './configs/external-hooks.config';
+import { FeatureFlagConfig } from './configs/feature-flags.config';
 import { GenericConfig } from './configs/generic.config';
 import { HiringBannerConfig } from './configs/hiring-banner.config';
 import { HttpRequestConfig } from './configs/http-request.config';
@@ -316,4 +317,7 @@ export class GlobalConfig {
 
 	@Nested
 	instanceSettingsLoader: InstanceSettingsLoaderConfig;
+
+	@Nested
+	featureFlags: FeatureFlagConfig;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -191,6 +191,9 @@ describe('GlobalConfig', () => {
 			separator: ':',
 			files: [],
 		},
+		featureFlags: {
+			override: {},
+		},
 		nodes: {
 			errorTriggerType: 'n8n-nodes-base.errorTrigger',
 			include: [],

--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -227,6 +227,7 @@ describe('PostHog', () => {
 				globalConfig.evaluation.agentEvalsEnabled = false;
 				globalConfig.instanceAi.mcpConnectionsEnabled = false;
 				globalConfig.instanceAi.canvasNodeContextEnabled = false;
+				globalConfig.featureFlags.override = {};
 			});
 
 			it('force-enables the eval-collections flag when N8N_EVAL_COLLECTIONS_ENABLED is set', async () => {
@@ -263,6 +264,72 @@ describe('PostHog', () => {
 				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
 
 				expect(flags).toMatchObject({ '089_instance_ai_mcp_connections': 'variant' });
+			});
+
+			it('applies the generic override map on top of resolved flags', async () => {
+				(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(
+					mockEvaluatedFlags({ 'some-other-flag': true }),
+				);
+				globalConfig.featureFlags.override = {
+					'multivariate-flag': 'variant',
+					'boolean-flag': true,
+				};
+
+				const ph = new PostHogClient(instanceSettings, globalConfig);
+				await ph.init();
+
+				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
+
+				expect(flags).toEqual({
+					'some-other-flag': true,
+					'multivariate-flag': 'variant',
+					'boolean-flag': true,
+				});
+			});
+
+			it('overrides a flag PostHog resolved to a different value', async () => {
+				(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(
+					mockEvaluatedFlags({ 'contested-flag': 'control' }),
+				);
+				globalConfig.featureFlags.override = { 'contested-flag': 'variant' };
+
+				const ph = new PostHogClient(instanceSettings, globalConfig);
+				await ph.init();
+
+				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
+
+				expect(flags).toEqual({ 'contested-flag': 'variant' });
+			});
+
+			// Unlike the per-feature envs (force-enable only), the generic map is
+			// also a kill switch — it must be able to turn an enabled flag off.
+			it('force-disables a flag PostHog resolved to true', async () => {
+				(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(
+					mockEvaluatedFlags({ 'live-flag': true }),
+				);
+				globalConfig.featureFlags.override = { 'live-flag': false };
+
+				const ph = new PostHogClient(instanceSettings, globalConfig);
+				await ph.init();
+
+				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
+
+				expect(flags).toEqual({ 'live-flag': false });
+			});
+
+			// A dedicated per-feature env var must have the final say, so the
+			// generic map cannot undo a feature an operator enabled explicitly.
+			it('does not override a per-feature env override for the same flag', async () => {
+				(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(mockEvaluatedFlags({}));
+				globalConfig.evaluation.configEvalsEnabled = true;
+				globalConfig.featureFlags.override = { '088_config_evaluations': false };
+
+				const ph = new PostHogClient(instanceSettings, globalConfig);
+				await ph.init();
+
+				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
+
+				expect(flags).toMatchObject({ '088_config_evaluations': 'variant' });
 			});
 
 			it('leaves flags untouched when no override is configured', async () => {

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -190,13 +190,21 @@ export class PostHogClient {
 	}
 
 	/**
-	 * Applies env-var overrides on top of PostHog-resolved flags. The override
-	 * is force-enable only — `false` defers to PostHog. Cached PostHog data is
-	 * stored without overrides so changing the env var (across restarts)
+	 * Applies env-var overrides on top of PostHog-resolved flags. Cached PostHog
+	 * data is stored without overrides so changing an env var (across restarts)
 	 * doesn't poison the cache.
+	 *
+	 * Both tiers win over PostHog. Between themselves, the generic map goes
+	 * first so a dedicated per-feature env var always has the final say:
+	 * 1. The generic map (`N8N_FEATURE_FLAG_OVERRIDES`) — sets a flag to any
+	 *    value, so unlike tier 2 it can force a flag *off* as well as on.
+	 * 2. Per-feature booleans (`N8N_CONFIG_EVALS_ENABLED`, …) — force-enable
+	 *    only; `false` defers to PostHog. Applied last so the generic map
+	 *    cannot undo a feature an operator enabled explicitly.
 	 */
 	private applyEnvOverrides(flags: FeatureFlags): FeatureFlags {
-		const overrides: FeatureFlags = {};
+		const overrides: FeatureFlags = { ...this.globalConfig.featureFlags.override };
+
 		if (this.globalConfig.evaluation.collectionsEnabled) {
 			overrides[EVAL_COLLECTIONS_FLAG] = true;
 		}


### PR DESCRIPTION

## Summary

Adds `N8N_FEATURE_FLAG_OVERRIDES`, a JSON map of feature flag name to override value, applied on top of the values resolved from PostHog. Boolean flags take `true`/`false`, multivariate flags take their variant string.

The overridden flags are per instance and are cached in the backend, so it also works for feature flags that are evaluated in the backend and not only in the browser. The existing per-feature env overrides take priority over the new generic override.

Invalid JSON, or a value that is neither a string nor a boolean, is rejected with a warning and leaves all flags untouched.

## How to test

1. set `N8N_FEATURE_FLAG_OVERRIDES='{"some_flag":"variant"}'` env var
2. start n8n
3. observe that flags returned from `/login` endpoint correctly return the flag override

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

