### PR TITLE
fix(core): Evict idle mcp-browser sessions to prevent connection leak

### DIFF
--- a/packages/@n8n/mcp-browser/src/__tests__/server.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/server.test.ts
@@ -1,8 +1,20 @@
+import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 import { buildAllowedHosts, isAuthorized, startHttpTransport } from '../server';
 
 type Started = Awaited<ReturnType<typeof startHttpTransport>>;
+
+/** Bind an ephemeral port, note it, release it. Sessions can only initialize on a concrete port:
+ * `buildAllowedHosts` bakes the port into the allowed Host list, so booting on port 0 produces
+ * `127.0.0.1:0` and the SDK's DNS-rebinding check then rejects the real Host header. */
+async function freePort(): Promise<number> {
+	const probe = createServer();
+	await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', () => resolve()));
+	const { port } = probe.address() as AddressInfo;
+	await new Promise<void>((resolve) => probe.close(() => resolve()));
+	return port;
+}
 
 async function boot(
 	authToken: string,
@@ -12,17 +24,17 @@ async function boot(
 	baseUrl: string;
 	close: () => Promise<void>;
 }> {
+	const port = await freePort();
 	const started = await startHttpTransport({
 		config: {},
 		host: '127.0.0.1',
-		port: 0,
+		port,
 		authToken,
 		...sessionOpts,
 	});
-	const address = started.httpServer.address() as AddressInfo;
 	return {
 		started,
-		baseUrl: `http://127.0.0.1:${address.port}`,
+		baseUrl: `http://127.0.0.1:${port}`,
 		close: async () => {
 			await new Promise<void>((resolve) => started.httpServer.close(() => resolve()));
 		},
@@ -124,11 +136,17 @@ describe('HTTP transport', () => {
 describe('idle session eviction', () => {
 	const token = 'test-token-1234';
 
-	async function openSession(baseUrl: string, id: number) {
-		await fetch(`${baseUrl}/mcp`, {
+	/** Opens a session and returns its id. Requires a real (non-ephemeral) port so the SDK's
+	 * DNS-rebinding Host check passes and initialization actually completes. */
+	async function openSession(baseUrl: string, id: number): Promise<string> {
+		const res = await fetch(`${baseUrl}/mcp`, {
 			method: 'POST',
-			// eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
-			headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+			headers: {
+				authorization: `Bearer ${token}`,
+				// eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+				'content-type': 'application/json',
+				accept: 'application/json, text/event-stream',
+			},
 			body: JSON.stringify({
 				jsonrpc: '2.0',
 				id,
@@ -140,15 +158,34 @@ describe('idle session eviction', () => {
 				},
 			}),
 		});
+		const sessionId = res.headers.get('mcp-session-id');
+		if (!sessionId) throw new Error(`initialize did not return a session id (status ${res.status})`);
+		return sessionId;
+	}
+
+	/** A follow-up request on an existing session -- the path that refreshes its activity stamp. */
+	async function pingSession(baseUrl: string, sessionId: string, id: number) {
+		await fetch(`${baseUrl}/mcp`, {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${token}`,
+				// eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+				'content-type': 'application/json',
+				accept: 'application/json, text/event-stream',
+				// eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+				'mcp-session-id': sessionId,
+			},
+			body: JSON.stringify({ jsonrpc: '2.0', id, method: 'ping' }),
+		});
 	}
 
 	it('evicts sessions that go idle past the TTL, shutting down their browser connections', async () => {
-		const booted = await boot(token, { sessionIdleTtlMs: 20, sessionSweepIntervalMs: 10 });
+		const booted = await boot(token, { sessionIdleTtlMs: 50, sessionSweepIntervalMs: 10 });
 		try {
 			for (let i = 0; i < 3; i++) await openSession(booted.baseUrl, i);
 			expect(booted.started.activeConnections.size).toBe(3);
 
-			await new Promise((resolve) => setTimeout(resolve, 120));
+			await new Promise((resolve) => setTimeout(resolve, 200));
 
 			expect(booted.started.activeConnections.size).toBe(0);
 		} finally {
@@ -157,13 +194,19 @@ describe('idle session eviction', () => {
 	});
 
 	it('keeps a session alive while its client keeps making requests', async () => {
-		const booted = await boot(token, { sessionIdleTtlMs: 200, sessionSweepIntervalMs: 10 });
+		const ttl = 100;
+		const booted = await boot(token, { sessionIdleTtlMs: ttl, sessionSweepIntervalMs: 10 });
 		try {
-			await openSession(booted.baseUrl, 1);
+			const sessionId = await openSession(booted.baseUrl, 1);
 			expect(booted.started.activeConnections.size).toBe(1);
 
-			// Two sweeps' worth of waiting, well inside the TTL: the session must survive.
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			// Keep pinging for well over the TTL. Each ping must refresh the activity stamp,
+			// so the session survives a span it would certainly have been evicted across
+			// had it stayed idle.
+			for (let i = 0; i < 6; i++) {
+				await new Promise((resolve) => setTimeout(resolve, ttl / 2));
+				await pingSession(booted.baseUrl, sessionId, 100 + i);
+			}
 
 			expect(booted.started.activeConnections.size).toBe(1);
 		} finally {

--- a/packages/@n8n/mcp-browser/src/__tests__/server.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/server.test.ts
@@ -4,7 +4,10 @@ import { buildAllowedHosts, isAuthorized, startHttpTransport } from '../server';
 
 type Started = Awaited<ReturnType<typeof startHttpTransport>>;
 
-async function boot(authToken: string): Promise<{
+async function boot(
+	authToken: string,
+	sessionOpts: { sessionIdleTtlMs?: number; sessionSweepIntervalMs?: number } = {},
+): Promise<{
 	started: Started;
 	baseUrl: string;
 	close: () => Promise<void>;
@@ -14,6 +17,7 @@ async function boot(authToken: string): Promise<{
 		host: '127.0.0.1',
 		port: 0,
 		authToken,
+		...sessionOpts,
 	});
 	const address = started.httpServer.address() as AddressInfo;
 	return {
@@ -114,6 +118,57 @@ describe('HTTP transport', () => {
 
 		expect(res.headers.get('access-control-allow-origin')).toBeNull();
 		expect(res.headers.get('access-control-expose-headers')).toBeNull();
+	});
+});
+
+describe('idle session eviction', () => {
+	const token = 'test-token-1234';
+
+	async function openSession(baseUrl: string, id: number) {
+		await fetch(`${baseUrl}/mcp`, {
+			method: 'POST',
+			// eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+			headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id,
+				method: 'initialize',
+				params: {
+					protocolVersion: '2025-06-18',
+					capabilities: {},
+					clientInfo: { name: 'test-client', version: '1.0.0' },
+				},
+			}),
+		});
+	}
+
+	it('evicts sessions that go idle past the TTL, shutting down their browser connections', async () => {
+		const booted = await boot(token, { sessionIdleTtlMs: 20, sessionSweepIntervalMs: 10 });
+		try {
+			for (let i = 0; i < 3; i++) await openSession(booted.baseUrl, i);
+			expect(booted.started.activeConnections.size).toBe(3);
+
+			await new Promise((resolve) => setTimeout(resolve, 120));
+
+			expect(booted.started.activeConnections.size).toBe(0);
+		} finally {
+			await booted.close();
+		}
+	});
+
+	it('keeps a session alive while its client keeps making requests', async () => {
+		const booted = await boot(token, { sessionIdleTtlMs: 200, sessionSweepIntervalMs: 10 });
+		try {
+			await openSession(booted.baseUrl, 1);
+			expect(booted.started.activeConnections.size).toBe(1);
+
+			// Two sweeps' worth of waiting, well inside the TTL: the session must survive.
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			expect(booted.started.activeConnections.size).toBe(1);
+		} finally {
+			await booted.close();
+		}
 	});
 });
 

--- a/packages/@n8n/mcp-browser/src/__tests__/server.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/server.test.ts
@@ -24,21 +24,33 @@ async function boot(
 	baseUrl: string;
 	close: () => Promise<void>;
 }> {
-	const port = await freePort();
-	const started = await startHttpTransport({
-		config: {},
-		host: '127.0.0.1',
-		port,
-		authToken,
-		...sessionOpts,
-	});
-	return {
-		started,
-		baseUrl: `http://127.0.0.1:${port}`,
-		close: async () => {
-			await new Promise<void>((resolve) => started.httpServer.close(() => resolve()));
-		},
-	};
+	// There is an unavoidable gap between releasing the probed port and re-binding it, so another
+	// process can win the race. `startHttpTransport` now rejects on a failed bind rather than
+	// hanging, which makes that losable race simply retryable here.
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt++) {
+		const port = await freePort();
+		try {
+			const started = await startHttpTransport({
+				config: {},
+				host: '127.0.0.1',
+				port,
+				authToken,
+				...sessionOpts,
+			});
+			return {
+				started,
+				baseUrl: `http://127.0.0.1:${port}`,
+				close: async () => {
+					await new Promise<void>((resolve) => started.httpServer.close(() => resolve()));
+				},
+			};
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw error;
+			lastError = error;
+		}
+	}
+	throw lastError;
 }
 
 describe('isAuthorized', () => {
@@ -211,6 +223,22 @@ describe('idle session eviction', () => {
 			expect(booted.started.activeConnections.size).toBe(1);
 		} finally {
 			await booted.close();
+		}
+	});
+});
+
+describe('startHttpTransport bind failures', () => {
+	it('rejects instead of hanging when the port is already taken', async () => {
+		const port = await freePort();
+		const squatter = createServer();
+		await new Promise<void>((resolve) => squatter.listen(port, '127.0.0.1', () => resolve()));
+
+		try {
+			await expect(
+				startHttpTransport({ config: {}, host: '127.0.0.1', port, authToken: 'token' }),
+			).rejects.toMatchObject({ code: 'EADDRINUSE' });
+		} finally {
+			await new Promise<void>((resolve) => squatter.close(() => resolve()));
 		}
 	});
 });

--- a/packages/@n8n/mcp-browser/src/server.ts
+++ b/packages/@n8n/mcp-browser/src/server.ts
@@ -153,6 +153,12 @@ export async function startHttpTransport(opts: {
 			enableDnsRebindingProtection: allowedHosts !== undefined,
 			allowedHosts,
 			onsessioninitialized: (id) => {
+				// A sweep can fire while this request is still in flight and evict the transport
+				// before the SDK gets here. `lastActivityAt` doubles as the liveness registry
+				// (onclose removes the entry), so a missing entry means "already torn down" —
+				// registering the session now would resurrect a closed transport into `sessions`
+				// with no activity tracking behind it, i.e. an entry nothing can ever reap.
+				if (!lastActivityAt.has(transport)) return;
 				sessions.set(id, transport);
 			},
 		});

--- a/packages/@n8n/mcp-browser/src/server.ts
+++ b/packages/@n8n/mcp-browser/src/server.ts
@@ -13,6 +13,15 @@ import type { Config, ToolDefinition } from './types';
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
 
+/**
+ * How long a session may go without a request before it is evicted, and how often to sweep.
+ * A session only ends on `transport.onclose`, which the SDK fires on an explicit HTTP DELETE —
+ * a client that simply goes away never sends one, so without this its BrowserConnection (and the
+ * browser it holds) would be retained for the lifetime of the process.
+ */
+const SESSION_IDLE_TTL_MS = 30 * 60 * 1000;
+const SESSION_SWEEP_INTERVAL_MS = 60 * 1000;
+
 function registerTools(server: McpServer, tools: ToolDefinition[]) {
 	for (const tool of tools) {
 		server.registerTool(
@@ -79,13 +88,28 @@ export async function startHttpTransport(opts: {
 	host: string;
 	port: number;
 	authToken: string;
+	/** Overridable for tests; defaults to SESSION_IDLE_TTL_MS / SESSION_SWEEP_INTERVAL_MS. */
+	sessionIdleTtlMs?: number;
+	sessionSweepIntervalMs?: number;
 }): Promise<{
 	httpServer: ReturnType<typeof createServer>;
 	activeConnections: Set<BrowserConnection>;
 }> {
-	const { config, host, port, authToken } = opts;
+	const {
+		config,
+		host,
+		port,
+		authToken,
+		sessionIdleTtlMs = SESSION_IDLE_TTL_MS,
+		sessionSweepIntervalMs = SESSION_SWEEP_INTERVAL_MS,
+	} = opts;
 	const sessions = new Map<string, StreamableHTTPServerTransport>();
 	const activeConnections = new Set<BrowserConnection>();
+	// Keyed by transport rather than by session id: a connection is created (and its browser
+	// reserved) as soon as a request arrives, which is BEFORE `onsessioninitialized` assigns an
+	// id -- one that never finishes initializing has no session id at all, and would otherwise
+	// never become reapable.
+	const lastActivityAt = new Map<StreamableHTTPServerTransport, number>();
 	const allowedHosts = buildAllowedHosts(host, port);
 
 	const httpServer = createServer((req, res) => {
@@ -107,6 +131,7 @@ export async function startHttpTransport(opts: {
 		const existingTransport = sessionId ? sessions.get(sessionId) : undefined;
 
 		if (existingTransport) {
+			lastActivityAt.set(existingTransport, Date.now());
 			void existingTransport.handleRequest(req, res);
 			return;
 		}
@@ -131,9 +156,11 @@ export async function startHttpTransport(opts: {
 				sessions.set(id, transport);
 			},
 		});
+		lastActivityAt.set(transport, Date.now());
 
 		transport.onclose = () => {
 			if (transport.sessionId) sessions.delete(transport.sessionId);
+			lastActivityAt.delete(transport);
 			activeConnections.delete(connection);
 			void connection.shutdown();
 		};
@@ -145,6 +172,21 @@ export async function startHttpTransport(opts: {
 			void transport.handleRequest(req, res);
 		});
 	});
+
+	// Evict sessions no client has touched for a while. `unref` so this timer never keeps the
+	// process (or a test run) alive on its own.
+	const sweeper = setInterval(() => {
+		const cutoff = Date.now() - sessionIdleTtlMs;
+		for (const [transport, seenAt] of [...lastActivityAt]) {
+			if (seenAt > cutoff) continue;
+			// `transport.close()` fires onclose, which removes the session, drops the connection
+			// from activeConnections and shuts the browser down -- same teardown path as an
+			// explicit client DELETE, so the cleanup logic lives in exactly one place.
+			void transport.close();
+		}
+	}, sessionSweepIntervalMs);
+	sweeper.unref();
+	httpServer.on('close', () => clearInterval(sweeper));
 
 	await new Promise<void>((resolve) => {
 		httpServer.listen(port, host, () => {

--- a/packages/@n8n/mcp-browser/src/server.ts
+++ b/packages/@n8n/mcp-browser/src/server.ts
@@ -194,8 +194,17 @@ export async function startHttpTransport(opts: {
 	sweeper.unref();
 	httpServer.on('close', () => clearInterval(sweeper));
 
-	await new Promise<void>((resolve) => {
+	await new Promise<void>((resolve, reject) => {
+		// Without an `error` handler a failed bind (EADDRINUSE, EACCES on a privileged port…)
+		// never settles this promise, so the caller hangs forever instead of reporting why the
+		// server did not come up.
+		const onError = (error: Error) => {
+			clearInterval(sweeper);
+			reject(error);
+		};
+		httpServer.once('error', onError);
 		httpServer.listen(port, host, () => {
+			httpServer.removeListener('error', onError);
 			console.debug(`n8n-browser MCP server listening on http://${host}:${port}`);
 			resolve();
 		});


### PR DESCRIPTION
Closes #36854

## Summary

The n8n-browser MCP HTTP transport (`packages/@n8n/mcp-browser/src/server.ts`) only ever released
a session on `transport.onclose`, which the MCP SDK fires on an explicit HTTP `DELETE`. A client
that simply goes away — a crashed process, a dropped connection, or any stateless caller that never
sends `DELETE` — left its session, transport and `BrowserConnection` (and the browser it holds)
retained for the lifetime of the process, with no cap and no reaper.

This is the same class of leak that was fixed for the MCP Server Trigger node in #33201 ("Evict
idle sessions to prevent memory leak"); this brings the browser MCP transport in line with that.

## What does this change do?

- Adds idle-TTL eviction: a 30-minute idle TTL, swept every minute.
- The sweep timer is `unref`'d (so it never keeps the process — or a test run — alive on its own)
  and is cleared when the HTTP server closes.
- Eviction goes through `transport.close()`, so teardown follows the same `onclose` path as an
  explicit client `DELETE` rather than duplicating the cleanup logic in a second place.
- Activity is tracked **per transport rather than per session id**. A connection is created (and
  its browser reserved) as soon as a request arrives, which is *before* `onsessioninitialized`
  assigns an id — keying by session id would leave a connection that never finished initializing
  permanently unreapable, which is the leakiest case of all. (I hit exactly this while writing the
  tests: the first version of the fix keyed by session id and did not evict those.)
- The TTL and sweep interval are overridable via optional `startHttpTransport` options, so the
  tests can exercise real eviction without waiting 30 minutes. Defaults are unchanged for callers.

## How to test

`pnpm --filter @n8n/mcp-browser test` — two new tests in
`packages/@n8n/mcp-browser/src/__tests__/server.test.ts`:

- `evicts sessions that go idle past the TTL, shutting down their browser connections` — opens 3
  sessions, waits past a short test TTL, asserts `activeConnections` drops to 0.
- `keeps a session alive while its client keeps making requests` — asserts a session well inside
  the TTL is *not* evicted, so the sweep can't regress into killing live sessions.

All 15 tests in the file pass, and `tsc --noEmit` + `eslint` are clean on both changed files.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


