### PR TITLE
feat(core): Register type-availability-policies module scaffold (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -38,6 +38,7 @@ export const MODULE_NAMES = [
 	'workflow-reviews',
 	'engine-v2',
 	'policy-infrastructure',
+	'type-availability-policies',
 ] as const;
 
 export type ModuleName = (typeof MODULE_NAMES)[number];

--- a/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policies.module.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policies.module.test.ts
@@ -1,0 +1,19 @@
+import { ModuleMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+// Importing the module runs the @BackendModule decorator, registering its metadata.
+import { TypeAvailabilityPoliciesModule } from '../type-availability-policies.module';
+
+describe('TypeAvailabilityPoliciesModule', () => {
+	it('registers itself under the correct module name', () => {
+		const entry = Container.get(ModuleMetadata).get('type-availability-policies');
+
+		expect(entry).toBeDefined();
+	});
+
+	it('initializes with no side effects (empty scaffold)', async () => {
+		const module = new TypeAvailabilityPoliciesModule();
+
+		await expect(module.init()).resolves.toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policies.module.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policies.module.ts
@@ -1,0 +1,7 @@
+import type { ModuleInterface } from '@n8n/decorators';
+import { BackendModule } from '@n8n/decorators';
+
+@BackendModule({ name: 'type-availability-policies' })
+export class TypeAvailabilityPoliciesModule implements ModuleInterface {
+	async init() {}
+}


### PR DESCRIPTION
## Summary

Registers a new `type-availability-policies` backend module: an empty `@BackendModule` class with a no-op `init()`. This is scaffolding only, no policy logic yet.

The module name is added to `MODULE_NAMES` so it is a valid target for `N8N_ENABLED_MODULES`, but it is **not** added to the default module set. This keeps it out of the loaded/enabled set entirely until the license gate lands in a follow-up ticket, so there is no window where the module is reachable without a license check.

## How to test

- Run the unit tests: `cd packages/cli && pnpm test type-availability-policies.module.test.ts`
- Start n8n normally (no env var set) → the module does not load, no behavior change.
- Start n8n with `N8N_ENABLED_MODULES=type-availability-policies` → the module loads cleanly with no behavior change (`init()` is a no-op).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1135

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI