### PR TITLE
feat(core): Schedule agent tasks via the durable scheduler behind a flag (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -269,6 +269,14 @@ export class SchedulerConfig {
 	enabledForPollTriggers: boolean = false;
 
 	/**
+	 * Whether agent scheduled tasks are scheduled by the durable scheduler
+	 * instead of n8n's in-process timer. Off by default; requires
+	 * {@link enabled} to also be on.
+	 */
+	@Env('N8N_SCHEDULER_AGENT_TASKS_ENABLED')
+	enabledForAgentTasks: boolean = false;
+
+	/**
 	 * Temporary escape hatch for the durable-scheduler rollout (preview to GA).
 	 * Off by default; intended to be removed once the durable scheduler is GA.
 	 *

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -475,6 +475,7 @@ describe('GlobalConfig', () => {
 			maxConcurrentPasses: 10,
 			triggerNodeMode: 'legacy',
 			enabledForPollTriggers: false,
+			enabledForAgentTasks: false,
 			allowSkipDurableScheduler: false,
 			maxAttempts: 5,
 			misfireGraceSeconds: 60,

--- a/packages/@n8n/db/src/repositories/scheduled-job.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-job.repository.ts
@@ -250,6 +250,16 @@ export class ScheduledJobRepository extends Repository<ScheduledJob> {
 	}
 
 	/**
+	 * Delete all jobs of one task type, whoever owns them; their tasks cascade
+	 * away. For teardown of a whole consumer, e.g. when its feature flag is off.
+	 * @returns how many jobs were deleted (0 when the driver can't report it).
+	 */
+	async deleteByTaskType(manager: EntityManager, taskType: string): Promise<number> {
+		const result = await manager.delete(ScheduledJob, { taskType });
+		return result.affected ?? 0;
+	}
+
+	/**
 	 * Delete all jobs of one task type owned by a workflow; their tasks cascade away.
 	 * @returns how many jobs were deleted (0 when the driver can't report it).
 	 */

--- a/packages/cli/src/modules/agents/__tests__/agent-task.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-task.service.test.ts
@@ -896,11 +896,10 @@ describe('AgentTaskService', () => {
 	});
 
 	describe('runTask', () => {
-		const publishedAgentWithTask = (enabled: boolean) =>
-			makePublishedAgent([{ id: 'task-1', enabled }]);
-
 		it('runs the published agent with the objective', async () => {
-			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
+			(agentRepository.findOne as Mock).mockResolvedValue(
+				makePublishedAgent([{ id: 'task-1', enabled: true }]),
+			);
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
 			(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
 				emptyStream(),
@@ -971,7 +970,9 @@ describe('AgentTaskService', () => {
 		});
 
 		it('skips when the published task snapshot is not enabled', async () => {
-			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
+			(agentRepository.findOne as Mock).mockResolvedValue(
+				makePublishedAgent([{ id: 'task-1', enabled: true }]),
+			);
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(
 				makeSnapshot({ enabled: false }),
 			);
@@ -982,7 +983,9 @@ describe('AgentTaskService', () => {
 		});
 
 		it('logs when execution throws', async () => {
-			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
+			(agentRepository.findOne as Mock).mockResolvedValue(
+				makePublishedAgent([{ id: 'task-1', enabled: true }]),
+			);
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
 			(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
 				throwingStream(),
@@ -998,14 +1001,18 @@ describe('AgentTaskService', () => {
 		});
 
 		it('allows a later scheduled run after a failed execution completes', async () => {
-			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
+			(agentRepository.findOne as Mock).mockResolvedValue(
+				makePublishedAgent([{ id: 'task-1', enabled: true }]),
+			);
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
 			(agentExecutionOrchestratorService.executeForTaskPublished as Mock)
 				.mockReturnValueOnce(throwingStream())
 				.mockReturnValueOnce(emptyStream());
 
 			await runScheduledTaskOf(service, AGENT_ID, 'task-1');
+			await flushAsyncWork();
 			await runScheduledTaskOf(service, AGENT_ID, 'task-1');
+			await flushAsyncWork();
 
 			expect(agentExecutionOrchestratorService.executeForTaskPublished).toHaveBeenCalledTimes(2);
 			expect(taskRunLockRepository.release).toHaveBeenCalledTimes(2);
@@ -1021,7 +1028,9 @@ describe('AgentTaskService', () => {
 						finishRun = resolve;
 					});
 				}
-				(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
+				(agentRepository.findOne as Mock).mockResolvedValue(
+					makePublishedAgent([{ id: 'task-1', enabled: true }]),
+				);
 				(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
 				(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
 					blockingStream(),
@@ -1043,6 +1052,57 @@ describe('AgentTaskService', () => {
 			} finally {
 				vi.useRealTimers();
 			}
+		});
+	});
+
+	describe('startScheduledRun', () => {
+		it("returns 'skipped-active' without running when the lock is held", async () => {
+			taskRunLockRepository.acquire.mockResolvedValue(null);
+
+			await expect(service.startScheduledRun(AGENT_ID, 'task-1')).resolves.toBe('skipped-active');
+
+			expect(agentExecutionOrchestratorService.executeForTaskPublished).not.toHaveBeenCalled();
+			expect(taskRunLockRepository.release).not.toHaveBeenCalled();
+		});
+
+		it("returns 'started' before the run resolves, then releases the lock after it", async () => {
+			let finishRun!: () => void;
+			// eslint-disable-next-line require-yield
+			async function* blockingStream(): AsyncGenerator<never> {
+				await new Promise<void>((resolve) => {
+					finishRun = resolve;
+				});
+			}
+			(agentRepository.findOne as Mock).mockResolvedValue(
+				makePublishedAgent([{ id: 'task-1', enabled: true }]),
+			);
+			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
+			(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
+				blockingStream(),
+			);
+
+			await expect(service.startScheduledRun(AGENT_ID, 'task-1')).resolves.toBe('started');
+			await flushAsyncWork();
+			expect(taskRunLockRepository.release).not.toHaveBeenCalled();
+
+			finishRun();
+			await flushAsyncWork();
+			expect(taskRunLockRepository.release).toHaveBeenCalledTimes(1);
+		});
+
+		it('releases the lock when the run fails', async () => {
+			(agentRepository.findOne as Mock).mockResolvedValue(
+				makePublishedAgent([{ id: 'task-1', enabled: true }]),
+			);
+			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
+			(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
+				throwingStream(),
+			);
+
+			await expect(service.startScheduledRun(AGENT_ID, 'task-1')).resolves.toBe('started');
+			await flushAsyncWork();
+
+			expect(taskRunLockRepository.release).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/cli/src/modules/agents/agent-task.service.ts
+++ b/packages/cli/src/modules/agents/agent-task.service.ts
@@ -481,33 +481,54 @@ export class AgentTaskService {
 	// ── Run ───────────────────────────────────────────────────────────────
 
 	private async runScheduledTask(agentId: string, taskId: string): Promise<void> {
-		const holderId = randomUUID();
-		let lock: AgentTaskRunLockHandle | null = null;
-		let renewInterval: ReturnType<typeof setInterval> | undefined;
 		try {
-			lock = await this.taskRunLockRepository.acquire(agentId, taskId, {
-				holderId,
-				ttlMs: TASK_RUN_LOCK_TTL_MS,
-			});
-			if (!lock) {
-				this.logger.info('[AgentTaskService] Skipping task because previous run is still active', {
-					taskId,
-					agentId,
-				});
-				return;
-			}
-
-			renewInterval = this.startTaskRunLockRenewal(lock);
-			await this.runTask(agentId, taskId);
+			await this.startScheduledRun(agentId, taskId);
 		} catch (error) {
 			this.logger.error('[AgentTaskService] Scheduled task lock failed', {
 				taskId,
 				agentId,
 				error: error instanceof Error ? error.message : String(error),
 			});
-		} finally {
-			if (renewInterval) clearInterval(renewInterval);
-			if (lock) {
+		}
+	}
+
+	/**
+	 * Take the run lock and start the task run in the background, resolving as
+	 * soon as the lock decision is made. Both schedulers enter here: the
+	 * in-memory cron via `runScheduledTask`, the durable handler directly — the
+	 * latter must report its dispatch decision within the occurrence's lease, so
+	 * it cannot wait out a run that takes minutes.
+	 *
+	 * A lock-acquisition failure propagates to the caller; run failures are
+	 * logged by the background continuation, which also renews the lock while
+	 * the run lasts and releases it after.
+	 */
+	async startScheduledRun(agentId: string, taskId: string): Promise<'started' | 'skipped-active'> {
+		const holderId = randomUUID();
+		const lock = await this.taskRunLockRepository.acquire(agentId, taskId, {
+			holderId,
+			ttlMs: TASK_RUN_LOCK_TTL_MS,
+		});
+		if (!lock) {
+			this.logger.info('[AgentTaskService] Skipping task because previous run is still active', {
+				taskId,
+				agentId,
+			});
+			return 'skipped-active';
+		}
+
+		const renewInterval = this.startTaskRunLockRenewal(lock);
+		void (async () => {
+			try {
+				await this.runTask(agentId, taskId);
+			} catch (error) {
+				this.logger.error('[AgentTaskService] Scheduled task run failed', {
+					taskId,
+					agentId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			} finally {
+				clearInterval(renewInterval);
 				await this.taskRunLockRepository.release(lock).catch((error) => {
 					this.logger.warn('[AgentTaskService] Failed to release task run lock', {
 						taskId,
@@ -516,7 +537,8 @@ export class AgentTaskService {
 					});
 				});
 			}
-		}
+		})();
+		return 'started';
 	}
 
 	private startTaskRunLockRenewal(lock: AgentTaskRunLockHandle): ReturnType<typeof setInterval> {

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -144,6 +144,27 @@ export class AgentsModule implements ModuleInterface {
 		} else {
 			logger.debug('[Agents] Skipping task reconnect on startup — not leader');
 		}
+
+		// Durable scheduling for agent tasks. Registered before DurableScheduler
+		// starts (module init precedes its start() in the start command); both the
+		// handler registration and the reconcile self-gate on the scheduler flags.
+		const { AgentTaskTaskHandler } = await import('./scheduling/agent-task-task-handler.js');
+		const { AgentTaskJobRegistrar } = await import('./scheduling/agent-task-job-registrar.js');
+		const { DurableScheduler } = await import('@/scheduling/durable-scheduler.js');
+		const agentTaskHandler = Container.get(AgentTaskTaskHandler);
+		Container.get(DurableScheduler).registerTaskHandler(
+			agentTaskHandler.taskType,
+			agentTaskHandler,
+		);
+		if (instanceSettings.instanceType === 'main') {
+			void Container.get(AgentTaskJobRegistrar)
+				.reconcileAll()
+				.catch((error) => {
+					logger.error('[Agents] Failed to reconcile durable agent-task jobs on startup', {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+		}
 	}
 
 	@OnShutdown()

--- a/packages/cli/src/modules/agents/repositories/agent-task-schedule.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-task-schedule.repository.ts
@@ -1,3 +1,4 @@
+import type { ScheduledJob } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DataSource, Repository } from '@n8n/typeorm';
 import type { EntityManager } from '@n8n/typeorm';
@@ -8,14 +9,36 @@ import { AgentTaskSchedule } from '../entities/agent-task-schedule.entity';
 export type NewAgentTaskSchedule = Pick<AgentTaskSchedule, 'jobId' | 'agentId' | 'taskId'>;
 
 /**
- * Ownership links between agents and their `scheduled_job` rows. Methods take
- * the caller's `EntityManager` so link writes commit atomically with the job
- * writes of the same provisioning transaction.
+ * Ownership links between agents and their `scheduled_job` rows. Methods that
+ * take an `EntityManager` run within the caller's provisioning transaction, so
+ * link writes commit atomically with the job writes they describe.
  */
 @Service()
 export class AgentTaskScheduleRepository extends Repository<AgentTaskSchedule> {
 	constructor(dataSource: DataSource) {
 		super(AgentTaskSchedule, dataSource.manager);
+	}
+
+	/** One agent's jobs of one task type, within the caller's transaction. */
+	async findJobsForAgent(
+		manager: EntityManager,
+		agentId: string,
+		taskType: string,
+	): Promise<ScheduledJob[]> {
+		const links = await manager.find(AgentTaskSchedule, {
+			where: { agentId },
+			relations: { job: true },
+		});
+		return links.map((link) => link.job).filter((job) => job.taskType === taskType);
+	}
+
+	/** Ids of one agent's jobs of one task type, for deprovisioning. */
+	async findJobIdsForAgent(agentId: string, taskType: string): Promise<number[]> {
+		const links = await this.find({
+			where: { agentId, job: { taskType } },
+			relations: { job: true },
+		});
+		return links.map((link) => link.jobId);
 	}
 
 	/**

--- a/packages/cli/src/modules/agents/scheduling/__tests__/agent-task-job-registrar.test.ts
+++ b/packages/cli/src/modules/agents/scheduling/__tests__/agent-task-job-registrar.test.ts
@@ -1,0 +1,225 @@
+import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
+import { ScheduledJobMisfirePolicy } from '@n8n/constants';
+import type { ScheduledJob } from '@n8n/db';
+import type { EntityManager } from '@n8n/typeorm';
+import { mock } from 'vitest-mock-extended';
+
+import type {
+	DurableJobProvisioner,
+	LinkedProvisionScope,
+} from '@/scheduling/durable-job-provisioner';
+
+import type { Agent } from '../../entities/agent.entity';
+import type { AgentTaskSnapshot } from '../../entities/agent-task-snapshot.entity';
+import type { AgentRepository } from '../../repositories/agent.repository';
+import type { AgentTaskScheduleRepository } from '../../repositories/agent-task-schedule.repository';
+import type { AgentTaskSnapshotRepository } from '../../repositories/agent-task-snapshot.repository';
+import { AGENT_TASK_TASK_TYPE } from '../agent-task-job';
+import { AgentTaskJobRegistrar } from '../agent-task-job-registrar';
+
+const AGENT_ID = 'agent-1';
+
+describe('AgentTaskJobRegistrar', () => {
+	const logger = mock<Logger>();
+	logger.scoped.mockReturnValue(logger);
+	const agentRepository = mock<AgentRepository>();
+	const taskSnapshotRepository = mock<AgentTaskSnapshotRepository>();
+	const taskScheduleRepository = mock<AgentTaskScheduleRepository>();
+	const provisioner = mock<DurableJobProvisioner>();
+	const manager = mock<EntityManager>();
+
+	const makeRegistrar = (scheduler: Partial<GlobalConfig['scheduler']> = {}) =>
+		new AgentTaskJobRegistrar(
+			logger,
+			mock<GlobalConfig>({
+				scheduler: { enabled: true, enabledForAgentTasks: true, ...scheduler },
+				generic: { timezone: 'UTC' },
+			}),
+			agentRepository,
+			taskSnapshotRepository,
+			taskScheduleRepository,
+			provisioner,
+		);
+
+	const publishedAgent = (overrides: Partial<Agent> = {}): Agent =>
+		mock<Agent>({ id: AGENT_ID, activeVersionId: 'version-1', ...overrides });
+
+	const snapshot = (overrides: Partial<AgentTaskSnapshot> = {}): AgentTaskSnapshot =>
+		mock<AgentTaskSnapshot>({
+			versionId: 'version-1',
+			taskId: 'task-1',
+			enabled: true,
+			cronExpression: '0 9 * * *',
+			timezone: null,
+			...overrides,
+		});
+
+	const provisionedScope = (): LinkedProvisionScope =>
+		provisioner.provisionLinked.mock.calls[0][0] as LinkedProvisionScope;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger.scoped.mockReturnValue(logger);
+		agentRepository.findById.mockResolvedValue(publishedAgent());
+		agentRepository.findPublished.mockResolvedValue([publishedAgent()]);
+		taskSnapshotRepository.findEnabledByVersionId.mockResolvedValue([snapshot()]);
+		taskScheduleRepository.findJobIdsForAgent.mockResolvedValue([]);
+		provisioner.provisionLinked.mockResolvedValue({
+			inserted: [],
+			redefined: [],
+			unchanged: [],
+			removed: [],
+		});
+		provisioner.deprovisionJobs.mockResolvedValue({ removed: 0 });
+		provisioner.deprovisionTaskType.mockResolvedValue({ removed: 0 });
+	});
+
+	describe('reconcile', () => {
+		it('provisions enabled snapshots as skip-policy cron jobs owned by the agent', async () => {
+			taskSnapshotRepository.findEnabledByVersionId.mockResolvedValue([
+				snapshot(),
+				snapshot({ taskId: 'task-2', cronExpression: '30 8 * * 1', timezone: 'Europe/Berlin' }),
+			]);
+
+			await makeRegistrar().reconcile(AGENT_ID);
+
+			expect(taskSnapshotRepository.findEnabledByVersionId).toHaveBeenCalledWith('version-1');
+			const [scope, desired] = provisioner.provisionLinked.mock.calls[0];
+			expect(scope).toMatchObject({
+				taskType: AGENT_TASK_TASK_TYPE,
+				misfirePolicy: ScheduledJobMisfirePolicy.Skip,
+			});
+			expect(desired).toEqual([
+				{
+					name: `agent-task:${AGENT_ID}:task-1`,
+					schedule: { kind: 'cron', cronExpression: '0 9 * * *', timezone: null },
+					firstRunAt: expect.any(Date),
+					payload: { agentId: AGENT_ID, taskId: 'task-1' },
+				},
+				{
+					name: `agent-task:${AGENT_ID}:task-2`,
+					schedule: { kind: 'cron', cronExpression: '30 8 * * 1', timezone: 'Europe/Berlin' },
+					firstRunAt: expect.any(Date),
+					payload: { agentId: AGENT_ID, taskId: 'task-2' },
+				},
+			]);
+		});
+
+		it('builds ownership links from the job name', async () => {
+			await makeRegistrar().reconcile(AGENT_ID);
+			const scope = provisionedScope();
+
+			await scope.linkInserted(manager, [{ id: 100, name: `agent-task:${AGENT_ID}:task-1` }]);
+			expect(taskScheduleRepository.insertMany).toHaveBeenCalledWith(manager, [
+				{ jobId: 100, agentId: AGENT_ID, taskId: 'task-1' },
+			]);
+		});
+
+		it("reads existing jobs through the agent's link table", async () => {
+			const existing = [mock<ScheduledJob>({ id: 10 })];
+			taskScheduleRepository.findJobsForAgent.mockResolvedValue(existing);
+
+			await makeRegistrar().reconcile(AGENT_ID);
+			const scope = provisionedScope();
+
+			await expect(scope.findExisting(manager)).resolves.toBe(existing);
+			expect(taskScheduleRepository.findJobsForAgent).toHaveBeenCalledWith(
+				manager,
+				AGENT_ID,
+				AGENT_TASK_TASK_TYPE,
+			);
+		});
+
+		it('omits a snapshot with an invalid cron, warning instead of failing the reconcile', async () => {
+			taskSnapshotRepository.findEnabledByVersionId.mockResolvedValue([
+				snapshot({ taskId: 'bad-task', cronExpression: 'not a cron' }),
+				snapshot(),
+			]);
+
+			await makeRegistrar().reconcile(AGENT_ID);
+
+			const [, desired] = provisioner.provisionLinked.mock.calls[0];
+			expect(desired).toHaveLength(1);
+			expect(desired[0].name).toBe(`agent-task:${AGENT_ID}:task-1`);
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Skipping task with invalid cron',
+				expect.objectContaining({ taskId: 'bad-task' }),
+			);
+		});
+
+		it('falls back to the instance timezone when a snapshot carries an unknown one', async () => {
+			taskSnapshotRepository.findEnabledByVersionId.mockResolvedValue([
+				snapshot({ timezone: 'Neverland/Nowhere' }),
+			]);
+
+			await makeRegistrar().reconcile(AGENT_ID);
+
+			const [, desired] = provisioner.provisionLinked.mock.calls[0];
+			expect(desired[0].schedule).toEqual({
+				kind: 'cron',
+				cronExpression: '0 9 * * *',
+				timezone: null,
+			});
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Task has unknown timezone, using instance timezone',
+				expect.objectContaining({ timezone: 'Neverland/Nowhere' }),
+			);
+		});
+
+		it.each([
+			['deleted', null],
+			['unpublished', mock<Agent>({ id: AGENT_ID, activeVersionId: null })],
+		])('deprovisions the jobs the link table names when the agent is %s', async (_name, agent) => {
+			agentRepository.findById.mockResolvedValue(agent);
+			taskScheduleRepository.findJobIdsForAgent.mockResolvedValue([10, 11]);
+
+			await makeRegistrar().reconcile(AGENT_ID);
+
+			expect(taskScheduleRepository.findJobIdsForAgent).toHaveBeenCalledWith(
+				AGENT_ID,
+				AGENT_TASK_TASK_TYPE,
+			);
+			expect(provisioner.deprovisionJobs).toHaveBeenCalledWith([10, 11]);
+			expect(provisioner.provisionLinked).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('reconcileAll', () => {
+		it('does nothing while the durable scheduler is off', async () => {
+			await makeRegistrar({ enabled: false }).reconcileAll();
+
+			expect(provisioner.deprovisionTaskType).not.toHaveBeenCalled();
+			expect(provisioner.provisionLinked).not.toHaveBeenCalled();
+			expect(agentRepository.findPublished).not.toHaveBeenCalled();
+		});
+
+		it('deletes all agent jobs when the agent-tasks flag is off, so no occurrences pile up', async () => {
+			await makeRegistrar({ enabledForAgentTasks: false }).reconcileAll();
+
+			expect(provisioner.deprovisionTaskType).toHaveBeenCalledWith(AGENT_TASK_TASK_TYPE);
+			expect(provisioner.provisionLinked).not.toHaveBeenCalled();
+		});
+
+		it('reconciles every published agent, continuing past one that fails', async () => {
+			agentRepository.findPublished.mockResolvedValue([
+				publishedAgent({ id: 'agent-broken' }),
+				publishedAgent(),
+			]);
+			const registrar = makeRegistrar();
+			const reconcile = vi
+				.spyOn(registrar, 'reconcile')
+				.mockRejectedValueOnce(new Error('boom'))
+				.mockResolvedValueOnce(undefined);
+
+			await registrar.reconcileAll();
+
+			expect(reconcile).toHaveBeenCalledTimes(2);
+			expect(reconcile).toHaveBeenNthCalledWith(2, AGENT_ID);
+			expect(logger.error).toHaveBeenCalledWith(
+				'Failed to reconcile an agent’s durable jobs',
+				expect.objectContaining({ agentId: 'agent-broken', error: 'boom' }),
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/scheduling/__tests__/agent-task-task-handler.test.ts
+++ b/packages/cli/src/modules/agents/scheduling/__tests__/agent-task-task-handler.test.ts
@@ -1,0 +1,133 @@
+import type { Logger } from '@n8n/backend-common';
+import { createDispatchReporter, type ClaimedTask } from '@n8n/scheduler';
+import { mock } from 'vitest-mock-extended';
+
+import type { AgentTaskService } from '../../agent-task.service';
+import type { Agent } from '../../entities/agent.entity';
+import type { AgentTaskSnapshot } from '../../entities/agent-task-snapshot.entity';
+import type { AgentRepository } from '../../repositories/agent.repository';
+import type { AgentTaskSnapshotRepository } from '../../repositories/agent-task-snapshot.repository';
+import type { AgentTaskJobRegistrar } from '../agent-task-job-registrar';
+import { AgentTaskTaskHandler } from '../agent-task-task-handler';
+
+const AGENT_ID = 'agent-1';
+const TASK_ID = 'task-1';
+
+describe('AgentTaskTaskHandler', () => {
+	const logger = mock<Logger>();
+	logger.scoped.mockReturnValue(logger);
+	const agentRepository = mock<AgentRepository>();
+	const taskSnapshotRepository = mock<AgentTaskSnapshotRepository>();
+	const agentTaskService = mock<AgentTaskService>();
+	const registrar = mock<AgentTaskJobRegistrar>();
+
+	const handler = new AgentTaskTaskHandler(
+		logger,
+		agentRepository,
+		taskSnapshotRepository,
+		agentTaskService,
+		registrar,
+	);
+
+	// The executor's dispatch-marker callback; cleared each test by vi.clearAllMocks().
+	const onDispatch = vi.fn();
+	const report = createDispatchReporter(onDispatch);
+
+	const scheduledFor = new Date('2026-08-04T09:00:00.000Z');
+
+	const buildTask = (overrides: Partial<ClaimedTask> = {}): ClaimedTask => ({
+		id: 'occurrence-1',
+		jobId: 7,
+		taskType: 'agent:scheduled-task',
+		payload: { agentId: AGENT_ID, taskId: TASK_ID },
+		scheduledFor,
+		runAt: scheduledFor,
+		status: 'running',
+		attempts: 0,
+		maxAttempts: 1,
+		leaseEpoch: 1,
+		...overrides,
+	});
+
+	const publishedAgent = (overrides: Partial<Agent> = {}): Agent =>
+		mock<Agent>({ id: AGENT_ID, activeVersionId: 'version-1', ...overrides });
+
+	const snapshot = (overrides: Partial<AgentTaskSnapshot> = {}): AgentTaskSnapshot =>
+		mock<AgentTaskSnapshot>({
+			versionId: 'version-1',
+			taskId: TASK_ID,
+			enabled: true,
+			cronExpression: '0 9 * * *',
+			...overrides,
+		});
+
+	const flushAsyncWork = async () => await new Promise(setImmediate);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger.scoped.mockReturnValue(logger);
+		agentRepository.findById.mockResolvedValue(publishedAgent());
+		taskSnapshotRepository.findByVersionAndTaskId.mockResolvedValue(snapshot());
+		agentTaskService.startScheduledRun.mockResolvedValue('started');
+		registrar.reconcile.mockResolvedValue(undefined);
+	});
+
+	it('throws on a malformed payload without reporting a dispatch', async () => {
+		const task = buildTask({ payload: { agentId: AGENT_ID } });
+
+		await expect(handler.execute(task, report)).rejects.toThrow(
+			'Agent-task payload is missing agentId or taskId',
+		);
+		expect(onDispatch).not.toHaveBeenCalled();
+		expect(agentTaskService.startScheduledRun).not.toHaveBeenCalled();
+	});
+
+	describe('stale occurrences', () => {
+		it.each([
+			['the agent is gone', () => agentRepository.findById.mockResolvedValue(null)],
+			[
+				'the agent is unpublished',
+				() => agentRepository.findById.mockResolvedValue(publishedAgent({ activeVersionId: null })),
+			],
+			[
+				'the snapshot is missing',
+				() => taskSnapshotRepository.findByVersionAndTaskId.mockResolvedValue(null),
+			],
+			[
+				'the snapshot is disabled',
+				() =>
+					taskSnapshotRepository.findByVersionAndTaskId.mockResolvedValue(
+						snapshot({ enabled: false }),
+					),
+			],
+		])('completes without effect and self-heals when %s', async (_name, arrange) => {
+			arrange();
+
+			const decision = await handler.execute(buildTask(), report);
+			await flushAsyncWork();
+
+			expect(decision).toBe(report.notDispatched());
+			expect(onDispatch).not.toHaveBeenCalled();
+			expect(agentTaskService.startScheduledRun).not.toHaveBeenCalled();
+			expect(registrar.reconcile).toHaveBeenCalledWith(AGENT_ID);
+		});
+	});
+
+	it('skips the tick without dispatching when the previous run still holds the lock', async () => {
+		agentTaskService.startScheduledRun.mockResolvedValue('skipped-active');
+
+		const decision = await handler.execute(buildTask(), report);
+
+		expect(decision).toBe(report.notDispatched());
+		expect(onDispatch).not.toHaveBeenCalled();
+		expect(registrar.reconcile).not.toHaveBeenCalled();
+	});
+
+	it('reports dispatched after handing the run off', async () => {
+		const decision = await handler.execute(buildTask(), report);
+
+		expect(agentTaskService.startScheduledRun).toHaveBeenCalledWith(AGENT_ID, TASK_ID);
+		expect(onDispatch).toHaveBeenCalledTimes(1);
+		expect(decision).toBe(report.dispatched());
+	});
+});

--- a/packages/cli/src/modules/agents/scheduling/agent-task-job-registrar.ts
+++ b/packages/cli/src/modules/agents/scheduling/agent-task-job-registrar.ts
@@ -1,0 +1,187 @@
+import { Logger } from '@n8n/backend-common';
+import { isValidTimeZone } from '@n8n/api-types';
+import { GlobalConfig } from '@n8n/config';
+import { ScheduledJobMisfirePolicy } from '@n8n/constants';
+import { Service } from '@n8n/di';
+import { computeFirstRunAt } from '@n8n/scheduler';
+import type { CronExpression } from 'n8n-workflow';
+
+import type { LinkedDesiredJob } from '@/scheduling/durable-job-provisioner';
+import { DurableJobProvisioner } from '@/scheduling/durable-job-provisioner';
+
+import type { AgentTaskSnapshot } from '../entities/agent-task-snapshot.entity';
+import { isValidCronExpression } from '../integrations/cron-validation';
+import { AgentRepository } from '../repositories/agent.repository';
+import { AgentTaskScheduleRepository } from '../repositories/agent-task-schedule.repository';
+import { AgentTaskSnapshotRepository } from '../repositories/agent-task-snapshot.repository';
+import { AGENT_TASK_TASK_TYPE, agentTaskJobName, taskIdFromJobName } from './agent-task-job';
+
+/**
+ * The write side of durable agent-task scheduling: keeps an agent's
+ * `scheduled_job` rows in step with its published, enabled task snapshots.
+ *
+ * Reconciles are plain DB writes, so any main can apply one directly — no
+ * leader, no pubsub. Missed occurrences are dropped (`skip`), matching the
+ * in-memory scheduler this replaces.
+ */
+@Service()
+export class AgentTaskJobRegistrar {
+	constructor(
+		private logger: Logger,
+		private readonly globalConfig: GlobalConfig,
+		private readonly agentRepository: AgentRepository,
+		private readonly taskSnapshotRepository: AgentTaskSnapshotRepository,
+		private readonly taskScheduleRepository: AgentTaskScheduleRepository,
+		private readonly provisioner: DurableJobProvisioner,
+	) {
+		this.logger = this.logger.scoped('scheduler');
+	}
+
+	/** Whether agent tasks are scheduled by the durable scheduler on this instance. */
+	isEnabled(): boolean {
+		const { enabled, enabledForAgentTasks } = this.globalConfig.scheduler;
+		return enabled && enabledForAgentTasks;
+	}
+
+	/**
+	 * Make an agent's durable jobs match its published config: enabled snapshots
+	 * of the active version become jobs, everything else is removed. An
+	 * unpublished or deleted agent keeps no jobs.
+	 */
+	async reconcile(agentId: string): Promise<void> {
+		const agent = await this.agentRepository.findById(agentId);
+		const versionId = agent?.activeVersionId;
+		if (!versionId) {
+			await this.deprovisionAgent(agentId);
+			return;
+		}
+
+		const snapshots = await this.taskSnapshotRepository.findEnabledByVersionId(versionId);
+		const desired = snapshots
+			.map((snapshot) => this.desiredJobFor(agentId, snapshot))
+			.filter((job): job is LinkedDesiredJob => job !== null);
+
+		await this.provisioner.provisionLinked(
+			{
+				taskType: AGENT_TASK_TASK_TYPE,
+				misfirePolicy: ScheduledJobMisfirePolicy.Skip,
+				findExisting: async (manager) =>
+					await this.taskScheduleRepository.findJobsForAgent(
+						manager,
+						agentId,
+						AGENT_TASK_TASK_TYPE,
+					),
+				linkInserted: async (manager, jobs) =>
+					await this.taskScheduleRepository.insertMany(
+						manager,
+						jobs.map(({ id, name }) => ({
+							jobId: id,
+							agentId,
+							taskId: taskIdFromJobName(agentId, name),
+						})),
+					),
+			},
+			desired,
+		);
+	}
+
+	/**
+	 * Bring stored state in line with the flag at startup. Flag on: backfill jobs
+	 * for every published agent (covers the first flip and any rows missed while
+	 * this instance was down). Flag off while the scheduler runs: delete all
+	 * agent jobs — the executor never claims an unregistered task type, so
+	 * leftover rows would pile up pending occurrences that fire as a storm on a
+	 * later flip. Deleting them is also the rollback path.
+	 *
+	 * Runs on every main; provisioning reconciles in place, so concurrent
+	 * startups converge.
+	 */
+	async reconcileAll(): Promise<void> {
+		if (!this.globalConfig.scheduler.enabled) return;
+
+		if (!this.isEnabled()) {
+			const { removed } = await this.provisioner.deprovisionTaskType(AGENT_TASK_TASK_TYPE);
+			if (removed > 0) {
+				this.logger.info('Removed durable agent-task jobs because the feature is off', {
+					removed,
+				});
+			}
+			return;
+		}
+
+		const agents = await this.agentRepository.findPublished();
+		this.logger.debug('Reconciling durable jobs of published agents', { count: agents.length });
+		for (const agent of agents) {
+			try {
+				await this.reconcile(agent.id);
+			} catch (error) {
+				this.logger.error('Failed to reconcile an agent’s durable jobs', {
+					agentId: agent.id,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+	}
+
+	/** Delete all of an agent's durable task jobs; links and occurrences cascade. */
+	private async deprovisionAgent(agentId: string): Promise<void> {
+		const jobIds = await this.taskScheduleRepository.findJobIdsForAgent(
+			agentId,
+			AGENT_TASK_TASK_TYPE,
+		);
+		const { removed } = await this.provisioner.deprovisionJobs(jobIds);
+		if (removed > 0) {
+			this.logger.info('Removed durable jobs of an unpublished agent', { agentId, removed });
+		}
+	}
+
+	/**
+	 * Map one enabled snapshot to a desired job. A snapshot whose cron or
+	 * timezone cannot be planned is omitted with a warning instead of failing the
+	 * agent's whole reconcile, mirroring the in-memory registration path.
+	 */
+	private desiredJobFor(agentId: string, snapshot: AgentTaskSnapshot): LinkedDesiredJob | null {
+		const { taskId, cronExpression } = snapshot;
+
+		if (!isCronExpression(cronExpression)) {
+			this.logger.warn('Skipping task with invalid cron', { taskId, agentId });
+			return null;
+		}
+
+		const timezone =
+			snapshot.timezone && isValidTimeZone(snapshot.timezone) ? snapshot.timezone : null;
+		if (snapshot.timezone && timezone === null) {
+			this.logger.warn('Task has unknown timezone, using instance timezone', {
+				taskId,
+				timezone: snapshot.timezone,
+			});
+		}
+
+		const schedule = { kind: 'cron' as const, cronExpression, timezone };
+
+		try {
+			const firstRunAt = computeFirstRunAt(
+				{ ...schedule, timezone: timezone ?? this.globalConfig.generic.timezone },
+				new Date(),
+			);
+			return {
+				name: agentTaskJobName(agentId, taskId),
+				schedule,
+				firstRunAt,
+				payload: { agentId, taskId },
+			};
+		} catch (error) {
+			this.logger.warn('Skipping task whose schedule cannot be planned', {
+				taskId,
+				agentId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return null;
+		}
+	}
+}
+
+/** Narrow a stored cron string to the scheduler's expression type by validating it. */
+function isCronExpression(expression: string): expression is CronExpression {
+	return isValidCronExpression(expression);
+}

--- a/packages/cli/src/modules/agents/scheduling/agent-task-job.ts
+++ b/packages/cli/src/modules/agents/scheduling/agent-task-job.ts
@@ -1,0 +1,33 @@
+/**
+ * Task type routing durable-scheduler occurrences to the agent-task handler.
+ * Jobs of this type are owned by an agent through `agent_task_schedule`, with
+ * `workflowId`/`nodeId` NULL on the job row.
+ */
+export const AGENT_TASK_TASK_TYPE = 'agent:scheduled-task';
+
+/**
+ * Stamped on every agent-task job and copied onto each occurrence. Carries no
+ * version id: the handler re-reads the agent's `activeVersionId` at fire time,
+ * so an occurrence materialized before a republish runs the newest published
+ * snapshot.
+ */
+export interface AgentTaskJobPayload {
+	agentId: string;
+	taskId: string;
+}
+
+export function isAgentTaskJobPayload(payload: unknown): payload is AgentTaskJobPayload {
+	if (typeof payload !== 'object' || payload === null) return false;
+	const candidate = payload as Record<string, unknown>;
+	return typeof candidate.agentId === 'string' && typeof candidate.taskId === 'string';
+}
+
+/** Unique job name for one agent task; task ids are unique within an agent. */
+export function agentTaskJobName(agentId: string, taskId: string): string {
+	return `agent-task:${agentId}:${taskId}`;
+}
+
+/** Recover the task id from a job name built by {@link agentTaskJobName}. */
+export function taskIdFromJobName(agentId: string, jobName: string): string {
+	return jobName.slice(`agent-task:${agentId}:`.length);
+}

--- a/packages/cli/src/modules/agents/scheduling/agent-task-task-handler.ts
+++ b/packages/cli/src/modules/agents/scheduling/agent-task-task-handler.ts
@@ -1,0 +1,93 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type { ClaimedTask, DispatchDecision, DispatchReporter, TaskHandler } from '@n8n/scheduler';
+import { UnexpectedError } from 'n8n-workflow';
+
+import { AgentTaskService } from '../agent-task.service';
+import { AgentRepository } from '../repositories/agent.repository';
+import { AgentTaskSnapshotRepository } from '../repositories/agent-task-snapshot.repository';
+import { AGENT_TASK_TASK_TYPE, isAgentTaskJobPayload } from './agent-task-job';
+import { AgentTaskJobRegistrar } from './agent-task-job-registrar';
+
+/**
+ * Runs a due agent-task occurrence.
+ *
+ * The handoff is starting the run: take the run lock, kick the agent run off
+ * in the background, report dispatched. The run itself lasts minutes — far
+ * beyond the occurrence's lease, which is never renewed mid-run — so the
+ * handler must not wait for it. Overlap and redelivery are bounded by the
+ * `agent_task_run_lock` the run holds, not by the lease.
+ */
+@Service()
+export class AgentTaskTaskHandler implements TaskHandler {
+	readonly taskType = AGENT_TASK_TASK_TYPE;
+
+	constructor(
+		private logger: Logger,
+		private readonly agentRepository: AgentRepository,
+		private readonly taskSnapshotRepository: AgentTaskSnapshotRepository,
+		private readonly agentTaskService: AgentTaskService,
+		private readonly registrar: AgentTaskJobRegistrar,
+	) {
+		this.logger = this.logger.scoped('scheduler');
+	}
+
+	async execute(task: ClaimedTask, report: DispatchReporter): Promise<DispatchDecision> {
+		if (!isAgentTaskJobPayload(task.payload)) {
+			throw new UnexpectedError('Agent-task payload is missing agentId or taskId', {
+				extra: { taskId: task.id, jobId: task.jobId },
+			});
+		}
+		const { agentId, taskId } = task.payload;
+
+		// The published config is the source of truth at fire time. An occurrence
+		// whose task no longer qualifies is stale: complete it without effect and
+		// re-reconcile so the job that produced it goes away.
+		const runnable = await this.isRunnable(agentId, taskId);
+		if (!runnable) {
+			this.logger.warn('Dropping occurrence of an agent task that is no longer scheduled', {
+				agentId,
+				taskId,
+				jobId: task.jobId,
+			});
+			this.selfHeal(agentId);
+			return report.notDispatched();
+		}
+
+		const outcome = await this.agentTaskService.startScheduledRun(agentId, taskId);
+		if (outcome === 'skipped-active') {
+			// Previous run still holds the lock: skip this tick, like the in-memory
+			// scheduler. The occurrence completes; the next tick is a fresh one.
+			return report.notDispatched();
+		}
+
+		this.logger.debug('Handed off agent-task occurrence to a run', {
+			agentId,
+			taskId,
+			jobId: task.jobId,
+		});
+		return report.dispatched();
+	}
+
+	/** Whether the task is still part of the agent's published, enabled config. */
+	private async isRunnable(agentId: string, taskId: string): Promise<boolean> {
+		const agent = await this.agentRepository.findById(agentId);
+		if (!agent?.activeVersionId) return false;
+
+		const snapshot = await this.taskSnapshotRepository.findByVersionAndTaskId(
+			agent.activeVersionId,
+			taskId,
+		);
+		return snapshot !== null && snapshot.enabled;
+	}
+
+	/** Remove the stale job behind this occurrence; best-effort, off the hot path. */
+	private selfHeal(agentId: string): void {
+		void this.registrar.reconcile(agentId).catch((error) => {
+			this.logger.warn('Failed to reconcile an agent after a stale occurrence', {
+				agentId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		});
+	}
+}

--- a/packages/cli/src/scheduling/durable-job-provisioner.ts
+++ b/packages/cli/src/scheduling/durable-job-provisioner.ts
@@ -61,12 +61,14 @@ type ProvisionScope = WorkflowNodeProvisionScope | LinkedProvisionScope;
 
 /**
  * Identifies jobs for deletion: one node's jobs, one workflow's jobs of a task
- * type, or specific jobs a linked owner resolved through its link table.
+ * type, specific jobs a linked owner resolved through its link table, or every
+ * job of a task type (whole-consumer teardown).
  */
 type DeprovisionScope =
 	| Pick<WorkflowNodeProvisionScope, 'workflowId' | 'nodeId'>
 	| Pick<WorkflowNodeProvisionScope, 'workflowId' | 'taskType'>
-	| { jobIds: number[] };
+	| { jobIds: number[] }
+	| { taskType: string };
 
 /** A job row's schedule columns: one `ScheduleDefinition` flattened for storage. */
 type ScheduleColumns = Pick<
@@ -173,6 +175,16 @@ export class DurableJobProvisioner {
 	async deprovisionJobs(jobIds: number[]): Promise<{ removed: number }> {
 		if (jobIds.length === 0) return { removed: 0 };
 		return await this.provisioner.deprovision({ jobIds });
+	}
+
+	/**
+	 * Delete every job of one task type, whoever owns them; their queued tasks
+	 * and ownership links cascade away. For tearing a whole consumer down, e.g.
+	 * at startup when its feature flag is off, so no unclaimed occurrences pile
+	 * up behind an unregistered handler.
+	 */
+	async deprovisionTaskType(taskType: string): Promise<{ removed: number }> {
+		return await this.provisioner.deprovision({ taskType });
 	}
 
 	/**
@@ -434,6 +446,9 @@ export class DurableJobProvisioner {
 						deleteAll: async () => {
 							if ('jobIds' in scope) {
 								return await this.jobs.deleteManyByIds(manager, scope.jobIds);
+							}
+							if (!('workflowId' in scope)) {
+								return await this.jobs.deleteByTaskType(manager, scope.taskType);
 							}
 							return 'nodeId' in scope
 								? await this.jobs.deleteByWorkflowNode(manager, scope.workflowId, scope.nodeId)


### PR DESCRIPTION
## Summary

PR 2 of 4 in migrating agent scheduled tasks from the in-memory `ScheduledTaskManager` onto the durable scheduler. Stacked on #36655. Adds the durable path behind a new flag — legacy scheduling is untouched (the flag-based routing of lifecycle events lands in the next PR):

- **`N8N_SCHEDULER_AGENT_TASKS_ENABLED`** (`SchedulerConfig.enabledForAgentTasks`, default off, effective only with `N8N_SCHEDULER_ENABLED`), following the poll-triggers flag pattern.
- **`AgentTaskJobRegistrar`** (write side): `reconcile(agentId)` keeps the agent's `scheduled_job` rows in step with its published, enabled task snapshots — cron kind with per-task timezone pass-through, `skip` misfire policy, payload `{agentId, taskId}`, ownership recorded in `agent_task_schedule`. A snapshot with an invalid cron or timezone is warned about and omitted rather than failing the reconcile. `reconcileAll()` at startup enforces the flag both ways: backfill on flag-on, delete-all agent jobs on flag-off — the executor never claims an unregistered task type, so leftover rows would pile up pending occurrences that fire as a storm on a later flip.
- **`AgentTaskTaskHandler`** (run side): re-reads the published config at fire time (a stale occurrence completes without effect and self-heals via reconcile), takes the existing `agent_task_run_lock`, kicks the run off in the background, and reports `dispatched()` immediately — a run lasts minutes while the occurrence lease (never renewed mid-run) is ~60s, so the handler must not wait. A held lock skips the tick via `notDispatched()`, matching legacy semantics.
- **`AgentTaskService.startScheduledRun`** extracted from `runScheduledTask`: resolves at the lock decision, runs the task in the background with lock renewal/release; shared by the legacy cron callback and the durable handler.
- Handler registration + `reconcileAll()` wired in `agents.module.ts` init (module init precedes `DurableScheduler.start()` in the start command).

## How to test

Unit tests: `packages/cli/src/modules/agents/scheduling/__tests__/` (registrar + handler) and new `startScheduledRun` cases in `agent-task.service.test.ts`.

Manual (requires the agents module): run with `N8N_SCHEDULER_ENABLED=true N8N_SCHEDULER_AGENT_TASKS_ENABLED=true`, publish an agent with an enabled scheduled task → a `scheduled_job` row (`taskType = 'agent:scheduled-task'`, `workflowId` NULL) plus an `agent_task_schedule` link row appear, occurrences materialize and the agent runs on schedule. Note: until PR 3 lands, the legacy leader cron is also still registered when the flag is on, so leave the flag off outside testing or expect the run lock to absorb the double-fire.

Flag off + restart → the agent job rows are deleted at startup.

## Related Linear tickets, Github issues, and Community forum posts

Part of the agent-tasks → durable-scheduler migration. Builds on #36655.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

