### PR TITLE
fix(workflow): allow mutating Array methods on augmented \ arrays in expressions

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -205,14 +205,14 @@ export function createDeepLazyProxy(
 					return {
 						configurable: true,
 						enumerable: true,
-						writable: false,
+						writable: true,
 						value: proxy[prop],
 					};
 				}
 				return undefined;
 			}
 			if (resolveObjectKeys().includes(prop)) {
-				return { configurable: true, enumerable: true, writable: false };
+				return { configurable: true, enumerable: true, writable: true };
 			}
 			return undefined;
 		},

--- a/packages/workflow/src/augment-object.ts
+++ b/packages/workflow/src/augment-object.ts
@@ -53,7 +53,7 @@ export function augmentArray<T>(data: T[]): T[] {
 				return Reflect.getOwnPropertyDescriptor(newData, key);
 			}
 
-			return Object.getOwnPropertyDescriptor(data, key) ?? defaultPropertyDescriptor;
+			return Reflect.getOwnPropertyDescriptor(newData, key);
 		},
 		has(target, key) {
 			return Reflect.has(newData ?? target, key);

--- a/packages/workflow/test/augment-object.test.ts
+++ b/packages/workflow/test/augment-object.test.ts
@@ -39,6 +39,16 @@ describe('AugmentObject', () => {
 
 			expect(augmentedObject.reverse()).toEqual([null, 4, 3, 1]);
 			expect(originalObject).toEqual(copyOriginal);
+
+			const toSort = augmentArray(['Mango', 'Apple', 'Kiwi']);
+			expect(toSort.sort()).toEqual(['Apple', 'Kiwi', 'Mango']);
+			expect(Object.getOwnPropertyDescriptor(toSort, '0')?.value).toEqual('Apple');
+
+			const toFill = augmentArray([1, 2, 3]);
+			expect(toFill.fill(9, 0, 2)).toEqual([9, 9, 3]);
+
+			const toCopyWithin = augmentArray([1, 2, 3, 4, 5]);
+			expect(toCopyWithin.copyWithin(0, 3)).toEqual([4, 5, 3, 4, 5]);
 		});
 
 		test('should work with arrays on any level', () => {


### PR DESCRIPTION
## Summary

Fixes #36540

Mutating array methods (`sort()`, `splice()`, `fill()`, `copyWithin()`) called on `$json` arrays in expressions previously evaluated to `null` or failed to reflect mutations.

## Root Cause
1. In `packages/workflow/src/augment-object.ts`, `augmentArray`'s `getOwnPropertyDescriptor` trap returned `Object.getOwnPropertyDescriptor(data, key)` from the unmutated original array `data` instead of the mutated copy `newData`, causing descriptor lookups to return stale/original values.
2. In `packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts`, `getOwnPropertyDescriptor` returned `writable: false` for array elements and object keys. In strict V8 evaluation contexts, mutating array methods attempting `[[Set]]` failed with TypeError and were swallowed, returning `null`.

## Changes
- Updated `augmentArray` in `packages/workflow/src/augment-object.ts` to return `Reflect.getOwnPropertyDescriptor(newData, key)` when `newData` is defined.
- Updated `packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts` property descriptors to use `writable: true`.
- Added unit tests in `packages/workflow/test/augment-object.test.ts` verifying `sort()`, `fill()`, `copyWithin()`, and property descriptors on augmented arrays.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

