### PR TITLE
fix(core): Limit domain restriction errors to the target host

### DIFF
--- a/packages/@n8n/backend-network/src/http/axios/__tests__/utils.test.ts
+++ b/packages/@n8n/backend-network/src/http/axios/__tests__/utils.test.ts
@@ -23,6 +23,7 @@ import {
 	resolveLegacyRequestUrl,
 	searchForHeader,
 	setAxiosAgents,
+	throwIfDomainNotAllowed,
 	tryParseUrl,
 	validateProxySsrf,
 } from '../utils';
@@ -94,6 +95,59 @@ describe('getHostFromRequestObject', () => {
 	test('should return null for invalid URLs', () => {
 		expect(getHostFromRequestObject({ url: 'not-a-url' })).toBeNull();
 		expect(getHostFromRequestObject({})).toBeNull();
+	});
+});
+
+describe('throwIfDomainNotAllowed', () => {
+	test('should not throw when the host is on the allowlist', () => {
+		expect(() =>
+			throwIfDomainNotAllowed({ url: 'https://example.com/api' }, 'example.com'),
+		).not.toThrow();
+	});
+
+	test('should not throw when no allowlist is configured', () => {
+		expect(() => throwIfDomainNotAllowed({ url: 'https://other.com/api' })).not.toThrow();
+	});
+
+	test('should throw when the host is off the allowlist', () => {
+		expect(() => throwIfDomainNotAllowed({ url: 'https://other.com/api' }, 'example.com')).toThrow(
+			'Domain not allowed: This credential is restricted from accessing other.com. Only the following domains are allowed: example.com',
+		);
+	});
+
+	test('should exclude query parameters from the message', () => {
+		expect(() =>
+			throwIfDomainNotAllowed(
+				{ url: 'https://other.com/api', params: { api_key: 'query-param-value' } },
+				'example.com',
+			),
+		).not.toThrow(/query-param-value/);
+	});
+
+	test('should exclude a query string already present on the url', () => {
+		expect(() =>
+			throwIfDomainNotAllowed({ url: 'https://other.com/api?api_key=inline-value' }, 'example.com'),
+		).not.toThrow(/inline-value/);
+	});
+
+	test('should resolve the target against baseURL', () => {
+		expect(() =>
+			throwIfDomainNotAllowed({ baseURL: 'https://example.com', url: '/api' }, 'example.com'),
+		).not.toThrow();
+
+		expect(() =>
+			throwIfDomainNotAllowed(
+				{ baseURL: 'https://other.com', url: '/api', params: { api_key: 'base-url-value' } },
+				'example.com',
+			),
+		).not.toThrow(/base-url-value/);
+	});
+
+	test('should accept a plain url string', () => {
+		expect(() => throwIfDomainNotAllowed('https://example.com/api', 'example.com')).not.toThrow();
+		expect(() => throwIfDomainNotAllowed('https://other.com/api', 'example.com')).toThrow(
+			'Domain not allowed',
+		);
 	});
 });
 

--- a/packages/@n8n/backend-network/src/http/axios/utils.ts
+++ b/packages/@n8n/backend-network/src/http/axios/utils.ts
@@ -22,7 +22,13 @@ export function throwIfDomainNotAllowed(
 	configOrUrl: AxiosRequestConfig | string,
 	allowedDomains?: string,
 ): void {
-	const url = typeof configOrUrl === 'string' ? configOrUrl : axios.getUri(configOrUrl);
+	// Resolve the bare target rather than `axios.getUri()`, which also serializes
+	// `config.params` onto the string. The allowlist check only needs the hostname,
+	// and this URL is what the thrown message embeds.
+	const url =
+		typeof configOrUrl === 'string'
+			? configOrUrl
+			: (buildTargetUrl(configOrUrl.url, configOrUrl.baseURL) ?? configOrUrl.url ?? '');
 	assertUrlAllowed({ url, allowedDomains });
 }
 

--- a/packages/workflow/src/credential-domain-restrictions.ts
+++ b/packages/workflow/src/credential-domain-restrictions.ts
@@ -133,6 +133,21 @@ export function isDomainAllowed(options: { url: string; allowedDomains: string }
 	return false;
 }
 
+/**
+ * The host alone — it is all the allowlist decision uses, and the only part the
+ * reader needs in order to act on the error. Dropping the rest keeps per-request
+ * values out of a message that is persisted with the execution.
+ */
+function toDisplayHost(url: string): string {
+	try {
+		return new URL(url).host;
+	} catch {
+		// No host to name. Fall back to the URL without the parts that carry
+		// per-request values: cut at the first `?`/`#` and drop any `user:pass@`.
+		return url.split(/[?#]/)[0].replace(/^([A-Za-z][\w+.-]*:\/\/)[^/@]*@/, '$1');
+	}
+}
+
 /** Throws `UserError` when `node` is omitted, so callers without an `INode` (axios helper) get a wrappable error. */
 export function assertUrlAllowed(options: {
 	url: string;
@@ -143,7 +158,7 @@ export function assertUrlAllowed(options: {
 	if (!allowedDomains) return;
 	if (isDomainAllowed({ url, allowedDomains })) return;
 
-	const message = `Domain not allowed: This credential is restricted from accessing ${url}. Only the following domains are allowed: ${allowedDomains}`;
+	const message = `Domain not allowed: This credential is restricted from accessing ${toDisplayHost(url)}. Only the following domains are allowed: ${allowedDomains}`;
 	throw node ? new NodeOperationError(node, message) : new UserError(message);
 }
 

--- a/packages/workflow/test/credential-domain-restrictions.test.ts
+++ b/packages/workflow/test/credential-domain-restrictions.test.ts
@@ -304,7 +304,7 @@ describe('assertUrlAllowed', () => {
 		expect(() =>
 			assertUrlAllowed({ url: 'https://attacker.example', allowedDomains: 'example.com' }),
 		).toThrow(
-			'Domain not allowed: This credential is restricted from accessing https://attacker.example. Only the following domains are allowed: example.com',
+			'Domain not allowed: This credential is restricted from accessing attacker.example. Only the following domains are allowed: example.com',
 		);
 	});
 
@@ -316,6 +316,43 @@ describe('assertUrlAllowed', () => {
 				allowedDomains: 'example.com',
 			}),
 		).toThrow(NodeOperationError);
+	});
+
+	describe('message contents', () => {
+		it.each([
+			['the path', 'https://attacker.example/api'],
+			['a query string', 'https://attacker.example/api?api_key=sentinel-value'],
+			['a fragment', 'https://attacker.example/api#sentinel-value'],
+			['userinfo', 'https://user:sentinel-value@attacker.example/api'],
+			['userinfo and a query string', 'https://user:sentinel-value@attacker.example/api?k=v'],
+			['a value carried in the path', 'https://attacker.example/v1/sentinel-value/items'],
+		])('names only the host, omitting %s', (_label, url) => {
+			expect(() => assertUrlAllowed({ url, allowedDomains: 'example.com' })).toThrow(
+				'Domain not allowed: This credential is restricted from accessing attacker.example. Only the following domains are allowed: example.com',
+			);
+		});
+
+		it('keeps the port, which is part of the host', () => {
+			expect(() =>
+				assertUrlAllowed({
+					url: 'https://attacker.example:8443/api?api_key=sentinel-value',
+					allowedDomains: 'example.com',
+				}),
+			).toThrow(
+				'Domain not allowed: This credential is restricted from accessing attacker.example:8443. Only the following domains are allowed: example.com',
+			);
+		});
+
+		it('falls back to a redacted URL when there is no host to name', () => {
+			expect(() =>
+				assertUrlAllowed({
+					url: 'attacker.example/api?api_key=sentinel-value',
+					allowedDomains: 'example.com',
+				}),
+			).toThrow(
+				'Domain not allowed: This credential is restricted from accessing attacker.example/api. Only the following domains are allowed: example.com',
+			);
+		});
 	});
 });
 
@@ -362,7 +399,7 @@ describe('assertCredentialAllowsUrl', () => {
 					url: 'https://attacker.example',
 				}),
 			).toThrow(
-				'Domain not allowed: This credential is restricted from accessing https://attacker.example. Only the following domains are allowed: example.com',
+				'Domain not allowed: This credential is restricted from accessing attacker.example. Only the following domains are allowed: example.com',
 			);
 		});
 


### PR DESCRIPTION
## Summary

A credential can be restricted to a list of allowed domains. When a node targets a host outside that list, the guard refuses the request and throws an error.

That error used to name the full request URL. The allowlist decision only uses the hostname, so the message now names the host and nothing else. The axios guard also resolves the bare target instead of `axios.getUri()`, which serializes request params onto the string. `assertCredentialAllowsUrl` is unchanged: its pinned-URL branch compares whole URLs, so it still needs the whole URL.

Before / after for a credential limited to `example.com`:

```
- Domain not allowed: This credential is restricted from accessing https://other.com/api?k=v. Only the following domains are allowed: example.com
+ Domain not allowed: This credential is restricted from accessing other.com. Only the following domains are allowed: example.com
```

## How to test

1. Create an HTTP Query Auth credential. Set **Allowed HTTP Request Domains** to `Specific Domains` and **Allowed Domains** to `example.com`.
2. Add an HTTP Request node. Select that credential. Set the URL to `https://other.com/api`.
3. Run the workflow. The node fails with `Domain not allowed`.
4. Confirm the message names `other.com` only. It must not contain a path or a query string.
5. Open the execution again from the executions list. Confirm the persisted message is the same.
6. Repeat with a GraphQL node and with an HTTP Header Auth credential. The behaviour is the same.

No feature flag, module, or licence is needed. The domain restriction fields are always available.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1201

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

