### PR TITLE
fix(editor): WIP (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
@@ -1,128 +1,21 @@
-import { SECRET_VALUE_PATTERNS } from '@n8n/utils/scrub-secrets';
+import {
+	base58Decode,
+	createPiiPatterns,
+	PII_PATTERNS as BROWSER_PII_PATTERNS,
+	resolvePatterns as resolvePatternsWith,
+	type PiiPatternTable,
+	type RedactionPattern,
+} from '@n8n/utils/redaction/pii-patterns';
 import { createHash } from 'node:crypto';
-import { z, type ZodType } from 'zod';
 
 import type { PiiDetectionType } from '../../types';
 
-/**
- * A category attached to every redaction match so callers can log *what kind*
- * of sensitive content was removed without ever handling the value itself.
- * `'secret'` covers credential/token patterns; the rest mirror the SDK's
- * {@link PiiDetectionType} vocabulary.
- */
-export type RedactionCategory = 'secret' | PiiDetectionType;
-
-export interface RedactionPattern {
-	readonly category: RedactionCategory;
-	/**
-	 * Precompiled regex matching the sensitive value. Always global — the
-	 * redactor relies on `g` both for replace-all and for the `exec` scan loop.
-	 * Compiled once at module load; callers reset `lastIndex` before reuse.
-	 */
-	readonly regex: RegExp;
-	/**
-	 * Optional gate: a candidate match is only redacted when this returns
-	 * `true`. Used to suppress false positives (e.g. Luhn check for cards).
-	 */
-	readonly validate?: (match: string) => boolean;
-}
-
-/** Compile a global regex once, adding the `g` flag if the source omits it. */
-function globalRegex(source: string, flags = ''): RegExp {
-	return new RegExp(source, flags.includes('g') ? flags : `${flags}g`);
-}
-
-/**
- * Secret/credential patterns, sourced from `@n8n/utils` so there is a single
- * place that defines what a credential looks like across the codebase.
- */
-const SECRET_PATTERNS: readonly RedactionPattern[] = SECRET_VALUE_PATTERNS.map((re) => ({
-	category: 'secret',
-	regex: globalRegex(re.source, re.flags),
-}));
-
-/** Luhn checksum — used to keep credit-card redaction from firing on any long digit run. */
-export function passesLuhn(candidate: string): boolean {
-	const digits = candidate.replace(/\D/g, '');
-	if (digits.length < 13 || digits.length > 19) return false;
-
-	let sum = 0;
-	let double = false;
-	for (let i = digits.length - 1; i >= 0; i--) {
-		let digit = digits.charCodeAt(i) - 48;
-		if (double) {
-			digit *= 2;
-			if (digit > 9) digit -= 9;
-		}
-		sum += digit;
-		double = !double;
-	}
-	return sum % 10 === 0;
-}
-
-/**
- * Adapt a Zod schema into a {@link RedactionPattern} `validate` gate: the
- * pattern's regex *locates* a candidate substring in free-form text (Zod cannot
- * scan prose), then the schema *confirms* it before redaction. Lets a rule
- * express its confidence check declaratively — including a `z.string().regex(…)`
- * — instead of as ad-hoc code (cf. {@link passesLuhn}). An optional `normalize`
- * step runs on the located substring before validation (e.g. stripping the
- * separators a regex tolerated so the schema sees a canonical value).
- */
-export function zodGuard(
-	schema: ZodType,
-	normalize?: (match: string) => string,
-): (match: string) => boolean {
-	return (match) => schema.safeParse(normalize ? normalize(match) : match).success;
-}
-
-/**
- * Confidence gate for phone candidates, encoding the **E.164** standard: a
- * leading `+`, a non-zero country code, and 7–15 digits total. This mirrors
- * Zod 4's `z.e164()`; expressed here as a classic-Zod regex because the repo is
- * on Zod 3.25, where `e164()` isn't exposed on the default `zod` import.
- * Validation runs on the digit/`+`-only normalized form (separators stripped).
- */
-const PHONE_SCHEMA = z.string().regex(/^\+[1-9]\d{6,14}$/);
-
-/**
- * IBAN mod-97 checksum (ISO 13616): drop spaces, move the first 4 chars to the
- * end, map letters A–Z → 10–35, and confirm the big-integer value mod 97 === 1.
- */
-export function passesIbanChecksum(candidate: string): boolean {
-	const compact = candidate.replace(/\s/g, '').toUpperCase();
-	if (!/^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$/.test(compact)) return false;
-
-	const rearranged = compact.slice(4) + compact.slice(0, 4);
-	let remainder = 0;
-	for (let i = 0; i < rearranged.length; i++) {
-		const code = rearranged.charCodeAt(i);
-		const value = code >= 65 ? code - 55 : code - 48; // 'A'→10 … 'Z'→35, '0'→0 … '9'→9
-		remainder = value > 9 ? (remainder * 100 + value) % 97 : (remainder * 10 + value) % 97;
-	}
-	return remainder === 1;
-}
-
-const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-
-function base58Decode(input: string): Uint8Array | undefined {
-	const bytes: number[] = [];
-	for (let i = 0; i < input.length; i++) {
-		let carry = BASE58_ALPHABET.indexOf(input[i]);
-		if (carry === -1) return undefined;
-		for (let j = 0; j < bytes.length; j++) {
-			carry += bytes[j] * 58;
-			bytes[j] = carry & 0xff;
-			carry >>= 8;
-		}
-		while (carry > 0) {
-			bytes.push(carry & 0xff);
-			carry >>= 8;
-		}
-	}
-	for (let i = 0; i < input.length && input[i] === '1'; i++) bytes.push(0);
-	return Uint8Array.from(bytes.reverse());
-}
+export type { RedactionCategory, RedactionPattern } from '@n8n/utils/redaction/pii-patterns';
+export {
+	passesLuhn,
+	passesIbanChecksum,
+	SUPPORTED_PII_CATEGORIES,
+} from '@n8n/utils/redaction/pii-patterns';
 
 /** Bitcoin Base58Check: the trailing 4 bytes are the SHA-256d checksum of the payload. */
 function passesBase58Check(candidate: string): boolean {
@@ -135,113 +28,29 @@ function passesBase58Check(candidate: string): boolean {
 	return true;
 }
 
-/** Ethereum (`0x`+40 hex), Bitcoin bech32 (`bc1`/`tb1`), or Bitcoin Base58Check address. */
+/**
+ * Ethereum (`0x`+40 hex), Bitcoin bech32 (`bc1`/`tb1`), or a checksum-verified
+ * legacy Base58Check address. Stricter than the shared `isCryptoWalletShape`
+ * in `@n8n/utils`, which can only length-check the legacy form — SHA-256 has
+ * no synchronous browser primitive.
+ */
 function isCryptoWallet(match: string): boolean {
 	if (/^0x[0-9a-fA-F]{40}$/.test(match)) return true; // ETH — `0x`+40 hex is distinctive
 	if (/^(?:bc1|tb1)[023456789acdefghjklmnpqrstuvwxyz]{11,71}$/.test(match)) return true; // bech32
 	return passesBase58Check(match); // legacy P2PKH/P2SH — checksum-gated
 }
 
-/** IPv4 with octets ≤ 255, or a colon-delimited IPv6 (shape already constrained by the regex). */
-function isIpAddress(match: string): boolean {
-	if (match.includes(':')) return true;
-	const octets = match.split('.');
-	return octets.length === 4 && octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255);
-}
+const WALLET_PATTERN = BROWSER_PII_PATTERNS['crypto-wallet'] as RedactionPattern;
 
-/**
- * Conservative, high-confidence PII patterns. Phone detection is best-effort:
- * only well-structured (E.164) formats are matched. New {@link PiiDetectionType}
- * categories slot in here; a category may map to `undefined` to declare it
- * before a pattern exists, in which case it is excluded from detection.
- */
-const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefined>> = {
-	email: {
-		category: 'email',
-		regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
-	},
-	'credit-card': {
-		category: 'credit-card',
-		// 13-19 digits, optionally grouped by single spaces or dashes.
-		regex: /\b\d(?:[ -]?\d){12,18}\b/g,
-		validate: passesLuhn,
-	},
-	'ssn-us': {
-		category: 'ssn-us',
-		// US Social Security Number, dashed form only (123-45-6789). Bare 9-digit
-		// runs are intentionally not matched (too false-positive-prone). Per-country
-		// national IDs each get their own `ssn-<cc>` category (e.g. a future `ssn-uk`).
-		regex: /\b\d{3}-\d{2}-\d{4}\b/g,
-	},
-	phone: {
-		category: 'phone',
-		// Best-effort, E.164 only: a leading `+` then 7–15 digits, tolerating
-		// the spaces/parens/dots/dashes people write between groups
-		// (e.g. `+1 (555) 123-4567`). Requiring the `+` keeps false positives
-		// low — bare digit runs (IDs, dates, NANP without `+`) are not matched.
-		// `zodGuard` normalizes to the digit/`+`-only form, then validates E.164.
-		regex: /\+\d(?:[\s().-]*\d){6,14}\b/g,
-		validate: zodGuard(PHONE_SCHEMA, (match) => match.replace(/[^\d+]/g, '')),
-	},
-	iban: {
-		category: 'iban',
-		// Two forms: the compact (un-spaced) IBAN is matched case-insensitively so
-		// lower/mixed-case IBANs are caught — with no internal spaces it can't bleed
-		// into a following word. The spaced, group-of-4 form is matched upper-case
-		// only: spaced IBANs are written upper-case by convention, and that keeps the
-		// greedy body from swallowing following lower-case prose (which would fail the
-		// checksum and suppress redaction, since the engine doesn't retry sub-matches).
-		// `passesIbanChecksum` upper-cases, strips spaces, and verifies mod-97.
-		regex: /\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b|\b[A-Z]{2}\d{2}(?: [A-Z0-9]{1,4}){2,8}\b/g,
-		validate: passesIbanChecksum,
-	},
-	'crypto-wallet': {
-		category: 'crypto-wallet',
-		// Ethereum `0x…40hex`, Bitcoin bech32 `bc1…`/`tb1…`, or Bitcoin Base58Check.
-		regex:
-			/\b(?:0x[0-9a-fA-F]{40}|(?:bc1|tb1)[023456789acdefghjklmnpqrstuvwxyz]{11,71}|[13][1-9A-HJ-NP-Za-km-z]{25,34})\b/g,
-		validate: isCryptoWallet,
-	},
-	// `mac` is declared before `ip`: a MAC is colon-delimited hex and would also
-	// match the IPv6 branch, so matching it as `mac` first keeps the category right.
-	mac: {
-		category: 'mac',
-		regex: /\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b/g,
-	},
-	ip: {
-		category: 'ip',
-		// IPv4 (octets validated) or IPv6 (full and `::`-compressed forms).
-		regex:
-			/\b(?:\d{1,3}\.){3}\d{1,3}\b|\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b|\b(?:[A-Fa-f0-9]{1,4}:){1,7}:(?:[A-Fa-f0-9]{1,4})?\b/g,
-		validate: isIpAddress,
-	},
-	url: {
-		category: 'url',
-		// Whole http(s) URL. Stops at whitespace and common trailing delimiters.
-		regex: /\bhttps?:\/\/[^\s<>"')\]}]+/g,
-	},
-};
-
-/**
- * PII categories that actually have a detection pattern today — the source of
- * truth for what redaction can detect. Any {@link PiiDetectionType} mapped to
- * `undefined` in {@link PII_PATTERNS} (declared but not yet implemented) is
- * excluded here.
- */
-export const SUPPORTED_PII_CATEGORIES: PiiDetectionType[] = (
-	Object.keys(PII_PATTERNS) as PiiDetectionType[]
-).filter((type) => PII_PATTERNS[type] !== undefined);
+/** Detection table for Node callers: the shared set, checksum-gated wallets. */
+export const PII_PATTERNS: PiiPatternTable = createPiiPatterns({
+	'crypto-wallet': { ...WALLET_PATTERN, validate: isCryptoWallet },
+});
 
 /** Resolve the active pattern set for the given options. */
 export function resolvePatterns(opts: {
 	secrets: boolean;
 	detect: readonly PiiDetectionType[];
 }): RedactionPattern[] {
-	const patterns: RedactionPattern[] = [];
-	if (opts.secrets) patterns.push(...SECRET_PATTERNS);
-	for (const type of opts.detect) {
-		const pattern = PII_PATTERNS[type];
-		if (pattern) patterns.push(pattern);
-	}
-	return patterns;
+	return resolvePatternsWith(opts, PII_PATTERNS);
 }

--- a/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
@@ -1,30 +1,25 @@
-import type { RedactionCategory } from './patterns';
-import { resolvePatterns } from './patterns';
+import {
+	findMatchRanges as findMatchRangesWith,
+	redactDeep as redactDeepWith,
+	redactText as redactTextWith,
+	type DeepRedactionResult,
+	type RedactionOptions,
+	type RedactionResult,
+} from '@n8n/utils/redaction/redact-text';
+
+import { PII_PATTERNS } from './patterns';
 import type { BuiltGuardrail, PiiDetectionType } from '../../types';
 
-export const DEFAULT_PLACEHOLDER = '[REDACTED]';
+export { DEFAULT_PLACEHOLDER } from '@n8n/utils/redaction/redact-text';
+export type { RedactionOptions, RedactionResult, DeepRedactionResult };
 
-export interface RedactionOptions {
-	/** Scan for credential/secret patterns. Defaults to `true`. */
-	secrets?: boolean;
-	/** PII categories to scan for. Defaults to none. */
-	detect?: readonly PiiDetectionType[];
-	/** Replacement text for a match. Defaults to `[REDACTED]`. */
-	placeholder?: string;
-	/** For `url` matches, keep origin + path + query names and redact the
-	 *  value-bearing parts: query values, token-like path segments (webhook
-	 *  secrets), userinfo, fragment. Off by default so guardrail behavior is
-	 *  unchanged; telemetry/trace scrubbing opts in. */
-	preserveUrlStructure?: boolean;
-	/** Replace values under secret-shaped object keys. */
-	redactSensitiveKeys?: boolean;
-}
-
-export interface RedactionResult {
-	/** The input with every detected match replaced by the placeholder. */
-	text: string;
-	/** One entry per replaced match (category only — never the value). */
-	matches: Array<{ category: RedactionCategory }>;
+/**
+ * The engine lives in `@n8n/utils` so the frontend can apply the same policy.
+ * These wrappers bind it to the Node detection table (checksum-verified crypto
+ * wallets); everything else is shared code.
+ */
+function withNodePatterns(opts: RedactionOptions): RedactionOptions {
+	return { ...opts, piiPatterns: opts.piiPatterns ?? PII_PATTERNS };
 }
 
 /**
@@ -44,76 +39,7 @@ export function redactionOptionsFromGuardrail(guardrail: BuiltGuardrail): Redact
  * already-redacted placeholders are left untouched by the underlying patterns.
  */
 export function redactText(input: string, opts: RedactionOptions = {}): RedactionResult {
-	const placeholder = opts.placeholder ?? DEFAULT_PLACEHOLDER;
-	const patterns = resolvePatterns({
-		secrets: opts.secrets ?? true,
-		detect: opts.detect ?? [],
-	});
-	// In preserve mode the url pass runs FIRST: it rewrites URLs with a URL-safe
-	// placeholder before other patterns can plant one containing `]` mid-URL —
-	// `]` stops the url regex, which would hide the URL's tail (and any secrets
-	// in it) from this pass entirely.
-	const ordered = opts.preserveUrlStructure
-		? [
-				...patterns.filter((pattern) => pattern.category === 'url'),
-				...patterns.filter((pattern) => pattern.category !== 'url'),
-			]
-		: patterns;
-
-	const matches: Array<{ category: RedactionCategory }> = [];
-	let text = input;
-
-	for (const pattern of ordered) {
-		// `replace` with a global regex scans from 0 and resets lastIndex, so the
-		// shared precompiled regex is safe to reuse across calls.
-		text = text.replace(pattern.regex, (match) => {
-			if (pattern.validate && !pattern.validate(match)) return match;
-			if (opts.preserveUrlStructure && pattern.category === 'url') {
-				const rebuilt = stripUrlSensitiveParts(match, placeholder);
-				if (rebuilt !== match) matches.push({ category: pattern.category });
-				return rebuilt;
-			}
-			matches.push({ category: pattern.category });
-			return placeholder;
-		});
-	}
-
-	return { text, matches };
-}
-
-/** True for a path segment that looks like an embedded token — webhook-style
- *  services (Slack/Discord/Telegram, …) carry their secret as a path segment.
- *  Shape-based on purpose: per-service URL grammars don't scale across hundreds
- *  of integrations. Conservative: words, readable slugs and digit-only ids are
- *  kept. */
-function isTokenLikeSegment(segment: string): boolean {
-	if (segment.length >= 16 && /[A-Za-z]/.test(segment) && /\d/.test(segment)) return true;
-	// Long single-class opaque blob (e.g. a letters-only token) — real words stay
-	// shorter and readable slugs contain separators.
-	return segment.length >= 24 && /^[A-Za-z]+$/.test(segment);
-}
-
-/** Keep origin + path (token-like segments redacted) + query names; redact
- *  query values, drop userinfo and fragment. The replacement is URL-safe (no
- *  `]`, which the url regex stops at) so re-scrubbing is stable. Unparseable ⇒
- *  fully redacted. */
-function stripUrlSensitiveParts(match: string, placeholder: string): string {
-	const urlPlaceholder = placeholder.replace(/[^A-Za-z0-9_.~-]/g, '') || 'REDACTED';
-	try {
-		const url = new URL(match);
-		const pathname = url.pathname
-			.split('/')
-			.map((segment) => (isTokenLikeSegment(segment) ? urlPlaceholder : segment))
-			.join('/');
-		const names = [...url.searchParams.keys()];
-		const query =
-			names.length > 0
-				? `?${names.map((name) => `${encodeURIComponent(name)}=${urlPlaceholder}`).join('&')}`
-				: '';
-		return `${url.origin}${pathname}${query}`;
-	} catch {
-		return placeholder;
-	}
+	return redactTextWith(input, withNodePatterns(opts));
 }
 
 /**
@@ -125,95 +51,18 @@ export function findMatchRanges(
 	input: string,
 	opts: RedactionOptions = {},
 ): Array<[number, number]> {
-	const patterns = resolvePatterns({
-		secrets: opts.secrets ?? true,
-		detect: opts.detect ?? [],
-	});
-
-	const ranges: Array<[number, number]> = [];
-	for (const pattern of patterns) {
-		const { regex } = pattern;
-		// Reset before the scan loop; reusing the shared global regex is safe
-		// because usage is synchronous and the loop always runs to completion.
-		regex.lastIndex = 0;
-		let match: RegExpExecArray | null;
-		while ((match = regex.exec(input)) !== null) {
-			if (match[0].length === 0) {
-				regex.lastIndex++;
-				continue;
-			}
-			if (pattern.validate && !pattern.validate(match[0])) continue;
-			ranges.push([match.index, match.index + match[0].length]);
-		}
-	}
-	return ranges;
-}
-
-const MAX_DEEP_DEPTH = 8;
-const SENSITIVE_KEY_PATTERN =
-	/(api[_-]?key|private[_-]?key|authorization|bearer|cookie|credentials?|password|secret|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|auth[_-]?token|(?:^|[._-])token$)/i;
-
-export interface DeepRedactionResult {
-	value: unknown;
-	matches: Array<{ category: RedactionCategory }>;
+	return findMatchRangesWith(input, withNodePatterns(opts));
 }
 
 /**
  * Recursively redact string values inside an arbitrary JSON-like value
  * (tool results, structured payloads). Object keys are left intact; only
- * string values are scanned. Recursion is depth-bounded as a cheap guard
- * against pathological/cyclic structures.
+ * string values are scanned.
  */
 export function redactDeep(
 	value: unknown,
 	opts: RedactionOptions = {},
 	depth = 0,
 ): DeepRedactionResult {
-	return redactDeepValue(value, opts, depth);
-}
-
-function redactDeepValue(
-	value: unknown,
-	opts: RedactionOptions,
-	depth: number,
-	key?: string,
-): DeepRedactionResult {
-	if (opts.redactSensitiveKeys && key && SENSITIVE_KEY_PATTERN.test(key)) {
-		return { value: opts.placeholder ?? DEFAULT_PLACEHOLDER, matches: [{ category: 'secret' }] };
-	}
-
-	if (typeof value === 'string') {
-		const { text, matches } = redactText(value, opts);
-		return { value: text, matches };
-	}
-
-	if (depth >= MAX_DEEP_DEPTH) {
-		if (opts.redactSensitiveKeys && value !== null && typeof value === 'object') {
-			return { value: opts.placeholder ?? DEFAULT_PLACEHOLDER, matches: [{ category: 'secret' }] };
-		}
-		return { value, matches: [] };
-	}
-
-	if (Array.isArray(value)) {
-		const matches: Array<{ category: RedactionCategory }> = [];
-		const next = value.map((item) => {
-			const result = redactDeepValue(item, opts, depth + 1, key);
-			matches.push(...result.matches);
-			return result.value;
-		});
-		return { value: next, matches };
-	}
-
-	if (value !== null && typeof value === 'object') {
-		const matches: Array<{ category: RedactionCategory }> = [];
-		const next: Record<string, unknown> = {};
-		for (const [key, item] of Object.entries(value)) {
-			const result = redactDeepValue(item, opts, depth + 1, key);
-			matches.push(...result.matches);
-			next[key] = result.value;
-		}
-		return { value: next, matches };
-	}
-
-	return { value, matches: [] };
+	return redactDeepWith(value, withNodePatterns(opts), depth);
 }

--- a/packages/@n8n/agents/src/types/sdk/guardrail.ts
+++ b/packages/@n8n/agents/src/types/sdk/guardrail.ts
@@ -1,15 +1,7 @@
 export type GuardrailType = 'pii' | 'prompt-injection' | 'moderation' | 'custom';
 export type GuardrailStrategy = 'block' | 'redact' | 'warn';
-export type PiiDetectionType =
-	| 'email'
-	| 'phone'
-	| 'credit-card'
-	| 'ssn-us'
-	| 'iban'
-	| 'crypto-wallet'
-	| 'ip'
-	| 'mac'
-	| 'url';
+/** Re-exported so the detection vocabulary has one definition (see `@n8n/utils`). */
+export type { PiiDetectionType } from '@n8n/utils/redaction/pii-patterns';
 
 export interface BuiltGuardrail {
 	readonly name: string;

--- a/packages/@n8n/telemetry/package.json
+++ b/packages/@n8n/telemetry/package.json
@@ -23,6 +23,7 @@
     "dist/**/*"
   ],
   "dependencies": {
+    "@n8n/utils": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/@n8n/telemetry/src/__tests__/redaction.test.ts
+++ b/packages/@n8n/telemetry/src/__tests__/redaction.test.ts
@@ -1,4 +1,4 @@
-import { redactTelemetryProperties, redactTelemetryText } from '../telemetry-redaction';
+import { redactTelemetryProperties, redactTelemetryText } from '../redaction';
 
 describe('redactTelemetryText', () => {
 	it('leaves ordinary assistant prose untouched', () => {
@@ -35,6 +35,22 @@ describe('redactTelemetryText', () => {
 
 		expect(redacted).toHaveLength(8_003);
 		expect(redacted.endsWith('...')).toBe(true);
+	});
+
+	it('keeps a size-gated value whole when the cap is lifted', () => {
+		const workflowJson = JSON.stringify({
+			nodes: [
+				{ url: 'https://api.example.com/v1/orders?token=abc123xyz', note: 'x'.repeat(20_000) },
+			],
+		});
+
+		const redacted = redactTelemetryText(workflowJson, { maxLength: Infinity });
+
+		expect(redacted).not.toContain('abc123xyz');
+		expect(redacted.length).toBeGreaterThan(20_000);
+		// The placeholder carries no JSON-breaking characters, so the blob stays parseable.
+		// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse -- asserting it parses
+		expect(() => JSON.parse(redacted) as unknown).not.toThrow();
 	});
 
 	it('passes through the empty string', () => {

--- a/packages/@n8n/telemetry/src/index.ts
+++ b/packages/@n8n/telemetry/src/index.ts
@@ -8,5 +8,7 @@ export type {
 	TelemetryEventInput,
 	TelemetryEventRegistry,
 } from './define';
+export { redactTelemetryProperties, redactTelemetryText } from './redaction';
+export type { TelemetryTextOptions } from './redaction';
 export { collectDuplicateNames, validateEntrySchemas } from './registry-checks';
 export { TELEMETRY_EVENT } from './telemetry-events';

--- a/packages/@n8n/telemetry/src/redaction.ts
+++ b/packages/@n8n/telemetry/src/redaction.ts
@@ -1,17 +1,15 @@
-import {
-	DEFAULT_PLACEHOLDER,
-	redactText,
-	SUPPORTED_PII_CATEGORIES,
-	type RedactionOptions,
-} from '@n8n/agents';
-import type { GenericValue, ITelemetryTrackProperties } from 'n8n-workflow';
+import { SUPPORTED_PII_CATEGORIES } from '@n8n/utils/redaction/pii-patterns';
+import { DEFAULT_PLACEHOLDER, redactText } from '@n8n/utils/redaction/redact-text';
+import type { RedactionOptions } from '@n8n/utils/redaction/redact-text';
 
 /**
  * Egress policy for free-text values leaving the instance as product telemetry
- * (RudderStack/PostHog). Mirrors the LangSmith exporter's policy
- * (`DEFAULT_TELEMETRY_REDACTION_OPTIONS` in the instance-ai package) and is
- * deliberately stricter than the user-facing output policy: secrets plus every
- * PII category.
+ * (RudderStack/PostHog). Deliberately stricter than the user-facing output
+ * policy: secrets plus every PII category.
+ *
+ * Shared by the backend and the editor UI. Frontend events reach RudderStack
+ * *and* PostHog straight from the browser, so redaction has to happen at the
+ * call site — there is no server hop that sees both.
  *
  * `preserveUrlStructure` keeps traced URLs readable; their value-bearing parts
  * are still redacted and secrets are matched first.
@@ -23,9 +21,10 @@ const TELEMETRY_REDACTION_OPTIONS: RedactionOptions = {
 };
 
 /**
- * Length cap for a single free-text telemetry property. `Telemetry.track`
- * silently drops any event whose serialized payload exceeds 32 KB, so an
- * uncapped assistant message loses the whole event; this keeps it well under.
+ * Length cap for a single free-text telemetry property. RudderStack silently
+ * drops any event whose serialized payload exceeds 32 KB, so an uncapped
+ * assistant message or workflow JSON loses the whole event; this keeps it well
+ * under.
  */
 const MAX_TELEMETRY_TEXT_LENGTH = 8_000;
 
@@ -61,25 +60,36 @@ function toSnakeCase(key: string): string {
 
 /**
  * Telemetry payloads are flat in practice. Rather than let an unexpectedly deep
- * value through unscrubbed (INS-685), replace it with a marker.
+ * value through unscrubbed, replace it with a marker.
  */
 const MAX_PROPERTY_DEPTH = 5;
 const OVER_DEPTH_MARKER = '[REDACTED_DEPTH]';
 
-/** Scrub secrets/PII from a free-text telemetry value and cap its length. */
-export function redactTelemetryText(value: string): string {
-	const redacted = redactText(value, TELEMETRY_REDACTION_OPTIONS).text;
+/** JSON-ish value accepted in a telemetry property bag. */
+type TelemetryValue = string | number | boolean | object | null | undefined;
 
-	return redacted.length > MAX_TELEMETRY_TEXT_LENGTH
-		? `${redacted.slice(0, MAX_TELEMETRY_TEXT_LENGTH)}...`
-		: redacted;
+export interface TelemetryTextOptions {
+	/**
+	 * Override the default {@link MAX_TELEMETRY_TEXT_LENGTH} cap. Pass
+	 * `Infinity` for values that are already size-gated by the caller and would
+	 * lose meaning truncated — a serialized workflow or execution payload.
+	 */
+	maxLength?: number;
 }
 
-function isNonNullObject(value: GenericValue): value is object {
+/** Scrub secrets/PII from a free-text telemetry value and cap its length. */
+export function redactTelemetryText(value: string, opts: TelemetryTextOptions = {}): string {
+	const maxLength = opts.maxLength ?? MAX_TELEMETRY_TEXT_LENGTH;
+	const redacted = redactText(value, TELEMETRY_REDACTION_OPTIONS).text;
+
+	return redacted.length > maxLength ? `${redacted.slice(0, maxLength)}...` : redacted;
+}
+
+function isNonNullObject(value: TelemetryValue): value is object {
 	return value !== null && typeof value === 'object';
 }
 
-function redactPropertyValue(key: string, value: GenericValue, depth: number): GenericValue {
+function redactPropertyValue(key: string, value: TelemetryValue, depth: number): TelemetryValue {
 	// Runs before the identifier exemption: a secret-shaped key wins over any
 	// key-based pass-through. Numbers/booleans are left alone — they can't carry
 	// a secret, and flags like `has_token` are worth keeping.
@@ -96,14 +106,18 @@ function redactPropertyValue(key: string, value: GenericValue, depth: number): G
 
 	if (Array.isArray(value)) {
 		if (depth >= MAX_PROPERTY_DEPTH) return OVER_DEPTH_MARKER;
-		return value.map((entry: GenericValue) => redactPropertyValue(key, entry, depth + 1));
+		return value.map((entry: TelemetryValue) => redactPropertyValue(key, entry, depth + 1));
 	}
 
 	if (isNonNullObject(value)) {
 		if (depth >= MAX_PROPERTY_DEPTH) return OVER_DEPTH_MARKER;
-		const redacted: Record<string, GenericValue> = {};
+		const redacted: Record<string, TelemetryValue> = {};
 		for (const [nestedKey, nestedValue] of Object.entries(value)) {
-			redacted[nestedKey] = redactPropertyValue(nestedKey, nestedValue as GenericValue, depth + 1);
+			redacted[nestedKey] = redactPropertyValue(
+				nestedKey,
+				nestedValue as TelemetryValue,
+				depth + 1,
+			);
 		}
 		return redacted;
 	}
@@ -113,15 +127,15 @@ function redactPropertyValue(key: string, value: GenericValue, depth: number): G
 
 /**
  * Scrub every free-text value in a telemetry payload. Used at boundaries where
- * the property bag is open-ended — notably the `trackTelemetry` channel handed
- * to tools, whose payloads (search queries, remediation reasons, node error
- * strings) are model- or user-derived and can't be audited call site by call
- * site. Identifier keys and non-string values pass through untouched.
+ * the property bag is open-ended — a `trackTelemetry` channel handed to tools,
+ * or a frontend event whose payload carries user prose — and the values can't
+ * be audited call site by call site. Identifier keys and non-string values pass
+ * through untouched.
  */
-export function redactTelemetryProperties(
-	properties: ITelemetryTrackProperties,
-): ITelemetryTrackProperties {
-	const redacted: ITelemetryTrackProperties = {};
+export function redactTelemetryProperties<T extends Record<string, TelemetryValue>>(
+	properties: T,
+): Record<string, TelemetryValue> {
+	const redacted: Record<string, TelemetryValue> = {};
 	for (const [key, value] of Object.entries(properties)) {
 		redacted[key] = redactPropertyValue(key, value, 0);
 	}

--- a/packages/@n8n/utils/src/redaction/pii-patterns.ts
+++ b/packages/@n8n/utils/src/redaction/pii-patterns.ts
@@ -1,0 +1,267 @@
+import { SECRET_VALUE_PATTERNS } from '../scrub-secrets';
+
+/**
+ * PII categories the detection vocabulary knows about. A category may be
+ * declared here before a pattern exists for it — see {@link PII_PATTERNS}.
+ */
+export type PiiDetectionType =
+	| 'email'
+	| 'phone'
+	| 'credit-card'
+	| 'ssn-us'
+	| 'iban'
+	| 'crypto-wallet'
+	| 'ip'
+	| 'mac'
+	| 'url';
+
+/**
+ * A category attached to every redaction match so callers can log *what kind*
+ * of sensitive content was removed without ever handling the value itself.
+ * `'secret'` covers credential/token patterns; the rest mirror
+ * {@link PiiDetectionType}.
+ */
+export type RedactionCategory = 'secret' | PiiDetectionType;
+
+export interface RedactionPattern {
+	readonly category: RedactionCategory;
+	/**
+	 * Precompiled regex matching the sensitive value. Always global — the
+	 * redactor relies on `g` both for replace-all and for the `exec` scan loop.
+	 * Compiled once at module load; callers reset `lastIndex` before reuse.
+	 */
+	readonly regex: RegExp;
+	/**
+	 * Optional gate: a candidate match is only redacted when this returns
+	 * `true`. Used to suppress false positives (e.g. Luhn check for cards).
+	 */
+	readonly validate?: (match: string) => boolean;
+}
+
+export type PiiPatternTable = Readonly<Record<PiiDetectionType, RedactionPattern | undefined>>;
+
+/** Compile a global regex once, adding the `g` flag if the source omits it. */
+function globalRegex(source: string, flags = ''): RegExp {
+	return new RegExp(source, flags.includes('g') ? flags : `${flags}g`);
+}
+
+/**
+ * Secret/credential patterns, sourced from {@link SECRET_VALUE_PATTERNS} so
+ * there is a single place that defines what a credential looks like.
+ */
+const SECRET_PATTERNS: readonly RedactionPattern[] = SECRET_VALUE_PATTERNS.map((re) => ({
+	category: 'secret',
+	regex: globalRegex(re.source, re.flags),
+}));
+
+/** Luhn checksum — used to keep credit-card redaction from firing on any long digit run. */
+export function passesLuhn(candidate: string): boolean {
+	const digits = candidate.replace(/\D/g, '');
+	if (digits.length < 13 || digits.length > 19) return false;
+
+	let sum = 0;
+	let double = false;
+	for (let i = digits.length - 1; i >= 0; i--) {
+		let digit = digits.charCodeAt(i) - 48;
+		if (double) {
+			digit *= 2;
+			if (digit > 9) digit -= 9;
+		}
+		sum += digit;
+		double = !double;
+	}
+	return sum % 10 === 0;
+}
+
+/**
+ * Confidence gate for phone candidates, encoding the **E.164** standard: a
+ * leading `+`, a non-zero country code, and 7–15 digits total. Runs on the
+ * digit/`+`-only normalized form (separators stripped).
+ */
+function passesE164(candidate: string): boolean {
+	return /^\+[1-9]\d{6,14}$/.test(candidate.replace(/[^\d+]/g, ''));
+}
+
+/**
+ * IBAN mod-97 checksum (ISO 13616): drop spaces, move the first 4 chars to the
+ * end, map letters A–Z → 10–35, and confirm the big-integer value mod 97 === 1.
+ */
+export function passesIbanChecksum(candidate: string): boolean {
+	const compact = candidate.replace(/\s/g, '').toUpperCase();
+	if (!/^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$/.test(compact)) return false;
+
+	const rearranged = compact.slice(4) + compact.slice(0, 4);
+	let remainder = 0;
+	for (let i = 0; i < rearranged.length; i++) {
+		const code = rearranged.charCodeAt(i);
+		const value = code >= 65 ? code - 55 : code - 48; // 'A'→10 … 'Z'→35, '0'→0 … '9'→9
+		remainder = value > 9 ? (remainder * 100 + value) % 97 : (remainder * 10 + value) % 97;
+	}
+	return remainder === 1;
+}
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+export function base58Decode(input: string): Uint8Array | undefined {
+	const bytes: number[] = [];
+	for (let i = 0; i < input.length; i++) {
+		let carry = BASE58_ALPHABET.indexOf(input[i]);
+		if (carry === -1) return undefined;
+		for (let j = 0; j < bytes.length; j++) {
+			carry += bytes[j] * 58;
+			bytes[j] = carry & 0xff;
+			carry >>= 8;
+		}
+		while (carry > 0) {
+			bytes.push(carry & 0xff);
+			carry >>= 8;
+		}
+	}
+	for (let i = 0; i < input.length && input[i] === '1'; i++) bytes.push(0);
+	return Uint8Array.from(bytes.reverse());
+}
+
+/**
+ * Ethereum (`0x`+40 hex) or Bitcoin bech32 (`bc1`/`tb1`) — both distinctive
+ * enough to accept on shape alone.
+ */
+function isDistinctiveWalletShape(match: string): boolean {
+	if (/^0x[0-9a-fA-F]{40}$/.test(match)) return true;
+	return /^(?:bc1|tb1)[023456789acdefghjklmnpqrstuvwxyz]{11,71}$/.test(match);
+}
+
+/**
+ * Default legacy-address gate: a Base58Check payload decodes to exactly 25
+ * bytes (1 version + 20 hash + 4 checksum). Verifying the checksum itself needs
+ * SHA-256, which has no synchronous cross-platform primitive — Node callers
+ * inject the stricter check via `createPiiPatterns`. Erring toward redaction is
+ * the safe direction: an unvalidated Base58 blob of that length is far more
+ * likely to be a credential than prose.
+ */
+function isLegacyWalletShape(match: string): boolean {
+	return base58Decode(match)?.length === 25;
+}
+
+/** Ethereum, Bitcoin bech32, or a legacy Base58 address of plausible length. */
+export function isCryptoWalletShape(match: string): boolean {
+	return isDistinctiveWalletShape(match) || isLegacyWalletShape(match);
+}
+
+/**
+ * Conservative, high-confidence PII patterns. Phone detection is best-effort:
+ * only well-structured (E.164) formats are matched. New {@link PiiDetectionType}
+ * categories slot in here; a category may map to `undefined` to declare it
+ * before a pattern exists, in which case it is excluded from detection.
+ *
+ * `overrides` swaps individual entries — used by `@n8n/agents` to layer its
+ * Node-only Base58Check validator onto `crypto-wallet`.
+ */
+export function createPiiPatterns(
+	overrides: Partial<Record<PiiDetectionType, RedactionPattern>> = {},
+): PiiPatternTable {
+	/* eslint-disable @typescript-eslint/naming-convention -- category ids are the
+	   public `PiiDetectionType` vocabulary, which is kebab-case */
+	return {
+		email: {
+			category: 'email',
+			regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+		},
+		'credit-card': {
+			category: 'credit-card',
+			// 13-19 digits, optionally grouped by single spaces or dashes.
+			regex: /\b\d(?:[ -]?\d){12,18}\b/g,
+			validate: passesLuhn,
+		},
+		'ssn-us': {
+			category: 'ssn-us',
+			// US Social Security Number, dashed form only (123-45-6789). Bare 9-digit
+			// runs are intentionally not matched (too false-positive-prone). Per-country
+			// national IDs each get their own `ssn-<cc>` category (e.g. a future `ssn-uk`).
+			regex: /\b\d{3}-\d{2}-\d{4}\b/g,
+		},
+		phone: {
+			category: 'phone',
+			// Best-effort, E.164 only: a leading `+` then 7–15 digits, tolerating
+			// the spaces/parens/dots/dashes people write between groups
+			// (e.g. `+1 (555) 123-4567`). Requiring the `+` keeps false positives
+			// low — bare digit runs (IDs, dates, NANP without `+`) are not matched.
+			regex: /\+\d(?:[\s().-]*\d){6,14}\b/g,
+			validate: passesE164,
+		},
+		iban: {
+			category: 'iban',
+			// Two forms: the compact (un-spaced) IBAN is matched case-insensitively so
+			// lower/mixed-case IBANs are caught — with no internal spaces it can't bleed
+			// into a following word. The spaced, group-of-4 form is matched upper-case
+			// only: spaced IBANs are written upper-case by convention, and that keeps the
+			// greedy body from swallowing following lower-case prose (which would fail the
+			// checksum and suppress redaction, since the engine doesn't retry sub-matches).
+			// `passesIbanChecksum` upper-cases, strips spaces, and verifies mod-97.
+			regex: /\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b|\b[A-Z]{2}\d{2}(?: [A-Z0-9]{1,4}){2,8}\b/g,
+			validate: passesIbanChecksum,
+		},
+		'crypto-wallet': {
+			category: 'crypto-wallet',
+			// Ethereum `0x…40hex`, Bitcoin bech32 `bc1…`/`tb1…`, or Bitcoin Base58Check.
+			regex:
+				/\b(?:0x[0-9a-fA-F]{40}|(?:bc1|tb1)[023456789acdefghjklmnpqrstuvwxyz]{11,71}|[13][1-9A-HJ-NP-Za-km-z]{25,34})\b/g,
+			validate: isCryptoWalletShape,
+		},
+		// `mac` is declared before `ip`: a MAC is colon-delimited hex and would also
+		// match the IPv6 branch, so matching it as `mac` first keeps the category right.
+		mac: {
+			category: 'mac',
+			regex: /\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b/g,
+		},
+		ip: {
+			category: 'ip',
+			// IPv4 (octets validated) or IPv6 (full and `::`-compressed forms).
+			regex:
+				/\b(?:\d{1,3}\.){3}\d{1,3}\b|\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b|\b(?:[A-Fa-f0-9]{1,4}:){1,7}:(?:[A-Fa-f0-9]{1,4})?\b/g,
+			validate: isIpAddress,
+		},
+		url: {
+			category: 'url',
+			// Whole http(s) URL. Stops at whitespace and common trailing delimiters.
+			regex: /\bhttps?:\/\/[^\s<>"')\]}]+/g,
+		},
+		...overrides,
+	};
+	/* eslint-enable @typescript-eslint/naming-convention */
+}
+
+/** IPv4 with octets ≤ 255, or a colon-delimited IPv6 (shape already constrained by the regex). */
+function isIpAddress(match: string): boolean {
+	if (match.includes(':')) return true;
+	const octets = match.split('.');
+	return octets.length === 4 && octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255);
+}
+
+/** Browser-safe default table. Node callers layer stricter validators on top. */
+export const PII_PATTERNS = createPiiPatterns();
+
+/**
+ * PII categories that actually have a detection pattern today — the source of
+ * truth for what redaction can detect. Any {@link PiiDetectionType} mapped to
+ * `undefined` in the table (declared but not yet implemented) is excluded here.
+ */
+export const SUPPORTED_PII_CATEGORIES: PiiDetectionType[] = (
+	Object.keys(PII_PATTERNS) as PiiDetectionType[]
+).filter((type) => PII_PATTERNS[type] !== undefined);
+
+/** Resolve the active pattern set for the given options. */
+export function resolvePatterns(
+	opts: {
+		secrets: boolean;
+		detect: readonly PiiDetectionType[];
+	},
+	piiPatterns: PiiPatternTable = PII_PATTERNS,
+): RedactionPattern[] {
+	const patterns: RedactionPattern[] = [];
+	if (opts.secrets) patterns.push(...SECRET_PATTERNS);
+	for (const type of opts.detect) {
+		const pattern = piiPatterns[type];
+		if (pattern) patterns.push(pattern);
+	}
+	return patterns;
+}

--- a/packages/@n8n/utils/src/redaction/redact-text.test.ts
+++ b/packages/@n8n/utils/src/redaction/redact-text.test.ts
@@ -1,0 +1,39 @@
+import { SUPPORTED_PII_CATEGORIES } from './pii-patterns';
+import { redactText } from './redact-text';
+
+describe('redactText', () => {
+	it('redacts secrets and PII while keeping URL structure', () => {
+		const { text } = redactText(
+			'mail jane@example.com from https://api.example.com/v1/orders?token=abc123xyz',
+			{ secrets: true, detect: SUPPORTED_PII_CATEGORIES, preserveUrlStructure: true },
+		);
+
+		expect(text).not.toContain('jane@example.com');
+		expect(text).not.toContain('abc123xyz');
+		expect(text).toContain('https://api.example.com/v1/orders');
+	});
+
+	it('leaves text with nothing sensitive untouched', () => {
+		const input = 'I added an HTTP Request node and connected it to the Schedule Trigger.';
+
+		expect(redactText(input, { detect: SUPPORTED_PII_CATEGORIES }).text).toBe(input);
+	});
+
+	describe('crypto-wallet detection without a synchronous SHA-256', () => {
+		it('redacts a valid legacy address', () => {
+			expect(
+				redactText('to 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', { detect: ['crypto-wallet'] }).text,
+			).toBe('to [REDACTED]');
+		});
+
+		it('also redacts one whose checksum is broken', () => {
+			// The browser table can only length-check Base58 payloads, so it redacts a
+			// superset of what `@n8n/agents` does (which verifies the checksum and
+			// leaves this string alone). Over-redacting an opaque blob is the safe
+			// direction for an egress boundary.
+			expect(
+				redactText('addr 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNb', { detect: ['crypto-wallet'] }).text,
+			).toBe('addr [REDACTED]');
+		});
+	});
+});

--- a/packages/@n8n/utils/src/redaction/redact-text.ts
+++ b/packages/@n8n/utils/src/redaction/redact-text.ts
@@ -1,0 +1,218 @@
+import type { PiiDetectionType, PiiPatternTable, RedactionCategory } from './pii-patterns';
+import { resolvePatterns } from './pii-patterns';
+
+export const DEFAULT_PLACEHOLDER = '[REDACTED]';
+
+export interface RedactionOptions {
+	/** Scan for credential/secret patterns. Defaults to `true`. */
+	secrets?: boolean;
+	/** PII categories to scan for. Defaults to none. */
+	detect?: readonly PiiDetectionType[];
+	/** Replacement text for a match. Defaults to `[REDACTED]`. */
+	placeholder?: string;
+	/** For `url` matches, keep origin + path + query names and redact the
+	 *  value-bearing parts: query values, token-like path segments (webhook
+	 *  secrets), userinfo, fragment. Off by default so guardrail behavior is
+	 *  unchanged; telemetry/trace scrubbing opts in. */
+	preserveUrlStructure?: boolean;
+	/** Replace values under secret-shaped object keys. */
+	redactSensitiveKeys?: boolean;
+	/**
+	 * Detection table to resolve PII categories against. Defaults to the
+	 * browser-safe {@link PII_PATTERNS}; `@n8n/agents` passes a table whose
+	 * `crypto-wallet` entry carries the Node-only Base58Check validator.
+	 */
+	piiPatterns?: PiiPatternTable;
+}
+
+export interface RedactionResult {
+	/** The input with every detected match replaced by the placeholder. */
+	text: string;
+	/** One entry per replaced match (category only — never the value). */
+	matches: Array<{ category: RedactionCategory }>;
+}
+
+/**
+ * Redact secret/PII patterns from a complete string. Pure and idempotent —
+ * already-redacted placeholders are left untouched by the underlying patterns.
+ */
+export function redactText(input: string, opts: RedactionOptions = {}): RedactionResult {
+	const placeholder = opts.placeholder ?? DEFAULT_PLACEHOLDER;
+	const patterns = resolvePatterns(
+		{
+			secrets: opts.secrets ?? true,
+			detect: opts.detect ?? [],
+		},
+		opts.piiPatterns,
+	);
+	// In preserve mode the url pass runs FIRST: it rewrites URLs with a URL-safe
+	// placeholder before other patterns can plant one containing `]` mid-URL —
+	// `]` stops the url regex, which would hide the URL's tail (and any secrets
+	// in it) from this pass entirely.
+	const ordered = opts.preserveUrlStructure
+		? [
+				...patterns.filter((pattern) => pattern.category === 'url'),
+				...patterns.filter((pattern) => pattern.category !== 'url'),
+			]
+		: patterns;
+
+	const matches: Array<{ category: RedactionCategory }> = [];
+	let text = input;
+
+	for (const pattern of ordered) {
+		// `replace` with a global regex scans from 0 and resets lastIndex, so the
+		// shared precompiled regex is safe to reuse across calls.
+		text = text.replace(pattern.regex, (match) => {
+			if (pattern.validate && !pattern.validate(match)) return match;
+			if (opts.preserveUrlStructure && pattern.category === 'url') {
+				const rebuilt = stripUrlSensitiveParts(match, placeholder);
+				if (rebuilt !== match) matches.push({ category: pattern.category });
+				return rebuilt;
+			}
+			matches.push({ category: pattern.category });
+			return placeholder;
+		});
+	}
+
+	return { text, matches };
+}
+
+/** True for a path segment that looks like an embedded token — webhook-style
+ *  services (Slack/Discord/Telegram, …) carry their secret as a path segment.
+ *  Shape-based on purpose: per-service URL grammars don't scale across hundreds
+ *  of integrations. Conservative: words, readable slugs and digit-only ids are
+ *  kept. */
+function isTokenLikeSegment(segment: string): boolean {
+	if (segment.length >= 16 && /[A-Za-z]/.test(segment) && /\d/.test(segment)) return true;
+	// Long single-class opaque blob (e.g. a letters-only token) — real words stay
+	// shorter and readable slugs contain separators.
+	return segment.length >= 24 && /^[A-Za-z]+$/.test(segment);
+}
+
+/** Keep origin + path (token-like segments redacted) + query names; redact
+ *  query values, drop userinfo and fragment. The replacement is URL-safe (no
+ *  `]`, which the url regex stops at) so re-scrubbing is stable. Unparseable ⇒
+ *  fully redacted. */
+function stripUrlSensitiveParts(match: string, placeholder: string): string {
+	const urlPlaceholder = placeholder.replace(/[^A-Za-z0-9_.~-]/g, '') || 'REDACTED';
+	try {
+		const url = new URL(match);
+		const pathname = url.pathname
+			.split('/')
+			.map((segment) => (isTokenLikeSegment(segment) ? urlPlaceholder : segment))
+			.join('/');
+		const names = [...url.searchParams.keys()];
+		const query =
+			names.length > 0
+				? `?${names.map((name) => `${encodeURIComponent(name)}=${urlPlaceholder}`).join('&')}`
+				: '';
+		return `${url.origin}${pathname}${query}`;
+	} catch {
+		return placeholder;
+	}
+}
+
+/**
+ * Find the `[start, end)` ranges of every (validated) match in `input`. Used by
+ * the streaming redactor to avoid emitting through the middle of a complete
+ * match that contains internal whitespace (e.g. a spaced credit-card number).
+ */
+export function findMatchRanges(
+	input: string,
+	opts: RedactionOptions = {},
+): Array<[number, number]> {
+	const patterns = resolvePatterns(
+		{
+			secrets: opts.secrets ?? true,
+			detect: opts.detect ?? [],
+		},
+		opts.piiPatterns,
+	);
+
+	const ranges: Array<[number, number]> = [];
+	for (const pattern of patterns) {
+		const { regex } = pattern;
+		// Reset before the scan loop; reusing the shared global regex is safe
+		// because usage is synchronous and the loop always runs to completion.
+		regex.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = regex.exec(input)) !== null) {
+			if (match[0].length === 0) {
+				regex.lastIndex++;
+				continue;
+			}
+			if (pattern.validate && !pattern.validate(match[0])) continue;
+			ranges.push([match.index, match.index + match[0].length]);
+		}
+	}
+	return ranges;
+}
+
+const MAX_DEEP_DEPTH = 8;
+const SENSITIVE_KEY_PATTERN =
+	/(api[_-]?key|private[_-]?key|authorization|bearer|cookie|credentials?|password|secret|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|auth[_-]?token|(?:^|[._-])token$)/i;
+
+export interface DeepRedactionResult {
+	value: unknown;
+	matches: Array<{ category: RedactionCategory }>;
+}
+
+/**
+ * Recursively redact string values inside an arbitrary JSON-like value
+ * (tool results, structured payloads). Object keys are left intact; only
+ * string values are scanned. Recursion is depth-bounded as a cheap guard
+ * against pathological/cyclic structures.
+ */
+export function redactDeep(
+	value: unknown,
+	opts: RedactionOptions = {},
+	depth = 0,
+): DeepRedactionResult {
+	return redactDeepValue(value, opts, depth);
+}
+
+function redactDeepValue(
+	value: unknown,
+	opts: RedactionOptions,
+	depth: number,
+	key?: string,
+): DeepRedactionResult {
+	if (opts.redactSensitiveKeys && key && SENSITIVE_KEY_PATTERN.test(key)) {
+		return { value: opts.placeholder ?? DEFAULT_PLACEHOLDER, matches: [{ category: 'secret' }] };
+	}
+
+	if (typeof value === 'string') {
+		const { text, matches } = redactText(value, opts);
+		return { value: text, matches };
+	}
+
+	if (depth >= MAX_DEEP_DEPTH) {
+		if (opts.redactSensitiveKeys && value !== null && typeof value === 'object') {
+			return { value: opts.placeholder ?? DEFAULT_PLACEHOLDER, matches: [{ category: 'secret' }] };
+		}
+		return { value, matches: [] };
+	}
+
+	if (Array.isArray(value)) {
+		const matches: Array<{ category: RedactionCategory }> = [];
+		const next = value.map((item) => {
+			const result = redactDeepValue(item, opts, depth + 1, key);
+			matches.push(...result.matches);
+			return result.value;
+		});
+		return { value: next, matches };
+	}
+
+	if (value !== null && typeof value === 'object') {
+		const matches: Array<{ category: RedactionCategory }> = [];
+		const next: Record<string, unknown> = {};
+		for (const [key, item] of Object.entries(value)) {
+			const result = redactDeepValue(item, opts, depth + 1, key);
+			matches.push(...result.matches);
+			next[key] = result.value;
+		}
+		return { value: next, matches };
+	}
+
+	return { value, matches: [] };
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -21,6 +21,7 @@ import {
 	WorkflowEntity,
 	WorkflowRepository,
 } from '@n8n/db';
+import { redactTelemetryText } from '@n8n/telemetry';
 import { Container, Service } from '@n8n/di';
 import type {
 	InstanceAiContext,
@@ -166,7 +167,6 @@ import {
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { InstanceAiMcpRegistryService } from './mcp';
 import { listNodeDiscriminators } from './node-definition-resolver';
-import { redactTelemetryText } from './telemetry-redaction';
 import { fetchAndExtract, maybeSummarize, LRUCache } from './web-research';
 import { WorkflowTemplatesService } from './workflow-templates.service';
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -113,7 +113,7 @@ import {
 } from '@n8n/instance-ai';
 import { buildResumeData, toConfirmationData } from '@n8n/instance-ai/confirmation-payload';
 import type { Scope } from '@n8n/permissions';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
+import { redactTelemetryProperties, redactTelemetryText, TELEMETRY_EVENT } from '@n8n/telemetry';
 import { lazyImport } from '@n8n/utils/lazy-import';
 import { setSchemaBaseDirs } from '@n8n/workflow-sdk';
 import { ErrorReporter, InstanceSettings } from 'n8n-core';
@@ -198,7 +198,6 @@ import {
 	type ResumableOrphan,
 } from './suspended-run-restorer.service';
 import { SuspendedThreadPersistenceService } from './suspended-thread-persistence.service';
-import { redactTelemetryProperties, redactTelemetryText } from './telemetry-redaction';
 import {
 	InstanceAiTracingService,
 	type MessageTraceFinalization,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -1,4 +1,5 @@
 import { chatWithAssistant } from '@/features/ai/assistant/assistant.api';
+import { redactTelemetryText } from '@n8n/telemetry';
 import { type VIEWS, EDITABLE_CANVAS_VIEWS } from '@/app/constants';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { ASSISTANT_ENABLED_VIEWS } from './constants';
@@ -694,7 +695,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 			return;
 		}
 		telemetry.track('User sent message in Assistant', {
-			message,
+			message: redactTelemetryText(message),
 			is_quick_reply: isQuickReply,
 			chat_session_id: currentSessionId.value,
 			message_number: usersMessages.value.length,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -1973,6 +1973,25 @@ describe('AI Builder store', () => {
 		});
 	});
 
+	describe('telemetry redaction', () => {
+		it('scrubs secrets and PII from the tracked user message', async () => {
+			const builderStore = useBuilderStore();
+
+			apiSpy.mockImplementationOnce(() => {});
+
+			await builderStore.sendChatMessage({
+				text: 'email jane.doe@example.com using sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+			});
+
+			const [, properties] = track.mock.calls.find(
+				([event]) => event === 'User submitted builder message',
+			) as [string, { message: string }];
+			expect(properties.message).not.toContain('jane.doe@example.com');
+			expect(properties.message).not.toContain('sk-ant-api03');
+			expect(properties.message).toContain('[REDACTED]');
+		});
+	});
+
 	describe('manual execution stats telemetry', () => {
 		it('should include success count in telemetry when sending message', async () => {
 			const builderStore = useBuilderStore();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -1,4 +1,5 @@
 import type { VIEWS } from '@/app/constants';
+import { redactTelemetryText } from '@n8n/telemetry';
 import { CODE_WORKFLOW_BUILDER_EXPERIMENT } from '@/app/constants';
 import { BUILDER_ENABLED_VIEWS } from './constants';
 import { usePostHog } from '@/app/stores/posthog.store';
@@ -761,9 +762,13 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 		const trackingPayload: UserSubmittedBuilderMessageTrackingPayload = {
 			source,
-			message: text,
+			// Scrubbed at the call site: this payload goes to RudderStack *and*
+			// straight to PostHog from the browser, so no backend hop sees both.
+			message: redactTelemetryText(text),
 			session_id: trackingSessionId.value,
-			start_workflow_json: currentWorkflowJson,
+			// Already size-gated below/by the caller — truncating a serialized
+			// workflow or execution would make it unparseable for analysis.
+			start_workflow_json: redactTelemetryText(currentWorkflowJson, { maxLength: Infinity }),
 			workflow_id: routeWorkflowId.value,
 			type,
 			manual_exec_success_count_since_prev_msg: manualExecStatsInBetweenMessages.value.success,
@@ -786,10 +791,11 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 				console.warn('Failed to stringify execution data for telemetry:', error);
 			}
 
-			trackingPayload.execution_data = resultDataSizeKb > 512 ? '{}' : resultData;
+			trackingPayload.execution_data =
+				resultDataSizeKb > 512 ? '{}' : redactTelemetryText(resultData, { maxLength: Infinity });
 			trackingPayload.execution_status = executionStatus ?? '';
 			if (executionStatus === 'error') {
-				trackingPayload.error_message = errorMessage ?? '';
+				trackingPayload.error_message = redactTelemetryText(errorMessage ?? '');
 				trackingPayload.error_node_type = errorNodeType ?? '';
 			}
 		}

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { QuickReplyType } from '@n8n/api-types';
+import { redactTelemetryText } from '@n8n/telemetry';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import { useUsersStore } from '@n8n/stores/users.store';
 import { computed, ref, useSlots } from 'vue';
@@ -57,7 +58,7 @@ async function onUserMessage(content: string, quickReplyType?: string, isFeedbac
 			is_quick_reply: !!quickReplyType,
 			is_positive: quickReplyType === 'all-good',
 			solution_count: solutionCount,
-			response: content,
+			response: redactTelemetryText(content),
 		});
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3795,6 +3795,9 @@ importers:
 
   packages/@n8n/telemetry:
     dependencies:
+      '@n8n/utils':
+        specifier: workspace:*
+        version: link:../utils
       zod:
         specifier: 3.25.76
         version: 3.25.76


### PR DESCRIPTION
## Summary

This PR applies the same policy the backend uses on FE telemetry.

**Sharing the logic, not copying it.** The redaction engine lived in `@n8n/agents`, which the browser cannot import: `guardrails/patterns.ts` needs `node:crypto`, and the package pulls the AI SDK tree. So:

- `@n8n/utils/redaction/` now holds the pattern table and the engine (`redactText`, `findMatchRanges`, `redactDeep`), moved over unchanged apart from two things: the phone gate is a plain E.164 regex instead of a Zod schema (same semantics, one less dependency), and `RedactionOptions` takes an optional pattern table.
- `@n8n/agents/guardrails/` keeps `node:crypto` and its Base58Check wallet validator, and injects that table into the shared engine. Backend behaviour is unchanged — the 40 existing guardrail tests pass untouched.
- `@n8n/telemetry` now owns the telemetry egress *policy* (options, length cap, identifier and secret key patterns, property walker), moved out of `packages/cli`. Backend and editor UI call the same functions instead of two copies.

Followup of #36789 (INS-704)

## How to test

Check what the telemetry sent from FE carries in various situations.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1243

Follows INS-704 and INS-695 (#36789).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

