### PR TITLE
fix(core): Keep an existing community package directory when a fresh install fails

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.fs.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.fs.test.ts
@@ -90,6 +90,12 @@ describe('CommunityPackagesService (real filesystem)', () => {
 	const backupDirectories = async () =>
 		(await readdir(nodeModulesDir)).filter((entry) => entry.includes('.backup-'));
 
+	/** The manifest `npm outdated` reads, so its entries must match what is on disk. */
+	const readLedgerDependencies = async () => {
+		const content = await readFile(path.join(downloadFolder, 'package.json'), 'utf-8');
+		return JSON.parse(content).dependencies;
+	};
+
 	beforeEach(async () => {
 		vi.clearAllMocks();
 
@@ -146,6 +152,7 @@ describe('CommunityPackagesService (real filesystem)', () => {
 
 			expect(await readMarker()).toBe(PREVIOUS_VERSION);
 			expect(await backupDirectories()).toEqual([]);
+			expect(await readLedgerDependencies()).toEqual({ [PACKAGE_NAME]: PREVIOUS_VERSION });
 		});
 
 		test('keeps the existing directory when the new version fails to load', async () => {
@@ -159,6 +166,7 @@ describe('CommunityPackagesService (real filesystem)', () => {
 
 			expect(await readMarker()).toBe(PREVIOUS_VERSION);
 			expect(await backupDirectories()).toEqual([]);
+			expect(await readLedgerDependencies()).toEqual({ [PACKAGE_NAME]: PREVIOUS_VERSION });
 		});
 
 		test('replaces the directory and leaves no backup behind on success', async () => {
@@ -169,7 +177,26 @@ describe('CommunityPackagesService (real filesystem)', () => {
 
 			expect(await readMarker()).toBe(NEW_VERSION);
 			expect(await backupDirectories()).toEqual([]);
+			expect(await readLedgerDependencies()).toEqual({ [PACKAGE_NAME]: NEW_VERSION });
 		});
+	});
+
+	test('restores the previous version when an update fails to persist', async () => {
+		await writeExistingPackage();
+		stubNpmAndTar();
+		installedPackageRepository.replaceInstalledPackageWithNodes.mockRejectedValueOnce(
+			new Error('database is locked'),
+		);
+
+		await expect(
+			service.updatePackage(
+				PACKAGE_NAME,
+				mock<InstalledPackages>({ packageName: PACKAGE_NAME, installedVersion: PREVIOUS_VERSION }),
+			),
+		).rejects.toThrow('Failed to save installed package');
+
+		expect(await readMarker()).toBe(PREVIOUS_VERSION);
+		expect(await readLedgerDependencies()).toEqual({ [PACKAGE_NAME]: PREVIOUS_VERSION });
 	});
 
 	test('removes the partially downloaded directory when there was nothing to restore', async () => {
@@ -179,5 +206,6 @@ describe('CommunityPackagesService (real filesystem)', () => {
 		await expect(service.installPackage(PACKAGE_NAME)).rejects.toThrow();
 
 		expect(await readdir(nodeModulesDir)).toEqual([]);
+		expect(await readLedgerDependencies()).toEqual({});
 	});
 });

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.fs.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.fs.test.ts
@@ -199,6 +199,46 @@ describe('CommunityPackagesService (real filesystem)', () => {
 		expect(await readLedgerDependencies()).toEqual({ [PACKAGE_NAME]: PREVIOUS_VERSION });
 	});
 
+	// The follower applies an install the leader already committed, so it has no database
+	// row to roll back to — only the directory.
+	describe('pubsub follower', () => {
+		test('keeps the existing directory and its ledger entry when the download fails', async () => {
+			await writeExistingPackage();
+			stubNpmAndTar({ packFails: true });
+
+			await service.handleInstallEvent({ packageName: PACKAGE_NAME, packageVersion: NEW_VERSION });
+
+			expect(await readMarker()).toBe(PREVIOUS_VERSION);
+			expect(await backupDirectories()).toEqual([]);
+			expect(await readLedgerDependencies()).toEqual({ [PACKAGE_NAME]: PREVIOUS_VERSION });
+		});
+
+		test('restores and reloads the existing directory when the new version fails to load', async () => {
+			await writeExistingPackage();
+			stubNpmAndTar();
+			loadNodesAndCredentials.loadPackage.mockRejectedValueOnce(new Error('broken package'));
+
+			await service.handleInstallEvent({ packageName: PACKAGE_NAME, packageVersion: NEW_VERSION });
+
+			expect(await readMarker()).toBe(PREVIOUS_VERSION);
+			expect(await backupDirectories()).toEqual([]);
+			// The restored version has to go back into memory: it was unloaded to make way
+			// for the one that failed to load.
+			expect(loadNodesAndCredentials.loadPackage).toHaveBeenCalledTimes(2);
+		});
+
+		test('replaces the directory and leaves no backup behind on success', async () => {
+			await writeExistingPackage();
+			stubNpmAndTar();
+
+			await service.handleInstallEvent({ packageName: PACKAGE_NAME, packageVersion: NEW_VERSION });
+
+			expect(await readMarker()).toBe(NEW_VERSION);
+			expect(await backupDirectories()).toEqual([]);
+			expect(await readLedgerDependencies()).toEqual({ [PACKAGE_NAME]: NEW_VERSION });
+		});
+	});
+
 	test('removes the partially downloaded directory when there was nothing to restore', async () => {
 		stubNpmAndTar();
 		loadNodesAndCredentials.loadPackage.mockRejectedValueOnce(new Error('broken package'));

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.fs.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.fs.test.ts
@@ -1,0 +1,183 @@
+import type { Logger } from '@n8n/backend-common';
+import type { HttpRequestClient, OutboundHttp } from '@n8n/backend-network';
+import type { InstanceSettings, PackageDirectoryLoader } from 'n8n-core';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { mock } from 'vitest-mock-extended';
+
+import type { License } from '@/license';
+import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import type { Publisher } from '@/scaling/pubsub/publisher.service';
+
+import type { CommunityPackagesConfig } from '../community-packages.config';
+import { CommunityPackagesService } from '../community-packages.service';
+import type { InstalledPackages } from '../installed-packages.entity';
+import type { InstalledPackagesRepository } from '../installed-packages.repository';
+import { executeNpmCommand } from '../npm-utils';
+
+vi.mock('../npm-utils', async () => ({
+	...(await vi.importActual<typeof import('../npm-utils')>('../npm-utils')),
+	executeNpmCommand: vi.fn(),
+	checkIfVersionExistsOrThrow: vi.fn().mockResolvedValue(true),
+	verifyIntegrity: vi.fn().mockResolvedValue(undefined),
+}));
+// A plain mock, without the `[util.promisify.custom]` symbol an automock would keep —
+// that symbol makes the source's module-level `promisify(execFile)` call the real binary.
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+
+const PACKAGE_NAME = 'n8n-nodes-test';
+const TARBALL_NAME = `${PACKAGE_NAME}-2.0.0.tgz`;
+const PREVIOUS_VERSION = '1.0.0';
+const NEW_VERSION = '2.0.0';
+
+/**
+ * Real-filesystem coverage for the install rollback. The mock-based tests in
+ * `community-packages.service.test.ts` assert the order of `rename` calls, which cannot
+ * observe a package directory disappearing — the failure mode this path exists to
+ * prevent. Here only npm and tar are stubbed, so the directory itself is real.
+ */
+describe('CommunityPackagesService (real filesystem)', () => {
+	let downloadFolder: string;
+	let nodeModulesDir: string;
+	let packageDirectory: string;
+	let service: CommunityPackagesService;
+
+	const loadNodesAndCredentials = mock<LoadNodesAndCredentials>();
+	const installedPackageRepository = mock<InstalledPackagesRepository>();
+	const publisher = mock<Publisher>();
+	const license = mock<License>();
+	const logger = mock<Logger>();
+
+	/** Stands in for `npm pack` + `tar -xzf`: writes the new version into the package directory. */
+	const stubNpmAndTar = ({ packFails = false } = {}) => {
+		vi.mocked(executeNpmCommand).mockImplementation(async (args, options = {}) => {
+			if (args[0] !== 'pack') return 'Done';
+			if (packFails) throw new Error('npm pack failed');
+
+			await writeFile(path.join(options.cwd!, TARBALL_NAME), 'tarball');
+			return TARBALL_NAME;
+		});
+
+		vi.mocked(execFile).mockImplementation(((...args: unknown[]) => {
+			const tarArgs = args[1] as string[];
+			const target = tarArgs[tarArgs.indexOf('-C') + 1];
+			const onDone = args[args.length - 1] as (error: Error | null, stdout: string) => void;
+
+			void writeFile(
+				path.join(target, 'package.json'),
+				JSON.stringify({ name: PACKAGE_NAME, version: NEW_VERSION, dependencies: {} }),
+			)
+				.then(async () => await writeFile(path.join(target, 'marker.txt'), NEW_VERSION))
+				.then(() => onDone(null, ''));
+		}) as unknown as typeof execFile);
+	};
+
+	/** An already-installed package on disk, as a crashed install or a reinstall would leave it. */
+	const writeExistingPackage = async () => {
+		await mkdir(packageDirectory, { recursive: true });
+		await writeFile(
+			path.join(packageDirectory, 'package.json'),
+			JSON.stringify({ name: PACKAGE_NAME, version: PREVIOUS_VERSION }),
+		);
+		await writeFile(path.join(packageDirectory, 'marker.txt'), PREVIOUS_VERSION);
+	};
+
+	const readMarker = async () => await readFile(path.join(packageDirectory, 'marker.txt'), 'utf-8');
+
+	const backupDirectories = async () =>
+		(await readdir(nodeModulesDir)).filter((entry) => entry.includes('.backup-'));
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+
+		downloadFolder = mkdtempSync(path.join(tmpdir(), 'n8n-community-packages-'));
+		nodeModulesDir = path.join(downloadFolder, 'node_modules');
+		packageDirectory = path.join(nodeModulesDir, PACKAGE_NAME);
+		await mkdir(nodeModulesDir, { recursive: true });
+		await writeFile(
+			path.join(downloadFolder, 'package.json'),
+			JSON.stringify({ name: 'installed-nodes', private: true, dependencies: {} }),
+		);
+
+		loadNodesAndCredentials.unloadPackage.mockResolvedValue(undefined);
+		loadNodesAndCredentials.loadPackage.mockResolvedValue(
+			mock<PackageDirectoryLoader>({ loadedNodes: [{ name: 'node', version: 1 }] }),
+		);
+		loadNodesAndCredentials.postProcessLoaders.mockResolvedValue(undefined);
+		installedPackageRepository.find.mockResolvedValue([]);
+		installedPackageRepository.saveInstalledPackageWithNodes.mockResolvedValue(
+			mock<InstalledPackages>({ installedVersion: NEW_VERSION }),
+		);
+		publisher.publishCommand.mockResolvedValue(undefined);
+
+		service = new CommunityPackagesService(
+			mock<InstanceSettings>({ nodesDownloadDir: downloadFolder }),
+			logger,
+			installedPackageRepository,
+			loadNodesAndCredentials,
+			publisher,
+			license,
+			mock<CommunityPackagesConfig>({
+				// The default registry, so no custom-registry licence check is involved.
+				registry: 'https://registry.npmjs.org',
+				unverifiedEnabled: true,
+				authToken: '',
+			}),
+			mock<OutboundHttp>({ requests: vi.fn().mockReturnValue(mock<HttpRequestClient>()) }),
+		);
+	});
+
+	afterEach(() => {
+		rmSync(downloadFolder, { recursive: true, force: true });
+	});
+
+	// A fresh install is one with no database record, which says nothing about what is on
+	// disk. A directory can already be there after a crash mid-install, or on a reinstall
+	// of a package the loader reports as missing.
+	describe('fresh install over an existing package directory', () => {
+		test('keeps the existing directory when the download fails', async () => {
+			await writeExistingPackage();
+			stubNpmAndTar({ packFails: true });
+
+			await expect(service.installPackage(PACKAGE_NAME)).rejects.toThrow('npm pack failed');
+
+			expect(await readMarker()).toBe(PREVIOUS_VERSION);
+			expect(await backupDirectories()).toEqual([]);
+		});
+
+		test('keeps the existing directory when the new version fails to load', async () => {
+			await writeExistingPackage();
+			stubNpmAndTar();
+			loadNodesAndCredentials.loadPackage.mockRejectedValueOnce(new Error('broken package'));
+
+			await expect(service.installPackage(PACKAGE_NAME)).rejects.toThrow(
+				'The specified package could not be loaded',
+			);
+
+			expect(await readMarker()).toBe(PREVIOUS_VERSION);
+			expect(await backupDirectories()).toEqual([]);
+		});
+
+		test('replaces the directory and leaves no backup behind on success', async () => {
+			await writeExistingPackage();
+			stubNpmAndTar();
+
+			await service.installPackage(PACKAGE_NAME);
+
+			expect(await readMarker()).toBe(NEW_VERSION);
+			expect(await backupDirectories()).toEqual([]);
+		});
+	});
+
+	test('removes the partially downloaded directory when there was nothing to restore', async () => {
+		stubNpmAndTar();
+		loadNodesAndCredentials.loadPackage.mockRejectedValueOnce(new Error('broken package'));
+
+		await expect(service.installPackage(PACKAGE_NAME)).rejects.toThrow();
+
+		expect(await readdir(nodeModulesDir)).toEqual([]);
+	});
+});

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -461,6 +461,10 @@ describe('CommunityPackagesService', () => {
 						dependencies: { [PACKAGE_NAME]: '2.0.0' },
 					}),
 				)
+				// The restored directory, which the rollback reads to find the version to record.
+				.mockResolvedValueOnce(
+					JSON.stringify({ name: PACKAGE_NAME, version: COMMUNITY_PACKAGE_VERSION.CURRENT }),
+				)
 				.mockResolvedValueOnce(
 					JSON.stringify({
 						name: 'installed-nodes',
@@ -574,6 +578,8 @@ describe('CommunityPackagesService', () => {
 						dependencies: { [PACKAGE_NAME]: '1.0.0' },
 					}),
 				)
+				// Nothing was restored, so the rollback finds no directory to read a version from.
+				.mockRejectedValueOnce(new Error('ENOENT'))
 				.mockResolvedValueOnce(
 					JSON.stringify({
 						name: 'installed-nodes',
@@ -852,6 +858,9 @@ describe('CommunityPackagesService', () => {
 			vi.mocked(rename).mockImplementation(async () => {
 				callOrder.push('rename');
 			});
+			vi.mocked(readFile).mockResolvedValue(
+				JSON.stringify({ name: packageName, version: '1.0.0' }),
+			);
 			vi.spyOn(communityPackagesService, 'updatePackageJsonDependency').mockImplementation(
 				async () => {
 					callOrder.push('updatePackageJsonDependency');
@@ -860,31 +869,40 @@ describe('CommunityPackagesService', () => {
 
 			await (communityPackagesService as any).restoreFailedPackageInstallation(packageName, {
 				backupDirectory,
-				previousVersion: '1.0.0',
 			});
 
 			expect(callOrder).toEqual(['rename', 'updatePackageJsonDependency']);
 		});
 
-		test('rolls the package.json dependency back even when restoring the directory fails', async () => {
+		test('drops the package.json dependency when the directory could not be restored', async () => {
 			const packageName = 'n8n-nodes-test';
 			const backupDirectory = `${nodesDownloadDir}/node_modules/${packageName}.backup-123`;
 
 			vi.mocked(rm).mockResolvedValue(undefined);
 			vi.mocked(rename).mockRejectedValue(new Error('EPERM'));
-			const updateDependency = vi
-				.spyOn(communityPackagesService, 'updatePackageJsonDependency')
-				.mockResolvedValue(undefined);
+			vi.mocked(readFile)
+				// The restore failed, so there is no directory left to read a version from.
+				.mockRejectedValueOnce(new Error('ENOENT'))
+				.mockResolvedValueOnce(
+					JSON.stringify({
+						name: 'installed-nodes',
+						private: true,
+						dependencies: { [packageName]: '2.0.0' },
+					}),
+				);
 
 			await (communityPackagesService as any).restoreFailedPackageInstallation(packageName, {
 				backupDirectory,
-				previousVersion: '1.0.0',
 				reloadPackage: true,
 			});
 
-			// The manifest must not keep naming the version that failed to install, even
-			// though the directory it describes could not be restored.
-			expect(updateDependency).toHaveBeenCalledWith(packageName, '1.0.0');
+			// An entry for a package that is not on disk gives `npm outdated` nothing to
+			// compare against, so the entry goes rather than naming the failed version.
+			expect(writeFile).toHaveBeenCalledWith(
+				path.join(nodesDownloadDir, 'package.json'),
+				JSON.stringify({ name: 'installed-nodes', private: true, dependencies: {} }, null, 2),
+				'utf-8',
+			);
 			// The restore failed, so there is nothing valid on disk to reload: reloading
 			// would only unload a working loader without anything to put back in its place.
 			expect(loadNodesAndCredentials.loadPackage).not.toHaveBeenCalled();

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -1544,9 +1544,8 @@ describe('CommunityPackagesService', () => {
 				packageVersion: '1.0.0',
 			});
 
-			await Promise.resolve();
-			await Promise.resolve();
-			expect(callOrder).toEqual(['start:pkg-http']);
+			// Only pkg-http's download should have been reached; pkg-pubsub is still waiting on the mutex.
+			await vi.waitFor(() => expect(callOrder).toEqual(['start:pkg-http']));
 
 			releaseFirst();
 			await Promise.all([installCall, pubsubCall]);

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -475,17 +475,14 @@ export class CommunityPackagesService {
 
 			let loader: PackageDirectoryLoader;
 			try {
-				await this.loadNodesAndCredentials.unloadPackage(packageName);
-				loader = await this.loadNodesAndCredentials.loadPackage(packageName);
+				loader = await this.reloadPackage(packageName);
 			} catch (error) {
 				await this.restoreFailedPackageInstallation(packageName, {
 					backupDirectory,
 					previousVersion,
 					reloadPackage: isUpdate,
 				});
-				throw new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_LOADING_FAILED, {
-					cause: error,
-				});
+				throw error;
 			}
 
 			if (loader.loadedNodes.length > 0) {
@@ -597,8 +594,7 @@ export class CommunityPackagesService {
 
 			const authToken = this.getNpmAuthToken();
 			await this.downloadPackage(packageName, packageVersion, authToken);
-			await this.loadNodesAndCredentials.unloadPackage(packageName);
-			await this.loadNodesAndCredentials.loadPackage(packageName);
+			await this.reloadPackage(packageName);
 			await this.loadNodesAndCredentials.postProcessLoaders();
 			this.loadNodesAndCredentials.releaseTypes();
 			this.logger.info(`Community package installed: ${packageName}`);
@@ -613,6 +609,16 @@ export class CommunityPackagesService {
 			this.loadNodesAndCredentials.releaseTypes();
 			this.logger.info(`Community package uninstalled: ${packageName}`);
 		});
+	}
+
+	/** Swaps the in-memory nodes for whatever is now in the package's directory. */
+	private async reloadPackage(packageName: string): Promise<PackageDirectoryLoader> {
+		try {
+			await this.loadNodesAndCredentials.unloadPackage(packageName);
+			return await this.loadNodesAndCredentials.loadPackage(packageName);
+		} catch (error) {
+			throw new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_LOADING_FAILED, { cause: error });
+		}
 	}
 
 	private resolvePackageDirectory(packageName: string) {
@@ -655,8 +661,7 @@ export class CommunityPackagesService {
 			// valid on disk to load and we'd just unload a working loader for nothing.
 			if (backupDirectory && reloadPackage) {
 				try {
-					await this.loadNodesAndCredentials.unloadPackage(packageName);
-					await this.loadNodesAndCredentials.loadPackage(packageName);
+					await this.reloadPackage(packageName);
 					await this.loadNodesAndCredentials.postProcessLoaders();
 					this.loadNodesAndCredentials.releaseTypes();
 				} catch (cleanupError) {

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -452,11 +452,9 @@ export class CommunityPackagesService {
 
 			const previousVersion = isUpdate ? options.installedPackage.installedVersion : undefined;
 
-			// Keep the previous version aside so a failed update can be rolled back
-			const backupDirectory =
-				isUpdate && (await this.packageDirectoryExists(packageName))
-					? await this.backupPackageDirectory(packageName)
-					: undefined;
+			// Whatever is currently on disk, kept aside so a failed install can be rolled back.
+			// Undefined when the package has no directory yet.
+			const backupDirectory = await this.backupPackageDirectory(packageName);
 
 			try {
 				await this.downloadPackage(packageName, packageVersion, authToken);
@@ -510,18 +508,7 @@ export class CommunityPackagesService {
 
 				// The new version is now authoritative; later failures must not roll back,
 				// or the DB record would end up inconsistent with the restored files.
-				// Removing the backup is housekeeping — a failure here must not fail the update.
-				if (backupDirectory) {
-					try {
-						await rm(backupDirectory, { recursive: true, force: true, maxRetries: 3 });
-					} catch (error) {
-						this.logger.warn('Failed to remove community package backup directory', {
-							error: ensureError(error),
-							packageName,
-							backupDirectory,
-						});
-					}
-				}
+				await this.discardBackupDirectory(packageName, backupDirectory);
 				// Publish the resolved version, not the requested specifier (e.g. `latest`),
 				// so peers install the exact version this instance just persisted.
 				const { installedVersion } = installedPackage;
@@ -634,11 +621,29 @@ export class CommunityPackagesService {
 		}
 	}
 
-	private async backupPackageDirectory(packageName: string) {
+	/** Moves the package directory aside so it can be restored. `undefined` means there was nothing there. */
+	private async backupPackageDirectory(packageName: string): Promise<string | undefined> {
+		if (!(await this.packageDirectoryExists(packageName))) return undefined;
+
 		const packageDirectory = this.resolvePackageDirectory(packageName);
 		const backupDirectory = `${packageDirectory}.backup-${Date.now()}`;
 		await rename(packageDirectory, backupDirectory);
 		return backupDirectory;
+	}
+
+	/** Housekeeping once the new version is committed — a failure here must not fail the install. */
+	private async discardBackupDirectory(packageName: string, backupDirectory: string | undefined) {
+		if (!backupDirectory) return;
+
+		try {
+			await rm(backupDirectory, { recursive: true, force: true, maxRetries: 3 });
+		} catch (error) {
+			this.logger.warn('Failed to remove community package backup directory', {
+				error: ensureError(error),
+				packageName,
+				backupDirectory,
+			});
+		}
 	}
 
 	/** Discards whatever is at `packageDirectory` and puts the backup back in its place, if any. */
@@ -704,9 +709,7 @@ export class CommunityPackagesService {
 
 		// Keep the previous install safe until the new one is fully built, so a failed
 		// pack/tar/npm-install never leaves the package permanently absent.
-		const backupDirectory = (await this.packageDirectoryExists(packageName))
-			? await this.backupPackageDirectory(packageName)
-			: undefined;
+		const backupDirectory = await this.backupPackageDirectory(packageName);
 
 		try {
 			await mkdir(packageDirectory, { recursive: true });
@@ -776,17 +779,7 @@ export class CommunityPackagesService {
 			throw error;
 		}
 
-		if (backupDirectory) {
-			try {
-				await rm(backupDirectory, { recursive: true, force: true, maxRetries: 3 });
-			} catch (error) {
-				this.logger.warn('Failed to remove community package backup directory', {
-					error: ensureError(error),
-					packageName,
-					backupDirectory,
-				});
-			}
-		}
+		await this.discardBackupDirectory(packageName, backupDirectory);
 
 		return packageDirectory;
 	}

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -572,8 +572,30 @@ export class CommunityPackagesService {
 			}
 
 			const authToken = this.getNpmAuthToken();
-			await this.downloadPackage(packageName, packageVersion, authToken);
-			await this.reloadPackage(packageName);
+
+			// Whatever is currently on disk, kept aside so a failed install can be rolled back.
+			// Undefined when the package has no directory yet.
+			const backupDirectory = await this.backupPackageDirectory(packageName);
+
+			try {
+				await this.downloadPackage(packageName, packageVersion, authToken);
+			} catch (error) {
+				// No reload here: the previous package was not unloaded before the download
+				await this.restoreFailedPackageInstallation(packageName, { backupDirectory });
+				throw error;
+			}
+
+			try {
+				await this.reloadPackage(packageName);
+			} catch (error) {
+				await this.restoreFailedPackageInstallation(packageName, {
+					backupDirectory,
+					reloadPackage: true,
+				});
+				throw error;
+			}
+
+			await this.discardBackupDirectory(packageName, backupDirectory);
 			await this.loadNodesAndCredentials.postProcessLoaders();
 			this.loadNodesAndCredentials.releaseTypes();
 			this.logger.info(`Community package installed: ${packageName}`);
@@ -700,79 +722,61 @@ export class CommunityPackagesService {
 		const registry = this.getNpmRegistry();
 		const packageDirectory = this.resolvePackageDirectory(packageName);
 
-		// Keep the previous install safe until the new one is fully built, so a failed
-		// pack/tar/npm-install never leaves the package permanently absent.
-		const backupDirectory = await this.backupPackageDirectory(packageName);
+		await mkdir(packageDirectory, { recursive: true });
+
+		// TODO: make sure that this works for scoped packages as well
+		// if (packageName.startsWith('@') && packageName.includes('/')) {}
+		const tarOutput = await executeNpmCommand(
+			['pack', `${packageName}@${packageVersion}`, '--quiet'],
+			{ cwd: this.downloadFolder, registry, authToken },
+		);
+
+		const tarballName = tarOutput?.trim();
 
 		try {
-			await mkdir(packageDirectory, { recursive: true });
-
-			// TODO: make sure that this works for scoped packages as well
-			// if (packageName.startsWith('@') && packageName.includes('/')) {}
-			const tarOutput = await executeNpmCommand(
-				['pack', `${packageName}@${packageVersion}`, '--quiet'],
-				{ cwd: this.downloadFolder, registry, authToken },
+			await asyncExecFile(
+				'tar',
+				['-xzf', tarballName, '-C', packageDirectory, '--strip-components=1'],
+				{ cwd: this.downloadFolder },
 			);
 
-			const tarballName = tarOutput?.trim();
+			// Strip dev, optional, and peer dependencies before running `npm install`
+			const packageJsonPath = `${packageDirectory}/package.json`;
+			const packageJsonContent = await readFile(packageJsonPath, 'utf-8');
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const {
+				devDependencies,
+				peerDependencies,
+				optionalDependencies,
+				...packageJson
+			}: {
+				version: string;
+				devDependencies: Record<string, string>;
+				peerDependencies: Record<string, string>;
+				optionalDependencies: Record<string, string>;
+			} = JSON.parse(packageJsonContent);
+			await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');
 
-			try {
-				await asyncExecFile(
-					'tar',
-					['-xzf', tarballName, '-C', packageDirectory, '--strip-components=1'],
-					{ cwd: this.downloadFolder },
-				);
-
-				// Strip dev, optional, and peer dependencies before running `npm install`
-				const packageJsonPath = `${packageDirectory}/package.json`;
-				const packageJsonContent = await readFile(packageJsonPath, 'utf-8');
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				const {
-					devDependencies,
-					peerDependencies,
-					optionalDependencies,
-					...packageJson
-				}: {
-					version: string;
-					devDependencies: Record<string, string>;
-					peerDependencies: Record<string, string>;
-					optionalDependencies: Record<string, string>;
-				} = JSON.parse(packageJsonContent);
-				await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');
-
-				await executeNpmCommand(
-					[
-						'install',
-						'--audit=false',
-						'--fund=false',
-						'--bin-links=false',
-						'--install-strategy=shallow',
-						'--ignore-scripts=true',
-						'--package-lock=false',
-					],
-					{ cwd: packageDirectory, registry, authToken },
-				);
-				await this.updatePackageJsonDependency(packageName, packageJson.version);
-			} finally {
-				// `npm pack` failing to print a filename would otherwise resolve this to
-				// `downloadFolder` itself, and the non-recursive `rm` would mask the real error.
-				if (tarballName) {
-					await rm(join(this.downloadFolder, tarballName));
-				}
+			await executeNpmCommand(
+				[
+					'install',
+					'--audit=false',
+					'--fund=false',
+					'--bin-links=false',
+					'--install-strategy=shallow',
+					'--ignore-scripts=true',
+					'--package-lock=false',
+				],
+				{ cwd: packageDirectory, registry, authToken },
+			);
+			await this.updatePackageJsonDependency(packageName, packageJson.version);
+		} finally {
+			// `npm pack` failing to print a filename would otherwise resolve this to
+			// `downloadFolder` itself, and the non-recursive `rm` would mask the real error.
+			if (tarballName) {
+				await rm(join(this.downloadFolder, tarballName));
 			}
-		} catch (error) {
-			try {
-				await this.restorePackageDirectoryFromBackup(packageName, backupDirectory);
-			} catch (restoreError) {
-				this.logger.warn('Failed to restore community package directory after failed download', {
-					error: ensureError(restoreError),
-					packageName,
-				});
-			}
-			throw error;
 		}
-
-		await this.discardBackupDirectory(packageName, backupDirectory);
 
 		return packageDirectory;
 	}

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -450,8 +450,6 @@ export class CommunityPackagesService {
 				authToken,
 			);
 
-			const previousVersion = isUpdate ? options.installedPackage.installedVersion : undefined;
-
 			// Whatever is currently on disk, kept aside so a failed install can be rolled back.
 			// Undefined when the package has no directory yet.
 			const backupDirectory = await this.backupPackageDirectory(packageName);
@@ -460,10 +458,7 @@ export class CommunityPackagesService {
 				await this.downloadPackage(packageName, packageVersion, authToken);
 			} catch (error) {
 				// No reload here: the previous package was not unloaded before the download
-				await this.restoreFailedPackageInstallation(packageName, {
-					backupDirectory,
-					previousVersion,
-				});
+				await this.restoreFailedPackageInstallation(packageName, { backupDirectory });
 
 				if (error instanceof Error && error.message === RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND) {
 					throw new UserError('npm package not found', { extra: { packageName } });
@@ -477,7 +472,6 @@ export class CommunityPackagesService {
 			} catch (error) {
 				await this.restoreFailedPackageInstallation(packageName, {
 					backupDirectory,
-					previousVersion,
 					reloadPackage: isUpdate,
 				});
 				throw error;
@@ -496,7 +490,6 @@ export class CommunityPackagesService {
 				} catch (error) {
 					await this.restoreFailedPackageInstallation(packageName, {
 						backupDirectory,
-						previousVersion,
 						reloadPackage: isUpdate,
 					});
 
@@ -531,7 +524,6 @@ export class CommunityPackagesService {
 			} else {
 				await this.restoreFailedPackageInstallation(packageName, {
 					backupDirectory,
-					previousVersion,
 					reloadPackage: isUpdate,
 				});
 
@@ -655,9 +647,9 @@ export class CommunityPackagesService {
 
 	private async restoreFailedPackageInstallation(
 		packageName: string,
-		options: { backupDirectory?: string; previousVersion?: string; reloadPackage?: boolean },
+		options: { backupDirectory?: string; reloadPackage?: boolean },
 	) {
-		const { backupDirectory, previousVersion, reloadPackage = false } = options;
+		const { backupDirectory, reloadPackage = false } = options;
 
 		try {
 			await this.restorePackageDirectoryFromBackup(packageName, backupDirectory);
@@ -683,11 +675,12 @@ export class CommunityPackagesService {
 			});
 		}
 
-		// Independent of the restore above: a failed restore must not leave package.json
-		// pointing at the version that failed to install.
+		// Independent of the restore above: point the ledger at whatever is now on disk, so
+		// a failed restore can't leave package.json naming a package that isn't there.
 		try {
-			if (previousVersion) {
-				await this.updatePackageJsonDependency(packageName, previousVersion);
+			const restoredVersion = await this.readInstalledPackageVersion(packageName);
+			if (restoredVersion) {
+				await this.updatePackageJsonDependency(packageName, restoredVersion);
 			} else {
 				await this.removePackageJsonDependency(packageName);
 			}


### PR DESCRIPTION
## Summary

Installing a community package moves the old directory aside first, so that a failed
install can put it back. That backup only happened on the **update** path. A **fresh**
install — one with no database row — skipped it, then still ran the cleanup that deletes
the package directory. If a directory happened to be there, it was deleted for good.

"Fresh install" says nothing about what is on disk. A directory can already be there after
a crash mid-install, or on a reinstall of a package the loader reports as missing
(`N8N_REINSTALL_MISSING_PACKAGES`). In those cases a failed retry deleted the package
instead of leaving it alone.

The reason this was possible: **two different functions each kept their own backup**, and
neither knew about the other. `downloadPackage()` backed up whenever a directory existed;
`installOrUpdatePackage()` backed up only on updates. That made "no backup handle" mean two
opposite things — "there was nothing here, deleting is correct" and "the other function has
it, deleting is catastrophic" — and the cleanup could not tell them apart.

### Main changes

**One function owns the backup.** `backupPackageDirectory()` now does its own existence
check and returns `undefined` only when there genuinely was no directory. Callers can no
longer decide whether to back up, so the check cannot be skipped again.

**The backup moved out of the download step.** `downloadPackage()` no longer backs up,
restores, or discards anything — it just downloads. Both callers (the normal install and
the pub/sub follower) now back up before they start and roll back if anything fails. One
mechanism, one owner, instead of two overlapping ones.

**The manifest follows the disk.** After a rollback, `package.json` is written from
whatever version is actually on disk, rather than from the database record that a fresh
install doesn't have.

### Bugs fixed

- **An existing package directory is no longer deleted when a fresh install fails**
  (CAT-4138). This is the data-loss bug; the rest fell out of fixing it properly.
- **The manifest entry is no longer dropped on a fresh install rollback.** The package
  survived on disk but disappeared from `package.json`, so `npm outdated` stopped
  reporting updates for it until the next restart.
- **The manifest no longer names a package that isn't there.** If the restore itself
  failed, the old code still wrote the previous version into `package.json`, pointing at a
  directory that no longer existed. The entry is now removed instead.
- **The pub/sub follower can now roll back a failed load.** On follower instances,
  `downloadPackage()` had already discarded its backup by the time the package was loaded,
  so a package that downloaded fine but failed to load left the instance on the broken
  version with nothing to restore.

### Tests

The six existing tests covering this path all passed on the broken code: they mock
`node:fs/promises` and assert the order of `rename` calls, which cannot observe a directory
disappearing. `community-packages.service.fs.test.ts` is new and uses a real temporary
directory, stubbing only npm and tar, so the package directory is genuine and a marker file
proves which version survived. Each case was checked against the unfixed code first.

## How to test

```
cd packages/cli
pnpm test src/modules/community-packages
```

Manually:

1. Install a community package.
2. Delete its row from the `installed_packages` table, leaving `node_modules/<pkg>` in place —
   this is the state a crash mid-install leaves behind.
3. Install the same package again with the registry unreachable, so the download fails.
4. The package directory is still there, with its original contents. On `master` it is gone.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4138

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

