### PR TITLE
feat(Confluence Node): Add attachment delete operation (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Confluence/actions/attachment/delete.operation.ts
+++ b/packages/nodes-base/nodes/Confluence/actions/attachment/delete.operation.ts
@@ -1,0 +1,118 @@
+import type { IExecuteFunctions, INodeProperties } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+
+import { confluenceApiRequest } from '../../transport';
+import type { ConfluenceOperation } from '../router';
+
+const showOnDelete = { resource: ['attachment'], operation: ['delete'] };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Attachment ID',
+		name: 'attachmentId',
+		type: 'string',
+		default: '',
+		required: true,
+		placeholder: 'e.g. att123456',
+		description:
+			'The ID of the attachment to delete. Attachment IDs come from the Get Many operation.',
+		displayOptions: { show: showOnDelete },
+	},
+	{
+		displayName: 'Permanently Delete (Purge)',
+		name: 'purge',
+		type: 'boolean',
+		default: false,
+		description:
+			"Whether to permanently delete the attachment instead of moving it to trash. This cannot be undone and requires admin permission in the attachment's space.",
+		displayOptions: { show: showOnDelete },
+	},
+];
+
+/**
+ * Moves the attachment to trash. Returns whether the trash was actually
+ * confirmed by a successful DELETE, as opposed to assumed: a 404 while
+ * purging is swallowed because an attachment already in the trash 404s
+ * here too, but that same 404 also covers a bad ID or a permission
+ * failure this endpoint masks as "not found". The caller needs to know
+ * which case it was to describe a later purge failure accurately.
+ */
+async function trashAttachment(
+	this: IExecuteFunctions,
+	endpoint: string,
+	purge: boolean,
+	itemIndex: number,
+): Promise<boolean> {
+	try {
+		await confluenceApiRequest.call(this, 'DELETE', endpoint);
+		return true;
+	} catch (error) {
+		// The endpoint documents no 403; permission failures arrive as 404
+		if (!(error instanceof NodeApiError && error.httpCode === '404')) throw error;
+		if (purge) return false;
+		throw new NodeOperationError(this.getNode(), 'Confluence could not delete the attachment', {
+			itemIndex,
+			description:
+				'The attachment may not exist or may already be in the trash, or the connected user may lack permission to view its page or to delete attachments in the space (Confluence reports permission failures as "not found").',
+		});
+	}
+}
+
+/** Permanently removes an attachment. Only called once `trashAttachment`
+ * has moved it there or the trash step was assumed already done. */
+async function purgeAttachment(
+	this: IExecuteFunctions,
+	endpoint: string,
+	itemIndex: number,
+	trashConfirmed: boolean,
+): Promise<void> {
+	try {
+		await confluenceApiRequest.call(this, 'DELETE', endpoint, {}, { purge: true });
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		// Only claim the attachment is safely in the trash when the first request
+		// actually confirmed it; a swallowed 404 could equally mean a bad ID or a
+		// permission failure, neither of which leaves anything to restore
+		if (trashConfirmed) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'The attachment was moved to trash, but could not be purged',
+				{
+					itemIndex,
+					description: `The attachment is in the trash and can be restored from the Confluence UI. Permanently deleting one usually requires permission to administer the space. Confluence said: ${detail}`,
+				},
+			);
+		}
+		throw new NodeOperationError(
+			this.getNode(),
+			'Confluence could not permanently delete the attachment',
+			{
+				itemIndex,
+				description: `The attachment may not exist, may never have been in the trash, or the connected user may lack permission to view its page or to delete or purge attachments in the space. Confluence said: ${detail}`,
+			},
+		);
+	}
+}
+
+export const execute: ConfluenceOperation = async function (
+	this: IExecuteFunctions,
+	itemIndex: number,
+) {
+	const attachmentId = String(this.getNodeParameter('attachmentId', itemIndex, '')).trim();
+	if (attachmentId === '') {
+		throw new NodeOperationError(this.getNode(), "The 'Attachment ID' parameter is empty", {
+			itemIndex,
+		});
+	}
+
+	// Strict compare, not a cast: an expression can hand back the string "false",
+	// which is truthy and would permanently delete the attachment by accident
+	const purge = this.getNodeParameter('purge', itemIndex, false) === true;
+	const endpoint = `/wiki/api/v2/attachments/${encodeURIComponent(attachmentId)}`;
+
+	const trashConfirmed = await trashAttachment.call(this, endpoint, purge, itemIndex);
+	if (purge) await purgeAttachment.call(this, endpoint, itemIndex, trashConfirmed);
+
+	// Responds 204 with no body, so report the outcome in page:delete's shape
+	return { deleted: true, attachmentId, purged: purge };
+};

--- a/packages/nodes-base/nodes/Confluence/actions/attachment/index.ts
+++ b/packages/nodes-base/nodes/Confluence/actions/attachment/index.ts
@@ -1,8 +1,9 @@
 import type { INodeProperties } from 'n8n-workflow';
 
+import * as deleteAttachment from './delete.operation';
 import * as getMany from './getMany.operation';
 
-export { getMany };
+export { deleteAttachment as delete, getMany };
 
 export const description: INodeProperties[] = [
 	{
@@ -17,13 +18,21 @@ export const description: INodeProperties[] = [
 		},
 		options: [
 			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Move an attachment to the trash, or permanently delete it',
+				action: 'Delete an attachment',
+			},
+			{
 				name: 'Get Many',
 				value: 'getMany',
 				description: 'List the attachments on a page, optionally downloading each file',
 				action: 'Get many attachments',
 			},
 		],
+		// Not the first option: the default must stay non-destructive
 		default: 'getMany',
 	},
+	...deleteAttachment.description,
 	...getMany.description,
 ];

--- a/packages/nodes-base/nodes/Confluence/actions/router.ts
+++ b/packages/nodes-base/nodes/Confluence/actions/router.ts
@@ -34,6 +34,9 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 			let responseItems: INodeExecutionData[] | undefined;
 
 			switch (`${resource}:${operation}`) {
+				case 'attachment:delete':
+					responseData = await attachment.delete.execute.call(this, i);
+					break;
 				case 'attachment:getMany':
 					responseItems = await attachment.getMany.execute.call(this, i);
 					break;

--- a/packages/nodes-base/nodes/Confluence/test/Confluence.node.test.ts
+++ b/packages/nodes-base/nodes/Confluence/test/Confluence.node.test.ts
@@ -6,10 +6,11 @@ import { mockExecuteCtx } from './shared';
 describe('Confluence Node', () => {
 	const node = new Confluence();
 
-	const operationOptions = (resource: string) =>
+	const operationProperty = (resource: string) =>
 		node.description.properties.find(
 			(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes(resource),
-		)?.options;
+		);
+	const operationOptions = (resource: string) => operationProperty(resource)?.options;
 
 	it('should stay hidden and off the AI-tool surface while operations land', () => {
 		expect(node.description.hidden).toBe(true);
@@ -26,7 +27,12 @@ describe('Confluence Node', () => {
 			expect.objectContaining({ value: 'space' }),
 		]);
 
-		expect(operationOptions('attachment')).toEqual([expect.objectContaining({ value: 'getMany' })]);
+		expect(operationOptions('attachment')).toEqual([
+			expect.objectContaining({ value: 'delete' }),
+			expect.objectContaining({ value: 'getMany' }),
+		]);
+		// Delete sorts first alphabetically; the default must stay non-destructive
+		expect(operationProperty('attachment')?.default).toBe('getMany');
 		expect(operationOptions('page')).toEqual([
 			expect.objectContaining({ value: 'append' }),
 			expect.objectContaining({ value: 'create' }),

--- a/packages/nodes-base/nodes/Confluence/test/actions/attachment/delete.operation.test.ts
+++ b/packages/nodes-base/nodes/Confluence/test/actions/attachment/delete.operation.test.ts
@@ -1,0 +1,144 @@
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+
+import { execute } from '../../../actions/attachment/delete.operation';
+import { confluenceApiRequest } from '../../../transport';
+import { mockExecuteCtx, testNode } from '../../shared';
+
+vi.mock('../../../transport', () => ({
+	CONFLUENCE_CREDENTIAL_NAME: 'confluenceCloudOAuth2Api',
+	confluenceApiRequest: vi.fn(),
+}));
+
+const apiRequest = vi.mocked(confluenceApiRequest);
+
+const ENDPOINT = '/wiki/api/v2/attachments/att123';
+
+const baseParams: Record<string, unknown> = {
+	resource: 'attachment',
+	operation: 'delete',
+	attachmentId: 'att123',
+	purge: false,
+};
+
+function apiError(httpCode: string) {
+	return new NodeApiError(testNode, { message: 'boom' }, { httpCode });
+}
+
+async function runDelete(overrides: Record<string, unknown> = {}) {
+	const ctx = mockExecuteCtx({ ...baseParams, ...overrides });
+	return await execute.call(ctx, 0);
+}
+
+describe('attachment:delete', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// The v2 endpoint answers 204 with an empty body
+		apiRequest.mockResolvedValue('' as never);
+	});
+
+	it('moves the attachment to trash and reports the outcome', async () => {
+		const result = await runDelete();
+
+		expect(apiRequest).toHaveBeenCalledWith('DELETE', ENDPOINT);
+		expect(result).toEqual({ deleted: true, attachmentId: 'att123', purged: false });
+	});
+
+	it('trims a padded ID before building the endpoint', async () => {
+		const result = await runDelete({ attachmentId: '  att123  ' });
+
+		expect(apiRequest).toHaveBeenCalledWith('DELETE', ENDPOINT);
+		expect(result).toEqual({ deleted: true, attachmentId: 'att123', purged: false });
+	});
+
+	it.each([
+		['empty', ''],
+		['whitespace only', '   '],
+	])('rejects an %s ID without calling the API', async (_label, attachmentId) => {
+		const promise = runDelete({ attachmentId });
+
+		await expect(promise).rejects.toThrow(NodeOperationError);
+		await expect(promise).rejects.toThrow("The 'Attachment ID' parameter is empty");
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('explains a 404 from the plain delete instead of leaking the API error', async () => {
+		apiRequest.mockRejectedValue(apiError('404'));
+
+		const promise = runDelete();
+
+		await expect(promise).rejects.toThrow(NodeOperationError);
+		await expect(promise).rejects.toThrow('Confluence could not delete the attachment');
+	});
+
+	it('rethrows a non-404 failure from the plain delete untouched', async () => {
+		apiRequest.mockRejectedValue(apiError('500'));
+
+		await expect(runDelete()).rejects.toThrow(NodeApiError);
+	});
+
+	describe('when purging', () => {
+		it('trashes first, then purges in a second request', async () => {
+			const result = await runDelete({ purge: true });
+
+			expect(apiRequest).toHaveBeenCalledTimes(2);
+			expect(apiRequest).toHaveBeenNthCalledWith(1, 'DELETE', ENDPOINT);
+			expect(apiRequest).toHaveBeenNthCalledWith(2, 'DELETE', ENDPOINT, {}, { purge: true });
+			expect(result).toEqual({ deleted: true, attachmentId: 'att123', purged: true });
+		});
+
+		it('still purges an attachment that is already in the trash', async () => {
+			// A trashed attachment 404s on the plain delete; the purge must still run
+			apiRequest.mockRejectedValueOnce(apiError('404')).mockResolvedValueOnce('' as never);
+
+			const result = await runDelete({ purge: true });
+
+			expect(apiRequest).toHaveBeenNthCalledWith(2, 'DELETE', ENDPOINT, {}, { purge: true });
+			expect(result).toEqual({ deleted: true, attachmentId: 'att123', purged: true });
+		});
+
+		// The endpoint documents no 403, so the partial state must be reported
+		// whatever Confluence answers with, not just for one status code
+		it.each(['403', '404', '500'])(
+			'reports the trashed-but-not-purged state when the purge fails with %s, given a confirmed trash',
+			async (httpCode) => {
+				apiRequest.mockResolvedValueOnce('' as never).mockRejectedValueOnce(apiError(httpCode));
+
+				const promise = runDelete({ purge: true });
+
+				await expect(promise).rejects.toThrow(NodeOperationError);
+				await expect(promise).rejects.toThrow(
+					'The attachment was moved to trash, but could not be purged',
+				);
+			},
+		);
+
+		// A 404 on the plain delete while purging could mean "already trashed" or
+		// "wrong ID" or "no permission" — if the purge then also fails, claiming the
+		// attachment is safely in the trash would be false for the latter two cases
+		it('does not claim the attachment is trashed when the trash step itself was only assumed', async () => {
+			apiRequest.mockRejectedValueOnce(apiError('404')).mockRejectedValueOnce(apiError('404'));
+
+			const promise = runDelete({ purge: true });
+
+			await expect(promise).rejects.toThrow(NodeOperationError);
+			await expect(promise).rejects.toThrow(
+				'Confluence could not permanently delete the attachment',
+			);
+			await expect(promise).rejects.not.toThrow('was moved to trash');
+		});
+	});
+
+	// A destructive, irreversible flag must fail closed: anything that is not
+	// boolean true leaves the attachment recoverable in the trash
+	it.each([
+		['the string "false"', 'false'],
+		['the string "true"', 'true'],
+		['undefined', undefined],
+	])('does not purge when the toggle resolves to %s', async (_label, purge) => {
+		const result = await runDelete({ purge });
+
+		expect(apiRequest).toHaveBeenCalledTimes(1);
+		expect(apiRequest).toHaveBeenCalledWith('DELETE', ENDPOINT);
+		expect(result).toEqual({ deleted: true, attachmentId: 'att123', purged: false });
+	});
+});

--- a/packages/nodes-base/nodes/Confluence/test/actions/router.test.ts
+++ b/packages/nodes-base/nodes/Confluence/test/actions/router.test.ts
@@ -58,6 +58,23 @@ describe('Confluence router', () => {
 		]);
 	});
 
+	it('dispatches attachment:delete and returns the deletion report', async () => {
+		apiRequest.mockResolvedValue('');
+
+		const result = await router.call(
+			mockExecuteCtx({
+				resource: 'attachment',
+				operation: 'delete',
+				attachmentId: 'att123',
+			}),
+		);
+
+		expect(apiRequest).toHaveBeenCalledWith('DELETE', '/wiki/api/v2/attachments/att123');
+		expect(result).toEqual([
+			[{ json: { deleted: true, attachmentId: 'att123', purged: false }, pairedItem: { item: 0 } }],
+		]);
+	});
+
 	it('dispatches attachment:getMany and pairs the emitted items', async () => {
 		apiRequest.mockResolvedValue({ results: [{ id: 'a1', title: 'notes.txt' }] });
 


### PR DESCRIPTION
## Summary

Adds the **Delete** operation to the Confluence node's Attachment resource. Paired with upload (ENT-368) this is what makes "replace a file" possible, which upload alone cannot do.

The user pastes an attachment ID, or pipes one in from Get Many, and the attachment is moved to the Confluence trash where it stays recoverable. A **Permanently Delete (Purge)** toggle opts into removing it for good.

Purge is a second request, because Confluence only purges attachments that are already in the trash. That also means an attachment already sitting in the trash still purges cleanly.

Two deliberate differences from the `page:delete` that landed recently:

- **The purge flag is compared strictly against `true`, not cast.** If someone drives the toggle from an expression that resolves to the text `"false"`, a cast would treat it as on and permanently delete the file. `page:delete` still has this and is worth a separate fix.
- **Every purge failure reports the partial state.** `page:delete` special-cases 403, but this endpoint documents only 204/400/401/404. The failure that actually happens would otherwise show a bare "Not Found", leaving the user unaware the attachment is already in the trash.

**Scope note:** the ticket lists purging as out of scope. It went in because ENT-329 shipped the same toggle for pages while this was in flight, and no ticket tracks attachment purge, so leaving it out meant two sibling deletes behaving differently with nothing recording the gap. Happy to split it out if you would rather.

**Based on ENT-306** (#36713, still open) rather than master, so this PR's own diff is clean: one commit, the six files above. This PR will auto-retarget to master once #36713 merges.

## How to test

Verified against the live QA site (`n8n-nodeqa`), not just mocks:

1. Attachment → Get Many on a page with attachments, copy an `id`
2. Attachment → Delete with that ID, purge off → attachment leaves the page, still restorable from the Confluence trash
3. Same again with purge on → attachment is gone for good

Round-trip workflow used for verification, which creates its own throwaway file so no fixtures are consumed: Manual Trigger → HTTP Request (upload, standing in for ENT-368) → Confluence Delete. Live run returned `{ deleted: true, attachmentId: "att14581761", purged: true }`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-369

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Node is still hidden; docs land with the release ticket ENT-311 -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


