### PR TITLE
refactor(API): Add a strict option to Z.class (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/__tests__/zod-class.test.ts
+++ b/packages/@n8n/api-types/src/__tests__/zod-class.test.ts
@@ -2,6 +2,32 @@ import { z } from 'zod';
 
 import { Z } from '../zod-class';
 
+describe('Z.class', () => {
+	const shape = { name: z.string() };
+
+	it('strips an unknown key when no option is passed', () => {
+		class LenientDto extends Z.class(shape) {}
+
+		expect(LenientDto.parse({ name: 'a', extra: 1 })).toEqual({ name: 'a' });
+	});
+
+	it('rejects an unknown key at every entry point when strict', () => {
+		class StrictDto extends Z.class(shape, { strict: true }) {}
+		const payload = { name: 'a', extra: 1 };
+
+		expect(StrictDto.safeParse(payload).success).toBe(false);
+		expect(() => StrictDto.parse(payload)).toThrow(z.ZodError);
+		expect(() => new StrictDto(payload)).toThrow(z.ZodError);
+	});
+
+	it('keeps strict through extend', () => {
+		class ChildDto extends Z.class(shape, { strict: true }).extend({ age: z.number() }) {}
+
+		expect(ChildDto.safeParse({ name: 'a', age: 1 }).success).toBe(true);
+		expect(ChildDto.safeParse({ name: 'a', age: 1, extra: 1 }).success).toBe(false);
+	});
+});
+
 describe('Z.array', () => {
 	class TagIdDto extends Z.array(z.object({ id: z.string() })) {}
 

--- a/packages/@n8n/api-types/src/dto/workflows/create-workflow-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/create-workflow-public.dto.ts
@@ -186,14 +186,6 @@ const createWorkflowPublicShape = {
 	activeVersion: readOnlyPublicSchema(workflowCreateReadOnlyFieldDocs.activeVersion),
 } as const;
 
-const createWorkflowPublicSchema = z.object(createWorkflowPublicShape).strict();
-
-// This endpoint has always returned 400 for a field it does not know. `Z.class` would drop the
-// field and return 200 instead, so `safeParse` and `schema` both use the strict schema above.
-export class CreateWorkflowPublicDto extends Z.class(createWorkflowPublicShape) {
-	static schema = createWorkflowPublicSchema;
-
-	static safeParse(data: unknown) {
-		return createWorkflowPublicSchema.safeParse(data);
-	}
-}
+export class CreateWorkflowPublicDto extends Z.class(createWorkflowPublicShape, {
+	strict: true,
+}) {}

--- a/packages/@n8n/api-types/src/zod-class.ts
+++ b/packages/@n8n/api-types/src/zod-class.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawShape> {
 	new (data: T): T;
-	schema: z.ZodObject<Shape, z.UnknownKeysParam>;
+	schema: z.ZodObject<Shape, 'strip' | 'strict'>;
 	safeParse(data: unknown): z.SafeParseReturnType<unknown, T>;
 	parse(data: unknown): T;
 	extend<U extends z.ZodRawShape>(shape: U): ZodClass<T & z.infer<z.ZodObject<U>>, Shape & U>;

--- a/packages/@n8n/api-types/src/zod-class.ts
+++ b/packages/@n8n/api-types/src/zod-class.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawShape> {
 	new (data: T): T;
-	schema: z.ZodObject<Shape>;
+	schema: z.ZodObject<Shape, z.UnknownKeysParam>;
 	safeParse(data: unknown): z.SafeParseReturnType<unknown, T>;
 	parse(data: unknown): T;
 	extend<U extends z.ZodRawShape>(shape: U): ZodClass<T & z.infer<z.ZodObject<U>>, Shape & U>;
@@ -33,11 +33,16 @@ export interface ZodArrayClass<T, Item extends z.ZodTypeAny = z.ZodTypeAny> {
  * export class ChildDto extends ParentDto.extend({
  *   additionalField: z.string(),
  * }) {}
+ *
+ * export class StrictDto extends Z.class({ email: z.string() }, { strict: true }) {}
  * ```
  */
 export const Z = {
-	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.objectOutputType<T, z.ZodTypeAny>, T> => {
-		const schema = z.object(shape);
+	class: <T extends z.ZodRawShape>(
+		shape: T,
+		options: { strict?: boolean } = {},
+	): ZodClass<z.objectOutputType<T, z.ZodTypeAny>, T> => {
+		const schema = options.strict ? z.object(shape).strict() : z.object(shape);
 		type Output = z.objectOutputType<T, z.ZodTypeAny>;
 
 		const DtoClass = class {
@@ -57,7 +62,7 @@ export const Z = {
 			}
 
 			static extend<U extends z.ZodRawShape>(additionalShape: U) {
-				return Z.class({ ...shape, ...additionalShape });
+				return Z.class({ ...shape, ...additionalShape }, options);
 			}
 		};
 

--- a/packages/@n8n/api-types/src/zod-class.ts
+++ b/packages/@n8n/api-types/src/zod-class.ts
@@ -66,7 +66,7 @@ export const Z = {
 			}
 		};
 
-		return DtoClass as unknown as ZodClass<Output, T>;
+		return DtoClass as ZodClass<Output, T>;
 	},
 
 	/**


### PR DESCRIPTION
## Summary

`Z.class` always built a lenient `z.object`, which strips a key it does not know. An endpoint whose contract is to **reject** that key had to define a second, strict schema and override `schema` and `safeParse` to point at it — which `CreateWorkflowPublicDto` did.

- `Z.class(shape, { strict: true })` builds the strict object once, so all four entry points agree: `schema`, `safeParse`, `parse` and the constructor.
- `CreateWorkflowPublicDto` uses it and drops both overrides. No behaviour change: the generated OpenAPI fragment is identical and `POST /workflows`'s integration tests are untouched.

## How to test

- `pnpm test src/__tests__/zod-class.test.ts` in `packages/@n8n/api-types`. Three new cases cover the default, the strict option, and `extend`.
- `pnpm test:integration test/integration/public-api/workflows.test.ts` in `packages/cli`. 209 pass, and the file is not in this diff.
- `pnpm build`, then `git status`. No generated YAML should appear.

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/API-84

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


