### PR TITLE
docs: Add spec creation flow to spec-driven-development skill

### DIFF
--- a/.agents/skills/spec-driven-development/SKILL.md
+++ b/.agents/skills/spec-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: n8n:spec-driven-development
-description: Keeps implementation and specs in sync. Use when working on a feature that has a spec in .agents/specs/, when the user says /spec, or when starting implementation of a documented feature. Also use when the user asks to verify implementation against a spec or update a spec after changes.
+description: Keeps implementation and specs in sync. Use when working on a feature that has a spec in .agents/specs/, when the user says /spec, or when starting implementation of a documented feature. Also use when the user asks to create a spec, verify implementation against a spec, or update a spec after changes.
 ---
 
 # Spec-Driven Development
@@ -12,8 +12,90 @@ must stay in sync — neither leads exclusively.
 ## Core Loop
 
 ```
-Read spec → Implement → Verify alignment → Update spec or code → Repeat
+Clarify → Write spec → Implement → Verify alignment → Update spec or code → Repeat
 ```
+
+## Creating a Spec
+
+A spec is worth writing when the work is non-trivial: a new module, a new API,
+a cross-package change, or anything touching `@n8n/api-types`. Skip it for
+bugfixes and one-file changes.
+
+### 1. Clarify before writing
+
+Ambiguity resolved before the spec is cheap. The same ambiguity found during
+implementation costs a rewrite. Scan the request against these categories and
+mark each **Clear**, **Partial**, or **Missing**:
+
+- **Scope** — what ships, and what is explicitly out
+- **Data & contracts** — entities, API shapes, types in `@n8n/api-types`
+- **Package boundaries** — which of `cli` / `core` / `workflow` / `editor-ui` /
+  `nodes-base` own what, and what crosses between them
+- **Persistence** — new entities or columns, and whether a migration is needed
+- **Frontend surface** — new components, Pinia store changes, i18n keys
+- **Failure modes** — error paths, partial failures, what the user sees
+- **Compatibility** — existing workflows, credentials, or APIs that must keep working
+- **Done** — how we will know it works, and what test proves it
+
+Then ask **at most 5 questions**, and only those whose answer would change the
+implementation or the tests. A question that does not change what you build is
+noise — leave it out. If more than 5 categories are unresolved, pick the ones
+with the highest (impact × uncertainty).
+
+Ask **one decision per question**, and always lead with your own recommendation
+— you have read the codebase, so the user should be approving a proposal rather
+than filling in a blank. If your harness offers a structured multiple-choice
+question tool, use it; otherwise ask in plain text, one question per message,
+and wait for the answer before moving on. Do not ask about anything the repo
+already answers: check `AGENTS.md` and the existing code first.
+
+### 2. Write the spec
+
+Create `.agents/specs/<ticket-id>-<short-name>.md`, using the Linear ticket ID
+where there is one, so the spec, the branch, and the ticket all match.
+
+Start from this skeleton and delete what does not apply — an empty section is
+worse than no section:
+
+```markdown
+# <Feature name>
+
+**Ticket**: https://linear.app/n8n/issue/<TICKET-ID>
+**Status**: Draft | In progress | Implemented
+
+## Goal
+<One paragraph: what this enables, and for whom.>
+
+## Out of scope
+<What this deliberately does not do. Prevents the scope creep argument later.>
+
+## Decisions
+| Decision | Choice | Why |
+|---|---|---|
+<The answers from the clarify pass. This is the section that stops the same
+question being re-litigated three weeks later.>
+
+## Contracts
+<API endpoints, types added to @n8n/api-types, config/env vars. Code blocks
+for shapes, tables for mappings.>
+
+## Structure
+<Which packages change, and which files are added.>
+
+## How we know it works
+<The test that proves it. Name the file.>
+
+## Implementation TODO
+- [ ] <item>
+```
+
+### 3. Hand off to the ticket
+
+When the TODO list is settled and the work has a Linear ticket, mirror the list
+into it so the work is visible outside the repo, using the `n8n:create-issue`
+skill for sub-issues rather than inventing a format. With no ticket, the TODO
+list stays in the spec and nothing else is needed. Either way the spec is the
+source of truth for *decisions*; the ticket only tracks *progress*.
 
 ## Before Starting Work
 
@@ -27,7 +109,8 @@ ls .agents/specs/
    open questions before writing code.
 
 3. **If no spec exists** and the task is non-trivial (new module, new API,
-   architectural change), ask the user whether to create one first.
+   architectural change), ask the user whether to create one first — see
+   **Creating a Spec** above.
 
 ## During Implementation
 
@@ -64,6 +147,7 @@ Run a spec verification pass:
 ## Spec File Conventions
 
 - One or more markdown files per feature in `.agents/specs/`.
+- Name them `<ticket-id>-<short-name>.md` when a Linear ticket exists.
 - Keep specs concise. Use tables for mappings, code blocks for shapes.
 - Use `## Implementation TODO` with checkboxes to track progress.
 - Split into multiple files when it helps (e.g. separate backend/frontend),


### PR DESCRIPTION
The skill covered reading, following and verifying specs, but had no path for creating one: it only said to ask the user whether to create a spec, with no process and no template. `.agents/specs/` does not exist yet.

Adds a "Creating a Spec" section with three steps:

- a clarify pass that scans the request for ambiguity across n8n-specific categories (package boundaries, contracts in @n8n/api-types, migrations, i18n, compatibility) and asks at most 5 questions — only those whose answer would change the implementation or the tests
- a minimal spec skeleton, with a Decisions table as its core section, so settled questions are not re-litigated later
- a handoff step that mirrors the TODO list into the Linear ticket when the work has one, and otherwise leaves it in the spec

Also states when a spec is *not* worth writing, so the process stays proportionate.

The flow is adapted from the clarify/plan commands in github/spec-kit (MIT). The prose here is original — no text was copied — and it is kept harness-neutral per .agents/skills/AGENTS.md, with no hardcoded tool names, so it still works when read from OpenCode.


Claude-Session: https://claude.ai/code/session_019TacrC3w2WsBWAb1NxjAEk

## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

