### PR TITLE
feat(core): Link unpublished sub-workflow IDs in the publish error

### DIFF
--- a/packages/cli/src/errors/response-errors/workflow-activation-bad-request.error.ts
+++ b/packages/cli/src/errors/response-errors/workflow-activation-bad-request.error.ts
@@ -1,5 +1,16 @@
 import { BadRequestError } from './bad-request.error';
 
+export type WorkflowActivationErrorMeta = {
+	nodeId?: string;
+	validationError?: boolean;
+	description?: string;
+	/**
+	 * `message` with links, for clients that render HTML. `message` itself stays
+	 * plain: the Public API, the MCP tools and Instance AI all read it as text.
+	 */
+	messageHtml?: string;
+};
+
 /**
  * Error thrown when a workflow fails to activate due to a node-level error.
  * Includes the node ID in meta so the frontend can identify the failing node.
@@ -7,7 +18,7 @@ import { BadRequestError } from './bad-request.error';
 export class WorkflowActivationBadRequestError extends BadRequestError {
 	constructor(
 		message: string,
-		readonly meta: { nodeId?: string; validationError?: boolean; description?: string } = {},
+		readonly meta: WorkflowActivationErrorMeta = {},
 	) {
 		super(message);
 		this.name = 'WorkflowActivationBadRequestError';

--- a/packages/cli/src/errors/response-errors/workflow-validation.error.ts
+++ b/packages/cli/src/errors/response-errors/workflow-validation.error.ts
@@ -1,13 +1,14 @@
-import { WorkflowActivationBadRequestError } from './workflow-activation-bad-request.error';
+import {
+	WorkflowActivationBadRequestError,
+	type WorkflowActivationErrorMeta,
+} from './workflow-activation-bad-request.error';
 
 /**
  * Error thrown when a workflow fails validation before activation.
  */
 export class WorkflowValidationError extends WorkflowActivationBadRequestError {
-	override readonly meta = { validationError: true as const };
-
-	constructor(message: string) {
-		super(message);
+	constructor(message: string, meta: Omit<WorkflowActivationErrorMeta, 'validationError'> = {}) {
+		super(message, { ...meta, validationError: true });
 		this.name = 'WorkflowValidationError';
 	}
 }

--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -11,7 +11,13 @@ import { mock } from 'vitest-mock-extended';
 import type { CredentialTypes } from '@/credential-types';
 import type { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { NodeTypes } from '@/node-types';
+import type { UrlService } from '@/services/url.service';
 import { WorkflowValidationService } from '@/workflows/workflow-validation.service';
+
+const INSTANCE_URL = 'https://n8n.example.com';
+
+const urlServiceMock = () =>
+	mock<UrlService>({ getInstanceBaseUrl: () => INSTANCE_URL } as unknown as UrlService);
 
 describe('WorkflowValidationService', () => {
 	let service: WorkflowValidationService;
@@ -33,6 +39,7 @@ describe('WorkflowValidationService', () => {
 			mockCredentialsRepository,
 			mockDynamicCredentialsProxy,
 			mock<CredentialTypes>(),
+			urlServiceMock(),
 		);
 	});
 
@@ -107,6 +114,11 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toContain('Node "Sub-workflow 1" references workflow workflow-1');
 			expect(result.error).toContain('("Draft Workflow")');
 			expect(result.error).toContain('which is not published');
+			// `error` feeds the Public API, the MCP tools and Instance AI as text.
+			expect(result.error).not.toContain('<a href');
+			expect(result.errorHtml).toContain(
+				`references workflow <a href="${INSTANCE_URL}/workflow/workflow-1" target="_blank">workflow-1</a> ("Draft Workflow")`,
+			);
 			expect(result.invalidReferences).toHaveLength(1);
 			expect(result.invalidReferences?.[0]).toEqual({
 				nodeName: 'Sub-workflow 1',
@@ -125,6 +137,9 @@ describe('WorkflowValidationService', () => {
 			const result = await service.validateSubWorkflowReferences('parent-workflow-id', nodes);
 
 			expect(result.isValid).toBe(false);
+			expect(result.error).toContain('references workflow non-existent which is not published');
+			// The workflow is gone, so even the HTML rendering must not link it.
+			expect(result.errorHtml).not.toContain('<a href');
 			expect(result.invalidReferences?.[0]).toEqual({
 				nodeName: 'Sub-workflow 1',
 				workflowId: 'non-existent',
@@ -1358,6 +1373,7 @@ describe('WorkflowValidationService', () => {
 				mock<CredentialsRepository>(),
 				mock<DynamicCredentialsProxy>(),
 				credentialTypes,
+				urlServiceMock(),
 			);
 
 		// The loader sets `supportedNodes` on the credential class to *short* names

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -27,6 +27,7 @@ import { isFormOAuth2Enabled } from '@/constants/oauth2-triggers';
 import { CredentialTypes } from '@/credential-types';
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { NodeTypes } from '@/node-types';
+import { UrlService } from '@/services/url.service';
 
 export interface WorkflowValidationResult {
 	isValid: boolean;
@@ -34,11 +35,18 @@ export interface WorkflowValidationResult {
 }
 
 export interface SubWorkflowValidationResult extends WorkflowValidationResult {
-	invalidReferences?: Array<{
-		nodeName: string;
-		workflowId: string;
-		workflowName?: string;
-	}>;
+	/**
+	 * `error` with each sub-workflow ID linked. Only for consumers that render
+	 * HTML — the Public API, the MCP tools and Instance AI all read `error`.
+	 */
+	errorHtml?: string;
+	invalidReferences?: SubWorkflowReference[];
+}
+
+interface SubWorkflowReference {
+	nodeName: string;
+	workflowId: string;
+	workflowName?: string;
 }
 
 export interface WorkflowStatus {
@@ -59,6 +67,7 @@ export class WorkflowValidationService {
 		private readonly credentialsRepository: CredentialsRepository,
 		private readonly dynamicCredentialsProxy: DynamicCredentialsProxy,
 		private readonly credentialTypes: CredentialTypes,
+		private readonly urlService: UrlService,
 	) {}
 
 	/**
@@ -516,11 +525,7 @@ export class WorkflowValidationService {
 			return { isValid: true };
 		}
 
-		const invalidReferences: Array<{
-			nodeName: string;
-			workflowId: string;
-			workflowName?: string;
-		}> = [];
+		const invalidReferences: SubWorkflowReference[] = [];
 
 		for (const node of executeWorkflowNodes) {
 			const subWorkflowId = this.extractWorkflowId(node);
@@ -543,19 +548,37 @@ export class WorkflowValidationService {
 		}
 
 		if (invalidReferences.length > 0) {
-			const errorMessages = invalidReferences.map((ref) => {
-				const workflowName = ref.workflowName ? ` ("${ref.workflowName}")` : '';
-				return `Node "${ref.nodeName}" references workflow ${ref.workflowId}${workflowName} which is not published`;
-			});
+			const compose = (renderId: (ref: SubWorkflowReference) => string) => {
+				const clauses = invalidReferences.map((ref) => {
+					const workflowName = ref.workflowName ? ` ("${ref.workflowName}")` : '';
+					return `Node "${ref.nodeName}" references workflow ${renderId(ref)}${workflowName} which is not published`;
+				});
+
+				return `Cannot publish workflow: ${clauses.join('; ')}. Please publish all referenced sub-workflows first.`;
+			};
 
 			return {
 				isValid: false,
-				error: `Cannot publish workflow: ${errorMessages.join('; ')}. Please publish all referenced sub-workflows first.`,
+				error: compose((ref) => ref.workflowId),
+				errorHtml: compose((ref) => this.linkToWorkflow(ref)),
 				invalidReferences,
 			};
 		}
 
 		return { isValid: true };
+	}
+
+	/**
+	 * Renders a sub-workflow ID as a link the editor can open, so the user can
+	 * reach the draft without searching for the ID by hand. A reference with no
+	 * name is a workflow that no longer exists, so it stays plain text.
+	 */
+	private linkToWorkflow(ref: SubWorkflowReference): string {
+		if (!ref.workflowName) return ref.workflowId;
+
+		const url = `${this.urlService.getInstanceBaseUrl()}/workflow/${ref.workflowId}`;
+
+		return `<a href="${url}" target="_blank">${ref.workflowId}</a>`;
 	}
 
 	/**

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -1666,7 +1666,9 @@ export class WorkflowService {
 				error: validation.error,
 				invalidReferences: validation.invalidReferences,
 			});
-			throw new WorkflowValidationError(validation.error ?? 'Sub-workflow validation failed');
+			throw new WorkflowValidationError(validation.error ?? 'Sub-workflow validation failed', {
+				messageHtml: validation.errorHtml,
+			});
 		}
 	}
 

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -36,6 +36,7 @@ import { Telemetry } from '@/telemetry';
 import { WebhookService } from '@/webhooks/webhook.service';
 import { WorkflowHookContextService } from '@/workflow-hook-context.service';
 import { WorkflowPublishBlockedError } from '@/errors/response-errors/workflow-publish-blocked.error';
+import { WorkflowValidationError } from '@/errors/response-errors/workflow-validation.error';
 import type { WorkflowPublicationNotifier } from '@/workflows/publication/workflow-publication-notifier';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -422,6 +423,29 @@ describe('activateWorkflow()', () => {
 				versionId: newVersionId,
 			}),
 		).rejects.toThrow('There is a conflict with one of the webhooks.');
+	});
+
+	test('should keep the thrown message plain and carry the linked one in meta', async () => {
+		const owner = await createOwner();
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		workflowValidationService.validateSubWorkflowReferences.mockResolvedValue({
+			isValid: false,
+			error: 'Cannot publish workflow: references workflow sub-a which is not published',
+			errorHtml:
+				'Cannot publish workflow: references workflow <a href="https://n8n.test/workflow/sub-a" target="_blank">sub-a</a> which is not published',
+		});
+
+		const error = await workflowService
+			.activateWorkflow(owner, workflow.id)
+			.catch((e: unknown) => e);
+
+		expect(error).toBeInstanceOf(WorkflowValidationError);
+		const validationError = error as WorkflowValidationError;
+		expect(validationError.message).not.toContain('<a href');
+		expect(validationError.meta.messageHtml).toContain(
+			'<a href="https://n8n.test/workflow/sub-a" target="_blank">sub-a</a>',
+		);
 	});
 
 	test('should use nodes from correct workflow version when checking conflicts and versionId is passed', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
@@ -70,8 +70,10 @@ vi.mock('@n8n/composables/useTelemetry', () => ({
 	useTelemetry: vi.fn().mockReturnValue({ track: vi.fn() }),
 }));
 
+const mockShowError = vi.hoisted(() => vi.fn());
+
 vi.mock('@n8n/composables/useToast', () => ({
-	useToast: vi.fn().mockReturnValue({ showError: vi.fn(), showMessage: vi.fn() }),
+	useToast: vi.fn().mockReturnValue({ showError: mockShowError, showMessage: vi.fn() }),
 }));
 
 vi.mock('@n8n/composables/useStorage', () => ({
@@ -155,6 +157,35 @@ describe('useWorkflowActivate', () => {
 
 			expect(result).toEqual({ success: false, errorHandled: true });
 			expect(mockSetPublicationStatus).not.toHaveBeenCalled();
+		});
+
+		it('shows the linked message when the error carries one', async () => {
+			mockPublishWorkflow.mockRejectedValueOnce(
+				Object.assign(new Error('references workflow sub-a which is not published'), {
+					meta: {
+						validationError: true,
+						messageHtml:
+							'references workflow <a href="/workflow/sub-a" target="_blank">sub-a</a> which is not published',
+					},
+				}),
+			);
+
+			const { publishWorkflow } = useWorkflowActivate();
+			await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(mockShowError.mock.calls[0][0].message).toBe(
+				'references workflow <a href="/workflow/sub-a" target="_blank">sub-a</a> which is not published',
+			);
+		});
+
+		it('passes the error through untouched when it carries no linked message', async () => {
+			const error = new Error('network error');
+			mockPublishWorkflow.mockRejectedValueOnce(error);
+
+			const { publishWorkflow } = useWorkflowActivate();
+			await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(mockShowError.mock.calls[0][0]).toBe(error);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -162,7 +162,11 @@ export function useWorkflowActivate() {
 				const title = i18n.baseText('workflowActivator.showError.title', {
 					interpolate: { newStateName: 'published' },
 				});
-				toast.showError(error, title, {
+				// `messageHtml` is the same message with links; `message` stays plain
+				// for the non-HTML consumers of this error.
+				const messageHtml = error.meta?.messageHtml as string | undefined;
+
+				toast.showError(messageHtml ? { ...error, message: messageHtml } : error, title, {
 					message: activationErrorMessage.value,
 					description: error.meta?.description as string | undefined,
 				});


### PR DESCRIPTION
## Summary

You cannot publish a workflow while a sub-workflow it calls is still a draft. The publish error names each blocker by ID only:

> Cannot publish workflow: Node "Call A" references workflow `k3nDp8vQm2xLtR7w` which is not published. Please publish all referenced sub-workflows first.

An ID is not a name. To act on this error, the user had to copy the ID out of the toast, open the workflow list, and search for a match by hand.

This PR makes each ID a link that opens that workflow in a new tab.

The wording is unchanged. No publish behaviour changes.

### Why the message is not simply changed to HTML

`SubworkflowPolicyDenialError` puts an anchor straight into its message, and that is the obvious precedent to copy. It does not apply here: that error has one consumer, the NDV, which renders HTML. `activateWorkflow` has four.

| Consumer | Renders HTML | Reads |
|---|---|---|
| Editor toast (`useWorkflowActivate`) | yes | `meta.messageHtml` |
| Public API (`workflows.public.controller.ts:424`) | no | `message` |
| MCP publish tool (`publish-workflow.tool.ts:129`) | no | `message` |
| Instance AI (`instance-ai.adapter.service.ts:772`) | no | `message` |

The last two feed an agent, which is meant to read the ID out of this error and go publish that sub-workflow. Wrapping the ID in markup for those callers would be a regression, not a cosmetic issue.

So `validateSubWorkflowReferences` composes the sentence twice from one template — `error` plain, `errorHtml` with anchors — and the anchored copy travels as `meta.messageHtml`. `serializePublicApiError` forwards only whitelisted `meta` keys, so it cannot leak.

Two details:

- **IDs of deleted workflows are never linked**, in either rendering. A reference with no name means the workflow is gone, so a link would lead to a 404.
- **URLs come from `UrlService.getInstanceBaseUrl()`**, built from `protocol/host/port/path`, so `N8N_PATH` deployments are covered.

Toasts already render error messages through `sanitizeHtml`, which permits `a` with `href` and `target` and restricts `href` to relative or `https` URLs.

## How to test

No env vars, license, or feature flags needed.

```bash
pnpm dev:be          # backend on :5678
pnpm dev:fe:editor   # editor on :8080
```

1. Create a workflow with a **When Executed by Another Workflow** trigger. Save it and **leave it unpublished**.
2. Create a second workflow with any trigger plus an **Execute Sub-workflow** node. **Select the first workflow from the dropdown list.**
3. Press **Publish** on the second workflow.
4. The toast appears bottom-right. The ID is a link, and it opens the draft in a new tab.

Two things that make it look broken:

- **Select the sub-workflow from the list.** Validation is skipped when the target comes from a URL, a parameter, or an expression, so no error appears at all.
- **Keep the parent otherwise valid.** Node-config and credential validation run first; a broken node surfaces that error instead.

To confirm the plain path, publish the same workflow through the Public API (`POST /api/v1/workflows/:id/activate`) and check the error message has no markup.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI