### PR TITLE
feat(API): Add endpoint to update role-mapping rules

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -232,6 +232,7 @@ export {
 	PatchRoleMappingRuleDto,
 	type PatchRoleMappingRuleInput,
 } from './roles/patch-role-mapping-rule.dto';
+export { UpdateRoleMappingRulePublicDto } from './roles/update-role-mapping-rule-public.dto';
 export { MoveRoleMappingRuleDto } from './roles/move-role-mapping-rule.dto';
 export {
 	ListRoleMappingRuleQueryDto,

--- a/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
@@ -6,6 +6,5 @@ export class UpdateRoleMappingRulePublicDto extends Z.class({
 	expression: z.string().min(1),
 	role: z.string().min(1).max(128),
 	type: z.enum(['instance', 'project']),
-	order: z.number().int().min(0).optional(),
 	projectIds: z.array(z.string()).optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 
 export class UpdateRoleMappingRulePublicDto extends Z.class({
-	expression: z.string().min(1),
-	role: z.string().min(1).max(128),
-	type: z.enum(['instance', 'project']),
-	projectIds: z.array(z.string()),
+	expression: z.string().min(1).optional(),
+	role: z.string().min(1).max(128).optional(),
+	projectIds: z.array(z.string()).optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
@@ -6,5 +6,5 @@ export class UpdateRoleMappingRulePublicDto extends Z.class({
 	expression: z.string().min(1),
 	role: z.string().min(1).max(128),
 	type: z.enum(['instance', 'project']),
-	projectIds: z.array(z.string()).optional(),
+	projectIds: z.array(z.string()),
 }) {}

--- a/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/update-role-mapping-rule-public.dto.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class UpdateRoleMappingRulePublicDto extends Z.class({
+	expression: z.string().min(1),
+	role: z.string().min(1).max(128),
+	type: z.enum(['instance', 'project']),
+	order: z.number().int().min(0).optional(),
+	projectIds: z.array(z.string()).optional(),
+}) {}

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
@@ -149,7 +149,12 @@ describe('RoleMappingRuleController', () => {
 			const result = await controller.patch(req, res, patchBody, ruleId);
 
 			expect(result).toEqual(updated);
-			expect(roleMappingRuleService.patch).toHaveBeenCalledWith(ruleId, patchBody);
+			expect(roleMappingRuleService.patch).toHaveBeenCalledWith({
+				id: ruleId,
+				dto: patchBody,
+				userId: req.user.id,
+				userEmail: req.user.email,
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
@@ -144,12 +144,12 @@ describe('RoleMappingRuleController', () => {
 			};
 
 			licenseState.isProvisioningLicensed.mockReturnValue(true);
-			roleMappingRuleService.patch.mockResolvedValue(updated);
+			roleMappingRuleService.update.mockResolvedValue(updated);
 
 			const result = await controller.patch(req, res, patchBody, ruleId);
 
 			expect(result).toEqual(updated);
-			expect(roleMappingRuleService.patch).toHaveBeenCalledWith({
+			expect(roleMappingRuleService.update).toHaveBeenCalledWith({
 				id: ruleId,
 				dto: patchBody,
 				userId: req.user.id,

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
@@ -144,12 +144,12 @@ describe('RoleMappingRuleController', () => {
 			};
 
 			licenseState.isProvisioningLicensed.mockReturnValue(true);
-			roleMappingRuleService.update.mockResolvedValue(updated);
+			roleMappingRuleService.patch.mockResolvedValue(updated);
 
 			const result = await controller.patch(req, res, patchBody, ruleId);
 
 			expect(result).toEqual(updated);
-			expect(roleMappingRuleService.update).toHaveBeenCalledWith({
+			expect(roleMappingRuleService.patch).toHaveBeenCalledWith({
 				id: ruleId,
 				dto: patchBody,
 				userId: req.user.id,

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -621,12 +621,26 @@ describe('RoleMappingRuleService', () => {
 
 		it('should return 404 when rule id is unknown', async () => {
 			await expect(
-				service.patch('00000000-0000-4000-8000-000000000000', { expression: 'true' }),
+				service.patch({
+					id: '00000000-0000-4000-8000-000000000000',
+					dto: { expression: 'true' },
+					userId: testUser.id,
+					userEmail: testUser.email,
+				}),
 			).rejects.toThrow(NotFoundError);
+
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
 		it('should reject an empty patch payload', async () => {
-			await expect(service.patch(existingInstanceRule.id, {})).rejects.toThrow(BadRequestError);
+			await expect(
+				service.patch({
+					id: existingInstanceRule.id,
+					dto: {},
+					userId: testUser.id,
+					userEmail: testUser.email,
+				}),
+			).rejects.toThrow(BadRequestError);
 		});
 
 		it('should update expression and return loaded rule', async () => {
@@ -641,13 +655,22 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.save.mockImplementation(async (r) => r as RoleMappingRule);
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(updatedRule);
 
-			const result = await service.patch(existingInstanceRule.id, {
-				expression: 'claims.new === 1',
+			const result = await service.patch({
+				id: existingInstanceRule.id,
+				dto: { expression: 'claims.new === 1' },
+				userId: testUser.id,
+				userEmail: testUser.email,
 			});
 
 			expect(result.expression).toBe('claims.new === 1');
 			expect(result.role).toBe(globalRole.slug);
 			expect(roleMappingRuleRepository.save).toHaveBeenCalledTimes(1);
+			expect(eventService.emit).toHaveBeenCalledWith('role-mapping-rule-updated', {
+				user: { id: testUser.id, email: testUser.email },
+				ruleId: existingInstanceRule.id,
+				ruleType: 'instance',
+				patchedFields: ['expression'],
+			});
 		});
 
 		it('should return 409 when order collides with another rule', async () => {
@@ -675,9 +698,16 @@ describe('RoleMappingRuleService', () => {
 				return null;
 			});
 
-			await expect(service.patch(existingInstanceRule.id, { order: 5 })).rejects.toThrow(
-				ConflictError,
-			);
+			await expect(
+				service.patch({
+					id: existingInstanceRule.id,
+					dto: { order: 5 },
+					userId: testUser.id,
+					userEmail: testUser.email,
+				}),
+			).rejects.toThrow(ConflictError);
+
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
 		it('should allow patch that keeps the same type and order', async () => {
@@ -716,7 +746,12 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(updatedRule);
 
 			await expect(
-				service.patch(existingInstanceRule.id, { expression: 'true' }),
+				service.patch({
+					id: existingInstanceRule.id,
+					dto: { expression: 'true' },
+					userId: testUser.id,
+					userEmail: testUser.email,
+				}),
 			).resolves.toMatchObject({ order: 0, type: 'instance' });
 		});
 	});
@@ -1009,11 +1044,16 @@ describe('RoleMappingRuleService', () => {
 					makeRule('rule-3', 2, 'instance'),
 				]); // old type: instance has gap
 
-			await service.patch('rule-1', {
-				type: 'project',
-				role: projectRole.slug,
-				projectIds: ['p1'],
-				order: 0,
+			await service.patch({
+				id: 'rule-1',
+				dto: {
+					type: 'project',
+					role: projectRole.slug,
+					projectIds: ['p1'],
+					order: 0,
+				},
+				userId: testUser.id,
+				userEmail: testUser.email,
 			});
 
 			// Called twice: once for new type (project), once for old type (instance)

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -643,20 +643,6 @@ describe('RoleMappingRuleService', () => {
 			).rejects.toThrow(BadRequestError);
 		});
 
-		it('should reject a type change', async () => {
-			await expect(
-				service.patch({
-					id: existingInstanceRule.id,
-					dto: { type: 'project' },
-					userId: testUser.id,
-					userEmail: testUser.email,
-				}),
-			).rejects.toThrow(BadRequestError);
-
-			expect(roleMappingRuleRepository.save).not.toHaveBeenCalled();
-			expect(eventService.emit).not.toHaveBeenCalled();
-		});
-
 		it('should update expression and return loaded rule', async () => {
 			const updatedRule = {
 				...existingInstanceRule,

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -590,7 +590,7 @@ describe('RoleMappingRuleService', () => {
 		});
 	});
 
-	describe('update', () => {
+	describe('patch', () => {
 		const existingInstanceRule = {
 			id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
 			expression: 'claims.group === "admins"',
@@ -621,7 +621,7 @@ describe('RoleMappingRuleService', () => {
 
 		it('should return 404 when rule id is unknown', async () => {
 			await expect(
-				service.update({
+				service.patch({
 					id: '00000000-0000-4000-8000-000000000000',
 					dto: { expression: 'true' },
 					userId: testUser.id,
@@ -634,7 +634,7 @@ describe('RoleMappingRuleService', () => {
 
 		it('should reject an empty patch payload', async () => {
 			await expect(
-				service.update({
+				service.patch({
 					id: existingInstanceRule.id,
 					dto: {},
 					userId: testUser.id,
@@ -645,7 +645,7 @@ describe('RoleMappingRuleService', () => {
 
 		it('should reject a type change', async () => {
 			await expect(
-				service.update({
+				service.patch({
 					id: existingInstanceRule.id,
 					dto: { type: 'project' },
 					userId: testUser.id,
@@ -669,7 +669,7 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.save.mockImplementation(async (r) => r as RoleMappingRule);
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(updatedRule);
 
-			const result = await service.update({
+			const result = await service.patch({
 				id: existingInstanceRule.id,
 				dto: { expression: 'claims.new === 1' },
 				userId: testUser.id,
@@ -713,7 +713,7 @@ describe('RoleMappingRuleService', () => {
 			});
 
 			await expect(
-				service.update({
+				service.patch({
 					id: existingInstanceRule.id,
 					dto: { order: 5 },
 					userId: testUser.id,
@@ -760,7 +760,7 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(updatedRule);
 
 			await expect(
-				service.update({
+				service.patch({
 					id: existingInstanceRule.id,
 					dto: { expression: 'true' },
 					userId: testUser.id,

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -1010,5 +1010,57 @@ describe('RoleMappingRuleService', () => {
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'b' }, { order: 1 });
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'c' }, { order: 2 });
 		});
+
+		it('should normalize both types when type changes during patch', async () => {
+			const existingRule = {
+				id: 'rule-1',
+				expression: 'true',
+				role: globalRole,
+				type: 'instance',
+				order: 1,
+				projects: [],
+			} as unknown as RoleMappingRule;
+
+			roleMappingRuleRepository.findOne.mockImplementation(async (opts) => {
+				if (opts?.where && 'id' in opts.where) return existingRule;
+				return null;
+			});
+			roleMappingRuleRepository.save.mockResolvedValue(existingRule);
+			roleMappingRuleRepository.findOneOrFail.mockResolvedValue({
+				...existingRule,
+				type: 'project',
+				role: projectRole,
+				projects: [{ id: 'p1' } as Project],
+				createdAt: new Date('2025-01-01T00:00:00.000Z'),
+				updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+			} as unknown as RoleMappingRule);
+			projectRepository.findBy.mockResolvedValue([{ id: 'p1' } as Project]);
+			roleRepository.findOne.mockResolvedValue(projectRole);
+
+			roleMappingRuleRepository.find
+				.mockResolvedValueOnce([makeRule('rule-1', 0, 'project')]) // new type: project — no gap
+				.mockResolvedValueOnce([
+					makeRule('rule-2', 0, 'instance'),
+					makeRule('rule-3', 2, 'instance'),
+				]); // old type: instance has gap
+
+			await service.patch({
+				id: 'rule-1',
+				dto: {
+					type: 'project',
+					role: projectRole.slug,
+					projectIds: ['p1'],
+					order: 0,
+				},
+				userId: testUser.id,
+				userEmail: testUser.email,
+			});
+
+			// Called twice: once for new type (project), once for old type (instance)
+			expect(roleMappingRuleRepository.find).toHaveBeenCalledTimes(2);
+			// Project sequence has no gap — no transaction needed for it
+			// Instance sequence has gap [0, 2] — transaction called once
+			expect(transactionSpy).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -590,7 +590,7 @@ describe('RoleMappingRuleService', () => {
 		});
 	});
 
-	describe('patch', () => {
+	describe('update', () => {
 		const existingInstanceRule = {
 			id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
 			expression: 'claims.group === "admins"',
@@ -621,7 +621,7 @@ describe('RoleMappingRuleService', () => {
 
 		it('should return 404 when rule id is unknown', async () => {
 			await expect(
-				service.patch({
+				service.update({
 					id: '00000000-0000-4000-8000-000000000000',
 					dto: { expression: 'true' },
 					userId: testUser.id,
@@ -634,7 +634,7 @@ describe('RoleMappingRuleService', () => {
 
 		it('should reject an empty patch payload', async () => {
 			await expect(
-				service.patch({
+				service.update({
 					id: existingInstanceRule.id,
 					dto: {},
 					userId: testUser.id,
@@ -655,7 +655,7 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.save.mockImplementation(async (r) => r as RoleMappingRule);
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(updatedRule);
 
-			const result = await service.patch({
+			const result = await service.update({
 				id: existingInstanceRule.id,
 				dto: { expression: 'claims.new === 1' },
 				userId: testUser.id,
@@ -699,7 +699,7 @@ describe('RoleMappingRuleService', () => {
 			});
 
 			await expect(
-				service.patch({
+				service.update({
 					id: existingInstanceRule.id,
 					dto: { order: 5 },
 					userId: testUser.id,
@@ -746,7 +746,7 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(updatedRule);
 
 			await expect(
-				service.patch({
+				service.update({
 					id: existingInstanceRule.id,
 					dto: { expression: 'true' },
 					userId: testUser.id,
@@ -1044,7 +1044,7 @@ describe('RoleMappingRuleService', () => {
 					makeRule('rule-3', 2, 'instance'),
 				]); // old type: instance has gap
 
-			await service.patch({
+			await service.update({
 				id: 'rule-1',
 				dto: {
 					type: 'project',

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -643,6 +643,20 @@ describe('RoleMappingRuleService', () => {
 			).rejects.toThrow(BadRequestError);
 		});
 
+		it('should reject a type change', async () => {
+			await expect(
+				service.update({
+					id: existingInstanceRule.id,
+					dto: { type: 'project' },
+					userId: testUser.id,
+					userEmail: testUser.email,
+				}),
+			).rejects.toThrow(BadRequestError);
+
+			expect(roleMappingRuleRepository.save).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
 		it('should update expression and return loaded rule', async () => {
 			const updatedRule = {
 				...existingInstanceRule,
@@ -1009,58 +1023,6 @@ describe('RoleMappingRuleService', () => {
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'a' }, { order: 0 });
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'b' }, { order: 1 });
 			expect(updateSpy).toHaveBeenCalledWith(expect.anything(), { id: 'c' }, { order: 2 });
-		});
-
-		it('should normalize both types when type changes during patch', async () => {
-			const existingRule = {
-				id: 'rule-1',
-				expression: 'true',
-				role: globalRole,
-				type: 'instance',
-				order: 1,
-				projects: [],
-			} as unknown as RoleMappingRule;
-
-			roleMappingRuleRepository.findOne.mockImplementation(async (opts) => {
-				if (opts?.where && 'id' in opts.where) return existingRule;
-				return null;
-			});
-			roleMappingRuleRepository.save.mockResolvedValue(existingRule);
-			roleMappingRuleRepository.findOneOrFail.mockResolvedValue({
-				...existingRule,
-				type: 'project',
-				role: projectRole,
-				projects: [{ id: 'p1' } as Project],
-				createdAt: new Date('2025-01-01T00:00:00.000Z'),
-				updatedAt: new Date('2025-01-01T00:00:00.000Z'),
-			} as unknown as RoleMappingRule);
-			projectRepository.findBy.mockResolvedValue([{ id: 'p1' } as Project]);
-			roleRepository.findOne.mockResolvedValue(projectRole);
-
-			roleMappingRuleRepository.find
-				.mockResolvedValueOnce([makeRule('rule-1', 0, 'project')]) // new type: project — no gap
-				.mockResolvedValueOnce([
-					makeRule('rule-2', 0, 'instance'),
-					makeRule('rule-3', 2, 'instance'),
-				]); // old type: instance has gap
-
-			await service.update({
-				id: 'rule-1',
-				dto: {
-					type: 'project',
-					role: projectRole.slug,
-					projectIds: ['p1'],
-					order: 0,
-				},
-				userId: testUser.id,
-				userEmail: testUser.email,
-			});
-
-			// Called twice: once for new type (project), once for old type (instance)
-			expect(roleMappingRuleRepository.find).toHaveBeenCalledTimes(2);
-			// Project sequence has no gap — no transaction needed for it
-			// Instance sequence has gap [0, 2] — transaction called once
-			expect(transactionSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
@@ -96,16 +96,12 @@ export class RoleMappingRuleController {
 			return res.status(403).json({ message: 'Provisioning is not licensed' });
 		}
 
-		const result = await this.roleMappingRuleService.patch(id, body);
-
-		this.eventService.emit('role-mapping-rule-updated', {
-			user: { id: req.user.id, email: req.user.email },
-			ruleId: result.id,
-			ruleType: result.type,
-			patchedFields: Object.keys(body),
+		return await this.roleMappingRuleService.patch({
+			id,
+			dto: body,
+			userId: req.user.id,
+			userEmail: req.user.email,
 		});
-
-		return result;
 	}
 
 	@Delete('/:id')

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
@@ -96,7 +96,7 @@ export class RoleMappingRuleController {
 			return res.status(403).json({ message: 'Provisioning is not licensed' });
 		}
 
-		return await this.roleMappingRuleService.patch({
+		return await this.roleMappingRuleService.update({
 			id,
 			dto: body,
 			userId: req.user.id,

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
@@ -96,7 +96,7 @@ export class RoleMappingRuleController {
 			return res.status(403).json({ message: 'Provisioning is not licensed' });
 		}
 
-		return await this.roleMappingRuleService.update({
+		return await this.roleMappingRuleService.patch({
 			id,
 			dto: body,
 			userId: req.user.id,

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -178,7 +178,17 @@ export class RoleMappingRuleService {
 		throw new ConflictError('Could not create role mapping rule due to an order conflict');
 	}
 
-	async patch(id: string, dto: PatchRoleMappingRuleInput): Promise<RoleMappingRuleResponse> {
+	async patch({
+		id,
+		dto,
+		userId,
+		userEmail,
+	}: {
+		id: string;
+		dto: PatchRoleMappingRuleInput;
+		userId: string;
+		userEmail?: string;
+	}): Promise<RoleMappingRuleResponse> {
 		if (typeof id !== 'string' || id.length === 0) {
 			throw new BadRequestError('Rule id is required');
 		}
@@ -249,7 +259,16 @@ export class RoleMappingRuleService {
 			relations: ['projects', 'role'],
 		});
 
-		return this.toResponse(loaded);
+		const result = this.toResponse(loaded);
+
+		this.eventService.emit('role-mapping-rule-updated', {
+			user: { id: userId, email: userEmail },
+			ruleId: result.id,
+			ruleType: result.type,
+			patchedFields: Object.keys(dto),
+		});
+
+		return result;
 	}
 
 	async delete(id: string): Promise<{ ruleType: 'instance' | 'project' }> {

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -178,7 +178,7 @@ export class RoleMappingRuleService {
 		throw new ConflictError('Could not create role mapping rule due to an order conflict');
 	}
 
-	async patch({
+	async update({
 		id,
 		dto,
 		userId,

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -178,7 +178,7 @@ export class RoleMappingRuleService {
 		throw new ConflictError('Could not create role mapping rule due to an order conflict');
 	}
 
-	async update({
+	async patch({
 		id,
 		dto,
 		userId,

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -206,14 +206,15 @@ export class RoleMappingRuleService {
 			throw new NotFoundError('Could not find role mapping rule');
 		}
 
-		const type = rule.type as 'instance' | 'project';
+		const originalType = rule.type as 'instance' | 'project';
+		const mergedType = dto.type ?? originalType;
 		const mergedOrder = dto.order ?? rule.order;
 		const mergedExpression = dto.expression ?? rule.expression;
 		const mergedRoleSlug = dto.role ?? rule.role.slug;
 
 		const fallbackProjectIds = rule.projects.map((p) => p.id);
 		const uniqueProjectIds = assertAndNormalizeProjectIdsForRuleType(
-			type,
+			mergedType,
 			dto.projectIds,
 			fallbackProjectIds,
 		);
@@ -227,9 +228,9 @@ export class RoleMappingRuleService {
 			throw new NotFoundError(`Could not find role with slug "${mergedRoleSlug}"`);
 		}
 
-		assertRoleCompatibleWithMappingType(role, type);
+		assertRoleCompatibleWithMappingType(role, mergedType);
 
-		await this.assertOrderAvailable(type, mergedOrder, id);
+		await this.assertOrderAvailable(mergedType, mergedOrder, id);
 
 		const projects =
 			uniqueProjectIds.length > 0
@@ -242,12 +243,16 @@ export class RoleMappingRuleService {
 
 		rule.expression = mergedExpression;
 		rule.role = role;
+		rule.type = mergedType;
 		rule.order = mergedOrder;
 		rule.projects = projects;
 
 		await this.roleMappingRuleRepository.save(rule);
 
-		await this.normalizeOrderForType(type);
+		await this.normalizeOrderForType(mergedType);
+		if (originalType !== mergedType) {
+			await this.normalizeOrderForType(originalType);
+		}
 
 		const loaded = await this.roleMappingRuleRepository.findOneOrFail({
 			where: { id: rule.id },

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -206,19 +206,14 @@ export class RoleMappingRuleService {
 			throw new NotFoundError('Could not find role mapping rule');
 		}
 
-		if (dto.type !== undefined && dto.type !== rule.type) {
-			throw new BadRequestError("A role mapping rule's type cannot be changed");
-		}
-
-		const originalType = rule.type as 'instance' | 'project';
-		const mergedType = dto.type ?? originalType;
+		const type = rule.type as 'instance' | 'project';
 		const mergedOrder = dto.order ?? rule.order;
 		const mergedExpression = dto.expression ?? rule.expression;
 		const mergedRoleSlug = dto.role ?? rule.role.slug;
 
 		const fallbackProjectIds = rule.projects.map((p) => p.id);
 		const uniqueProjectIds = assertAndNormalizeProjectIdsForRuleType(
-			mergedType,
+			type,
 			dto.projectIds,
 			fallbackProjectIds,
 		);
@@ -232,9 +227,9 @@ export class RoleMappingRuleService {
 			throw new NotFoundError(`Could not find role with slug "${mergedRoleSlug}"`);
 		}
 
-		assertRoleCompatibleWithMappingType(role, mergedType);
+		assertRoleCompatibleWithMappingType(role, type);
 
-		await this.assertOrderAvailable(mergedType, mergedOrder, id);
+		await this.assertOrderAvailable(type, mergedOrder, id);
 
 		const projects =
 			uniqueProjectIds.length > 0
@@ -247,16 +242,12 @@ export class RoleMappingRuleService {
 
 		rule.expression = mergedExpression;
 		rule.role = role;
-		rule.type = mergedType;
 		rule.order = mergedOrder;
 		rule.projects = projects;
 
 		await this.roleMappingRuleRepository.save(rule);
 
-		await this.normalizeOrderForType(mergedType);
-		if (originalType !== mergedType) {
-			await this.normalizeOrderForType(originalType);
-		}
+		await this.normalizeOrderForType(type);
 
 		const loaded = await this.roleMappingRuleRepository.findOneOrFail({
 			where: { id: rule.id },

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -206,6 +206,10 @@ export class RoleMappingRuleService {
 			throw new NotFoundError('Could not find role mapping rule');
 		}
 
+		if (dto.type !== undefined && dto.type !== rule.type) {
+			throw new BadRequestError("A role mapping rule's type cannot be changed");
+		}
+
 		const originalType = rule.type as 'instance' | 'project';
 		const mergedType = dto.type ?? originalType;
 		const mergedOrder = dto.order ?? rule.order;

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -138,7 +138,7 @@ export class RoleMappingRulesPublicController {
 	@ApiKeyScope('roleMappingRule:update')
 	@ApiSummary('Update a role-mapping rule')
 	@ApiDescription(
-		"Replaces a rule's claim expression, role, type, order and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. Omitting `order` keeps the rule's current position; setting it moves the rule to that position within its type's evaluation sequence, or use the move endpoint instead. A value beyond the last position is clamped to the end. Setting a position already taken by another rule of the same type fails with a conflict.",
+		"Replaces a rule's claim expression, role, type and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.",
 	)
 	@ApiTags(['RoleMappingRule'])
 	@ApiResponse(200, RoleMappingRulePublicDto)

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -151,7 +151,7 @@ export class RoleMappingRulesPublicController {
 	): Promise<RoleMappingRulePublicDto> {
 		this.assertProvisioningLicensed();
 
-		const rule = await this.roleMappingRuleService.patch({
+		const rule = await this.roleMappingRuleService.update({
 			id: roleMappingRuleId,
 			dto: body,
 			userId: req.user.id,

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -18,9 +18,9 @@ import {
 	Body,
 	Get,
 	Param,
+	Patch,
 	Post,
 	PublicApiController,
-	Put,
 	Query,
 } from '@n8n/decorators';
 import type { Response } from 'express';
@@ -134,7 +134,7 @@ export class RoleMappingRulesPublicController {
 		return toRoleMappingRulePublicDto(rule);
 	}
 
-	@Put('/:roleMappingRuleId')
+	@Patch('/:roleMappingRuleId')
 	@ApiKeyScope('roleMappingRule:update')
 	@ApiSummary('Update a role-mapping rule')
 	@ApiDescription(
@@ -151,7 +151,7 @@ export class RoleMappingRulesPublicController {
 	): Promise<RoleMappingRulePublicDto> {
 		this.assertProvisioningLicensed();
 
-		const rule = await this.roleMappingRuleService.update({
+		const rule = await this.roleMappingRuleService.patch({
 			id: roleMappingRuleId,
 			dto: body,
 			userId: req.user.id,

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -140,6 +140,7 @@ export class RoleMappingRulesPublicController {
 	@ApiDescription(
 		"Replaces a rule's claim expression, role, type, order and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. Omitting `order` keeps the rule's current position; setting it moves the rule to that position within its type's evaluation sequence, or use the move endpoint instead. A value beyond the last position is clamped to the end. Setting a position already taken by another rule of the same type fails with a conflict.",
 	)
+	@ApiTags(['RoleMappingRule'])
 	@ApiResponse(200, RoleMappingRulePublicDto)
 	@ApiErrorResponse(404)
 	@ApiErrorResponse(409)

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -4,6 +4,7 @@ import {
 	RoleMappingRuleListPublicDto,
 	RoleMappingRuleListQueryPublicDto,
 	RoleMappingRulePublicDto,
+	UpdateRoleMappingRulePublicDto,
 } from '@n8n/api-types';
 import { LicenseState } from '@n8n/backend-common';
 import { AuthenticatedRequest } from '@n8n/db';
@@ -19,6 +20,7 @@ import {
 	Param,
 	Post,
 	PublicApiController,
+	Put,
 	Query,
 } from '@n8n/decorators';
 import type { Response } from 'express';
@@ -125,6 +127,33 @@ export class RoleMappingRulesPublicController {
 		const rule = await this.roleMappingRuleService.move({
 			id: roleMappingRuleId,
 			targetIndex: body.targetIndex,
+			userId: req.user.id,
+			userEmail: req.user.email,
+		});
+
+		return toRoleMappingRulePublicDto(rule);
+	}
+
+	@Put('/:roleMappingRuleId')
+	@ApiKeyScope('roleMappingRule:update')
+	@ApiSummary('Update a role-mapping rule')
+	@ApiDescription(
+		"Replaces a rule's claim expression, role, type, order and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. Omitting `order` keeps the rule's current position; setting it moves the rule to that position within its type's evaluation sequence, or use the move endpoint instead. A value beyond the last position is clamped to the end. Setting a position already taken by another rule of the same type fails with a conflict.",
+	)
+	@ApiResponse(200, RoleMappingRulePublicDto)
+	@ApiErrorResponse(404)
+	@ApiErrorResponse(409)
+	async updateRoleMappingRule(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('roleMappingRuleId') roleMappingRuleId: string,
+		@Body body: UpdateRoleMappingRulePublicDto,
+	): Promise<RoleMappingRulePublicDto> {
+		this.assertProvisioningLicensed();
+
+		const rule = await this.roleMappingRuleService.patch({
+			id: roleMappingRuleId,
+			dto: body,
 			userId: req.user.id,
 			userEmail: req.user.email,
 		});

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -138,7 +138,7 @@ export class RoleMappingRulesPublicController {
 	@ApiKeyScope('roleMappingRule:update')
 	@ApiSummary('Update a role-mapping rule')
 	@ApiDescription(
-		"Replaces a rule's claim expression, role, type and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.",
+		"Replaces a rule's claim expression, role, type and project assignments. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.",
 	)
 	@ApiTags(['RoleMappingRule'])
 	@ApiResponse(200, RoleMappingRulePublicDto)

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -138,7 +138,7 @@ export class RoleMappingRulesPublicController {
 	@ApiKeyScope('roleMappingRule:update')
 	@ApiSummary('Update a role-mapping rule')
 	@ApiDescription(
-		"Replaces a rule's claim expression, role and project assignments. `type` must match the rule's current type — a rule's type cannot be changed once created. The rule keeps its position in the evaluation order — use the move endpoint to reorder it.",
+		"Updates a rule's claim expression, role, and/or project assignments. A rule's type cannot be changed once created, so `type` isn't accepted here, and reordering is handled by the move endpoint.",
 	)
 	@ApiTags(['RoleMappingRule'])
 	@ApiResponse(200, RoleMappingRulePublicDto)

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -138,12 +138,11 @@ export class RoleMappingRulesPublicController {
 	@ApiKeyScope('roleMappingRule:update')
 	@ApiSummary('Update a role-mapping rule')
 	@ApiDescription(
-		"Replaces a rule's claim expression, role, type and project assignments. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.",
+		"Replaces a rule's claim expression, role and project assignments. `type` must match the rule's current type — a rule's type cannot be changed once created. The rule keeps its position in the evaluation order — use the move endpoint to reorder it.",
 	)
 	@ApiTags(['RoleMappingRule'])
 	@ApiResponse(200, RoleMappingRulePublicDto)
 	@ApiErrorResponse(404)
-	@ApiErrorResponse(409)
 	async updateRoleMappingRule(
 		req: AuthenticatedRequest,
 		_res: Response,

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
@@ -2,7 +2,7 @@ operationId: updateRoleMappingRule
 tags:
   - RoleMappingRule
 summary: Update a role-mapping rule
-description: Updates a rule's claim expression, role, and/or project assignments — omit a field to leave it unchanged. A rule's type cannot be changed once created, so `type` isn't accepted here, and reordering is handled by the move endpoint.
+description: Updates a rule's claim expression, role, and/or project assignments. A rule's type cannot be changed once created, so `type` isn't accepted here, and reordering is handled by the move endpoint.
 x-required-scope: roleMappingRule:update
 x-eov-operation-id: unreachable
 x-eov-operation-handler: v1/handlers/decorator-routed.handler

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
@@ -2,7 +2,7 @@ operationId: updateRoleMappingRule
 tags:
   - RoleMappingRule
 summary: Update a role-mapping rule
-description: Replaces a rule's claim expression, role, type, order and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. Omitting `order` keeps the rule's current position; setting it moves the rule to that position within its type's evaluation sequence, or use the move endpoint instead. A value beyond the last position is clamped to the end. Setting a position already taken by another rule of the same type fails with a conflict.
+description: Replaces a rule's claim expression, role, type and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.
 x-required-scope: roleMappingRule:update
 x-eov-operation-id: unreachable
 x-eov-operation-handler: v1/handlers/decorator-routed.handler
@@ -31,9 +31,6 @@ requestBody:
             enum:
               - instance
               - project
-          order:
-            type: integer
-            minimum: 0
           projectIds:
             type: array
             items:

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
@@ -1,0 +1,59 @@
+operationId: updateRoleMappingRule
+summary: Update a role-mapping rule
+description: Replaces a rule's claim expression, role, type, order and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. Omitting `order` keeps the rule's current position; setting it moves the rule to that position within its type's evaluation sequence, or use the move endpoint instead. A value beyond the last position is clamped to the end. Setting a position already taken by another rule of the same type fails with a conflict.
+x-required-scope: roleMappingRule:update
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    name: roleMappingRuleId
+    in: path
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          expression:
+            type: string
+            minLength: 1
+          role:
+            type: string
+            minLength: 1
+            maxLength: 128
+          type:
+            type: string
+            enum:
+              - instance
+              - project
+          order:
+            type: integer
+            minimum: 0
+          projectIds:
+            type: array
+            items:
+              type: string
+        required:
+          - expression
+          - role
+          - type
+responses:
+  '200':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          $ref: ../../../../shared/spec/schemas/roleMappingRulePublicDto.generated.yml
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml
+  '409':
+    $ref: ../../../../shared/spec/responses/conflict.yml

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
@@ -2,7 +2,7 @@ operationId: updateRoleMappingRule
 tags:
   - RoleMappingRule
 summary: Update a role-mapping rule
-description: Replaces a rule's claim expression, role, type and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.
+description: Replaces a rule's claim expression, role, type and project assignments. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.
 x-required-scope: roleMappingRule:update
 x-eov-operation-id: unreachable
 x-eov-operation-handler: v1/handlers/decorator-routed.handler
@@ -39,6 +39,7 @@ requestBody:
           - expression
           - role
           - type
+          - projectIds
 responses:
   '200':
     description: Operation successful.

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
@@ -1,4 +1,6 @@
 operationId: updateRoleMappingRule
+tags:
+  - RoleMappingRule
 summary: Update a role-mapping rule
 description: Replaces a rule's claim expression, role, type, order and project assignments. Set `projectIds` when `type` is `project`; omit it when `type` is `instance`. Omitting `order` keeps the rule's current position; setting it moves the rule to that position within its type's evaluation sequence, or use the move endpoint instead. A value beyond the last position is clamped to the end. Setting a position already taken by another rule of the same type fails with a conflict.
 x-required-scope: roleMappingRule:update

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
@@ -2,7 +2,7 @@ operationId: updateRoleMappingRule
 tags:
   - RoleMappingRule
 summary: Update a role-mapping rule
-description: Replaces a rule's claim expression, role, type and project assignments. The rule keeps its position in the evaluation order — use the move endpoint to reorder it. Changing `type` moves the rule into the other type's sequence at its current numeric position, which fails with a conflict if that position is already taken.
+description: Replaces a rule's claim expression, role and project assignments. `type` must match the rule's current type — a rule's type cannot be changed once created. The rule keeps its position in the evaluation order — use the move endpoint to reorder it.
 x-required-scope: roleMappingRule:update
 x-eov-operation-id: unreachable
 x-eov-operation-handler: v1/handlers/decorator-routed.handler
@@ -55,5 +55,3 @@ responses:
     $ref: ../../../../shared/spec/responses/forbidden.yml
   '404':
     $ref: ../../../../shared/spec/responses/notFound.yml
-  '409':
-    $ref: ../../../../shared/spec/responses/conflict.yml

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
@@ -2,7 +2,7 @@ operationId: updateRoleMappingRule
 tags:
   - RoleMappingRule
 summary: Update a role-mapping rule
-description: Replaces a rule's claim expression, role and project assignments. `type` must match the rule's current type — a rule's type cannot be changed once created. The rule keeps its position in the evaluation order — use the move endpoint to reorder it.
+description: Updates a rule's claim expression, role, and/or project assignments — omit a field to leave it unchanged. A rule's type cannot be changed once created, so `type` isn't accepted here, and reordering is handled by the move endpoint.
 x-required-scope: roleMappingRule:update
 x-eov-operation-id: unreachable
 x-eov-operation-handler: v1/handlers/decorator-routed.handler
@@ -26,20 +26,10 @@ requestBody:
             type: string
             minLength: 1
             maxLength: 128
-          type:
-            type: string
-            enum:
-              - instance
-              - project
           projectIds:
             type: array
             items:
               type: string
-        required:
-          - expression
-          - role
-          - type
-          - projectIds
 responses:
   '200':
     description: Operation successful.

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -30,7 +30,7 @@ paths:
     post:
       $ref: ./handlers/role-mapping-rules/spec/paths/moveRoleMappingRule.generated.yml
   /role-mapping-rules/{roleMappingRuleId}:
-    put:
+    patch:
       $ref: ./handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
   /roles:
     get:

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -29,6 +29,9 @@ paths:
   /role-mapping-rules/{roleMappingRuleId}/move:
     post:
       $ref: ./handlers/role-mapping-rules/spec/paths/moveRoleMappingRule.generated.yml
+  /role-mapping-rules/{roleMappingRuleId}:
+    put:
+      $ref: ./handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
   /roles:
     get:
       $ref: ./handlers/roles/spec/paths/getAllRoles.generated.yml

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -619,7 +619,7 @@ describe('Role mapping rules in Public API', () => {
 			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([first.id, second.id]);
 		});
 
-		it('converts an instance rule into a project rule', async () => {
+		it('rejects an attempt to change an instance rule to project with 400', async () => {
 			const rule = await createInstanceRule();
 
 			const response = await testServer
@@ -632,9 +632,8 @@ describe('Role mapping rules in Public API', () => {
 					projectIds: [teamProject.id],
 				});
 
-			expect(response.status).toBe(200);
-			expect(response.body.type).toBe('project');
-			expect(response.body.projectIds).toEqual([teamProject.id]);
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBe("A role mapping rule's type cannot be changed");
 		});
 
 		it('rejects with 404 when the rule id is unknown', async () => {
@@ -749,30 +748,6 @@ describe('Role mapping rules in Public API', () => {
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe('One or more projects were not found');
-		});
-
-		it('rejects with 409 when the new type already has a rule at the same position', async () => {
-			const agent = testServer.publicApiAgentFor(owner);
-
-			// Two instance rules, so the second one sits at order 1.
-			await createInstanceRule();
-			const second = await createInstanceRule({
-				expression: `${validInstancePayload.expression} || false`,
-			});
-
-			// Two project rules, so order 1 is taken in the project sequence too.
-			await createProjectRule();
-			await createProjectRule({ expression: 'claims.project === "beta"' });
-
-			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
-				expression: 'claims.project === "gamma"',
-				role: 'project:editor',
-				type: 'project',
-				projectIds: [teamProject.id],
-			});
-
-			expect(response.status).toBe(409);
-			expect(response.body.message).toContain('already exists');
 		});
 
 		it('rejects with 401 without an API key', async () => {

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -552,6 +552,7 @@ describe('Role mapping rules in Public API', () => {
 					expression: 'claims.group === "engineers"',
 					role: 'global:admin',
 					type: 'instance',
+					projectIds: [],
 				});
 
 			expect(response.status).toBe(200);
@@ -608,6 +609,7 @@ describe('Role mapping rules in Public API', () => {
 				expression: 'claims.group === "engineers"',
 				role: 'global:member',
 				type: 'instance',
+				projectIds: [],
 			});
 
 			expect(response.status).toBe(200);
@@ -643,6 +645,7 @@ describe('Role mapping rules in Public API', () => {
 					expression: 'claims.group === "engineers"',
 					role: 'global:member',
 					type: 'instance',
+					projectIds: [],
 				});
 
 			expect(response.status).toBe(404);
@@ -659,6 +662,7 @@ describe('Role mapping rules in Public API', () => {
 					expression: 'claims.group === "engineers"',
 					role: 'global:nonexistent',
 					type: 'instance',
+					projectIds: [],
 				});
 
 			expect(response.status).toBe(404);
@@ -682,22 +686,21 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.put(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: '', role: 'global:member', type: 'instance' });
+				.send({ expression: '', role: 'global:member', type: 'instance', projectIds: [] });
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe('String must contain at least 1 character(s)');
 		});
 
-		it('rejects a project rule without projectIds with 400', async () => {
+		it('rejects a body missing projectIds with 400', async () => {
 			const rule = await createInstanceRule();
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.put(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'true', role: 'project:editor', type: 'project' });
+				.send({ expression: 'true', role: 'global:member', type: 'instance' });
 
 			expect(response.status).toBe(400);
-			expect(response.body.message).toBe('projectIds is required when type is project');
 		});
 
 		it('rejects an instance rule carrying projectIds with 400', async () => {
@@ -725,7 +728,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.put(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'true', role: 'project:editor', type: 'instance' });
+				.send({ expression: 'true', role: 'project:editor', type: 'instance', projectIds: [] });
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe('Instance mapping rules must use a global role');
@@ -831,6 +834,7 @@ describe('Role mapping rules in Public API', () => {
 					expression: 'claims.group === "engineers"',
 					role: 'global:member',
 					type: 'instance',
+					projectIds: [],
 				});
 
 			expect(response.status).toBe(403);

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -1,4 +1,4 @@
-import type { CreateRoleMappingRuleDto } from '@n8n/api-types';
+import type { CreateRoleMappingRuleDto, RoleMappingRulePublicDto } from '@n8n/api-types';
 import { createTeamProject, testDb } from '@n8n/backend-test-utils';
 import { RoleMappingRuleRepository, type Project, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -22,6 +22,32 @@ describe('Role mapping rules in Public API', () => {
 		type: 'instance' as const,
 		order: 0,
 	};
+
+	const createRule = async (payload: Partial<CreateRoleMappingRuleDto>) => {
+		const response = await testServer
+			.publicApiAgentFor(owner)
+			.post('/role-mapping-rules')
+			.send(payload);
+
+		expect(response.status).toBe(201);
+
+		return response.body as RoleMappingRulePublicDto;
+	};
+
+	const createInstanceRule = async (overrides: Partial<CreateRoleMappingRuleDto> = {}) => {
+		const { expression, role, type } = validInstancePayload;
+
+		return await createRule({ expression, role, type, ...overrides });
+	};
+
+	const createProjectRule = async (overrides: Partial<CreateRoleMappingRuleDto> = {}) =>
+		await createRule({
+			expression: 'claims.project === "alpha"',
+			role: 'project:editor',
+			type: 'project',
+			projectIds: [teamProject.id],
+			...overrides,
+		});
 
 	beforeAll(async () => {
 		await testDb.init();
@@ -219,7 +245,7 @@ describe('Role mapping rules in Public API', () => {
 
 		it('returns the configured rules with the full public field set', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
+			await createInstanceRule();
 
 			const response = await agent.get('/role-mapping-rules');
 
@@ -241,12 +267,8 @@ describe('Role mapping rules in Public API', () => {
 
 		it('returns rules for a type in evaluation order', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
-			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
-			await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type })
-				.expect(201);
+			await createInstanceRule();
+			await createInstanceRule({ expression: `${validInstancePayload.expression} || false` });
 
 			const response = await agent.get('/role-mapping-rules').query({ type: 'instance' });
 
@@ -256,16 +278,8 @@ describe('Role mapping rules in Public API', () => {
 
 		it('filters by type', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
-			await agent
-				.post('/role-mapping-rules')
-				.send({
-					expression: 'claims.project === "alpha"',
-					role: 'project:editor',
-					type: 'project',
-					projectIds: [teamProject.id],
-				})
-				.expect(201);
+			await createInstanceRule();
+			await createProjectRule();
 
 			const instanceOnly = await agent.get('/role-mapping-rules').query({ type: 'instance' });
 			expect(instanceOnly.body.data).toHaveLength(1);
@@ -278,12 +292,8 @@ describe('Role mapping rules in Public API', () => {
 
 		it('paginates with cursor and limit', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
-			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
-			await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type })
-				.expect(201);
+			await createInstanceRule();
+			await createInstanceRule({ expression: `${validInstancePayload.expression} || false` });
 
 			const firstPage = await agent.get('/role-mapping-rules').query({ limit: 1 });
 			expect(firstPage.status).toBe(200);
@@ -356,21 +366,20 @@ describe('Role mapping rules in Public API', () => {
 	describe('POST /role-mapping-rules/{roleMappingRuleId}/move', () => {
 		it('moves a rule to an earlier position and returns 200', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
 
-			const first = await agent.post('/role-mapping-rules').send(validInstancePayload);
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
+			const first = await createInstanceRule();
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
 
 			const response = await agent
-				.post(`/role-mapping-rules/${second.body.id}/move`)
+				.post(`/role-mapping-rules/${second.id}/move`)
 				.send({ targetIndex: 0 });
 
 			expect(response.status).toBe(200);
 			expect(response.body).toEqual({
-				id: second.body.id,
-				expression: second.body.expression,
+				id: second.id,
+				expression: second.expression,
 				role: 'global:member',
 				type: 'instance',
 				order: 0,
@@ -380,25 +389,21 @@ describe('Role mapping rules in Public API', () => {
 			});
 
 			const list = await agent.get('/role-mapping-rules');
-			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([
-				second.body.id,
-				first.body.id,
-			]);
+			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([second.id, first.id]);
 		});
 
 		it('renumbers sibling rules of the same type', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
 
-			const first = await agent.post('/role-mapping-rules').send(validInstancePayload);
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
-			const third = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || true`, role, type });
+			const first = await createInstanceRule();
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
+			const third = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || true`,
+			});
 
-			await agent.post(`/role-mapping-rules/${third.body.id}/move`).send({ targetIndex: 0 });
+			await agent.post(`/role-mapping-rules/${third.id}/move`).send({ targetIndex: 0 });
 
 			const list = await agent.get('/role-mapping-rules');
 			expect(
@@ -407,37 +412,26 @@ describe('Role mapping rules in Public API', () => {
 					order: rule.order,
 				})),
 			).toEqual([
-				{ id: third.body.id, order: 0 },
-				{ id: first.body.id, order: 1 },
-				{ id: second.body.id, order: 2 },
+				{ id: third.id, order: 0 },
+				{ id: first.id, order: 1 },
+				{ id: second.id, order: 2 },
 			]);
 		});
 
 		it("only renumbers the moved rule's own type", async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
 
-			await agent.post('/role-mapping-rules').send(validInstancePayload);
-			const secondInstance = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
-
-			const firstProject = await agent.post('/role-mapping-rules').send({
-				expression: 'claims.project === "alpha"',
-				role: 'project:editor',
-				type: 'project',
-				projectIds: [teamProject.id],
+			await createInstanceRule();
+			const secondInstance = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
 			});
-			const secondProject = await agent.post('/role-mapping-rules').send({
+
+			const firstProject = await createProjectRule();
+			const secondProject = await createProjectRule({
 				expression: 'claims.project === "beta"',
-				role: 'project:editor',
-				type: 'project',
-				projectIds: [teamProject.id],
 			});
 
-			await agent
-				.post(`/role-mapping-rules/${secondInstance.body.id}/move`)
-				.send({ targetIndex: 0 });
+			await agent.post(`/role-mapping-rules/${secondInstance.id}/move`).send({ targetIndex: 0 });
 
 			const projectRules = await agent.get('/role-mapping-rules').query({ type: 'project' });
 			expect(
@@ -446,40 +440,36 @@ describe('Role mapping rules in Public API', () => {
 					order: rule.order,
 				})),
 			).toEqual([
-				{ id: firstProject.body.id, order: 0 },
-				{ id: secondProject.body.id, order: 1 },
+				{ id: firstProject.id, order: 0 },
+				{ id: secondProject.id, order: 1 },
 			]);
 		});
 
 		it('clamps a targetIndex beyond the last position to the end', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
 
-			const first = await agent.post('/role-mapping-rules').send(validInstancePayload);
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
+			const first = await createInstanceRule();
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
 
 			const response = await agent
-				.post(`/role-mapping-rules/${first.body.id}/move`)
+				.post(`/role-mapping-rules/${first.id}/move`)
 				.send({ targetIndex: 99 });
 
 			expect(response.status).toBe(200);
 			expect(response.body.order).toBe(1);
 
 			const list = await agent.get('/role-mapping-rules');
-			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([
-				second.body.id,
-				first.body.id,
-			]);
+			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([second.id, first.id]);
 		});
 
 		it('rejects a negative targetIndex with 400', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const created = await agent.post('/role-mapping-rules').send(validInstancePayload);
+			const created = await createInstanceRule();
 
 			const response = await agent
-				.post(`/role-mapping-rules/${created.body.id}/move`)
+				.post(`/role-mapping-rules/${created.id}/move`)
 				.send({ targetIndex: -1 });
 
 			expect(response.status).toBe(400);
@@ -487,9 +477,9 @@ describe('Role mapping rules in Public API', () => {
 
 		it('rejects a missing targetIndex with 400', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const created = await agent.post('/role-mapping-rules').send(validInstancePayload);
+			const created = await createInstanceRule();
 
-			const response = await agent.post(`/role-mapping-rules/${created.body.id}/move`).send({});
+			const response = await agent.post(`/role-mapping-rules/${created.id}/move`).send({});
 
 			expect(response.status).toBe(400);
 		});
@@ -523,14 +513,11 @@ describe('Role mapping rules in Public API', () => {
 
 		it('rejects with 403 when the key lacks roleMappingRule:update', async () => {
 			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
-			const created = await testServer
-				.publicApiAgentFor(owner)
-				.post('/role-mapping-rules')
-				.send(validInstancePayload);
+			const created = await createInstanceRule();
 
 			const response = await testServer
 				.publicApiAgentFor(scopedOwner)
-				.post(`/role-mapping-rules/${created.body.id}/move`)
+				.post(`/role-mapping-rules/${created.id}/move`)
 				.send({ targetIndex: 0 });
 
 			expect(response.status).toBe(403);
@@ -538,13 +525,13 @@ describe('Role mapping rules in Public API', () => {
 
 		it('rejects with 403 when provisioning is not licensed', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const created = await agent.post('/role-mapping-rules').send(validInstancePayload);
+			const created = await createInstanceRule();
 
 			testServer.license.disable('feat:saml');
 			testServer.license.disable('feat:oidc');
 
 			const response = await agent
-				.post(`/role-mapping-rules/${created.body.id}/move`)
+				.post(`/role-mapping-rules/${created.id}/move`)
 				.send({ targetIndex: 0 });
 
 			expect(response.status).toBe(403);
@@ -555,33 +542,6 @@ describe('Role mapping rules in Public API', () => {
 	});
 
 	describe('PUT /role-mapping-rules/{roleMappingRuleId}', () => {
-		const createInstanceRule = async () => {
-			const response = await testServer
-				.publicApiAgentFor(owner)
-				.post('/role-mapping-rules')
-				.send(validInstancePayload);
-
-			expect(response.status).toBe(201);
-
-			return response.body as { id: string; order: number };
-		};
-
-		const createProjectRule = async () => {
-			const response = await testServer
-				.publicApiAgentFor(owner)
-				.post('/role-mapping-rules')
-				.send({
-					expression: 'claims.project === "alpha"',
-					role: 'project:editor',
-					type: 'project',
-					projectIds: [teamProject.id],
-				});
-
-			expect(response.status).toBe(201);
-
-			return response.body as { id: string; order: number };
-		};
-
 		it('replaces an instance rule and returns 200', async () => {
 			const rule = await createInstanceRule();
 
@@ -638,14 +598,13 @@ describe('Role mapping rules in Public API', () => {
 
 		it('keeps the rule at its position in the evaluation order', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
 
 			const first = await createInstanceRule();
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
 
-			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
+			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
 				expression: 'claims.group === "engineers"',
 				role: 'global:member',
 				type: 'instance',
@@ -655,23 +614,20 @@ describe('Role mapping rules in Public API', () => {
 			expect(response.body.order).toBe(1);
 
 			const list = await agent.get('/role-mapping-rules');
-			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([
-				first.id,
-				second.body.id,
-			]);
+			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([first.id, second.id]);
 		});
 
 		it('allows a rule to keep its position when order is set explicitly', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
+			const { role, type } = validInstancePayload;
 
 			await createInstanceRule();
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
 
-			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
-				expression: second.body.expression,
+			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
+				expression: second.expression,
 				role,
 				type,
 				order: 1,
@@ -683,15 +639,15 @@ describe('Role mapping rules in Public API', () => {
 
 		it('clamps an order beyond the last position to the end', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
+			const { role, type } = validInstancePayload;
 
 			const first = await createInstanceRule();
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
-			const third = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || true`, role, type });
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
+			const third = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || true`,
+			});
 
 			const response = await agent.put(`/role-mapping-rules/${first.id}`).send({
 				expression: validInstancePayload.expression,
@@ -705,23 +661,23 @@ describe('Role mapping rules in Public API', () => {
 
 			const list = await agent.get('/role-mapping-rules');
 			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([
-				second.body.id,
-				third.body.id,
+				second.id,
+				third.id,
 				first.id,
 			]);
 		});
 
 		it('rejects with 409 when order collides with another rule of the same type', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
+			const { role, type } = validInstancePayload;
 
 			await createInstanceRule();
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
 
-			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
-				expression: second.body.expression,
+			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
+				expression: second.expression,
 				role,
 				type,
 				order: 0,
@@ -875,24 +831,18 @@ describe('Role mapping rules in Public API', () => {
 
 		it('rejects with 409 when the new type already has a rule at the same position', async () => {
 			const agent = testServer.publicApiAgentFor(owner);
-			const { expression, role, type } = validInstancePayload;
 
 			// Two instance rules, so the second one sits at order 1.
 			await createInstanceRule();
-			const second = await agent
-				.post('/role-mapping-rules')
-				.send({ expression: `${expression} || false`, role, type });
+			const second = await createInstanceRule({
+				expression: `${validInstancePayload.expression} || false`,
+			});
 
 			// Two project rules, so order 1 is taken in the project sequence too.
 			await createProjectRule();
-			await agent.post('/role-mapping-rules').send({
-				expression: 'claims.project === "beta"',
-				role: 'project:editor',
-				type: 'project',
-				projectIds: [teamProject.id],
-			});
+			await createProjectRule({ expression: 'claims.project === "beta"' });
 
-			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
+			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
 				expression: 'claims.project === "gamma"',
 				role: 'project:editor',
 				type: 'project',

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -617,76 +617,6 @@ describe('Role mapping rules in Public API', () => {
 			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([first.id, second.id]);
 		});
 
-		it('allows a rule to keep its position when order is set explicitly', async () => {
-			const agent = testServer.publicApiAgentFor(owner);
-			const { role, type } = validInstancePayload;
-
-			await createInstanceRule();
-			const second = await createInstanceRule({
-				expression: `${validInstancePayload.expression} || false`,
-			});
-
-			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
-				expression: second.expression,
-				role,
-				type,
-				order: 1,
-			});
-
-			expect(response.status).toBe(200);
-			expect(response.body.order).toBe(1);
-		});
-
-		it('clamps an order beyond the last position to the end', async () => {
-			const agent = testServer.publicApiAgentFor(owner);
-			const { role, type } = validInstancePayload;
-
-			const first = await createInstanceRule();
-			const second = await createInstanceRule({
-				expression: `${validInstancePayload.expression} || false`,
-			});
-			const third = await createInstanceRule({
-				expression: `${validInstancePayload.expression} || true`,
-			});
-
-			const response = await agent.put(`/role-mapping-rules/${first.id}`).send({
-				expression: validInstancePayload.expression,
-				role,
-				type,
-				order: 999,
-			});
-
-			expect(response.status).toBe(200);
-			expect(response.body.order).toBe(2);
-
-			const list = await agent.get('/role-mapping-rules');
-			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([
-				second.id,
-				third.id,
-				first.id,
-			]);
-		});
-
-		it('rejects with 409 when order collides with another rule of the same type', async () => {
-			const agent = testServer.publicApiAgentFor(owner);
-			const { role, type } = validInstancePayload;
-
-			await createInstanceRule();
-			const second = await createInstanceRule({
-				expression: `${validInstancePayload.expression} || false`,
-			});
-
-			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
-				expression: second.expression,
-				role,
-				type,
-				order: 0,
-			});
-
-			expect(response.status).toBe(409);
-			expect(response.body.message).toContain('already exists');
-		});
-
 		it('converts an instance rule into a project rule', async () => {
 			const rule = await createInstanceRule();
 
@@ -756,17 +686,6 @@ describe('Role mapping rules in Public API', () => {
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe('String must contain at least 1 character(s)');
-		});
-
-		it('rejects a negative order with 400', async () => {
-			const rule = await createInstanceRule();
-
-			const response = await testServer
-				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'true', role: 'global:member', type: 'instance', order: -1 });
-
-			expect(response.status).toBe(400);
 		});
 
 		it('rejects a project rule without projectIds with 400', async () => {

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -542,7 +542,7 @@ describe('Role mapping rules in Public API', () => {
 	});
 
 	describe('PATCH /role-mapping-rules/{roleMappingRuleId}', () => {
-		it('replaces an instance rule and returns 200', async () => {
+		it('updates all provided fields on an instance rule and returns 200', async () => {
 			const rule = await createInstanceRule();
 
 			const response = await testServer
@@ -551,7 +551,6 @@ describe('Role mapping rules in Public API', () => {
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:admin',
-					type: 'instance',
 					projectIds: [],
 				});
 
@@ -586,15 +585,12 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'claims.project === "beta"',
-					role: 'project:editor',
-					type: 'project',
-					projectIds: [otherProject.id],
-				});
+				.send({ projectIds: [otherProject.id] });
 
 			expect(response.status).toBe(200);
 			expect(response.body.projectIds).toEqual([otherProject.id]);
+			expect(response.body.expression).toBe(rule.expression);
+			expect(response.body.role).toBe(rule.role);
 		});
 
 		it('keeps the rule at its position in the evaluation order', async () => {
@@ -605,12 +601,9 @@ describe('Role mapping rules in Public API', () => {
 				expression: `${validInstancePayload.expression} || false`,
 			});
 
-			const response = await agent.patch(`/role-mapping-rules/${second.id}`).send({
-				expression: 'claims.group === "engineers"',
-				role: 'global:member',
-				type: 'instance',
-				projectIds: [],
-			});
+			const response = await agent
+				.patch(`/role-mapping-rules/${second.id}`)
+				.send({ expression: 'claims.group === "engineers"' });
 
 			expect(response.status).toBe(200);
 			expect(response.body.order).toBe(1);
@@ -619,33 +612,37 @@ describe('Role mapping rules in Public API', () => {
 			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([first.id, second.id]);
 		});
 
-		it('rejects an attempt to change an instance rule to project with 400', async () => {
+		it("ignores an attempt to change an instance rule's type", async () => {
 			const rule = await createInstanceRule();
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'claims.project === "alpha"',
-					role: 'project:editor',
-					type: 'project',
-					projectIds: [teamProject.id],
-				});
+				.send({ expression: 'claims.group === "engineers"', type: 'project' });
 
-			expect(response.status).toBe(400);
-			expect(response.body.message).toBe("A role mapping rule's type cannot be changed");
+			expect(response.status).toBe(200);
+			expect(response.body.type).toBe('instance');
+			expect(response.body.expression).toBe('claims.group === "engineers"');
+		});
+
+		it("ignores an attempt to change a project rule's type", async () => {
+			const rule = await createProjectRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/role-mapping-rules/${rule.id}`)
+				.send({ expression: 'claims.project === "beta"', type: 'instance' });
+
+			expect(response.status).toBe(200);
+			expect(response.body.type).toBe('project');
+			expect(response.body.expression).toBe('claims.project === "beta"');
 		});
 
 		it('rejects with 404 when the rule id is unknown', async () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch('/role-mapping-rules/00000000-0000-4000-8000-000000000000')
-				.send({
-					expression: 'claims.group === "engineers"',
-					role: 'global:member',
-					type: 'instance',
-					projectIds: [],
-				});
+				.send({ expression: 'claims.group === "engineers"' });
 
 			expect(response.status).toBe(404);
 			expect(response.body.message).toBe('Could not find role mapping rule');
@@ -657,26 +654,34 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'claims.group === "engineers"',
-					role: 'global:nonexistent',
-					type: 'instance',
-					projectIds: [],
-				});
+				.send({ role: 'global:nonexistent' });
 
 			expect(response.status).toBe(404);
 			expect(response.body.message).toBe('Could not find role with slug "global:nonexistent"');
 		});
 
-		it('rejects a partial body with 400', async () => {
+		it('rejects an empty body with 400', async () => {
 			const rule = await createInstanceRule();
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'claims.group === "engineers"' });
+				.send({});
 
 			expect(response.status).toBe(400);
+			expect(response.body.message).toBe('At least one field is required');
+		});
+
+		it('rejects a body with only an unsupported field with 400', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/role-mapping-rules/${rule.id}`)
+				.send({ type: 'project' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBe('At least one field is required');
 		});
 
 		it('rejects a malformed body with 400', async () => {
@@ -685,21 +690,10 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: '', role: 'global:member', type: 'instance', projectIds: [] });
+				.send({ expression: '' });
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe('String must contain at least 1 character(s)');
-		});
-
-		it('rejects a body missing projectIds with 400', async () => {
-			const rule = await createInstanceRule();
-
-			const response = await testServer
-				.publicApiAgentFor(owner)
-				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'true', role: 'global:member', type: 'instance' });
-
-			expect(response.status).toBe(400);
 		});
 
 		it('rejects an instance rule carrying projectIds with 400', async () => {
@@ -708,12 +702,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'true',
-					role: 'global:member',
-					type: 'instance',
-					projectIds: [teamProject.id],
-				});
+				.send({ projectIds: [teamProject.id] });
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe(
@@ -727,7 +716,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'true', role: 'project:editor', type: 'instance', projectIds: [] });
+				.send({ role: 'project:editor' });
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe('Instance mapping rules must use a global role');
@@ -739,12 +728,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'true',
-					role: 'project:editor',
-					type: 'project',
-					projectIds: ['00000000-0000-4000-8000-000000000000'],
-				});
+				.send({ projectIds: ['00000000-0000-4000-8000-000000000000'] });
 
 			expect(response.status).toBe(400);
 			expect(response.body.message).toBe('One or more projects were not found');
@@ -756,11 +740,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentWithoutApiKey()
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'claims.group === "engineers"',
-					role: 'global:member',
-					type: 'instance',
-				});
+				.send({ expression: 'claims.group === "engineers"' });
 
 			expect(response.status).toBe(401);
 		});
@@ -771,11 +751,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentWithApiKey('invalid-key')
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'claims.group === "engineers"',
-					role: 'global:member',
-					type: 'instance',
-				});
+				.send({ expression: 'claims.group === "engineers"' });
 
 			expect(response.status).toBe(401);
 		});
@@ -787,11 +763,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(scopedOwner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'claims.group === "engineers"',
-					role: 'global:member',
-					type: 'instance',
-				});
+				.send({ expression: 'claims.group === "engineers"' });
 
 			expect(response.status).toBe(403);
 		});
@@ -805,12 +777,7 @@ describe('Role mapping rules in Public API', () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({
-					expression: 'claims.group === "engineers"',
-					role: 'global:member',
-					type: 'instance',
-					projectIds: [],
-				});
+				.send({ expression: 'claims.group === "engineers"' });
 
 			expect(response.status).toBe(403);
 			expect(response.body.message).toBe('Provisioning is not licensed');

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -541,13 +541,13 @@ describe('Role mapping rules in Public API', () => {
 		});
 	});
 
-	describe('PUT /role-mapping-rules/{roleMappingRuleId}', () => {
+	describe('PATCH /role-mapping-rules/{roleMappingRuleId}', () => {
 		it('replaces an instance rule and returns 200', async () => {
 			const rule = await createInstanceRule();
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:admin',
@@ -585,7 +585,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.project === "beta"',
 					role: 'project:editor',
@@ -605,7 +605,7 @@ describe('Role mapping rules in Public API', () => {
 				expression: `${validInstancePayload.expression} || false`,
 			});
 
-			const response = await agent.put(`/role-mapping-rules/${second.id}`).send({
+			const response = await agent.patch(`/role-mapping-rules/${second.id}`).send({
 				expression: 'claims.group === "engineers"',
 				role: 'global:member',
 				type: 'instance',
@@ -624,7 +624,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.project === "alpha"',
 					role: 'project:editor',
@@ -639,7 +639,7 @@ describe('Role mapping rules in Public API', () => {
 		it('rejects with 404 when the rule id is unknown', async () => {
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put('/role-mapping-rules/00000000-0000-4000-8000-000000000000')
+				.patch('/role-mapping-rules/00000000-0000-4000-8000-000000000000')
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:member',
@@ -656,7 +656,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:nonexistent',
@@ -673,7 +673,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({ expression: 'claims.group === "engineers"' });
 
 			expect(response.status).toBe(400);
@@ -684,7 +684,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({ expression: '', role: 'global:member', type: 'instance', projectIds: [] });
 
 			expect(response.status).toBe(400);
@@ -696,7 +696,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({ expression: 'true', role: 'global:member', type: 'instance' });
 
 			expect(response.status).toBe(400);
@@ -707,7 +707,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'true',
 					role: 'global:member',
@@ -726,7 +726,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({ expression: 'true', role: 'project:editor', type: 'instance', projectIds: [] });
 
 			expect(response.status).toBe(400);
@@ -738,7 +738,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'true',
 					role: 'project:editor',
@@ -755,7 +755,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentWithoutApiKey()
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:member',
@@ -770,7 +770,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentWithApiKey('invalid-key')
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:member',
@@ -786,7 +786,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(scopedOwner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:member',
@@ -804,7 +804,7 @@ describe('Role mapping rules in Public API', () => {
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.put(`/role-mapping-rules/${rule.id}`)
+				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({
 					expression: 'claims.group === "engineers"',
 					role: 'global:member',

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -553,4 +553,421 @@ describe('Role mapping rules in Public API', () => {
 			testServer.license.enable('feat:saml');
 		});
 	});
+
+	describe('PUT /role-mapping-rules/{roleMappingRuleId}', () => {
+		const createInstanceRule = async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send(validInstancePayload);
+
+			expect(response.status).toBe(201);
+
+			return response.body as { id: string; order: number };
+		};
+
+		const createProjectRule = async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({
+					expression: 'claims.project === "alpha"',
+					role: 'project:editor',
+					type: 'project',
+					projectIds: [teamProject.id],
+				});
+
+			expect(response.status).toBe(201);
+
+			return response.body as { id: string; order: number };
+		};
+
+		it('replaces an instance rule and returns 200', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.group === "engineers"',
+					role: 'global:admin',
+					type: 'instance',
+				});
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({
+				id: rule.id,
+				expression: 'claims.group === "engineers"',
+				role: 'global:admin',
+				type: 'instance',
+				order: 0,
+				projectIds: [],
+				createdAt: expect.any(String),
+				updatedAt: expect.any(String),
+			});
+
+			const stored = await Container.get(RoleMappingRuleRepository).findOne({
+				where: { id: rule.id },
+				relations: ['projects', 'role'],
+			});
+
+			assert(stored, 'Rule should still be stored in the database');
+
+			expect(stored.expression).toBe('claims.group === "engineers"');
+			expect(stored.role.slug).toBe('global:admin');
+			expect(stored.projects).toHaveLength(0);
+		});
+
+		it('replaces the project assignments of a project rule', async () => {
+			const rule = await createProjectRule();
+			const otherProject = await createTeamProject(undefined, owner);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.project === "beta"',
+					role: 'project:editor',
+					type: 'project',
+					projectIds: [otherProject.id],
+				});
+
+			expect(response.status).toBe(200);
+			expect(response.body.projectIds).toEqual([otherProject.id]);
+		});
+
+		it('keeps the rule at its position in the evaluation order', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			const { expression, role, type } = validInstancePayload;
+
+			const first = await createInstanceRule();
+			const second = await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type });
+
+			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
+				expression: 'claims.group === "engineers"',
+				role: 'global:member',
+				type: 'instance',
+			});
+
+			expect(response.status).toBe(200);
+			expect(response.body.order).toBe(1);
+
+			const list = await agent.get('/role-mapping-rules');
+			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([
+				first.id,
+				second.body.id,
+			]);
+		});
+
+		it('allows a rule to keep its position when order is set explicitly', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			const { expression, role, type } = validInstancePayload;
+
+			await createInstanceRule();
+			const second = await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type });
+
+			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
+				expression: second.body.expression,
+				role,
+				type,
+				order: 1,
+			});
+
+			expect(response.status).toBe(200);
+			expect(response.body.order).toBe(1);
+		});
+
+		it('clamps an order beyond the last position to the end', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			const { expression, role, type } = validInstancePayload;
+
+			const first = await createInstanceRule();
+			const second = await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type });
+			const third = await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || true`, role, type });
+
+			const response = await agent.put(`/role-mapping-rules/${first.id}`).send({
+				expression: validInstancePayload.expression,
+				role,
+				type,
+				order: 999,
+			});
+
+			expect(response.status).toBe(200);
+			expect(response.body.order).toBe(2);
+
+			const list = await agent.get('/role-mapping-rules');
+			expect(list.body.data.map((rule: { id: string }) => rule.id)).toEqual([
+				second.body.id,
+				third.body.id,
+				first.id,
+			]);
+		});
+
+		it('rejects with 409 when order collides with another rule of the same type', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			const { expression, role, type } = validInstancePayload;
+
+			await createInstanceRule();
+			const second = await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type });
+
+			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
+				expression: second.body.expression,
+				role,
+				type,
+				order: 0,
+			});
+
+			expect(response.status).toBe(409);
+			expect(response.body.message).toContain('already exists');
+		});
+
+		it('converts an instance rule into a project rule', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.project === "alpha"',
+					role: 'project:editor',
+					type: 'project',
+					projectIds: [teamProject.id],
+				});
+
+			expect(response.status).toBe(200);
+			expect(response.body.type).toBe('project');
+			expect(response.body.projectIds).toEqual([teamProject.id]);
+		});
+
+		it('rejects with 404 when the rule id is unknown', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put('/role-mapping-rules/00000000-0000-4000-8000-000000000000')
+				.send({
+					expression: 'claims.group === "engineers"',
+					role: 'global:member',
+					type: 'instance',
+				});
+
+			expect(response.status).toBe(404);
+			expect(response.body.message).toBe('Could not find role mapping rule');
+		});
+
+		it('rejects with 404 when the role slug is unknown', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.group === "engineers"',
+					role: 'global:nonexistent',
+					type: 'instance',
+				});
+
+			expect(response.status).toBe(404);
+			expect(response.body.message).toBe('Could not find role with slug "global:nonexistent"');
+		});
+
+		it('rejects a partial body with 400', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({ expression: 'claims.group === "engineers"' });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects a malformed body with 400', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({ expression: '', role: 'global:member', type: 'instance' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBe('String must contain at least 1 character(s)');
+		});
+
+		it('rejects a negative order with 400', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({ expression: 'true', role: 'global:member', type: 'instance', order: -1 });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects a project rule without projectIds with 400', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({ expression: 'true', role: 'project:editor', type: 'project' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBe('projectIds is required when type is project');
+		});
+
+		it('rejects an instance rule carrying projectIds with 400', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'true',
+					role: 'global:member',
+					type: 'instance',
+					projectIds: [teamProject.id],
+				});
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBe(
+				'projectIds must be omitted or empty when type is instance',
+			);
+		});
+
+		it('rejects a role incompatible with the rule type with 400', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({ expression: 'true', role: 'project:editor', type: 'instance' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBe('Instance mapping rules must use a global role');
+		});
+
+		it('rejects an unknown project with 400', async () => {
+			const rule = await createProjectRule();
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'true',
+					role: 'project:editor',
+					type: 'project',
+					projectIds: ['00000000-0000-4000-8000-000000000000'],
+				});
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toBe('One or more projects were not found');
+		});
+
+		it('rejects with 409 when the new type already has a rule at the same position', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+			const { expression, role, type } = validInstancePayload;
+
+			// Two instance rules, so the second one sits at order 1.
+			await createInstanceRule();
+			const second = await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type });
+
+			// Two project rules, so order 1 is taken in the project sequence too.
+			await createProjectRule();
+			await agent.post('/role-mapping-rules').send({
+				expression: 'claims.project === "beta"',
+				role: 'project:editor',
+				type: 'project',
+				projectIds: [teamProject.id],
+			});
+
+			const response = await agent.put(`/role-mapping-rules/${second.body.id}`).send({
+				expression: 'claims.project === "gamma"',
+				role: 'project:editor',
+				type: 'project',
+				projectIds: [teamProject.id],
+			});
+
+			expect(response.status).toBe(409);
+			expect(response.body.message).toContain('already exists');
+		});
+
+		it('rejects with 401 without an API key', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentWithoutApiKey()
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.group === "engineers"',
+					role: 'global:member',
+					type: 'instance',
+				});
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 401 with an invalid API key', async () => {
+			const rule = await createInstanceRule();
+
+			const response = await testServer
+				.publicApiAgentWithApiKey('invalid-key')
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.group === "engineers"',
+					role: 'global:member',
+					type: 'instance',
+				});
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when the key lacks roleMappingRule:update', async () => {
+			const rule = await createInstanceRule();
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
+
+			const response = await testServer
+				.publicApiAgentFor(scopedOwner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.group === "engineers"',
+					role: 'global:member',
+					type: 'instance',
+				});
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects with 403 when provisioning is not licensed', async () => {
+			const rule = await createInstanceRule();
+
+			testServer.license.disable('feat:saml');
+			testServer.license.disable('feat:oidc');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/role-mapping-rules/${rule.id}`)
+				.send({
+					expression: 'claims.group === "engineers"',
+					role: 'global:member',
+					type: 'instance',
+				});
+
+			expect(response.status).toBe(403);
+			expect(response.body.message).toBe('Provisioning is not licensed');
+
+			testServer.license.enable('feat:saml');
+		});
+	});
 });

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -50,7 +50,7 @@
 		"POST /role-mapping-rules/{roleMappingRuleId}/move": {
 			"status": "gap"
 		},
-		"PUT /role-mapping-rules/{roleMappingRuleId}": {
+		"PATCH /role-mapping-rules/{roleMappingRuleId}": {
 			"status": "gap"
 		},
 		"GET /settings/security-policy": {

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -50,6 +50,9 @@
 		"POST /role-mapping-rules/{roleMappingRuleId}/move": {
 			"status": "gap"
 		},
+		"PUT /role-mapping-rules/{roleMappingRuleId}": {
+			"status": "gap"
+		},
 		"GET /settings/security-policy": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/v1/role-mapping-rules/{roleMappingRuleId}` to the Public API, a thin `@PublicApiController` wrapper over `RoleMappingRuleService.patch`
- New `UpdateRoleMappingRulePublicDto`: `expression`, `role` and `projectIds`can be updated
- Moves `role-mapping-rule-updated` event emission into the shared service

Demo:
https://www.loom.com/share/760af985fa524a5f97a5d3c709b9f0d4

## How to test

With an API key that has the `roleMappingRule:update` scope and an instance with the provisioning licence enabled:

```bash
curl -X PATCH "http://localhost:5678/api/v1/role-mapping-rules/<ruleId>" \
  -H "X-N8N-API-KEY: $KEY" \
  -H "Content-Type: application/json" \
  -d '{"expression": "claims.group === \"admins\"", "role": "global:admin" }'
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-50

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

