### PR TITLE
fix: Return list-search pagination token as a string in github-issues template

### DIFF
--- a/packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/nodes/GithubIssues/listSearch/getIssues.ts
+++ b/packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/nodes/GithubIssues/listSearch/getIssues.ts
@@ -45,5 +45,5 @@ export async function getIssues(
 	}));
 
 	const nextPaginationToken = page * per_page < responseData.total_count ? page + 1 : undefined;
-	return { results, paginationToken: nextPaginationToken };
+	return { results, paginationToken: nextPaginationToken?.toString() };
 }

--- a/packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/nodes/GithubIssues/listSearch/getRepositories.ts
+++ b/packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/nodes/GithubIssues/listSearch/getRepositories.ts
@@ -46,5 +46,5 @@ export async function getRepositories(
 	}));
 
 	const nextPaginationToken = page * per_page < responseData.total_count ? page + 1 : undefined;
-	return { results, paginationToken: nextPaginationToken };
+	return { results, paginationToken: nextPaginationToken?.toString() };
 }

--- a/packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/nodes/GithubIssues/listSearch/getUsers.ts
+++ b/packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/nodes/GithubIssues/listSearch/getUsers.ts
@@ -45,5 +45,5 @@ export async function getUsers(
 	}));
 
 	const nextPaginationToken = page * per_page < responseData.total_count ? page + 1 : undefined;
-	return { results, paginationToken: nextPaginationToken };
+	return { results, paginationToken: nextPaginationToken?.toString() };
 }


### PR DESCRIPTION
## Summary

`INodeListSearchResult.paginationToken` is typed `string | undefined`, but the
`declarative/github-issues` scaffolding template (`packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/nodes/GithubIssues/listSearch/{getIssues,getRepositories,getUsers}.ts`)
computed the next page as a `number` and returned it unconverted:

```ts
const nextPaginationToken = page * per_page < responseData.total_count ? page + 1 : undefined;
return { results, paginationToken: nextPaginationToken }; // number, but the field wants string
```

Any project scaffolded with `n8n-node new --template declarative/github-issues`
fails type checking out of the box. This fixes all three list-search files to
convert the token back to a string before returning it.

## How to test

```bash
cd packages/@n8n/node-cli
pnpm build
node dist/index.js new test-project --template declarative/github-issues --force --skip-install
cd test-project && pnpm install && pnpm typecheck
```

Before this fix, `typecheck` fails on `getIssues.ts`, `getRepositories.ts`,
and `getUsers.ts` with a type mismatch on `paginationToken`. After, it passes.

## Related Linear tickets, Github issues, and Community forum posts

Related to https://linear.app/n8n/issue/CE-828 (drift between the CLI templates
and `n8n-nodes-starter` / generated projects) — this is one concrete instance
of that drift, though it doesn't implement CE-828's broader regeneration
workflow.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

