### PR TITLE
docs: Update README quick-start setup command (no-changelog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Fair-code platform to build and deploy AI agents and workflows. Combine a visual
 
 ## Quick Start
 
-Try n8n instantly with [npx](https://docs.n8n.io/hosting/installation/npm/) (requires [Node.js](https://nodejs.org/en/)):
+Try n8n instantly with our install script (requires [Docker](https://www.docker.com/)):
 
-```
-npx n8n
+```sh
+curl -fsSL https://get.n8n.io | sh
 ```
 
-Or deploy with [Docker](https://docs.n8n.io/hosting/installation/docker/):
+Or deploy manually with [Docker](https://docs.n8n.io/hosting/installation/docker/):
 
 ```
 docker volume create n8n_data


### PR DESCRIPTION
## Summary

Update the Quick Start section of the root `README.md`:

- Replace the `npx n8n` command with the install script: `curl -fsSL https://get.n8n.io | sh`
- Note that the script requires [Docker](https://www.docker.com/)
- Reword the Docker section to "Or deploy manually with Docker" to distinguish it from the script

## How to test

Open `README.md` and check the Quick Start section. Confirm the install script command is correct and the links work.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4200

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

