### PR TITLE
fix(API): Improve config handling on instance-settings endpoints

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/config-redaction.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/config-redaction.test.ts
@@ -1,0 +1,106 @@
+import type { INodeProperties } from 'n8n-workflow';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
+
+import {
+	collectSecretFieldNames,
+	redactSecretConfig,
+	restoreSecretConfig,
+} from '../config-redaction';
+
+// Top-level secret + a secret nested inside a fixedCollection.
+const options: INodeProperties[] = [
+	{ displayName: 'Client ID', name: 'clientId', type: 'string', default: '' },
+	{
+		displayName: 'Signing Secret',
+		name: 'signingSecret',
+		type: 'string',
+		typeOptions: { password: true },
+		default: '',
+	},
+	{
+		displayName: 'Advanced',
+		name: 'advanced',
+		type: 'fixedCollection',
+		default: {},
+		options: [
+			{
+				displayName: 'Auth',
+				name: 'auth',
+				values: [
+					{
+						displayName: 'Nested Secret',
+						name: 'nestedSecret',
+						type: 'string',
+						typeOptions: { password: true },
+						default: '',
+					},
+					{ displayName: 'Nested Plain', name: 'nestedPlain', type: 'string', default: '' },
+				],
+			},
+		],
+	},
+];
+
+describe('config-redaction', () => {
+	describe('collectSecretFieldNames', () => {
+		it('collects secret fields at the top level and inside collections', () => {
+			expect(collectSecretFieldNames(options)).toEqual(new Set(['signingSecret', 'nestedSecret']));
+		});
+
+		it('returns an empty set when there are no options', () => {
+			expect(collectSecretFieldNames(undefined)).toEqual(new Set());
+		});
+	});
+
+	describe('redactSecretConfig', () => {
+		it('blanks secret fields at any depth and keeps non-secret fields intact', () => {
+			const secretFields = collectSecretFieldNames(options);
+			const redacted = redactSecretConfig(
+				{
+					clientId: 'id',
+					signingSecret: 'top-secret',
+					advanced: { auth: { nestedSecret: 'deep-secret', nestedPlain: 'plain' } },
+				},
+				secretFields,
+			);
+
+			expect(redacted).toEqual({
+				clientId: 'id',
+				signingSecret: CREDENTIAL_BLANKING_VALUE,
+				advanced: { auth: { nestedSecret: CREDENTIAL_BLANKING_VALUE, nestedPlain: 'plain' } },
+			});
+		});
+	});
+
+	describe('restoreSecretConfig', () => {
+		it('restores blanked secrets at any depth from the stored config', () => {
+			const secretFields = collectSecretFieldNames(options);
+			const stored = {
+				clientId: 'id',
+				signingSecret: 'top-secret',
+				advanced: { auth: { nestedSecret: 'deep-secret', nestedPlain: 'plain' } },
+			};
+			const incoming = {
+				clientId: 'changed-id',
+				signingSecret: CREDENTIAL_BLANKING_VALUE,
+				advanced: { auth: { nestedSecret: CREDENTIAL_BLANKING_VALUE, nestedPlain: 'plain' } },
+			};
+
+			expect(restoreSecretConfig(incoming, stored, secretFields)).toEqual({
+				clientId: 'changed-id',
+				signingSecret: 'top-secret',
+				advanced: { auth: { nestedSecret: 'deep-secret', nestedPlain: 'plain' } },
+			});
+		});
+
+		it('keeps a newly provided secret instead of the stored one', () => {
+			const secretFields = collectSecretFieldNames(options);
+			const stored = { signingSecret: 'old-secret' };
+			const incoming = { signingSecret: 'new-secret' };
+
+			expect(restoreSecretConfig(incoming, stored, secretFields)).toEqual({
+				signingSecret: 'new-secret',
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/credential-resolvers.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/credential-resolvers.controller.test.ts
@@ -1,6 +1,7 @@
 import type { AuthenticatedRequest } from '@n8n/db';
-import { CredentialResolverValidationError } from '@n8n/decorators';
+import { CredentialResolverValidationError, type ICredentialResolver } from '@n8n/decorators';
 import type { Response } from 'express';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -62,6 +63,86 @@ describe('CredentialResolversController', () => {
 
 			expect(result[0]).not.toHaveProperty('decryptedConfig');
 			expect(result[0].config).toBe('');
+		});
+	});
+
+	describe('secret redaction', () => {
+		const secretTypeMetadata = [
+			{
+				metadata: {
+					name: 'credential-resolver.slack-1.0',
+					description: 'Slack resolver',
+					options: [
+						{
+							displayName: 'Signing Secret',
+							name: 'signingSecret',
+							type: 'string',
+							typeOptions: { password: true },
+						},
+						{ displayName: 'Subject Claim', name: 'subjectClaim', type: 'options' },
+					],
+				},
+			},
+		] as unknown as ICredentialResolver[];
+
+		const secretResolver = {
+			id: 'row-id',
+			name: 'Slack Resolver',
+			type: 'credential-resolver.slack-1.0',
+			config: 'encrypted',
+			decryptedConfig: { signingSecret: 'REAL-SECRET', subjectClaim: 'user_id' },
+			createdAt: new Date('2024-01-01'),
+			updatedAt: new Date('2024-01-01'),
+		} as unknown as DynamicCredentialResolver;
+
+		beforeEach(() => {
+			service.getAvailableTypes.mockReturnValue(secretTypeMetadata);
+		});
+
+		it('getResolver blanks password-typed fields but keeps non-secret fields', async () => {
+			service.findById.mockResolvedValue(secretResolver);
+
+			const result = await controller.getResolver(req, res, 'row-id');
+
+			expect(result.decryptedConfig?.signingSecret).toBe(CREDENTIAL_BLANKING_VALUE);
+			expect(result.decryptedConfig?.subjectClaim).toBe('user_id');
+			expect(result.config).toBe('');
+		});
+
+		it('createResolver blanks password-typed fields in the response', async () => {
+			service.create.mockResolvedValue(secretResolver);
+
+			const result = await controller.createResolver(req, res, {
+				name: 'Slack Resolver',
+				type: 'credential-resolver.slack-1.0',
+				config: { signingSecret: 'REAL-SECRET', subjectClaim: 'user_id' },
+			});
+
+			expect(result.decryptedConfig?.signingSecret).toBe(CREDENTIAL_BLANKING_VALUE);
+			expect(result.decryptedConfig?.subjectClaim).toBe('user_id');
+		});
+
+		it('updateResolver blanks password-typed fields in the response', async () => {
+			service.update.mockResolvedValue(secretResolver);
+
+			const result = await controller.updateResolver(req, res, 'row-id', {
+				config: { signingSecret: CREDENTIAL_BLANKING_VALUE, subjectClaim: 'user_id' },
+			});
+
+			expect(result.decryptedConfig?.signingSecret).toBe(CREDENTIAL_BLANKING_VALUE);
+			expect(result.decryptedConfig?.subjectClaim).toBe('user_id');
+		});
+
+		it('getResolver drops the decrypted config when the resolver type is not registered', async () => {
+			service.findById.mockResolvedValue({
+				...secretResolver,
+				type: 'credential-resolver.unregistered-9.9',
+			} as unknown as DynamicCredentialResolver);
+
+			const result = await controller.getResolver(req, res, 'row-id');
+
+			expect(result.decryptedConfig).toBeUndefined();
+			expect(result.config).toBe('');
 		});
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/config-redaction.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/config-redaction.ts
@@ -1,0 +1,102 @@
+import type { CredentialResolverConfiguration } from '@n8n/decorators';
+import { CREDENTIAL_BLANKING_VALUE, isINodePropertyCollection } from 'n8n-workflow';
+import type { INodeProperties } from 'n8n-workflow';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	value !== null && typeof value === 'object' && !Array.isArray(value);
+
+/**
+ * Collect the names of every config field a resolver type marks as secret
+ * (`typeOptions.password`), descending into `collection`/`fixedCollection` subtrees so a
+ * secret nested inside a container is not missed. Names are matched by key at any depth.
+ */
+export const collectSecretFieldNames = (options: INodeProperties[] | undefined): Set<string> => {
+	const names = new Set<string>();
+	for (const prop of options ?? []) {
+		if (prop.typeOptions?.password === true) {
+			names.add(prop.name);
+		}
+		for (const option of prop.options ?? []) {
+			if (isINodePropertyCollection(option)) {
+				// fixedCollection: the nested properties live under `values`
+				for (const name of collectSecretFieldNames(option.values)) names.add(name);
+			} else if ('type' in option) {
+				// collection: the entry is itself a property
+				for (const name of collectSecretFieldNames([option])) names.add(name);
+			}
+		}
+	}
+	return names;
+};
+
+const redactValue = (value: unknown, secretNames: Set<string>): unknown => {
+	if (Array.isArray(value)) {
+		return value.map((item) => redactValue(item, secretNames));
+	}
+	if (isRecord(value)) {
+		const result: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(value)) {
+			result[key] = secretNames.has(key)
+				? CREDENTIAL_BLANKING_VALUE
+				: redactValue(val, secretNames);
+		}
+		return result;
+	}
+	return value;
+};
+
+/** Return a copy of the config with every secret field (at any depth) replaced by the blanking sentinel. */
+export const redactSecretConfig = (
+	config: CredentialResolverConfiguration | undefined,
+	secretNames: Set<string>,
+): CredentialResolverConfiguration => {
+	const result: CredentialResolverConfiguration = {};
+	for (const [key, val] of Object.entries(config ?? {})) {
+		result[key] = secretNames.has(key) ? CREDENTIAL_BLANKING_VALUE : redactValue(val, secretNames);
+	}
+	return result;
+};
+
+const restoreValue = (incoming: unknown, stored: unknown, secretNames: Set<string>): unknown => {
+	if (Array.isArray(incoming)) {
+		return incoming.map((item, index) =>
+			restoreValue(item, Array.isArray(stored) ? stored[index] : undefined, secretNames),
+		);
+	}
+	if (isRecord(incoming)) {
+		const storedObj = isRecord(stored) ? stored : undefined;
+		const result: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(incoming)) {
+			if (secretNames.has(key) && val === CREDENTIAL_BLANKING_VALUE) {
+				// Restore the stored secret only when we have one; a changed resolver type
+				// gets fresh fields, so no matching stored value exists there.
+				result[key] = storedObj && key in storedObj ? storedObj[key] : val;
+			} else {
+				result[key] = restoreValue(val, storedObj?.[key], secretNames);
+			}
+		}
+		return result;
+	}
+	return incoming;
+};
+
+/**
+ * Return a copy of the incoming config where any secret field (at any depth) still holding
+ * the blanking sentinel is replaced with the stored value, so a redacted round-trip save
+ * does not overwrite the real secret.
+ */
+export const restoreSecretConfig = (
+	incoming: CredentialResolverConfiguration,
+	stored: CredentialResolverConfiguration,
+	secretNames: Set<string>,
+): CredentialResolverConfiguration => {
+	const result: CredentialResolverConfiguration = {};
+	for (const [key, val] of Object.entries(incoming)) {
+		if (secretNames.has(key) && val === CREDENTIAL_BLANKING_VALUE) {
+			result[key] = key in stored ? stored[key] : val;
+		} else {
+			result[key] = restoreValue(val, stored[key], secretNames);
+		}
+	}
+	return result;
+};

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -24,12 +24,12 @@ import {
 	CredentialResolverValidationError,
 } from '@n8n/decorators';
 import { Response } from 'express';
-import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
+import { collectSecretFieldNames, redactSecretConfig } from './config-redaction';
 import { CredentialResolutionError } from './errors/credential-resolution.error';
 import { DynamicCredentialResolverNotFoundError } from './errors/credential-resolver-not-found.error';
 import { SystemResolverModificationError } from './errors/system-resolver-modification.error';
@@ -41,9 +41,10 @@ export class CredentialResolversController {
 
 	/**
 	 * Blank the resolver's secret config fields before returning it over HTTP.
-	 * Secret fields are those the resolver type marks with `typeOptions.password`;
-	 * non-secret fields stay intact so the editor can still prefill them. The raw
-	 * secret remains reachable only through the internal resolution path.
+	 * Secret fields are those the resolver type marks with `typeOptions.password`
+	 * (including fields nested in collections); non-secret fields stay intact so the
+	 * editor can still prefill them. The raw secret remains reachable only through the
+	 * internal resolution path.
 	 */
 	private redactSecrets(resolver: CredentialResolver): CredentialResolver {
 		const type = this.service.getAvailableTypes().find((t) => t.metadata.name === resolver.type);
@@ -55,18 +56,13 @@ export class CredentialResolversController {
 			return { ...rest, config: '' };
 		}
 
-		const secretFields = (type.metadata.options ?? [])
-			.filter((p) => p.typeOptions?.password === true)
-			.map((p) => p.name);
+		const secretFields = collectSecretFieldNames(type.metadata.options);
 
-		const decryptedConfig = { ...resolver.decryptedConfig };
-		for (const field of secretFields) {
-			if (field in decryptedConfig) {
-				decryptedConfig[field] = CREDENTIAL_BLANKING_VALUE;
-			}
-		}
-
-		return { ...resolver, config: '', decryptedConfig };
+		return {
+			...resolver,
+			config: '',
+			decryptedConfig: redactSecretConfig(resolver.decryptedConfig, secretFields),
+		};
 	}
 
 	@Get('/')

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -24,6 +24,7 @@ import {
 	CredentialResolverValidationError,
 } from '@n8n/decorators';
 import { Response } from 'express';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
@@ -37,6 +38,36 @@ import { DynamicCredentialResolverService } from './services/credential-resolver
 @RestController('/credential-resolvers')
 export class CredentialResolversController {
 	constructor(private readonly service: DynamicCredentialResolverService) {}
+
+	/**
+	 * Blank the resolver's secret config fields before returning it over HTTP.
+	 * Secret fields are those the resolver type marks with `typeOptions.password`;
+	 * non-secret fields stay intact so the editor can still prefill them. The raw
+	 * secret remains reachable only through the internal resolution path.
+	 */
+	private redactSecrets(resolver: CredentialResolver): CredentialResolver {
+		const type = this.service.getAvailableTypes().find((t) => t.metadata.name === resolver.type);
+
+		// Fail closed: an unregistered type means we can't tell which fields are secret,
+		// so drop the decrypted config entirely rather than risk leaking a secret.
+		if (!type) {
+			const { decryptedConfig: _drop, ...rest } = resolver;
+			return { ...rest, config: '' };
+		}
+
+		const secretFields = (type.metadata.options ?? [])
+			.filter((p) => p.typeOptions?.password === true)
+			.map((p) => p.name);
+
+		const decryptedConfig = { ...resolver.decryptedConfig };
+		for (const field of secretFields) {
+			if (field in decryptedConfig) {
+				decryptedConfig[field] = CREDENTIAL_BLANKING_VALUE;
+			}
+		}
+
+		return { ...resolver, config: '', decryptedConfig };
+	}
 
 	@Get('/')
 	@GlobalScope('credentialResolver:list')
@@ -87,7 +118,7 @@ export class CredentialResolversController {
 				config: dto.config,
 				user: req.user,
 			});
-			return credentialResolverSchema.parse(createdResolver);
+			return this.redactSecrets(credentialResolverSchema.parse(createdResolver));
 		} catch (e: unknown) {
 			if (e instanceof SystemResolverModificationError) {
 				throw new BadRequestError(e.message);
@@ -134,7 +165,7 @@ export class CredentialResolversController {
 		@Param('id') id: string,
 	): Promise<CredentialResolver> {
 		try {
-			return credentialResolverSchema.parse(await this.service.findById(id));
+			return this.redactSecrets(credentialResolverSchema.parse(await this.service.findById(id)));
 		} catch (e: unknown) {
 			if (e instanceof DynamicCredentialResolverNotFoundError) {
 				throw new NotFoundError(e.message);
@@ -155,14 +186,16 @@ export class CredentialResolversController {
 		@Body dto: UpdateCredentialResolverDto,
 	): Promise<CredentialResolver> {
 		try {
-			return credentialResolverSchema.parse(
-				await this.service.update(id, {
-					type: dto.type,
-					name: dto.name,
-					config: dto.config,
-					clearCredentials: dto.clearCredentials,
-					user: req.user,
-				}),
+			return this.redactSecrets(
+				credentialResolverSchema.parse(
+					await this.service.update(id, {
+						type: dto.type,
+						name: dto.name,
+						config: dto.config,
+						clearCredentials: dto.clearCredentials,
+						user: req.user,
+					}),
+				),
 			);
 		} catch (e: unknown) {
 			if (e instanceof DynamicCredentialResolverNotFoundError) {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@n8n/decorators';
 import { Not, type UpdateResult } from '@n8n/typeorm';
 import type { Cipher } from 'n8n-core';
-import { UnexpectedError } from 'n8n-workflow';
+import { CREDENTIAL_BLANKING_VALUE, UnexpectedError } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 
 import type { ActiveWorkflowManager } from '@/active-workflow-manager';
@@ -305,6 +305,42 @@ describe('DynamicCredentialResolverService', () => {
 			expect(mockResolverImplementation.validateOptions).toHaveBeenCalledWith(newConfig);
 			expect(mockCipher.encryptV2).toHaveBeenCalledWith(newConfig);
 			expect(mockRepository.save).toHaveBeenCalled();
+		});
+
+		it('reuses the stored secret when a redacted secret field is submitted', async () => {
+			const entity = createMockEntity({ type: 'credential-resolver.slack-1.0' });
+			const storedConfig = { signingSecret: 'REAL-STORED-SECRET', subjectClaim: 'user_id' };
+			const incomingConfig = {
+				signingSecret: CREDENTIAL_BLANKING_VALUE,
+				subjectClaim: 'user_id',
+			};
+			const mockUser = createMockUser();
+			const resolverWithSecretField = {
+				...mockResolverImplementation,
+				metadata: {
+					name: 'credential-resolver.slack-1.0',
+					description: 'Slack',
+					options: [
+						{ name: 'signingSecret', type: 'string', typeOptions: { password: true } },
+						{ name: 'subjectClaim', type: 'options' },
+					],
+				},
+			} as unknown as Mocked<ICredentialResolver>;
+
+			mockRepository.findOneBy.mockResolvedValue(entity);
+			mockRegistry.getResolverByTypename.mockReturnValue(resolverWithSecretField);
+			mockResolverImplementation.validateOptions.mockResolvedValue(undefined);
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(storedConfig));
+			mockCipher.encryptV2.mockResolvedValue('re-encrypted');
+			mockRepository.save.mockResolvedValue(entity);
+
+			await service.update('resolver-id-123', { config: incomingConfig, user: mockUser });
+
+			// The redacted placeholder must not be persisted; the stored secret is reused.
+			expect(mockCipher.encryptV2).toHaveBeenCalledWith({
+				signingSecret: 'REAL-STORED-SECRET',
+				subjectClaim: 'user_id',
+			});
 		});
 
 		it('should throw DynamicCredentialResolverNotFoundError when resolver not found', async () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
@@ -9,7 +9,7 @@ import { Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
 import { Not } from '@n8n/typeorm';
 import { Cipher } from 'n8n-core';
-import { jsonParse, UnexpectedError } from 'n8n-workflow';
+import { CREDENTIAL_BLANKING_VALUE, jsonParse, UnexpectedError } from 'n8n-workflow';
 
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 
@@ -155,8 +155,9 @@ export class DynamicCredentialResolverService {
 		}
 
 		if (params.config !== undefined) {
-			await this.validateConfig(existing.type, params.config, canUseExternalSecrets);
-			existing.config = await this.encryptConfig(params.config);
+			const config = await this.restoreRedactedSecrets(existing, params.config);
+			await this.validateConfig(existing.type, config, canUseExternalSecrets);
+			existing.config = await this.encryptConfig(config);
 		}
 
 		if (params.name !== undefined) {
@@ -282,6 +283,39 @@ export class DynamicCredentialResolverService {
 
 		// Validate the resolved config against the resolver's schema
 		await resolverImplementation.validateOptions(resolvedConfig);
+	}
+
+	/** Names of the config fields the resolver type marks as secret (`typeOptions.password`). */
+	private getSecretFieldNames(type: string): string[] {
+		return (this.registry.getResolverByTypename(type)?.metadata.options ?? [])
+			.filter((p) => p.typeOptions?.password === true)
+			.map((p) => p.name);
+	}
+
+	/**
+	 * A redacted config GET returns the blanking sentinel for secret fields. When the
+	 * editor round-trips that config back on save, restore each sentinel secret from the
+	 * stored config so it is not overwritten with the placeholder.
+	 */
+	private async restoreRedactedSecrets(
+		existing: DynamicCredentialResolver,
+		incoming: CredentialResolverConfiguration,
+	): Promise<CredentialResolverConfiguration> {
+		const secretFields = this.getSecretFieldNames(existing.type);
+		if (!secretFields.some((f) => incoming[f] === CREDENTIAL_BLANKING_VALUE)) {
+			return incoming;
+		}
+
+		const stored = await this.decryptConfig(existing.config);
+		const result = { ...incoming };
+		for (const field of secretFields) {
+			// ponytail: only restore fields present in the stored config; a changed
+			// resolver type gets fresh fields from the editor, so no sentinel appears there.
+			if (result[field] === CREDENTIAL_BLANKING_VALUE && field in stored) {
+				result[field] = stored[field];
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
@@ -9,10 +9,11 @@ import { Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
 import { Not } from '@n8n/typeorm';
 import { Cipher } from 'n8n-core';
-import { CREDENTIAL_BLANKING_VALUE, jsonParse, UnexpectedError } from 'n8n-workflow';
+import { jsonParse, UnexpectedError } from 'n8n-workflow';
 
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 
+import { collectSecretFieldNames, restoreSecretConfig } from '../config-redaction';
 import { SYSTEM_RESOLVER_ID, SYSTEM_RESOLVER_TYPE } from '../constants';
 import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
 import { ResolverConfigExpressionService } from './resolver-config-expression.service';
@@ -285,37 +286,25 @@ export class DynamicCredentialResolverService {
 		await resolverImplementation.validateOptions(resolvedConfig);
 	}
 
-	/** Names of the config fields the resolver type marks as secret (`typeOptions.password`). */
-	private getSecretFieldNames(type: string): string[] {
-		return (this.registry.getResolverByTypename(type)?.metadata.options ?? [])
-			.filter((p) => p.typeOptions?.password === true)
-			.map((p) => p.name);
-	}
-
 	/**
 	 * A redacted config GET returns the blanking sentinel for secret fields. When the
-	 * editor round-trips that config back on save, restore each sentinel secret from the
-	 * stored config so it is not overwritten with the placeholder.
+	 * editor round-trips that config back on save, restore each sentinel secret (including
+	 * fields nested in collections) from the stored config so it is not overwritten with
+	 * the placeholder.
 	 */
 	private async restoreRedactedSecrets(
 		existing: DynamicCredentialResolver,
 		incoming: CredentialResolverConfiguration,
 	): Promise<CredentialResolverConfiguration> {
-		const secretFields = this.getSecretFieldNames(existing.type);
-		if (!secretFields.some((f) => incoming[f] === CREDENTIAL_BLANKING_VALUE)) {
+		const secretFields = collectSecretFieldNames(
+			this.registry.getResolverByTypename(existing.type)?.metadata.options,
+		);
+		if (secretFields.size === 0) {
 			return incoming;
 		}
 
 		const stored = await this.decryptConfig(existing.config);
-		const result = { ...incoming };
-		for (const field of secretFields) {
-			// ponytail: only restore fields present in the stored config; a changed
-			// resolver type gets fresh fields from the editor, so no sentinel appears there.
-			if (result[field] === CREDENTIAL_BLANKING_VALUE && field in stored) {
-				result[field] = stored[field];
-			}
-		}
-		return result;
+		return restoreSecretConfig(incoming, stored, secretFields);
 	}
 
 	/**

--- a/packages/cli/src/modules/ldap.ee/__tests__/ldap.controller.ee.test.ts
+++ b/packages/cli/src/modules/ldap.ee/__tests__/ldap.controller.ee.test.ts
@@ -1,0 +1,81 @@
+import type { LdapConfig } from '@n8n/constants';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { EventService } from '@/events/event.service';
+
+import { LdapController } from '../ldap.controller.ee';
+import type { LdapService } from '../ldap.service.ee';
+import type { LdapConfiguration } from '../types';
+
+describe('LdapController', () => {
+	const ldapService = mock<LdapService>();
+	const eventService = mock<EventService>();
+	const controller = new LdapController(ldapService, eventService);
+
+	const baseConfig: LdapConfig = {
+		loginEnabled: true,
+		loginLabel: 'label',
+		connectionUrl: 'connection.url',
+		allowUnauthorizedCerts: true,
+		connectionSecurity: 'none',
+		connectionPort: 1234,
+		baseDn: 'dc=example,dc=com',
+		bindingAdminDn: 'cn=admin,dc=example,dc=com',
+		bindingAdminPassword: 'REAL-PASSWORD',
+		firstNameAttribute: 'givenName',
+		lastNameAttribute: 'sn',
+		emailAttribute: 'mail',
+		loginIdAttribute: 'uid',
+		ldapIdAttribute: 'uid',
+		userFilter: '(uid=jdoe)',
+		synchronizationEnabled: true,
+		synchronizationInterval: 60,
+		searchPageSize: 1,
+		searchTimeout: 6,
+		enforceEmailUniqueness: true,
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('getConfig', () => {
+		it('blanks bindingAdminPassword when a password is stored', async () => {
+			ldapService.loadConfig.mockResolvedValue({
+				...baseConfig,
+				bindingAdminPassword: 'REAL-PASSWORD',
+			});
+
+			const result = await controller.getConfig();
+
+			expect(result.bindingAdminPassword).toBe(CREDENTIAL_BLANKING_VALUE);
+		});
+
+		it('returns an empty string when no password is stored', async () => {
+			ldapService.loadConfig.mockResolvedValue({ ...baseConfig, bindingAdminPassword: '' });
+
+			const result = await controller.getConfig();
+
+			expect(result.bindingAdminPassword).toBe('');
+		});
+	});
+
+	describe('updateConfig', () => {
+		it('blanks bindingAdminPassword in the response', async () => {
+			ldapService.loadConfig.mockResolvedValue({
+				...baseConfig,
+				bindingAdminPassword: 'REAL-PASSWORD',
+			});
+
+			const req = {
+				body: { ...baseConfig },
+				user: { id: 'user-1' },
+			} as unknown as LdapConfiguration.Update;
+
+			const result = await controller.updateConfig(req);
+
+			expect(result.bindingAdminPassword).toBe(CREDENTIAL_BLANKING_VALUE);
+		});
+	});
+});

--- a/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
@@ -8,7 +8,7 @@ import { Container } from '@n8n/di';
 import { QueryFailedError } from '@n8n/typeorm';
 import { Client } from 'ldapts';
 import type { Cipher } from 'n8n-core';
-import { randomString } from 'n8n-workflow';
+import { CREDENTIAL_BLANKING_VALUE, randomString } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -355,6 +355,34 @@ describe('LdapService', () => {
 			expect(cipherMock.encryptV2).toHaveBeenCalledTimes(1);
 			expect(cipherMock.encryptV2).toHaveBeenCalledWith(ldapConfig.bindingAdminPassword);
 			expect(newConfig.bindingAdminPassword).toEqual('encryptedPassword');
+		});
+
+		it('reuses the stored admin password when the redacted placeholder is submitted', async () => {
+			// loadConfig reads the stored (encrypted) password and deciphers it
+			mockSettingsRespositoryFindOneByOrFail({
+				...ldapConfig,
+				bindingAdminPassword: 'storedEncrypted',
+			});
+
+			const cipherMock = mock<Cipher>({
+				decryptV2: vi.fn().mockResolvedValue('realStoredPassword'),
+				encryptV2: vi.fn().mockResolvedValue('reEncrypted'),
+			});
+
+			config.set('userManagement.authenticationMethod', 'email');
+			const ldapService = new LdapService(
+				mockLogger(),
+				settingsRepository,
+				cipherMock,
+				mock(),
+				mock<LicenseState>(),
+			);
+
+			const newConfig = { ...ldapConfig, bindingAdminPassword: CREDENTIAL_BLANKING_VALUE };
+			await ldapService.updateConfig(newConfig);
+
+			// The placeholder must never be encrypted and stored as the real password.
+			expect(cipherMock.encryptV2).toHaveBeenCalledWith('realStoredPassword');
 		});
 
 		it('should delete all ldap identities if login is disabled and ldap users exist', async () => {

--- a/packages/cli/src/modules/ldap.ee/ldap.controller.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.controller.ee.ts
@@ -1,5 +1,7 @@
+import type { LdapConfig } from '@n8n/constants';
 import { Get, Post, Put, RestController, GlobalScope, Licensed } from '@n8n/decorators';
 import pick from 'lodash/pick';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { EventService } from '@/events/event.service';
@@ -20,7 +22,15 @@ export class LdapController {
 	@Licensed('feat:ldap')
 	@GlobalScope('ldap:manage')
 	async getConfig() {
-		return await this.ldapService.loadConfig();
+		return this.redactConfig(await this.ldapService.loadConfig());
+	}
+
+	/** Blank the bind password before returning the config over HTTP. */
+	private redactConfig(config: LdapConfig): LdapConfig {
+		return {
+			...config,
+			bindingAdminPassword: config.bindingAdminPassword ? CREDENTIAL_BLANKING_VALUE : '',
+		};
 	}
 
 	@Post('/test-connection')
@@ -51,7 +61,7 @@ export class LdapController {
 			...pick(data, NON_SENSIBLE_LDAP_CONFIG_PROPERTIES),
 		});
 
-		return data;
+		return this.redactConfig(data);
 	}
 
 	@Get('/sync')

--- a/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
@@ -10,7 +10,7 @@ import { Constructable, Container } from '@n8n/di';
 import { lazyImport } from '@n8n/utils/lazy-import';
 import type { Entry as LdapUser, ClientOptions, Client } from 'ldapts';
 import { Cipher } from 'n8n-core';
-import { jsonParse, UnexpectedError } from 'n8n-workflow';
+import { CREDENTIAL_BLANKING_VALUE, jsonParse, UnexpectedError } from 'n8n-workflow';
 import type { ConnectionOptions } from 'tls';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -115,6 +115,13 @@ export class LdapService implements IPasswordAuthHandler<User> {
 	}
 
 	async updateConfig(ldapConfig: LdapConfig): Promise<void> {
+		// The config GET blanks the bind password; when the editor round-trips it back,
+		// keep the currently-stored password instead of overwriting it with the placeholder.
+		if (ldapConfig.bindingAdminPassword === CREDENTIAL_BLANKING_VALUE) {
+			const stored = await this.loadConfig();
+			ldapConfig.bindingAdminPassword = stored.bindingAdminPassword;
+		}
+
 		const { valid, message } = validateLdapConfigurationSchema(ldapConfig);
 
 		if (!valid) {

--- a/packages/cli/test/integration/dynamic-credentials.ee/credential-resolvers.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/credential-resolvers.api.test.ts
@@ -4,6 +4,7 @@ import type { User } from '@n8n/db';
 import { GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
 import nock from 'nock';
 import { mock } from 'vitest-mock-extended';
 
@@ -171,16 +172,20 @@ describe('Credential Resolvers API', () => {
 				name: 'Test Resolver',
 				type: 'credential-resolver.oauth2-1.0',
 			});
+			// Secret fields are blanked in the response; non-secret fields stay intact.
 			expect(response.body.data.decryptedConfig).toMatchObject({
 				metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
 				clientId: 'test-client-id',
-				clientSecret: 'test-client-secret',
+				clientSecret: CREDENTIAL_BLANKING_VALUE,
 				validation: 'oauth2-introspection',
 			});
+			expect(response.body.data.config).toBe('');
 
-			// Verify it was actually created (system row + 1 custom)
+			// The real secret is still persisted (encrypted) and readable internally.
 			const resolvers = await repository.find();
 			expect(resolvers).toHaveLength(2);
+			const created = await service.findById(response.body.data.id);
+			expect(created.decryptedConfig?.clientSecret).toBe('test-client-secret');
 		});
 
 		it('should reject unknown resolver type', async () => {
@@ -231,6 +236,10 @@ describe('Credential Resolvers API', () => {
 				name: 'Test Resolver',
 				type: 'credential-resolver.oauth2-1.0',
 			});
+			// Secret fields are blanked; non-secret fields stay intact.
+			expect(response.body.data.decryptedConfig.clientSecret).toBe(CREDENTIAL_BLANKING_VALUE);
+			expect(response.body.data.decryptedConfig.clientId).toBe('test-client-id');
+			expect(response.body.data.config).toBe('');
 		});
 
 		it('should return 404 for non-existent resolver', async () => {
@@ -258,6 +267,37 @@ describe('Credential Resolvers API', () => {
 				.expect(200);
 
 			expect(response.body.data.name).toBe('Updated Name');
+		});
+
+		it('keeps the stored secret when the blanked value is saved back', async () => {
+			const resolver = await service.create({
+				name: 'Round-trip Resolver',
+				type: 'credential-resolver.oauth2-1.0',
+				config: {
+					metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+					clientId: 'test-client-id',
+					clientSecret: 'original-secret',
+					validation: 'oauth2-introspection',
+				},
+				user: owner,
+			});
+
+			// Simulate the editor saving back the blanked secret while changing another field.
+			await ownerAgent
+				.patch(`/credential-resolvers/${resolver.id}`)
+				.send({
+					config: {
+						metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+						clientId: 'updated-client-id',
+						clientSecret: CREDENTIAL_BLANKING_VALUE,
+						validation: 'oauth2-introspection',
+					},
+				})
+				.expect(200);
+
+			const stored = await service.findById(resolver.id);
+			expect(stored.decryptedConfig?.clientSecret).toBe('original-secret');
+			expect(stored.decryptedConfig?.clientId).toBe('updated-client-id');
 		});
 
 		it('should return 404 for non-existent resolver', async () => {


### PR DESCRIPTION
## Summary

Aligns config handling on the credential-resolver and LDAP admin endpoints with the
existing behavior of the SAML config endpoint. Existing edit-and-save flows are unaffected.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-1240

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

