### PR TITLE
feat(editor): TagsInput tweaks

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -247,8 +247,10 @@
 	--tag--padding: 0 var(--spacing--4xs);
 	--tag--color--background: var(--color--neutral-125);
 	--tag--color--background--hover: var(--color--neutral-150);
+	--tag--color--background--active: var(--color--neutral-200);
 	--tag--border-color: var(--color--neutral-150);
 	--tag--border-color--hover: var(--color--neutral-200);
+	--tag--border-color--active: var(--color--neutral-250);
 	--tag--radius: var(--radius);
 	--tag--color--text: var(--color--text);
 	--tag--font-size: var(--font-size--2xs);
@@ -877,8 +879,10 @@
 	// Tag
 	--tag--color--background: var(--color--neutral-700);
 	--tag--color--background--hover: var(--color--neutral-600);
+	--tag--color--background--active: var(--color--neutral-500);
 	--tag--border-color: var(--color--neutral-800);
 	--tag--border-color--hover: var(--color--neutral-700);
+	--tag--border-color--active: var(--color--neutral-600);
 	--tag--color--text: var(--color--text--shade-1);
 
 	// Variables

--- a/packages/frontend/@n8n/design-system/src/v2/components/TagsInput/TagsInput.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/TagsInput/TagsInput.vue
@@ -17,8 +17,8 @@ import type {
 	TagsInputSlots,
 	TagsInputValue,
 } from './TagsInput.types';
-import type { IconSize } from '../../../types/icon';
 import Icon from '../../../components/N8nIcon/Icon.vue';
+import type { IconSize } from '../../../types/icon';
 
 defineOptions({ inheritAttrs: false });
 

--- a/packages/frontend/@n8n/design-system/src/v2/components/TagsInput/TagsInput.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/TagsInput/TagsInput.vue
@@ -344,8 +344,8 @@ function getInputClass(isEmpty: boolean): string {
 
 	&[data-state='active'],
 	&[aria-current='true'] {
-		background-color: var(--tag--color--background--hover);
-		border-color: var(--tag--border-color--hover);
+		background-color: var(--tag--color--background--active);
+		border-color: var(--tag--border-color--active);
 	}
 }
 

--- a/packages/frontend/@n8n/design-system/src/v2/components/TagsInput/TagsInput.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/TagsInput/TagsInput.vue
@@ -17,6 +17,7 @@ import type {
 	TagsInputSlots,
 	TagsInputValue,
 } from './TagsInput.types';
+import type { IconSize } from '../../../types/icon';
 import Icon from '../../../components/N8nIcon/Icon.vue';
 
 defineOptions({ inheritAttrs: false });
@@ -41,6 +42,10 @@ const sizes: Record<TagsInputSizes, string> = {
 	large: $style.large,
 	xlarge: $style.xlarge,
 };
+
+const deleteIconSize = computed(
+	(): IconSize => (props.size === 'mini' || props.size === 'small' ? 'xsmall' : 'small'),
+);
 
 const rootRef = useTemplateRef<HTMLElement>('root');
 
@@ -176,7 +181,7 @@ function getInputClass(isEmpty: boolean): string {
 					>
 						<TagsInputItemText :class="$style.tagText" />
 						<TagsInputItemDelete :class="$style.tagDelete" :disabled="props.disabled">
-							<Icon icon="x" size="small" />
+							<Icon icon="x" :size="deleteIconSize" />
 						</TagsInputItemDelete>
 					</slot>
 				</TagsInputItem>
@@ -212,6 +217,9 @@ function getInputClass(isEmpty: boolean): string {
 
 	--tags-input--gap: calc(var(--tags-input--padding) - 1px);
 	--tag--height: calc(var(--input--height) - 2 * var(--tags-input--padding));
+	--tag--gap: var(--spacing--4xs);
+	--tag--delete--size: max(var(--height--4xs), calc(var(--tag--height) - 2 * var(--spacing--4xs)));
+	--tag--padding-inline-end: calc((var(--tag--height) - var(--tag--delete--size) - 2px) / 2);
 
 	display: flex;
 	flex: 1;
@@ -254,10 +262,10 @@ function getInputClass(isEmpty: boolean): string {
 
 	--tags-input--padding: var(--spacing--4xs);
 	--tags-input--input--padding-inline-start: var(--spacing--5xs);
-	--tag--padding: 0 var(--spacing--5xs) 1px var(--spacing--4xs);
+	--tag--padding-block-end: 1px;
+	--tag--padding: 0 var(--tag--padding-inline-end) 0 var(--spacing--4xs);
 	--tag--radius: var(--radius--4xs);
 	--tag--font-size: var(--font-size--3xs);
-	--tag--delete--offset: 1px;
 }
 
 .small {
@@ -265,10 +273,10 @@ function getInputClass(isEmpty: boolean): string {
 
 	--tags-input--padding: var(--spacing--4xs);
 	--tags-input--input--padding-inline-start: var(--spacing--4xs);
-	--tag--padding: 0 var(--spacing--4xs) var(--spacing--5xs) var(--spacing--3xs);
+	--tag--padding-block-end: var(--spacing--5xs);
+	--tag--padding: 0 var(--tag--padding-inline-end) 0 var(--spacing--3xs);
 	--tag--radius: var(--radius--4xs);
 	--tag--font-size: var(--font-size--2xs);
-	--tag--delete--offset: 2px;
 }
 
 .medium {
@@ -276,10 +284,10 @@ function getInputClass(isEmpty: boolean): string {
 
 	--tags-input--padding: var(--spacing--4xs);
 	--tags-input--input--padding-inline-start: var(--spacing--4xs);
-	--tag--padding: 0 var(--spacing--4xs) var(--spacing--5xs) var(--spacing--3xs);
+	--tag--padding-block-end: var(--spacing--5xs);
+	--tag--padding: 0 var(--tag--padding-inline-end) 0 var(--spacing--3xs);
 	--tag--radius: var(--radius--4xs);
 	--tag--font-size: var(--font-size--2xs);
-	--tag--delete--offset: var(--spacing--5xs);
 }
 
 .large {
@@ -287,10 +295,10 @@ function getInputClass(isEmpty: boolean): string {
 
 	--tags-input--padding: var(--spacing--4xs);
 	--tags-input--input--padding-inline-start: var(--spacing--3xs);
-	--tag--padding: 0 var(--spacing--4xs) var(--spacing--5xs) var(--spacing--3xs);
+	--tag--padding-block-end: var(--spacing--5xs);
+	--tag--padding: 0 var(--tag--padding-inline-end) 0 var(--spacing--3xs);
 	--tag--radius: var(--radius--3xs);
 	--tag--font-size: var(--font-size--xs);
-	--tag--delete--offset: var(--spacing--5xs);
 }
 
 .xlarge {
@@ -298,10 +306,10 @@ function getInputClass(isEmpty: boolean): string {
 
 	--tags-input--padding: var(--spacing--4xs);
 	--tags-input--input--padding-inline-start: var(--spacing--2xs);
-	--tag--padding: 0 var(--spacing--4xs) var(--spacing--5xs) var(--spacing--2xs);
+	--tag--padding-block-end: var(--spacing--5xs);
+	--tag--padding: 0 var(--tag--padding-inline-end) 0 var(--spacing--2xs);
 	--tag--radius: var(--radius--3xs);
 	--tag--font-size: var(--font-size--xs);
-	--tag--delete--offset: var(--spacing--5xs);
 }
 
 .tags {
@@ -321,7 +329,7 @@ function getInputClass(isEmpty: boolean): string {
 .tag {
 	display: inline-flex;
 	align-items: center;
-	gap: var(--spacing--5xs);
+	gap: var(--tag--gap);
 	max-width: 100%;
 	min-width: 0;
 	height: var(--tag--height);
@@ -347,6 +355,7 @@ function getInputClass(isEmpty: boolean): string {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	line-height: normal;
+	padding-block-end: var(--tag--padding-block-end);
 }
 
 .tagDelete {
@@ -354,17 +363,26 @@ function getInputClass(isEmpty: boolean): string {
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
+	width: var(--tag--delete--size);
+	height: var(--tag--delete--size);
 	padding: 0;
 	border: none;
-	border-radius: var(--radius--full);
+	border-radius: var(--radius--4xs);
 	background: transparent;
 	color: var(--icon-color);
 	cursor: pointer;
-	margin-top: var(--tag--delete--offset);
 
-	&:hover,
-	&:focus {
+	@media (hover: hover) {
+		&:hover {
+			background-color: var(--background--hover);
+			color: var(--icon-color--strong);
+		}
+	}
+
+	&:focus,
+	&:focus-visible {
 		outline: none;
+		background-color: var(--background--hover);
 		color: var(--icon-color--strong);
 	}
 


### PR DESCRIPTION
## Summary

- Increased the TagsInput tag delete button hit area
- Darkened the backspace active state so the pending-delete highlight is easier to see

## How to test

- Go to Storybook -> TagsInput -> Sizes
- Check that all tag sizes look ok

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-629/component-tagsinput-tweaks

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
