### PR TITLE
feat(API): Add endpoint to delete role-mapping rules

### DIFF
--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -118,7 +118,7 @@ export const API_KEY_RESOURCES = {
 	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
 	role: ['manage', 'manageProject', 'list', 'read'] as const,
-	roleMappingRule: ['create', 'list', 'update'] as const,
+	roleMappingRule: ['create', 'delete', 'list', 'update'] as const,
 } as const;
 
 export const GLOBAL_OWNER_ROLE_SLUG = 'global:owner';

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -101,6 +101,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'role:list',
 	'role:read',
 	'roleMappingRule:create',
+	'roleMappingRule:delete',
 	'roleMappingRule:list',
 	'roleMappingRule:update',
 ];

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
@@ -3,8 +3,6 @@ import type { AuthenticatedRequest } from '@n8n/db';
 import type { Response } from 'express';
 import { mock } from 'vitest-mock-extended';
 
-import type { EventService } from '@/events/event.service';
-
 import { RoleMappingRuleController } from '../role-mapping-rule.controller.ee';
 import type {
 	RoleMappingRuleListResponse,
@@ -14,13 +12,8 @@ import type {
 
 const roleMappingRuleService = mock<RoleMappingRuleService>();
 const licenseState = mock<LicenseState>();
-const eventService = mock<EventService>();
 
-const controller = new RoleMappingRuleController(
-	roleMappingRuleService,
-	licenseState,
-	eventService,
-);
+const controller = new RoleMappingRuleController(roleMappingRuleService, licenseState);
 
 describe('RoleMappingRuleController', () => {
 	beforeEach(() => {
@@ -230,8 +223,6 @@ describe('RoleMappingRuleController', () => {
 				userId: req.user.id,
 				userEmail: req.user.email,
 			});
-			// The service owns the `role-mapping-rule-deleted` emission now.
-			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
@@ -225,11 +225,13 @@ describe('RoleMappingRuleController', () => {
 			const result = await controller.delete(req, res, ruleId);
 
 			expect(result).toEqual({ success: true });
-			expect(roleMappingRuleService.delete).toHaveBeenCalledWith(ruleId);
-			expect(eventService.emit).toHaveBeenCalledWith(
-				'role-mapping-rule-deleted',
-				expect.objectContaining({ ruleId, ruleType: 'instance' }),
-			);
+			expect(roleMappingRuleService.delete).toHaveBeenCalledWith({
+				id: ruleId,
+				userId: req.user.id,
+				userEmail: req.user.email,
+			});
+			// The service owns the `role-mapping-rule-deleted` emission now.
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
@@ -213,7 +213,16 @@ describe('RoleMappingRuleController', () => {
 
 		it('should delete a role mapping rule when provisioning is licensed', async () => {
 			licenseState.isProvisioningLicensed.mockReturnValue(true);
-			roleMappingRuleService.delete.mockResolvedValue({ ruleType: 'instance' });
+			roleMappingRuleService.delete.mockResolvedValue({
+				id: ruleId,
+				expression: 'claims.group === "admins"',
+				role: 'global:member',
+				type: 'instance',
+				order: 0,
+				projectIds: [],
+				createdAt: '2025-01-01T00:00:00.000Z',
+				updatedAt: '2025-01-01T00:00:00.000Z',
+			});
 
 			const result = await controller.delete(req, res, ruleId);
 

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -1017,8 +1017,8 @@ describe('RoleMappingRuleService', () => {
 				makeRule('c', 3),
 			]);
 
-			roleMappingRuleRepository.findOne.mockResolvedValue(makeRule('x', 0));
-			roleMappingRuleRepository.remove.mockResolvedValue(makeRule('x', 0));
+			roleMappingRuleRepository.findOne.mockResolvedValue(makeRule('x', 1));
+			roleMappingRuleRepository.remove.mockResolvedValue(makeRule('x', 1));
 
 			await service.delete({ id: 'x', userId: testUser.id, userEmail: testUser.email });
 

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -769,25 +769,44 @@ describe('RoleMappingRuleService', () => {
 		} as unknown as RoleMappingRule;
 
 		it('should reject an empty id', async () => {
-			await expect(service.delete('')).rejects.toThrow(BadRequestError);
+			await expect(
+				service.delete({ id: '', userId: testUser.id, userEmail: testUser.email }),
+			).rejects.toThrow(BadRequestError);
+
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
 		it('should return 404 when rule id is unknown', async () => {
 			roleMappingRuleRepository.findOne.mockResolvedValue(null);
 
-			await expect(service.delete('00000000-0000-4000-8000-000000000000')).rejects.toThrow(
-				NotFoundError,
-			);
+			await expect(
+				service.delete({
+					id: '00000000-0000-4000-8000-000000000000',
+					userId: testUser.id,
+					userEmail: testUser.email,
+				}),
+			).rejects.toThrow(NotFoundError);
 			expect(roleMappingRuleRepository.remove).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
-		it('should remove the rule when it exists', async () => {
+		it('should remove the rule and emit the deleted event when it exists', async () => {
 			roleMappingRuleRepository.findOne.mockResolvedValue(rule);
 			roleMappingRuleRepository.remove.mockResolvedValue(rule);
 
-			await service.delete(rule.id);
+			const result = await service.delete({
+				id: rule.id,
+				userId: testUser.id,
+				userEmail: testUser.email,
+			});
 
+			expect(result).toEqual({ ruleType: 'instance' });
 			expect(roleMappingRuleRepository.remove).toHaveBeenCalledWith(rule);
+			expect(eventService.emit).toHaveBeenCalledWith('role-mapping-rule-deleted', {
+				user: { id: testUser.id, email: testUser.email },
+				ruleId: rule.id,
+				ruleType: 'instance',
+			});
 		});
 	});
 
@@ -985,7 +1004,7 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.findOne.mockResolvedValue(makeRule('a', 0));
 			roleMappingRuleRepository.remove.mockResolvedValue(makeRule('a', 0));
 
-			await service.delete('a');
+			await service.delete({ id: 'a', userId: testUser.id, userEmail: testUser.email });
 
 			expect(transactionSpy).not.toHaveBeenCalled();
 		});
@@ -1001,7 +1020,7 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.findOne.mockResolvedValue(makeRule('x', 0));
 			roleMappingRuleRepository.remove.mockResolvedValue(makeRule('x', 0));
 
-			await service.delete('x');
+			await service.delete({ id: 'x', userId: testUser.id, userEmail: testUser.email });
 
 			expect(transactionSpy).toHaveBeenCalledTimes(1);
 

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -800,7 +800,20 @@ describe('RoleMappingRuleService', () => {
 				userEmail: testUser.email,
 			});
 
-			expect(result).toEqual({ ruleType: 'instance' });
+			expect(result).toEqual({
+				id: rule.id,
+				expression: rule.expression,
+				role: rule.role.slug,
+				type: rule.type,
+				order: rule.order,
+				projectIds: rule.projects.map((p) => p.id),
+				createdAt: '2025-01-01T00:00:00.000Z',
+				updatedAt: '2025-01-01T00:00:00.000Z',
+			});
+			expect(roleMappingRuleRepository.findOne).toHaveBeenCalledWith({
+				where: { id: rule.id },
+				relations: ['projects', 'role'],
+			});
 			expect(roleMappingRuleRepository.remove).toHaveBeenCalledWith(rule);
 			expect(eventService.emit).toHaveBeenCalledWith('role-mapping-rule-deleted', {
 				user: { id: testUser.id, email: testUser.email },
@@ -975,7 +988,16 @@ describe('RoleMappingRuleService', () => {
 
 	describe('normalizeOrderForType', () => {
 		const makeRule = (id: string, order: number, type = 'instance') =>
-			({ id, order, type }) as unknown as RoleMappingRule;
+			({
+				id,
+				order,
+				type,
+				expression: 'true',
+				role: globalRole,
+				projects: [],
+				createdAt: new Date('2025-01-01T00:00:00.000Z'),
+				updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+			}) as unknown as RoleMappingRule;
 
 		const updateSpy = vi.fn().mockResolvedValue(undefined);
 		const transactionSpy = vi.fn();

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
@@ -19,8 +19,6 @@ import {
 } from '@n8n/decorators';
 import type { Response } from 'express';
 
-import { EventService } from '@/events/event.service';
-
 import type {
 	RoleMappingRuleListResponse,
 	RoleMappingRuleResponse,
@@ -32,7 +30,6 @@ export class RoleMappingRuleController {
 	constructor(
 		private readonly roleMappingRuleService: RoleMappingRuleService,
 		private readonly licenseState: LicenseState,
-		private readonly eventService: EventService,
 	) {}
 
 	@Get('/')

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
@@ -115,12 +115,10 @@ export class RoleMappingRuleController {
 			return res.status(403).json({ message: 'Provisioning is not licensed' });
 		}
 
-		const { ruleType } = await this.roleMappingRuleService.delete(id);
-
-		this.eventService.emit('role-mapping-rule-deleted', {
-			user: { id: req.user.id, email: req.user.email },
-			ruleId: id,
-			ruleType,
+		await this.roleMappingRuleService.delete({
+			id,
+			userId: req.user.id,
+			userEmail: req.user.email,
 		});
 
 		return { success: true };

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -279,28 +279,32 @@ export class RoleMappingRuleService {
 		id: string;
 		userId: string;
 		userEmail?: string;
-	}): Promise<{ ruleType: 'instance' | 'project' }> {
+	}): Promise<RoleMappingRuleResponse> {
 		if (typeof id !== 'string' || id.length === 0) {
 			throw new BadRequestError('Rule id is required');
 		}
 
-		const rule = await this.roleMappingRuleRepository.findOne({ where: { id } });
+		const rule = await this.roleMappingRuleRepository.findOne({
+			where: { id },
+			relations: ['projects', 'role'],
+		});
 
 		if (!rule) {
 			throw new NotFoundError('Could not find role mapping rule');
 		}
 
-		const ruleType = rule.type as 'instance' | 'project';
+		const result = this.toResponse(rule);
+
 		await this.roleMappingRuleRepository.remove(rule);
-		await this.normalizeOrderForType(ruleType);
+		await this.normalizeOrderForType(result.type);
 
 		this.eventService.emit('role-mapping-rule-deleted', {
 			user: { id: userId, email: userEmail },
 			ruleId: id,
-			ruleType,
+			ruleType: result.type,
 		});
 
-		return { ruleType };
+		return result;
 	}
 
 	async deleteAllOfType(type: 'instance' | 'project', tx?: EntityManager): Promise<number> {

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -271,7 +271,15 @@ export class RoleMappingRuleService {
 		return result;
 	}
 
-	async delete(id: string): Promise<{ ruleType: 'instance' | 'project' }> {
+	async delete({
+		id,
+		userId,
+		userEmail,
+	}: {
+		id: string;
+		userId: string;
+		userEmail?: string;
+	}): Promise<{ ruleType: 'instance' | 'project' }> {
 		if (typeof id !== 'string' || id.length === 0) {
 			throw new BadRequestError('Rule id is required');
 		}
@@ -285,6 +293,13 @@ export class RoleMappingRuleService {
 		const ruleType = rule.type as 'instance' | 'project';
 		await this.roleMappingRuleRepository.remove(rule);
 		await this.normalizeOrderForType(ruleType);
+
+		this.eventService.emit('role-mapping-rule-deleted', {
+			user: { id: userId, email: userEmail },
+			ruleId: id,
+			ruleType,
+		});
+
 		return { ruleType };
 	}
 

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -16,6 +16,7 @@ import {
 	ApiSummary,
 	ApiTags,
 	Body,
+	Delete,
 	Get,
 	Param,
 	Patch,
@@ -159,6 +160,29 @@ export class RoleMappingRulesPublicController {
 		});
 
 		return toRoleMappingRulePublicDto(rule);
+	}
+
+	@Delete('/:roleMappingRuleId')
+	@ApiKeyScope('roleMappingRule:delete')
+	@ApiSummary('Delete a role-mapping rule')
+	@ApiDescription(
+		'Deletes a role-mapping rule. The remaining rules of the same type close the gap, so their `order` values stay a contiguous sequence starting at 0.',
+	)
+	@ApiTags(['RoleMappingRule'])
+	@ApiResponse(204)
+	@ApiErrorResponse(404)
+	async deleteRoleMappingRule(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('roleMappingRuleId') roleMappingRuleId: string,
+	): Promise<void> {
+		this.assertProvisioningLicensed();
+
+		await this.roleMappingRuleService.delete({
+			id: roleMappingRuleId,
+			userId: req.user.id,
+			userEmail: req.user.email,
+		});
 	}
 
 	private assertProvisioningLicensed(): void {

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -169,20 +169,22 @@ export class RoleMappingRulesPublicController {
 		'Deletes a role-mapping rule. The remaining rules of the same type close the gap, so their `order` values stay a contiguous sequence starting at 0.',
 	)
 	@ApiTags(['RoleMappingRule'])
-	@ApiResponse(204)
+	@ApiResponse(200, RoleMappingRulePublicDto)
 	@ApiErrorResponse(404)
 	async deleteRoleMappingRule(
 		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('roleMappingRuleId') roleMappingRuleId: string,
-	): Promise<void> {
+	): Promise<RoleMappingRulePublicDto> {
 		this.assertProvisioningLicensed();
 
-		await this.roleMappingRuleService.delete({
+		const rule = await this.roleMappingRuleService.delete({
 			id: roleMappingRuleId,
 			userId: req.user.id,
 			userEmail: req.user.email,
 		});
+
+		return toRoleMappingRulePublicDto(rule);
 	}
 
 	private assertProvisioningLicensed(): void {

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/deleteRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/deleteRoleMappingRule.generated.yml
@@ -14,8 +14,12 @@ parameters:
     name: roleMappingRuleId
     in: path
 responses:
-  '204':
+  '200':
     description: Operation successful.
+    content:
+      application/json:
+        schema:
+          $ref: ../../../../shared/spec/schemas/roleMappingRulePublicDto.generated.yml
   '401':
     $ref: ../../../../shared/spec/responses/unauthorized.yml
   '403':

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/deleteRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/deleteRoleMappingRule.generated.yml
@@ -1,0 +1,24 @@
+operationId: deleteRoleMappingRule
+tags:
+  - RoleMappingRule
+summary: Delete a role-mapping rule
+description: Deletes a role-mapping rule. The remaining rules of the same type close the gap, so their `order` values stay a contiguous sequence starting at 0.
+x-required-scope: roleMappingRule:delete
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    name: roleMappingRuleId
+    in: path
+responses:
+  '204':
+    description: Operation successful.
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -43,6 +43,8 @@ paths:
   /role-mapping-rules/{roleMappingRuleId}:
     patch:
       $ref: ./handlers/role-mapping-rules/spec/paths/updateRoleMappingRule.generated.yml
+    delete:
+      $ref: ./handlers/role-mapping-rules/spec/paths/deleteRoleMappingRule.generated.yml
   /roles:
     get:
       $ref: ./handlers/roles/spec/paths/getAllRoles.generated.yml

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -787,38 +787,31 @@ describe('Role mapping rules in Public API', () => {
 	});
 
 	describe('DELETE /role-mapping-rules/:roleMappingRuleId', () => {
-		const createRule = async (payload: CreateRoleMappingRuleDto) => {
-			const response = await testServer
-				.publicApiAgentFor(owner)
-				.post('/role-mapping-rules')
-				.send(payload)
-				.expect(201);
-
-			return response.body.id as string;
-		};
-
 		it('deletes a rule and returns 204 with no content', async () => {
-			const ruleId = await createRule(validInstancePayload);
+			const rule = await createInstanceRule(validInstancePayload);
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.delete(`/role-mapping-rules/${ruleId}`);
+				.delete(`/role-mapping-rules/${rule.id}`);
 
 			expect(response.status).toBe(204);
 			expect(response.body).toEqual({});
 
-			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: ruleId });
+			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: rule.id });
 			expect(stored).toBeNull();
 		});
 
 		it('closes the gap in the evaluation order of the remaining rules', async () => {
 			const { expression, role, type } = validInstancePayload;
 
-			const first = await createRule(validInstancePayload);
-			const second = await createRule({ expression, role, type, order: 1 });
-			const third = await createRule({ expression, role, type, order: 2 });
+			const first = await createInstanceRule(validInstancePayload);
+			const second = await createInstanceRule({ expression, role, type, order: 1 });
+			const third = await createInstanceRule({ expression, role, type, order: 2 });
 
-			await testServer.publicApiAgentFor(owner).delete(`/role-mapping-rules/${second}`).expect(204);
+			await testServer
+				.publicApiAgentFor(owner)
+				.delete(`/role-mapping-rules/${second.id}`)
+				.expect(204);
 
 			const remaining = await testServer
 				.publicApiAgentFor(owner)
@@ -826,22 +819,25 @@ describe('Role mapping rules in Public API', () => {
 				.expect(200);
 
 			expect(remaining.body.data).toEqual([
-				expect.objectContaining({ id: first, order: 0 }),
-				expect.objectContaining({ id: third, order: 1 }),
+				expect.objectContaining({ id: first.id, order: 0 }),
+				expect.objectContaining({ id: third.id, order: 1 }),
 			]);
 		});
 
 		it('deletes a project rule without deleting the projects it referenced', async () => {
-			const ruleId = await createRule({
+			const rule = await createProjectRule({
 				expression: 'claims.project === "alpha"',
 				role: 'project:editor',
 				type: 'project',
 				projectIds: [teamProject.id],
 			});
 
-			await testServer.publicApiAgentFor(owner).delete(`/role-mapping-rules/${ruleId}`).expect(204);
+			await testServer
+				.publicApiAgentFor(owner)
+				.delete(`/role-mapping-rules/${rule.id}`)
+				.expect(204);
 
-			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: ruleId });
+			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: rule.id });
 			expect(stored).toBeNull();
 
 			const project = await Container.get(ProjectRepository).findOneBy({ id: teamProject.id });
@@ -857,45 +853,45 @@ describe('Role mapping rules in Public API', () => {
 		});
 
 		it('rejects with 401 without an API key', async () => {
-			const ruleId = await createRule(validInstancePayload);
+			const rule = await createInstanceRule(validInstancePayload);
 
 			const response = await testServer
 				.publicApiAgentWithoutApiKey()
-				.delete(`/role-mapping-rules/${ruleId}`);
+				.delete(`/role-mapping-rules/${rule.id}`);
 
 			expect(response.status).toBe(401);
 		});
 
 		it('rejects with 401 with an invalid API key', async () => {
-			const ruleId = await createRule(validInstancePayload);
+			const rule = await createInstanceRule(validInstancePayload);
 
 			const response = await testServer
 				.publicApiAgentWithApiKey('invalid-key')
-				.delete(`/role-mapping-rules/${ruleId}`);
+				.delete(`/role-mapping-rules/${rule.id}`);
 
 			expect(response.status).toBe(401);
 		});
 
 		it('rejects with 403 when the key lacks roleMappingRule:delete', async () => {
-			const ruleId = await createRule(validInstancePayload);
+			const rule = await createInstanceRule(validInstancePayload);
 			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
 
 			const response = await testServer
 				.publicApiAgentFor(scopedOwner)
-				.delete(`/role-mapping-rules/${ruleId}`);
+				.delete(`/role-mapping-rules/${rule.id}`);
 
 			expect(response.status).toBe(403);
 		});
 
 		it('rejects with 403 when provisioning is not licensed', async () => {
-			const ruleId = await createRule(validInstancePayload);
+			const rule = await createInstanceRule(validInstancePayload);
 
 			testServer.license.disable('feat:saml');
 			testServer.license.disable('feat:oidc');
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
-				.delete(`/role-mapping-rules/${ruleId}`);
+				.delete(`/role-mapping-rules/${rule.id}`);
 
 			expect(response.status).toBe(403);
 			expect(response.body.message).toBe('Provisioning is not licensed');

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -1,6 +1,6 @@
 import type { CreateRoleMappingRuleDto, RoleMappingRulePublicDto } from '@n8n/api-types';
 import { createTeamProject, testDb } from '@n8n/backend-test-utils';
-import { RoleMappingRuleRepository, type Project, type User } from '@n8n/db';
+import { ProjectRepository, RoleMappingRuleRepository, type Project, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import assert from 'node:assert';
 
@@ -778,6 +778,124 @@ describe('Role mapping rules in Public API', () => {
 				.publicApiAgentFor(owner)
 				.patch(`/role-mapping-rules/${rule.id}`)
 				.send({ expression: 'claims.group === "engineers"' });
+
+			expect(response.status).toBe(403);
+			expect(response.body.message).toBe('Provisioning is not licensed');
+
+			testServer.license.enable('feat:saml');
+		});
+	});
+
+	describe('DELETE /role-mapping-rules/:roleMappingRuleId', () => {
+		const createRule = async (payload: CreateRoleMappingRuleDto) => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send(payload)
+				.expect(201);
+
+			return response.body.id as string;
+		};
+
+		it('deletes a rule and returns 204 with no content', async () => {
+			const ruleId = await createRule(validInstancePayload);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.delete(`/role-mapping-rules/${ruleId}`);
+
+			expect(response.status).toBe(204);
+			expect(response.body).toEqual({});
+
+			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: ruleId });
+			expect(stored).toBeNull();
+		});
+
+		it('closes the gap in the evaluation order of the remaining rules', async () => {
+			const { expression, role, type } = validInstancePayload;
+
+			const first = await createRule(validInstancePayload);
+			const second = await createRule({ expression, role, type, order: 1 });
+			const third = await createRule({ expression, role, type, order: 2 });
+
+			await testServer.publicApiAgentFor(owner).delete(`/role-mapping-rules/${second}`).expect(204);
+
+			const remaining = await testServer
+				.publicApiAgentFor(owner)
+				.get('/role-mapping-rules?type=instance')
+				.expect(200);
+
+			expect(remaining.body.data).toEqual([
+				expect.objectContaining({ id: first, order: 0 }),
+				expect.objectContaining({ id: third, order: 1 }),
+			]);
+		});
+
+		it('deletes a project rule without deleting the projects it referenced', async () => {
+			const ruleId = await createRule({
+				expression: 'claims.project === "alpha"',
+				role: 'project:editor',
+				type: 'project',
+				projectIds: [teamProject.id],
+			});
+
+			await testServer.publicApiAgentFor(owner).delete(`/role-mapping-rules/${ruleId}`).expect(204);
+
+			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: ruleId });
+			expect(stored).toBeNull();
+
+			const project = await Container.get(ProjectRepository).findOneBy({ id: teamProject.id });
+			expect(project).not.toBeNull();
+		});
+
+		it('rejects an unknown rule id with 404', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.delete('/role-mapping-rules/00000000-0000-4000-8000-000000000000');
+
+			expect(response.status).toBe(404);
+		});
+
+		it('rejects with 401 without an API key', async () => {
+			const ruleId = await createRule(validInstancePayload);
+
+			const response = await testServer
+				.publicApiAgentWithoutApiKey()
+				.delete(`/role-mapping-rules/${ruleId}`);
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 401 with an invalid API key', async () => {
+			const ruleId = await createRule(validInstancePayload);
+
+			const response = await testServer
+				.publicApiAgentWithApiKey('invalid-key')
+				.delete(`/role-mapping-rules/${ruleId}`);
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when the key lacks roleMappingRule:delete', async () => {
+			const ruleId = await createRule(validInstancePayload);
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
+
+			const response = await testServer
+				.publicApiAgentFor(scopedOwner)
+				.delete(`/role-mapping-rules/${ruleId}`);
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects with 403 when provisioning is not licensed', async () => {
+			const ruleId = await createRule(validInstancePayload);
+
+			testServer.license.disable('feat:saml');
+			testServer.license.disable('feat:oidc');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.delete(`/role-mapping-rules/${ruleId}`);
 
 			expect(response.status).toBe(403);
 			expect(response.body.message).toBe('Provisioning is not licensed');

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -787,15 +787,24 @@ describe('Role mapping rules in Public API', () => {
 	});
 
 	describe('DELETE /role-mapping-rules/:roleMappingRuleId', () => {
-		it('deletes a rule and returns 204 with no content', async () => {
+		it('deletes a rule and returns 200 with the deleted rule', async () => {
 			const rule = await createInstanceRule(validInstancePayload);
 
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.delete(`/role-mapping-rules/${rule.id}`);
 
-			expect(response.status).toBe(204);
-			expect(response.body).toEqual({});
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({
+				id: rule.id,
+				expression: rule.expression,
+				role: rule.role,
+				type: rule.type,
+				order: rule.order,
+				projectIds: rule.projectIds,
+				createdAt: rule.createdAt,
+				updatedAt: rule.updatedAt,
+			});
 
 			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: rule.id });
 			expect(stored).toBeNull();
@@ -811,7 +820,7 @@ describe('Role mapping rules in Public API', () => {
 			await testServer
 				.publicApiAgentFor(owner)
 				.delete(`/role-mapping-rules/${second.id}`)
-				.expect(204);
+				.expect(200);
 
 			const remaining = await testServer
 				.publicApiAgentFor(owner)
@@ -835,7 +844,7 @@ describe('Role mapping rules in Public API', () => {
 			await testServer
 				.publicApiAgentFor(owner)
 				.delete(`/role-mapping-rules/${rule.id}`)
-				.expect(204);
+				.expect(200);
 
 			const stored = await Container.get(RoleMappingRuleRepository).findOneBy({ id: rule.id });
 			expect(stored).toBeNull();

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -189,24 +189,6 @@ describe('Role mapping rules in Public API', () => {
 			);
 		});
 
-		it('rejects with 401 without an API key', async () => {
-			const response = await testServer
-				.publicApiAgentWithoutApiKey()
-				.post('/role-mapping-rules')
-				.send(validInstancePayload);
-
-			expect(response.status).toBe(401);
-		});
-
-		it('rejects with 401 with an invalid API key', async () => {
-			const response = await testServer
-				.publicApiAgentWithApiKey('invalid-key')
-				.post('/role-mapping-rules')
-				.send(validInstancePayload);
-
-			expect(response.status).toBe(401);
-		});
-
 		it('rejects with 403 when the key lacks roleMappingRule:create', async () => {
 			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
 
@@ -326,20 +308,6 @@ describe('Role mapping rules in Public API', () => {
 				.query({ type: 'bogus' });
 
 			expect(response.status).toBe(400);
-		});
-
-		it('rejects with 401 without an API key', async () => {
-			const response = await testServer.publicApiAgentWithoutApiKey().get('/role-mapping-rules');
-
-			expect(response.status).toBe(401);
-		});
-
-		it('rejects with 401 with an invalid API key', async () => {
-			const response = await testServer
-				.publicApiAgentWithApiKey('invalid-key')
-				.get('/role-mapping-rules');
-
-			expect(response.status).toBe(401);
 		});
 
 		it('rejects with 403 when the key lacks roleMappingRule:list', async () => {
@@ -491,24 +459,6 @@ describe('Role mapping rules in Public API', () => {
 				.send({ targetIndex: 0 });
 
 			expect(response.status).toBe(404);
-		});
-
-		it('rejects with 401 without an API key', async () => {
-			const response = await testServer
-				.publicApiAgentWithoutApiKey()
-				.post('/role-mapping-rules/does-not-exist/move')
-				.send({ targetIndex: 0 });
-
-			expect(response.status).toBe(401);
-		});
-
-		it('rejects with 401 with an invalid API key', async () => {
-			const response = await testServer
-				.publicApiAgentWithApiKey('invalid-key')
-				.post('/role-mapping-rules/does-not-exist/move')
-				.send({ targetIndex: 0 });
-
-			expect(response.status).toBe(401);
 		});
 
 		it('rejects with 403 when the key lacks roleMappingRule:update', async () => {
@@ -734,28 +684,6 @@ describe('Role mapping rules in Public API', () => {
 			expect(response.body.message).toBe('One or more projects were not found');
 		});
 
-		it('rejects with 401 without an API key', async () => {
-			const rule = await createInstanceRule();
-
-			const response = await testServer
-				.publicApiAgentWithoutApiKey()
-				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'claims.group === "engineers"' });
-
-			expect(response.status).toBe(401);
-		});
-
-		it('rejects with 401 with an invalid API key', async () => {
-			const rule = await createInstanceRule();
-
-			const response = await testServer
-				.publicApiAgentWithApiKey('invalid-key')
-				.patch(`/role-mapping-rules/${rule.id}`)
-				.send({ expression: 'claims.group === "engineers"' });
-
-			expect(response.status).toBe(401);
-		});
-
 		it('rejects with 403 when the key lacks roleMappingRule:update', async () => {
 			const rule = await createInstanceRule();
 			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
@@ -859,26 +787,6 @@ describe('Role mapping rules in Public API', () => {
 				.delete('/role-mapping-rules/00000000-0000-4000-8000-000000000000');
 
 			expect(response.status).toBe(404);
-		});
-
-		it('rejects with 401 without an API key', async () => {
-			const rule = await createInstanceRule(validInstancePayload);
-
-			const response = await testServer
-				.publicApiAgentWithoutApiKey()
-				.delete(`/role-mapping-rules/${rule.id}`);
-
-			expect(response.status).toBe(401);
-		});
-
-		it('rejects with 401 with an invalid API key', async () => {
-			const rule = await createInstanceRule(validInstancePayload);
-
-			const response = await testServer
-				.publicApiAgentWithApiKey('invalid-key')
-				.delete(`/role-mapping-rules/${rule.id}`);
-
-			expect(response.status).toBe(401);
 		});
 
 		it('rejects with 403 when the key lacks roleMappingRule:delete', async () => {

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -53,6 +53,9 @@
 		"PATCH /role-mapping-rules/{roleMappingRuleId}": {
 			"status": "gap"
 		},
+		"DELETE /role-mapping-rules/{roleMappingRuleId}": {
+			"status": "gap"
+		},
 		"GET /settings/security-policy": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/v1/role-mapping-rules/{roleMappingRuleId}` to the Public API, a thin `@PublicApiController` wrapper over `RoleMappingRuleService.delete`
- Returns `200` with the deleted rule. Deleting a rule closes the gap in its type's evaluation order, so the remaining `order` values stay a contiguous sequence starting at 0
- Moves `role-mapping-rule-deleted` event emission into the shared service, out of the internal controller, so the internal `DELETE` and the public route emit identically — the same pattern used for `move` in API-51
- Adds `roleMappingRule:delete` to `API_KEY_RESOURCES` and `OWNER_API_KEY_SCOPES`

Demo:
https://www.loom.com/share/47039803af56443eb20e15616bc67f85

## How to test

With an API key that has the `roleMappingRule:delete` scope and an instance with the provisioning licence enabled:

```bash
# Create a rule to delete
curl -X POST "http://localhost:5678/api/v1/role-mapping-rules" \
  -H "X-N8N-API-KEY: $KEY" \
  -H "Content-Type: application/json" \
  -d '{"expression": "claims.group === \"admins\"", "role": "global:member", "type": "instance"}'

# Delete it — expect 200 with the deleted rule
curl -i -X DELETE "http://localhost:5678/api/v1/role-mapping-rules/<ruleId>" \
  -H "X-N8N-API-KEY: $KEY"

# Deleting it again returns 404
curl -i -X DELETE "http://localhost:5678/api/v1/role-mapping-rules/<ruleId>" \
  -H "X-N8N-API-KEY: $KEY"
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-52

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
