### PR TITLE
ci: Skip `-pc` steps when the built ref has no `-pc` tags

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -211,7 +211,7 @@ jobs:
 
       - name: Build and push n8n -pc Docker image
         id: build-n8n-pc
-        if: needs.determine-build-context.outputs.push_enabled == 'true'
+        if: needs.determine-build-context.outputs.push_enabled == 'true' && steps.determine-tags.outputs.n8n_pc_tags != ''
         uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
@@ -368,6 +368,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DATE_TAG: ${{ inputs.date_tag }}
           SHORT_SHA: ${{ needs.determine-build-context.outputs.short_sha }}
+          N8N_PC_MANIFEST_TAG: ${{ needs.build-and-push-docker.outputs.n8n_pc_primary_ghcr_manifest_tag }}
         run: |
           VERSION="${{ needs.determine-build-context.outputs.n8n_version }}"
           DOCKER_BASE="$DOCKER_USERNAME"
@@ -375,10 +376,12 @@ jobs:
           # Create manifests for each image type
           declare -A images=(
             ["n8n"]="${VERSION}"
-            ["n8n-pc"]="${VERSION}-pc"
             ["runners"]="${VERSION}"
             ["runners-distroless"]="${VERSION}-distroless"
           )
+          if [[ -n "$N8N_PC_MANIFEST_TAG" ]]; then
+            images["n8n-pc"]="${VERSION}-pc"
+          fi
 
           for image in "${!images[@]}"; do
             TAG_SUFFIX="${images[$image]}"
@@ -674,6 +677,7 @@ jobs:
     needs: [determine-build-context, build-and-push-docker, create_multi_arch_manifest]
     if: |
       success() &&
+      needs.build-and-push-docker.outputs.n8n_pc_primary_ghcr_manifest_tag != '' &&
       (needs.determine-build-context.outputs.release_type == 'stable' ||
        needs.determine-build-context.outputs.release_type == 'nightly' ||
        needs.determine-build-context.outputs.release_type == 'rc')

--- a/.github/workflows/test-e2e-pc-nightly.yml
+++ b/.github/workflows/test-e2e-pc-nightly.yml
@@ -3,8 +3,6 @@ name: 'Test: E2E on -pc image'
 # Boots the pointer-compressed n8n image and runs the e2e suite against it.
 
 on:
-  schedule:
-    - cron: '0 2 * * *' # after the nightly Docker build at midnight
   workflow_dispatch:
     inputs:
       image:


### PR DESCRIPTION
## Summary

The v3 nightly [failed](https://github.com/n8n-io/n8n/actions/runs/32627510046) because it runs this workflow from `master` but builds `3.x`, whose `docker-tags.mjs` predates PC support. A release from any branch cut before PC support landed would hit the same crash. 

Hence let's skip the `-pc` build step when the built ref produces no `-pc` tags.

Validated from this branch: a [v3 nightly dispatch](https://github.com/n8n-io/n8n/actions/runs/32657439932) now skips the `-pc` step instead of crashing (it still fails later on the pre-existing `3.x` corepack issue, which is waiting for #36833). A [normal build dispatch](https://github.com/n8n-io/n8n/actions/runs/32657442236) still builds and pushes the `-pc` image as usual.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)