### PR TITLE
refactor(core): Extract participant resolution from the review inbox service (no-changelog)

### DIFF
--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.detail.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.detail.service.test.ts
@@ -1,12 +1,9 @@
 import type { LicenseState } from '@n8n/backend-common';
 import type {
 	User,
-	UserRepository,
 	WorkflowHistory,
 	WorkflowReviewRequest,
-	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
-	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestState,
 	WorkflowReviewRequestWorkflowDetailRow,
 	WorkflowReviewRequestWorkflowRepository,
@@ -21,6 +18,10 @@ import type { WorkflowReviewAccessService } from '../workflow-review-access.serv
 import type { WorkflowReviewEligibilityService } from '../workflow-review-eligibility.service';
 import { WorkflowReviewFeatureGate } from '../workflow-review-feature-gate.service';
 import { WorkflowReviewInboxService } from '../workflow-review-inbox.service';
+import type {
+	WorkflowReviewParticipantResolver,
+	WorkflowReviewParticipants,
+} from '../workflow-review-participant.resolver';
 
 const requestId = 'req-1';
 const workflowId = 'wf-1';
@@ -64,9 +65,7 @@ describe('WorkflowReviewInboxService.getDetail', () => {
 	const workflowHistoryService = mock<WorkflowHistoryService>();
 	const requestRepository = mock<WorkflowReviewRequestRepository>();
 	const workflowRepository = mock<WorkflowReviewRequestWorkflowRepository>();
-	const reviewerRepository = mock<WorkflowReviewRequestReviewerRepository>();
-	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
-	const userRepository = mock<UserRepository>();
+	const participantResolver = mock<WorkflowReviewParticipantResolver>();
 	const eligibilityService = mock<WorkflowReviewEligibilityService>();
 	const licenseState = mock<LicenseState>();
 
@@ -76,11 +75,16 @@ describe('WorkflowReviewInboxService.getDetail', () => {
 		workflowHistoryService,
 		requestRepository,
 		workflowRepository,
-		reviewerRepository,
-		authorRepository,
-		userRepository,
+		participantResolver,
 		eligibilityService,
 	);
+
+	/** The resolver is exercised in its own test; here it only has to answer. */
+	function mockParticipants(participants: Partial<WorkflowReviewParticipants> = {}) {
+		participantResolver.resolve.mockResolvedValue({
+			for: () => ({ requester: null, authors: [], reviewers: [], ...participants }),
+		});
+	}
 
 	/** The read gate resolved: `readableWorkflowRows` are what the caller may still read. */
 	function mockGate(readableWorkflowRows: WorkflowReviewRequestWorkflowDetailRow[] = []) {
@@ -97,9 +101,7 @@ describe('WorkflowReviewInboxService.getDetail', () => {
 		licenseState.isWorkflowReviewsLicensed.mockReturnValue(true);
 		workflowReviewPolicyService.get.mockResolvedValue({ enabled: true });
 		mockGate();
-		reviewerRepository.findByRequestIds.mockResolvedValue([]);
-		authorRepository.findByRequestIds.mockResolvedValue([]);
-		userRepository.findManyByIds.mockResolvedValue([]);
+		mockParticipants();
 		workflowHistoryService.findVersion.mockResolvedValue(null);
 		eligibilityService.resolveViewerEligibility.mockResolvedValue({
 			canDecide: true,
@@ -194,65 +196,21 @@ describe('WorkflowReviewInboxService.getDetail', () => {
 	});
 
 	describe('the people on the review', () => {
-		function mockUsers(...ids: string[]) {
-			userRepository.findManyByIds.mockResolvedValue(
-				ids.map((id) =>
-					mock<User>({ id, email: `${id}@example.com`, firstName: id, lastName: id }),
-				),
-			);
-		}
-
-		it('returns the requester, every author, and the reviewers', async () => {
-			authorRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: requestId, userId: requester.id }),
-				mock({ workflowReviewRequestId: requestId, userId: 'author-2' }),
-			]);
-			reviewerRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: requestId, userId: 'reviewer-1' }),
-			]);
-			mockUsers(requester.id, 'author-2', 'reviewer-1');
+		it('carries the resolved participants onto the detail', async () => {
+			mockParticipants({
+				requester: mock({ id: requester.id }),
+				authors: [mock({ id: requester.id }), mock({ id: 'author-2' })],
+				reviewers: [mock({ id: 'reviewer-1' })],
+			});
 
 			const detail = await service.getDetail(requester, requestId);
 
-			expect(authorRepository.findByRequestIds).toHaveBeenCalledWith([requestId]);
+			expect(participantResolver.resolve).toHaveBeenCalledWith([
+				expect.objectContaining({ id: requestId }),
+			]);
 			expect(detail.requester).toMatchObject({ id: requester.id });
-			// The requester stays in `authors`; deduplication is the frontend's job.
 			expect(detail.authors.map((author) => author.id)).toEqual([requester.id, 'author-2']);
 			expect(detail.reviewers.map((reviewer) => reviewer.id)).toEqual(['reviewer-1']);
-		});
-
-		it('resolves a user holding several roles with a single deduplicated lookup', async () => {
-			authorRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: requestId, userId: requester.id }),
-				mock({ workflowReviewRequestId: requestId, userId: 'reviewer-1' }),
-			]);
-			reviewerRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: requestId, userId: 'reviewer-1' }),
-			]);
-			mockUsers(requester.id, 'reviewer-1');
-
-			await service.getDetail(requester, requestId);
-
-			expect(userRepository.findManyByIds).toHaveBeenCalledTimes(1);
-			expect(userRepository.findManyByIds).toHaveBeenCalledWith([requester.id, 'reviewer-1']);
-		});
-
-		it('omits an author whose user no longer resolves, keeping the others', async () => {
-			authorRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: requestId, userId: requester.id }),
-				mock({ workflowReviewRequestId: requestId, userId: 'deleted-author' }),
-			]);
-			mockUsers(requester.id);
-
-			const detail = await service.getDetail(requester, requestId);
-
-			expect(detail.authors.map((author) => author.id)).toEqual([requester.id]);
-		});
-
-		it('returns no authors when the review has no author rows', async () => {
-			const detail = await service.getDetail(requester, requestId);
-
-			expect(detail.authors).toEqual([]);
 		});
 	});
 

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.list.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.list.service.test.ts
@@ -1,13 +1,6 @@
 import { LicenseState } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
-import type {
-	InboxVisibility,
-	User,
-	UserRepository,
-	WorkflowReviewRequest,
-	WorkflowReviewRequestAuthorRepository,
-	WorkflowReviewRequestReviewerRepository,
-} from '@n8n/db';
+import type { InboxVisibility, User, WorkflowReviewRequest } from '@n8n/db';
 import { WorkflowReviewRequestRepository, WorkflowReviewRequestWorkflowRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
@@ -15,6 +8,10 @@ import type { WorkflowReviewAccessService } from '../workflow-review-access.serv
 import type { WorkflowReviewEligibilityService } from '../workflow-review-eligibility.service';
 import { WorkflowReviewFeatureGate } from '../workflow-review-feature-gate.service';
 import { WorkflowReviewInboxService } from '../workflow-review-inbox.service';
+import type {
+	WorkflowReviewParticipantResolver,
+	WorkflowReviewParticipants,
+} from '../workflow-review-participant.resolver';
 
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -27,22 +24,25 @@ describe('WorkflowReviewInboxService', () => {
 	const workflowReviewRequestWorkflowRepository = mockInstance(
 		WorkflowReviewRequestWorkflowRepository,
 	);
-	const reviewerRepository = mock<WorkflowReviewRequestReviewerRepository>();
-	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
-	const userRepository = mock<UserRepository>();
+	const participantResolver = mock<WorkflowReviewParticipantResolver>();
 	const licenseState = mockInstance(LicenseState);
 
 	let service: WorkflowReviewInboxService;
 
 	const user = mock<User>({ id: 'user-1', role: { slug: 'global:member', scopes: [] } });
 
+	/** The resolver is exercised in its own test; here it only has to answer. */
+	function mockParticipants(participants: Partial<WorkflowReviewParticipants> = {}) {
+		participantResolver.resolve.mockResolvedValue({
+			for: () => ({ requester: null, authors: [], reviewers: [], ...participants }),
+		});
+	}
+
 	beforeEach(() => {
 		vi.resetAllMocks();
 		licenseState.isWorkflowReviewsLicensed.mockReturnValue(true);
 		workflowReviewPolicyService.get.mockResolvedValue({ enabled: true });
-		reviewerRepository.findByRequestIds.mockResolvedValue([]);
-		authorRepository.findByRequestIds.mockResolvedValue([]);
-		userRepository.findManyByIds.mockResolvedValue([]);
+		mockParticipants();
 
 		service = new WorkflowReviewInboxService(
 			new WorkflowReviewFeatureGate(licenseState, workflowReviewPolicyService),
@@ -50,9 +50,7 @@ describe('WorkflowReviewInboxService', () => {
 			workflowHistoryService,
 			workflowReviewRequestRepository,
 			workflowReviewRequestWorkflowRepository,
-			reviewerRepository,
-			authorRepository,
-			userRepository,
+			participantResolver,
 			mock<WorkflowReviewEligibilityService>(),
 		);
 	});
@@ -115,8 +113,7 @@ describe('WorkflowReviewInboxService', () => {
 			);
 			expect(result.nextCursor).toBe(expectedCursor);
 			// Participants are only resolved for the page, never for the lookahead row.
-			expect(authorRepository.findByRequestIds).toHaveBeenCalledWith(['req-2']);
-			expect(reviewerRepository.findByRequestIds).toHaveBeenCalledWith(['req-2']);
+			expect(participantResolver.resolve).toHaveBeenCalledWith([rows[0]]);
 		});
 
 		it('decodes the incoming cursor into a keyset boundary', async () => {
@@ -200,14 +197,6 @@ describe('WorkflowReviewInboxService', () => {
 			updatedAt: new Date('2024-01-01T00:00:00.000Z'),
 		});
 
-		function mockUsers(...ids: string[]) {
-			userRepository.findManyByIds.mockResolvedValue(
-				ids.map((id) =>
-					mock<User>({ id, email: `${id}@example.com`, firstName: id, lastName: id }),
-				),
-			);
-		}
-
 		beforeEach(() => {
 			accessService.resolveInboxVisibility.mockResolvedValue(involvedVisibility);
 			workflowReviewRequestRepository.findManyForInbox.mockResolvedValue([inboxRow]);
@@ -216,59 +205,18 @@ describe('WorkflowReviewInboxService', () => {
 			);
 		});
 
-		it('returns the requester, every author, and the reviewers', async () => {
-			authorRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: 'req-1', userId: 'requester-1' }),
-				mock({ workflowReviewRequestId: 'req-1', userId: 'author-2' }),
-			]);
-			reviewerRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: 'req-1', userId: 'reviewer-1' }),
-			]);
-			mockUsers('requester-1', 'author-2', 'reviewer-1');
+		it('carries the resolved participants onto the inbox item', async () => {
+			mockParticipants({
+				requester: mock({ id: 'requester-1' }),
+				authors: [mock({ id: 'requester-1' }), mock({ id: 'author-2' })],
+				reviewers: [mock({ id: 'reviewer-1' })],
+			});
 
 			const [item] = (await service.listForInbox(user, { limit: 15 })).data;
 
 			expect(item?.requester).toMatchObject({ id: 'requester-1' });
-			// The requester stays in `authors`; deduplication is the frontend's job.
 			expect(item?.authors.map((author) => author.id)).toEqual(['requester-1', 'author-2']);
 			expect(item?.reviewers.map((reviewer) => reviewer.id)).toEqual(['reviewer-1']);
-		});
-
-		it('resolves a user holding several roles with a single deduplicated lookup', async () => {
-			authorRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: 'req-1', userId: 'requester-1' }),
-				mock({ workflowReviewRequestId: 'req-1', userId: 'reviewer-1' }),
-			]);
-			reviewerRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: 'req-1', userId: 'reviewer-1' }),
-			]);
-			mockUsers('requester-1', 'reviewer-1');
-
-			const [item] = (await service.listForInbox(user, { limit: 15 })).data;
-
-			expect(userRepository.findManyByIds).toHaveBeenCalledTimes(1);
-			expect(userRepository.findManyByIds).toHaveBeenCalledWith(['requester-1', 'reviewer-1']);
-			expect(item?.authors.map((author) => author.id)).toEqual(['requester-1', 'reviewer-1']);
-		});
-
-		it('omits an author whose user no longer resolves, keeping the others', async () => {
-			authorRepository.findByRequestIds.mockResolvedValue([
-				mock({ workflowReviewRequestId: 'req-1', userId: 'requester-1' }),
-				mock({ workflowReviewRequestId: 'req-1', userId: 'deleted-author' }),
-			]);
-			mockUsers('requester-1');
-
-			const [item] = (await service.listForInbox(user, { limit: 15 })).data;
-
-			expect(item?.authors.map((author) => author.id)).toEqual(['requester-1']);
-		});
-
-		it('returns no authors when the review has no author rows', async () => {
-			mockUsers('requester-1');
-
-			const [item] = (await service.listForInbox(user, { limit: 15 })).data;
-
-			expect(item?.authors).toEqual([]);
 		});
 	});
 });

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-participant.resolver.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-participant.resolver.test.ts
@@ -1,0 +1,132 @@
+import type {
+	User,
+	UserRepository,
+	WorkflowReviewRequest,
+	WorkflowReviewRequestAuthorRepository,
+	WorkflowReviewRequestReviewerRepository,
+} from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import { WorkflowReviewParticipantResolver } from '../workflow-review-participant.resolver';
+
+describe('WorkflowReviewParticipantResolver', () => {
+	const reviewerRepository = mock<WorkflowReviewRequestReviewerRepository>();
+	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
+	const userRepository = mock<UserRepository>();
+
+	const resolver = new WorkflowReviewParticipantResolver(
+		reviewerRepository,
+		authorRepository,
+		userRepository,
+	);
+
+	function request(id: string, createdById: string | null = 'requester-1') {
+		return mock<WorkflowReviewRequest>({ id, createdById });
+	}
+
+	function mockUsers(...ids: string[]) {
+		userRepository.findManyByIds.mockResolvedValue(
+			ids.map((id) => mock<User>({ id, email: `${id}@example.com`, firstName: id, lastName: id })),
+		);
+	}
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		reviewerRepository.findByRequestIds.mockResolvedValue([]);
+		authorRepository.findByRequestIds.mockResolvedValue([]);
+		userRepository.findManyByIds.mockResolvedValue([]);
+	});
+
+	it('returns the requester, every author, and the reviewers', async () => {
+		authorRepository.findByRequestIds.mockResolvedValue([
+			mock({ workflowReviewRequestId: 'req-1', userId: 'requester-1' }),
+			mock({ workflowReviewRequestId: 'req-1', userId: 'author-2' }),
+		]);
+		reviewerRepository.findByRequestIds.mockResolvedValue([
+			mock({ workflowReviewRequestId: 'req-1', userId: 'reviewer-1' }),
+		]);
+		mockUsers('requester-1', 'author-2', 'reviewer-1');
+
+		const participants = (await resolver.resolve([request('req-1')])).for('req-1');
+
+		expect(authorRepository.findByRequestIds).toHaveBeenCalledWith(['req-1']);
+		expect(reviewerRepository.findByRequestIds).toHaveBeenCalledWith(['req-1']);
+		expect(participants.requester).toMatchObject({
+			id: 'requester-1',
+			email: 'requester-1@example.com',
+			firstName: 'requester-1',
+			lastName: 'requester-1',
+		});
+		// The requester stays in `authors`; deduplication is the frontend's job.
+		expect(participants.authors.map((author) => author.id)).toEqual(['requester-1', 'author-2']);
+		expect(participants.reviewers.map((reviewer) => reviewer.id)).toEqual(['reviewer-1']);
+	});
+
+	it('keys participants by request across a batch', async () => {
+		authorRepository.findByRequestIds.mockResolvedValue([
+			mock({ workflowReviewRequestId: 'req-1', userId: 'author-1' }),
+			mock({ workflowReviewRequestId: 'req-2', userId: 'author-2' }),
+		]);
+		mockUsers('requester-1', 'requester-2', 'author-1', 'author-2');
+
+		const participants = await resolver.resolve([
+			request('req-1'),
+			request('req-2', 'requester-2'),
+		]);
+
+		expect(participants.for('req-1').requester).toMatchObject({ id: 'requester-1' });
+		expect(participants.for('req-1').authors.map((author) => author.id)).toEqual(['author-1']);
+		expect(participants.for('req-2').requester).toMatchObject({ id: 'requester-2' });
+		expect(participants.for('req-2').authors.map((author) => author.id)).toEqual(['author-2']);
+	});
+
+	it('resolves a user holding several roles with a single deduplicated lookup', async () => {
+		authorRepository.findByRequestIds.mockResolvedValue([
+			mock({ workflowReviewRequestId: 'req-1', userId: 'requester-1' }),
+			mock({ workflowReviewRequestId: 'req-1', userId: 'reviewer-1' }),
+		]);
+		reviewerRepository.findByRequestIds.mockResolvedValue([
+			mock({ workflowReviewRequestId: 'req-1', userId: 'reviewer-1' }),
+		]);
+		mockUsers('requester-1', 'reviewer-1');
+
+		const participants = (await resolver.resolve([request('req-1')])).for('req-1');
+
+		expect(userRepository.findManyByIds).toHaveBeenCalledTimes(1);
+		expect(userRepository.findManyByIds).toHaveBeenCalledWith(['requester-1', 'reviewer-1']);
+		expect(participants.authors.map((author) => author.id)).toEqual(['requester-1', 'reviewer-1']);
+	});
+
+	it('omits an author whose user no longer resolves, keeping the others', async () => {
+		authorRepository.findByRequestIds.mockResolvedValue([
+			mock({ workflowReviewRequestId: 'req-1', userId: 'requester-1' }),
+			mock({ workflowReviewRequestId: 'req-1', userId: 'deleted-author' }),
+		]);
+		mockUsers('requester-1');
+
+		const participants = (await resolver.resolve([request('req-1')])).for('req-1');
+
+		expect(participants.authors.map((author) => author.id)).toEqual(['requester-1']);
+	});
+
+	it('leaves the requester null when their user no longer resolves', async () => {
+		const participants = (await resolver.resolve([request('req-1')])).for('req-1');
+
+		expect(participants.requester).toBeNull();
+		expect(participants.authors).toEqual([]);
+		expect(participants.reviewers).toEqual([]);
+	});
+
+	it('skips the user lookup when no request carries a participant', async () => {
+		const participants = await resolver.resolve([request('req-1', null)]);
+
+		expect(userRepository.findManyByIds).not.toHaveBeenCalled();
+		expect(participants.for('req-1')).toEqual({ requester: null, authors: [], reviewers: [] });
+	});
+
+	it('returns empty participants for a request outside the resolved batch', async () => {
+		const participants = await resolver.resolve([]);
+
+		expect(participants.for('req-1')).toEqual({ requester: null, authors: [], reviewers: [] });
+	});
+});

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
@@ -2,25 +2,19 @@ import type {
 	GetWorkflowReviewInboxSummaryResponse,
 	ListWorkflowReviewInboxQueryDto,
 	ListWorkflowReviewInboxResponse,
-	WorkflowReviewEligibleReviewer,
 	WorkflowReviewInboxItem,
 	WorkflowReviewRequestDetail,
 	WorkflowReviewRequestWorkflowDetail,
 	WorkflowReviewVersionSnapshot,
 } from '@n8n/api-types';
 import {
-	UserRepository,
-	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
-	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestWorkflowRepository,
 	type InboxCursor,
 	type User,
 	type WorkflowHistory,
 	type WorkflowReviewRequest,
-	type WorkflowReviewRequestAuthor,
 	type WorkflowReviewRequestLinkedWorkflow,
-	type WorkflowReviewRequestReviewer,
 	type WorkflowReviewRequestWorkflowDetailRow,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -31,7 +25,10 @@ import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-hi
 import { WorkflowReviewAccessService } from './workflow-review-access.service';
 import { WorkflowReviewEligibilityService } from './workflow-review-eligibility.service';
 import { WorkflowReviewFeatureGate } from './workflow-review-feature-gate.service';
-import { toEligibleReviewer } from './workflow-review.mapper';
+import {
+	WorkflowReviewParticipantResolver,
+	type WorkflowReviewParticipants,
+} from './workflow-review-participant.resolver';
 
 /**
  * The reviewer-facing read side of workflow reviews: the cross-project inbox, its
@@ -47,9 +44,7 @@ export class WorkflowReviewInboxService {
 		private readonly workflowHistoryService: WorkflowHistoryService,
 		private readonly workflowReviewRequestRepository: WorkflowReviewRequestRepository,
 		private readonly workflowReviewRequestWorkflowRepository: WorkflowReviewRequestWorkflowRepository,
-		private readonly workflowReviewRequestReviewerRepository: WorkflowReviewRequestReviewerRepository,
-		private readonly workflowReviewRequestAuthorRepository: WorkflowReviewRequestAuthorRepository,
-		private readonly userRepository: UserRepository,
+		private readonly participantResolver: WorkflowReviewParticipantResolver,
 		private readonly eligibilityService: WorkflowReviewEligibilityService,
 	) {}
 
@@ -74,30 +69,21 @@ export class WorkflowReviewInboxService {
 		const data = rows.slice(0, limit);
 		const lastRow = data.at(-1);
 		const nextCursor = hasMore && lastRow ? this.encodeInboxCursor(lastRow) : null;
-		const requestIds = data.map((row) => row.id);
-		const [linkedWorkflowByRequestId, reviewerRows, authorRows] = await Promise.all([
-			this.workflowReviewRequestWorkflowRepository.findLinkedWorkflowsByRequestIds(requestIds),
-			this.workflowReviewRequestReviewerRepository.findByRequestIds(requestIds),
-			this.workflowReviewRequestAuthorRepository.findByRequestIds(requestIds),
+		const [linkedWorkflowByRequestId, participants] = await Promise.all([
+			this.workflowReviewRequestWorkflowRepository.findLinkedWorkflowsByRequestIds(
+				data.map((row) => row.id),
+			),
+			this.participantResolver.resolve(data),
 		]);
 
-		const participantsByRequestId = await this.hydrateParticipants(data, reviewerRows, authorRows);
-
 		return {
-			data: data.map((row) => {
-				const { requester, authors, reviewers } = participantsByRequestId.get(row.id) ?? {
-					requester: null,
-					authors: [],
-					reviewers: [],
-				};
-				return this.toInboxItem(
+			data: data.map((row) =>
+				this.toInboxItem(
 					row,
 					linkedWorkflowByRequestId.get(row.id) ?? null,
-					requester,
-					authors,
-					reviewers,
-				);
-			}),
+					participants.for(row.id),
+				),
+			),
 			nextCursor,
 			hasMore,
 		};
@@ -122,36 +108,23 @@ export class WorkflowReviewInboxService {
 		);
 		const { request, readableWorkflowRows } = access;
 
-		const [workflows, participantsByRequestId, eligibility] = await Promise.all([
+		const [workflows, participants, eligibility] = await Promise.all([
 			Promise.all(readableWorkflowRows.map(async (row) => await this.toWorkflowDetail(row))),
-			this.resolveParticipants(request),
+			this.participantResolver.resolve([request]),
 			// Resolved against the pinned (pre-read-filter) row, matching the row
 			// decide() authorizes against — not against what the caller can read.
 			this.eligibilityService.resolveViewerEligibility(user, access),
 		]);
 
-		const { requester, authors, reviewers } = participantsByRequestId.get(request.id) ?? {
-			requester: null,
-			authors: [],
-			reviewers: [],
-		};
 		return {
 			// One workflow per review for now, so the summary fields mirror the first row
-			...this.toInboxItem(request, workflows.at(0) ?? null, requester, authors, reviewers),
+			...this.toInboxItem(request, workflows.at(0) ?? null, participants.for(request.id)),
 			description: request.description,
 			workflows,
 			viewerCanDecide: eligibility.canDecide,
 			viewerDecisionIneligibilityReason: eligibility.decisionIneligibilityReason,
 			viewerCanComment: eligibility.canComment,
 		};
-	}
-
-	private async resolveParticipants(request: WorkflowReviewRequest) {
-		const [reviewerRows, authorRows] = await Promise.all([
-			this.workflowReviewRequestReviewerRepository.findByRequestIds([request.id]),
-			this.workflowReviewRequestAuthorRepository.findByRequestIds([request.id]),
-		]);
-		return await this.hydrateParticipants([request], reviewerRows, authorRows);
 	}
 
 	/**
@@ -224,57 +197,6 @@ export class WorkflowReviewInboxService {
 	}
 
 	/**
-	 * Batch-resolve the requester, authors, and requested reviewers for each request
-	 * row, keyed by request id. Deleted users simply drop out of the result. The
-	 * requester stays in `authors` too — deduplication is the caller's presentation
-	 * concern, and the canonical requester is returned separately.
-	 */
-	private async hydrateParticipants(
-		rows: WorkflowReviewRequest[],
-		reviewerRows: WorkflowReviewRequestReviewer[],
-		authorRows: WorkflowReviewRequestAuthor[],
-	): Promise<
-		Map<
-			string,
-			{
-				requester: WorkflowReviewEligibleReviewer | null;
-				authors: WorkflowReviewEligibleReviewer[];
-				reviewers: WorkflowReviewEligibleReviewer[];
-			}
-		>
-	> {
-		const reviewerIdsByRequestId = groupUserIdsByRequestId(reviewerRows);
-		const authorIdsByRequestId = groupUserIdsByRequestId(authorRows);
-
-		const userIds = new Set([
-			...rows.map((row) => row.createdById).filter((id) => id !== null),
-			...reviewerRows.map((row) => row.userId),
-			...authorRows.map((row) => row.userId),
-		]);
-
-		const usersById = new Map<string, WorkflowReviewEligibleReviewer>();
-		if (userIds.size > 0) {
-			for (const user of await this.userRepository.findManyByIds([...userIds])) {
-				usersById.set(user.id, toEligibleReviewer(user));
-			}
-		}
-
-		const resolve = (userIdsForRequest: string[]) =>
-			userIdsForRequest.map((userId) => usersById.get(userId)).filter((user) => user !== undefined);
-
-		return new Map(
-			rows.map((row) => [
-				row.id,
-				{
-					requester: row.createdById ? (usersById.get(row.createdById) ?? null) : null,
-					authors: resolve(authorIdsByRequestId.get(row.id) ?? []),
-					reviewers: resolve(reviewerIdsByRequestId.get(row.id) ?? []),
-				},
-			]),
-		);
-	}
-
-	/**
 	 * Encode the keyset boundary (createdAt + id) into an opaque cursor so the
 	 * next page is resolved without re-reading the anchor row — a review deleted
 	 * between requests no longer truncates the rest of the inbox.
@@ -302,9 +224,7 @@ export class WorkflowReviewInboxService {
 	private toInboxItem(
 		entity: WorkflowReviewRequest,
 		linkedWorkflow: WorkflowReviewRequestLinkedWorkflow | null,
-		requester: WorkflowReviewEligibleReviewer | null,
-		authors: WorkflowReviewEligibleReviewer[],
-		reviewers: WorkflowReviewEligibleReviewer[],
+		{ requester, authors, reviewers }: WorkflowReviewParticipants,
 	): WorkflowReviewInboxItem {
 		return {
 			id: entity.id,
@@ -321,18 +241,4 @@ export class WorkflowReviewInboxService {
 			reviewers,
 		};
 	}
-}
-
-/** Junction rows (reviewers, authors) collapsed into user ids per request. */
-function groupUserIdsByRequestId(
-	rows: Array<{ workflowReviewRequestId: string; userId: string }>,
-): Map<string, string[]> {
-	const idsByRequestId = new Map<string, string[]>();
-	for (const { workflowReviewRequestId, userId } of rows) {
-		const ids = idsByRequestId.get(workflowReviewRequestId) ?? [];
-		ids.push(userId);
-		idsByRequestId.set(workflowReviewRequestId, ids);
-	}
-
-	return idsByRequestId;
 }

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-participant.resolver.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-participant.resolver.ts
@@ -1,0 +1,98 @@
+import type { WorkflowReviewEligibleReviewer } from '@n8n/api-types';
+import {
+	UserRepository,
+	WorkflowReviewRequestAuthorRepository,
+	WorkflowReviewRequestReviewerRepository,
+	type WorkflowReviewRequest,
+} from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { toEligibleReviewer } from './workflow-review.mapper';
+
+/** Everyone involved in one review, projected onto the boundary user shape. */
+export interface WorkflowReviewParticipants {
+	requester: WorkflowReviewEligibleReviewer | null;
+	authors: WorkflowReviewEligibleReviewer[];
+	reviewers: WorkflowReviewEligibleReviewer[];
+}
+
+/** Participants of a resolved batch, looked up by review request id. */
+export interface WorkflowReviewParticipantLookup {
+	for(requestId: string): WorkflowReviewParticipants;
+}
+
+/**
+ * Resolves who is involved in a review — requester, authors, requested reviewers —
+ * for a batch of requests at once, so the inbox list and the detail view share one
+ * set of rules and one set of queries.
+ */
+@Service()
+export class WorkflowReviewParticipantResolver {
+	constructor(
+		private readonly workflowReviewRequestReviewerRepository: WorkflowReviewRequestReviewerRepository,
+		private readonly workflowReviewRequestAuthorRepository: WorkflowReviewRequestAuthorRepository,
+		private readonly userRepository: UserRepository,
+	) {}
+
+	/**
+	 * Deleted users simply drop out of the result. The requester stays in `authors`
+	 * too — deduplication is the caller's presentation concern, and the canonical
+	 * requester is returned separately.
+	 */
+	async resolve(requests: WorkflowReviewRequest[]): Promise<WorkflowReviewParticipantLookup> {
+		const requestIds = requests.map((request) => request.id);
+		const [reviewerRows, authorRows] = await Promise.all([
+			this.workflowReviewRequestReviewerRepository.findByRequestIds(requestIds),
+			this.workflowReviewRequestAuthorRepository.findByRequestIds(requestIds),
+		]);
+
+		const reviewerIdsByRequestId = groupUserIdsByRequestId(reviewerRows);
+		const authorIdsByRequestId = groupUserIdsByRequestId(authorRows);
+
+		const userIds = new Set([
+			...requests.map((request) => request.createdById).filter((id) => id !== null),
+			...reviewerRows.map((row) => row.userId),
+			...authorRows.map((row) => row.userId),
+		]);
+
+		const usersById = new Map<string, WorkflowReviewEligibleReviewer>();
+		if (userIds.size > 0) {
+			for (const user of await this.userRepository.findManyByIds([...userIds])) {
+				usersById.set(user.id, toEligibleReviewer(user));
+			}
+		}
+
+		const project = (userIdsForRequest: string[]) =>
+			userIdsForRequest.map((userId) => usersById.get(userId)).filter((user) => user !== undefined);
+
+		const participantsByRequestId = new Map<string, WorkflowReviewParticipants>(
+			requests.map((request) => [
+				request.id,
+				{
+					requester: request.createdById ? (usersById.get(request.createdById) ?? null) : null,
+					authors: project(authorIdsByRequestId.get(request.id) ?? []),
+					reviewers: project(reviewerIdsByRequestId.get(request.id) ?? []),
+				},
+			]),
+		);
+
+		return {
+			for: (requestId) =>
+				participantsByRequestId.get(requestId) ?? { requester: null, authors: [], reviewers: [] },
+		};
+	}
+}
+
+/** Junction rows (reviewers, authors) collapsed into user ids per request. */
+function groupUserIdsByRequestId(
+	rows: Array<{ workflowReviewRequestId: string; userId: string }>,
+): Map<string, string[]> {
+	const idsByRequestId = new Map<string, string[]>();
+	for (const { workflowReviewRequestId, userId } of rows) {
+		const ids = idsByRequestId.get(workflowReviewRequestId) ?? [];
+		ids.push(userId);
+		idsByRequestId.set(workflowReviewRequestId, ids);
+	}
+
+	return idsByRequestId;
+}


### PR DESCRIPTION
## Summary

`WorkflowReviewInboxService` did two jobs: it assembled the inbox and detail payloads, and it resolved who is involved in each review. This PR moves the second job into a new `WorkflowReviewParticipantResolver`.

The resolver has one entry point, `resolve(requests)`. It owns the reviewer, author, and user repositories. It batches the two junction queries, does one deduplicated user lookup, and returns the requester, the authors, and the reviewers for each request id. `resolve` returns a small lookup object with a `for(requestId)` method, so the "no entry" fallback stays inside the resolver.

The inbox service now injects the resolver instead of the three repositories. The list view and the detail view both use it. `hydrateParticipants` and `resolveParticipants` are removed, and `toInboxItem` takes one participants object instead of three positional parameters.

The change is behavior preserving. The query fan-out is unchanged: the list still resolves participants in the same `Promise.all` as the linked-workflow lookup, and the detail still resolves them in the same `Promise.all` as the workflow details and the eligibility check.

Test changes:
- New `workflow-review-participant.resolver.test.ts` holds the participant behavior. It covers the requester, the authors, the reviewers, the keying across a batch, the deduplicated single user lookup, a deleted user that drops out, an unresolvable requester, and a request id outside the batch.
- The two inbox test files replace three repository mocks with one resolver mock. Each keeps one test that asserts the resolved participants reach the item or the detail. The list test keeps the check that participants are resolved for the page only, and never for the lookahead row.

## How to test

This is an internal refactor with no API change. The inbox and detail responses are identical.

Automated:

```bash
cd packages/cli
pnpm test src/modules/workflow-reviews.ee
pnpm test:integration src/modules/workflow-reviews.ee
```

Result: 243 unit tests pass and 240 integration tests pass. The integration run includes the 169-test workflow reviews controller suite, which exercises the participants end to end.

Manual (optional): the workflow reviews module needs `N8N_ENABLED_MODULES=workflow-reviews` and an enterprise license with the workflow reviews feature. Open the review inbox and then open a review. The requester, the authors, and the reviewers must show as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-1042

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

