### PR TITLE
fix(core): Persist OTel traceparent before enqueueing queue-mode jobs

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -520,6 +520,41 @@ describe('enqueueExecution', () => {
 
 		expect(addJob).toHaveBeenCalledWith(expect.objectContaining(processData), expect.any(Object));
 	});
+
+	it('runs workflowExecuteBefore before enqueueing the job, so a worker cannot dequeue and start executing before its tracing context is persisted', async () => {
+		const activeExecutions = Container.get(ActiveExecutions);
+		vi.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValue();
+		vi.spyOn(runner, 'processError').mockResolvedValue();
+		const data = mock<IWorkflowExecutionDataProcess>({
+			workflowData: { nodes: [], staticData: {} },
+			executionData: undefined,
+		});
+
+		const callOrder: string[] = [];
+		const actualGetLifecycleHooksForScalingMain =
+			ExecutionLifecycleHooks.getLifecycleHooksForScalingMain;
+		vi.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForScalingMain').mockImplementation(
+			(...args) => {
+				const hooks = actualGetLifecycleHooksForScalingMain(...args);
+				const originalRunHook = hooks.runHook.bind(hooks);
+				vi.spyOn(hooks, 'runHook').mockImplementation(async (hookName, params) => {
+					if (hookName === 'workflowExecuteBefore') callOrder.push('workflowExecuteBefore');
+					return await originalRunHook(hookName, params);
+				});
+				return hooks;
+			},
+		);
+
+		addJob.mockImplementationOnce(async () => {
+			callOrder.push('addJob');
+			throw new Error('stop for test purposes');
+		});
+
+		// @ts-expect-error Private method
+		await expect(runner.enqueueExecution('1', 'workflow-xyz', data)).rejects.toThrow();
+
+		expect(callOrder).toEqual(['workflowExecuteBefore', 'addJob']);
+	});
 });
 
 describe('workflow timeout with startedAt', () => {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -551,13 +551,18 @@ export class WorkflowRunner {
 		let job: Job;
 		let lifecycleHooks: ExecutionLifecycleHooks;
 		try {
-			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100 });
-
 			lifecycleHooks = getLifecycleHooksForScalingMain(data, executionId);
 
+			// Run before enqueueing: this is what starts (and persists to the execution
+			// row) the OTel traceparent a worker parents its own workflow.execute span
+			// under. Enqueueing first let a fast-dequeuing worker start executing - and
+			// look up that traceparent - before it was written, orphaning the worker's
+			// span (and its node.execute children) onto a disconnected trace.
 			// Normally also workflow should be supplied here but as it only used for sending
 			// data to editor-UI is not needed.
 			await lifecycleHooks.runHook('workflowExecuteBefore', [undefined, data.executionData]);
+
+			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100 });
 		} catch (error) {
 			// We use "getLifecycleHooksForScalingWorker" as "getLifecycleHooksForScalingMain" does not contain the
 			// "workflowExecuteAfter" which we require.


### PR DESCRIPTION
## Summary

In queue mode, `enqueueExecution` adds the job to the queue before it runs
the `workflowExecuteBefore` hook. This hook starts the OTel `workflow.execute`
span for the main process and persists its traceparent to the execution row.

A worker can dequeue and start a job almost immediately. If the worker starts
before the traceparent write finishes, the worker looks up a traceparent that
is not there yet. This orphans the worker's own `workflow.execute` span, and
every `node.execute` span nested under it, onto a disconnected trace instead
of the trace under the main process span.

This PR runs the hook before the job is enqueued. This guarantees the
traceparent is persisted by the time a worker can pick up the job.

## How to test

1. Run n8n in queue mode with a worker process and Redis.
2. Enable OTel tracing:
   - `N8N_OTEL_ENABLED=true`
   - `N8N_OTEL_EXPORTER_OTLP_ENDPOINT=<your OTLP collector, e.g. Jaeger on :4318>`
   - `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=true`
   - `N8N_OTEL_TRACES_PRODUCTION_ONLY=false`
3. Execute a multi-node workflow (any workflow with 2+ nodes after the trigger).
4. In your trace viewer, confirm a single `workflow.execute` trace contains
   all of that execution's `node.execute` spans nested underneath it.

Example workflow to import onto the canvas:

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [0, 0],
      "id": "3f1a2b4c-1111-4a1a-9c1a-000000000001",
      "name": "Trigger"
    },
    {
      "parameters": { "category": "doNothing" },
      "type": "n8n-nodes-base.debugHelper",
      "typeVersion": 1,
      "position": [220, 0],
      "id": "3f1a2b4c-1111-4a1a-9c1a-000000000002",
      "name": "Step 1"
    },
    {
      "parameters": { "category": "doNothing" },
      "type": "n8n-nodes-base.debugHelper",
      "typeVersion": 1,
      "position": [440, 0],
      "id": "3f1a2b4c-1111-4a1a-9c1a-000000000003",
      "name": "Step 2"
    }
  ],
  "connections": {
    "Trigger": { "main": [[{ "node": "Step 1", "type": "main", "index": 0 }]] },
    "Step 1": { "main": [[{ "node": "Step 2", "type": "main", "index": 0 }]] }
  },
  "pinData": {}
}
```

Added a regression test (`workflow-runner.test.ts`) asserting
`workflowExecuteBefore` runs before the job is added to the queue.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #36769

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


