### PR TITLE
fix(core): Gate browser credential creation on its own permission

### DIFF
--- a/packages/@n8n/api-types/src/schemas/__tests__/instance-ai.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/instance-ai.schema.test.ts
@@ -175,6 +175,7 @@ describe('applyBranchReadOnlyOverrides', () => {
 		expect(result.readFilesystem).toBe('require_approval');
 		expect(result.fetchUrl).toBe('require_approval');
 		expect(result.publishWorkflow).toBe('require_approval');
+		expect(result.createCredential).toBe('require_approval');
 		expect(result.deleteCredential).toBe('require_approval');
 		expect(result.restoreWorkflowVersion).toBe('require_approval');
 
@@ -198,6 +199,7 @@ describe('applyBranchReadOnlyOverrides', () => {
 		const permissions: InstanceAiPermissions = {
 			...DEFAULT_INSTANCE_AI_PERMISSIONS,
 			publishWorkflow: 'always_allow',
+			createCredential: 'always_allow',
 			deleteCredential: 'always_allow',
 			readFilesystem: 'always_allow',
 		};
@@ -205,6 +207,7 @@ describe('applyBranchReadOnlyOverrides', () => {
 		const result = applyBranchReadOnlyOverrides(permissions);
 
 		expect(result.publishWorkflow).toBe('always_allow');
+		expect(result.createCredential).toBe('always_allow');
 		expect(result.deleteCredential).toBe('always_allow');
 		expect(result.readFilesystem).toBe('always_allow');
 	});

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1664,6 +1664,7 @@ const instanceAiPermissionsSchema = z.object({
 	runWorkflow: instanceAiPermissionModeSchema,
 	publishWorkflow: instanceAiPermissionModeSchema,
 	deleteWorkflow: instanceAiPermissionModeSchema,
+	createCredential: instanceAiPermissionModeSchema,
 	deleteCredential: instanceAiPermissionModeSchema,
 	createFolder: instanceAiPermissionModeSchema,
 	deleteFolder: instanceAiPermissionModeSchema,
@@ -1689,6 +1690,7 @@ export const DEFAULT_INSTANCE_AI_PERMISSIONS: InstanceAiPermissions = {
 	runWorkflow: 'require_approval',
 	publishWorkflow: 'require_approval',
 	deleteWorkflow: 'require_approval',
+	createCredential: 'require_approval',
 	deleteCredential: 'require_approval',
 	createFolder: 'require_approval',
 	deleteFolder: 'require_approval',
@@ -1724,6 +1726,7 @@ const BRANCH_READ_ONLY_SAFE_PERMISSIONS: ReadonlySet<keyof InstanceAiPermissions
 	'fetchUrl',
 	'webSearch',
 	'publishWorkflow',
+	'createCredential',
 	'deleteCredential',
 	'restoreWorkflowVersion',
 ]);

--- a/packages/@n8n/computer-use/src/gateway-client.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.test.ts
@@ -291,7 +291,8 @@ describe('GatewayClient.checkPermissions', () => {
 				resource: '/custom/path: ls',
 				description: 'Execute shell command: ls in /custom/path',
 			});
-			expect(session.check).toHaveBeenCalledWith('shell', '/custom/path: ls');
+			// Shell resources carry no kind — only browser tools set one.
+			expect(session.check).toHaveBeenCalledWith('shell', '/custom/path: ls', undefined);
 			expect(execute).not.toHaveBeenCalled();
 			expect(confirmResourceAccess).not.toHaveBeenCalled();
 		});

--- a/packages/@n8n/computer-use/src/gateway-client.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.ts
@@ -495,7 +495,7 @@ export class GatewayClient {
 		const { session, confirmResourceAccess, config } = this.options;
 
 		for (const resource of resources) {
-			const rule = session.check(resource.toolGroup, resource.resource);
+			const rule = session.check(resource.toolGroup, resource.resource, resource.kind);
 
 			if (rule === 'deny') {
 				throw new Error(

--- a/packages/@n8n/computer-use/src/gateway-session.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-session.test.ts
@@ -224,9 +224,27 @@ describe('GatewaySession', () => {
 					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
 					store as unknown as SettingsStore,
 				);
-				expect(session.check('browser', 'credentials')).toBe('ask');
+				expect(session.check('browser', 'credentials', 'credential-write')).toBe('ask');
 				// The group mode still covers ordinary domains.
-				expect(session.check('browser', 'example.com')).toBe('allow');
+				expect(session.check('browser', 'example.com', 'host')).toBe('allow');
+			});
+
+			it('treats a host named "credentials" as a domain, not a credential write', () => {
+				const store = makeStore();
+				const session = new GatewaySession(
+					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
+					store as unknown as SettingsStore,
+				);
+				expect(session.check('browser', 'credentials', 'host')).toBe('allow');
+			});
+
+			it('applies the group mode when no kind is given', () => {
+				const store = makeStore();
+				const session = new GatewaySession(
+					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
+					store as unknown as SettingsStore,
+				);
+				expect(session.check('browser', 'credentials')).toBe('allow');
 			});
 
 			it('honours an explicit session approval for the credentials resource', () => {
@@ -236,7 +254,7 @@ describe('GatewaySession', () => {
 					store as unknown as SettingsStore,
 				);
 				session.allowForSession('browser', 'credentials');
-				expect(session.check('browser', 'credentials')).toBe('allow');
+				expect(session.check('browser', 'credentials', 'credential-write')).toBe('allow');
 			});
 
 			it('honours an explicit persistent approval for the credentials resource', () => {
@@ -245,7 +263,7 @@ describe('GatewaySession', () => {
 					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
 					store as unknown as SettingsStore,
 				);
-				expect(session.check('browser', 'credentials')).toBe('allow');
+				expect(session.check('browser', 'credentials', 'credential-write')).toBe('allow');
 			});
 
 			it('still denies when the credentials resource is on the deny list', () => {
@@ -254,7 +272,7 @@ describe('GatewaySession', () => {
 					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
 					store as unknown as SettingsStore,
 				);
-				expect(session.check('browser', 'credentials')).toBe('deny');
+				expect(session.check('browser', 'credentials', 'credential-write')).toBe('deny');
 			});
 		});
 

--- a/packages/@n8n/computer-use/src/gateway-session.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-session.test.ts
@@ -217,6 +217,47 @@ describe('GatewaySession', () => {
 			expect(session.check('shell', 'npm')).toBe('ask');
 		});
 
+		describe('credential creation', () => {
+			it('asks when only the browser group mode would allow it', () => {
+				const store = makeStore();
+				const session = new GatewaySession(
+					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
+					store as unknown as SettingsStore,
+				);
+				expect(session.check('browser', 'credentials')).toBe('ask');
+				// The group mode still covers ordinary domains.
+				expect(session.check('browser', 'example.com')).toBe('allow');
+			});
+
+			it('honours an explicit session approval for the credentials resource', () => {
+				const store = makeStore();
+				const session = new GatewaySession(
+					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
+					store as unknown as SettingsStore,
+				);
+				session.allowForSession('browser', 'credentials');
+				expect(session.check('browser', 'credentials')).toBe('allow');
+			});
+
+			it('honours an explicit persistent approval for the credentials resource', () => {
+				const store = makeStore({ allow: { browser: ['credentials'] } });
+				const session = new GatewaySession(
+					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
+					store as unknown as SettingsStore,
+				);
+				expect(session.check('browser', 'credentials')).toBe('allow');
+			});
+
+			it('still denies when the credentials resource is on the deny list', () => {
+				const store = makeStore({ deny: { browser: ['credentials'] } });
+				const session = new GatewaySession(
+					{ permissions: FULL_ALLOW_PERMISSIONS, dir: '/' },
+					store as unknown as SettingsStore,
+				);
+				expect(session.check('browser', 'credentials')).toBe('deny');
+			});
+		});
+
 		describe('settings self-protection', () => {
 			const settingsFile = config.getSettingsFilePath();
 			const settingsDir = config.getSettingsDir();

--- a/packages/@n8n/computer-use/src/gateway-session.ts
+++ b/packages/@n8n/computer-use/src/gateway-session.ts
@@ -1,12 +1,8 @@
-import { BROWSER_CREDENTIALS_RESOURCE } from '@n8n/mcp-browser';
+import type { AffectedResourceKind } from '@n8n/mcp-browser';
 
 import type { PermissionMode, ToolGroup } from './config';
 import { isProtectedSettingsPath, TOOL_GROUP_DEFINITIONS } from './config';
 import type { SettingsStore } from './settings-store';
-
-function isCredentialCreationResource(toolGroup: ToolGroup, resource: string): boolean {
-	return toolGroup === 'browser' && resource === BROWSER_CREDENTIALS_RESOURCE;
-}
 
 /**
  * Holds all session-scoped state for a single gateway connection.
@@ -82,7 +78,7 @@ export class GatewaySession {
 	 * an approval aimed at that resource, so a group-wide mode alone leaves it at
 	 * 'ask'.
 	 */
-	check(toolGroup: ToolGroup, resource: string): PermissionMode {
+	check(toolGroup: ToolGroup, resource: string, kind?: AffectedResourceKind): PermissionMode {
 		// Self-protection: prevent tools from accessing the gateway settings directory
 		if (
 			(toolGroup === 'filesystemWrite' || toolGroup === 'filesystemRead') &&
@@ -97,7 +93,7 @@ export class GatewaySession {
 		if (this.hasSessionAllow(toolGroup, resource)) return 'allow';
 
 		const groupMode = this.getGroupMode(toolGroup);
-		if (groupMode === 'allow' && isCredentialCreationResource(toolGroup, resource)) return 'ask';
+		if (groupMode === 'allow' && kind === 'credential-write') return 'ask';
 		return groupMode;
 	}
 

--- a/packages/@n8n/computer-use/src/gateway-session.ts
+++ b/packages/@n8n/computer-use/src/gateway-session.ts
@@ -1,6 +1,12 @@
+import { BROWSER_CREDENTIALS_RESOURCE } from '@n8n/mcp-browser';
+
 import type { PermissionMode, ToolGroup } from './config';
 import { isProtectedSettingsPath, TOOL_GROUP_DEFINITIONS } from './config';
 import type { SettingsStore } from './settings-store';
+
+function isCredentialCreationResource(toolGroup: ToolGroup, resource: string): boolean {
+	return toolGroup === 'browser' && resource === BROWSER_CREDENTIALS_RESOURCE;
+}
 
 /**
  * Holds all session-scoped state for a single gateway connection.
@@ -71,6 +77,10 @@ export class GatewaySession {
 	 *  2. Persistent allow list → 'allow'
 	 *  3. Session allow set     → 'allow'
 	 *  4. Group mode            → via getGroupMode() (includes cross-group constraints)
+	 *
+	 * Step 4 does not blanket-allow credential creation. Writing a credential needs
+	 * an approval aimed at that resource, so a group-wide mode alone leaves it at
+	 * 'ask'.
 	 */
 	check(toolGroup: ToolGroup, resource: string): PermissionMode {
 		// Self-protection: prevent tools from accessing the gateway settings directory
@@ -85,7 +95,10 @@ export class GatewaySession {
 		if (rp.deny.includes(resource)) return 'deny';
 		if (rp.allow.includes(resource)) return 'allow';
 		if (this.hasSessionAllow(toolGroup, resource)) return 'allow';
-		return this.getGroupMode(toolGroup);
+
+		const groupMode = this.getGroupMode(toolGroup);
+		if (groupMode === 'allow' && isCredentialCreationResource(toolGroup, resource)) return 'ask';
+		return groupMode;
 	}
 
 	// ---------------------------------------------------------------------------

--- a/packages/@n8n/computer-use/src/tools/types.ts
+++ b/packages/@n8n/computer-use/src/tools/types.ts
@@ -1,10 +1,14 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import type { CreateCredentialPayload, SecretsBuffer } from '@n8n/mcp-browser';
+import type {
+	AffectedResourceKind,
+	CreateCredentialPayload,
+	SecretsBuffer,
+} from '@n8n/mcp-browser';
 import type { z } from 'zod';
 
 import type { GatewayConfig, ToolGroup } from '../config';
 
-export type { CallToolResult, CreateCredentialPayload, SecretsBuffer };
+export type { AffectedResourceKind, CallToolResult, CreateCredentialPayload, SecretsBuffer };
 
 export interface McpTool {
 	name: string;
@@ -39,6 +43,11 @@ export interface ToolAnnotations {
 
 export interface AffectedResource {
 	toolGroup: ToolGroup;
+	/**
+	 * How to interpret `resource`. Browser tools always set it; the filesystem, shell
+	 * and computer tools have no equivalent distinction and leave it unset.
+	 */
+	kind?: AffectedResourceKind;
 	resource: string;
 	description: string;
 }

--- a/packages/@n8n/mcp-browser/src/index.ts
+++ b/packages/@n8n/mcp-browser/src/index.ts
@@ -8,13 +8,13 @@ export { BROWSER_USE_EXTENSION_ID, buildExtensionConnectUrl } from './extension-
 // behaviour here changes.
 export { BrowserDiscovery, getDefaultDiscovery } from './browser-discovery';
 export { createBrowserTools } from './tools/index';
-export { BROWSER_CREDENTIALS_RESOURCE } from './tools/credential';
 export { configureLogger } from './logger';
 export type { LogLevel } from './logger';
 export { parseServerOptions } from './server-config';
 export type { ServerOptions } from './server-config';
 export type {
 	AffectedResource,
+	AffectedResourceKind,
 	BrowserInfo,
 	DiscoveredBrowsers,
 	BrowserName,

--- a/packages/@n8n/mcp-browser/src/index.ts
+++ b/packages/@n8n/mcp-browser/src/index.ts
@@ -8,11 +8,13 @@ export { BROWSER_USE_EXTENSION_ID, buildExtensionConnectUrl } from './extension-
 // behaviour here changes.
 export { BrowserDiscovery, getDefaultDiscovery } from './browser-discovery';
 export { createBrowserTools } from './tools/index';
+export { BROWSER_CREDENTIALS_RESOURCE } from './tools/credential';
 export { configureLogger } from './logger';
 export type { LogLevel } from './logger';
 export { parseServerOptions } from './server-config';
 export type { ServerOptions } from './server-config';
 export type {
+	AffectedResource,
 	BrowserInfo,
 	DiscoveredBrowsers,
 	BrowserName,

--- a/packages/@n8n/mcp-browser/src/tools/credential.test.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.test.ts
@@ -1,7 +1,7 @@
 import type { Mocked, MockedFunction } from 'vitest';
 
 import type { SecretsBuffer, ToolContext } from '../types';
-import { createCredentialTools } from './credential';
+import { BROWSER_CREDENTIALS_RESOURCE, createCredentialTools } from './credential';
 import { createMockConnection, findTool, structuredOf } from './test-helpers';
 
 // ---------------------------------------------------------------------------
@@ -480,6 +480,23 @@ describe('browser_create_credential', () => {
 			expect(createCredential).toHaveBeenCalledWith(
 				expect.objectContaining({ name: 'My Cred', type: 'googleApi', projectId: 'proj-1' }),
 			);
+		});
+	});
+
+	describe('getAffectedResources', () => {
+		it('reports the credentials resource and names the credential in the description', async () => {
+			const resources = await getTool().getAffectedResources(
+				{ credentialsKey: 'k1', type: 'googleApi', name: 'My Cred' },
+				ctx(),
+			);
+
+			expect(resources).toEqual([
+				{
+					toolGroup: 'browser',
+					resource: BROWSER_CREDENTIALS_RESOURCE,
+					description: 'Create credential "My Cred" (googleApi)',
+				},
+			]);
 		});
 	});
 

--- a/packages/@n8n/mcp-browser/src/tools/credential.test.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.test.ts
@@ -1,7 +1,7 @@
 import type { Mocked, MockedFunction } from 'vitest';
 
 import type { SecretsBuffer, ToolContext } from '../types';
-import { BROWSER_CREDENTIALS_RESOURCE, createCredentialTools } from './credential';
+import { createCredentialTools } from './credential';
 import { createMockConnection, findTool, structuredOf } from './test-helpers';
 
 // ---------------------------------------------------------------------------
@@ -493,7 +493,8 @@ describe('browser_create_credential', () => {
 			expect(resources).toEqual([
 				{
 					toolGroup: 'browser',
-					resource: BROWSER_CREDENTIALS_RESOURCE,
+					kind: 'credential-write',
+					resource: 'credentials',
 					description: 'Create credential "My Cred" (googleApi)',
 				},
 			]);

--- a/packages/@n8n/mcp-browser/src/tools/credential.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.ts
@@ -21,11 +21,12 @@ export function createCredentialTools(connection: BrowserConnection): ToolDefini
 	return [browserCaptureSecret(connection), browserCreateCredential(connection)];
 }
 
-const CREATE_CREDENTIAL_RESOURCE: AffectedResource = {
-	toolGroup: 'browser',
-	resource: 'credentials',
-	description: 'Browser: credentials',
-};
+/**
+ * Resource id reported by `browser_create_credential`. Unlike every other browser
+ * tool this is not a hostname, so callers gate it on a credential permission of
+ * their own rather than on domain access.
+ */
+export const BROWSER_CREDENTIALS_RESOURCE = 'credentials';
 
 // ---------------------------------------------------------------------------
 // browser_capture_secret
@@ -175,8 +176,16 @@ function browserCreateCredential(
 
 			return formatCallToolResult({ ok: true, credentialId: credential.credentialId });
 		},
-		getAffectedResources() {
-			return [CREATE_CREDENTIAL_RESOURCE];
+		getAffectedResources(args): AffectedResource[] {
+			// The confirmation card shows this description, so name the credential being
+			// created rather than the tool doing it.
+			return [
+				{
+					toolGroup: 'browser',
+					resource: BROWSER_CREDENTIALS_RESOURCE,
+					description: `Create credential "${args.name}" (${args.type})`,
+				},
+			];
 		},
 	};
 }

--- a/packages/@n8n/mcp-browser/src/tools/credential.ts
+++ b/packages/@n8n/mcp-browser/src/tools/credential.ts
@@ -21,12 +21,8 @@ export function createCredentialTools(connection: BrowserConnection): ToolDefini
 	return [browserCaptureSecret(connection), browserCreateCredential(connection)];
 }
 
-/**
- * Resource id reported by `browser_create_credential`. Unlike every other browser
- * tool this is not a hostname, so callers gate it on a credential permission of
- * their own rather than on domain access.
- */
-export const BROWSER_CREDENTIALS_RESOURCE = 'credentials';
+/** Display/approval id reported by `browser_create_credential`. Not a hostname. */
+const BROWSER_CREDENTIALS_RESOURCE = 'credentials';
 
 // ---------------------------------------------------------------------------
 // browser_capture_secret
@@ -182,6 +178,7 @@ function browserCreateCredential(
 			return [
 				{
 					toolGroup: 'browser',
+					kind: 'credential-write',
 					resource: BROWSER_CREDENTIALS_RESOURCE,
 					description: `Create credential "${args.name}" (${args.type})`,
 				},

--- a/packages/@n8n/mcp-browser/src/tools/helpers.ts
+++ b/packages/@n8n/mcp-browser/src/tools/helpers.ts
@@ -142,7 +142,9 @@ export function createConnectedTool<
 			const resource = getResourceFromArgs
 				? getResourceFromArgs(args)
 				: getConnectionResource(connection);
-			return [{ toolGroup: 'browser', resource, description: `Browser: ${resource}` }];
+			return [
+				{ toolGroup: 'browser', kind: 'host', resource, description: `Browser: ${resource}` },
+			];
 		},
 	};
 }

--- a/packages/@n8n/mcp-browser/src/types.ts
+++ b/packages/@n8n/mcp-browser/src/types.ts
@@ -307,8 +307,16 @@ export interface ToolDefinition<TSchema extends z.ZodType = z.ZodType> {
 	): AffectedResource[] | Promise<AffectedResource[]>;
 }
 
+/**
+ * What the `resource` string identifies. Callers gate on this rather than on the
+ * string itself: `resource` is a hostname for `host`, and a hostname can legitimately
+ * be the literal `credentials`.
+ */
+export type AffectedResourceKind = 'host' | 'credential-write';
+
 export interface AffectedResource {
 	toolGroup: 'browser';
+	kind: AffectedResourceKind;
 	resource: string;
 	description: string;
 }

--- a/packages/cli/src/modules/instance-ai/__tests__/browser-local-mcp-server.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/browser-local-mcp-server.test.ts
@@ -30,8 +30,9 @@ function makeServer(tool: ToolDefinition) {
 function gate(
 	tracker: DomainAccessTracker,
 	permissionMode: BrowserDomainGate['permissionMode'] = 'require_approval',
+	createCredentialPermissionMode: BrowserDomainGate['createCredentialPermissionMode'] = 'require_approval',
 ): BrowserDomainGate {
-	return { tracker, runId: RUN_ID, permissionMode };
+	return { tracker, runId: RUN_ID, permissionMode, createCredentialPermissionMode };
 }
 
 async function call(
@@ -160,5 +161,129 @@ describe('BrowserLocalMcpServer domain gating', () => {
 			expect(tracker.approveDomain).not.toHaveBeenCalled();
 			expect(tracker.approveOnce).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe('BrowserLocalMcpServer credential-creation gating', () => {
+	let tracker: ReturnType<typeof mock<DomainAccessTracker>>;
+
+	beforeEach(() => {
+		tracker = mock<DomainAccessTracker>();
+		tracker.isHostAllowed.mockReturnValue(false);
+	});
+
+	const CREDENTIAL_DESCRIPTION = 'Create credential "My key" (openAiApi)';
+
+	function makeCredentialTool(): ToolDefinition {
+		return {
+			name: 'browser_create_credential',
+			description: 'Assemble buffered secrets into a credential',
+			inputSchema: z.object({ name: z.string(), type: z.string() }),
+			execute: vi.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] })),
+			getAffectedResources: vi.fn(async () => [
+				{ toolGroup: 'browser', resource: 'credentials', description: CREDENTIAL_DESCRIPTION },
+			]),
+		} as unknown as ToolDefinition;
+	}
+
+	function makeCredentialServer(tool: ToolDefinition) {
+		const toolkit = { tools: [tool], connection: {} } as unknown as BrowserToolkit;
+		return new BrowserLocalMcpServer(toolkit, mock<ToolContext>(), mock<Logger>());
+	}
+
+	async function callCreate(server: BrowserLocalMcpServer, extra: Record<string, unknown> = {}) {
+		return await server.callTool({
+			name: 'browser_create_credential',
+			arguments: { name: 'My key', type: 'openAiApi', ...extra },
+		});
+	}
+
+	function parseConfirmation(result: Awaited<ReturnType<typeof callCreate>>) {
+		const text = (result.content[0] as { text: string }).text;
+		expect(text.startsWith(GATEWAY_CONFIRMATION_REQUIRED_PREFIX)).toBe(true);
+		return JSON.parse(text.slice(GATEWAY_CONFIRMATION_REQUIRED_PREFIX.length));
+	}
+
+	it('requires confirmation regardless of the domain-access mode', async () => {
+		const tool = makeCredentialTool();
+		const server = makeCredentialServer(tool);
+		server.setDomainGate(gate(tracker, 'always_allow'));
+
+		const result = await callCreate(server);
+
+		expect(result.isError).toBe(true);
+		expect(parseConfirmation(result)).toMatchObject({ resource: 'credentials' });
+		expect(tool.execute).not.toHaveBeenCalled();
+	});
+
+	it('requires confirmation regardless of thread-level domain approvals', async () => {
+		tracker.isHostAllowed.mockReturnValue(true);
+		const tool = makeCredentialTool();
+		const server = makeCredentialServer(tool);
+		server.setDomainGate(gate(tracker));
+
+		const result = await callCreate(server);
+
+		expect(result.isError).toBe(true);
+		expect(tool.execute).not.toHaveBeenCalled();
+		expect(tracker.isHostAllowed).not.toHaveBeenCalled();
+	});
+
+	it('offers no session-wide option and names the credential in the confirmation', async () => {
+		const tool = makeCredentialTool();
+		const server = makeCredentialServer(tool);
+		server.setDomainGate(gate(tracker));
+
+		const payload = parseConfirmation(await callCreate(server));
+
+		expect(payload.options).toEqual(['denyOnce', 'allowOnce']);
+		expect(payload.description).toBe(CREDENTIAL_DESCRIPTION);
+	});
+
+	it('executes without prompting when the credential permission is always_allow', async () => {
+		const tool = makeCredentialTool();
+		const server = makeCredentialServer(tool);
+		server.setDomainGate(gate(tracker, 'require_approval', 'always_allow'));
+
+		await callCreate(server);
+
+		expect(tool.execute).toHaveBeenCalledTimes(1);
+	});
+
+	it('blocks when the credential permission is blocked', async () => {
+		const tool = makeCredentialTool();
+		const server = makeCredentialServer(tool);
+		server.setDomainGate(gate(tracker, 'always_allow', 'blocked'));
+
+		const result = await callCreate(server);
+
+		expect(result.isError).toBe(true);
+		expect((result.content[0] as { text: string }).text).toContain('blocked by admin');
+		expect(tool.execute).not.toHaveBeenCalled();
+	});
+
+	it('executes on allowOnce without recording a domain approval', async () => {
+		const tool = makeCredentialTool();
+		const server = makeCredentialServer(tool);
+		server.setDomainGate(gate(tracker));
+
+		await callCreate(server, { _confirmation: 'allowOnce' });
+
+		expect(tool.execute).toHaveBeenCalledTimes(1);
+		expect(tracker.approveOnce).not.toHaveBeenCalled();
+		expect(tracker.approveDomain).not.toHaveBeenCalled();
+	});
+
+	it.each(['denyOnce', 'allowForSession'])('denies on %s', async (confirmation) => {
+		const tool = makeCredentialTool();
+		const server = makeCredentialServer(tool);
+		server.setDomainGate(gate(tracker));
+
+		const result = await callCreate(server, { _confirmation: confirmation });
+
+		expect(result.isError).toBe(true);
+		expect((result.content[0] as { text: string }).text).toContain('denied by user');
+		expect(tool.execute).not.toHaveBeenCalled();
+		expect(tracker.approveDomain).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/browser-local-mcp-server.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/browser-local-mcp-server.test.ts
@@ -16,7 +16,12 @@ function makeTool(overrides: Partial<ToolDefinition> = {}): ToolDefinition {
 		inputSchema: z.object({ url: z.string().optional() }),
 		execute: vi.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] })),
 		getAffectedResources: vi.fn(async () => [
-			{ toolGroup: 'browser', resource: 'example.com', description: 'Browser: example.com' },
+			{
+				toolGroup: 'browser',
+				kind: 'host',
+				resource: 'example.com',
+				description: 'Browser: example.com',
+			},
 		]),
 		...overrides,
 	} as unknown as ToolDefinition;
@@ -104,7 +109,12 @@ describe('BrowserLocalMcpServer domain gating', () => {
 		it('does not gate when there is no real domain (sentinel host)', async () => {
 			const tool = makeTool({
 				getAffectedResources: vi.fn(async () => [
-					{ toolGroup: 'browser', resource: 'browser', description: 'Browser: browser' },
+					{
+						toolGroup: 'browser',
+						kind: 'host',
+						resource: 'browser',
+						description: 'Browser: browser',
+					},
 				]),
 			} as unknown as Partial<ToolDefinition>);
 			const server = makeServer(tool);
@@ -113,6 +123,31 @@ describe('BrowserLocalMcpServer domain gating', () => {
 			await call(server);
 
 			expect(tool.execute).toHaveBeenCalledTimes(1);
+		});
+
+		it('treats a host named "credentials" as a domain, not a credential write', async () => {
+			const tool = makeTool({
+				getAffectedResources: vi.fn(async () => [
+					{
+						toolGroup: 'browser',
+						kind: 'host',
+						resource: 'credentials',
+						description: 'Browser: credentials',
+					},
+				]),
+			} as unknown as Partial<ToolDefinition>);
+			const server = makeServer(tool);
+			// Credential writes are allowed outright; the domain still has to be approved.
+			server.setDomainGate(gate(tracker, 'require_approval', 'always_allow'));
+
+			const result = await call(server);
+
+			expect(result.isError).toBe(true);
+			const text = (result.content[0] as { text: string }).text;
+			const payload = JSON.parse(text.slice(GATEWAY_CONFIRMATION_REQUIRED_PREFIX.length));
+			expect(payload.options).toContain('allowForSession');
+			expect(tracker.isHostAllowed).toHaveBeenCalledWith('credentials', RUN_ID);
+			expect(tool.execute).not.toHaveBeenCalled();
 		});
 
 		it('executes unconditionally when no gate is bound', async () => {
@@ -181,7 +216,12 @@ describe('BrowserLocalMcpServer credential-creation gating', () => {
 			inputSchema: z.object({ name: z.string(), type: z.string() }),
 			execute: vi.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] })),
 			getAffectedResources: vi.fn(async () => [
-				{ toolGroup: 'browser', resource: 'credentials', description: CREDENTIAL_DESCRIPTION },
+				{
+					toolGroup: 'browser',
+					kind: 'credential-write',
+					resource: 'credentials',
+					description: CREDENTIAL_DESCRIPTION,
+				},
 			]),
 		} as unknown as ToolDefinition;
 	}

--- a/packages/cli/src/modules/instance-ai/browser/browser-local-mcp-server.ts
+++ b/packages/cli/src/modules/instance-ai/browser/browser-local-mcp-server.ts
@@ -1,5 +1,6 @@
 import type {
 	InstanceAiPermissionMode,
+	InstanceGatewayResourceDecision,
 	McpTool,
 	McpToolCallRequest,
 	McpToolCallResult,
@@ -11,13 +12,26 @@ import {
 } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type { DomainAccessTracker, LocalMcpServer } from '@n8n/instance-ai';
-import type { BrowserToolkit, ToolContext, ToolDefinition } from '@n8n/mcp-browser';
+import { BROWSER_CREDENTIALS_RESOURCE } from '@n8n/mcp-browser';
+import type {
+	AffectedResource,
+	BrowserToolkit,
+	ToolContext,
+	ToolDefinition,
+} from '@n8n/mcp-browser';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
 export interface BrowserDomainGate {
 	tracker: DomainAccessTracker;
 	runId: string;
+	/** Governs domain access — every browser tool whose affected resource is a host. */
 	permissionMode?: InstanceAiPermissionMode;
+	/**
+	 * Governs `browser_create_credential`, which reports `credentials` rather than a host.
+	 * Writing a credential to the instance is a different kind of action from reading a
+	 * page, so it carries its own permission.
+	 */
+	createCredentialPermissionMode?: InstanceAiPermissionMode;
 }
 
 const NO_DOMAIN = 'browser';
@@ -76,7 +90,7 @@ export class BrowserLocalMcpServer implements LocalMcpServer {
 			const { _confirmation, ...rawArgs } = req.arguments;
 			const args: unknown = tool.inputSchema.parse(rawArgs);
 
-			const gateResult = await this.gateDomainAccess(tool, args, _confirmation);
+			const gateResult = await this.gateAccess(tool, args, _confirmation);
 			if (gateResult) {
 				return gateResult;
 			}
@@ -96,7 +110,7 @@ export class BrowserLocalMcpServer implements LocalMcpServer {
 		}
 	}
 
-	private async gateDomainAccess(
+	private async gateAccess(
 		tool: ToolDefinition,
 		args: unknown,
 		confirmation: unknown,
@@ -106,49 +120,89 @@ export class BrowserLocalMcpServer implements LocalMcpServer {
 			return undefined;
 		}
 
-		const host = await this.affectedHost(tool, args);
-		if (!host || host === NO_DOMAIN) {
+		const affected = await this.affectedResource(tool, args);
+		if (!affected || affected.resource === NO_DOMAIN) {
 			return undefined;
 		}
 
-		if (typeof confirmation === 'string') {
-			switch (confirmation) {
-				case 'allowForSession':
-					await gate.tracker.approveDomain(host);
-					return undefined;
-				case 'allowOnce':
-					gate.tracker.approveOnce(gate.runId, host);
-					return undefined;
-				default:
-					return errorResult('Access denied by user');
-			}
-		}
-
-		if (gate.permissionMode === 'blocked') {
-			return errorResult('Browser access blocked by admin');
-		}
-		if (gate.permissionMode !== 'always_allow' && !gate.tracker.isHostAllowed(host, gate.runId)) {
-			return confirmationRequiredResult(host);
-		}
-		return undefined;
+		return affected.resource === BROWSER_CREDENTIALS_RESOURCE
+			? gateCredentialCreation(gate, affected, confirmation)
+			: await gateDomainAccess(gate, affected, confirmation);
 	}
 
-	private async affectedHost(tool: ToolDefinition, args: unknown): Promise<string | undefined> {
+	private async affectedResource(
+		tool: ToolDefinition,
+		args: unknown,
+	): Promise<AffectedResource | undefined> {
 		try {
 			const resources = await tool.getAffectedResources(args, this.toolContext);
-			return resources[0]?.resource;
+			return resources[0];
 		} catch {
 			return undefined;
 		}
 	}
 }
 
-function confirmationRequiredResult(host: string): McpToolCallResult {
+async function gateDomainAccess(
+	gate: BrowserDomainGate,
+	affected: AffectedResource,
+	confirmation: unknown,
+): Promise<McpToolCallResult | undefined> {
+	const host = affected.resource;
+
+	if (typeof confirmation === 'string') {
+		switch (confirmation) {
+			case 'allowForSession':
+				await gate.tracker.approveDomain(host);
+				return undefined;
+			case 'allowOnce':
+				gate.tracker.approveOnce(gate.runId, host);
+				return undefined;
+			default:
+				return errorResult('Access denied by user');
+		}
+	}
+
+	if (gate.permissionMode === 'blocked') {
+		return errorResult('Browser access blocked by admin');
+	}
+	if (gate.permissionMode !== 'always_allow' && !gate.tracker.isHostAllowed(host, gate.runId)) {
+		return confirmationRequiredResult(affected, ['denyOnce', 'allowOnce', 'allowForSession']);
+	}
+	return undefined;
+}
+
+/**
+ * Credential creation is confirmed per call against its own permission: there is no
+ * session-wide option, and the domain tracker plays no part in the decision.
+ */
+function gateCredentialCreation(
+	gate: BrowserDomainGate,
+	affected: AffectedResource,
+	confirmation: unknown,
+): McpToolCallResult | undefined {
+	if (typeof confirmation === 'string') {
+		return confirmation === 'allowOnce' ? undefined : errorResult('Access denied by user');
+	}
+
+	if (gate.createCredentialPermissionMode === 'blocked') {
+		return errorResult('Credential creation blocked by admin');
+	}
+	if (gate.createCredentialPermissionMode !== 'always_allow') {
+		return confirmationRequiredResult(affected, ['denyOnce', 'allowOnce']);
+	}
+	return undefined;
+}
+
+function confirmationRequiredResult(
+	affected: AffectedResource,
+	options: InstanceGatewayResourceDecision[],
+): McpToolCallResult {
 	const payload = {
-		toolGroup: 'browser',
-		resource: host,
-		description: `Browser: ${host}`,
-		options: ['denyOnce', 'allowOnce', 'allowForSession'],
+		toolGroup: affected.toolGroup,
+		resource: affected.resource,
+		description: affected.description,
+		options,
 	};
 	return {
 		content: [

--- a/packages/cli/src/modules/instance-ai/browser/browser-local-mcp-server.ts
+++ b/packages/cli/src/modules/instance-ai/browser/browser-local-mcp-server.ts
@@ -12,7 +12,6 @@ import {
 } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type { DomainAccessTracker, LocalMcpServer } from '@n8n/instance-ai';
-import { BROWSER_CREDENTIALS_RESOURCE } from '@n8n/mcp-browser';
 import type {
 	AffectedResource,
 	BrowserToolkit,
@@ -125,7 +124,7 @@ export class BrowserLocalMcpServer implements LocalMcpServer {
 			return undefined;
 		}
 
-		return affected.resource === BROWSER_CREDENTIALS_RESOURCE
+		return affected.kind === 'credential-write'
 			? gateCredentialCreation(gate, affected, confirmation)
 			: await gateDomainAccess(gate, affected, confirmation);
 	}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -2503,6 +2503,7 @@ export class InstanceAiService {
 			tracker: domainTracker,
 			runId,
 			permissionMode: context.permissions?.fetchUrl,
+			createCredentialPermissionMode: context.permissions?.createCredential,
 		});
 
 		// Compute gateway status for the system prompt. The direct browser

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5406,6 +5406,7 @@
 	"settings.n8nAgent.permissions.runWorkflow": "Run workflows",
 	"settings.n8nAgent.permissions.publishWorkflow": "Activate workflows",
 	"settings.n8nAgent.permissions.deleteWorkflow": "Delete workflows",
+	"settings.n8nAgent.permissions.createCredential": "Create credentials from a browser session",
 	"settings.n8nAgent.permissions.deleteCredential": "Delete credentials",
 	"settings.n8nAgent.permissions.createFolder": "Create folders",
 	"settings.n8nAgent.permissions.deleteFolder": "Delete folders",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
@@ -208,7 +208,7 @@ const PERMISSION_GROUPS: PermissionGroup[] = [
 	{
 		id: 'credentials',
 		labelKey: 'settings.n8nAgent.permissions.group.credentials',
-		keys: ['deleteCredential'],
+		keys: ['createCredential', 'deleteCredential'],
 	},
 	{
 		id: 'system',


### PR DESCRIPTION
## Summary

`browser_create_credential` reports `credentials` as its affected resource instead of a hostname. The browser gate evaluated that resource on the same path as domain access, so the domain-access permission decided whether credential creation needed confirmation.

This PR separates the two:

- **New `createCredential` permission** (`@n8n/api-types`), default `require_approval`. Persisted admin settings merge over the defaults, so existing instances pick it up with no migration. It joins `deleteCredential` in the branch-read-only safe set, which matches what the read-only system prompt already tells the agent.
- **The browser gate now routes on the affected resource.** `browser_create_credential` is evaluated against the new permission, and the domain tracker plays no part in the decision.
- **The confirmation is per call.** It offers deny / allow-once with no session-wide option, so each credential is approved on its own. This also stops the tool from writing a `fetch-url:credentials` grant into the domain-grant namespace. Grants already stored under that key become inert.
- **The confirmation card names the credential.** `getAffectedResources` returns `Create credential "<name>" (<type>)` instead of `Browser: credentials`, and the gate forwards the tool's own description rather than rebuilding it. Host confirmations are unchanged.
- **The same split is applied to the local gateway.** `GatewaySession.check()` fell through to the `browser` tool-group mode for every resource. The group mode alone now leaves the credentials resource at `ask`. Explicit per-resource decisions still apply: session approvals, persistent allow entries, and the deny list all behave as before.

The new permission appears under **Settings → AI Assistant → Permissions → Credentials** as "Create credentials from a browser session". The label is scoped on purpose: the ordinary setup-card flow, where the user fills in the credential form, is not affected by this permission.

## How to test

Browser Use is gated in a default instance. You need:

- Enable browser use with `window.featureFlags.override('090_instance_ai_browser_use', 'variant')` and `window.featureFlags.override('094_instance_ai_browser_credential_setup', 'variant')`
- Browser Use enabled in **Settings → AI Assistant**. A persisted `instanceAi.settings` row overrides `N8N_INSTANCE_AI_BROWSER_USE_ENABLED`, so check the toggle rather than the env var.
- A Chromium browser with the n8n Browser Use extension connected. The agent gets no browser tools until the extension attaches.

Serve a page holding a fake secret, for example an `index.html` with a readonly `<input type="password" value="sk-test-123">` on `http://127.0.0.1:8123`. Use the literal host in your prompt, because the gate keys approvals on `new URL(url).hostname`.

**1. Credential creation asks even when browsing is unrestricted.** Set **Fetch URLs → Allow** and **Create credentials → Ask first**. Ask the assistant to open the page, take the key, and save it as a credential. Browsing runs with no prompt. Credential creation stops and shows a card reading `Create credential "…" (…)` with exactly two buttons, Deny and Allow once, and no dropdown caret. Approving creates the credential. Denying creates nothing.

**2. Thread-level domain approvals do not carry over.** Set **Fetch URLs → Ask first** and run the same prompt. Choose **Allow for session** on the domain prompt. Credential creation still asks.

**3. Blocked mode.** Set **Create credentials → Block** and **Fetch URLs → Allow**. Browsing works. Credential creation returns "Credential creation blocked by admin" and writes nothing.

**4. Settings row.** Check the new row renders under Credentials, offers all three modes, and persists across a reload.

**5. Local gateway (optional).** Run the gateway daemon with `PERMISSION_BROWSER=allow` and repeat step 1. Browsing is silent, credential creation asks. Choosing "Allow for session" on that prompt lets a second credential through in the same daemon session.

Unit tests: `packages/cli` `browser-local-mcp-server.test.ts`, `@n8n/computer-use` `gateway-session.test.ts`, `@n8n/mcp-browser` `credential.test.ts`, `@n8n/api-types` `instance-ai.schema.test.ts`. The gate tests were confirmed to fail against the previous behaviour.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-713

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI