### PR TITLE
fix(editor): Update AI credential and model selection

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.types.ts
@@ -12,6 +12,8 @@ export interface AiModelSelectorMenuItemData {
 	credentialType?: string;
 	/** Icon name shown instead of the credential icon (e.g. for "Configure credentials" actions). */
 	leadingIcon?: string;
+	/** Whether the item label represents content that is being resolved. */
+	loading?: boolean;
 }
 
 export type AiModelSelectorMenuItem<

--- a/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
@@ -30,6 +30,7 @@ const SUB_MENU_MAX_HEIGHT = 'calc(var(--spacing--5xl) * 2)';
 
 const {
 	items,
+	isLoading = false,
 	selectedLabel,
 	selectedCredentialName,
 	credentialsMissing = false,
@@ -42,6 +43,8 @@ const {
 } = defineProps<{
 	/** Menu items to render in the dropdown. */
 	items: Array<AiModelSelectorMenuItem<TData>>;
+	/** Whether the dropdown is currently loading items. */
+	isLoading?: boolean;
 	/** Label for the currently selected model shown in the trigger. */
 	selectedLabel: string;
 	/** Credential name shown below the selected model, when available. */
@@ -130,8 +133,9 @@ defineExpose({
 						<N8nText bold truncate>
 							{{ truncateBeforeLast(selectedLabel, MAX_SELECTED_NAME_CHARS) }}
 						</N8nText>
+						<span v-if="isLoading" :class="$style.loading"></span>
 						<N8nBadge
-							v-if="credentialsMissing"
+							v-if="credentialsMissing && !isLoading"
 							theme="danger"
 							size="small"
 							:class="$style.credsBadge"
@@ -139,7 +143,7 @@ defineExpose({
 							{{ resolvedCredentialsMissingLabel }}
 						</N8nBadge>
 						<N8nText
-							v-else-if="selectedCredentialName"
+							v-else-if="selectedCredentialName && !isLoading"
 							bold
 							color="text-light"
 							:data-test-id="credentialDataTestId"
@@ -220,6 +224,7 @@ defineExpose({
 
 <style lang="scss" module>
 @use '../../css/mixins/focus';
+@use '../../css/mixins/motion' as motion;
 
 .dropdownButton {
 	flex: 1;
@@ -342,5 +347,17 @@ defineExpose({
 .credsBadge {
 	flex-shrink: 0;
 	transform: translateY(-1px);
+}
+
+.loading {
+	flex-shrink: 0;
+	align-self: center;
+	width: calc(var(--height--3xl) * 2);
+	/** TODO (DS-339): N8nBadge doesnt have fixed height. This means height diff for loading skeleton causes layout jank. Remove the calc() when heights are added and matched in N8nBadge **/
+	height: calc(var(--height--2xs) - 2px);
+	border-radius: var(--radius);
+	background-color: var(--background--active);
+
+	@include motion.skeleton-pulse;
 }
 </style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
@@ -100,6 +100,10 @@ function handleSelect(id: string) {
 	emit('select', id);
 }
 
+function getItemContentClass(item: AiModelSelectorMenuItem<TData>, className: string): string {
+	return item.data?.loading ? `${className} ${$style.itemLoading}` : className;
+}
+
 defineExpose({
 	open: () => {
 		if (!disabled) dropdownRef.value?.open();
@@ -157,22 +161,25 @@ defineExpose({
 		</template>
 
 		<template #item-leading="{ item, ui }">
-			<slot name="item-leading" :item="item" :ui="ui" />
+			<slot name="item-leading" :item="item" :ui="{ class: getItemContentClass(item, ui.class) }" />
 			<N8nIcon
 				v-if="!item.data && item.icon?.type === 'icon'"
 				:icon="item.icon.value"
-				:class="ui.class"
+				:class="getItemContentClass(item, ui.class)"
 				color="text-light"
 				size="large"
 			/>
-			<span v-else-if="!item.data && item.icon?.type === 'emoji'" :class="[$style.emoji, ui.class]">
+			<span
+				v-else-if="!item.data && item.icon?.type === 'emoji'"
+				:class="[$style.emoji, getItemContentClass(item, ui.class)]"
+			>
 				{{ item.icon.value }}
 			</span>
 		</template>
 
 		<template #item-label="{ item, ui }">
 			<template v-if="item.data?.parts">
-				<div :class="[$style.flattenedLabel, ui.class]">
+				<div :class="[$style.flattenedLabel, getItemContentClass(item, ui.class)]">
 					<template v-for="(part, index) in item.data.parts" :key="index">
 						<N8nText v-if="index > 0" color="text-light" :class="$style.separator">
 							<N8nIcon icon="chevron-right" size="small" />
@@ -186,10 +193,11 @@ defineExpose({
 					</template>
 				</div>
 			</template>
-			<div v-else :class="[$style.labelWithBadge, ui.class]">
-				<N8nText size="medium" :color="item.disabled ? 'text-xlight' : 'text-dark'">{{
-					item.label
-				}}</N8nText>
+			<div v-else :class="[$style.labelWithBadge, getItemContentClass(item, ui.class)]">
+				<span v-if="item.data?.loading" :class="$style.modelLoading" aria-hidden="true"></span>
+				<N8nText v-else size="medium" :color="item.disabled ? 'text-xlight' : 'text-dark'">
+					{{ item.label }}
+				</N8nText>
 				<N8nBadge
 					v-if="item.data?.badgeLabel"
 					:class="$style.badge"
@@ -212,7 +220,7 @@ defineExpose({
 			<N8nTooltip
 				v-if="item.data?.description"
 				:content="truncateBeforeLast(item.data.description, 320, 0)"
-				:class="ui.class"
+				:class="getItemContentClass(item, ui.class)"
 				placement="right"
 				:teleported="item.data?.descriptionTooltipTeleported ?? true"
 			>
@@ -358,6 +366,16 @@ defineExpose({
 	border-radius: var(--radius);
 	background-color: var(--background--active);
 
+	@include motion.skeleton-pulse;
+}
+
+.modelLoading {
+	display: inline-block;
+	flex-shrink: 0;
+	width: calc(var(--height--3xl) * 2);
+	height: var(--height--3xs);
+	border-radius: var(--radius);
+	background-color: var(--background--active);
 	@include motion.skeleton-pulse;
 }
 </style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
@@ -100,10 +100,6 @@ function handleSelect(id: string) {
 	emit('select', id);
 }
 
-function getItemContentClass(item: AiModelSelectorMenuItem<TData>, className: string): string {
-	return item.data?.loading ? `${className} ${$style.itemLoading}` : className;
-}
-
 defineExpose({
 	open: () => {
 		if (!disabled) dropdownRef.value?.open();
@@ -161,25 +157,22 @@ defineExpose({
 		</template>
 
 		<template #item-leading="{ item, ui }">
-			<slot name="item-leading" :item="item" :ui="{ class: getItemContentClass(item, ui.class) }" />
+			<slot name="item-leading" :item="item" :ui="{ class: ui.class }" />
 			<N8nIcon
 				v-if="!item.data && item.icon?.type === 'icon'"
 				:icon="item.icon.value"
-				:class="getItemContentClass(item, ui.class)"
+				:class="ui.class"
 				color="text-light"
 				size="large"
 			/>
-			<span
-				v-else-if="!item.data && item.icon?.type === 'emoji'"
-				:class="[$style.emoji, getItemContentClass(item, ui.class)]"
-			>
+			<span v-else-if="!item.data && item.icon?.type === 'emoji'" :class="[$style.emoji, ui.class]">
 				{{ item.icon.value }}
 			</span>
 		</template>
 
 		<template #item-label="{ item, ui }">
 			<template v-if="item.data?.parts">
-				<div :class="[$style.flattenedLabel, getItemContentClass(item, ui.class)]">
+				<div :class="[$style.flattenedLabel, ui.class]">
 					<template v-for="(part, index) in item.data.parts" :key="index">
 						<N8nText v-if="index > 0" color="text-light" :class="$style.separator">
 							<N8nIcon icon="chevron-right" size="small" />
@@ -193,7 +186,7 @@ defineExpose({
 					</template>
 				</div>
 			</template>
-			<div v-else :class="[$style.labelWithBadge, getItemContentClass(item, ui.class)]">
+			<div v-else :class="[$style.labelWithBadge, ui.class]">
 				<span v-if="item.data?.loading" :class="$style.modelLoading" aria-hidden="true"></span>
 				<N8nText v-else size="medium" :color="item.disabled ? 'text-xlight' : 'text-dark'">
 					{{ item.label }}
@@ -220,7 +213,7 @@ defineExpose({
 			<N8nTooltip
 				v-if="item.data?.description"
 				:content="truncateBeforeLast(item.data.description, 320, 0)"
-				:class="getItemContentClass(item, ui.class)"
+				:class="ui.class"
 				placement="right"
 				:teleported="item.data?.descriptionTooltipTeleported ?? true"
 			>

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -694,6 +694,7 @@ export interface NewCredentialsModal extends ModalState {
 	showAuthSelector?: boolean;
 	forceManualMode?: boolean;
 	closeOnSave?: boolean;
+	onCredentialCreated?: (credential: { id: string }) => void;
 	projectId?: string;
 	suggestedName?: string;
 	/** Agent-supplied Templated Custom Auth recipe — pre-fills the credential's

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -451,6 +451,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 			projectId: undefined,
 			contextNode: undefined,
 			closeOnSave: false,
+			onCredentialCreated: undefined,
 			hideAskAssistant: options.hideAskAssistant,
 			appendToBody: options.appendToBody,
 			instanceAiCredentialHelp: options.instanceAiCredentialHelp,
@@ -470,6 +471,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 			hideAskAssistant?: boolean;
 			appendToBody?: boolean;
 			closeOnSave?: boolean;
+			onCredentialCreated?: NewCredentialsModal['onCredentialCreated'];
 			instanceAiCredentialHelp?: NewCredentialsModal['instanceAiCredentialHelp'];
 			usageScope?: NewCredentialsModal['usageScope'];
 			credentialSetupHint?: NewCredentialsModal['credentialSetupHint'];
@@ -480,6 +482,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		patchModalState(CREDENTIAL_EDIT_MODAL_KEY, {
 			forceManualMode,
 			closeOnSave: options.closeOnSave ?? false,
+			onCredentialCreated: options.onCredentialCreated,
 			projectId,
 			suggestedName,
 			nodeName,

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
@@ -346,14 +346,10 @@ describe('AgentInfoPanel', () => {
 				.vm.$emit('select-credential', 'openai', 'credential-2');
 			await wrapper.vm.$nextTick();
 
-			defaultModelHolder.value = {
+			wrapper.findComponent({ name: 'AgentModelSelector' }).vm.$emit('change', {
 				provider: 'openai',
 				model: 'gpt-5-mini',
-				name: 'GPT-5 mini',
-				description: null,
-				createdAt: null,
-				metadata: { functionCalling: true, available: true },
-			};
+			});
 			await wrapper.vm.$nextTick();
 
 			expect(wrapper.emitted('update:config')).toContainEqual([

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
@@ -332,6 +332,38 @@ describe('AgentInfoPanel', () => {
 			]);
 		});
 
+		it('replaces another provider model with the selected credential verified default', async () => {
+			credsHolder.value = { anthropic: 'credential-1', openai: 'credential-2' };
+			const wrapper = mountModelPanel({
+				name: 'Support agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				credential: 'credential-1',
+				instructions: 'Help users.',
+			});
+
+			wrapper
+				.findComponent({ name: 'AgentModelSelector' })
+				.vm.$emit('select-credential', 'openai', 'credential-2');
+			await wrapper.vm.$nextTick();
+
+			defaultModelHolder.value = {
+				provider: 'openai',
+				model: 'gpt-5-mini',
+				name: 'GPT-5 mini',
+				description: null,
+				createdAt: null,
+				metadata: { functionCalling: true, available: true },
+			};
+			await wrapper.vm.$nextTick();
+
+			expect(wrapper.emitted('update:config')).toContainEqual([
+				expect.objectContaining({
+					model: 'openai/gpt-5-mini',
+					credential: 'credential-2',
+				}),
+			]);
+		});
+
 		it('applies the verified default on mount when a credential is already available', async () => {
 			defaultModelHolder.value = {
 				provider: 'anthropic',

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
@@ -332,34 +332,6 @@ describe('AgentInfoPanel', () => {
 			]);
 		});
 
-		it('replaces another provider model with the selected credential verified default', async () => {
-			credsHolder.value = { anthropic: 'credential-1', openai: 'credential-2' };
-			const wrapper = mountModelPanel({
-				name: 'Support agent',
-				model: 'anthropic/claude-sonnet-4-5',
-				credential: 'credential-1',
-				instructions: 'Help users.',
-			});
-
-			wrapper
-				.findComponent({ name: 'AgentModelSelector' })
-				.vm.$emit('select-credential', 'openai', 'credential-2');
-			await wrapper.vm.$nextTick();
-
-			wrapper.findComponent({ name: 'AgentModelSelector' }).vm.$emit('change', {
-				provider: 'openai',
-				model: 'gpt-5-mini',
-			});
-			await wrapper.vm.$nextTick();
-
-			expect(wrapper.emitted('update:config')).toContainEqual([
-				expect.objectContaining({
-					model: 'openai/gpt-5-mini',
-					credential: 'credential-2',
-				}),
-			]);
-		});
-
 		it('applies the verified default on mount when a credential is already available', async () => {
 			defaultModelHolder.value = {
 				provider: 'anthropic',

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
@@ -159,6 +159,28 @@ vi.mock('@/app/stores/ui.store', () => ({
 	useUIStore: () => ({ openNewCredential, openModalWithData }),
 }));
 
+vi.mock('../composables/useModelCatalog', () => ({
+	useModelCatalog: () => ({
+		ensureLoaded: vi.fn(),
+		getDefaultModelForPicker: (
+			_credentials: Record<string, string | null> | null,
+			provider: string,
+		) =>
+			provider === 'openai'
+				? {
+						provider: 'openai',
+						model: 'gpt-5-mini',
+						name: 'GPT-5 mini',
+						description: null,
+						createdAt: null,
+						metadata: { functionCalling: true, available: true },
+					}
+				: null,
+		getVerificationStatus: (_projectId: string, _provider: string, credentialId: string) =>
+			credentialId === 'free-openai-credential' ? 'resolved' : 'loading',
+	}),
+}));
+
 const modelsByProvider: AgentModelsByProvider = {
 	anthropic: {
 		models: [
@@ -475,6 +497,7 @@ describe('AgentModelSelector', () => {
 		const wrapper = await mountSelector({ openai: null });
 
 		getDropdown(wrapper).vm.$emit('select', 'openai::select::free-openai-credential');
+		await wrapper.vm.$nextTick();
 
 		expect(wrapper.emitted('selectCredential')).toEqual([['openai', 'free-openai-credential']]);
 		expect(wrapper.emitted('change')).toEqual([[{ provider: 'openai', model: 'gpt-5-mini' }]]);

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
@@ -524,7 +524,7 @@ describe('AgentModelSelector', () => {
 		);
 	});
 
-	it('selects the first model after creating a credential when no model is selected', async () => {
+	it('lets the parent resolve the verified default after creating a credential', async () => {
 		credentialsByType.value = {};
 		const wrapper = await mountSelector({ anthropic: null }, { selectedModel: null });
 
@@ -537,9 +537,7 @@ describe('AgentModelSelector', () => {
 		expect(wrapper.emitted('selectCredential')).toEqual([
 			['anthropic', 'new-anthropic-credential'],
 		]);
-		expect(wrapper.emitted('change')).toEqual([
-			[{ provider: 'anthropic', model: 'claude-sonnet-4-5' }],
-		]);
+		expect(wrapper.emitted('change')).toBeUndefined();
 	});
 
 	it('does not replace the selected model after creating a credential', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
@@ -3,9 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AI_GATEWAY_MANAGED_TAG } from '@n8n/api-types';
 
-import type { AgentModelsByProvider } from '../model-providers';
+import type { AgentModelOption, AgentModelsByProvider } from '../model-providers';
 
-type Credential = { id: string; name: string; type: string };
+type Credential = { id: string; name: string; type: string; isManaged?: boolean };
 type TestMenuItem = {
 	id: string;
 	label: string;
@@ -179,6 +179,7 @@ async function mountSelector(
 	extraProps: {
 		credentialModalAppendToBody?: boolean;
 		boundCredentialId?: string | null;
+		selectedModel?: AgentModelOption | null;
 	} = {},
 ) {
 	const { default: AgentModelSelector } = await import('../components/AgentModelSelector.vue');
@@ -457,6 +458,26 @@ describe('AgentModelSelector', () => {
 
 		getDropdown(wrapper).vm.$emit('select', 'anthropic::select::anthropic-cred');
 		expect(wrapper.emitted('selectCredential')).toEqual([['anthropic', 'anthropic-cred']]);
+		expect(wrapper.emitted('change')).toBeUndefined();
+	});
+
+	it('selects gpt-5-mini when an existing free OpenAI credits credential is selected', async () => {
+		credentialsByType.value = {
+			openAiApi: [
+				{
+					id: 'free-openai-credential',
+					name: 'n8n free OpenAI API credits',
+					type: 'openAiApi',
+					isManaged: true,
+				},
+			],
+		};
+		const wrapper = await mountSelector({ openai: null });
+
+		getDropdown(wrapper).vm.$emit('select', 'openai::select::free-openai-credential');
+
+		expect(wrapper.emitted('selectCredential')).toEqual([['openai', 'free-openai-credential']]);
+		expect(wrapper.emitted('change')).toEqual([[{ provider: 'openai', model: 'gpt-5-mini' }]]);
 	});
 
 	it('groups the submenu with "Connect to <provider>" and "Models" section headers', async () => {
@@ -501,6 +522,38 @@ describe('AgentModelSelector', () => {
 			undefined,
 			{ hideAskAssistant: true, onCredentialCreated: expect.any(Function) },
 		);
+	});
+
+	it('selects the first model after creating a credential when no model is selected', async () => {
+		credentialsByType.value = {};
+		const wrapper = await mountSelector({ anthropic: null }, { selectedModel: null });
+
+		getDropdown(wrapper).vm.$emit('select', 'anthropic::configure::anthropicApi');
+		const onCredentialCreated = openNewCredential.mock.calls[0]?.[7]?.onCredentialCreated;
+		expect(onCredentialCreated).toBeTypeOf('function');
+
+		onCredentialCreated?.({ id: 'new-anthropic-credential' });
+
+		expect(wrapper.emitted('selectCredential')).toEqual([
+			['anthropic', 'new-anthropic-credential'],
+		]);
+		expect(wrapper.emitted('change')).toEqual([
+			[{ provider: 'anthropic', model: 'claude-sonnet-4-5' }],
+		]);
+	});
+
+	it('does not replace the selected model after creating a credential', async () => {
+		credentialsByType.value = {};
+		const wrapper = await mountSelector({ anthropic: null });
+
+		getDropdown(wrapper).vm.$emit('select', 'anthropic::configure::anthropicApi');
+		const onCredentialCreated = openNewCredential.mock.calls[0]?.[7]?.onCredentialCreated;
+		onCredentialCreated?.({ id: 'new-anthropic-credential' });
+
+		expect(wrapper.emitted('selectCredential')).toEqual([
+			['anthropic', 'new-anthropic-credential'],
+		]);
+		expect(wrapper.emitted('change')).toBeUndefined();
 	});
 
 	it('opens a new model credential at the body level when requested', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
@@ -499,7 +499,7 @@ describe('AgentModelSelector', () => {
 			undefined,
 			undefined,
 			undefined,
-			{ hideAskAssistant: true },
+			{ hideAskAssistant: true, onCredentialCreated: expect.any(Function) },
 		);
 	});
 
@@ -517,7 +517,11 @@ describe('AgentModelSelector', () => {
 			undefined,
 			undefined,
 			undefined,
-			{ hideAskAssistant: true, appendToBody: true },
+			{
+				hideAskAssistant: true,
+				appendToBody: true,
+				onCredentialCreated: expect.any(Function),
+			},
 		);
 	});
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
@@ -234,17 +234,8 @@ watch(
 function onSelectCredential(provider: AgentModelProvider, credentialId: string | null) {
 	selectCredential(provider, credentialId);
 	const parsed = parseModelString(modelToString(props.config?.model));
-	if (credentialId && parsed?.provider !== provider) {
-		pendingDefaultProvider.value = provider;
-	}
 	if (parsed?.provider === provider && credentialId) {
 		emit('update:config', { credential: credentialId });
-	}
-}
-
-function onConfigureCredential(provider: AgentModelProvider) {
-	if (!modelToString(props.config?.model)) {
-		pendingDefaultProvider.value = provider;
 	}
 }
 
@@ -298,7 +289,6 @@ function onInstructionsInput(value: string) {
 				data-testid="agent-model-selector"
 				@change="onModelChange"
 				@select-credential="onSelectCredential"
-				@configure-credential="onConfigureCredential"
 			/>
 			<N8nCallout
 				v-if="defaultModelHint && !props.disabled"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
@@ -191,7 +191,14 @@ watch(
 			: null,
 	(defaultModel) => {
 		const currentModel = parseModelString(modelToString(props.config?.model));
-		if (!defaultModel || props.disabled || currentModel?.provider === defaultModel.provider) return;
+		if (
+			!defaultModel ||
+			props.disabled ||
+			(currentModel?.provider === defaultModel.provider && currentModel.name === defaultModel.model)
+		) {
+			pendingDefaultProvider.value = null;
+			return;
+		}
 
 		pendingDefaultProvider.value = null;
 		onModelChange(defaultModel, 'auto');

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
@@ -190,7 +190,8 @@ watch(
 			? getDefaultModelForPicker(effectiveCredentials.value, pendingDefaultProvider.value)
 			: null,
 	(defaultModel) => {
-		if (!defaultModel || props.disabled || modelToString(props.config?.model)) return;
+		const currentModel = parseModelString(modelToString(props.config?.model));
+		if (!defaultModel || props.disabled || currentModel?.provider === defaultModel.provider) return;
 
 		pendingDefaultProvider.value = null;
 		onModelChange(defaultModel, 'auto');
@@ -225,10 +226,10 @@ watch(
 
 function onSelectCredential(provider: AgentModelProvider, credentialId: string | null) {
 	selectCredential(provider, credentialId);
-	if (credentialId && !modelToString(props.config?.model)) {
+	const parsed = parseModelString(modelToString(props.config?.model));
+	if (credentialId && parsed?.provider !== provider) {
 		pendingDefaultProvider.value = provider;
 	}
-	const parsed = parseModelString(modelToString(props.config?.model));
 	if (parsed?.provider === provider && credentialId) {
 		emit('update:config', { credential: credentialId });
 	}

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, useTemplateRef } from 'vue';
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
 import {
 	N8nAiModelSelectorDropdown,
 	useDropdownSearch,
@@ -18,6 +18,7 @@ import { AI_GATEWAY_MANAGED_TAG } from '@n8n/api-types';
 import ModelSelectorTriggerIcon from './model-selector/ModelSelectorTriggerIcon.vue';
 import ModelSelectorItemLeadingIcon from './model-selector/ModelSelectorItemLeadingIcon.vue';
 import { buildMenuItemId, parseMenuItemId } from './model-selector/menuItemId';
+import { useModelCatalog } from '../composables/useModelCatalog';
 import {
 	AGENT_MODEL_PROVIDER_DEFINITIONS,
 	AGENT_MODEL_PROVIDERS,
@@ -81,6 +82,15 @@ const credentialsStore = useCredentialsStore();
 const projectsStore = useProjectsStore();
 const uiStore = useUIStore();
 const aiGateway = useAiGateway();
+const { ensureLoaded, getDefaultModelForPicker, getVerificationStatus } = useModelCatalog();
+const pendingDefaultCredential = ref<{
+	provider: AgentModelProvider;
+	credentialId: string;
+} | null>(null);
+const forceModelOptionsDisabled = ref(false);
+const isResolvingDefaultModel = computed(
+	() => pendingDefaultCredential.value !== null || forceModelOptionsDisabled.value,
+);
 
 const aiGatewayBalancePill = computed(() => {
 	const balance = aiGateway.balance.value;
@@ -184,19 +194,6 @@ function getCredentialsForProvider(provider: AgentModelProvider) {
 	}
 
 	return [...credentialsById.values()].toSorted((a, b) => a.name.localeCompare(b.name));
-}
-
-function isFreeOpenAiCreditsCredential(
-	provider: AgentModelProvider,
-	credentialId: string,
-): boolean {
-	const credential = credentialsStore.getCredentialById(credentialId);
-
-	return (
-		provider === FREE_OPENAI_CREDITS_PROVIDER &&
-		credential?.type === getProviderCredentialTypes(FREE_OPENAI_CREDITS_PROVIDER)[0] &&
-		credential.isManaged
-	);
 }
 
 const canUseFreeOpenAiCredits = computed(
@@ -314,10 +311,11 @@ function providerToMenuItem(provider: AgentModelProvider): MenuItem {
 		? models.map<MenuItem>((model) => ({
 				id: buildMenuItemId(provider, 'model', model.model),
 				label: truncateBeforeLast(model.name, MAX_MODEL_NAME_CHARS),
-				disabled: false,
+				disabled: isResolvingDefaultModel.value,
 				checked: selectedModel?.provider === provider && selectedModel.model === model.model,
 				data: {
 					provider,
+					loading: isResolvingDefaultModel.value,
 					description: model.description ?? undefined,
 					descriptionTooltipTeleported: false,
 					fullName: `${model.name} ${model.model}`,
@@ -483,19 +481,47 @@ const filteredMenu = computed(() => {
 	});
 });
 
-function selectCredentialWithDefaultModel(
+function selectCredentialAndResolveDefaultModel(
 	provider: AgentModelProvider,
 	credentialId: string,
-	defaultModel?: string,
 ) {
+	void ensureLoaded(projectId);
 	emit('selectCredential', provider, credentialId);
-	const model =
-		defaultModel ??
-		(selectedModel?.provider !== provider
-			? modelsByProvider[provider]?.models[0]?.model
-			: undefined);
-	if (model) emit('change', { provider, model });
+	pendingDefaultCredential.value = { provider, credentialId };
 }
+
+function getPendingDefaultModelResolution() {
+	const pending = pendingDefaultCredential.value;
+	if (!pending) return null;
+
+	const pendingCredentials: AgentCredentialsByProvider = {
+		...(credentials ?? {}),
+		[pending.provider]: pending.credentialId,
+	};
+	const defaultModel = getDefaultModelForPicker(pendingCredentials, pending.provider);
+	const status = getVerificationStatus(projectId, pending.provider, pending.credentialId);
+	return { pending, defaultModel, status };
+}
+
+function handleDefaultModelResolution(result: ReturnType<typeof getPendingDefaultModelResolution>) {
+	if (!result || result.status === 'idle' || result.status === 'loading') return;
+	if (
+		pendingDefaultCredential.value?.provider !== result.pending.provider ||
+		pendingDefaultCredential.value.credentialId !== result.pending.credentialId
+	) {
+		return;
+	}
+
+	pendingDefaultCredential.value = null;
+	if (result.status === 'resolved' && result.defaultModel) {
+		emit('change', {
+			provider: result.defaultModel.provider,
+			model: result.defaultModel.model,
+		});
+	}
+}
+
+watch(getPendingDefaultModelResolution, handleDefaultModelResolution);
 
 function openNewCredential(provider: AgentModelProvider, credentialType: string) {
 	if (!disabled && canCreateCredentials.value) {
@@ -510,7 +536,7 @@ function openNewCredential(provider: AgentModelProvider, credentialType: string)
 			{
 				hideAskAssistant: true,
 				onCredentialCreated: function selectCreatedCredential(credential) {
-					emit('selectCredential', provider, credential.id);
+					selectCredentialAndResolveDefaultModel(provider, credential.id);
 				},
 				...(credentialModalAppendToBody ? { appendToBody: true } : {}),
 			},
@@ -532,18 +558,14 @@ async function onSelect(id: string) {
 	}
 
 	if (action === 'select') {
-		selectCredentialWithDefaultModel(
-			providerId,
-			value,
-			isFreeOpenAiCreditsCredential(providerId, value) ? FREE_OPENAI_CREDITS_MODEL : undefined,
-		);
+		selectCredentialAndResolveDefaultModel(providerId, value);
 		return;
 	}
 
 	if (action === 'n8nConnect') {
 		// Radio-style: selecting n8n credits always picks the managed tag. There's no
 		// toggle-off — you switch away by choosing another credential.
-		selectCredentialWithDefaultModel(providerId, AI_GATEWAY_MANAGED_TAG);
+		selectCredentialAndResolveDefaultModel(providerId, AI_GATEWAY_MANAGED_TAG);
 		return;
 	}
 
@@ -557,19 +579,27 @@ async function onSelect(id: string) {
 
 		if (!credential) return;
 
-		selectCredentialWithDefaultModel(providerId, credential.id, value);
+		selectCredentialAndResolveDefaultModel(providerId, credential.id);
 		return;
 	}
 
 	if (action === 'model') {
+		pendingDefaultCredential.value = null;
 		emit('change', { provider: providerId, model: value });
 	}
 }
 
+function openDropdown() {
+	if (!disabled) dropdownRef.value?.open();
+}
+
+function setModelOptionsDisabled(disabled: boolean) {
+	if (import.meta.env.DEV) forceModelOptionsDisabled.value = disabled;
+}
+
 defineExpose({
-	open: () => {
-		if (!disabled) dropdownRef.value?.open();
-	},
+	open: openDropdown,
+	setModelOptionsDisabled,
 });
 </script>
 
@@ -577,7 +607,7 @@ defineExpose({
 	<N8nAiModelSelectorDropdown
 		ref="dropdownRef"
 		:items="filteredMenu"
-		:is-loading="isLoading"
+		:is-loading="isLoading || isResolvingDefaultModel"
 		:selected-label="selectedLabel"
 		:selected-credential-name="selectedCredentialName"
 		:credentials-missing="isCredentialsMissing"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
@@ -186,6 +186,19 @@ function getCredentialsForProvider(provider: AgentModelProvider) {
 	return [...credentialsById.values()].toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
+function isFreeOpenAiCreditsCredential(
+	provider: AgentModelProvider,
+	credentialId: string,
+): boolean {
+	const credential = credentialsStore.getCredentialById(credentialId);
+
+	return (
+		provider === FREE_OPENAI_CREDITS_PROVIDER &&
+		credential?.type === getProviderCredentialTypes(FREE_OPENAI_CREDITS_PROVIDER)[0] &&
+		credential.isManaged
+	);
+}
+
 const canUseFreeOpenAiCredits = computed(
 	() => credentials !== null && canCreateCredentials.value && userCanClaimOpenAiCredits.value,
 );
@@ -470,6 +483,15 @@ const filteredMenu = computed(() => {
 	});
 });
 
+function selectCredentialWithDefaultModel(
+	provider: AgentModelProvider,
+	credentialId: string,
+	defaultModel?: string,
+) {
+	emit('selectCredential', provider, credentialId);
+	if (defaultModel) emit('change', { provider, model: defaultModel });
+}
+
 function openNewCredential(provider: AgentModelProvider, credentialType: string) {
 	if (!disabled && canCreateCredentials.value) {
 		uiStore.openNewCredential(
@@ -483,7 +505,10 @@ function openNewCredential(provider: AgentModelProvider, credentialType: string)
 			{
 				hideAskAssistant: true,
 				onCredentialCreated: function selectCreatedCredential(credential) {
-					emit('selectCredential', provider, credential.id);
+					const defaultModel = selectedModel
+						? undefined
+						: modelsByProvider[provider]?.models[0]?.model;
+					selectCredentialWithDefaultModel(provider, credential.id, defaultModel);
 				},
 				...(credentialModalAppendToBody ? { appendToBody: true } : {}),
 			},
@@ -505,7 +530,11 @@ async function onSelect(id: string) {
 	}
 
 	if (action === 'select') {
-		emit('selectCredential', providerId, value);
+		selectCredentialWithDefaultModel(
+			providerId,
+			value,
+			isFreeOpenAiCreditsCredential(providerId, value) ? FREE_OPENAI_CREDITS_MODEL : undefined,
+		);
 		return;
 	}
 
@@ -526,8 +555,7 @@ async function onSelect(id: string) {
 
 		if (!credential) return;
 
-		emit('selectCredential', providerId, credential.id);
-		emit('change', { provider: providerId, model: value });
+		selectCredentialWithDefaultModel(providerId, credential.id, value);
 		return;
 	}
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
@@ -227,7 +227,7 @@ function providerToMenuItem(provider: AgentModelProvider): MenuItem {
 		id: buildMenuItemId(provider, 'select', credential.id),
 		label: credential.name,
 		disabled: false,
-		checked: selectedProviderCredentialId === credential.id,
+		checked: selectedModel?.provider === provider && selectedProviderCredentialId === credential.id,
 		keepOpen: true,
 		data: { provider },
 	}));
@@ -489,7 +489,12 @@ function selectCredentialWithDefaultModel(
 	defaultModel?: string,
 ) {
 	emit('selectCredential', provider, credentialId);
-	if (defaultModel) emit('change', { provider, model: defaultModel });
+	const model =
+		defaultModel ??
+		(selectedModel?.provider !== provider
+			? modelsByProvider[provider]?.models[0]?.model
+			: undefined);
+	if (model) emit('change', { provider, model });
 }
 
 function openNewCredential(provider: AgentModelProvider, credentialType: string) {
@@ -505,10 +510,7 @@ function openNewCredential(provider: AgentModelProvider, credentialType: string)
 			{
 				hideAskAssistant: true,
 				onCredentialCreated: function selectCreatedCredential(credential) {
-					const defaultModel = selectedModel
-						? undefined
-						: modelsByProvider[provider]?.models[0]?.model;
-					selectCredentialWithDefaultModel(provider, credential.id, defaultModel);
+					emit('selectCredential', provider, credential.id);
 				},
 				...(credentialModalAppendToBody ? { appendToBody: true } : {}),
 			},
@@ -541,7 +543,7 @@ async function onSelect(id: string) {
 	if (action === 'n8nConnect') {
 		// Radio-style: selecting n8n credits always picks the managed tag. There's no
 		// toggle-off — you switch away by choosing another credential.
-		emit('selectCredential', providerId, AI_GATEWAY_MANAGED_TAG);
+		selectCredentialWithDefaultModel(providerId, AI_GATEWAY_MANAGED_TAG);
 		return;
 	}
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
@@ -470,7 +470,7 @@ const filteredMenu = computed(() => {
 	});
 });
 
-function openNewCredential(credentialType: string) {
+function openNewCredential(provider: AgentModelProvider, credentialType: string) {
 	if (!disabled && canCreateCredentials.value) {
 		uiStore.openNewCredential(
 			credentialType,
@@ -482,6 +482,9 @@ function openNewCredential(credentialType: string) {
 			undefined,
 			{
 				hideAskAssistant: true,
+				onCredentialCreated: function selectCreatedCredential(credential) {
+					emit('selectCredential', provider, credential.id);
+				},
 				...(credentialModalAppendToBody ? { appendToBody: true } : {}),
 			},
 		);
@@ -497,7 +500,7 @@ async function onSelect(id: string) {
 
 	if (action === 'configure') {
 		emit('configureCredential', providerId);
-		openNewCredential(value);
+		openNewCredential(providerId, value);
 		return;
 	}
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
@@ -544,6 +544,7 @@ defineExpose({
 	<N8nAiModelSelectorDropdown
 		ref="dropdownRef"
 		:items="filteredMenu"
+		:is-loading="isLoading"
 		:selected-label="selectedLabel"
 		:selected-credential-name="selectedCredentialName"
 		:credentials-missing="isCredentialsMissing"

--- a/packages/frontend/editor-ui/src/features/agents/composables/useModelCatalog.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useModelCatalog.ts
@@ -33,6 +33,7 @@ const verifiedDefaultModelsByKey = ref<Record<string, string | null>>({});
 // "couldn't load" rather than "no models available".
 const unavailableByKey = ref<Record<string, boolean>>({});
 const verifiedFetchesInFlight = new Set<string>();
+const verificationStatusByKey = ref<Record<string, 'loading' | 'resolved' | 'failed'>>({});
 
 function createEmptyModelsResponse(): AgentModelsByProvider {
 	const response: AgentModelsByProvider = {};
@@ -114,6 +115,7 @@ export function useModelCatalog() {
 		if (key in verifiedModelsByKey.value || verifiedFetchesInFlight.has(key)) return;
 
 		verifiedFetchesInFlight.add(key);
+		verificationStatusByKey.value = { ...verificationStatusByKey.value, [key]: 'loading' };
 		getProviderModels(rootStore.restApiContext, projectId, provider, providerCredentialId)
 			.then((result) => {
 				verifiedModelsByKey.value = {
@@ -125,13 +127,29 @@ export function useModelCatalog() {
 					[key]: result.defaultModelId ?? null,
 				};
 				unavailableByKey.value = { ...unavailableByKey.value, [key]: result.unavailable === true };
+				verificationStatusByKey.value = {
+					...verificationStatusByKey.value,
+					[key]: 'resolved',
+				};
 			})
 			.catch(() => {
 				verifiedModelsByKey.value = { ...verifiedModelsByKey.value, [key]: null };
+				verificationStatusByKey.value = {
+					...verificationStatusByKey.value,
+					[key]: 'failed',
+				};
 			})
 			.finally(() => {
 				verifiedFetchesInFlight.delete(key);
 			});
+	}
+
+	function getVerificationStatus(
+		projectId: string,
+		provider: AgentModelProvider,
+		credentialId: string,
+	): 'idle' | 'loading' | 'resolved' | 'failed' {
+		return verificationStatusByKey.value[`${projectId}|${provider}|${credentialId}`] ?? 'idle';
 	}
 
 	function getModelsForPicker(
@@ -194,6 +212,7 @@ export function useModelCatalog() {
 		catalog,
 		isLoading,
 		ensureLoaded,
+		getVerificationStatus,
 		getModelsForProvider,
 		getModelsForPicker,
 		getDefaultModelForPicker,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
@@ -187,6 +187,7 @@ defineExpose({
 	<N8nAiModelSelectorDropdown
 		ref="dropdownRef"
 		:items="filteredMenu"
+		:is-loading="isLoading"
 		:selected-label="selectedLabel"
 		:selected-credential-name="credentialsName"
 		:credentials-missing="isCredentialsMissing"

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -1383,6 +1383,67 @@ describe('CredentialEdit', () => {
 			expect(credentialsStore.testCredential).not.toHaveBeenCalled();
 		});
 
+		test('calls onCredentialCreated with the newly created credential', async function () {
+			const onCredentialCreated = vi.fn();
+			const credentialType = {
+				name: 'testApi',
+				displayName: 'Test API',
+				properties: [],
+			} as ICredentialType;
+			const { credentialsStore, pinia } = setupNewCredential(credentialType, {
+				onCredentialCreated,
+			});
+			const createdCredential = createCredentialResponse({
+				id: 'new-credential',
+				name: 'Test API account',
+				type: credentialType.name,
+			});
+			credentialsStore.createNewCredential.mockResolvedValue(createdCredential);
+
+			const { getByTestId } = renderComponent({
+				props: {
+					activeId: credentialType.name,
+					modalName: CREDENTIAL_EDIT_MODAL_KEY,
+					mode: 'new',
+				},
+				pinia,
+			});
+
+			await waitFor(() => expect(credentialsStore.getNewCredentialName).toHaveBeenCalled());
+			await userEvent.click(within(getByTestId('credential-save-button')).getByRole('button'));
+
+			await waitFor(() => expect(onCredentialCreated).toHaveBeenCalledWith(createdCredential));
+			expect(onCredentialCreated).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not call onCredentialCreated when credential creation fails', async function () {
+			const onCredentialCreated = vi.fn();
+			const credentialType = {
+				name: 'testApi',
+				displayName: 'Test API',
+				properties: [],
+			} as ICredentialType;
+			const { credentialsStore, pinia } = setupNewCredential(credentialType, {
+				onCredentialCreated,
+			});
+			credentialsStore.createNewCredential.mockRejectedValue(new Error('Failed to create'));
+
+			const { getByTestId } = renderComponent({
+				props: {
+					activeId: credentialType.name,
+					modalName: CREDENTIAL_EDIT_MODAL_KEY,
+					mode: 'new',
+				},
+				pinia,
+			});
+
+			await waitFor(() => expect(credentialsStore.getNewCredentialName).toHaveBeenCalled());
+			await userEvent.click(within(getByTestId('credential-save-button')).getByRole('button'));
+
+			await waitFor(() => expect(credentialsStore.createNewCredential).toHaveBeenCalled());
+			expect(onCredentialCreated).not.toHaveBeenCalled();
+		});
+
 		test('creates the credential in the project the modal was opened for', async () => {
 			const credentialType = {
 				name: 'testApi',
@@ -1513,6 +1574,20 @@ describe('CredentialEdit', () => {
 
 			await waitFor(() => expect(credentialsStore.testCredential).toHaveBeenCalled());
 			expect(uiStore.closeModal).not.toHaveBeenCalled();
+		});
+
+		test('does not call onCredentialCreated when updating a credential', async function () {
+			const onCredentialCreated = vi.fn();
+			const { credentialsStore, getByTestId } = setupExistingOAuthCredential({
+				onCredentialCreated,
+			});
+
+			await waitFor(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
+			await waitFor(() => expect(getByTestId('quick-connect-button')).toBeVisible());
+			await userEvent.click(getByTestId('quick-connect-button'));
+
+			await waitFor(() => expect(credentialsStore.updateCredential).toHaveBeenCalled());
+			expect(onCredentialCreated).not.toHaveBeenCalled();
 		});
 
 		test('closes the modal only after a successful OAuth callback when closeOnSave is enabled', async () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -276,6 +276,11 @@ const closeOnSave = computed<boolean>(() => {
 	return isCredentialModalState(modalState) && modalState.closeOnSave === true;
 });
 
+const onCredentialCreated = computed<NewCredentialsModal['onCredentialCreated']>(() => {
+	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	return isCredentialModalState(modalState) ? modalState.onCredentialCreated : undefined;
+});
+
 const presetUsageScope = computed<NewCredentialsModal['usageScope']>(() => {
 	if (props.mode !== 'new') return undefined;
 	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
@@ -708,6 +713,7 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 			credentialDetails.usageScope = presetUsageScope.value;
 		}
 		credential = await createCredential(credentialDetails, homeProject.value);
+		if (credential) onCredentialCreated.value?.(credential);
 	} else {
 		if (settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing]) {
 			credentialDetails.sharedWithProjects = credentialData.value


### PR DESCRIPTION
## Summary

Fixes [AGENT-537](https://linear.app/n8n/issue/AGENT-537) [DS-588](https://linear.app/n8n/issue/DS-588)

Updates `AiModelSelectorDropdown` and related components that handle model selection.

* Adds `isLoading` prop to `AIModelSelectorDropdown` to properly handle loading state. This stops a flash of 'Credential missing\` whilst credentials are being retrieved.
* Adds callback to `uiStore.openNewCredential()` that returns the newly created credential ID. This allows us to set a default model after the users adds a new credential.
* When changing providers, a new default model is selected
* When selecting 'Free Credits' on dropdown, now auto-selects default 'Free Credit' model (e.g `gpt-5-mini`)
* Fix showing ✔️ for every credential which confuses users not knowing what credential is active

[CleanShot 2026-08-21 at 10.23.27.mp4](https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/2781cef4-3a6d-4c71-8964-28928fba6b15/ad1756a7-c106-44f3-a656-5864b07c3d5f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi8yNzgxY2VmNC0zYTZkLTRjNzEtODk2NC0yODkyOGZiYTZiMTUvYWQxNzU2YTctYzEwNi00NGYzLWE2NTYtNTg2NGIwN2MzZDVmIiwiaWF0IjoxNzg3MzA0MjM4LCJleHAiOjE4MTg4NzQ3OTh9.ixs9al3LcA7mrxprRUqTq-H1DnMctbvP50DMdQzI5t4)

## How to test

 1. Open the agent builder with no selected model/no credentials.
 2. Add new credential
 3. Verify that first model of that credential (e.g Anthropic → Fable 5) is automatically selected

1. Open Agent config page with model selected
2. Verify, if loading, loading state is shown not flash of 'Credentials Missing'

1. When using Free Credits, select free credits credential
2. Verify that model (e.g gpt-5-mini) is auto selected on selecting credential

## Related Linear tickets, Github issues, and Community forum posts

[AGENT-537](https://linear.app/n8n/issue/AGENT-537)

[DS-588](https://linear.app/n8n/issue/DS-588)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)