### PR TITLE
fix(Anthropic Chat Model Node): Update default model to Claude Sonnet 5 and improve model guidance

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -589,6 +589,10 @@ export class LmChatAnthropic implements INodeType {
 			promptCaching?: 'disabled' | '5m' | '1h';
 		};
 
+		// Pre-flight check for the one model family we have confirmed rejects manual thinking, so
+		// those users fail fast instead of spending a request. Newer generations likely reject it
+		// too, but rather than guess a capability matrix that drifts every release, anything this
+		// misses is caught by manualThinkingErrorHandler once the provider rejects the call.
 		const isOpus47Model = modelName.startsWith('claude-opus-4-7');
 		const thinkingMode: 'disabled' | 'adaptive' | 'manual' =
 			version >= 1.5
@@ -711,9 +715,28 @@ export class LmChatAnthropic implements INodeType {
 			}
 		};
 
+		// Same shape as the sampling-parameter backstop above, for the same reason: newer Claude
+		// generations drop the legacy manual thinking mode, and the pre-flight check below only
+		// recognises the models we have confirmed. This catches the rest — including gateway
+		// traffic, whose capabilities we cannot infer from the model name.
+		const manualThinkingErrorHandler = (error: unknown) => {
+			if (thinkingMode !== 'manual') return;
+			const message = error instanceof Error ? error.message : String(error);
+			const mentionsThinking = /thinking|budget_tokens/i.test(message);
+			const isRejection = /not supported|unsupported|not allowed|deprecated|invalid/i.test(message);
+			if (mentionsThinking && isRejection) {
+				throw new NodeOperationError(
+					this.getNode(),
+					`The model "${modelName}" does not support the legacy Manual thinking mode. Set Thinking Mode to Adaptive and choose an Effort level.`,
+					{ itemIndex },
+				);
+			}
+		};
+
 		const failedAttemptHandler = (error: unknown) => {
 			gatewayErrorHandler?.(error);
 			deprecatedSamplingParamErrorHandler(error);
+			manualThinkingErrorHandler(error);
 		};
 
 		const chatAnthropicParams: ChatAnthropicInput = {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -21,9 +21,20 @@ import { getCustomCredentialHeader } from '@utils/helpers';
 
 import { searchModels } from './methods/searchModels';
 
+// The 1.3+ resource locator accepts any id the provider lists, so the newest
+// generation is the right answer on every one of those versions. Phrased as
+// choice guidance rather than a validity claim: older versions still default to
+// an older model, and that stored value is not wrong, just superseded.
 const ANTHROPIC_MODEL_BUILDER_HINT = {
 	propertyHint:
-		'Default to claude-sonnet-5 (latest Sonnet); use claude-opus-5 when the user needs the most capable model. Never pick an earlier generation — Claude Sonnet 4.6 and below, Claude 3.x, Claude 2, and LEGACY options are superseded and are not valid choices. Tell the user which model you picked, why, and that they can change it at any time. When extended thinking is needed, set Thinking Mode to Adaptive and choose an Effort level. The legacy Manual thinking mode is rejected by Opus 4.7.',
+		'Default to claude-sonnet-5 (latest Sonnet); use claude-opus-5 when the user needs the most capable model. Do not fall back to an older generation (Claude Sonnet 4.6 or earlier, Claude 3.x, Claude 2, LEGACY options) unless the user asks for a specific model. Tell the user which model you picked, why, and that they can change it at any time. When extended thinking is needed, set Thinking Mode to Adaptive and choose an Effort level. The legacy Manual thinking mode is rejected by Opus 4.7.',
+};
+
+// Versions 1 to 1.2 expose a fixed enum that predates the current generation,
+// so the recommendation above names nothing those versions can actually select.
+const ANTHROPIC_LEGACY_MODEL_BUILDER_HINT = {
+	propertyHint:
+		'This node version only offers superseded Claude models. Pick claude-3-5-sonnet-20241022 if the node has to stay on this version; otherwise rebuild it on the latest node version, where the current Claude generation is selectable.',
 };
 
 const modelField: INodeProperties = {
@@ -76,7 +87,7 @@ const modelField: INodeProperties = {
 	description:
 		'The model which will generate the completion. <a href="https://docs.anthropic.com/claude/docs/models-overview">Learn more</a>.',
 	default: 'claude-2',
-	builderHint: ANTHROPIC_MODEL_BUILDER_HINT,
+	builderHint: ANTHROPIC_LEGACY_MODEL_BUILDER_HINT,
 };
 
 const MIN_THINKING_BUDGET = 1024;

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -723,7 +723,13 @@ export class LmChatAnthropic implements INodeType {
 			if (thinkingMode !== 'manual') return;
 			const message = error instanceof Error ? error.message : String(error);
 			const mentionsThinking = /thinking|budget_tokens/i.test(message);
-			const isRejection = /not supported|unsupported|not allowed|deprecated|invalid/i.test(message);
+			// Match the verb stem rather than the participle: providers phrase this both ways
+			// ("thinking is not supported" and "this model does not support thinking"), and
+			// "not supported" never appears in the active-voice form.
+			const isRejection =
+				/(?:not|n['’]?t) support|unsupported|not allowed|not permitted|deprecated|invalid|only supports/i.test(
+					message,
+				);
 			if (mentionsThinking && isRejection) {
 				throw new NodeOperationError(
 					this.getNode(),

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -23,7 +23,7 @@ import { searchModels } from './methods/searchModels';
 
 const ANTHROPIC_MODEL_BUILDER_HINT = {
 	propertyHint:
-		'Default to claude-sonnet-4-6 (latest Sonnet); use claude-opus-4-7 when the user needs the most capable model. Never use Claude Sonnet 4.5, Claude 3.x, Claude 2, or LEGACY options — those are superseded and are not valid choices. When extended thinking is needed on Opus 4.7+, set Thinking Mode to Adaptive and choose an Effort level. The legacy Manual thinking mode is rejected by Opus 4.7.',
+		'Default to claude-sonnet-5 (latest Sonnet); use claude-opus-5 when the user needs the most capable model. Never pick an earlier generation — Claude Sonnet 4.6 and below, Claude 3.x, Claude 2, and LEGACY options are superseded and are not valid choices. Tell the user which model you picked, why, and that they can change it at any time. When extended thinking is needed, set Thinking Mode to Adaptive and choose an Effort level. The legacy Manual thinking mode is rejected by Opus 4.7.',
 };
 
 const modelField: INodeProperties = {
@@ -127,8 +127,8 @@ export class LmChatAnthropic implements INodeType {
 		name: 'lmChatAnthropic',
 		icon: 'file:anthropic.svg',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
-		defaultVersion: 1.5,
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
+		defaultVersion: 1.6,
 		description: 'Language Model Anthropic',
 		defaults: {
 			name: 'Anthropic Chat Model',
@@ -297,7 +297,44 @@ export class LmChatAnthropic implements INodeType {
 					'The model. Choose from the list, or specify an ID. <a href="https://docs.anthropic.com/claude/docs/models-overview">Learn more</a>.',
 				displayOptions: {
 					show: {
-						'@version': [{ _cnd: { gte: 1.5 } }],
+						'@version': [1.5],
+					},
+				},
+			},
+			{
+				displayName: 'Model',
+				name: 'model',
+				type: 'resourceLocator',
+				default: {
+					mode: 'list',
+					value: 'claude-sonnet-5',
+					cachedResultName: 'Claude Sonnet 5',
+				},
+				builderHint: ANTHROPIC_MODEL_BUILDER_HINT,
+				required: true,
+				modes: [
+					{
+						displayName: 'From List',
+						name: 'list',
+						type: 'list',
+						placeholder: 'Select a model...',
+						typeOptions: {
+							searchListMethod: 'searchModels',
+							searchable: true,
+						},
+					},
+					{
+						displayName: 'ID',
+						name: 'id',
+						type: 'string',
+						placeholder: 'Claude Sonnet',
+					},
+				],
+				description:
+					'The model. Choose from the list, or specify an ID. <a href="https://docs.anthropic.com/claude/docs/models-overview">Learn more</a>.',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.6 } }],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -706,6 +706,36 @@ describe('LmChatAnthropic', () => {
 		});
 	});
 
+	describe('model builder hints', () => {
+		const modelFields = (type: string) =>
+			lmChatAnthropic.description.properties.filter((p) => p.name === 'model' && p.type === type);
+
+		it('should recommend the current Claude generation on every resource locator', () => {
+			const hints = modelFields('resourceLocator').map((p) => p.builderHint?.propertyHint);
+
+			expect(hints).toHaveLength(4);
+			for (const hint of hints) {
+				expect(hint).toContain('claude-sonnet-5');
+				expect(hint).toContain('claude-opus-5');
+				expect(hint).not.toContain('Default to claude-sonnet-4-6');
+			}
+		});
+
+		it('should only name models a fixed-enum model field can actually select', () => {
+			const enumFields = modelFields('options');
+			expect(enumFields.length).toBeGreaterThan(0);
+
+			for (const field of enumFields) {
+				const hint = field.builderHint?.propertyHint ?? '';
+				const selectable = (field.options ?? []).map((o) => ('value' in o ? String(o.value) : ''));
+
+				for (const named of hint.match(/claude-[a-z0-9-]+/g) ?? []) {
+					expect(selectable).toContain(named);
+				}
+			}
+		});
+	});
+
 	describe('thinking modes (v1.5)', () => {
 		it('should not set thinking-related invocationKwargs when thinkingMode is disabled', async () => {
 			const mockContext = setupMockContext({ typeVersion: 1.5 });

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -599,6 +599,58 @@ describe('LmChatAnthropic', () => {
 			expect(() => capturedHandler!(new Error('rate limit exceeded'))).not.toThrow();
 		});
 
+		it('should sanitize a manual-thinking rejection into an actionable message', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.6 });
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-5';
+				if (paramName === 'options') return { thinkingMode: 'manual' };
+				return undefined;
+			});
+
+			let capturedHandler: ((error: unknown) => void) | undefined;
+			mockedMakeN8nLlmFailedAttemptHandler.mockImplementation((_ctx, handler) => {
+				capturedHandler = handler as (error: unknown) => void;
+				return vi.fn();
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+			expect(capturedHandler).toBeDefined();
+
+			expect(() =>
+				capturedHandler!(new Error('`thinking.budget_tokens` is not supported on this model.')),
+			).toThrow(NodeOperationError);
+			expect(() =>
+				capturedHandler!(new Error('`thinking.budget_tokens` is not supported on this model.')),
+			).toThrow(/claude-sonnet-5/);
+
+			// Unrelated errors should pass through without throwing
+			expect(() => capturedHandler!(new Error('rate limit exceeded'))).not.toThrow();
+		});
+
+		it('should not claim a manual-thinking problem when thinking is not manual', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.6 });
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-5';
+				if (paramName === 'options') return { thinkingMode: 'adaptive' };
+				return undefined;
+			});
+
+			let capturedHandler: ((error: unknown) => void) | undefined;
+			mockedMakeN8nLlmFailedAttemptHandler.mockImplementation((_ctx, handler) => {
+				capturedHandler = handler as (error: unknown) => void;
+				return vi.fn();
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+			expect(capturedHandler).toBeDefined();
+
+			expect(() =>
+				capturedHandler!(new Error('`thinking.budget_tokens` is not supported on this model.')),
+			).not.toThrow();
+		});
+
 		it('should throw when model is empty (v1.3)', async () => {
 			const mockContext = setupMockContext({ typeVersion: 1.3 });
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -617,15 +617,26 @@ describe('LmChatAnthropic', () => {
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 			expect(capturedHandler).toBeDefined();
 
-			expect(() =>
-				capturedHandler!(new Error('`thinking.budget_tokens` is not supported on this model.')),
-			).toThrow(NodeOperationError);
-			expect(() =>
-				capturedHandler!(new Error('`thinking.budget_tokens` is not supported on this model.')),
-			).toThrow(/claude-sonnet-5/);
+			// Providers phrase the rejection in either voice, so both must be recognised
+			for (const providerMessage of [
+				'`thinking.budget_tokens` is not supported on this model.',
+				'This model does not support thinking.',
+				"claude-sonnet-5 doesn't support the `thinking` parameter",
+				'unsupported parameter: thinking',
+				'This model only supports adaptive thinking',
+			]) {
+				expect(() => capturedHandler!(new Error(providerMessage))).toThrow(NodeOperationError);
+				expect(() => capturedHandler!(new Error(providerMessage))).toThrow(/claude-sonnet-5/);
+			}
 
 			// Unrelated errors should pass through without throwing
-			expect(() => capturedHandler!(new Error('rate limit exceeded'))).not.toThrow();
+			for (const unrelated of [
+				'rate limit exceeded',
+				'overloaded_error: the model is currently overloaded',
+				'Could not resolve authentication method',
+			]) {
+				expect(() => capturedHandler!(new Error(unrelated))).not.toThrow();
+			}
 		});
 
 		it('should not claim a manual-thinking problem when thinking is not manual', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -85,7 +85,7 @@ describe('LmChatAnthropic', () => {
 				displayName: 'Anthropic Chat Model',
 				name: 'lmChatAnthropic',
 				group: ['transform'],
-				version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
+				version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
 				description: 'Language Model Anthropic',
 			});
 		});
@@ -687,6 +687,23 @@ describe('LmChatAnthropic', () => {
 				cachedResultName: 'Claude Sonnet 4.6',
 			});
 		});
+
+		it('should have Claude Sonnet 5 as default for v1.6+ resource locator', () => {
+			const v16ModelField = lmChatAnthropic.description.properties.find(
+				(p) =>
+					p.name === 'model' &&
+					p.type === 'resourceLocator' &&
+					(p.displayOptions?.show?.['@version']?.[0] as { _cnd?: { gte?: number } })?._cnd?.gte ===
+						1.6,
+			);
+
+			expect(v16ModelField).toBeDefined();
+			expect(v16ModelField!.default).toEqual({
+				mode: 'list',
+				value: 'claude-sonnet-5',
+				cachedResultName: 'Claude Sonnet 5',
+			});
+		});
 	});
 
 	describe('thinking modes (v1.5)', () => {
@@ -734,6 +751,33 @@ describe('LmChatAnthropic', () => {
 						top_k: undefined,
 						top_p: undefined,
 						temperature: undefined,
+					},
+				}),
+			);
+		});
+
+		it('should keep the v1.5 thinking-mode branch on v1.6', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.6 });
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-5';
+				if (paramName === 'options') return { thinkingMode: 'adaptive', promptCaching: '5m' };
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: 'claude-sonnet-5',
+					invocationKwargs: {
+						thinking: { type: 'adaptive' },
+						output_config: { effort: 'medium' },
+						max_tokens: 4096,
+						top_k: undefined,
+						top_p: undefined,
+						temperature: undefined,
+						cache_control: { type: 'ephemeral', ttl: '5m' },
 					},
 				}),
 			);
@@ -871,8 +915,7 @@ describe('LmChatAnthropic', () => {
 				(p) =>
 					p.name === 'model' &&
 					p.type === 'resourceLocator' &&
-					(p.displayOptions?.show?.['@version']?.[0] as { _cnd?: { gte?: number } })?._cnd?.gte ===
-						1.5,
+					p.displayOptions?.show?.['@version']?.[0] === 1.5,
 			);
 			expect(v15ModelField).toBeDefined();
 			expect(v15ModelField!.default).toEqual({

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
@@ -72,7 +72,7 @@ describe('LmChatAnthropic', () => {
 				displayName: 'Anthropic Chat Model',
 				name: 'lmChatAnthropic',
 				group: ['transform'],
-				version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
+				version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
 				description: 'Language Model Anthropic',
 			});
 		});


### PR DESCRIPTION
## Summary

The Anthropic Chat Model node told MCP-driven builders to `Default to claude-sonnet-4-6 (latest Sonnet)`. Sonnet 5 superseded that model, so `get_node_types` handed agents a stale model as authoritative guidance. The SDK reference instructs agents to obey `@builderHint`, so the stale string won over anything the model otherwise knew.

Three changes, in the order they were found.

**1. Ship Claude Sonnet 5 as the default (typeVersion 1.6).**

- A new `>= 1.6` model block defaults to `claude-sonnet-5` / `Claude Sonnet 5`.
- The existing `>= 1.5` block is narrowed to exactly `[1.5]`, so nodes already on 1.5 keep Sonnet 4.6. This also covers workflows that omit the parameter and resolve the node type default at runtime.
- Not breaking: before this PR no gate pinned to exactly 1.5. Every behavioural gate is `gte`-based — `thinkingMode`, both `effort` fields, `thinkingBudget`, and the `version >= 1.5` branch in `supplyData` — so 1.6 inherits all of them. Same shape as 639e1dab1c0 (#28864), which did 1.3 to 1.4.
- Safe as a default: Claude 5 models reject `temperature`, `top_p` and `top_k`, but #33667 already allow-lists that and covers `claude-sonnet-5` in its test matrix.

**2. Scope the builder hint to the versions it fits.**

The hint was shared by all five model properties, including the fixed enum used by versions 1 to 1.2. On that property it recommended a model the enum cannot select while ruling out every value the enum does offer. Those versions now get their own hint naming the newest model they can actually reach. The resource-locator hint is also reworded so the exclusion reads as choice guidance rather than a validity claim, since 1.4 and 1.5 legitimately still default to Sonnet 4.6.

**3. Report manual-thinking rejections instead of swallowing them.**

The manual thinking check matched one hardcoded prefix (`claude-opus-4-7`), so any other model that rejects the mode produced a bare provider 400 that reached the user as "Bad request - please check your parameters". A backstop now sits on the same `onFailedAttempt` chain as the existing sampling-parameter one: when manual thinking is selected and the provider rejects the call, the error names the model and points at Adaptive mode. This covers gateway traffic, whose capabilities cannot be inferred from the model name.

The pre-flight check stays as a fast path for the one family confirmed to reject the mode. Extending it into an allow-list was considered and rejected: the sampling allow-list can silently drop offending params for backwards compatibility, but manual thinking changes output semantics and so must throw, which means a wrong entry would block a working configuration. Tracked in AI-2730 along with the live-API check that would settle whether Claude 5 rejects the mode.

## How to test

1. Add a new Anthropic Chat Model node. It must come in at typeVersion 1.6 with Claude Sonnet 5 preselected.
2. Open a workflow with an Anthropic Chat Model node on typeVersion 1.5. It must still show Claude Sonnet 4.6.
3. On the 1.6 node, open Options. Thinking Mode, Effort, Thinking Budget and Prompt Caching must all still be present.
4. Call `get_node_types` over MCP for `@n8n/n8n-nodes-langchain.lmChatAnthropic`. The response must emit the Sonnet 5 `@builderHint`.
5. Set Thinking Mode to Manual on a model that rejects it. The node must report which model refused and suggest Adaptive, not "Bad request - please check your parameters".

No feature flag, module or licence is needed.

```
cd packages/@n8n/nodes-langchain && pnpm test LmChatAnthropic
```

97 tests pass. Each new test was checked with a negative control — reverting the behaviour it covers fails that test and only that test.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5813
- https://linear.app/n8n/issue/AI-2730 — filed from this work. Covers the remaining half of change 3: confirming whether Claude 5 models actually reject manual thinking, and optionally hiding the Manual option for newer models.
- https://linear.app/n8n/issue/AI-2606 — earlier report whose finding 1 flagged this same stale hint. Cancelled so its five findings could be filed individually. Its sampling-parameter half was already fixed by #33667. Its finding 2, provider error bodies collapsing into a generic "Bad request", is the general form of change 3 and is still unfiled.
- https://linear.app/n8n/issue/INS-539 — the same drift for the OpenAI and Gemini nodes, still open. The Bedrock hints and the `LmChatOpenAi` and `LmChatGoogleGemini` hints have drifted from `LLM_PROVIDER_DEFAULTS` the same way.
- https://linear.app/n8n/issue/AI-2412 — the Sonnet 4.6 precedent (#28864).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
