### PR TITLE
feat(core): Enforce policy on workflow save (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-creation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-creation.service.test.ts
@@ -13,6 +13,7 @@ import type { McpSettingsService } from '@/modules/mcp/mcp.settings.service';
 import type { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import type { NodeTypes } from '@/node-types';
 import { userHasScopes } from '@/permissions.ee/check-access';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { ProjectService } from '@/services/project.service.ee';
 import * as WorkflowHelpers from '@/workflow-helpers';
 import type { WorkflowHookContextService } from '@/workflow-hook-context.service';
@@ -42,6 +43,7 @@ describe('WorkflowCreationService', () => {
 	let workflowFinderServiceMock: MockProxy<WorkflowFinderService>;
 	let workflowHookContextServiceMock: MockProxy<WorkflowHookContextService>;
 	let mcpSettingsService: MockProxy<McpSettingsService>;
+	let policyEnforcementServiceMock: MockProxy<PolicyEnforcementService>;
 	let loggerMock: MockProxy<Logger>;
 
 	beforeEach(() => {
@@ -68,6 +70,11 @@ describe('WorkflowCreationService', () => {
 
 		mcpSettingsService = mock<McpSettingsService>();
 
+		// Stands in for the dummy always-allow check: with no policy backend registered the
+		// real service clears every save, so this is what production does by default.
+		policyEnforcementServiceMock = mock<PolicyEnforcementService>();
+		policyEnforcementServiceMock.enforceWorkflowSave.mockResolvedValue(mock());
+
 		workflowCreationService = new WorkflowCreationService(
 			loggerMock,
 			mock(), // sharedWorkflowRepository
@@ -89,6 +96,7 @@ describe('WorkflowCreationService', () => {
 			instanceRedactionEnforcementServiceMock,
 			workflowHookContextServiceMock,
 			mcpSettingsService,
+			policyEnforcementServiceMock,
 		);
 	});
 
@@ -311,6 +319,95 @@ describe('WorkflowCreationService', () => {
 					expectedActor,
 				]);
 			});
+		});
+	});
+
+	describe('policy enforcement on create', () => {
+		const arrangeSuccessfulCreate = () => {
+			licenseStateMock.isSharingLicensed.mockReturnValue(false);
+			licenseStateMock.isDataRedactionLicensed.mockReturnValue(false);
+			projectServiceMock.getProjectWithScope.mockResolvedValue({ id: 'project-1' } as never);
+			const { transactionManager } = setupTransactionMocks();
+			transactionManager.save.mockImplementation(async (entity: unknown) => entity);
+			workflowHistoryServiceMock.saveVersion.mockResolvedValue(undefined as never);
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(
+				makeWorkflow({ id: 'workflow-1' }),
+			);
+			return { transactionManager };
+		};
+
+		it('enforces the save with no stored workflow and the resolved project', async () => {
+			arrangeSuccessfulCreate();
+			const newWorkflow = makeWorkflow({ name: 'My workflow' });
+
+			await workflowCreationService.createWorkflow(mock<User>(), newWorkflow, {
+				projectId: 'project-1',
+			});
+
+			expect(policyEnforcementServiceMock.enforceWorkflowSave).toHaveBeenCalledExactlyOnceWith({
+				workflow: { id: null, name: 'My workflow', nodes: [] },
+				storedWorkflow: null,
+				projectId: 'project-1',
+			});
+		});
+
+		it("falls back to the user's personal project when no project is given", async () => {
+			arrangeSuccessfulCreate();
+			projectRepositoryMock.getPersonalProjectForUserOrFail.mockResolvedValue({
+				id: 'personal-project',
+			} as never);
+
+			await workflowCreationService.createWorkflow(mock<User>(), makeWorkflow());
+
+			expect(policyEnforcementServiceMock.enforceWorkflowSave).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: 'personal-project' }),
+			);
+		});
+
+		it('creates the workflow unchanged when the check clears', async () => {
+			const { transactionManager } = arrangeSuccessfulCreate();
+
+			const savedWorkflow = await workflowCreationService.createWorkflow(
+				mock<User>(),
+				makeWorkflow(),
+				{ projectId: 'project-1' },
+			);
+
+			expect(transactionManager.save).toHaveBeenCalled();
+			expect(savedWorkflow.id).toBe('workflow-1');
+		});
+
+		it('persists nothing when the check throws', async () => {
+			const { transactionManager } = arrangeSuccessfulCreate();
+			const violation = new Error('blocked by policy');
+			policyEnforcementServiceMock.enforceWorkflowSave.mockRejectedValue(violation);
+
+			await expect(
+				workflowCreationService.createWorkflow(mock<User>(), makeWorkflow(), {
+					projectId: 'project-1',
+				}),
+			).rejects.toThrow(violation);
+
+			expect(transactionManager.save).not.toHaveBeenCalled();
+			expect(workflowHistoryServiceMock.saveVersion).not.toHaveBeenCalled();
+		});
+
+		it('runs the external hook before enforcing, so hook mutations are covered', async () => {
+			arrangeSuccessfulCreate();
+			const callOrder: string[] = [];
+			externalHooksMock.run.mockImplementation(async (hookName: string) => {
+				callOrder.push(hookName);
+			});
+			policyEnforcementServiceMock.enforceWorkflowSave.mockImplementation(async () => {
+				callOrder.push('enforceWorkflowSave');
+				return await mock();
+			});
+
+			await workflowCreationService.createWorkflow(mock<User>(), makeWorkflow(), {
+				projectId: 'project-1',
+			});
+
+			expect(callOrder).toEqual(['workflow.create', 'enforceWorkflowSave', 'workflow.afterCreate']);
 		});
 	});
 

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -33,6 +33,7 @@ import type { ExecutionPersistence } from '@/executions/execution-persistence';
 import type { ExternalHooks, WorkflowLifecycleHookActor } from '@/external-hooks';
 import type { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
 import { userHasScopes } from '@/permissions.ee/check-access';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { PollTriggerJobRegistrar } from '@/scheduling/poll-trigger-node/poll-trigger-job-registrar';
 import type { ScheduleTriggerJobRegistrar } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
 import type { OwnershipService } from '@/services/ownership.service';
@@ -112,6 +113,7 @@ describe('WorkflowService', () => {
 				mock(), // workflowHookContextService
 				mock(), // workflowPublishGuard
 				mock(), // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 		});
 
@@ -382,6 +384,7 @@ describe('WorkflowService', () => {
 				workflowHookContextServiceMock, // workflowHookContextService
 				mock(), // workflowPublishGuard
 				mock(), // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 
 			vi.clearAllMocks();
@@ -1139,6 +1142,7 @@ describe('WorkflowService', () => {
 				workflowHookContextServiceMock, // workflowHookContextService
 				workflowPublishGuardMock, // workflowPublishGuard
 				workflowMutationHooksMock, // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 
 			// Bypass validation internals
@@ -1676,6 +1680,7 @@ describe('WorkflowService', () => {
 				mock(), // workflowHookContextService
 				mock(), // workflowPublishGuard
 				mock(), // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 		});
 
@@ -1796,6 +1801,7 @@ describe('WorkflowService', () => {
 				mock(), // workflowHookContextService
 				mock(), // workflowPublishGuard
 				workflowMutationHooksMock, // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 		});
 
@@ -2015,6 +2021,7 @@ describe('WorkflowService', () => {
 				mock(), // workflowHookContextService
 				mock(), // workflowPublishGuard
 				mock(), // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 		});
 
@@ -2098,6 +2105,169 @@ describe('WorkflowService', () => {
 		});
 	});
 
+	describe('update() policy enforcement', () => {
+		let workflowService: WorkflowService;
+		let workflowFinderServiceMock: MockProxy<WorkflowFinderService>;
+		let externalHooksMock: MockProxy<ExternalHooks>;
+		let ownershipServiceMock: MockProxy<OwnershipService>;
+		let workflowHistoryServiceMock: MockProxy<WorkflowHistoryService>;
+		let policyEnforcementServiceMock: MockProxy<PolicyEnforcementService>;
+		let workflowRepositoryMock: MockProxy<{ update: Mock; findOne: Mock }>;
+
+		const WORKFLOW_ID = 'workflow-1';
+		const storedNodes = [{ name: 'Start' }] as unknown as INode[];
+
+		const makeStoredWorkflow = () =>
+			mock<WorkflowEntity>({
+				id: WORKFLOW_ID,
+				name: 'Stored name',
+				isArchived: false,
+				versionId: 'v1',
+				nodes: storedNodes,
+				connections: {},
+				settings: {},
+				activeVersionId: undefined as unknown as string,
+				tags: [],
+			});
+
+		beforeEach(() => {
+			workflowFinderServiceMock = mock<WorkflowFinderService>();
+			externalHooksMock = mock<ExternalHooks>();
+			ownershipServiceMock = mock<OwnershipService>();
+			ownershipServiceMock.getWorkflowProjectCached.mockResolvedValue(
+				mock<Project>({ id: 'project-1' }),
+			);
+			workflowHistoryServiceMock = mock<WorkflowHistoryService>();
+			workflowRepositoryMock = mock();
+
+			const licenseStateMock = mock<LicenseState>();
+			licenseStateMock.isSharingLicensed.mockReturnValue(false);
+
+			// Stands in for the dummy always-allow check: with no policy backend registered
+			// the real service clears every save, so this is what production does by default.
+			policyEnforcementServiceMock = mock<PolicyEnforcementService>();
+			policyEnforcementServiceMock.enforceWorkflowSave.mockResolvedValue(mock());
+
+			const storedWorkflow = makeStoredWorkflow();
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(storedWorkflow);
+			workflowRepositoryMock.findOne.mockResolvedValue(storedWorkflow);
+
+			workflowService = new WorkflowService(
+				mock(), // logger
+				mock(), // sharedWorkflowRepository
+				workflowRepositoryMock as never, // workflowRepository
+				mock(), // workflowTagMappingRepository
+				ownershipServiceMock, // ownershipService
+				mock(), // tagService
+				workflowHistoryServiceMock, // workflowHistoryService
+				externalHooksMock, // externalHooks
+				mock(), // activeWorkflowManager
+				mock(), // roleService
+				mock(), // projectService
+				mock(), // executionPersistence
+				mock(), // eventService
+				mock(), // globalConfig
+				mock(), // folderRepository
+				workflowFinderServiceMock, // workflowFinderService
+				mock(), // workflowPublishHistoryRepository
+				mock(), // outboxRepository
+				Object.assign(mock<WorkflowValidationService>(), {
+					validateCredentialNodeRestrictions: () => ({ isValid: true }),
+				}), // workflowValidationService
+				mock(), // nodeTypes
+				mock(), // webhookService
+				licenseStateMock, // licenseState
+				mock(), // projectRepository
+				mock(), // redactionEnforcementService
+				mock(), // workflowPublicationNotifier
+				mock(), // scheduleTriggerJobRegistrar
+				mock(), // pollTriggerJobRegistrar
+				mock(), // workflowPublishedVersionRepository
+				mock(), // workflowHookContextService
+				mock(), // workflowPublishGuard
+				mock(), // workflowMutationHooks
+				policyEnforcementServiceMock, // policyEnforcementService
+			);
+		});
+
+		it('enforces the save with the submitted workflow, the stored one, and the owning project', async () => {
+			const submittedNodes = [{ name: 'Start' }, { name: 'Slack' }] as unknown as INode[];
+
+			await workflowService.update(
+				mock<User>({ id: 'user-1' }),
+				{ name: 'New name', nodes: submittedNodes, connections: {} } as unknown as WorkflowEntity,
+				WORKFLOW_ID,
+			);
+
+			expect(policyEnforcementServiceMock.enforceWorkflowSave).toHaveBeenCalledExactlyOnceWith({
+				workflow: { id: WORKFLOW_ID, name: 'New name', nodes: submittedNodes },
+				storedWorkflow: { id: WORKFLOW_ID, name: 'Stored name', nodes: storedNodes },
+				projectId: 'project-1',
+			});
+		});
+
+		// A partial update (e.g. renaming only) omits `nodes` entirely. The check still needs
+		// the effective graph, otherwise it would see an empty workflow and clear anything.
+		it('falls back to the stored name and nodes for a partial update', async () => {
+			await workflowService.update(
+				mock<User>({ id: 'user-1' }),
+				{ settings: { timezone: 'Europe/Berlin' } } as unknown as WorkflowEntity,
+				WORKFLOW_ID,
+			);
+
+			expect(policyEnforcementServiceMock.enforceWorkflowSave).toHaveBeenCalledExactlyOnceWith({
+				workflow: { id: WORKFLOW_ID, name: 'Stored name', nodes: storedNodes },
+				storedWorkflow: { id: WORKFLOW_ID, name: 'Stored name', nodes: storedNodes },
+				projectId: 'project-1',
+			});
+		});
+
+		it('updates the workflow unchanged when the check clears', async () => {
+			await workflowService.update(
+				mock<User>({ id: 'user-1' }),
+				{ nodes: [], connections: {} } as unknown as WorkflowEntity,
+				WORKFLOW_ID,
+			);
+
+			expect(workflowRepositoryMock.update).toHaveBeenCalledTimes(1);
+		});
+
+		it('persists nothing when the check throws', async () => {
+			const violation = new Error('blocked by policy');
+			policyEnforcementServiceMock.enforceWorkflowSave.mockRejectedValue(violation);
+
+			await expect(
+				workflowService.update(
+					mock<User>({ id: 'user-1' }),
+					{ nodes: [], connections: {} } as unknown as WorkflowEntity,
+					WORKFLOW_ID,
+				),
+			).rejects.toThrow(violation);
+
+			expect(workflowRepositoryMock.update).not.toHaveBeenCalled();
+			expect(workflowHistoryServiceMock.saveVersion).not.toHaveBeenCalled();
+		});
+
+		it('runs the external hook before enforcing, so hook mutations are covered', async () => {
+			const callOrder: string[] = [];
+			externalHooksMock.run.mockImplementation(async (hookName: string) => {
+				callOrder.push(hookName);
+			});
+			policyEnforcementServiceMock.enforceWorkflowSave.mockImplementation(async () => {
+				callOrder.push('enforceWorkflowSave');
+				return await mock();
+			});
+
+			await workflowService.update(
+				mock<User>({ id: 'user-1' }),
+				{ nodes: [], connections: {} } as unknown as WorkflowEntity,
+				WORKFLOW_ID,
+			);
+
+			expect(callOrder.slice(0, 2)).toEqual(['workflow.update', 'enforceWorkflowSave']);
+		});
+	});
+
 	describe('archive() and unarchive() hooks', () => {
 		let workflowService: WorkflowService;
 		let workflowFinderServiceMock: MockProxy<WorkflowFinderService>;
@@ -2174,6 +2344,7 @@ describe('WorkflowService', () => {
 				mock(), // workflowHookContextService
 				mock(), // workflowPublishGuard
 				workflowMutationHooksMock, // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 		});
 
@@ -2272,6 +2443,7 @@ describe('WorkflowService', () => {
 				mock(), // workflowHookContextService
 				mock(), // workflowPublishGuard
 				mock(), // workflowMutationHooks
+				mock(), // policyEnforcementService
 			);
 		});
 

--- a/packages/cli/src/workflows/workflow-creation.service.ts
+++ b/packages/cli/src/workflows/workflow-creation.service.ts
@@ -28,6 +28,7 @@ import { InstanceRedactionEnforcementService } from '@/modules/redaction/instanc
 import { policyForFloor, policyMeetsFloor } from '@/modules/redaction/redaction-policy';
 import { NodeTypes } from '@/node-types';
 import { userHasScopes } from '@/permissions.ee/check-access';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { FolderService } from '@/services/folder.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { TagService } from '@/services/tag.service';
@@ -63,6 +64,7 @@ export class WorkflowCreationService {
 		private readonly instanceRedactionEnforcementService: InstanceRedactionEnforcementService,
 		private readonly workflowHookContextService: WorkflowHookContextService,
 		private readonly mcpSettingsService: McpSettingsService,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 	) {}
 
 	async createWorkflow(
@@ -181,6 +183,14 @@ export class WorkflowCreationService {
 			this.workflowHookContextService,
 			toWorkflowLifecycleHookActor(user),
 		]);
+
+		// Gate the save on policy before persisting, so the author learns about a violation
+		// while editing rather than at runtime. No stored workflow: this one is new.
+		await this.policyEnforcementService.enforceWorkflowSave({
+			workflow: { id: newWorkflow.id ?? null, name: newWorkflow.name, nodes: newWorkflow.nodes },
+			storedWorkflow: null,
+			projectId: effectiveProjectId,
+		});
 
 		const floor = await this.readActiveRedactionFloor();
 

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -54,6 +54,7 @@ import { validateEntity } from '@/generic-helpers';
 import { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
 import { NodeTypes } from '@/node-types';
 import { userHasScopes } from '@/permissions.ee/check-access';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { ListQuery } from '@/requests';
 import { hasSharing } from '@/requests';
 import { PollTriggerJobRegistrar } from '@/scheduling/poll-trigger-node/poll-trigger-job-registrar';
@@ -105,6 +106,7 @@ export class WorkflowService {
 		private readonly workflowHookContextService: WorkflowHookContextService,
 		private readonly workflowPublishGuard: WorkflowPublishGuardProxy,
 		private readonly workflowMutationHooks: WorkflowMutationHooksProxy,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 	) {}
 
 	async getMany(
@@ -538,6 +540,19 @@ export class WorkflowService {
 			this.workflowHookContextService,
 			toWorkflowLifecycleHookActor(user),
 		]);
+
+		// Gate the save on policy before persisting, so the author learns about a violation
+		// while editing rather than at runtime. Carries the stored workflow alongside the
+		// submitted one so a check can restrict its verdict to what this save adds.
+		await this.policyEnforcementService.enforceWorkflowSave({
+			workflow: {
+				id: workflow.id,
+				name: workflowUpdateData.name ?? workflow.name,
+				nodes: workflowUpdateData.nodes ?? workflow.nodes,
+			},
+			storedWorkflow: { id: workflow.id, name: workflow.name, nodes: workflow.nodes },
+			projectId: ownerProject.id,
+		});
 
 		const fieldsToUpdate = [
 			'name',

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -29,6 +29,7 @@ import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import type { ExternalHooks } from '@/external-hooks';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { NodeTypes } from '@/node-types';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
@@ -113,6 +114,9 @@ beforeAll(async () => {
 		Container.get(WorkflowHookContextService), // workflowHookContextService
 		workflowPublishGuard,
 		mock(), // workflowMutationHooks
+		// Real service on purpose: with no policy backend registered it clears every save,
+		// so these tests also prove save behavior is unchanged when the module is off.
+		Container.get(PolicyEnforcementService), // policyEnforcementService
 	);
 });
 


### PR DESCRIPTION
## Summary

Wires the `workflowSave` enforcement point. `PolicyEnforcementService.enforceWorkflowSave` is now called from the two service methods that the editor UI and the public API share — `WorkflowCreationService.createWorkflow()` and `WorkflowService.update()` — after all existing validation and before anything is persisted. The update call carries the stored workflow next to the submitted one, so a future check can restrict its verdict to what the save adds (grandfathering); both values were already loaded for the permission and credential checks, so this adds no database reads. No policy backend is registered by default, so the proxy clears every save and behavior is unchanged.

Note for reviewers: these two methods are also the save path for the MCP workflow-builder tools, the AI Builder adapter, the n8n-packages workflow importer, and the breaking-changes migration service, so those paths are gated too. Source-control import is not affected — it has its own `contentImport` enforcement point.

## How to test

The gate is a no-op in a default instance, so testing is about proving nothing changed. Create and update a workflow in the editor, then do the same over the public API (`POST /api/v1/workflows` and `PUT /api/v1/workflows/:id`); all four must behave exactly as before. To see the call take effect, start n8n with `N8N_ENABLED_MODULES=policy-infrastructure` and register a check that returns a violation — the save must fail and persist nothing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1122

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

