### PR TITLE
fix(core): Redact secrets and PII from AIA message telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -3340,6 +3340,7 @@ function createRunAdapterForTests(
 		postExecutePromise?: Promise<unknown>;
 		threadId?: string;
 		queueMode?: boolean;
+		allowSendingParameterValues?: boolean;
 	},
 ) {
 	const mockWorkflowFinderService = {
@@ -3373,7 +3374,7 @@ function createRunAdapterForTests(
 			typeof InstanceAiAdapterService
 		>[0],
 		{
-			ai: { allowSendingParameterValues: false },
+			ai: { allowSendingParameterValues: options?.allowSendingParameterValues ?? false },
 			executions: { mode: options?.queueMode ? 'queue' : 'regular' },
 		} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[1],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[2],
@@ -3679,6 +3680,59 @@ describe('createExecutionAdapter run()', () => {
 				error: 'boom',
 			}),
 		);
+	});
+
+	it('scrubs secrets and PII from the tracked execution error', async () => {
+		const { adapter, mockTelemetry } = createRunAdapterForTests(
+			{ id: 'wf-1', nodes: [], connections: {}, settings: {} },
+			{
+				execution: makeExecution({
+					status: 'error',
+					error: {
+						message:
+							'Auth failed for jane.doe@example.com using sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+					},
+				}),
+				threadId: 'thread-1',
+			},
+		);
+
+		await adapter.run('wf-1');
+
+		const tracked = mockTelemetry.track.mock.calls.find(
+			([event]) => event === 'Builder executed workflow',
+		);
+		expect(tracked?.[1].error).not.toContain('jane.doe@example.com');
+		expect(tracked?.[1].error).not.toContain('sk-ant-api03');
+		expect(tracked?.[1].error).toContain('[REDACTED]');
+	});
+
+	it('keeps upstream error details out of telemetry even when the privacy setting allows them', async () => {
+		const { adapter, mockTelemetry } = createRunAdapterForTests(
+			{ id: 'wf-1', nodes: [], connections: {}, settings: {} },
+			{
+				execution: makeExecution({
+					status: 'error',
+					error: {
+						message: 'Request failed with status code 403',
+						description: 'Account 12 Ridge Road is suspended',
+					},
+				}),
+				threadId: 'thread-1',
+				allowSendingParameterValues: true,
+			},
+		);
+
+		const result = await adapter.run('wf-1');
+
+		// The agent still sees the upstream detail the operator opted into...
+		expect(result.error).toContain('Account 12 Ridge Road is suspended');
+		// ...but analytics only gets the sanitized message.
+		const tracked = mockTelemetry.track.mock.calls.find(
+			([event]) => event === 'Builder executed workflow',
+		);
+		expect(tracked?.[1].error).toContain('Request failed with status code 403');
+		expect(tracked?.[1].error).not.toContain('Ridge Road');
 	});
 
 	it('tracks timeout cancellation as an error status', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3197,6 +3197,42 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		});
 	});
 
+	it('scrubs secrets from the "Builder generation errored" message', async () => {
+		const service = createTerminalGuardOrderService();
+		const abortController = new AbortController();
+		mockClaimedResumeResult({
+			status: 'errored',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve(''),
+			error: new Error(
+				'provider rejected key sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+			),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+			},
+		);
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Builder generation errored',
+			expect.objectContaining({
+				error_message: 'provider rejected key [REDACTED]',
+			}),
+		);
+	});
+
 	it('claims credits when a resumed run completes', async () => {
 		const service = createTerminalGuardOrderService();
 		const abortController = new AbortController();

--- a/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
@@ -93,6 +93,13 @@ describe('redactTelemetryProperties', () => {
 		).toEqual({ config: { clientSecret: '[REDACTED]', apiKey: '[REDACTED]' } });
 	});
 
+	it('catches kebab-case secret keys too', () => {
+		expect(redactTelemetryProperties({ 'private-key': 'plain', 'api-key': 'plain' })).toEqual({
+			'private-key': '[REDACTED]',
+			'api-key': '[REDACTED]',
+		});
+	});
+
 	it('keeps properties that only describe a credential', () => {
 		const properties = {
 			credential_type: 'httpBasicAuth',

--- a/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
@@ -87,10 +87,17 @@ describe('redactTelemetryProperties', () => {
 		});
 	});
 
+	it('catches camelCase secret keys too', () => {
+		expect(
+			redactTelemetryProperties({ config: { clientSecret: 'plain', apiKey: 'plain' } }),
+		).toEqual({ config: { clientSecret: '[REDACTED]', apiKey: '[REDACTED]' } });
+	});
+
 	it('keeps properties that only describe a credential', () => {
 		const properties = {
 			credential_type: 'httpBasicAuth',
 			credential_kind: 'n8n_connect',
+			credentials: ['slackApi', 'googleSheetsOAuth2Api'],
 			has_token: true,
 			total_tokens: 1_200,
 		};

--- a/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
@@ -1,4 +1,4 @@
-import { redactTelemetryText } from '../telemetry-redaction';
+import { redactTelemetryProperties, redactTelemetryText } from '../telemetry-redaction';
 
 describe('redactTelemetryText', () => {
 	it('leaves ordinary assistant prose untouched', () => {
@@ -39,5 +39,61 @@ describe('redactTelemetryText', () => {
 
 	it('passes through the empty string', () => {
 		expect(redactTelemetryText('')).toBe('');
+	});
+});
+
+describe('redactTelemetryProperties', () => {
+	it('scrubs free-text values and leaves everything else intact', () => {
+		const redacted = redactTelemetryProperties({
+			thread_id: 'thread-1',
+			run_id: 'run-1',
+			query: 'send a receipt to jane.doe@example.com',
+			attempt_count: 2,
+			multi_gate: true,
+			templates_version: null,
+		});
+
+		expect(redacted).toEqual({
+			thread_id: 'thread-1',
+			run_id: 'run-1',
+			query: 'send a receipt to [REDACTED]',
+			attempt_count: 2,
+			multi_gate: true,
+			templates_version: null,
+		});
+	});
+
+	it('leaves identifier-shaped values unscrubbed so events stay joinable', () => {
+		const properties = {
+			workflow_id: '0d7d274c-1e7a-409f-8d77-bc868a97abd7',
+			source_hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+			node_ids: ['10.0.0.5', '192.168.1.1'],
+		};
+
+		expect(redactTelemetryProperties(properties)).toEqual(properties);
+	});
+
+	it('recurses into nested objects and arrays', () => {
+		const redacted = redactTelemetryProperties({
+			errors: [
+				{
+					node: 'HTTP Request',
+					message: 'rejected ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+				},
+			],
+		});
+
+		expect(redacted).toEqual({
+			errors: [{ node: 'HTTP Request', message: 'rejected [REDACTED]' }],
+		});
+	});
+
+	it('drops values nested deeper than the scrub depth instead of shipping them raw', () => {
+		const redacted = redactTelemetryProperties({
+			a: { b: { c: { d: { e: { f: { secret: 'jane.doe@example.com' } } } } } },
+		});
+
+		expect(JSON.stringify(redacted)).not.toContain('jane.doe@example.com');
+		expect(JSON.stringify(redacted)).toContain('[REDACTED_DEPTH]');
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
@@ -73,6 +73,31 @@ describe('redactTelemetryProperties', () => {
 		expect(redactTelemetryProperties(properties)).toEqual(properties);
 	});
 
+	it('replaces values under secret-shaped keys, even when they match no pattern', () => {
+		const redacted = redactTelemetryProperties({
+			password: 'hunter2',
+			api_key: 'plain-value',
+			config: { access_token: 'not-token-shaped' },
+		});
+
+		expect(redacted).toEqual({
+			password: '[REDACTED]',
+			api_key: '[REDACTED]',
+			config: { access_token: '[REDACTED]' },
+		});
+	});
+
+	it('keeps properties that only describe a credential', () => {
+		const properties = {
+			credential_type: 'httpBasicAuth',
+			credential_kind: 'n8n_connect',
+			has_token: true,
+			total_tokens: 1_200,
+		};
+
+		expect(redactTelemetryProperties(properties)).toEqual(properties);
+	});
+
 	it('recurses into nested objects and arrays', () => {
 		const redacted = redactTelemetryProperties({
 			errors: [

--- a/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/telemetry-redaction.test.ts
@@ -1,0 +1,43 @@
+import { redactTelemetryText } from '../telemetry-redaction';
+
+describe('redactTelemetryText', () => {
+	it('leaves ordinary assistant prose untouched', () => {
+		const text = 'I added an HTTP Request node and connected it to the Schedule Trigger.';
+
+		expect(redactTelemetryText(text)).toBe(text);
+	});
+
+	it('replaces secret-shaped values', () => {
+		const redacted = redactTelemetryText(
+			'I used your key sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA for the request.',
+		);
+
+		expect(redacted).not.toContain('sk-ant-api03');
+		expect(redacted).toContain('[REDACTED]');
+	});
+
+	it('replaces PII categories the user-facing policy leaves alone', () => {
+		const redacted = redactTelemetryText('Sent the invoice to jane.doe@example.com.');
+
+		expect(redacted).not.toContain('jane.doe@example.com');
+		expect(redacted).toContain('[REDACTED]');
+	});
+
+	it('keeps URL structure while dropping query values', () => {
+		const redacted = redactTelemetryText('Call https://api.example.com/v1/orders?token=abc123xyz');
+
+		expect(redacted).toContain('https://api.example.com/v1/orders');
+		expect(redacted).not.toContain('abc123xyz');
+	});
+
+	it('caps long text so the event stays under the RudderStack payload limit', () => {
+		const redacted = redactTelemetryText('a'.repeat(20_000));
+
+		expect(redacted).toHaveLength(8_003);
+		expect(redacted.endsWith('...')).toBe(true);
+	});
+
+	it('passes through the empty string', () => {
+		expect(redactTelemetryText('')).toBe('');
+	});
+});

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -166,6 +166,7 @@ import {
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { InstanceAiMcpRegistryService } from './mcp';
 import { listNodeDiscriminators } from './node-definition-resolver';
+import { redactTelemetryText } from './telemetry-redaction';
 import { fetchAndExtract, maybeSummarize, LRUCache } from './web-research';
 import { WorkflowTemplatesService } from './workflow-templates.service';
 
@@ -1407,7 +1408,7 @@ export class InstanceAiAdapterService {
 						pinned_node_count: Object.keys(runData.pinData ?? {}).length,
 						exec_type: runData.executionMode,
 						status,
-						...(error ? { error } : {}),
+						...(error ? { error: redactTelemetryText(error) } : {}),
 					});
 				};
 
@@ -1503,9 +1504,12 @@ export class InstanceAiAdapterService {
 						}
 					}
 
-					const result = await extractExecutionResult(executionId, allowSendingParameterValues);
+					const { result, telemetryError } = await extractExecutionOutcome(
+						executionId,
+						allowSendingParameterValues,
+					);
 					await pruneVerificationPins(result.executedNodeNames);
-					trackBuilderExecutedWorkflow(result.status, result.error);
+					trackBuilderExecutedWorkflow(result.status, telemetryError);
 					// Saved workflow pins fed this run (they ride every instance-ai run) —
 					// report them so callers don't mistake pin-fed nodes for live ones.
 					const workflowPinnedNodeNames = Object.keys(workflow.pinData ?? {});
@@ -3480,13 +3484,28 @@ export async function extractExecutionResult(
 	executionId: string,
 	includeOutputData = true,
 ): Promise<ExecutionResult> {
+	return (await extractExecutionOutcome(executionId, includeOutputData)).result;
+}
+
+/**
+ * The execution result the agent sees, plus the error string telemetry may use.
+ * They differ when `N8N_AI_ALLOW_SENDING_PARAMETER_VALUES` is on: that setting
+ * opts the operator into sending upstream response content (`error.description`
+ * / `.messages`, which routinely echo API keys and record-level PII) *to the
+ * model*, not into n8n's product analytics. So the telemetry copy is always
+ * formatted with upstream details suppressed.
+ */
+export async function extractExecutionOutcome(
+	executionId: string,
+	includeOutputData = true,
+): Promise<{ result: ExecutionResult; telemetryError?: string }> {
 	const execution = await Container.get(ExecutionPersistence).findSingleExecution(executionId, {
 		includeData: true,
 		unflattenData: true,
 	});
 
 	if (!execution) {
-		return { executionId, status: 'unknown' };
+		return { result: { executionId, status: 'unknown' } };
 	}
 
 	const status =
@@ -3530,18 +3549,21 @@ export async function extractExecutionResult(
 	const nodeErrors = extractNodeErrors(runData, includeOutputData, execution.workflowData?.nodes);
 
 	return {
-		executionId,
-		status,
-		data:
-			Object.keys(resultData).length > 0
-				? wrapResultDataEntries(truncateResultData(resultData))
-				: undefined,
-		executedNodeNames: executedNodeNames.length > 0 ? executedNodeNames : undefined,
-		nodeErrors: nodeErrors.length > 0 ? nodeErrors : undefined,
-		lastNodeExecuted: execution.data?.resultData?.lastNodeExecuted,
-		error: errorMessage,
-		startedAt: execution.startedAt?.toISOString(),
-		finishedAt: execution.stoppedAt?.toISOString(),
+		result: {
+			executionId,
+			status,
+			data:
+				Object.keys(resultData).length > 0
+					? wrapResultDataEntries(truncateResultData(resultData))
+					: undefined,
+			executedNodeNames: executedNodeNames.length > 0 ? executedNodeNames : undefined,
+			nodeErrors: nodeErrors.length > 0 ? nodeErrors : undefined,
+			lastNodeExecuted: execution.data?.resultData?.lastNodeExecuted,
+			error: errorMessage,
+			startedAt: execution.startedAt?.toISOString(),
+			finishedAt: execution.stoppedAt?.toISOString(),
+		},
+		telemetryError: error ? formatExecutionError(error, false) : undefined,
 	};
 }
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -198,6 +198,7 @@ import {
 	type ResumableOrphan,
 } from './suspended-run-restorer.service';
 import { SuspendedThreadPersistenceService } from './suspended-thread-persistence.service';
+import { redactTelemetryText } from './telemetry-redaction';
 import {
 	InstanceAiTracingService,
 	type MessageTraceFinalization,
@@ -4140,7 +4141,7 @@ export class InstanceAiService {
 				if (intermediateText) {
 					this.telemetry.track('Builder sent message', {
 						thread_id: threadId,
-						message: intermediateText,
+						message: redactTelemetryText(intermediateText),
 						is_intermediate: true,
 					});
 				}
@@ -4317,7 +4318,7 @@ export class InstanceAiService {
 			if (result.status === 'completed') {
 				this.telemetry.track('Builder sent message', {
 					thread_id: threadId,
-					message: outputText,
+					message: redactTelemetryText(outputText),
 				});
 				this.telemetry.track('Builder satisfied user intent', {
 					thread_id: threadId,
@@ -5483,7 +5484,7 @@ export class InstanceAiService {
 				if (intermediateText) {
 					this.telemetry.track('Builder sent message', {
 						thread_id: opts.threadId,
-						message: intermediateText,
+						message: redactTelemetryText(intermediateText),
 						is_intermediate: true,
 					});
 				}
@@ -5665,7 +5666,7 @@ export class InstanceAiService {
 				);
 				this.telemetry.track('Builder sent message', {
 					thread_id: opts.threadId,
-					message: outputText,
+					message: redactTelemetryText(outputText),
 				});
 				this.telemetry.track('Builder satisfied user intent', {
 					thread_id: opts.threadId,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -198,7 +198,7 @@ import {
 	type ResumableOrphan,
 } from './suspended-run-restorer.service';
 import { SuspendedThreadPersistenceService } from './suspended-thread-persistence.service';
-import { redactTelemetryText } from './telemetry-redaction';
+import { redactTelemetryProperties, redactTelemetryText } from './telemetry-redaction';
 import {
 	InstanceAiTracingService,
 	type MessageTraceFinalization,
@@ -2625,8 +2625,11 @@ export class InstanceAiService {
 		context.workspaceRoot = workspaceRoot;
 		context.threadId = threadId;
 		context.threadMemory = memory;
+		// Tool-emitted telemetry is an open-ended property bag (search queries,
+		// remediation reasons, node error strings) — scrub at the boundary so a
+		// new call site can't leak by omission.
 		context.trackTelemetry = (eventName, properties) => {
-			this.telemetry.track(eventName, properties);
+			this.telemetry.track(eventName, redactTelemetryProperties(properties));
 		};
 		const domainTools = createAllTools(context);
 
@@ -2643,7 +2646,7 @@ export class InstanceAiService {
 			logger: this.logger,
 			outputRedaction: resolveOutputRedaction(this.instanceAiConfig),
 			trackTelemetry: (eventName, properties) => {
-				this.telemetry.track(eventName, properties);
+				this.telemetry.track(eventName, redactTelemetryProperties(properties));
 			},
 			// Aggregate on the instance-AI thread (not the `ia-builder:` session
 			// thread) so the credit service's per-thread display total and FE push
@@ -6505,7 +6508,7 @@ export class InstanceAiService {
 			this.telemetry.track('Builder generation errored', {
 				thread_id: threadId,
 				run_id: runId,
-				error_message: errorInfo?.errorMessage ?? reason ?? 'unknown',
+				error_message: redactTelemetryText(errorInfo?.errorMessage ?? reason ?? 'unknown'),
 				...(errorInfo?.errorSource ? { error_source: errorInfo.errorSource } : {}),
 				...(userId ? { user_id: userId } : {}),
 			});

--- a/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
+++ b/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
@@ -51,9 +51,12 @@ const IDENTIFIER_KEY_PATTERN = /(?:^|_)(?:id|ids|hash)$/;
 const SECRET_KEY_PATTERN =
 	/(?:^|_)(?:password|passwd|pwd|secret|token|api_?key|apikey|access_?token|refresh_?token|id_?token|session_?token|auth_?token|authorization|cookie|private_?key)$/i;
 
-/** `clientSecret` → `client_secret`, so camelCase keys hit the same pattern. */
+/**
+ * `clientSecret` → `client_secret`, `private-key` → `private_key`, so
+ * camelCase and kebab-case keys both hit the same (snake_case) pattern.
+ */
 function toSnakeCase(key: string): string {
-	return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2');
+	return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').replace(/-/g, '_');
 }
 
 /**

--- a/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
+++ b/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
@@ -13,11 +13,6 @@ import type { GenericValue, ITelemetryTrackProperties } from 'n8n-workflow';
  * deliberately stricter than the user-facing output policy: secrets plus every
  * PII category.
  *
- * Intentionally independent of `N8N_INSTANCE_AI_OUTPUT_REDACTION_*` and the
- * durable-log flag — those decide what the *user* sees on their own instance
- * (and today turn the stream-side redactor off entirely), which says nothing
- * about what may be shipped to a third party.
- *
  * `preserveUrlStructure` keeps traced URLs readable; their value-bearing parts
  * are still redacted and secrets are matched first.
  */

--- a/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
+++ b/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
@@ -1,0 +1,38 @@
+import { redactText, SUPPORTED_PII_CATEGORIES, type RedactionOptions } from '@n8n/agents';
+
+/**
+ * Egress policy for free-text values leaving the instance as product telemetry
+ * (RudderStack/PostHog). Mirrors the LangSmith exporter's policy
+ * (`DEFAULT_TELEMETRY_REDACTION_OPTIONS` in the instance-ai package) and is
+ * deliberately stricter than the user-facing output policy: secrets plus every
+ * PII category.
+ *
+ * Intentionally independent of `N8N_INSTANCE_AI_OUTPUT_REDACTION_*` and the
+ * durable-log flag — those decide what the *user* sees on their own instance
+ * (and today turn the stream-side redactor off entirely), which says nothing
+ * about what may be shipped to a third party.
+ *
+ * `preserveUrlStructure` keeps traced URLs readable; their value-bearing parts
+ * are still redacted and secrets are matched first.
+ */
+const TELEMETRY_REDACTION_OPTIONS: RedactionOptions = {
+	secrets: true,
+	detect: SUPPORTED_PII_CATEGORIES,
+	preserveUrlStructure: true,
+};
+
+/**
+ * Length cap for a single free-text telemetry property. `Telemetry.track`
+ * silently drops any event whose serialized payload exceeds 32 KB, so an
+ * uncapped assistant message loses the whole event; this keeps it well under.
+ */
+const MAX_TELEMETRY_TEXT_LENGTH = 8_000;
+
+/** Scrub secrets/PII from a free-text telemetry value and cap its length. */
+export function redactTelemetryText(value: string): string {
+	const redacted = redactText(value, TELEMETRY_REDACTION_OPTIONS).text;
+
+	return redacted.length > MAX_TELEMETRY_TEXT_LENGTH
+		? `${redacted.slice(0, MAX_TELEMETRY_TEXT_LENGTH)}...`
+		: redacted;
+}

--- a/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
+++ b/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
@@ -47,9 +47,19 @@ const IDENTIFIER_KEY_PATTERN = /(?:^|_)(?:id|ids|hash)$/;
  * sail through — these are replaced wholesale instead. Anchored at the end of
  * the key so properties that merely describe a credential (`credential_type`,
  * `credential_kind` on `Node credential assigned`) keep their analytics value.
+ *
+ * Deliberately excludes a bare `credential(s)` key: in this codebase such a
+ * property is a dimension (a list of credential *types*), and wiping it would
+ * be a silent analytics regression. A credential object nested under it is
+ * still walked key by key.
  */
 const SECRET_KEY_PATTERN =
-	/(?:^|_)(?:password|passwd|pwd|secret|token|api_?key|apikey|access_?token|refresh_?token|id_?token|session_?token|auth_?token|authorization|cookie|private_?key|credentials?)$/i;
+	/(?:^|_)(?:password|passwd|pwd|secret|token|api_?key|apikey|access_?token|refresh_?token|id_?token|session_?token|auth_?token|authorization|cookie|private_?key)$/i;
+
+/** `clientSecret` → `client_secret`, so camelCase keys hit the same pattern. */
+function toSnakeCase(key: string): string {
+	return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2');
+}
 
 /**
  * Telemetry payloads are flat in practice. Rather than let an unexpectedly deep
@@ -75,7 +85,10 @@ function redactPropertyValue(key: string, value: GenericValue, depth: number): G
 	// Runs before the identifier exemption: a secret-shaped key wins over any
 	// key-based pass-through. Numbers/booleans are left alone — they can't carry
 	// a secret, and flags like `has_token` are worth keeping.
-	if (SECRET_KEY_PATTERN.test(key) && (typeof value === 'string' || isNonNullObject(value))) {
+	if (
+		SECRET_KEY_PATTERN.test(toSnakeCase(key)) &&
+		(typeof value === 'string' || isNonNullObject(value))
+	) {
 		return DEFAULT_PLACEHOLDER;
 	}
 

--- a/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
+++ b/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
@@ -1,4 +1,5 @@
 import { redactText, SUPPORTED_PII_CATEGORIES, type RedactionOptions } from '@n8n/agents';
+import type { GenericValue, ITelemetryTrackProperties } from 'n8n-workflow';
 
 /**
  * Egress policy for free-text values leaving the instance as product telemetry
@@ -28,6 +29,20 @@ const TELEMETRY_REDACTION_OPTIONS: RedactionOptions = {
  */
 const MAX_TELEMETRY_TEXT_LENGTH = 8_000;
 
+/**
+ * Identifier-shaped keys (`thread_id`, `workflow_id`, `source_hash`, …). Their
+ * values are internally generated, carry no user content, and are the join keys
+ * every dashboard groups by — scrubbing them is all downside.
+ */
+const IDENTIFIER_KEY_PATTERN = /(?:^|_)(?:id|ids|hash)$/;
+
+/**
+ * Telemetry payloads are flat in practice. Rather than let an unexpectedly deep
+ * value through unscrubbed (INS-685), replace it with a marker.
+ */
+const MAX_PROPERTY_DEPTH = 5;
+const OVER_DEPTH_MARKER = '[REDACTED_DEPTH]';
+
 /** Scrub secrets/PII from a free-text telemetry value and cap its length. */
 export function redactTelemetryText(value: string): string {
 	const redacted = redactText(value, TELEMETRY_REDACTION_OPTIONS).text;
@@ -35,4 +50,43 @@ export function redactTelemetryText(value: string): string {
 	return redacted.length > MAX_TELEMETRY_TEXT_LENGTH
 		? `${redacted.slice(0, MAX_TELEMETRY_TEXT_LENGTH)}...`
 		: redacted;
+}
+
+function redactPropertyValue(key: string, value: GenericValue, depth: number): GenericValue {
+	if (typeof value === 'string') {
+		return IDENTIFIER_KEY_PATTERN.test(key) ? value : redactTelemetryText(value);
+	}
+
+	if (Array.isArray(value)) {
+		if (depth >= MAX_PROPERTY_DEPTH) return OVER_DEPTH_MARKER;
+		return value.map((entry: GenericValue) => redactPropertyValue(key, entry, depth + 1));
+	}
+
+	if (value !== null && typeof value === 'object') {
+		if (depth >= MAX_PROPERTY_DEPTH) return OVER_DEPTH_MARKER;
+		const redacted: Record<string, GenericValue> = {};
+		for (const [nestedKey, nestedValue] of Object.entries(value)) {
+			redacted[nestedKey] = redactPropertyValue(nestedKey, nestedValue as GenericValue, depth + 1);
+		}
+		return redacted;
+	}
+
+	return value;
+}
+
+/**
+ * Scrub every free-text value in a telemetry payload. Used at boundaries where
+ * the property bag is open-ended — notably the `trackTelemetry` channel handed
+ * to tools, whose payloads (search queries, remediation reasons, node error
+ * strings) are model- or user-derived and can't be audited call site by call
+ * site. Identifier keys and non-string values pass through untouched.
+ */
+export function redactTelemetryProperties(
+	properties: ITelemetryTrackProperties,
+): ITelemetryTrackProperties {
+	const redacted: ITelemetryTrackProperties = {};
+	for (const [key, value] of Object.entries(properties)) {
+		redacted[key] = redactPropertyValue(key, value, 0);
+	}
+	return redacted;
 }

--- a/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
+++ b/packages/cli/src/modules/instance-ai/telemetry-redaction.ts
@@ -1,4 +1,9 @@
-import { redactText, SUPPORTED_PII_CATEGORIES, type RedactionOptions } from '@n8n/agents';
+import {
+	DEFAULT_PLACEHOLDER,
+	redactText,
+	SUPPORTED_PII_CATEGORIES,
+	type RedactionOptions,
+} from '@n8n/agents';
 import type { GenericValue, ITelemetryTrackProperties } from 'n8n-workflow';
 
 /**
@@ -37,6 +42,16 @@ const MAX_TELEMETRY_TEXT_LENGTH = 8_000;
 const IDENTIFIER_KEY_PATTERN = /(?:^|_)(?:id|ids|hash)$/;
 
 /**
+ * Keys whose *value is itself* the credential. A pattern scan only catches
+ * secrets with a recognizable shape, so a plain `password: 'hunter2'` would
+ * sail through — these are replaced wholesale instead. Anchored at the end of
+ * the key so properties that merely describe a credential (`credential_type`,
+ * `credential_kind` on `Node credential assigned`) keep their analytics value.
+ */
+const SECRET_KEY_PATTERN =
+	/(?:^|_)(?:password|passwd|pwd|secret|token|api_?key|apikey|access_?token|refresh_?token|id_?token|session_?token|auth_?token|authorization|cookie|private_?key|credentials?)$/i;
+
+/**
  * Telemetry payloads are flat in practice. Rather than let an unexpectedly deep
  * value through unscrubbed (INS-685), replace it with a marker.
  */
@@ -52,7 +67,18 @@ export function redactTelemetryText(value: string): string {
 		: redacted;
 }
 
+function isNonNullObject(value: GenericValue): value is object {
+	return value !== null && typeof value === 'object';
+}
+
 function redactPropertyValue(key: string, value: GenericValue, depth: number): GenericValue {
+	// Runs before the identifier exemption: a secret-shaped key wins over any
+	// key-based pass-through. Numbers/booleans are left alone — they can't carry
+	// a secret, and flags like `has_token` are worth keeping.
+	if (SECRET_KEY_PATTERN.test(key) && (typeof value === 'string' || isNonNullObject(value))) {
+		return DEFAULT_PLACEHOLDER;
+	}
+
 	if (typeof value === 'string') {
 		return IDENTIFIER_KEY_PATTERN.test(key) ? value : redactTelemetryText(value);
 	}
@@ -62,7 +88,7 @@ function redactPropertyValue(key: string, value: GenericValue, depth: number): G
 		return value.map((entry: GenericValue) => redactPropertyValue(key, entry, depth + 1));
 	}
 
-	if (value !== null && typeof value === 'object') {
+	if (isNonNullObject(value)) {
 		if (depth >= MAX_PROPERTY_DEPTH) return OVER_DEPTH_MARKER;
 		const redacted: Record<string, GenericValue> = {};
 		for (const [nestedKey, nestedValue] of Object.entries(value)) {


### PR DESCRIPTION
## Summary

Apply our redaction logic on AIA telemetry messages.

## How to test

Have telemetry on and inspect the messages that get sent in various situations.
(Or review the unit tests)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-704
https://linear.app/n8n/issue/INS-695

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

