### PR TITLE
fix(core): Normalize env values before schema-based parsing

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/security.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/security.config.test.ts
@@ -19,16 +19,18 @@ describe('SecurityConfig', () => {
 			expect(Container.get(SecurityConfig).awsSystemCredentialsSdkSources).toBe('all');
 		});
 
+		// Leading/trailing whitespace is trimmed before parsing; inner whitespace is
+		// preserved and handled by the consumer (`usesSdk` trims per source).
 		test.each([
-			'all',
-			'none',
-			'environment',
-			'environment,instanceMetadata',
-			' environment , podIdentity ',
-			'environment,',
-		])('accepts valid value %p', (value) => {
+			['all', 'all'],
+			['none', 'none'],
+			['environment', 'environment'],
+			['environment,instanceMetadata', 'environment,instanceMetadata'],
+			[' environment , podIdentity ', 'environment , podIdentity'],
+			['environment,', 'environment,'],
+		])('accepts valid value %p', (value, expected) => {
 			process.env = { N8N_AWS_SYSTEM_CREDENTIALS_SDK_SOURCES: value };
-			expect(Container.get(SecurityConfig).awsSystemCredentialsSdkSources).toBe(value);
+			expect(Container.get(SecurityConfig).awsSystemCredentialsSdkSources).toBe(expected);
 		});
 
 		test('falls back to the default and warns on an unknown source', () => {

--- a/packages/@n8n/config/src/decorators.ts
+++ b/packages/@n8n/config/src/decorators.ts
@@ -23,14 +23,14 @@ const readEnv = (envName: string) => {
 	const filePath = process.env[`${envName}_FILE`];
 	if (filePath) {
 		const value = readFileSync(filePath, 'utf8');
-		if (value !== value.trim()) {
+		// File contents commonly carry a trailing newline (e.g. `echo value > file`)
+		const trimmed = value.trim();
+		if (value !== trimmed) {
 			console.warn(
-				`[n8n] Warning: The file specified by ${envName}_FILE contains leading or trailing whitespace, which may cause authentication failures.`,
+				`[n8n] Warning: The file specified by ${envName}_FILE contained leading or trailing whitespace; the value was trimmed.`,
 			);
 		}
-		// Config file contents commonly carry a trailing newline (e.g. `echo value > file`);
-		// leaving it in silently fails schema/type parsing and falls back to the default value.
-		return value.trim();
+		return trimmed;
 	}
 
 	return undefined;

--- a/packages/@n8n/config/src/decorators.ts
+++ b/packages/@n8n/config/src/decorators.ts
@@ -36,6 +36,10 @@ const readEnv = (envName: string) => {
 	return undefined;
 };
 
+// Env values commonly carry stray whitespace or surrounding quotes (e.g. compose env_file,
+// `echo value > file`); strip both so parsing doesn't silently fall back to the default value.
+const normalizeEnvValue = (value: string) => value.trim().replace(/^(['"])(.*)\1$/, '$2');
+
 export const Config: ClassDecorator = (ConfigClass: Class) => {
 	const factory = function (...args: unknown[]) {
 		const config = new (ConfigClass as new (...a: unknown[]) => Record<PropertyKey, unknown>)(
@@ -54,7 +58,7 @@ export const Config: ClassDecorator = (ConfigClass: Class) => {
 				if (value === undefined) continue;
 
 				if (schema) {
-					const result = schema.safeParse(value);
+					const result = schema.safeParse(normalizeEnvValue(value));
 					if (result.error) {
 						console.warn(
 							`Invalid value for ${envName} - ${result.error.issues[0].message}. Falling back to default value.`,
@@ -85,7 +89,7 @@ export const Config: ClassDecorator = (ConfigClass: Class) => {
 						config[key] = new Date(timestamp);
 					}
 				} else if (type === String) {
-					config[key] = value.trim().replace(/^(['"])(.*)\1$/, '$2');
+					config[key] = normalizeEnvValue(value);
 				} else {
 					config[key] = new (type as Constructable)(value);
 				}

--- a/packages/@n8n/config/src/decorators.ts
+++ b/packages/@n8n/config/src/decorators.ts
@@ -28,7 +28,9 @@ const readEnv = (envName: string) => {
 				`[n8n] Warning: The file specified by ${envName}_FILE contains leading or trailing whitespace, which may cause authentication failures.`,
 			);
 		}
-		return value;
+		// Config file contents commonly carry a trailing newline (e.g. `echo value > file`);
+		// leaving it in silently fails schema/type parsing and falls back to the default value.
+		return value.trim();
 	}
 
 	return undefined;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -872,7 +872,7 @@ describe('GlobalConfig', () => {
 		expect(config.database.postgresdb.password).toBe('password-from-file');
 		expect(consoleWarnMock).toHaveBeenCalledWith(
 			expect.stringContaining(
-				'DB_POSTGRESDB_PASSWORD_FILE contains leading or trailing whitespace',
+				'DB_POSTGRESDB_PASSWORD_FILE contained leading or trailing whitespace',
 			),
 		);
 	});

--- a/packages/@n8n/config/test/decorators.test.ts
+++ b/packages/@n8n/config/test/decorators.test.ts
@@ -64,7 +64,7 @@ describe('decorators', () => {
 		const config = Container.get(TestConfig);
 		expect(config.value).toBe('secret-value');
 		expect(consoleWarnSpy).toHaveBeenCalledWith(
-			expect.stringContaining('TEST_VALUE_FILE contains leading or trailing whitespace'),
+			expect.stringContaining('TEST_VALUE_FILE contained leading or trailing whitespace'),
 		);
 		consoleWarnSpy.mockRestore();
 	});
@@ -113,6 +113,7 @@ describe('decorators', () => {
 		const filePath = '/path/to/secret';
 		process.env.TEST_VALUE_FILE = filePath;
 		mockFs.readFileSync.mockReturnValueOnce('legacy\n');
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		@Config
 		class TestConfig {
@@ -122,5 +123,7 @@ describe('decorators', () => {
 
 		const config = Container.get(TestConfig);
 		expect(config.value).toBe('legacy');
+		expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('the value was trimmed'));
+		consoleWarnSpy.mockRestore();
 	});
 });

--- a/packages/@n8n/config/test/decorators.test.ts
+++ b/packages/@n8n/config/test/decorators.test.ts
@@ -85,6 +85,30 @@ describe('decorators', () => {
 		expect(mockFs.readFileSync).not.toHaveBeenCalled();
 	});
 
+	it('should trim whitespace from a direct env value before parsing it with a zod schema', () => {
+		process.env.TEST_VALUE = 'legacy ';
+
+		@Config
+		class TestConfig {
+			@Env('TEST_VALUE', z.enum(['legacy', 'vm']))
+			value: string = 'vm';
+		}
+
+		expect(Container.get(TestConfig).value).toBe('legacy');
+	});
+
+	it('should strip surrounding quotes from an env value before parsing it with a zod schema', () => {
+		process.env.TEST_VALUE = "'legacy'";
+
+		@Config
+		class TestConfig {
+			@Env('TEST_VALUE', z.enum(['legacy', 'vm']))
+			value: string = 'vm';
+		}
+
+		expect(Container.get(TestConfig).value).toBe('legacy');
+	});
+
 	it('should trim trailing newline from _FILE value before parsing it with a zod schema', () => {
 		const filePath = '/path/to/secret';
 		process.env.TEST_VALUE_FILE = filePath;

--- a/packages/@n8n/config/test/decorators.test.ts
+++ b/packages/@n8n/config/test/decorators.test.ts
@@ -1,5 +1,6 @@
 import { Container } from '@n8n/di';
 import fs from 'fs';
+import { z } from 'zod';
 
 import { Config, Env } from '../src/decorators';
 
@@ -82,5 +83,20 @@ describe('decorators', () => {
 		const config = Container.get(TestConfig);
 		expect(config.value).toBe('direct-value');
 		expect(mockFs.readFileSync).not.toHaveBeenCalled();
+	});
+
+	it('should trim trailing newline from _FILE value before parsing it with a zod schema', () => {
+		const filePath = '/path/to/secret';
+		process.env.TEST_VALUE_FILE = filePath;
+		mockFs.readFileSync.mockReturnValueOnce('legacy\n');
+
+		@Config
+		class TestConfig {
+			@Env('TEST_VALUE', z.enum(['legacy', 'vm']))
+			value: string = 'vm';
+		}
+
+		const config = Container.get(TestConfig);
+		expect(config.value).toBe('legacy');
 	});
 });


### PR DESCRIPTION
## Summary

Config values validated with a zod schema went straight into `schema.safeParse()` unchanged. Values carrying stray whitespace or surrounding quotes — a trailing newline in a `*_FILE` (`echo value > file` adds one by default), a trailing space from a k8s ConfigMap, or quotes surviving Docker Compose's `env_file:` (which doesn't strip them the way a shell does) — fail validation. On failure the code only logs a warning and falls back to the field's default value; it does not surface the error to the operator.

Concretely, an operator who sets `N8N_EXPRESSION_ENGINE=legacy` (or the `_FILE` variant) to opt out of the vm expression engine could silently end up running the opposite of what they configured, with no error, only a warning in the logs.

The fix normalizes the value — trim plus stripping one pair of surrounding quotes — before zod parsing, for both the direct env var and the `_FILE` source. This is the same normalization String-typed fields have always applied. `_FILE` contents are additionally trimmed at read time (with a warning) so the remaining field types (Boolean, Date, Constructable) also cope with a trailing newline.

### Blast radius

All zod-typed `@Env` fields were inventoried: they are enums, coerced numbers, or string schemas that either trim internally (`N8N_AWS_SYSTEM_CREDENTIALS_SDK_SOURCES`, `N8N_SSRF_BLOCKED_IP_RANGES`) or whose valid values cannot begin with a quote character (`N8N_QUICK_CONNECT_OPTIONS` takes a JSON array, `N8N_MCP_BASE_URL` an http(s) URL). No currently-valid value changes meaning.

**Upgrade note:** values that previously failed parsing and were silently ignored now take effect after upgrading — e.g. a forgotten `*_FILE` with a trailing newline pointing at a Boolean field.

## How to test

1. Write a file containing `legacy\n` (e.g. `echo legacy > /tmp/engine-opt-out`).
2. Set `N8N_EXPRESSION_ENGINE_FILE=/tmp/engine-opt-out` and start n8n with no `N8N_EXPRESSION_ENGINE` set.
3. Before this fix: the value fails schema validation, n8n falls back to the default (`vm`), console shows a whitespace warning only.
4. After this fix: n8n picks up `legacy` correctly. Same for `N8N_EXPRESSION_ENGINE='legacy '` or `"'legacy'"` set directly.

Unit test coverage added in `packages/@n8n/config/test/decorators.test.ts` covers whitespace and quotes for zod-validated fields on both sources.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4127

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->