### PR TITLE
fix(editor): Show personalization survey and community registration modal on Instance AI landing page

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -10,6 +10,7 @@ import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
+import { useUsersStore } from '@n8n/stores/users.store';
 import { useInstanceAiStore } from './instanceAi.store';
 import { useInstanceAiSettingsStore } from './instanceAiSettings.store';
 import InstanceAiThreadList from './components/InstanceAiThreadList.vue';
@@ -26,6 +27,7 @@ const route = useRoute();
 const router = useRouter();
 const uiStore = useUIStore();
 const rootStore = useRootStore();
+const usersStore = useUsersStore();
 const telemetry = useTelemetry();
 const { isCtrlKeyPressed } = useDeviceSupport();
 const setupCompletionState = computed(
@@ -126,6 +128,9 @@ onMounted(() => {
 	if (showOnboarding.value && route.name !== INSTANCE_AI_VIEW) {
 		void router.replace({ name: INSTANCE_AI_VIEW });
 	}
+	// New owners land here instead of the homepage, so the signup modals
+	// (personalization survey → community registration) must trigger here too.
+	void usersStore.showPersonalizationSurvey();
 	// In-app navigations expose the previous route via history state; direct
 	// visits (bookmark, external link) fall back to the document referrer.
 	const previousRoute = router.options.history.state.back;

--- a/packages/frontend/editor-ui/src/features/settings/users/components/PersonalizationModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/PersonalizationModal.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue';
 import { VIEWS } from '@/app/constants';
+import { isInstanceAiChatRoute } from '@/features/ai/instanceAi/constants';
 import {
 	COMPANY_SIZE_100_499,
 	COMPANY_SIZE_1000_OR_MORE,
@@ -563,8 +564,9 @@ const onSave = () => {
 
 const closeCallback = () => {
 	// In case the redirect to homepage for new users didn't happen
-	// we try again after closing the modal
-	if (route.name !== VIEWS.HOMEPAGE) {
+	// we try again after closing the modal. New owners land on the
+	// Instance AI homepage instead, so stay put there.
+	if (route.name !== VIEWS.HOMEPAGE && !isInstanceAiChatRoute(route.name)) {
 		void router.replace({ name: VIEWS.HOMEPAGE });
 	}
 };


### PR DESCRIPTION
## Summary

New owners on self-hosted now land on `/assistant` after setup, but the personalization survey and community registration modal were only triggered from the homepage views — so they didn't show until the user happened to navigate to 'home' (or until the assistant opened a workflow artifact, which embeds `NodeView` and fired them mid-conversation).

- `InstanceAiView` now triggers the survey on mount, same as the homepage views. The community modal chains after survey submission as before.
- The survey's close callback no longer redirects to the homepage when the user is on an Instance AI route — they stay on `/assistant`.

With Instance AI disabled, everything behaves as before: setup redirects to `/home/workflows` and the modals show there.

## How to test

1. Start with a fresh DB and no license: `N8N_USER_FOLDER=$(mktemp -d) pnpm start`
2. Complete owner setup → you land on `/assistant` with the survey on top.
3. Submit → community modal shows → skip → you stay on `/assistant`.
4. Regression: repeat with `N8N_DISABLED_MODULES=instance-ai` → same sequence on `/home/workflows`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1217

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

