### PR TITLE
feat(Telegram Node): Add option to delete sent message on Send and Wait response

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -23,7 +23,7 @@ import {
 	createSendAndWaitMessageBody,
 	getPropertyName,
 } from './GenericFunctions';
-import { telegramHitlProperties } from './hitl/descriptions';
+import { deleteOnResponseOption, telegramHitlProperties } from './hitl/descriptions';
 import { prepareChatApproval } from './hitl/setup';
 import { telegramSendAndWaitWebhook } from './hitl/webhook';
 import { appendAttributionOption } from '../../utils/descriptions';
@@ -2039,6 +2039,7 @@ export class Telegram implements INodeType {
 					noButtonStyle: true,
 					defaultApproveLabel: '✅ Approve',
 					defaultDisapproveLabel: '❌ Decline',
+					extraOptions: [deleteOnResponseOption],
 				},
 			).filter((p) => p.name !== 'subject'),
 		],
@@ -2070,7 +2071,22 @@ export class Telegram implements INodeType {
 			body = createSendAndWaitMessageBody(this, chatApproval);
 
 			try {
-				await apiRequest.call(this, 'POST', 'sendMessage', body);
+				const options = this.getNodeParameter('options', 0, {}) as IDataObject;
+				// Persist the message identity so the resume webhook can delete it;
+				// prefer the API response since Telegram resolves @channelusername to a numeric id.
+				const sentMessage = (await apiRequest.call(this, 'POST', 'sendMessage', body)) as {
+					chat?: { id?: string | number };
+					message_id?: number;
+				};
+				if (options.deleteOnResponse === true) {
+					this.customData.set(
+						'tgDeleteTarget',
+						JSON.stringify({
+							chatId: sentMessage.chat?.id ?? body.chat_id,
+							messageId: sentMessage.message_id,
+						}),
+					);
+				}
 			} catch (error) {
 				if (this.continueOnFail()) {
 					return [[{ json: { error: (error as JsonObject).message } }]];

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -2074,16 +2074,20 @@ export class Telegram implements INodeType {
 				const options = this.getNodeParameter('options', 0, {}) as IDataObject;
 				// Persist the message identity so the resume webhook can delete it;
 				// prefer the API response since Telegram resolves @channelusername to a numeric id.
-				const sentMessage = (await apiRequest.call(this, 'POST', 'sendMessage', body)) as {
-					chat?: { id?: string | number };
-					message_id?: number;
-				};
+				const sentMessage = await apiRequest.call(this, 'POST', 'sendMessage', body);
+				// apiRequest returns the Telegram envelope ({ ok, result }), not the message.
+				// Prefer the API response: Telegram resolves @channelusername to a numeric id.
+				const result = (
+					sentMessage as
+						| { result?: { chat?: { id?: string | number }; message_id?: number } }
+						| undefined
+				)?.result;
 				if (options.deleteOnResponse === true) {
 					this.customData.set(
 						'tgDeleteTarget',
 						JSON.stringify({
-							chatId: sentMessage.chat?.id ?? body.chat_id,
-							messageId: sentMessage.message_id,
+							chatId: result?.chat?.id ?? body.chat_id,
+							messageId: result?.message_id,
 						}),
 					);
 				}

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -2090,6 +2090,13 @@ export class Telegram implements INodeType {
 							messageId: result?.message_id,
 						}),
 					);
+					// set() silently drops new keys once execution metadata is full
+					// (KV_LIMIT = 10); verify the write landed so the missing cleanup is visible.
+					if (!this.customData.get('tgDeleteTarget')) {
+						this.logger.warn(
+							'Telegram node: could not store the message identity for Delete Message on Response because execution custom data is full',
+						);
+					}
 				}
 			} catch (error) {
 				if (this.continueOnFail()) {

--- a/packages/nodes-base/nodes/Telegram/hitl/descriptions.ts
+++ b/packages/nodes-base/nodes/Telegram/hitl/descriptions.ts
@@ -82,6 +82,14 @@ export const telegramHitlProperties: INodeProperties[] = [
 	},
 ];
 
+export const deleteOnResponseOption: INodeProperties = {
+	displayName: 'Delete Message on Response',
+	name: 'deleteOnResponse',
+	type: 'boolean',
+	default: false,
+	description: 'Whether to delete the sent message once the user responds',
+};
+
 export interface TelegramChatApprovalOptions {
 	approverIds?: string;
 	unauthorizedReplyText?: string;

--- a/packages/nodes-base/nodes/Telegram/hitl/webhook.ts
+++ b/packages/nodes-base/nodes/Telegram/hitl/webhook.ts
@@ -1,11 +1,12 @@
 import { timingSafeEqual } from 'crypto';
 import { parseHitlCallbackReference } from 'n8n-core';
+import isbot from 'isbot';
 import type { IDataObject, IWebhookFunctions, IWebhookResponseData } from 'n8n-workflow';
 
 import type { TelegramChatApprovalOptions } from './descriptions';
 import { deriveHitlSecretToken } from './tokens';
 import type { SendAndWaitResponder } from '../../../utils/sendAndWait/interfaces';
-import { sendAndWaitWebhook } from '../../../utils/sendAndWait/utils';
+import { isMicrosoftPreviewService, sendAndWaitWebhook } from '../../../utils/sendAndWait/utils';
 import { apiRequest } from '../GenericFunctions';
 import type { CallbackQuery } from '../IEvent';
 
@@ -102,9 +103,19 @@ async function deleteMessageOnResponse(context: IWebhookFunctions): Promise<void
 	const options = context.getNodeParameter('options', {}) as IDataObject;
 	if (!options || options.deleteOnResponse !== true) return;
 
-	const method = context.getRequestObject().method;
+	const req = context.getRequestObject();
+	const method = req.method;
 	const responseType = context.getNodeParameter('responseType', 'approval') as string;
 	if ((responseType === 'freeText' || responseType === 'customForm') && method === 'GET') return;
+
+	// Mirror the shared handler's bot guard: a preview crawler fetching the
+	// approval link must not delete the message while the execution keeps waiting.
+	if (
+		responseType === 'approval' &&
+		(isbot(req.headers['user-agent']) || isMicrosoftPreviewService(req.headers['user-agent']))
+	) {
+		return;
+	}
 
 	let stored: { chatId?: string | number; messageId?: string | number } | undefined;
 	try {

--- a/packages/nodes-base/nodes/Telegram/hitl/webhook.ts
+++ b/packages/nodes-base/nodes/Telegram/hitl/webhook.ts
@@ -1,6 +1,6 @@
 import { timingSafeEqual } from 'crypto';
 import { parseHitlCallbackReference } from 'n8n-core';
-import type { IWebhookFunctions, IWebhookResponseData } from 'n8n-workflow';
+import type { IDataObject, IWebhookFunctions, IWebhookResponseData } from 'n8n-workflow';
 
 import type { TelegramChatApprovalOptions } from './descriptions';
 import { deriveHitlSecretToken } from './tokens';
@@ -76,6 +76,46 @@ async function applyPostDecisionEdit(
 	}
 }
 
+/** Best-effort cleanup: response delivery must not depend on message deletion succeeding. */
+async function deleteSentMessage(
+	context: IWebhookFunctions,
+	chatId: unknown,
+	messageId: unknown,
+): Promise<void> {
+	if (chatId === undefined || messageId === undefined) return;
+	try {
+		await apiRequest.call(context, 'POST', 'deleteMessage', {
+			chat_id: chatId,
+			message_id: messageId,
+		});
+	} catch {
+		// intentional
+	}
+}
+
+/**
+ * Link-button / form responses carry no message ids, so the target comes from
+ * the `tgDeleteTarget` execution metadata written at send time. Never fires on
+ * the form-render GET, which must not remove the message before it is answered.
+ */
+async function deleteMessageOnResponse(context: IWebhookFunctions): Promise<void> {
+	const options = context.getNodeParameter('options', {}) as IDataObject;
+	if (!options || options.deleteOnResponse !== true) return;
+
+	const method = context.getRequestObject().method;
+	const responseType = context.getNodeParameter('responseType', 'approval') as string;
+	if ((responseType === 'freeText' || responseType === 'customForm') && method === 'GET') return;
+
+	let stored: { chatId?: string | number; messageId?: string | number } | undefined;
+	try {
+		stored = JSON.parse(context.customData.get('tgDeleteTarget') ?? '') as typeof stored;
+	} catch {
+		stored = undefined;
+	}
+
+	await deleteSentMessage(context, stored?.chatId, stored?.messageId);
+}
+
 /**
  * Resume handler for the Telegram node's Send and Wait webhook. Detects a
  * one-tap chat-approval callback and handles it end to end (secret-token
@@ -94,6 +134,7 @@ export async function telegramSendAndWaitWebhook(
 	const chatApproval = this.getNodeParameter('chatApproval', false) as boolean;
 
 	if (!bodyData.callback_query || !chatApproval) {
+		await deleteMessageOnResponse(this);
 		return await sendAndWaitWebhook.call(this);
 	}
 
@@ -164,16 +205,22 @@ export async function telegramSendAndWaitWebhook(
 		'postDecisionBehavior',
 		'showOutcome',
 	) as TelegramChatApprovalOptions['postDecisionBehavior'];
+	const deleteOnResponse =
+		(this.getNodeParameter('options', {}) as IDataObject).deleteOnResponse === true;
 
 	if (chatId !== undefined && messageId !== undefined) {
-		await applyPostDecisionEdit(this, {
-			chatId,
-			messageId,
-			approved,
-			from,
-			originalText: callbackQuery.message?.text ?? '',
-			postDecisionBehavior,
-		});
+		if (deleteOnResponse) {
+			await deleteSentMessage(this, chatId, messageId);
+		} else {
+			await applyPostDecisionEdit(this, {
+				chatId,
+				messageId,
+				approved,
+				from,
+				originalText: callbackQuery.message?.text ?? '',
+				postDecisionBehavior,
+			});
+		}
 	}
 
 	// --- response: resume the execution with the decision and responder identity ---

--- a/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
@@ -166,8 +166,8 @@ describe('Test Telegram, message => sendAndWait', () => {
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ deleteOnResponse: true }); // options (deleteOnResponse check)
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options.limitWaitTime.values
 		(genericFunctions.apiRequest as Mock).mockResolvedValueOnce({
-			message_id: 55,
-			chat: { id: 999 },
+			ok: true,
+			result: { message_id: 55, chat: { id: 999 } },
 		});
 
 		await telegram.execute.call(mockExecuteFunctions);

--- a/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
@@ -27,8 +27,12 @@ describe('Test Telegram, message => sendAndWait', () => {
 	beforeEach(() => {
 		telegram = new Telegram();
 		mockExecuteFunctions = mock<IExecuteFunctions>();
+		// mock-extended cannot proxy IWorkflowExecutionCustomData (index signature)
+		mockExecuteFunctions.customData = {
+			get: vi.fn(),
+			set: vi.fn(),
+		} as unknown as IExecuteFunctions['customData'];
 	});
-
 	afterEach(() => {
 		vi.clearAllMocks();
 	});
@@ -56,6 +60,7 @@ describe('Test Telegram, message => sendAndWait', () => {
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // approvalOptions
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options (deleteOnResponse check)
 
 		// configureWaitTillDate
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); //options.limitWaitTime.values
@@ -102,6 +107,7 @@ describe('Test Telegram, message => sendAndWait', () => {
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({});
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({});
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options (deleteOnResponse check)
 		mockExecuteFunctions.continueOnFail.mockReturnValue(true);
 
 		(genericFunctions.apiRequest as Mock).mockRejectedValueOnce(new Error('chat_not_found'));
@@ -130,12 +136,71 @@ describe('Test Telegram, message => sendAndWait', () => {
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({});
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({});
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options (deleteOnResponse check)
 		mockExecuteFunctions.continueOnFail.mockReturnValue(false);
 
 		(genericFunctions.apiRequest as Mock).mockRejectedValueOnce(new Error('chat_not_found'));
 
 		await expect(telegram.execute.call(mockExecuteFunctions)).rejects.toThrow('chat_not_found');
 		expect(mockExecuteFunctions.putExecutionToWait).not.toHaveBeenCalled();
+	});
+
+	it('should store the delete target in execution metadata when deleteOnResponse is on', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(SEND_AND_WAIT_OPERATION);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false);
+		mockExecuteFunctions.getNode.mockReturnValue(mock<INode>());
+		mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false); // chatApproval (prepareChatApproval)
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('chatID');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my subject');
+		mockExecuteFunctions.getSignedResumeUrl.mockReturnValue(
+			'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+		);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // approvalOptions
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ deleteOnResponse: true }); // options
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval'); // responseType
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ deleteOnResponse: true }); // options (deleteOnResponse check)
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options.limitWaitTime.values
+		(genericFunctions.apiRequest as Mock).mockResolvedValueOnce({
+			message_id: 55,
+			chat: { id: 999 },
+		});
+
+		await telegram.execute.call(mockExecuteFunctions);
+		expect(mockExecuteFunctions.customData.set).toHaveBeenCalledWith(
+			'tgDeleteTarget',
+			JSON.stringify({ chatId: 999, messageId: 55 }),
+		);
+	});
+
+	it('should not store a delete target when deleteOnResponse is off', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(SEND_AND_WAIT_OPERATION);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false);
+		mockExecuteFunctions.getNode.mockReturnValue(mock<INode>());
+		mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false); // chatApproval (prepareChatApproval)
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('chatID');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my subject');
+		mockExecuteFunctions.getSignedResumeUrl.mockReturnValue(
+			'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+		);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // approvalOptions
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval'); // responseType
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options (deleteOnResponse check)
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options.limitWaitTime.values
+
+		await telegram.execute.call(mockExecuteFunctions);
+
+		expect(mockExecuteFunctions.customData.set).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
@@ -29,8 +29,11 @@ describe('Test Telegram, message => sendAndWait', () => {
 	beforeEach(() => {
 		telegram = new Telegram();
 		mockExecuteFunctions = mock<IExecuteFunctions>();
-		customDataGet = vi.fn();
-		customDataSet = vi.fn();
+		const backingStore = new Map<string, string>();
+		customDataSet = vi.fn((key: string, value: string) => {
+			backingStore.set(key, value);
+		});
+		customDataGet = vi.fn((key: string) => backingStore.get(key) ?? '');
 		// mock-extended cannot proxy IWorkflowExecutionCustomData (index signature)
 		mockExecuteFunctions.customData = {
 			get: customDataGet,
@@ -182,6 +185,8 @@ describe('Test Telegram, message => sendAndWait', () => {
 			'tgDeleteTarget',
 			JSON.stringify({ chatId: 999, messageId: 55 }),
 		);
+		// A landed write must not trigger the dropped-write warning.
+		expect(mockExecuteFunctions.logger.warn).not.toHaveBeenCalled();
 	});
 
 	it('should not store a delete target when deleteOnResponse is off', async () => {
@@ -231,7 +236,7 @@ describe('Test Telegram, message => sendAndWait', () => {
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ deleteOnResponse: true }); // options (deleteOnResponse check)
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options.limitWaitTime.values
 		// Simulate the execution-metadata KV limit: set() drops the write silently.
-		customDataGet.mockReturnValue('');
+		customDataSet.mockImplementation(() => {});
 
 		await telegram.execute.call(mockExecuteFunctions);
 

--- a/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
@@ -23,15 +23,22 @@ vi.mock('../../GenericFunctions', async () => {
 describe('Test Telegram, message => sendAndWait', () => {
 	let telegram: Telegram;
 	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+	let customDataGet: Mock;
+	let customDataSet: Mock;
 
 	beforeEach(() => {
 		telegram = new Telegram();
 		mockExecuteFunctions = mock<IExecuteFunctions>();
+		customDataGet = vi.fn();
+		customDataSet = vi.fn();
 		// mock-extended cannot proxy IWorkflowExecutionCustomData (index signature)
 		mockExecuteFunctions.customData = {
-			get: vi.fn(),
-			set: vi.fn(),
+			get: customDataGet,
+			set: customDataSet,
 		} as unknown as IExecuteFunctions['customData'];
+		mockExecuteFunctions.logger = {
+			warn: vi.fn(),
+		} as unknown as IExecuteFunctions['logger'];
 	});
 	afterEach(() => {
 		vi.clearAllMocks();
@@ -171,7 +178,7 @@ describe('Test Telegram, message => sendAndWait', () => {
 		});
 
 		await telegram.execute.call(mockExecuteFunctions);
-		expect(mockExecuteFunctions.customData.set).toHaveBeenCalledWith(
+		expect(customDataSet).toHaveBeenCalledWith(
 			'tgDeleteTarget',
 			JSON.stringify({ chatId: 999, messageId: 55 }),
 		);
@@ -200,7 +207,38 @@ describe('Test Telegram, message => sendAndWait', () => {
 
 		await telegram.execute.call(mockExecuteFunctions);
 
-		expect(mockExecuteFunctions.customData.set).not.toHaveBeenCalled();
+		expect(customDataSet).not.toHaveBeenCalled();
+	});
+
+	it('should warn when the delete target write does not land because metadata is full', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(SEND_AND_WAIT_OPERATION);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false);
+		mockExecuteFunctions.getNode.mockReturnValue(mock<INode>());
+		mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false); // chatApproval (prepareChatApproval)
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('chatID');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my subject');
+		mockExecuteFunctions.getSignedResumeUrl.mockReturnValue(
+			'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+		);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // approvalOptions
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ deleteOnResponse: true }); // options
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval'); // responseType
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ deleteOnResponse: true }); // options (deleteOnResponse check)
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options.limitWaitTime.values
+		// Simulate the execution-metadata KV limit: set() drops the write silently.
+		customDataGet.mockReturnValue('');
+
+		await telegram.execute.call(mockExecuteFunctions);
+
+		expect(customDataSet).toHaveBeenCalledTimes(1);
+		expect(mockExecuteFunctions.logger.warn).toHaveBeenCalledWith(
+			'Telegram node: could not store the message identity for Delete Message on Response because execution custom data is full',
+		);
 	});
 });
 

--- a/packages/nodes-base/nodes/Telegram/tests/node/telegramHitlWebhook.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/telegramHitlWebhook.test.ts
@@ -51,11 +51,17 @@ function makeCallbackQueryBody(overrides: Record<string, unknown> = {}) {
 
 describe('telegramSendAndWaitWebhook', () => {
 	let webhookFns: ReturnType<typeof mock<IWebhookFunctions>>;
+	let customDataGet: Mock;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		webhookFns = mock<IWebhookFunctions>();
 		webhookFns.getCredentials.mockResolvedValue({ accessToken: ACCESS_TOKEN });
+		customDataGet = vi.fn();
+		webhookFns.customData = {
+			get: customDataGet,
+			set: vi.fn(),
+		} as unknown as IWebhookFunctions['customData'];
 	});
 
 	it('delegates to the shared sendAndWaitWebhook when chatApproval is off', async () => {
@@ -358,5 +364,113 @@ describe('telegramSendAndWaitWebhook', () => {
 		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'answerCallbackQuery', {
 			callback_query_id: 'cbq-1',
 		});
+	});
+
+	it('deletes the sent message instead of editing it when deleteOnResponse is on (callback path)', async () => {
+		webhookFns.getBodyData.mockReturnValue(makeCallbackQueryBody());
+		webhookFns.getNodeParameter.mockImplementation((name: unknown, fallback?: unknown) => {
+			if (name === 'chatApproval') return true;
+			if (name === 'postDecisionBehavior') return 'showOutcome';
+			if (name === 'options') return { deleteOnResponse: true };
+			return fallback as never;
+		});
+		webhookFns.getHeaderData.mockReturnValue({
+			'x-telegram-bot-api-secret-token': VALID_SECRET_TOKEN,
+		});
+
+		const result = await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'answerCallbackQuery', {
+			callback_query_id: 'cbq-1',
+		});
+		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'deleteMessage', {
+			chat_id: 999,
+			message_id: 55,
+		});
+		expect(genericFunctions.apiRequest).not.toHaveBeenCalledWith('POST', 'editMessageText', expect.anything());
+		const resumed = (
+			result as { workflowData?: Array<Array<{ json: { data: { approved: boolean } } }>> }
+		).workflowData?.[0]?.[0]?.json.data;
+		expect(resumed?.approved).toBe(true);
+	});
+
+	it('deletes via stored metadata on the approval-link GET and still delegates', async () => {
+		(sendAndWaitWebhook as Mock).mockResolvedValue({ noWebhookResponse: true });
+		webhookFns.getBodyData.mockReturnValue({});
+		webhookFns.getNodeParameter.mockImplementation((name: unknown, fallback?: unknown) => {
+			if (name === 'options') return { deleteOnResponse: true };
+			if (name === 'responseType') return 'approval';
+			return fallback as never;
+		});
+		webhookFns.getRequestObject.mockReturnValue({ method: 'GET' } as never);
+		customDataGet.mockReturnValue(JSON.stringify({ chatId: 999, messageId: 55 }));
+
+		const result = await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'deleteMessage', {
+			chat_id: 999,
+			message_id: 55,
+		});
+		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({ noWebhookResponse: true });
+	});
+
+	it('does not delete on the form-render GET of a freeText/customForm response', async () => {
+		(sendAndWaitWebhook as Mock).mockResolvedValue({ noWebhookResponse: true });
+		webhookFns.getBodyData.mockReturnValue({});
+		webhookFns.getNodeParameter.mockImplementation((name: unknown, fallback?: unknown) => {
+			if (name === 'options') return { deleteOnResponse: true };
+			if (name === 'responseType') return 'freeText';
+			return fallback as never;
+		});
+		webhookFns.getRequestObject.mockReturnValue({ method: 'GET' } as never);
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(genericFunctions.apiRequest).not.toHaveBeenCalledWith(
+			'POST',
+			'deleteMessage',
+			expect.anything(),
+		);
+		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
+	});
+
+	it('deletes via stored metadata on the form POST that completes the response', async () => {
+		(sendAndWaitWebhook as Mock).mockResolvedValue({ noWebhookResponse: true });
+		webhookFns.getBodyData.mockReturnValue({});
+		webhookFns.getNodeParameter.mockImplementation((name: unknown, fallback?: unknown) => {
+			if (name === 'options') return { deleteOnResponse: true };
+			if (name === 'responseType') return 'customForm';
+			return fallback as never;
+		});
+		webhookFns.getRequestObject.mockReturnValue({ method: 'POST' } as never);
+		customDataGet.mockReturnValue(JSON.stringify({ chatId: 999, messageId: 55 }));
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'deleteMessage', {
+			chat_id: 999,
+			message_id: 55,
+		});
+		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips deletion without crashing when no delete target was stored', async () => {
+		(sendAndWaitWebhook as Mock).mockResolvedValue({ noWebhookResponse: true });
+		webhookFns.getBodyData.mockReturnValue({});
+		webhookFns.getNodeParameter.mockImplementation((name: unknown, fallback?: unknown) => {
+			if (name === 'options') return { deleteOnResponse: true };
+			if (name === 'responseType') return 'approval';
+			return fallback as never;
+		});
+		webhookFns.getRequestObject.mockReturnValue({ method: 'GET' } as never);
+		// Executions waiting since before this feature have no stored target.
+		customDataGet.mockReturnValue('');
+
+		const result = await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(genericFunctions.apiRequest).not.toHaveBeenCalled();
+		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({ noWebhookResponse: true });
 	});
 });

--- a/packages/nodes-base/nodes/Telegram/tests/node/telegramHitlWebhook.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/telegramHitlWebhook.test.ts
@@ -387,7 +387,11 @@ describe('telegramSendAndWaitWebhook', () => {
 			chat_id: 999,
 			message_id: 55,
 		});
-		expect(genericFunctions.apiRequest).not.toHaveBeenCalledWith('POST', 'editMessageText', expect.anything());
+		expect(genericFunctions.apiRequest).not.toHaveBeenCalledWith(
+			'POST',
+			'editMessageText',
+			expect.anything(),
+		);
 		const resumed = (
 			result as { workflowData?: Array<Array<{ json: { data: { approved: boolean } } }>> }
 		).workflowData?.[0]?.[0]?.json.data;
@@ -402,11 +406,16 @@ describe('telegramSendAndWaitWebhook', () => {
 			if (name === 'responseType') return 'approval';
 			return fallback as never;
 		});
-		webhookFns.getRequestObject.mockReturnValue({ method: 'GET' } as never);
+		webhookFns.getRequestObject.mockReturnValue({
+			method: 'GET',
+			headers: {
+				'user-agent':
+					'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120 Safari/537.36',
+			},
+		} as never);
 		customDataGet.mockReturnValue(JSON.stringify({ chatId: 999, messageId: 55 }));
 
 		const result = await telegramSendAndWaitWebhook.call(webhookFns);
-
 		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'deleteMessage', {
 			chat_id: 999,
 			message_id: 55,
@@ -463,7 +472,7 @@ describe('telegramSendAndWaitWebhook', () => {
 			if (name === 'responseType') return 'approval';
 			return fallback as never;
 		});
-		webhookFns.getRequestObject.mockReturnValue({ method: 'GET' } as never);
+		webhookFns.getRequestObject.mockReturnValue({ method: 'GET', headers: {} } as never);
 		// Executions waiting since before this feature have no stored target.
 		customDataGet.mockReturnValue('');
 
@@ -472,5 +481,29 @@ describe('telegramSendAndWaitWebhook', () => {
 		expect(genericFunctions.apiRequest).not.toHaveBeenCalled();
 		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
 		expect(result).toEqual({ noWebhookResponse: true });
+	});
+
+	it('does not delete on a bot-fetched approval link, mirroring the shared handler guard', async () => {
+		(sendAndWaitWebhook as Mock).mockResolvedValue({ noWebhookResponse: true });
+		webhookFns.getBodyData.mockReturnValue({});
+		webhookFns.getNodeParameter.mockImplementation((name: unknown, fallback?: unknown) => {
+			if (name === 'options') return { deleteOnResponse: true };
+			if (name === 'responseType') return 'approval';
+			return fallback as never;
+		});
+		webhookFns.getRequestObject.mockReturnValue({
+			method: 'GET',
+			headers: { 'user-agent': 'Twitterbot/1.0' },
+		} as never);
+		customDataGet.mockReturnValue(JSON.stringify({ chatId: 999, messageId: 55 }));
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(genericFunctions.apiRequest).not.toHaveBeenCalledWith(
+			'POST',
+			'deleteMessage',
+			expect.anything(),
+		);
+		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -338,7 +338,7 @@ const getFormResponseCustomizations = (context: IWebhookFunctions) => {
 
 // Block requests from Microsoft Preview Service to prevent accidental
 // approval/disapproval when sending links in Teams
-const isMicrosoftPreviewService = (userAgent?: string) => {
+export const isMicrosoftPreviewService = (userAgent?: string) => {
 	// The request that the Preview Service makes when the message is sent in
 	// Teams does not have a user-agent header
 	if (!userAgent) {


### PR DESCRIPTION
## Summary

When using *Send and Wait for Response* on Telegram, the bot's message tends to stick around long after it has served its purpose — once somebody has responded, you're left with stale buttons or a dead form link sitting in the chat.

This PR adds an **Options → Delete Message on Response** toggle to the operation. When enabled, the bot deletes its own message as soon as the user responds, regardless of how they did it:

- tapping an in-chat approval button
- clicking the approval link in a browser
- submitting a Free Text or Custom Form response

Implementation-wise, the message identity (chat + message ID) is captured from the `sendMessage` response and stored in execution metadata (`customData`), which is persisted while the execution waits and is available again when the webhook resumes the execution. That means no extra Telegram API calls at send time and no IDs embedded in signed URLs.

Deletion is deliberately best-effort — if the `deleteMessage` call fails, the execution still resumes normally. Old executions that were already waiting before this change simply skip deletion (no stored metadata).

## How to test

1. Create a workflow with Telegram → *Message → Send and Wait for Response*.
2. Under **Options**, enable **Delete Message on Response**.
3. Execute the workflow and respond in Telegram (button tap, link, or form submission).
4. The bot's message should disappear from the chat right away, and the execution output should be identical to a run with the option off.

You'll need a real Telegram bot credential and an instance reachable over public HTTPS for the resume webhook.

## Related Linear tickets, Github issues, and Community forum posts

- Related: https://community.n8n.io/t/telegram-send-and-wait-for-response-return-message-id-chat-id-so-we-can-delete-messages-after-approval/165250
- Related: https://community.n8n.io/t/telegram-send-and-wait-for-response-need-full-output-message-id/123002

Both posts describe the same problem this solves: after someone responds to a Send and Wait message, the stale approval buttons/form stay in the chat forever, and users want the bot to clean up its own message.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


