### PR TITLE
ci: Speed up the single-instance npm-install check

### DIFF
--- a/.github/workflows/test-single-instance-npm.yml
+++ b/.github/workflows/test-single-instance-npm.yml
@@ -69,16 +69,17 @@ jobs:
               ;;
           esac
 
+      # Checking out `base-branch` directly (rather than fetching everything and switching
+      # afterwards) keeps that case to a single-commit fetch. scope=changed does need history back
+      # to `base-ref`, but only to diff it: `git diff --name-only --no-renames` reads trees, so the
+      # blobs can stay on the server. Nothing after this step reads an object outside the working
+      # tree, which the checkout materializes in full.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          ref: ${{ inputs.base-branch }}
+          fetch-depth: ${{ inputs.base-branch != '' && 1 || 0 }}
+          filter: blob:none
           persist-credentials: false
-
-      - name: Switch to base branch
-        if: inputs.base-branch != ''
-        env:
-          BASE_BRANCH: ${{ inputs.base-branch }}
-        run: git checkout "$BASE_BRANCH"
 
       # A `base-branch` can point at a release line that predates this tooling (the v1 patch track
       # is the live case), where there is simply nothing to verify. Without a base-branch the ref is
@@ -100,8 +101,8 @@ jobs:
           fi
 
       # Only the verifier's own closure needs compiling. The check reads package.json out of the
-      # npm-install graph, so the packed tarballs' contents don't matter, and the two packages with
-      # a prepack hook build themselves.
+      # npm-install graph, so the packed tarballs' contents don't matter — packing skips lifecycle
+      # scripts, and the workspace install exists so `pnpm pack` can resolve `workspace:` specs.
       - name: Setup and Build
         if: steps.verifier.outputs.present == 'true'
         uses: ./.github/actions/setup-nodejs

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.test.ts
@@ -10,7 +10,6 @@ import {
 /** Build a WorkspacePkg fixture from `[depName, section]` pairs (only names + sections matter). */
 function ws(name: string, deps: Array<[string, string]>) {
 	return {
-		dir: `/x/${name}`,
 		relDir: `packages/${name}`,
 		info: {
 			filePath: `/x/${name}/package.json`,

--- a/packages/testing/code-health/src/single-instance/verify-npm-install.ts
+++ b/packages/testing/code-health/src/single-instance/verify-npm-install.ts
@@ -1,14 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import {
-	appendFileSync,
-	mkdirSync,
-	mkdtempSync,
-	readdirSync,
-	rmSync,
-	writeFileSync,
-} from 'node:fs';
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
 import { analyze, collectCopies } from './collect-copies.js';
@@ -104,8 +97,13 @@ function exemptPackages(byName: Map<string, WorkspacePkg>): Set<string> {
 	return new Set(names.map(([name]) => name));
 }
 
+/** One entry of `pnpm pack --json`. */
+interface Packed {
+	name: string;
+	filename: string;
+}
+
 interface WorkspacePkg {
-	dir: string;
 	relDir: string;
 	info: PackageJsonInfo;
 }
@@ -116,7 +114,7 @@ async function loadWorkspace(rootDir: string): Promise<Map<string, WorkspacePkg>
 	for (const file of await findPackageJsonFiles(rootDir)) {
 		const info = parsePackageJson(file);
 		if (info.private) continue;
-		byName.set(info.packageName, { dir: dirname(file), relDir: relativeDir(rootDir, file), info });
+		byName.set(info.packageName, { relDir: relativeDir(rootDir, file), info });
 	}
 	return byName;
 }
@@ -160,7 +158,10 @@ function changedPackages(
 	}
 	let out: string;
 	try {
-		out = execFileSync('git', ['diff', '--name-only', baseRef, 'HEAD'], {
+		// `--no-renames`: a moved file has to count against both the old and the new package, and
+		// rename detection would also read blob contents — which the CI checkout deliberately
+		// leaves on the server.
+		out = execFileSync('git', ['diff', '--name-only', '--no-renames', baseRef, 'HEAD'], {
 			cwd: rootDir,
 			encoding: 'utf8',
 		});
@@ -216,6 +217,68 @@ export function resolveTargets(
 }
 
 /**
+ * Pack the named packages in one recursive pnpm run, and return name -> tarball path.
+ *
+ * One invocation rather than one per package: packing these tarballs is quick, so ~50 pnpm startups
+ * dominate the step. `--json` reports the tarball each project produced, which also removes the
+ * need to diff the destination directory — that mis-attributes a tarball whose name is already
+ * present, and reads as "pack produced nothing".
+ *
+ * Scripts are off. The only `prepack` hook among publishable packages rebuilds `dist`, and this
+ * check reads package.json out of the installed graph, so nothing here needs compiling.
+ */
+function packWorkspacePackages(
+	names: string[],
+	destination: string,
+	rootDir: string,
+): Record<string, string> {
+	let stdout: string;
+	try {
+		stdout = execFileSync(
+			'pnpm',
+			[
+				'pack',
+				'--recursive',
+				...names.flatMap((name) => ['--filter', name]),
+				'--config.ignore-scripts=true',
+				'--pack-destination',
+				destination,
+				'--json',
+			],
+			{
+				cwd: rootDir,
+				encoding: 'utf8',
+				// The report lists every packed file, so it runs to several MB. The default 1MB cap
+				// would kill pnpm mid-pack.
+				maxBuffer: 256 * 1024 * 1024,
+				stdio: ['ignore', 'pipe', 'inherit'],
+			},
+		);
+	} catch (error) {
+		// `--json` puts the failure on stdout, which is captured rather than inherited — print it or
+		// the throw reads as a bare "Command failed" with the cause nowhere in the log.
+		const captured = (error as { stdout?: string }).stdout;
+		if (captured) console.error(captured);
+		throw error;
+	}
+	// pnpm reports a bare object for a single project and an array for several.
+	let packed: Packed | Packed[];
+	try {
+		packed = JSON.parse(stdout) as Packed | Packed[];
+	} catch {
+		throw new Error(`Could not read the pnpm pack report: ${stdout.slice(0, 500)}`);
+	}
+	const tarballByName = Object.fromEntries(
+		[packed].flat().map(({ name, filename }) => [name, filename]),
+	);
+	const missing = names.filter((name) => !tarballByName[name]);
+	if (missing.length > 0) {
+		throw new Error(`pnpm pack produced no tarball for: ${missing.join(', ')}`);
+	}
+	return tarballByName;
+}
+
+/**
  * Reproduce the `npm install` graph for the targeted publishable packages and run the closure
  * verifier against it. Local pnpm dev and the `pnpm deploy` closure both apply root
  * `pnpm.overrides`, which hide duplication; those don't travel in published tarballs, so
@@ -255,19 +318,7 @@ export async function runVerifyNpmInstall(args: string[], rootDir: string): Prom
 	try {
 		const packStartedAt = Date.now();
 		console.log(`Packing ${toPack.length} workspace package(s) (targets: ${targets.length})...`);
-		const tarballByName: Record<string, string> = {};
-		for (const name of toPack) {
-			const entry = byName.get(name);
-			if (!entry) continue;
-			const before = new Set(readdirSync(tarballs));
-			execFileSync('pnpm', ['pack', '--pack-destination', tarballs], {
-				cwd: entry.dir,
-				stdio: ['ignore', 'ignore', 'inherit'],
-			});
-			const produced = readdirSync(tarballs).find((f) => !before.has(f) && f.endsWith('.tgz'));
-			if (!produced) throw new Error(`pnpm pack produced no tarball for ${name}`);
-			tarballByName[name] = join(tarballs, produced);
-		}
+		const tarballByName = packWorkspacePackages(toPack, tarballs, rootDir);
 
 		// Scratch project: install targets as file: deps, force ALL packed workspace deps to their
 		// local tarballs. Third-party deps resolve from the real npm registry.


### PR DESCRIPTION
## Summary

Second layer of stack on top of #36579.

The last master run of this job took 4m26s:

| step | time |
|---|---|
| checkout | 34s |
| toolchain setup | 21s |
| `pnpm install --frozen-lockfile` | 35s |
| turbo build (verifier only) | 2s |
| pack 51 packages | 17s |
| scratch `npm install` | 2m20s |
| analyze | <1s |

This PR takes the two steps that are cheap to fix. The scratch install is left to the layers above.

**Pack in one recursive run.** The tool spawned `pnpm pack` once per package. It now runs `pnpm pack --recursive --filter ... --json` once. Measured locally on the same 51 packages: **32.9s to 17.3s**. On CI the tarballs are smaller, so process startup is a larger share of the 17s.

- `--json` reports the tarball each project produced. The old code diffed the destination directory to guess it, which mis-attributes a tarball whose name is already present and then reports "pack produced nothing". This bit me while testing.
- `--config.ignore-scripts=true` skips lifecycle scripts. The only `prepack` among publishable packages rebuilds `dist`, and this check reads `package.json` out of the resolved graph.
- pnpm reports a bare object for one project and an array for several, and reports errors as JSON on **stdout**. Both are handled, so a pack failure still prints its cause.

**Fetch fewer objects.** History blobs are 866MiB of the 1.0GiB pack, and `git diff --name-only` reads trees only, so the checkout uses `filter: blob:none`. `base-branch` is checked out through `ref` instead of a `git checkout` afterwards, so that case fetches one commit instead of all history. Nothing after the checkout step reads an object outside the working tree.

**Diff with `--no-renames`.** A moved file now counts against both the old and the new package, which is what prefix matching wants. Rename detection also reads blob contents, which the checkout above deliberately leaves on the server.

**Quiet the scratch install.** Third-party deprecation notices ran to about 2000 lines and buried the report. npm's install summary still prints.

Expected: about 4m26s to about 3m30s. The scratch install is still over half the job.

## How to test

The verifier runs from source, so a full build is not needed.

```bash
pnpm install --frozen-lockfile
pnpm turbo run build --filter=@n8n/code-health...

pnpm --dir packages/testing/code-health exec tsx src/cli.ts \
  verify-npm-install "@n8n/api-types" "@n8n/tournament" --report-only
```

Expect `Packing 8 workspace package(s) (targets: 2)`, then the closure report. No `npm warn deprecated` lines.

Check that a pack failure is still diagnosable: remove a packed package's `node_modules` and confirm the run prints `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL` rather than a bare `Command failed`.

`pnpm test`, `pnpm typecheck`, `pnpm lint` and `pnpm format:check` pass in `packages/testing/code-health`. `actionlint` passes on the workflow.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No user-facing docs. -->
- [ ] Tests included. <!-- The existing unit tests cover the pure helpers and still pass. The changed code shells out to pnpm, npm and git, so it is covered by the end-to-end runs above rather than by new unit tests. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
