### PR TITLE
build: Install corepack explicitly in runners images (no-changelog)

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -19,7 +19,11 @@ WORKDIR /app/task-runner-javascript
 # already-vetted, already-pinned dependency set; the real supply-chain age
 # policy is enforced by the host install (pnpm-workspace.yaml + SafeChain).
 ARG PNPM_VERSION=10.32.1
-RUN corepack enable pnpm && corepack prepare "pnpm@${PNPM_VERSION}" --activate
+# Node >= 25 ships without corepack, so install it explicitly. 0.35.0 is the
+# version Node 24 bundled.
+ARG COREPACK_VERSION=0.35.0
+RUN npm install -g "corepack@${COREPACK_VERSION}" && \
+    corepack enable pnpm && corepack prepare "pnpm@${PNPM_VERSION}" --activate
 
 # Remove `catalog` and `workspace` references from package.json to allow `pnpm add` in extended images
 RUN node -e "const pkg = require('./package.json'); \
@@ -138,8 +142,9 @@ RUN apk add --no-cache ca-certificates tini libstdc++ libc6-compat && \
     pip install --no-cache-dir "pip>=26.0" && \
     apk del apk-tools
 
-# Bring corepack and pnpm over, to make the image easier to extend
-COPY --from=node-alpine /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/corepack
+# Bring corepack and pnpm over, to make the image easier to extend. The
+# builder installs corepack itself, since Node >= 25 images do not ship it.
+COPY --from=javascript-runner-builder /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/corepack
 RUN ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
 		ln -s ../lib/node_modules/corepack/dist/pnpm.js /usr/local/bin/pnpm
 

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -34,7 +34,11 @@ WORKDIR /app/task-runner-javascript
 # already-vetted, already-pinned dependency set; the real supply-chain age
 # policy is enforced by the host install (pnpm-workspace.yaml + SafeChain).
 ARG PNPM_VERSION=10.32.1
-RUN corepack enable pnpm && corepack prepare "pnpm@${PNPM_VERSION}" --activate
+# Node >= 25 ships without corepack, so install it explicitly. 0.35.0 is the
+# version Node 24 bundled.
+ARG COREPACK_VERSION=0.35.0
+RUN npm install -g "corepack@${COREPACK_VERSION}" && \
+    corepack enable pnpm && corepack prepare "pnpm@${PNPM_VERSION}" --activate
 
 # Remove `catalog` and `workspace` references from package.json to allow `pnpm add`
 RUN node -e "const pkg = require('./package.json'); \


### PR DESCRIPTION
## Summary

The nightly Docker build broke on the first run after the Node 26 switch ([failed run](https://github.com/n8n-io/n8n/actions/runs/32316821305)). The runners images took corepack from the official `node` image, and Node 26 images no longer ship corepack (removed from the distribution in Node 25). The runtime copy failed, and the builder's `corepack enable` would fail next, in both variants.

The builder now installs corepack explicitly, pinned to `0.35.0`, the version the Node 24 images bundled. The runtime copies corepack from the builder instead of from the `node` image.

Verified locally: full runners image build on Node 26 passes, and the built image reports the same corepack, pnpm, and Node output as the published `n8nio/runners:nightly` (modulo the Node version).

## Related Linear tickets, Github issues, and Community forum posts

https://app.notion.com/p/n8n/Halving-memory-usage-via-pointer-compression-3ac5b6e0c94f8005af87e93a9f837b53

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

