### PR TITLE
feat(core): Enforce policy on workflow start (no-changelog)

### DIFF
--- a/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
@@ -40,11 +40,7 @@ export type WorkflowExecuteBeforeContext = {
 	type: 'workflowExecuteBefore';
 	workflow: IWorkflowBase;
 	mode: WorkflowExecuteMode;
-	/**
-	 * Absent when the event is not a real execution start: queue mode fires it on the main
-	 * process once the job is enqueued, and the pre-flight-failure recorder fires it for an
-	 * execution that already failed. Only the engine's own call carries an instance.
-	 */
+	/** Only the engine's own call carries one — queue-mode main and the failure recorder don't. */
 	workflowInstance: Workflow | undefined;
 	executionData?: IRunExecutionData;
 	executionId: string;

--- a/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
@@ -40,7 +40,12 @@ export type WorkflowExecuteBeforeContext = {
 	type: 'workflowExecuteBefore';
 	workflow: IWorkflowBase;
 	mode: WorkflowExecuteMode;
-	workflowInstance: Workflow;
+	/**
+	 * Absent when the event is not a real execution start: queue mode fires it on the main
+	 * process once the job is enqueued, and the pre-flight-failure recorder fires it for an
+	 * execution that already failed. Only the engine's own call carries an instance.
+	 */
+	workflowInstance: Workflow | undefined;
 	executionData?: IRunExecutionData;
 	executionId: string;
 };

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -11,7 +11,7 @@ import {
 	ExecutionLifecycleHooks,
 	BinaryDataConfig,
 } from 'n8n-core';
-import { createRunExecutionData, ExpressionError } from 'n8n-workflow';
+import { createRunExecutionData, ExpressionError, UnexpectedError } from 'n8n-workflow';
 import type {
 	IRunExecutionData,
 	ITaskData,
@@ -24,6 +24,9 @@ import type {
 	ITaskStartedData,
 } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
+
+import { LifecycleMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
@@ -488,6 +491,50 @@ describe('Execution Lifecycle Hooks', () => {
 			});
 		});
 	};
+
+	describe('module lifecycle handlers', () => {
+		const vetoed = new UnexpectedError('vetoed by a module');
+
+		type HandlerClass = Parameters<LifecycleMetadata['register']>[0]['handlerClass'];
+
+		class ThrowingHandler {
+			async onWorkflowExecuteBefore() {
+				throw vetoed;
+			}
+		}
+
+		let registered: LifecycleMetadata;
+
+		beforeEach(() => {
+			// A fresh registry, so this handler is not visible to the handler-count assertions
+			// in the other suites.
+			registered = new LifecycleMetadata();
+			registered.register({
+				handlerClass: ThrowingHandler as unknown as HandlerClass,
+				methodName: 'onWorkflowExecuteBefore',
+				eventName: 'workflowExecuteBefore',
+			});
+			Container.set(ThrowingHandler, new ThrowingHandler());
+		});
+
+		it('lets a throw abort the hook run instead of swallowing it', async () => {
+			const original = Container.get(LifecycleMetadata);
+			Container.set(LifecycleMetadata, registered);
+
+			try {
+				const hooks = getLifecycleHooksForRegularMain(
+					{ executionMode: 'manual', workflowData },
+					executionId,
+				);
+
+				await expect(
+					hooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]),
+				).rejects.toThrow(vetoed);
+			} finally {
+				Container.set(LifecycleMetadata, original);
+			}
+		});
+	});
 
 	describe('getLifecycleHooksForRegularMain', () => {
 		const createHooks = (

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -52,7 +52,7 @@ import {
 import { type ExecutionSaveSettings, toSaveSettings } from './to-save-settings';
 
 @Service()
-export class ModulesHooksRegistry {
+class ModulesHooksRegistry {
 	/**
 	 * `source` is not carried on `ExecutionLifecycleHooks`, so it is passed in
 	 * here to let module handlers tell agent-initiated runs from user ones.

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -52,7 +52,7 @@ import {
 import { type ExecutionSaveSettings, toSaveSettings } from './to-save-settings';
 
 @Service()
-class ModulesHooksRegistry {
+export class ModulesHooksRegistry {
 	/**
 	 * `source` is not carried on `ExecutionLifecycleHooks`, so it is passed in
 	 * here to let module handlers tell agent-initiated runs from user ones.

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
@@ -208,6 +208,30 @@ describe('PolicyDecisionService', () => {
 		});
 	});
 
+	describe('hasChecksFor', () => {
+		it('is false when nothing is registered', () => {
+			expect(serviceWith().hasChecksFor('workflowStart')).toBe(false);
+		});
+
+		it('is true for a point a registered check implements', () => {
+			expect(serviceWith(StartOnlyCheck).hasChecksFor('workflowStart')).toBe(true);
+		});
+
+		// A host skips context assembly on `false`, so counting a check registered for another
+		// point would make it do that work — and carry that work's failure modes — for nothing.
+		it('is false for a point no registered check implements', () => {
+			expect(serviceWith(SilentCheck).hasChecksFor('workflowStart')).toBe(false);
+		});
+
+		it('agrees with what enforce would run', async () => {
+			const service = serviceWith(SilentCheck);
+
+			expect(service.hasChecksFor('workflowSave')).toBe(true);
+			expect((await service.enforce('workflowSave', saveContext)).violations).toEqual([]);
+			expect(service.hasChecksFor('workflowStart')).toBe(false);
+		});
+	});
+
 	describe('evaluate', () => {
 		it('returns an empty decision when no checks are registered', async () => {
 			expect(await serviceWith().evaluate('workflowSave', saveContext)).toEqual({

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
@@ -217,8 +217,6 @@ describe('PolicyDecisionService', () => {
 			expect(serviceWith(StartOnlyCheck).hasChecksFor('workflowStart')).toBe(true);
 		});
 
-		// A host skips context assembly on `false`, so counting a check registered for another
-		// point would make it do that work — and carry that work's failure modes — for nothing.
 		it('is false for a point no registered check implements', () => {
 			expect(serviceWith(SilentCheck).hasChecksFor('workflowStart')).toBe(false);
 		});

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
@@ -5,11 +5,9 @@ import type {
 } from '@n8n/decorators';
 import { LifecycleMetadata, PolicyCheck } from '@n8n/decorators';
 import { Container } from '@n8n/di';
-import { ExecutionLifecycleHooks } from 'n8n-core';
 import type { IWorkflowBase, Workflow } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
-import { ModulesHooksRegistry } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { PolicyViolationError } from '@/policy/policy-violation.error';
 import { OwnershipService } from '@/services/ownership.service';
@@ -135,37 +133,34 @@ describe('workflowExecuteBefore wiring', () => {
 		});
 	});
 
-	describe('through the hook chain', () => {
-		const runBeforeHook = async () => {
-			const hooks = new ExecutionLifecycleHooks('trigger', 'exec-1', workflow);
-			Container.get(ModulesHooksRegistry).addHooks(hooks);
+	// That a throw survives the hook chain is covered where the chain lives, in
+	// `execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts`.
+	describe('against the real decision service', () => {
+		const ownership = mock<OwnershipService>();
 
-			await hooks.runHook('workflowExecuteBefore', [mock<Workflow>(), undefined]);
-		};
-
-		beforeEach(() => {
+		const handler = () => {
 			// A fresh service each time: `setImplementation` is single-shot.
 			const enforcement = new PolicyEnforcementService();
 			enforcement.setImplementation(Container.get(PolicyDecisionService));
 
-			const ownership = mock<OwnershipService>();
+			return new PolicyLifecycleHandler(enforcement, ownership);
+		};
+
+		beforeEach(() => {
 			ownership.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
-
-			// The registry resolves the handler through DI, so it has to be this instance —
-			// the one wired to the real service that `ConfigurableCheck` is registered with.
-			Container.set(PolicyLifecycleHandler, new PolicyLifecycleHandler(enforcement, ownership));
-
 			Container.get(ConfigurableCheck).result = { violations: [] };
 		});
 
 		it('lets an always-allowed start through', async () => {
-			await expect(runBeforeHook()).resolves.toBeUndefined();
+			await expect(handler().onWorkflowExecuteBefore(beforeContext())).resolves.toBeUndefined();
 		});
 
-		it('propagates a violation, so nothing in the chain swallows it', async () => {
+		it('throws a PolicyViolationError when a check reports one', async () => {
 			Container.get(ConfigurableCheck).result = { violations: [violation] };
 
-			await expect(runBeforeHook()).rejects.toThrow(PolicyViolationError);
+			await expect(handler().onWorkflowExecuteBefore(beforeContext())).rejects.toThrow(
+				PolicyViolationError,
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
@@ -1,11 +1,10 @@
-import type { Logger } from '@n8n/backend-common';
-import { mockLogger } from '@n8n/backend-test-utils';
 import type {
+	PolicyCheckClass,
 	PolicyCheckResult,
 	RegisteredPolicyCheck,
 	WorkflowExecuteBeforeContext,
 } from '@n8n/decorators';
-import { LifecycleMetadata, PolicyCheck } from '@n8n/decorators';
+import { LifecycleMetadata, PolicyCheck, PolicyCheckMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { ExecutionLifecycleHooks } from 'n8n-core';
 import type { IWorkflowBase, Workflow } from 'n8n-workflow';
@@ -46,13 +45,17 @@ const beforeContext = (
 describe('PolicyLifecycleHandler', () => {
 	const policyEnforcementService = mock<PolicyEnforcementService>();
 	const ownershipService = mock<OwnershipService>();
-	const scopedLogger = mock<Logger>();
-	const logger = mock<Logger>({ scoped: vi.fn().mockReturnValue(scopedLogger) });
+	const checkMetadata = mock<PolicyCheckMetadata>();
 
-	const handler = new PolicyLifecycleHandler(policyEnforcementService, ownershipService, logger);
+	const handler = new PolicyLifecycleHandler(
+		policyEnforcementService,
+		ownershipService,
+		checkMetadata,
+	);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		checkMetadata.getClasses.mockReturnValue([mock<PolicyCheckClass>()]);
 		ownershipService.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
 		policyEnforcementService.enforceWorkflowStart.mockResolvedValue(mock());
 	});
@@ -84,16 +87,26 @@ describe('PolicyLifecycleHandler', () => {
 		await expect(handler.onWorkflowExecuteBefore(beforeContext())).rejects.toBe(error);
 	});
 
-	it('still enforces with a null project when the project cannot be resolved', async () => {
-		ownershipService.getWorkflowProjectCached.mockRejectedValue(new Error('no shared row'));
+	it('blocks the run when the owning project cannot be resolved', async () => {
+		// An unevaluated project-scoped rule is not a passed one, so this must not degrade into
+		// enforcing with no project.
+		const error = new Error('no shared row');
+		ownershipService.getWorkflowProjectCached.mockRejectedValue(error);
+
+		await expect(handler.onWorkflowExecuteBefore(beforeContext())).rejects.toBe(error);
+
+		expect(policyEnforcementService.enforceWorkflowStart).not.toHaveBeenCalled();
+	});
+
+	it('does nothing at all when no policy check is registered', async () => {
+		// The feature being absent must never fail an execution, so it must not even reach the
+		// project lookup, which can throw.
+		checkMetadata.getClasses.mockReturnValue([]);
 
 		await handler.onWorkflowExecuteBefore(beforeContext());
 
-		expect(policyEnforcementService.enforceWorkflowStart).toHaveBeenCalledExactlyOnceWith({
-			workflow,
-			projectId: null,
-		});
-		expect(scopedLogger.warn).toHaveBeenCalledTimes(1);
+		expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
+		expect(policyEnforcementService.enforceWorkflowStart).not.toHaveBeenCalled();
 	});
 
 	it('does not enforce when the event carries no workflow instance', async () => {
@@ -144,10 +157,11 @@ describe('workflowExecuteBefore wiring', () => {
 			ownership.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
 
 			// The registry resolves the handler through DI, so the instance it gets has to be
-			// the one wired to the real enforcement service.
+			// the one wired to the real enforcement service. The real metadata registry is used
+			// on both sides, so `ConfigurableCheck` below is what makes the handler act.
 			Container.set(
 				PolicyLifecycleHandler,
-				new PolicyLifecycleHandler(enforcement, ownership, mockLogger()),
+				new PolicyLifecycleHandler(enforcement, ownership, Container.get(PolicyCheckMetadata)),
 			);
 
 			Container.get(ConfigurableCheck).result = { violations: [] };

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
@@ -1,0 +1,166 @@
+import type { Logger } from '@n8n/backend-common';
+import { mockLogger } from '@n8n/backend-test-utils';
+import type {
+	PolicyCheckResult,
+	RegisteredPolicyCheck,
+	WorkflowExecuteBeforeContext,
+} from '@n8n/decorators';
+import { LifecycleMetadata, PolicyCheck } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import { ExecutionLifecycleHooks } from 'n8n-core';
+import type { IWorkflowBase, Workflow } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { ModulesHooksRegistry } from '@/execution-lifecycle/execution-lifecycle-hooks';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
+import { OwnershipService } from '@/services/ownership.service';
+
+import { PolicyCheckFailedError } from '../policy-check-failed.error';
+import { PolicyDecisionService } from '../policy-decision.service';
+import { PolicyLifecycleHandler } from '../policy-lifecycle-handler';
+
+const violation = {
+	kind: 'node-type-unavailable',
+	checkId: 'node-types',
+	message: 'n8n-nodes-base.slack is not available',
+};
+
+const workflow = mock<IWorkflowBase>({
+	id: 'wf-1',
+	name: 'My workflow',
+	nodes: [],
+});
+
+const beforeContext = (
+	overrides: Partial<WorkflowExecuteBeforeContext> = {},
+): WorkflowExecuteBeforeContext => ({
+	type: 'workflowExecuteBefore',
+	workflow,
+	mode: 'trigger',
+	workflowInstance: mock<Workflow>(),
+	executionId: 'exec-1',
+	...overrides,
+});
+
+describe('PolicyLifecycleHandler', () => {
+	const policyEnforcementService = mock<PolicyEnforcementService>();
+	const ownershipService = mock<OwnershipService>();
+	const scopedLogger = mock<Logger>();
+	const logger = mock<Logger>({ scoped: vi.fn().mockReturnValue(scopedLogger) });
+
+	const handler = new PolicyLifecycleHandler(policyEnforcementService, ownershipService, logger);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
+		policyEnforcementService.enforceWorkflowStart.mockResolvedValue(mock());
+	});
+
+	it('enforces the workflow start point with the workflow and its owning project', async () => {
+		await handler.onWorkflowExecuteBefore(beforeContext());
+
+		expect(policyEnforcementService.enforceWorkflowStart).toHaveBeenCalledExactlyOnceWith({
+			workflow,
+			projectId: 'proj-1',
+		});
+	});
+
+	it('lets the execution proceed when the checks clear', async () => {
+		await expect(handler.onWorkflowExecuteBefore(beforeContext())).resolves.toBeUndefined();
+	});
+
+	it('propagates a policy violation instead of swallowing it', async () => {
+		const error = new PolicyViolationError([violation]);
+		policyEnforcementService.enforceWorkflowStart.mockRejectedValue(error);
+
+		await expect(handler.onWorkflowExecuteBefore(beforeContext())).rejects.toBe(error);
+	});
+
+	it('propagates a check that failed to run', async () => {
+		const error = new PolicyCheckFailedError('workflowStart', ['corr-1']);
+		policyEnforcementService.enforceWorkflowStart.mockRejectedValue(error);
+
+		await expect(handler.onWorkflowExecuteBefore(beforeContext())).rejects.toBe(error);
+	});
+
+	it('still enforces with a null project when the project cannot be resolved', async () => {
+		ownershipService.getWorkflowProjectCached.mockRejectedValue(new Error('no shared row'));
+
+		await handler.onWorkflowExecuteBefore(beforeContext());
+
+		expect(policyEnforcementService.enforceWorkflowStart).toHaveBeenCalledExactlyOnceWith({
+			workflow,
+			projectId: null,
+		});
+		expect(scopedLogger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not enforce when the event carries no workflow instance', async () => {
+		// Queue mode fires this on main once the job is enqueued, and the pre-flight-failure
+		// recorder fires it for a run that already failed.
+		await handler.onWorkflowExecuteBefore(beforeContext({ workflowInstance: undefined }));
+
+		expect(policyEnforcementService.enforceWorkflowStart).not.toHaveBeenCalled();
+		expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
+	});
+});
+
+/** Stands in for a real check; the only one registered in this suite. */
+@PolicyCheck()
+class ConfigurableCheck implements RegisteredPolicyCheck {
+	readonly id = 'configurable';
+
+	result: PolicyCheckResult = { violations: [] };
+
+	async onWorkflowStart(): Promise<PolicyCheckResult> {
+		return this.result;
+	}
+}
+
+describe('workflowExecuteBefore wiring', () => {
+	it('registers the handler for the workflowExecuteBefore lifecycle event', () => {
+		expect(Container.get(LifecycleMetadata).getHandlers()).toContainEqual({
+			handlerClass: PolicyLifecycleHandler,
+			methodName: 'onWorkflowExecuteBefore',
+			eventName: 'workflowExecuteBefore',
+		});
+	});
+
+	describe('through the hook chain', () => {
+		const runBeforeHook = async () => {
+			const hooks = new ExecutionLifecycleHooks('trigger', 'exec-1', workflow);
+			Container.get(ModulesHooksRegistry).addHooks(hooks);
+
+			await hooks.runHook('workflowExecuteBefore', [mock<Workflow>(), undefined]);
+		};
+
+		beforeEach(() => {
+			// A fresh service each time: `setImplementation` is single-shot.
+			const enforcement = new PolicyEnforcementService();
+			enforcement.setImplementation(Container.get(PolicyDecisionService));
+
+			const ownership = mock<OwnershipService>();
+			ownership.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
+
+			// The registry resolves the handler through DI, so the instance it gets has to be
+			// the one wired to the real enforcement service.
+			Container.set(
+				PolicyLifecycleHandler,
+				new PolicyLifecycleHandler(enforcement, ownership, mockLogger()),
+			);
+
+			Container.get(ConfigurableCheck).result = { violations: [] };
+		});
+
+		it('lets an always-allowed start through', async () => {
+			await expect(runBeforeHook()).resolves.toBeUndefined();
+		});
+
+		it('propagates a violation, so nothing in the chain swallows it', async () => {
+			Container.get(ConfigurableCheck).result = { violations: [violation] };
+
+			await expect(runBeforeHook()).rejects.toThrow(PolicyViolationError);
+		});
+	});
+});

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
@@ -82,8 +82,6 @@ describe('PolicyLifecycleHandler', () => {
 	});
 
 	it('blocks the run when the owning project cannot be resolved', async () => {
-		// An unevaluated project-scoped rule is not a passed one, so this must not degrade into
-		// enforcing with no project.
 		const error = new Error('no shared row');
 		ownershipService.getWorkflowProjectCached.mockRejectedValue(error);
 
@@ -93,8 +91,6 @@ describe('PolicyLifecycleHandler', () => {
 	});
 
 	it('does nothing at all when no check guards the workflow start point', async () => {
-		// The feature being absent must never fail an execution, so it must not even reach the
-		// project lookup, which can throw.
 		policyEnforcementService.hasChecksFor.mockReturnValue(false);
 
 		await handler.onWorkflowExecuteBefore(beforeContext());
@@ -104,15 +100,13 @@ describe('PolicyLifecycleHandler', () => {
 	});
 
 	it('asks about the workflow start point specifically', async () => {
-		// A check registered only for another point must not drag this one into a lookup.
+		// So a check registered only for another point can't drag this one into a lookup.
 		await handler.onWorkflowExecuteBefore(beforeContext());
 
 		expect(policyEnforcementService.hasChecksFor).toHaveBeenCalledExactlyOnceWith('workflowStart');
 	});
 
 	it('does not enforce when the event carries no workflow instance', async () => {
-		// Queue mode fires this on main once the job is enqueued, and the pre-flight-failure
-		// recorder fires it for a run that already failed.
 		await handler.onWorkflowExecuteBefore(beforeContext({ workflowInstance: undefined }));
 
 		expect(policyEnforcementService.enforceWorkflowStart).not.toHaveBeenCalled();
@@ -157,9 +151,8 @@ describe('workflowExecuteBefore wiring', () => {
 			const ownership = mock<OwnershipService>();
 			ownership.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
 
-			// The registry resolves the handler through DI, so the instance it gets has to be
-			// the one wired to the real enforcement service — which is also what answers
-			// `hasChecksFor`, so `ConfigurableCheck` below is what makes the handler act.
+			// The registry resolves the handler through DI, so it has to be this instance —
+			// the one wired to the real service that `ConfigurableCheck` is registered with.
 			Container.set(PolicyLifecycleHandler, new PolicyLifecycleHandler(enforcement, ownership));
 
 			Container.get(ConfigurableCheck).result = { violations: [] };

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-lifecycle-handler.test.ts
@@ -1,10 +1,9 @@
 import type {
-	PolicyCheckClass,
 	PolicyCheckResult,
 	RegisteredPolicyCheck,
 	WorkflowExecuteBeforeContext,
 } from '@n8n/decorators';
-import { LifecycleMetadata, PolicyCheck, PolicyCheckMetadata } from '@n8n/decorators';
+import { LifecycleMetadata, PolicyCheck } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { ExecutionLifecycleHooks } from 'n8n-core';
 import type { IWorkflowBase, Workflow } from 'n8n-workflow';
@@ -45,17 +44,12 @@ const beforeContext = (
 describe('PolicyLifecycleHandler', () => {
 	const policyEnforcementService = mock<PolicyEnforcementService>();
 	const ownershipService = mock<OwnershipService>();
-	const checkMetadata = mock<PolicyCheckMetadata>();
 
-	const handler = new PolicyLifecycleHandler(
-		policyEnforcementService,
-		ownershipService,
-		checkMetadata,
-	);
+	const handler = new PolicyLifecycleHandler(policyEnforcementService, ownershipService);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		checkMetadata.getClasses.mockReturnValue([mock<PolicyCheckClass>()]);
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
 		ownershipService.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
 		policyEnforcementService.enforceWorkflowStart.mockResolvedValue(mock());
 	});
@@ -98,15 +92,22 @@ describe('PolicyLifecycleHandler', () => {
 		expect(policyEnforcementService.enforceWorkflowStart).not.toHaveBeenCalled();
 	});
 
-	it('does nothing at all when no policy check is registered', async () => {
+	it('does nothing at all when no check guards the workflow start point', async () => {
 		// The feature being absent must never fail an execution, so it must not even reach the
 		// project lookup, which can throw.
-		checkMetadata.getClasses.mockReturnValue([]);
+		policyEnforcementService.hasChecksFor.mockReturnValue(false);
 
 		await handler.onWorkflowExecuteBefore(beforeContext());
 
 		expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
 		expect(policyEnforcementService.enforceWorkflowStart).not.toHaveBeenCalled();
+	});
+
+	it('asks about the workflow start point specifically', async () => {
+		// A check registered only for another point must not drag this one into a lookup.
+		await handler.onWorkflowExecuteBefore(beforeContext());
+
+		expect(policyEnforcementService.hasChecksFor).toHaveBeenCalledExactlyOnceWith('workflowStart');
 	});
 
 	it('does not enforce when the event carries no workflow instance', async () => {
@@ -157,12 +158,9 @@ describe('workflowExecuteBefore wiring', () => {
 			ownership.getWorkflowProjectCached.mockResolvedValue(mock({ id: 'proj-1' }));
 
 			// The registry resolves the handler through DI, so the instance it gets has to be
-			// the one wired to the real enforcement service. The real metadata registry is used
-			// on both sides, so `ConfigurableCheck` below is what makes the handler act.
-			Container.set(
-				PolicyLifecycleHandler,
-				new PolicyLifecycleHandler(enforcement, ownership, Container.get(PolicyCheckMetadata)),
-			);
+			// the one wired to the real enforcement service — which is also what answers
+			// `hasChecksFor`, so `ConfigurableCheck` below is what makes the handler act.
+			Container.set(PolicyLifecycleHandler, new PolicyLifecycleHandler(enforcement, ownership));
 
 			Container.get(ConfigurableCheck).result = { violations: [] };
 		});

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
@@ -138,6 +138,14 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 		return failures.length > 0 ? { ...decision, checkErrors: failures } : decision;
 	}
 
+	/**
+	 * Answered from `runnersFor`, the same thing `enforce` and `evaluate` run, so this can't
+	 * disagree with them — a check registered for another point does not count here.
+	 */
+	hasChecksFor(point: EnforcementPoint): boolean {
+		return this.runnersFor(point).length > 0;
+	}
+
 	private async runChecks<Point extends EnforcementPoint>(
 		point: Point,
 		context: PolicyContext<Point>,

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
@@ -138,10 +138,7 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 		return failures.length > 0 ? { ...decision, checkErrors: failures } : decision;
 	}
 
-	/**
-	 * Answered from `runnersFor`, the same thing `enforce` and `evaluate` run, so this can't
-	 * disagree with them — a check registered for another point does not count here.
-	 */
+	/** From `runnersFor`, so this cannot disagree with what `enforce` and `evaluate` run. */
 	hasChecksFor(point: EnforcementPoint): boolean {
 		return this.runnersFor(point).length > 0;
 	}

--- a/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
@@ -21,5 +21,8 @@ export class PolicyInfrastructureModule implements ModuleInterface {
 		const { PolicyDecisionService } = await import('./policy-decision.service.js');
 
 		Container.get(PolicyEnforcementService).setImplementation(Container.get(PolicyDecisionService));
+
+		// Imported for its side effect: `@OnLifecycleEvent` registers on class definition.
+		await import('./policy-lifecycle-handler.js');
 	}
 }

--- a/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
@@ -6,12 +6,11 @@ import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { OwnershipService } from '@/services/ownership.service';
 
 /**
- * The execution backstop: every run passes through `workflowExecuteBefore`, so one
- * registration here covers all four hook-assembly variants — regular main, queue-mode
- * worker, sub-execution and manual — through `ModulesHooksRegistry`.
+ * The execution backstop. Every way an execution starts — main, queue worker,
+ * sub-execution, manual — runs `workflowExecuteBefore`, so one registration covers them all.
  *
- * A violation throws, and nothing between here and the engine catches it, so the run is
- * aborted and stored as `error`.
+ * Nothing catches a violation's throw before the engine, so the run is aborted and stored
+ * as `error`.
  */
 @Service()
 export class PolicyLifecycleHandler {
@@ -22,24 +21,16 @@ export class PolicyLifecycleHandler {
 
 	@OnLifecycleEvent('workflowExecuteBefore')
 	async onWorkflowExecuteBefore(ctx: WorkflowExecuteBeforeContext): Promise<void> {
-		// Queue mode fires this on main after enqueueing, and the pre-flight-failure recorder
-		// fires it for a run that already failed. Neither is about to execute anything: the
-		// worker's own hook gates the queued run, and blocking a failure record would only
-		// leave the execution half-written.
+		// Nothing is about to run: queue mode also fires this on main once the job is enqueued,
+		// where the worker's own hook gates it, and the failure recorder fires it for a dead run.
 		if (!ctx.workflowInstance) return;
 
-		// Nothing to decide means nothing worth a database lookup, and that lookup can fail —
-		// without this, a feature that is merely absent could fail an execution. Asked of the
-		// enforcement layer rather than worked out here, so a check registered only for another
-		// point cannot be mistaken for one that guards this one. Asked per invocation, so module
-		// load order can't decide whether a check runs.
+		// The lookup below can fail, so skip it when no check would read it — a feature that is
+		// merely absent must not fail executions. Asked per call, so load order can't hide one.
 		if (!this.policyEnforcementService.hasChecksFor('workflowStart')) return;
 
-		// Deliberately unguarded. Not knowing which project owns the workflow means
-		// project-scoped rules cannot be evaluated, and an unevaluated rule is not a passed
-		// one — so the run fails instead of proceeding under an assumed policy. This matches
-		// the other pre-execution gates (`credentials-permission-checker`,
-		// `subworkflow-policy-checker`), which also let this lookup throw.
+		// Deliberately unguarded: an unevaluated project rule is not a passed one, so a failed
+		// lookup fails the run. The other pre-execution gates let this throw too.
 		const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
 
 		await this.policyEnforcementService.enforceWorkflowStart({

--- a/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
@@ -1,0 +1,61 @@
+import { Logger } from '@n8n/backend-common';
+import { OnLifecycleEvent } from '@n8n/decorators';
+import type { WorkflowExecuteBeforeContext } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { OwnershipService } from '@/services/ownership.service';
+
+/**
+ * The execution backstop: every run passes through `workflowExecuteBefore`, so one
+ * registration here covers all four hook-assembly variants — regular main, queue-mode
+ * worker, sub-execution and manual — through `ModulesHooksRegistry`.
+ *
+ * A violation throws, and nothing between here and the engine catches it, so the run is
+ * aborted and stored as `error`.
+ */
+@Service()
+export class PolicyLifecycleHandler {
+	constructor(
+		private readonly policyEnforcementService: PolicyEnforcementService,
+		private readonly ownershipService: OwnershipService,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('policy');
+	}
+
+	@OnLifecycleEvent('workflowExecuteBefore')
+	async onWorkflowExecuteBefore(ctx: WorkflowExecuteBeforeContext): Promise<void> {
+		// Queue mode fires this on main after enqueueing, and the pre-flight-failure recorder
+		// fires it for a run that already failed. Neither is about to execute anything: the
+		// worker's own hook gates the queued run, and blocking a failure record would only
+		// leave the execution half-written.
+		if (!ctx.workflowInstance) return;
+
+		await this.policyEnforcementService.enforceWorkflowStart({
+			workflow: ctx.workflow,
+			projectId: await this.resolveProjectId(ctx),
+		});
+	}
+
+	/**
+	 * `null` when the workflow has no owning project we can find — an unsaved workflow run
+	 * from the editor, say. Instance-scoped checks still run; project-scoped ones are skipped
+	 * rather than enforced, which is why this is logged rather than swallowed silently.
+	 */
+	private async resolveProjectId(ctx: WorkflowExecuteBeforeContext): Promise<string | null> {
+		try {
+			const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
+
+			return project.id;
+		} catch (error) {
+			this.logger.warn('Could not resolve the project for a workflow start policy check', {
+				workflowId: ctx.workflow.id,
+				executionId: ctx.executionId,
+				error,
+			});
+
+			return null;
+		}
+	}
+}

--- a/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
@@ -1,5 +1,4 @@
-import { Logger } from '@n8n/backend-common';
-import { OnLifecycleEvent } from '@n8n/decorators';
+import { OnLifecycleEvent, PolicyCheckMetadata } from '@n8n/decorators';
 import type { WorkflowExecuteBeforeContext } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 
@@ -19,10 +18,8 @@ export class PolicyLifecycleHandler {
 	constructor(
 		private readonly policyEnforcementService: PolicyEnforcementService,
 		private readonly ownershipService: OwnershipService,
-		private readonly logger: Logger,
-	) {
-		this.logger = this.logger.scoped('policy');
-	}
+		private readonly checkMetadata: PolicyCheckMetadata,
+	) {}
 
 	@OnLifecycleEvent('workflowExecuteBefore')
 	async onWorkflowExecuteBefore(ctx: WorkflowExecuteBeforeContext): Promise<void> {
@@ -32,30 +29,21 @@ export class PolicyLifecycleHandler {
 		// leave the execution half-written.
 		if (!ctx.workflowInstance) return;
 
+		// Nothing registered means nothing to decide, and resolving the owning project below
+		// can fail — without this, a feature that is merely absent could fail an execution.
+		// Read per invocation, so module load order can't decide whether a check runs.
+		if (this.checkMetadata.getClasses().length === 0) return;
+
+		// Deliberately unguarded. Not knowing which project owns the workflow means
+		// project-scoped rules cannot be evaluated, and an unevaluated rule is not a passed
+		// one — so the run fails instead of proceeding under an assumed policy. This matches
+		// the other pre-execution gates (`credentials-permission-checker`,
+		// `subworkflow-policy-checker`), which also let this lookup throw.
+		const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
+
 		await this.policyEnforcementService.enforceWorkflowStart({
 			workflow: ctx.workflow,
-			projectId: await this.resolveProjectId(ctx),
+			projectId: project.id,
 		});
-	}
-
-	/**
-	 * `null` when the workflow has no owning project we can find — an unsaved workflow run
-	 * from the editor, say. Instance-scoped checks still run; project-scoped ones are skipped
-	 * rather than enforced, which is why this is logged rather than swallowed silently.
-	 */
-	private async resolveProjectId(ctx: WorkflowExecuteBeforeContext): Promise<string | null> {
-		try {
-			const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
-
-			return project.id;
-		} catch (error) {
-			this.logger.warn('Could not resolve the project for a workflow start policy check', {
-				workflowId: ctx.workflow.id,
-				executionId: ctx.executionId,
-				error,
-			});
-
-			return null;
-		}
 	}
 }

--- a/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-lifecycle-handler.ts
@@ -1,4 +1,4 @@
-import { OnLifecycleEvent, PolicyCheckMetadata } from '@n8n/decorators';
+import { OnLifecycleEvent } from '@n8n/decorators';
 import type { WorkflowExecuteBeforeContext } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 
@@ -18,7 +18,6 @@ export class PolicyLifecycleHandler {
 	constructor(
 		private readonly policyEnforcementService: PolicyEnforcementService,
 		private readonly ownershipService: OwnershipService,
-		private readonly checkMetadata: PolicyCheckMetadata,
 	) {}
 
 	@OnLifecycleEvent('workflowExecuteBefore')
@@ -29,10 +28,12 @@ export class PolicyLifecycleHandler {
 		// leave the execution half-written.
 		if (!ctx.workflowInstance) return;
 
-		// Nothing registered means nothing to decide, and resolving the owning project below
-		// can fail — without this, a feature that is merely absent could fail an execution.
-		// Read per invocation, so module load order can't decide whether a check runs.
-		if (this.checkMetadata.getClasses().length === 0) return;
+		// Nothing to decide means nothing worth a database lookup, and that lookup can fail —
+		// without this, a feature that is merely absent could fail an execution. Asked of the
+		// enforcement layer rather than worked out here, so a check registered only for another
+		// point cannot be mistaken for one that guards this one. Asked per invocation, so module
+		// load order can't decide whether a check runs.
+		if (!this.policyEnforcementService.hasChecksFor('workflowStart')) return;
 
 		// Deliberately unguarded. Not knowing which project owns the workflow means
 		// project-scoped rules cannot be evaluated, and an unevaluated rule is not a passed

--- a/packages/cli/src/policy/__tests__/policy-enforcement.service.test.ts
+++ b/packages/cli/src/policy/__tests__/policy-enforcement.service.test.ts
@@ -106,6 +106,11 @@ describe('PolicyEnforcementService', () => {
 
 			expect(second.violations).toEqual([]);
 		});
+
+		it('reports no checks for any point', () => {
+			expect(service.hasChecksFor('workflowStart')).toBe(false);
+			expect(service.hasChecksFor('credentialDecrypt')).toBe(false);
+		});
 	});
 
 	describe('setImplementation', () => {
@@ -127,6 +132,13 @@ describe('PolicyEnforcementService', () => {
 			backend = mock<PolicyEnforcementBackend>();
 			service = new PolicyEnforcementService();
 			service.setImplementation(backend);
+		});
+
+		it('asks the implementation about the point it was given', () => {
+			backend.hasChecksFor.mockReturnValue(true);
+
+			expect(service.hasChecksFor('workflowStart')).toBe(true);
+			expect(backend.hasChecksFor).toHaveBeenCalledExactlyOnceWith('workflowStart');
 		});
 
 		it('throws with every violation instead of minting', async () => {

--- a/packages/cli/src/policy/policy-enforcement-backend.ts
+++ b/packages/cli/src/policy/policy-enforcement-backend.ts
@@ -39,9 +39,6 @@ export interface PolicyEnforcementBackend {
 		context: PolicyContext<Point>,
 	): Promise<PolicyDecision>;
 
-	/**
-	 * Whether any check would run at this point. Must agree with what `enforce`/`evaluate`
-	 * would actually run, so it belongs here rather than being worked out by each host.
-	 */
+	/** Whether any check would run at this point. Must agree with `enforce` and `evaluate`. */
 	hasChecksFor(point: EnforcementPoint): boolean;
 }

--- a/packages/cli/src/policy/policy-enforcement-backend.ts
+++ b/packages/cli/src/policy/policy-enforcement-backend.ts
@@ -38,4 +38,10 @@ export interface PolicyEnforcementBackend {
 		point: Point,
 		context: PolicyContext<Point>,
 	): Promise<PolicyDecision>;
+
+	/**
+	 * Whether any check would run at this point. Must agree with what `enforce`/`evaluate`
+	 * would actually run, so it belongs here rather than being worked out by each host.
+	 */
+	hasChecksFor(point: EnforcementPoint): boolean;
 }

--- a/packages/cli/src/policy/policy-enforcement.service.ts
+++ b/packages/cli/src/policy/policy-enforcement.service.ts
@@ -52,6 +52,19 @@ export class PolicyEnforcementService {
 		this.implementation = implementation;
 	}
 
+	/**
+	 * Whether any check would run at `point`.
+	 *
+	 * For skipping work needed to *build* a context — a database lookup, say — when nothing
+	 * would read it. Not for deciding whether policy applies: `enforce*` already clears when
+	 * nothing is registered, so a host that has its context to hand should just call it. A host
+	 * that skips on `false` must skip the whole call, since a context it declined to assemble
+	 * cannot be passed.
+	 */
+	hasChecksFor(point: EnforcementPoint): boolean {
+		return this.implementation?.hasChecksFor(point) ?? false;
+	}
+
 	async enforceWorkflowSave(context: WorkflowSaveContext): Promise<PolicyCleared<'workflowSave'>> {
 		return await this.enforce('workflowSave', context, workflowSubject(context.workflow));
 	}

--- a/packages/cli/src/policy/policy-enforcement.service.ts
+++ b/packages/cli/src/policy/policy-enforcement.service.ts
@@ -53,13 +53,8 @@ export class PolicyEnforcementService {
 	}
 
 	/**
-	 * Whether any check would run at `point`.
-	 *
-	 * For skipping work needed to *build* a context — a database lookup, say — when nothing
-	 * would read it. Not for deciding whether policy applies: `enforce*` already clears when
-	 * nothing is registered, so a host that has its context to hand should just call it. A host
-	 * that skips on `false` must skip the whole call, since a context it declined to assemble
-	 * cannot be passed.
+	 * Whether any check would run at `point`. Only for skipping expensive work needed to build
+	 * a context — `enforce*` already clears, so a host holding its context should just call it.
 	 */
 	hasChecksFor(point: EnforcementPoint): boolean {
 		return this.implementation?.hasChecksFor(point) ?? false;

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -128,6 +128,64 @@ describe('processRunExecutionData', () => {
 		expect(runHook).toHaveBeenNthCalledWith(6, 'workflowExecuteAfter', expect.any(Array));
 	});
 
+	describe('a handler that throws at workflowExecuteBefore', () => {
+		const blocked = new UnexpectedError('blocked before the first node ran');
+
+		const rejectBeforeHook = () =>
+			runHook.mockImplementation(async (hookName: string) => {
+				if (hookName === 'workflowExecuteBefore') throw blocked;
+			});
+
+		const hookNames = () => (runHook.mock.calls as Array<[string]>).map(([name]) => name);
+
+		test('aborts the execution and keeps the error it was given', async () => {
+			// ARRANGE
+			const node = createNodeData({ name: 'node', type: types.passThrough });
+			const workflow = new DirectedGraph()
+				.addNodes(node)
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const executionData = createRunExecutionData({
+				startData: { startNodes: [{ name: node.name, sourceData: null }] },
+				executionData: {
+					nodeExecutionStack: [{ data: { main: [[{ json: { foo: 1 } }]] }, node, source: null }],
+				},
+			});
+
+			rejectBeforeHook();
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			expect(result.data.resultData.error?.message).toBe(blocked.message);
+			expect(hookNames()).toEqual(['workflowExecuteBefore', 'workflowExecuteAfter']);
+		});
+
+		// The stack is empty for e.g. a Chat Trigger-only workflow. Fabricating run data for a
+		// start node that isn't there used to throw a TypeError over the top of the real error.
+		test('keeps the error when there is no node on the execution stack', async () => {
+			// ARRANGE
+			const node = createNodeData({ name: 'node', type: types.passThrough });
+			const workflow = new DirectedGraph()
+				.addNodes(node)
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const executionData = createRunExecutionData({ executionData: { nodeExecutionStack: [] } });
+
+			rejectBeforeHook();
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			expect(result.data.resultData.error?.message).toBe(blocked.message);
+			expect(hookNames()).toEqual(['workflowExecuteBefore', 'workflowExecuteAfter']);
+		});
+	});
+
 	test('agent node emits nodeExecuteBefore only once when resuming after tool execution', async () => {
 		// ARRANGE
 		// Create agent node that returns EngineRequest, then resumes with tool results

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -7,6 +7,7 @@ import type {
 	IPairedItemData,
 	INodeExecutionData,
 	INodeType,
+	IRunExecutionData,
 } from 'n8n-workflow';
 import {
 	BaseError,
@@ -130,59 +131,47 @@ describe('processRunExecutionData', () => {
 
 	describe('a handler that throws at workflowExecuteBefore', () => {
 		const blocked = new UnexpectedError('blocked before the first node ran');
+		const node = createNodeData({ name: 'node', type: types.passThrough });
+		const workflow = new DirectedGraph()
+			.addNodes(node)
+			.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
 
-		const rejectBeforeHook = () =>
+		const runBlocked = async (executionData: IRunExecutionData) => {
 			runHook.mockImplementation(async (hookName: string) => {
 				if (hookName === 'workflowExecuteBefore') throw blocked;
 			});
 
-		const hookNames = () => (runHook.mock.calls as Array<[string]>).map(([name]) => name);
+			const result = await new WorkflowExecute(
+				additionalData,
+				executionMode,
+				executionData,
+			).processRunExecutionData(workflow);
+
+			return { result, hooks: (runHook.mock.calls as Array<[string]>).map(([name]) => name) };
+		};
 
 		test('aborts the execution and keeps the error it was given', async () => {
-			// ARRANGE
-			const node = createNodeData({ name: 'node', type: types.passThrough });
-			const workflow = new DirectedGraph()
-				.addNodes(node)
-				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+			const { result, hooks } = await runBlocked(
+				createRunExecutionData({
+					startData: { startNodes: [{ name: node.name, sourceData: null }] },
+					executionData: {
+						nodeExecutionStack: [{ data: { main: [[{ json: { foo: 1 } }]] }, node, source: null }],
+					},
+				}),
+			);
 
-			const executionData = createRunExecutionData({
-				startData: { startNodes: [{ name: node.name, sourceData: null }] },
-				executionData: {
-					nodeExecutionStack: [{ data: { main: [[{ json: { foo: 1 } }]] }, node, source: null }],
-				},
-			});
-
-			rejectBeforeHook();
-			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
-
-			// ACT
-			const result = await workflowExecute.processRunExecutionData(workflow);
-
-			// ASSERT
 			expect(result.data.resultData.error?.message).toBe(blocked.message);
-			expect(hookNames()).toEqual(['workflowExecuteBefore', 'workflowExecuteAfter']);
+			expect(hooks).toEqual(['workflowExecuteBefore', 'workflowExecuteAfter']);
 		});
 
-		// The stack is empty for e.g. a Chat Trigger-only workflow. Fabricating run data for a
-		// start node that isn't there used to throw a TypeError over the top of the real error.
+		// Empty for e.g. a Chat Trigger-only workflow, which used to mask the error with a TypeError.
 		test('keeps the error when there is no node on the execution stack', async () => {
-			// ARRANGE
-			const node = createNodeData({ name: 'node', type: types.passThrough });
-			const workflow = new DirectedGraph()
-				.addNodes(node)
-				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+			const { result, hooks } = await runBlocked(
+				createRunExecutionData({ executionData: { nodeExecutionStack: [] } }),
+			);
 
-			const executionData = createRunExecutionData({ executionData: { nodeExecutionStack: [] } });
-
-			rejectBeforeHook();
-			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
-
-			// ACT
-			const result = await workflowExecute.processRunExecutionData(workflow);
-
-			// ASSERT
 			expect(result.data.resultData.error?.message).toBe(blocked.message);
-			expect(hookNames()).toEqual(['workflowExecuteBefore', 'workflowExecuteAfter']);
+			expect(hooks).toEqual(['workflowExecuteBefore', 'workflowExecuteAfter']);
 		});
 	});
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1641,9 +1641,8 @@ export class WorkflowExecute {
 					};
 
 					// Set the incoming data of the node that it can be saved correctly.
-					// The stack is empty for an execution containing only a Chat Trigger, and there
-					// is then no node to attribute the failure to — record the error on its own
-					// rather than throwing over the top of it.
+					// A Chat Trigger-only workflow has an empty stack, so there may be no node to
+					// blame — recording the error alone beats throwing over the top of it.
 					const startItem = this.runExecutionData.executionData!.nodeExecutionStack.at(0);
 
 					if (startItem) {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1640,27 +1640,35 @@ export class WorkflowExecute {
 						stack: e.stack,
 					};
 
-					// Set the incoming data of the node that it can be saved correctly
+					// Set the incoming data of the node that it can be saved correctly.
+					// The stack is empty for an execution containing only a Chat Trigger, and there
+					// is then no node to attribute the failure to — record the error on its own
+					// rather than throwing over the top of it.
+					const startItem = this.runExecutionData.executionData!.nodeExecutionStack.at(0);
 
-					executionData = this.runExecutionData.executionData!.nodeExecutionStack[0];
-					const taskData: ITaskData = {
-						startTime: Date.now(),
-						executionIndex: 0,
-						executionTime: 0,
-						data: {
-							main: executionData.data.main,
-						},
-						source: [],
-						executionStatus: 'error',
-						hints: [],
-					};
-					this.runExecutionData.resultData = {
-						runData: {
-							[executionData.node.name]: [taskData],
-						},
-						lastNodeExecuted: executionData.node.name,
-						error: executionError,
-					};
+					if (startItem) {
+						executionData = startItem;
+						const taskData: ITaskData = {
+							startTime: Date.now(),
+							executionIndex: 0,
+							executionTime: 0,
+							data: {
+								main: executionData.data.main,
+							},
+							source: [],
+							executionStatus: 'error',
+							hints: [],
+						};
+						this.runExecutionData.resultData = {
+							runData: {
+								[executionData.node.name]: [taskData],
+							},
+							lastNodeExecuted: executionData.node.name,
+							error: executionError,
+						};
+					} else {
+						this.runExecutionData.resultData.error = executionError;
+					}
 
 					throw error;
 				}


### PR DESCRIPTION
## Summary

Wires the `workflowStart` enforcement point — the execution backstop. A new `PolicyLifecycleHandler` in the `policy-infrastructure` module registers one `@OnLifecycleEvent('workflowExecuteBefore')` handler that calls `PolicyEnforcementService.enforceWorkflowStart`. One registration covers all four hook-assembly variants (regular main, queue-mode worker, sub-execution, manual) through `ModulesHooksRegistry`, so the queue-mode gap closes by construction instead of needing four separate edits. Nothing between the handler and the engine catches the throw, so a violation aborts the run and the execution is stored as `error`. No policy backend is registered by default, so the proxy clears every start and behavior is unchanged.

Four notes for reviewers:

**The owning project is looked up, not passed in.** `WorkflowExecuteBeforeContext` carries no project. Threading `data.projectId` through `ModulesHooksRegistry.addHooks` was rejected because `job-processor.ts` builds the worker's hook data without a `projectId`, which would recreate exactly the queue-mode gap this design exists to close. The handler uses `OwnershipService.getWorkflowProjectCached` instead, cached per workflow.

**That lookup is deliberately unguarded, and only runs once a check guards this point.** Not knowing which project owns a workflow means project-scoped rules cannot be evaluated, and an unevaluated rule is not a passed one — so a failed lookup fails the run rather than enforcing with no project. This matches the other pre-execution gates, `credentials-permission-checker` and `subworkflow-policy-checker`, which both let this same lookup throw; the handlers that swallow it (OTEL, workflow statistics) are telemetry, where a lost span is harmless. To keep that from turning an absent feature into an outage, the handler returns early unless a check actually guards `workflowStart`. It asks the enforcement layer via the new `PolicyEnforcementService.hasChecksFor(point)`, answered from the same `runnersFor` that `enforce` and `evaluate` use, so the two cannot disagree and a check registered only for another point is not mistaken for one that guards this one. Asked per invocation, so module load order cannot decide whether a check runs.

**The handler skips two paths that fire the event without a `Workflow` instance.** Queue mode fires `workflowExecuteBefore` on **main** once the job is enqueued (`workflow-runner.ts:560`), and the pre-flight-failure recorder fires it for a run that already failed (`workflow-runner.ts:179`). Neither is about to execute anything. Without the guard, queue mode would enforce twice per execution for no gain — the worker's own hook gates the queued run — and a violation raised inside `failExecution` would break the failure-recording path, leaving the execution row half-written. `WorkflowExecuteBeforeContext.workflowInstance` is widened to `Workflow | undefined` because those two sites genuinely pass `undefined` and nothing ever caught it: `runHook`'s `Params` generic is inferred from the argument and only constrained to `unknown[]`, so no type relationship with the handler signature is enforced. The OTEL tests already admit this with `undefined as never`.

**One commit fixes error reporting in the engine, which this feature depends on.** The catch around the hook (`workflow-execute.ts`) fabricates run data for the start node without checking there is one. The node execution stack is empty for an execution containing only a Chat Trigger — a documented state, see `checkForWorkflowIssues` and `execution-context.ts` — so reading the start node's data threw a `TypeError` over the top of the real error, and the execution was stored with that message instead. This is pre-existing and affects every `workflowExecuteBefore` thrower, but the policy handler is the first one that throws on purpose, so a blocked run would have reported `Cannot read properties of undefined (reading 'data')` instead of the violation. The fix guards the lookup and records the error on its own when there is no node to attribute it to. Test 2 below fails without it.

Known gap, out of scope: a resumed execution fires `workflowExecuteResume`, not `workflowExecuteBefore`, so a waiting execution that resumes after a policy change is not re-checked. This is a property of the RFC's chosen hook. Happy to file a follow-up for a second registration on `workflowExecuteResume`.

Full per-execution-path integration coverage (main / queue worker / sub-execution / manual) is a separate ticket.

## How to test

The gate is a no-op in a default instance, so testing is mostly about proving nothing changed. Run any workflow — manual, trigger, sub-workflow, and queue mode — and it must behave exactly as before.

To see the call take effect, start n8n with `N8N_ENABLED_MODULES=policy-infrastructure` and register a `@PolicyCheck()` class whose `onWorkflowStart` returns a violation. Then:

1. Run an ordinary workflow. The execution must abort and be stored with status `error` and the violation message.
2. Run a **Chat Trigger-only** workflow. The execution must fail with the same violation message, not a `TypeError`. This is the case the engine fix is for.
3. Run a workflow in queue mode. The worker must block it too.
4. With the module enabled but **no** check registered, executions must run normally — including for a workflow whose owner row is missing.
5. Register a check that implements only `onWorkflowSave`. Executions must still run normally, since no check guards `workflowStart`.

```bash
cd packages/core
pnpm test src/execution-engine
pnpm typecheck

cd ../cli
pnpm test src/modules/policy-infrastructure
pnpm test src/execution-lifecycle
pnpm typecheck
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1124

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
