### PR TITLE
feat(core)!: Lower Compression node default zip limits

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/compression.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/compression.config.test.ts
@@ -15,8 +15,8 @@ describe('CompressionNodeConfig', () => {
 	it('should use default values', () => {
 		const { compressionNode } = Container.get(GlobalConfig);
 
-		expect(compressionNode.maxDecompressedSize).toBe(2 * 1024 * 1024 * 1024);
-		expect(compressionNode.maxZipEntries).toBe(5000);
+		expect(compressionNode.maxDecompressedSize).toBe(256 * 1024 * 1024);
+		expect(compressionNode.maxZipEntries).toBe(1000);
 	});
 
 	it('should use custom max decompressed size from env', () => {

--- a/packages/@n8n/config/src/configs/compression.config.ts
+++ b/packages/@n8n/config/src/configs/compression.config.ts
@@ -2,11 +2,11 @@ import { Config, Env } from '../decorators';
 
 @Config
 export class CompressionNodeConfig {
-	/** Maximum total decompressed output size in bytes. Default: 2 GiB. */
+	/** Maximum total decompressed output size in bytes. Default: 256 MiB. */
 	@Env('N8N_COMPRESSION_NODE_MAX_DECOMPRESSED_SIZE_BYTES')
-	maxDecompressedSize: number = 2 * 1024 * 1024 * 1024;
+	maxDecompressedSize: number = 256 * 1024 * 1024;
 
-	/** Maximum number of entries allowed in a ZIP archive. Default: 5000. */
+	/** Maximum number of entries allowed in a ZIP archive. Default: 1000. */
 	@Env('N8N_COMPRESSION_NODE_MAX_ZIP_ENTRIES')
-	maxZipEntries: number = 5000;
+	maxZipEntries: number = 1000;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -307,8 +307,8 @@ describe('GlobalConfig', () => {
 			disablePublicChat: false,
 		},
 		compressionNode: {
-			maxDecompressedSize: 2 * 1024 * 1024 * 1024,
-			maxZipEntries: 5000,
+			maxDecompressedSize: 256 * 1024 * 1024,
+			maxZipEntries: 1000,
 		},
 		mcpClient: {
 			cacheTtl: 300000,

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -173,22 +173,18 @@ describe('DeprecationService', () => {
 	});
 
 	describe('default-flip warnings', () => {
-		test.each([
-			'N8N_UNVERIFIED_PACKAGES_ENABLED',
-			'N8N_RUNNERS_TASK_TIMEOUT',
-			'N8N_COMPRESSION_NODE_MAX_DECOMPRESSED_SIZE_BYTES',
-			'N8N_COMPRESSION_NODE_MAX_ZIP_ENTRIES',
-		])('should warn when %s is unset', (envVar) => {
-			delete process.env[envVar];
-			deprecationService.warn();
-			expect(logger.warn.mock.lastCall?.[0] ?? '').toContain(envVar);
-		});
+		test.each(['N8N_UNVERIFIED_PACKAGES_ENABLED', 'N8N_RUNNERS_TASK_TIMEOUT'])(
+			'should warn when %s is unset',
+			(envVar) => {
+				delete process.env[envVar];
+				deprecationService.warn();
+				expect(logger.warn.mock.lastCall?.[0] ?? '').toContain(envVar);
+			},
+		);
 
 		test.each([
 			['N8N_UNVERIFIED_PACKAGES_ENABLED', 'false'],
 			['N8N_RUNNERS_TASK_TIMEOUT', '120'],
-			['N8N_COMPRESSION_NODE_MAX_DECOMPRESSED_SIZE_BYTES', '1048576'],
-			['N8N_COMPRESSION_NODE_MAX_ZIP_ENTRIES', '100'],
 		])('should not warn when %s is set explicitly', (envVar, value) => {
 			process.env[envVar] = value;
 			deprecationService.warn();

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -80,18 +80,6 @@ export class DeprecationService {
 			checkValue: (value?: string) => value === undefined,
 		},
 		{
-			envVar: 'N8N_COMPRESSION_NODE_MAX_DECOMPRESSED_SIZE_BYTES',
-			message:
-				'The default for this variable will be reduced from 2 GiB to 256 MiB in a future version. Set it explicitly to keep your current limit.',
-			checkValue: (value?: string) => value === undefined,
-		},
-		{
-			envVar: 'N8N_COMPRESSION_NODE_MAX_ZIP_ENTRIES',
-			message:
-				'The default for this variable will be reduced from 5000 to 1000 in a future version. Set it explicitly to keep your current limit.',
-			checkValue: (value?: string) => value === undefined,
-		},
-		{
 			envVar: 'N8N_EXPRESSION_ENGINE',
 			message:
 				'The `legacy` expression engine runs expressions without isolation, is no longer considered secure, and will be removed in a future version. Remove this environment variable to use the default `vm` engine.',


### PR DESCRIPTION
## Summary

Lowers the Compression node decompression limit defaults, as announced by the deprecation warnings shipped on `master`:

- `N8N_COMPRESSION_NODE_MAX_DECOMPRESSED_SIZE_BYTES`: 2 GiB → **256 MiB**
- `N8N_COMPRESSION_NODE_MAX_ZIP_ENTRIES`: 5000 → **1000**

Also removes the two now-fulfilled default-flip deprecation warnings from `DeprecationService`.

Instances that need the previous limits can keep them by setting the two environment variables explicitly. Cloud already overrides the size limit per plan, and the v3 breaking-change detection rule (`compression-node-limits.rule.ts`) already announces these exact values, so no copy changes are needed there.

**Related Docs change:** https://github.com/n8n-io/n8n-docs/pull/5274

## How to test

1. Start n8n from this branch with neither env var set.
2. Run a workflow with a Compression node that decompresses a ZIP with more than 1000 entries, or more than 256 MiB decompressed. The node must fail with the limit error.
3. Set `N8N_COMPRESSION_NODE_MAX_DECOMPRESSED_SIZE_BYTES=2147483648` and `N8N_COMPRESSION_NODE_MAX_ZIP_ENTRIES=5000`, restart, and run the same workflow. The node must succeed.
4. Check the startup logs: no deprecation warning is shown for the two variables.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4212

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

