### PR TITLE
test: Add e2e coverage for agent config validation tooltip

### DIFF
--- a/packages/testing/playwright/pages/AgentBuilderPage.ts
+++ b/packages/testing/playwright/pages/AgentBuilderPage.ts
@@ -1,0 +1,33 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { BasePage } from './BasePage';
+import { getVisibleTooltip } from './components/tooltipLocators';
+
+export class AgentBuilderPage extends BasePage {
+	constructor(page: Page) {
+		super(page);
+	}
+
+	async goto(projectId: string, agentId: string): Promise<void> {
+		await this.page.goto(`/projects/${projectId}/agents/${agentId}`);
+		await expect(this.getHeader()).toBeVisible();
+	}
+
+	getHeader(): Locator {
+		// This header uses `data-testid`, not the configured `data-test-id`
+		// attribute, so it isn't reachable via getByTestId().
+		return this.page.locator('[data-testid="agent-builder-header"]');
+	}
+
+	getPreviewButton(): Locator {
+		return this.page.locator('[data-testid="agent-header-preview-btn"]');
+	}
+
+	getPublishButton(): Locator {
+		return this.page.locator('[data-testid="publish-agent-button"]');
+	}
+
+	getVisibleTooltip(): Locator {
+		return getVisibleTooltip(this.page);
+	}
+}

--- a/packages/testing/playwright/pages/WorkflowSettingsModal.ts
+++ b/packages/testing/playwright/pages/WorkflowSettingsModal.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 
 import { BasePage } from './BasePage';
+import { getVisibleTooltip } from './components/tooltipLocators';
 import { WorkflowMenu } from './components/WorkflowMenu';
 
 export class WorkflowSettingsModal extends BasePage {
@@ -81,7 +82,7 @@ export class WorkflowSettingsModal extends BasePage {
 	}
 
 	getTooltip(): Locator {
-		return this.page.getByTestId('tooltip-content').filter({ visible: true });
+		return getVisibleTooltip(this.page);
 	}
 
 	getSaveButton(): Locator {

--- a/packages/testing/playwright/pages/components/tooltipLocators.ts
+++ b/packages/testing/playwright/pages/components/tooltipLocators.ts
@@ -1,0 +1,6 @@
+import type { Locator, Page } from '@playwright/test';
+
+/** Returns the currently-visible `N8nTooltip` content bubble, if any. */
+export function getVisibleTooltip(page: Page): Locator {
+	return page.getByTestId('tooltip-content').filter({ visible: true });
+}

--- a/packages/testing/playwright/pages/n8nPage.ts
+++ b/packages/testing/playwright/pages/n8nPage.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 
+import { AgentBuilderPage } from './AgentBuilderPage';
 import { AgentSessionsPage } from './AgentSessionsPage';
 import { AIAssistantPage } from './AIAssistantPage';
 import { CanvasPage } from './CanvasPage';
@@ -79,6 +80,7 @@ export class n8nPage {
 	// Pages
 	readonly aiAssistant: AIAssistantPage;
 	readonly aiBuilder: AIBuilderPage;
+	readonly agentBuilder: AgentBuilderPage;
 	readonly agentSessions: AgentSessionsPage;
 	readonly canvas: CanvasPage;
 	readonly chatHubChat: ChatHubChatPage;
@@ -164,6 +166,7 @@ export class n8nPage {
 		// Pages
 		this.aiAssistant = new AIAssistantPage(page);
 		this.aiBuilder = new AIBuilderPage(page);
+		this.agentBuilder = new AgentBuilderPage(page);
 		this.agentSessions = new AgentSessionsPage(page);
 		this.canvas = new CanvasPage(page);
 		this.chatHubChat = new ChatHubChatPage(page);

--- a/packages/testing/playwright/services/agents-api-helper.ts
+++ b/packages/testing/playwright/services/agents-api-helper.ts
@@ -11,9 +11,11 @@ export class AgentsApiHelper {
 	constructor(private readonly api: ApiHelpers) {}
 
 	/**
-	 * Creates an agent with only a name — no model, credential, or instructions.
-	 * Useful for exercising config-validation UI without clicking through the builder,
-	 * since a bare agent is naturally invalid (missing instructions + missing model).
+	 * Creates an agent with only a name, then explicitly clears its model —
+	 * useful for exercising config-validation UI without clicking through the
+	 * builder. Creation alone doesn't guarantee an empty model: when the
+	 * project already has a usable LLM credential (or the instance is wired to
+	 * n8n's managed AI gateway), the backend auto-assigns a default.
 	 */
 	async createAgent(projectId: string, name: string): Promise<CreatedAgent> {
 		const response = await this.api.request.post(`/rest/projects/${projectId}/agents/v2/`, {
@@ -25,6 +27,25 @@ export class AgentsApiHelper {
 		}
 
 		const result = await response.json();
-		return result.data ?? result;
+		const agent: CreatedAgent = result.data ?? result;
+		await this.clearModel(projectId, agent.id);
+		return agent;
+	}
+
+	private async clearModel(projectId: string, agentId: string): Promise<void> {
+		const configPath = `/rest/projects/${projectId}/agents/v2/${agentId}/config`;
+		const configResponse = await this.api.request.get(configPath);
+		if (!configResponse.ok()) {
+			throw new TestError(`Failed to fetch agent config: ${await configResponse.text()}`);
+		}
+		const configResult = await configResponse.json();
+		const config = configResult.data ?? configResult;
+
+		const putResponse = await this.api.request.put(configPath, {
+			data: { config: { ...config, model: '' } },
+		});
+		if (!putResponse.ok()) {
+			throw new TestError(`Failed to clear agent model: ${await putResponse.text()}`);
+		}
 	}
 }

--- a/packages/testing/playwright/services/agents-api-helper.ts
+++ b/packages/testing/playwright/services/agents-api-helper.ts
@@ -1,0 +1,30 @@
+import type { ApiHelpers } from './api-helper';
+import { TestError } from '../Types';
+
+export interface CreatedAgent {
+	id: string;
+	name: string;
+}
+
+/** Helper for driving the Agents (v2) REST API directly, bypassing the editor UI. */
+export class AgentsApiHelper {
+	constructor(private readonly api: ApiHelpers) {}
+
+	/**
+	 * Creates an agent with only a name — no model, credential, or instructions.
+	 * Useful for exercising config-validation UI without clicking through the builder,
+	 * since a bare agent is naturally invalid (missing instructions + missing model).
+	 */
+	async createAgent(projectId: string, name: string): Promise<CreatedAgent> {
+		const response = await this.api.request.post(`/rest/projects/${projectId}/agents/v2/`, {
+			data: { name },
+		});
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to create agent: ${await response.text()}`);
+		}
+
+		const result = await response.json();
+		return result.data ?? result;
+	}
+}

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -17,6 +17,7 @@ import {
 	INSTANCE_CHAT_CREDENTIALS,
 } from '../config/test-users';
 import { TestError } from '../Types';
+import { AgentsApiHelper } from './agents-api-helper';
 import { CredentialApiHelper } from './credential-api-helper';
 import { DynamicCredentialApiHelper } from './dynamic-credential-api-helper';
 import { ExternalSecretsApiHelper } from './external-secrets-api-helper';
@@ -87,6 +88,7 @@ export class ApiHelpers {
 	securitySettings: SecuritySettingsApiHelper;
 	tokenExchange: TokenExchangeApiHelper;
 	instanceAi: InstanceAiApiHelper;
+	agents: AgentsApiHelper;
 
 	publicApi: PublicApiHelper;
 
@@ -109,6 +111,7 @@ export class ApiHelpers {
 		this.securitySettings = new SecuritySettingsApiHelper(this);
 		this.tokenExchange = new TokenExchangeApiHelper(this);
 		this.instanceAi = new InstanceAiApiHelper(this);
+		this.agents = new AgentsApiHelper(this);
 
 		this.publicApi = new PublicApiHelper(this);
 	}

--- a/packages/testing/playwright/tests/e2e/agents/agent-validation-tooltip.spec.ts
+++ b/packages/testing/playwright/tests/e2e/agents/agent-validation-tooltip.spec.ts
@@ -1,0 +1,45 @@
+import { nanoid } from 'nanoid';
+
+import { expect, test } from '../../../fixtures/base';
+
+test.use({
+	capability: {
+		env: {
+			N8N_ENABLED_MODULES: 'agents',
+			TEST_ISOLATION: 'agent-validation-tooltip',
+		},
+	},
+});
+
+test.describe(
+	'Agent config validation tooltip',
+	{ annotation: [{ type: 'owner', description: 'AI' }] },
+	() => {
+		test('lists the specific missing fields on the disabled preview and publish buttons', async ({
+			n8n,
+			api,
+		}) => {
+			const project = await api.projects.getMyPersonalProject();
+			const agent = await api.agents.createAgent(project.id, `Agent ${nanoid(8)}`);
+
+			await n8n.start.fromHome();
+			await n8n.agentBuilder.goto(project.id, agent.id);
+
+			await n8n.agentBuilder.getPreviewButton().hover();
+			await expect(n8n.agentBuilder.getVisibleTooltip()).toContainText(
+				'Instructions: A required field is missing',
+			);
+			await expect(n8n.agentBuilder.getVisibleTooltip()).toContainText(
+				'Model: A required field is missing',
+			);
+
+			await n8n.agentBuilder.getPublishButton().hover();
+			await expect(n8n.agentBuilder.getVisibleTooltip()).toContainText(
+				'Instructions: A required field is missing',
+			);
+			await expect(n8n.agentBuilder.getVisibleTooltip()).toContainText(
+				'Model: A required field is missing',
+			);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Adds Playwright coverage for the behavior introduced in
https://github.com/n8n-io/n8n/pull/36772 ("Show agent validation
details in tooltips"), which added a new `AgentValidationTooltip.vue`
component (~140 lines of issue-code-to-message mapping logic) with no
test files changed.

New test: creates a bare agent via the API (no model, no
instructions — naturally invalid), opens the builder, and hovers the
disabled Preview and Publish buttons to confirm the tooltip lists the
specific missing fields ("Instructions: A required field is missing",
"Model: A required field is missing") rather than a generic message.

Also:
- Adds a minimal `api.agents.createAgent()` helper (no prior API
  helper existed for the Agents v2 REST endpoints).
- Adds an `AgentBuilderPage` page object for the builder header/
  preview/publish buttons. Note both buttons use a `data-testid`
  attribute rather than this repo's configured `data-test-id`, so
  they need a raw attribute locator instead of `getByTestId()`.
- Extracts the repeated "visible tooltip content" locator into
  `pages/components/tooltipLocators.ts`, reused by the existing
  `WorkflowSettingsModal` page object (the janitor flagged the
  duplicate).

## How to test

```bash
pnpm --filter=n8n-playwright test:local tests/e2e/agents/agent-validation-tooltip.spec.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-596

Follow-up on https://github.com/n8n-io/n8n/pull/36772, which
shipped this behavior without tests.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


