### PR TITLE
fix: Fix setup credential tool description

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -1,4 +1,5 @@
 import type { InstanceAiPermissions } from '@n8n/api-types';
+import { isZodSchema, zodToJsonSchema } from '@n8n/agents';
 import type { Mock } from 'vitest';
 
 import { executeTool } from '../../__tests__/tool-test-utils';
@@ -61,6 +62,30 @@ function getDescription(tool: unknown): string {
 	return (tool as { description: string }).description;
 }
 
+type JsonSchema = NonNullable<ReturnType<typeof zodToJsonSchema>>;
+
+function inputJsonSchema(tool: unknown): JsonSchema {
+	const { inputSchema } = tool as { inputSchema: unknown };
+	if (!isZodSchema(inputSchema)) throw new Error('expected a Zod input schema');
+	const jsonSchema = zodToJsonSchema(inputSchema);
+	if (!jsonSchema) throw new Error('expected the input schema to convert');
+	return jsonSchema;
+}
+
+function property(schema: JsonSchema, name: string): JsonSchema {
+	const value = schema.properties?.[name];
+	if (typeof value !== 'object') throw new Error(`expected an object schema for "${name}"`);
+	return value;
+}
+
+function arrayItems(schema: JsonSchema): JsonSchema {
+	const value = schema.items;
+	if (typeof value !== 'object' || Array.isArray(value)) {
+		throw new Error('expected a single items schema');
+	}
+	return value;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('credentials tool', () => {
@@ -83,6 +108,17 @@ describe('credentials tool', () => {
 				}).success,
 			).toBe(true);
 			expect(getDescription(tool)).toContain('set up new credentials');
+		});
+
+		it('should describe credentialType with existing "gmailOAuth2" credential type and not "gmailOAuth2Api"', () => {
+			const tool = createCredentialsTool(createMockContext());
+			const credentialType = property(
+				arrayItems(property(inputJsonSchema(tool), 'credentials')),
+				'credentialType',
+			);
+
+			expect(credentialType.description).toContain('gmailOAuth2"');
+			expect(credentialType.description).not.toContain('gmailOAuth2Api');
 		});
 
 		it('should require requireUserSelection to be a boolean when provided', () => {

--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -1,5 +1,5 @@
-import type { InstanceAiPermissions } from '@n8n/api-types';
 import { isZodSchema, zodToJsonSchema } from '@n8n/agents';
+import type { InstanceAiPermissions } from '@n8n/api-types';
 import type { Mock } from 'vitest';
 
 import { executeTool } from '../../__tests__/tool-test-utils';

--- a/packages/@n8n/instance-ai/src/tools/__tests__/n8n-docs.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/n8n-docs.tool.test.ts
@@ -155,7 +155,7 @@ describe('n8n-docs tool', () => {
 		const matches = rankN8nDocsEntries(registry.entries, {
 			query: 'How do I set up Gmail OAuth2 API credentials?',
 			intent: 'credential-setup',
-			credentialType: 'gmailOAuth2Api',
+			credentialType: 'gmailOAuth2',
 			credentialDisplayName: 'Gmail OAuth2 API',
 			nodeType: 'n8n-nodes-base.gmail',
 		});
@@ -197,7 +197,7 @@ describe('n8n-docs tool', () => {
 			action: 'lookup',
 			query: 'How do I set up Gmail OAuth2 API credentials?',
 			intent: 'credential-setup',
-			credentialType: 'gmailOAuth2Api',
+			credentialType: 'gmailOAuth2',
 			credentialDisplayName: 'Gmail OAuth2 API',
 			oauthRedirectUrl: 'http://localhost:5678/rest/oauth2-credential/callback',
 		});

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -290,7 +290,7 @@ const setupAction = z.object({
 			z.object({
 				credentialType: z
 					.string()
-					.describe('n8n credential type name (e.g. "slackApi", "gmailOAuth2Api")'),
+					.describe('n8n credential type name (e.g. "slackApi", "gmailOAuth2")'),
 				reason: z.string().optional().describe('Why this credential is needed (shown to user)'),
 				suggestedName: z
 					.string()

--- a/packages/@n8n/instance-ai/src/tools/n8n-docs/schemas.ts
+++ b/packages/@n8n/instance-ai/src/tools/n8n-docs/schemas.ts
@@ -22,7 +22,7 @@ const sharedLookupFields = {
 	credentialType: z
 		.string()
 		.optional()
-		.describe('n8n credential type name, for example "gmailOAuth2Api".'),
+		.describe('n8n credential type name, for example "gmailOAuth2".'),
 	credentialDisplayName: z
 		.string()
 		.optional()

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/resolve-credentials.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/resolve-credentials.test.ts
@@ -875,7 +875,7 @@ describe('resolveCredentials', () => {
 						type: 'n8n-nodes-base.gmail',
 						typeVersion: 2,
 						position: [0, 0],
-						credentials: { gmailOAuth2Api: undefined as unknown as { id: string; name: string } },
+						credentials: { gmailOAuth2: undefined as unknown as { id: string; name: string } },
 					},
 				],
 			});
@@ -883,8 +883,8 @@ describe('resolveCredentials', () => {
 			const result = await resolveCredentials(json, undefined, createMockContext());
 
 			expect(result.mockedNodeNames).toEqual(['Gmail']);
-			expect(result.mockedCredentialTypes).toEqual(['gmailOAuth2Api']);
-			expect(result.mockedCredentialsByNode).toEqual({ Gmail: ['gmailOAuth2Api'] });
+			expect(result.mockedCredentialTypes).toEqual(['gmailOAuth2']);
+			expect(result.mockedCredentialsByNode).toEqual({ Gmail: ['gmailOAuth2'] });
 			expect(json.nodes[0].credentials).toEqual({});
 			// json.pinData must NOT be mutated
 			expect(json.pinData).toBeUndefined();
@@ -953,7 +953,7 @@ describe('resolveCredentials', () => {
 		const availableCredentials = makeCredentialMap([
 			{ id: 'slack-1', name: 'Team Slack', type: 'slackApi' },
 			{ id: 'slack-2', name: 'Backup Slack', type: 'slackApi' },
-			{ id: 'gmail-1', name: 'Gmail', type: 'gmailOAuth2Api' },
+			{ id: 'gmail-1', name: 'Gmail', type: 'gmailOAuth2' },
 		]);
 
 		it('keeps a raw credential id that exists in the snapshot for the same type', async () => {
@@ -1047,7 +1047,7 @@ describe('resolveCredentials', () => {
 						type: 'n8n-nodes-base.gmail',
 						typeVersion: 2,
 						position: [0, 0],
-						credentials: { gmailOAuth2Api: { id: 'mock-gmail-oauth2', name: 'Gmail' } },
+						credentials: { gmailOAuth2: { id: 'mock-gmail-oauth2', name: 'Gmail' } },
 					},
 				],
 			});
@@ -1060,7 +1060,7 @@ describe('resolveCredentials', () => {
 			);
 
 			expect(result.mockedNodeNames).toEqual(['Gmail']);
-			expect(result.mockedCredentialTypes).toEqual(['gmailOAuth2Api']);
+			expect(result.mockedCredentialTypes).toEqual(['gmailOAuth2']);
 			expect(json.nodes[0].credentials).toEqual({});
 		});
 
@@ -1274,7 +1274,7 @@ describe('resolveCredentials', () => {
 						type: 'n8n-nodes-base.gmail',
 						typeVersion: 2,
 						position: [200, 0],
-						credentials: { gmailOAuth2Api: undefined as unknown as { id: string; name: string } },
+						credentials: { gmailOAuth2: undefined as unknown as { id: string; name: string } },
 					},
 				],
 				pinData: {
@@ -1285,7 +1285,7 @@ describe('resolveCredentials', () => {
 			const result = await resolveCredentials(json, undefined, createMockContext());
 
 			expect(result.mockedNodeNames).toEqual(['Gmail']);
-			expect(result.mockedCredentialTypes).toEqual(['gmailOAuth2Api']);
+			expect(result.mockedCredentialTypes).toEqual(['gmailOAuth2']);
 			// Slack should be untouched
 			expect(json.nodes[0].credentials).toEqual({
 				slackApi: { id: 'real-id', name: 'Real Slack' },

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2653,7 +2653,7 @@ describe('createWorkflowAdapter', () => {
 					parameters: {},
 					credentials: {
 						slackApi: { name: 'Slack' },
-						gmailOAuth2Api: { id: '', name: 'Gmail' },
+						gmailOAuth2: { id: '', name: 'Gmail' },
 						openAiApi: { id: null, name: 'OpenAI' },
 						httpHeaderAuth: { id: 'cred-1', name: 'HTTP Header' },
 					},
@@ -2714,7 +2714,7 @@ describe('createWorkflowAdapter', () => {
 					parameters: {},
 					credentials: {
 						slackApi: { name: 'Slack' },
-						gmailOAuth2Api: { id: '  ', name: 'Gmail' },
+						gmailOAuth2: { id: '  ', name: 'Gmail' },
 					},
 				},
 			],

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -237,7 +237,7 @@ describe('InstanceAiController', () => {
 				context: {
 					source: 'credential-modal',
 					credential: {
-						credentialType: 'gmailOAuth2Api',
+						credentialType: 'gmailOAuth2',
 						displayName: 'Gmail OAuth2 API',
 						documentationUrl:
 							'https://docs.n8n.io/integrations/builtin/credentials/google/oauth-single-service/',

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1403,7 +1403,7 @@ describe('InstanceAiService — background task auto-follow-up', () => {
 		const context = {
 			source: 'credential-modal' as const,
 			credential: {
-				credentialType: 'gmailOAuth2Api',
+				credentialType: 'gmailOAuth2',
 				displayName: 'Gmail OAuth2 API',
 				documentationUrl:
 					'https://docs.n8n.io/integrations/builtin/credentials/google/oauth-single-service/',

--- a/packages/cli/src/modules/instance-ai/__tests__/internal-messages.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/internal-messages.test.ts
@@ -31,7 +31,7 @@ function editorContextMarker(
 function credentialContextMarker(): string {
 	return `<credential-context>\n${JSON.stringify({
 		source: 'credential-modal',
-		credential: { credentialType: 'gmailOAuth2Api', displayName: 'Gmail OAuth2 API' },
+		credential: { credentialType: 'gmailOAuth2', displayName: 'Gmail OAuth2 API' },
 	})}\n\nThe user opened this conversation from the credential setup modal.\n</credential-context>`;
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useDynamicCredentialsStatus.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useDynamicCredentialsStatus.test.ts
@@ -40,7 +40,7 @@ function createExecutionStatus(
 			{
 				credentialId: 'cred-2',
 				credentialName: 'Gmail',
-				credentialType: 'gmailOAuth2Api',
+				credentialType: 'gmailOAuth2',
 				credentialStatus: 'configured',
 				authorizationUrl:
 					'https://n8n.example.com/rest/credentials/cred-2/authorize?resolverId=resolver-2',
@@ -156,7 +156,7 @@ describe('useDynamicCredentialsStatus', () => {
 						{
 							credentialId: 'cred-2',
 							credentialName: 'Gmail',
-							credentialType: 'gmailOAuth2Api',
+							credentialType: 'gmailOAuth2',
 							credentialStatus: 'configured',
 						},
 					],
@@ -297,7 +297,7 @@ describe('useDynamicCredentialsStatus', () => {
 						{
 							credentialId: 'cred-2',
 							credentialName: 'Gmail',
-							credentialType: 'gmailOAuth2Api',
+							credentialType: 'gmailOAuth2',
 							credentialStatus: 'configured',
 							authorizationUrl:
 								'https://n8n.example.com/rest/credentials/cred-2/authorize?resolverId=resolver-2',

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiArtifactsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiArtifactsPanel.test.ts
@@ -201,7 +201,7 @@ describe('InstanceAiArtifactsPanel', () => {
 				context: {
 					source: 'credential-modal',
 					credential: {
-						credentialType: 'gmailOAuth2Api',
+						credentialType: 'gmailOAuth2',
 						displayName: 'Gmail OAuth2 API',
 					},
 				},
@@ -367,7 +367,7 @@ describe('InstanceAiArtifactsPanel', () => {
 		const pendingComposerContext = ref({
 			source: 'credential-modal' as const,
 			credential: {
-				credentialType: 'gmailOAuth2Api',
+				credentialType: 'gmailOAuth2',
 				displayName: 'Gmail OAuth2 API',
 			},
 		});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
@@ -1105,7 +1105,7 @@ describe('createThreadRuntime - SSE and hydration', () => {
 		const context = {
 			source: 'credential-modal' as const,
 			credential: {
-				credentialType: 'gmailOAuth2Api',
+				credentialType: 'gmailOAuth2',
 				displayName: 'Gmail OAuth2 API',
 				documentationUrl:
 					'https://docs.n8n.io/integrations/builtin/credentials/google/oauth-single-service/',

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useInstanceAiHandoff.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useInstanceAiHandoff.test.ts
@@ -63,7 +63,7 @@ describe('useInstanceAiHandoff', () => {
 	it('builds credential modal handoff context without empty optional fields', () => {
 		expect(
 			buildInstanceAiCredentialHandoffContext({
-				credentialType: 'gmailOAuth2Api',
+				credentialType: 'gmailOAuth2',
 				displayName: 'Gmail OAuth2 API',
 				nodeName: 'Gmail',
 				nodeType: 'n8n-nodes-base.gmail',
@@ -74,7 +74,7 @@ describe('useInstanceAiHandoff', () => {
 		).toEqual({
 			source: 'credential-modal',
 			credential: {
-				credentialType: 'gmailOAuth2Api',
+				credentialType: 'gmailOAuth2',
 				displayName: 'Gmail OAuth2 API',
 				nodeName: 'Gmail',
 				nodeType: 'n8n-nodes-base.gmail',


### PR DESCRIPTION
## Summary

Fixes the setup credential tool description to contain the correct `gmailOAuth2` credential type and not the non-existing `gmailOAuth2Api`.

The fix is one line, most changes in this PR are replacing the incorrect credential type across test files

## How to test

1. ask AI Assistant to `run the "setup credential" tool with gmail credential type`
2. observe that the setup card correctly says `Set up Gmail` and references the Gmail credential (Gmail icon), not `Set up gmailOAuth2Api`

Reproduced the bug on `2.35.4`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5512/automatically-set-up-credentials-showing-for-managed-credentials

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
