### PR TITLE
fix(editor): Improve N8nCopyInput focus and hover states (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
@@ -4,8 +4,8 @@ import { computed, onBeforeUnmount, ref } from 'vue';
 
 import { useI18n } from '../../composables/useI18n';
 import type { InputSize } from '../../types/input';
-import N8nButton from '../N8nButton';
 import N8nIcon from '../N8nIcon';
+import N8nIconButton from '../N8nIconButton';
 import N8nInput from '../N8nInput';
 import N8nTooltip from '../N8nTooltip';
 
@@ -83,10 +83,10 @@ const copyButtonLabel = computed(() =>
 	<N8nInput :model-value="displayValue ?? value" :size="size" readonly :class="$style.copyInput">
 		<template #append>
 			<N8nTooltip :content="copyButtonLabel">
-				<N8nButton
+				<N8nIconButton
 					variant="ghost"
 					:size="buttonSize"
-					icon-only
+					icon="copy"
 					:aria-label="copyButtonLabel"
 					data-test-id="copy-input-button"
 					:class="$style.button"
@@ -103,7 +103,7 @@ const copyButtonLabel = computed(() =>
 							</Transition>
 						</span>
 					</template>
-				</N8nButton>
+				</N8nIconButton>
 			</N8nTooltip>
 		</template>
 	</N8nInput>

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
@@ -89,6 +89,7 @@ const copyButtonLabel = computed(() =>
 					icon-only
 					:aria-label="copyButtonLabel"
 					data-test-id="copy-input-button"
+					:class="$style.button"
 					@click="onCopyClick"
 				>
 					<template #icon>
@@ -140,6 +141,12 @@ const copyButtonLabel = computed(() =>
 		margin: 0;
 		padding: 0;
 	}
+}
+
+.button {
+	/** Overrides radius so that hover state doesnt leave gaps in left corners **/
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 /*

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
@@ -2,10 +2,12 @@
 import { useClipboard } from '@vueuse/core';
 import { computed, onBeforeUnmount, ref } from 'vue';
 
+import { useI18n } from '../../composables/useI18n';
 import type { InputSize } from '../../types/input';
 import N8nButton from '../N8nButton';
 import N8nIcon from '../N8nIcon';
 import N8nInput from '../N8nInput';
+import N8nTooltip from '../N8nTooltip';
 
 interface CopyInputProps {
 	/** Full value written to the clipboard. */
@@ -29,18 +31,17 @@ defineOptions({ name: 'N8nCopyInput' });
 const props = withDefaults(defineProps<CopyInputProps>(), {
 	displayValue: undefined,
 	size: 'large',
-	copyLabel: 'Copy',
-	copiedLabel: 'Copied to clipboard',
+	copyLabel: undefined,
+	copiedLabel: undefined,
 	feedbackDurationMs: 2000,
 });
 
+const { t } = useI18n();
+
 const emit = defineEmits<{
-	/** Emitted after the value has been written to the clipboard. */
 	copy: [value: string];
 }>();
 
-// legacy: falls back to document.execCommand on insecure origins (plain-http
-// self-hosted instances), where navigator.clipboard is unavailable.
 const clipboard = useClipboard({ legacy: true });
 
 const showCopiedFeedback = ref(false);
@@ -70,47 +71,47 @@ const buttonSize = computed(() => {
 			return 'medium';
 	}
 });
+
+const copyButtonLabel = computed(() =>
+	showCopiedFeedback.value
+		? (props.copiedLabel ?? t('generic.copiedToClipboard'))
+		: (props.copyLabel ?? t('generic.copy')),
+);
 </script>
 
 <template>
 	<N8nInput :model-value="displayValue ?? value" :size="size" readonly :class="$style.copyInput">
 		<template #append>
-			<N8nButton
-				variant="ghost"
-				:size="buttonSize"
-				icon-only
-				:aria-label="showCopiedFeedback ? copiedLabel : copyLabel"
-				data-test-id="copy-input-button"
-				@click="onCopyClick"
-			>
-				<template #icon>
-					<span :class="$style.iconSwap">
-						<Transition
-							:enter-active-class="$style.swapEnterActive"
-							:leave-active-class="$style.swapLeaveActive"
-						>
-							<N8nIcon v-if="showCopiedFeedback" key="check" icon="check" :size="buttonSize" />
-							<N8nIcon v-else key="copy" icon="copy" :size="buttonSize" />
-						</Transition>
-					</span>
-				</template>
-			</N8nButton>
+			<N8nTooltip :content="copyButtonLabel">
+				<N8nButton
+					variant="ghost"
+					:size="buttonSize"
+					icon-only
+					:aria-label="copyButtonLabel"
+					data-test-id="copy-input-button"
+					@click="onCopyClick"
+				>
+					<template #icon>
+						<span :class="$style.iconSwap">
+							<Transition
+								:enter-active-class="$style.swapEnterActive"
+								:leave-active-class="$style.swapLeaveActive"
+							>
+								<N8nIcon v-if="showCopiedFeedback" key="check" icon="check" :size="buttonSize" />
+								<N8nIcon v-else key="copy" icon="copy" :size="buttonSize" />
+							</Transition>
+						</span>
+					</template>
+				</N8nButton>
+			</N8nTooltip>
 		</template>
 	</N8nInput>
 </template>
 
 <style lang="scss" module>
+@use '../../css/mixins/focus';
 @use '../../css/mixins/motion';
 
-/*
- * One continuous bordered field (the instance-settings copy-field pattern):
- * border, radius and background move onto the input CONTAINER (with overflow
- * hidden so the append segment is clipped by the outer radius), the wrapper
- * drops its own border so it doesn't double up, and the append becomes a
- * transparent, full-height button segment separated from the value by a single
- * border-left divider. Focus indication is unaffected — the design system
- * draws it with outline, not box-shadow.
- */
 .copyInput {
 	gap: 0;
 	border-radius: var(--input--radius);
@@ -118,14 +119,24 @@ const buttonSize = computed(() => {
 	box-shadow: inset var(--input--border--shadow);
 	overflow: hidden;
 
+	&:focus-within {
+		@include focus.focus-ring;
+		box-shadow: inset var(--input--border--shadow--focus);
+	}
+
 	:global(.n8n-input__wrapper) {
-		box-shadow: none;
 		background-color: transparent;
+
+		&,
+		&:hover:not(.disabled):not(:focus-within),
+		&:focus-within {
+			box-shadow: none;
+		}
 	}
 
 	:global(.n8n-input__wrapper) + span {
 		background-color: transparent;
-		border-left: var(--border);
+		border-left: var(--border-width) var(--border-style) var(--input--border-color);
 		margin: 0;
 		padding: 0;
 	}

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -42,6 +42,8 @@ export default {
 	'codeDiff.replaceMyCode': 'Replace my code',
 	'codeDiff.replacing': 'Replacing...',
 	'codeDiff.undo': 'Undo',
+	'generic.copy': 'Copy',
+	'generic.copiedToClipboard': 'Copied to clipboard',
 	'codeBlock.copy': 'Copy code',
 	'codeBlock.copiedToClipboard': 'Copied to clipboard',
 	'codeBlock.copyFailed': "Couldn't copy code. Try again or copy it manually.",


### PR DESCRIPTION
## Summary

Add proper focus and hover states to a contained input component, plus fixing some broken `i18n` translations

* Add a visible focus ring to `N8nCopyInput`.
* Remove the input wrapper hover border state.
* Add translated labels and tooltip feedback to the copy button.

<!-- linear:table-colwidths:403,403 -->
| **Before** | **After** |
| -- | -- |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/89425c6a-9e29-460c-9a21-62b46d2145e1/7cdf0363-9883-4ab5-9232-aa8134b8663a?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi84OTQyNWM2YS05ZTI5LTQ2MGMtOWEyMS02MmI0NmQyMTQ1ZTEvN2NkZjAzNjMtOTg4My00YWI1LTkyMzItYWE4MTM0Yjg2NjNhIiwiaWF0IjoxNzg3NTYyODM2LCJleHAiOjE4MTkxMzMzOTZ9.HeHB6DSoXxzvUI5nZ_m_shmuc32W0uYIi2vdibz0RD4 " alt="CleanShot 2026-08-24 at 10.12.57@2x.png" width="2084" data-linear-height="662" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/9f575bce-3d6c-4664-bc8c-08ea447cd062/c82d2d9a-e972-4104-bd93-2b7b0c37b38b?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi85ZjU3NWJjZS0zZDZjLTQ2NjQtYmM4Yy0wOGVhNDQ3Y2QwNjIvYzgyZDJkOWEtZTk3Mi00MTA0LWJkOTMtMmI3YjBjMzdiMzhiIiwiaWF0IjoxNzg3NTYyODM2LCJleHAiOjE4MTkxMzMzOTZ9.zncY5CkBQos84JEGBmNzz2PObnbP520rIJe6Wcv17vc " alt="CleanShot 2026-08-24 at 10.11.54@2x.png" width="2026" data-linear-height="624" /> |

## How to test

1. Open a page or Storybook story that uses `N8nCopyInput`.
2. Move focus to the copy button with the Tab key.
3. Confirm that the component shows a focus ring.
4. Move the pointer over the input and the copy button.
5. Confirm that the field border does not change on hover.
6. Select the copy button.
7. Confirm that the tooltip and accessible label change from "Copy" to "Copied to clipboard".

## Related Linear tickets, Github issues, and Community forum posts

[DS-630](https://linear.app/n8n/issue/DS-630)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)