### PR TITLE
test: Add unit coverage for Instance AI personalization survey

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
@@ -6,6 +6,7 @@ import InstanceAiView from '../InstanceAiView.vue';
 import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
 import { INSTANCE_AI_VIEW } from '../constants';
 import { useSettingsStore } from '@n8n/stores/settings.store';
+import { useUsersStore } from '@n8n/stores/users.store';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 
@@ -105,6 +106,12 @@ describe('InstanceAiView', () => {
 		);
 
 		expect(routerPush).toHaveBeenCalledWith({ name: INSTANCE_AI_VIEW, force: true });
+	});
+
+	it('triggers the personalization survey on mount, same as the homepage views', () => {
+		renderView({ pinia });
+
+		expect(useUsersStore().showPersonalizationSurvey).toHaveBeenCalled();
 	});
 
 	it('tracks "User viewed AI assistant" with the previous in-app route on mount', () => {

--- a/packages/frontend/editor-ui/src/features/settings/users/components/PersonalizationModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/PersonalizationModal.test.ts
@@ -1,8 +1,11 @@
 import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { getDropdownItems } from '@/__tests__/utils';
 import PersonalizationModal from './PersonalizationModal.vue';
 import { createTestingPinia } from '@pinia/testing';
+import { VIEWS } from '@/app/constants';
+import { INSTANCE_AI_VIEW } from '@/features/ai/instanceAi/constants';
 import {
 	COMPANY_TYPE_KEY,
 	COMPANY_INDUSTRY_EXTENDED_KEY,
@@ -15,13 +18,16 @@ import {
 	DEVOPS_AUTOMATION_GOAL_KEY,
 } from '../users.constants';
 
+const flushPromises = async () => await new Promise(setImmediate);
+
+const mockRoute = vi.hoisted(() => ({ name: undefined as string | undefined }));
+const mockRouterReplace = vi.hoisted(() => vi.fn());
+
 vi.mock('vue-router', () => ({
 	useRouter: () => ({
-		replace: vi.fn(),
+		replace: mockRouterReplace,
 	}),
-	useRoute: () => ({
-		location: {},
-	}),
+	useRoute: () => mockRoute,
 	RouterLink: vi.fn(),
 }));
 
@@ -43,6 +49,11 @@ const renderModal = createComponentRenderer(PersonalizationModal, {
 });
 
 describe('PersonalizationModal', () => {
+	beforeEach(() => {
+		mockRoute.name = undefined;
+		mockRouterReplace.mockClear();
+	});
+
 	it('mounts', () => {
 		const { getByTitle } = renderModal({ pinia: createTestingPinia() });
 		expect(getByTitle('Customize n8n to you')).toBeInTheDocument();
@@ -147,5 +158,26 @@ describe('PersonalizationModal', () => {
 
 		await userEvent.click(otherItem);
 		expect(getByTestId(OTHER_MARKETING_AUTOMATION_GOAL_KEY)).toBeInTheDocument();
+	});
+
+	describe('closing the survey', () => {
+		it('redirects to the homepage when closed outside an Instance AI route', async () => {
+			mockRoute.name = 'SomeOtherRoute';
+			const { getByRole } = renderModal({ pinia: createTestingPinia() });
+
+			await userEvent.click(getByRole('button', { name: 'Get started' }));
+
+			await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith({ name: VIEWS.HOMEPAGE }));
+		});
+
+		it('does not redirect away when closed on an Instance AI chat route', async () => {
+			mockRoute.name = INSTANCE_AI_VIEW;
+			const { getByRole } = renderModal({ pinia: createTestingPinia() });
+
+			await userEvent.click(getByRole('button', { name: 'Get started' }));
+			await flushPromises();
+
+			expect(mockRouterReplace).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds missing test coverage for the behavior introduced in
https://github.com/n8n-io/n8n/pull/36809 ("Show personalization
survey and community registration modal on Instance AI landing
page"), which shipped with no tests:

- `InstanceAiView.test.ts`: asserts `usersStore.showPersonalizationSurvey()`
  is called on mount, matching the homepage views' existing behavior.
- `PersonalizationModal.test.ts`: asserts the survey's close callback
  redirects to the homepage on a normal route, but does **not**
  redirect away when closed on an Instance AI chat route.

**Why unit tests, not e2e:** I first tried adding Playwright e2e
coverage for the full flow (survey → community modal → stay on
`/assistant`), since that's this repo's usual convention for editor
UI behavior. That's not possible here: `packages/cli/src/config/index.ts`
hardcodes `N8N_PERSONALIZATION_ENABLED=false` (and disables
diagnostics) whenever `E2E_TESTS=true`, which every Playwright run
sets at boot, before any per-test env override can take effect. I
verified this against a live instance — `personalizationSurveyEnabled`
reports `false` regardless of env vars passed to the test. This is
also why no e2e test exists anywhere in the suite for
`PersonalizationModal`. Unit-testing the two changed components
directly sidesteps the gate and still exercises the actual new logic.

## How to test

```bash
cd packages/frontend/editor-ui
pnpm vitest run src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts src/features/settings/users/components/PersonalizationModal.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1217

Follow-up on https://github.com/n8n-io/n8n/pull/36809, which
shipped this behavior without tests.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


