### PR TITLE
chore: Bump Browser Use Chrome extension to 0.0.7

### DIFF
--- a/packages/@n8n/mcp-browser-extension/manifest.json
+++ b/packages/@n8n/mcp-browser-extension/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "n8n Browser Use",
 	"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvRoWEdJjhgP9qs6R1jcemywrw+I91EJZtYur5C97hjjUc5nPao4jSv1qXFksdKuMddb9IEvzBElr5EYsXSaiVqdbRl8Gge0xYV1gGga653T2d9BuXL7NKv/wZxJ2i/coHSjhhIULQUBAVwu0JFMbHY5T8LfqrzBljuY7u1Xa7jmLmx0QrsoKLbGUoOBVZz4ztEGKEQHEelgg+ph2LrcYJczMBZ80PaHQAaWrvbCYF4vnZLd++Svy70ZCt7gr93L8BXHc8j1c3VojQTk+Uvqhm/4nZdYHlEmruQkd0pE+zTyegbcDlw0oc+6sLbsc0CqmJz8zH0OvSTfSVK7h6LNwbQIDAQAB",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"description": "Let n8n AI set up credentials, fill out forms, and automate anything in your browser",
 	"permissions": ["debugger", "activeTab", "tabs", "storage", "webNavigation"],
 	"host_permissions": ["<all_urls>"],

--- a/packages/@n8n/mcp-browser-extension/package.json
+++ b/packages/@n8n/mcp-browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/mcp-browser-extension",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "description": "Chrome extension that lets n8n AI control browser tabs via CDP",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps `@n8n/mcp-browser-extension` from `0.0.6` to `0.0.7` in both `package.json` and `manifest.json`, so the extension can be uploaded to the Chrome Web Store.

## How to test

1. Run `pnpm --filter @n8n/mcp-browser-extension bundle`.
2. Load the built `dist` folder as an unpacked extension in `chrome://extensions`.
3. Confirm the extension shows version `0.0.7`.

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket — release chore.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

