### PR TITLE
fix(core): Validate credential types in AI Assistant credential setup

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -1471,6 +1471,142 @@ describe('credentials tool', () => {
 				}),
 			);
 		});
+
+		describe('credential type validation', () => {
+			function createValidatingContext(existingTypes: string[]) {
+				const context = createMockContext();
+				context.credentialService.credentialTypeExists = vi
+					.fn()
+					.mockImplementation(
+						async (type: string) => await Promise.resolve(existingTypes.includes(type)),
+					);
+				return context;
+			}
+
+			it('should return unknown_credential_type with suggestions instead of suspending', async () => {
+				const context = createValidatingContext(['gmailOAuth2']);
+				(context.credentialService.searchCredentialTypes as Mock).mockImplementation(
+					async (query: string) =>
+						await Promise.resolve(
+							query === 'gmail' ? [{ type: 'gmailOAuth2', displayName: 'Gmail OAuth2 API' }] : [],
+						),
+				);
+
+				const suspendFn = vi.fn();
+				const tool = createCredentialsTool(context);
+				const result = await executeTool(
+					tool,
+					{
+						action: 'setup' as const,
+						credentials: [{ credentialType: 'gmailOAuth2Api', reason: 'Send email' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(suspendFn).not.toHaveBeenCalled();
+				expect(result).toEqual({
+					error: 'unknown_credential_type',
+					message: expect.stringContaining('"gmailOAuth2Api"'),
+					suggestions: {
+						gmailOAuth2Api: [{ type: 'gmailOAuth2', displayName: 'Gmail OAuth2 API' }],
+					},
+				});
+				// The exact name is tried before falling back to the service prefix.
+				expect(context.credentialService.searchCredentialTypes).toHaveBeenNthCalledWith(
+					1,
+					'gmailOAuth2Api',
+				);
+				expect(context.credentialService.searchCredentialTypes).toHaveBeenNthCalledWith(2, 'gmail');
+			});
+
+			it('should omit suggestions when no near-match is found', async () => {
+				const context = createValidatingContext([]);
+
+				const tool = createCredentialsTool(context);
+				const result = await executeTool(
+					tool,
+					{
+						action: 'setup' as const,
+						credentials: [{ credentialType: 'noSuchThingApi' }],
+					},
+					suspendCtx(),
+				);
+
+				expect(result).toEqual({
+					error: 'unknown_credential_type',
+					message: expect.stringContaining('"noSuchThingApi"'),
+				});
+			});
+
+			it('should list only the unknown types when known and unknown are mixed', async () => {
+				const context = createValidatingContext(['slackApi']);
+
+				const result = await executeTool(
+					createCredentialsTool(context),
+					{
+						action: 'setup' as const,
+						credentials: [{ credentialType: 'slackApi' }, { credentialType: 'gmailOAuth2Api' }],
+					},
+					suspendCtx(),
+				);
+
+				expect(result).toMatchObject({ error: 'unknown_credential_type' });
+				expect((result as { message: string }).message).not.toContain('"slackApi"');
+				expect((result as { message: string }).message).toContain('"gmailOAuth2Api"');
+			});
+
+			it('should suspend normally when every requested type exists', async () => {
+				const context = createValidatingContext(['slackApi']);
+
+				const suspendFn = vi.fn();
+				await executeTool(
+					createCredentialsTool(context),
+					{
+						action: 'setup' as const,
+						credentials: [{ credentialType: 'slackApi', reason: 'Send messages' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(suspendFn).toHaveBeenCalledTimes(1);
+			});
+
+			it('should not look up the templated custom auth type', async () => {
+				const context = createValidatingContext([]);
+
+				const suspendFn = vi.fn();
+				await executeTool(
+					createCredentialsTool(context),
+					{
+						action: 'setup' as const,
+						credentials: [{ credentialType: 'httpTemplatedCustomAuth', reason: 'Custom API' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(context.credentialService.credentialTypeExists).not.toHaveBeenCalled();
+				expect(suspendFn).toHaveBeenCalledTimes(1);
+			});
+
+			it('should treat a failing existence lookup as known and proceed', async () => {
+				const context = createMockContext();
+				context.credentialService.credentialTypeExists = vi
+					.fn()
+					.mockRejectedValue(new Error('registry unavailable'));
+
+				const suspendFn = vi.fn();
+				await executeTool(
+					createCredentialsTool(context),
+					{
+						action: 'setup' as const,
+						credentials: [{ credentialType: 'slackApi' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(suspendFn).toHaveBeenCalledTimes(1);
+			});
+		});
 	});
 
 	// ── test ────────────────────────────────────────────────────────────────

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -217,6 +217,71 @@ export function findSetupHintProblems(
 export const INVALID_SETUP_HINT_MESSAGE =
 	'Each setup hint must be a secret-free template whose {{marker}}s match its placeholders one-to-one. Fix the recipe (or omit it entirely) and retry.';
 
+/**
+ * Registered type names often diverge from credential class names, and a
+ * made-up name sails through to a setup card the frontend cannot render.
+ * Resolve which requested types are unknown so setup fails fast with a
+ * corrective error instead. Types are trusted as-is when the service doesn't
+ * expose the lookup.
+ */
+async function findUnknownCredentialTypes(
+	context: InstanceAiContext,
+	credentialTypes: string[],
+): Promise<string[]> {
+	const service = context.credentialService;
+	if (!service.credentialTypeExists) return [];
+
+	const unknown: string[] = [];
+	for (const credentialType of new Set(credentialTypes)) {
+		// The templated type is created from the setupHint recipe, not looked up.
+		if (credentialType === TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE) continue;
+		try {
+			if (!(await service.credentialTypeExists(credentialType))) {
+				unknown.push(credentialType);
+			}
+		} catch {
+			// Existence lookup failing is a soft signal — don't block setup on it.
+		}
+	}
+	return unknown;
+}
+
+/**
+ * Search queries for near-matches of an unknown type, most to least specific:
+ * the name itself, the name without its OAuth2/Api suffix, and the leading
+ * lowercase run (the service part of a camelCase name).
+ */
+function deriveTypeSuggestionQueries(credentialType: string): string[] {
+	const queries = [credentialType];
+	const withoutSuffix = credentialType.replace(/(?:OAuth2(?:Api)?|Api)$/, '');
+	if (withoutSuffix && !queries.includes(withoutSuffix)) queries.push(withoutSuffix);
+	const service = /^[a-z0-9]+/.exec(credentialType)?.[0];
+	if (service && !queries.includes(service)) queries.push(service);
+	return queries;
+}
+
+const MAX_TYPE_SUGGESTIONS = 5;
+
+async function suggestCredentialTypes(
+	context: InstanceAiContext,
+	credentialType: string,
+): Promise<Array<{ type: string; displayName: string }>> {
+	const service = context.credentialService;
+	if (!service.searchCredentialTypes) return [];
+
+	for (const query of deriveTypeSuggestionQueries(credentialType)) {
+		try {
+			const results = (await service.searchCredentialTypes(query)).filter(
+				(result) => !GENERIC_AUTH_CREDENTIAL_TYPES.has(result.type),
+			);
+			if (results.length > 0) return results.slice(0, MAX_TYPE_SUGGESTIONS);
+		} catch {
+			// Try the next, broader query.
+		}
+	}
+	return [];
+}
+
 // ── Action schemas ─────────────────────────────────────────────────────────
 
 const listAction = z.object({
@@ -290,7 +355,9 @@ const setupAction = z.object({
 			z.object({
 				credentialType: z
 					.string()
-					.describe('n8n credential type name (e.g. "slackApi", "gmailOAuth2")'),
+					.describe(
+						'n8n credential type name (e.g. "slackApi", "gmailOAuth2"). Must be the registered type name, which can differ from the credential class name — verify with action "search-types" when unsure.',
+					),
 				reason: z.string().optional().describe('Why this credential is needed (shown to user)'),
 				suggestedName: z
 					.string()
@@ -638,6 +705,27 @@ async function handleSetup(
 
 	// State 1: First call — look up existing credentials per type and suspend
 	if (resumeData === undefined || resumeData === null) {
+		const unknownTypes = await findUnknownCredentialTypes(
+			context,
+			input.credentials.map((req: { credentialType: string }) => req.credentialType),
+		);
+		if (unknownTypes.length > 0) {
+			const suggestions: Record<string, Array<{ type: string; displayName: string }>> = {};
+			for (const credentialType of unknownTypes) {
+				const matches = await suggestCredentialTypes(context, credentialType);
+				if (matches.length > 0) suggestions[credentialType] = matches;
+			}
+			return {
+				error: 'unknown_credential_type',
+				message: `No credential type named ${unknownTypes
+					.map((type) => `"${type}"`)
+					.join(
+						', ',
+					)} is registered on this instance. Type names can differ from credential class names. Pick the exact type from the suggestions, or find it with credentials(action: "search-types"), then retry.`,
+				...(Object.keys(suggestions).length > 0 ? { suggestions } : {}),
+			};
+		}
+
 		const hintProblems = input.credentials.flatMap(
 			(req: { credentialType: string; setupHint?: InstanceAiCredentialSetupHint }) => {
 				if (!req.setupHint) return [];

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -504,6 +504,8 @@ export interface InstanceAiCredentialService {
 	): CredentialFieldInfo[] | Promise<CredentialFieldInfo[]>;
 	/** Search available credential types by keyword. Returns matching types with display names. */
 	searchCredentialTypes?(query: string): Promise<CredentialTypeSearchResult[]>;
+	/** Whether a credential type with this exact registered name exists on the instance. */
+	credentialTypeExists?(credentialType: string): Promise<boolean>;
 	/** HTTP-usable credential types with the API host(s) they authenticate against,
 	 *  derived from credential metadata. Powers steering generic HTTP-node auth toward
 	 *  a predefined credential when one already exists for the target service. */

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -4739,4 +4739,42 @@ describe('createCredentialAdapter', () => {
 			await expect(credentialService.isTestable!('kafka')).resolves.toBe(false);
 		});
 	});
+
+	describe('credentialTypeExists', () => {
+		const loader = {
+			knownCredentials: { gmailOAuth2: {} },
+			getCredential: (type: string) => {
+				// Runtime-registered types resolve through a loader without being in
+				// knownCredentials (e.g. MCP registry).
+				if (type === 'linearMcpOAuth2Api') return { type: { name: type } };
+				throw new Error(`Unrecognized credential type: ${type}`);
+			},
+		};
+
+		it('is true for a known credential type', async () => {
+			const { credentialService } = createNodeAdapterServiceForTests([], {
+				loadNodesAndCredentials: loader,
+			});
+
+			await expect(credentialService.credentialTypeExists!('gmailOAuth2')).resolves.toBe(true);
+		});
+
+		it('is true for a runtime-registered type resolvable only via getCredential', async () => {
+			const { credentialService } = createNodeAdapterServiceForTests([], {
+				loadNodesAndCredentials: loader,
+			});
+
+			await expect(credentialService.credentialTypeExists!('linearMcpOAuth2Api')).resolves.toBe(
+				true,
+			);
+		});
+
+		it('is false for an unregistered type', async () => {
+			const { credentialService } = createNodeAdapterServiceForTests([], {
+				loadNodesAndCredentials: loader,
+			});
+
+			await expect(credentialService.credentialTypeExists!('gmailOAuth2Api')).resolves.toBe(false);
+		});
+	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1858,6 +1858,18 @@ export class InstanceAiAdapterService {
 				}
 			},
 
+			async credentialTypeExists(credentialType: string): Promise<boolean> {
+				if (credentialType in loadNodesAndCredentials.knownCredentials) return true;
+				// Runtime-registered types (e.g. MCP registry loaders) may not appear
+				// in knownCredentials — fall back to resolving the credential class.
+				try {
+					loadNodesAndCredentials.getCredential(credentialType);
+					return true;
+				} catch {
+					return false;
+				}
+			},
+
 			async searchCredentialTypes(query: string): Promise<CredentialTypeSearchResult[]> {
 				const q = query.toLowerCase().trim();
 				if (!q) return [];


### PR DESCRIPTION
## Summary

Asking the assistant for a standalone Gmail credential got you a broken setup card with a blank Connection tab. The setup tool's schema example taught the model a credential type that doesn't exist (`gmailOAuth2Api` — the class name, not the registered `gmailOAuth2`), and nothing downstream ever checked whether the type was real.

The bad example itself was already corrected on master, but the deeper problem remains: any hallucinated type sails straight through to a card the frontend can't render. So this PR makes `setup` validate requested credential types before opening the card. Unknown types return a retriable error with near-match suggestions (exact name → suffix stripped → service prefix), letting the model correct itself in one turn instead of the user hitting a dead-end modal. Backed by a new optional `credentialTypeExists` on the credential service, implemented in the CLI adapter via `knownCredentials` with a `getCredential()` fallback so runtime-registered types (MCP registry) still pass. The schema description also now warns that type names can differ from class names and points at `search-types`.

## How to test

1. Open a fresh AI Assistant chat and ask: `Please create a standalone gmail credential`
2. Before: setup card titled "Set up gmailOAuth2Api", clicking it opens an empty credential modal. Now: the tool call errors internally, the model retries with `gmailOAuth2`, and you get a working Gmail setup card.

Unit tests cover the error shape, suggestion fallback order, the templated-custom-auth exemption, and graceful skip when the service doesn't implement the lookup.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1231

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
