### PR TITLE
test: Extend agent sessions e2e coverage

### DIFF
--- a/packages/testing/playwright/pages/AgentSessionsPage.ts
+++ b/packages/testing/playwright/pages/AgentSessionsPage.ts
@@ -5,6 +5,17 @@ import { MessageBox } from './components/messageBoxLocators';
 
 type AgentSessionStatusMock = 'running' | 'succeeded' | 'error' | 'cancelled' | 'interrupted';
 
+// The filter dropdown's option labels don't all match their status value
+// (`cancelled` renders as "Canceled"), so map explicitly rather than deriving
+// the label from the value.
+const STATUS_FILTER_LABELS: Record<AgentSessionStatusMock, string> = {
+	running: 'Running',
+	succeeded: 'Succeeded',
+	error: 'Error',
+	cancelled: 'Canceled',
+	interrupted: 'Interrupted',
+};
+
 interface AgentThreadListMock {
 	id: string;
 	title: string;
@@ -292,7 +303,7 @@ export class AgentSessionsPage extends BasePage {
 		await this.page
 			.getByRole('listbox')
 			.filter({ visible: true })
-			.getByRole('option', { name: new RegExp(`^${status}\\b`, 'i') })
+			.getByRole('option', { name: STATUS_FILTER_LABELS[status], exact: true })
 			.click();
 	}
 

--- a/packages/testing/playwright/pages/AgentSessionsPage.ts
+++ b/packages/testing/playwright/pages/AgentSessionsPage.ts
@@ -1,6 +1,16 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
 import { BasePage } from './BasePage';
+import { MessageBox } from './components/messageBoxLocators';
+
+type AgentSessionStatusMock = 'running' | 'succeeded' | 'error' | 'cancelled' | 'interrupted';
+
+interface AgentThreadListMock {
+	id: string;
+	title: string;
+	status: AgentSessionStatusMock;
+	updatedAt?: string;
+}
 
 interface ToolCallMock {
 	name: string;
@@ -132,6 +142,181 @@ export class AgentSessionsPage extends BasePage {
 		);
 	}
 
+	/**
+	 * Mocks the sessions list endpoint for the given threads, honouring the
+	 * `status` query param the same way the real API filters server-side.
+	 */
+	async mockThreadsList(
+		projectId: string,
+		agentId: string,
+		threads: AgentThreadListMock[],
+	): Promise<void> {
+		const threadsPath = `/rest/projects/${projectId}/agents/v2/${agentId}/threads`;
+
+		await this.page.route(
+			(url) => url.pathname === threadsPath,
+			async (route) => {
+				const statusFilter = new URL(route.request().url()).searchParams.get('status');
+				const filtered = statusFilter
+					? threads.filter((thread) => thread.status === statusFilter)
+					: threads;
+
+				await route.fulfill({
+					json: {
+						data: {
+							threads: filtered.map((thread) => ({
+								id: thread.id,
+								agentId,
+								agentName: 'Agent session E2E',
+								parentThreadId: null,
+								parentAgentId: null,
+								projectId,
+								taskId: null,
+								sessionNumber: 1,
+								title: thread.title,
+								emoji: null,
+								totalPromptTokens: 10,
+								totalCompletionTokens: 5,
+								totalCost: 0,
+								totalDuration: 3_000,
+								createdAt: thread.updatedAt ?? '2026-01-01T12:00:00.000Z',
+								updatedAt: thread.updatedAt ?? '2026-01-01T12:00:00.000Z',
+								firstMessage: null,
+								source: 'chat',
+								status: thread.status,
+							})),
+							nextCursor: null,
+						},
+					},
+				});
+			},
+		);
+	}
+
+	async mockDeleteThread(projectId: string, agentId: string, threadId: string): Promise<void> {
+		const threadPath = `/rest/projects/${projectId}/agents/v2/${agentId}/threads/${threadId}`;
+
+		await this.page.route(
+			(url) => url.pathname === threadPath,
+			async (route) => {
+				if (route.request().method() !== 'DELETE') {
+					await route.fallback();
+					return;
+				}
+				await route.fulfill({ json: { data: { success: true } } });
+			},
+		);
+	}
+
+	/** Mocks a session whose only execution ended in an error, without any tool calls. */
+	async mockErrorSession({
+		projectId,
+		agentId,
+		threadId,
+		errorMessage,
+	}: {
+		projectId: string;
+		agentId: string;
+		threadId: string;
+		errorMessage: string;
+	}): Promise<void> {
+		const createdAt = '2026-01-01T12:00:00.000Z';
+		const stoppedAt = '2026-01-01T12:00:03.000Z';
+		const thread = {
+			id: threadId,
+			agentId,
+			agentName: 'Agent session E2E',
+			parentThreadId: null,
+			parentAgentId: null,
+			projectId,
+			taskId: null,
+			sessionNumber: 1,
+			title: 'Errored agent session',
+			emoji: null,
+			totalPromptTokens: 10,
+			totalCompletionTokens: 5,
+			totalCost: 0,
+			totalDuration: 3_000,
+			createdAt,
+			updatedAt: stoppedAt,
+			firstMessage: null,
+			source: 'chat',
+			status: 'error',
+		};
+		const execution = {
+			id: 'agent-execution-e2e-error',
+			threadId,
+			agentId,
+			status: 'error',
+			createdAt,
+			startedAt: createdAt,
+			stoppedAt,
+			duration: 3_000,
+			userMessage: null,
+			attachments: null,
+			model: null,
+			promptTokens: 10,
+			completionTokens: 5,
+			totalTokens: 15,
+			cost: 0,
+			timeline: [],
+			error: errorMessage,
+			hitlStatus: null,
+			source: 'chat',
+		};
+		const threadsPath = `/rest/projects/${projectId}/agents/v2/${agentId}/threads`;
+
+		await this.page.route(
+			(url) => url.pathname === `${threadsPath}/${threadId}`,
+			async (route) => {
+				await route.fulfill({ json: { data: { thread, executions: [execution] } } });
+			},
+		);
+	}
+
+	getSessionRows(): Locator {
+		return this.page.getByTestId('agent-session-list-item');
+	}
+
+	getEmptyState(): Locator {
+		return this.page.getByTestId('agent-sessions-empty');
+	}
+
+	async openFilters(): Promise<void> {
+		await this.page.getByTestId('agent-sessions-filter-button').click();
+	}
+
+	async filterByStatus(status: AgentSessionStatusMock): Promise<void> {
+		await this.openFilters();
+		await this.page.getByTestId('agent-sessions-filter-status').click();
+		await this.page
+			.getByRole('listbox')
+			.filter({ visible: true })
+			.getByRole('option', { name: new RegExp(`^${status}\\b`, 'i') })
+			.click();
+	}
+
+	async resetFilters(): Promise<void> {
+		await this.page.getByTestId('agent-sessions-filter-reset').click();
+	}
+
+	async deleteSession(title: string): Promise<void> {
+		const row = this.getSessionRows().filter({ hasText: title });
+		await row.getByTestId('agent-session-actions').getByRole('button').click();
+		await this.page.getByTestId('agent-session-actions-item-delete').click();
+		await new MessageBox(this.page).confirmButton.click();
+	}
+
+	getSuccessToast(): Locator {
+		return this.page.locator('.el-notification:has(.el-notification--success)');
+	}
+
+	getExecutionErrorCallout(): Locator {
+		// This component uses `data-testid`, not the configured `data-test-id`
+		// attribute, so it isn't reachable via getByTestId().
+		return this.page.locator('[data-testid="execution-error-callout"]');
+	}
+
 	async goto(projectId: string, agentId: string, threadId: string): Promise<void> {
 		await this.page.goto(`/projects/${projectId}/agents/${agentId}/sessions/${threadId}`);
 		await expect(this.getTimelineRows().first()).toBeVisible();
@@ -139,7 +324,8 @@ export class AgentSessionsPage extends BasePage {
 
 	async gotoList(projectId: string, agentId: string): Promise<void> {
 		await this.page.goto(`/projects/${projectId}/agents/${agentId}/sessions`);
-		await expect(this.getSessionTitle()).toBeVisible();
+		// Waits on the table itself, not a row, so this also works for the empty-sessions case.
+		await expect(this.page.getByTestId('table-base-scroll')).toBeVisible();
 	}
 
 	async setViewportWidth(width: number): Promise<void> {

--- a/packages/testing/playwright/tests/e2e/agents/agent-sessions.spec.ts
+++ b/packages/testing/playwright/tests/e2e/agents/agent-sessions.spec.ts
@@ -161,4 +161,78 @@ test.describe('Agent sessions', { annotation: [{ type: 'owner', description: 'AI
 		await expect(n8n.agentSessions.getInputRunData()).toContainText(WORKFLOW_INPUT_MARKER);
 		await expect(n8n.agentSessions.getOutputRunData()).toContainText(WORKFLOW_OUTPUT_MARKER);
 	});
+
+	test('shows an empty state when the agent has no sessions', async ({ n8n, api }) => {
+		const project = await api.projects.getMyPersonalProject();
+		const agentId = `agent-${nanoid(8)}`;
+		await n8n.agentSessions.mockThreadsList(project.id, agentId, []);
+
+		await n8n.start.fromHome();
+		await n8n.agentSessions.gotoList(project.id, agentId);
+
+		await expect(n8n.agentSessions.getEmptyState()).toBeVisible();
+		await expect(n8n.agentSessions.getSessionRows()).toHaveCount(0);
+	});
+
+	test('filters sessions by status', async ({ n8n, api }) => {
+		const project = await api.projects.getMyPersonalProject();
+		const agentId = `agent-${nanoid(8)}`;
+		const succeededTitle = `Succeeded session ${nanoid(6)}`;
+		const erroredTitle = `Errored session ${nanoid(6)}`;
+		await n8n.agentSessions.mockThreadsList(project.id, agentId, [
+			{ id: `thread-${nanoid(8)}`, title: succeededTitle, status: 'succeeded' },
+			{ id: `thread-${nanoid(8)}`, title: erroredTitle, status: 'error' },
+		]);
+
+		await n8n.start.fromHome();
+		await n8n.agentSessions.gotoList(project.id, agentId);
+
+		await expect(n8n.agentSessions.getSessionRows()).toHaveCount(2);
+
+		await n8n.agentSessions.filterByStatus('error');
+		await expect(n8n.agentSessions.getSessionRows()).toHaveCount(1);
+		await expect(n8n.agentSessions.getSessionRows()).toContainText(erroredTitle);
+
+		await n8n.agentSessions.resetFilters();
+		await expect(n8n.agentSessions.getSessionRows()).toHaveCount(2);
+	});
+
+	test('deletes a session from the sessions list', async ({ n8n, api }) => {
+		const project = await api.projects.getMyPersonalProject();
+		const agentId = `agent-${nanoid(8)}`;
+		const threadId = `thread-${nanoid(8)}`;
+		const sessionTitle = `Session to delete ${nanoid(6)}`;
+		await n8n.agentSessions.mockThreadsList(project.id, agentId, [
+			{ id: threadId, title: sessionTitle, status: 'succeeded' },
+		]);
+		await n8n.agentSessions.mockDeleteThread(project.id, agentId, threadId);
+
+		await n8n.start.fromHome();
+		await n8n.agentSessions.gotoList(project.id, agentId);
+		await expect(n8n.agentSessions.getSessionRows()).toHaveCount(1);
+
+		await n8n.agentSessions.deleteSession(sessionTitle);
+
+		await expect(n8n.agentSessions.getSessionRows()).toHaveCount(0);
+		await expect(n8n.agentSessions.getSuccessToast()).toContainText('Session deleted');
+	});
+
+	test('shows the execution error for a failed session', async ({ n8n, api }) => {
+		const project = await api.projects.getMyPersonalProject();
+		const agentId = `agent-${nanoid(8)}`;
+		const threadId = `thread-${nanoid(8)}`;
+		const errorMessage = `Something went wrong ${nanoid(6)}`;
+		await n8n.agentSessions.mockErrorSession({
+			projectId: project.id,
+			agentId,
+			threadId,
+			errorMessage,
+		});
+
+		await n8n.start.fromHome();
+		await n8n.agentSessions.goto(project.id, agentId, threadId);
+
+		await n8n.agentSessions.openTimelineItem(errorMessage);
+		await expect(n8n.agentSessions.getExecutionErrorCallout()).toContainText(errorMessage);
+	});
 });


### PR DESCRIPTION
## Summary

Extends the Playwright coverage for the Agent Sessions feature
(`packages/testing/playwright/tests/e2e/agents/agent-sessions.spec.ts`),
which previously only covered long-title truncation in the sessions
table and tool call input/output rendering in the timeline.

New coverage:
- Sessions list: empty state when an agent has no sessions
- Sessions list: filtering sessions by status
- Sessions list: deleting a session (row action + confirm + toast)
- Session detail: displaying an execution error in the timeline

Also fixes `AgentSessionsPage.gotoList()`'s readiness check, which
waited on a session title that never renders when the list is empty,
and adds a `getExecutionErrorCallout()` locator that targets the
error callout's `data-testid` attribute directly, since that
component doesn't use the `data-test-id` attribute Playwright is
configured to look up by default.

## How to test

```bash
pnpm --filter=n8n-playwright test:local tests/e2e/agents/agent-sessions.spec.ts
```

## Related Linear tickets, Github issues, and Community forum posts

Closes #36871

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


