### PR TITLE
Discord nested object resolution

### DIFF
--- a/packages/nodes-base/nodes/Discord/v2/helpers/__tests__/utils.test.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep } from 'vitest-mock-extended';
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { NodeOperationError, jsonParse } from 'n8n-workflow';
-import { getAuditLogReasonHeaders, prepareMultiPartForm } from '../utils';
+import { getAuditLogReasonHeaders, prepareEmbeds, prepareMultiPartForm } from '../utils';
 
 describe('Discord V2 Utils', () => {
 	describe('prepareMultiPartForm', () => {
@@ -359,6 +359,215 @@ describe('Discord V2 Utils', () => {
 			expect(mockExecuteFunctions.helpers.assertBinaryData).toHaveBeenCalledWith(2, 'file1');
 			expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(2, 'file1');
 			expect(result).toBeDefined();
+		});
+	});
+
+	describe('prepareEmbeds', () => {
+		let mockExecuteFunctions: IExecuteFunctions;
+
+		beforeEach(() => {
+			mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+			mockExecuteFunctions.getNode = vi.fn().mockReturnValue({ name: 'Discord' });
+		});
+
+		afterEach(() => {
+			vi.resetAllMocks();
+		});
+
+		it('should build an embed from form fields, dropping empty string values', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					title: 'Hello',
+					description: '',
+					url: 'https://example.com',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([{ title: 'Hello', url: 'https://example.com' }]);
+		});
+
+		it('should convert a string author into an author object', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					author: 'Jane Doe',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([{ author: { name: 'Jane Doe' } }]);
+		});
+
+		it('should convert a hex color string into a decimal integer', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					color: '#FF0000',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([{ color: 16711680 }]);
+		});
+
+		it('should wrap a video URL string into a video object with default dimensions', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					video: 'https://example.com/video.mp4',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([
+				{
+					video: {
+						url: 'https://example.com/video.mp4',
+						width: 1270,
+						height: 720,
+					},
+				},
+			]);
+		});
+
+		it('should wrap a thumbnail URL string into a thumbnail object', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					thumbnail: 'https://example.com/thumb.png',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([
+				{
+					thumbnail: { url: 'https://example.com/thumb.png' },
+				},
+			]);
+		});
+
+		it('should wrap an image URL string into an image object', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					image: 'https://example.com/image.png',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([
+				{
+					image: { url: 'https://example.com/image.png' },
+				},
+			]);
+		});
+
+		it('should not re-wrap an image that is already an object', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					image: { url: 'https://example.com/image.png', width: 100, height: 100 },
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([
+				{
+					image: { url: 'https://example.com/image.png', width: 100, height: 100 },
+				},
+			]);
+		});
+
+		it('should preserve sibling fields when the image is already an object', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					title: 'Has image object',
+					image: { url: 'https://example.com/pic.png' },
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([
+				{
+					title: 'Has image object',
+					image: { url: 'https://example.com/pic.png' },
+				},
+			]);
+		});
+
+		it('should parse a valid JSON string when inputMethod is json', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'json',
+					json: '{"title":"From JSON","color":"#00FF00"}',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([{ title: 'From JSON', color: 65280 }]);
+		});
+
+		it('should throw a NodeOperationError when the JSON string is invalid', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'json',
+					json: '{invalid json',
+				},
+			];
+
+			expect(() => prepareEmbeds.call(mockExecuteFunctions, embeds)).toThrow(NodeOperationError);
+			expect(() => prepareEmbeds.call(mockExecuteFunctions, embeds)).toThrow('Not a valid JSON');
+		});
+
+		it('should filter out embeds that end up empty', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					description: '',
+				},
+				{
+					inputMethod: 'fields',
+					title: 'Kept',
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([{ title: 'Kept' }]);
+		});
+
+		it('should process multiple embeds independently', () => {
+			const embeds: IDataObject[] = [
+				{
+					inputMethod: 'fields',
+					title: 'First',
+					image: 'https://example.com/first.png',
+				},
+				{
+					inputMethod: 'fields',
+					title: 'Second',
+					image: { url: 'https://example.com/second.png' },
+				},
+			];
+
+			const result = prepareEmbeds.call(mockExecuteFunctions, embeds);
+
+			expect(result).toEqual([
+				{ title: 'First', image: { url: 'https://example.com/first.png' } },
+				{ title: 'Second', image: { url: 'https://example.com/second.png' } },
+			]);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
@@ -173,7 +173,8 @@ export function prepareEmbeds(this: IExecuteFunctions, embeds: IDataObject[]) {
 					url: embedReturnData.thumbnail,
 				};
 			}
-			if (embedReturnData.image) {
+
+			if (embedReturnData.image && typeof embedReturnData.image !== 'object') {
 				embedReturnData.image = {
 					url: embedReturnData.image,
 				};


### PR DESCRIPTION
## Summary

Fix Discord embed JSON parsing when the `image` field is already provided as a valid Discord embed object.

When using the JSON input method, a valid embed such as:

```json
{
  "image": {
    "url": "https://example.com/image.png"
  }
}
```

was incorrectly transformed into:

```json
{
  "image": {
    "url": {
      "url": "https://example.com/image.png"
    }
  }
}
```

This happened because the image normalization logic wrapped `embedReturnData.image` in a `{ url: ... }` object even when the image was already an object.

The change ensures that image values are only wrapped when they are not already objects.

## How to test

1. Create a Discord node using webhook authentication.
2. Select the message operation.
3. Under **Embeds**, select the JSON/Raw JSON input method.
4. Use the following embed:

```json
{
  "image": {
    "url": "https://upload.wikimedia.org/wikipedia/commons/9/9f/Old_wikipedia_logo.png"
  }
}
```

5. Execute the workflow.
6. Verify that the Discord message is sent successfully and the image is displayed.
7. Also test the non-JSON/string image input:

```json
{
  "image": "https://upload.wikimedia.org/wikipedia/commons/9/9f/Old_wikipedia_logo.png"
}
```

8. Verify that the string image is still converted to the expected Discord format.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add the issue number here once confirmed -->

Fixes #36506

## Review / Merge checklist

* [x] I have seen this code, I have run this code.
* [x] PR title and summary are descriptive.
* [x] Docs updated or follow-up ticket created.
* [x] Tests included.
* [x] PR labeled appropriately if backporting is required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

