### PR TITLE
fix(core): Raise AI Assistant model verification token limit

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-verification.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-verification.service.test.ts
@@ -105,7 +105,8 @@ describe('InstanceAiVerificationService', () => {
 			);
 			expect(createModelMock).toHaveBeenCalledWith(modelConfig, expect.any(Function));
 			expect(generateTextMock).toHaveBeenCalledWith(
-				expect.objectContaining({ prompt: 'Reply with OK.', maxOutputTokens: 8 }),
+				// OpenAI's Responses API rejects max_output_tokens below 16.
+				expect.objectContaining({ prompt: 'Reply with OK.', maxOutputTokens: 16 }),
 			);
 		});
 

--- a/packages/cli/src/modules/instance-ai/instance-ai-verification.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-verification.service.ts
@@ -27,6 +27,12 @@ const VERIFICATION_TIMEOUT_MS = 30_000;
 const MAX_ERROR_MESSAGE_LENGTH = 512;
 
 /**
+ * The probe only needs the call to succeed, not its text, but OpenAI's
+ * Responses API rejects `max_output_tokens` below 16.
+ */
+const VERIFICATION_MAX_OUTPUT_TOKENS = 16;
+
+/**
  * Providers can echo credentials back in error messages. Scrub known secret
  * shapes (API keys, bearer tokens, key=value pairs), drop URL query strings
  * (e.g. ?key=...), and cap the length.
@@ -135,7 +141,7 @@ export class InstanceAiVerificationService {
 			await generateText({
 				model: createModel(modelConfig, createAiProxyFetch(this.outboundHttp)),
 				prompt: 'Reply with OK.',
-				maxOutputTokens: 8,
+				maxOutputTokens: VERIFICATION_MAX_OUTPUT_TOKENS,
 				abortSignal: AbortSignal.timeout(VERIFICATION_TIMEOUT_MS),
 			});
 			return { ok: true, latencyMs: Math.round(performance.now() - startedAt) };


### PR DESCRIPTION
## Summary

The AI Assistant setup screen verifies a model connection with a small `generateText` probe. The probe sent `maxOutputTokens: 8`. OpenAI's Responses API rejects any `max_output_tokens` below 16, so the check always failed for OpenAI models on self-hosted instances:

```
Instance AI model verification failed {"error":"Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 8 instead.","failure":"provider_error"}
```

Only OpenAI is affected. Its credentials carry the official base URL, so the model factory routes them to the Responses API (`/responses`). Anthropic and OpenAI-compatible endpoints have no such minimum and passed with 8.

This PR raises the probe limit to 16 and names the constant so the reason stays visible. The probe reads no output text, so the higher limit changes nothing else. The agent itself never used this value, so only the setup check was broken.

The bug has been present since the self-hosted AI Assistant onboarding shipped in 2.35.0 (#35579).

## How to test

1. Start n8n and open the AI Assistant setup.
2. Choose OpenAI as the provider and enter a valid API key.
3. Run the connection test.
4. The test passes. Before this change it failed with `provider_error`.

Unit tests:

```
cd packages/cli && pnpm vitest run src/modules/instance-ai/__tests__/instance-ai-verification.service.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1237

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI