### PR TITLE
feat(core): Don't show nps survey in canvas only mode (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/npsStore.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/npsStore.store.test.ts
@@ -301,4 +301,17 @@ describe('useNpsSurvey', () => {
 		expect(openModal).not.toHaveBeenCalled();
 		expect(updateNpsSurveyState).not.toHaveBeenCalled();
 	});
+
+	it('if canvas only mode is enabled, does not show nps survey', async () => {
+		useSettingsStore().settings.canvasOnly = true;
+		npsSurveyStore.setupNpsSurveyOnLogin('1', {
+			userActivated: true,
+			userActivatedAt: NOW - THREE_DAYS_IN_MILLIS - 10000,
+		});
+
+		await npsSurveyStore.showNpsSurveyIfPossible();
+
+		expect(openModal).not.toHaveBeenCalled();
+		expect(updateNpsSurveyState).not.toHaveBeenCalled();
+	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/npsSurvey.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/npsSurvey.store.ts
@@ -33,7 +33,7 @@ export const useNpsSurveyStore = defineStore('npsSurvey', () => {
 	}
 
 	function setShouldShowNpsSurvey(settings: IUserSettings) {
-		if (!settingsStore.isTelemetryEnabled) {
+		if (!settingsStore.isTelemetryEnabled || settingsStore.isCanvasOnly) {
 			shouldShowNpsSurveyNext.value = false;
 			return;
 		}


### PR DESCRIPTION
## Summary

Hides this in canvas only mode:
<img width="1685" height="119" alt="image" src="https://github.com/user-attachments/assets/210b84e0-3b0f-4350-894f-fc35a0c41d5e" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-183/hide-how-likely-are-you-to-recommend-n8n-for-canvas-only


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

