### PR TITLE
fix(core): Reuse native Agent channel capabilities

### DIFF
--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -727,8 +727,9 @@ appears in the agents-module builder UI.
 | `workflowContext` | array | no | `{ id, name, description? }` refs to session-built workflows the builder may attach as tools |
 
 **Returns**: `{ ok: true, builderReply, configUpdated, agentId,
-agentName? }` on success, or `{ ok: false, error, configUpdated?, agentId?,
-agentName? }` on failure (`agentId`/`agentName` identify the targeted agent
+agentName?, requiredArtifacts? }` on success, or `{ ok: false, error,
+configUpdated?, agentId?, agentName?, requiredArtifacts? }` on failure
+(`agentId`/`agentName` identify the targeted agent
 once a builder turn was dispatched; precondition failures before any turn
 omit them). `configUpdated` is optional: it's included (reporting mutations
 from passes that already ran) once a builder turn has actually been
@@ -737,6 +738,13 @@ checkpoint ref — but omitted for precondition failures before any turn
 starts (agents module not configured, missing `name`/`agentId`, no project
 context to bind `agentId`, or a resume whose suspend payload has no
 checkpoint ref to carry).
+
+`requiredArtifacts` contains structured workflows or data tables that the
+embedded builder cannot create. Build an `agent-tool` workflow and pass it back
+through `workflowContext`. Build an `agent-entrypoint` workflow around the
+returned Agent ID and never attach it to the Agent; this is used for unsupported
+chat channels whose trigger and reply nodes live in a workflow. Requirements
+reported before an interactive suspension are carried across its checkpoint.
 
 **Interactive requests:** when the builder suspends on one of its interactive
 tools (batched questions, a credential picker, channel setup, or a standard SDK

--- a/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
@@ -49,8 +49,8 @@ and interactive tools.
 
 ## Prerequisites
 
-Before the first `build-agent` call, create every prerequisite the builder
-cannot create:
+Before the first `build-agent` call, create prerequisites the builder cannot
+create when they must be attached to or used by the Agent:
 
 - Create a workflow tool only when one Agent tool call must run an ordered
   multi-node procedure, or when the user explicitly needs that workflow to be
@@ -64,8 +64,27 @@ List prerequisite names and schemas in `message`. Let the builder gather the
 remaining Agent-specific requirements, including model, credentials,
 integrations, and direct tools.
 
-If a `builderReply` lists missing workflows or tables, create them and call
-`build-agent` again. Never ask the user to create them manually.
+`build-agent` can return structured `requiredArtifacts` when the embedded
+builder discovers something Instance AI must create:
+
+- For a workflow with `relationship: "agent-tool"`, build it, pass it in
+  `workflowContext`, and call `build-agent` again so the builder can attach it.
+- For a workflow with `relationship: "agent-entrypoint"`, build it after the
+  Agent exists, using the returned `agentId`. This workflow invokes the Agent;
+  never pass it in `workflowContext`, never attach it to the Agent as a tool,
+  and do not call `build-agent` again solely to attach it.
+- For a data table, create it and call `build-agent` again with its name and
+  schema in `message`.
+
+For an unsupported chat channel, an `agent-entrypoint` workflow should connect
+the platform trigger to Message an Agent, map the incoming message, use a
+stable platform conversation/sender identifier as the custom session key, and
+send the Agent's `text` response through the platform. Native Agent channels do
+not need this wrapper.
+
+If an older builder only lists missing workflows or tables in `builderReply`,
+handle them the same way based on whether the workflow calls the Agent or is
+called by the Agent. Never ask the user to create prerequisites manually.
 
 ## Targeting across turns
 

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -198,6 +198,16 @@ export {
 } from './types';
 export { deriveCredentialHosts } from './tools/workflows/credential-url-resolver';
 export { instanceAiBuilderThreadPrefix } from './tools/orchestration/builder-thread-id';
+export {
+	builderRequiredArtifactSchema,
+	builderRequiredArtifactsSchema,
+	REPORT_REQUIRED_ARTIFACT_TOOL_NAME,
+	reportRequiredArtifactInputSchema,
+} from './tools/orchestration/builder-required-artifact';
+export type {
+	BuilderRequiredArtifact,
+	ReportRequiredArtifactInput,
+} from './tools/orchestration/builder-required-artifact';
 export type { CredentialHostMeta } from './tools/workflows/credential-url-resolver';
 export {
 	agentBuilderTargetMetadata,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
@@ -27,6 +27,7 @@ import {
 	type AgentBuilderTarget,
 } from '../agent-target-binding';
 import { createBuildAgentTool } from '../build-agent.tool';
+import type { BuilderRequiredArtifact } from '../builder-required-artifact';
 
 vi.mock('../agent-target-binding', async () => {
 	const actual = await vi.importActual<typeof AgentTargetBindingModule>('../agent-target-binding');
@@ -50,6 +51,7 @@ interface BuildAgentOutput {
 	agentRef?: string;
 	agentName?: string;
 	answers?: QuestionAnswer[];
+	requiredArtifacts?: BuilderRequiredArtifact[];
 }
 
 function fakeStream(chunks: unknown[], text: string): BuilderTurnStream {
@@ -1542,9 +1544,23 @@ describe('build-agent tool', () => {
 		class FakeBuilderCheckpointUnavailableError extends UserError {
 			readonly code = BUILDER_CHECKPOINT_UNAVAILABLE_CODE;
 		}
+		const requiredArtifacts: BuilderRequiredArtifact[] = [
+			{
+				type: 'workflow',
+				name: 'WhatsApp Agent entrypoint',
+				purpose: 'Connect incoming WhatsApp messages to the Agent',
+				relationship: 'agent-entrypoint',
+				requirements: ['Trigger on incoming WhatsApp messages and invoke the Agent'],
+			},
+		];
 
 		function suspendPayloadWithCheckpoint(
-			overrides: Partial<{ runId: string; toolCallId: string; configUpdated: boolean }> = {},
+			overrides: Partial<{
+				runId: string;
+				toolCallId: string;
+				configUpdated: boolean;
+				requiredArtifacts: BuilderRequiredArtifact[];
+			}> = {},
 		) {
 			return {
 				...askQuestionsSuspendPayload(),
@@ -1753,11 +1769,15 @@ describe('build-agent tool', () => {
 			const result = await runToolWithCtx(
 				context,
 				{ message: 'Build it', name: 'New Agent' },
-				{ resumeData: { approved: true }, suspendPayload: suspendPayloadWithCheckpoint() },
+				{
+					resumeData: { approved: true },
+					suspendPayload: suspendPayloadWithCheckpoint({ requiredArtifacts }),
+				},
 			);
 
 			expect(result.ok).toBe(false);
 			expect(result.error).toContain('does not match');
+			expect(result.requiredArtifacts).toEqual(requiredArtifacts);
 			expect(delegate.resumeBuild).not.toHaveBeenCalled();
 		});
 
@@ -1769,11 +1789,15 @@ describe('build-agent tool', () => {
 			const result = await runToolWithCtx(
 				context,
 				{ message: 'Build it', name: 'New Agent' },
-				{ resumeData: { approved: true }, suspendPayload: suspendPayloadWithCheckpoint() },
+				{
+					resumeData: { approved: true },
+					suspendPayload: suspendPayloadWithCheckpoint({ requiredArtifacts }),
+				},
 			);
 
 			expect(result.ok).toBe(false);
 			expect(result.error).toContain('no longer open');
+			expect(result.requiredArtifacts).toEqual(requiredArtifacts);
 			expect(delegate.resumeBuild).not.toHaveBeenCalled();
 		});
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -715,6 +715,7 @@ async function handleResume(
 			ok: false,
 			error: 'The builder question this answer belongs to is no longer open.',
 			configUpdated: ref.configUpdated,
+			...(ref.requiredArtifacts ? { requiredArtifacts: ref.requiredArtifacts } : {}),
 			...targetIdentity(target),
 		};
 	}
@@ -728,6 +729,7 @@ async function handleResume(
 			error:
 				"The answer does not match the builder's open question (stale or superseded suspension). Ask the user again with a fresh build-agent call.",
 			configUpdated: ref.configUpdated,
+			...(ref.requiredArtifacts ? { requiredArtifacts: ref.requiredArtifacts } : {}),
 			...targetIdentity(target),
 		};
 	}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -45,6 +45,10 @@ import {
 	saveAgentBuilderTarget,
 	type AgentBuilderTarget,
 } from './agent-target-binding';
+import {
+	builderRequiredArtifactsSchema,
+	type BuilderRequiredArtifact,
+} from './builder-required-artifact';
 import { instanceAiBuilderThreadPrefix } from './builder-thread-id';
 import { failTraceRun, finishTraceRun, startSubAgentTrace, withTraceRun } from './tracing-utils';
 import {
@@ -116,6 +120,14 @@ function formatWorkflowContextEnvelope(workflowContext: SessionWorkflowRef[]): s
 function buildOutboundMessage(message: string, workflowContext?: SessionWorkflowRef[]): string {
 	if (!workflowContext || workflowContext.length === 0) return message;
 	return `${message}\n\n${formatWorkflowContextEnvelope(workflowContext)}`;
+}
+
+async function collectRequiredArtifacts(
+	turn: BuilderTurnStream,
+	carriedRequiredArtifacts: BuilderRequiredArtifact[],
+): Promise<BuilderRequiredArtifact[]> {
+	const turnRequiredArtifacts = turn.requiredArtifacts ? await turn.requiredArtifacts : [];
+	return [...carriedRequiredArtifacts, ...turnRequiredArtifacts];
 }
 
 /** Builder sessions are keyed per assistant thread + target agent; the resume
@@ -221,6 +233,11 @@ const buildAgentOutputSchema = z.object({
 		.array(questionAnswerSchema)
 		.optional()
 		.describe('Answers submitted when resuming a cascaded questions request.'),
+	requiredArtifacts: builderRequiredArtifactsSchema
+		.optional()
+		.describe(
+			'Workflows or data tables Instance AI must create outside the Agent. An agent-entrypoint workflow invokes the Agent and must not be passed back as workflowContext.',
+		),
 });
 
 type BuildAgentOutput = z.infer<typeof buildAgentOutputSchema>;
@@ -233,6 +250,8 @@ const builderCheckpointRefSchema = z.object({
 	toolCallId: z.string(),
 	/** Whether any builder pass before this suspension already mutated the agent config. */
 	configUpdated: z.boolean(),
+	/** Host-owned artifacts reported before this suspension. */
+	requiredArtifacts: builderRequiredArtifactsSchema.optional(),
 	/** Target the suspended build belongs to; optional for checkpoints persisted before this field existed. */
 	target: z
 		.object({
@@ -383,6 +402,7 @@ async function finishTurn(
 	builderAgentId: string,
 	result: Extract<ConsumeStreamCascadingResult, { status: 'completed' | 'cancelled' | 'errored' }>,
 	carriedConfigUpdated: boolean,
+	requiredArtifacts: BuilderRequiredArtifact[],
 ): Promise<BuildAgentOutput> {
 	if (result.status === 'completed') {
 		const text = await result.text;
@@ -393,7 +413,12 @@ async function finishTurn(
 			agentId: builderAgentId,
 			payload: { role: BUILDER_SUB_AGENT_ROLE, result: text.slice(0, 200) },
 		});
-		return { ok: true, builderReply: text, configUpdated };
+		return {
+			ok: true,
+			builderReply: text,
+			configUpdated,
+			...(requiredArtifacts.length > 0 ? { requiredArtifacts } : {}),
+		};
 	}
 
 	const error = `The agent builder run ${result.status}.`;
@@ -404,7 +429,12 @@ async function finishTurn(
 		agentId: builderAgentId,
 		payload: { role: BUILDER_SUB_AGENT_ROLE, result: '', error },
 	});
-	return { ok: false, error, configUpdated };
+	return {
+		ok: false,
+		error,
+		configUpdated,
+		...(requiredArtifacts.length > 0 ? { requiredArtifacts } : {}),
+	};
 }
 
 /** Target identity stamped on every output of a dispatched builder turn so the
@@ -435,6 +465,8 @@ async function runBuilderConsumeLoop(params: {
 	turn: BuilderTurnStream;
 	/** configUpdated already accumulated by passes before this one (false on the first leg; carried from the suspend payload on resume). */
 	carriedConfigUpdated: boolean;
+	/** Host-owned artifacts accumulated by passes before this one. */
+	carriedRequiredArtifacts: BuilderRequiredArtifact[];
 	/** Runs once the stream settles (any status) — used to persist a deferred agentId-path bind. */
 	onSettled?: () => Promise<void>;
 	/** Trace inputs recorded on the child run (distinct per leg: outbound message vs. resume marker). */
@@ -450,6 +482,7 @@ async function runBuilderConsumeLoop(params: {
 		builderAgentId,
 		turn,
 		carriedConfigUpdated,
+		carriedRequiredArtifacts,
 		onSettled,
 		traceInputs,
 		dedupeBase,
@@ -497,10 +530,12 @@ async function runBuilderConsumeLoop(params: {
 		// not from the `delegate.streamBuild`/`resumeBuild` call sites.
 		const message = publishAgentBuilderFailure(context, builderAgentId, error);
 		if (isFriendlyMappableBuilderError(error)) {
+			const requiredArtifacts = await collectRequiredArtifacts(turn, carriedRequiredArtifacts);
 			return await settle({
 				ok: false,
 				error: message,
 				configUpdated: carriedConfigUpdated,
+				...(requiredArtifacts.length > 0 ? { requiredArtifacts } : {}),
 				...targetIdentity(target),
 			});
 		}
@@ -511,6 +546,7 @@ async function runBuilderConsumeLoop(params: {
 	// the builder agent was constructed — scope check and existence check both
 	// passed — so a deferred agentId-path bind is now safe to persist.
 	await onSettled?.();
+	const requiredArtifacts = await collectRequiredArtifacts(turn, carriedRequiredArtifacts);
 
 	if (result.status === 'cancelled') {
 		const cancelled = createAbortError(BUILDER_RUN_CANCELLED_MESSAGE);
@@ -544,7 +580,13 @@ async function runBuilderConsumeLoop(params: {
 	}
 
 	if (result.status !== 'suspended') {
-		const output = await finishTurn(context, builderAgentId, result, carriedConfigUpdated);
+		const output = await finishTurn(
+			context,
+			builderAgentId,
+			result,
+			carriedConfigUpdated,
+			requiredArtifacts,
+		);
 		if (output.ok) {
 			await finishTraceRun(context, traceRun, { outputs: output });
 		} else {
@@ -584,6 +626,7 @@ async function runBuilderConsumeLoop(params: {
 			ok: false,
 			error: message,
 			configUpdated: configUpdatedSoFar,
+			...(requiredArtifacts.length > 0 ? { requiredArtifacts } : {}),
 			...targetIdentity(target),
 		});
 	}
@@ -603,6 +646,7 @@ async function runBuilderConsumeLoop(params: {
 			runId: builderRunId,
 			toolCallId: result.suspension.toolCallId,
 			configUpdated: configUpdatedSoFar,
+			...(requiredArtifacts.length > 0 ? { requiredArtifacts } : {}),
 			target: {
 				agentId: target.agentId,
 				projectId: target.projectId,
@@ -715,6 +759,7 @@ async function handleResume(
 		builderAgentId,
 		turn,
 		carriedConfigUpdated: ref.configUpdated,
+		carriedRequiredArtifacts: ref.requiredArtifacts ?? [],
 		traceInputs: { resumed: true },
 		dedupeBase: `${context.runId}:${ctx.toolCallId ?? builderAgentId}:${ref.toolCallId}`,
 	});
@@ -948,7 +993,10 @@ export function createBuildAgentTool(context: OrchestrationContext) {
 				'tools. If a workflow build seems to need a utility tool the workspace does not ' +
 				'provide, ask the user or use a placeholder; do not route around that by calling ' +
 				'`build-agent`. Returns the builder’s reply, the target `agentRef`/`agentId`, and ' +
-				'whether it updated the Agent config.',
+				'whether it updated the Agent config. It can also return structured ' +
+				'`requiredArtifacts` for workflows or data tables Instance AI must create. Build ' +
+				'an `agent-entrypoint` workflow around the returned Agent; never pass it back in ' +
+				'`workflowContext` or attach it as an Agent tool.',
 		)
 		.input(buildAgentInputSchema)
 		.output(buildAgentOutputSchema)
@@ -1024,6 +1072,7 @@ export function createBuildAgentTool(context: OrchestrationContext) {
 				builderAgentId,
 				turn,
 				carriedConfigUpdated: false,
+				carriedRequiredArtifacts: [],
 				traceInputs: { message: outboundMessage },
 				dedupeBase: `${context.runId}:${ctx.toolCallId ?? builderAgentId}`,
 				onSettled: bindAfterTurn

--- a/packages/@n8n/instance-ai/src/tools/orchestration/builder-required-artifact.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/builder-required-artifact.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+export const REPORT_REQUIRED_ARTIFACT_TOOL_NAME = 'report_required_artifact';
+
+const requiredWorkflowSchema = z.object({
+	type: z.literal('workflow'),
+	name: z.string().min(1).describe('Suggested workflow name'),
+	purpose: z.string().min(1).describe('Why the workflow is required'),
+	relationship: z
+		.enum(['agent-tool', 'agent-entrypoint'])
+		.describe(
+			'How the workflow relates to the Agent. An agent-entrypoint invokes the Agent and must not be attached as an Agent tool.',
+		),
+	requirements: z
+		.array(z.string().min(1))
+		.min(1)
+		.describe('Observable behavior and data-flow requirements for the workflow'),
+});
+
+const requiredDataTableSchema = z.object({
+	type: z.literal('data-table'),
+	name: z.string().min(1).describe('Suggested data table name'),
+	purpose: z.string().min(1).describe('Why the data table is required'),
+	columns: z
+		.array(
+			z.object({
+				name: z.string().min(1),
+				type: z.string().min(1),
+				description: z.string().optional(),
+			}),
+		)
+		.optional()
+		.describe('Known columns; omit when the schema still needs to be inferred'),
+});
+
+export const builderRequiredArtifactSchema = z.discriminatedUnion('type', [
+	requiredWorkflowSchema,
+	requiredDataTableSchema,
+]);
+
+export const builderRequiredArtifactsSchema = z.array(builderRequiredArtifactSchema);
+
+export const reportRequiredArtifactInputSchema = z.object({
+	artifact: builderRequiredArtifactSchema.describe(
+		'The workflow or data table Instance AI must create outside the target Agent',
+	),
+});
+
+export type BuilderRequiredArtifact = z.infer<typeof builderRequiredArtifactSchema>;
+export type ReportRequiredArtifactInput = z.infer<typeof reportRequiredArtifactInputSchema>;

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -46,6 +46,7 @@ import type { TraceStatus } from './runtime/resumable-stream-executor';
 import type { IterationLog } from './storage/iteration-log';
 import type { PatchableThreadMemory } from './storage/thread-patch';
 import type { BuilderUsageItem } from './stream/usage-accumulator';
+import type { BuilderRequiredArtifact } from './tools/orchestration/builder-required-artifact';
 import type { IdRemapper, TraceIndex, TraceWriter } from './tracing/trace-replay';
 import type {
 	VerificationResult,
@@ -1012,6 +1013,8 @@ export interface BuilderDelegateSession {
 export interface BuilderTurnStream {
 	fullStream: AsyncIterable<unknown>;
 	text: Promise<string>;
+	/** Structured host artifacts the embedded builder reported during this turn. */
+	requiredArtifacts?: Promise<BuilderRequiredArtifact[]>;
 }
 
 /** Reference to a suspended builder tool call awaiting user input. */

--- a/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
@@ -142,6 +142,7 @@ describe('InstanceAiBuilderDelegateAdapterService', () => {
 					instructionsAddendum: INSTANCE_AI_BUILDER_ADDENDUM,
 					telemetry: sentinel,
 					mcpTools,
+					onRequiredArtifact: expect.any(Function),
 				},
 			);
 		});
@@ -226,6 +227,7 @@ describe('InstanceAiBuilderDelegateAdapterService', () => {
 					abortSignal,
 					instructionsAddendum: INSTANCE_AI_BUILDER_ADDENDUM,
 					mcpTools,
+					onRequiredArtifact: expect.any(Function),
 				},
 			);
 		});

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -15,10 +15,14 @@ import { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import {
+	REPORT_REQUIRED_ARTIFACT_TOOL_NAME,
+	reportRequiredArtifactInputSchema,
 	resolveAIAPromptCaching,
 	resolveAIAReasoning,
 	tokenUsageToBuilderUsageItems,
+	type BuilderRequiredArtifact,
 	type InstanceAiToolRegistry,
+	type ReportRequiredArtifactInput,
 } from '@n8n/instance-ai';
 import { jsonParse } from 'n8n-workflow';
 
@@ -77,6 +81,8 @@ export interface InstanceAiBuilderSessionOptions {
 	abortSignal: AbortSignal;
 	/** The parent orchestrator's validated, approval-wrapped MCP tools. */
 	mcpTools?: InstanceAiToolRegistry;
+	/** Reports host-owned artifacts requested by the embedded builder. Omitted in the standalone builder. */
+	onRequiredArtifact?: (artifact: BuilderRequiredArtifact) => void;
 }
 
 @Service()
@@ -244,7 +250,7 @@ export class AgentsBuilderService {
 			{ threadId: session.hostThreadId, runId: session.runId },
 		);
 
-		const { Agent, Memory, createPlannerTodosTool } = await import('@n8n/agents');
+		const { Agent, Memory, Tool, createPlannerTodosTool } = await import('@n8n/agents');
 
 		const onMemoryUsage = async (report: MemoryTaskUsageReport) => {
 			try {
@@ -294,7 +300,25 @@ export class AgentsBuilderService {
 			description: BUILDER_PLANNER_TODOS_DESCRIPTION,
 			systemInstruction: BUILDER_PLANNER_TODOS_SYSTEM_INSTRUCTION,
 		});
-		const builderTools = [...tools.json, ...tools.shared, plannerTodosTool];
+		const reportRequiredArtifactTool = session.onRequiredArtifact
+			? new Tool(REPORT_REQUIRED_ARTIFACT_TOOL_NAME)
+					.description(
+						'Report a workflow or data table that Instance AI must create outside the target Agent. ' +
+							'Use relationship "agent-entrypoint" for a channel bridge that invokes the Agent; it will not be attached as an Agent tool.',
+					)
+					.input(reportRequiredArtifactInputSchema)
+					.handler(async (input: ReportRequiredArtifactInput) => {
+						session.onRequiredArtifact?.(input.artifact);
+						return { ok: true };
+					})
+					.build()
+			: undefined;
+		const builderTools = [
+			...tools.json,
+			...tools.shared,
+			plannerTodosTool,
+			...(reportRequiredArtifactTool ? [reportRequiredArtifactTool] : []),
+		];
 		const claimedToolNames = new Set(builderTools.map((tool) => tool.name));
 
 		for (const tool of builderTools) {

--- a/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
+++ b/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
@@ -20,6 +20,11 @@ configuring a node tool.
 - Chat/trigger integration: call \`list_integration_types\`, then
   \`configure_channel\` with a returned type. Do not call \`resolve_integration\`
   for chat/trigger integrations.
+- A configured chat integration generates its own context and action tools for
+  every top-level Agent run, including scheduled tasks. When its capabilities
+  include the requested action, do not add a same-platform node, MCP, or
+  workflow tool. A scheduled or proactive message with no inbound conversation
+  is not, by itself, a reason to add another tool.
 - Callable external service: the conversation or trigger happens elsewhere and
   the agent only operates on the product. For each requested non-chat callable
   service, call \`resolve_integration\` separately, using \`queries\` as
@@ -81,6 +86,7 @@ Custom tools are last resort and only for pure computation. Load
   fetching.
 - Live crawling, fetching, and API integrations need MCP, workflow, or node tools, not custom tools.
 - Do not invent MCP servers, node type names, workflow names, credential ids, or provider tool keys.
+- Do not duplicate an action already supplied by a configured chat integration.
 
 ### Verify
 

--- a/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
@@ -59,6 +59,12 @@ Agent's replies. Do not add a same-platform node, MCP, or workflow tool merely
 so the Agent can reply, send a normal conversational message, or use interaction
 features already listed in that integration's capabilities.
 
+Configured integrations also generate their listed context and action tools for
+every top-level Agent run, including scheduled tasks. A scheduled task can use
+actions such as \`send_dm\` or \`send_channel_message\` without an inbound
+message. Being proactive, scheduled, or outside an open conversation is never
+by itself a reason to add a same-platform node, MCP, or workflow tool.
+
 Use an MCP, node, or workflow tool when the product is only something the agent
 operates on: searching records, creating tickets, updating objects, or sending a
 business-process notification while the conversation happens elsewhere.
@@ -66,9 +72,9 @@ business-process notification while the conversation happens elsewhere.
 When building an agent that should interact with Slack, Discord, Telegram, or
 Linear, use the matching chat integration instead of an MCP, node, or workflow
 tool when the platform is the conversation surface. Add a callable tool only
-for an explicitly requested operation that the selected integration's returned
-capabilities do not support, especially a business action outside the current
-conversation context.
+for an explicitly requested operation that is absent from the selected
+integration's returned capabilities. Compare the exact operation; do not infer
+that the integration is unavailable merely because the run starts from a task.
 
 Examples:
 
@@ -78,7 +84,8 @@ Examples:
 - Discord integration: the agent should be mentioned or messaged in Discord,
   respond in Discord threads or DMs, or render approval buttons there.
 - Telegram integration: the agent should receive or send Telegram messages,
-  continue conversations there, or render supported interactive messages.
+  continue conversations there, render supported interactive messages, or use
+  \`send_dm\` to initiate a scheduled message to a known Telegram user ID.
 - Linear integration: the agent should be triggered from Linear issues/comments,
   understand the current Linear subject, or reply in the same Linear
   conversation.
@@ -105,6 +112,15 @@ Agent needs an external channel-bridge workflow instead:
 For callable (non-chat) services, call \`resolve_integration\` separately per
 service and follow the returned \`kind\`: \`"mcp"\` -> MCP Servers section
 below, \`"node"\` -> load \`agent-builder-node-tools\`.
+
+### Correcting a redundant channel tool
+
+If the user questions why a same-platform tool exists, inspect the current
+config and the integration's returned capabilities before answering. When the
+integration supplies the tool's purpose, remove the redundant node, MCP, or
+workflow tool and explain the correction. Do not defend it merely because the
+message is proactive, scheduled, or has no current conversation; generated
+actions such as \`send_dm\` are available without inbound message context.
 
 ## Chat Integrations
 
@@ -147,8 +163,9 @@ The \`integrations\` array controls how the target agent is triggered.
 - Do not add a chat integration just because the agent needs CRUD or notifications
   for that product. Resolve the callable capability through \`resolve_integration\`
   unless the product itself is the chat/trigger context.
-- For recurring or scheduled runs, create a task (\`create_tasks\`), not an
-  integration.
+- For recurring or scheduled runs, create a task (\`create_tasks\`) for the
+  cadence. Keep a requested chat integration, and use its generated action
+  tools when the task sends through that same platform.
 - Omitting \`integrations\` from a config write preserves the current channels.
   To remove one, write an explicit filtered array or remove the exact array
   entry.
@@ -323,6 +340,8 @@ Auth, or None) via \`${ASK_QUESTIONS_TOOL_NAME}\`. Then map to:
 - The chosen integration matches \`useIntegrationWhen\`; otherwise resolve the
   callable capability through \`resolve_integration\` and use MCP, node, or
   workflow tools.
+- No node, MCP, or workflow tool duplicates an action listed by a configured
+  chat integration, including for proactive scheduled tasks.
 - Generic non-chat external services were routed through \`resolve_integration\`
   before MCP or node setup.
 - The final \`integrations\` array keeps unrelated integrations intact and

--- a/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
@@ -36,6 +36,7 @@ export function externalServicesSkill(): RuntimeSkill {
 			'read_config',
 			'patch_config',
 			'write_config',
+			'report_required_artifact',
 			'load_skill',
 		],
 		instructions: `\
@@ -52,15 +53,22 @@ Use an integration when the product is the agent's conversation or trigger
 surface: humans will mention, message, comment to, or resume the agent there,
 or the agent needs to respond in that same platform conversation context.
 
+Native Agent chat integrations are bidirectional within their conversation
+context. The integration both receives the triggering message and delivers the
+Agent's replies. Do not add a same-platform node, MCP, or workflow tool merely
+so the Agent can reply, send a normal conversational message, or use interaction
+features already listed in that integration's capabilities.
+
 Use an MCP, node, or workflow tool when the product is only something the agent
 operates on: searching records, creating tickets, updating objects, or sending a
 business-process notification while the conversation happens elsewhere.
 
-When building an agent that should interact with Slack, Discord, or Telegram,
-prefer the matching chat integration over an MCP, node, or workflow tool, even
-when a callable tool could perform the same messaging action. Use a callable
-tool instead only when the user explicitly asks for one or the requested
-operation is not supported by the chat integration.
+When building an agent that should interact with Slack, Discord, Telegram, or
+Linear, use the matching chat integration instead of an MCP, node, or workflow
+tool when the platform is the conversation surface. Add a callable tool only
+for an explicitly requested operation that the selected integration's returned
+capabilities do not support, especially a business action outside the current
+conversation context.
 
 Examples:
 
@@ -77,6 +85,22 @@ Examples:
 - Linear callable tools: the agent is triggered from Slack, Preview, a task, or a
   workflow and only needs to search/create/update Linear tickets via MCP or node
   tools.
+
+If \`list_integration_types\` does not return the requested conversation
+platform, do not substitute a platform messaging node as an Agent tool. The
+Agent needs an external channel-bridge workflow instead:
+
+1. Finish the Agent without a native integration for that platform.
+2. When \`report_required_artifact\` is available, call it once with an
+   \`artifact\` whose \`type\` is \`"workflow"\` and \`relationship\` is
+   \`"agent-entrypoint"\`. Require the
+   platform trigger, Message an Agent using the incoming message and a stable
+   platform conversation/sender identifier as its custom session key, and the
+   platform send action using the Agent's text response.
+3. The bridge invokes the Agent. Never add it to the Agent's \`tools\` array and
+   never report it as \`relationship: "agent-tool"\`.
+4. If the reporting tool is unavailable, state the same workflow requirement
+   clearly in the final reply so the calling surface can create it.
 
 For callable (non-chat) services, call \`resolve_integration\` separately per
 service and follow the returned \`kind\`: \`"mcp"\` -> MCP Servers section

--- a/packages/cli/src/modules/agents/builder/skills/target-tasks.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/target-tasks.skill.ts
@@ -89,9 +89,13 @@ Initial Build rules in your system prompt. Never create a placeholder or
 - For each new or replacement objective, fill every template section with
   run-specific details. Do not duplicate Agent Instructions or Skill bodies;
   name a configured capability only when it helps route the work.
-- Make sure the agent already has every tool the steps need (an integration,
-  node/workflow tool, or web search). If something is missing, add it to the agent
-  config first — a task can only use tools the agent already has.
+- Make sure the agent already has every capability the steps need (an
+  integration, node/workflow tool, or web search). Configured chat integrations
+  automatically generate their context and action tools in scheduled runs too.
+  If the task sends through a configured platform and the integration lists the
+  needed action (for example \`send_dm\`), use that action; do not add a
+  same-platform node, MCP, or workflow tool. Add a tool only when the exact
+  operation is not supplied by an existing integration.
 - Translate each cadence into a valid 5-field cron expression (e.g. daily 09:00
   -> "0 9 * * *"; weekdays 08:30 -> "30 8 * * 1-5"; hourly -> "0 * * * *").
   Keep this cadence out of the objective; only a data lookback window belongs
@@ -126,8 +130,15 @@ Initial Build rules in your system prompt. Never create a placeholder or
 - To disable or remove a task, edit \`config.tasks\` with \`patch_config\` (set
   \`enabled: false\`, or drop the ref). Changes take effect on the next
   \`publish_agent\`.
-- \`create_tasks\` does NOT add tools — if a task needs a tool the agent lacks,
-  add it to the config yourself first.
+- \`create_tasks\` does not add config tools. This does not mean a scheduled
+  message needs a messaging node: configured integrations supply their generated
+  action tools at runtime even when the task has no inbound conversation.
+- A proactive or scheduled send through a connected chat platform is not a
+  separate backend integration. Use the channel's \`send_dm\` or
+  \`send_channel_message\` action when available.
+- Never claim that a task requires a same-platform messaging node solely because
+  it starts without an inbound conversation. If such a redundant tool already
+  exists and the integration covers its action, remove it.
 - Do not call \`create_tasks\` once per task when several are ready; batch them
   into one call so the whole set is stored in a single round trip.`,
 	};

--- a/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
+++ b/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
@@ -1,11 +1,12 @@
 import type { CredentialProvider, StreamChunk } from '@n8n/agents';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { instanceAiBuilderThreadPrefix } from '@n8n/instance-ai';
-import type {
-	BuilderDelegateSession,
-	BuilderTurnStream,
-	InstanceAiBuilderDelegate,
+import {
+	instanceAiBuilderThreadPrefix,
+	type BuilderDelegateSession,
+	type BuilderRequiredArtifact,
+	type BuilderTurnStream,
+	type InstanceAiBuilderDelegate,
 } from '@n8n/instance-ai';
 import { type Scope } from '@n8n/permissions';
 import { Like } from '@n8n/typeorm';
@@ -32,7 +33,9 @@ Preview links work in this chat. Include a markdown Preview link after a success
 
 You can publish and unpublish the target agent with \`publish_agent\` and \`unpublish_agent\`. Never tell the user to open the agent editor and click Publish.
 
-The Instance AI orchestrator can create workflows and data tables — never ask the user to create them manually. State missing prerequisites in your reply; the orchestrator will provision them and call you again.`;
+The Instance AI orchestrator can create workflows and data tables — never ask the user to create them manually. For each missing artifact, call \`report_required_artifact\` with its concrete requirements before your final reply; the orchestrator will provision them and call you again when the Agent needs the result.
+
+Some requested chat platforms do not have a native Agent integration. In that case, finish the Agent without adding same-platform messaging nodes as Agent tools, then report an \`agent-entrypoint\` workflow. It must use the platform trigger, pass the incoming message and a stable conversation identifier into Message an Agent with a custom session key, then send the Agent's text response back through the platform. This workflow invokes the Agent and must never be attached to the Agent as a workflow tool.`;
 
 function isTextDeltaChunk(
 	chunk: StreamChunk,
@@ -43,10 +46,17 @@ function isTextDeltaChunk(
 /** Wrap a builder stream generator as a `BuilderTurnStream`: forwards every chunk
  *  as-is, while resolving `text` to the concatenated text-delta content once the
  *  stream ends (mirrors the SDK's own `fullStream` + `text` shape). */
-function toBuilderTurnStream(chunks: AsyncGenerator<StreamChunk>): BuilderTurnStream {
+function toBuilderTurnStream(
+	chunks: AsyncGenerator<StreamChunk>,
+	requiredArtifacts: BuilderRequiredArtifact[],
+): BuilderTurnStream {
 	let resolveText: (text: string) => void;
 	const text = new Promise<string>((resolve) => {
 		resolveText = resolve;
+	});
+	let resolveRequiredArtifacts: (artifacts: BuilderRequiredArtifact[]) => void;
+	const requiredArtifactsPromise = new Promise<BuilderRequiredArtifact[]>((resolve) => {
+		resolveRequiredArtifacts = resolve;
 	});
 	let acc = '';
 
@@ -58,10 +68,11 @@ function toBuilderTurnStream(chunks: AsyncGenerator<StreamChunk>): BuilderTurnSt
 			}
 		} finally {
 			resolveText(acc);
+			resolveRequiredArtifacts([...requiredArtifacts]);
 		}
 	}
 
-	return { fullStream: pump(), text };
+	return { fullStream: pump(), text, requiredArtifacts: requiredArtifactsPromise };
 }
 
 /**
@@ -87,7 +98,10 @@ export class InstanceAiBuilderDelegateAdapterService {
 	) {}
 
 	/** Builder session options for the sub-agent surface: appends the sub-agent prompt rules. */
-	private buildSubAgentSession(session: BuilderDelegateSession): InstanceAiBuilderSessionOptions {
+	private buildSubAgentSession(
+		session: BuilderDelegateSession,
+		onRequiredArtifact: (artifact: BuilderRequiredArtifact) => void,
+	): InstanceAiBuilderSessionOptions {
 		return {
 			threadId: session.threadId,
 			hostThreadId: session.hostThreadId,
@@ -98,6 +112,7 @@ export class InstanceAiBuilderDelegateAdapterService {
 			...(session.memoryTaskObserver ? { memoryTaskObserver: session.memoryTaskObserver } : {}),
 			abortSignal: session.abortSignal,
 			...(session.mcpTools ? { mcpTools: session.mcpTools } : {}),
+			onRequiredArtifact,
 		};
 	}
 
@@ -128,6 +143,7 @@ export class InstanceAiBuilderDelegateAdapterService {
 
 			streamBuild: async (agentId, message, session) => {
 				await assertProjectScope('agent:update');
+				const requiredArtifacts: BuilderRequiredArtifact[] = [];
 				return toBuilderTurnStream(
 					this.agentsBuilderService.buildAgent(
 						agentId,
@@ -135,13 +151,15 @@ export class InstanceAiBuilderDelegateAdapterService {
 						message,
 						credentialProvider,
 						user,
-						this.buildSubAgentSession(session),
+						this.buildSubAgentSession(session, (artifact) => requiredArtifacts.push(artifact)),
 					),
+					requiredArtifacts,
 				);
 			},
 
 			resumeBuild: async (agentId, resume, session) => {
 				await assertProjectScope('agent:update');
+				const requiredArtifacts: BuilderRequiredArtifact[] = [];
 				return toBuilderTurnStream(
 					this.agentsBuilderService.resumeBuild(
 						agentId,
@@ -151,8 +169,9 @@ export class InstanceAiBuilderDelegateAdapterService {
 						resume.resumeData,
 						credentialProvider,
 						user,
-						this.buildSubAgentSession(session),
+						this.buildSubAgentSession(session, (artifact) => requiredArtifacts.push(artifact)),
 					),
+					requiredArtifacts,
 				);
 			},
 

--- a/packages/cli/src/modules/agents/integrations/platforms/discord-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/discord-integration.ts
@@ -93,10 +93,11 @@ export class DiscordIntegration extends AgentChatIntegration {
 			'The agent needs to reply to Discord users in the same conversation context.',
 			'The agent needs to update or react to a Discord message in the current conversation.',
 			'The agent should send Discord messages as the connected Discord bot.',
+			'A scheduled Agent task should proactively send a DM or channel message through the connected Discord bot.',
 		],
 		useNodeToolWhen: [
 			'Discord is only a backend API step and the agent does not need to be connected as a Discord chat surface.',
-			'The request is a one-off Discord operation from another trigger without ongoing Discord conversation context.',
+			'The Discord operation is performed by a non-Agent workflow, or the exact operation is not listed in the Agent integration capabilities.',
 		],
 	};
 
@@ -128,6 +129,7 @@ export class DiscordIntegration extends AgentChatIntegration {
 	];
 
 	readonly actionToolGuidance = [
+		'For scheduled tasks without an inbound conversation, use send_dm or send_channel_message with the known destination ID. These actions do not require current message context.',
 		'For edit_message, pass the messageId returned by a previous Discord action or get_current_message_context. The current Discord conversation is selected automatically.',
 		'For send_channel_message, channelId must be shaped "discord:<guildId>:<channelId>" — pass the value returned by search_channels or get_current_message_context. A bare Discord channel ID copied from the Discord app is rejected.',
 		'A Discord mention is answered inside a thread created off that message. Use send_channel_message when the reply belongs in the channel itself rather than that thread.',

--- a/packages/cli/src/modules/agents/integrations/platforms/slack/slack-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack/slack-integration.ts
@@ -68,10 +68,11 @@ export class SlackIntegration extends AgentChatIntegration {
 			'The agent should be chatted with from Slack, invoked with @mentions, or keep conversing in Slack threads.',
 			'The agent needs Slack message context, user/channel lookup, DMs, channel messages, emoji reactions, or rich UI in Slack.',
 			'The agent should communicate as the connected Slack bot rather than merely call Slack as a backend API.',
+			'A scheduled Agent task should proactively send a DM or channel message through the connected Slack bot.',
 		],
 		useNodeToolWhen: [
 			'Slack is only a backend API step in a broader task and the agent does not need Slack conversation context.',
-			'The user asks for a one-off Slack operation from another trigger and does not need the agent connected as a Slack chat surface.',
+			'The Slack operation is performed by a non-Agent workflow, or the exact operation is not listed in the Agent integration capabilities.',
 		],
 	};
 

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -68,10 +68,11 @@ export class TelegramIntegration extends AgentChatIntegration {
 			'The agent needs to reply to Telegram users in the same conversation context.',
 			'The agent needs to update a Telegram message in the current conversation.',
 			'The agent should send Telegram messages as the connected Telegram bot.',
+			'A scheduled Agent task should proactively send a direct message to a known Telegram user ID.',
 		],
 		useNodeToolWhen: [
 			'Telegram is only a backend API step and the agent does not need to be connected as a Telegram chat surface.',
-			'The request is a one-off Telegram operation from another trigger without ongoing Telegram conversation context.',
+			'The Telegram operation is performed by a non-Agent workflow, or the exact operation is not listed in the Agent integration capabilities.',
 		],
 	};
 
@@ -89,6 +90,7 @@ export class TelegramIntegration extends AgentChatIntegration {
 	]);
 
 	readonly actionToolGuidance = [
+		'For scheduled tasks without an inbound conversation, use send_dm with the known Telegram user ID. The integration action does not require current message context.',
 		'For edit_message, pass the messageId returned by a previous Telegram action or get_current_message_context. The current Telegram conversation is selected automatically.',
 	];
 


### PR DESCRIPTION
## Summary

- Prevent Agent Builder from adding a same-platform messaging tool when a native Agent channel already supplies the requested action.
- Reuse native channel actions during scheduled Agent tasks. These actions can send proactive messages without an inbound conversation.
- Tell Agent Builder to remove a redundant channel tool when a user questions it.
- Add a structured handoff for workflows and data tables that Agent Builder cannot create.
- Let Instance AI build entrypoint workflows for unsupported channels such as WhatsApp. The workflow invokes the Agent and does not become an Agent tool.
- Preserve required-artifact requests across interactive suspend and resume boundaries.

Telegram agent without extra tools:
<img width="2236" height="1236" alt="image" src="https://github.com/user-attachments/assets/5d561f04-8bd5-44cc-b2cb-684b3a3a6d9c" />

Describing its knowledge:
<img width="1598" height="802" alt="image" src="https://github.com/user-attachments/assets/7267e171-db72-4bed-bbe8-a2ed7801e40a" />

Building a whatsapp channel workflow:
<img width="1842" height="1460" alt="image" src="https://github.com/user-attachments/assets/975129ce-b83c-407b-bfc6-836c7f65ccb4" />


## How to test

Enable the Agent and Instance AI modules with `N8N_ENABLED_MODULES=instance-ai,agents`. Configure Instance AI model and sandbox access.

1. Ask Instance AI to build an Agent that users can chat with in Telegram.
2. Ask it to send a scheduled Telegram check-in to a known Telegram user ID.
3. Confirm that the Agent contains the Telegram integration and the scheduled task.
4. Confirm that the Agent does not contain a Telegram node, MCP, or workflow tool for the message.
5. Ask why a redundant Telegram tool exists on an Agent that already has the channel. Confirm that Agent Builder removes the tool instead of defending it.
6. Ask Instance AI to build an Agent for an unsupported channel such as WhatsApp.
7. Confirm that Instance AI builds a separate trigger → Message an Agent → reply workflow.
8. Confirm that the workflow is not attached back to the Agent as a tool.

Checks completed:

- CLI and Instance AI builds pass.
- Targeted lint passes.
- 252 focused Vitest tests pass.
- The native Slack live eval passes all 3 expectations.
- The unsupported WhatsApp live eval passes all 5 expectations.
- The scheduled Telegram live eval passes 3/3 iterations and all 9 expectation judgments.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-474

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

