### PR TITLE
fix(editor): Keep AI Assistant step narration inside thinking blocks

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
@@ -399,10 +399,41 @@ describe('buildTimelineBlocks', () => {
 		expect(blocks.map((b) => b.type)).toEqual(['thinking', 'text']);
 	});
 
-	test('streaming tail text without same-response trace renders outside', () => {
+	test('short streaming tail text of a later response stays inside the block', () => {
 		const blocks = blocksOf([reasoning('r1'), text('Quick answer.', 'r2')], [], 'active');
 
-		expect(blocks.map((b) => b.type)).toEqual(['thinking', 'text']);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].type === 'thinking' && blocks[0].entries).toHaveLength(2);
+	});
+
+	test('streaming text with no trace anywhere in the run renders outside', () => {
+		const blocks = blocksOf([text('Quick answer.', 'r1')], [], 'active');
+
+		expect(blocks.map((b) => b.type)).toEqual(['text']);
+	});
+
+	test('narration leading a reasoning-less step never renders outside the block', () => {
+		const narration = text('No services are connected yet.', 'r2');
+		const toolCalls = [makeToolCall({ toolCallId: 'tc-1' }), makeToolCall({ toolCallId: 'tc-2' })];
+
+		// The step emits its narration a few hundred ms before its tool call and
+		// carries no reasoning, so its response has no trace content of its own.
+		const streaming = blocksOf(
+			[reasoning('r1'), toolEntry('tc-1', 'r1'), narration],
+			toolCalls,
+			'active',
+		);
+		expect(streaming).toHaveLength(1);
+		expect(streaming[0].type === 'thinking' && streaming[0].entries).toHaveLength(3);
+
+		// Once the tool call lands the grouping is unchanged — nothing re-flows.
+		const withToolCall = blocksOf(
+			[reasoning('r1'), toolEntry('tc-1', 'r1'), narration, toolEntry('tc-2', 'r2')],
+			toolCalls,
+			'active',
+		);
+		expect(withToolCall).toHaveLength(1);
+		expect(withToolCall[0].type === 'thinking' && withToolCall[0].entries).toHaveLength(4);
 	});
 
 	test('short trailing text promotes out once the run settles', () => {
@@ -613,10 +644,10 @@ describe('buildTimelineBlocks', () => {
 	});
 
 	test('the trailing thinking block stays active while tentative tail text streams', () => {
-		// Tail text may still fold back into the block (if same-response trace
-		// content follows), so the block must not settle to "Thought for Xs" yet.
+		// Tail text kept inside the block is still tentative, so the block must
+		// not settle to "Thought for Xs" yet.
 		const tailText = blocksOf([reasoning('r1'), text('Answer...', 'r2')], [], 'active');
-		expect(tailText.map((b) => b.type)).toEqual(['thinking', 'text']);
+		expect(tailText.map((b) => b.type)).toEqual(['thinking']);
 		expect(tailText[0].type === 'thinking' && tailText[0].active).toBe(true);
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
@@ -87,6 +87,13 @@ export function buildTimelineBlocks(
 	// kept working after writing it. Trailing text of a response (and text
 	// without a responseId, from old snapshots) is user-facing.
 	const lastTraceIdxByResponse = new Map<string, number>();
+	// Index of the first trace entry anywhere in the run — tells the tail guard
+	// below that the model is already in a tool loop, whatever response it is on.
+	let firstTraceIdx: number | undefined;
+	const markTrace = (responseId: string, idx: number) => {
+		lastTraceIdxByResponse.set(responseId, idx);
+		firstTraceIdx ??= idx;
+	};
 	const builderChildResponseIds = new Set(
 		entries
 			.filter(
@@ -103,7 +110,7 @@ export function buildTimelineBlocks(
 	entries.forEach((entry, idx) => {
 		if (entry.responseId === undefined) return;
 		if (entry.type === 'reasoning') {
-			lastTraceIdxByResponse.set(entry.responseId, idx);
+			markTrace(entry.responseId, idx);
 		} else if (entry.type === 'tool-call') {
 			const tc = toolCallsById[entry.toolCallId];
 			if (
@@ -114,7 +121,7 @@ export function buildTimelineBlocks(
 					hasBuilderChildInResponse(entry.responseId, builderChildResponseIds)
 				)
 			) {
-				lastTraceIdxByResponse.set(entry.responseId, idx);
+				markTrace(entry.responseId, idx);
 			}
 		}
 	});
@@ -126,14 +133,22 @@ export function buildTimelineBlocks(
 		// Streaming tail text is ambiguous — narration before the next tool call
 		// and the final answer look identical until either a tool call follows
 		// or the run ends. Rendering it outside and folding it back in reads as
-		// an answer flashing and vanishing, so short tail text following this
-		// response's trace content is optimistically kept INSIDE the block (its
-		// first sentence feeds the status line). It promotes out — an additive,
-		// non-jarring motion — once it grows answer-length or the run settles.
+		// an answer flashing and vanishing, so short tail text is optimistically
+		// kept INSIDE the block (its first sentence feeds the status line). It
+		// promotes out — an additive, non-jarring motion — once it grows
+		// answer-length or the run settles.
+		//
+		// The condition is run-scoped, not response-scoped: a step that emits no
+		// reasoning leads with its narration text, so keying on the current
+		// response would render it outside for the few hundred ms until that
+		// step's tool call lands. Trace content earlier in the run is enough to
+		// know the model is mid-tool-loop; a first answer with no trace at all
+		// still renders as text immediately.
 		return (
 			agentStatus === 'active' &&
 			idx === entries.length - 1 &&
-			lastTraceIdx !== undefined &&
+			firstTraceIdx !== undefined &&
+			firstTraceIdx < idx &&
 			entry.content.length <= TAIL_NARRATION_MAX_LENGTH
 		);
 	};


### PR DESCRIPTION
## Summary

Narration text from a model step was shown as normal answer text for a few hundred milliseconds, and then moved into the thinking block above it.

This caused the thinking traces to appear as regular agent output text while being streamed, like here

<img width="866" height="266" alt="image" src="https://github.com/user-attachments/assets/56097908-79a9-4bc9-960d-81e196b1c202" />

The timeline groups text into a thinking block when trace content (reasoning or a generic tool call) follows it. The streaming guard for the last text entry required trace content **from the same response**. A step that emits no reasoning starts with its narration text, so that response has no trace content yet. The text was rendered outside the block until the tool call of the step arrived, and then it was folded back in. The thinking block also split and merged again in the same moment.

The guard is now scoped to the run. Trace content anywhere earlier in the timeline shows that the model is in a tool loop. A first answer with no trace content at all is still rendered as text immediately.

Behaviour change: short text (200 characters or less) that follows a tool call in a step without reasoning now streams inside the thinking block, and moves out when the run ends. Steps that emit reasoning before the text already behaved this way. I tested this locally and this felt okay, and it fixed the original case reported here.

## How to test

1. Start the AI Assistant.
2. Ask a question that makes the assistant call a tool more than once, for example `What linear issues are assigned to me?` with no MCP server connected. The assistant calls `mcp-servers` for `connected`, then for `search`, then for `connect`.
3. Watch the chat while the assistant streams.
4. Confirm that the narration between the tool calls, for example `No services are connected yet. Let me check if there's a Linear server available to connect.`, stays inside the thinking block. It must not appear as normal answer text first.
5. Confirm that the final answer of the run is still rendered as normal answer text below the block.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1238

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

