### PR TITLE
fix: Use sub-agent names and publish before assignment

### DIFF
--- a/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
@@ -82,6 +82,26 @@ to a workflow `filePath`.
 
 Naming or renaming the current Agent never silently creates another one.
 
+## Saved sub-agent dependencies
+
+When the user asks for an Agent that uses other newly built Agents as saved
+sub-agents, treat publication as a dependency:
+
+1. Build each child Agent under its own `agentRef` before attaching it to the
+   parent.
+2. A saved sub-agent must be published before the parent can attach it. Building
+   the child does not imply publication. Never attach a draft child or pass its
+   raw `agentId` to the parent builder as a user requirement.
+3. If the user already asked to publish, activate, or make the Agents usable,
+   call `build-agent` for the child and faithfully forward that publication
+   intent. Otherwise, ask whether to publish the child before continuing with
+   the parent attachment.
+4. Wait for the child publication to succeed. Then call `build-agent` for the
+   parent and identify the child by its display name. The parent builder must
+   discover the published child and map its name to the valid stored ID.
+5. If publication is declined or fails, leave the child unattached and explain
+   that saved sub-agents must be published first.
+
 ## Builder-owned interactions
 
 When the user asks to test, run, publish, activate, make usable, unpublish, or

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -191,6 +191,16 @@ describe('Instance AI runtime skills', () => {
 			const loadResult = await loadTool.handler?.({ skillId }, {});
 			expect(skillLoadText(loadResult)).toContain(`[Skill: "${skillId}"]`);
 		}
+
+		const agentBuilder = await source.loadSkill('agent-builder');
+		expect(agentBuilder?.instructions).toContain('## Saved sub-agent dependencies');
+		expect(agentBuilder?.instructions).toContain(
+			'A saved sub-agent must be published before the parent can attach it',
+		);
+		expect(agentBuilder?.instructions).toMatch(
+			/Never attach a draft child or pass its\s+raw `agentId`/,
+		);
+		expect(agentBuilder?.instructions).toContain('identify the child by its display name');
 	});
 
 	it('loads the bundled Computer Use credential setup skill', async () => {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7726,6 +7726,7 @@
 	"agents.builder.subAgents.settings.description": "Configure delegation limits and inline sub-agent model choices.",
 	"agents.builder.subAgents.add": "Add sub-agent",
 	"agents.builder.subAgents.loadError": "Could not load project agents",
+	"agents.builder.subAgents.unavailable": "Sub-agent unavailable",
 	"agents.builder.subAgents.remove": "Remove {name}",
 	"agents.builder.subAgents.useWhen.label": "When should this agent be used?",
 	"agents.builder.subAgents.useWhen.hint": "Tell the parent agent when to delegate work to this agent.",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
@@ -51,10 +51,12 @@ vi.mock('@n8n/composables/useToast', () => ({
 
 const projectAgentsListRef = ref<AgentResource[] | null>([]);
 const ensureProjectAgentsLoadedSpy = vi.fn();
+const refreshProjectAgentsSpy = vi.fn();
 vi.mock('../composables/useProjectAgentsList', () => ({
 	useProjectAgentsList: () => ({
 		list: projectAgentsListRef,
 		ensureLoaded: ensureProjectAgentsLoadedSpy,
+		refresh: refreshProjectAgentsSpy,
 	}),
 }));
 
@@ -176,7 +178,8 @@ describe('AgentCapabilitiesSection', () => {
 		vi.clearAllMocks();
 		getAgentTasksSpy.mockResolvedValue([]);
 		projectAgentsListRef.value = [];
-		ensureProjectAgentsLoadedSpy.mockResolvedValue([]);
+		ensureProjectAgentsLoadedSpy.mockImplementation(async () => projectAgentsListRef.value ?? []);
+		refreshProjectAgentsSpy.mockImplementation(async () => projectAgentsListRef.value ?? []);
 		integrationsCatalogRef.value = [];
 	});
 
@@ -417,6 +420,55 @@ describe('AgentCapabilitiesSection', () => {
 				},
 			},
 		]);
+	});
+
+	it('refreshes a stale project-agent cache and renders only the sub-agent name', async () => {
+		const child = makeAgent({ id: 'agent-new', name: 'Notion Research Agent' });
+		refreshProjectAgentsSpy.mockImplementationOnce(async () => {
+			projectAgentsListRef.value = [makeAgent({ id: 'agent-id' }), child];
+			return projectAgentsListRef.value;
+		});
+
+		const wrapper = mountSection(
+			[],
+			{},
+			{
+				name: 'Parent Agent',
+				model: '',
+				instructions: '',
+				tools: [],
+				subAgents: { agents: [{ agentId: child.id }] },
+			},
+			[],
+			[makeAgent({ id: 'agent-id' })],
+		);
+		await flushPromises();
+
+		expect(refreshProjectAgentsSpy).toHaveBeenCalledOnce();
+		expect(wrapper.text()).toContain('Notion Research Agent');
+		expect(wrapper.text()).not.toContain(child.id);
+	});
+
+	it('never exposes an unresolved sub-agent id as the chip label', async () => {
+		const missingAgentId = 'agent-missing';
+		const wrapper = mountSection(
+			[],
+			{},
+			{
+				name: 'Parent Agent',
+				model: '',
+				instructions: '',
+				tools: [],
+				subAgents: { agents: [{ agentId: missingAgentId }] },
+			},
+			[],
+			[makeAgent({ id: 'agent-id' })],
+		);
+		await flushPromises();
+
+		const chip = wrapper.find('[data-testid="agent-capabilities-sub-agent-row"]');
+		expect(chip.text()).toContain('agents.builder.subAgents.unavailable');
+		expect(chip.text()).not.toContain(missingAgentId);
 	});
 
 	it('opens an existing sub-agent chip for editing and removal', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -78,8 +78,11 @@ const uiStore = useUIStore();
 const nodeTypesStore = useNodeTypesStore();
 
 const projectIdRef = computed(() => props.projectId);
-const { list: projectAgents, ensureLoaded: ensureProjectAgentsLoaded } =
-	useProjectAgentsList(projectIdRef);
+const {
+	list: projectAgents,
+	ensureLoaded: ensureProjectAgentsLoaded,
+	refresh: refreshProjectAgents,
+} = useProjectAgentsList(projectIdRef);
 
 type TaskRow = AgentTaskDto & {
 	enabled: boolean;
@@ -104,10 +107,14 @@ const availableSubAgents = computed(() =>
 const selectedSubAgents = computed(() =>
 	selectedSubAgentRefs.value.map(({ agentId, useWhen }) => {
 		const agent = projectAgents.value?.find((candidate) => candidate.id === agentId);
-		const reasons = subAgentIssueMessages.value.get(agentId) ?? [];
+		const validationReasons = subAgentIssueMessages.value.get(agentId) ?? [];
+		const reasons =
+			validationReasons.length > 0 || agent || projectAgents.value === null
+				? validationReasons
+				: [i18n.baseText('agents.builder.validation.issue.subAgent.missingReference')];
 		return {
 			id: agentId,
-			name: agent?.name ?? agentId,
+			name: agent?.name ?? i18n.baseText('agents.builder.subAgents.unavailable'),
 			useWhen: useWhen ?? '',
 			invalid: reasons.length > 0,
 			invalidReasons: reasons,
@@ -254,13 +261,25 @@ async function reloadTasks() {
 	}
 }
 
+async function ensureSubAgentNamesLoaded() {
+	const agents = await ensureProjectAgentsLoaded();
+	const loadedIds = new Set(agents.map((agent) => agent.id));
+	if (selectedSubAgentIds.value.some((agentId) => !loadedIds.has(agentId))) {
+		await refreshProjectAgents();
+	}
+}
+
 onMounted(() => {
 	if (showSection('tasks')) void reloadTasks();
-	if (showSection('subAgents')) void ensureProjectAgentsLoaded().catch(() => {});
+	if (showSection('subAgents')) void ensureSubAgentNamesLoaded().catch(() => {});
 });
 
 watch([() => props.reloadKey, () => props.projectId, () => props.agentId], () => {
 	if (showSection('tasks')) void reloadTasks();
+});
+
+watch([() => props.projectId, selectedSubAgentIds], () => {
+	if (showSection('subAgents')) void ensureSubAgentNamesLoaded().catch(() => {});
 });
 
 function openTaskModal(task: TaskRow | null) {

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -417,6 +417,7 @@ async function fetchAgent(
 	if (isStaleAgentTarget(targetProjectId, targetAgentId)) return;
 	agent.value = data;
 	agentName.value = data.name;
+	upsertProjectAgentsListCache(targetProjectId, data);
 }
 
 async function fetchAgentFiles(


### PR DESCRIPTION
## Summary

- Resolve attached sub-agent names without displaying raw IDs.
- Refresh stale agent metadata and publish saved sub-agents before assignment.

<img width="893" height="516" alt="image" src="https://github.com/user-attachments/assets/e9850ff1-4ce9-457e-967d-398b031873e6" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-580

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

