### PR TITLE
test: Add benchmarks for memory guard execution overhead

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -117,6 +117,7 @@ jobs:
               packages/testing/performance/**
               packages/workflow/src/**
               packages/@n8n/expression-runtime/src/**
+              packages/cli/src/memory-guard/**
               .github/workflows/test-bench-reusable.yml
             e2e-performance:
               packages/testing/playwright/tests/performance/**

--- a/packages/testing/performance/README.md
+++ b/packages/testing/performance/README.md
@@ -78,6 +78,7 @@ my operation    20,000   0.04   0.20   0.05   0.10  ±0.5%   10000
 |------|------------------|----------------|
 | Expression Engine | `={{ }}` evaluation speed | Runs for every node parameter |
 | Workflow graph traversal | `getChildNodes` / `getParentNodes` on branching graphs | Runs on every execution (`checkReadyForExecution`) and across the editor; must stay linear in graph size |
+| Memory guard estimator | `estimateItemsSize` on realistic and pathological node outputs | Runs once per output branch per node run when `N8N_MEMORY_GUARD_ENABLED` is set; sampling, walk budget and depth cap must keep it flat as outputs grow |
 
 
 ## Tips

--- a/packages/testing/performance/benchmarks/memory-guard/estimate-items-size.bench.ts
+++ b/packages/testing/performance/benchmarks/memory-guard/estimate-items-size.bench.ts
@@ -1,0 +1,147 @@
+/**
+ * Memory guard estimator benchmarks.
+ *
+ * `estimateItemsSize` runs in `ExecutionMemoryTracker.onNodeFinish`, once per
+ * output branch per run of every node, on every execution. It therefore sits on
+ * the hottest path the memory guard touches, and its cost must stay far below
+ * the cost of executing a node.
+ *
+ * The estimator walks values instead of serializing them. Three bounds keep the
+ * walk cheap: it measures at most SAMPLE_SIZE (10) items per output, visits at
+ * most WALK_BUDGET (10,000) values, and descends at most MAX_DEPTH (64) levels.
+ * The benchmarks below exercise each bound, plus the shapes a real workflow
+ * produces.
+ *
+ * The estimator lives in `packages/cli`, which this package does not depend on.
+ * It imports one type and nothing else, so a relative import is enough and adds
+ * no dependency edge.
+ *
+ * Run: pnpm --filter=@n8n/performance bench
+ */
+import { bench, describe } from 'vitest';
+
+import { estimateItemsSize } from '../../../../cli/src/memory-guard/estimate-items-size';
+import { BENCH_OPTIONS } from '../bench-options';
+import {
+	bigStringItems,
+	binaryItems,
+	deepItems,
+	fanOutItem,
+	flatItems,
+	warmSeenSet,
+	wideItems,
+} from './fixtures/items';
+
+// A production execution keeps one WeakSet for its whole life, and every node
+// adds to it. Each cold benchmark therefore starts from an empty set, which is
+// what the first node of an execution sees.
+
+describe('Memory guard estimator: realistic outputs', () => {
+	const empty: never[] = [];
+	bench(
+		'empty output (floor: call plus WeakSet allocation)',
+		() => {
+			estimateItemsSize(empty, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+
+	const flat100 = flatItems(100);
+	bench(
+		'100 flat items, 12 fields each (typical node output)',
+		() => {
+			estimateItemsSize(flat100, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+
+	const flat10k = flatItems(10_000);
+	bench(
+		'10,000 flat items, 12 fields each (sampling must keep this flat)',
+		() => {
+			estimateItemsSize(flat10k, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+
+	const binary100 = binaryItems(100, 50_000);
+	bench(
+		'100 items with a 50 KB base64 buffer each',
+		() => {
+			estimateItemsSize(binary100, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+
+	const passThrough = flatItems(100);
+	const warmSeen = warmSeenSet(passThrough);
+	bench(
+		'100 flat items already counted (pass-through node)',
+		() => {
+			estimateItemsSize(passThrough, warmSeen);
+		},
+		BENCH_OPTIONS,
+	);
+});
+
+describe('Memory guard estimator: cost drivers', () => {
+	const wide = wideItems(100, 200);
+	bench(
+		'100 items, 200 fields each (field count drives cost)',
+		() => {
+			estimateItemsSize(wide, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+
+	const bigStrings = bigStringItems(100, 50_000);
+	bench(
+		'100 items, one 50 KB string each (string length is read, not walked)',
+		() => {
+			estimateItemsSize(bigStrings, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+
+	const deep = deepItems(100, 40);
+	bench(
+		'100 items nested 40 levels (inside MAX_DEPTH)',
+		() => {
+			estimateItemsSize(deep, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+});
+
+describe('Memory guard estimator: pathological shapes', () => {
+	const tooDeep = deepItems(100, 500);
+	bench(
+		'100 items nested 500 levels (MAX_DEPTH must cap this)',
+		() => {
+			estimateItemsSize(tooDeep, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+
+	const fanOut = fanOutItem(5_000);
+	bench(
+		'1 item holding ~25,000 values (WALK_BUDGET must cap this)',
+		() => {
+			estimateItemsSize(fanOut, new WeakSet());
+		},
+		BENCH_OPTIONS,
+	);
+});
+
+describe('Memory guard estimator: whole execution', () => {
+	// 20 nodes, 100 items each, one shared WeakSet, as the tracker holds it.
+	const outputs = Array.from({ length: 20 }, () => flatItems(100));
+	bench(
+		'20 nodes x 100 flat items, one shared WeakSet',
+		() => {
+			const seen = new WeakSet<object>();
+			for (const items of outputs) estimateItemsSize(items, seen);
+		},
+		BENCH_OPTIONS,
+	);
+});

--- a/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
+++ b/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
@@ -1,0 +1,151 @@
+/**
+ * What the memory guard costs a real workflow execution.
+ *
+ * `estimate-items-size.bench.ts` times the estimator on its own. That says the
+ * function is fast, but not what share of an execution it takes. This file
+ * supplies the denominator: the same workflow runs twice, once with the guard's
+ * lifecycle handlers attached and once without, so the ratio between the two
+ * rows is the guard's cost.
+ *
+ * "Guard off" is master's behaviour. `ExecutionMemoryTracker.onNodeStart` and
+ * `onNodeFinish` both return immediately when `config.enabled` is false, so
+ * attaching nothing is faithful.
+ *
+ * "Guard on" replicates the body of those two methods
+ * (`packages/cli/src/memory-guard/execution-memory-tracker.ts`). The tracker
+ * itself is not imported, because its `@Service` and `@OnLifecycleEvent`
+ * decorators need decorator support this package does not enable. The work
+ * measured is the same: one Map lookup per node, plus the estimator walk over
+ * every output branch.
+ *
+ * Node count varies so the per-node slope is readable. A single stub node is
+ * cheaper than the engine's fixed startup cost, and reading one chain length
+ * alone would overstate the guard's share.
+ *
+ * Run: pnpm --filter=@n8n/performance bench
+ */
+import { ExecutionLifecycleHooks, WorkflowExecute } from 'n8n-core';
+import type { IRunExecutionData, ITaskData, IWorkflowBase } from 'n8n-workflow';
+import { bench, describe } from 'vitest';
+
+import { estimateItemsSize } from '../../../../cli/src/memory-guard/estimate-items-size';
+import { BENCH_OPTIONS } from '../bench-options';
+import { flatItems } from './fixtures/items';
+import {
+	buildAdditionalData,
+	buildChainWorkflow,
+	buildRunExecutionData,
+	silenceEngineLogging,
+} from './fixtures/workflow-run';
+
+silenceEngineLogging();
+
+/** Mirrors `ExecutionMemoryEntry` in the tracker. */
+interface TrackerEntry {
+	estimatedBytes: number;
+	inNodeSince: number | undefined;
+	seen: WeakSet<object>;
+	runExecutionData: IRunExecutionData | undefined;
+}
+
+function attachGuardHandlers(hooks: ExecutionLifecycleHooks) {
+	const executions = new Map<string, TrackerEntry>();
+
+	const getOrCreate = (executionId: string) => {
+		let entry = executions.get(executionId);
+		if (!entry) {
+			entry = {
+				estimatedBytes: 0,
+				inNodeSince: undefined,
+				seen: new WeakSet(),
+				runExecutionData: undefined,
+			};
+			executions.set(executionId, entry);
+		}
+		return entry;
+	};
+
+	hooks.addHandler('nodeExecuteBefore', function () {
+		getOrCreate(this.executionId).inNodeSince = Date.now();
+	});
+
+	hooks.addHandler('nodeExecuteAfter', function (_nodeName, taskData: ITaskData, executionData) {
+		const entry = getOrCreate(this.executionId);
+		entry.inNodeSince = undefined;
+		entry.runExecutionData = executionData;
+
+		const outputs = taskData.data;
+		if (!outputs) return;
+
+		for (const runs of Object.values(outputs)) {
+			if (!Array.isArray(runs)) continue;
+			for (const items of runs) {
+				if (items) entry.estimatedBytes += estimateItemsSize(items, entry.seen);
+			}
+		}
+	});
+}
+
+const workflowData = {} as unknown as IWorkflowBase;
+
+/**
+ * Constructing a `Workflow` resolves parameters for every node, which costs far
+ * more than one execution. Build it and the seed items once per case, outside
+ * the measured callback, so only the run itself is timed.
+ *
+ * Everything else must be fresh per iteration: run data accumulates node output,
+ * and `WorkflowExecute` carries per-run status and an abort controller.
+ */
+function makeCase(nodeCount: number, itemCount: number) {
+	const workflow = buildChainWorkflow(nodeCount);
+	const items = flatItems(itemCount);
+
+	return async (withGuard: boolean) => {
+		const hooks = new ExecutionLifecycleHooks('manual', 'bench', workflowData);
+		if (withGuard) attachGuardHandlers(hooks);
+
+		const additionalData = buildAdditionalData(hooks);
+		const runExecutionData = buildRunExecutionData(workflow, items);
+		const workflowExecute = new WorkflowExecute(additionalData, 'manual', runExecutionData);
+
+		await workflowExecute.processRunExecutionData(workflow);
+	};
+}
+
+// Each case pairs "off" and "on" over identical work. Read the two rows
+// together: the ratio between them is what the guard costs. Node count varies so
+// the per-node slope is visible, since the engine's fixed startup cost does not
+// scale with it.
+const CASES = [
+	{ nodes: 5, items: 100 },
+	{ nodes: 20, items: 100 },
+	{ nodes: 20, items: 1_000 },
+];
+
+/**
+ * A whole execution allocates, so GC pauses land in the samples and inflate the
+ * mean. Run longer than the default to push the pauses down into the noise.
+ */
+const EXECUTION_BENCH_OPTIONS = { ...BENCH_OPTIONS, time: 5_000, warmupTime: 2_000 };
+
+for (const { nodes, items } of CASES) {
+	const run = makeCase(nodes, items);
+
+	describe(`Workflow execution: ${nodes} nodes, ${items} items`, () => {
+		bench(
+			`guard off (${nodes} nodes, ${items} items)`,
+			async () => {
+				await run(false);
+			},
+			EXECUTION_BENCH_OPTIONS,
+		);
+
+		bench(
+			`guard on (${nodes} nodes, ${items} items)`,
+			async () => {
+				await run(true);
+			},
+			EXECUTION_BENCH_OPTIONS,
+		);
+	});
+}

--- a/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
+++ b/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
@@ -128,9 +128,27 @@ const CASES = [
  */
 const EXECUTION_BENCH_OPTIONS = { ...BENCH_OPTIONS, time: 5_000, warmupTime: 2_000 };
 
-for (const { nodes, items } of CASES) {
-	const run = makeCase(nodes, items);
+const runners = CASES.map(({ nodes, items }) => ({ nodes, items, run: makeCase(nodes, items) }));
 
+/**
+ * Warm both paths before any measurement, at module load.
+ *
+ * `bench()` runs in declaration order, so "guard off" always went first and paid
+ * the JIT cost that "guard on" then inherited. Under CodSpeed that does not wash
+ * out: simulation mode counts instructions over few iterations, and vitest's own
+ * `warmupIterations` does not apply. The first report showed "guard on" beating
+ * "guard off" by 3%, which is impossible, because "on" does strictly more work.
+ *
+ * Warming both here means each measured run starts from the same compiled state.
+ */
+for (const { run } of runners) {
+	for (let i = 0; i < 30; i++) {
+		await run(false);
+		await run(true);
+	}
+}
+
+for (const { nodes, items, run } of runners) {
 	describe(`Workflow execution: ${nodes} nodes, ${items} items`, () => {
 		bench(
 			`guard off (${nodes} nodes, ${items} items)`,

--- a/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
+++ b/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
@@ -131,21 +131,22 @@ const EXECUTION_BENCH_OPTIONS = { ...BENCH_OPTIONS, time: 5_000, warmupTime: 2_0
 const runners = CASES.map(({ nodes, items }) => ({ nodes, items, run: makeCase(nodes, items) }));
 
 /**
- * Warm both paths before any measurement, at module load.
+ * Executions performed per measured callback.
  *
- * `bench()` runs in declaration order, so "guard off" always went first and paid
- * the JIT cost that "guard on" then inherited. Under CodSpeed that does not wash
- * out: simulation mode counts instructions over few iterations, and vitest's own
- * `warmupIterations` does not apply. The first report showed "guard on" beating
- * "guard off" by 3%, which is impossible, because "on" does strictly more work.
+ * CodSpeed measures exactly one call of the callback, between
+ * `InstrumentHooks.startBenchmark()` and `stopBenchmark()` (see
+ * `@codspeed/vitest-plugin/dist/analysis.mjs`). One workflow run takes a few
+ * milliseconds and allocates, so whether a GC lands inside that window decides
+ * the count. The first two CI runs showed "guard on" beating "guard off", which
+ * is impossible, and the small cases swung by a factor of two between runs.
  *
- * Warming both here means each measured run starts from the same compiled state.
+ * Looping here makes the measured window large enough that one GC is a small
+ * share of it instead of the whole signal.
  */
-for (const { run } of runners) {
-	for (let i = 0; i < 30; i++) {
-		await run(false);
-		await run(true);
-	}
+const ITERATIONS = 50;
+
+async function runMany(run: (withGuard: boolean) => Promise<void>, withGuard: boolean) {
+	for (let i = 0; i < ITERATIONS; i++) await run(withGuard);
 }
 
 for (const { nodes, items, run } of runners) {
@@ -153,7 +154,7 @@ for (const { nodes, items, run } of runners) {
 		bench(
 			`guard off (${nodes} nodes, ${items} items)`,
 			async () => {
-				await run(false);
+				await runMany(run, false);
 			},
 			EXECUTION_BENCH_OPTIONS,
 		);
@@ -161,7 +162,7 @@ for (const { nodes, items, run } of runners) {
 		bench(
 			`guard on (${nodes} nodes, ${items} items)`,
 			async () => {
-				await run(true);
+				await runMany(run, true);
 			},
 			EXECUTION_BENCH_OPTIONS,
 		);

--- a/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
+++ b/packages/testing/performance/benchmarks/memory-guard/execution-overhead.bench.ts
@@ -116,10 +116,13 @@ function makeCase(nodeCount: number, itemCount: number) {
 // together: the ratio between them is what the guard costs. Node count varies so
 // the per-node slope is visible, since the engine's fixed startup cost does not
 // scale with it.
+// `iterations` is tuned per case so the measured callback lands in the hundreds
+// of milliseconds under CodSpeed. Above one second CodSpeed reports two
+// significant figures ("2.4 s"), which cannot express a 1% difference.
 const CASES = [
-	{ nodes: 5, items: 100 },
-	{ nodes: 20, items: 100 },
-	{ nodes: 20, items: 1_000 },
+	{ nodes: 5, items: 100, iterations: 50 },
+	{ nodes: 20, items: 100, iterations: 50 },
+	{ nodes: 20, items: 1_000, iterations: 10 },
 ];
 
 /**
@@ -128,10 +131,13 @@ const CASES = [
  */
 const EXECUTION_BENCH_OPTIONS = { ...BENCH_OPTIONS, time: 5_000, warmupTime: 2_000 };
 
-const runners = CASES.map(({ nodes, items }) => ({ nodes, items, run: makeCase(nodes, items) }));
+const runners = CASES.map((testCase) => ({
+	...testCase,
+	run: makeCase(testCase.nodes, testCase.items),
+}));
 
 /**
- * Executions performed per measured callback.
+ * Each measured callback performs many executions, not one.
  *
  * CodSpeed measures exactly one call of the callback, between
  * `InstrumentHooks.startBenchmark()` and `stopBenchmark()` (see
@@ -140,21 +146,23 @@ const runners = CASES.map(({ nodes, items }) => ({ nodes, items, run: makeCase(n
  * the count. The first two CI runs showed "guard on" beating "guard off", which
  * is impossible, and the small cases swung by a factor of two between runs.
  *
- * Looping here makes the measured window large enough that one GC is a small
- * share of it instead of the whole signal.
+ * Looping makes the measured window large enough that one GC is a small share of
+ * it instead of the whole signal.
  */
-const ITERATIONS = 50;
-
-async function runMany(run: (withGuard: boolean) => Promise<void>, withGuard: boolean) {
-	for (let i = 0; i < ITERATIONS; i++) await run(withGuard);
+async function runMany(
+	run: (withGuard: boolean) => Promise<void>,
+	withGuard: boolean,
+	iterations: number,
+) {
+	for (let i = 0; i < iterations; i++) await run(withGuard);
 }
 
-for (const { nodes, items, run } of runners) {
+for (const { nodes, items, iterations, run } of runners) {
 	describe(`Workflow execution: ${nodes} nodes, ${items} items`, () => {
 		bench(
 			`guard off (${nodes} nodes, ${items} items)`,
 			async () => {
-				await runMany(run, false);
+				await runMany(run, false, iterations);
 			},
 			EXECUTION_BENCH_OPTIONS,
 		);
@@ -162,7 +170,7 @@ for (const { nodes, items, run } of runners) {
 		bench(
 			`guard on (${nodes} nodes, ${items} items)`,
 			async () => {
-				await runMany(run, true);
+				await runMany(run, true, iterations);
 			},
 			EXECUTION_BENCH_OPTIONS,
 		);

--- a/packages/testing/performance/benchmarks/memory-guard/fixtures/items.ts
+++ b/packages/testing/performance/benchmarks/memory-guard/fixtures/items.ts
@@ -1,0 +1,103 @@
+/**
+ * Node output fixtures for the memory guard estimator benchmarks.
+ *
+ * Every builder is deterministic, so a run measures the same bytes as the run
+ * before it and CodSpeed can compare instruction counts across commits.
+ */
+import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
+
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+/** Deterministic filler string of the requested length. */
+function filler(length: number, seed: number): string {
+	let out = '';
+	for (let i = 0; i < length; i++) out += ALPHABET[(i + seed) % ALPHABET.length];
+	return out;
+}
+
+/** The shape an HTTP Request or database node typically returns: flat, ~12 fields. */
+function flatRecord(index: number): IDataObject {
+	return {
+		id: index,
+		orderNumber: `ORD-${100000 + index}`,
+		customerName: filler(18, index),
+		customerEmail: `${filler(10, index)}@example.com`,
+		status: index % 3 === 0 ? 'shipped' : 'pending',
+		currency: 'EUR',
+		total: 49.99 + index,
+		taxRate: 0.19,
+		createdAt: '2026-08-20T09:15:00.000Z',
+		updatedAt: '2026-08-20T11:42:00.000Z',
+		isPaid: index % 2 === 0,
+		notes: filler(40, index),
+	};
+}
+
+/** `count` flat records. The common case for every node on every execution. */
+export function flatItems(count: number): INodeExecutionData[] {
+	return Array.from({ length: count }, (_, i) => ({ json: flatRecord(i) }));
+}
+
+/** `count` records with `fieldCount` flat fields each. Cost scales with field count. */
+export function wideItems(count: number, fieldCount: number): INodeExecutionData[] {
+	return Array.from({ length: count }, (_, i) => {
+		const json: IDataObject = {};
+		for (let f = 0; f < fieldCount; f++) json[`field_${f}`] = filler(12, i + f);
+		return { json };
+	});
+}
+
+/** `count` records nested `depth` levels deep. Above MAX_DEPTH the walk must stop. */
+export function deepItems(count: number, depth: number): INodeExecutionData[] {
+	return Array.from({ length: count }, (_, i) => {
+		let node: IDataObject = { leaf: filler(16, i), index: i };
+		for (let d = 0; d < depth; d++) node = { level: d, child: node };
+		return { json: node };
+	});
+}
+
+/**
+ * `count` records each holding one large string. The walk reads `.length`, so
+ * these must cost the same as short strings.
+ */
+export function bigStringItems(count: number, charsPerItem: number): INodeExecutionData[] {
+	const payload = filler(charsPerItem, 7);
+	return Array.from({ length: count }, (_, i) => ({
+		json: { id: i, payload },
+	}));
+}
+
+/** `count` records carrying a base64 binary buffer, as a file-producing node returns. */
+export function binaryItems(count: number, base64Chars: number): INodeExecutionData[] {
+	const data = filler(base64Chars, 3);
+	return Array.from({ length: count }, (_, i) => ({
+		json: { id: i, fileName: `report-${i}.pdf` },
+		binary: {
+			data: { data, mimeType: 'application/pdf', fileName: `report-${i}.pdf` },
+		},
+	}));
+}
+
+/**
+ * One record whose object graph holds `leafCount` values. Nothing bounds this
+ * shape except WALK_BUDGET, so it is the worst case a single item can reach.
+ */
+export function fanOutItem(leafCount: number): INodeExecutionData[] {
+	const json: IDataObject = {};
+	for (let i = 0; i < leafCount; i++) {
+		json[`k${i}`] = { a: i, b: filler(8, i), c: [i, i + 1, i + 2] };
+	}
+	return [{ json }];
+}
+
+/** A WeakSet already holding every object in `items`, as after a pass-through node. */
+export function warmSeenSet(items: INodeExecutionData[]): WeakSet<object> {
+	const seen = new WeakSet<object>();
+	const add = (value: unknown) => {
+		if (value === null || typeof value !== 'object') return;
+		seen.add(value);
+		for (const entry of Object.values(value)) add(entry);
+	};
+	for (const item of items) add(item.json);
+	return seen;
+}

--- a/packages/testing/performance/benchmarks/memory-guard/fixtures/workflow-run.ts
+++ b/packages/testing/performance/benchmarks/memory-guard/fixtures/workflow-run.ts
@@ -1,0 +1,160 @@
+/**
+ * A minimal in-process workflow execution harness for the memory guard
+ * benchmarks.
+ *
+ * The setup mirrors `packages/core/nodes-testing/node-test-harness.ts`
+ * (`executeWorkflow`), reduced to what a benchmark needs: a chain of stub nodes,
+ * a real `ExecutionLifecycleHooks`, and no DI container.
+ *
+ * Two details keep the container out of the measurement:
+ * - `executionData.runtimeData` is pre-set, so `establishExecutionContext`
+ *   returns early instead of resolving `ExecutionContextService`.
+ * - The stub node declares no properties, so validation has nothing to check.
+ */
+import type {
+	IExecuteFunctions,
+	IHttpRequestOptions,
+	INode,
+	INodeExecutionData,
+	INodeType,
+	INodeTypes,
+	IRun,
+	IRunExecutionData,
+	IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
+import {
+	createRunExecutionData,
+	LoggerProxy,
+	NodeConnectionTypes,
+	NodeHelpers,
+	Workflow,
+} from 'n8n-workflow';
+
+const NODE_TYPE_NAME = 'benchPassThrough';
+
+/**
+ * Silences this module graph's copy of the logger proxy. `vitest.config.ts` sets
+ * `N8N_LOG_LEVEL=silent`, which covers the engine's own (CJS) copy; this covers
+ * the ESM copy the bench files resolve.
+ */
+export function silenceEngineLogging() {
+	const noOp = () => {};
+	LoggerProxy.init({ error: noOp, warn: noOp, info: noOp, debug: noOp });
+}
+
+/** Returns its input unchanged, so per-node cost is engine plus hooks only. */
+const passThroughNode: INodeType = {
+	description: {
+		displayName: 'Bench Pass Through',
+		name: NODE_TYPE_NAME,
+		group: ['transform'],
+		version: 1,
+		description: 'A minimal node for benchmarking the execution engine',
+		defaults: { name: 'Bench Pass Through' },
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
+		properties: [],
+	},
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		return await Promise.resolve([this.getInputData()]);
+	},
+};
+
+const nodeTypeData: Record<string, { type: INodeType; sourcePath: string }> = {
+	[NODE_TYPE_NAME]: { type: passThroughNode, sourcePath: '' },
+};
+
+const nodeTypes: INodeTypes = {
+	getByName: (name) => nodeTypeData[name].type,
+	getByNameAndVersion: (name, version) =>
+		NodeHelpers.getVersionedNodeType(nodeTypeData[name].type, version),
+	getKnownTypes: () => ({}),
+};
+
+/** A linear chain of `length` pass-through nodes, so cost scales with node count. */
+export function buildChainWorkflow(length: number): Workflow {
+	const nodes: INode[] = [];
+	const connections: Record<
+		string,
+		{ main: Array<Array<{ node: string; type: 'main'; index: number }>> }
+	> = {};
+
+	for (let i = 0; i < length; i++) {
+		const name = `node${i}`;
+		nodes.push({
+			id: name,
+			name,
+			type: NODE_TYPE_NAME,
+			typeVersion: 1,
+			position: [i * 100, 0],
+			parameters: {},
+		});
+		if (i > 0) {
+			connections[`node${i - 1}`] = { main: [[{ node: name, type: 'main', index: 0 }]] };
+		}
+	}
+
+	return new Workflow({
+		id: 'bench',
+		nodes,
+		connections,
+		active: false,
+		nodeTypes,
+		settings: { executionOrder: 'v1' },
+	});
+}
+
+/**
+ * `IWorkflowExecuteAdditionalData` reduced to the fields the engine reads on a
+ * normal node run. `restartExecutionId` stays undefined on purpose: a truthy
+ * value sends the engine down the resume path.
+ */
+export function buildAdditionalData(hooks: unknown): IWorkflowExecuteAdditionalData {
+	return {
+		credentialsHelper: {
+			authenticate: async (_c: unknown, _t: string, requestParams: IHttpRequestOptions) =>
+				await Promise.resolve(requestParams),
+		},
+		executionId: 'bench',
+		currentNodeExecutionIndex: 0,
+		restartExecutionId: undefined,
+		webhookWaitingBaseUrl: 'http://localhost/waiting-webhook',
+		formWaitingBaseUrl: 'http://localhost/waiting-form',
+		webhookBaseUrl: 'http://localhost/webhook',
+		webhookTestBaseUrl: 'http://localhost/webhook-test',
+		instanceBaseUrl: 'http://localhost',
+		variables: {},
+		hooks,
+	} as unknown as IWorkflowExecuteAdditionalData;
+}
+
+/**
+ * Run data seeded with `items` on the first node. Two details matter:
+ * - The chain is seeded on `node0` explicitly. `workflow.getStartNode()` returns
+ *   undefined here, because the stub node is neither a trigger nor one of
+ *   `STARTING_NODE_TYPES`.
+ * - `runtimeData` is pre-set, so the engine skips the DI-backed context setup.
+ */
+export function buildRunExecutionData(
+	workflow: Workflow,
+	items: INodeExecutionData[],
+): IRunExecutionData {
+	const runExecutionData = createRunExecutionData({
+		executionData: {
+			waitingExecutionSource: null,
+			nodeExecutionStack: [
+				{ node: workflow.getNode('node0')!, data: { main: [items] }, source: null },
+			],
+		},
+	});
+
+	runExecutionData.executionData!.runtimeData = {
+		version: 1,
+		establishedAt: 0,
+		source: 'manual',
+	};
+
+	return runExecutionData;
+}
+
+export type { IRun };

--- a/packages/testing/performance/package.json
+++ b/packages/testing/performance/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@codspeed/vitest-plugin": "^5.2.0",
     "@n8n/expression-runtime": "workspace:*",
+    "n8n-core": "workspace:*",
     "vitest": "catalog:",
     "n8n-workflow": "workspace:*",
     "typescript": "catalog:typescript"

--- a/packages/testing/performance/vitest.config.ts
+++ b/packages/testing/performance/vitest.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	plugins: [process.env.CODSPEED ? codspeedPlugin() : null].filter(Boolean),
 	test: {
+		// The execution-engine benches import `n8n-core`, whose logger writes a
+		// line per node. Set before any module loads, so the console I/O never
+		// lands inside a measurement.
+		env: { N8N_LOG_LEVEL: 'silent' },
 		benchmark: {
 			include: ['benchmarks/**/*.bench.ts'],
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6826,6 +6826,9 @@ importers:
       '@n8n/expression-runtime':
         specifier: workspace:*
         version: link:../../@n8n/expression-runtime
+      n8n-core:
+        specifier: workspace:*
+        version: link:../../core
       n8n-workflow:
         specifier: workspace:*
         version: link:../../workflow
@@ -22661,8 +22664,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.9:
-    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
+  vue-component-type-helpers@3.3.10:
+    resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -29713,7 +29716,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@6.0.2)
-      vue-component-type-helpers: 3.3.9
+      vue-component-type-helpers: 3.3.10
 
   '@stryker-mutator/api@9.6.1':
     dependencies:
@@ -42424,7 +42427,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.9: {}
+  vue-component-type-helpers@3.3.10: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@6.0.2)):
     dependencies:


### PR DESCRIPTION
## Summary

Benchmarks the memory guard on `hackmation-memory-guard`.

CodSpeed, instruction counts ([full report](https://github.com/n8n-io/n8n/pull/36712/checks?check_run_id=96408437335)):

| case | guard off | guard on | delta |
| --- | --- | --- | --- |
| 5 nodes, 100 items | 101.4 ms | 102.4 ms | +1.0% |
| 20 nodes, 100 items | 388.5 ms | 393.6 ms | +1.3% |
| 20 nodes, 1000 items | 320.5 ms | 322.1 ms | +0.5% |

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
