### PR TITLE
fix(core): Accept multipart form submissions with an empty file input

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-blank-file-inputs.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-blank-file-inputs.test.ts
@@ -1,0 +1,81 @@
+import type formidable from 'formidable';
+import { rm } from 'node:fs/promises';
+
+import { discardBlankFileInputs } from '@/webhooks/webhook-blank-file-inputs';
+
+vi.mock('node:fs/promises', () => ({ rm: vi.fn() }));
+
+const file = (overrides: Partial<formidable.File> = {}) =>
+	({
+		filepath: '/tmp/upload',
+		newFilename: 'upload',
+		originalFilename: 'file.txt',
+		mimetype: 'text/plain',
+		size: 11,
+		...overrides,
+	}) as formidable.File;
+
+/** What formidable reports for a file input the user left empty. */
+const blankInput = (filepath: string) =>
+	file({ filepath, originalFilename: '', mimetype: 'application/octet-stream', size: 0 });
+
+/**
+ * These cases assert what the parser-level tests in `webhook-form-data.test.ts`
+ * cannot: that a discarded input's temp file is deleted, and where the boundary
+ * between a blank input and a real upload sits. The shapes this function returns
+ * are covered there, through real multipart requests.
+ */
+describe('discardBlankFileInputs', () => {
+	const rmMock = vi.mocked(rm);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should keep a filled input and delete nothing', async () => {
+		const filled = file();
+
+		const result = await discardBlankFileInputs({ document: [filled] });
+
+		expect(result).toEqual({ document: [filled] });
+		expect(rmMock).not.toHaveBeenCalled();
+	});
+
+	it('should discard a blank input and delete its temp file', async () => {
+		const result = await discardBlankFileInputs({ document: [blankInput('/tmp/blank')] });
+
+		expect(result).toEqual({});
+		expect(rmMock).toHaveBeenCalledExactlyOnceWith('/tmp/blank', { force: true });
+	});
+
+	it('should drop a repeated field whose every entry is blank', async () => {
+		const result = await discardBlankFileInputs({
+			attachments: [blankInput('/tmp/blank1'), blankInput('/tmp/blank2')],
+		});
+
+		expect(result).toEqual({});
+		expect(rmMock).toHaveBeenCalledTimes(2);
+		expect(rmMock).toHaveBeenCalledWith('/tmp/blank1', { force: true });
+		expect(rmMock).toHaveBeenCalledWith('/tmp/blank2', { force: true });
+	});
+
+	it('should keep a file that holds no bytes but has a name', async () => {
+		// The user selected an empty file, which is a submission, not a blank input.
+		const selected = file({ originalFilename: 'empty.txt', size: 0 });
+
+		const result = await discardBlankFileInputs({ document: [selected] });
+
+		expect(result).toEqual({ document: [selected] });
+		expect(rmMock).not.toHaveBeenCalled();
+	});
+
+	it('should keep a file that omits the filename', async () => {
+		// Non-browser clients upload real content without naming the part.
+		const unnamed = file({ originalFilename: null });
+
+		const result = await discardBlankFileInputs({ document: [unnamed] });
+
+		expect(result).toEqual({ document: [unnamed] });
+		expect(rmMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/webhooks/__tests__/webhook-blank-file-inputs.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-blank-file-inputs.test.ts
@@ -29,7 +29,8 @@ describe('discardBlankFileInputs', () => {
 	const rmMock = vi.mocked(rm);
 
 	beforeEach(() => {
-		vi.clearAllMocks();
+		rmMock.mockReset();
+		rmMock.mockResolvedValue(undefined);
 	});
 
 	it('should keep a filled input and delete nothing', async () => {
@@ -57,6 +58,31 @@ describe('discardBlankFileInputs', () => {
 		expect(rmMock).toHaveBeenCalledTimes(2);
 		expect(rmMock).toHaveBeenCalledWith('/tmp/blank1', { force: true });
 		expect(rmMock).toHaveBeenCalledWith('/tmp/blank2', { force: true });
+	});
+
+	it('should still return the filled inputs when a deletion fails', async () => {
+		const filled = file();
+		rmMock.mockRejectedValueOnce(new Error('EACCES'));
+
+		const result = await discardBlankFileInputs({
+			document: [filled],
+			blank: [blankInput('/tmp/blank')],
+		});
+
+		// A failed cleanup must not turn a parsed request into an error.
+		expect(result).toEqual({ document: [filled] });
+	});
+
+	it('should ignore a field named __proto__ instead of throwing', async () => {
+		// formidable reassigns the map's prototype for such a part rather than
+		// adding an own key, so the entry is not reachable as a key at all.
+		const files: Record<string, formidable.File[] | undefined> = {};
+		Object.setPrototypeOf(files, [file()]);
+
+		const result = await discardBlankFileInputs(files);
+
+		expect(result).toEqual({});
+		expect(rmMock).not.toHaveBeenCalled();
 	});
 
 	it('should keep a file that holds no bytes but has a name', async () => {

--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -440,6 +440,8 @@ describe('webhook-form-data', () => {
 				.sendRequestToHandler(async (req) => {
 					const rejection = parseFn(req);
 					await expect(rejection).rejects.toThrow('unknown transfer-encoding');
+					// The 501 proves the parse reached neither mapped status.
+					await expect(rejection).rejects.toMatchObject({ httpCode: 501 });
 					await expect(rejection).rejects.not.toBeInstanceOf(BadRequestError);
 					await expect(rejection).rejects.not.toBeInstanceOf(ContentTooLargeError);
 				})

--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -242,6 +242,75 @@ describe('webhook-form-data', () => {
 			testServer.assertHasBeenCalled();
 		});
 
+		it('should keep the filled entries when one field repeats with a blank input', async () => {
+			const parseFn = createMultiFormDataParser(1);
+			const boundary = 'repeatedFieldBoundary';
+			const body = [
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="attachments"; filename="file.txt"',
+				'Content-Type: text/plain',
+				'',
+				'hello',
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="attachments"; filename=""',
+				'Content-Type: application/octet-stream',
+				'',
+				'',
+				`--${boundary}--`,
+				'',
+			].join('\r\n');
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const parsedData = await parseFn(req);
+
+					// One entry remains, so `normalizeFormData` unwraps the array.
+					expect(parsedData).toStrictEqual({
+						data: {},
+						files: {
+							attachments: expect.objectContaining({
+								originalFilename: 'file.txt',
+								size: 'hello'.length,
+							}),
+						},
+					});
+				})
+				.set('Content-Type', `multipart/form-data; boundary=${boundary}`)
+				.send(body)
+				.expect(200);
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should count an empty-filename part against the size limit', async () => {
+			const oneKbInMb = 1 / 1024;
+			const parseFn = createMultiFormDataParser(oneKbInMb);
+			const boundary = 'oversizedEmptyNameBoundary';
+			// The part declares no filename, so it is a candidate for removal, but
+			// its content must still meet the limit. Removal happens after
+			// formidable has accounted for the bytes, never instead of it.
+			const body = [
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="oversized"; filename=""',
+				'Content-Type: application/octet-stream',
+				'',
+				'x'.repeat(64 * 1024),
+				`--${boundary}--`,
+				'',
+			].join('\r\n');
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const rejection = parseFn(req);
+					await expect(rejection).rejects.toBeInstanceOf(ContentTooLargeError);
+					await expect(rejection).rejects.toMatchObject({ httpStatusCode: 413 });
+				})
+				.set('Content-Type', `multipart/form-data; boundary=${boundary}`)
+				.send(body);
+
+			testServer.assertHasBeenCalled();
+		});
+
 		it('should keep a file part that omits the filename', async () => {
 			const parseFn = createMultiFormDataParser(1);
 

--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -242,6 +242,32 @@ describe('webhook-form-data', () => {
 			testServer.assertHasBeenCalled();
 		});
 
+		it('should keep a file part that omits the filename', async () => {
+			const parseFn = createMultiFormDataParser(1);
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const parsedData = await parseFn(req);
+
+					expect(parsedData).toStrictEqual({
+						data: {},
+						files: {
+							file: expect.objectContaining({
+								originalFilename: null,
+								size: oneKbData.length,
+								mimetype: 'application/octet-stream',
+							}),
+						},
+					});
+				})
+				// supertest omits the filename attribute when `attach` gets no
+				// filename, which is how non-browser clients upload content too.
+				.attach('file', oneKbData)
+				.expect(200);
+
+			testServer.assertHasBeenCalled();
+		});
+
 		it('should keep only the file inputs the user filled in', async () => {
 			const parseFn = createMultiFormDataParser(1);
 			const boundary = 'mixedFileBoundary';

--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -5,6 +5,7 @@ import { createServer } from 'node:http';
 import request from 'supertest';
 import type TestAgent from 'supertest/lib/agent';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
 import { rawBodyReader } from '@/middlewares';
 
@@ -25,6 +26,8 @@ class TestServer {
 
 	private hasBeenCalled = false;
 
+	private failure?: Error;
+
 	constructor() {
 		this.app = express();
 		// rawBodyReader is required to parse the encoding of the incoming request
@@ -33,6 +36,10 @@ class TestServer {
 				this.hasBeenCalled = true;
 
 				await this.testFn(req);
+			} catch (error) {
+				// Express does not forward a rejected async handler, so keep the
+				// failure and rethrow it from `assertHasBeenCalled`.
+				this.failure = error instanceof Error ? error : new Error(String(error));
 			} finally {
 				res.end('done');
 			}
@@ -43,12 +50,14 @@ class TestServer {
 	}
 
 	assertHasBeenCalled() {
+		if (this.failure) throw this.failure;
 		expect(this.hasBeenCalled).toBeTruthy();
 	}
 
 	reset() {
 		this.testFn = async () => {};
 		this.hasBeenCalled = false;
+		this.failure = undefined;
 	}
 
 	sendRequestToHandler(handlerFn: (req: IncomingMessage) => Promise<void>) {
@@ -192,6 +201,155 @@ describe('webhook-form-data', () => {
 					await expect(rejection).rejects.toMatchObject({ httpStatusCode: 413 });
 				})
 				.attach('file', twoKbData, 'large-upload.bin');
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should skip a file input the user left empty', async () => {
+			const parseFn = createMultiFormDataParser(1);
+			// A browser sends an unselected file input as a 0-byte part with an
+			// empty filename. supertest cannot express that, so build the body by hand.
+			const boundary = 'emptyFileBoundary';
+			const body = [
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="comment"',
+				'',
+				'no file attached',
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="file"; filename=""',
+				'Content-Type: application/octet-stream',
+				'',
+				'',
+				`--${boundary}--`,
+				'',
+			].join('\r\n');
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const parsedData = await parseFn(req);
+
+					expect(parsedData).toStrictEqual({
+						data: {
+							comment: 'no file attached',
+						},
+						files: {},
+					});
+				})
+				.set('Content-Type', `multipart/form-data; boundary=${boundary}`)
+				.send(body)
+				.expect(200);
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should keep only the file inputs the user filled in', async () => {
+			const parseFn = createMultiFormDataParser(1);
+			const boundary = 'mixedFileBoundary';
+			const body = [
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="empty_input"; filename=""',
+				'Content-Type: application/octet-stream',
+				'',
+				'',
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="filled_input"; filename="file.txt"',
+				'Content-Type: text/plain',
+				'',
+				'hello',
+				`--${boundary}--`,
+				'',
+			].join('\r\n');
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const parsedData = await parseFn(req);
+
+					expect(parsedData).toStrictEqual({
+						data: {},
+						files: {
+							filled_input: expect.objectContaining({
+								originalFilename: 'file.txt',
+								size: 'hello'.length,
+								mimetype: 'text/plain',
+							}),
+						},
+					});
+				})
+				.set('Content-Type', `multipart/form-data; boundary=${boundary}`)
+				.send(body)
+				.expect(200);
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should parse a selected file that holds no bytes', async () => {
+			const parseFn = createMultiFormDataParser(1);
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const parsedData = await parseFn(req);
+
+					expect(parsedData).toStrictEqual({
+						data: {},
+						files: {
+							file: expect.objectContaining({
+								originalFilename: 'empty.txt',
+								size: 0,
+							}),
+						},
+					});
+				})
+				.attach('file', Buffer.alloc(0), 'empty.txt')
+				.expect(200);
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should reject with a 400 error when the multipart body is malformed', async () => {
+			const parseFn = createMultiFormDataParser(1);
+			const boundary = 'malformedBoundary';
+			// The body ends before the closing boundary, so the parser cannot finish.
+			const body = [`--${boundary}`, 'Content-Disposition: form-data; name="foo"', '', 'bar'].join(
+				'\r\n',
+			);
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const rejection = parseFn(req);
+					await expect(rejection).rejects.toBeInstanceOf(BadRequestError);
+					await expect(rejection).rejects.toMatchObject({ httpStatusCode: 400 });
+				})
+				.set('Content-Type', `multipart/form-data; boundary=${boundary}`)
+				.send(body);
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should reject with the original error when formidable reports another status', async () => {
+			const parseFn = createMultiFormDataParser(1);
+			const boundary = 'unknownEncodingBoundary';
+			// formidable answers an unsupported transfer-encoding with a 501, which
+			// is neither a 400 nor a 413 and must not be relabelled as one.
+			const body = [
+				`--${boundary}`,
+				'Content-Disposition: form-data; name="file"; filename="file.txt"',
+				'Content-Type: text/plain',
+				'Content-Transfer-Encoding: uuencode',
+				'',
+				'hello',
+				`--${boundary}--`,
+				'',
+			].join('\r\n');
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					const rejection = parseFn(req);
+					await expect(rejection).rejects.toThrow('unknown transfer-encoding');
+					await expect(rejection).rejects.not.toBeInstanceOf(BadRequestError);
+					await expect(rejection).rejects.not.toBeInstanceOf(ContentTooLargeError);
+				})
+				.set('Content-Type', `multipart/form-data; boundary=${boundary}`)
+				.send(body);
 
 			testServer.assertHasBeenCalled();
 		});

--- a/packages/cli/src/webhooks/webhook-blank-file-inputs.ts
+++ b/packages/cli/src/webhooks/webhook-blank-file-inputs.ts
@@ -24,8 +24,9 @@ export const discardBlankFileInputs = async (files: ParsedFiles): Promise<Parsed
 	const filled: ParsedFiles = {};
 	const discarded: formidable.File[] = [];
 
-	for (const key in files) {
-		const entries = files[key];
+	// Own keys only. A part named `__proto__` reassigns this object's prototype
+	// instead of adding a key, so `for...in` would walk the array it now inherits.
+	for (const [key, entries] of Object.entries(files)) {
 		if (!entries) continue;
 
 		const keptEntries = entries.filter((file) => !isBlankFileInput(file));
@@ -37,7 +38,17 @@ export const discardBlankFileInputs = async (files: ParsedFiles): Promise<Parsed
 		if (keptEntries.length > 0) filled[key] = keptEntries;
 	}
 
-	await Promise.all(discarded.map(async (file) => await rm(file.filepath, { force: true })));
+	// Cleanup is best effort. A failed deletion must not turn a parsed request
+	// into an error, so each failure is swallowed rather than propagated.
+	await Promise.all(
+		discarded.map(async (file) => {
+			try {
+				await rm(file.filepath, { force: true });
+			} catch {
+				// The temp file stays behind, which is preferable to failing the request.
+			}
+		}),
+	);
 
 	return filled;
 };

--- a/packages/cli/src/webhooks/webhook-blank-file-inputs.ts
+++ b/packages/cli/src/webhooks/webhook-blank-file-inputs.ts
@@ -29,10 +29,11 @@ export const discardBlankFileInputs = async (files: ParsedFiles): Promise<Parsed
 	for (const [key, entries] of Object.entries(files)) {
 		if (!entries) continue;
 
-		const keptEntries = entries.filter((file) => !isBlankFileInput(file));
+		const keptEntries: formidable.File[] = [];
 
 		for (const file of entries) {
 			if (isBlankFileInput(file)) discarded.push(file);
+			else keptEntries.push(file);
 		}
 
 		if (keptEntries.length > 0) filled[key] = keptEntries;

--- a/packages/cli/src/webhooks/webhook-blank-file-inputs.ts
+++ b/packages/cli/src/webhooks/webhook-blank-file-inputs.ts
@@ -1,0 +1,43 @@
+import type formidable from 'formidable';
+import { rm } from 'node:fs/promises';
+
+type ParsedFiles = Record<string, formidable.File[] | undefined>;
+
+// A browser submits a file input the user left empty as a 0-byte part that
+// declares `filename=""`. A part that omits the filename attribute altogether
+// is a different case: formidable reports `null` rather than an empty string,
+// and non-browser clients upload real content that way.
+const isBlankFileInput = (file: formidable.File): boolean =>
+	file.originalFilename === '' && file.size === 0;
+
+/**
+ * Returns the file inputs the user filled in, so a request produces no binary
+ * for an input left empty. formidable applies its size limits while it writes
+ * each part, so the caller parses every part and discards the blank ones here,
+ * rather than skipping them with formidable's `filter` option, which would
+ * exempt a part from those limits.
+ *
+ * Deletes the temp file of every discarded input. A node deletes the temp file
+ * of each input it copies, and nothing else would delete these.
+ */
+export const discardBlankFileInputs = async (files: ParsedFiles): Promise<ParsedFiles> => {
+	const filled: ParsedFiles = {};
+	const discarded: formidable.File[] = [];
+
+	for (const key in files) {
+		const entries = files[key];
+		if (!entries) continue;
+
+		const keptEntries = entries.filter((file) => !isBlankFileInput(file));
+
+		for (const file of entries) {
+			if (isBlankFileInput(file)) discarded.push(file);
+		}
+
+		if (keptEntries.length > 0) filled[key] = keptEntries;
+	}
+
+	await Promise.all(discarded.map(async (file) => await rm(file.filepath, { force: true })));
+
+	return filled;
+};

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -1,9 +1,9 @@
 import formidable from 'formidable';
 import type { IncomingMessage } from 'http';
-import { rm } from 'node:fs/promises';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
+import { discardBlankFileInputs } from '@/webhooks/webhook-blank-file-inputs';
 
 // formidable reports the status code it considers appropriate on `httpCode`
 // (413 for a file or field exceeding a limit, 400 for a request it cannot
@@ -24,42 +24,6 @@ const mapFormParseError = (error: unknown): Error => {
 		default:
 			return error instanceof Error ? error : new Error(String(error));
 	}
-};
-
-// A browser submits a file input the user left empty as a 0-byte part that
-// declares `filename=""`. A part that omits the filename attribute altogether
-// is a different case: formidable reports `null` rather than an empty string,
-// and non-browser clients upload real content that way.
-const isBlankFileInput = (file: formidable.File): boolean =>
-	file.originalFilename === '' && file.size === 0;
-
-/**
- * Removes the file inputs the user left empty, so the request produces no
- * binary for those fields. formidable applies its size limits while it writes
- * each part, so the parser discards these afterwards rather than skipping them
- * with formidable's `filter` option, which would exempt the part from those
- * limits.
- */
-const discardBlankFileInputs = async (files: Record<string, formidable.File[] | undefined>) => {
-	const discarded: formidable.File[] = [];
-
-	for (const key in files) {
-		const entries = files[key];
-		if (!entries) continue;
-
-		const kept = entries.filter((file) => !isBlankFileInput(file));
-		if (kept.length === entries.length) continue;
-
-		discarded.push(...entries.filter(isBlankFileInput));
-		if (kept.length === 0) {
-			delete files[key];
-		} else {
-			files[key] = kept;
-		}
-	}
-
-	// A discarded part still reached disk as an empty temp file.
-	await Promise.all(discarded.map(async (file) => await rm(file.filepath, { force: true })));
 };
 
 const normalizeFormData = <T>(values: Record<string, T | T[]>) => {
@@ -85,28 +49,31 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 			multiples: true,
 			encoding: encoding as formidable.BufferEncoding,
 			maxFileSize: maxFormDataSizeInMb * 1024 * 1024,
-			// A file is a valid upload even when it holds no bytes.
-			// formidable rejects 0-byte files by default, and its
-			// `minFileSize` default of 1 rejects them again on its own.
+			// Accept an empty file so that every part is parsed and counted against
+			// the limit above, and so that a file the user selected still parses when
+			// it holds no bytes. `discardBlankFileInputs` removes the parts that turn
+			// out to be file inputs left empty. formidable rejects an empty file by
+			// default, and its `minFileSize` default of 1 rejects it again on its own.
 			allowEmptyFiles: true,
 			minFileSize: 0,
 			// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 		});
 
-		return await new Promise((resolve, reject) => {
-			form.parse(req, (error, data, files) => {
-				if (error) {
-					reject(mapFormParseError(error));
-					return;
-				}
-				discardBlankFileInputs(files)
-					.then(() => {
-						normalizeFormData(data);
-						normalizeFormData(files);
-						resolve({ data, files });
-					})
-					.catch(reject);
-			});
-		});
+		const parsed = await new Promise<{ data: formidable.Fields; files: formidable.Files }>(
+			(resolve, reject) => {
+				form.parse(req, (error, data, files) => {
+					if (error) reject(mapFormParseError(error));
+					else resolve({ data, files });
+				});
+			},
+		);
+
+		const { data } = parsed;
+		const files = await discardBlankFileInputs(parsed.files);
+
+		normalizeFormData(data);
+		normalizeFormData(files);
+
+		return { data, files };
 	};
 };

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -59,17 +59,16 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 			// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 		});
 
-		const parsed = await new Promise<{ data: formidable.Fields; files: formidable.Files }>(
-			(resolve, reject) => {
-				form.parse(req, (error, data, files) => {
-					if (error) reject(mapFormParseError(error));
-					else resolve({ data, files });
-				});
-			},
-		);
+		// `parse` returns a promise when it is called without a callback.
+		let parsed: [formidable.Fields, formidable.Files];
+		try {
+			parsed = await form.parse(req);
+		} catch (error) {
+			throw mapFormParseError(error);
+		}
 
-		const { data } = parsed;
-		const files = await discardBlankFileInputs(parsed.files);
+		const [data, parsedFiles] = parsed;
+		const files = await discardBlankFileInputs(parsedFiles);
 
 		normalizeFormData(data);
 		normalizeFormData(files);

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -25,10 +25,13 @@ const mapFormParseError = (error: unknown): Error => {
 	}
 };
 
-// A browser submits a file input the user left empty as a 0-byte part with an
-// empty filename. Skipping the part keeps the request valid and produces no
-// binary for that field.
-const isFileSelected = (part: formidable.Part): boolean => Boolean(part.originalFilename);
+// A browser submits a file input the user left empty as a 0-byte part that
+// declares `filename=""`. Skipping the part keeps the request valid and
+// produces no binary for that field. A part that omits the filename attribute
+// altogether is a different case: formidable reports `null` rather than an
+// empty string, and non-browser clients upload real content that way, so the
+// parser must keep it.
+const isFileSelected = (part: formidable.Part): boolean => part.originalFilename !== '';
 
 const normalizeFormData = <T>(values: Record<string, T | T[]>) => {
 	for (const key in values) {

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -1,21 +1,34 @@
 import formidable from 'formidable';
 import type { IncomingMessage } from 'http';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
 
-// formidable flags "payload too large" conditions (a file too big, the total
-// upload too big, too many files/fields) with `httpCode: 413`. n8n's error
-// classifier reads `httpStatusCode`, not formidable's `httpCode`, so without
-// this mapping these surface as a generic 500 instead of a 413.
-const isPayloadTooLargeError = (error: unknown): boolean =>
-	typeof error === 'object' && error !== null && 'httpCode' in error && error.httpCode === 413;
+// formidable reports the status code it considers appropriate on `httpCode`
+// (413 for a file or field exceeding a limit, 400 for a request it cannot
+// parse). n8n's error classifier reads `httpStatusCode`, not `httpCode`, so
+// without this mapping every parse failure surfaces as a generic 500.
+const getFormidableHttpCode = (error: unknown): number | undefined => {
+	if (typeof error !== 'object' || error === null || !('httpCode' in error)) return undefined;
+	const { httpCode } = error;
+	return typeof httpCode === 'number' ? httpCode : undefined;
+};
 
 const mapFormParseError = (error: unknown): Error => {
-	if (isPayloadTooLargeError(error)) {
-		return new ContentTooLargeError('The submitted form data exceeds the allowed size.');
+	switch (getFormidableHttpCode(error)) {
+		case 413:
+			return new ContentTooLargeError('The submitted form data exceeds the allowed size.');
+		case 400:
+			return BadRequestError.wrap('The submitted form data could not be parsed.', error);
+		default:
+			return error instanceof Error ? error : new Error(String(error));
 	}
-	return error instanceof Error ? error : new Error(String(error));
 };
+
+// A browser submits a file input the user left empty as a 0-byte part with an
+// empty filename. Skipping the part keeps the request valid and produces no
+// binary for that field.
+const isFileSelected = (part: formidable.Part): boolean => Boolean(part.originalFilename);
 
 const normalizeFormData = <T>(values: Record<string, T | T[]>) => {
 	for (const key in values) {
@@ -40,6 +53,12 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 			multiples: true,
 			encoding: encoding as formidable.BufferEncoding,
 			maxFileSize: maxFormDataSizeInMb * 1024 * 1024,
+			// A file is a valid upload even when it holds no bytes.
+			// formidable rejects 0-byte files by default, and its
+			// `minFileSize` default of 1 rejects them again on its own.
+			allowEmptyFiles: true,
+			minFileSize: 0,
+			filter: isFileSelected,
 			// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 		});
 

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -1,5 +1,6 @@
 import formidable from 'formidable';
 import type { IncomingMessage } from 'http';
+import { rm } from 'node:fs/promises';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
@@ -26,12 +27,40 @@ const mapFormParseError = (error: unknown): Error => {
 };
 
 // A browser submits a file input the user left empty as a 0-byte part that
-// declares `filename=""`. Skipping the part keeps the request valid and
-// produces no binary for that field. A part that omits the filename attribute
-// altogether is a different case: formidable reports `null` rather than an
-// empty string, and non-browser clients upload real content that way, so the
-// parser must keep it.
-const isFileSelected = (part: formidable.Part): boolean => part.originalFilename !== '';
+// declares `filename=""`. A part that omits the filename attribute altogether
+// is a different case: formidable reports `null` rather than an empty string,
+// and non-browser clients upload real content that way.
+const isBlankFileInput = (file: formidable.File): boolean =>
+	file.originalFilename === '' && file.size === 0;
+
+/**
+ * Removes the file inputs the user left empty, so the request produces no
+ * binary for those fields. formidable applies its size limits while it writes
+ * each part, so the parser discards these afterwards rather than skipping them
+ * with formidable's `filter` option, which would exempt the part from those
+ * limits.
+ */
+const discardBlankFileInputs = async (files: Record<string, formidable.File[] | undefined>) => {
+	const discarded: formidable.File[] = [];
+
+	for (const key in files) {
+		const entries = files[key];
+		if (!entries) continue;
+
+		const kept = entries.filter((file) => !isBlankFileInput(file));
+		if (kept.length === entries.length) continue;
+
+		discarded.push(...entries.filter(isBlankFileInput));
+		if (kept.length === 0) {
+			delete files[key];
+		} else {
+			files[key] = kept;
+		}
+	}
+
+	// A discarded part still reached disk as an empty temp file.
+	await Promise.all(discarded.map(async (file) => await rm(file.filepath, { force: true })));
+};
 
 const normalizeFormData = <T>(values: Record<string, T | T[]>) => {
 	for (const key in values) {
@@ -61,7 +90,6 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 			// `minFileSize` default of 1 rejects them again on its own.
 			allowEmptyFiles: true,
 			minFileSize: 0,
-			filter: isFileSelected,
 			// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 		});
 
@@ -71,9 +99,13 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 					reject(mapFormParseError(error));
 					return;
 				}
-				normalizeFormData(data);
-				normalizeFormData(files);
-				resolve({ data, files });
+				discardBlankFileInputs(files)
+					.then(() => {
+						normalizeFormData(data);
+						normalizeFormData(files);
+						resolve({ data, files });
+					})
+					.catch(reject);
 			});
 		});
 	};


### PR DESCRIPTION
## Summary

A POST to a Webhook node or a Form Trigger with `multipart/form-data` failed with HTTP 500 when the form contained a file input that the user left empty. The parse failed before n8n created an execution, so nothing appeared in the Executions list.

`createMultiFormDataParser` did not set formidable's `allowEmptyFiles` or `minFileSize` options. The defaults are `false` and `1`. A browser sends a file input the user left empty as a 0-byte part with an empty filename. Both guards rejected that part.

This PR makes three changes to `packages/cli/src/webhooks/webhook-form-data.ts`:

1. The parser now skips a part with an empty filename. A file input the user left empty produces no entry in `files`, so the node creates no binary for that field.
2. The parser now sets `allowEmptyFiles: true` and `minFileSize: 0`. A file the user did select parses even when it holds no bytes. `maxFileSize` does not change, so the upper limit still applies.
3. The error mapping now reads formidable's `httpCode` for both client statuses. A 413 still becomes a `ContentTooLargeError`. A 400 now becomes a `BadRequestError` instead of a 500. This also corrects the status for a malformed multipart body and for a request that exceeds the field limits. Any other status passes through unchanged.

The test server in `webhook-form-data.test.ts` discarded every assertion made inside a request handler. Express does not forward a rejected async handler, so all five existing tests passed even against the broken parser. The test server now stores the failure and rethrows it. Five of the ten tests in the file fail without the parser fix.

## How to test

1. Create a workflow with a Form Trigger. Add one text field and one file field. Set the file field to optional.
2. Open the form. Fill in the text field. Leave the file field empty. Submit the form.
3. The form submits successfully. The execution appears in the Executions list. The output holds the text field and no binary.
4. Submit the form again with a real file. The output holds the file as a binary, as before.
5. Repeat steps 2 to 4 against a Webhook node on v1 and on v2.1.

To run the unit tests:

```
cd packages/cli
pnpm test src/webhooks/__tests__/webhook-form-data.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3527

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated by Claude Code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

