### PR TITLE
refactor(core): Remove unused applyPlannedTaskPermissions helper (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/__tests__/index.test.ts
+++ b/packages/@n8n/instance-ai/src/__tests__/index.test.ts
@@ -162,10 +162,6 @@ vi.mock('../planned-tasks/planned-task-service', () => ({
 }));
 vi.mock('../planned-tasks/planned-task-permissions', () => ({
 	PLANNED_TASK_PERMISSION_OVERRIDES: { checkpoint: { runWorkflow: 'always_allow' } },
-	applyPlannedTaskPermissions: (context: { permissions: Record<string, unknown> }) => ({
-		...context,
-		permissions: { ...context.permissions, runWorkflow: 'always_allow' },
-	}),
 }));
 vi.mock('../parsers/structured-file-parser', () => ({
 	classifyAttachments: () => [{ index: 0, parseable: true, format: 'csv' }],
@@ -326,10 +322,6 @@ describe('@n8n/instance-ai public entrypoint', () => {
 		expect(construct(entrypoint.PlannedTaskCoordinator)).toBeInstanceOf(
 			entrypoint.PlannedTaskCoordinator,
 		);
-		expect(
-			entrypoint.applyPlannedTaskPermissions({ permissions: {} } as never, 'checkpoint')
-				.permissions!.runWorkflow,
-		).toBe('always_allow');
 		expect(entrypoint.PLANNED_TASK_PERMISSION_OVERRIDES.checkpoint!.runWorkflow).toBe(
 			'always_allow',
 		);

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -603,8 +603,6 @@ export const WorkflowLoopRuntime: typeof WorkflowLoopRuntimeMod.WorkflowLoopRunt
 export type PlannedTaskCoordinator = PlannedTaskServiceMod.PlannedTaskCoordinator;
 export const PlannedTaskCoordinator: typeof PlannedTaskServiceMod.PlannedTaskCoordinator =
 	lazyClass(() => loadPlannedTaskService().PlannedTaskCoordinator);
-export const applyPlannedTaskPermissions: typeof PlannedTaskPermissionsMod.applyPlannedTaskPermissions =
-	lazyFunction(() => loadPlannedTaskPermissions().applyPlannedTaskPermissions);
 export declare const PLANNED_TASK_PERMISSION_OVERRIDES: typeof PlannedTaskPermissionsMod.PLANNED_TASK_PERMISSION_OVERRIDES;
 export type {
 	InstanceAiContext,

--- a/packages/@n8n/instance-ai/src/planned-tasks/__tests__/planned-task-permissions.test.ts
+++ b/packages/@n8n/instance-ai/src/planned-tasks/__tests__/planned-task-permissions.test.ts
@@ -1,32 +1,9 @@
-import { DEFAULT_INSTANCE_AI_PERMISSIONS } from '@n8n/api-types';
+import { PLANNED_TASK_PERMISSION_OVERRIDES } from '../planned-task-permissions';
 
-import type { InstanceAiContext } from '../../types';
-import { applyPlannedTaskPermissions } from '../planned-task-permissions';
-
-function makeContext(
-	permissionOverrides: Partial<typeof DEFAULT_INSTANCE_AI_PERMISSIONS> = {},
-): InstanceAiContext {
-	return {
-		userId: 'user-1',
-		projectId: 'project-1',
-		permissions: { ...DEFAULT_INSTANCE_AI_PERMISSIONS, ...permissionOverrides },
-		workflowService: {} as InstanceAiContext['workflowService'],
-		executionService: {} as InstanceAiContext['executionService'],
-		credentialService: {} as InstanceAiContext['credentialService'],
-		nodeService: {} as InstanceAiContext['nodeService'],
-		dataTableService: {} as InstanceAiContext['dataTableService'],
-		workflowTemplateService: {} as InstanceAiContext['workflowTemplateService'],
-		logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
-	};
-}
-
-describe('applyPlannedTaskPermissions', () => {
+describe('PLANNED_TASK_PERMISSION_OVERRIDES', () => {
 	describe('build-workflow', () => {
 		it('should auto-approve workflow and data-table work owned by the builder task', () => {
-			const context = makeContext();
-			const result = applyPlannedTaskPermissions(context, 'build-workflow');
-
-			expect(result.permissions).toMatchObject({
+			expect(PLANNED_TASK_PERMISSION_OVERRIDES['build-workflow']).toMatchObject({
 				createWorkflow: 'always_allow',
 				updateWorkflow: 'always_allow',
 				runWorkflow: 'always_allow',
@@ -37,61 +14,26 @@ describe('applyPlannedTaskPermissions', () => {
 			});
 		});
 
-		it('should not affect destructive or open-ended permissions', () => {
-			const context = makeContext();
-			const result = applyPlannedTaskPermissions(context, 'build-workflow');
+		it('should not grant destructive or open-ended permissions', () => {
+			const overrides = PLANNED_TASK_PERMISSION_OVERRIDES['build-workflow'];
 
-			expect(result.permissions?.deleteWorkflow).toBe('require_approval');
-			expect(result.permissions?.deleteDataTable).toBe('require_approval');
-			expect(result.permissions?.fetchUrl).toBe('require_approval');
-		});
-
-		it('should preserve admin always_allow settings on other keys', () => {
-			const context = makeContext({ fetchUrl: 'always_allow' });
-			const result = applyPlannedTaskPermissions(context, 'build-workflow');
-
-			expect(result.permissions?.fetchUrl).toBe('always_allow');
-			expect(result.permissions?.createWorkflow).toBe('always_allow');
+			expect(overrides).not.toHaveProperty('deleteWorkflow');
+			expect(overrides).not.toHaveProperty('deleteDataTable');
+			expect(overrides).not.toHaveProperty('deleteCredential');
+			expect(overrides).not.toHaveProperty('fetchUrl');
+			expect(overrides).not.toHaveProperty('readFile');
 		});
 	});
 
-	it('should return a new context object for overridden kinds', () => {
-		const context = makeContext();
-		const result = applyPlannedTaskPermissions(context, 'build-workflow');
-
-		expect(result).not.toBe(context);
-		expect(result.permissions).not.toBe(context.permissions);
+	describe('checkpoint', () => {
+		it('should grant only runWorkflow for the verification step', () => {
+			expect(PLANNED_TASK_PERMISSION_OVERRIDES.checkpoint).toEqual({
+				runWorkflow: 'always_allow',
+			});
+		});
 	});
 
-	it('should not mutate the original context', () => {
-		const context = makeContext();
-		applyPlannedTaskPermissions(context, 'build-workflow');
-
-		expect(context.permissions?.createWorkflow).toBe('require_approval');
-		expect(context.permissions?.updateWorkflow).toBe('require_approval');
-		expect(context.permissions?.runWorkflow).toBe('require_approval');
-	});
-
-	it('should share service references with the original context', () => {
-		const context = makeContext();
-		const result = applyPlannedTaskPermissions(context, 'build-workflow');
-
-		expect(result.dataTableService).toBe(context.dataTableService);
-		expect(result.workflowService).toBe(context.workflowService);
-		expect(result.userId).toBe(context.userId);
-	});
-
-	it('should preserve the bound projectId so sub-agents stay scoped to the thread project', () => {
-		const context = makeContext();
-		const result = applyPlannedTaskPermissions(context, 'build-workflow');
-
-		expect(result.projectId).toBe(context.projectId);
-	});
-
-	it('returns the original context for legacy delegate tasks', () => {
-		const context = makeContext();
-		const result = applyPlannedTaskPermissions(context, 'delegate');
-
-		expect(result).toBe(context);
+	it('should not override permissions for legacy delegate tasks', () => {
+		expect(PLANNED_TASK_PERMISSION_OVERRIDES).not.toHaveProperty('delegate');
 	});
 });

--- a/packages/@n8n/instance-ai/src/planned-tasks/planned-task-permissions.ts
+++ b/packages/@n8n/instance-ai/src/planned-tasks/planned-task-permissions.ts
@@ -1,6 +1,6 @@
 import type { InstanceAiPermissions } from '@n8n/api-types';
 
-import type { InstanceAiContext, PlannedTaskKind, StoredPlannedTaskKind } from '../types';
+import type { PlannedTaskKind } from '../types';
 
 /**
  * Permission overrides applied when a planned task has been approved by the user.
@@ -30,24 +30,3 @@ export const PLANNED_TASK_PERMISSION_OVERRIDES: Partial<
 		runWorkflow: 'always_allow',
 	},
 };
-
-/**
- * Returns a shallow clone of the context with plan-approved permission overrides
- * applied for the given task kind. If no overrides exist for the kind, the
- * original context is returned unchanged.
- */
-export function applyPlannedTaskPermissions(
-	context: InstanceAiContext,
-	taskKind: StoredPlannedTaskKind,
-): InstanceAiContext {
-	const overrides = PLANNED_TASK_PERMISSION_OVERRIDES[taskKind as PlannedTaskKind];
-	if (!overrides) return context;
-
-	return {
-		...context,
-		permissions: {
-			...context.permissions,
-			...overrides,
-		} as InstanceAiPermissions,
-	};
-}


### PR DESCRIPTION
## Summary

`applyPlannedTaskPermissions` in `@n8n/instance-ai` has no remaining call sites. Its former callers were removed when the planned-task context was reworked. The two places that still apply plan-approved permission overrides — the checkpoint and planned-build follow-up branches in `instance-ai.service.ts` — spread `PLANNED_TASK_PERMISSION_OVERRIDES` directly instead.

This PR removes the helper, its lazy re-export from the package entrypoint, and the mocked reference in the entrypoint test.

## How to test

This is a dead-code removal, so nothing should change.

## Related Linear tickets, Github issues, and Community forum posts

Found while reviewing https://linear.app/n8n/issue/INS-682.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

