### PR TITLE
ci: Run nightly e2e against `-pc` image

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -394,6 +394,7 @@ Push to master/1.x
 | Daily 00:00               | `util-check-docs-urls.yml`        | Doc link validation      |
 | Daily 01:30, 02:30, 03:30 | `test-benchmark-nightly.yml`      | Performance benchmarks   |
 | Daily 02:00               | `test-get-n8n.yml`                | get.n8n.io installer health |
+| Daily 02:00               | `test-e2e-pc-nightly.yml`         | E2E on the `-pc` image   |
 | Daily 05:00               | `test-benchmark-destroy-nightly.yml`| Cleanup benchmark env  |
 | Daily 06:00               | `util-sync-master-to-3x.yml`      | Replay 3.x onto master (v3) |
 | Daily 08:00               | `build-v3-nightly.yml`            | Nightly v3 Docker images |

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -619,7 +619,7 @@ jobs:
     name: Notify Cats on nightly build failure
     runs-on: ubuntu-latest
     needs: [build-and-push-docker]
-    if: needs.build-and-push-docker.result == 'failure' && github.event_name == 'schedule'
+    if: always() && needs.build-and-push-docker.result == 'failure' && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-e2e-pc-nightly.yml
+++ b/.github/workflows/test-e2e-pc-nightly.yml
@@ -60,7 +60,7 @@ jobs:
     name: Notify Cats on -pc e2e failure
     runs-on: ubuntu-latest
     needs: [e2e-pc]
-    if: needs.e2e-pc.result == 'failure' && github.event_name == 'schedule'
+    if: always() && needs.e2e-pc.result == 'failure' && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-e2e-pc-nightly.yml
+++ b/.github/workflows/test-e2e-pc-nightly.yml
@@ -1,0 +1,76 @@
+name: 'Test: E2E on -pc image'
+
+# Boots the pointer-compressed n8n image and runs the e2e suite against it.
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # after the nightly Docker build at midnight
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'n8n image to test'
+        required: false
+        default: 'n8nio/n8n:nightly-pc'
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  TEST_IMAGE_N8N: ${{ inputs.image || 'n8nio/n8n:nightly-pc' }}
+
+jobs:
+  e2e-pc:
+    name: E2E on -pc image (${{ matrix.shard }}/4)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          persist-credentials: false
+
+      - name: Pull image and assert pointer compression
+        run: |
+          docker pull --quiet "$TEST_IMAGE_N8N"
+          docker run --rm --entrypoint node "$TEST_IMAGE_N8N" -e "
+            if (!process.config.variables.v8_enable_pointer_compression) {
+              throw new Error('image is not pointer-compressed');
+            }
+            console.log(process.version, 'pointer compression: on');
+          "
+
+      - name: Build the test harness
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: 'pnpm turbo build --filter=n8n-playwright...'
+
+      - name: Install Playwright browsers
+        working-directory: packages/testing/playwright
+        run: npx playwright install chromium --with-deps
+
+      - name: Run e2e against the image
+        working-directory: packages/testing/playwright
+        run: pnpm test:container:sqlite:e2e -- --shard=${{ matrix.shard }}/4
+
+  notify-on-failure:
+    name: Notify Cats on -pc e2e failure
+    runs-on: ubuntu-latest
+    needs: [e2e-pc]
+    if: needs.e2e-pc.result == 'failure' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts/slack
+          sparse-checkout-cone-mode: false
+      - name: Notify Slack
+        env:
+          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel '#team-catalysts' \
+            --text 'Nightly e2e on the -pc image failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
## Summary

This PR adds a nightly job (02:00 UTC, after the Docker nightly) that

- pulls `n8nio/n8n:nightly-pc` and asserts pointer compression is on
- runs the container e2e suite against it in 4 shards
- pings `#team-catalysts` on scheduled failures

The PC-specific risk we're hedging is native-module drift, i.e. a dep whose native binding breaks under PC, which no PR pipeline exercises.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4147/run-nightly-e2e-against-the-pc-image

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)