### PR TITLE
fix(core): Route leader-only channel operations through the leader

### DIFF
--- a/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
+++ b/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
@@ -40,6 +40,8 @@ export type PubSubEventName =
 	| 'cancel-collection'
 	| 'agent-chat-integration-changed'
 	| 'agent-chat-subscription-changed'
+	| 'agent-chat-leader-channel-request'
+	| 'agent-chat-leader-channel-result'
 	| 'agent-config-changed'
 	| 'agent-tasks-changed'
 	| 'redaction-floor-changed';

--- a/packages/cli/src/modules/agents/__tests__/agent-integration-management.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-integration-management.service.test.ts
@@ -168,7 +168,7 @@ describe('AgentIntegrationManagementService', () => {
 			const persistedEntry = { type: 'slack', credentialId: 'credential-1' } as const;
 			const agent = makeAgent({ integrations: [persistedEntry] });
 			stubRow(agentRepository, [persistedEntry]);
-			chatService.getChatInstance.mockReturnValue({} as never);
+			chatService.isChannelLive.mockReturnValue(true);
 			persistenceService.applyIntegrationDelta.mockRejectedValue(new Error('write failed'));
 
 			await expect(service.connect({ agent, user: user as never, integration })).rejects.toThrow(
@@ -193,7 +193,7 @@ describe('AgentIntegrationManagementService', () => {
 			const persistedEntry = { type: 'slack', credentialId: 'credential-1' } as const;
 			const agent = makeAgent({ integrations: [persistedEntry] });
 			stubRow(agentRepository, [persistedEntry]);
-			chatService.getChatInstance.mockReturnValue({} as never);
+			chatService.isChannelLive.mockReturnValue(true);
 			chatService.connect.mockRejectedValueOnce(new Error('Slack connect failed'));
 
 			await expect(service.connect({ agent, user: user as never, integration })).rejects.toThrow(
@@ -352,7 +352,7 @@ describe('AgentIntegrationManagementService', () => {
 			stubRow(agentRepository, []);
 			// Never live: not before the connect, and gone again by the time the write
 			// finished — as if a peer's disconnect broadcast landed in between.
-			chatService.getChatInstance.mockReturnValue(undefined);
+			chatService.isChannelLive.mockReturnValue(false);
 			persistenceService.applyIntegrationDelta.mockImplementation(async () =>
 				deltaResult(agent, true),
 			);

--- a/packages/cli/src/modules/agents/__tests__/agent-integration-management.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-integration-management.service.test.ts
@@ -282,6 +282,27 @@ describe('AgentIntegrationManagementService', () => {
 			expect(chatService.connect).not.toHaveBeenCalled();
 			expect(persistenceService.applyIntegrationDelta).not.toHaveBeenCalled();
 		});
+
+		it('starts no runtime when a draft channel fails its pre-connect validation', async () => {
+			// A leader-only channel on a follower reports as live without the follower
+			// being able to check — so without the publication gate, the rollback below
+			// would start a poller for an agent that must not receive events.
+			const { service, chatService, agentRepository } = makeService();
+			const persistedEntry = { type: 'slack', credentialId: 'credential-1' } as const;
+			const agent = makeAgent({ activeVersionId: null, integrations: [persistedEntry] });
+			stubRow(agentRepository, [persistedEntry], null);
+			chatService.isChannelLive.mockReturnValue(true);
+			chatService.validateBeforeConnect.mockRejectedValue(
+				new Error('credential is already connected to another agent'),
+			);
+
+			await expect(service.connect({ agent, user: user as never, integration })).rejects.toThrow(
+				'credential is already connected to another agent',
+			);
+
+			// Nothing was running, so there is nothing to put back.
+			expect(chatService.connect).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('publication state changing mid-request', () => {

--- a/packages/cli/src/modules/agents/agent-integration-management.service.ts
+++ b/packages/cli/src/modules/agents/agent-integration-management.service.ts
@@ -173,7 +173,7 @@ export class AgentIntegrationManagementService {
 		// `connect` restarts a connection that is already live — a settings-only
 		// save, or re-connecting the same credential — so a rollback has to know
 		// whether step 1 created this connection or merely replaced it.
-		const wasLive = !!add && this.chatService.getChatInstance(agent.id, add) !== undefined;
+		const wasLive = !!add && this.chatService.isChannelLive(agent.id, add);
 		const persistedBefore =
 			add && state
 				? (state.integrations ?? []).find((entry) => matchesIntegrationRef(entry, add))
@@ -207,7 +207,7 @@ export class AgentIntegrationManagementService {
 					// both drops the failed attempt and puts the previous entry back.
 					await this.restorePersistedRuntime(agent, persistedBefore);
 				} else {
-					await this.chatService.disconnect(agent.id, add);
+					await this.releaseRuntimeQuietly(agent, add);
 				}
 			}
 			throw error;
@@ -274,7 +274,7 @@ export class AgentIntegrationManagementService {
 			return false;
 		}
 
-		if (connected && published && this.chatService.getChatInstance(agent.id, add) === undefined) {
+		if (connected && published && !this.chatService.isChannelLive(agent.id, add)) {
 			this.logger.info(
 				'[AgentIntegrationManagementService] Channel runtime went away while the mutation was in flight — restarting it',
 				{ agentId: agent.id, type: add.type },
@@ -381,7 +381,7 @@ export class AgentIntegrationManagementService {
 			'[AgentIntegrationManagementService] No persisted channel matched the removal — clearing runtime only',
 			{ agentId: agent.id, type: remove.type },
 		);
-		await this.chatService.disconnect(agent.id, remove);
+		await this.releaseRuntimeQuietly(agent, remove);
 
 		// A peer main can still hold this connection — an earlier removal whose
 		// broadcast was dropped leaves one behind — so tell the cluster too.
@@ -390,6 +390,29 @@ export class AgentIntegrationManagementService {
 		const parsed = AgentIntegrationSchema.safeParse(remove);
 		if (parsed.success) {
 			await this.chatService.broadcastIntegrationChange(agent.id, parsed.data, 'disconnect');
+		}
+	}
+
+	/**
+	 * Release a channel's runtime without letting the failure surface.
+	 *
+	 * These are compensating teardowns: one runs while an error is already on its
+	 * way to the caller, the other from a `finally` after the removal is durable.
+	 * A leader-routed teardown can time out, and neither caller can act on that —
+	 * reporting it would replace the failure that actually matters.
+	 */
+	private async releaseRuntimeQuietly(agent: Agent, integration: IntegrationRef): Promise<void> {
+		try {
+			await this.chatService.disconnect(agent.id, integration);
+		} catch (error) {
+			this.logger.warn(
+				'[AgentIntegrationManagementService] Could not release the channel runtime',
+				{
+					agentId: agent.id,
+					type: integration.type,
+					error,
+				},
+			);
 		}
 	}
 

--- a/packages/cli/src/modules/agents/agent-integration-management.service.ts
+++ b/packages/cli/src/modules/agents/agent-integration-management.service.ts
@@ -173,7 +173,13 @@ export class AgentIntegrationManagementService {
 		// `connect` restarts a connection that is already live — a settings-only
 		// save, or re-connecting the same credential — so a rollback has to know
 		// whether step 1 created this connection or merely replaced it.
-		const wasLive = !!add && this.chatService.isChannelLive(agent.id, add);
+		//
+		// An unpublished agent has no live channel to begin with: it never receives
+		// events, so nothing was started for it to restore. The publication check is
+		// what makes that explicit — `isChannelLive` reports a leader-routed channel
+		// as live without being able to inspect the leader, so on its own it would
+		// have a draft's failed pre-connect validation start a runtime.
+		const wasLive = !!add && publishedBefore && this.chatService.isChannelLive(agent.id, add);
 		const persistedBefore =
 			add && state
 				? (state.integrations ?? []).find((entry) => matchesIntegrationRef(entry, add))

--- a/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
@@ -24,7 +24,30 @@ import {
 import type { AgentChatSubscriptionStateService } from '../agent-chat-subscription-state.service';
 import { ChatIntegrationService } from '../chat-integration.service';
 import * as esmLoader from '../esm-loader';
+import {
+	LEADER_CHANNEL_REQUEST_TIMEOUT_MS,
+	type LeaderChannelRelayService,
+} from '../leader-channel-relay.service';
 import type { AgentIntegrationConfig } from '@n8n/api-types';
+
+/**
+ * The peer-reconciliation and leader-request handlers deliberately call the
+ * local-only variants, so the spies have to reach past the routing wrappers.
+ */
+interface PrivateChannelMethods {
+	connectLocal: ChatIntegrationService['connect'];
+	disconnectLocal: (
+		agentId: string,
+		integration: { credentialId: string; type: string },
+		options?: { skipExternalHooks?: boolean },
+	) => Promise<void>;
+	disconnectOne: (key: string, options?: { skipExternalHooks?: boolean }) => Promise<void>;
+}
+
+const spyOnPrivate = <K extends keyof PrivateChannelMethods>(
+	service: ChatIntegrationService,
+	method: K,
+) => vi.spyOn(service as unknown as PrivateChannelMethods, method);
 
 /**
  * Test double — exposes the registry without invoking the real Chat SDK
@@ -43,8 +66,9 @@ class FakeIntegration extends AgentChatIntegration {
 	readonly displayLabel = this.type;
 	readonly displayIcon = this.type;
 
-	override requiresLeader(): boolean {
-		return this.leaderOnly;
+	override requiresLeader({ ingressEnabled } = { ingressEnabled: true }): boolean {
+		// Mirrors the real integrations: an outbound connection opens no poller.
+		return this.leaderOnly && ingressEnabled;
 	}
 
 	async createAdapter(_ctx: AgentChatIntegrationContext): Promise<unknown> {
@@ -102,6 +126,7 @@ function buildServiceWith(
 		publisher?: ReturnType<typeof mock<Publisher>>;
 		urlService?: ReturnType<typeof mock<UrlService>>;
 		chatSubscriptionStateService?: ReturnType<typeof mock<AgentChatSubscriptionStateService>>;
+		leaderChannelRelay?: ReturnType<typeof mock<LeaderChannelRelayService>>;
 	} = {},
 ) {
 	const registry = opts.registry ?? new ChatIntegrationRegistry();
@@ -111,6 +136,7 @@ function buildServiceWith(
 	const urlService = opts.urlService ?? mock<UrlService>();
 	const chatSubscriptionStateService =
 		opts.chatSubscriptionStateService ?? mock<AgentChatSubscriptionStateService>();
+	const leaderChannelRelay = opts.leaderChannelRelay ?? mock<LeaderChannelRelayService>();
 	const logger = mockLogger();
 	const instanceSettings = mock<InstanceSettings>({ isLeader: opts.isLeader ?? true });
 	const globalConfig = mock<GlobalConfig>({
@@ -127,6 +153,7 @@ function buildServiceWith(
 		publisher,
 		globalConfig,
 		chatSubscriptionStateService,
+		leaderChannelRelay,
 	);
 
 	return {
@@ -137,6 +164,8 @@ function buildServiceWith(
 		publisher,
 		urlService,
 		chatSubscriptionStateService,
+		leaderChannelRelay,
+		instanceSettings,
 		logger,
 	};
 }
@@ -246,6 +275,7 @@ describe('ChatIntegrationService', () => {
 			mock(),
 			mock<GlobalConfig>({ multiMainSetup: { enabled: false } } as Partial<GlobalConfig>),
 			mock<AgentChatSubscriptionStateService>(),
+			mock<LeaderChannelRelayService>(),
 		);
 
 	it('disconnects subscription state when setup fails before chat initialization starts', async () => {
@@ -997,14 +1027,7 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 			internal.connections.set('agent-1:telegram:c1', {});
 			internal.connections.set('agent-1:linear:c2', {});
 
-			const disconnectOneSpy = vi
-				.spyOn(
-					service as unknown as {
-						disconnectOne: (k: string, options?: { skipExternalHooks?: boolean }) => Promise<void>;
-					},
-					'disconnectOne',
-				)
-				.mockImplementation(async () => undefined);
+			const disconnectOneSpy = spyOnPrivate(service, 'disconnectOne').mockResolvedValue();
 
 			await service.disconnectLeaderOnlyIntegrations();
 
@@ -1015,12 +1038,479 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				skipExternalHooks: true,
 			});
 		});
+
+		it('gives up on a stuck leader operation instead of stalling the stepdown', async () => {
+			vi.useFakeTimers();
+			try {
+				const registry = new ChatIntegrationRegistry();
+				registry.register(new FakeIntegration('telegram', true));
+				const agentRepository = mock<AgentRepository>();
+				agentRepository.findOne.mockResolvedValue(makeAgent({ id: 'agent-1', projectId: 'p1' }));
+				const { service } = buildServiceWith({ registry, agentRepository });
+
+				const connectLocal = spyOnPrivate(service, 'connectLocal').mockReturnValue(
+					new Promise(() => {}),
+				);
+				void service.handleLeaderChannelRequest({
+					requestId: 'lch_1',
+					replyTo: 'follower-1',
+					agentId: 'agent-1',
+					integration: { type: 'telegram', credentialId: 'c1' },
+					action: 'connect',
+				});
+				await vi.waitFor(() => expect(connectLocal).toHaveBeenCalled());
+
+				const steppingDown = service.disconnectLeaderOnlyIntegrations();
+				await vi.advanceTimersByTimeAsync(LEADER_CHANNEL_REQUEST_TIMEOUT_MS);
+
+				// A platform call that never returns must not hold the demotion open;
+				// the straggler releases itself via the leadership re-check.
+				await expect(steppingDown).resolves.toBeUndefined();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('drains an in-flight leader-side connect before sweeping', async () => {
+			const registry = new ChatIntegrationRegistry();
+			registry.register(new FakeIntegration('telegram', true));
+
+			const agentRepository = mock<AgentRepository>();
+			agentRepository.findOne.mockResolvedValue(makeAgent({ id: 'agent-1', projectId: 'p1' }));
+			const { service } = buildServiceWith({ registry, agentRepository });
+
+			// A connect that is still starting up when the stepdown begins: the sweep
+			// has to see the connection it registers, not miss it and leave a poller
+			// running on a main that no longer leads.
+			let finishConnect: () => void = () => {};
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockImplementation(
+				async () =>
+					await new Promise<void>((resolve) => {
+						finishConnect = () => {
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							(service as any).connections.set('agent-1:telegram:c1', {});
+							resolve();
+						};
+					}),
+			);
+			const disconnectOneSpy = spyOnPrivate(service, 'disconnectOne').mockResolvedValue();
+
+			const connecting = service.handleLeaderChannelRequest({
+				requestId: 'lch_1',
+				replyTo: 'follower-1',
+				agentId: 'agent-1',
+				integration: { type: 'telegram', credentialId: 'c1' },
+				action: 'connect',
+			});
+			// Let the handler reach `connectLocal` before the stepdown starts draining.
+			await vi.waitFor(() => expect(connectLocal).toHaveBeenCalled());
+
+			const steppingDown = service.disconnectLeaderOnlyIntegrations();
+			finishConnect();
+			await Promise.all([connecting, steppingDown]);
+
+			expect(disconnectOneSpy).toHaveBeenCalledWith('agent-1:telegram:c1', {
+				skipExternalHooks: true,
+			});
+		});
+	});
+
+	describe('leader-only channel routing', () => {
+		const telegram: AgentIntegrationConfig = { type: 'telegram', credentialId: 'c1' };
+
+		/** A follower in multi-main mode with a leader-only telegram integration. */
+		function buildFollower() {
+			const registry = new ChatIntegrationRegistry();
+			registry.register(new FakeIntegration('telegram', true));
+			registry.register(new FakeIntegration('linear', false));
+
+			const built = buildServiceWith({ isLeader: false, multiMainEnabled: true, registry });
+			built.leaderChannelRelay.requestWithoutAck.mockResolvedValue();
+			const connectLocal = spyOnPrivate(built.service, 'connectLocal').mockResolvedValue();
+			const disconnectLocal = spyOnPrivate(built.service, 'disconnectLocal').mockResolvedValue();
+
+			return { ...built, connectLocal, disconnectLocal };
+		}
+
+		it('hands a connect to the leader and builds nothing locally', async () => {
+			const { service, leaderChannelRelay, connectLocal, disconnectLocal } = buildFollower();
+			leaderChannelRelay.request.mockResolvedValue();
+
+			await service.connect('agent-1', telegram, 'project-1');
+
+			expect(leaderChannelRelay.request).toHaveBeenCalledWith({
+				agentId: 'agent-1',
+				integration: telegram,
+				action: 'connect',
+			});
+			// The whole point: a follower must never end up owning a poller.
+			expect(connectLocal).not.toHaveBeenCalled();
+			// Anything it still held for the key goes, with external teardown left to
+			// the leader.
+			expect(disconnectLocal).toHaveBeenCalledWith('agent-1', telegram, {
+				skipExternalHooks: true,
+			});
+		});
+
+		it('hands a disconnect to the leader', async () => {
+			const { service, leaderChannelRelay, disconnectLocal } = buildFollower();
+			leaderChannelRelay.request.mockResolvedValue();
+
+			await service.disconnect('agent-1', telegram);
+
+			expect(leaderChannelRelay.request).toHaveBeenCalledWith({
+				agentId: 'agent-1',
+				integration: telegram,
+				action: 'disconnect',
+			});
+			// Only local state — the cluster-wide release is the leader's to run.
+			expect(disconnectLocal).toHaveBeenCalledWith('agent-1', telegram, {
+				skipExternalHooks: true,
+			});
+		});
+
+		it('surfaces the failure and releases the leader runtime when the ack does not arrive', async () => {
+			const { service, leaderChannelRelay } = buildFollower();
+			leaderChannelRelay.request.mockRejectedValue(new Error('no acknowledgement'));
+
+			await expect(service.connect('agent-1', telegram, 'project-1')).rejects.toThrow(
+				'no acknowledgement',
+			);
+
+			// A leader that started polling but lost its ack would otherwise keep a
+			// runtime claim for a channel this request just reported as failed.
+			expect(leaderChannelRelay.requestWithoutAck).toHaveBeenCalledWith({
+				agentId: 'agent-1',
+				integration: telegram,
+				action: 'disconnect',
+			});
+		});
+
+		it('still reports the original failure when the release cannot be delivered', async () => {
+			const { service, leaderChannelRelay } = buildFollower();
+			leaderChannelRelay.request.mockRejectedValue(new Error('no acknowledgement'));
+			leaderChannelRelay.requestWithoutAck.mockRejectedValue(new Error('redis is down'));
+
+			await expect(service.connect('agent-1', telegram, 'project-1')).rejects.toThrow(
+				'no acknowledgement',
+			);
+		});
+
+		it('connects locally on the leader without a round-trip', async () => {
+			const registry = new ChatIntegrationRegistry();
+			registry.register(new FakeIntegration('telegram', true));
+			const { service, leaderChannelRelay } = buildServiceWith({
+				isLeader: true,
+				multiMainEnabled: true,
+				registry,
+			});
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
+
+			await service.connect('agent-1', telegram, 'project-1');
+
+			expect(connectLocal).toHaveBeenCalledWith('agent-1', telegram, 'project-1', {});
+			expect(leaderChannelRelay.request).not.toHaveBeenCalled();
+		});
+
+		it('connects locally in a single-main setup', async () => {
+			const registry = new ChatIntegrationRegistry();
+			registry.register(new FakeIntegration('telegram', true));
+			// A single main is never the leader in the multi-main sense, but there is
+			// no other instance to hand the work to.
+			const { service, leaderChannelRelay } = buildServiceWith({
+				isLeader: false,
+				multiMainEnabled: false,
+				registry,
+			});
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
+
+			await service.connect('agent-1', telegram, 'project-1');
+
+			expect(connectLocal).toHaveBeenCalled();
+			expect(leaderChannelRelay.request).not.toHaveBeenCalled();
+		});
+
+		it('keeps outbound preview connections local on a follower', async () => {
+			const { service, leaderChannelRelay, connectLocal } = buildFollower();
+
+			// Ingress off means no poller (Telegram forces webhook mode), so every
+			// main builds these for itself.
+			await service.connect('agent-1', telegram, 'project-1', { ingressEnabled: false });
+
+			expect(connectLocal).toHaveBeenCalled();
+			expect(leaderChannelRelay.request).not.toHaveBeenCalled();
+		});
+
+		it('keeps a webhook integration local on a follower', async () => {
+			const { service, leaderChannelRelay, connectLocal } = buildFollower();
+
+			await service.connect('agent-1', { type: 'linear', credentialId: 'c2' }, 'project-1');
+
+			expect(connectLocal).toHaveBeenCalled();
+			expect(leaderChannelRelay.request).not.toHaveBeenCalled();
+		});
+
+		it('clears a local draft reference without involving the leader', async () => {
+			const { service, leaderChannelRelay, disconnectLocal } = buildFollower();
+
+			// A builder draft entry (`credentialId: ''`) is not a real connection
+			// anywhere, so there is nothing for the leader to release.
+			await service.disconnect('agent-1', { type: 'telegram', credentialId: '' });
+
+			expect(leaderChannelRelay.request).not.toHaveBeenCalled();
+			// Local-only cleanup, and external teardown is not skipped: nothing else
+			// in the cluster is going to run it for a reference only this main holds.
+			expect(disconnectLocal).toHaveBeenCalledWith(
+				'agent-1',
+				{ type: 'telegram', credentialId: '' },
+				{},
+			);
+		});
+	});
+
+	describe('disconnectChannel', () => {
+		it('still tells peers to drop the channel when the teardown failed', async () => {
+			const registry = new ChatIntegrationRegistry();
+			registry.register(new FakeIntegration('telegram', true));
+			const { service, publisher } = buildServiceWith({
+				isLeader: false,
+				multiMainEnabled: true,
+				registry,
+			});
+			spyOnPrivate(service, 'disconnectLocal').mockResolvedValue();
+			// A leader that never acknowledged is exactly when peers are most likely to
+			// be holding runtime for a channel that is going away.
+			(service as unknown as { leaderChannelRelay: { request: Mock } }).leaderChannelRelay.request =
+				vi.fn().mockRejectedValue(new Error('no acknowledgement'));
+
+			await service.disconnectChannel('agent-1', { type: 'telegram', credentialId: 'c1' });
+
+			expect(publisher.publishCommand).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: 'agent-chat-integration-changed',
+					payload: expect.objectContaining({ action: 'disconnect' }),
+				}),
+			);
+		});
+	});
+
+	describe('handleLeaderChannelRequest', () => {
+		const telegram: AgentIntegrationConfig = { type: 'telegram', credentialId: 'c1' };
+		const request = {
+			requestId: 'lch_1',
+			replyTo: 'follower-1',
+			agentId: 'agent-1',
+			integration: telegram,
+			action: 'connect' as const,
+		};
+
+		/** A leader ready to execute a relayed request. */
+		function buildLeader(opts: { isLeader?: boolean } = {}) {
+			const registry = new ChatIntegrationRegistry();
+			registry.register(new FakeIntegration('telegram', true));
+
+			const agentRepository = mock<AgentRepository>();
+			agentRepository.findOne.mockResolvedValue(makeAgent({ id: 'agent-1', projectId: 'p1' }));
+
+			return buildServiceWith({
+				isLeader: opts.isLeader ?? true,
+				multiMainEnabled: true,
+				registry,
+				agentRepository,
+			});
+		}
+
+		it('connects locally and acknowledges success', async () => {
+			const { service, leaderChannelRelay } = buildLeader();
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
+
+			await service.handleLeaderChannelRequest(request);
+
+			expect(connectLocal).toHaveBeenCalledWith('agent-1', telegram, 'p1');
+			expect(leaderChannelRelay.respond).toHaveBeenCalledWith(request);
+		});
+
+		it('joins a concurrent request for the same channel instead of running it twice', async () => {
+			const { service, leaderChannelRelay } = buildLeader();
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
+
+			await Promise.all([
+				service.handleLeaderChannelRequest(request),
+				service.handleLeaderChannelRequest({ ...request, requestId: 'lch_2' }),
+			]);
+
+			// Re-running would tear down the runtime the first request is building.
+			expect(connectLocal).toHaveBeenCalledTimes(1);
+			expect(leaderChannelRelay.respond).toHaveBeenCalledTimes(2);
+		});
+
+		it('runs a request for a different channel independently', async () => {
+			const { service } = buildLeader();
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
+
+			await Promise.all([
+				service.handleLeaderChannelRequest(request),
+				service.handleLeaderChannelRequest({
+					...request,
+					requestId: 'lch_2',
+					integration: { type: 'telegram', credentialId: 'c2' },
+				}),
+			]);
+
+			expect(connectLocal).toHaveBeenCalledTimes(2);
+		});
+
+		it('releases the channel after a failed request so the next one retries', async () => {
+			const { service } = buildLeader();
+			const connectLocal = spyOnPrivate(service, 'connectLocal')
+				.mockRejectedValueOnce(new Error('bot token already in use'))
+				.mockResolvedValue();
+
+			await service.handleLeaderChannelRequest(request);
+			await service.handleLeaderChannelRequest({ ...request, requestId: 'lch_2' });
+
+			expect(connectLocal).toHaveBeenCalledTimes(2);
+		});
+
+		it('joins a duplicate request for the action already running', async () => {
+			const { service, leaderChannelRelay } = buildLeader();
+			let finishConnect: () => void = () => {};
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockImplementation(
+				async () =>
+					await new Promise<void>((resolve) => {
+						finishConnect = resolve;
+					}),
+			);
+
+			const first = service.handleLeaderChannelRequest(request);
+			await vi.waitFor(() => expect(connectLocal).toHaveBeenCalled());
+			const retry = service.handleLeaderChannelRequest({ ...request, requestId: 'lch_2' });
+			finishConnect();
+			await Promise.all([first, retry]);
+
+			// A retry, or a request whose ack was lost, must not restart a startup that
+			// is already under way.
+			expect(connectLocal).toHaveBeenCalledTimes(1);
+			expect(leaderChannelRelay.respond).toHaveBeenCalledTimes(2);
+		});
+
+		it('rebuilds a live channel, so a settings-only save reaches the runtime', async () => {
+			const { service, leaderChannelRelay } = buildLeader();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(service as any).connections.set('agent-1:telegram:c1', {});
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
+			const settings = { accessMode: 'private' as const, allowedUsers: ['@someone'] };
+
+			await service.handleLeaderChannelRequest({
+				...request,
+				integration: { ...telegram, settings },
+			});
+
+			// The connection key excludes settings, so a live key is exactly what a
+			// settings edit arrives on — skipping the rebuild would keep the leader
+			// enforcing the previous allowlist.
+			expect(connectLocal).toHaveBeenCalledWith('agent-1', { ...telegram, settings }, 'p1');
+			expect(leaderChannelRelay.respond).toHaveBeenCalledWith(
+				expect.objectContaining({ requestId: 'lch_1' }),
+			);
+		});
+
+		it('queues a disconnect behind an in-flight connect instead of joining it', async () => {
+			const { service, leaderChannelRelay } = buildLeader();
+			const order: string[] = [];
+			let finishConnect: () => void = () => {};
+			const connectLocal = spyOnPrivate(service, 'connectLocal').mockImplementation(
+				async () =>
+					await new Promise<void>((resolve) => {
+						finishConnect = () => {
+							order.push('connect');
+							resolve();
+						};
+					}),
+			);
+			const disconnectLocal = spyOnPrivate(service, 'disconnectLocal').mockImplementation(
+				async () => {
+					order.push('disconnect');
+				},
+			);
+
+			const connecting = service.handleLeaderChannelRequest(request);
+			await vi.waitFor(() => expect(connectLocal).toHaveBeenCalled());
+			const disconnecting = service.handleLeaderChannelRequest({
+				...request,
+				requestId: 'lch_2',
+				action: 'disconnect',
+			});
+			finishConnect();
+			await Promise.all([connecting, disconnecting]);
+
+			// Joining the connect would have acknowledged the removal as done while
+			// leaving the leader polling a channel the caller has already deleted.
+			expect(disconnectLocal).toHaveBeenCalledTimes(1);
+			expect(order).toEqual(['connect', 'disconnect']);
+			expect(leaderChannelRelay.respond).toHaveBeenCalledTimes(2);
+		});
+
+		it('tears the runtime down and reports failure when leadership was lost mid-startup', async () => {
+			const { service, leaderChannelRelay, instanceSettings } = buildLeader();
+			spyOnPrivate(service, 'connectLocal').mockImplementation(async () => {
+				Object.defineProperty(instanceSettings, 'isLeader', { value: false, writable: true });
+			});
+			const disconnectOne = spyOnPrivate(service, 'disconnectOne').mockResolvedValue();
+
+			await service.handleLeaderChannelRequest(request);
+
+			expect(disconnectOne).toHaveBeenCalledWith('agent-1:telegram:c1', {
+				skipExternalHooks: true,
+			});
+			expect(leaderChannelRelay.respond).toHaveBeenCalledWith(
+				request,
+				expect.objectContaining({ message: expect.stringContaining('stopped being the leader') }),
+			);
+		});
+
+		it('reports failure when the connect throws', async () => {
+			const { service, leaderChannelRelay } = buildLeader();
+			spyOnPrivate(service, 'connectLocal').mockRejectedValue(
+				new Error('bot token already in use'),
+			);
+
+			await service.handleLeaderChannelRequest(request);
+
+			expect(leaderChannelRelay.respond).toHaveBeenCalledWith(
+				request,
+				expect.objectContaining({ message: 'bot token already in use' }),
+			);
+		});
+
+		it('reports failure when the agent no longer exists', async () => {
+			const { service, leaderChannelRelay, agentRepository } = buildLeader();
+			agentRepository.findOne.mockResolvedValue(null);
+
+			await service.handleLeaderChannelRequest(request);
+
+			expect(leaderChannelRelay.respond).toHaveBeenCalledWith(
+				request,
+				expect.objectContaining({ message: expect.stringContaining('not found') }),
+			);
+		});
+
+		it('tears down locally on a disconnect request and acknowledges', async () => {
+			const { service, leaderChannelRelay } = buildLeader();
+			const disconnectLocal = spyOnPrivate(service, 'disconnectLocal').mockResolvedValue();
+			const disconnectRequest = { ...request, action: 'disconnect' as const };
+
+			await service.handleLeaderChannelRequest(disconnectRequest);
+
+			expect(disconnectLocal).toHaveBeenCalledWith('agent-1', telegram);
+			expect(leaderChannelRelay.respond).toHaveBeenCalledWith(disconnectRequest);
+		});
 	});
 
 	describe('handleIntegrationChanged', () => {
-		it('routes disconnect actions to disconnect() and skips external hooks on the peer', async () => {
+		it("tears down the peer's local runtime on disconnect and skips external hooks", async () => {
 			const { service } = buildServiceWith();
-			const disconnectSpy = vi.spyOn(service, 'disconnect').mockResolvedValue();
+			const disconnectSpy = spyOnPrivate(service, 'disconnectLocal').mockResolvedValue();
 
 			await service.handleIntegrationChanged({
 				agentId: 'a1',
@@ -1043,7 +1533,7 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 
 			const { service } = buildServiceWith({ isLeader: false, registry });
 
-			const connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
+			const connectSpy = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
 
 			await service.handleIntegrationChanged({
 				agentId: 'a1',
@@ -1067,7 +1557,7 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				agentRepository,
 			});
 
-			const connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
+			const connectSpy = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
 
 			await service.handleIntegrationChanged({
 				agentId: 'a1',
@@ -1094,7 +1584,9 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				agentRepository,
 			});
 
-			vi.spyOn(service, 'connect').mockRejectedValue(new Error('not accessible to project'));
+			spyOnPrivate(service, 'connectLocal').mockRejectedValue(
+				new Error('not accessible to project'),
+			);
 
 			await expect(
 				service.handleIntegrationChanged({
@@ -1114,7 +1606,7 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 
 			const { service } = buildServiceWith({ registry, agentRepository });
 
-			const connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
+			const connectSpy = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
 
 			await service.handleIntegrationChanged({
 				agentId: 'gone',
@@ -1135,7 +1627,7 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 			const internal = service as any;
 			internal.connections.set('a1:linear:c1', {});
 
-			const connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
+			const connectSpy = spyOnPrivate(service, 'connectLocal').mockResolvedValue();
 
 			await service.handleIntegrationChanged({
 				agentId: 'a1',

--- a/packages/cli/src/modules/agents/integrations/__tests__/leader-channel-relay.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/leader-channel-relay.service.test.ts
@@ -1,0 +1,233 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { InstanceSettings } from 'n8n-core';
+import { mock } from 'vitest-mock-extended';
+
+import type { Publisher } from '@/scaling/pubsub/publisher.service';
+import type { PubSubCommandMap } from '@/scaling/pubsub/pubsub.event-map';
+
+import {
+	LEADER_CHANNEL_REQUEST_TIMEOUT_MS,
+	LeaderChannelRelayService,
+} from '../leader-channel-relay.service';
+
+type Request = PubSubCommandMap['agent-chat-leader-channel-request'];
+
+const telegram = { type: 'telegram' as const, credentialId: 'cred-1' };
+
+function buildRelay() {
+	const publisher = mock<Publisher>();
+	publisher.publishCommand.mockResolvedValue();
+	const instanceSettings = mock<InstanceSettings>({ hostId: 'follower-1' });
+	const relay = new LeaderChannelRelayService(mockLogger(), publisher, instanceSettings);
+
+	/** The request payload the relay just published, including its generated id. */
+	const publishedRequest = (): Request => {
+		const call = publisher.publishCommand.mock.calls.find(
+			([msg]) => msg.command === 'agent-chat-leader-channel-request',
+		);
+		if (!call) throw new Error('No request was published');
+		return call[0].payload as Request;
+	};
+
+	/** Issue the request under test; `publishedRequest()` reads back its id. */
+	const start = async (action: 'connect' | 'disconnect' = 'connect') =>
+		await relay.request({ agentId: 'agent-1', integration: telegram, action });
+
+	return { relay, publisher, publishedRequest, start };
+}
+
+describe('LeaderChannelRelayService', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('request', () => {
+		it('resolves only once the leader acknowledges success', async () => {
+			const { relay, publishedRequest, start } = buildRelay();
+
+			const pending = start();
+			let settled = false;
+			void pending.then(() => {
+				settled = true;
+			});
+
+			// The leader has not answered yet, so the caller must still be waiting.
+			await vi.advanceTimersByTimeAsync(LEADER_CHANNEL_REQUEST_TIMEOUT_MS - 1);
+			expect(settled).toBe(false);
+
+			relay.handleResult({ requestId: publishedRequest().requestId, ok: true });
+
+			await expect(pending).resolves.toBeUndefined();
+		});
+
+		it('carries this host as the reply address so the ack can be targeted back', async () => {
+			const { relay, publishedRequest, start } = buildRelay();
+
+			const pending = start();
+
+			expect(publishedRequest()).toMatchObject({
+				replyTo: 'follower-1',
+				agentId: 'agent-1',
+				action: 'connect',
+			});
+
+			relay.handleResult({ requestId: publishedRequest().requestId, ok: true });
+			await pending;
+		});
+
+		it("rejects with the leader's reason on a negative acknowledgement", async () => {
+			const { relay, publishedRequest, start } = buildRelay();
+
+			const pending = start();
+			const rejection = expect(pending).rejects.toThrow(
+				/could not connect telegram for agent agent-1: bot token already in use/,
+			);
+
+			relay.handleResult({
+				requestId: publishedRequest().requestId,
+				ok: false,
+				error: 'bot token already in use',
+			});
+
+			await rejection;
+		});
+
+		it('rejects when no acknowledgement arrives within the timeout', async () => {
+			const { start } = buildRelay();
+
+			const pending = start();
+			const rejection = expect(pending).rejects.toThrow(
+				/did not acknowledge the request to connect telegram for agent agent-1/,
+			);
+
+			await vi.advanceTimersByTimeAsync(LEADER_CHANNEL_REQUEST_TIMEOUT_MS);
+
+			await rejection;
+		});
+
+		it('rejects immediately when the request cannot be published', async () => {
+			const { publisher, start } = buildRelay();
+			publisher.publishCommand.mockRejectedValue(new Error('redis is down'));
+
+			await expect(start()).rejects.toThrow(/Could not reach the leader instance.*redis is down/);
+		});
+
+		it('ignores an acknowledgement for an unknown request', () => {
+			const { relay } = buildRelay();
+
+			expect(() => relay.handleResult({ requestId: 'lch_gone', ok: true })).not.toThrow();
+		});
+
+		it('ignores a late acknowledgement for a request that already timed out', async () => {
+			const { relay, publishedRequest, start } = buildRelay();
+
+			const pending = start();
+			const rejection = expect(pending).rejects.toThrow();
+			await vi.advanceTimersByTimeAsync(LEADER_CHANNEL_REQUEST_TIMEOUT_MS);
+			await rejection;
+
+			expect(() =>
+				relay.handleResult({ requestId: publishedRequest().requestId, ok: true }),
+			).not.toThrow();
+		});
+	});
+
+	describe('pending requests on lifecycle events', () => {
+		it('rejects pending requests when this main becomes the leader', async () => {
+			const { relay, start } = buildRelay();
+
+			const pending = start();
+			const rejection = expect(pending).rejects.toThrow(/leadership changed/);
+
+			relay.rejectPendingOnTakeover();
+
+			await rejection;
+		});
+
+		it('rejects pending requests on shutdown instead of leaving the caller hanging', async () => {
+			const { relay, start } = buildRelay();
+
+			const pending = start('disconnect');
+			const rejection = expect(pending).rejects.toThrow(/shutting down/);
+
+			relay.rejectPendingOnShutdown();
+
+			await rejection;
+		});
+	});
+
+	describe('requestWithoutAck', () => {
+		it('publishes without registering a pending request', async () => {
+			const { relay, publishedRequest } = buildRelay();
+
+			await relay.requestWithoutAck({
+				agentId: 'agent-1',
+				integration: telegram,
+				action: 'disconnect',
+			});
+
+			expect(publishedRequest()).toMatchObject({ action: 'disconnect', replyTo: 'follower-1' });
+			// No pending entry and no live timer: an ack for this would be dropped, and
+			// nothing here can keep the process from exiting.
+			expect(vi.getTimerCount()).toBe(0);
+		});
+
+		it('propagates a publish failure to the caller', async () => {
+			const { relay, publisher } = buildRelay();
+			publisher.publishCommand.mockRejectedValue(new Error('redis is down'));
+
+			await expect(
+				relay.requestWithoutAck({
+					agentId: 'agent-1',
+					integration: telegram,
+					action: 'disconnect',
+				}),
+			).rejects.toThrow('redis is down');
+		});
+	});
+
+	describe('respond', () => {
+		const request: Request = {
+			requestId: 'lch_1',
+			replyTo: 'follower-2',
+			agentId: 'agent-1',
+			integration: telegram,
+			action: 'connect',
+		};
+
+		it('targets the acknowledgement at the requesting main', async () => {
+			const { relay, publisher } = buildRelay();
+
+			await relay.respond(request);
+
+			expect(publisher.publishCommand).toHaveBeenCalledWith({
+				command: 'agent-chat-leader-channel-result',
+				payload: { requestId: 'lch_1', ok: true },
+				targets: ['follower-2'],
+			});
+		});
+
+		it('reports the failure reason on a negative acknowledgement', async () => {
+			const { relay, publisher } = buildRelay();
+
+			await relay.respond(request, new Error('bot token already in use'));
+
+			expect(publisher.publishCommand).toHaveBeenCalledWith({
+				command: 'agent-chat-leader-channel-result',
+				payload: { requestId: 'lch_1', ok: false, error: 'bot token already in use' },
+				targets: ['follower-2'],
+			});
+		});
+
+		it('swallows a publish failure so the leader keeps its own teardown path', async () => {
+			const { relay, publisher } = buildRelay();
+			publisher.publishCommand.mockRejectedValue(new Error('redis is down'));
+
+			await expect(relay.respond(request)).resolves.toBeUndefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -266,8 +266,14 @@ export abstract class AgentChatIntegration {
 	 * mains and either duplicate or get lost. Webhook-based platforms return
 	 * false so any main can answer inbound webhooks (which the load balancer
 	 * routes round-robin across all mains).
+	 *
+	 * `ingressEnabled` is passed because exclusivity can depend on it: an outbound
+	 * connection that receives nothing may well be safe on every main even when the
+	 * ingress one is not. Only the integration knows — it is the same input its
+	 * `createAdapter` uses to pick a transport — so the answer belongs here rather
+	 * than inferred by the caller.
 	 */
-	requiresLeader(): boolean {
+	requiresLeader(_options: { ingressEnabled: boolean } = { ingressEnabled: true }): boolean {
 		return false;
 	}
 

--- a/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
+++ b/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
@@ -3,8 +3,10 @@ import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { OnLeaderStepdown, OnLeaderTakeover, OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
 import type { Channel, Chat as ChatSdk, StateAdapter, Thread, UserInfo } from 'chat';
 import { InstanceSettings } from 'n8n-core';
+import { OperationalError, UnexpectedError } from 'n8n-workflow';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
@@ -22,6 +24,10 @@ import type { CallbackMetadata } from './callback-store';
 import { ComponentMapper, type ShortenCallback } from './component-mapper';
 import { loadChatSdk, loadMemoryState } from './esm-loader';
 import { buildIntegrationConnectionId } from './integration-tools';
+import {
+	LEADER_CHANNEL_REQUEST_TIMEOUT_MS,
+	LeaderChannelRelayService,
+} from './leader-channel-relay.service';
 import { channelIntegrationRecorder } from './recording/channel-integration-recorder';
 import { recordAdapterCalls } from './recording/recording-adapter';
 import type { Agent } from '../entities/agent.entity';
@@ -109,6 +115,18 @@ export class ChatIntegrationService {
 		Promise<ChatInstance | undefined>
 	>();
 
+	/**
+	 * Leader-only operations this main is running as leader, keyed by connection
+	 * key. Doubles as a dedupe map — a repeated request joins the running
+	 * operation instead of racing it — and as the set a stepdown has to drain.
+	 * The action is kept because only a matching one may join; see
+	 * {@link runLeaderOperation}.
+	 */
+	private readonly leaderOperations = new Map<
+		string,
+		{ action: 'connect' | 'disconnect'; done: Promise<void> }
+	>();
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly agentRepository: AgentRepository,
@@ -119,6 +137,7 @@ export class ChatIntegrationService {
 		private readonly publisher: Publisher,
 		private readonly globalConfig: GlobalConfig,
 		private readonly chatSubscriptionStateService: AgentChatSubscriptionStateService,
+		private readonly leaderChannelRelay: LeaderChannelRelayService,
 	) {}
 
 	/**
@@ -181,8 +200,9 @@ export class ChatIntegrationService {
 	/**
 	 * Connect an agent to a chat platform via the Chat SDK.
 	 *
-	 * Creates a Chat instance with the appropriate adapter, initializes it,
-	 * and wires up the AgentChatBridge for event handling.
+	 * A leader-only integration is routed to the leader and awaited — see
+	 * {@link LeaderChannelRelayService}. Everything else connects locally on the
+	 * main that was asked.
 	 *
 	 * `options.skipExternalHooks` skips `onBeforeConnect` and `onAfterConnect`.
 	 * These hooks can touch external services and must run exactly once per
@@ -191,6 +211,41 @@ export class ChatIntegrationService {
 	 * only build local runtime state.
 	 */
 	async connect(
+		agentId: string,
+		integration: AgentIntegrationConfig,
+		projectId: string,
+		options: ConnectOptions = {},
+	): Promise<void> {
+		const ingress = options.ingressEnabled ?? true;
+		if (!this.shouldRouteToLeader(integration.type, ingress)) {
+			return await this.connectLocal(agentId, integration, projectId, options);
+		}
+
+		// Runtime state for this key on this main is ours alone and the leader knows
+		// nothing about it: an outbound preview connection a local connect would have
+		// replaced, or ingress state left over from a term as leader. Either way a
+		// follower must hold neither once the leader owns this channel.
+		await this.disconnectLocal(agentId, integration, { skipExternalHooks: true });
+
+		try {
+			await this.leaderChannelRelay.request({ agentId, integration, action: 'connect' });
+		} catch (error) {
+			// A lost acknowledgement can still leave the leader polling, which would
+			// keep a runtime claim for a channel this request is about to report as
+			// failed. Unacknowledged: the original failure is what the caller needs to
+			// see, and a leader that did not answer the connect will not answer this.
+			void this.leaderChannelRelay
+				.requestWithoutAck({ agentId, integration, action: 'disconnect' })
+				.catch((releaseError: unknown) => {
+					this.logger.warn(
+						`[ChatIntegrationService] Could not release the leader's runtime after a failed connect for ${integration.type} on agent ${agentId}: ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
+					);
+				});
+			throw error;
+		}
+	}
+
+	private async connectLocal(
 		agentId: string,
 		integration: AgentIntegrationConfig,
 		projectId: string,
@@ -350,6 +405,9 @@ export class ChatIntegrationService {
 	 * If `type` and `credentialId` are provided, disconnects only that integration.
 	 * Otherwise disconnects all integrations for the agent.
 	 *
+	 * A leader-only integration lives on the leader, so its teardown is routed
+	 * there and awaited — see {@link LeaderChannelRelayService}.
+	 *
 	 * `options.skipExternalHooks` skips `onBeforeDisconnect` — set this on peer
 	 * mains reacting to a PubSub broadcast so the cluster-wide remote release
 	 * happens exactly once.
@@ -359,11 +417,7 @@ export class ChatIntegrationService {
 		integration?: { credentialId: string; type: string },
 		options: DisconnectOptions = {},
 	): Promise<void> {
-		if (integration) {
-			const key = this.connectionKey(agentId, integration.type, integration.credentialId);
-			await this.disconnectOne(key, options);
-			await this.disconnectOutboundOne(key);
-		} else {
+		if (!integration) {
 			const keysToRemove = new Set(
 				[
 					...this.connections.keys(),
@@ -375,7 +429,20 @@ export class ChatIntegrationService {
 				await this.disconnectOne(k, options);
 				await this.disconnectOutboundOne(k);
 			}
+			return;
 		}
+
+		// A draft reference (`credentialId: ''`) is not a live connection on any main,
+		// so there is nothing for the leader to release — only local state to clear.
+		if (integration.credentialId !== '' && this.shouldRouteToLeader(integration.type, true)) {
+			// Whatever this main still holds for the key is local state the leader does
+			// not know about; external teardown is the leader's to run.
+			await this.disconnectLocal(agentId, integration, { skipExternalHooks: true });
+			await this.leaderChannelRelay.request({ agentId, integration, action: 'disconnect' });
+			return;
+		}
+
+		await this.disconnectLocal(agentId, integration, options);
 	}
 
 	/**
@@ -391,12 +458,16 @@ export class ChatIntegrationService {
 
 		try {
 			await this.disconnect(agentId, integration);
-			await this.broadcastIntegrationChange(agentId, integration, 'disconnect');
 		} catch (error) {
 			this.logger.warn(
 				`[ChatIntegrationService] Disconnect failed for ${integration.type} on agent ${agentId}: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}
+
+		// Outside the catch above: the broadcast is what clears peers holding runtime
+		// for a channel that is going away, so a teardown that failed — a leader that
+		// did not acknowledge in time — is the case that needs it most.
+		await this.broadcastIntegrationChange(agentId, integration, 'disconnect');
 
 		if (!deleteSubscriptions) return;
 
@@ -440,6 +511,12 @@ export class ChatIntegrationService {
 	 */
 	@OnLeaderStepdown()
 	async disconnectLeaderOnlyIntegrations(): Promise<void> {
+		// A connect this main accepted as leader can still be starting up. Let it
+		// finish so the sweep below sees its connection, instead of leaving a poller
+		// running on a main that no longer leads. Stepdown handlers run concurrently,
+		// so the drain has to be awaited here rather than ordered between handlers.
+		await this.settleLeaderOperations();
+
 		for (const key of [...this.connections.keys()]) {
 			const integration = this.integrationFromConnectionKey(key);
 			if (integration?.requiresLeader()) {
@@ -525,6 +602,21 @@ export class ChatIntegrationService {
 			if (k.startsWith(`${agentId}:`)) return conn.chat;
 		}
 		return undefined;
+	}
+
+	/**
+	 * Whether a runtime for this channel is live, as far as this main can tell.
+	 *
+	 * Read it as "do not create or tear down", not as proof of a running poller: a
+	 * leader-only channel routed to the leader is deliberately absent from this
+	 * main's `connections` map and cannot be inspected from here, so this reports
+	 * `true` for one without checking. That is the useful answer for both callers —
+	 * a follower must neither restart a channel the leader just started nor tear
+	 * down one it cannot see — but a caller needing certainty has to ask the leader.
+	 */
+	isChannelLive(agentId: string, integration: { type: string; credentialId: string }): boolean {
+		if (this.shouldRouteToLeader(integration.type, true)) return true;
+		return this.getChatInstance(agentId, integration) !== undefined;
 	}
 
 	/**
@@ -697,8 +789,10 @@ export class ChatIntegrationService {
 
 		if (action === 'disconnect') {
 			// The originating main already ran integration-defined external teardown.
-			// Peers only clear local runtime state to avoid duplicate external side effects.
-			await this.disconnect(agentId, integration, { skipExternalHooks: true });
+			// Peers only clear local runtime state to avoid duplicate external side
+			// effects — and this must stay local, or a follower would relay a teardown
+			// the originator has already had the leader perform.
+			await this.disconnectLocal(agentId, integration, { skipExternalHooks: true });
 			return;
 		}
 
@@ -726,7 +820,7 @@ export class ChatIntegrationService {
 			// Peers only build local runtime state to avoid duplicate external
 			// side effects.
 			const options: ConnectOptions = { skipExternalHooks: true };
-			await this.connect(agentId, integration, agent.projectId, options);
+			await this.connectLocal(agentId, integration, agent.projectId, options);
 		} catch (error) {
 			this.logger.error(
 				`[ChatIntegrationService] Failed to connect ${type} for agent ${agentId} — credential not accessible to the project: ${error instanceof Error ? error.message : String(error)}`,
@@ -734,9 +828,154 @@ export class ChatIntegrationService {
 		}
 	}
 
+	/**
+	 * Execute a leader-only channel operation another main asked us to run, and
+	 * acknowledge the outcome so that main can report it to the user.
+	 *
+	 * The `instanceRole` filter is re-evaluated per event, so a follower that once
+	 * led never picks this up. Operations for the same connection key are
+	 * serialised and joined by the relay, which makes a repeated connect or
+	 * disconnect request idempotent rather than a teardown-rebuild race.
+	 */
+	@OnPubSubEvent('agent-chat-leader-channel-request', {
+		instanceType: 'main',
+		instanceRole: 'leader',
+	})
+	async handleLeaderChannelRequest(
+		payload: PubSubCommandMap['agent-chat-leader-channel-request'],
+	): Promise<void> {
+		const { agentId, integration, action } = payload;
+		const key = this.connectionKey(agentId, integration.type, integration.credentialId);
+
+		try {
+			await this.runLeaderOperation(key, action, async () => {
+				if (action === 'disconnect') {
+					await this.disconnectLocal(agentId, integration);
+					return;
+				}
+
+				// No "already connected, nothing to do" shortcut: the connection key
+				// excludes settings, so a settings-only save arrives on a live key and
+				// has to rebuild — same as a local connect does. Duplicate requests are
+				// deduped by `runLeaderOperation`, not by inspecting the runtime.
+				const agent = await this.agentRepository.findOne({ where: { id: agentId } });
+				if (!agent) {
+					throw new UnexpectedError(`Agent ${agentId} not found on the leader instance`);
+				}
+
+				await this.connectLocal(agentId, integration, agent.projectId);
+
+				// Leadership can change during startup. A poller must not outlive our
+				// term, and the requester has to hear that its channel is not running.
+				if (!this.instanceSettings.isLeader) {
+					await this.disconnectOne(key, { skipExternalHooks: true });
+					throw new OperationalError(
+						'This instance stopped being the leader while the channel was starting up',
+					);
+				}
+			});
+			await this.leaderChannelRelay.respond(payload);
+		} catch (error) {
+			const failure = ensureError(error);
+			this.logger.warn(
+				`[ChatIntegrationService] Leader-only ${action} failed for ${key}: ${failure.message}`,
+			);
+			await this.leaderChannelRelay.respond(payload, failure);
+		}
+	}
+
 	// ---------------------------------------------------------------------------
 	// Private helpers
 	// ---------------------------------------------------------------------------
+
+	/**
+	 * Whether this main has to hand the operation to the leader instead of running
+	 * it locally. Whether ingress makes a connection leader-bound is the
+	 * integration's call, not ours.
+	 */
+	private shouldRouteToLeader(type: string, ingressEnabled: boolean): boolean {
+		return (
+			this.globalConfig.multiMainSetup.enabled &&
+			!this.instanceSettings.isLeader &&
+			this.integrationRegistry.get(type)?.requiresLeader({ ingressEnabled }) === true
+		);
+	}
+
+	/**
+	 * Run a leader-only operation for one channel, serialised against whatever else
+	 * is running for the same channel.
+	 *
+	 * A request for the action already in flight joins it, so a retry or a lost
+	 * acknowledgement costs nothing and reports the same outcome. A request for the
+	 * *other* action queues behind it instead: joining would have a teardown report
+	 * success while the connect it joined leaves the leader polling a channel the
+	 * caller has already deleted.
+	 */
+	private async runLeaderOperation(
+		key: string,
+		action: 'connect' | 'disconnect',
+		operation: () => Promise<void>,
+	): Promise<void> {
+		const running = this.leaderOperations.get(key);
+		if (running?.action === action) return await running.done;
+
+		// Its failure is its own requester's to report, so only the ordering matters
+		// here.
+		const previous = running?.done.catch(() => {});
+
+		const entry = {
+			action,
+			done: (async () => {
+				await previous;
+				await operation();
+			})(),
+		};
+		// Registered before the first await, so a request arriving mid-operation
+		// chains onto this one rather than the one it replaced.
+		this.leaderOperations.set(key, entry);
+
+		try {
+			await entry.done;
+		} finally {
+			if (this.leaderOperations.get(key) === entry) this.leaderOperations.delete(key);
+		}
+	}
+
+	/**
+	 * Wait for leader-only operations to finish so a stepdown sweep sees the
+	 * connections they register.
+	 *
+	 * Bounded, because an operation is only as bounded as the platform call inside
+	 * it and a stepdown cannot wait forever. A straggler that lands after the
+	 * deadline releases itself: the connect path re-checks leadership and tears its
+	 * own connection down.
+	 */
+	private async settleLeaderOperations(): Promise<void> {
+		const running = [...this.leaderOperations.values()];
+		if (running.length === 0) return;
+
+		let expire: NodeJS.Timeout | undefined;
+		try {
+			await Promise.race([
+				Promise.allSettled(running.map(async ({ done }) => await done)),
+				new Promise<void>((resolve) => {
+					expire = setTimeout(resolve, LEADER_CHANNEL_REQUEST_TIMEOUT_MS);
+				}),
+			]);
+		} finally {
+			clearTimeout(expire);
+		}
+	}
+
+	private async disconnectLocal(
+		agentId: string,
+		integration: { credentialId: string; type: string },
+		options: DisconnectOptions = {},
+	): Promise<void> {
+		const key = this.connectionKey(agentId, integration.type, integration.credentialId);
+		await this.disconnectOne(key, options);
+		await this.disconnectOutboundOne(key);
+	}
 
 	private async disconnectOutboundOne(key: string): Promise<void> {
 		await this.outboundConnectionInitializations.get(key);

--- a/packages/cli/src/modules/agents/integrations/leader-channel-relay.service.ts
+++ b/packages/cli/src/modules/agents/integrations/leader-channel-relay.service.ts
@@ -1,0 +1,184 @@
+import { Logger } from '@n8n/backend-common';
+import { OnLeaderTakeover, OnPubSubEvent, OnShutdown } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+import type { DistributiveOmit } from '@n8n/utils/types';
+import { InstanceSettings } from 'n8n-core';
+import { nanoid } from 'nanoid';
+
+import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
+import { Publisher } from '@/scaling/pubsub/publisher.service';
+import type { PubSubCommandMap } from '@/scaling/pubsub/pubsub.event-map';
+
+/**
+ * How long a requesting main waits for the leader to acknowledge a leader-only
+ * channel operation. Connect runs external setup (a Telegram `getMe` probe, a
+ * `setWebhook` call), so the budget has to cover a slow platform API while
+ * still failing inside a request the user is waiting on.
+ */
+export const LEADER_CHANNEL_REQUEST_TIMEOUT_MS = 20_000;
+
+type LeaderChannelRequest = PubSubCommandMap['agent-chat-leader-channel-request'];
+
+/** A request as the caller states it; the relay fills in the correlation fields. */
+export type LeaderChannelRequestInput = DistributiveOmit<
+	LeaderChannelRequest,
+	'requestId' | 'replyTo'
+>;
+
+interface PendingRequest {
+	resolve: () => void;
+	reject: (error: Error) => void;
+	label: string;
+}
+
+/**
+ * Correlated request/acknowledgement transport for channel operations that only
+ * the leader main may perform (e.g. Telegram polling).
+ *
+ * A follower publishes a request and awaits the leader's acknowledgement, so it
+ * never builds the runtime itself and never reports success for a startup that
+ * did not happen. This class is only the transport — `ChatIntegrationService`
+ * decides what to route and executes the leader side.
+ */
+@Service()
+export class LeaderChannelRelayService {
+	/** Requests this main is waiting on an acknowledgement for. */
+	private readonly pending = new Map<string, PendingRequest>();
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly publisher: Publisher,
+		private readonly instanceSettings: InstanceSettings,
+	) {}
+
+	/**
+	 * Ask the leader to run this operation and resolve once it acknowledges.
+	 * Rejects on timeout, on a negative acknowledgement, and if this main becomes
+	 * leader or shuts down while waiting — never silently, so the caller can
+	 * surface it.
+	 */
+	async request(input: LeaderChannelRequestInput): Promise<void> {
+		const requestId = `lch_${nanoid()}`;
+		const label = this.describe(input);
+
+		return await new Promise<void>((resolve, reject) => {
+			// Dropping the entry is the settle-once guard: `handleResult` and
+			// `rejectPending` both reach a request through the map, and re-rejecting an
+			// already-settled promise is a no-op.
+			const settle = (action: () => void) => {
+				clearTimeout(timer);
+				this.pending.delete(requestId);
+				action();
+			};
+
+			const timer = setTimeout(() => {
+				settle(() => {
+					reject(
+						new ServiceUnavailableError(
+							`The leader instance did not acknowledge the request to ${label} within ${LEADER_CHANNEL_REQUEST_TIMEOUT_MS}ms`,
+						),
+					);
+				});
+			}, LEADER_CHANNEL_REQUEST_TIMEOUT_MS);
+
+			this.pending.set(requestId, {
+				resolve: () => settle(resolve),
+				reject: (error) => settle(() => reject(error)),
+				label,
+			});
+
+			this.publish(input, requestId).catch((error: unknown) => {
+				// Nothing is listening for this request, so waiting out the timeout
+				// would only delay the same failure.
+				settle(() =>
+					reject(
+						new ServiceUnavailableError(
+							`Could not reach the leader instance to ${label}: ${error instanceof Error ? error.message : String(error)}`,
+						),
+					),
+				);
+			});
+		});
+	}
+
+	/**
+	 * Publish a request without waiting for an acknowledgement.
+	 *
+	 * For a compensating teardown, where the outcome changes nothing the caller
+	 * can act on. Correlating it would cost a pending entry and a live timeout for
+	 * an answer nobody reads — and when the request it compensates for timed out,
+	 * that answer is the one already known not to be coming.
+	 */
+	async requestWithoutAck(input: LeaderChannelRequestInput): Promise<void> {
+		await this.publish(input, `lch_${nanoid()}`);
+	}
+
+	/** Acknowledge a request back to the main that sent it. */
+	async respond(request: LeaderChannelRequest, error?: Error): Promise<void> {
+		try {
+			await this.publisher.publishCommand({
+				command: 'agent-chat-leader-channel-result',
+				payload: error
+					? { requestId: request.requestId, ok: false, error: error.message }
+					: { requestId: request.requestId, ok: true },
+				targets: [request.replyTo],
+			});
+		} catch (publishError) {
+			// The requester falls back to its timeout, and its compensating
+			// disconnect releases whatever this main started.
+			this.logger.warn(
+				`[LeaderChannelRelayService] Could not acknowledge request ${request.requestId}: ${publishError instanceof Error ? publishError.message : String(publishError)}`,
+			);
+		}
+	}
+
+	@OnPubSubEvent('agent-chat-leader-channel-result', { instanceType: 'main' })
+	handleResult(payload: PubSubCommandMap['agent-chat-leader-channel-result']): void {
+		const pending = this.pending.get(payload.requestId);
+		// Already settled by a timeout, or an acknowledgement for another main.
+		if (!pending) return;
+
+		if (payload.ok) {
+			pending.resolve();
+			return;
+		}
+
+		pending.reject(
+			new ServiceUnavailableError(
+				`The leader instance could not ${pending.label}: ${payload.error ?? 'unknown error'}`,
+			),
+		);
+	}
+
+	/**
+	 * We are the leader now, so the main we were waiting on is gone or demoted and
+	 * its acknowledgement is never arriving. Fail fast instead of waiting out the
+	 * timeout — the caller's next attempt runs locally.
+	 */
+	@OnLeaderTakeover()
+	rejectPendingOnTakeover(): void {
+		this.rejectPending('leadership changed while the request was in flight');
+	}
+
+	@OnShutdown()
+	rejectPendingOnShutdown(): void {
+		this.rejectPending('this instance is shutting down');
+	}
+
+	private rejectPending(reason: string): void {
+		for (const pending of [...this.pending.values()]) {
+			pending.reject(new ServiceUnavailableError(`Could not ${pending.label} — ${reason}`));
+		}
+	}
+
+	private async publish(input: LeaderChannelRequestInput, requestId: string): Promise<void> {
+		await this.publisher.publishCommand({
+			command: 'agent-chat-leader-channel-request',
+			payload: { ...input, requestId, replyTo: this.instanceSettings.hostId },
+		});
+	}
+
+	private describe(input: LeaderChannelRequestInput): string {
+		return `${input.action} ${input.integration.type} for agent ${input.agentId}`;
+	}
+}

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -166,9 +166,12 @@ export class TelegramIntegration extends AgentChatIntegration {
 	 * In polling mode the Chat SDK adapter long-polls Telegram, which must be
 	 * done by exactly one main — otherwise multiple instances race for the same
 	 * updates. Webhook mode is safe on every main.
+	 *
+	 * Mirrors `createAdapter`, which forces webhook mode when ingress is off: an
+	 * outbound connection opens no poll loop, so it is not leader-bound.
 	 */
-	override requiresLeader(): boolean {
-		return this.getMode() === 'polling';
+	override requiresLeader({ ingressEnabled } = { ingressEnabled: true }): boolean {
+		return ingressEnabled && this.getMode() === 'polling';
 	}
 
 	/**

--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -43,6 +43,10 @@ export const IMMEDIATE_COMMANDS = new Set<PubSub.Command['command']>([
 	'relay-instance-ai-task-control',
 	'agent-chat-subscription-changed',
 	'agent-chat-integration-changed',
+	// Correlated request/response pairs: the subscriber debounces by command name,
+	// so debouncing would collapse concurrent requests (or their acks) into one.
+	'agent-chat-leader-channel-request',
+	'agent-chat-leader-channel-result',
 	'cancel-test-run',
 	'stop-execution',
 	'display-workflow-activation',

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -274,6 +274,44 @@ export type PubSubCommandMap = {
 	};
 
 	/**
+	 * Ask the current leader to start or stop a leader-only channel runtime
+	 * (e.g. Telegram in polling mode) on behalf of the main that handled the
+	 * user's request. See `LeaderChannelRelayService` for the mechanism.
+	 *
+	 * Broadcast to every main rather than targeted at the leader's host: the
+	 * leader key can be stale by the time we read it, and leadership can change
+	 * between publish and receive. Followers ignore this command, so whoever
+	 * holds leadership when it lands is the one that acts.
+	 *
+	 * `replyTo` carries the requester's host ID because the subscriber emits
+	 * only the payload — `senderId` is stripped before handlers see the message.
+	 *
+	 * A connect carries the whole config: it runs before the config is persisted,
+	 * so the leader cannot read it back. A teardown only needs the connection key,
+	 * which every caller already holds.
+	 */
+	'agent-chat-leader-channel-request': {
+		requestId: string;
+		replyTo: string;
+		agentId: string;
+	} & (
+		| { action: 'connect'; integration: AgentIntegrationConfig }
+		| { action: 'disconnect'; integration: { type: string; credentialId: string } }
+	);
+
+	/**
+	 * Acknowledge an `agent-chat-leader-channel-request`, targeted at the
+	 * requester's host ID. Published by the leader once the operation has fully
+	 * completed, so the requesting main can only report success after the
+	 * leader's startup or teardown finished.
+	 */
+	'agent-chat-leader-channel-result': {
+		requestId: string;
+		ok: boolean;
+		error?: string;
+	};
+
+	/**
 	 * Keep per-main thread subscription state in sync across the cluster. The
 	 * originating main persists the subscription change before publishing; peers
 	 * update their local in-memory subscription state so load-balanced follow-up

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -76,6 +76,8 @@ export namespace PubSub {
 		export type CancelCollection = ToCommand<'cancel-collection'>;
 		export type AgentChatIntegrationChanged = ToCommand<'agent-chat-integration-changed'>;
 		export type AgentChatSubscriptionChanged = ToCommand<'agent-chat-subscription-changed'>;
+		export type AgentChatLeaderChannelRequest = ToCommand<'agent-chat-leader-channel-request'>;
+		export type AgentChatLeaderChannelResult = ToCommand<'agent-chat-leader-channel-result'>;
 		export type AgentConfigChanged = ToCommand<'agent-config-changed'>;
 		export type AgentTasksChanged = ToCommand<'agent-tasks-changed'>;
 		export type RedactionFloorChanged = ToCommand<'redaction-floor-changed'>;
@@ -119,6 +121,8 @@ export namespace PubSub {
 		| Commands.CancelCollection
 		| Commands.AgentChatIntegrationChanged
 		| Commands.AgentChatSubscriptionChanged
+		| Commands.AgentChatLeaderChannelRequest
+		| Commands.AgentChatLeaderChannelResult
 		| Commands.AgentConfigChanged
 		| Commands.AgentTasksChanged
 		| Commands.RedactionFloorChanged;


### PR DESCRIPTION
## Summary

In multi-main mode, a follower handling a publish or channel-setup request started leader-only integrations — Telegram in polling mode — **locally**, then broadcast the same desired state to the leader. Two problems: the follower ended up owning a long-poll loop it must never own, and the broadcast was fire-and-forget, so the request returned 200 whether or not the leader's startup actually succeeded.

Leader-only connect and disconnect now execute on the current leader and return an acknowledged result to the requesting main.

**`LeaderChannelRelayService`** — a correlated request/ack over the existing `n8n.commands` channel. Requests are broadcast rather than targeted at the leader's host, so a stale leader key or a leadership change between publish and receive cannot misroute them; whoever holds leadership when the request lands is the one that acts. The ack is targeted back via the `targets` field the subscriber already filters on. Both commands are in `IMMEDIATE_COMMANDS` — the subscriber debounces by command name, so concurrent requests (or their acks) would otherwise collapse into one.

**Routing** — `ChatIntegrationService.connect`/`disconnect` hand leader-only channels to the leader and await the ack, so a follower builds no runtime and reports success only once the leader finished. A timeout or negative ack surfaces as a 503 and fires a compensating teardown, so a leader that started polling but lost its ack does not keep a claim on a channel the request just reported as failed.

**Idempotence and draining** — leader-side operations are serialised per channel: a duplicate request joins the one in flight, while a *differing* action queues behind it (joining would have a removal acked as done while the connect it joined leaves the leader polling a deleted channel). Leader stepdown drains in-flight operations, bounded, before sweeping established leader-only connections.

Two smaller changes fall out of this:

- `requiresLeader()` takes the ingress flag, so whether a connection is leader-bound is the integration's decision — it is the same input `createAdapter` uses to pick a transport — instead of being inferred by the caller from knowledge two layers away.
- `isChannelLive()` replaces `getChatInstance()` as the liveness check for callers that must not restart or tear down a channel the leader owns. Without it, every leader-only channel mutation on a follower logged "runtime went away" and issued a redundant second round trip.

## How to test

Requires a multi-main setup, so the interesting paths need two mains against shared Redis/Postgres:

```bash
pnpm --filter n8n-containers services --services postgres,redis,mailpit,proxy
# then two backends with N8N_MULTI_MAIN_SETUP_ENABLED=true, EXECUTIONS_MODE=queue
```

1. Create an agent, add a **Telegram** channel with **polling** mode, and publish it — from the main that is *not* the leader.
2. Confirm the poller runs on the leader only (`[ChatIntegrationService] Connected: <agentId>:telegram:<credId>` appears in the leader's log, not the follower's), and that the request only returns once it has.
3. Message the bot — exactly one main answers.
4. Remove the channel from the follower; confirm the leader tears the poller down and the request waits for that.
5. Kill the leader mid-connect (or stop Redis) and retry: the request fails with a 503 naming the unacknowledged operation rather than reporting success.
6. Trigger a leadership change while a polling channel is live: the demoted main drops the poller, the new leader picks it up on takeover.

Single-instance behaviour is unchanged — routing is gated on `multiMainSetup.enabled`.

Unit coverage: `leader-channel-relay.service.test.ts` (new, transport: ack/timeout/negative-ack/takeover/shutdown) and additions to `chat-integration.service.test.ts` (routing, leader-side execution, per-channel serialisation, stepdown drain).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-549

Found while reviewing AGENT-542 / #35468 in multi-main mode.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

