### PR TITLE
ci: Pin the runner image in the `-pc` e2e job

### DIFF
--- a/.github/workflows/test-e2e-pc-nightly.yml
+++ b/.github/workflows/test-e2e-pc-nightly.yml
@@ -12,12 +12,18 @@ on:
         required: false
         default: 'n8nio/n8n:nightly-pc'
         type: string
+      runners-image:
+        description: 'Task runner image to boot beside it'
+        required: false
+        default: 'n8nio/runners:nightly'
+        type: string
 
 permissions:
   contents: read
 
 env:
   TEST_IMAGE_N8N: ${{ inputs.image || 'n8nio/n8n:nightly-pc' }}
+  TEST_IMAGE_TASK_RUNNER: ${{ inputs.runners-image || 'n8nio/runners:nightly' }}
 
 jobs:
   e2e-pc:


### PR DESCRIPTION
## Summary

The first dispatch of the `-pc` e2e job [failed](https://github.com/n8n-io/n8n/actions/runs/32477149510) because the test harness derives the task runner image from the n8n tag. Runners have no `-pc` variant. Hence let's pin `TEST_IMAGE_TASK_RUNNER` to `n8nio/runners:nightly`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4147/run-nightly-e2e-against-the-pc-image

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)