### PR TITLE
fix(ai-builder): Fix session timeline/trace not showing on preview dock when full screen

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7922,6 +7922,7 @@
 	"agents.builder.header.saving": "Saving…",
 	"agents.builder.header.saved": "Saved",
 	"agents.builder.preview.button": "Preview",
+	"agents.builder.preview.showChat": "Show chat",
 	"agents.builder.preview.disabledTooltip": "This agent's configuration has errors. Resolve them before previewing.",
 	"agents.builder.preview.layout.change": "Change layout",
 	"agents.builder.preview.layout.floating": "Floating",

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.test.ts
@@ -127,6 +127,39 @@ describe('usePushConnectionStore', () => {
 			expect(store.isConnectionRequested).toBe(true);
 		});
 
+		test('should keep the connection open until the last owner disconnects', () => {
+			const { store, mockWebSocketClient } = createTestInitialState();
+
+			store.pushConnect();
+			store.pushConnect();
+			expect(mockWebSocketClient.connect).toHaveBeenCalledTimes(1);
+			expect(store.isConnectionRequested).toBe(true);
+
+			vi.advanceTimersByTime(500);
+
+			store.pushDisconnect();
+			expect(mockWebSocketClient.disconnect).not.toHaveBeenCalled();
+			expect(store.isConnectionRequested).toBe(true);
+
+			store.pushDisconnect();
+			vi.advanceTimersByTime(500);
+			expect(mockWebSocketClient.disconnect).toHaveBeenCalledTimes(1);
+			expect(store.isConnectionRequested).toBe(false);
+		});
+
+		test('should ignore disconnect calls that exceed connect calls', () => {
+			const { store, mockWebSocketClient } = createTestInitialState();
+
+			store.pushConnect();
+			vi.advanceTimersByTime(500);
+
+			store.pushDisconnect();
+			store.pushDisconnect();
+			vi.advanceTimersByTime(500);
+
+			expect(mockWebSocketClient.disconnect).toHaveBeenCalledTimes(1);
+		});
+
 		test('should not disconnect if connect is called during disconnect debounce window', () => {
 			const { store, mockWebSocketClient } = createTestInitialState();
 

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
@@ -123,6 +123,9 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 	 */
 	let disconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 
+	/** Number of active pushConnect owners; disconnect only when this reaches zero. */
+	let connectionOwnerCount = 0;
+
 	const pushConnect = () => {
 		recentConnectIntent = true;
 
@@ -141,12 +144,31 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 			disconnectTimeout = null;
 		}
 
+		connectionOwnerCount++;
+		if (connectionOwnerCount !== 1) {
+			return;
+		}
+
 		isConnectionRequested.value = true;
 		isConnecting.value = true;
 		client.value.connect();
 	};
 
 	const pushDisconnect = () => {
+		if (connectionOwnerCount === 0) {
+			return;
+		}
+
+		connectionOwnerCount--;
+
+		if (connectionOwnerCount > 0) {
+			if (disconnectTimeout) {
+				clearTimeout(disconnectTimeout);
+				disconnectTimeout = null;
+			}
+			return;
+		}
+
 		// If connect was called recently, don't disconnect
 		// (handles race condition where new view mounts before old view unmounts)
 		if (recentConnectIntent) {
@@ -160,7 +182,7 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 
 		disconnectTimeout = setTimeout(() => {
 			// Double-check in case connect was called while we were waiting
-			if (recentConnectIntent) {
+			if (recentConnectIntent || connectionOwnerCount > 0) {
 				disconnectTimeout = null;
 				return;
 			}

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
@@ -28,19 +28,27 @@ const defaultAgentConfig: AgentJsonConfig = {
 	instructions: 'Help.',
 };
 
-vi.mock('@n8n/i18n', () => ({
-	useI18n: () => ({
-		baseText: (key: string, options?: { interpolate?: Record<string, string> }) => {
-			const translations: Record<string, string> = {
-				'agents.chat.input.placeholder.withAgent': `Message ${options?.interpolate?.agentName}…`,
-				'agents.chat.misconfigured.issuesPrefix': 'Check:',
-				'agents.chat.misconfigured.missing.tools': 'Tool configuration',
-				'agents.chat.misconfigured.missing.mcpServers': 'MCP server',
-				'agents.chat.misconfigured.missing.subAgents.agents': 'Sub-agent',
-			};
-			return translations[key] ?? key;
-		},
-	}),
+vi.mock('@n8n/i18n', () => {
+	const baseText = (key: string, options?: { interpolate?: Record<string, string> }) => {
+		const translations: Record<string, string> = {
+			'agents.chat.input.placeholder.withAgent': `Message ${options?.interpolate?.agentName}…`,
+			'agents.chat.misconfigured.issuesPrefix': 'Check:',
+			'agents.chat.misconfigured.missing.tools': 'Tool configuration',
+			'agents.chat.misconfigured.missing.mcpServers': 'MCP server',
+			'agents.chat.misconfigured.missing.subAgents.agents': 'Sub-agent',
+		};
+		return translations[key] ?? key;
+	};
+	const i18n = { baseText };
+	return { useI18n: () => i18n, i18n };
+});
+
+vi.mock('../components/AgentSessionTimelinePanel.vue', () => ({
+	default: {
+		name: 'AgentSessionTimelinePanel',
+		props: ['projectId', 'agentId', 'threadId'],
+		template: '<div data-testid="agent-preview-session-timeline" />',
+	},
 }));
 
 vi.mock('@n8n/design-system', () => ({

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentPreviewDock.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentPreviewDock.test.ts
@@ -38,6 +38,14 @@ vi.mock('@n8n/i18n', () => ({
 	useI18n: () => ({ baseText: (key: string) => key }),
 }));
 
+vi.mock('../components/AgentSessionTimelinePanel.vue', () => ({
+	default: {
+		name: 'AgentSessionTimelinePanel',
+		props: ['projectId', 'agentId', 'threadId'],
+		template: '<div data-testid="agent-preview-session-timeline" />',
+	},
+}));
+
 vi.mock('@n8n/design-system', () => ({
 	N8nButton: {
 		name: 'N8nButton',
@@ -79,7 +87,16 @@ const AgentPreviewChatPageStub = {
 	name: 'AgentPreviewChatPage',
 	props: ['beforeSend', 'layout'],
 	emits: ['continue-loaded', 'open-build', 'send-to-assistant'],
+	setup(_props: unknown, { expose }: { expose: (exposed: Record<string, unknown>) => void }) {
+		expose({ focusInput: vi.fn() });
+	},
 	template: '<div data-testid="agent-preview-chat-page-stub" />',
+};
+
+const AgentSessionTimelinePanelStub = {
+	name: 'AgentSessionTimelinePanel',
+	props: ['projectId', 'agentId', 'threadId'],
+	template: '<div data-testid="agent-preview-session-timeline" />',
 };
 
 function mountDock(
@@ -87,6 +104,7 @@ function mountDock(
 		hasSession: boolean;
 		effectiveSessionId?: string;
 		beforeSend: () => Promise<void> | void;
+		isOpen: boolean;
 	}> = {},
 	attachTo?: HTMLElement,
 ) {
@@ -107,7 +125,10 @@ function mountDock(
 			...overrides,
 		},
 		global: {
-			stubs: { AgentPreviewChatPage: AgentPreviewChatPageStub },
+			stubs: {
+				AgentPreviewChatPage: AgentPreviewChatPageStub,
+				AgentSessionTimelinePanel: AgentSessionTimelinePanelStub,
+			},
 		},
 	});
 }
@@ -286,6 +307,80 @@ describe('AgentPreviewDock', () => {
 		wrapper.unmount();
 		host.remove();
 		outsideButton.remove();
+	});
+
+	it('shows the session timeline in full-page layout without navigating', async () => {
+		localStorage.setItem('N8N_AGENT_PREVIEW_LAYOUT', 'fullpage');
+		const wrapper = mountDock();
+
+		await wrapper.get('[data-testid="agent-preview-view-session-btn"]').trigger('click');
+
+		expect(wrapper.emitted('view-trace')).toBeUndefined();
+		expect(wrapper.find('[data-testid="agent-preview-session-timeline"]').exists()).toBe(true);
+		expect(wrapper.find('[data-testid="agent-preview-chat-page-stub"]').isVisible()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-preview-show-chat-btn"]').exists()).toBe(true);
+		expect(
+			wrapper
+				.find('[data-testid="agent-preview-show-chat-btn"]')
+				.find('[data-icon="message-circle"]')
+				.exists(),
+		).toBe(true);
+	});
+
+	it('returns to chat from the full-page timeline view', async () => {
+		localStorage.setItem('N8N_AGENT_PREVIEW_LAYOUT', 'fullpage');
+		const wrapper = mountDock();
+
+		await wrapper.get('[data-testid="agent-preview-view-session-btn"]').trigger('click');
+		await wrapper.get('[data-testid="agent-preview-show-chat-btn"]').trigger('click');
+
+		expect(wrapper.find('[data-testid="agent-preview-session-timeline"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-preview-chat-page-stub"]').isVisible()).toBe(true);
+		expect(wrapper.find('[data-testid="agent-preview-view-session-btn"]').exists()).toBe(true);
+		expect(wrapper.emitted('view-trace')).toBeUndefined();
+	});
+
+	it('returns to chat when switching from full-page timeline to docked layout', async () => {
+		localStorage.setItem('N8N_AGENT_PREVIEW_LAYOUT', 'fullpage');
+		const wrapper = mountDock();
+		const layoutMenu = wrapper.findAllComponents({ name: 'N8nDropdownMenu' })[1];
+
+		await wrapper.get('[data-testid="agent-preview-view-session-btn"]').trigger('click');
+		expect(wrapper.find('[data-testid="agent-preview-session-timeline"]').exists()).toBe(true);
+
+		layoutMenu?.vm.$emit('select', 'docked');
+		await wrapper.vm.$nextTick();
+
+		expect(wrapper.find('[data-testid="agent-preview-session-timeline"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-preview-chat-page-stub"]').isVisible()).toBe(true);
+		expect(wrapper.emitted('view-trace')).toBeUndefined();
+	});
+
+	it('returns to chat when starting a new session from the full-page timeline', async () => {
+		localStorage.setItem('N8N_AGENT_PREVIEW_LAYOUT', 'fullpage');
+		const wrapper = mountDock();
+
+		await wrapper.get('[data-testid="agent-preview-view-session-btn"]').trigger('click');
+		await wrapper.get('[data-testid="agent-preview-new-chat-btn"]').trigger('click');
+
+		expect(wrapper.find('[data-testid="agent-preview-session-timeline"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-preview-chat-page-stub"]').isVisible()).toBe(true);
+		expect(wrapper.emitted('new-session')).toEqual([[]]);
+		expect(wrapper.emitted('view-trace')).toBeUndefined();
+	});
+
+	it('returns to chat when the dock closes while showing the timeline', async () => {
+		localStorage.setItem('N8N_AGENT_PREVIEW_LAYOUT', 'fullpage');
+		const wrapper = mountDock();
+
+		await wrapper.get('[data-testid="agent-preview-view-session-btn"]').trigger('click');
+		expect(wrapper.find('[data-testid="agent-preview-session-timeline"]').exists()).toBe(true);
+
+		await wrapper.setProps({ isOpen: false });
+		await wrapper.setProps({ isOpen: true });
+
+		expect(wrapper.find('[data-testid="agent-preview-session-timeline"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-preview-view-session-btn"]').exists()).toBe(true);
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentPreviewDock.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentPreviewDock.vue
@@ -10,7 +10,7 @@ import {
 } from '@n8n/design-system';
 import type { DropdownMenuItemProps } from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
-import { computed, nextTick, useTemplateRef, watch } from 'vue';
+import { computed, nextTick, useTemplateRef, watch, ref } from 'vue';
 import { useStorage } from '@vueuse/core';
 import { useRouter } from 'vue-router';
 
@@ -27,6 +27,10 @@ import type {
 } from '../types';
 import AgentPersonalisationIcon from './AgentPersonalisationIcon.vue';
 import AgentPreviewChatPage from './AgentPreviewChatPage.vue';
+import AgentSessionTimelinePanel from './AgentSessionTimelinePanel.vue';
+
+type DockBody = 'chat' | 'timeline';
+const dockView = ref<DockBody>('chat');
 
 interface SessionOption {
 	id: string;
@@ -133,7 +137,15 @@ function getLayoutAriaLabel() {
 
 function viewTrace() {
 	if (!props.hasSession || !props.effectiveSessionId) return;
+	if (layout.value === PreviewLayout.Fullpage) {
+		dockView.value = 'timeline';
+		return;
+	}
 	emit('view-trace');
+}
+
+function showChat() {
+	dockView.value = 'chat';
 }
 
 function exportSession() {
@@ -146,6 +158,7 @@ function exportSession() {
 }
 
 function createNewSession() {
+	showChat();
 	emit('new-session');
 }
 
@@ -169,6 +182,15 @@ function setLayout(nextLayout: string) {
 function isFocusWithinDock() {
 	return dock.value?.contains(document.activeElement) === true;
 }
+
+watch(
+	[layout, () => props.isOpen, () => props.hasSession],
+	function resetDockView([nextLayout, isOpen, hasSession]) {
+		if (nextLayout !== PreviewLayout.Fullpage || !isOpen || !hasSession) {
+			showChat();
+		}
+	},
+);
 
 watch(
 	[() => props.isOpen, () => props.initialized, () => props.effectiveSessionId],
@@ -241,12 +263,19 @@ useKeybindings({
 				<div :class="$style.actions">
 					<N8nTooltip
 						v-if="props.hasSession && props.effectiveSessionId"
-						:content="i18n.baseText('agents.builder.preview.viewSession')"
+						:content="
+							i18n.baseText(
+								dockView === 'chat'
+									? 'agents.builder.preview.viewSession'
+									: ('agents.builder.preview.showChat' as BaseTextKey),
+							)
+						"
 						placement="bottom"
 						:show-after="TOOLTIP_DELAY_MS"
 						data-testid="agent-preview-view-session-tooltip"
 					>
 						<N8nIconButton
+							v-if="dockView === 'chat'"
 							icon="list-tree"
 							variant="ghost"
 							size="small"
@@ -254,6 +283,16 @@ useKeybindings({
 							:aria-label="i18n.baseText('agents.builder.preview.viewSession')"
 							data-testid="agent-preview-view-session-btn"
 							@click="viewTrace"
+						/>
+						<N8nIconButton
+							v-else
+							icon="message-circle"
+							variant="ghost"
+							size="small"
+							icon-size="large"
+							:aria-label="i18n.baseText('agents.builder.preview.showChat' as BaseTextKey)"
+							data-testid="agent-preview-show-chat-btn"
+							@click="showChat"
 						/>
 					</N8nTooltip>
 
@@ -313,6 +352,7 @@ useKeybindings({
 			</header>
 
 			<AgentPreviewChatPage
+				v-show="dockView === 'chat'"
 				ref="previewChatPage"
 				:initialized="props.initialized"
 				:project-id="props.projectId"
@@ -328,6 +368,13 @@ useKeybindings({
 				@continue-loaded="emit('continue-loaded', $event)"
 				@open-build="emit('open-build')"
 				@send-to-assistant="emit('send-to-assistant', $event)"
+			/>
+			<AgentSessionTimelinePanel
+				v-if="dockView === 'timeline' && props.effectiveSessionId"
+				:project-id="props.projectId"
+				:agent-id="props.agentId"
+				:thread-id="props.effectiveSessionId"
+				data-testid="agent-preview-session-timeline"
 			/>
 		</div>
 	</aside>


### PR DESCRIPTION
## Summary
Currently in the agent builder preview chat, when the preview layout is set to Full Screen (fullpage) instead of Docked, clicking the timeline icon (view session trace) does not switch the view to the session timeline.

Now we render the session trace timeline on the same full screen component rather than activating it on the docked component.


## How to test
1. Create an agent.
2. Open said agent from "Personal" > "Agents" >  "$name-of-agent" view.
3. Start a preview chat with the agent. Change the layout to "Full Screen". Send a message to the agent.
4. Click on the "View Session Trace" button (list-tree icon).
5.  If the timeline appears, the issue is solved 😁

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-704/bug-agent-builder-preview-timeline-icon-does-not-switch-to-timeline-in


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

