### PR TITLE
fix(editor): Add padding to evaluation single run view

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
@@ -247,7 +247,7 @@ onBeforeUnmount(() => evaluationStore.cleanupPolling());
 	height: fit-content;
 	width: 100%;
 	max-width: var(--content-container--width);
-	padding: var(--spacing--lg) 0 var(--spacing--3xl) 0;
+	padding: var(--spacing--lg) var(--spacing--2xl) var(--spacing--3xl);
 }
 
 .header {


### PR DESCRIPTION
## Summary

The evaluation single run view (Evaluations tab → open a run) lost its horizontal padding. Above roughly 1310px viewport width, the container's `max-width` kept it narrower than the screen, so it looked centered. Below that width, the container fills the screen and the "Run #N" heading, score card, and test case cards sit flush against the left and right edges.

This adds horizontal padding to the container, matching the pattern used on other full-width views (for example the executions list).

## How to test

1. Open a workflow and go to the Evaluations tab.
2. Open a single run.
3. Resize the browser window to below ~1310px wide.
4. Confirm the content keeps left/right padding and no longer touches the screen edges.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-170

### Before:

<img width="2416" height="1848" alt="image" src="https://github.com/user-attachments/assets/a7bfb257-d0b3-4f1c-b1cb-07c582d83669" />

### After:

<img width="996" height="1072" alt="image" src="https://github.com/user-attachments/assets/dc047c78-9c52-489e-b38e-bb39dc8a95e2" />

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

