### PR TITLE
feat(editor): Add adaptive layout to ChatInput

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.stories.ts
@@ -128,6 +128,14 @@ Adaptive.args = {
 	maxLength: 1000,
 	layout: 'adaptive',
 };
+Adaptive.parameters = {
+	docs: {
+		description: {
+			story:
+				'Adaptive supports the default icon-only send/stop button. A custom button label or action slot falls back to the multiline layout.',
+		},
+	},
+};
 
 const workflowSuggestions: WorkflowSuggestion[] = [
 	{

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.stories.ts
@@ -18,7 +18,7 @@ export default {
 		},
 		layout: {
 			control: 'select',
-			options: ['single-line', 'multiline'],
+			options: ['single-line', 'multiline', 'adaptive'],
 		},
 		placeholder: {
 			control: 'text',
@@ -120,6 +120,13 @@ export const MultiLine = Template.bind({});
 MultiLine.args = {
 	placeholder: 'Type your message here...',
 	maxLength: 1000,
+};
+
+export const Adaptive = Template.bind({});
+Adaptive.args = {
+	placeholder: 'Starts as one line and grows with your text...',
+	maxLength: 1000,
+	layout: 'adaptive',
 };
 
 const workflowSuggestions: WorkflowSuggestion[] = [

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { fireEvent } from '@testing-library/vue';
 import { mount } from '@vue/test-utils';
 import { vi } from 'vitest';
+import { defineComponent, h, nextTick, ref } from 'vue';
 
 import N8nChatInput from './ChatInput.vue';
 import { createComponentRenderer } from '../../__tests__/render';
@@ -249,6 +250,34 @@ describe('N8nChatInput', () => {
 				expect(warn).toHaveBeenCalledWith(expect.stringContaining('Falling back to `multiline`'));
 			},
 		);
+
+		it('falls back to multiline when an action slot appears after mount', async () => {
+			const showAction = ref(false);
+			const Host = defineComponent({
+				setup() {
+					return () =>
+						h(
+							N8nChatInput,
+							{ layout: 'adaptive' },
+							showAction.value ? { 'right-actions': () => h('button', 'Custom action') } : {},
+						);
+				},
+			});
+
+			const wrapper = mount(Host, {
+				attachTo: document.body,
+				global: { stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'] },
+			});
+			const chatContainer = wrapper.find('.container');
+			expect(chatContainer.classes().join(' ')).toContain('adaptiveContainer');
+
+			showAction.value = true;
+			await nextTick();
+
+			expect(wrapper.find('.container').classes().join(' ')).not.toContain('adaptiveContainer');
+			expect(wrapper.find('.container').attributes('style')).toContain('min-height: 80px');
+			wrapper.unmount();
+		});
 
 		it('autosizes the textarea like multiline', async () => {
 			const originalDescriptor = Object.getOwnPropertyDescriptor(

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
@@ -177,6 +177,92 @@ describe('N8nChatInput', () => {
 		});
 	});
 
+	describe('adaptive layout', () => {
+		it('does not reserve the multiline minimum height', () => {
+			const { container } = renderComponent({
+				props: {
+					layout: 'adaptive',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const chatContainer = container.querySelector('.container') as HTMLElement;
+			expect(chatContainer.style.minHeight).toBe('');
+			expect(chatContainer.classList.toString()).toContain('adaptiveContainer');
+		});
+
+		it('keeps the multiline minimum height for the default layout', () => {
+			const { container } = renderComponent({
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const chatContainer = container.querySelector('.container') as HTMLElement;
+			expect(chatContainer.style.minHeight).toBe('80px');
+		});
+
+		it('autosizes the textarea like multiline', async () => {
+			const originalDescriptor = Object.getOwnPropertyDescriptor(
+				HTMLTextAreaElement.prototype,
+				'scrollHeight',
+			);
+			Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+				configurable: true,
+				get(this: HTMLTextAreaElement) {
+					return this.value?.includes('\n') ? 72 : 24;
+				},
+			});
+
+			try {
+				const { container } = renderComponent({
+					props: {
+						layout: 'adaptive',
+						modelValue: '',
+					},
+					global: {
+						stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+					},
+				});
+
+				const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+				textarea.value = 'Line 1\nLine 2\nLine 3';
+				await fireEvent.input(textarea);
+
+				await vi.waitFor(() => expect(textarea.getAttribute('style')).toContain('height: 72px'));
+			} finally {
+				if (originalDescriptor) {
+					Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', originalDescriptor);
+				} else {
+					Reflect.deleteProperty(HTMLTextAreaElement.prototype, 'scrollHeight');
+				}
+			}
+		});
+
+		it('submits on Enter and inserts a newline on Shift+Enter, like multiline', async () => {
+			const render = renderComponent({
+				props: {
+					layout: 'adaptive',
+					modelValue: 'Test message',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
+
+			await fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+			expect(render.emitted('submit')).toBeFalsy();
+			expect(render.emitted('update:modelValue')).toBeTruthy();
+
+			await fireEvent.keyDown(textarea, { key: 'Enter' });
+			expect(render.emitted('submit')).toBeTruthy();
+		});
+	});
+
 	describe('character limit', () => {
 		it('should show warning banner when at character limit', () => {
 			const { container } = renderComponent({

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
@@ -279,6 +279,94 @@ describe('N8nChatInput', () => {
 			wrapper.unmount();
 		});
 
+		it('remeasures the height when a slot flips the effective layout', async () => {
+			// Adaptive and multiline use different textarea padding, so identical content
+			// measures differently; stand in for that with a mutable measurement.
+			let measured = 32;
+			const originalDescriptor = Object.getOwnPropertyDescriptor(
+				HTMLTextAreaElement.prototype,
+				'scrollHeight',
+			);
+			Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+				configurable: true,
+				get: () => measured,
+			});
+
+			try {
+				const showAction = ref(false);
+				const Host = defineComponent({
+					setup() {
+						return () =>
+							h(
+								N8nChatInput,
+								{ layout: 'adaptive', modelValue: 'hello' },
+								showAction.value ? { 'right-actions': () => h('button', 'Action') } : {},
+							);
+					},
+				});
+
+				const wrapper = mount(Host, {
+					attachTo: document.body,
+					global: { stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'] },
+				});
+				await vi.waitFor(() =>
+					expect(wrapper.find('textarea').attributes('style')).toContain('height: 32px'),
+				);
+
+				measured = 36;
+				showAction.value = true;
+				await nextTick();
+
+				await vi.waitFor(() =>
+					expect(wrapper.find('textarea').attributes('style')).toContain('height: 36px'),
+				);
+				wrapper.unmount();
+			} finally {
+				if (originalDescriptor) {
+					Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', originalDescriptor);
+				} else {
+					Reflect.deleteProperty(HTMLTextAreaElement.prototype, 'scrollHeight');
+				}
+			}
+		});
+
+		it('remeasures the height when the layout prop changes', async () => {
+			let measured = 32;
+			const originalDescriptor = Object.getOwnPropertyDescriptor(
+				HTMLTextAreaElement.prototype,
+				'scrollHeight',
+			);
+			Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+				configurable: true,
+				get: () => measured,
+			});
+
+			try {
+				const wrapper = mount(N8nChatInput, {
+					attachTo: document.body,
+					props: { layout: 'adaptive', modelValue: 'hello' },
+					global: { stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'] },
+				});
+				await vi.waitFor(() =>
+					expect(wrapper.find('textarea').attributes('style')).toContain('height: 32px'),
+				);
+
+				measured = 36;
+				await wrapper.setProps({ layout: 'multiline' });
+
+				await vi.waitFor(() =>
+					expect(wrapper.find('textarea').attributes('style')).toContain('height: 36px'),
+				);
+				wrapper.unmount();
+			} finally {
+				if (originalDescriptor) {
+					Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', originalDescriptor);
+				} else {
+					Reflect.deleteProperty(HTMLTextAreaElement.prototype, 'scrollHeight');
+				}
+			}
+		});
+
 		it('autosizes the textarea like multiline', async () => {
 			const originalDescriptor = Object.getOwnPropertyDescriptor(
 				HTMLTextAreaElement.prototype,

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
@@ -204,6 +204,44 @@ describe('N8nChatInput', () => {
 			expect(chatContainer.style.minHeight).toBe('80px');
 		});
 
+		it('falls back to multiline for a custom send button label', () => {
+			const { container } = renderComponent({
+				props: {
+					layout: 'adaptive',
+					buttonLabel: 'Send message',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const chatContainer = container.querySelector('.container') as HTMLElement;
+			expect(chatContainer.style.minHeight).toBe('80px');
+			expect(chatContainer.classList.toString()).not.toContain('adaptiveContainer');
+		});
+
+		it.each(['left-actions', 'actions', 'extra-actions', 'right-actions'])(
+			'falls back to multiline for the %s slot',
+			(slotName) => {
+				const { container } = renderComponent({
+					props: {
+						layout: 'adaptive',
+					},
+					slots: {
+						[slotName]: '<button>Custom action</button>',
+					},
+					global: {
+						stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+					},
+				});
+
+				const chatContainer = container.querySelector('.container') as HTMLElement;
+				expect(chatContainer.style.minHeight).toBe('80px');
+				expect(chatContainer.classList.toString()).not.toContain('adaptiveContainer');
+				expect(container).toHaveTextContent('Custom action');
+			},
+		);
+
 		it('autosizes the textarea like multiline', async () => {
 			const originalDescriptor = Object.getOwnPropertyDescriptor(
 				HTMLTextAreaElement.prototype,

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.test.ts
@@ -178,6 +178,10 @@ describe('N8nChatInput', () => {
 	});
 
 	describe('adaptive layout', () => {
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
 		it('does not reserve the multiline minimum height', () => {
 			const { container } = renderComponent({
 				props: {
@@ -205,6 +209,7 @@ describe('N8nChatInput', () => {
 		});
 
 		it('falls back to multiline for a custom send button label', () => {
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 			const { container } = renderComponent({
 				props: {
 					layout: 'adaptive',
@@ -218,11 +223,13 @@ describe('N8nChatInput', () => {
 			const chatContainer = container.querySelector('.container') as HTMLElement;
 			expect(chatContainer.style.minHeight).toBe('80px');
 			expect(chatContainer.classList.toString()).not.toContain('adaptiveContainer');
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining('Falling back to `multiline`'));
 		});
 
 		it.each(['left-actions', 'actions', 'extra-actions', 'right-actions'])(
 			'falls back to multiline for the %s slot',
 			(slotName) => {
+				const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 				const { container } = renderComponent({
 					props: {
 						layout: 'adaptive',
@@ -239,6 +246,7 @@ describe('N8nChatInput', () => {
 				expect(chatContainer.style.minHeight).toBe('80px');
 				expect(chatContainer.classList.toString()).not.toContain('adaptiveContainer');
 				expect(container).toHaveTextContent('Custom action');
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining('Falling back to `multiline`'));
 			},
 		);
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, toRef, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, toRef, useSlots, watch } from 'vue';
 
 import { useAutosizeTextarea } from '../../composables/useAutosizeTextarea';
 import { useCharacterLimit } from '../../composables/useCharacterLimit';
@@ -36,7 +36,9 @@ export interface N8nChatInputProps {
 	 * - 'single-line': one fixed row; Enter always submits.
 	 * - 'adaptive': starts as a single row with the send button inline and grows
 	 *   smoothly with the content, up to `maxLinesBeforeScroll`. Keyboard behavior
-	 *   matches 'multiline' (Shift+Enter inserts a newline).
+	 *   matches 'multiline' (Shift+Enter inserts a newline). Supports only the
+	 *   default icon-only send/stop button; custom labels or action slots fall
+	 *   back to 'multiline'.
 	 */
 	layout?: 'multiline' | 'single-line' | 'adaptive';
 	autosize?: boolean | { minRows: number; maxRows: number };
@@ -77,18 +79,29 @@ const emit = defineEmits<{
 	'upgrade-click': [];
 }>();
 
+const slots = useSlots();
 const { t } = useI18n();
 
 const textareaRef = ref<HTMLTextAreaElement>();
 const isFocused = ref(false);
 const textValue = ref(props.modelValue || '');
+const hasCustomActions = computed(
+	() =>
+		Boolean(props.buttonLabel) ||
+		Boolean(
+			slots['left-actions'] ?? slots.actions ?? slots['extra-actions'] ?? slots['right-actions'],
+		),
+);
+const effectiveLayout = computed(() =>
+	props.layout === 'adaptive' && hasCustomActions.value ? 'multiline' : props.layout,
+);
 const autosizeRows = computed(() =>
 	typeof props.autosize === 'object'
 		? props.autosize
 		: { minRows: 1, maxRows: props.maxLinesBeforeScroll },
 );
 const isAutosizeEnabled = computed(
-	() => props.layout !== 'single-line' && props.autosize !== false,
+	() => effectiveLayout.value !== 'single-line' && props.autosize !== false,
 );
 const { textareaStyles, calculateTextareaHeight, clearTextareaHeight } = useAutosizeTextarea({
 	textarea: textareaRef,
@@ -115,7 +128,7 @@ const sendDisabled = computed(
 const containerStyle = computed(() => {
 	// Only the classic multiline composer reserves the tall block; 'adaptive'
 	// starts at one row and lets the autosized textarea drive the height.
-	return props.layout === 'multiline' ? { minHeight: '80px' } : undefined;
+	return effectiveLayout.value === 'multiline' ? { minHeight: '80px' } : undefined;
 });
 
 const hasNoCredits = computed(() => {
@@ -143,7 +156,7 @@ watch(
 	async (newValue) => {
 		textValue.value = newValue || '';
 		await nextTick();
-		if (props.layout === 'single-line' || props.autosize === false) return;
+		if (effectiveLayout.value === 'single-line' || props.autosize === false) return;
 
 		// Wait for an additional animation frame to ensure DOM has fully updated
 		await new Promise(requestAnimationFrame);
@@ -151,7 +164,7 @@ watch(
 	},
 );
 
-watch([() => props.layout, () => props.autosize], ([layout, autosize]) => {
+watch([effectiveLayout, () => props.autosize], ([layout, autosize]) => {
 	if (layout === 'single-line' || autosize === false) {
 		clearTextareaHeight();
 		return;
@@ -163,7 +176,7 @@ watch([() => props.layout, () => props.autosize], ([layout, autosize]) => {
 watch(textValue, (newValue, oldValue) => {
 	emit('update:modelValue', newValue);
 	// Single-line layout has fixed height; only multiline needs autosizing.
-	if (props.layout === 'single-line' || props.autosize === false) return;
+	if (effectiveLayout.value === 'single-line' || props.autosize === false) return;
 
 	// Only adjust height if value actually changed
 	if (newValue !== oldValue) {
@@ -192,7 +205,7 @@ async function handleStop() {
 }
 
 async function handleKeyDown(event: KeyboardEvent) {
-	if (props.layout === 'single-line' && event.key === 'Enter' && !event.isComposing) {
+	if (effectiveLayout.value === 'single-line' && event.key === 'Enter' && !event.isComposing) {
 		event.preventDefault();
 		if (!sendDisabled.value) {
 			await handleSubmit();
@@ -283,8 +296,8 @@ defineExpose({
 					{
 						[$style.focused]: isFocused,
 						[$style.disabled]: disabled || hasNoCredits,
-						[$style.singleLineContainer]: layout === 'single-line',
-						[$style.adaptiveContainer]: layout === 'adaptive',
+						[$style.singleLineContainer]: effectiveLayout === 'single-line',
+						[$style.adaptiveContainer]: effectiveLayout === 'adaptive',
 					},
 				]"
 				:style="containerStyle"
@@ -302,8 +315,8 @@ defineExpose({
 					:class="[
 						$style.textarea,
 						{
-							[$style.singleLineTextarea]: layout === 'single-line',
-							[$style.adaptiveTextarea]: layout === 'adaptive',
+							[$style.singleLineTextarea]: effectiveLayout === 'single-line',
+							[$style.adaptiveTextarea]: effectiveLayout === 'adaptive',
 						},
 						'ignore-key-press-node-creator',
 						'ignore-key-press-canvas',
@@ -315,15 +328,17 @@ defineExpose({
 					@keydown="handleKeyDown"
 					@focus="handleFocus"
 					@blur="handleBlur"
-					@input="layout === 'single-line' || autosize === false ? undefined : adjustHeight"
+					@input="
+						effectiveLayout === 'single-line' || autosize === false ? undefined : adjustHeight
+					"
 					@click="handleFocusableRegionClick"
 				/>
 				<div
 					:class="[
 						$style.bottomActions,
 						{
-							[$style.singleLineActions]: layout === 'single-line',
-							[$style.adaptiveActions]: layout === 'adaptive',
+							[$style.singleLineActions]: effectiveLayout === 'single-line',
+							[$style.adaptiveActions]: effectiveLayout === 'adaptive',
 						},
 					]"
 					@click="handleFocusableRegionClick"
@@ -357,7 +372,7 @@ defineExpose({
 					</div>
 				</div>
 			</div>
-			<div v-if="$slots.trailing && layout !== 'single-line'" :class="$style.trailing">
+			<div v-if="$slots.trailing && effectiveLayout !== 'single-line'" :class="$style.trailing">
 				<slot name="trailing" />
 			</div>
 		</div>

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
@@ -35,10 +35,10 @@ export interface N8nChatInputProps {
 	 *   their own bottom row.
 	 * - 'single-line': one fixed row; Enter always submits.
 	 * - 'adaptive': starts as a single row with the send button inline and grows
-	 *   smoothly with the content, up to `maxLinesBeforeScroll`. Keyboard behavior
-	 *   matches 'multiline' (Shift+Enter inserts a newline). Supports only the
-	 *   default icon-only send/stop button; custom labels or action slots fall
-	 *   back to 'multiline'.
+	 *   with the content, up to `maxLinesBeforeScroll`. Keyboard behavior matches
+	 *   'multiline' (Shift+Enter inserts a newline). Supports only the default
+	 *   icon-only send/stop button; custom labels or action slots fall back to
+	 *   'multiline'.
 	 */
 	layout?: 'multiline' | 'single-line' | 'adaptive';
 	autosize?: boolean | { minRows: number; maxRows: number };
@@ -85,20 +85,25 @@ const { t } = useI18n();
 const textareaRef = ref<HTMLTextAreaElement>();
 const isFocused = ref(false);
 const textValue = ref(props.modelValue || '');
-const hasCustomActions = computed(
-	() =>
-		Boolean(props.buttonLabel) ||
-		Boolean(
-			slots['left-actions'] ?? slots.actions ?? slots['extra-actions'] ?? slots['right-actions'],
-		),
-);
-const effectiveLayout = computed(() =>
-	props.layout === 'adaptive' && hasCustomActions.value ? 'multiline' : props.layout,
-);
+function hasCustomActions() {
+	return Boolean(
+		props.buttonLabel ||
+			slots['left-actions'] ||
+			slots.actions ||
+			slots['extra-actions'] ||
+			slots['right-actions'],
+	);
+}
+
+// Read fresh on every use instead of via a computed: slots are not reactive, so a
+// computed would cache the first result and miss action slots that appear later.
+function effectiveLayout() {
+	return props.layout === 'adaptive' && hasCustomActions() ? 'multiline' : props.layout;
+}
 
 if (import.meta.env.DEV) {
 	watchEffect(() => {
-		if (props.layout === 'adaptive' && hasCustomActions.value) {
+		if (props.layout === 'adaptive' && hasCustomActions()) {
 			// eslint-disable-next-line no-console
 			console.warn(
 				'[N8nChatInput] `layout="adaptive"` supports only the default icon-only send/stop button. ' +
@@ -114,7 +119,7 @@ const autosizeRows = computed(() =>
 		: { minRows: 1, maxRows: props.maxLinesBeforeScroll },
 );
 const isAutosizeEnabled = computed(
-	() => effectiveLayout.value !== 'single-line' && props.autosize !== false,
+	() => props.layout !== 'single-line' && props.autosize !== false,
 );
 const { textareaStyles, calculateTextareaHeight, clearTextareaHeight } = useAutosizeTextarea({
 	textarea: textareaRef,
@@ -138,11 +143,11 @@ const sendDisabled = computed(
 			props.creditsRemaining === 0),
 );
 
-const containerStyle = computed(() => {
-	// Only the classic multiline composer reserves the tall block; 'adaptive'
-	// starts at one row and lets the autosized textarea drive the height.
-	return effectiveLayout.value === 'multiline' ? { minHeight: '80px' } : undefined;
-});
+// Only the classic multiline composer reserves the tall block; 'adaptive' starts
+// at one row and lets the autosized textarea drive the height.
+function containerStyle() {
+	return effectiveLayout() === 'multiline' ? { minHeight: '80px' } : undefined;
+}
 
 const hasNoCredits = computed(() => {
 	return (
@@ -169,7 +174,7 @@ watch(
 	async (newValue) => {
 		textValue.value = newValue || '';
 		await nextTick();
-		if (effectiveLayout.value === 'single-line' || props.autosize === false) return;
+		if (!isAutosizeEnabled.value) return;
 
 		// Wait for an additional animation frame to ensure DOM has fully updated
 		await new Promise(requestAnimationFrame);
@@ -177,19 +182,10 @@ watch(
 	},
 );
 
-watch([effectiveLayout, () => props.autosize], ([layout, autosize]) => {
-	if (layout === 'single-line' || autosize === false) {
-		clearTextareaHeight();
-		return;
-	}
-
-	void nextTick(() => adjustHeight());
-});
-
 watch(textValue, (newValue, oldValue) => {
 	emit('update:modelValue', newValue);
 	// Single-line layout has fixed height; only multiline needs autosizing.
-	if (effectiveLayout.value === 'single-line' || props.autosize === false) return;
+	if (!isAutosizeEnabled.value) return;
 
 	// Only adjust height if value actually changed
 	if (newValue !== oldValue) {
@@ -218,7 +214,7 @@ async function handleStop() {
 }
 
 async function handleKeyDown(event: KeyboardEvent) {
-	if (effectiveLayout.value === 'single-line' && event.key === 'Enter' && !event.isComposing) {
+	if (effectiveLayout() === 'single-line' && event.key === 'Enter' && !event.isComposing) {
 		event.preventDefault();
 		if (!sendDisabled.value) {
 			await handleSubmit();
@@ -309,11 +305,11 @@ defineExpose({
 					{
 						[$style.focused]: isFocused,
 						[$style.disabled]: disabled || hasNoCredits,
-						[$style.singleLineContainer]: effectiveLayout === 'single-line',
-						[$style.adaptiveContainer]: effectiveLayout === 'adaptive',
+						[$style.singleLineContainer]: effectiveLayout() === 'single-line',
+						[$style.adaptiveContainer]: effectiveLayout() === 'adaptive',
 					},
 				]"
-				:style="containerStyle"
+				:style="containerStyle()"
 				@click.self="handleContainerClick"
 			>
 				<slot name="leading" />
@@ -328,8 +324,8 @@ defineExpose({
 					:class="[
 						$style.textarea,
 						{
-							[$style.singleLineTextarea]: effectiveLayout === 'single-line',
-							[$style.adaptiveTextarea]: effectiveLayout === 'adaptive',
+							[$style.singleLineTextarea]: effectiveLayout() === 'single-line',
+							[$style.adaptiveTextarea]: effectiveLayout() === 'adaptive',
 						},
 						'ignore-key-press-node-creator',
 						'ignore-key-press-canvas',
@@ -341,17 +337,15 @@ defineExpose({
 					@keydown="handleKeyDown"
 					@focus="handleFocus"
 					@blur="handleBlur"
-					@input="
-						effectiveLayout === 'single-line' || autosize === false ? undefined : adjustHeight
-					"
+					@input="isAutosizeEnabled ? adjustHeight : undefined"
 					@click="handleFocusableRegionClick"
 				/>
 				<div
 					:class="[
 						$style.bottomActions,
 						{
-							[$style.singleLineActions]: effectiveLayout === 'single-line',
-							[$style.adaptiveActions]: effectiveLayout === 'adaptive',
+							[$style.singleLineActions]: effectiveLayout() === 'single-line',
+							[$style.adaptiveActions]: effectiveLayout() === 'adaptive',
 						},
 					]"
 					@click="handleFocusableRegionClick"
@@ -385,7 +379,7 @@ defineExpose({
 					</div>
 				</div>
 			</div>
-			<div v-if="$slots.trailing && effectiveLayout !== 'single-line'" :class="$style.trailing">
+			<div v-if="$slots.trailing && effectiveLayout() !== 'single-line'" :class="$style.trailing">
 				<slot name="trailing" />
 			</div>
 		</div>
@@ -436,12 +430,11 @@ defineExpose({
 
 /* Adaptive: one visual row that grows with the autosized textarea. The send button
 	is pinned to the bottom-right corner instead of holding a dedicated actions row,
-	so the only moving part while typing is the (transitioned) textarea height — the
-	button just rides the bottom edge. See the overrides next to the single-line
-	ones at the end of this stylesheet. */
+	so the textarea height is the only thing that moves while typing — the button
+	just rides the bottom edge. See the overrides next to the single-line ones at
+	the end of this stylesheet. */
 .adaptiveContainer {
 	position: relative;
-	justify-content: center;
 	/* The pinned button is taller than one line of text; without this floor it
 		would poke out of the single-row state. */
 	min-height: calc(var(--height--md) + 2 * var(--spacing--2xs));
@@ -528,12 +521,6 @@ defineExpose({
 	/* A 24px text line plus 4px above and below matches the 32px send button,
 		leaving the same 8px inset on every side in the compact state. */
 	padding-block: var(--spacing--4xs);
-	/* The autosize composable writes explicit pixel heights, so they interpolate. */
-	transition: height 0.15s ease;
-
-	@media (prefers-reduced-motion: reduce) {
-		transition: none;
-	}
 }
 
 .adaptiveActions {

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, toRef, useSlots, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, toRef, useSlots, watch, watchEffect } from 'vue';
 
 import { useAutosizeTextarea } from '../../composables/useAutosizeTextarea';
 import { useCharacterLimit } from '../../composables/useCharacterLimit';
@@ -95,6 +95,19 @@ const hasCustomActions = computed(
 const effectiveLayout = computed(() =>
 	props.layout === 'adaptive' && hasCustomActions.value ? 'multiline' : props.layout,
 );
+
+if (import.meta.env.DEV) {
+	watchEffect(() => {
+		if (props.layout === 'adaptive' && hasCustomActions.value) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'[N8nChatInput] `layout="adaptive"` supports only the default icon-only send/stop button. ' +
+					'Falling back to `multiline` because a custom button label or action slot was provided.',
+			);
+		}
+	});
+}
+
 const autosizeRows = computed(() =>
 	typeof props.autosize === 'object'
 		? props.autosize

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
@@ -30,7 +30,15 @@ export interface N8nChatInputProps {
 	refocusAfterSend?: boolean;
 	autofocus?: boolean;
 	buttonLabel?: string;
-	layout?: 'multiline' | 'single-line';
+	/**
+	 * - 'multiline': the tall composer — a fixed minimum height with the actions on
+	 *   their own bottom row.
+	 * - 'single-line': one fixed row; Enter always submits.
+	 * - 'adaptive': starts as a single row with the send button inline and grows
+	 *   smoothly with the content, up to `maxLinesBeforeScroll`. Keyboard behavior
+	 *   matches 'multiline' (Shift+Enter inserts a newline).
+	 */
+	layout?: 'multiline' | 'single-line' | 'adaptive';
 	autosize?: boolean | { minRows: number; maxRows: number };
 	submitDisabled?: boolean;
 	sendButtonTestId?: string;
@@ -105,7 +113,9 @@ const sendDisabled = computed(
 );
 
 const containerStyle = computed(() => {
-	return props.layout === 'single-line' ? undefined : { minHeight: '80px' };
+	// Only the classic multiline composer reserves the tall block; 'adaptive'
+	// starts at one row and lets the autosized textarea drive the height.
+	return props.layout === 'multiline' ? { minHeight: '80px' } : undefined;
 });
 
 const hasNoCredits = computed(() => {
@@ -274,6 +284,7 @@ defineExpose({
 						[$style.focused]: isFocused,
 						[$style.disabled]: disabled || hasNoCredits,
 						[$style.singleLineContainer]: layout === 'single-line',
+						[$style.adaptiveContainer]: layout === 'adaptive',
 					},
 				]"
 				:style="containerStyle"
@@ -290,7 +301,10 @@ defineExpose({
 					v-model="textValue"
 					:class="[
 						$style.textarea,
-						{ [$style.singleLineTextarea]: layout === 'single-line' },
+						{
+							[$style.singleLineTextarea]: layout === 'single-line',
+							[$style.adaptiveTextarea]: layout === 'adaptive',
+						},
 						'ignore-key-press-node-creator',
 						'ignore-key-press-canvas',
 					]"
@@ -305,7 +319,13 @@ defineExpose({
 					@click="handleFocusableRegionClick"
 				/>
 				<div
-					:class="[$style.bottomActions, { [$style.singleLineActions]: layout === 'single-line' }]"
+					:class="[
+						$style.bottomActions,
+						{
+							[$style.singleLineActions]: layout === 'single-line',
+							[$style.adaptiveActions]: layout === 'adaptive',
+						},
+					]"
 					@click="handleFocusableRegionClick"
 				>
 					<div
@@ -386,6 +406,19 @@ defineExpose({
 	align-items: center;
 }
 
+/* Adaptive: one visual row that grows with the autosized textarea. The send button
+	is pinned to the bottom-right corner instead of holding a dedicated actions row,
+	so the only moving part while typing is the (transitioned) textarea height — the
+	button just rides the bottom edge. See the overrides next to the single-line
+	ones at the end of this stylesheet. */
+.adaptiveContainer {
+	position: relative;
+	justify-content: center;
+	/* The pinned button is taller than one line of text; without this floor it
+		would poke out of the single-row state. */
+	min-height: calc(var(--height--md) + 2 * var(--spacing--2xs));
+}
+
 .textarea {
 	width: 100%;
 	border: none;
@@ -456,6 +489,29 @@ defineExpose({
 
 .singleLineActions {
 	padding: 0;
+}
+
+/* Placed after `.textarea`, whose `padding` shorthand would otherwise win the tie. */
+.adaptiveTextarea {
+	/* Reserve the pinned button's column at every height: a width that differed
+		between the compact and grown states would re-wrap the text and make the
+		two states oscillate. */
+	padding-right: calc(var(--height--md) + var(--spacing--3xs));
+	/* A 24px text line plus 4px above and below matches the 32px send button,
+		leaving the same 8px inset on every side in the compact state. */
+	padding-block: var(--spacing--4xs);
+	/* The autosize composable writes explicit pixel heights, so they interpolate. */
+	transition: height 0.15s ease;
+
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+}
+
+.adaptiveActions {
+	position: absolute;
+	right: var(--spacing--2xs);
+	bottom: var(--spacing--2xs);
 }
 
 .leading {

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
@@ -1,5 +1,15 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, toRef, useSlots, watch, watchEffect } from 'vue';
+import {
+	computed,
+	nextTick,
+	onMounted,
+	onUpdated,
+	ref,
+	toRef,
+	useSlots,
+	watch,
+	watchEffect,
+} from 'vue';
 
 import { useAutosizeTextarea } from '../../composables/useAutosizeTextarea';
 import { useCharacterLimit } from '../../composables/useCharacterLimit';
@@ -281,6 +291,17 @@ function handleFocusableRegionClick(event: MouseEvent) {
 function focusInput(options?: FocusOptions) {
 	textareaRef.value?.focus(options);
 }
+
+// Each layout measures to a different height, so switching leaves a stale one.
+// Slot-driven switches aren't reactive, so re-check on render, not in a watcher.
+let renderedLayout = effectiveLayout();
+onUpdated(() => {
+	const currentLayout = effectiveLayout();
+	if (currentLayout === renderedLayout) return;
+
+	renderedLayout = currentLayout;
+	adjustHeight();
+});
 
 onMounted(() => {
 	// Adjust height on mount to respect initial content

--- a/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.test.ts
+++ b/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.test.ts
@@ -102,6 +102,7 @@ describe('useAutosizeTextarea', () => {
 		const TestComponent = defineComponent({
 			props: {
 				enabled: { type: Boolean, default: true },
+				content: { type: String, default: 'one\ntwo\nthree' },
 			},
 			setup(props) {
 				const textarea = ref<HTMLTextAreaElement>();
@@ -114,7 +115,7 @@ describe('useAutosizeTextarea', () => {
 
 				return { textarea, textareaStyles, calculateTextareaHeight, clearTextareaHeight };
 			},
-			template: '<textarea ref="textarea" value="one\ntwo\nthree" />',
+			template: '<textarea ref="textarea" :value="content" />',
 		});
 
 		it('recalculates height into reactive styles', () => {
@@ -149,6 +150,23 @@ describe('useAutosizeTextarea', () => {
 			await nextTick();
 
 			expect(textarea.scrollTop).toBe(textarea.scrollHeight);
+		});
+
+		it('does not scroll a textarea whose content still fits within maxRows', async () => {
+			const wrapper = mount(TestComponent, {
+				attachTo: document.body,
+				props: { content: 'one\ntwo' },
+			});
+			const textarea = wrapper.vm.textarea as HTMLTextAreaElement;
+			textarea.focus();
+			textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+			textarea.scrollTop = 0;
+
+			wrapper.vm.calculateTextareaHeight();
+			await nextTick();
+
+			expect(wrapper.vm.textareaStyles.overflowY).toBe('hidden');
+			expect(textarea.scrollTop).toBe(0);
 		});
 
 		it('preserves the scroll position when the caret is mid-content', async () => {

--- a/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.ts
+++ b/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.ts
@@ -143,7 +143,10 @@ export function useAutosizeTextarea({
 		if (!toValue(enabled) || !textareaElement) return;
 
 		textareaStyles.value = calcTextareaHeight(textareaElement, toValue(rows));
-		void scrollCaretIntoView();
+		// Only scroll when the content genuinely exceeds maxRows.
+		if (textareaStyles.value.overflowY === 'auto') {
+			void scrollCaretIntoView();
+		}
 	};
 
 	function clearTextareaHeight() {


### PR DESCRIPTION
## Summary
- Add a compact ChatInput layout that grows with its content.
- Fall back to multiline for custom labels or action slots.
- Cover the layout in tests and Storybook.

## Test plan
- `pnpm vitest run src/components/N8nChatInput/ChatInput.test.ts`