### PR TITLE
feat(ai-builder): Surface thread provenance on Instance AI traces (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
@@ -182,6 +182,25 @@ describe('createBuildOrchestrator', () => {
 		);
 	});
 
+	it('forwards the case identity so the build can stamp its trace', async () => {
+		// Same class of bug as credentialFixture above, different symptom: the
+		// harness passes these to ensureThread as sourceContext, which is what
+		// puts `source_context.evalCase` on the LangSmith trace. Dropped, every
+		// build in the project looks identical and no export can group them.
+		const tracedBuild = vi.fn().mockResolvedValue(okBuild());
+		const orchestrator = createBuildOrchestrator(
+			makeDeps([makeLane(1, tracedBuild)], {
+				testCaseByFileSlug: new Map([['case-a', baseCase()]]),
+			}),
+		);
+
+		await orchestrator.getOrBuild(3, 'case-a');
+
+		expect(tracedBuild).toHaveBeenCalledWith(
+			expect.objectContaining({ fileSlug: 'case-a', iteration: 3 }),
+		);
+	});
+
 	it('builds once per (iteration, fileSlug) and caches the promise', async () => {
 		const tracedBuild = vi.fn().mockResolvedValue(okBuild());
 		const orchestrator = createBuildOrchestrator(makeDeps([makeLane(1, tracedBuild)]));

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -270,7 +270,15 @@ export class N8nClient {
 	 * Ensure a conversation thread exists before sending chat messages.
 	 * POST /rest/instance-ai/threads body: { threadId, projectId, source }
 	 */
-	async ensureThread(threadId: string, projectId?: string): Promise<void> {
+	/** `sourceContext` is persisted on the thread and surfaced on the run's
+	 *  LangSmith trace (prefixed `source_context.`), so pass what a later reader
+	 *  needs to tell one build apart from another — the eval harness sends the
+	 *  case slug and iteration. Capped at 2 KB by the API. */
+	async ensureThread(
+		threadId: string,
+		projectId?: string,
+		sourceContext?: Record<string, string | number | boolean>,
+	): Promise<void> {
 		const resolvedProjectId = projectId ?? (await this.getPersonalProjectId());
 		await this.fetch('/rest/instance-ai/threads', {
 			method: 'POST',
@@ -279,6 +287,7 @@ export class N8nClient {
 				projectId: resolvedProjectId,
 				source: 'evals',
 				origin: 'internal',
+				...(sourceContext ? { sourceContext } : {}),
 			},
 		});
 	}

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -458,6 +458,11 @@ export interface BuildWorkflowConfig {
 	/** Credential type for a `local` run, where there is no fixture manifest to
 	 *  read it from. */
 	credentialSetupType?: string;
+	/** Which case this build is, and which repeat of it. Recorded on the thread
+	 *  as sourceContext, which n8n surfaces on the LangSmith trace — the only
+	 *  thing that distinguishes one build from the hundreds of near-identical
+	 *  ones a suite produces. */
+	caseIdentity?: { fileSlug: string; iteration: number };
 }
 
 /** A case needs a workflow iff something judges one: execution scenarios or
@@ -637,7 +642,16 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 		);
 
 		const projectId = await client.getPersonalProjectId();
-		await client.ensureThread(threadId, projectId);
+		await client.ensureThread(
+			threadId,
+			projectId,
+			config.caseIdentity
+				? {
+						evalCase: config.caseIdentity.fileSlug,
+						evalIteration: config.caseIdentity.iteration,
+					}
+				: undefined,
+		);
 
 		// Pin the thread's credential view to the case's declared set (empty by
 		// default) before the first message, so every build-workflow call inside

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -115,7 +115,15 @@ export type BuildArgs = Pick<
 	// callback's parameter type, so tsc cannot catch a dropped field here; the
 	// orchestrator test pins it.
 	| 'credentialFixture'
-> & { timeoutMs: number };
+> & {
+	timeoutMs: number;
+	/** Which case this build is, and which repeat of it. Not used by the build
+	 *  itself — it rides to `ensureThread` as sourceContext so the LangSmith
+	 *  trace carries `source_context.evalCase` / `evalIteration`. Without it
+	 *  every build in a traced project is an anonymous conversation. */
+	fileSlug: string;
+	iteration: number;
+};
 
 /** A lane plus the allocator-managed counters and the caller-provided (traced)
  *  build/execute wrappers. `runner` is the underlying Lane (n8n client,
@@ -624,6 +632,8 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						outcomeExpectations: entry.outcomeExpectations,
 						credentialFixture: entry.credentialFixture,
 						timeoutMs,
+						fileSlug,
+						iteration,
 					});
 				} finally {
 					allocator.release(lane, fileSlug);

--- a/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
@@ -160,6 +160,7 @@ export function createEvalSession(config: EvalSessionConfig): EvalSession {
 							// launches and no port opens.
 							credentialSetupSelection: await resolveCredentialSetupFixture(buildArgs),
 							credentialSetupType: buildArgs.credentials?.[0]?.type,
+							caseIdentity: { fileSlug: buildArgs.fileSlug, iteration: buildArgs.iteration },
 						}),
 					),
 			),

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -239,6 +239,10 @@ export type {
 	AgentSnapshotReason,
 } from './tracing/agent-snapshot-event';
 
+// Plain re-export, not a lazyFunction: this is a pure mapping with no imports,
+// so it costs nothing to load eagerly.
+export { threadProvenanceMetadata } from './tracing/thread-provenance';
+
 export const createInstanceAiTraceContext: typeof LangsmithTracingMod.createInstanceAiTraceContext =
 	lazyFunction(() => loadLangsmithTracing().createInstanceAiTraceContext);
 

--- a/packages/@n8n/instance-ai/src/tracing/__tests__/thread-provenance.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/thread-provenance.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { threadProvenanceMetadata } from '../thread-provenance';
+
+describe('threadProvenanceMetadata', () => {
+	it('surfaces the entry point a thread was opened from', () => {
+		expect(threadProvenanceMetadata({ source: 'evals', origin: 'internal' })).toEqual({
+			thread_source: 'evals',
+		});
+	});
+
+	it('flattens sourceContext so each entry is filterable on its own', () => {
+		// Nested documents are not filterable in LangSmith — `eq(metadata_key, …)`
+		// matches a key, not a path into a JSON value. Flat scalars are the whole
+		// point: they are what lets every build of one eval case be selected.
+		expect(
+			threadProvenanceMetadata({
+				source: 'evals',
+				sourceContext: { evalCase: 'gmail-inbox-triage', evalIteration: 2, prebuilt: false },
+			}),
+		).toEqual({
+			thread_source: 'evals',
+			'source_context.evalCase': 'gmail-inbox-triage',
+			'source_context.evalIteration': 2,
+			'source_context.prebuilt': false,
+		});
+	});
+
+	it('cannot overwrite the trace fields n8n sets itself', () => {
+		// buildBaseMetadata spreads caller metadata LAST, so an unprefixed
+		// `user_id` in a caller's bag would replace the real one. The prefix is
+		// what makes an arbitrary caller bag safe to merge at all.
+		const out = threadProvenanceMetadata({
+			source: 'evals',
+			sourceContext: { user_id: 'spoofed', thread_id: 'spoofed' },
+		});
+
+		expect(out.user_id).toBeUndefined();
+		expect(out.thread_id).toBeUndefined();
+		expect(out['source_context.user_id']).toBe('spoofed');
+	});
+
+	it('drops non-scalar entries rather than nesting documents in the trace', () => {
+		const out = threadProvenanceMetadata({
+			source: 'canvas_action_button',
+			sourceContext: { keep: 'yes', nested: { a: 1 }, list: [1, 2], nothing: null },
+		});
+
+		expect(out).toEqual({ thread_source: 'canvas_action_button', 'source_context.keep': 'yes' });
+	});
+
+	it('bounds how many entries reach the trace', () => {
+		const sourceContext = Object.fromEntries(
+			Array.from({ length: 40 }, (_, i) => [`k${String(i)}`, i]),
+		);
+
+		const out = threadProvenanceMetadata({ source: 'evals', sourceContext });
+
+		// thread_source + the cap.
+		expect(Object.keys(out)).toHaveLength(21);
+	});
+
+	it('returns nothing for a thread with no recorded provenance', () => {
+		expect(threadProvenanceMetadata(undefined)).toEqual({});
+		expect(threadProvenanceMetadata({})).toEqual({});
+		expect(threadProvenanceMetadata('not-an-object')).toEqual({});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tracing/__tests__/thread-provenance.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/thread-provenance.test.ts
@@ -10,9 +10,9 @@ describe('threadProvenanceMetadata', () => {
 	});
 
 	it('flattens sourceContext so each entry is filterable on its own', () => {
-		// Nested documents are not filterable in LangSmith — `eq(metadata_key, …)`
-		// matches a key, not a path into a JSON value. Flat scalars are the whole
-		// point: they are what lets every build of one eval case be selected.
+		// `eq(metadata_key, …)` matches a key, not a path into a JSON value, so
+		// flat entries are the whole point: they are what lets every build of one
+		// eval case be selected.
 		expect(
 			threadProvenanceMetadata({
 				source: 'evals',
@@ -38,26 +38,6 @@ describe('threadProvenanceMetadata', () => {
 		expect(out.user_id).toBeUndefined();
 		expect(out.thread_id).toBeUndefined();
 		expect(out['source_context.user_id']).toBe('spoofed');
-	});
-
-	it('drops non-scalar entries rather than nesting documents in the trace', () => {
-		const out = threadProvenanceMetadata({
-			source: 'canvas_action_button',
-			sourceContext: { keep: 'yes', nested: { a: 1 }, list: [1, 2], nothing: null },
-		});
-
-		expect(out).toEqual({ thread_source: 'canvas_action_button', 'source_context.keep': 'yes' });
-	});
-
-	it('bounds how many entries reach the trace', () => {
-		const sourceContext = Object.fromEntries(
-			Array.from({ length: 40 }, (_, i) => [`k${String(i)}`, i]),
-		);
-
-		const out = threadProvenanceMetadata({ source: 'evals', sourceContext });
-
-		// thread_source + the cap.
-		expect(Object.keys(out)).toHaveLength(21);
 	});
 
 	it('returns nothing for a thread with no recorded provenance', () => {

--- a/packages/@n8n/instance-ai/src/tracing/thread-provenance.ts
+++ b/packages/@n8n/instance-ai/src/tracing/thread-provenance.ts
@@ -1,0 +1,65 @@
+/**
+ * Thread provenance → trace metadata.
+ *
+ * A thread records where it was opened from (`source`, from
+ * INSTANCE_AI_THREAD_SOURCES) plus an optional caller bag (`sourceContext`),
+ * both written at `ensureThread` and persisted in the thread's metadata. Until
+ * now neither reached the trace, so a LangSmith project could not answer
+ * "which entry point produced this run?" — let alone "show me every run of
+ * this one eval case", which is what the offline eval harness needs when its
+ * builds are traced.
+ *
+ * Two rules make an arbitrary caller bag safe to merge into a trace:
+ *
+ *   1. PREFIXED. `buildBaseMetadata` spreads caller metadata LAST, so an
+ *      unprefixed `user_id` in a sourceContext would replace the real one.
+ *   2. FLAT AND SCALAR. LangSmith filters match a metadata KEY, not a path
+ *      into a JSON document, so a nested object is unfilterable — dropping it
+ *      is more honest than shipping something that can't be queried.
+ */
+
+/** Entry point the thread was opened from (INSTANCE_AI_THREAD_SOURCES). */
+export const THREAD_SOURCE_KEY = 'thread_source';
+
+/** Namespace for the caller's own `sourceContext` entries. */
+export const SOURCE_CONTEXT_PREFIX = 'source_context.';
+
+/** `sourceContext` is size-capped at the API boundary (2 KB), but that still
+ *  allows a lot of tiny keys; traces are not a place to page through them. */
+const MAX_SOURCE_CONTEXT_KEYS = 20;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isScalar(value: unknown): value is string | number | boolean {
+	return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+/**
+ * Project a thread's stored metadata onto the flat, filterable trace fields.
+ * Returns an empty object for anything unrecognised — provenance is a nice-to-
+ * have on a trace and must never be the reason a run fails.
+ */
+export function threadProvenanceMetadata(threadMetadata: unknown): Record<string, unknown> {
+	if (!isRecord(threadMetadata)) return {};
+
+	const out: Record<string, unknown> = {};
+
+	if (typeof threadMetadata.source === 'string' && threadMetadata.source) {
+		out[THREAD_SOURCE_KEY] = threadMetadata.source;
+	}
+
+	const sourceContext = threadMetadata.sourceContext;
+	if (isRecord(sourceContext)) {
+		let taken = 0;
+		for (const [key, value] of Object.entries(sourceContext)) {
+			if (taken >= MAX_SOURCE_CONTEXT_KEYS) break;
+			if (!isScalar(value)) continue;
+			out[`${SOURCE_CONTEXT_PREFIX}${key}`] = value;
+			taken++;
+		}
+	}
+
+	return out;
+}

--- a/packages/@n8n/instance-ai/src/tracing/thread-provenance.ts
+++ b/packages/@n8n/instance-ai/src/tracing/thread-provenance.ts
@@ -1,65 +1,32 @@
 /**
  * Thread provenance → trace metadata.
  *
- * A thread records where it was opened from (`source`, from
- * INSTANCE_AI_THREAD_SOURCES) plus an optional caller bag (`sourceContext`),
- * both written at `ensureThread` and persisted in the thread's metadata. Until
- * now neither reached the trace, so a LangSmith project could not answer
- * "which entry point produced this run?" — let alone "show me every run of
- * this one eval case", which is what the offline eval harness needs when its
- * builds are traced.
- *
- * Two rules make an arbitrary caller bag safe to merge into a trace:
- *
- *   1. PREFIXED. `buildBaseMetadata` spreads caller metadata LAST, so an
- *      unprefixed `user_id` in a sourceContext would replace the real one.
- *   2. FLAT AND SCALAR. LangSmith filters match a metadata KEY, not a path
- *      into a JSON document, so a nested object is unfilterable — dropping it
- *      is more honest than shipping something that can't be queried.
+ * `ensureThread` records where a thread was opened from (`source`) plus the
+ * opener's own `sourceContext`, and persists both in the thread's metadata.
+ * This projects them onto the trace so a LangSmith project can answer "which
+ * entry point produced this run?" — and, for the eval harness, "show me every
+ * run of this one case".
  */
-
-/** Entry point the thread was opened from (INSTANCE_AI_THREAD_SOURCES). */
-export const THREAD_SOURCE_KEY = 'thread_source';
-
-/** Namespace for the caller's own `sourceContext` entries. */
-export const SOURCE_CONTEXT_PREFIX = 'source_context.';
-
-/** `sourceContext` is size-capped at the API boundary (2 KB), but that still
- *  allows a lot of tiny keys; traces are not a place to page through them. */
-const MAX_SOURCE_CONTEXT_KEYS = 20;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function isScalar(value: unknown): value is string | number | boolean {
-	return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
-}
 
 /**
- * Project a thread's stored metadata onto the flat, filterable trace fields.
- * Returns an empty object for anything unrecognised — provenance is a nice-to-
- * have on a trace and must never be the reason a run fails.
+ * Prefixed, because `buildBaseMetadata` spreads caller metadata LAST: an
+ * unprefixed `user_id` in a sourceContext would replace the real one.
+ * `sourceContext` is size-capped at the API boundary, so nothing more is
+ * bounded here.
  */
 export function threadProvenanceMetadata(threadMetadata: unknown): Record<string, unknown> {
-	if (!isRecord(threadMetadata)) return {};
+	if (typeof threadMetadata !== 'object' || threadMetadata === null) return {};
+	const { source, sourceContext } = threadMetadata as {
+		source?: unknown;
+		sourceContext?: unknown;
+	};
 
 	const out: Record<string, unknown> = {};
-
-	if (typeof threadMetadata.source === 'string' && threadMetadata.source) {
-		out[THREAD_SOURCE_KEY] = threadMetadata.source;
-	}
-
-	const sourceContext = threadMetadata.sourceContext;
-	if (isRecord(sourceContext)) {
-		let taken = 0;
+	if (typeof source === 'string' && source) out.thread_source = source;
+	if (typeof sourceContext === 'object' && sourceContext !== null) {
 		for (const [key, value] of Object.entries(sourceContext)) {
-			if (taken >= MAX_SOURCE_CONTEXT_KEYS) break;
-			if (!isScalar(value)) continue;
-			out[`${SOURCE_CONTEXT_PREFIX}${key}`] = value;
-			taken++;
+			out[`source_context.${key}`] = value;
 		}
 	}
-
 	return out;
 }

--- a/packages/@n8n/instance-ai/src/tracing/thread-provenance.ts
+++ b/packages/@n8n/instance-ai/src/tracing/thread-provenance.ts
@@ -13,6 +13,12 @@
  * unprefixed `user_id` in a sourceContext would replace the real one.
  * `sourceContext` is size-capped at the API boundary, so nothing more is
  * bounded here.
+ *
+ * Values are forwarded as given. Scalars (and homogeneous arrays) stay
+ * filterable; an object arrives JSON-stringified by `toTelemetryAttributeValue`
+ * and can then only be matched whole. Forwarding it beats dropping it — a
+ * provenance field that silently disappears is worse than one you have to read
+ * instead of filter — and every caller today sends plain ids.
  */
 export function threadProvenanceMetadata(threadMetadata: unknown): Record<string, unknown> {
 	if (typeof threadMetadata !== 'object' || threadMetadata === null) return {};

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -7,6 +7,12 @@ vi.mock('@n8n/agents', async (importOriginal) => ({
 vi.mock('@n8n/instance-ai', async () => {
 	const { z } = await vi.importActual<typeof import('zod')>('zod');
 	return {
+		// Wiring-only stub: the real mapping has its own unit tests
+		// (instance-ai/src/tracing/__tests__/thread-provenance.test.ts). What the
+		// service tests pin is that its OUTPUT reaches the trace — spreading an
+		// undefined mock here is a no-op, so a missing entry would look like a
+		// passing test with silently empty metadata.
+		threadProvenanceMetadata: vi.fn(() => ({ thread_source: 'evals' })),
 		orchestratorAgentId: (runId: string) => `orchestrator-${runId}`,
 		isQuotaExhaustedError: (error: unknown) =>
 			typeof error === 'object' &&
@@ -214,6 +220,7 @@ import {
 	setupSandboxWorkspace,
 	shutdownProductTelemetryProviders,
 	emitAgentSnapshotTraceEvent,
+	threadProvenanceMetadata,
 	type BuilderUsageItem,
 	type ManagedBackgroundTask,
 	type InstanceAiTraceContext,
@@ -1934,9 +1941,10 @@ type SuspendedRunResumeServiceInternals = {
 		getActiveRun: Mock;
 	};
 	emitTerminalRun: Mock;
-	logger: { warn: Mock };
+	logger: { warn: Mock; debug: Mock };
 	dbSnapshotStorage: unknown;
 	tracing: { createOrchestratorResumeTraceContext: Mock; finalizeDetachedTraceRun: Mock };
+	memoryService: { getThreadMetadata: Mock };
 	processResumedStream: Mock;
 	suspendedThreads: { dropPendingConfirmation: Mock };
 	trackInFlightExecution: Mock;
@@ -1976,7 +1984,8 @@ function createSuspendedRunResumeService(): SuspendedRunResumeServiceInternals {
 		getActiveRun: vi.fn(() => undefined),
 	};
 	service.emitTerminalRun = vi.fn(async () => {});
-	service.logger = { warn: vi.fn() };
+	service.logger = { warn: vi.fn(), debug: vi.fn() };
+	service.memoryService = { getThreadMetadata: vi.fn(async () => undefined) };
 	service.dbSnapshotStorage = {};
 	service.tracing = {
 		createOrchestratorResumeTraceContext: vi.fn(async () => undefined),
@@ -2483,6 +2492,39 @@ describe('InstanceAiService — suspended run user revalidation', () => {
 				browserExtension: { connectionState: 'connected', version: '0.0.7' },
 			}),
 		);
+	});
+
+	it('stamps the thread provenance on the approval-resume trace', async () => {
+		// The build finishes on a RESUME beat, so this is where an eval build's
+		// spans actually live — stamping only the message turn would leave them
+		// unattributable, which is the whole point of carrying provenance.
+		const service = createSuspendedRunResumeService();
+		service.revalidateActiveUser.mockResolvedValue(fakeUser);
+		const threadMetadata = {
+			source: 'evals',
+			sourceContext: { evalCase: 'gmail-inbox-triage', evalIteration: 1 },
+		};
+		service.memoryService.getThreadMetadata.mockResolvedValue(threadMetadata);
+
+		await service.resumeSuspendedRun('user-1', 'req-1', { approved: true });
+
+		expect(threadProvenanceMetadata).toHaveBeenCalledWith(threadMetadata);
+		expect(service.tracing.createOrchestratorResumeTraceContext).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: expect.objectContaining({ thread_source: 'evals' }),
+			}),
+		);
+	});
+
+	it('resumes even when the thread provenance read fails', async () => {
+		const service = createSuspendedRunResumeService();
+		service.revalidateActiveUser.mockResolvedValue(fakeUser);
+		service.memoryService.getThreadMetadata.mockRejectedValue(new Error('db down'));
+
+		const result = await service.resumeSuspendedRun('user-1', 'req-1', { approved: true });
+
+		expect(result).toEqual({ ok: true, runId: 'run-1' });
+		expect(service.tracing.createOrchestratorResumeTraceContext).toHaveBeenCalled();
 	});
 
 	it('passes the revalidated user into the resumed stream', async () => {
@@ -4531,7 +4573,8 @@ describe('InstanceAiService — user message persistence on cancel', () => {
 		agentMemory: { saveMessages: Mock };
 		eventBus: { publish: Mock };
 		terminalOutcome: { evaluateTerminalResponse: Mock };
-		logger: { warn: Mock; error: Mock };
+		logger: { warn: Mock; error: Mock; debug: Mock };
+		memoryService: { getThreadMetadata: Mock };
 		createProxyRunConfig: Mock;
 		isRunDebugEnabled: Mock;
 		runState: { clearActiveRun: Mock; hasSuspendedRun: Mock };
@@ -4547,7 +4590,8 @@ describe('InstanceAiService — user message persistence on cancel', () => {
 		service.agentMemory = { saveMessages: vi.fn(async () => {}) };
 		service.eventBus = { publish: vi.fn() };
 		service.terminalOutcome = { evaluateTerminalResponse: vi.fn() };
-		service.logger = { warn: vi.fn(), error: vi.fn() };
+		service.logger = { warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+		service.memoryService = { getThreadMetadata: vi.fn(async () => undefined) };
 		service.createProxyRunConfig = vi.fn(async () => ({ tracingProxyConfig: undefined }));
 		service.isRunDebugEnabled = vi.fn(() => false);
 		// hasSuspendedRun → true short-circuits the finally's post-run scheduling

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -43,6 +43,7 @@ import {
 	loadInstanceAiRuntimeSkillSource,
 	disabledInstanceAiSkillIds,
 	createInstanceAiTraceContext,
+	threadProvenanceMetadata,
 	createInternalOperationTraceContext,
 	emitAgentSnapshotTraceEvent,
 	createInstanceAiLivenessPolicyConfig,
@@ -3605,6 +3606,24 @@ export class InstanceAiService {
 	 * and shutdown can drain it before the DB closes.
 	 */
 	// eslint-disable-next-line complexity
+	/** Thread provenance for the trace. Best-effort by construction: a failed
+	 *  metadata read must not take the run with it — the trace just loses a
+	 *  label it would have been nice to have. */
+	private async readThreadProvenance(
+		userId: string,
+		threadId: string,
+	): Promise<Record<string, unknown>> {
+		try {
+			return threadProvenanceMetadata(await this.memoryService.getThreadMetadata(userId, threadId));
+		} catch (error) {
+			this.logger.debug('Could not read thread provenance for tracing', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return {};
+		}
+	}
+
 	private async executeRun(
 		user: User,
 		threadId: string,
@@ -3688,6 +3707,12 @@ export class InstanceAiService {
 			// Read per run: Chrome auto-updates extensions silently.
 			const browserExtension = this.browserSessionService.getExtensionTraceContext(user.id);
 
+			// Where this thread came from (entry point + the opener's own context),
+			// stamped on every run of it. Both trace paths get it: a build finishes
+			// on the RESUME beat, so stamping only the message turn would leave the
+			// spans that actually contain the work unattributable.
+			const threadProvenance = await this.readThreadProvenance(user.id, threadId);
+
 			// Create the trace before run-start so the SSE event carries traceId (modelId lands at finalization).
 			if (resumeReason) {
 				tracing = await this.tracing.createOrchestratorResumeTraceContext({
@@ -3699,6 +3724,7 @@ export class InstanceAiService {
 					input: traceInput,
 					resumeReason,
 					metadata: {
+						...threadProvenance,
 						...(checkpoint?.isCheckpointFollowUp
 							? { checkpoint_task_id: checkpoint.checkpointTaskId }
 							: {}),
@@ -3716,6 +3742,7 @@ export class InstanceAiService {
 					runId,
 					userId: user.id,
 					input: traceInput,
+					metadata: threadProvenance,
 					proxyConfig: proxyRunConfig.tracingProxyConfig,
 					n8nVersion: N8N_VERSION,
 					workflowSdkVersion: WORKFLOW_SDK_VERSION,
@@ -5193,6 +5220,7 @@ export class InstanceAiService {
 			},
 			resumeReason: 'approval',
 			metadata: {
+				...(await this.readThreadProvenance(activeUser.id, threadId)),
 				request_id: requestId,
 				pending_tool_call_id: toolCallId,
 				approved: data.approved,


### PR DESCRIPTION
## Summary

A thread already records where it was opened from: `source` (required, from `INSTANCE_AI_THREAD_SOURCES`) plus the opener's own `sourceContext` bag, both persisted in the thread's metadata by `ensureThread`. Neither ever reached the trace.

This stamps them on: `thread_source`, and each `sourceContext` entry as `source_context.<key>`.

So a LangSmith project can now answer *"which entry point produced this run?"* — canvas vs template vs node-error vs evals — which it could not before. Today's callers make that concrete: `{templateId, templateName}`, `{agentId}`, `{workflowId, executionId}`, and from the eval harness `{evalCase, evalIteration}`.

## Why now

The LangTracer eval harness is enabling builder tracing on its eval containers. Every build in that project is the same handful of test cases run over and over, and a trace carries only a bare-UUID `thread_id` — so the conversations are indistinguishable and no export can group them. `sourceContext` is the existing hook for exactly this.

## Design

One rule is load-bearing: **the `source_context.` prefix.** `buildBaseMetadata` spreads caller metadata *last*, so an unprefixed `user_id` in a sourceContext would replace the real one. There is a test for that specifically.

Nothing else is bounded here — `sourceContext` is size-capped where it enters the API, and `sanitizeTraceValue` handles values downstream. (An earlier revision also capped key count and filtered to scalars; both were dropped as redundant, and the cap silently dropped valid entries under the documented limit.)

**Stamped on all three trace paths** — message turn, orchestrator resume, approval resume. This is load-bearing: a build finishes on a *resume beat*, so stamping only the message turn would leave the spans containing the actual work unattributable.

Reading the provenance is best-effort — a failed metadata read costs the trace a label, never the run.

## Harness side

`fileSlug`/`iteration` ride `BuildArgs` → `buildWorkflow` → `ensureThread`. `BuildArgs` gets a pin test for the same reason the `credentialFixture` comment gives: `wrap()` erases the callback's parameter type, so a dropped field still type-checks.

## Verification

- Unit tests for the mapping: entry point, flattening, the prefix collision guard, empty cases.
- Service tests pin the wiring on the approval-resume path, plus that a failed provenance read still resumes.
- Both new guards verified to bite: removing the fields from the `tracedBuild` call, and removing the stamp from the resume path, each turn their test red; restoring turns it green.
- `packages/@n8n/instance-ai`: tsc clean, full evaluations + tracing suites pass. `packages/cli`: tsc clean, instance-ai service suite 166 pass.
- Note: one hand-written mock of `@n8n/instance-ai` in the cli service tests needed the new export added — without it the function is `undefined` and `...undefined` spreads to nothing, which reads as a passing test with silently empty metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)