### PR TITLE
fix(Evaluation Trigger Node): Respect the row limit when reading from a data table

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -235,8 +235,9 @@ export class EvaluationTrigger implements INodeType {
 				throw new NodeOperationError(this.getNode(), 'No row found');
 			}
 
-			const effectiveTotal = Math.min(count, maxRows);
-			const rowsLeft = Math.max(0, effectiveTotal - 1);
+			// `count` is the number of rows still matching (current row included), so the
+			// row limit has to be measured against the rows already consumed.
+			const rowsLeft = Math.max(0, Math.min(count - 1, maxRows - currentIndex - 1));
 
 			const currentRow = {
 				json: {

--- a/packages/nodes-base/nodes/Evaluation/test/EvaluationTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/EvaluationTrigger.node.test.ts
@@ -451,6 +451,71 @@ describe('Evaluation Trigger Node', () => {
 					},
 				});
 			});
+
+			test('should stop after maxRows when the table has more matching rows', async () => {
+				mockDataTable.getManyRowsAndCount
+					.mockResolvedValueOnce({ data: [{ id: 1 }], count: 5 })
+					.mockResolvedValueOnce({ data: [{ id: 2 }], count: 4 })
+					.mockResolvedValueOnce({ data: [{ id: 3 }], count: 3 });
+
+				mockExecuteFunctions.getNodeParameter.mockImplementation(
+					(key: string, _: number, fallbackValue?: string | number | boolean | object) => {
+						const mockParams: { [key: string]: unknown } = {
+							source: 'dataTable',
+							limitRows: true,
+							maxRows: 3,
+							dataTableId: 'mockDataTableId',
+							'filters.conditions': [],
+							matchType: 'anyCondition',
+						};
+						return (mockParams[key] ?? fallbackValue) as NodeParameterValueType;
+					},
+				);
+
+				const evaluationTrigger = new EvaluationTrigger();
+
+				mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+				const result1 = await evaluationTrigger.execute.call(mockExecuteFunctions);
+				expect(result1[0][0].json._rowsLeft).toBe(2);
+
+				mockExecuteFunctions.getInputData.mockReturnValue(result1[0]);
+				const result2 = await evaluationTrigger.execute.call(mockExecuteFunctions);
+				expect(result2[0][0].json._rowsLeft).toBe(1);
+
+				mockExecuteFunctions.getInputData.mockReturnValue(result2[0]);
+				const result3 = await evaluationTrigger.execute.call(mockExecuteFunctions);
+				expect(result3[0][0].json._rowsLeft).toBe(0);
+			});
+
+			test('should stop early when the table runs out before maxRows', async () => {
+				mockDataTable.getManyRowsAndCount
+					.mockResolvedValueOnce({ data: [{ id: 1 }], count: 2 })
+					.mockResolvedValueOnce({ data: [{ id: 2 }], count: 1 });
+
+				mockExecuteFunctions.getNodeParameter.mockImplementation(
+					(key: string, _: number, fallbackValue?: string | number | boolean | object) => {
+						const mockParams: { [key: string]: unknown } = {
+							source: 'dataTable',
+							limitRows: true,
+							maxRows: 10,
+							dataTableId: 'mockDataTableId',
+							'filters.conditions': [],
+							matchType: 'anyCondition',
+						};
+						return (mockParams[key] ?? fallbackValue) as NodeParameterValueType;
+					},
+				);
+
+				const evaluationTrigger = new EvaluationTrigger();
+
+				mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+				const result1 = await evaluationTrigger.execute.call(mockExecuteFunctions);
+				expect(result1[0][0].json._rowsLeft).toBe(1);
+
+				mockExecuteFunctions.getInputData.mockReturnValue(result1[0]);
+				const result2 = await evaluationTrigger.execute.call(mockExecuteFunctions);
+				expect(result2[0][0].json._rowsLeft).toBe(0);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

The Evaluation Trigger ignored **Max Rows to Process** when the source was a Data Table. The workflow ran once for every row in the table, not once per allowed row. Only `maxRows = 1` worked.

The trigger runs the workflow once per dataset row. It tells the editor to continue with `_rowsLeft`, and the editor re-runs the trigger while that value is above zero.

PR #22389 replaced offset pagination with `id > previousRunRowId` filtering. After that change, `count` reports the rows that **still match**, not the table total. The code did not subtract the rows that the loop had already used:

```ts
const effectiveTotal = Math.min(count, maxRows);
const rowsLeft = Math.max(0, effectiveTotal - 1);
```

While `count >= maxRows`, `rowsLeft` stayed at `maxRows - 1`. The loop stopped only when the table itself ran out, or at the 1000-row cap. `maxRows = 1` worked by accident, because `min(count, 1) - 1 = 0`.

The fix bounds `rowsLeft` by the remaining limit budget as well. `currentIndex` already counts the rows the loop has used:

```ts
const rowsLeft = Math.max(0, Math.min(count - 1, maxRows - currentIndex - 1));
```

For a 5-row table with `maxRows = 3`, `_rowsLeft` now goes `2, 1, 0` over 3 runs. Before, it went `2, 2, 2, 1, 0` over 5 runs.

This affects canvas execution only. The Evaluations tab uses a different path (`customOperations.dataset.getRows`), which already passed `take: maxRows` correctly.

## How to test

You need a Data Table. Start n8n with the module enabled:

```
N8N_ENABLED_MODULES=data-table
```

1. Create a Data Table. Add 5 or more rows. The row contents do not matter.
2. Create a new workflow. Import the workflow below.
3. Open **When fetching a dataset row**. Select your Data Table.
4. Confirm that **Limit Rows** is on and **Max Rows to Process** is 3.
5. Run the workflow from the canvas.

**Expected:** the workflow runs 3 times, then stops.
**Before this PR:** the workflow runs 5 times, once per table row.

Open the trigger output on each run and watch `_rowsLeft`. It must count down `2, 1, 0`. Before this PR it stayed at `2` for three runs.

Also check these cases:

- Set **Max Rows to Process** to 10 on the same 5-row table. The workflow must run 5 times and stop. A limit above the table size must not extend the run.
- Set **Max Rows to Process** to 1. The workflow must run once. This case worked before, so it must not regress.
- Turn **Limit Rows** off. The workflow must run once per table row.
- Open the **Evaluations** tab and start a test run. It must still honour the limit, because it uses a separate code path.

<details>
<summary>Example workflow</summary>

```json
{
  "name": "NODE-5297 — Eval Trigger maxRows",
  "nodes": [
    {
      "parameters": {
        "source": "dataTable",
        "dataTableId": { "__rl": true, "mode": "list", "value": "" },
        "limitRows": true,
        "maxRows": 3,
        "filterRows": false
      },
      "type": "n8n-nodes-base.evaluationTrigger",
      "typeVersion": 4.7,
      "position": [0, 0],
      "id": "b3f1c0de-0000-4000-8000-000000000001",
      "name": "When fetching a dataset row"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [220, 0],
      "id": "b3f1c0de-0000-4000-8000-000000000002",
      "name": "No Operation"
    }
  ],
  "connections": {
    "When fetching a dataset row": {
      "main": [[{ "node": "No Operation", "type": "main", "index": 0 }]]
    }
  },
  "pinData": {},
  "settings": { "executionOrder": "v1" }
}
```

`dataTableId` is empty on purpose. Data Table IDs are specific to each instance, so you must select the table yourself.

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5297

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

