### PR TITLE
fix(editor): Distinguish session timeline errors

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/SessionEventFilter.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/SessionEventFilter.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import-x/no-extraneous-dependencies -- test-only patterns */
 import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import SessionEventFilter from '../components/SessionEventFilter.vue';
@@ -6,17 +5,33 @@ import type { FilterOption } from '../session-timeline.types';
 
 vi.mock('@n8n/design-system', () => ({
 	N8nButton: { template: '<button><slot /></button>' },
-	N8nPopover: {
-		props: ['open'],
-		emits: ['update:open'],
-		template:
-			'<div><div @click="$emit(\'update:open\', true)"><slot name="trigger" /></div><div v-if="open"><slot name="content" /></div></div>',
+	N8nDropdownMenu: {
+		props: ['items'],
+		emits: ['select'],
+		data() {
+			return { open: false };
+		},
+		template: `
+			<div>
+				<div @click="open = true"><slot name="trigger" /></div>
+				<div v-if="open">
+					<template v-for="item in items" :key="item.id">
+						<div v-if="item.header">{{ item.label }}</div>
+						<button
+							v-else
+							:data-test-id="item.testId"
+							:disabled="item.disabled"
+							@click="$emit('select', item.id)"
+						>
+							<slot name="item-leading" :item="item" :ui="{ class: '' }" />
+							<slot name="item-label" :item="item" :ui="{ class: '' }">{{ item.label }}</slot>
+						</button>
+					</template>
+				</div>
+			</div>
+		`,
 	},
-	N8nBadge: {
-		props: ['theme'],
-		template: '<span :data-theme="theme"><slot /></span>',
-	},
-	N8nIcon: { template: '<span />' },
+	N8nTooltip: { template: '<div><slot /></div>' },
 }));
 
 const options: FilterOption[] = [
@@ -36,101 +51,101 @@ const options: FilterOption[] = [
 	},
 ];
 
+function mountFilter(selected = new Set<string>(), available = options) {
+	return mount(SessionEventFilter, {
+		props: { available, selected },
+	});
+}
+
+async function openMenu(wrapper: ReturnType<typeof mountFilter>) {
+	await wrapper.get('[data-test-id="filter-trigger"]').trigger('click');
+}
+
 describe('SessionEventFilter', () => {
-	it('renders a button labeled "Events"', () => {
-		const w = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>() },
-		});
-		expect(w.find('[data-test-id="filter-trigger"]').text()).toContain('Events');
+	it('renders an icon button labeled "Events"', () => {
+		const wrapper = mountFilter();
+
+		expect(wrapper.get('[data-test-id="filter-trigger"]').attributes('aria-label')).toBe('Events');
 	});
 
-	it('shows a count badge when items are selected', () => {
-		const w = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>(['user']) },
-		});
-		expect(w.find('[data-test-id="filter-trigger"]').text()).toContain('(1)');
+	it('shows an active indicator when items are selected', () => {
+		const wrapper = mountFilter(new Set(['user']));
+
+		expect(wrapper.find('[aria-hidden="true"]').exists()).toBe(true);
 	});
 
-	it('omits the count badge when nothing is selected', () => {
-		const w = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>() },
-		});
-		expect(w.find('[data-test-id="filter-trigger"]').text()).not.toMatch(/\(\d+\)/);
+	it('omits the active indicator when nothing is selected', () => {
+		const wrapper = mountFilter();
+
+		expect(wrapper.find('[aria-hidden="true"]').exists()).toBe(false);
 	});
 
-	it('opens the popover on trigger click, hiding options until opened', async () => {
-		const w = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>() },
-		});
-		expect(w.find('[data-test-id="filter-option-user"]').exists()).toBe(false);
-		await w.find('[data-test-id="filter-trigger"]').trigger('click');
-		expect(w.find('[data-test-id="filter-option-user"]').exists()).toBe(true);
+	it('opens the menu on trigger click, hiding options until opened', async () => {
+		const wrapper = mountFilter();
+		expect(wrapper.find('[data-test-id="filter-option-user"]').exists()).toBe(false);
+
+		await openMenu(wrapper);
+
+		expect(wrapper.find('[data-test-id="filter-option-user"]').exists()).toBe(true);
 	});
 
-	it.each([
-		['approved', 'Approved', 'success'],
-		['declined', 'Declined', 'default'],
-		['error', 'Error', 'danger'],
-	] as const)('renders the %s status option using its timeline pill', async (key, label, theme) => {
-		const w = mount(SessionEventFilter, {
-			props: {
-				available: [
-					{
-						key,
-						label,
-						presentation: 'badge',
-						badgeTheme: theme,
-						count: 1,
-					},
-				],
-				selected: new Set<string>(),
+	it('groups event and status options and shows their counts', async () => {
+		const available: FilterOption[] = [
+			...options,
+			{
+				key: 'approved',
+				label: 'Approved',
+				presentation: 'badge',
+				badgeTheme: 'success',
+				count: 3,
 			},
-		});
-		await w.find('[data-test-id="filter-trigger"]').trigger('click');
+		];
+		const wrapper = mountFilter(new Set(), available);
+		await openMenu(wrapper);
 
-		const pill = w.get(`[data-test-id="filter-status-pill-${key}"]`);
-		expect(pill.text()).toBe(label);
-		expect(pill.attributes('data-theme')).toBe(theme);
+		expect(wrapper.text()).toContain('Events');
+		expect(wrapper.text()).toContain('Status');
+		expect(wrapper.get('[data-test-id="filter-option-user"]').text()).toContain('User 2');
+		expect(wrapper.get('[data-test-id="filter-option-approved"]').text()).toContain('Approved 3');
 	});
 
-	it('emits update with the toggled key added to the selection', async () => {
-		const w = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>() },
-		});
-		await w.find('[data-test-id="filter-trigger"]').trigger('click');
-		const checkbox = w.find('[data-test-id="filter-option-user"] input[type=checkbox]');
-		await checkbox.setValue(true);
-		const events = w.emitted('update') ?? [];
-		const last = events[events.length - 1]?.[0] as Set<string>;
+	it('emits update with the selected key added', async () => {
+		const wrapper = mountFilter();
+		await openMenu(wrapper);
+		await wrapper.get('[data-test-id="filter-option-user"]').trigger('click');
+
+		const events = wrapper.emitted('update') ?? [];
+		const last = events.at(-1)?.[0] as Set<string>;
 		expect(Array.from(last)).toEqual(['user']);
 	});
 
-	it('emits update with the toggled key removed when unchecked', async () => {
-		const w = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>(['user', 'workflow']) },
-		});
-		await w.find('[data-test-id="filter-trigger"]').trigger('click');
-		const checkbox = w.find('[data-test-id="filter-option-user"] input[type=checkbox]');
-		await checkbox.setValue(false);
-		const events = w.emitted('update') ?? [];
-		const last = events[events.length - 1]?.[0] as Set<string>;
+	it('emits update with the selected key removed', async () => {
+		const wrapper = mountFilter(new Set(['user', 'workflow']));
+		await openMenu(wrapper);
+		await wrapper.get('[data-test-id="filter-option-user"]').trigger('click');
+
+		const events = wrapper.emitted('update') ?? [];
+		const last = events.at(-1)?.[0] as Set<string>;
 		expect(Array.from(last)).toEqual(['workflow']);
 	});
 
-	it('shows Clear only when selection is non-empty, and emits empty set when clicked', async () => {
-		const w1 = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>() },
-		});
-		await w1.find('[data-test-id="filter-trigger"]').trigger('click');
-		expect(w1.find('[data-test-id="filter-clear"]').exists()).toBe(false);
+	it('disables Reset when the selection is empty', async () => {
+		const wrapper = mountFilter();
+		await openMenu(wrapper);
 
-		const w2 = mount(SessionEventFilter, {
-			props: { available: options, selected: new Set<string>(['user']) },
-		});
-		await w2.find('[data-test-id="filter-trigger"]').trigger('click');
-		await w2.find('[data-test-id="filter-clear"]').trigger('click');
-		const events = w2.emitted('update') ?? [];
-		const last = events[events.length - 1]?.[0] as Set<string>;
+		expect(wrapper.get('[data-test-id="filter-clear"]').attributes()).toHaveProperty('disabled');
+	});
+
+	it('enables Reset and emits an empty selection when clicked', async () => {
+		const wrapper = mountFilter(new Set(['user']));
+		await openMenu(wrapper);
+		const reset = wrapper.get('[data-test-id="filter-clear"]');
+
+		expect(reset.attributes()).not.toHaveProperty('disabled');
+		await reset.trigger('click');
+
+		const events = wrapper.emitted('update') ?? [];
+		const last = events.at(-1)?.[0] as Set<string>;
 		expect(last.size).toBe(0);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/SessionTimelineChart.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/SessionTimelineChart.spec.ts
@@ -110,7 +110,7 @@ describe('SessionTimelineChart', () => {
 		const block = w.get('[data-test-id="timeline-block"]');
 
 		expect(block.attributes('data-error')).toBe('true');
-		expect(block.attributes('style')).toContain('var(--color--red-400)');
+		expect(block.attributes('style')).toContain('var(--color--red-600)');
 	});
 
 	it('renders idle blobs interleaved with events in chronological order', () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionEventFilter.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionEventFilter.vue
@@ -1,7 +1,12 @@
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from '@n8n/i18n';
-import { N8nBadge, N8nButton, N8nPopover } from '@n8n/design-system';
+import {
+	N8nButton,
+	N8nDropdownMenu,
+	N8nTooltip,
+	type DropdownMenuItemProps,
+} from '@n8n/design-system';
 import type { FilterOption } from '../session-timeline.types';
 import { swatchBackground } from '../session-timeline.styles';
 
@@ -14,98 +19,144 @@ const emit = defineEmits<{ update: [next: Set<string>] }>();
 
 const i18n = useI18n();
 
-const open = ref(false);
+const RESET_ID = '__reset__';
+const EVENTS_HEADER_ID = '__events__';
+const STATUS_HEADER_ID = '__status__';
 
-function toggle(key: string, checked: boolean): void {
-	const next = new Set(props.selected);
-	if (checked) next.add(key);
-	else next.delete(key);
-	emit('update', next);
+type FilterMenuItem = DropdownMenuItemProps<string, { option?: FilterOption }>;
+
+const menuItems = computed<FilterMenuItem[]>(() => {
+	const eventOptions = props.available.filter((option) => option.presentation === 'swatch');
+	const statusOptions = props.available.filter((option) => option.presentation === 'badge');
+	const items: FilterMenuItem[] = [];
+
+	if (eventOptions.length > 0) {
+		items.push({
+			id: EVENTS_HEADER_ID,
+			label: i18n.baseText('agentSessions.timeline.events'),
+			header: true,
+		});
+		items.push(...eventOptions.map(toMenuItem));
+	}
+
+	if (statusOptions.length > 0) {
+		items.push({
+			id: STATUS_HEADER_ID,
+			label: i18n.baseText('agentSessions.timeline.status'),
+			header: true,
+		});
+		items.push(...statusOptions.map(toMenuItem));
+	}
+
+	items.push({
+		id: RESET_ID,
+		label: i18n.baseText('generic.reset'),
+		divided: true,
+		disabled: props.selected.size === 0,
+		testId: 'filter-clear',
+	});
+
+	return items;
+});
+
+function toMenuItem(option: FilterOption): FilterMenuItem {
+	return {
+		id: option.key,
+		label: option.label,
+		checked: props.selected.has(option.key),
+		keepOpen: true,
+		testId: `filter-option-${option.key}`,
+		data: { option },
+	};
 }
 
-function clearAll(): void {
-	emit('update', new Set());
+function optionColor(option: FilterOption): string {
+	if (option.presentation === 'swatch') return option.color;
+
+	switch (option.key) {
+		case 'approved':
+			return 'var(--color--green-600)';
+		case 'error':
+			return 'var(--color--red-600)';
+		default:
+			return 'var(--color--neutral-600)';
+	}
+}
+
+function handleSelect(key: string): void {
+	if (key === RESET_ID) {
+		emit('update', new Set());
+		return;
+	}
+
+	const next = new Set(props.selected);
+	if (next.has(key)) next.delete(key);
+	else next.add(key);
+	emit('update', next);
 }
 </script>
 
 <template>
-	<N8nPopover v-model:open="open" side="bottom" align="end" :content-class="$style.panel">
+	<N8nDropdownMenu :items="menuItems" placement="bottom-end" @select="handleSelect">
 		<template #trigger>
-			<N8nButton variant="outline" icon="funnel" data-test-id="filter-trigger">
-				<span>{{ i18n.baseText('agentSessions.timeline.events') }}</span>
-				<span v-if="props.selected.size > 0">&nbsp;({{ props.selected.size }})</span>
-			</N8nButton>
-		</template>
-		<template #content>
-			<label
-				v-for="opt in props.available"
-				:key="opt.key"
-				:data-test-id="`filter-option-${opt.key}`"
-				:class="$style.option"
-			>
-				<input
-					type="checkbox"
-					:checked="props.selected.has(opt.key)"
-					@change="toggle(opt.key, ($event.target as HTMLInputElement).checked)"
-				/>
-				<span v-if="opt.presentation === 'badge'" :class="$style.label">
-					<N8nBadge
-						:theme="opt.badgeTheme"
-						size="xsmall"
-						:data-test-id="`filter-status-pill-${opt.key}`"
-					>
-						{{ opt.label }}
-					</N8nBadge>
+			<N8nTooltip :content="i18n.baseText('agentSessions.timeline.events')" placement="top">
+				<span :class="$style.trigger">
+					<N8nButton
+						variant="outline"
+						icon="funnel"
+						icon-only
+						:aria-label="i18n.baseText('agentSessions.timeline.events')"
+						data-test-id="filter-trigger"
+					/>
+					<span v-if="props.selected.size > 0" :class="$style.activeIndicator" aria-hidden="true" />
 				</span>
-				<template v-else>
-					<span :class="$style.swatch" :style="{ backgroundColor: swatchBackground(opt.color) }" />
-					<span :class="$style.label">{{ opt.label }}</span>
-				</template>
-				<span :class="$style.count">{{ opt.count }}</span>
-			</label>
-			<button
-				v-if="props.selected.size > 0"
-				type="button"
-				data-test-id="filter-clear"
-				:class="$style.clear"
-				@click="clearAll"
-			>
-				{{ i18n.baseText('agentSessions.timeline.clearFilter') }}
-			</button>
+			</N8nTooltip>
 		</template>
-	</N8nPopover>
+
+		<template #item-leading="{ item, ui }">
+			<span
+				v-if="item.data?.option"
+				:class="[$style.swatch, ui.class]"
+				:style="{ backgroundColor: swatchBackground(optionColor(item.data.option)) }"
+			/>
+		</template>
+
+		<template #item-label="{ item, ui }">
+			<span :class="ui.class">
+				{{ item.label }}
+				<span v-if="item.data?.option" :class="$style.count">
+					{{ item.data.option.count }}
+				</span>
+			</span>
+		</template>
+	</N8nDropdownMenu>
 </template>
 
 <style module lang="scss">
-.panel {
-	padding: var(--spacing--sm) var(--spacing--md);
+.trigger {
+	position: relative;
+	display: inline-flex;
 }
-.option {
-	display: flex;
-	align-items: center;
-	gap: var(--spacing--2xs);
-	padding: var(--spacing--3xs) 0;
-	font-size: var(--font-size--2xs);
-	cursor: pointer;
+
+.activeIndicator {
+	position: absolute;
+	top: calc(var(--spacing--3xs) * -0.5);
+	right: calc(var(--spacing--3xs) * -0.5);
+	width: var(--spacing--2xs);
+	height: var(--spacing--2xs);
+	outline: var(--spacing--5xs) solid var(--background--surface);
+	border-radius: var(--radius--full);
+	background: var(--color--primary);
+	pointer-events: none;
 }
+
 .swatch {
-	width: 10px;
-	height: 10px;
-	border-radius: 2px;
+	width: var(--spacing--xs);
+	height: var(--spacing--xs);
+	border-radius: var(--radius--4xs);
 }
-.label {
-	flex: 1;
-}
+
 .count {
-	color: var(--color--text);
-}
-.clear {
-	margin-top: var(--spacing--3xs);
-	padding: var(--spacing--4xs);
-	background: none;
-	border: none;
-	color: var(--color--primary);
-	font-size: var(--font-size--3xs);
-	cursor: pointer;
+	color: var(--text-color--subtle);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
@@ -375,6 +375,7 @@ onBeforeUnmount(() => {
 				v-for="(seg, segIdx) in segments"
 				:key="segIdx"
 				data-test-id="timeline-cell"
+				:data-error="seg.kind === 'event' && isErroredTimelineItem(seg.item) ? 'true' : undefined"
 				:class="$style.cell"
 				:style="cellStyle(seg)"
 			>
@@ -449,6 +450,7 @@ onBeforeUnmount(() => {
  * anchored to the active block/idle element.
  */
 .cell {
+	position: relative;
 	display: flex;
 	align-items: stretch;
 	min-width: 24px;
@@ -458,8 +460,20 @@ onBeforeUnmount(() => {
 		transform var(--duration--snappy) var(--easing--ease-out);
 }
 
+.cell[data-error='true']::before {
+	position: absolute;
+	top: calc(var(--spacing--5xs) * -1);
+	left: 0;
+	width: 100%;
+	height: var(--spacing--4xs);
+	border-radius: var(--radius--sm);
+	background-color: var(--color--danger);
+	content: '';
+	z-index: 10;
+}
+
 .chart:has(.block:hover, .block.selected) .block:not(:hover):not(.selected) {
-	opacity: 0.6;
+	opacity: 0.4;
 }
 
 .idle {
@@ -500,14 +514,6 @@ onBeforeUnmount(() => {
 	background-color: var(--session-timeline-chart-block-color);
 	cursor: pointer;
 	transition: filter 0.15s;
-}
-
-.selected {
-	outline: var(--focus--border-width) solid var(--session-timeline-chart-block-color);
-	outline-offset: var(--spacing--5xs);
-	/* Lift above neighbouring idle stripes so the highlight outline doesn't
-	   get covered by the adjacent .idle background. */
-	z-index: 2;
 }
 
 /*

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.styles.ts
@@ -16,7 +16,7 @@ export function pillColors(
 		case 'tool':
 			return { backgroundColor: 'var(--color--green-200)', color: 'var(--color--green-950)' };
 		case 'workflow':
-			return { backgroundColor: 'var(--color--orange-200)', color: 'var(--color--orange-950)' };
+			return { backgroundColor: 'var(--color--pink-200)', color: 'var(--color--pink-950)' };
 		case 'node':
 			return { backgroundColor: 'var(--color--neutral-200)', color: 'var(--color--neutral-950)' };
 		case 'execution-error':

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
@@ -332,8 +332,8 @@ const CHART_BLOCK_COLOR_MAP: Record<EventKind, string> = {
 	agent: 'var(--color--purple-600)',
 	tool: 'var(--color--green-600)',
 	node: 'var(--color--neutral-600)',
-	workflow: 'var(--color--orange-600)',
-	'execution-error': 'var(--color--red-400)',
+	workflow: 'var(--color--pink-600)',
+	'execution-error': 'var(--color--red-600)',
 	suspension: 'var(--color--yellow-600)',
 	'hitl-response': 'var(--color--blue-600)',
 };


### PR DESCRIPTION
## Summary

Fixes [AGENT-685](https://linear.app/n8n/issue/AGENT-685)

- Swaps workflow-as-a-tool colour for events so they do not clash with errors.
- Add a keyline above errored timeline cells so errors are visible at a glance.
- Tidy filter menu to follow existing filter patterns across product

<img width="3203" height="1944" alt="CleanShot 2026-08-21 at 11 53 10@2x" src="https://github.com/user-attachments/assets/f9775ceb-cf47-4ed6-a029-932bb7a630af" />


## How to test

1. Open the Agents sessions view.
2. Open a session that includes workflow-as-a-tool events and errors.
3. Confirm that workflow events are pink and error events are red.
4. Confirm that each errored timeline cell has a red keyline.
5. Select a timeline cell and confirm that the other cells become less prominent.
6. Open the event filter.
7. Confirm that event and status options appear in separate groups.
8. Select multiple options and confirm that the menu stays open.
9. Confirm that the filter button shows an active indicator.
10. Select **Reset** and confirm that all filters clear.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-685

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)