### PR TITLE
fix(editor): Remove doubled code block box in markdown renderer

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.stories.ts
@@ -76,6 +76,13 @@ WithCheckboxes.args = {
 	loading: false,
 };
 
+export const WithCodeBlock = Template.bind({});
+WithCodeBlock.args = {
+	content:
+		'To get started, run the following in a terminal:\n\n```\necho "Hello world"\n```\n\nInline code like `EXAMPLE_VAR=true` should also render.\n',
+	loading: false,
+};
+
 const TemplateWithYoutubeEmbed: StoryFn = (args, { argTypes }) => ({
 	setup: () => ({ args }),
 	props: Object.keys(argTypes),

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -328,8 +328,10 @@ const onCheckboxChange = (index: number) => {
 		}
 	}
 
+	// The pre box (background + padding) comes from the global .n8n-markdown
+	// styles in css/markdown.scss; a second box on code doubles it up.
 	pre > code {
-		background-color: var(--color--background);
+		background-color: transparent;
 		color: var(--color--text--shade-1);
 	}
 
@@ -432,6 +434,7 @@ input[type='checkbox'] + label {
 	}
 
 	pre > code {
+		padding: var(--spacing--sm);
 		background-color: var(--sticky--code--color--background);
 		color: var(--sticky--code--color--text);
 	}
@@ -468,7 +471,6 @@ input[type='checkbox'] + label {
 
 	pre > code {
 		display: block;
-		padding: var(--spacing--sm);
 		overflow-x: auto;
 	}
 


### PR DESCRIPTION
## Summary

Code blocks rendered by `N8nMarkdown` (for example in the "What's New" modal) show two nested boxes with uneven bottom spacing:

| Before | After |
| ------ | ----- |
| <img width="860" height="604" alt="Screenshot 2026-08-21 at 16 54 31" src="https://github.com/user-attachments/assets/b15585de-1a29-47a6-af22-eeed8af427af" /> | <img width="866" height="592" alt="Screenshot 2026-08-21 at 16 50 43" src="https://github.com/user-attachments/assets/ec17c876-18b0-4942-8201-3c806c5d3695" /> |




The cause is a style collision. #29988 moved the chat widget's markdown styles into the design system's global CSS under the `.n8n-markdown` class. The old `N8nMarkdown` component has used that same class on its root element since before the move. As a result, every `N8nMarkdown` instance now gets two competing sets of code block styles:

- The global `.n8n-markdown pre` rule paints a box (background + padding).
- The component's own `pre > code` rule paints a second box inside it.
- The global `pre code:last-of-type { padding-bottom: 0 }` rule removes the inner bottom padding, which makes the spacing asymmetric.

This PR lets the global `pre` rule paint the single box:

- Set the component's `pre > code` background to `transparent`.
- Remove the doubled `pre > code` padding.
- Keep sticky notes unchanged: their code padding moves into the sticky-only style block.

It also adds a code block story to `Markdown.stories.ts` as a regression canary.

Note: several components (AgentInfoPanel, AgentSkillViewer, MCP snippets) now rely on the global `.n8n-markdown` styles applying to this component, so un-globalizing the class was not an option here. Feedback on the approach is welcome.

## How to test

1. Run the design system Storybook: `pnpm --filter @n8n/design-system dev`.
2. Open **Core/Markdown → With Code Block**.
3. Check the code block: it must render as one box with symmetric padding, in light and dark theme.
4. Optional: open the "What's New" modal in the editor with an entry that contains a fenced code block.
5. Check a sticky note with a code block: it must render as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-10905

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
