### PR TITLE
build(core): Upgrade Instance AI NanoID

### DIFF
--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -80,7 +80,7 @@
     "luxon": "catalog:",
     "mammoth": "1.12.1",
     "n8n-workflow": "workspace:*",
-    "nanoid": "catalog:",
+    "nanoid": "catalog:nanoid-v6",
     "pdf-parse": "catalog:",
     "psl": "1.15.0",
     "source-map-support": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,6 +650,10 @@ catalogs:
     vue-router:
       specifier: ^4.5.0
       version: 4.5.0
+  nanoid-v6:
+    nanoid:
+      specifier: 6.0.1
+      version: 6.0.1
   p-limit-v7:
     p-limit:
       specifier: ^7.3.1
@@ -2699,8 +2703,8 @@ importers:
         specifier: workspace:*
         version: link:../../workflow
       nanoid:
-        specifier: 'catalog:'
-        version: 3.3.18
+        specifier: catalog:nanoid-v6
+        version: 6.0.1
       pdf-parse:
         specifier: 2.4.5
         version: 2.4.5
@@ -19607,6 +19611,11 @@ packages:
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   napi-build-utils@2.0.0:
@@ -39298,6 +39307,8 @@ snapshots:
   nanoclone@0.2.1: {}
 
   nanoid@3.3.18: {}
+
+  nanoid@6.0.1: {}
 
   napi-build-utils@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -260,6 +260,8 @@ catalogs:
     vue-markdown-render: ^2.2.1
     vue-router: ^4.5.0
     vue-tsc: ^2.2.8
+  nanoid-v6:
+    nanoid: 6.0.1
   p-limit-v7:
     p-limit: ^7.3.1
   sentry:


### PR DESCRIPTION
## Summary

- Add a `nanoid-v6` catalog pinned to `6.0.1`.
- Use it only in `@n8n/instance-ai`.
- Keep the default NanoID `3.3.18` catalog and the existing transitive override unchanged.
- Retain the existing static imports and ID behavior.

This draft is stacked on #36635. Retarget it to `master` after #36635 merges.

## How to test

- Run the focused run-state and workflow-loop tests in `packages/@n8n/instance-ai` (127 tests passed).
- Run Instance AI lint, typecheck, full tests, and build (4,360 tests passed).
- Load the compiled CommonJS output on Node 24 and generate default and sized IDs.
- Run CLI typecheck and build.
- Run `pnpm build > build.log 2>&1` (69/69 tasks passed).
- Confirm Instance AI resolves NanoID `6.0.1` while all other direct consumers resolve `3.3.18`.

`pnpm test:affected` reaches the existing TypeORM suite and requires a local `ormconfig.json`; scoped tests and the full build pass.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-1229
- Parent: https://linear.app/n8n/issue/INS-1178
- Stacked on https://github.com/n8n-io/n8n/pull/36635

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs are not required for this dependency-only change.
- [x] Existing tests cover the unchanged ID behavior.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (not required)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

