### PR TITLE
test(ai-builder): Pin `threadIds` in the eval-results dispatcher contract (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -63,6 +63,7 @@ function iteration1(): WorkflowTestCaseResult {
 	return {
 		testCase,
 		workflowBuildSuccess: true,
+		threadId: '3f0c9a2e-8d41-4b77-9a10-1c2d3e4f5a6b',
 		transcript,
 		workflowChecks: [passingCheck],
 		workflowJson: {
@@ -130,6 +131,7 @@ interface DispatcherView {
 		buildTurnsPerRun?: Array<number | null>;
 		transcriptPerRun: Array<TranscriptTurn[] | null>;
 		buildErrorPerRun: Array<string | null>;
+		threadIds: Array<string | null>;
 		scenarios: Array<{
 			name: string;
 			passCount: number;
@@ -222,6 +224,14 @@ describe('eval-results.json — dispatcher contract', () => {
 
 		// Per-iteration build-failure reason — one `string | null` per run.
 		expect(tc.buildErrorPerRun).toEqual([null, 'agent stopped before producing a workflow']);
+
+		// Build thread ids — one per iteration, null when the iteration never
+		// reached a build. LangTracer persists these (case_run_artifacts.thread_ids)
+		// as the join key from a case run to its LangSmith builder trace
+		// (`metadata.thread_id`) when eval trace capture is enabled on the n8n
+		// container. Dropping the field orphans every captured trace: the trace
+		// itself carries only a bare UUID, with no case, verdict, or version.
+		expect(tc.threadIds).toEqual(['3f0c9a2e-8d41-4b77-9a10-1c2d3e4f5a6b', null]);
 
 		// Scenario blocks serialize under the flat `scenarios` key with a flat
 		// `name` — the shape the dispatcher's fallback reader consumes today.


### PR DESCRIPTION
## Summary

`writeEvalResults` already emits `testCases[].threadIds` (`evaluations/run/persist.ts`) — one entry per build iteration, `null` where an iteration never reached a build. The dispatcher contract test pins `workflowJson`, `transcriptPerRun`, `buildErrorPerRun` and friends, but not this field, so it can be renamed or dropped without anything going red.

This adds it to the pin. No production code changes.

## Why now

LangTracer is about to depend on it. Its eval runs are driven through the LangTracer dispatcher, which spawns this CLI in direct (no-LangSmith) mode and reads `eval-results.json`.

We're enabling **builder** tracing on the eval n8n container so the build conversations land in LangSmith. Those traces carry only a bare UUID `metadata.thread_id` — no case name, no verdict, no version. `threadIds` is the only join key from a captured trace back to the case run that produced it. LangTracer now persists it (`case_run_artifacts.thread_ids`).

## Verification

Confirmed the guard actually bites rather than passing vacuously: removing the `threadIds` line from `run/persist.ts` turns this test red (`expected undefined to deeply equal [ …(2) ]`), restoring it turns it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

