### PR TITLE
ci: Run tests when Instance AI runtime markdown changes (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -401,7 +401,7 @@ describe('Instance AI runtime skills', () => {
 			'ask once whether the user wants to build an error workflow for that workflow',
 		);
 		expect(loaded?.instructions).toContain(
-			'Do not replace this explicit opt-in with a generic "add\n   anything else?", publish, or test question.',
+			'Do not replace this explicit opt-in with a generic "add\n    anything else?", publish, or test question.',
 		);
 		expect(loaded?.instructions).toMatch(
 			/ask only whether the user wants the live test\. Do not\s+mention publishing or ask about the error workflow/,


### PR DESCRIPTION
## Summary

PR #36448 changed only two `SKILL.md` files and merged green while breaking a unit test: every CI filter excludes `**/*.md`, so md-only PRs skip tests entirely. But Instance AI skill and knowledge-base markdown is shipped runtime content (`files: skills/**/*` in the package) and a direct input to four unit test files — not docs.

Changes:
- **`.github/workflows/ci-pull-requests.yml`** — re-include `packages/@n8n/instance-ai/skills/**` and `knowledge-base/**` (the only md directories any unit test reads) after the `!**/*.md` exclusion in the `ci`, `runtime`, and `unit` filters, and add them to `instance-ai-workflow-eval`.
- **`packages/testing/test-impact/src/changes.ts`** — stop classifying those paths as non-impactful docs so e2e impact selection does not skip them.
- **`runtime-skills.test.ts`** — fix the assertion #36448 broke: the skill text moved into list item 10, so its wrapped lines are indented 4 spaces instead of 3.

## How to test

```bash
cd packages/@n8n/instance-ai && pnpm vitest run src/skills/__tests__/runtime-skills.test.ts
cd packages/testing/test-impact && pnpm vitest run src/changes.test.ts
```

Filter behavior verified against the real `ci-filter` parser: skill/knowledge-base md triggers `ci`/`runtime`/`unit`/`instance-ai-workflow-eval`; `docs/*.md` and `README.md` still trigger nothing.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)