### PR TITLE
fix(HTTP Request Node): Show the API response when a file upload fails

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.test.ts
@@ -2,7 +2,7 @@ import { reactive, computed } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import userEvent from '@testing-library/user-event';
-import type { NodeError } from 'n8n-workflow';
+import type { IDataObject, NodeError } from 'n8n-workflow';
 import { mockedStore } from '@/__tests__/utils';
 import { createComponentRenderer } from '@/__tests__/render';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
@@ -181,6 +181,38 @@ describe('NodeErrorView.vue', () => {
 			props: { error, showDetails: true },
 		});
 		expect(getByText('Test stack trace')).toBeTruthy();
+	});
+
+	describe('circular error payloads', () => {
+		// Streamed request bodies (e.g. a binary file upload) reach the UI with a
+		// circular object graph; interpolating one used to throw and blank the panel.
+		function circular() {
+			const value: IDataObject = { method: 'POST', nested: {} };
+			(value.nested as IDataObject).self = value;
+			return value;
+		}
+
+		// `httpCode` is load-bearing: the enclosing <details> is gated on it.
+		function renderWith(extra: IDataObject) {
+			return renderComponent({
+				props: {
+					error: { ...error, httpCode: '400', ...extra } as unknown as NodeError,
+					showDetails: true,
+				},
+			});
+		}
+
+		it.each([
+			['context.request', { context: { request: circular() } }],
+			['context.data', { context: { data: circular() } }],
+			['context.causeDetailed', { context: { causeDetailed: circular() } }],
+			['extra', { extra: circular() }],
+			['cause', { cause: circular() }],
+		])('renders %s', (_name, extra) => {
+			const { getByText } = renderWith(extra);
+
+			expect(getByText(/\[Circular Reference\]/)).toBeTruthy();
+		});
 	});
 
 	it('renders open node button when the error is in sub node', () => {

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, toRaw } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useClipboard } from '@n8n/composables/useClipboard';
@@ -20,7 +20,7 @@ import type {
 	NodeError,
 	NodeOperationError,
 } from 'n8n-workflow';
-import { isCommunityPackageName } from 'n8n-workflow';
+import { isCommunityPackageName, replaceCircularReferences } from 'n8n-workflow';
 import { sanitizeHtml } from '@/app/utils/htmlUtils';
 import { MAX_DISPLAY_DATA_SIZE, NEW_ASSISTANT_SESSION_MODAL, VIEWS } from '@/app/constants';
 import type { BaseTextKey } from '@n8n/i18n';
@@ -63,8 +63,16 @@ const uiStore = useUIStore();
 
 const executionId = computed(() => workflowExecutionStateStore.value.activeExecution?.id);
 
+// Error payloads can carry live request/response objects, whose graphs are
+// circular. Vue interpolates via `JSON.stringify`, which throws on those — and
+// the render error blanks the whole panel — so interpolate sanitized copies.
+// `toRaw` keeps the copy off the reactive proxy, which is far cheaper to walk.
+const safeContext = computed(() => replaceCircularReferences(toRaw(props.error.context)));
+const safeExtra = computed(() => replaceCircularReferences(toRaw(props.error.extra)));
+const safeCause = computed(() => replaceCircularReferences(toRaw(props.error.cause)));
+
 const displayCause = computed(() => {
-	return JSON.stringify(props.error.cause ?? '').length < MAX_DISPLAY_DATA_SIZE;
+	return JSON.stringify(safeCause.value ?? '').length < MAX_DISPLAY_DATA_SIZE;
 });
 
 const node = computed(() => {
@@ -321,7 +329,7 @@ function getParameterName(
 }
 
 function copyErrorDetails() {
-	const error = props.error;
+	const error = toRaw(props.error);
 
 	const errorInfo: IDataObject = {
 		errorMessage: getErrorMessage(),
@@ -401,7 +409,7 @@ function copyErrorDetails() {
 
 	errorInfo.n8nDetails = n8nDetails;
 
-	void clipboard.copy(JSON.stringify(errorInfo, null, 2));
+	void clipboard.copy(JSON.stringify(replaceCircularReferences(errorInfo), null, 2));
 	copySuccess();
 }
 
@@ -582,7 +590,7 @@ async function onInstanceAiHandoffClick() {
 								{{ i18n.baseText('nodeErrorView.details.errorData') }}
 							</p>
 							<div class="node-error-view__details-value">
-								<pre><code>{{ error.context.data }}</code></pre>
+								<pre><code>{{ safeContext?.data }}</code></pre>
 							</div>
 						</div>
 						<div v-if="error.extra" class="node-error-view__details-row">
@@ -590,15 +598,15 @@ async function onInstanceAiHandoffClick() {
 								{{ i18n.baseText('nodeErrorView.details.errorExtra') }}
 							</p>
 							<div class="node-error-view__details-value">
-								<pre><code>{{ error.extra }}</code></pre>
+								<pre><code>{{ safeExtra }}</code></pre>
 							</div>
 						</div>
-						<div v-if="error.context && error.context.request" class="node-error-view__details-row">
+						<div v-if="error.context?.request" class="node-error-view__details-row">
 							<p class="node-error-view__details-label">
 								{{ i18n.baseText('nodeErrorView.details.request') }}
 							</p>
 							<div class="node-error-view__details-value">
-								<pre><code>{{ error.context.request }}</code></pre>
+								<pre><code>{{ safeContext?.request }}</code></pre>
 							</div>
 						</div>
 					</div>
@@ -690,20 +698,17 @@ async function onInstanceAiHandoffClick() {
 								{{ i18n.baseText('nodeErrorView.details.errorCause') }}
 							</p>
 
-							<pre class="node-error-view__details-value"><code>{{ error.cause }}</code></pre>
+							<pre class="node-error-view__details-value"><code>{{ safeCause }}</code></pre>
 						</div>
 
-						<div
-							v-if="error.context && error.context.causeDetailed"
-							class="node-error-view__details-row"
-						>
+						<div v-if="error.context?.causeDetailed" class="node-error-view__details-row">
 							<p class="node-error-view__details-label">
 								{{ i18n.baseText('nodeErrorView.details.causeDetailed') }}
 							</p>
 
 							<pre
 								class="node-error-view__details-value"
-							><code>{{ error.context.causeDetailed }}</code></pre>
+							><code>{{ safeContext?.causeDetailed }}</code></pre>
 						</div>
 
 						<div v-if="error.stack" class="node-error-view__details-row">

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 	type IOAuth2Options,
 	type IRequestOptions,
 } from 'n8n-workflow';
-import type { Readable } from 'stream';
+import { Stream, type Readable } from 'stream';
 import type { SecureContextOptions } from 'tls';
 
 import type { HttpSslAuthCredentials } from './interfaces';
@@ -37,8 +37,40 @@ export const replaceNullValues = (item: INodeExecutionData) => {
 
 export const REDACTED = '**hidden**';
 
+const STREAM_REPLACEMENT = 'Binary data got replaced with this text. Original was a stream.';
+
 function isObject(obj: unknown): obj is IDataObject {
 	return isPlainObject(obj);
+}
+
+/**
+ * Swaps an upload out of a value headed for the browser. A stream has to go
+ * before `deepCopy` runs: once the request is in flight its pipe chain is
+ * circular, and `deepCopy` faithfully preserves cycles.
+ *
+ * A multipart upload is a `form-data` instance from node version 4.2 on, but a
+ * plain `{ field: { value, options } }` map below that and in V1/V2 — hence the
+ * nested case.
+ */
+function replaceUploads(value: IDataObject[string]): IDataObject[string] {
+	if (value instanceof Stream) return STREAM_REPLACEMENT;
+
+	if (Buffer.isBuffer(value)) {
+		return value.length > 250000
+			? `Binary data got replaced with this text. Original was a Buffer with a size of ${value.length} bytes.`
+			: value;
+	}
+
+	if (!isObject(value)) return value;
+
+	const substituted: IDataObject = {};
+	for (const [key, entry] of Object.entries(value)) {
+		substituted[key] =
+			isObject(entry) && entry.value instanceof Stream
+				? { ...entry, value: STREAM_REPLACEMENT }
+				: entry;
+	}
+	return substituted;
 }
 
 function redactString(str: string, secrets: string[]): string {
@@ -71,35 +103,24 @@ export function sanitizeUiMessage(
 ) {
 	const { body, ...rest } = request as IDataObject;
 
-	let sendRequest: IDataObject = { body };
+	// `body` is not copied: `deepCopy` turns a Buffer into `{ type, data }`.
+	const sendRequest: IDataObject = { body: replaceUploads(body) };
 	for (const [key, value] of Object.entries(rest)) {
-		sendRequest[key] = deepCopy(value);
-	}
-
-	// Protect browser from sending large binary data
-	if (Buffer.isBuffer(sendRequest.body) && sendRequest.body.length > 250000) {
-		sendRequest = {
-			...request,
-			body: `Binary data got replaced with this text. Original was a Buffer with a size of ${
-				(request.body as string).length
-			} bytes.`,
-		};
+		sendRequest[key] = deepCopy(replaceUploads(value));
 	}
 
 	// Remove credential information
-	for (const requestProperty of Object.keys(authDataKeys)) {
-		sendRequest = {
-			...sendRequest,
-			[requestProperty]: Object.keys(sendRequest[requestProperty] as object).reduce(
-				(acc: IDataObject, curr) => {
-					acc[curr] = authDataKeys[requestProperty].includes(curr)
-						? REDACTED
-						: (sendRequest[requestProperty] as IDataObject)[curr];
-					return acc;
-				},
-				{},
-			),
-		};
+	for (const [requestProperty, authKeys] of Object.entries(authDataKeys)) {
+		const target = sendRequest[requestProperty];
+		// A property swapped for a placeholder string has nothing to redact, and
+		// iterating it would yield one key per character.
+		if (!isObject(target)) continue;
+
+		const redacted = { ...target };
+		for (const key of authKeys) {
+			if (key in redacted) redacted[key] = REDACTED;
+		}
+		sendRequest[requestProperty] = redacted;
 	}
 	const HEADER_BLOCKLIST = new Set([
 		'authorization',

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -49,8 +49,9 @@ function isObject(obj: unknown): obj is IDataObject {
  * circular, and `deepCopy` faithfully preserves cycles.
  *
  * A multipart upload is a `form-data` instance from node version 4.2 on, but a
- * plain `{ field: { value, options } }` map below that and in V1/V2 — hence the
- * nested case.
+ * plain `{ field: { value, options } }` map below that and in V1/V2, so a field
+ * value gets the same treatment as the root — it is a stream or a Buffer
+ * depending on whether binary data is stored outside the run data.
  */
 function replaceUploads(value: IDataObject[string]): IDataObject[string] {
 	if (value instanceof Stream) return STREAM_REPLACEMENT;
@@ -69,8 +70,8 @@ function replaceUploads(value: IDataObject[string]): IDataObject[string] {
 	return Object.fromEntries(
 		Object.entries(value).map(([key, entry]) => [
 			key,
-			isObject(entry) && entry.value instanceof Stream
-				? { ...entry, value: STREAM_REPLACEMENT }
+			isObject(entry) && 'value' in entry
+				? { ...entry, value: replaceUploads(entry.value) }
 				: entry,
 		]),
 	) as IDataObject;

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -63,14 +63,17 @@ function replaceUploads(value: IDataObject[string]): IDataObject[string] {
 
 	if (!isObject(value)) return value;
 
-	const substituted: IDataObject = {};
-	for (const [key, entry] of Object.entries(value)) {
-		substituted[key] =
+	// `Object.fromEntries` defines each key instead of assigning it, so a request
+	// property carrying an own `__proto__` key keeps it rather than retargeting
+	// this object's prototype.
+	return Object.fromEntries(
+		Object.entries(value).map(([key, entry]) => [
+			key,
 			isObject(entry) && entry.value instanceof Stream
 				? { ...entry, value: STREAM_REPLACEMENT }
-				: entry;
-	}
-	return substituted;
+				: entry,
+		]),
+	) as IDataObject;
 }
 
 function redactString(str: string, secrets: string[]): string {

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
@@ -1,7 +1,9 @@
 import FormData from 'form-data';
 import { Readable } from 'stream';
+import { jsonParse } from 'n8n-workflow';
 import type {
 	ICredentialDataDecryptedObject,
+	IDataObject,
 	INodeExecutionData,
 	IRequestOptions,
 } from 'n8n-workflow';
@@ -182,6 +184,19 @@ describe('HTTP Node Utils', () => {
 				file: { value: STREAM_REPLACEMENT, options: { filename: 'f.pdf' } },
 				name: 'invoice',
 			});
+		});
+
+		// `__proto__` arrives as an own key on anything JSON.parse builds, and
+		// assigning it would retarget the copy's prototype and drop the key.
+		it('should keep an own __proto__ key without retargeting the prototype', () => {
+			const body = jsonParse('{"__proto__": {"injected": "yes"}, "keep": 1}');
+			const requestOptions: IRequestOptions = { method: 'POST', uri: 'https://example.com', body };
+
+			const sanitized = sanitizeUiMessage(requestOptions, {}).body as IDataObject;
+
+			expect(Object.getPrototypeOf(sanitized)).toBe(Object.prototype);
+			expect(Object.getOwnPropertyNames(sanitized)).toEqual(['__proto__', 'keep']);
+			expect(sanitized.injected).toBeUndefined();
 		});
 
 		it('should keep the placeholder when the body also carries auth data', () => {

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
@@ -170,20 +170,55 @@ describe('HTTP Node Utils', () => {
 			expect(sanitizeUiMessage(requestOptions, {}).formData).toEqual(STREAM_REPLACEMENT);
 		});
 
-		it('should remove a stream nested in a formData field (node version < 4.2, V1, V2)', () => {
-			const requestOptions: IRequestOptions = {
-				method: 'POST',
-				uri: 'https://example.com',
-				formData: {
-					file: { value: Readable.from(Buffer.alloc(10)), options: { filename: 'f.pdf' } },
-					name: 'invoice',
-				},
-			};
+		// Below node version 4.2 (and in V1/V2) the upload sits one level down, as
+		// `{ field: { value, options } }`. `value` is a stream when binary data is
+		// stored outside the run data and a Buffer when it is inline, so a field has
+		// to be capped there just like a root body.
+		it.each([
+			['a stream', () => Readable.from(Buffer.alloc(10)), STREAM_REPLACEMENT],
+			[
+				'an oversized Buffer',
+				() => Buffer.alloc(300000),
+				'Binary data got replaced with this text. Original was a Buffer with a size of 300000 bytes.',
+			],
+		])('should replace %s nested in a formData field', (_name, upload, replacement) => {
+			const uri = 'https://example.com';
 
-			expect(sanitizeUiMessage(requestOptions, {}).formData).toEqual({
-				file: { value: STREAM_REPLACEMENT, options: { filename: 'f.pdf' } },
+			expect(
+				sanitizeUiMessage(
+					{
+						method: 'POST',
+						uri,
+						formData: {
+							file: { value: upload(), options: { filename: 'f.pdf' } },
+							name: 'invoice',
+						},
+					},
+					{},
+				).formData,
+			).toEqual({
+				file: { value: replacement, options: { filename: 'f.pdf' } },
 				name: 'invoice',
 			});
+
+			// The same upload at the root has to reach the same verdict, so the two
+			// branches cannot drift apart again.
+			expect(sanitizeUiMessage({ method: 'POST', uri, body: upload() }, {}).body).toEqual(
+				replacement,
+			);
+		});
+
+		it('should keep a Buffer nested in a formData field below the size limit', () => {
+			const sanitized = sanitizeUiMessage(
+				{
+					method: 'POST',
+					uri: 'https://example.com',
+					formData: { file: { value: Buffer.alloc(10), options: { filename: 'f.pdf' } } },
+				},
+				{},
+			).formData as IDataObject;
+
+			expect(typeof (sanitized.file as IDataObject).value).not.toBe('string');
 		});
 
 		// `__proto__` arrives as an own key on anything JSON.parse builds, and

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
@@ -132,6 +132,8 @@ describe('HTTP Node Utils', () => {
 	});
 
 	describe('sanitizeUiMessage', () => {
+		const STREAM_REPLACEMENT = 'Binary data got replaced with this text. Original was a stream.';
+
 		it('should remove large Buffers', async () => {
 			const requestOptions: IRequestOptions = {
 				method: 'POST',
@@ -141,6 +143,56 @@ describe('HTTP Node Utils', () => {
 
 			expect(sanitizeUiMessage(requestOptions, {}).body).toEqual(
 				'Binary data got replaced with this text. Original was a Buffer with a size of 900000 bytes.',
+			);
+		});
+
+		it('should remove a streamed body', () => {
+			const requestOptions: IRequestOptions = {
+				method: 'POST',
+				uri: 'https://example.com',
+				body: Readable.from(Buffer.alloc(10)),
+			};
+
+			expect(sanitizeUiMessage(requestOptions, {}).body).toEqual(STREAM_REPLACEMENT);
+		});
+
+		it('should remove a multipart upload built as form-data (node version >= 4.2)', () => {
+			const formData = new FormData();
+			formData.append('file', Readable.from(Buffer.alloc(10)), { filename: 'f.pdf' });
+			const requestOptions: IRequestOptions = {
+				method: 'POST',
+				uri: 'https://example.com',
+				formData,
+			};
+
+			expect(sanitizeUiMessage(requestOptions, {}).formData).toEqual(STREAM_REPLACEMENT);
+		});
+
+		it('should remove a stream nested in a formData field (node version < 4.2, V1, V2)', () => {
+			const requestOptions: IRequestOptions = {
+				method: 'POST',
+				uri: 'https://example.com',
+				formData: {
+					file: { value: Readable.from(Buffer.alloc(10)), options: { filename: 'f.pdf' } },
+					name: 'invoice',
+				},
+			};
+
+			expect(sanitizeUiMessage(requestOptions, {}).formData).toEqual({
+				file: { value: STREAM_REPLACEMENT, options: { filename: 'f.pdf' } },
+				name: 'invoice',
+			});
+		});
+
+		it('should keep the placeholder when the body also carries auth data', () => {
+			const requestOptions: IRequestOptions = {
+				method: 'POST',
+				uri: 'https://example.com',
+				body: Readable.from(Buffer.alloc(10)),
+			};
+
+			expect(sanitizeUiMessage(requestOptions, { body: ['token'] }).body).toEqual(
+				STREAM_REPLACEMENT,
 			);
 		});
 


### PR DESCRIPTION
## Summary

An HTTP Request node that POSTs a file and gets a 4xx back rendered an **empty output panel**. The toast showed `Bad request - please check your parameters`, but the API's actual response was nowhere to be seen.

The response body was never lost — the error view crashed while rendering.

1. A binary upload read from external binary storage (`filesystem`/`s3`, the cloud default) stays a live `Readable`, not a `Buffer`.
2. `sanitizeUiMessage` only swapped the body out when it was a `Buffer` over 250 KB, so the stream passed through into `error.context.request`.
3. While the request is in flight, that stream's `_readableState.pipes` chain is circular (`res → socket → _httpMessage`).
4. Execution data travels as `flatted`, which faithfully **restores** the cycle in the browser.
5. `NodeErrorView` interpolated the value. Vue's `toDisplayString` calls `JSON.stringify`, which threw, and the render error tore down the whole error view.

This is why it only appeared with real files: a small inline binary is a serializable `Buffer`, a stored one is a stream.

**The fix has two halves.** `sanitizeUiMessage` now replaces upload streams before `deepCopy` preserves the cycle — covering `body`, a `form-data` instance (node version 4.2+), and the plain `{ field: { value, options } }` map used below 4.2 and in V1/V2. `NodeErrorView` renders sanitized copies, so an execution **already recorded** before this fix still shows its error after an upgrade.

| Before | After |
|---|---|
| `OUTPUT ⚠` + `1 item`, blank body | Error box with the API's message |

Before:

```
OUTPUT ⚠ ⓘ
1 item
                          ← nothing
```
```
Uncaught TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'res' -> object with constructor 'Object'
    |     property 'socket' -> object with constructor 'Object'
    --- property '_httpMessage' closes the circle
    at JSON.stringify (<anonymous>)
    at toDisplayString (vue.runtime.esm-bundler…)
```

After:

```
OUTPUT ⚠ ⓘ
1 item
  Bad request - please check your parameters
  file exceeds the maximum allowed size          ← the API's response

  Error details ▸ From HTTP Request
    Error code    400
    Full message  400 - "{"type":"error","error":{"type":"invalid_request_error",
                  "message":"file exceeds the maximum allowed size"}}"
    Request       { "body": "Binary data got replaced with this text. Original
                  was a stream.", "headers": { … }, "method": "POST", … }
```

## How to test

The bug needs binary data stored **outside** the run data — with the default binary mode the upload is an inline `Buffer`, which was always serializable, and nothing reproduces.

**1.** Save the mock API below as `mock-server.mjs` and start it:

```bash
node mock-server.mjs
```

<details>
<summary><code>mock-server.mjs</code></summary>

```js
// Mock file-upload API: serves a ~6 MB PDF, and rejects any upload with a 400 + JSON body.
import { createServer } from 'node:http';

const PORT = Number(process.env.PORT ?? 4599);

const server = createServer((req, res) => {
	const url = new URL(req.url, `http://${req.headers.host}`);
	console.log(`[mock] ${req.method} ${url.pathname} content-length=${req.headers['content-length']}`);

	if (url.pathname === '/big.pdf') {
		const body = Buffer.concat([Buffer.from('%PDF-1.4\n'), Buffer.alloc(6 * 1024 * 1024, 0x41)]);
		res.writeHead(200, { 'content-type': 'application/pdf', 'content-length': body.length });
		res.end(body);
		return;
	}

	if (url.pathname === '/v1/files') {
		const payload = JSON.stringify({
			type: 'error',
			error: { type: 'invalid_request_error', message: 'file exceeds the maximum allowed size' },
		});
		req.resume();
		req.on('end', () => {
			res.writeHead(400, { 'content-type': 'application/json' });
			res.end(payload);
		});
		return;
	}

	res.writeHead(404).end();
});

server.listen(PORT, () => console.log(`[mock] listening on http://127.0.0.1:${PORT}`));
```

</details>

**2.** Start n8n with binary data stored on disk:

```bash
N8N_DEFAULT_BINARY_DATA_MODE=filesystem \
N8N_AVAILABLE_BINARY_DATA_MODES=filesystem,default \
  pnpm start
```

**3.** Import the workflow below, run it, then open the **Upload PDF to Files API** node.

<details>
<summary>Example workflow</summary>

```json
{
  "name": "NODE-5292 repro: POST binary upload error",
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [0, 0],
      "id": "11111111-1111-1111-1111-111111111111",
      "name": "When clicking 'Execute workflow'"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:4599/big.pdf",
        "options": {
          "response": { "response": { "fullResponse": true, "responseFormat": "file" } }
        }
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.4,
      "position": [220, 0],
      "id": "22222222-2222-2222-2222-222222222222",
      "name": "Fetch example PDF file"
    },
    {
      "parameters": {
        "method": "POST",
        "url": "http://127.0.0.1:4599/v1/files",
        "sendBody": true,
        "contentType": "binaryData",
        "inputDataFieldName": "data",
        "options": { "response": { "response": { "fullResponse": true } } }
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.4,
      "position": [440, 0],
      "id": "33333333-3333-3333-3333-333333333333",
      "name": "Upload PDF to Files API"
    }
  ],
  "pinData": {},
  "connections": {
    "When clicking 'Execute workflow'": {
      "main": [[{ "node": "Fetch example PDF file", "type": "main", "index": 0 }]]
    },
    "Fetch example PDF file": {
      "main": [[{ "node": "Upload PDF to Files API", "type": "main", "index": 0 }]]
    }
  },
  "active": false,
  "settings": { "executionOrder": "v1" }
}
```

</details>

**Expected:** the output panel shows the error box with `file exceeds the maximum allowed size`. Expand **Error details → From HTTP Request** and confirm `Request.body` reads `Binary data got replaced with this text. Original was a stream.` The browser console must stay clean.

**To see the bug**, check out `master` and repeat step 3: the panel shows only `OUTPUT ⚠` and `1 item`, and the console logs `Converting circular structure to JSON` from `toDisplayString`.

**Also worth checking (multipart, the other upload shape):** set **Body Content Type** to `Form-Data`, add a parameter of type `n8n Binary File` with input field `data`, and point it at the same URL. The panel must render its error too.

**No regressions in the request preview:** open any normal HTTP Request node and confirm the request shown under **Error details** is unchanged for JSON, string, and form-urlencoded bodies.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5292

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

