### PR TITLE
feat(core): Revert - Make form trigger OAuth2 authentication generally available

### DIFF
--- a/packages/cli/src/constants/oauth2-triggers.ts
+++ b/packages/cli/src/constants/oauth2-triggers.ts
@@ -1,0 +1,8 @@
+/**
+ * Form-trigger OAuth2 is opt-in. When the flag is off, `n8nUserAuth` form triggers
+ * keep their existing cookie/HMAC auth and must not be exposed as OAuth protected
+ * resources, so the resolvers short-circuit.
+ */
+export function isFormOAuth2Enabled(): boolean {
+	return process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2 === 'true';
+}

--- a/packages/cli/src/modules/oauth-server/__tests__/form-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/form-trigger-resource.resolver.api.test.ts
@@ -82,9 +82,14 @@ const resolveResource = async (webhookPath: string) =>
 	);
 
 beforeAll(async () => {
+	process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2 = 'true'; // gates the form-trigger resolver
 	owner = await createOwner();
 	member = await createMember();
 	formEndpoint = Container.get(GlobalConfig).endpoints.form;
+});
+
+afterAll(() => {
+	delete process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2;
 });
 
 afterEach(async () => {
@@ -143,6 +148,19 @@ describe('protected resource metadata for form triggers', () => {
 		const response = await testServer.restlessAgent.get(prmPathFor(randomUUID()));
 
 		expect(response.statusCode).toBe(404);
+	});
+
+	test('should not resolve when the feature flag is disabled', async () => {
+		const webhookPath = randomUUID();
+		await createPublishedFormWorkflow(webhookPath, formTriggerNode());
+
+		delete process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2;
+		try {
+			const response = await testServer.restlessAgent.get(prmPathFor(webhookPath));
+			expect(response.statusCode).toBe(404);
+		} finally {
+			process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2 = 'true';
+		}
 	});
 
 	test('should not resolve a non-form path even if the webhook exists', async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/form-trigger-test-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/form-trigger-test-resource.resolver.api.test.ts
@@ -97,12 +97,17 @@ const resolveResource = async (webhookPath: string) =>
 	);
 
 beforeAll(async () => {
+	process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2 = 'true'; // gates the form-trigger resolver
 	owner = await createOwner();
 	member = await createMember();
 	const { endpoints } = Container.get(GlobalConfig);
 	formEndpoint = endpoints.form;
 	formTestEndpoint = endpoints.formTest;
 	registrations = Container.get(TestWebhookRegistrationsService);
+});
+
+afterAll(() => {
+	delete process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2;
 });
 
 afterEach(async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-flow.service.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-flow.service.api.test.ts
@@ -92,6 +92,7 @@ const authorizeAndMintCode = async (
 };
 
 beforeAll(async () => {
+	process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2 = 'true'; // gates the form-trigger resolver
 	owner = await createOwner();
 	member = await createMember();
 	formEndpoint = Container.get(GlobalConfig).endpoints.form;
@@ -99,6 +100,10 @@ beforeAll(async () => {
 	codes = Container.get(OAuthAuthorizationCodeService);
 	oauthServer = Container.get(OAuthServerService);
 	tokenService = Container.get(OAuthTokenService);
+});
+
+afterAll(() => {
+	delete process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2;
 });
 
 afterEach(async () => {

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/form-trigger-resource.resolver.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/form-trigger-resource.resolver.ts
@@ -4,6 +4,7 @@ import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { FORM_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 
+import { isFormOAuth2Enabled } from '@/constants/oauth2-triggers';
 import type { ProtectedResourceResolver } from '@/services/protected-resource.registry';
 import { UrlService } from '@/services/url.service';
 import { WebhookService } from '@/webhooks/webhook.service';
@@ -42,6 +43,10 @@ export class FormTriggerResourceResolver implements ProtectedResourceResolver {
 	}
 
 	async resolveByPath(pathname: string) {
+		if (!isFormOAuth2Enabled()) {
+			return undefined;
+		}
+
 		if (!pathname.startsWith(`/${this.config.endpoints.form}/`)) {
 			return undefined;
 		}

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/form-trigger-test-resource.resolver.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/form-trigger-test-resource.resolver.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { FORM_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 
+import { isFormOAuth2Enabled } from '@/constants/oauth2-triggers';
 import type { ProtectedResourceResolver } from '@/services/protected-resource.registry';
 import { UrlService } from '@/services/url.service';
 import { TestWebhookRegistrationsService } from '@/webhooks/test-webhook-registrations.service';
@@ -40,6 +41,10 @@ export class FormTriggerTestResourceResolver implements ProtectedResourceResolve
 	}
 
 	async resolveByPath(pathname: string) {
+		if (!isFormOAuth2Enabled()) {
+			return undefined;
+		}
+
 		if (!pathname.startsWith(`/${this.config.endpoints.formTest}/`)) {
 			return undefined;
 		}

--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -709,6 +709,13 @@ describe('WorkflowValidationService', () => {
 
 		beforeEach(() => {
 			mockNodeTypes = mock<NodeTypes>();
+			// Pin the flag off so the expected copy never depends on the ambient env.
+			// Tests that need it on opt in with `withFormOAuth2(true)`.
+			vi.stubEnv('N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2', 'false');
+		});
+
+		afterEach(() => {
+			vi.unstubAllEnvs();
 		});
 
 		it('should return valid when no credentials are used', async () => {
@@ -881,7 +888,7 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toContain('end-user credentials');
 			expect(result.error).toContain('"My OAuth2"');
 			expect(result.error).toContain(
-				'only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication',
+				'only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP or webhook triggers with n8n user authentication',
 			);
 		});
 
@@ -1161,6 +1168,9 @@ describe('WorkflowValidationService', () => {
 			expect(result.isValid).toBe(true);
 		});
 
+		const withFormOAuth2 = (enabled: boolean) =>
+			vi.stubEnv('N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2', enabled ? 'true' : 'false');
+
 		describe('webhook trigger', () => {
 			const validateWithOAuth2Webhook = async () => {
 				const nodes: INode[] = [
@@ -1218,13 +1228,17 @@ describe('WorkflowValidationService', () => {
 				return await service.validateDynamicCredentials(nodes, mockNodeTypes);
 			};
 
-			it('should return valid for n8nUserAuth', async () => {
+			it('should return valid for n8nUserAuth when form OAuth2 is enabled', async () => {
+				withFormOAuth2(true);
+
 				const result = await validateWithFormTrigger('n8nUserAuth');
 
 				expect(result.isValid).toBe(true);
 			});
 
 			it.each(['none', 'basicAuth'])('should reject authentication %s', async (authentication) => {
+				withFormOAuth2(true);
+
 				const result = await validateWithFormTrigger(authentication);
 
 				expect(result.isValid).toBe(false);
@@ -1233,7 +1247,23 @@ describe('WorkflowValidationService', () => {
 				);
 			});
 
-			it('should offer the form option in the generic message', async () => {
+			it('should reject n8nUserAuth when form OAuth2 is disabled', async () => {
+				// The form authenticates the submitter over cookie/HMAC but establishes no
+				// identity, so this must be caught at publish rather than mid-execution.
+				withFormOAuth2(false);
+
+				const result = await validateWithFormTrigger('n8nUserAuth');
+
+				expect(result.isValid).toBe(false);
+				// The form option is not advertised while the flag is off.
+				expect(result.error).toContain(
+					'only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP or webhook triggers with n8n user authentication',
+				);
+			});
+
+			it('should offer the form option in the generic message when form OAuth2 is enabled', async () => {
+				withFormOAuth2(true);
+
 				const nodes: INode[] = [
 					createNode('Schedule', 'n8n-nodes-base.scheduleTrigger'),
 					createNode('HTTP', 'n8n-nodes-base.httpRequest', {
@@ -1301,7 +1331,7 @@ describe('WorkflowValidationService', () => {
 			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
 
 			expect(result.error).toBe(
-				'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
+				'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
 			);
 		});
 

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -23,6 +23,7 @@ import type {
 } from 'n8n-workflow';
 
 import { STARTING_NODES } from '@/constants';
+import { isFormOAuth2Enabled } from '@/constants/oauth2-triggers';
 import { CredentialTypes } from '@/credential-types';
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { NodeTypes } from '@/node-types';
@@ -348,7 +349,7 @@ export class WorkflowValidationService {
 	 * - A custom resolver (OAuth, Slack, …) keys on an external identity extracted
 	 *   from trigger data, so it needs a trigger with a context establishment hook.
 	 * - The default/system resolver keys on the n8n user identity, so it needs a
-	 *   trigger that establishes it (manual, sub-workflow, Chat Hub chat, MCP, form, or webhook with n8n user auth).
+	 *   trigger that establishes it (manual, sub-workflow, Chat Hub chat, MCP or webhook with n8n user auth).
 	 */
 	async validateDynamicCredentials(
 		nodes: INode[],
@@ -403,7 +404,8 @@ export class WorkflowValidationService {
 
 		if (workflowResolverId === this.dynamicCredentialsProxy.getSystemResolverId()) {
 			// System resolver: every trigger must establish the n8n user identity. Chat and MCP only
-			// qualify in their identity-carrying configurations.
+			// qualify in their identity-carrying configurations; form is only listed while the form
+			// OAuth2 flag is enabled, since without it a form establishes no identity.
 			if (allTriggersProvideN8nIdentity) return undefined;
 
 			const triggersList = this.getN8nUserAuthTriggersList();
@@ -418,10 +420,13 @@ export class WorkflowValidationService {
 	/**
 	 * Describes which trigger configurations the system resolver currently accepts,
 	 * for the publish-error copy. Chat only qualifies when available in Chat Hub and
-	 * MCP only with n8n user auth (OAuth2). Mirrors `classifyTriggerIdentity`.
+	 * MCP only with n8n user auth (OAuth2); form only joins while the form OAuth2
+	 * flag is enabled. Mirrors `classifyTriggerIdentity`.
 	 */
 	private getN8nUserAuthTriggersList(): string {
-		return 'manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication';
+		const authTriggers = isFormOAuth2Enabled() ? 'MCP, form, or webhook' : 'MCP or webhook';
+
+		return `manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and ${authTriggers} triggers with n8n user authentication`;
 	}
 
 	/** Collects the ids of all credentials referenced by enabled nodes. */
@@ -463,6 +468,7 @@ export class WorkflowValidationService {
 		let allTriggersProvideExternalIdentity = true;
 		let allTriggersProvideN8nIdentity = true;
 		let hasTrigger = false;
+		const formOAuth2Enabled = isFormOAuth2Enabled();
 
 		for (const node of nodes) {
 			if (node.disabled) continue;
@@ -478,6 +484,7 @@ export class WorkflowValidationService {
 			const { providesExternalIdentity, providesN8nIdentity } = classifyTriggerIdentity(
 				node.type,
 				node.parameters,
+				{ isFormOAuth2Enabled: formOAuth2Enabled },
 			);
 			allTriggersProvideExternalIdentity &&= providesExternalIdentity;
 			allTriggersProvideN8nIdentity &&= providesN8nIdentity;

--- a/packages/cli/test/integration/dynamic-credentials.ee/form-trigger-submit-gate.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/form-trigger-submit-gate.api.test.ts
@@ -129,6 +129,7 @@ const executionCountFor = async (workflowId: string) =>
 	await Container.get(ExecutionRepository).count({ where: { workflowId } });
 
 beforeAll(async () => {
+	process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2 = 'true';
 	formEndpoint = Container.get(GlobalConfig).endpoints.form;
 
 	// The webhook path is served by a real `WebhookServer` running the real Form
@@ -145,6 +146,10 @@ beforeAll(async () => {
 	const server = new WebhookServer();
 	await server.start();
 	agent = testAgent(server.app) as unknown as SuperAgentTest;
+});
+
+afterAll(() => {
+	delete process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2;
 });
 
 beforeEach(async () => {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4354,6 +4354,7 @@
 	"nodeIssues.credentials.notIdentified": "Credentials with name {name} exist for {type}.",
 	"nodeIssues.credentials.notIdentified.hint": "Credentials are not clearly identified. Please select the correct credentials.",
 	"nodeIssues.credentials.privateNotConnected": "'{name}' end-user credential is not connected for you. Connect yours to execute this step manually.",
+	"nodeIssues.credentials.privateRequiresIdentityTriggerWithWebhook": "End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 	"nodeIssues.credentials.privateRequiresIdentityTriggerWithFormAndWebhook": "End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 	"nodeIssues.credentials.privateRequiresIdentityExtractor": "End-user credentials with this resolver need a trigger that extracts an identity. Configure an identity extractor on the trigger, or switch this credential to Fixed.",
 	"nodeIssues.input.missing": "No node connected to required input \"{inputName}\"",

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -880,13 +880,17 @@ describe('useNodeHelpers()', () => {
 			// incompatible-trigger issue is copy about the workflow, so it doesn't read
 			// anything off the trigger's node type.
 			mockedStore(useNodeTypesStore).getNodeType = vi.fn(() => notionNodeType);
-			mockedStore(useSettingsStore).settings.envFeatureFlags = {};
+			mockedStore(useSettingsStore).settings.envFeatureFlags = {
+				N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2: 'false',
+			};
 		});
 
 		afterEach(() => {
 			mockDocumentStore.workflowTriggerNodes = [];
 			mockDocumentStore.settings = {};
-			mockedStore(useSettingsStore).settings.envFeatureFlags = {};
+			mockedStore(useSettingsStore).settings.envFeatureFlags = {
+				N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2: 'false',
+			};
 		});
 
 		describe('not connected', () => {
@@ -1041,7 +1045,7 @@ describe('useNodeHelpers()', () => {
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 				expect(result?.credentials?.[NOTION_API]).toEqual([
-					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 				]);
 			});
 
@@ -1055,6 +1059,13 @@ describe('useNodeHelpers()', () => {
 				expect(result).toBeNull();
 			});
 
+			const setFormOAuth2 = (enabled: boolean) => {
+				mockedStore(useSettingsStore).settings.envFeatureFlags = {
+					...mockedStore(useSettingsStore).settings.envFeatureFlags,
+					N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2: enabled ? 'true' : 'false',
+				};
+			};
+
 			it('warns with the base message when a private credential is used under a webhook trigger not using n8n User Auth', () => {
 				mockConnectedPrivateCred(true);
 				mockDocumentStore.workflowTriggerNodes = [buildTriggerNode(WEBHOOK_TRIGGER)];
@@ -1063,7 +1074,7 @@ describe('useNodeHelpers()', () => {
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 				expect(result?.credentials?.[NOTION_API]).toEqual([
-					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 				]);
 			});
 
@@ -1077,7 +1088,7 @@ describe('useNodeHelpers()', () => {
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 				expect(result?.credentials?.[NOTION_API]).toEqual([
-					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 				]);
 			});
 
@@ -1114,7 +1125,8 @@ describe('useNodeHelpers()', () => {
 				const buildFormTrigger = (authentication: string) =>
 					buildTriggerNode(FORM_TRIGGER, { parameters: { authentication } });
 
-				it('does not warn for n8nUserAuth', () => {
+				it('does not warn for n8nUserAuth when form OAuth2 is enabled', () => {
+					setFormOAuth2(true);
 					mockConnectedPrivateCred(true);
 					mockDocumentStore.workflowTriggerNodes = [buildFormTrigger('n8nUserAuth')];
 
@@ -1125,6 +1137,7 @@ describe('useNodeHelpers()', () => {
 				});
 
 				it.each(['none', 'basicAuth'])('warns for authentication %s', (authentication) => {
+					setFormOAuth2(true);
 					mockConnectedPrivateCred(true);
 					mockDocumentStore.workflowTriggerNodes = [buildFormTrigger(authentication)];
 
@@ -1133,6 +1146,21 @@ describe('useNodeHelpers()', () => {
 
 					expect(result?.credentials?.[NOTION_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					]);
+				});
+
+				it('warns without listing form for n8nUserAuth when form OAuth2 is disabled', () => {
+					// Mirrors the backend: without the flag the form establishes no identity,
+					// and the copy must not offer a fix that is unavailable.
+					setFormOAuth2(false);
+					mockConnectedPrivateCred(true);
+					mockDocumentStore.workflowTriggerNodes = [buildFormTrigger('n8nUserAuth')];
+
+					const { getNodeCredentialIssues } = useNodeHelpers();
+					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+					expect(result?.credentials?.[NOTION_API]).toEqual([
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
 			});
@@ -1354,7 +1382,7 @@ describe('useNodeHelpers()', () => {
 					const result = getNodeCredentialIssues(buildGenericAuthNode(), httpRequestWithSslAuth);
 
 					expect(result?.credentials?.[OAUTH2_API]).toEqual([
-						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
 
@@ -1386,7 +1414,7 @@ describe('useNodeHelpers()', () => {
 					const result = getNodeCredentialIssues(buildPredefinedAuthNode(), httpRequestWithSslAuth);
 
 					expect(result?.credentials?.[OAUTH2_API]).toEqual([
-						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -52,6 +52,7 @@ import { useSettingsStore } from '@n8n/stores/settings.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { injectWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { usePrivateCredentials } from '@/features/resolvers/composables/usePrivateCredentials';
+import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 
 declare namespace HttpRequestNode {
 	namespace V2 {
@@ -73,6 +74,7 @@ export function useNodeHelpers() {
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 	const { isEnabled: isPrivateCredentialsEnabled } = usePrivateCredentials();
+	const { check: isEnvFeatureEnabled } = useEnvFeatureFlag();
 
 	const isInsertingNodes = ref(false);
 	const credentialsUpdated = ref(false);
@@ -426,7 +428,10 @@ export function useNodeHelpers() {
 	//
 	// A workflow with no triggers is left un-warned: it's a transient state while
 	// building. The backend still catches it at publish time.
-	function getBlockingTrigger(): { isSystemResolver: boolean } | null {
+	function getBlockingTrigger(): {
+		isSystemResolver: boolean;
+		formOAuth2Enabled: boolean;
+	} | null {
 		const triggers = workflowDocumentStore.value.workflowTriggerNodes.filter(
 			(trigger) => !trigger.disabled,
 		);
@@ -434,16 +439,18 @@ export function useNodeHelpers() {
 
 		const resolverId = workflowDocumentStore.value.settings?.credentialResolverId;
 		const isSystemResolver = !resolverId || resolverId === SYSTEM_RESOLVER_ID;
+		const formOAuth2Enabled = isEnvFeatureEnabled.value('FORM_TRIGGER_OAUTH2');
 
 		const hasBlockingTrigger = triggers.some((trigger) => {
 			const { providesN8nIdentity, providesExternalIdentity } = classifyTriggerIdentity(
 				trigger.type,
 				trigger.parameters,
+				{ isFormOAuth2Enabled: formOAuth2Enabled },
 			);
 			return isSystemResolver ? !providesN8nIdentity : !providesExternalIdentity;
 		});
 
-		return hasBlockingTrigger ? { isSystemResolver } : null;
+		return hasBlockingTrigger ? { isSystemResolver, formOAuth2Enabled } : null;
 	}
 
 	function collectPrivateCredentialIssues(
@@ -466,11 +473,18 @@ export function useNodeHelpers() {
 			// merely-not-yet-connected credential is surfaced via the callout/banner.
 			// The message depends on the resolver: the system resolver needs a trigger
 			// that establishes the n8n user identity, a custom resolver needs one that
-			// extracts an external identity.
+			// extracts an external identity. Form is only listed as supported while its
+			// OAuth2 flag is on — without it the form establishes no identity, so listing
+			// it would advertise a fix that doesn't work.
 			if (blockingTrigger) {
-				const messageKey: BaseTextKey = blockingTrigger.isSystemResolver
-					? 'nodeIssues.credentials.privateRequiresIdentityTriggerWithFormAndWebhook'
-					: 'nodeIssues.credentials.privateRequiresIdentityExtractor';
+				let messageKey: BaseTextKey =
+					'nodeIssues.credentials.privateRequiresIdentityTriggerWithWebhook';
+
+				if (!blockingTrigger.isSystemResolver) {
+					messageKey = 'nodeIssues.credentials.privateRequiresIdentityExtractor';
+				} else if (blockingTrigger.formOAuth2Enabled) {
+					messageKey = 'nodeIssues.credentials.privateRequiresIdentityTriggerWithFormAndWebhook';
+				}
 				foundIssues[credTypeName] = [i18n.baseText(messageKey)];
 			}
 		}

--- a/packages/nodes-base/nodes/Form/interfaces.ts
+++ b/packages/nodes-base/nodes/Form/interfaces.ts
@@ -56,9 +56,9 @@ export type FormTriggerData = {
 	// Only a form that identifies its submitter can be refused by the submit-time
 	// credential gate, so this is what decides whether the handling for that
 	// rejection is rendered at all. Deliberately broader than the gate's own
-	// condition: on a real `n8nUserAuth` GET the submitter is redirected to the
-	// OAuth2 provider, which would make the client branch untestable without
-	// Keycloak and a license.
+	// condition, which also needs `isFormOAuth2Enabled()`: with that on the GET
+	// redirects to the OAuth2 provider, which would make the client branch
+	// untestable without Keycloak and a license.
 	hasAuthenticatedSubmitter?: boolean;
 };
 

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -836,7 +836,234 @@ describe('FormTrigger, formWebhook', () => {
 		);
 	});
 
-	describe('n8nUserAuth with OAuth2 flow', () => {
+	describe('n8nUserAuth', () => {
+		const authedUser = {
+			id: 'user-1',
+			email: 'user@example.com',
+			firstName: 'Test',
+			lastName: 'User',
+		};
+		const formFields: FormFieldsParameter = [
+			{ fieldLabel: 'Name', fieldType: 'text', requiredField: true },
+		];
+
+		const setupContext = (
+			ctx: ReturnType<typeof mock<IWebhookFunctions>>,
+			overrides: { method: 'GET' | 'POST'; cookie?: string; options?: IDataObject } = {
+				method: 'GET',
+			},
+		) => {
+			const status = vi.fn(() => ({ send: vi.fn() })) as any;
+			const writeHead = vi.fn();
+			const end = vi.fn();
+			const setHeader = vi.fn();
+			const render = vi.fn();
+			const request = {
+				method: overrides.method,
+				originalUrl: '/form/test',
+				query: {},
+				headers: {
+					host: 'localhost:5678',
+					...(overrides.cookie ? { cookie: overrides.cookie } : {}),
+				},
+				protocol: 'http',
+				contentType: overrides.method === 'POST' ? 'multipart/form-data' : undefined,
+			};
+
+			ctx.getNode.mockReturnValue({ typeVersion: 2.6 } as INode);
+			ctx.getNodeParameter.calledWith('options').mockReturnValue(overrides.options ?? {});
+			ctx.getNodeParameter.calledWith('formTitle').mockReturnValue('Test Form');
+			ctx.getNodeParameter.calledWith('formDescription').mockReturnValue('Test Description');
+			ctx.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
+			ctx.getNodeParameter.calledWith('authentication', 'none').mockReturnValue('n8nUserAuth');
+			ctx.getNodeParameter.calledWith('formFields.values').mockReturnValue(formFields);
+			ctx.getRequestObject.mockReturnValue(request as any);
+			ctx.getHeaderData.mockReturnValue(request.headers);
+			ctx.getResponseObject.mockReturnValue({
+				status,
+				writeHead,
+				end,
+				setHeader,
+				render,
+			} as any);
+			ctx.getMode.mockReturnValue('manual');
+			ctx.getInstanceId.mockReturnValue('instanceId');
+			ctx.getBodyData.mockReturnValue({ data: { 'field-0': 'John' }, files: {} });
+			ctx.getWorkflowSettings.mockReturnValue(mock<IWorkflowSettings>({}));
+			ctx.getChildNodes.mockReturnValue([]);
+
+			return { status, writeHead, end, setHeader, render };
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('redirects to /signin on GET when no cookie is present with an absolute redirect URL', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { writeHead, end } = setupContext(ctx, { method: 'GET' });
+
+			const result = await formWebhook(ctx);
+
+			expect(writeHead).toHaveBeenCalledWith(302, {
+				Location: '/signin?redirect=' + encodeURIComponent('http://localhost:5678/form/test'),
+			});
+			expect(end).toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('honours x-forwarded-proto/host when building the redirect URL', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const writeHead = vi.fn();
+			const end = vi.fn();
+			const headers = {
+				host: 'localhost:5678',
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'forms.example.com',
+			};
+			ctx.getNode.mockReturnValue({ typeVersion: 2.6 } as INode);
+			ctx.getNodeParameter.calledWith('options').mockReturnValue({});
+			ctx.getNodeParameter.calledWith('authentication', 'none').mockReturnValue('n8nUserAuth');
+			ctx.getRequestObject.mockReturnValue({
+				method: 'GET',
+				originalUrl: '/form/test',
+				query: {},
+				headers,
+				protocol: 'http',
+			} as any);
+			ctx.getHeaderData.mockReturnValue(headers);
+			ctx.getResponseObject.mockReturnValue({
+				writeHead,
+				end,
+				status: vi.fn(() => ({ send: vi.fn() })),
+				setHeader: vi.fn(),
+				render: vi.fn(),
+			} as any);
+
+			await formWebhook(ctx);
+
+			expect(writeHead).toHaveBeenCalledWith(302, {
+				Location: '/signin?redirect=' + encodeURIComponent('https://forms.example.com/form/test'),
+			});
+		});
+
+		it('returns 401 on POST when no cookie is present', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const send = vi.fn();
+			const status = vi.fn(() => ({ send })) as any;
+			const writeHead = vi.fn();
+			const end = vi.fn();
+			const setHeader = vi.fn();
+			setupContext(ctx, { method: 'POST' });
+			ctx.getResponseObject.mockReturnValue({
+				status,
+				writeHead,
+				end,
+				setHeader,
+				render: vi.fn(),
+			} as any);
+
+			const result = await formWebhook(ctx);
+
+			expect(setHeader).toHaveBeenCalledWith('WWW-Authenticate', 'Basic realm="Enter credentials"');
+			expect(status).toHaveBeenCalledWith(401);
+			expect(send).toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('redirects to /signin on GET when cookie is invalid', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { writeHead } = setupContext(ctx, {
+				method: 'GET',
+				cookie: 'n8n-auth=bad.token',
+			});
+			ctx.validateCookieAuth.mockRejectedValue(new Error('Unauthorized'));
+
+			const result = await formWebhook(ctx);
+
+			expect(ctx.validateCookieAuth).toHaveBeenCalledWith('bad.token');
+			expect(writeHead).toHaveBeenCalledWith(
+				302,
+				expect.objectContaining({ Location: expect.stringContaining('/signin?redirect=') }),
+			);
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('renders the form when GET with a valid cookie', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { render } = setupContext(ctx, {
+				method: 'GET',
+				cookie: 'n8n-auth=valid.jwt.token',
+			});
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			await formWebhook(ctx);
+
+			expect(ctx.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
+			expect(render).toHaveBeenCalledWith('form-trigger', expect.any(Object));
+		});
+
+		// The gate can only reject a form that knows who is submitting, so this is the
+		// only rendering that carries its client-side handling.
+		it('sets hasAuthenticatedSubmitter so the form handles a submit-time gate rejection', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { render } = setupContext(ctx, {
+				method: 'GET',
+				cookie: 'n8n-auth=valid.jwt.token',
+			});
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			await formWebhook(ctx);
+
+			expect(render).toHaveBeenCalledWith(
+				'form-trigger',
+				expect.objectContaining({ hasAuthenticatedSubmitter: true }),
+			);
+		});
+
+		it('parses n8n-auth alongside other cookies', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			setupContext(ctx, {
+				method: 'GET',
+				cookie: 'other=value; n8n-auth=valid.jwt.token; another=thing',
+			});
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			await formWebhook(ctx);
+
+			expect(ctx.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
+		});
+
+		it('includes the user in trigger output on POST with valid cookie', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			setupContext(ctx, { method: 'POST', cookie: 'n8n-auth=valid.jwt.token' });
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			const result = await formWebhook(ctx);
+
+			expect(result).toMatchObject({
+				webhookResponse: { status: 200 },
+				workflowData: [[{ json: expect.objectContaining({ user: authedUser }) }]],
+			});
+		});
+
+		it('omits the user when includeUserInOutput is false', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			setupContext(ctx, {
+				method: 'POST',
+				cookie: 'n8n-auth=valid.jwt.token',
+				options: { includeUserInOutput: false },
+			});
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			const result = await formWebhook(ctx);
+
+			const json = (result as any).workflowData[0][0].json;
+			expect(json.user).toBeUndefined();
+		});
+	});
+
+	describe('n8nUserAuth with OAuth2 flow (N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2)', () => {
 		const authedUser = {
 			id: 'user-1',
 			email: 'user@example.com',
@@ -856,7 +1083,6 @@ describe('FormTrigger, formWebhook', () => {
 				headers?: Record<string, string>;
 				originalUrl?: string;
 				nodeType?: string;
-				options?: IDataObject;
 			} = { method: 'GET' },
 		) => {
 			const send = vi.fn();
@@ -881,7 +1107,7 @@ describe('FormTrigger, formWebhook', () => {
 				typeVersion: 2.6,
 				type: overrides.nodeType ?? FORM_TRIGGER_NODE_TYPE,
 			} as INode);
-			ctx.getNodeParameter.calledWith('options').mockReturnValue(overrides.options ?? {});
+			ctx.getNodeParameter.calledWith('options').mockReturnValue({});
 			ctx.getNodeParameter.calledWith('formTitle').mockReturnValue('Test Form');
 			ctx.getNodeParameter.calledWith('formDescription').mockReturnValue('Test Description');
 			ctx.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
@@ -911,6 +1137,11 @@ describe('FormTrigger, formWebhook', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
+			vi.stubEnv('N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2', 'true');
+		});
+
+		afterEach(() => {
+			vi.unstubAllEnvs();
 		});
 
 		it('redirects to the authorization URL on GET without a code', async () => {
@@ -1124,50 +1355,6 @@ describe('FormTrigger, formWebhook', () => {
 			expect(status).toHaveBeenCalledWith(401);
 			expect(send).toHaveBeenCalled();
 			expect(result).toEqual({ noWebhookResponse: true });
-		});
-
-		it('sets hasAuthenticatedSubmitter so the form handles a submit-time gate rejection', async () => {
-			const ctx = mock<IWebhookFunctions>();
-			const { render } = setupContext(ctx, {
-				method: 'GET',
-				headers: { cookie: 'n8n-form-oauth=as-token' },
-			});
-			ctx.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user: authedUser });
-
-			await formWebhook(ctx);
-
-			expect(render).toHaveBeenCalledWith(
-				'form-trigger',
-				expect.objectContaining({ hasAuthenticatedSubmitter: true }),
-			);
-		});
-
-		it('includes the submitter in the trigger output on POST', async () => {
-			const ctx = mock<IWebhookFunctions>();
-			setupContext(ctx, { method: 'POST', headers: { 'x-auth-token': 'as-token' } });
-			ctx.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user: authedUser });
-
-			const result = await formWebhook(ctx);
-
-			expect(result).toMatchObject({
-				webhookResponse: { status: 200 },
-				workflowData: [[{ json: expect.objectContaining({ user: authedUser }) }]],
-			});
-		});
-
-		it('omits the submitter when includeUserInOutput is false', async () => {
-			const ctx = mock<IWebhookFunctions>();
-			setupContext(ctx, {
-				method: 'POST',
-				headers: { 'x-auth-token': 'as-token' },
-				options: { includeUserInOutput: false },
-			});
-			ctx.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user: authedUser });
-
-			const result = await formWebhook(ctx);
-
-			const json = (result as any).workflowData[0][0].json;
-			expect(json.user).toBeUndefined();
 		});
 
 		describe('submit-time credential readiness gate', () => {
@@ -3834,22 +4021,6 @@ describe('validateFormPageAuth', () => {
 		expect(res.end).toHaveBeenCalled();
 		expect(result.responded).toBe(true);
 		expect(result.authedUser).toBeUndefined();
-	});
-
-	it('honours x-forwarded-proto/host when building the redirect URL', async () => {
-		const { ctx, res, req } = buildContext('GET');
-		Object.assign(req.headers, {
-			'x-forwarded-proto': 'https',
-			'x-forwarded-host': 'forms.example.com',
-		});
-		ctx.getHeaderData.mockReturnValue(req.headers);
-
-		await validateFormPageAuth(ctx, 'n8nUserAuth');
-
-		expect(res.writeHead).toHaveBeenCalledWith(302, {
-			Location:
-				'/signin?redirect=' + encodeURIComponent('https://forms.example.com/form-waiting/exec-id'),
-		});
 	});
 
 	it('responds with 401 on POST when no cookie is present', async () => {

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -75,6 +75,10 @@ function isFormUserAuthClaims(value: unknown): value is FormUserAuthClaims {
 	);
 }
 
+export function isFormOAuth2Enabled(): boolean {
+	return process.env.N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2 === 'true';
+}
+
 export function sanitizeHtml(text: string) {
 	return sanitize(text, {
 		allowedTags: [
@@ -776,11 +780,11 @@ function clearFormOAuthToken(res: Response, req: Request, resourceUrl: string): 
  */
 async function authenticateFormUserOrRespond(
 	context: IWebhookFunctions,
-	runOAuth2Flow: boolean = false,
+	oauth2Enabled: boolean = false,
 ): Promise<{ user: IUser; token: string | null } | null> {
 	const req = context.getRequestObject();
 
-	if (runOAuth2Flow) {
+	if (oauth2Enabled) {
 		const res = context.getResponseObject();
 		const url = context.getWebhookResourceUrl('default');
 		if (!url) {
@@ -1108,7 +1112,8 @@ export async function formWebhook(
 	let oAuth2Token: string | undefined;
 	if (node.typeVersion > 1) {
 		if (authentication === 'n8nUserAuth') {
-			const { user, token } = (await authenticateFormUserOrRespond(context, true)) ?? {};
+			const { user, token } =
+				(await authenticateFormUserOrRespond(context, isFormOAuth2Enabled())) ?? {};
 			if (!user) return { noWebhookResponse: true };
 			authedUser = user;
 			oAuth2Token = token ?? undefined;
@@ -1196,11 +1201,17 @@ export async function formWebhook(
 
 		// Connect-before-submit: when the workflow needs the submitter's own
 		// (private) credentials, establish their identity from the OAuth2 token and
-		// check readiness server-side. If anything is still missing — and we're not
-		// already rendering the inner iframe — wrap the form in the hosting shell
-		// (form + connect panel, submit disabled). No-op unless OAuth2 form auth and
-		// the dynamic-credentials module are both active.
-		if (authentication === 'n8nUserAuth' && authedUser && oAuth2Token && !shellInner) {
+		// check readiness server-side. As long as the trigger requires any end-user
+		// account — and we're not already rendering the inner iframe — wrap the form
+		// in the hosting shell (form + connect panel). No-op unless OAuth2 form auth
+		// and the dynamic-credentials module are both active.
+		if (
+			authentication === 'n8nUserAuth' &&
+			authedUser &&
+			isFormOAuth2Enabled() &&
+			oAuth2Token &&
+			!shellInner
+		) {
 			// Must name the endpoint actually being served (test vs production) — the
 			// OAuth2 token is bound to that resource, same as in the auth path above.
 			const resourceUrl = trimTrailingSlash(context.getWebhookResourceUrl('default') ?? '');
@@ -1235,9 +1246,14 @@ export async function formWebhook(
 		let authToken: string | undefined;
 		if (node.typeVersion > 1) {
 			if (authentication === 'n8nUserAuth' && authedUser) {
-				// Cookies aren't sent on POST from the sandboxed form page (null origin +
-				// SameSite=Lax), so the POST re-authenticates off this token.
-				authToken = oAuth2Token;
+				if (!isFormOAuth2Enabled()) {
+					// Cookies aren't sent on POST from the sandboxed form page
+					// (null origin + SameSite=Lax). Embed an HMAC token so the
+					// POST handler can re-authenticate the user.
+					authToken = generateFormUserAuthToken(node, authedUser);
+				} else {
+					authToken = oAuth2Token;
+				}
 			} else {
 				authToken = await generateFormPostBasicAuthToken(context, authProperty);
 			}

--- a/packages/testing/playwright/pages/PublicFormPage.ts
+++ b/packages/testing/playwright/pages/PublicFormPage.ts
@@ -27,26 +27,7 @@ export class PublicFormPage extends BasePage {
 
 	/** Navigate this tab to the form URL. */
 	async goto(url: string) {
-		// First-party OAuth for `n8nUserAuth` can bounce through /oauth/authorize
-		// before the consent page or form HTML loads.
-		await this.page.goto(url, { timeout: 30_000 });
-		await this.completeFirstPartyConsentIfShown();
-	}
-
-	/**
-	 * `n8nUserAuth` forms always start the first-party OAuth flow. Approve the
-	 * consent screen when it appears so the follow-up GET can render the form.
-	 * First-party clients skip the redirect-URI trust checkbox.
-	 */
-	private async completeFirstPartyConsentIfShown() {
-		if (!this.page.url().includes('/oauth/consent')) {
-			return;
-		}
-
-		const allow = this.page.getByRole('button', { name: 'Allow access' });
-		await expect(allow).toBeEnabled();
-		await allow.click();
-		await expect(this.page.locator('#n8n-form')).toBeVisible();
+		await this.page.goto(url);
 	}
 
 	async fillField(label: string, value: string) {

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts
@@ -13,11 +13,9 @@ import type { ApiHelpers } from '../../../services/api-helper';
  *
  * Unlike the other specs in this directory this one carries **no
  * `@capability:dynamic-credentials` / `@licensed` tag** and runs locally without
- * Keycloak: it exercises the client branch only, injecting the gate response
- * with `context.route` instead of provisioning a private credential. Opening
- * the form still goes through first-party n8n OAuth (the GET for `n8nUserAuth`
- * always does) — that hop does not need Keycloak or a license. The server side
- * that produces these bodies is covered by
+ * Keycloak or a container: it exercises the client branch only, injecting the
+ * gate response with `context.route` instead of provisioning a private
+ * credential. The server side that produces these bodies is covered by
  * `packages/nodes-base/nodes/Form/test/utils.test.ts` and
  * `packages/cli/test/integration/dynamic-credentials.ee/form-trigger-submit-gate.api.test.ts`.
  */
@@ -62,7 +60,7 @@ function formWorkflow(options: { withNextPage: boolean }): Partial<IWorkflowBase
 				formFields: { values: [{ fieldLabel: FIELD_LABEL }] },
 				// Only a form that authenticates the submitter can ever be gated, so the
 				// client handling is rendered only for this option (added in 2.6). The GET
-				// runs first-party n8n OAuth; PublicFormPage approves the consent screen.
+				// authenticates off the editor session cookie this browser context holds.
 				authentication: 'n8nUserAuth',
 				options: {},
 			},

--- a/packages/workflow/src/trigger-identity.ts
+++ b/packages/workflow/src/trigger-identity.ts
@@ -27,6 +27,18 @@ const NO_IDENTITY: TriggerIdentityCapabilities = {
 	providesExternalIdentity: false,
 };
 
+/** Instance-level toggles that change what a trigger can establish. */
+export interface TriggerIdentityOptions {
+	/**
+	 * Whether `N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2` is on for the instance — not a
+	 * per-node setting. The flag doesn't gate the form's `n8nUserAuth` option
+	 * (that's `typeVersion >= 2.6`); it selects which flow backs it. On ⇒ OAuth2,
+	 * establishing the submitter's identity. Off ⇒ the legacy cookie/HMAC flow,
+	 * which authenticates the submitter but establishes no identity.
+	 */
+	isFormOAuth2Enabled?: boolean;
+}
+
 /** Whether a trigger's parameters declare at least one context establishment hook. */
 function hasContextEstablishmentHook(parameters: INodeParameters | undefined): boolean {
 	const hookParams = toExecutionContextEstablishmentHookParameter(parameters);
@@ -49,6 +61,7 @@ function hasContextEstablishmentHook(parameters: INodeParameters | undefined): b
 export function classifyTriggerIdentity(
 	nodeType: string,
 	parameters: INodeParameters | undefined,
+	options: TriggerIdentityOptions = {},
 ): TriggerIdentityCapabilities {
 	// Sub-workflows inherit identity from the parent; Chat Hub and MCP-over-n8nOAuth2
 	// inject it. All provide both identity families.
@@ -61,10 +74,15 @@ export function classifyTriggerIdentity(
 	// identity the same way the MCP trigger does — sharing the `n8nOAuth2` value.
 	const isOAuth2Webhook =
 		nodeType === WEBHOOK_NODE_TYPE && parameters?.authentication === 'n8nOAuth2';
-	// The form trigger establishes the submitter's identity through its OAuth2 flow,
-	// which is what `n8nUserAuth` (typeVersion >= 2.6) now always runs on.
+	// The form trigger only establishes an identity through its OAuth2 flow, so callers
+	// must opt the branch in with the instance's `isFormOAuth2Enabled`. Omitting it fails
+	// closed: without the flag a `n8nUserAuth` form takes the legacy cookie/HMAC path,
+	// which authenticates the submitter but establishes no identity to resolve
+	// credentials with — publish must reject that instead of failing mid-execution.
 	const isFormTrigger =
-		nodeType === FORM_TRIGGER_NODE_TYPE && parameters?.authentication === 'n8nUserAuth';
+		nodeType === FORM_TRIGGER_NODE_TYPE &&
+		parameters?.authentication === 'n8nUserAuth' &&
+		options.isFormOAuth2Enabled === true;
 	if (
 		isSubWorkflowTrigger ||
 		isChatHubTrigger ||

--- a/packages/workflow/test/trigger-identity.test.ts
+++ b/packages/workflow/test/trigger-identity.test.ts
@@ -73,30 +73,56 @@ describe('classifyTriggerIdentity', () => {
 	});
 
 	describe('Form Trigger', () => {
-		it('provides both identities when n8nUserAuth is used', () => {
-			// `n8nUserAuth` always runs the OAuth2 flow, which establishes the submitter's
-			// identity.
+		it('provides both identities when n8nUserAuth is used and form OAuth2 is enabled', () => {
 			expect(
-				classifyTriggerIdentity(FORM_TRIGGER_NODE_TYPE, { authentication: 'n8nUserAuth' }),
+				classifyTriggerIdentity(
+					FORM_TRIGGER_NODE_TYPE,
+					{ authentication: 'n8nUserAuth' },
+					{ isFormOAuth2Enabled: true },
+				),
 			).toEqual({ providesN8nIdentity: true, providesExternalIdentity: true });
 		});
 
+		it('provides no identity when n8nUserAuth is used but form OAuth2 is disabled', () => {
+			// Without OAuth2 the form falls back to the cookie/HMAC flow, which gates page
+			// access without establishing an identity to resolve credentials with.
+			expect(
+				classifyTriggerIdentity(
+					FORM_TRIGGER_NODE_TYPE,
+					{ authentication: 'n8nUserAuth' },
+					{ isFormOAuth2Enabled: false },
+				),
+			).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
+		});
+
+		it('provides no identity when the options bag is omitted', () => {
+			// Fails closed: a caller that has not read the flag must not let the
+			// combination through.
+			expect(
+				classifyTriggerIdentity(FORM_TRIGGER_NODE_TYPE, { authentication: 'n8nUserAuth' }),
+			).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
+		});
+
 		it.each(['none', 'basicAuth'])(
-			'provides no identity for authentication %s',
+			'provides no identity for authentication %s even when form OAuth2 is enabled',
 			(authentication) => {
-				expect(classifyTriggerIdentity(FORM_TRIGGER_NODE_TYPE, { authentication })).toEqual({
-					providesN8nIdentity: false,
-					providesExternalIdentity: false,
-				});
+				expect(
+					classifyTriggerIdentity(
+						FORM_TRIGGER_NODE_TYPE,
+						{ authentication },
+						{ isFormOAuth2Enabled: true },
+					),
+				).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
 			},
 		);
 
 		it('provides the external identity when an extractor hook is configured without n8nUserAuth', () => {
 			expect(
-				classifyTriggerIdentity(FORM_TRIGGER_NODE_TYPE, {
-					authentication: 'none',
-					...hooksParameters,
-				}),
+				classifyTriggerIdentity(
+					FORM_TRIGGER_NODE_TYPE,
+					{ authentication: 'none', ...hooksParameters },
+					{ isFormOAuth2Enabled: true },
+				),
 			).toEqual({ providesN8nIdentity: false, providesExternalIdentity: true });
 		});
 	});


### PR DESCRIPTION
Reverts n8n-io/n8n#36451

This reverts commit 2cb6a34045ab824652540d8c370cb53c6dfaf63f.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

