### PR TITLE
fix(core): Stop code editors mangling values typed by browser_type (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/fixture-server.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/fixture-server.test.ts
@@ -536,6 +536,40 @@ describe('slack fixture served to a real browser', () => {
 		await page.close();
 	});
 
+	it('mangles a manifest entered key by key, and Next refuses it', async () => {
+		// The other half of the editor trap: auto-close fires per keystroke, so the
+		// manifest's own closers pile up and the result is no longer JSON. Guards the
+		// keydown handler — without it the box is a plain textarea and nothing traps.
+		const page = await fx.ctx.newPage();
+		await page.goto('https://api.slack.com/apps');
+		await page.getByRole('button', { name: 'Create New App' }).click();
+		await page.getByRole('button', { name: 'From a manifest' }).click();
+
+		const manifest = '{\n    "display_information": {\n        "name": "n8n"\n    }\n}';
+		await page.locator('#manifest-input').pressSequentially(manifest);
+		expect(await page.locator('#manifest-input').inputValue()).not.toBe(manifest);
+
+		await page.getByRole('button', { name: 'Next' }).click();
+		expect(await page.locator('#manifest-error').isVisible()).toBe(true);
+		expect(new URL(page.url()).pathname).toBe('/apps');
+		await page.close();
+	});
+
+	it('accepts the same manifest inserted in one operation', async () => {
+		const page = await fx.ctx.newPage();
+		await page.goto('https://api.slack.com/apps');
+		await page.getByRole('button', { name: 'Create New App' }).click();
+		await page.getByRole('button', { name: 'From a manifest' }).click();
+
+		const manifest = '{\n    "display_information": {\n        "name": "n8n"\n    }\n}';
+		await page.locator('#manifest-input').fill(manifest);
+		expect(await page.locator('#manifest-input').inputValue()).toBe(manifest);
+
+		await page.getByRole('button', { name: 'Next' }).click();
+		await page.waitForURL(/\/apps\/A0\w+\/general/);
+		await page.close();
+	});
+
 	it('leaves Next enabled — nothing here is gated on a required field', async () => {
 		const page = await fx.ctx.newPage();
 		await page.goto('https://api.slack.com/apps');

--- a/packages/@n8n/instance-ai/evaluations/fixtures/providers/slack/apps.html
+++ b/packages/@n8n/instance-ai/evaluations/fixtures/providers/slack/apps.html
@@ -14,6 +14,11 @@
     click on it times out while typing into it works. That is the real
     CodeMirror behaviour and the live reproduction for LangTracer case 599 —
     replacing it with a plain visible textarea deletes the trap
+  - the editor auto-closes brackets ON KEYSTROKE. Entering the manifest one key
+    at a time therefore leaves stray closers behind and "Next" rejects it; one
+    atomic insert is the only way through. Dropping that handler deletes the
+    trap. It keys off real key events, so a typer built on Input.insertText
+    sails past it — that is the difference under test, not an oversight
   - "Next" is ENABLED throughout. The real run assumed it was disabled and spent
     three browser_evaluate scripts on that theory; it never was (not NODE-5755)
 -->
@@ -116,6 +121,25 @@
 			document.getElementById('from-manifest').addEventListener('click', () => {
 				chooser.hidden = true;
 				dialog.hidden = false;
+			});
+
+			// Auto-close, as the real editor does. It fires on keydown only, so one
+			// atomic insert is unaffected — that difference is the point.
+			const PAIRS = { '{': '}', '[': ']', '"': '"' };
+
+			input.addEventListener('keydown', (event) => {
+				if (event.metaKey || event.ctrlKey || event.altKey) return;
+				if (!PAIRS[event.key]) return;
+
+				event.preventDefault();
+				const start = input.selectionStart;
+				input.value =
+					input.value.slice(0, start) +
+					event.key +
+					PAIRS[event.key] +
+					input.value.slice(input.selectionEnd);
+				input.selectionStart = input.selectionEnd = start + 1;
+				input.dispatchEvent(new Event('input', { bubbles: true }));
 			});
 
 			// Mirror typed text into the rendered surface, as the editor does.

--- a/packages/@n8n/mcp-browser/src/adapters/agent-browser.test.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/agent-browser.test.ts
@@ -308,6 +308,13 @@ describe('AgentBrowserAdapter', () => {
 			expect(getRunArgs(1)).toEqual(['press', 'Enter']);
 		});
 
+		it('accepts paste mode but still types, having no atomic insert of its own yet', async () => {
+			stubRun({ success: true });
+			await adapter.type('t1', { ref: 'e1' }, '{"a": 1}', { mode: 'paste' });
+
+			expect(getRunArgs(0)).toEqual(['type', '@e1', '{"a": 1}']);
+		});
+
 		it('splits a single leading dash into a separate type call', async () => {
 			stubRun({ success: true }); // type '-'
 			stubRun({ success: true }); // type '5'

--- a/packages/@n8n/mcp-browser/src/adapters/agent-browser.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/agent-browser.ts
@@ -357,6 +357,11 @@ export class AgentBrowserAdapter implements Adapter {
 		const ref = this.resolveTarget(target);
 		const baseCmd = options?.clear ? 'fill' : 'type';
 
+		// TODO: `mode: 'paste'` is accepted but not honoured here — this adapter still
+		// types key by key, so code editors are still corrupted. Implementing it needs an
+		// atomic insert that replaces existing content (the CLI's `fill` does not, on a
+		// contenteditable) and that reports failure (the `eval` channel does not).
+
 		// agent-browser's CLI scans all raw args for "--help"/"-h" before parsing,
 		// so any arg starting with "-" would be misinterpreted as a flag.
 		// Peel each leading "-" into a separate type call so no single arg starts with "-".

--- a/packages/@n8n/mcp-browser/src/adapters/playwright.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/playwright.ts
@@ -445,11 +445,16 @@ export class PlaywrightAdapter {
 		const locator = await this.resolveLocator(pageId, target);
 		await this.ensureActionable(locator, target, 'editable');
 
-		if (options?.clear) {
-			await locator.clear();
-		}
+		if (options?.mode === 'paste') {
+			// Code editors mangle key-by-key entry: auto-close and auto-indent fire per keystroke.
+			await locator.fill(text);
+		} else {
+			if (options?.clear) {
+				await locator.clear();
+			}
 
-		await locator.pressSequentially(text, { delay: options?.delay });
+			await locator.pressSequentially(text, { delay: options?.delay });
+		}
 
 		if (options?.submit) {
 			await locator.press('Enter');

--- a/packages/@n8n/mcp-browser/src/adapters/playwright.type.test.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/playwright.type.test.ts
@@ -1,0 +1,62 @@
+import { adapterWithLocator } from './test-helpers';
+import { configureLogger } from '../logger';
+
+configureLogger({ level: 'silent' });
+
+function typeLocator() {
+	return {
+		count: vi.fn().mockResolvedValue(1),
+		isEditable: vi.fn().mockResolvedValue(true),
+		clear: vi.fn().mockResolvedValue(undefined),
+		fill: vi.fn().mockResolvedValue(undefined),
+		pressSequentially: vi.fn().mockResolvedValue(undefined),
+		press: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+const MANIFEST = '{\n    "display_information": {\n        "name": "n8n"\n    }\n}';
+
+describe('PlaywrightAdapter.type', () => {
+	describe('paste mode', () => {
+		it('inserts the value in a single operation', async () => {
+			const locator = typeLocator();
+			const adapter = adapterWithLocator('p1', locator);
+
+			await adapter.type('p1', { ref: 'e3' }, MANIFEST, { mode: 'paste' });
+
+			expect(locator.fill).toHaveBeenCalledWith(MANIFEST);
+			expect(locator.pressSequentially).not.toHaveBeenCalled();
+		});
+
+		it('still submits when asked', async () => {
+			const locator = typeLocator();
+			const adapter = adapterWithLocator('p1', locator);
+
+			await adapter.type('p1', { ref: 'e3' }, MANIFEST, { mode: 'paste', submit: true });
+
+			expect(locator.press).toHaveBeenCalledWith('Enter');
+		});
+
+		it('does not clear separately, because the insert already replaces', async () => {
+			const locator = typeLocator();
+			const adapter = adapterWithLocator('p1', locator);
+
+			await adapter.type('p1', { ref: 'e3' }, MANIFEST, { mode: 'paste', clear: true });
+
+			expect(locator.clear).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('type mode', () => {
+		it('is the default, and still enters the value key by key', async () => {
+			const locator = typeLocator();
+			const adapter = adapterWithLocator('p1', locator);
+
+			await adapter.type('p1', { ref: 'e3' }, 'hello', { clear: true });
+
+			expect(locator.clear).toHaveBeenCalled();
+			expect(locator.pressSequentially).toHaveBeenCalledWith('hello', { delay: undefined });
+			expect(locator.fill).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/@n8n/mcp-browser/src/tools/interaction.test.ts
+++ b/packages/@n8n/mcp-browser/src/tools/interaction.test.ts
@@ -137,6 +137,18 @@ describe('createInteractionTools', () => {
 				expect(() => getTool().inputSchema.parse({ text: 'hello' })).toThrow();
 			});
 
+			it('accepts a paste mode for values that must land in one operation', () => {
+				expect(() =>
+					getTool().inputSchema.parse({ element: { ref: 'e1' }, text: '{}', mode: 'paste' }),
+				).not.toThrow();
+			});
+
+			it('rejects an unknown mode', () => {
+				expect(() =>
+					getTool().inputSchema.parse({ element: { ref: 'e1' }, text: '{}', mode: 'slowly' }),
+				).toThrow();
+			});
+
 			it('accepts optional clear, submit, delay', () => {
 				expect(() =>
 					getTool().inputSchema.parse({
@@ -166,6 +178,20 @@ describe('createInteractionTools', () => {
 				expect(data.typed).toBe(true);
 				expect(data.text).toBe('hello');
 				expect(data.ref).toBe('e1');
+			});
+
+			it('passes the paste mode down to the adapter', async () => {
+				await getTool().execute(
+					{ element: { ref: 'e1' }, text: '{"a": 1}', mode: 'paste' },
+					TOOL_CONTEXT,
+				);
+
+				expect(mockConnection.adapter.type).toHaveBeenCalledWith(
+					'page1',
+					{ ref: 'e1' },
+					'{"a": 1}',
+					expect.objectContaining({ mode: 'paste' }),
+				);
 			});
 
 			it('routes a failure through the connection so it can be explained', async () => {

--- a/packages/@n8n/mcp-browser/src/tools/interaction.ts
+++ b/packages/@n8n/mcp-browser/src/tools/interaction.ts
@@ -81,6 +81,12 @@ const browserTypeSchema = z
 	.object({
 		element: elementTargetSchema.describe('Element to type into'),
 		text: z.string().describe('Text to type'),
+		mode: z
+			.enum(['type', 'paste'])
+			.optional()
+			.describe(
+				'"type" (default) sends one keystroke per character. "paste" inserts the whole value in one operation and replaces any existing content, so `clear` is redundant with it. Use "paste" for multi-line values, code or JSON editors, and whenever typed text comes back garbled, duplicated or wrongly indented.',
+			),
 		clear: z.boolean().optional().describe('Clear existing text first'),
 		submit: z.boolean().optional().describe('Press Enter after typing'),
 		delay: z.number().optional().describe('Delay between keystrokes in ms'),
@@ -103,6 +109,7 @@ function browserType(connection: BrowserConnection): ToolDefinition {
 		browserTypeSchema,
 		async (state, input, pageId) => {
 			await state.adapter.type(pageId, input.element, input.text, {
+				mode: input.mode,
 				clear: input.clear,
 				submit: input.submit,
 				delay: input.delay,

--- a/packages/@n8n/mcp-browser/src/types.ts
+++ b/packages/@n8n/mcp-browser/src/types.ts
@@ -244,6 +244,8 @@ export interface ClickOptions {
 }
 
 export interface TypeOptions {
+	/** 'paste' inserts the value in one operation, replacing existing content. */
+	mode?: 'type' | 'paste';
 	clear?: boolean;
 	submit?: boolean;
 	delay?: number;


### PR DESCRIPTION
## Summary

`browser_type` sends one keystroke per character (`locator.pressSequentially`). A code editor reacts to each one, so a value typed into it is not the value that arrives:

- **auto-closing brackets** — every `{`, `[` and `"` gets a partner inserted. The value's own closers never type over them, so they pile up as a garbage tail.
- **auto-indent on Enter** — the editor's indentation stacks on top of the indentation already in the value.

Entering a 593-character Slack app manifest key by key produced 1033 characters of unparseable JSON, and Slack's console refused it. In the original trace the agent noticed, retried with `clear`, then Ctrl+A, then retyped — every remedy routes through the same primitive — and eventually abandoned app creation and reused an unrelated existing app.

This adds an opt-in `mode: 'type' | 'paste'` to `browser_type`. `'paste'` inserts the whole value in one operation and replaces existing content. **The default is unchanged**, so nothing that works today changes behaviour.

Measured against a CodeMirror 6 editor with a 593-char manifest:

| | result |
|---|---|
| `clear()` + `pressSequentially()` (today) | 1033 chars, **invalid JSON** |
| `fill()` (`mode: 'paste'`) | 593 chars, exact, valid |

The Playwright adapter implements it. The agent-browser adapter accepts the option and still types, marked with a `TODO` — its CLI's `fill` leaves a contenteditable's old content in place and its `eval` channel does not report failure, so a correct implementation there is its own piece of work.

The Slack eval fixture's manifest box was a plain `<textarea>`, so it modelled the click trap but not this one. It now auto-closes brackets on keydown, which is what discriminates the two paths.

## How to test

The bug needs a real code editor, so here is a self-contained stand-in for Slack's "create app from manifest" page. Save it as `slack-manifest-mock.html`:

```html
<!doctype html>
<!-- Stand-in for Slack's "create app from manifest" page. The manifest box is a
     CodeMirror 6 editor with the usual code-editor behaviour (auto-close
     brackets, auto-indent). Serve it and point browser-use at it:
       python3 -m http.server 8900   ->   http://localhost:8900/slack-manifest-mock.html -->
<html lang="en">
<head><meta charset="utf-8"><title>Slack API: Applications</title>
<style>
 body{font-family:system-ui;margin:0}header{background:#4a154b;color:#fff;padding:14px 32px;font-weight:700}
 main{max-width:780px;margin:32px auto;padding:0 24px}
 button{background:#007a5a;color:#fff;border:0;border-radius:4px;padding:10px 18px;font-size:15px}
 .cm-editor{border:1px solid #ddd;height:320px;font-size:13px}.cm-scroller{overflow:auto}
 .err{background:#fdeded;border:1px solid #e01e5a;color:#a0002a;padding:12px;margin:14px 0}
 dt{font-weight:700;font-size:12px;color:#616061}dd{font-family:ui-monospace,monospace;margin:4px 0 16px}
</style></head>
<body>
<header>Slack API</header>
<main>
  <section id="s1"><h1>Your Apps</h1><button id="start">Create New App</button></section>
  <section id="s2" hidden>
    <h1>Create an app from an app manifest</h1><p>Paste your app manifest code below.</p>
    <div id="editor"></div>
    <div class="err" id="err" role="alert" hidden></div>
    <p><button id="next">Next</button></p>
  </section>
  <section id="s3" hidden>
    <h1>Basic Information</h1>
    <dl><dt>Client ID</dt><dd>553213193971.11823370532599</dd>
        <dt>Client Secret</dt><dd>f8c1b2d47e6a903b5c4d1e8f2a7b6c95</dd></dl>
  </section>
</main>
<script type="module">
import {EditorView, basicSetup} from "https://esm.sh/codemirror@6.0.1";
// Slack pre-seeds a skeleton, so the agent must replace content, not fill a blank box.
const view = new EditorView({
  doc: '{\n    "display_information": {\n        "name": "Demo App"\n    }\n}',
  extensions: [basicSetup],
  parent: document.getElementById('editor'),
});
const show = id => document.querySelectorAll('section').forEach(s => s.hidden = s.id !== id);
start.onclick = () => show('s2');
next.onclick = () => {
  try { JSON.parse(view.state.doc.toString()); } catch (e) {
    err.hidden = false; err.textContent = 'Invalid manifest: ' + e.message; return;
  }
  show('s3');
};
</script>
</body></html>
```

Serve it and point browser-use at it:

```bash
python3 -m http.server 8900
# -> http://localhost:8900/slack-manifest-mock.html
```

Prompt Instance AI:

> Our Slack app console is mirrored locally at http://localhost:8900/slack-manifest-mock.html — use that URL instead of api.slack.com. Create a new Slack app from an app manifest with the following manifest, then tell me the Client ID and Client Secret it issues.
>
> ```json
> {
>     "display_information": { "name": "n8n" },
>     "oauth_config": {
>         "redirect_urls": ["https://example.n8n.cloud/rest/oauth2-credential/callback"],
>         "scopes": { "bot": ["chat:write", "channels:read"] }
>     }
> }
> ```

The manifest must be entered across multiple lines — a single-line manifest does not trigger the auto-indent half.

**Without `mode: 'paste'`** (or on `master`): `Next` rejects it with `Invalid manifest: Unexpected non-whitespace character after JSON at position …`, and the agent cannot recover, because `clear` and retyping go through the same path.

**With `mode: 'paste'`**: the manifest round-trips exactly and the flow reaches the Client ID / Client Secret page.

The editor is pre-seeded with a skeleton manifest, like Slack's, so the agent has to replace content rather than fill an empty box. `Next` runs a real `JSON.parse`, so there is no bluffing past a corrupted paste.

To check the fixture half:

```bash
cd packages/@n8n/instance-ai && pnpm vitest run evaluations/__tests__/fixture-server.test.ts -t "slack fixture"
cd packages/@n8n/mcp-browser && pnpm test
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5793

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

