### PR TITLE
fix(editor): Fix authenticated multi-page forms not loading the next page (no-changelog)

### DIFF
--- a/packages/cli/src/auth/__tests__/auth.service.test.ts
+++ b/packages/cli/src/auth/__tests__/auth.service.test.ts
@@ -13,7 +13,7 @@ import jwt from 'jsonwebtoken';
 import { mock } from 'vitest-mock-extended';
 
 import { AuthService } from '@/auth/auth.service';
-import { AUTH_COOKIE_NAME, FORM_AUTH_COOKIE_NAME } from '@/constants';
+import { AUTH_COOKIE_NAME } from '@/constants';
 import type { License } from '@/license';
 import type { MfaService } from '@/mfa/mfa.service';
 import { JwtService } from '@/services/jwt.service';
@@ -961,42 +961,16 @@ describe('AuthService', () => {
 		});
 	});
 
-	// A multi-page form hands its follow-up pages an identity cookie of their own,
-	// so signing out has to take that one with it.
 	describe('clearCookie', () => {
-		it('should clear the session cookie and the form page cookie', () => {
-			globalConfig.endpoints.formWaiting = 'form-waiting';
-			urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.test/');
+		it('should clear the session cookie', () => {
 			const res = mock<Response>();
 
 			authService.clearCookie(res);
 
 			expect(res.clearCookie).toHaveBeenCalledWith(AUTH_COOKIE_NAME);
-			expect(res.clearCookie).toHaveBeenCalledWith(FORM_AUTH_COOKIE_NAME, {
-				path: '/form-waiting',
-			});
-		});
-
-		it('should scope the form page cookie to the instance path prefix', () => {
-			globalConfig.endpoints.formWaiting = 'form-waiting';
-			urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.test/prefix/');
-			const res = mock<Response>();
-
-			authService.clearCookie(res);
-
-			expect(res.clearCookie).toHaveBeenCalledWith(FORM_AUTH_COOKIE_NAME, {
-				path: '/prefix/form-waiting',
-			});
-		});
-
-		it('should fall back to the root path when the base URL cannot be read', () => {
-			globalConfig.endpoints.formWaiting = 'form-waiting';
-			urlService.getWebhookBaseUrl.mockReturnValue('not a url');
-			const res = mock<Response>();
-
-			authService.clearCookie(res);
-
-			expect(res.clearCookie).toHaveBeenCalledWith(FORM_AUTH_COOKIE_NAME, { path: '/' });
+			// The form page cookies are not clearable from here: their names embed the
+			// workflow/execution they were minted for, unknown to this response.
+			expect(res.clearCookie).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/cli/src/auth/__tests__/auth.service.test.ts
+++ b/packages/cli/src/auth/__tests__/auth.service.test.ts
@@ -13,7 +13,7 @@ import jwt from 'jsonwebtoken';
 import { mock } from 'vitest-mock-extended';
 
 import { AuthService } from '@/auth/auth.service';
-import { AUTH_COOKIE_NAME } from '@/constants';
+import { AUTH_COOKIE_NAME, FORM_AUTH_COOKIE_NAME } from '@/constants';
 import type { License } from '@/license';
 import type { MfaService } from '@/mfa/mfa.service';
 import { JwtService } from '@/services/jwt.service';
@@ -958,6 +958,45 @@ describe('AuthService', () => {
 				token: validToken,
 				expiresAt: new Date('2024-02-08T01:23:45.000Z'),
 			});
+		});
+	});
+
+	// A multi-page form hands its follow-up pages an identity cookie of their own,
+	// so signing out has to take that one with it.
+	describe('clearCookie', () => {
+		it('should clear the session cookie and the form page cookie', () => {
+			globalConfig.endpoints.formWaiting = 'form-waiting';
+			urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.test/');
+			const res = mock<Response>();
+
+			authService.clearCookie(res);
+
+			expect(res.clearCookie).toHaveBeenCalledWith(AUTH_COOKIE_NAME);
+			expect(res.clearCookie).toHaveBeenCalledWith(FORM_AUTH_COOKIE_NAME, {
+				path: '/form-waiting',
+			});
+		});
+
+		it('should scope the form page cookie to the instance path prefix', () => {
+			globalConfig.endpoints.formWaiting = 'form-waiting';
+			urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.test/prefix/');
+			const res = mock<Response>();
+
+			authService.clearCookie(res);
+
+			expect(res.clearCookie).toHaveBeenCalledWith(FORM_AUTH_COOKIE_NAME, {
+				path: '/prefix/form-waiting',
+			});
+		});
+
+		it('should fall back to the root path when the base URL cannot be read', () => {
+			globalConfig.endpoints.formWaiting = 'form-waiting';
+			urlService.getWebhookBaseUrl.mockReturnValue('not a url');
+			const res = mock<Response>();
+
+			authService.clearCookie(res);
+
+			expect(res.clearCookie).toHaveBeenCalledWith(FORM_AUTH_COOKIE_NAME, { path: '/' });
 		});
 	});
 

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -9,7 +9,7 @@ import type { NextFunction, Request, Response } from 'express';
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import type { StringValue as TimeUnitValue } from 'ms';
 
-import { AUTH_COOKIE_NAME, FORM_AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
+import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { License } from '@/license';
@@ -209,28 +209,11 @@ export class AuthService {
 
 	clearCookie(res: Response) {
 		res.clearCookie(AUTH_COOKIE_NAME);
-		// A multi-page form hands its follow-up pages their own identity cookie, so
-		// dropping the session has to drop that one too. It is scoped to the
-		// form-waiting path and `clearCookie` only matches the path it was set with.
-		res.clearCookie(FORM_AUTH_COOKIE_NAME, { path: this.getFormWaitingPath() });
-	}
-
-	/**
-	 * Path the form-waiting endpoint is served under. Derived exactly as the Form
-	 * nodes derive the scope of their page auth cookie — from the pathname of a
-	 * resume URL, `<form-waiting base URL>/<execution id>`, minus the last segment —
-	 * so the two agree on the path even when the endpoint is configured oddly. Falls
-	 * back to `/`, as they do, when the URL can't be parsed.
-	 */
-	private getFormWaitingPath(): string {
-		const { formWaiting } = this.globalConfig.endpoints;
-		try {
-			const base = `${this.urlService.getWebhookBaseUrl()}${formWaiting}`;
-			const { pathname } = new URL(`${base}/an-execution-id`);
-			return pathname.slice(0, pathname.lastIndexOf('/')) || '/';
-		} catch {
-			return '/';
-		}
+		// The form page auth cookies (`n8n-form-auth-*`) are NOT cleared here: their
+		// names embed the workflow/execution they were minted for, and this response
+		// can neither read them (they're scoped to the form-waiting path) nor clear a
+		// cookie without naming it exactly. They are httpOnly, expire within an hour,
+		// and a session for a different user overrides them on the form pages.
 	}
 
 	async invalidateToken(req: AuthenticatedRequest) {

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -9,7 +9,7 @@ import type { NextFunction, Request, Response } from 'express';
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import type { StringValue as TimeUnitValue } from 'ms';
 
-import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
+import { AUTH_COOKIE_NAME, FORM_AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { License } from '@/license';
@@ -209,6 +209,28 @@ export class AuthService {
 
 	clearCookie(res: Response) {
 		res.clearCookie(AUTH_COOKIE_NAME);
+		// A multi-page form hands its follow-up pages their own identity cookie, so
+		// dropping the session has to drop that one too. It is scoped to the
+		// form-waiting path and `clearCookie` only matches the path it was set with.
+		res.clearCookie(FORM_AUTH_COOKIE_NAME, { path: this.getFormWaitingPath() });
+	}
+
+	/**
+	 * Path the form-waiting endpoint is served under. Derived exactly as the Form
+	 * nodes derive the scope of their page auth cookie — from the pathname of a
+	 * resume URL, `<form-waiting base URL>/<execution id>`, minus the last segment —
+	 * so the two agree on the path even when the endpoint is configured oddly. Falls
+	 * back to `/`, as they do, when the URL can't be parsed.
+	 */
+	private getFormWaitingPath(): string {
+		const { formWaiting } = this.globalConfig.endpoints;
+		try {
+			const base = `${this.urlService.getWebhookBaseUrl()}${formWaiting}`;
+			const { pathname } = new URL(`${base}/an-execution-id`);
+			return pathname.slice(0, pathname.lastIndexOf('/')) || '/';
+		} catch {
+			return '/';
+		}
 	}
 
 	async invalidateToken(req: AuthenticatedRequest) {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -78,10 +78,13 @@ export const OIDC_NONCE_COOKIE_NAME = 'n8n-oidc-nonce';
 /**
  * Cookies the Form nodes set on their own pages, duplicated here because the
  * names are owned by `nodes-base/nodes/Form/utils/utils.ts`
- * (`FORM_AUTH_COOKIE_NAME` / `FORM_OAUTH_COOKIE_NAME`) and this package must not
- * reach into that package's internals. Keep both sides in step.
+ * (`FORM_AUTH_COOKIE_PREFIX` / `FORM_OAUTH_COOKIE_NAME`) and this package must
+ * not reach into that package's internals. Keep both sides in step. The form
+ * auth cookie's full name appends the workflow or execution it was minted for
+ * (`<prefix>-wf-<id>` / `<prefix>-ex-<id>`), so concurrent forms don't
+ * overwrite each other's cookie.
  */
-export const FORM_AUTH_COOKIE_NAME = 'n8n-form-auth';
+export const FORM_AUTH_COOKIE_PREFIX = 'n8n-form-auth';
 export const FORM_OAUTH_COOKIE_NAME = 'n8n-form-oauth';
 
 export const NPM_COMMAND_TOKENS = {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -75,6 +75,15 @@ export const AUTH_COOKIE_NAME = 'n8n-auth';
 export const OIDC_STATE_COOKIE_NAME = 'n8n-oidc-state';
 export const OIDC_NONCE_COOKIE_NAME = 'n8n-oidc-nonce';
 
+/**
+ * Cookies the Form nodes set on their own pages, duplicated here because the
+ * names are owned by `nodes-base/nodes/Form/utils/utils.ts`
+ * (`FORM_AUTH_COOKIE_NAME` / `FORM_OAUTH_COOKIE_NAME`) and this package must not
+ * reach into that package's internals. Keep both sides in step.
+ */
+export const FORM_AUTH_COOKIE_NAME = 'n8n-form-auth';
+export const FORM_OAUTH_COOKIE_NAME = 'n8n-form-oauth';
+
 export const NPM_COMMAND_TOKENS = {
 	NPM_PACKAGE_NOT_FOUND_ERROR: '404 Not Found',
 	NPM_PACKAGE_VERSION_NOT_FOUND_ERROR: 'No matching version found for',

--- a/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
@@ -299,6 +299,21 @@ describe('webhookRequestSanitizer', () => {
 			});
 		});
 
+		it('should leave an unrelated cookie that merely begins with the prefix', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-form-authentic=abc123; n8n-form-auth-ex-12345=def',
+			};
+			mockRequest.cookies = {
+				'n8n-form-authentic': 'abc123',
+				'n8n-form-auth-ex-12345': 'def',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('n8n-form-authentic=abc123');
+			expect(mockRequest.cookies).toEqual({ 'n8n-form-authentic': 'abc123' });
+		});
+
 		it('should remove every disallowed cookie in one pass', () => {
 			mockRequest.headers = {
 				cookie:

--- a/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
@@ -265,4 +265,50 @@ describe('webhookRequestSanitizer', () => {
 			});
 		});
 	});
+
+	// The form endpoints skip sanitizing for their own node types, so removing these
+	// here only affects the webhooks that have no use for them.
+	describe('when the form cookies are present', () => {
+		it.each(['n8n-form-auth', 'n8n-form-oauth'])('should remove %s from the header', (name) => {
+			mockRequest.headers = {
+				cookie: `${name}=abc123; other-cookie=value`,
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+		});
+
+		it.each(['n8n-form-auth', 'n8n-form-oauth'])('should remove %s from parsed cookies', (name) => {
+			mockRequest.cookies = {
+				[name]: 'abc123',
+				'other-cookie': 'value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.cookies).toEqual({
+				'other-cookie': 'value',
+			});
+		});
+
+		it('should remove every disallowed cookie in one pass', () => {
+			mockRequest.headers = {
+				cookie:
+					'n8n-auth=a; n8n-browserId=b; n8n-form-auth=c; n8n-form-oauth=d; other-cookie=value',
+			};
+			mockRequest.cookies = {
+				'n8n-auth': 'a',
+				'n8n-browserId': 'b',
+				'n8n-form-auth': 'c',
+				'n8n-form-oauth': 'd',
+				'other-cookie': 'value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+			expect(mockRequest.cookies).toEqual({ 'other-cookie': 'value' });
+		});
+	});
 });

--- a/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
@@ -267,9 +267,16 @@ describe('webhookRequestSanitizer', () => {
 	});
 
 	// The form endpoints skip sanitizing for their own node types, so removing these
-	// here only affects the webhooks that have no use for them.
+	// here only affects the webhooks that have no use for them. The form auth cookie
+	// names embed the workflow or execution they were minted for, hence the suffixes.
 	describe('when the form cookies are present', () => {
-		it.each(['n8n-form-auth', 'n8n-form-oauth'])('should remove %s from the header', (name) => {
+		const formCookieNames = [
+			'n8n-form-auth-wf-a-workflow-id',
+			'n8n-form-auth-ex-12345',
+			'n8n-form-oauth',
+		];
+
+		it.each(formCookieNames)('should remove %s from the header', (name) => {
 			mockRequest.headers = {
 				cookie: `${name}=abc123; other-cookie=value`,
 			};
@@ -279,7 +286,7 @@ describe('webhookRequestSanitizer', () => {
 			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
 		});
 
-		it.each(['n8n-form-auth', 'n8n-form-oauth'])('should remove %s from parsed cookies', (name) => {
+		it.each(formCookieNames)('should remove %s from parsed cookies', (name) => {
 			mockRequest.cookies = {
 				[name]: 'abc123',
 				'other-cookie': 'value',
@@ -295,12 +302,12 @@ describe('webhookRequestSanitizer', () => {
 		it('should remove every disallowed cookie in one pass', () => {
 			mockRequest.headers = {
 				cookie:
-					'n8n-auth=a; n8n-browserId=b; n8n-form-auth=c; n8n-form-oauth=d; other-cookie=value',
+					'n8n-auth=a; n8n-browserId=b; n8n-form-auth-ex-12345=c; n8n-form-oauth=d; other-cookie=value',
 			};
 			mockRequest.cookies = {
 				'n8n-auth': 'a',
 				'n8n-browserId': 'b',
-				'n8n-form-auth': 'c',
+				'n8n-form-auth-ex-12345': 'c',
 				'n8n-form-oauth': 'd',
 				'other-cookie': 'value',
 			};

--- a/packages/cli/src/webhooks/webhook-request-sanitizer.ts
+++ b/packages/cli/src/webhooks/webhook-request-sanitizer.ts
@@ -1,10 +1,18 @@
 import type { Request } from 'express';
 
-import { AUTH_COOKIE_NAME } from '@/constants';
+import { AUTH_COOKIE_NAME, FORM_AUTH_COOKIE_NAME, FORM_OAUTH_COOKIE_NAME } from '@/constants';
 
 const BROWSER_ID_COOKIE_NAME = 'n8n-browserId';
 
-const DISALLOWED_COOKIES = new Set([AUTH_COOKIE_NAME, BROWSER_ID_COOKIE_NAME]);
+// The form cookies belong to the form endpoints, which skip sanitizing entirely
+// for their own node types (see `authAllowlistedNodes`), so a form page still
+// receives them. Every other webhook has no use for them.
+const DISALLOWED_COOKIES = new Set([
+	AUTH_COOKIE_NAME,
+	BROWSER_ID_COOKIE_NAME,
+	FORM_AUTH_COOKIE_NAME,
+	FORM_OAUTH_COOKIE_NAME,
+]);
 
 /**
  * Removes a cookie with the given name from the request header

--- a/packages/cli/src/webhooks/webhook-request-sanitizer.ts
+++ b/packages/cli/src/webhooks/webhook-request-sanitizer.ts
@@ -14,9 +14,11 @@ const DISALLOWED_COOKIES = new Set([
 ]);
 
 // The form auth cookie's name appends the workflow or execution it was minted
-// for, so it is matched by prefix rather than listed above.
+// for (`<prefix>-…`), so it is matched by prefix rather than listed above. The
+// separator is required so an unrelated cookie that merely begins with the
+// prefix (e.g. `n8n-form-authentic`) passes through untouched.
 const isDisallowedCookie = (name: string) =>
-	DISALLOWED_COOKIES.has(name) || name.startsWith(FORM_AUTH_COOKIE_PREFIX);
+	DISALLOWED_COOKIES.has(name) || name.startsWith(`${FORM_AUTH_COOKIE_PREFIX}-`);
 
 /**
  * Removes a cookie with the given name from the request header

--- a/packages/cli/src/webhooks/webhook-request-sanitizer.ts
+++ b/packages/cli/src/webhooks/webhook-request-sanitizer.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 
-import { AUTH_COOKIE_NAME, FORM_AUTH_COOKIE_NAME, FORM_OAUTH_COOKIE_NAME } from '@/constants';
+import { AUTH_COOKIE_NAME, FORM_AUTH_COOKIE_PREFIX, FORM_OAUTH_COOKIE_NAME } from '@/constants';
 
 const BROWSER_ID_COOKIE_NAME = 'n8n-browserId';
 
@@ -10,9 +10,13 @@ const BROWSER_ID_COOKIE_NAME = 'n8n-browserId';
 const DISALLOWED_COOKIES = new Set([
 	AUTH_COOKIE_NAME,
 	BROWSER_ID_COOKIE_NAME,
-	FORM_AUTH_COOKIE_NAME,
 	FORM_OAUTH_COOKIE_NAME,
 ]);
+
+// The form auth cookie's name appends the workflow or execution it was minted
+// for, so it is matched by prefix rather than listed above.
+const isDisallowedCookie = (name: string) =>
+	DISALLOWED_COOKIES.has(name) || name.startsWith(FORM_AUTH_COOKIE_PREFIX);
 
 /**
  * Removes a cookie with the given name from the request header
@@ -26,7 +30,7 @@ const removeCookiesFromHeader = (req: Request) => {
 	const cookies = cookiesHeader.split(';').map((cookie) => cookie.trim());
 	const filteredCookies = cookies.filter((cookie) => {
 		const cookieName = cookie.split('=')[0];
-		return !DISALLOWED_COOKIES.has(cookieName);
+		return !isDisallowedCookie(cookieName);
 	});
 
 	if (filteredCookies.length !== cookies.length) {
@@ -39,8 +43,8 @@ const removeCookiesFromHeader = (req: Request) => {
  */
 const removeCookiesFromParsedCookies = (req: Request) => {
 	if (req.cookies !== null && typeof req.cookies === 'object') {
-		for (const cookieName of DISALLOWED_COOKIES) {
-			delete req.cookies[cookieName];
+		for (const cookieName of Object.keys(req.cookies)) {
+			if (isDisallowedCookie(cookieName)) delete req.cookies[cookieName];
 		}
 	}
 };

--- a/packages/cli/templates/form-shell.handlebars
+++ b/packages/cli/templates/form-shell.handlebars
@@ -338,6 +338,9 @@
 			// follow-up pages: the frame is author-scriptable, so this must not become a
 			// way to point it at arbitrary n8n pages. Returns null when the target isn't
 			// one of them.
+			//
+			// The flag tells the page it is rendering inside this shell, which is what
+			// makes it hand its own next navigation back here instead of doing it itself.
 			var FORM_WAITING_PATH = '{{formWaitingPath}}';
 			function resolveFrameNavigation(target) {
 				if (typeof target !== 'string' || !target || !FORM_WAITING_PATH) return null;
@@ -351,6 +354,22 @@
 					) {
 						return null;
 					}
+					resolved.searchParams.set('n8nShellHosted', '1');
+					return resolved.toString();
+				} catch (e) {
+					return null;
+				}
+			}
+
+			// The author's own redirect target, once the form is done. Any http(s) URL is
+			// allowed — this is where the author said to send the submitter, and a form
+			// outside the shell goes there too — but the scheme has to be one of those two.
+			// Returns null otherwise.
+			function resolveExternalRedirect(target) {
+				if (typeof target !== 'string' || !target) return null;
+				try {
+					var resolved = new URL(target, window.location.href);
+					if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') return null;
 					return resolved.toString();
 				} catch (e) {
 					return null;
@@ -368,14 +387,22 @@
 			} catch (e) {}
 			window.addEventListener('message', function (event) {
 				// The sandboxed form iframe can't spoof a connect: it is only ever answered
-				// with a page move inside this form, or with the POST gate's rejection, which
-				// carries ids and moves rows one way only — so the worst author script can do
-				// is degrade its own form's UX. `event.origin` is the string 'null' for an
-				// opaque-origin frame and cannot be checked; `event.source` identifies it.
+				// with a page move inside this form, the author's own end-of-form redirect,
+				// or the POST gate's rejection, which carries ids and moves rows one way only
+				// — so the worst author script can do is degrade its own form's UX.
+				// `event.origin` is the string 'null' for an opaque-origin frame and cannot be
+				// checked; `event.source` identifies it.
 				if (frame && event.source === frame.contentWindow) {
 					if (event.data && event.data.type === 'n8n-form-navigate') {
 						var next = resolveFrameNavigation(event.data.url);
 						if (next) frame.src = next;
+						return;
+					}
+					if (event.data && event.data.type === 'n8n-form-redirect') {
+						// The form is finished, so the author's redirect takes the whole tab —
+						// the same place a form rendered without this shell would end up.
+						var away = resolveExternalRedirect(event.data.url);
+						if (away) window.location.replace(away);
 						return;
 					}
 					handleGateRejection(event.data);

--- a/packages/cli/templates/form-shell.handlebars
+++ b/packages/cli/templates/form-shell.handlebars
@@ -331,6 +331,32 @@
 
 			var pendingId = null;
 
+			// The frame is sandboxed to an opaque origin, so its own navigations are
+			// treated as cross-site and lose the form's auth cookie. It asks the shell to
+			// move it instead, and the shell — on the real origin — sets `src`, which is a
+			// same-origin navigation that keeps the cookie. Narrowed to this form's own
+			// follow-up pages: the frame is author-scriptable, so this must not become a
+			// way to point it at arbitrary n8n pages. Returns null when the target isn't
+			// one of them.
+			var FORM_WAITING_PATH = '{{formWaitingPath}}';
+			function resolveFrameNavigation(target) {
+				if (typeof target !== 'string' || !target || !FORM_WAITING_PATH) return null;
+				try {
+					var here = new URL(window.location.href);
+					var resolved = new URL(target, here);
+					if (resolved.origin !== here.origin) return null;
+					if (
+						resolved.pathname !== FORM_WAITING_PATH &&
+						resolved.pathname.indexOf(FORM_WAITING_PATH + '/') !== 0
+					) {
+						return null;
+					}
+					return resolved.toString();
+				} catch (e) {
+					return null;
+				}
+			}
+
 			// Connected only on the oauth-callback success signal — never on popup close,
 			// which also happens on provider-side failures.
 			function onSuccessSignal() { if (pendingId) markConnected(pendingId); }
@@ -341,10 +367,17 @@
 				});
 			} catch (e) {}
 			window.addEventListener('message', function (event) {
-				// The sandboxed form iframe can't spoof a connect: its only accepted message is
-				// the POST gate's rejection, which carries ids and moves rows one way only, so
-				// the worst author script can do is degrade its own form's UX.
+				// The sandboxed form iframe can't spoof a connect: it is only ever answered
+				// with a page move inside this form, or with the POST gate's rejection, which
+				// carries ids and moves rows one way only — so the worst author script can do
+				// is degrade its own form's UX. `event.origin` is the string 'null' for an
+				// opaque-origin frame and cannot be checked; `event.source` identifies it.
 				if (frame && event.source === frame.contentWindow) {
+					if (event.data && event.data.type === 'n8n-form-navigate') {
+						var next = resolveFrameNavigation(event.data.url);
+						if (next) frame.src = next;
+						return;
+					}
 					handleGateRejection(event.data);
 					return;
 				}

--- a/packages/cli/templates/form-trigger-completion.handlebars
+++ b/packages/cli/templates/form-trigger-completion.handlebars
@@ -162,6 +162,8 @@
 		const url = new URL(window.location.href);
 		const formSignature = url.searchParams.get('signature');
 
+		{{> formHostNavigation path=hostNavigationPath withRedirect=true}}
+
 		let interval = 1000;
 		let timeoutId;
 		const checkExecutionStatus = async () => {
@@ -183,7 +185,7 @@
 					if (formSignature) {
 						redirectUrl.searchParams.set('signature', formSignature);
 					}
-					window.location.replace(redirectUrl.toString());
+					navigateTo(redirectUrl.toString());
 					return;
 				}
 
@@ -250,7 +252,7 @@
 					if (response.status === 200) {
 						const redirectUrl = document.getElementById("redirectUrl");
 						if (redirectUrl) {
-							window.location.replace(redirectUrl.href);
+							redirectTo(redirectUrl.href);
 						}
 					}
 
@@ -262,7 +264,7 @@
 					} catch (e) {}
 
 					if (json?.redirectURL) {
-							window.location.replace(json.redirectURL);
+							redirectTo(json.redirectURL);
 					}
 			})
 			.catch(function (error) {

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -736,37 +736,7 @@
 			const url = new URL(window.location.href);
 			let formSignature = url.searchParams.get('signature');
 
-			// Set only inside the n8n hosting shell's frame: the path prefix whose pages
-			// this form may hand to the host to navigate to. Empty everywhere else.
-			const hostNavigationPath = '{{hostNavigationPath}}';
-
-			function isHostNavigable(target) {
-				if (!hostNavigationPath) return false;
-				try {
-					const here = new URL(window.location.href);
-					const resolved = new URL(target, here);
-					if (resolved.origin !== here.origin) return false;
-					return resolved.pathname === hostNavigationPath
-						|| resolved.pathname.startsWith(hostNavigationPath + '/');
-				} catch (e) {
-					return false;
-				}
-			}
-
-			// Move to the next page of the form. Inside the hosting shell this document is
-			// sandboxed to an opaque origin, so a navigation it starts itself counts as
-			// cross-site and the browser withholds the form's own auth cookie — ask the
-			// shell, which runs on the real origin, to move the frame instead. Every other
-			// destination, and every form not hosted in the shell, navigates as before.
-			function navigateTo(target) {
-				if (window.parent !== window && isHostNavigable(target)) {
-					// targetOrigin '*': an opaque-origin document cannot name its parent's
-					// origin, and the payload is only a URL the parent can already read.
-					window.parent.postMessage({ type: 'n8n-form-navigate', url: String(target) }, '*');
-					return;
-				}
-				window.location.replace(target);
-			}
+			{{> formHostNavigation path=hostNavigationPath}}
 
 			function updateError(errorElement, action = 'add', message = '') {
 				if(action === 'add') {

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -736,6 +736,38 @@
 			const url = new URL(window.location.href);
 			let formSignature = url.searchParams.get('signature');
 
+			// Set only inside the n8n hosting shell's frame: the path prefix whose pages
+			// this form may hand to the host to navigate to. Empty everywhere else.
+			const hostNavigationPath = '{{hostNavigationPath}}';
+
+			function isHostNavigable(target) {
+				if (!hostNavigationPath) return false;
+				try {
+					const here = new URL(window.location.href);
+					const resolved = new URL(target, here);
+					if (resolved.origin !== here.origin) return false;
+					return resolved.pathname === hostNavigationPath
+						|| resolved.pathname.startsWith(hostNavigationPath + '/');
+				} catch (e) {
+					return false;
+				}
+			}
+
+			// Move to the next page of the form. Inside the hosting shell this document is
+			// sandboxed to an opaque origin, so a navigation it starts itself counts as
+			// cross-site and the browser withholds the form's own auth cookie — ask the
+			// shell, which runs on the real origin, to move the frame instead. Every other
+			// destination, and every form not hosted in the shell, navigates as before.
+			function navigateTo(target) {
+				if (window.parent !== window && isHostNavigable(target)) {
+					// targetOrigin '*': an opaque-origin document cannot name its parent's
+					// origin, and the payload is only a URL the parent can already read.
+					window.parent.postMessage({ type: 'n8n-form-navigate', url: String(target) }, '*');
+					return;
+				}
+				window.location.replace(target);
+			}
+
 			function updateError(errorElement, action = 'add', message = '') {
 				if(action === 'add') {
 					errorElement.textContent = message;
@@ -999,7 +1031,7 @@
 						if (formSignature) {
 							redirectUrl.searchParams.set('signature', formSignature);
 						}
-						window.location.replace(redirectUrl.toString());
+						navigateTo(redirectUrl.toString());
 						return;
 					}
 
@@ -1143,7 +1175,7 @@
 								}
 
 								if (json?.redirectURL) {
-									window.location.replace(json.redirectURL);
+									navigateTo(json.redirectURL);
 									return;
 								}
 
@@ -1169,12 +1201,12 @@
 
 							if (response.status === 200) {
 								if(response.redirected) {
-									window.location.replace(response.url);
+									navigateTo(response.url);
 									return;
 								}
 								const redirectUrl = document.getElementById("redirectUrl");
 								if (redirectUrl) {
-									window.location.replace(redirectUrl.href);
+									navigateTo(redirectUrl.href);
 								} else {
 									form.style.display = 'none';
 									document.querySelector('#submitted-form').style.display = 'block';

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -736,7 +736,7 @@
 			const url = new URL(window.location.href);
 			let formSignature = url.searchParams.get('signature');
 
-			{{> formHostNavigation path=hostNavigationPath}}
+			{{> formHostNavigation path=hostNavigationPath withRedirect=true}}
 
 			function updateError(errorElement, action = 'add', message = '') {
 				if(action === 'add') {
@@ -1145,7 +1145,9 @@
 								}
 
 								if (json?.redirectURL) {
-									navigateTo(json.redirectURL);
+									// The author's end-of-form redirect leaves the form, so inside the
+									// hosting shell it must take the whole tab, not the sandboxed frame.
+									redirectTo(json.redirectURL);
 									return;
 								}
 
@@ -1171,12 +1173,15 @@
 
 							if (response.status === 200) {
 								if(response.redirected) {
-									navigateTo(response.url);
+									// Another page of this form moves the frame; anything else is a
+									// redirect out of the form and takes the tab.
+									if (isHostNavigable(response.url)) navigateTo(response.url);
+									else redirectTo(response.url);
 									return;
 								}
 								const redirectUrl = document.getElementById("redirectUrl");
 								if (redirectUrl) {
-									navigateTo(redirectUrl.href);
+									redirectTo(redirectUrl.href);
 								} else {
 									form.style.display = 'none';
 									document.querySelector('#submitted-form').style.display = 'block';

--- a/packages/cli/templates/partials/formHostNavigation.handlebars
+++ b/packages/cli/templates/partials/formHostNavigation.handlebars
@@ -1,0 +1,44 @@
+// Set only inside the n8n hosting shell's frame: the path prefix whose pages this
+// page may hand to the host to navigate to. Empty everywhere else.
+const hostNavigationPath = '{{path}}';
+const isShellHosted = window.parent !== window && !!hostNavigationPath;
+
+// True for this form's own follow-up pages, the only ones the shell will move to.
+function isHostNavigable(target) {
+	if (!hostNavigationPath) return false;
+	try {
+		const here = new URL(window.location.href);
+		const resolved = new URL(target, here);
+		if (resolved.origin !== here.origin) return false;
+		return resolved.pathname === hostNavigationPath
+			|| resolved.pathname.startsWith(hostNavigationPath + '/');
+	} catch (e) {
+		return false;
+	}
+}
+
+// Ask the host for a move this document can't make itself: inside the shell it is
+// sandboxed to an opaque origin, so a navigation it starts counts as cross-site and
+// the browser withholds the form's own auth cookie. The shell runs on the real
+// origin, so the move it makes for us keeps the cookie. `type` says which move —
+// another page of this form inside the frame, or the author's redirect for the tab.
+function requestHostNavigation(type, target) {
+	// targetOrigin '*': an opaque-origin document cannot name its parent's origin,
+	// and the payload is only a URL the parent can already read.
+	window.parent.postMessage({ type, url: String(target) }, '*');
+}
+
+// Move to another page of this form.
+function navigateTo(target) {
+	if (isShellHosted && isHostNavigable(target)) requestHostNavigation('n8n-form-navigate', target);
+	else window.location.replace(target);
+}
+{{#if withRedirect}}
+
+// Leave for the redirect the form's author configured. The form is finished, so this
+// takes the whole tab, which is where a form rendered without the shell ends up too.
+function redirectTo(target) {
+	if (isShellHosted) requestHostNavigation('n8n-form-redirect', target);
+	else window.location.replace(target);
+}
+{{/if}}

--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -400,6 +400,15 @@ export class Form extends Node {
 
 		const method = context.getRequestObject().method;
 
+		// Same submit-time readiness gate as the trigger (see `formWebhook`): every
+		// POST here resumes the execution, and doing so with an account disconnected
+		// mid-journey — from the hosting shell's panel — would kill the run at
+		// credential resolution. That includes the completion resume POST, which can
+		// arrive long after the last page's own gate ran if its redirect hop was lost.
+		if (method === 'POST' && (await respondIfCredentialsNotReady(context, res))) {
+			return { noWebhookResponse: true };
+		}
+
 		if (operation === 'completion' && method === 'GET') {
 			return await renderFormCompletion(context, res, trigger, authResult.authedUser);
 		}
@@ -412,13 +421,6 @@ export class Form extends Node {
 
 		if (method === 'GET') {
 			return await renderFormNode(context, res, trigger, fields, mode, authResult.authedUser);
-		}
-
-		// Same submit-time readiness gate as the trigger (see `formWebhook`): an
-		// account can be disconnected mid-journey from the hosting shell's panel,
-		// and resuming the execution anyway would kill it at credential resolution.
-		if (await respondIfCredentialsNotReady(context, res)) {
-			return { noWebhookResponse: true };
 		}
 
 		let useWorkflowTimezone = context.evaluateExpression(

--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -31,6 +31,7 @@ import {
 	getNodeReference,
 	parseFormFields,
 	prepareFormReturnItem,
+	respondIfCredentialsNotReady,
 	validateFormPageAuth,
 } from './utils/utils';
 
@@ -411,6 +412,13 @@ export class Form extends Node {
 
 		if (method === 'GET') {
 			return await renderFormNode(context, res, trigger, fields, mode, authResult.authedUser);
+		}
+
+		// Same submit-time readiness gate as the trigger (see `formWebhook`): an
+		// account can be disconnected mid-journey from the hosting shell's panel,
+		// and resuming the execution anyway would kill it at credential resolution.
+		if (await respondIfCredentialsNotReady(context, res)) {
+			return { noWebhookResponse: true };
 		}
 
 		let useWorkflowTimezone = context.evaluateExpression(

--- a/packages/nodes-base/nodes/Form/interfaces.ts
+++ b/packages/nodes-base/nodes/Form/interfaces.ts
@@ -60,6 +60,13 @@ export type FormTriggerData = {
 	// redirects to the OAuth2 provider, which would make the client branch
 	// untestable without Keycloak and a license.
 	hasAuthenticatedSubmitter?: boolean;
+	// Set only when this render sits inside the n8n hosting shell's frame: the path
+	// prefix whose pages the form may ask the shell to navigate to, instead of
+	// navigating itself (a navigation the sandboxed document starts itself is
+	// treated as cross-site and loses the form's auth cookie). Absent everywhere
+	// else — including a form embedded on someone else's site — which leaves the
+	// form navigating itself, as it always has.
+	hostNavigationPath?: string;
 };
 
 export const FORM_TRIGGER_AUTHENTICATION_PROPERTY = 'authentication';

--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -906,6 +906,105 @@ describe('Form Node', () => {
 			expect(mockResponseObject.writeHead).not.toHaveBeenCalled();
 			expect(mockResponseObject.render).toHaveBeenCalled();
 		});
+
+		describe('submit-time credential readiness gate', () => {
+			const setupAuthedPost = () => {
+				const json = vi.fn();
+				const mockResponseObject = {
+					render: vi.fn(),
+					writeHead: vi.fn(),
+					end: vi.fn(),
+					setHeader: vi.fn(),
+					status: vi.fn().mockReturnValue({ json, send: vi.fn() }),
+				};
+				mockWebhookFunctions.getResponseObject.mockReturnValue(
+					mockResponseObject as unknown as Response,
+				);
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'POST',
+					contentType: 'multipart/form-data',
+					originalUrl: '/form-waiting/exec',
+					headers: { cookie: 'n8n-auth=valid.jwt.token' },
+					query: {},
+				} as unknown as Request);
+				mockWebhookFunctions.getNode.mockReturnValue(
+					mock<INode>({ type: 'n8n-nodes-base.form', typeVersion: 2.6 }),
+				);
+				mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+					if (paramName === 'operation') return 'page';
+					if (paramName === 'useJson') return false;
+					if (paramName === 'formFields.values') return [{ fieldLabel: 'test' }];
+					if (paramName === 'options') return {};
+					return undefined;
+				});
+				mockWebhookFunctions.getBodyData.mockReturnValue({
+					data: { 'field-0': 'value' },
+					files: {},
+				});
+				setupParentTriggerWithAuth('n8nUserAuth', true);
+				mockWebhookFunctions.validateCookieAuth.mockResolvedValue(authedUser);
+				(mockWebhookFunctions as unknown as { logger: unknown }).logger = {
+					warn: vi.fn(),
+					error: vi.fn(),
+					debug: vi.fn(),
+					info: vi.fn(),
+				};
+				return { status: mockResponseObject.status, json };
+			};
+
+			it('returns 428 and does not resume when an account is not connected', async () => {
+				const { status, json } = setupAuthedPost();
+				mockWebhookFunctions.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: false,
+					credentials: [
+						{
+							credentialId: 'cred-missing',
+							credentialName: 'My Gmail',
+							credentialType: 'gmailOAuth2',
+							resolverId: 'resolver-1',
+							status: 'missing',
+						},
+					],
+				});
+
+				const result = await form.webhook(mockWebhookFunctions);
+
+				expect(status).toHaveBeenCalledWith(428);
+				expect(json).toHaveBeenCalledWith(
+					expect.objectContaining({ status: 'credential_connections_required' }),
+				);
+				expect(result).toEqual({ noWebhookResponse: true });
+			});
+
+			it('resumes the execution when the check reports ready', async () => {
+				const { status } = setupAuthedPost();
+				mockWebhookFunctions.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: true,
+					credentials: [],
+				});
+
+				const result = await form.webhook(mockWebhookFunctions);
+
+				expect(status).not.toHaveBeenCalled();
+				expect(result).toMatchObject({
+					webhookResponse: { status: 200 },
+					workflowData: [[expect.anything()]],
+				});
+			});
+
+			it('fails closed with 503 when the check throws', async () => {
+				const { status, json } = setupAuthedPost();
+				mockWebhookFunctions.checkTriggerCredentialStatus.mockRejectedValue(
+					new Error('check failed'),
+				);
+
+				const result = await form.webhook(mockWebhookFunctions);
+
+				expect(status).toHaveBeenCalledWith(503);
+				expect(json).toHaveBeenCalledWith({ status: 'credential_readiness_check_failed' });
+				expect(result).toEqual({ noWebhookResponse: true });
+			});
+		});
 	});
 
 	describe('webhook method - completion and redirect', () => {

--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -908,7 +908,7 @@ describe('Form Node', () => {
 		});
 
 		describe('submit-time credential readiness gate', () => {
-			const setupAuthedPost = () => {
+			const setupAuthedPost = (operation: 'page' | 'completion' = 'page') => {
 				const json = vi.fn();
 				const mockResponseObject = {
 					render: vi.fn(),
@@ -931,7 +931,7 @@ describe('Form Node', () => {
 					mock<INode>({ type: 'n8n-nodes-base.form', typeVersion: 2.6 }),
 				);
 				mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
-					if (paramName === 'operation') return 'page';
+					if (paramName === 'operation') return operation;
 					if (paramName === 'useJson') return false;
 					if (paramName === 'formFields.values') return [{ fieldLabel: 'test' }];
 					if (paramName === 'options') return {};
@@ -1002,6 +1002,33 @@ describe('Form Node', () => {
 
 				expect(status).toHaveBeenCalledWith(503);
 				expect(json).toHaveBeenCalledWith({ status: 'credential_readiness_check_failed' });
+				expect(result).toEqual({ noWebhookResponse: true });
+			});
+
+			// The completion resume POST can arrive long after the last page's own gate
+			// ran (a lost redirect hop parks the run at the completion node), so it must
+			// be gated too — nodes can still follow the completion node.
+			it('gates the completion resume POST as well', async () => {
+				const { status, json } = setupAuthedPost('completion');
+				mockWebhookFunctions.checkTriggerCredentialStatus.mockResolvedValue({
+					readyToExecute: false,
+					credentials: [
+						{
+							credentialId: 'cred-missing',
+							credentialName: 'My Gmail',
+							credentialType: 'gmailOAuth2',
+							resolverId: 'resolver-1',
+							status: 'missing',
+						},
+					],
+				});
+
+				const result = await form.webhook(mockWebhookFunctions);
+
+				expect(status).toHaveBeenCalledWith(428);
+				expect(json).toHaveBeenCalledWith(
+					expect.objectContaining({ status: 'credential_connections_required' }),
+				);
 				expect(result).toEqual({ noWebhookResponse: true });
 			});
 		});

--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -38,6 +38,12 @@ describe('Form Node', () => {
 
 		mockExecuteFunctions.getWorkflowSettings.mockReturnValue(mock<IWorkflowSettings>({}));
 		mockWebhookFunctions.getWorkflowSettings.mockReturnValue(mock<IWorkflowSettings>({}));
+		mockWebhookFunctions.getWorkflow.mockReturnValue({
+			id: 'workflow-id',
+			name: 'Workflow',
+			active: true,
+		});
+		mockWebhookFunctions.getExecutionId.mockReturnValue(testExecutionId);
 	});
 
 	describe('execute method', () => {
@@ -769,6 +775,7 @@ describe('Form Node', () => {
 				end: vi.fn(),
 				setHeader: vi.fn(),
 				status: vi.fn().mockReturnValue({ send: vi.fn() }),
+				cookie: vi.fn(),
 			};
 			mockWebhookFunctions.getResponseObject.mockReturnValue(
 				mockResponseObject as unknown as Response,

--- a/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
@@ -86,6 +86,12 @@ describe('formCompletionUtils', () => {
 		mockWebhookFunctions = mock<IWebhookFunctions>();
 
 		mockWebhookFunctions.getNode.mockReturnValue(mockNode);
+		mockWebhookFunctions.getWorkflow.mockReturnValue({
+			id: 'workflow-id',
+			name: 'Workflow',
+			active: true,
+		});
+		mockWebhookFunctions.getExecutionId.mockReturnValue('execution-id');
 	});
 
 	afterEach(() => {
@@ -471,7 +477,11 @@ describe('formCompletionUtils', () => {
 				authToken: string;
 			};
 			expect(renderArgs.authToken).toBeTruthy();
-			expect(verifyFormUserAuthToken(renderArgs.authToken, mockNode)).toEqual(authedUser);
+			// Bound to the run that rendered the page, so it is only accepted for it.
+			expect(verifyFormUserAuthToken(renderArgs.authToken, mockNode, 'execution-id')).toEqual(
+				authedUser,
+			);
+			expect(verifyFormUserAuthToken(renderArgs.authToken, mockNode, 'other-execution')).toBeNull();
 		});
 
 		it('should NOT set Content-Security-Policy header when form HTML sandboxing is disabled', async () => {

--- a/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
@@ -10,7 +10,7 @@ vi.mock('n8n-core', () => ({
 }));
 
 import { Container } from '@n8n/di';
-import { type Response } from 'express';
+import { type Request, type Response } from 'express';
 import { type MockProxy, mock } from 'vitest-mock-extended';
 import { getHtmlSandboxCSP, InstanceSettings, isFormHtmlSandboxingDisabled } from 'n8n-core';
 import { ExpressionError, type INode, type IUser, type IWebhookFunctions } from 'n8n-workflow';
@@ -92,6 +92,10 @@ describe('formCompletionUtils', () => {
 			active: true,
 		});
 		mockWebhookFunctions.getExecutionId.mockReturnValue('execution-id');
+		// A plain top-level page: no shell around it, so nothing to delegate to.
+		mockWebhookFunctions.getRequestObject.mockReturnValue(
+			mock<Request>({ headers: {}, query: {} }),
+		);
 	});
 
 	afterEach(() => {
@@ -482,6 +486,54 @@ describe('formCompletionUtils', () => {
 				authedUser,
 			);
 			expect(verifyFormUserAuthToken(renderArgs.authToken, mockNode, 'other-execution')).toBeNull();
+		});
+
+		// The completion page reloads itself while the run finishes, and inside the
+		// hosting shell that hop has to go through the host like every other one.
+		describe('host-driven navigation', () => {
+			const setupCompletionParams = () => {
+				mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+					const params: { [key: string]: any } = {
+						completionTitle: 'Form Completion',
+						completionMessage: 'Done',
+						options: { formTitle: 'Form Title' },
+					};
+					return params[parameterName];
+				});
+			};
+
+			it('is offered when the shell navigated its frame here', async () => {
+				setupCompletionParams();
+				mockWebhookFunctions.getRequestObject.mockReturnValue(
+					mock<Request>({
+						headers: { 'sec-fetch-dest': 'iframe', 'sec-fetch-site': 'same-origin' },
+						query: { n8nShellHosted: '1' },
+					}),
+				);
+				mockWebhookFunctions.evaluateExpression.mockImplementation((expression) =>
+					expression === '{{ $execution.resumeFormUrl }}'
+						? 'http://localhost:5678/form-waiting/execution-id'
+						: '',
+				);
+
+				await renderFormCompletion(mockWebhookFunctions, mockResponse, trigger);
+
+				expect(mockResponse.render).toHaveBeenCalledWith(
+					'form-trigger-completion',
+					expect.objectContaining({ hostNavigationPath: '/form-waiting' }),
+				);
+			});
+
+			it('is not offered to a top-level completion page', async () => {
+				setupCompletionParams();
+
+				await renderFormCompletion(mockWebhookFunctions, mockResponse, trigger);
+
+				expect(mockResponse.render).toHaveBeenCalledWith(
+					'form-trigger-completion',
+					expect.objectContaining({ hostNavigationPath: undefined }),
+				);
+			});
 		});
 
 		it('should NOT set Content-Security-Policy header when form HTML sandboxing is disabled', async () => {

--- a/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
@@ -305,7 +305,8 @@ describe('formNodeUtils', () => {
 				'http://localhost:5678/form-waiting/execution-1' as never,
 			);
 			const cookie = vi.fn();
-			const res = mock<Response>({ render: vi.fn(), cookie } as never);
+			const render = vi.fn();
+			const res = mock<Response>({ render, cookie } as never);
 			webhookFunctions.getResponseObject.mockReturnValue(res);
 
 			await renderFormNode(
@@ -317,7 +318,7 @@ describe('formNodeUtils', () => {
 				authedUser,
 			);
 
-			return { cookie };
+			return { cookie, render };
 		};
 
 		it('is set for an authenticated submitter, scoped to the form-waiting path', async () => {
@@ -339,6 +340,15 @@ describe('formNodeUtils', () => {
 				wfid: 'workflow-1',
 				eid: 'execution-1',
 			});
+		});
+
+		it('ships the client-side credential-gate handling for an authenticated submitter', async () => {
+			const { render } = await renderAuthedPage();
+
+			expect(render).toHaveBeenCalledWith(
+				'form-trigger',
+				expect.objectContaining({ hasAuthenticatedSubmitter: true }),
+			);
 		});
 
 		it('is not set when the page has no authenticated submitter', async () => {

--- a/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
@@ -325,7 +325,8 @@ describe('formNodeUtils', () => {
 			const { cookie } = await renderAuthedPage();
 
 			expect(cookie).toHaveBeenCalledWith(
-				'n8n-form-auth',
+				// Named for the run, so concurrent forms don't overwrite each other.
+				'n8n-form-auth-ex-execution-1',
 				expect.any(String),
 				expect.objectContaining({ httpOnly: true, sameSite: 'lax', path: '/form-waiting' }),
 			);

--- a/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
@@ -1,8 +1,12 @@
+import { Container } from '@n8n/di';
 import { type Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { InstanceSettings } from 'n8n-core';
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 import {
 	type FormFieldsParameter,
+	type IUser,
 	type IWebhookFunctions,
 	type NodeTypeAndVersion,
 	NodeOperationError,
@@ -11,11 +15,18 @@ import {
 
 import { renderFormNode, getFormTriggerNode } from '../utils/formNodeUtils';
 
+Container.set(InstanceSettings, { hmacSignatureSecret: 'test-hmac-secret' } as InstanceSettings);
+
 describe('formNodeUtils', () => {
 	let webhookFunctions: MockProxy<IWebhookFunctions>;
 
 	beforeEach(() => {
 		webhookFunctions = mock<IWebhookFunctions>();
+		webhookFunctions.getRequestObject.mockReturnValue({
+			method: 'GET',
+			headers: { host: 'localhost:5678' },
+			protocol: 'http',
+		} as never);
 	});
 
 	afterEach(() => {
@@ -261,6 +272,91 @@ describe('formNodeUtils', () => {
 				buttonLabel: '={{ 1 + 1 }}',
 			}),
 		);
+	});
+
+	// The next page is reached by navigating to it, which can present no header, so
+	// the page render also hands it the token as a cookie.
+	describe('form page auth cookie', () => {
+		const authedUser: IUser = {
+			id: 'user-1',
+			email: 'user@example.com',
+			firstName: 'Test',
+			lastName: 'User',
+		};
+
+		const renderAuthedPage = async () => {
+			webhookFunctions.getNode.mockReturnValue({
+				id: 'page-node',
+				webhookId: 'page-webhook',
+				typeVersion: 2.5,
+			} as never);
+			webhookFunctions.getNodeParameter.calledWith('options').mockReturnValue({
+				formTitle: 'Test Title',
+				formDescription: '',
+				buttonLabel: 'Submit',
+			});
+			webhookFunctions.getWorkflow.mockReturnValue({
+				id: 'workflow-1',
+				name: 'wf',
+				active: true,
+			});
+			webhookFunctions.getExecutionId.mockReturnValue('execution-1');
+			webhookFunctions.evaluateExpression.mockReturnValue(
+				'http://localhost:5678/form-waiting/execution-1' as never,
+			);
+			const cookie = vi.fn();
+			const res = mock<Response>({ render: vi.fn(), cookie } as never);
+			webhookFunctions.getResponseObject.mockReturnValue(res);
+
+			await renderFormNode(
+				webhookFunctions,
+				res,
+				mock<NodeTypeAndVersion>({ name: 'triggerName' } as never),
+				[],
+				'production',
+				authedUser,
+			);
+
+			return { cookie };
+		};
+
+		it('is set for an authenticated submitter, scoped to the form-waiting path', async () => {
+			const { cookie } = await renderAuthedPage();
+
+			expect(cookie).toHaveBeenCalledWith(
+				'n8n-form-auth',
+				expect.any(String),
+				expect.objectContaining({ httpOnly: true, sameSite: 'lax', path: '/form-waiting' }),
+			);
+		});
+
+		it('carries the workflow and the execution the page belongs to', async () => {
+			const { cookie } = await renderAuthedPage();
+
+			const [, token] = cookie.mock.calls[0] as [string, string];
+			expect(jwt.decode(token)).toMatchObject({
+				sub: authedUser.id,
+				wfid: 'workflow-1',
+				eid: 'execution-1',
+			});
+		});
+
+		it('is not set when the page has no authenticated submitter', async () => {
+			webhookFunctions.getNode.mockReturnValue({ typeVersion: 2.1 } as never);
+			webhookFunctions.getNodeParameter.calledWith('options').mockReturnValue({});
+			const cookie = vi.fn();
+			const res = mock<Response>({ render: vi.fn(), cookie } as never);
+
+			await renderFormNode(
+				webhookFunctions,
+				res,
+				mock<NodeTypeAndVersion>({ name: 'triggerName' } as never),
+				[],
+				'production',
+			);
+
+			expect(cookie).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('getFormTriggerNode', () => {

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -1100,7 +1100,9 @@ describe('FormTrigger, formWebhook', () => {
 				await formWebhook(ctx);
 
 				expect(cookie).toHaveBeenCalledWith(
-					'n8n-form-auth',
+					// Named for the workflow: no run exists yet at the trigger, and other
+					// forms' cookies must not be overwritten.
+					'n8n-form-auth-wf-workflow-1',
 					expect.any(String),
 					expect.objectContaining({
 						httpOnly: true,
@@ -4243,9 +4245,20 @@ describe('validateFormPageAuth', () => {
 		return { ctx, res, req };
 	};
 
-	/** The cookie the form pages present, as the page renders set it. */
-	const pageAuthCookie = (binding: { workflowId?: string; executionId?: string }) =>
-		`n8n-form-auth=${generateFormUserAuthToken(pageNode, authedUser, binding)}`;
+	/** The name a page render gives the cookie: bound to the run, or — from the
+	 * trigger, before a run exists — to the workflow. */
+	const formAuthCookieName = (binding: { workflowId?: string; executionId?: string }) =>
+		binding.executionId
+			? `n8n-form-auth-ex-${binding.executionId}`
+			: `n8n-form-auth-wf-${binding.workflowId}`;
+
+	/** The cookie the form pages present, as the page renders set it. An explicit
+	 * `cookieName` mimics a stale or foreign token sitting under a name the served
+	 * page looks for. */
+	const pageAuthCookie = (
+		binding: { workflowId?: string; executionId?: string },
+		cookieName = formAuthCookieName(binding),
+	) => `${cookieName}=${generateFormUserAuthToken(pageNode, authedUser, binding)}`;
 
 	it('returns empty object and skips validation when authentication is not n8nUserAuth', async () => {
 		const { ctx } = buildContext('GET');
@@ -4396,8 +4409,31 @@ describe('validateFormPageAuth', () => {
 			expect(result.authedUser).toEqual(authedUser);
 		});
 
-		it('ignores a cookie bound to another workflow', async () => {
-			const { ctx, res } = buildContext('GET', pageAuthCookie({ workflowId: 'other-workflow' }));
+		it("selects this form's cookies among other forms' cookies", async () => {
+			// Each form journey names its cookie after its own run/workflow, so several
+			// can sit in the browser side by side without overwriting one another.
+			const { ctx } = buildContext(
+				'GET',
+				[
+					pageAuthCookie({ workflowId: 'other-workflow' }),
+					pageAuthCookie({ workflowId: WORKFLOW_ID, executionId: 'other-execution' }),
+					pageAuthCookie({ workflowId: WORKFLOW_ID, executionId: EXECUTION_ID }),
+				].join('; '),
+			);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(authedUser);
+		});
+
+		it('ignores a token bound to another workflow sitting under the expected name', async () => {
+			const { ctx, res } = buildContext(
+				'GET',
+				pageAuthCookie(
+					{ workflowId: 'other-workflow' },
+					formAuthCookieName({ workflowId: WORKFLOW_ID }),
+				),
+			);
 
 			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
 
@@ -4408,10 +4444,13 @@ describe('validateFormPageAuth', () => {
 			);
 		});
 
-		it('ignores a cookie bound to another execution', async () => {
+		it('ignores a token bound to another execution sitting under the expected name', async () => {
 			const { ctx, res } = buildContext(
 				'GET',
-				pageAuthCookie({ workflowId: WORKFLOW_ID, executionId: 'other-execution' }),
+				pageAuthCookie(
+					{ workflowId: WORKFLOW_ID, executionId: 'other-execution' },
+					formAuthCookieName({ workflowId: WORKFLOW_ID, executionId: EXECUTION_ID }),
+				),
 			);
 
 			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
@@ -4421,7 +4460,10 @@ describe('validateFormPageAuth', () => {
 		});
 
 		it('ignores a token that carries no workflow binding', async () => {
-			const { ctx, res } = buildContext('GET', pageAuthCookie({}));
+			const { ctx, res } = buildContext(
+				'GET',
+				pageAuthCookie({}, formAuthCookieName({ workflowId: WORKFLOW_ID })),
+			);
 
 			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
 
@@ -4448,7 +4490,7 @@ describe('validateFormPageAuth', () => {
 		});
 
 		it('ignores a malformed cookie', async () => {
-			const { ctx, res } = buildContext('GET', 'n8n-form-auth=garbage');
+			const { ctx, res } = buildContext('GET', 'n8n-form-auth-ex-exec-id=garbage');
 
 			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
 
@@ -4457,7 +4499,10 @@ describe('validateFormPageAuth', () => {
 		});
 
 		it('falls back to the session cookie when the form cookie does not verify', async () => {
-			const { ctx } = buildContext('GET', 'n8n-form-auth=garbage; n8n-auth=valid.jwt.token');
+			const { ctx } = buildContext(
+				'GET',
+				'n8n-form-auth-ex-exec-id=garbage; n8n-auth=valid.jwt.token',
+			);
 			ctx.validateCookieAuth.mockResolvedValue(authedUser);
 
 			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
@@ -4469,7 +4514,10 @@ describe('validateFormPageAuth', () => {
 		// A value that isn't valid percent-encoding must be treated as no cookie, not
 		// surface as a failed request for every page load that carries it.
 		it('falls back to the session cookie when the form cookie value cannot be decoded', async () => {
-			const { ctx } = buildContext('GET', 'n8n-form-auth=%E0%A4%A; n8n-auth=valid.jwt.token');
+			const { ctx } = buildContext(
+				'GET',
+				'n8n-form-auth-ex-exec-id=%E0%A4%A; n8n-auth=valid.jwt.token',
+			);
 			ctx.validateCookieAuth.mockResolvedValue(authedUser);
 
 			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
@@ -4479,7 +4527,7 @@ describe('validateFormPageAuth', () => {
 		});
 
 		it('redirects rather than throwing when an undecodable cookie is all the request has', async () => {
-			const { ctx, res } = buildContext('GET', 'n8n-form-auth=%E0%A4%A');
+			const { ctx, res } = buildContext('GET', 'n8n-form-auth-ex-exec-id=%E0%A4%A');
 
 			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
 

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -1181,6 +1181,12 @@ describe('FormTrigger, formWebhook', () => {
 				await formWebhook(ctx);
 
 				expectHostNavigationPath(render, '/form-waiting');
+				// The follow-up page is the shell's inner frame too: it must render the
+				// readiness listener and leave its submit state to the connect panel.
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ shellInner: true }),
+				);
 			});
 
 			// The flag is what carries the shell across a proxy that drops fetch metadata,
@@ -1215,6 +1221,10 @@ describe('FormTrigger, formWebhook', () => {
 				await formWebhook(ctx);
 
 				expectHostNavigationPath(render, undefined);
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ shellInner: undefined }),
+				);
 			});
 
 			it('is not offered to a top-level page carrying the flag', async () => {

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -19,6 +19,7 @@ import { rm } from 'fs/promises';
 import type * as _fsPromises from 'fs/promises';
 import { Container } from '@n8n/di';
 import type { Request } from 'express';
+import jwt from 'jsonwebtoken';
 import { mock } from 'vitest-mock-extended';
 import { DateTime } from 'luxon';
 import { InstanceSettings } from 'n8n-core';
@@ -34,7 +35,12 @@ import type {
 	MultiPartFormData,
 	NodeTypeAndVersion,
 } from 'n8n-workflow';
-import { BINARY_MODE_COMBINED, FORM_TRIGGER_NODE_TYPE, WAIT_NODE_TYPE } from 'n8n-workflow';
+import {
+	BINARY_MODE_COMBINED,
+	FORM_NODE_TYPE,
+	FORM_TRIGGER_NODE_TYPE,
+	WAIT_NODE_TYPE,
+} from 'n8n-workflow';
 
 import {
 	formWebhook,
@@ -849,7 +855,12 @@ describe('FormTrigger, formWebhook', () => {
 
 		const setupContext = (
 			ctx: ReturnType<typeof mock<IWebhookFunctions>>,
-			overrides: { method: 'GET' | 'POST'; cookie?: string; options?: IDataObject } = {
+			overrides: {
+				method: 'GET' | 'POST';
+				cookie?: string;
+				options?: IDataObject;
+				headers?: Record<string, string>;
+			} = {
 				method: 'GET',
 			},
 		) => {
@@ -858,6 +869,7 @@ describe('FormTrigger, formWebhook', () => {
 			const end = vi.fn();
 			const setHeader = vi.fn();
 			const render = vi.fn();
+			const cookie = vi.fn();
 			const request = {
 				method: overrides.method,
 				originalUrl: '/form/test',
@@ -865,12 +877,14 @@ describe('FormTrigger, formWebhook', () => {
 				headers: {
 					host: 'localhost:5678',
 					...(overrides.cookie ? { cookie: overrides.cookie } : {}),
+					...(overrides.headers ?? {}),
 				},
 				protocol: 'http',
 				contentType: overrides.method === 'POST' ? 'multipart/form-data' : undefined,
 			};
 
 			ctx.getNode.mockReturnValue({ typeVersion: 2.6 } as INode);
+			ctx.getWorkflow.mockReturnValue({ id: 'workflow-1', name: 'wf', active: true });
 			ctx.getNodeParameter.calledWith('options').mockReturnValue(overrides.options ?? {});
 			ctx.getNodeParameter.calledWith('formTitle').mockReturnValue('Test Form');
 			ctx.getNodeParameter.calledWith('formDescription').mockReturnValue('Test Description');
@@ -885,6 +899,7 @@ describe('FormTrigger, formWebhook', () => {
 				end,
 				setHeader,
 				render,
+				cookie,
 			} as any);
 			ctx.getMode.mockReturnValue('manual');
 			ctx.getInstanceId.mockReturnValue('instanceId');
@@ -892,7 +907,7 @@ describe('FormTrigger, formWebhook', () => {
 			ctx.getWorkflowSettings.mockReturnValue(mock<IWorkflowSettings>({}));
 			ctx.getChildNodes.mockReturnValue([]);
 
-			return { status, writeHead, end, setHeader, render };
+			return { status, writeHead, end, setHeader, render, cookie };
 		};
 
 		beforeEach(() => {
@@ -1060,6 +1075,143 @@ describe('FormTrigger, formWebhook', () => {
 
 			const json = (result as any).workflowData[0][0].json;
 			expect(json.user).toBeUndefined();
+		});
+
+		// The follow-up pages are reached by navigating, which can present no header
+		// and — from the sandboxed form document — no session cookie either.
+		describe('form page auth cookie', () => {
+			const setupMultiPageGet = (ctx: ReturnType<typeof mock<IWebhookFunctions>>) => {
+				const res = setupContext(ctx, { method: 'GET', cookie: 'n8n-auth=valid.jwt.token' });
+				ctx.validateCookieAuth.mockResolvedValue(authedUser);
+				ctx.getChildNodes.mockReturnValue([
+					{ name: 'Form', type: FORM_NODE_TYPE, typeVersion: 2.5, disabled: false },
+				]);
+				ctx.evaluateExpression.mockReturnValue(
+					'http://localhost:5678/form-waiting/__UNKNOWN__' as never,
+				);
+				return res;
+			};
+
+			it('is set on GET for a form with a next page, scoped to the form-waiting path', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { cookie } = setupMultiPageGet(ctx);
+
+				await formWebhook(ctx);
+
+				expect(cookie).toHaveBeenCalledWith(
+					'n8n-form-auth',
+					expect.any(String),
+					expect.objectContaining({
+						httpOnly: true,
+						sameSite: 'lax',
+						secure: false,
+						path: '/form-waiting',
+					}),
+				);
+			});
+
+			it('carries the submitter and the workflow it was issued for', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { cookie } = setupMultiPageGet(ctx);
+
+				await formWebhook(ctx);
+
+				const [, token] = cookie.mock.calls[0] as [string, string];
+				expect(jwt.decode(token)).toMatchObject({
+					sub: authedUser.id,
+					email: authedUser.email,
+					wfid: 'workflow-1',
+				});
+				// No run exists yet at the trigger, so nothing binds it to one.
+				expect(jwt.decode(token)).not.toHaveProperty('eid');
+			});
+
+			it('is not set for a single-page form, which never navigates', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { cookie } = setupContext(ctx, {
+					method: 'GET',
+					cookie: 'n8n-auth=valid.jwt.token',
+				});
+				ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+				await formWebhook(ctx);
+
+				expect(cookie).not.toHaveBeenCalled();
+			});
+		});
+
+		// The rendered form only hands its page navigations to its host when that host
+		// is the n8n hosting shell; anywhere else it must keep navigating itself.
+		describe('host-driven page navigation', () => {
+			const setupRender = (
+				ctx: ReturnType<typeof mock<IWebhookFunctions>>,
+				headers?: Record<string, string>,
+			) => {
+				const res = setupContext(ctx, {
+					method: 'GET',
+					cookie: 'n8n-auth=valid.jwt.token',
+					headers,
+				});
+				ctx.validateCookieAuth.mockResolvedValue(authedUser);
+				ctx.evaluateExpression.mockReturnValue(
+					'http://localhost:5678/form-waiting/__UNKNOWN__' as never,
+				);
+				return res;
+			};
+
+			it('is offered inside a same-origin frame, scoped to the form-waiting path', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx, {
+					'sec-fetch-dest': 'iframe',
+					'sec-fetch-site': 'same-origin',
+				});
+
+				await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ hostNavigationPath: '/form-waiting' }),
+				);
+			});
+
+			it('is not offered to a top-level form', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx, { 'sec-fetch-dest': 'document' });
+
+				await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ hostNavigationPath: undefined }),
+				);
+			});
+
+			it('is not offered to a form embedded on another site', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx, {
+					'sec-fetch-dest': 'iframe',
+					'sec-fetch-site': 'cross-site',
+				});
+
+				await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ hostNavigationPath: undefined }),
+				);
+			});
+
+			it('is not offered when the browser sends no fetch metadata', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx);
+
+				await formWebhook(ctx);
+
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ hostNavigationPath: undefined }),
+				);
+			});
 		});
 	});
 
@@ -3978,6 +4130,10 @@ describe('validateFormPageAuth', () => {
 		lastName: 'User',
 	};
 
+	const pageNode = { id: 'page-node', webhookId: 'page-webhook' } as INode;
+	const WORKFLOW_ID = 'workflow-1';
+	const EXECUTION_ID = 'exec-id';
+
 	const buildContext = (method: 'GET' | 'POST', cookie?: string) => {
 		const res = {
 			writeHead: vi.fn(),
@@ -3985,7 +4141,12 @@ describe('validateFormPageAuth', () => {
 			setHeader: vi.fn(),
 			status: vi.fn().mockReturnValue({ send: vi.fn() }),
 		};
-		const req = {
+		const req: {
+			method: string;
+			originalUrl: string;
+			headers: Record<string, string>;
+			protocol: string;
+		} = {
 			method,
 			originalUrl: '/form-waiting/exec-id',
 			headers: {
@@ -3997,8 +4158,15 @@ describe('validateFormPageAuth', () => {
 		const ctx = mock<IWebhookFunctions>();
 		ctx.getRequestObject.mockReturnValue(req as unknown as Request);
 		ctx.getResponseObject.mockReturnValue(res as never);
+		ctx.getNode.mockReturnValue(pageNode);
+		ctx.getWorkflow.mockReturnValue({ id: WORKFLOW_ID, name: 'wf', active: true });
+		ctx.getExecutionId.mockReturnValue(EXECUTION_ID);
 		return { ctx, res, req };
 	};
+
+	/** The cookie the form pages present, as the page renders set it. */
+	const pageAuthCookie = (binding: { workflowId?: string; executionId?: string }) =>
+		`n8n-form-auth=${generateFormUserAuthToken(pageNode, authedUser, binding)}`;
 
 	it('returns empty object and skips validation when authentication is not n8nUserAuth', async () => {
 		const { ctx } = buildContext('GET');
@@ -4082,7 +4250,10 @@ describe('validateFormPageAuth', () => {
 			firstName: 'Test',
 			lastName: 'User',
 		};
-		const token = generateFormUserAuthToken(node, authedFormUser);
+		const token = generateFormUserAuthToken(node, authedFormUser, {
+			workflowId: WORKFLOW_ID,
+			executionId: EXECUTION_ID,
+		});
 
 		const res = {
 			writeHead: vi.fn(),
@@ -4100,6 +4271,7 @@ describe('validateFormPageAuth', () => {
 		ctx.getRequestObject.mockReturnValue(req as unknown as Request);
 		ctx.getResponseObject.mockReturnValue(res as never);
 		ctx.getNode.mockReturnValue(node);
+		ctx.getExecutionId.mockReturnValue(EXECUTION_ID);
 
 		const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
 
@@ -4107,6 +4279,148 @@ describe('validateFormPageAuth', () => {
 		expect(result.responded).toBeFalsy();
 		// cookie path wasn't attempted because there's no cookie
 		expect(ctx.validateCookieAuth).not.toHaveBeenCalled();
+	});
+
+	// A page is reached by navigating to it, which can attach no header — and, from a
+	// sandboxed form document, no session cookie either. The form page auth cookie is
+	// the only credential such a request carries.
+	describe('form page auth cookie', () => {
+		it('returns the authedUser from a cookie minted before the run started', async () => {
+			const { ctx } = buildContext('GET', pageAuthCookie({ workflowId: WORKFLOW_ID }));
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(authedUser);
+			expect(result.responded).toBeFalsy();
+			expect(ctx.validateCookieAuth).not.toHaveBeenCalled();
+		});
+
+		it('returns the authedUser from a cookie bound to the execution being served', async () => {
+			const { ctx } = buildContext(
+				'GET',
+				pageAuthCookie({ workflowId: WORKFLOW_ID, executionId: EXECUTION_ID }),
+			);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(authedUser);
+		});
+
+		it('parses the cookie alongside other cookies', async () => {
+			const { ctx } = buildContext(
+				'GET',
+				`other=value; ${pageAuthCookie({ workflowId: WORKFLOW_ID })}; another=thing`,
+			);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(authedUser);
+		});
+
+		it('ignores a cookie bound to another workflow', async () => {
+			const { ctx, res } = buildContext('GET', pageAuthCookie({ workflowId: 'other-workflow' }));
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.responded).toBe(true);
+			expect(res.writeHead).toHaveBeenCalledWith(
+				302,
+				expect.objectContaining({ Location: expect.stringContaining('/signin?redirect=') }),
+			);
+		});
+
+		it('ignores a cookie bound to another execution', async () => {
+			const { ctx, res } = buildContext(
+				'GET',
+				pageAuthCookie({ workflowId: WORKFLOW_ID, executionId: 'other-execution' }),
+			);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.responded).toBe(true);
+			expect(res.writeHead).toHaveBeenCalledWith(302, expect.any(Object));
+		});
+
+		it('ignores a token that carries no workflow binding', async () => {
+			const { ctx, res } = buildContext('GET', pageAuthCookie({}));
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.responded).toBe(true);
+			expect(res.writeHead).toHaveBeenCalledWith(302, expect.any(Object));
+		});
+
+		it('ignores an expired cookie', async () => {
+			const realNow = Date.now();
+			vi.useFakeTimers();
+			let cookie: string;
+			try {
+				vi.setSystemTime(realNow - 2 * 60 * 60 * 1000);
+				cookie = pageAuthCookie({ workflowId: WORKFLOW_ID });
+			} finally {
+				vi.useRealTimers();
+			}
+			const { ctx, res } = buildContext('GET', cookie);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.responded).toBe(true);
+			expect(res.writeHead).toHaveBeenCalledWith(302, expect.any(Object));
+		});
+
+		it('ignores a malformed cookie', async () => {
+			const { ctx, res } = buildContext('GET', 'n8n-form-auth=garbage');
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.responded).toBe(true);
+			expect(res.writeHead).toHaveBeenCalledWith(302, expect.any(Object));
+		});
+
+		it('falls back to the session cookie when the form cookie does not verify', async () => {
+			const { ctx } = buildContext('GET', 'n8n-form-auth=garbage; n8n-auth=valid.jwt.token');
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(ctx.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
+			expect(result.authedUser).toEqual(authedUser);
+		});
+
+		it('is not consulted on POST, which carries the token in a header', async () => {
+			const token = generateFormUserAuthToken(pageNode, authedUser, {
+				workflowId: WORKFLOW_ID,
+				executionId: EXECUTION_ID,
+			});
+			const { ctx, req } = buildContext('POST', pageAuthCookie({ workflowId: WORKFLOW_ID }));
+			req.headers = { ...req.headers, 'x-auth-token': token };
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(authedUser);
+		});
+	});
+
+	// The OAuth2 token's audience is the trigger's URL, which a page's own resource
+	// URL is not, so a page can never satisfy that check — it must not try.
+	it('does not attempt the OAuth2 flow even when it is enabled', async () => {
+		vi.stubEnv('N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2', 'true');
+		try {
+			const { ctx, res } = buildContext('GET');
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(ctx.beginN8nOAuth2Flow).not.toHaveBeenCalled();
+			expect(ctx.validateN8nOAuth2Token).not.toHaveBeenCalled();
+			expect(ctx.establishTriggerIdentity).not.toHaveBeenCalled();
+			expect(result.responded).toBe(true);
+			expect(res.writeHead).toHaveBeenCalledWith(
+				302,
+				expect.objectContaining({ Location: expect.stringContaining('/signin?redirect=') }),
+			);
+		} finally {
+			vi.unstubAllEnvs();
+		}
 	});
 });
 
@@ -4118,20 +4432,21 @@ describe('generateFormUserAuthToken / verifyFormUserAuthToken', () => {
 		firstName: 'Test',
 		lastName: 'User',
 	};
+	const binding = { workflowId: 'workflow-id' };
 
 	it('round-trips a freshly generated token', () => {
-		const token = generateFormUserAuthToken(node, user);
+		const token = generateFormUserAuthToken(node, user, binding);
 		expect(verifyFormUserAuthToken(token, node)).toEqual(user);
 	});
 
 	it('rejects a token signed for a different node', () => {
-		const token = generateFormUserAuthToken(node, user);
+		const token = generateFormUserAuthToken(node, user, binding);
 		const otherNode = { id: 'node-2', webhookId: 'webhook-2' } as INode;
 		expect(verifyFormUserAuthToken(token, otherNode)).toBeNull();
 	});
 
 	it('rejects a tampered signature', () => {
-		const token = generateFormUserAuthToken(node, user);
+		const token = generateFormUserAuthToken(node, user, binding);
 		const parts = token.split('.');
 		parts[2] = parts[2].replace(/.$/, (c) => (c === 'A' ? 'B' : 'A'));
 		const tampered = parts.join('.');
@@ -4139,7 +4454,7 @@ describe('generateFormUserAuthToken / verifyFormUserAuthToken', () => {
 	});
 
 	it('rejects a tampered payload', () => {
-		const token = generateFormUserAuthToken(node, user);
+		const token = generateFormUserAuthToken(node, user, binding);
 		const parts = token.split('.');
 		parts[1] = Buffer.from(
 			JSON.stringify({
@@ -4160,7 +4475,7 @@ describe('generateFormUserAuthToken / verifyFormUserAuthToken', () => {
 		vi.useFakeTimers();
 		try {
 			vi.setSystemTime(realNow - 2 * 60 * 60 * 1000);
-			const token = generateFormUserAuthToken(node, user);
+			const token = generateFormUserAuthToken(node, user, binding);
 			vi.setSystemTime(realNow);
 			expect(verifyFormUserAuthToken(token, node)).toBeNull();
 		} finally {
@@ -4172,5 +4487,40 @@ describe('generateFormUserAuthToken / verifyFormUserAuthToken', () => {
 		expect(verifyFormUserAuthToken('garbage', node)).toBeNull();
 		expect(verifyFormUserAuthToken('a.b', node)).toBeNull();
 		expect(verifyFormUserAuthToken('a.b.c.d', node)).toBeNull();
+	});
+
+	it('accepts a token minted without an execution for any execution', () => {
+		const token = generateFormUserAuthToken(node, user, binding);
+		expect(verifyFormUserAuthToken(token, node, 'exec-1')).toEqual(user);
+		expect(verifyFormUserAuthToken(token, node, undefined)).toEqual(user);
+	});
+
+	it('accepts a token bound to the execution being served', () => {
+		const token = generateFormUserAuthToken(node, user, { ...binding, executionId: 'exec-1' });
+		expect(verifyFormUserAuthToken(token, node, 'exec-1')).toEqual(user);
+	});
+
+	it('rejects a token bound to another execution', () => {
+		const token = generateFormUserAuthToken(node, user, { ...binding, executionId: 'exec-1' });
+		expect(verifyFormUserAuthToken(token, node, 'exec-2')).toBeNull();
+		expect(verifyFormUserAuthToken(token, node, undefined)).toBeNull();
+	});
+
+	// Tokens minted by an older version carry neither binding claim and stay valid
+	// for the node they name, so a rolling deploy doesn't invalidate open forms.
+	it('accepts a token carrying neither binding claim', () => {
+		const token = jwt.sign(
+			{
+				sub: user.id,
+				email: user.email,
+				firstName: user.firstName,
+				lastName: user.lastName,
+				nid: node.id,
+				wid: node.webhookId,
+			},
+			'test-hmac-secret',
+			{ algorithm: 'HS256', expiresIn: 60 },
+		);
+		expect(verifyFormUserAuthToken(token, node, 'exec-1')).toEqual(user);
 	});
 });

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -860,6 +860,7 @@ describe('FormTrigger, formWebhook', () => {
 				cookie?: string;
 				options?: IDataObject;
 				headers?: Record<string, string>;
+				query?: IDataObject;
 			} = {
 				method: 'GET',
 			},
@@ -873,7 +874,7 @@ describe('FormTrigger, formWebhook', () => {
 			const request = {
 				method: overrides.method,
 				originalUrl: '/form/test',
-				query: {},
+				query: overrides.query ?? {},
 				headers: {
 					host: 'localhost:5678',
 					...(overrides.cookie ? { cookie: overrides.cookie } : {}),
@@ -1141,16 +1142,18 @@ describe('FormTrigger, formWebhook', () => {
 		});
 
 		// The rendered form only hands its page navigations to its host when that host
-		// is the n8n hosting shell; anywhere else it must keep navigating itself.
+		// is the n8n hosting shell; anywhere else it must keep navigating itself. The
+		// shell says so outright, by flagging every URL it moves its frame to.
 		describe('host-driven page navigation', () => {
 			const setupRender = (
 				ctx: ReturnType<typeof mock<IWebhookFunctions>>,
-				headers?: Record<string, string>,
+				overrides: { headers?: Record<string, string>; query?: IDataObject } = {},
 			) => {
 				const res = setupContext(ctx, {
 					method: 'GET',
 					cookie: 'n8n-auth=valid.jwt.token',
-					headers,
+					headers: overrides.headers,
+					query: overrides.query,
 				});
 				ctx.validateCookieAuth.mockResolvedValue(authedUser);
 				ctx.evaluateExpression.mockReturnValue(
@@ -1159,58 +1162,105 @@ describe('FormTrigger, formWebhook', () => {
 				return res;
 			};
 
-			it('is offered inside a same-origin frame, scoped to the form-waiting path', async () => {
+			const expectHostNavigationPath = (
+				render: ReturnType<typeof setupRender>['render'],
+				path?: string,
+			) =>
+				expect(render).toHaveBeenCalledWith(
+					'form-trigger',
+					expect.objectContaining({ hostNavigationPath: path }),
+				);
+
+			it('is offered to a page the shell navigated its frame to', async () => {
 				const ctx = mock<IWebhookFunctions>();
 				const { render } = setupRender(ctx, {
-					'sec-fetch-dest': 'iframe',
-					'sec-fetch-site': 'same-origin',
+					query: { n8nShellHosted: '1' },
+					headers: { 'sec-fetch-dest': 'iframe', 'sec-fetch-site': 'same-origin' },
 				});
 
 				await formWebhook(ctx);
 
-				expect(render).toHaveBeenCalledWith(
-					'form-trigger',
-					expect.objectContaining({ hostNavigationPath: '/form-waiting' }),
-				);
+				expectHostNavigationPath(render, '/form-waiting');
 			});
 
-			it('is not offered to a top-level form', async () => {
+			// The flag is what carries the shell across a proxy that drops fetch metadata,
+			// which is the whole point of not inferring the shell from those headers.
+			it('is offered when the browser sends no fetch metadata', async () => {
 				const ctx = mock<IWebhookFunctions>();
-				const { render } = setupRender(ctx, { 'sec-fetch-dest': 'document' });
+				const { render } = setupRender(ctx, { query: { n8nShellHosted: '1' } });
 
 				await formWebhook(ctx);
 
-				expect(render).toHaveBeenCalledWith(
-					'form-trigger',
-					expect.objectContaining({ hostNavigationPath: undefined }),
-				);
+				expectHostNavigationPath(render, '/form-waiting');
+			});
+
+			it("is offered to the shell's own inner render, which carries no flag yet", async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx, {
+					query: { n8nShellInner: '1' },
+					headers: { 'sec-fetch-dest': 'iframe' },
+				});
+
+				await formWebhook(ctx);
+
+				expectHostNavigationPath(render, '/form-waiting');
+			});
+
+			it('is not offered to a same-origin frame that is not the shell', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx, {
+					headers: { 'sec-fetch-dest': 'iframe', 'sec-fetch-site': 'same-origin' },
+				});
+
+				await formWebhook(ctx);
+
+				expectHostNavigationPath(render, undefined);
+			});
+
+			it('is not offered to a top-level page carrying the flag', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx, {
+					query: { n8nShellHosted: '1' },
+					headers: { 'sec-fetch-dest': 'document' },
+				});
+
+				await formWebhook(ctx);
+
+				expectHostNavigationPath(render, undefined);
 			});
 
 			it('is not offered to a form embedded on another site', async () => {
 				const ctx = mock<IWebhookFunctions>();
 				const { render } = setupRender(ctx, {
-					'sec-fetch-dest': 'iframe',
-					'sec-fetch-site': 'cross-site',
+					headers: { 'sec-fetch-dest': 'iframe', 'sec-fetch-site': 'cross-site' },
 				});
 
 				await formWebhook(ctx);
 
-				expect(render).toHaveBeenCalledWith(
-					'form-trigger',
-					expect.objectContaining({ hostNavigationPath: undefined }),
-				);
+				expectHostNavigationPath(render, undefined);
 			});
 
-			it('is not offered when the browser sends no fetch metadata', async () => {
+			// Otherwise an embedding page could opt itself in and be handed the URL of
+			// the form's next page.
+			it('is not offered to a form embedded on another site that carries the flag', async () => {
+				const ctx = mock<IWebhookFunctions>();
+				const { render } = setupRender(ctx, {
+					query: { n8nShellHosted: '1' },
+					headers: { 'sec-fetch-dest': 'iframe', 'sec-fetch-site': 'cross-site' },
+				});
+
+				await formWebhook(ctx);
+
+				expectHostNavigationPath(render, undefined);
+			});
+
+			it('is not offered to a plain top-level form', async () => {
 				const ctx = mock<IWebhookFunctions>();
 				const { render } = setupRender(ctx);
 
 				await formWebhook(ctx);
 
-				expect(render).toHaveBeenCalledWith(
-					'form-trigger',
-					expect.objectContaining({ hostNavigationPath: undefined }),
-				);
+				expectHostNavigationPath(render, undefined);
 			});
 		});
 	});
@@ -1308,6 +1358,25 @@ describe('FormTrigger, formWebhook', () => {
 				Location: 'http://localhost:5678/oauth/authorize?state=abc',
 			});
 			expect(end).toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		// A value that isn't valid percent-encoding must read as no cookie, so the flow
+		// simply restarts instead of the request failing.
+		it('restarts the flow when the one-hop cookie value cannot be decoded', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { writeHead } = setupContext(ctx, {
+				method: 'GET',
+				headers: { cookie: 'n8n-form-oauth=%E0%A4%A' },
+			});
+			ctx.beginN8nOAuth2Flow.mockResolvedValue('http://localhost:5678/oauth/authorize?state=abc');
+
+			const result = await formWebhook(ctx);
+
+			expect(ctx.validateN8nOAuth2Token).not.toHaveBeenCalled();
+			expect(writeHead).toHaveBeenCalledWith(302, {
+				Location: 'http://localhost:5678/oauth/authorize?state=abc',
+			});
 			expect(result).toEqual({ noWebhookResponse: true });
 		});
 
@@ -4385,6 +4454,73 @@ describe('validateFormPageAuth', () => {
 
 			expect(ctx.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
 			expect(result.authedUser).toEqual(authedUser);
+		});
+
+		// A value that isn't valid percent-encoding must be treated as no cookie, not
+		// surface as a failed request for every page load that carries it.
+		it('falls back to the session cookie when the form cookie value cannot be decoded', async () => {
+			const { ctx } = buildContext('GET', 'n8n-form-auth=%E0%A4%A; n8n-auth=valid.jwt.token');
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(ctx.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
+			expect(result.authedUser).toEqual(authedUser);
+		});
+
+		it('redirects rather than throwing when an undecodable cookie is all the request has', async () => {
+			const { ctx, res } = buildContext('GET', 'n8n-form-auth=%E0%A4%A');
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.responded).toBe(true);
+			expect(res.writeHead).toHaveBeenCalledWith(302, expect.any(Object));
+		});
+
+		// The same browser can be signed out and signed back in as someone else while a
+		// form is open; the live session decides who the page is served to.
+		it("discards the cookie when the request also carries a different user's session", async () => {
+			const otherUser = {
+				id: 'user-2',
+				email: 'other@example.com',
+				firstName: 'Other',
+				lastName: 'User',
+			};
+			const { ctx } = buildContext(
+				'GET',
+				`${pageAuthCookie({ workflowId: WORKFLOW_ID })}; n8n-auth=valid.jwt.token`,
+			);
+			ctx.validateCookieAuth.mockResolvedValue(otherUser);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(otherUser);
+		});
+
+		it('keeps the cookie when the session belongs to the same user', async () => {
+			const { ctx } = buildContext(
+				'GET',
+				`${pageAuthCookie({ workflowId: WORKFLOW_ID })}; n8n-auth=valid.jwt.token`,
+			);
+			ctx.validateCookieAuth.mockResolvedValue(authedUser);
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(authedUser);
+			expect(result.responded).toBeFalsy();
+		});
+
+		it('keeps the cookie when the session alongside it no longer validates', async () => {
+			const { ctx } = buildContext(
+				'GET',
+				`${pageAuthCookie({ workflowId: WORKFLOW_ID })}; n8n-auth=stale.jwt.token`,
+			);
+			ctx.validateCookieAuth.mockRejectedValue(new Error('Unauthorized'));
+
+			const result = await validateFormPageAuth(ctx, 'n8nUserAuth');
+
+			expect(result.authedUser).toEqual(authedUser);
+			expect(result.responded).toBeFalsy();
 		});
 
 		it('is not consulted on POST, which carries the token in a header', async () => {

--- a/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
@@ -122,7 +122,10 @@ export const renderFormCompletion = async (
 	// resumes the paused workflow) can re-authenticate the user — cookies
 	// aren't sent on fetch from the sandboxed completion page.
 	const authToken = authedUser
-		? generateFormUserAuthToken(context.getNode(), authedUser)
+		? generateFormUserAuthToken(context.getNode(), authedUser, {
+				workflowId: context.getWorkflow().id,
+				executionId: context.getExecutionId(),
+			})
 		: undefined;
 
 	res.render('form-trigger-completion', {

--- a/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
@@ -12,6 +12,7 @@ import {
 
 import {
 	generateFormUserAuthToken,
+	getHostNavigationPath,
 	getNodeReference,
 	handleNewlines,
 	resolveRawData,
@@ -138,6 +139,10 @@ export const renderFormCompletion = async (
 		dangerousCustomCss: sanitizeCustomCss(options.customCss),
 		redirectUrl: validateSafeRedirectUrl(redirectUrl) ?? undefined,
 		authToken,
+		// The completion page reloads itself while the run finishes, and that hop is
+		// subject to the same cookie semantics as every other page of the form, so it
+		// goes through the host when the host is the shell.
+		hostNavigationPath: getHostNavigationPath(context),
 	});
 
 	return { noWebhookResponse: true };

--- a/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
@@ -83,6 +83,9 @@ export const renderFormNode = async (
 		buttonLabel,
 		customCss: options.customCss,
 		authToken,
+		// The submit-time credential gate (Form.node.ts POST) can refuse this page
+		// too, so ship the client-side 428 handling whenever there's a submitter.
+		hasAuthenticatedSubmitter: !!authedUser,
 	});
 
 	return {

--- a/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
@@ -57,17 +57,16 @@ export const renderFormNode = async (
 
 	// Embed the form auth token so subsequent POSTs can re-authenticate the
 	// user — cookies aren't sent on fetch from a sandboxed form page.
-	const authToken = authedUser
-		? generateFormUserAuthToken(context.getNode(), authedUser, {
-				workflowId: context.getWorkflow().id,
-				executionId: context.getExecutionId(),
-			})
-		: undefined;
-
-	// The same token doubles as the page auth cookie the next page's navigation
-	// presents, refreshed here so a long multi-page form doesn't outlive it.
-	if (authToken) {
-		setFormAuthCookie(context, authToken);
+	let authToken: string | undefined;
+	if (authedUser) {
+		const binding = {
+			workflowId: context.getWorkflow().id,
+			executionId: context.getExecutionId(),
+		};
+		authToken = generateFormUserAuthToken(context.getNode(), authedUser, binding);
+		// The same token doubles as the page auth cookie the next page's navigation
+		// presents, refreshed here so a long multi-page form doesn't outlive it.
+		setFormAuthCookie(context, authToken, binding);
 	}
 
 	renderForm({

--- a/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
@@ -16,6 +16,7 @@ import {
 	renderForm,
 	resolveRawData,
 	sanitizeHtml,
+	setFormAuthCookie,
 } from './utils';
 
 export const renderFormNode = async (
@@ -57,8 +58,17 @@ export const renderFormNode = async (
 	// Embed the form auth token so subsequent POSTs can re-authenticate the
 	// user — cookies aren't sent on fetch from a sandboxed form page.
 	const authToken = authedUser
-		? generateFormUserAuthToken(context.getNode(), authedUser)
+		? generateFormUserAuthToken(context.getNode(), authedUser, {
+				workflowId: context.getWorkflow().id,
+				executionId: context.getExecutionId(),
+			})
 		: undefined;
+
+	// The same token doubles as the page auth cookie the next page's navigation
+	// presents, refreshed here so a long multi-page form doesn't outlive it.
+	if (authToken) {
+		setFormAuthCookie(context, authToken);
+	}
 
 	renderForm({
 		context,

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -649,6 +649,11 @@ export function renderForm({
 
 	formFields = prepareFormFields(formFields);
 
+	// A follow-up page the shell navigated its frame to is the shell's inner render
+	// just like the flagged page-1 request — it must render the readiness listener
+	// and leave the submit button's enabled state to the shell's connect panel.
+	const inShell = isHostedInFormShell(context.getRequestObject(), shellInner);
+
 	const data = prepareFormData({
 		formTitle,
 		formDescription,
@@ -664,9 +669,9 @@ export function renderForm({
 		customCss,
 		nodeVersion: context.getNode().typeVersion,
 		authToken,
-		shellInner,
+		shellInner: inShell,
 		hasAuthenticatedSubmitter,
-		hostNavigationPath: getHostNavigationPath(context, shellInner),
+		hostNavigationPath: getHostNavigationPath(context, inShell),
 	});
 
 	if (!isFormHtmlSandboxingDisabled()) {
@@ -748,6 +753,38 @@ export const isFormConnected = (nodes: NodeTypeAndVersion[]) => {
 			n.type === FORM_NODE_TYPE || (n.type === WAIT_NODE_TYPE && n.parameters?.resume === 'form'),
 	);
 };
+
+/**
+ * Submit-time credential readiness gate, shared by the trigger's POST and the
+ * Form node's POST. Answers 428 with the missing-credential list when the
+ * submitter's required accounts aren't all connected, 503 when the check itself
+ * fails. Returns true when a response was sent and the submission must not
+ * proceed. A no-op (`undefined` readiness) outside the dynamic-credentials flow.
+ */
+export async function respondIfCredentialsNotReady(
+	context: IWebhookFunctions,
+	res: Response,
+): Promise<boolean> {
+	let readiness: CredentialCheckResult | undefined;
+	try {
+		readiness = await context.checkTriggerCredentialStatus();
+	} catch (error) {
+		// Fail closed. Throwing here is swallowed by the webhook layer, which then
+		// enqueues the execution anyway — exactly the doomed run we're preventing.
+		context.logger.error('Form submit credential readiness check failed', { error });
+		res.status(503).json({ status: 'credential_readiness_check_failed' });
+		return true;
+	}
+
+	if (readiness && !readiness.readyToExecute) {
+		// 428, matching the webhook trigger's gate (webhook-helpers.ts) so all
+		// trigger paths answer an unconnected credential the same way.
+		res.status(428).json(buildCredentialConnectionsRequiredResponse(readiness));
+		return true;
+	}
+
+	return false;
+}
 
 /**
  * Generate a form auth token for n8nUserAuth. The token embeds the user info
@@ -1529,25 +1566,11 @@ export async function formWebhook(
 	// iframe. It also works off the state at render time, so a required credential can
 	// be revoked — or the page simply left open — between render and submit. Re-check
 	// here, after identity establishment and before the execution is enqueued, so a
-	// stale page can't spawn a run that dies at credential resolution. Scoped to the
-	// trigger: the Wait node shares `formWebhook`, but its form resume continues an
-	// already-running execution.
+	// stale page can't spawn a run that dies at credential resolution. The Form node
+	// runs the same gate on its own POST (Form.node.ts); the Wait node shares
+	// `formWebhook`, so scope this call site to the trigger.
 	if (node.type === FORM_TRIGGER_NODE_TYPE) {
-		let readiness: CredentialCheckResult | undefined;
-		try {
-			readiness = await context.checkTriggerCredentialStatus();
-		} catch (error) {
-			// Fail closed. Throwing here is swallowed by the webhook layer, which then
-			// enqueues the execution anyway — exactly the doomed run we're preventing.
-			context.logger.error('Form submit credential readiness check failed', { error });
-			res.status(503).json({ status: 'credential_readiness_check_failed' });
-			return { noWebhookResponse: true };
-		}
-
-		if (readiness && !readiness.readyToExecute) {
-			// 428, matching the webhook trigger's gate (webhook-helpers.ts) so both
-			// trigger paths answer an unconnected credential the same way.
-			res.status(428).json(buildCredentialConnectionsRequiredResponse(readiness));
+		if (await respondIfCredentialsNotReady(context, res)) {
 			return { noWebhookResponse: true };
 		}
 	}

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -666,9 +666,7 @@ export function renderForm({
 		authToken,
 		shellInner,
 		hasAuthenticatedSubmitter,
-		hostNavigationPath: isHostedInFormShell(context.getRequestObject(), shellInner)
-			? (getFormWaitingBasePath(context) ?? undefined)
-			: undefined,
+		hostNavigationPath: getHostNavigationPath(context, shellInner),
 	});
 
 	if (!isFormHtmlSandboxingDisabled()) {
@@ -706,16 +704,42 @@ function buildAbsoluteFormUrl(req: Request): string {
  * inner render (flagged in the URL) or a follow-up page the shell navigated its
  * frame to. Only then may the form hand its page navigations to the host.
  *
- * Derived from `Sec-Fetch-*` so a form embedded on someone else's site is never
- * mistaken for the shell, and so browsers that don't send those headers simply
- * keep navigating the form themselves.
+ * A follow-up page is recognised by the `n8nShellHosted` flag the shell appends
+ * to every URL it moves its frame to. Being told outright, rather than inferred
+ * from `Sec-Fetch-*`, keeps delegation working where those headers never arrive
+ * (a proxy that strips them) and keeps a same-origin frame that is *not* the
+ * shell from being treated as one.
+ *
+ * Where those headers do arrive they still have to agree — a same-origin frame —
+ * so a top-level document, or a form embedded on someone else's site, keeps
+ * navigating itself even with the flag in its URL.
+ *
+ * Nothing rests on the flag being unguessable: a frame that sets it on itself
+ * gains only the ability to ask its own parent to move it, and the shell accepts
+ * that ask for this form's own pages alone.
  */
 function isHostedInFormShell(req: Request, shellInner?: boolean): boolean {
 	if (shellInner) return true;
+	const secFetchDest = req.headers?.['sec-fetch-dest'];
+	const secFetchSite = req.headers?.['sec-fetch-site'];
 	return (
-		req.headers?.['sec-fetch-dest'] === 'iframe' &&
-		req.headers?.['sec-fetch-site'] === 'same-origin'
+		req.query?.n8nShellHosted === '1' &&
+		(secFetchDest === undefined || secFetchDest === 'iframe') &&
+		(secFetchSite === undefined || secFetchSite === 'same-origin')
 	);
+}
+
+/**
+ * The path prefix this render may ask the hosting shell to navigate to, or
+ * `undefined` when the render isn't in the shell's frame and so keeps navigating
+ * itself.
+ */
+export function getHostNavigationPath(
+	context: IWebhookFunctions,
+	shellInner?: boolean,
+): string | undefined {
+	if (!isHostedInFormShell(context.getRequestObject(), shellInner)) return undefined;
+	return getFormWaitingBasePath(context) ?? undefined;
 }
 
 export const isFormConnected = (nodes: NodeTypeAndVersion[]) => {
@@ -849,9 +873,22 @@ function setFormOAuthToken(res: Response, req: Request, resourceUrl: string, tok
 	});
 }
 
+/**
+ * Decode a cookie value, or `null` when it isn't valid percent-encoding. A value
+ * we can't read is treated as no cookie at all — the caller's other checks still
+ * get their turn — rather than throwing out of the request.
+ */
+function decodeCookieValue(value: string): string | null {
+	try {
+		return decodeURIComponent(value.trim());
+	} catch {
+		return null;
+	}
+}
+
 function readFormOAuthToken(req: Request): string | null {
 	const match = (req.headers.cookie ?? '').match(/(?:^|;\s*)n8n-form-oauth=([^;]+)/);
-	return match ? decodeURIComponent(match[1].trim()) : null;
+	return match ? decodeCookieValue(match[1]) : null;
 }
 
 function clearFormOAuthToken(res: Response, req: Request, resourceUrl: string): void {
@@ -911,11 +948,31 @@ function readFormAuthCookieUser(context: IWebhookFunctions): IUser | null {
 	// path may bypass cookie-parser middleware in some deployments.
 	const match = (req.headers.cookie ?? '').match(/(?:^|;\s*)n8n-form-auth=([^;]+)/);
 	if (!match) return null;
-	return verifyFormPageAuthCookie(
-		decodeURIComponent(match[1].trim()),
-		context.getWorkflow().id,
-		context.getExecutionId(),
-	);
+	const token = decodeCookieValue(match[1]);
+	if (!token) return null;
+	return verifyFormPageAuthCookie(token, context.getWorkflow().id, context.getExecutionId());
+}
+
+/**
+ * True when the request also carries a session that belongs to someone other
+ * than the form cookie's user — a sign-out and sign-in as a different person in
+ * the same browser. The live session wins: the form cookie is dropped and the
+ * request re-authenticates through the normal path. An unusable session cookie
+ * names nobody, so it leaves the form cookie alone.
+ */
+async function isSessionForDifferentUser(
+	context: IWebhookFunctions,
+	formCookieUser: IUser,
+): Promise<boolean> {
+	const req = context.getRequestObject();
+	const match = (req.headers.cookie ?? '').match(/(?:^|;\s*)n8n-auth=([^;]+)/);
+	if (!match) return false;
+	try {
+		const sessionUser = await context.validateCookieAuth(match[1].trim());
+		return sessionUser.id !== formCookieUser.id;
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -1082,8 +1139,9 @@ async function authenticateFormUserOrRespond(
  *
  * A page is reached by navigating to it, which cannot carry an `x-auth-token`
  * header, so a GET is authenticated from the form page auth cookie first. Every
- * other request — and any GET whose cookie is missing or doesn't verify — falls
- * through to the session cookie / `x-auth-token` checks, unchanged.
+ * other request — and any GET whose cookie is missing, doesn't verify, or names
+ * someone other than the session on the same request — falls through to the
+ * session cookie / `x-auth-token` checks, unchanged.
  *
  * Form pages never take the OAuth2 branch: the OAuth2 token's audience is the
  * trigger's URL, which a page's own resource URL is not.
@@ -1099,7 +1157,9 @@ export async function validateFormPageAuth(
 
 	if (context.getRequestObject().method === 'GET') {
 		const cookieUser = readFormAuthCookieUser(context);
-		if (cookieUser) return { authedUser: cookieUser };
+		if (cookieUser && !(await isSessionForDifferentUser(context, cookieUser))) {
+			return { authedUser: cookieUser };
+		}
 	}
 
 	const { user } = (await authenticateFormUserOrRespond(context, false)) ?? {};

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -936,7 +936,32 @@ function clearFormOAuthToken(res: Response, req: Request, resourceUrl: string): 
 // Those pages are reached by a navigation, which can present neither the
 // `x-auth-token` header nor — from a sandboxed, opaque-origin form document —
 // the `n8n-auth` session cookie.
-const FORM_AUTH_COOKIE_NAME = 'n8n-form-auth';
+//
+// The name carries the token's binding, so forms open in other tabs don't
+// overwrite each other's cookie: pages of a run use the run's id, and the
+// trigger — rendered before any run exists — uses the workflow's. Duplicated in
+// `packages/cli/src/constants.ts` (prefix only); keep both sides in step.
+const FORM_AUTH_COOKIE_PREFIX = 'n8n-form-auth';
+
+function getFormAuthCookieName(binding: FormUserAuthTokenBinding): string {
+	return binding.executionId
+		? `${FORM_AUTH_COOKIE_PREFIX}-ex-${binding.executionId}`
+		: `${FORM_AUTH_COOKIE_PREFIX}-wf-${binding.workflowId ?? ''}`;
+}
+
+/**
+ * Value of the request's cookie with exactly this name, or `null`. Parses the
+ * raw header (the webhook path may bypass cookie-parser) by splitting rather
+ * than a regex, since the name embeds a workflow or execution id.
+ */
+function readCookieValue(req: Request, name: string): string | null {
+	for (const part of (req.headers.cookie ?? '').split(';')) {
+		const separator = part.indexOf('=');
+		if (separator === -1 || part.slice(0, separator).trim() !== name) continue;
+		return decodeCookieValue(part.slice(separator + 1));
+	}
+	return null;
+}
 
 /**
  * Path the form-waiting endpoint is served under, or `null` when it can't be
@@ -960,9 +985,13 @@ function getFormWaitingBasePath(context: IWebhookFunctions): string | null {
  * the form-waiting path. Re-set on every page render, so a long form's later
  * pages get a token that is still within its TTL.
  */
-export function setFormAuthCookie(context: IWebhookFunctions, token: string): void {
+export function setFormAuthCookie(
+	context: IWebhookFunctions,
+	token: string,
+	binding: FormUserAuthTokenBinding,
+): void {
 	const req = context.getRequestObject();
-	context.getResponseObject().cookie(FORM_AUTH_COOKIE_NAME, token, {
+	context.getResponseObject().cookie(getFormAuthCookieName(binding), token, {
 		httpOnly: true,
 		// Lax, and only ever sent on a navigation the shell (or the top-level page)
 		// initiates from the real origin.
@@ -981,13 +1010,22 @@ export function setFormAuthCookie(context: IWebhookFunctions, token: string): vo
  */
 function readFormAuthCookieUser(context: IWebhookFunctions): IUser | null {
 	const req = context.getRequestObject();
-	// Parse the raw Cookie header rather than `req.cookies` because the webhook
-	// path may bypass cookie-parser middleware in some deployments.
-	const match = (req.headers.cookie ?? '').match(/(?:^|;\s*)n8n-form-auth=([^;]+)/);
-	if (!match) return null;
-	const token = decodeCookieValue(match[1]);
-	if (!token) return null;
-	return verifyFormPageAuthCookie(token, context.getWorkflow().id, context.getExecutionId());
+	const workflowId = context.getWorkflow().id;
+	const executionId = context.getExecutionId();
+	if (!workflowId) return null;
+	// The run's own cookie first; the trigger's workflow-scoped one covers the
+	// first hop into the run, made before the run existed.
+	const candidateNames = [
+		getFormAuthCookieName({ workflowId, executionId }),
+		getFormAuthCookieName({ workflowId }),
+	];
+	for (const name of candidateNames) {
+		const token = readCookieValue(req, name);
+		if (!token) continue;
+		const user = verifyFormPageAuthCookie(token, workflowId, executionId);
+		if (user) return user;
+	}
+	return null;
 }
 
 /**
@@ -1462,10 +1500,8 @@ export async function formWebhook(
 		// opaque-origin frame — the `n8n-auth` session cookie. Give the follow-up pages
 		// their own path-scoped token so they can authenticate the same submitter.
 		if (authentication === 'n8nUserAuth' && authedUser && hasNextPage) {
-			setFormAuthCookie(
-				context,
-				generateFormUserAuthToken(node, authedUser, { workflowId: context.getWorkflow().id }),
-			);
+			const binding = { workflowId: context.getWorkflow().id };
+			setFormAuthCookie(context, generateFormUserAuthToken(node, authedUser, binding), binding);
 		}
 
 		// The inner render is the form loaded inside the hosting-shell iframe. Honor the

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -60,7 +60,21 @@ type FormUserAuthClaims = {
 	lastName: string;
 	nid: string;
 	wid: string;
+	/** Workflow the token was minted for. */
+	wfid?: string;
+	/** Execution the token was minted for, when one was already running. */
+	eid?: string;
 };
+
+/** Binding claims tying a form auth token to the run that minted it. */
+export type FormUserAuthTokenBinding = {
+	workflowId?: string;
+	executionId?: string;
+};
+
+function isOptionalString(value: unknown): boolean {
+	return value === undefined || typeof value === 'string';
+}
 
 function isFormUserAuthClaims(value: unknown): value is FormUserAuthClaims {
 	if (typeof value !== 'object' || value === null) return false;
@@ -71,8 +85,19 @@ function isFormUserAuthClaims(value: unknown): value is FormUserAuthClaims {
 		typeof c.firstName === 'string' &&
 		typeof c.lastName === 'string' &&
 		typeof c.nid === 'string' &&
-		typeof c.wid === 'string'
+		typeof c.wid === 'string' &&
+		isOptionalString(c.wfid) &&
+		isOptionalString(c.eid)
 	);
+}
+
+function userFromFormUserAuthClaims(claims: FormUserAuthClaims): IUser {
+	return {
+		id: claims.sub,
+		email: claims.email,
+		firstName: claims.firstName,
+		lastName: claims.lastName,
+	};
 }
 
 export function isFormOAuth2Enabled(): boolean {
@@ -243,6 +268,7 @@ export function prepareFormData({
 	authToken,
 	shellInner,
 	hasAuthenticatedSubmitter,
+	hostNavigationPath,
 }: {
 	formTitle: string;
 	formDescription: string;
@@ -261,6 +287,7 @@ export function prepareFormData({
 	authToken?: string;
 	shellInner?: boolean;
 	hasAuthenticatedSubmitter?: boolean;
+	hostNavigationPath?: string;
 }) {
 	const utm_campaign = instanceId ? `&utm_campaign=${instanceId}` : '';
 	const n8nWebsiteLink = `https://n8n.io/?utm_source=n8n-internal&utm_medium=form-trigger${utm_campaign}`;
@@ -287,6 +314,7 @@ export function prepareFormData({
 		shellInner: shellInner || undefined,
 		// Only set for forms that can be gated, so the rest never ship the client handling.
 		hasAuthenticatedSubmitter: hasAuthenticatedSubmitter || undefined,
+		hostNavigationPath: hostNavigationPath || undefined,
 	};
 
 	if (redirectUrl) {
@@ -638,6 +666,9 @@ export function renderForm({
 		authToken,
 		shellInner,
 		hasAuthenticatedSubmitter,
+		hostNavigationPath: isHostedInFormShell(context.getRequestObject(), shellInner)
+			? (getFormWaitingBasePath(context) ?? undefined)
+			: undefined,
 	});
 
 	if (!isFormHtmlSandboxingDisabled()) {
@@ -670,6 +701,23 @@ function buildAbsoluteFormUrl(req: Request): string {
 	return `${protocol}://${host}${req.originalUrl}`;
 }
 
+/**
+ * True when this render is the hosting shell's frame — either the shell's own
+ * inner render (flagged in the URL) or a follow-up page the shell navigated its
+ * frame to. Only then may the form hand its page navigations to the host.
+ *
+ * Derived from `Sec-Fetch-*` so a form embedded on someone else's site is never
+ * mistaken for the shell, and so browsers that don't send those headers simply
+ * keep navigating the form themselves.
+ */
+function isHostedInFormShell(req: Request, shellInner?: boolean): boolean {
+	if (shellInner) return true;
+	return (
+		req.headers?.['sec-fetch-dest'] === 'iframe' &&
+		req.headers?.['sec-fetch-site'] === 'same-origin'
+	);
+}
+
 export const isFormConnected = (nodes: NodeTypeAndVersion[]) => {
 	return nodes.some(
 		(n) =>
@@ -685,10 +733,16 @@ export const isFormConnected = (nodes: NodeTypeAndVersion[]) => {
  * cookie is `SameSite=Lax`).
  *
  * The `nid` and `wid` claims bind the token to a specific node + webhook,
- * preventing replay across forms. Signed with HS256 using the instance's
- * hmac signature secret.
+ * preventing replay across forms. `wfid`/`eid` additionally bind it to the
+ * workflow and — for tokens minted while a run is in progress — that run, which
+ * is what lets the same token be accepted as the form page auth cookie. Signed
+ * with HS256 using the instance's hmac signature secret.
  */
-export function generateFormUserAuthToken(node: INode, user: IUser): string {
+export function generateFormUserAuthToken(
+	node: INode,
+	user: IUser,
+	binding: FormUserAuthTokenBinding,
+): string {
 	const secret = Container.get(InstanceSettings).hmacSignatureSecret;
 	const payload: FormUserAuthClaims = {
 		sub: user.id,
@@ -697,6 +751,8 @@ export function generateFormUserAuthToken(node: INode, user: IUser): string {
 		lastName: user.lastName,
 		nid: node.id,
 		wid: node.webhookId ?? '',
+		...(binding.workflowId ? { wfid: binding.workflowId } : {}),
+		...(binding.executionId ? { eid: binding.executionId } : {}),
 	};
 	return jwt.sign(payload, secret, {
 		algorithm: 'HS256',
@@ -705,11 +761,28 @@ export function generateFormUserAuthToken(node: INode, user: IUser): string {
 }
 
 /**
- * Verify a form auth token issued by `generateFormUserAuthToken`. Returns the
- * encoded user on success or `null` on any failure (bad format, expired,
- * wrong signature, wrong node). The caller decides how to surface the failure.
+ * Verify a form auth token issued by `generateFormUserAuthToken` and presented
+ * in the `x-auth-token` header. Returns the encoded user on success or `null` on
+ * any failure (bad format, expired, wrong signature, wrong node, wrong
+ * execution). The caller decides how to surface the failure.
+ *
+ * A token carrying an `eid` is only accepted for that execution. Tokens minted
+ * before a run existed carry none and stay valid for the node they name.
  */
-export function verifyFormUserAuthToken(token: string, node: INode): IUser | null {
+export function verifyFormUserAuthToken(
+	token: string,
+	node: INode,
+	executionId?: string,
+): IUser | null {
+	const claims = decodeFormUserAuthClaims(token);
+	if (!claims) return null;
+	if (claims.nid !== node.id) return null;
+	if (claims.wid !== (node.webhookId ?? '')) return null;
+	if (claims.eid !== undefined && claims.eid !== executionId) return null;
+	return userFromFormUserAuthClaims(claims);
+}
+
+function decodeFormUserAuthClaims(token: string): FormUserAuthClaims | null {
 	const secret = Container.get(InstanceSettings).hmacSignatureSecret;
 	let claims: unknown;
 	try {
@@ -717,15 +790,26 @@ export function verifyFormUserAuthToken(token: string, node: INode): IUser | nul
 	} catch {
 		return null;
 	}
-	if (!isFormUserAuthClaims(claims)) return null;
-	if (claims.nid !== node.id) return null;
-	if (claims.wid !== (node.webhookId ?? '')) return null;
-	return {
-		id: claims.sub,
-		email: claims.email,
-		firstName: claims.firstName,
-		lastName: claims.lastName,
-	};
+	return isFormUserAuthClaims(claims) ? claims : null;
+}
+
+/**
+ * Verify a form auth token presented as the form page auth cookie. Unlike the
+ * `x-auth-token` variant this is not bound to a single node: the cookie rides
+ * along a navigation to whichever node serves the next page of the same form,
+ * so it is bound to the workflow (`wfid`) and, once a run exists, to that run
+ * (`eid`). Tokens predating those claims are not accepted here.
+ */
+function verifyFormPageAuthCookie(
+	token: string,
+	workflowId: string | undefined,
+	executionId: string | undefined,
+): IUser | null {
+	const claims = decodeFormUserAuthClaims(token);
+	if (!claims) return null;
+	if (!claims.wfid || !workflowId || claims.wfid !== workflowId) return null;
+	if (claims.eid !== undefined && claims.eid !== executionId) return null;
+	return userFromFormUserAuthClaims(claims);
 }
 
 function trimTrailingSlash(url: string): string {
@@ -738,16 +822,22 @@ function trimTrailingSlash(url: string): string {
 // (the page sends it back as `x-auth-token` on POST), so this is not a new exposure.
 const FORM_OAUTH_COOKIE_NAME = 'n8n-form-oauth';
 
-function formOAuthCookieOptions(req: Request, resourceUrl: string) {
-	// Derive `secure` from the request scheme (honouring x-forwarded-proto, as
-	// buildAbsoluteFormUrl does) rather than config, so the cookie is actually sent
-	// back on the follow-up GET over http in dev while staying Secure over https.
+/**
+ * Derive `secure` from the request scheme (honouring x-forwarded-proto, as
+ * buildAbsoluteFormUrl does) rather than config, so form cookies are actually
+ * sent back over http in dev while staying Secure over https.
+ */
+function isSecureRequest(req: Request): boolean {
 	const forwardedProto = req.headers['x-forwarded-proto'];
 	const proto = (typeof forwardedProto === 'string' ? forwardedProto.trim() : '') || req.protocol;
+	return proto === 'https';
+}
+
+function formOAuthCookieOptions(req: Request, resourceUrl: string) {
 	return {
 		httpOnly: true,
 		sameSite: 'lax' as const, // must be Lax: sent on our own top-level 302 → GET
-		secure: proto === 'https',
+		secure: isSecureRequest(req),
 		path: new URL(resourceUrl).pathname, // scope the bearer token to this form
 	};
 }
@@ -766,6 +856,66 @@ function readFormOAuthToken(req: Request): string | null {
 
 function clearFormOAuthToken(res: Response, req: Request, resourceUrl: string): void {
 	res.clearCookie(FORM_OAUTH_COOKIE_NAME, formOAuthCookieOptions(req, resourceUrl));
+}
+
+// Carries the submitter's identity to the follow-up pages of a multi-page form.
+// Those pages are reached by a navigation, which can present neither the
+// `x-auth-token` header nor — from a sandboxed, opaque-origin form document —
+// the `n8n-auth` session cookie.
+const FORM_AUTH_COOKIE_NAME = 'n8n-form-auth';
+
+/**
+ * Path the form-waiting endpoint is served under, or `null` when it can't be
+ * derived. It is configurable and the instance may sit behind a path prefix, so
+ * derive it rather than assume it: `$execution.resumeFormUrl` is
+ * `<formWaitingBaseUrl>/<executionId>`, and dropping the last segment leaves the
+ * base path.
+ */
+function getFormWaitingBasePath(context: IWebhookFunctions): string | null {
+	try {
+		const resumeFormUrl = context.evaluateExpression('{{ $execution.resumeFormUrl }}') as string;
+		const { pathname } = new URL(resumeFormUrl);
+		return pathname.slice(0, pathname.lastIndexOf('/')) || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Hand the follow-up pages of a multi-page form their own auth token, scoped to
+ * the form-waiting path. Re-set on every page render, so a long form's later
+ * pages get a token that is still within its TTL.
+ */
+export function setFormAuthCookie(context: IWebhookFunctions, token: string): void {
+	const req = context.getRequestObject();
+	context.getResponseObject().cookie(FORM_AUTH_COOKIE_NAME, token, {
+		httpOnly: true,
+		// Lax, and only ever sent on a navigation the shell (or the top-level page)
+		// initiates from the real origin.
+		sameSite: 'lax',
+		secure: isSecureRequest(req),
+		// Nothing narrower is derivable when the base path is unknown; the cookie is
+		// httpOnly and expires with the token either way.
+		path: getFormWaitingBasePath(context) ?? '/',
+		maxAge: FORM_USER_AUTH_TOKEN_TTL_SECONDS * 1000,
+	});
+}
+
+/**
+ * Resolve the submitter from the form page auth cookie, or `null` when it is
+ * absent or doesn't verify for the workflow/execution being served.
+ */
+function readFormAuthCookieUser(context: IWebhookFunctions): IUser | null {
+	const req = context.getRequestObject();
+	// Parse the raw Cookie header rather than `req.cookies` because the webhook
+	// path may bypass cookie-parser middleware in some deployments.
+	const match = (req.headers.cookie ?? '').match(/(?:^|;\s*)n8n-form-auth=([^;]+)/);
+	if (!match) return null;
+	return verifyFormPageAuthCookie(
+		decodeURIComponent(match[1].trim()),
+		context.getWorkflow().id,
+		context.getExecutionId(),
+	);
 }
 
 /**
@@ -909,7 +1059,7 @@ async function authenticateFormUserOrRespond(
 
 	const formToken = req.headers['x-auth-token'];
 	if (typeof formToken === 'string' && formToken) {
-		const user = verifyFormUserAuthToken(formToken, context.getNode());
+		const user = verifyFormUserAuthToken(formToken, context.getNode(), context.getExecutionId());
 		if (user) return { user, token: null };
 	}
 
@@ -930,6 +1080,14 @@ async function authenticateFormUserOrRespond(
  * Multi-step Form/Wait nodes inherit `authentication` from the upstream
  * Form Trigger. This wrapper short-circuits when n8nUserAuth isn't in use.
  *
+ * A page is reached by navigating to it, which cannot carry an `x-auth-token`
+ * header, so a GET is authenticated from the form page auth cookie first. Every
+ * other request — and any GET whose cookie is missing or doesn't verify — falls
+ * through to the session cookie / `x-auth-token` checks, unchanged.
+ *
+ * Form pages never take the OAuth2 branch: the OAuth2 token's audience is the
+ * trigger's URL, which a page's own resource URL is not.
+ *
  * Returns `{ authedUser }` on success, `{ responded: true }` after sending a
  * 302/401 on failure, or `{}` if the trigger doesn't require auth.
  */
@@ -938,6 +1096,12 @@ export async function validateFormPageAuth(
 	triggerAuthentication: string,
 ): Promise<{ authedUser?: IUser; responded?: boolean }> {
 	if (triggerAuthentication !== 'n8nUserAuth') return {};
+
+	if (context.getRequestObject().method === 'GET') {
+		const cookieUser = readFormAuthCookieUser(context);
+		if (cookieUser) return { authedUser: cookieUser };
+	}
+
 	const { user } = (await authenticateFormUserOrRespond(context, false)) ?? {};
 	return user ? { authedUser: user } : { responded: true };
 }
@@ -959,6 +1123,7 @@ function renderFormShell({
 	resourceUrl,
 	credentials,
 	submitterEmail,
+	formWaitingPath,
 }: {
 	res: Response;
 	req: Request;
@@ -966,6 +1131,7 @@ function renderFormShell({
 	resourceUrl: string;
 	credentials: CredentialCheckStatus[];
 	submitterEmail?: string;
+	formWaitingPath?: string;
 }) {
 	// The iframe loads the same form via a real URL (so the form's relative POST
 	// works exactly as it does top-level today) flagged as the inner render.
@@ -977,6 +1143,8 @@ function renderFormShell({
 		formTitle,
 		iframeSrc: `${inner.pathname}${inner.search}`,
 		resourceUrl,
+		// The only paths the shell will move its frame to on the form's request.
+		formWaitingPath,
 		...buildFormShellViewModel(credentials, submitterEmail),
 	});
 }
@@ -1192,6 +1360,17 @@ export async function formWebhook(
 			responseMode = 'responseNode';
 		}
 
+		// A multi-page form hops to `/form-waiting/<execution>` by navigating, which
+		// carries neither the `x-auth-token` header nor — from the hosting shell's
+		// opaque-origin frame — the `n8n-auth` session cookie. Give the follow-up pages
+		// their own path-scoped token so they can authenticate the same submitter.
+		if (authentication === 'n8nUserAuth' && authedUser && hasNextPage) {
+			setFormAuthCookie(
+				context,
+				generateFormUserAuthToken(node, authedUser, { workflowId: context.getWorkflow().id }),
+			);
+		}
+
 		// The inner render is the form loaded inside the hosting-shell iframe. Honor the
 		// flag only for iframe navigations (per Sec-Fetch-Dest, absent on older browsers)
 		// so a hand-typed URL can't skip the connect UI; the POST gate enforces regardless.
@@ -1237,6 +1416,7 @@ export async function formWebhook(
 						resourceUrl,
 						credentials: credentialStatus.credentials,
 						submitterEmail: authedUser?.email,
+						formWaitingPath: getFormWaitingBasePath(context) ?? undefined,
 					});
 					return { noWebhookResponse: true };
 				}
@@ -1250,7 +1430,9 @@ export async function formWebhook(
 					// Cookies aren't sent on POST from the sandboxed form page
 					// (null origin + SameSite=Lax). Embed an HMAC token so the
 					// POST handler can re-authenticate the user.
-					authToken = generateFormUserAuthToken(node, authedUser);
+					authToken = generateFormUserAuthToken(node, authedUser, {
+						workflowId: context.getWorkflow().id,
+					});
 				} else {
 					authToken = oAuth2Token;
 				}

--- a/packages/testing/playwright/pages/PublicFormPage.ts
+++ b/packages/testing/playwright/pages/PublicFormPage.ts
@@ -89,6 +89,15 @@ export class PublicFormPage extends BasePage {
 		return this.page.url();
 	}
 
+	/**
+	 * Wait for this tab itself to navigate away from the form — the author's
+	 * end-of-form redirect must take the whole tab, even when the form was
+	 * rendered inside the hosting shell's iframe.
+	 */
+	async waitForRedirect(url: string | RegExp, options?: { timeout?: number }) {
+		await this.page.waitForURL(url, options);
+	}
+
 	async close() {
 		await this.page.close();
 	}

--- a/packages/testing/playwright/pages/PublicFormPage.ts
+++ b/packages/testing/playwright/pages/PublicFormPage.ts
@@ -1,4 +1,4 @@
-import { expect, type BrowserContext, type Locator } from '@playwright/test';
+import { expect, type BrowserContext, type FrameLocator, type Locator } from '@playwright/test';
 
 import { BasePage } from './BasePage';
 
@@ -91,5 +91,64 @@ export class PublicFormPage extends BasePage {
 
 	async close() {
 		await this.page.close();
+	}
+
+	// --- Hosting shell ---
+	// A form that needs the submitter's own accounts is served inside an n8n-owned
+	// shell page: the connect panel lives in the shell, the author's form in a
+	// sandboxed iframe beside it. The shell is on the real origin; the frame is not.
+
+	/** Root of the hosting shell wrapped around a form that needs connected accounts. */
+	get shell(): Locator {
+		return this.page.locator('.shell');
+	}
+
+	/** The author's form, rendered in the shell's sandboxed iframe. */
+	private get formFrame(): FrameLocator {
+		return this.page.frameLocator('#form-frame');
+	}
+
+	/** One account's row in the connect panel, by the credential it stands for. */
+	credentialRow(credentialId: string): Locator {
+		return this.page.locator(`.cred-row[data-cred-id="${credentialId}"]`).first();
+	}
+
+	/**
+	 * The authorize link the row's Connect button would open. Reading it lets a test
+	 * drive the provider flow directly instead of through a popup.
+	 */
+	async credentialConnectUrl(credentialId: string): Promise<string> {
+		const url = await this.credentialRow(credentialId).locator('.connect').getAttribute('data-url');
+		if (!url) throw new Error(`No connect link rendered for credential ${credentialId}`);
+		return url;
+	}
+
+	/**
+	 * The form's own OAuth2 flow sends the submitter through n8n's consent screen the
+	 * first time. Approve it if it is showing, then wait for the shell to render.
+	 */
+	async allowOAuthConsentAndWaitForShell() {
+		const allow = this.page.getByRole('button', { name: 'Allow access' });
+		await expect(allow.or(this.shell).first()).toBeVisible();
+		if (await allow.isVisible()) {
+			await allow.click();
+		}
+		await expect(this.shell).toBeVisible();
+	}
+
+	frameField(label: string): Locator {
+		return this.formFrame.getByLabel(label);
+	}
+
+	async fillFrameField(label: string, value: string) {
+		await this.frameField(label).fill(value);
+	}
+
+	async submitInFrame(buttonName = 'Submit') {
+		await this.formFrame.getByRole('button', { name: buttonName }).click();
+	}
+
+	frameText(text: string): Locator {
+		return this.formFrame.getByText(text);
 	}
 }

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
@@ -248,8 +248,11 @@ test.describe(
 				await expect(formPage.frameText(COMPLETION_MESSAGE)).toBeVisible();
 				await expect(formPage.shell).toBeVisible();
 
-				const execution = await api.workflows.waitForExecution(workflowId, 20_000);
-				expect(execution.status).toBe('success');
+				// The completion screen renders off the finished run, so by now there is
+				// nothing new to wait for — poll this workflow's one execution for its
+				// terminal status instead of waiting for another one to appear.
+				const execution = await api.workflows.waitForWorkflowStatus(workflowId, 'success', 20_000);
+				expect(execution.workflowId).toBe(workflowId);
 
 				await formPage.close();
 			} finally {

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
@@ -1,0 +1,260 @@
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+import { PublicFormPage } from '../../../pages/PublicFormPage';
+
+/**
+ * E2E for a multi-page form that needs the submitter's own account, driven end to end
+ * in a browser: connect the account in the hosting shell, submit the author's first
+ * page inside the shell's sandboxed iframe, fill in the second page, and land on the
+ * completion screen.
+ *
+ * This is the only coverage of the shell's iframe, and it is the coverage whose
+ * absence let IAM-1249 ship. Submitting a page parks the execution on the waiting
+ * webhook, and the next page is reached by *navigating* the frame to
+ * `/form-waiting/<id>` — a request that can carry no `x-auth-token` header, and whose
+ * `n8n-auth` session cookie the browser withholds when the opaque-origin frame
+ * navigates itself. So the page render hands the submitter's identity to a separate
+ * form auth cookie scoped to the form-waiting path, and the frame asks the shell —
+ * which runs on the real origin — to perform the navigation, which is what makes the
+ * browser send that cookie. None of it is observable from a unit test: it is entirely
+ * browser cookie semantics.
+ *
+ * Uses the `dynamic-credentials` capability config (Keycloak as the account's OAuth2
+ * provider, plus the seeded `system-n8n` resolver), inlined here so the unreleased
+ * form-trigger OAuth2 flag can ride along.
+ */
+test.use({
+	capability: {
+		services: ['keycloak'],
+		env: {
+			N8N_ENV_FEAT_DYNAMIC_CREDENTIALS: 'true',
+			N8N_DYNAMIC_CREDENTIALS_ENDPOINT_AUTH_TOKEN: 'e2e-test-endpoint-token',
+			// Gates end-user credentials on the Form Trigger: without it the form never
+			// authenticates the submitter over OAuth2 and no shell is rendered.
+			N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2: 'true',
+		},
+	},
+	ignoreHTTPSErrors: true, // Keycloak uses a self-signed certificate
+});
+
+const FIELD_LABEL = 'Email';
+const SECOND_PAGE_FIELD_LABEL = 'Reference';
+const COMPLETION_TITLE = 'All done';
+const COMPLETION_MESSAGE = 'Your response has been recorded';
+
+test.describe(
+	'Form Trigger end-user credentials in the hosting shell @capability:dynamic-credentials @licensed',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test('should carry the submitter through the sandboxed frame across every form page @auth:owner', async ({
+			api,
+			services,
+			n8n,
+			baseURL,
+		}) => {
+			// The OAuth endpoints (authorize/token) the form's own flow runs through.
+			await api.setMcpAccess(true);
+
+			const keycloak = services.keycloak;
+			// authUrl is the EXTERNAL URL (this machine follows the redirect); the token
+			// URL is INTERNAL (n8n exchanges the code server-to-server).
+			const externalBase = keycloak.discoveryUrl.replace('/.well-known/openid-configuration', '');
+			const internalBase = keycloak.internalDiscoveryUrl.replace(
+				'/.well-known/openid-configuration',
+				'',
+			);
+
+			// End-user credentials can only live in team projects
+			await api.enableFeature('projectRole:admin');
+			await api.enableFeature('projectRole:editor');
+			await api.setMaxTeamProjectsQuota(-1);
+			const project = await api.projects.createProject('Dynamic Credentials');
+
+			// Resolvable: the seeded `system-n8n` resolver stores its tokens per n8n user,
+			// so the form must know who submitted it before this can resolve.
+			const credential = await api.credentials.createCredential({
+				name: `Form End-User OAuth2 ${nanoid()}`,
+				type: 'oAuth2Api',
+				data: {
+					grantType: 'authorizationCode',
+					authUrl: `${externalBase}/protocol/openid-connect/auth`,
+					accessTokenUrl: `${internalBase}/protocol/openid-connect/token`,
+					clientId: keycloak.clientId,
+					clientSecret: keycloak.clientSecret,
+					scope: 'openid',
+					ignoreSSLIssues: true,
+				},
+				isResolvable: true,
+				projectId: project.id,
+			});
+
+			// The form trigger's production path is its webhookId when no path is set.
+			const formWebhookId = nanoid();
+
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				{
+					name: `Form End-User Credential Shell ${nanoid()}`,
+					nodes: [
+						{
+							id: nanoid(),
+							name: 'On form submission',
+							type: 'n8n-nodes-base.formTrigger',
+							typeVersion: 2.6,
+							position: [0, 0] as [number, number],
+							webhookId: formWebhookId,
+							parameters: {
+								formTitle: 'End-user credential form',
+								formFields: { values: [{ fieldLabel: FIELD_LABEL, requiredField: true }] },
+								// Only a form that authenticates its submitter can resolve their
+								// own accounts, so this is what puts the shell on the page.
+								authentication: 'n8nUserAuth',
+								options: {},
+							},
+						},
+						{
+							id: nanoid(),
+							name: 'HTTP Request',
+							type: 'n8n-nodes-base.httpRequest',
+							typeVersion: 4.2,
+							position: [208, 0] as [number, number],
+							parameters: {
+								// Keycloak userinfo accepts the resolved Bearer token and returns 200
+								url: `${internalBase}/protocol/openid-connect/userinfo`,
+								authentication: 'predefinedCredentialType',
+								nodeCredentialType: 'oAuth2Api',
+							},
+							credentials: {
+								oAuth2Api: { id: credential.id, name: credential.name },
+							},
+						},
+						// A real second page, so the run parks on a waiting webhook that has to
+						// authenticate the submitter again before it will render anything.
+						{
+							id: nanoid(),
+							name: 'Second page',
+							type: 'n8n-nodes-base.form',
+							typeVersion: 2.5,
+							position: [416, 0] as [number, number],
+							webhookId: nanoid(),
+							parameters: {
+								operation: 'page',
+								defineForm: 'fields',
+								formFields: {
+									values: [{ fieldLabel: SECOND_PAGE_FIELD_LABEL, requiredField: true }],
+								},
+								options: { formTitle: 'One more thing' },
+							},
+						},
+						{
+							id: nanoid(),
+							name: 'Form',
+							type: 'n8n-nodes-base.form',
+							typeVersion: 2.5,
+							position: [624, 0] as [number, number],
+							webhookId: nanoid(),
+							parameters: {
+								operation: 'completion',
+								respondWith: 'text',
+								completionTitle: COMPLETION_TITLE,
+								completionMessage: COMPLETION_MESSAGE,
+								options: {},
+							},
+						},
+					],
+					connections: {
+						'On form submission': {
+							main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]],
+						},
+						'HTTP Request': { main: [[{ node: 'Second page', type: 'main', index: 0 }]] },
+						'Second page': { main: [[{ node: 'Form', type: 'main', index: 0 }]] },
+					},
+					// The completion screen is served off the saved execution, so the run has
+					// to be persisted for the form-waiting request to have anything to render.
+					settings: {
+						executionOrder: 'v1',
+						saveDataSuccessExecution: 'all',
+						saveDataErrorExecution: 'all',
+					},
+				},
+				// The trigger path is the webhookId set above; leave it alone.
+				{ makeUnique: false, projectId: project.id },
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId as string);
+
+			try {
+				// The trigger's protected resource — what the submitter's token is bound to —
+				// is registered with the webhook, asynchronously after activation. The form's
+				// own OAuth2 flow cannot start until it resolves.
+				await expect
+					.poll(
+						async () =>
+							(await api.mcpOauth.getProtectedResourceMetadata(`form/${formWebhookId}`)).status(),
+						{ timeout: 20_000, intervals: [500, 1000, 2000] },
+					)
+					.toBe(200);
+
+				const formUrl = `${baseURL}/form/${formWebhookId}`;
+				const formPage = await PublicFormPage.fromNewTab(n8n.page.context(), formUrl);
+
+				// The GET authenticates the submitter off this browser's n8n session — via a
+				// one-time consent interstitial — and then the shell renders with the account
+				// still unconnected.
+				await formPage.allowOAuthConsentAndWaitForShell();
+				await expect(formPage.credentialRow(credential.id)).toBeVisible();
+				await expect(formPage.credentialRow(credential.id)).toHaveAttribute(
+					'data-status',
+					'missing',
+				);
+
+				// Connect out of band rather than through the popup the button opens: the link
+				// is bound to this user's session, so n8n redirects it to Keycloak and the
+				// callback stores their tokens against the resolver-keyed credential.
+				const connectUrl = await formPage.credentialConnectUrl(credential.id);
+				const providerUrl =
+					await api.dynamicCredentials.resolveProviderUrlFromAuthorizeLink(connectUrl);
+				const callbackUrl = await keycloak.completeAuthorizationCodeFlow(providerUrl);
+				await api.dynamicCredentials.completeAuthorizationCallback(callbackUrl);
+
+				await formPage.goto(formUrl);
+				await formPage.allowOAuthConsentAndWaitForShell();
+				await expect(formPage.credentialRow(credential.id)).toHaveAttribute(
+					'data-connected',
+					'true',
+				);
+
+				// Submit the author's first page, which lives in the sandboxed frame.
+				await formPage.fillFrameField(FIELD_LABEL, 'submitter@example.com');
+				await formPage.submitInFrame();
+
+				// The regression: the frame moves to `/form-waiting/<id>` for the next page,
+				// and before the fix that request had no credential to present, so it 302'd
+				// to `/signin` and the frame went blank while the run stayed on the wait.
+				await expect(formPage.frameField(SECOND_PAGE_FIELD_LABEL)).toBeVisible({
+					timeout: 20_000,
+				});
+				// The shell — and with it the submitter's connected account — survived the hop.
+				await expect(formPage.shell).toBeVisible();
+
+				// The second page's own POST resumes the run, and the hop after it has to
+				// authenticate off the token that page render issued.
+				await formPage.fillFrameField(SECOND_PAGE_FIELD_LABEL, 'ref-123');
+				await formPage.submitInFrame();
+
+				await expect(formPage.frameText(COMPLETION_TITLE)).toBeVisible({ timeout: 20_000 });
+				await expect(formPage.frameText(COMPLETION_MESSAGE)).toBeVisible();
+				await expect(formPage.shell).toBeVisible();
+
+				const execution = await api.workflows.waitForExecution(workflowId, 20_000);
+				expect(execution.status).toBe('success');
+
+				await formPage.close();
+			} finally {
+				await api.workflows.deactivate(workflowId);
+			}
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
@@ -1,23 +1,32 @@
+import type { ServiceHelpers } from 'n8n-containers/services/types';
+import type { INodeParameters } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 
 import { test, expect } from '../../../fixtures/base';
 import { PublicFormPage } from '../../../pages/PublicFormPage';
+import type { ApiHelpers } from '../../../services/api-helper';
 
 /**
- * E2E for a multi-page form that needs the submitter's own account, driven end to end
- * in a browser: connect the account in the hosting shell, submit the author's first
- * page inside the shell's sandboxed iframe, fill in the second page, and land on the
- * completion screen.
+ * E2E for forms that need the submitter's own account, driven end to end in a
+ * browser: connect the account in the hosting shell, then run the author's form
+ * inside the shell's sandboxed iframe.
  *
- * This is the only coverage of the shell's iframe. Submitting a page parks the execution on the waiting
- * webhook, and the next page is reached by *navigating* the frame to
- * `/form-waiting/<id>` — a request that can carry no `x-auth-token` header, and whose
- * `n8n-auth` session cookie the browser withholds when the opaque-origin frame
- * navigates itself. So the page render hands the submitter's identity to a separate
- * form auth cookie scoped to the form-waiting path, and the frame asks the shell —
- * which runs on the real origin — to perform the navigation, which is what makes the
- * browser send that cookie. None of it is observable from a unit test: it is entirely
- * browser cookie semantics.
+ * This is the only coverage of the shell's iframe, and it exists because none of it
+ * is observable from a unit test — it is entirely browser cookie and navigation
+ * semantics:
+ *
+ * - Multi-page: submitting a page parks the execution on the waiting webhook, and the
+ *   next page is reached by *navigating* the frame to `/form-waiting/<id>` — a request
+ *   that can carry no `x-auth-token` header, and whose `n8n-auth` session cookie the
+ *   browser withholds when the opaque-origin frame navigates itself. So the page
+ *   render hands the submitter's identity to a separate form auth cookie scoped to
+ *   the form-waiting path, and the frame asks the shell — which runs on the real
+ *   origin — to perform the navigation, which is what makes the browser send that
+ *   cookie.
+ * - Redirect ending: the author's end-of-form redirect must leave the form, so from
+ *   inside the shell the frame hands it to the shell to navigate the whole tab —
+ *   a sandboxed document replacing only itself would render the redirect target
+ *   inside the little iframe.
  *
  * Uses the `dynamic-credentials` capability config (Keycloak as the account's OAuth2
  * provider, plus the seeded `system-n8n` resolver), inlined here so the unreleased
@@ -42,6 +51,126 @@ const SECOND_PAGE_FIELD_LABEL = 'Reference';
 const COMPLETION_TITLE = 'All done';
 const COMPLETION_MESSAGE = 'Your response has been recorded';
 
+type Keycloak = ServiceHelpers['keycloak'];
+
+/** The OAuth endpoints the form's own flow runs through: authUrl is EXTERNAL (this
+ * machine follows the redirect); the token URL is INTERNAL (n8n exchanges the code
+ * server-to-server). */
+const oauthBases = (keycloak: Keycloak) => ({
+	externalBase: keycloak.discoveryUrl.replace('/.well-known/openid-configuration', ''),
+	internalBase: keycloak.internalDiscoveryUrl.replace('/.well-known/openid-configuration', ''),
+});
+
+/**
+ * Everything a shell journey needs before the workflow exists: the OAuth endpoints
+ * enabled, a team project (end-user credentials can only live in team projects), and
+ * a resolvable credential on the seeded `system-n8n` resolver — it stores its tokens
+ * per n8n user, so the form must know who submitted it before this can resolve.
+ */
+async function setupResolvableCredential(api: ApiHelpers, keycloak: Keycloak) {
+	await api.setMcpAccess(true);
+	await api.enableFeature('projectRole:admin');
+	await api.enableFeature('projectRole:editor');
+	await api.setMaxTeamProjectsQuota(-1);
+	const project = await api.projects.createProject('Dynamic Credentials');
+
+	const { externalBase, internalBase } = oauthBases(keycloak);
+	const credential = await api.credentials.createCredential({
+		name: `Form End-User OAuth2 ${nanoid()}`,
+		type: 'oAuth2Api',
+		data: {
+			grantType: 'authorizationCode',
+			authUrl: `${externalBase}/protocol/openid-connect/auth`,
+			accessTokenUrl: `${internalBase}/protocol/openid-connect/token`,
+			clientId: keycloak.clientId,
+			clientSecret: keycloak.clientSecret,
+			scope: 'openid',
+			ignoreSSLIssues: true,
+		},
+		isResolvable: true,
+		projectId: project.id,
+	});
+
+	return { project, credential };
+}
+
+/**
+ * The trigger's protected resource — what the submitter's token is bound to — is
+ * registered with the webhook, asynchronously after activation. The form's own
+ * OAuth2 flow cannot start until it resolves.
+ */
+async function waitForFormResource(api: ApiHelpers, formWebhookId: string) {
+	await expect
+		.poll(
+			async () =>
+				(await api.mcpOauth.getProtectedResourceMetadata(`form/${formWebhookId}`)).status(),
+			{ timeout: 20_000, intervals: [500, 1000, 2000] },
+		)
+		.toBe(200);
+}
+
+/**
+ * Connect the submitter's account out of band rather than through the popup the
+ * shell's button opens: the link is bound to this user's session, so n8n redirects
+ * it to Keycloak and the callback stores their tokens against the resolver-keyed
+ * credential. Reloads the form afterwards so the shell shows the connected row.
+ */
+async function connectSubmitterAccount(
+	formPage: PublicFormPage,
+	api: ApiHelpers,
+	keycloak: Keycloak,
+	credentialId: string,
+	formUrl: string,
+) {
+	const connectUrl = await formPage.credentialConnectUrl(credentialId);
+	const providerUrl = await api.dynamicCredentials.resolveProviderUrlFromAuthorizeLink(connectUrl);
+	const callbackUrl = await keycloak.completeAuthorizationCodeFlow(providerUrl);
+	await api.dynamicCredentials.completeAuthorizationCallback(callbackUrl);
+
+	await formPage.goto(formUrl);
+	await formPage.allowOAuthConsentAndWaitForShell();
+	await expect(formPage.credentialRow(credentialId)).toHaveAttribute('data-connected', 'true');
+}
+
+/** The trigger every variant shares: an authenticated form whose workflow needs the
+ * submitter's own account, which is what puts the shell on the page. */
+const formTriggerNode = (
+	formWebhookId: string,
+	options: INodeParameters = {},
+	formTitle = 'End-user credential form',
+) => ({
+	id: nanoid(),
+	name: 'On form submission',
+	type: 'n8n-nodes-base.formTrigger',
+	typeVersion: 2.6,
+	position: [0, 0] as [number, number],
+	webhookId: formWebhookId,
+	parameters: {
+		formTitle,
+		formFields: { values: [{ fieldLabel: FIELD_LABEL, requiredField: true }] },
+		authentication: 'n8nUserAuth',
+		options,
+	},
+});
+
+/** Keycloak userinfo accepts the resolved Bearer token and returns 200 — the node
+ * that makes the credential resolvable-and-required. */
+const httpRequestNode = (internalBase: string, credential: { id: string; name: string }) => ({
+	id: nanoid(),
+	name: 'HTTP Request',
+	type: 'n8n-nodes-base.httpRequest',
+	typeVersion: 4.2,
+	position: [208, 0] as [number, number],
+	parameters: {
+		url: `${internalBase}/protocol/openid-connect/userinfo`,
+		authentication: 'predefinedCredentialType',
+		nodeCredentialType: 'oAuth2Api',
+	},
+	credentials: {
+		oAuth2Api: { id: credential.id, name: credential.name },
+	},
+});
+
 test.describe(
 	'Form Trigger end-user credentials in the hosting shell @capability:dynamic-credentials @licensed',
 	{
@@ -54,41 +183,9 @@ test.describe(
 			n8n,
 			baseURL,
 		}) => {
-			// The OAuth endpoints (authorize/token) the form's own flow runs through.
-			await api.setMcpAccess(true);
-
 			const keycloak = services.keycloak;
-			// authUrl is the EXTERNAL URL (this machine follows the redirect); the token
-			// URL is INTERNAL (n8n exchanges the code server-to-server).
-			const externalBase = keycloak.discoveryUrl.replace('/.well-known/openid-configuration', '');
-			const internalBase = keycloak.internalDiscoveryUrl.replace(
-				'/.well-known/openid-configuration',
-				'',
-			);
-
-			// End-user credentials can only live in team projects
-			await api.enableFeature('projectRole:admin');
-			await api.enableFeature('projectRole:editor');
-			await api.setMaxTeamProjectsQuota(-1);
-			const project = await api.projects.createProject('Dynamic Credentials');
-
-			// Resolvable: the seeded `system-n8n` resolver stores its tokens per n8n user,
-			// so the form must know who submitted it before this can resolve.
-			const credential = await api.credentials.createCredential({
-				name: `Form End-User OAuth2 ${nanoid()}`,
-				type: 'oAuth2Api',
-				data: {
-					grantType: 'authorizationCode',
-					authUrl: `${externalBase}/protocol/openid-connect/auth`,
-					accessTokenUrl: `${internalBase}/protocol/openid-connect/token`,
-					clientId: keycloak.clientId,
-					clientSecret: keycloak.clientSecret,
-					scope: 'openid',
-					ignoreSSLIssues: true,
-				},
-				isResolvable: true,
-				projectId: project.id,
-			});
+			const { internalBase } = oauthBases(keycloak);
+			const { project, credential } = await setupResolvableCredential(api, keycloak);
 
 			// The form trigger's production path is its webhookId when no path is set.
 			const formWebhookId = nanoid();
@@ -97,38 +194,8 @@ test.describe(
 				{
 					name: `Form End-User Credential Shell ${nanoid()}`,
 					nodes: [
-						{
-							id: nanoid(),
-							name: 'On form submission',
-							type: 'n8n-nodes-base.formTrigger',
-							typeVersion: 2.6,
-							position: [0, 0] as [number, number],
-							webhookId: formWebhookId,
-							parameters: {
-								formTitle: 'End-user credential form',
-								formFields: { values: [{ fieldLabel: FIELD_LABEL, requiredField: true }] },
-								// Only a form that authenticates its submitter can resolve their
-								// own accounts, so this is what puts the shell on the page.
-								authentication: 'n8nUserAuth',
-								options: {},
-							},
-						},
-						{
-							id: nanoid(),
-							name: 'HTTP Request',
-							type: 'n8n-nodes-base.httpRequest',
-							typeVersion: 4.2,
-							position: [208, 0] as [number, number],
-							parameters: {
-								// Keycloak userinfo accepts the resolved Bearer token and returns 200
-								url: `${internalBase}/protocol/openid-connect/userinfo`,
-								authentication: 'predefinedCredentialType',
-								nodeCredentialType: 'oAuth2Api',
-							},
-							credentials: {
-								oAuth2Api: { id: credential.id, name: credential.name },
-							},
-						},
+						formTriggerNode(formWebhookId),
+						httpRequestNode(internalBase, credential),
 						// A real second page, so the run parks on a waiting webhook that has to
 						// authenticate the submitter again before it will render anything.
 						{
@@ -185,16 +252,7 @@ test.describe(
 			await api.workflows.activate(workflowId, createdWorkflow.versionId as string);
 
 			try {
-				// The trigger's protected resource — what the submitter's token is bound to —
-				// is registered with the webhook, asynchronously after activation. The form's
-				// own OAuth2 flow cannot start until it resolves.
-				await expect
-					.poll(
-						async () =>
-							(await api.mcpOauth.getProtectedResourceMetadata(`form/${formWebhookId}`)).status(),
-						{ timeout: 20_000, intervals: [500, 1000, 2000] },
-					)
-					.toBe(200);
+				await waitForFormResource(api, formWebhookId);
 
 				const formUrl = `${baseURL}/form/${formWebhookId}`;
 				const formPage = await PublicFormPage.fromNewTab(n8n.page.context(), formUrl);
@@ -209,21 +267,7 @@ test.describe(
 					'missing',
 				);
 
-				// Connect out of band rather than through the popup the button opens: the link
-				// is bound to this user's session, so n8n redirects it to Keycloak and the
-				// callback stores their tokens against the resolver-keyed credential.
-				const connectUrl = await formPage.credentialConnectUrl(credential.id);
-				const providerUrl =
-					await api.dynamicCredentials.resolveProviderUrlFromAuthorizeLink(connectUrl);
-				const callbackUrl = await keycloak.completeAuthorizationCodeFlow(providerUrl);
-				await api.dynamicCredentials.completeAuthorizationCallback(callbackUrl);
-
-				await formPage.goto(formUrl);
-				await formPage.allowOAuthConsentAndWaitForShell();
-				await expect(formPage.credentialRow(credential.id)).toHaveAttribute(
-					'data-connected',
-					'true',
-				);
+				await connectSubmitterAccount(formPage, api, keycloak, credential.id, formUrl);
 
 				// Submit the author's first page, which lives in the sandboxed frame.
 				await formPage.fillFrameField(FIELD_LABEL, 'submitter@example.com');
@@ -250,6 +294,75 @@ test.describe(
 				// The completion screen renders off the finished run, so by now there is
 				// nothing new to wait for — poll this workflow's one execution for its
 				// terminal status instead of waiting for another one to appear.
+				const execution = await api.workflows.waitForWorkflowStatus(workflowId, 'success', 20_000);
+				expect(execution.workflowId).toBe(workflowId);
+
+				await formPage.close();
+			} finally {
+				await api.workflows.deactivate(workflowId);
+			}
+		});
+
+		test("should hand the author's end-of-form redirect to the tab, not the sandboxed frame @auth:owner", async ({
+			api,
+			services,
+			n8n,
+			baseURL,
+		}) => {
+			const keycloak = services.keycloak;
+			const { internalBase } = oauthBases(keycloak);
+			const { project, credential } = await setupResolvableCredential(api, keycloak);
+
+			const formWebhookId = nanoid();
+			// Somewhere real on the instance, so the tab actually lands there. What matters
+			// is that it is NOT a form page: the shell's frame may only move to those, so a
+			// redirect handled inside the frame would go nowhere visible to this assertion.
+			const redirectUrl = `${baseURL}/healthz`;
+
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				{
+					name: `Form End-User Credential Redirect ${nanoid()}`,
+					nodes: [
+						// Single page with the author's redirect ending: submitting responds 200
+						// and the page itself performs the configured redirect.
+						formTriggerNode(
+							formWebhookId,
+							{ respondWithOptions: { values: { respondWith: 'redirect', redirectUrl } } },
+							'End-user credential redirect form',
+						),
+						httpRequestNode(internalBase, credential),
+					],
+					connections: {
+						'On form submission': {
+							main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]],
+						},
+					},
+					settings: { executionOrder: 'v1' },
+				},
+				{ makeUnique: false, projectId: project.id },
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId as string);
+
+			try {
+				await waitForFormResource(api, formWebhookId);
+
+				const formUrl = `${baseURL}/form/${formWebhookId}`;
+				const formPage = await PublicFormPage.fromNewTab(n8n.page.context(), formUrl);
+
+				await formPage.allowOAuthConsentAndWaitForShell();
+				await connectSubmitterAccount(formPage, api, keycloak, credential.id, formUrl);
+
+				await formPage.fillFrameField(FIELD_LABEL, 'submitter@example.com');
+				await formPage.submitInFrame();
+
+				// The regression: the sandboxed frame used to replace only itself, so the
+				// redirect target rendered inside the little iframe while the tab stayed on
+				// the shell. The frame must hand the redirect to the shell, which navigates
+				// the whole tab — where a form rendered without the shell ends up too.
+				await formPage.waitForRedirect(/\/healthz/, { timeout: 20_000 });
+
+				// The submission itself went through: the run used the connected account.
 				const execution = await api.workflows.waitForWorkflowStatus(workflowId, 'success', 20_000);
 				expect(execution.workflowId).toBe(workflowId);
 

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts
@@ -9,8 +9,7 @@ import { PublicFormPage } from '../../../pages/PublicFormPage';
  * page inside the shell's sandboxed iframe, fill in the second page, and land on the
  * completion screen.
  *
- * This is the only coverage of the shell's iframe, and it is the coverage whose
- * absence let IAM-1249 ship. Submitting a page parks the execution on the waiting
+ * This is the only coverage of the shell's iframe. Submitting a page parks the execution on the waiting
  * webhook, and the next page is reached by *navigating* the frame to
  * `/form-waiting/<id>` — a request that can carry no `x-auth-token` header, and whose
  * `n8n-auth` session cookie the browser withholds when the opaque-origin frame


### PR DESCRIPTION
## Summary
Fixes an issue where only the first page in a multi-page form would load when the form uses n8n auth. The issue was caused by the sandboxed inner-shell using `window.location.replace` to change it's internal content, which cannot use custom headers (which is the method used for POST requests).

To fix this, navigation is now handled by the outer-shell. The inner-shell posts a message to its parent (the outer-shell) to navigate; that is received and then the outer-shell changes the frames `.src` property to load new content. This also works around another issue; the frame has a `null` origin which means that no matter how we change the content internally, it will never pass cookies (because a `null` origin does not match another `null` origin, and our cookies are `SameSite=lax` meaning they require the same site). Making the parent navigate means that it actually **does** count as the same origin, and therefore we can use a cookie to solve the problem as maintaining authentication between steps.

Page 1 is unaffected - this works the same as it did before. For pages 2+, before each page renders we mint a new token - this token is bound to the workflow ID and the execution ID so it cannot be replayed for anything else. It also has a TTL of 1 hour, which should give the user enough time to finish a page before it expires, but we can look at increasing this (or making it customisable) in the future. Each page gets its own token with its own 1h TTL.
We also now support redirects for the form-end nodes, in which that the outer-shell replaces its own content.

We now also implement the same credential validation on pages 2+, i.e. the user cannot submit the form until the credentials are connected, and we gracefully handle the backend error if they attempt to work around this.

We now also clear the n8n form auth cookies when the user logs out.

### Known limitation
As it stands, for n8n authed forms **only** there would be a cookie collision if a user was filling out more than one form at the same time, since the form auth cookie name is not unique. We should fix this in the future, but it was left out of this PR to reduce the complexity. Non-authed forms are unaffected.

## How to test
1. Create a workflow that has more than one form node in it.
2. Set the form trigger node to have `n8n auth` as the authentication method.
3. Open and fill out the form, and see that you are navigated to the next form (or redirected at the final form if that is what you chose).

https://github.com/user-attachments/assets/a7639f51-fdf4-4664-a7dc-da5fb5860bbf


<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-1249/bugs-to-fix-on-end-user-forms
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

