### PR TITLE
fix(core): Stop retaining Instance AI events in memory under the durable log (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -196,7 +196,10 @@ are never persisted. Rows cascade-delete with their thread
 (`N8N_INSTANCE_AI_THREAD_TTL_DAYS`). Setting it to `false` is the rollback
 switch until the legacy paths sunset at Gate B: events then live only in a
 bounded in-memory buffer per thread (500 events / 2 MB, FIFO-evicted; ids
-reset on restart, so replay does not survive a restart).
+reset on restart, so replay does not survive a restart). That bound is
+per-thread only: a buffer is released when its thread is deleted or expires,
+so a main's memory scales with the number of threads it has served until the
+process restarts. The main logs a warning at boot when the switch is set.
 
 Runtime behavior:
 - One active run per thread. Additional `POST /instance-ai/chat/:threadId`

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
@@ -74,7 +74,6 @@ function createLivenessService() {
 		),
 	};
 	const eventBus = {
-		getEventsForRun: vi.fn((_threadId: string, _runId: string) => [] as InstanceAiEvent[]),
 		publish: vi.fn((_threadId: string, _event: InstanceAiEvent) => {}),
 	};
 	const finalizeCancelledSuspendedRun = vi.fn(
@@ -231,19 +230,33 @@ describe('InstanceAiLivenessService', () => {
 
 	it('deduplicates timeout notices per run', () => {
 		const { service, eventBus } = createLivenessService();
-		eventBus.getEventsForRun.mockReturnValue([
-			{
-				type: 'text-delta',
-				runId: 'run-1',
-				agentId: 'agent-001',
-				responseId: 'run-timeout:run-1',
-				payload: { text: 'Already published' },
-			},
-		]);
 
 		service.publishRunTimeoutNotice('thread-1', 'run-1');
+		service.publishRunTimeoutNotice('thread-1', 'run-1');
 
-		expect(eventBus.publish).not.toHaveBeenCalled();
+		expect(eventBus.publish).toHaveBeenCalledTimes(1);
+		expect(eventBus.publish).toHaveBeenCalledWith(
+			'thread-1',
+			expect.objectContaining({ responseId: 'run-timeout:run-1' }),
+		);
+	});
+
+	it('publishes a notice per run, and evicts the oldest dedupe entry past the cap', () => {
+		const { service, eventBus } = createLivenessService();
+
+		service.publishRunTimeoutNotice('thread-1', 'run-a');
+		service.publishRunTimeoutNotice('thread-1', 'run-b');
+		expect(eventBus.publish).toHaveBeenCalledTimes(2);
+
+		// Push `run-a` out of the capped FIFO, after which its notice can repeat —
+		// the accepted trade-off for a bounded guard.
+		for (let i = 0; i < InstanceAiLivenessService.NOTICE_DEDUPE_CACHE_SIZE; i++) {
+			service.publishRunTimeoutNotice('thread-1', `filler-${i}`);
+		}
+		eventBus.publish.mockClear();
+		service.publishRunTimeoutNotice('thread-1', 'run-a');
+
+		expect(eventBus.publish).toHaveBeenCalledTimes(1);
 	});
 
 	it('keeps sweeping run state when background task timeout handling fails', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-tracing.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-tracing.service.test.ts
@@ -1,4 +1,5 @@
 import type { Mock } from 'vitest';
+import type { InstanceAiEvent } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import type { InstanceAiTraceContext } from '@n8n/instance-ai';
@@ -18,7 +19,7 @@ vi.mock('@n8n/instance-ai', () => ({
 import {
 	InstanceAiTracingService,
 	type InstanceAiTracingAiService,
-	type InstanceAiTracingEventBus,
+	type InstanceAiTracingEventReader,
 	type InstanceAiTracingRunState,
 	type InstanceAiTracingSnapshotStorage,
 } from '../tracing';
@@ -51,16 +52,16 @@ function makeTraceContext(overrides: Partial<FakeTraceContext> = {}): InstanceAi
 function createService(
 	overrides: {
 		logger?: Partial<Logger>;
-		eventBus?: Partial<InstanceAiTracingEventBus>;
+		eventReader?: Partial<InstanceAiTracingEventReader>;
 		runState?: Partial<InstanceAiTracingRunState>;
 		dbSnapshotStorage?: Partial<InstanceAiTracingSnapshotStorage>;
 		aiService?: Partial<InstanceAiTracingAiService>;
 	} = {},
 ) {
 	const logger = mock<Logger>(overrides.logger);
-	const eventBus: InstanceAiTracingEventBus = {
-		getEventsForRun: vi.fn(() => []),
-		...overrides.eventBus,
+	const eventReader: InstanceAiTracingEventReader = {
+		getEventsForRun: vi.fn(async () => []),
+		...overrides.eventReader,
 	};
 	const runState: InstanceAiTracingRunState = {
 		attachTracing: vi.fn(),
@@ -78,13 +79,13 @@ function createService(
 
 	const service = new InstanceAiTracingService({
 		logger,
-		eventBus,
+		eventReader,
 		runState,
 		dbSnapshotStorage,
 		aiService,
 	});
 
-	return { service, logger, eventBus, runState, dbSnapshotStorage, aiService };
+	return { service, logger, eventReader, runState, dbSnapshotStorage, aiService };
 }
 
 describe('InstanceAiTracingService', () => {
@@ -92,6 +93,60 @@ describe('InstanceAiTracingService', () => {
 		continueInstanceAiTraceContext.mockReset();
 		releaseTraceClient.mockReset();
 		submitLangsmithUserFeedback.mockReset();
+	});
+
+	describe('buildMessageTraceMetadata', () => {
+		it('annotates the trace from the run events', async () => {
+			const { service } = createService({
+				eventReader: {
+					getEventsForRun: vi.fn(async () => [
+						{
+							type: 'text-block',
+							runId: 'run-1',
+							agentId: 'agent-1',
+							payload: { text: 'On it.' },
+						} as InstanceAiEvent,
+					]),
+				},
+			});
+
+			await expect(
+				service.buildMessageTraceMetadata('thread-1', 'run-1', { status: 'completed' }),
+			).resolves.toEqual({
+				completion_source: 'orchestrator',
+				first_visible_state: 'assistant_text',
+			});
+		});
+
+		it('degrades instead of throwing when the events read fails', async () => {
+			// Most callers run inside a run's terminal catch block: a throw here
+			// would skip run-finish and hang the client until the liveness sweep.
+			const { service, logger } = createService({
+				eventReader: {
+					getEventsForRun: vi.fn(async () => {
+						throw new Error('SQLITE_BUSY: database is locked');
+					}),
+				},
+			});
+
+			await expect(
+				service.buildMessageTraceMetadata('thread-1', 'run-1', {
+					status: 'cancelled',
+					cancellationReason: 'timeout',
+				}),
+			).resolves.toEqual({
+				completion_source: 'orchestrator',
+				// Options-derived fields survive; the events-derived one is flagged so
+				// it can't be read as a genuinely empty run.
+				first_visible_state: 'empty',
+				first_visible_state_unavailable: true,
+				cancellation_type: 'idle_timeout',
+			});
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to read run events for Instance AI trace metadata',
+				expect.objectContaining({ runId: 'run-1', threadId: 'thread-1' }),
+			);
+		});
 	});
 
 	describe('storeTraceContext / getTraceContext', () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/run-trace-metadata.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/run-trace-metadata.test.ts
@@ -61,6 +61,42 @@ describe('buildInstanceAiRunTraceMetadata', () => {
 		});
 	});
 
+	it('reads assistant text from a coalesced block, as the durable log persists it', () => {
+		const events: InstanceAiEvent[] = [
+			{
+				type: 'text-block',
+				...baseEvent,
+				payload: { text: 'I will check the workflow first.' },
+			},
+			{
+				type: 'tool-call',
+				...baseEvent,
+				payload: { toolCallId: 'tool-1', toolName: 'workflows', args: { action: 'get' } },
+			},
+		];
+
+		expect(buildInstanceAiRunTraceMetadata(events, { status: 'completed' })).toEqual({
+			first_visible_state: 'assistant_text',
+			first_tool_name: 'workflows',
+		});
+	});
+
+	it('ignores a whitespace-only block, same as a whitespace-only delta', () => {
+		const events: InstanceAiEvent[] = [
+			{ type: 'text-block', ...baseEvent, payload: { text: '  \n ' } },
+			{
+				type: 'tool-call',
+				...baseEvent,
+				payload: { toolCallId: 'tool-1', toolName: 'workflows', args: { action: 'get' } },
+			},
+		];
+
+		expect(buildInstanceAiRunTraceMetadata(events, { status: 'completed' })).toEqual({
+			first_visible_state: 'tool_call',
+			first_tool_name: 'workflows',
+		});
+	});
+
 	it('records timeout cancellation type and idle tail without extra fields', () => {
 		const metadata = buildInstanceAiRunTraceMetadata([], {
 			status: 'cancelled',

--- a/packages/cli/src/modules/instance-ai/event-bus/__tests__/durable-event-log.test.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/__tests__/durable-event-log.test.ts
@@ -35,7 +35,14 @@ class FakeRepo {
 	/** Hold the next append until released — models an in-flight DB round trip. */
 	gateNextAppend: Promise<void> | undefined;
 
+	/** Called when a gated append is entered, before it starts waiting. */
+	onGatedAppend: (() => void) | undefined;
+
+	/** Seq seeds served from the DB — proves whether the writer's cache was dropped. */
+	maxSeqCalls = 0;
+
 	async maxSeq(_threadId: string): Promise<number> {
+		this.maxSeqCalls++;
 		if (this.failNextMaxSeq > 0) {
 			this.failNextMaxSeq--;
 			throw new Error('connect ETIMEDOUT');
@@ -52,6 +59,7 @@ class FakeRepo {
 		if (this.gateNextAppend) {
 			const gate = this.gateNextAppend;
 			this.gateNextAppend = undefined;
+			this.onGatedAppend?.();
 			await gate;
 		}
 		if (this.failNextAppendsTransient > 0) {
@@ -161,7 +169,15 @@ async function publishAll(
 	return emitted;
 }
 
+function useIdleFlushTimers(): void {
+	vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+}
+
 describe('DurableEventLog', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it('coalesces a segment into one text-block flushed immediately before the next structural fact', async () => {
 		const repo = new FakeRepo();
 		const { log } = buildLog(repo);
@@ -519,6 +535,7 @@ describe('DurableEventLog', () => {
 		// e.g. a terminal-outcome line published after run-finish, or a liveness
 		// timeout notice: without the idle flush these would never reach the log
 		// and disappear on reload.
+		useIdleFlushTimers();
 		const repo = new FakeRepo();
 		const { log } = buildLog(repo);
 		log.idleFlushMs = 25;
@@ -527,12 +544,94 @@ describe('DurableEventLog', () => {
 		log.publish(THREAD, textDelta('The background workflow-builder task was cancelled.'), (d) =>
 			emitted.push(d),
 		);
-		await new Promise((resolve) => setTimeout(resolve, 120));
+		await vi.advanceTimersByTimeAsync(25);
 
 		const blocks = repo.rows.filter((r) => r.event.type === 'text-block');
 		expect(blocks).toHaveLength(1);
 		expect(blocks[0].event.payload).toEqual({
 			text: 'The background workflow-builder task was cancelled.',
 		});
+	});
+
+	it("releases a quiet thread's drain state, and reseeds the seq when it speaks again", async () => {
+		useIdleFlushTimers();
+		const repo = new FakeRepo();
+		const { log } = buildLog(repo);
+		log.idleFlushMs = 25;
+
+		await publishAll(log, [textDelta('hello'), toolCall('tool-1')]);
+		expect(log.retainedThreadCount()).toBe(1);
+
+		await vi.advanceTimersByTimeAsync(25);
+		expect(log.retainedThreadCount()).toBe(0);
+
+		// The dropped seq cache reseeds from the DB, so the next fact continues the
+		// sequence rather than colliding with a row already written.
+		const seqsBefore = repo.rows.map((r) => r.seq);
+		await publishAll(log, [toolCall('tool-2')]);
+		expect(repo.rows.map((r) => r.seq)).toEqual([
+			...seqsBefore,
+			seqsBefore[seqsBefore.length - 1] + 1,
+		]);
+	});
+
+	it('keeps the drain state when the thread speaks again mid-settle', async () => {
+		useIdleFlushTimers();
+		const repo = new FakeRepo();
+		const { log } = buildLog(repo);
+		log.idleFlushMs = 10;
+
+		// Park the idle flush inside its DB round trip, so the settle is still
+		// awaiting when the next publish lands — without the stall the settle
+		// runs to completion first and the race never happens.
+		let releaseAppend!: () => void;
+		repo.gateNextAppend = new Promise<void>((resolve) => {
+			releaseAppend = resolve;
+		});
+		const settleReachedDb = new Promise<void>((resolve) => {
+			repo.onGatedAppend = resolve;
+		});
+
+		log.publish(THREAD, textDelta('first'), () => {});
+		await vi.advanceTimersByTimeAsync(10);
+		await settleReachedDb;
+		const seedsBeforeRace = repo.maxSeqCalls;
+
+		// Re-arms the idle timer while the settle is parked. A STRUCTURAL fact on
+		// purpose: it persists instead of buffering, so by the time the settle
+		// reaches its guards the pending queue and the coalesce buffers are both
+		// empty and the idle-timer check is the only thing standing between the
+		// racing publish and a released cache. A racing delta would leave a
+		// buffer behind and the later guard would mask this one.
+		log.idleFlushMs = 60_000;
+		log.publish(THREAD, toolCall('tool-race'), () => {});
+		releaseAppend();
+		// Let the parked settle finish its awaits and run its guard checks.
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// A fact published after the settle must reuse the cached seq. Had the
+		// settle released it, this persist re-seeds from MAX(seq) — the only
+		// observable difference, since `retainedThreadCount` cannot tell "never
+		// released" from "released, then recreated by the racing publish".
+		log.publish(THREAD, toolCall('tool-after'), () => {});
+		await log.flush(THREAD);
+
+		expect(repo.maxSeqCalls).toBe(seedsBeforeRace);
+		expect(log.retainedThreadCount()).toBe(1);
+	});
+
+	it('closes an open segment before releasing the quiet thread', async () => {
+		useIdleFlushTimers();
+		const repo = new FakeRepo();
+		const { log } = buildLog(repo);
+		log.idleFlushMs = 25;
+
+		log.publish(THREAD, textDelta('streaming'), () => {});
+		await vi.advanceTimersByTimeAsync(25);
+
+		// The idle flush closed the segment into a block, so the thread is now
+		// genuinely quiet and its state is gone.
+		expect(log.getOpenSegments(THREAD)).toHaveLength(0);
+		expect(log.retainedThreadCount()).toBe(0);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/event-bus/__tests__/in-process-event-bus.test.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/__tests__/in-process-event-bus.test.ts
@@ -27,6 +27,7 @@ describe('InProcessEventBus', () => {
 	let bus: InProcessEventBus;
 	let publisher: ReturnType<typeof mock<Publisher>>;
 	let eventLog: ReturnType<typeof mock<DurableEventLog>>;
+	let logger: ReturnType<typeof mock<Logger>>;
 	let instanceSettings: { isMultiMain: boolean };
 
 	/** Shared fake Redis sequence — one Map plays the role of the Redis server,
@@ -74,7 +75,7 @@ describe('InProcessEventBus', () => {
 	};
 
 	function buildBus({ durableLog = false } = {}) {
-		const logger = mock<Logger>();
+		logger = mock<Logger>();
 		logger.scoped.mockReturnValue(logger);
 		publisher = mock<Publisher>();
 		publisher.publishCommand.mockResolvedValue(undefined);
@@ -557,7 +558,7 @@ describe('InProcessEventBus', () => {
 			expect(incrbyCalls).toHaveLength(0);
 		});
 
-		it('caches drained durable facts and emits live ones with their DB seq', () => {
+		it('emits a drained durable fact with its DB seq and retains nothing', () => {
 			const received: Array<{ id?: number; event: InstanceAiEvent }> = [];
 			bus.subscribe('thread-1', (stored) => received.push(stored));
 			const event = makeEvent('a', 'run_1');
@@ -566,10 +567,10 @@ describe('InProcessEventBus', () => {
 			emit({ id: 7, event, live: true });
 
 			expect(received).toEqual([{ id: 7, event }]);
-			expect(bus.getEventsAfter('thread-1', 0).map((e) => e.id)).toEqual([7]);
+			expect(bus.getEventsForRun('thread-1', 'run_1')).toHaveLength(0);
 		});
 
-		it('emits ephemeral events live without an id and never caches them', () => {
+		it('emits ephemeral events live without an id', () => {
 			const received: Array<{ id?: number; event: InstanceAiEvent }> = [];
 			bus.subscribe('thread-1', (stored) => received.push(stored));
 			const event = makeEvent('a', 'run_1');
@@ -579,10 +580,9 @@ describe('InProcessEventBus', () => {
 
 			expect(received).toEqual([{ event }]);
 			expect(received[0]).not.toHaveProperty('id');
-			expect(bus.getEventsAfter('thread-1', 0)).toHaveLength(0);
 		});
 
-		it('caches a coalesced block without live-emitting it (subscribers saw its deltas)', () => {
+		it('drops a coalesced block entirely (subscribers saw its deltas, the DB has the row)', () => {
 			const received: unknown[] = [];
 			bus.subscribe('thread-1', (stored) => received.push(stored));
 			const event = makeEvent('a', 'run_1');
@@ -591,7 +591,42 @@ describe('InProcessEventBus', () => {
 			emit({ id: 3, event, live: false });
 
 			expect(received).toHaveLength(0);
-			expect(bus.getEventsAfter('thread-1', 0).map((e) => e.id)).toEqual([3]);
+			expect(publisher.publishCommand).not.toHaveBeenCalled();
+			expect(bus.getEventsForRun('thread-1', 'run_1')).toHaveLength(0);
+		});
+
+		it('retains no per-thread state across a burst of drained facts', () => {
+			for (let thread = 0; thread < 50; thread++) {
+				const threadId = `thread-${thread}`;
+				const event = makeEvent('a', 'run_1');
+				const emit = publishAndCaptureEmit(threadId, event);
+				for (let seq = 1; seq <= 20; seq++) emit({ id: seq, event, live: true });
+			}
+
+			// Nothing to release on run completion, thread deletion or the TTL prune,
+			// because nothing was retained in the first place.
+			expect(bus.retainedThreadCount()).toBe(0);
+		});
+
+		it('reports a store read as a wiring bug, once per entry point', () => {
+			expect(bus.getEventsAfter('thread-1', 0)).toEqual([]);
+			expect(bus.getEventsAfter('thread-1', 0)).toEqual([]);
+			// Names the entry point the caller used, not the method it delegates to.
+			expect(bus.getEventsForRun('thread-1', 'run_1')).toEqual([]);
+			expect(bus.getEventsForRuns('thread-1', ['run_1'])).toEqual([]);
+
+			expect(logger.error.mock.calls).toEqual([
+				[expect.stringContaining('getEventsAfter'), { threadId: 'thread-1' }],
+				[expect.stringContaining('getEventsForRun '), { threadId: 'thread-1' }],
+				[expect.stringContaining('getEventsForRuns'), { threadId: 'thread-1' }],
+			]);
+		});
+
+		it('answers the next event id from the durable log, never from memory', async () => {
+			eventLog.getNextEventId.mockResolvedValue(42);
+
+			await expect(bus.getNextEventId('thread-1')).resolves.toBe(42);
+			expect(eventLog.getNextEventId).toHaveBeenCalledWith('thread-1');
 		});
 
 		it('relays live drained events to siblings with the DB seq passed through', () => {
@@ -615,18 +650,25 @@ describe('InProcessEventBus', () => {
 			});
 		});
 
-		it('re-emits a relayed id-less frame to subscribers without storing it', () => {
+		it('re-emits a relayed frame to subscribers without storing it, id-bearing or not', () => {
 			const received: Array<{ id?: number; event: InstanceAiEvent }> = [];
 			bus.subscribe('thread-1', (stored) => received.push(stored));
+			const event = makeEvent('a', 'run_1');
 
+			bus.handleRelayInstanceAiEvent({ threadId: 'thread-1', storedEvent: { event } });
+			bus.handleRelayInstanceAiEvent({ threadId: 'thread-1', storedEvent: { id: 4, event } });
+
+			expect(received).toEqual([{ event }, { id: 4, event }]);
+			expect(bus.retainedThreadCount()).toBe(0);
+		});
+
+		it('drops a relayed frame for a thread this main has no subscriber for', () => {
 			bus.handleRelayInstanceAiEvent({
 				threadId: 'thread-1',
-				storedEvent: { event: makeEvent('a', 'run_1') },
+				storedEvent: { id: 4, event: makeEvent('a', 'run_1') },
 			});
 
-			expect(received).toHaveLength(1);
-			expect(received[0]).not.toHaveProperty('id');
-			expect(bus.getEventsAfter('thread-1', 0)).toHaveLength(0);
+			expect(bus.retainedThreadCount()).toBe(0);
 		});
 
 		it('clearThread and clear drop the durable log drain state too', () => {

--- a/packages/cli/src/modules/instance-ai/event-bus/durable-event-log.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/durable-event-log.ts
@@ -38,6 +38,7 @@ const MAX_APPEND_ATTEMPTS = 5;
  * line published after run-finish, or a liveness timeout notice) would sit in
  * the coalescer forever; after this quiet period the open buffers are flushed
  * as blocks so they reach the durable log and replay/history stay complete.
+ * The same tick releases the thread's drain state.
  */
 const IDLE_FLUSH_MS = 3_000;
 
@@ -160,12 +161,84 @@ export class DurableEventLog {
 		if (existing) clearTimeout(existing);
 		const timer = setTimeout(() => {
 			this.idleFlushTimers.delete(threadId);
-			void this.flush(threadId).catch((error) => {
+			void this.settleIdleThread(threadId).catch((error) => {
 				this.logger.error('Instance AI event log idle flush failed', { threadId, error });
 			});
 		}, this.idleFlushMs);
 		timer.unref();
 		this.idleFlushTimers.set(threadId, timer);
+	}
+
+	/**
+	 * Flush the quiet thread's trailing deltas, then drop its drain state so the
+	 * per-thread maps don't accumulate one entry per thread the process has ever
+	 * served — a thread is only cleared explicitly or by the TTL prune,
+	 * which never reaches a non-leader main at all.
+	 *
+	 * All three are caches: `lastSeq` re-seeds from MAX(seq) (the append path
+	 * already drops it on a conflict), `emitters` is re-set by every publish, and
+	 * `lifecycles` mints a fresh token on demand — so a later publish for the
+	 * same thread just pays one seed query.
+	 */
+	private async settleIdleThread(threadId: string): Promise<void> {
+		await this.flush(threadId);
+		// flush() resolves from inside the drain, before the loop clears its
+		// `draining` entry — await the drain itself so "quiet" really means quiet.
+		await this.draining.get(threadId);
+		// Everything below is synchronous, so a publish cannot interleave between
+		// the checks and the deletes; one arriving after them simply recreates
+		// the state. Releasing under work in flight is not merely wasteful —
+		// dropping `emitters` while a drain is queued makes drainBatch bail and
+		// discard that batch — so bail on any sign of it.
+		//
+		// A publish during the awaits above already re-armed the timer, so that
+		// tick does the release.
+		if (this.idleFlushTimers.has(threadId)) return;
+		// The rest have no tick of their own: flush() enqueues a marker and calls
+		// ensureDraining without ever arming a timer (every run boundary does this
+		// via readRunEvents), and a drain batch that throws resolves its flush
+		// signals in ensureDraining's catch while leaving open buffers behind.
+		// Re-arm rather than deferring the release to a publish that may never
+		// come — a thread going silent in that window would keep its drain state
+		// for the process lifetime.
+		//
+		// `draining` is belt-and-braces: reaching here with a drain in flight
+		// needs one started without arming a timer, which today cannot happen
+		// (flush() only drains when pending/buffers are already non-empty, and
+		// both only fill via publish, which always arms one). Cheap to check, and
+		// releasing under an in-flight batch is not merely wasteful — dropping
+		// `lifecycles` makes the resuming batch bail, and its coalesced blocks are
+		// already out of `buffers`, so that streamed text would be lost.
+		if (
+			this.pendingByThread.has(threadId) ||
+			this.draining.has(threadId) ||
+			(this.buffers.get(threadId)?.size ?? 0) > 0
+		) {
+			this.scheduleIdleFlush(threadId);
+			return;
+		}
+		this.buffers.delete(threadId);
+		this.lastSeq.delete(threadId);
+		this.emitters.delete(threadId);
+		this.lifecycles.delete(threadId);
+	}
+
+	/**
+	 * Threads holding any drain state in this process. Every per-thread map, so
+	 * the count stays honest mid-drain too: a flush() with no prior publish
+	 * starts a drain without an emitter, leaving the thread in `draining` alone
+	 * until the batch bails.
+	 */
+	retainedThreadCount(): number {
+		return new Set([
+			...this.pendingByThread.keys(),
+			...this.draining.keys(),
+			...this.lastSeq.keys(),
+			...this.buffers.keys(),
+			...this.emitters.keys(),
+			...this.lifecycles.keys(),
+			...this.idleFlushTimers.keys(),
+		]).size;
 	}
 
 	async getEventsAfter(threadId: string, afterSeq: number): Promise<StoredEvent[]> {
@@ -590,6 +663,9 @@ export class DurableEventLog {
 			const text = this.takeBlock('text', fact.runId, agentId, buffer);
 			if (text) flushed.push(text);
 		}
+		// Don't leave an empty map behind: it would outlive the run and pin one
+		// entry per thread the process has served.
+		if (threadBuffers.size === 0) this.buffers.delete(threadId);
 		return flushed;
 	}
 

--- a/packages/cli/src/modules/instance-ai/event-bus/in-process-event-bus.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/in-process-event-bus.ts
@@ -12,10 +12,16 @@ import { Publisher } from '@/scaling/pubsub/publisher.service';
 
 import { DurableEventLog, type DrainedEvent } from './durable-event-log';
 
-// With the durable log ON, the in-memory store is a live-delivery CACHE over
-// instance_ai_events, not the source of truth: eviction bounds the cache and
-// can no longer lose data (replay reads the DB through DurableEventLog).
-// With the flag OFF it is today's only store, and eviction is data loss.
+// The store below is FLAG-OFF ONLY, and these caps bound it per thread. It has
+// no cap on thread COUNT and is released only when a thread is cleared, so with
+// the flag off a long-lived process retains up to 2MB per thread it has served.
+// Accepted for the rollback switch rather than fixed there: a global eviction
+// policy on the only store is data loss (the empty-agentTree bug class), and
+// the path sunsets with the flag at Gate B.
+//
+// With the durable log ON nothing is stored here at all: instance_ai_events is
+// the source of truth, every read goes through DurableEventLog, and this bus is
+// a pure fan-out (local SSE subscribers + the cross-main relay).
 const MAX_EVENTS_PER_THREAD = 500;
 const MAX_BYTES_PER_THREAD = 2 * 1024 * 1024; // 2 MB
 
@@ -67,6 +73,9 @@ export class InProcessEventBus implements InstanceAiEventBus {
 
 	private readonly durableLogEnabled: boolean;
 
+	/** Store-read methods already reported under the durable log (log once). */
+	private readonly warnedStoreReads = new Set<string>();
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly instanceSettings: InstanceSettings,
@@ -86,14 +95,14 @@ export class InProcessEventBus implements InstanceAiEventBus {
 	 *
 	 * Durable log ON: synchronous enqueue into the durable log's per-thread
 	 * drain, which assigns `seq` from the DB, persists durable facts, and hands
-	 * each event back here (`onDrained`): durable ones enter the cache; live
-	 * ones go to local SSE subscribers and — in multi-main — to sibling mains
-	 * via the pubsub relay. Ephemeral events (deltas, status) carry NO id, so
-	 * their SSE frames have no `id:` line and the browser's replay cursor only
-	 * ever points at durable facts. The Redis sequence machinery below is never
-	 * touched: the flag picks exactly one drain (INS-844's composition was
-	 * cancelled), and the flag-off paths below survive only as the rollback
-	 * switch until they sunset at Gate B (INS-847).
+	 * each event back here (`onDrained`) for fan-out only — live ones go to
+	 * local SSE subscribers and — in multi-main — to sibling mains via the
+	 * pubsub relay. Nothing is retained in this process. Ephemeral events
+	 * (deltas, status) carry NO id, so their SSE frames have no `id:` line and
+	 * the browser's replay cursor only ever points at durable facts. The Redis
+	 * sequence machinery below is never touched: the flag picks exactly one drain
+	 * (INS-844's composition was cancelled), and the flag-off paths below survive
+	 * only as the rollback switch until they sunset at Gate B (INS-847).
 	 *
 	 * Flag OFF, single-main: assign the next local id and deliver in the same tick.
 	 *
@@ -133,36 +142,25 @@ export class InProcessEventBus implements InstanceAiEventBus {
 	}
 
 	/**
-	 * An event handed back by the durable log's drain (flag on). Durable events
-	 * (id = DB-assigned seq) enter the live-delivery cache; live ones are
-	 * emitted to local SSE subscribers and relayed to sibling mains. Coalesced
-	 * blocks are durable but NOT live (subscribers already saw their deltas).
+	 * An event handed back by the durable log's drain (flag on): fan it out to
+	 * local SSE subscribers and sibling mains. Nothing is retained — the row is
+	 * already in instance_ai_events, and every replay/run-scoped read goes to
+	 * the log, so keeping a copy here would only pin memory per thread for the
+	 * process lifetime. Coalesced blocks are durable but NOT live
+	 * (subscribers already saw their deltas), so they fan out to nobody.
 	 */
 	private onDrained(threadId: string, drained: DrainedEvent): void {
-		const sizeBytes = Buffer.byteLength(JSON.stringify(drained.event), 'utf8');
-		if (drained.id !== undefined) {
-			this.cacheSequencedEvent(threadId, { id: drained.id, event: drained.event }, sizeBytes);
-		}
-		if (drained.live) {
-			const stored: StoredEvent = {
-				...(drained.id !== undefined ? { id: drained.id } : {}),
-				event: drained.event,
-			};
-			this.emitter.emit(threadId, stored);
-			this.relayToSiblings(threadId, stored, sizeBytes);
-		}
-	}
-
-	/** Insert into the bounded cache without emitting (durable-log path). */
-	private cacheSequencedEvent(
-		threadId: string,
-		sequenced: SequencedEvent,
-		sizeBytes: number,
-	): void {
-		const events = this.getOrCreateStore(threadId);
-		if (!this.insertById(events, sequenced)) return;
-		this.sizeBytes.set(threadId, (this.sizeBytes.get(threadId) ?? 0) + sizeBytes);
-		this.evictIfNeeded(threadId, events);
+		if (!drained.live) return;
+		const stored: StoredEvent = {
+			...(drained.id !== undefined ? { id: drained.id } : {}),
+			event: drained.event,
+		};
+		this.emitter.emit(threadId, stored);
+		this.relayToSiblings(
+			threadId,
+			stored,
+			Buffer.byteLength(JSON.stringify(drained.event), 'utf8'),
+		);
 	}
 
 	/**
@@ -335,6 +333,14 @@ export class InProcessEventBus implements InstanceAiEventBus {
 		threadId,
 		storedEvent,
 	}: { threadId: string; storedEvent: StoredEvent }): void {
+		if (this.durableLogEnabled) {
+			// Pure live delivery: seqs come from the DB (no local high-water mark to
+			// track) and reconnect replay reads the log, so a relayed frame is only
+			// ever needed by a subscriber attached right now. A frame delivered
+			// twice is dropped client-side by its id.
+			if (this.hasSubscribers(threadId)) this.emitter.emit(threadId, storedEvent);
+			return;
+		}
 		// Track the shared-sequence high-water mark even without subscribers, so
 		// a Redis-outage fallback keeps assigning ids above what siblings used.
 		if (storedEvent.id !== undefined) {
@@ -342,8 +348,6 @@ export class InProcessEventBus implements InstanceAiEventBus {
 		}
 		if (!this.hasSubscribers(threadId)) return;
 		if (storedEvent.id === undefined) {
-			// Ephemeral durable-log frame: deliver live, never store (the DB seq
-			// is the shared replay authority, so the cache doesn't need it).
 			this.emitter.emit(threadId, storedEvent);
 			return;
 		}
@@ -361,24 +365,42 @@ export class InProcessEventBus implements InstanceAiEventBus {
 	}
 
 	/**
-	 * Events still awaiting a sequence number are intentionally excluded: they
-	 * have no id yet, and once sequenced they reach subscribers live — the SSE
-	 * bootstrap subscribes before calling this, so nothing is missed.
-	 *
-	 * Durable log ON: cache-scoped read for same-process consumers;
-	 * cross-restart/cross-main replay must use DurableEventLog.getEventsAfter.
+	 * Threads with events retained in this process. Always 0 under the durable
+	 * log; with the flag off it grows with every thread this main has served
+	 * until each is cleared.
+	 */
+	retainedThreadCount(): number {
+		return this.store.size;
+	}
+
+	/**
+	 * FLAG-OFF ONLY. Events still awaiting a sequence number are intentionally
+	 * excluded: they have no id yet, and once sequenced they reach subscribers
+	 * live — the SSE bootstrap subscribes before calling this, so nothing is
+	 * missed. With the durable log on, use DurableEventLog.getEventsAfter.
 	 */
 	getEventsAfter(threadId: string, afterId: number): StoredEvent[] {
+		if (this.assertNoStoreUnderDurableLog('getEventsAfter', threadId)) return [];
 		const events = this.store.get(threadId);
 		if (!events) return [];
 		return events.filter((e) => e.id > afterId);
 	}
 
+	/** FLAG-OFF ONLY — see {@link getEventsForRuns}. */
 	getEventsForRun(threadId: string, runId: string): InstanceAiEvent[] {
+		// Guarded before delegating so the report names the entry point the
+		// caller actually used, and so the two entry points dedupe separately.
+		if (this.assertNoStoreUnderDurableLog('getEventsForRun', threadId)) return [];
 		return this.getEventsForRuns(threadId, [runId]);
 	}
 
+	/**
+	 * FLAG-OFF ONLY. With the durable log on nothing is stored here, so a caller
+	 * must go through DurableEventLog.getEventsForRuns (via the service's
+	 * `readRunEvents`, which flushes open coalesce buffers first).
+	 */
 	getEventsForRuns(threadId: string, runIds: string[]): InstanceAiEvent[] {
+		if (this.assertNoStoreUnderDurableLog('getEventsForRuns', threadId)) return [];
 		if (runIds.length === 0) return [];
 		const runIdSet = new Set(runIds);
 		const stored = (this.store.get(threadId) ?? [])
@@ -396,12 +418,10 @@ export class InProcessEventBus implements InstanceAiEventBus {
 	}
 
 	async getNextEventId(threadId: string): Promise<number> {
-		if (this.durableLogEnabled) {
-			// Cache-scoped; the durable authority is DurableEventLog.getNextEventId.
-			const events = this.store.get(threadId);
-			const last = events?.length ? events[events.length - 1].id : undefined;
-			return (last ?? 0) + 1;
-		}
+		// Delegated rather than guarded: unlike the store-scoped reads above this
+		// one is cheap to answer correctly, and the SSE cursor it seeds must never
+		// silently come back as 1.
+		if (this.durableLogEnabled) return await this.eventLog.getNextEventId(threadId);
 		if (this.instanceSettings.isMultiMain) {
 			try {
 				const value = await this.getRedisClient().get(this.seqKey(threadId));
@@ -449,6 +469,27 @@ export class InProcessEventBus implements InstanceAiEventBus {
 		this.inFlightByThread.clear();
 		this.eventLog.clear();
 		this.emitter.removeAllListeners();
+	}
+
+	/**
+	 * The store is not populated under the durable log, so a read of it there is
+	 * a wiring bug: the caller wants the log. Reported once per method rather
+	 * than thrown — an empty result degrades a trace annotation or a replay that
+	 * the log-backed path will serve anyway, where a throw would take down run
+	 * finalization.
+	 */
+	private assertNoStoreUnderDurableLog(method: string, threadId: string): boolean {
+		if (!this.durableLogEnabled) return false;
+		// Once per entry point: any call is a bug, but a regression could sit in
+		// a per-group loop (the flag-off replay has one), and this is a read path.
+		if (!this.warnedStoreReads.has(method)) {
+			this.warnedStoreReads.add(method);
+			this.logger.error(
+				`InProcessEventBus.${method} was read with the durable event log enabled, where nothing is stored in memory — the caller must use DurableEventLog instead`,
+				{ threadId },
+			);
+		}
+		return true;
 	}
 
 	private evictIfNeeded(threadId: string, events: SequencedEvent[]): void {

--- a/packages/cli/src/modules/instance-ai/instance-ai-terminal-outcome.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-terminal-outcome.service.ts
@@ -372,7 +372,7 @@ export class InstanceAiTerminalOutcomeService {
 		return {
 			status: 'error',
 			reason: 'invalid_confirmation_payload',
-			metadata: this.tracing.buildMessageTraceMetadata(args.threadId, args.runId, {
+			metadata: await this.tracing.buildMessageTraceMetadata(args.threadId, args.runId, {
 				status: 'error',
 			}),
 		};

--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -49,6 +49,17 @@ export class InstanceAiModule implements ModuleInterface {
 			void sweeper.sweep().catch((error: unknown) => {
 				logger.error('Interrupted-run sweep failed on startup', { error });
 			});
+		} else {
+			// Surfaced at boot because the off switch changes this main's resource
+			// profile, not just where events are read from: the legacy buffer is
+			// held per thread until that thread is deleted or expires, so memory
+			// grows with the threads this main serves. Fixed only for the
+			// durable-log path; the legacy one sunsets with the flag at Gate B.
+			Container.get(Logger)
+				.scoped('instance-ai')
+				.warn(
+					'N8N_INSTANCE_AI_DURABLE_LOG is off: Instance AI events are held in a per-thread in-memory buffer (500 events / 2MB each) instead of the durable log. Memory scales with the number of threads this main has served, and replay does not survive a restart. Intended as a temporary rollback switch.',
+				);
 		}
 
 		if (process.env.E2E_TESTS === 'true' && process.env.NODE_ENV !== 'production') {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -877,14 +877,11 @@ export class InstanceAiService {
 		});
 		this.tracing = new InstanceAiTracingService({
 			logger: this.logger,
-			// Flag-resolved read: `first_visible_state` has to see the run's
-			// streamed text, which under the durable log lives in the log (as
-			// coalesced blocks), never in the bus cache.
+			// `first_visible_state` has to see the run's streamed text, which under
+			// the durable log lives in the log (as coalesced blocks), never in the
+			// bus cache.
 			eventReader: {
-				getEventsForRun: async (threadId, runId) =>
-					this.instanceAiConfig.durableLog
-						? await this.readDurableEventsForRuns(threadId, [runId])
-						: this.eventBus.getEventsForRun(threadId, runId),
+				getEventsForRun: async (threadId, runId) => await this.readRunEvents(threadId, [runId]),
 			},
 			runState: this.runState,
 			dbSnapshotStorage: this.dbSnapshotStorage,
@@ -901,19 +898,13 @@ export class InstanceAiService {
 		});
 		this.terminalOutcome = new InstanceAiTerminalOutcomeService({
 			durableLog: globalConfig.instanceAi.durableLog,
-			// Flag-resolved reads: the terminal guard and outcome-replay dedup must
-			// see the run's events after a restart too, which only the durable log
-			// can provide (the bus cache is empty in a fresh process).
+			// The terminal guard and outcome-replay dedup must see the run's events
+			// after a restart too, which only the durable log can provide (the bus
+			// cache is empty in a fresh process).
 			eventBus: {
 				publish: (threadId, event) => this.eventBus.publish(threadId, event),
-				getEventsForRun: async (threadId, runId) =>
-					this.instanceAiConfig.durableLog
-						? await this.readDurableEventsForRuns(threadId, [runId])
-						: this.eventBus.getEventsForRun(threadId, runId),
-				getEventsForRuns: async (threadId, runIds) =>
-					this.instanceAiConfig.durableLog
-						? await this.readDurableEventsForRuns(threadId, runIds)
-						: this.eventBus.getEventsForRuns(threadId, runIds),
+				getEventsForRun: async (threadId, runId) => await this.readRunEvents(threadId, [runId]),
+				getEventsForRuns: async (threadId, runIds) => await this.readRunEvents(threadId, runIds),
 			},
 			dbSnapshotStorage: this.dbSnapshotStorage,
 			agentMemory: this.agentMemory,
@@ -6792,16 +6783,18 @@ export class InstanceAiService {
 	}
 
 	/**
-	 * Read-own-writes barrier for decision reads from the durable log: settle
-	 * the thread's drain (including open coalesce buffers) so everything
-	 * published before this call is visible to the read. Used at run
-	 * boundaries — terminal-guard inputs and snapshot builds — where closing
-	 * the open segment early is correct anyway.
+	 * The one place the run-event source is chosen. With the durable log on it
+	 * is a read-own-writes barrier: settle the thread's drain (including open
+	 * coalesce buffers) so everything published before this call is visible,
+	 * then read the log. With it off the in-memory bus store is the only
+	 * source. Every caller is a run boundary — terminal-guard inputs, trace
+	 * metadata, snapshot builds — where closing the open segment early is
+	 * correct anyway.
 	 */
-	private async readDurableEventsForRuns(
-		threadId: string,
-		runIds: string[],
-	): Promise<InstanceAiEvent[]> {
+	private async readRunEvents(threadId: string, runIds: string[]): Promise<InstanceAiEvent[]> {
+		if (!this.instanceAiConfig.durableLog) {
+			return this.eventBus.getEventsForRuns(threadId, runIds);
+		}
 		await this.eventLog.flush(threadId);
 		return await this.eventLog.getEventsForRuns(threadId, runIds);
 	}
@@ -6828,13 +6821,9 @@ export class InstanceAiService {
 					const snapshot = await snapshotStorage.getLatest(threadId, { messageGroupId, runId });
 					groupRunIds = snapshot?.runIds?.length ? snapshot.runIds : [runId];
 				}
-				events = this.instanceAiConfig.durableLog
-					? await this.readDurableEventsForRuns(threadId, groupRunIds)
-					: this.eventBus.getEventsForRuns(threadId, groupRunIds);
+				events = await this.readRunEvents(threadId, groupRunIds);
 			} else {
-				events = this.instanceAiConfig.durableLog
-					? await this.readDurableEventsForRuns(threadId, [runId])
-					: this.eventBus.getEventsForRun(threadId, runId);
+				events = await this.readRunEvents(threadId, [runId]);
 			}
 			// Durable-log flag on: the tree input comes from the DB, so long runs can
 			// no longer out-evict their own snapshot input (the empty-agentTree bug

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -877,7 +877,15 @@ export class InstanceAiService {
 		});
 		this.tracing = new InstanceAiTracingService({
 			logger: this.logger,
-			eventBus: this.eventBus,
+			// Flag-resolved read: `first_visible_state` has to see the run's
+			// streamed text, which under the durable log lives in the log (as
+			// coalesced blocks), never in the bus cache.
+			eventReader: {
+				getEventsForRun: async (threadId, runId) =>
+					this.instanceAiConfig.durableLog
+						? await this.readDurableEventsForRuns(threadId, [runId])
+						: this.eventBus.getEventsForRun(threadId, runId),
+			},
 			runState: this.runState,
 			dbSnapshotStorage: this.dbSnapshotStorage,
 			aiService: this.aiService,
@@ -4271,7 +4279,9 @@ export class InstanceAiService {
 				status: finalStatus,
 				outputText,
 				modelId,
-				metadata: this.tracing.buildMessageTraceMetadata(threadId, runId, { status: finalStatus }),
+				metadata: await this.tracing.buildMessageTraceMetadata(threadId, runId, {
+					status: finalStatus,
+				}),
 			};
 			const archivedWorkflowIds = await this.temporaryWorkflowService.reapForRun(
 				threadId,
@@ -4349,7 +4359,7 @@ export class InstanceAiService {
 				messageTraceFinalization = {
 					status: 'cancelled',
 					reason: cancellationReason,
-					metadata: this.tracing.buildMessageTraceMetadata(threadId, runId, {
+					metadata: await this.tracing.buildMessageTraceMetadata(threadId, runId, {
 						status: 'cancelled',
 						cancellationReason,
 						runTimeout,
@@ -4425,7 +4435,9 @@ export class InstanceAiService {
 			messageTraceFinalization = {
 				status: 'error',
 				reason: errorMessage,
-				metadata: this.tracing.buildMessageTraceMetadata(threadId, runId, { status: 'error' }),
+				metadata: await this.tracing.buildMessageTraceMetadata(threadId, runId, {
+					status: 'error',
+				}),
 			};
 
 			const archivedWorkflowIds = await this.temporaryWorkflowService.reapForRun(
@@ -5609,7 +5621,7 @@ export class InstanceAiService {
 			messageTraceFinalization = {
 				status: finalStatus,
 				outputText,
-				metadata: this.tracing.buildMessageTraceMetadata(opts.threadId, opts.runId, {
+				metadata: await this.tracing.buildMessageTraceMetadata(opts.threadId, opts.runId, {
 					status: finalStatus,
 				}),
 			};
@@ -5696,7 +5708,7 @@ export class InstanceAiService {
 				messageTraceFinalization = {
 					status: 'cancelled',
 					reason: cancellationReason,
-					metadata: this.tracing.buildMessageTraceMetadata(opts.threadId, opts.runId, {
+					metadata: await this.tracing.buildMessageTraceMetadata(opts.threadId, opts.runId, {
 						status: 'cancelled',
 						cancellationReason,
 						runTimeout,
@@ -5773,7 +5785,7 @@ export class InstanceAiService {
 			messageTraceFinalization = {
 				status: 'error',
 				reason: errorMessage,
-				metadata: this.tracing.buildMessageTraceMetadata(opts.threadId, opts.runId, {
+				metadata: await this.tracing.buildMessageTraceMetadata(opts.threadId, opts.runId, {
 					status: 'error',
 				}),
 			};
@@ -6448,7 +6460,7 @@ export class InstanceAiService {
 		await this.tracing.maybeFinalizeRunTraceRoot(suspended.runId, {
 			status: 'cancelled',
 			reason,
-			metadata: this.tracing.buildMessageTraceMetadata(suspended.threadId, suspended.runId, {
+			metadata: await this.tracing.buildMessageTraceMetadata(suspended.threadId, suspended.runId, {
 				status: 'cancelled',
 				cancellationReason: reason,
 				...(runTimeout ? { runTimeout } : {}),

--- a/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
+++ b/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
@@ -77,7 +77,6 @@ export type InstanceAiLivenessBackgroundTasks = {
 };
 
 export type InstanceAiLivenessEventBus = {
-	getEventsForRun: (threadId: string, runId: string) => Array<Pick<InstanceAiEvent, 'responseId'>>;
 	publish: (threadId: string, event: InstanceAiEvent) => void;
 };
 
@@ -103,6 +102,18 @@ export class InstanceAiLivenessService<
 
 	private readonly timedOutActiveRunThreads = new Set<string>();
 
+	/**
+	 * Runs whose timeout notice has already been published, so a run cancelled
+	 * by the sweep and then finalised by its own abort handler only gets the
+	 * notice once. Capped FIFO (see {@link NOTICE_DEDUPE_CACHE_SIZE}): dedupe
+	 * only has to hold across a single run's cancellation window, and a run
+	 * lives on one main for one process lifetime.
+	 */
+	private readonly noticedRunIds = new Set<string>();
+
+	/** Max retained run ids in {@link noticedRunIds}; oldest evicted first. */
+	static readonly NOTICE_DEDUPE_CACHE_SIZE = 1000;
+
 	constructor(private readonly options: InstanceAiLivenessServiceOptions<TSuspendedRun>) {}
 
 	get backgroundTaskIdleTimeoutMs(): number {
@@ -124,6 +135,7 @@ export class InstanceAiLivenessService<
 		}
 		this.timedOutRunIds.clear();
 		this.timedOutActiveRunThreads.clear();
+		this.noticedRunIds.clear();
 	}
 
 	clearThreadState(threadId: string): void {
@@ -233,18 +245,33 @@ export class InstanceAiLivenessService<
 	}
 
 	publishRunTimeoutNotice(threadId: string, runId: string): void {
-		const responseId = `run-timeout:${runId}`;
-		const alreadyPublished = this.options.eventBus
-			.getEventsForRun(threadId, runId)
-			.some((event) => event.responseId === responseId);
-		if (alreadyPublished) return;
+		// Deduped locally rather than by scanning the run's events: the notice is
+		// a delta, and under the durable log deltas are ephemeral (never stored,
+		// persisted only once their segment coalesces), so a read-back cannot see
+		// a notice published moments earlier.
+		if (this.noticedRunIds.has(runId)) return;
 
+		// Recorded only after the publish lands: marking first would suppress the
+		// notice permanently if publish threw.
 		this.options.eventBus.publish(threadId, {
 			type: 'text-delta',
 			runId,
 			agentId: orchestratorAgentId(runId),
-			responseId,
+			responseId: `run-timeout:${runId}`,
 			payload: { text: RUN_TIMEOUT_MESSAGE },
 		});
+		this.rememberNoticedRunId(runId);
+	}
+
+	/**
+	 * Record a notified run id, evicting the oldest once the cap is reached. A
+	 * Set keeps insertion order, so the first value is the oldest entry.
+	 */
+	private rememberNoticedRunId(runId: string): void {
+		this.noticedRunIds.add(runId);
+		if (this.noticedRunIds.size > InstanceAiLivenessService.NOTICE_DEDUPE_CACHE_SIZE) {
+			const oldest = this.noticedRunIds.values().next().value;
+			if (oldest !== undefined) this.noticedRunIds.delete(oldest);
+		}
 	}
 }

--- a/packages/cli/src/modules/instance-ai/run-trace-metadata.ts
+++ b/packages/cli/src/modules/instance-ai/run-trace-metadata.ts
@@ -62,7 +62,13 @@ function getFirstVisibleSummary(events: InstanceAiEvent[]): FirstVisibleSummary 
 			};
 		}
 
-		if (event.type === 'text-delta' && event.payload.text.trim().length > 0) {
+		// A streamed segment reaches this read as deltas mid-run and as one
+		// coalesced `text-block` once it closes (the durable log never persists
+		// deltas), so both spellings have to count as visible assistant text.
+		if (
+			(event.type === 'text-delta' || event.type === 'text-block') &&
+			event.payload.text.trim().length > 0
+		) {
 			return withFirstToolName('assistant_text', firstToolName);
 		}
 

--- a/packages/cli/src/modules/instance-ai/tracing/index.ts
+++ b/packages/cli/src/modules/instance-ai/tracing/index.ts
@@ -1,7 +1,7 @@
 export {
 	InstanceAiTracingService,
 	type InstanceAiTracingAiService,
-	type InstanceAiTracingEventBus,
+	type InstanceAiTracingEventReader,
 	type InstanceAiTracingRunState,
 	type InstanceAiTracingServiceOptions,
 	type InstanceAiTracingSnapshotStorage,

--- a/packages/cli/src/modules/instance-ai/tracing/instance-ai-tracing.service.ts
+++ b/packages/cli/src/modules/instance-ai/tracing/instance-ai-tracing.service.ts
@@ -1,3 +1,4 @@
+import type { InstanceAiEvent } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import {
@@ -18,7 +19,6 @@ import { N8N_VERSION, WORKFLOW_SDK_VERSION } from '@/constants';
 import type { AiService } from '@/services/ai.service';
 import { ProxyTokenManager } from '@/services/proxy-token-manager';
 
-import type { InProcessEventBus } from '../event-bus/in-process-event-bus';
 import {
 	buildInstanceAiRunTraceMetadata,
 	type InstanceAiRunTraceMetadataOptions,
@@ -56,7 +56,15 @@ export type OrchestratorResumeReason =
 
 // The slice of each collaborator the tracing service actually uses. Anchored to
 // the concrete types via `Pick` so the signatures stay in sync with the source.
-export type InstanceAiTracingEventBus = Pick<InProcessEventBus, 'getEventsForRun'>;
+/**
+ * Flag-resolved run-event read: the durable log with `instanceAi.durableLog` on,
+ * the in-memory bus store with it off. Async because the durable read flushes
+ * the thread's open coalesce buffers and then queries — which is what makes the
+ * streamed text of a run visible to `first_visible_state` at all.
+ */
+export type InstanceAiTracingEventReader = {
+	getEventsForRun: (threadId: string, runId: string) => Promise<InstanceAiEvent[]>;
+};
 
 export type InstanceAiTracingRunState = Pick<RunStateRegistry<User>, 'attachTracing'>;
 
@@ -66,7 +74,7 @@ export type InstanceAiTracingAiService = Pick<AiService, 'isProxyEnabled' | 'get
 
 export type InstanceAiTracingServiceOptions = {
 	logger: Logger;
-	eventBus: InstanceAiTracingEventBus;
+	eventReader: InstanceAiTracingEventReader;
 	runState: InstanceAiTracingRunState;
 	dbSnapshotStorage: InstanceAiTracingSnapshotStorage;
 	aiService: InstanceAiTracingAiService;
@@ -100,7 +108,7 @@ export class InstanceAiTracingService {
 
 	private readonly logger: Logger;
 
-	private readonly eventBus: InstanceAiTracingEventBus;
+	private readonly eventReader: InstanceAiTracingEventReader;
 
 	private readonly runState: InstanceAiTracingRunState;
 
@@ -110,7 +118,7 @@ export class InstanceAiTracingService {
 
 	constructor(options: InstanceAiTracingServiceOptions) {
 		this.logger = options.logger;
-		this.eventBus = options.eventBus;
+		this.eventReader = options.eventReader;
 		this.runState = options.runState;
 		this.dbSnapshotStorage = options.dbSnapshotStorage;
 		this.aiService = options.aiService;
@@ -280,11 +288,11 @@ export class InstanceAiTracingService {
 		await this.finalizeMessageTraceRoot(runId, tracing, options);
 	}
 
-	buildMessageTraceMetadata(
+	async buildMessageTraceMetadata(
 		threadId: string,
 		runId: string,
 		options: InstanceAiRunTraceMetadataOptions,
-	): Record<string, unknown> {
+	): Promise<Record<string, unknown>> {
 		const traceOptions = {
 			status: options.status,
 			...(options.cancellationReason !== undefined
@@ -293,12 +301,29 @@ export class InstanceAiTracingService {
 			...(options.runTimeout !== undefined ? { runTimeout: options.runTimeout } : {}),
 		};
 
+		// The events read hits the DB under the durable log, and most callers run
+		// inside a run's terminal catch block — throwing there would skip
+		// run-finish and leave the client spinning until the liveness sweep. This
+		// is a trace annotation, not a correctness input, so degrade instead.
+		let events: InstanceAiEvent[] = [];
+		let eventsUnavailable = false;
+		try {
+			events = await this.eventReader.getEventsForRun(threadId, runId);
+		} catch (error) {
+			eventsUnavailable = true;
+			this.logger.warn('Failed to read run events for Instance AI trace metadata', {
+				runId,
+				threadId,
+				error: getErrorMessage(error),
+			});
+		}
+
 		return {
 			completion_source: 'orchestrator',
-			...buildInstanceAiRunTraceMetadata(
-				this.eventBus.getEventsForRun(threadId, runId),
-				traceOptions,
-			),
+			...buildInstanceAiRunTraceMetadata(events, traceOptions),
+			// Without this, a failed read is indistinguishable from a run that
+			// genuinely produced nothing — both report `first_visible_state: empty`.
+			...(eventsUnavailable ? { first_visible_state_unavailable: true } : {}),
 		};
 	}
 


### PR DESCRIPTION
## Summary

The in-process event bus kept a per-thread buffer of every id-bearing event, capped at 500 events / 2MB **each**, with no cap on the number of threads and no release on run completion. `clearThread()` only fires on explicit thread deletion, run cancel, the leader's TTL prune, or shutdown — and the TTL prune is leader-local, so on a non-leader main a thread's buffer was never released at all. A main therefore pinned up to 2MB per thread it had served, for the life of the process.

With the durable log on (the default since #34349), `instance_ai_events` is the source of truth and every replay and run-scoped read already goes through `DurableEventLog`. Auditing the readers turned up only two still reaching into the in-memory store — and **both were already broken by the durable-log flip**, so they needed fixing regardless:

- `tracing.buildMessageTraceMetadata` classified a run by scanning for a `text-delta`. Deltas are ephemeral under the durable log — never stored, persisted only as a coalesced `text-block` — so `first_visible_state` could not report `assistant_text` at all, and a run that streamed text was logged as `tool_call` or `empty`.
- `liveness.publishRunTimeoutNotice` deduped by reading the run's events back for its own `responseId`. Same reason: the notice is a delta, invisible to that read until its segment coalesces. A run cancelled by the liveness sweep and then finalised by its own abort handler published the timeout notice twice.

With those rewired, the buffer has no readers left under the flag, so this drops it entirely rather than adding an eviction policy: nothing is retained, so there is nothing to evict or cap. `onDrained` and the cross-main relay now fan out to live subscribers only, `getNextEventId` delegates to the log, and the store-scoped reads report a wiring bug (log-once, not throw) instead of silently answering empty.

The flag-off path (`N8N_INSTANCE_AI_DURABLE_LOG=false`) is deliberately untouched — it is the only store there, where eviction would be data loss (the empty-`agentTree` bug class) — so a rollback still carries the original retention. This will be removed at INS-847 at followup PR https://github.com/n8n-io/n8n/pull/36729

Two things worth a reviewer's eye:

- Removing the store-based duplicate-id drop on the relay path is safe because the frontend already drops duplicate durable frames by id (`instanceAi.threadRuntime.ts:779`).
- The idle release awaits both the flush *and* the drain, then does all its checks and deletes in one synchronous block, so a concurrent publish cannot interleave. All three released maps are caches: the seq cache re-seeds from `MAX(seq)`, the emitter is re-set by every publish, and the lifecycle token is minted on demand.

## How to test

No user-visible change is expected — this is a memory-retention fix on the default path.

1. Run with the default config (`N8N_INSTANCE_AI_DURABLE_LOG` unset).
2. Hold an Instance AI conversation with a few turns, reload mid-stream, and cancel a run. Streaming, SSE reconnect replay, history rendering and terminal outcomes should all behave exactly as before — all of it now reads from `instance_ai_events`.
3. Set `N8N_INSTANCE_AI_DURABLE_LOG=false` and repeat: the legacy in-memory path is unchanged, and the main logs a warning at boot describing the retention trade-off.
4. Multi-main: confirm a thread streaming on one main still renders live on another (the relay is now emit-only under the flag).

`pnpm test src/modules/instance-ai` in `packages/cli`: 2199 passing across 99 files. `pnpm typecheck` clean.

The four timer-dependent tests in `durable-event-log.test.ts` use fake timers scoped to `setTimeout`/`clearTimeout` only, so `unref()` and the drain's `setImmediate` chains still behave. The release and mid-settle tests are mutation-checked: removing the idle-timer guard fails the mid-settle test, and removing the release fails both release tests.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-706

Related: INS-847 (Gate B sunset will delete this PR's read guards and the flag-off store outright).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




