### PR TITLE
fix: Show modern form fields in Send and Wait custom forms

### DIFF
--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -2489,6 +2489,53 @@ describe('prepareFormReturnItem', () => {
 		expect(result.json.formMode).toBe('production');
 	});
 
+	it('should key output by custom field name when an explicit node version is passed', async () => {
+		mockContext.getBodyData.mockReturnValue({
+			data: { 'field-0': 'test value' },
+			files: {},
+		});
+		mockContext.getNode.mockReturnValue(
+			mock<INode>({ type: 'n8n-nodes-base.gmail', typeVersion: 1.2 }),
+		);
+
+		const formFields = [
+			{ fieldLabel: 'Email Address', fieldName: 'email', fieldType: 'text' as const },
+		];
+		const result = await prepareFormReturnItem(
+			mockContext,
+			formFields,
+			'production',
+			false,
+			undefined,
+			2.5,
+		);
+
+		expect(result.json.email).toBe('test value');
+		expect(result.json['Email Address']).toBeUndefined();
+	});
+
+	it('should fall back to the field label when no custom field name is set', async () => {
+		mockContext.getBodyData.mockReturnValue({
+			data: { 'field-0': 'test value' },
+			files: {},
+		});
+		mockContext.getNode.mockReturnValue(
+			mock<INode>({ type: 'n8n-nodes-base.gmail', typeVersion: 1.2 }),
+		);
+
+		const formFields = [{ fieldLabel: 'Email Address', fieldType: 'text' as const }];
+		const result = await prepareFormReturnItem(
+			mockContext,
+			formFields,
+			'production',
+			false,
+			undefined,
+			2.5,
+		);
+
+		expect(result.json['Email Address']).toBe('test value');
+	});
+
 	it('should process number fields correctly', async () => {
 		mockContext.getBodyData.mockReturnValue({
 			data: { 'field-0': '42' },

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -456,6 +456,7 @@ export async function prepareFormReturnItem(
 	mode: 'test' | 'production',
 	useWorkflowTimezone: boolean = false,
 	authedUser?: IUser,
+	nodeVersion: number = context.getNode().typeVersion,
 ) {
 	const req = context.getRequestObject() as MultiPartFormData.Request;
 	a.ok(req.contentType === 'multipart/form-data', 'Expected multipart/form-data');
@@ -500,7 +501,7 @@ export async function prepareFormReturnItem(
 
 		const entryIndex = Number(key.replace(/field-/g, ''));
 		const field = isNaN(entryIndex) ? null : formFields[entryIndex];
-		const fieldLabel = field ? getFieldIdentifier(field, context.getNode().typeVersion) : key;
+		const fieldLabel = field ? getFieldIdentifier(field, nodeVersion) : key;
 
 		let fileCount = 0;
 		for (const file of processFiles) {
@@ -531,8 +532,7 @@ export async function prepareFormReturnItem(
 		}
 	}
 
-	addFormResponseDataToReturnItem(returnItem, formFields, bodyData, context.getNode().typeVersion);
-
+	addFormResponseDataToReturnItem(returnItem, formFields, bodyData, nodeVersion);
 	const timezone = useWorkflowTimezone ? context.getTimezone() : 'UTC';
 	returnItem.json.submittedAt = DateTime.now().setZone(timezone).toISO();
 

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -2,6 +2,8 @@ import type { Request, Response } from 'express';
 import { type MockProxy, mock } from 'vitest-mock-extended';
 import type {
 	IExecuteFunctions,
+	INode,
+	INodeExecutionData,
 	INodeProperties,
 	IWebhookFunctions,
 	IWorkflowSettings,
@@ -62,32 +64,43 @@ describe('Send and Wait utils tests', () => {
 				]),
 			);
 		});
-
-		it('should always render modern custom-form fields regardless of host node version', () => {
+		it('should embed legacy and modern custom-form field schemas gated by Field Naming', () => {
 			const result = getSendAndWaitProperties([], 'message');
 
 			const customFormProps = result.filter((p) =>
 				(p.displayOptions?.show?.responseType as string[] | undefined)?.includes('customForm'),
 			);
-			const fields = customFormProps.find(
+			const schemas = customFormProps.filter(
 				(p) => p.name === 'formFields' && p.type === 'fixedCollection',
 			);
-			if (!fields) throw new Error('formFields fixedCollection not found');
-			expect(customFormProps.filter((p) => p.name === 'formFields')).toHaveLength(1);
+			// Legacy carries the Form node's own 2.4/2.5 collection pair; modern collapses
+			// both into the current dynamic-attributes editor.
+			const byNaming = (naming: string) =>
+				schemas.filter(
+					(p) => (p.displayOptions?.show?.formFieldsNaming as string[] | undefined)?.[0] === naming,
+				);
+			expect(byNaming('legacy')).toHaveLength(2);
+			expect(byNaming('modern')).toHaveLength(1);
 
-			const collection = fields.options?.[0] as { values: INodeProperties[] } | undefined;
-			if (!collection) throw new Error('form field values not found');
-			const values = collection.values;
-			expect(values.some((v) => v.name === 'fieldLabel' && v.displayName === 'Label')).toBe(true);
-			expect(
-				values.some((v) => v.name === 'fieldName' && v.displayName === 'Custom Field Name'),
-			).toBe(true);
-			expect(values.some((v) => v.name === 'fieldLabel' && v.displayName === 'Field Name')).toBe(
-				false,
+			const valuesOf = (schema: INodeProperties) =>
+				(schema.options?.[0] as { values: INodeProperties[] }).values;
+
+			// Legacy keeps the version-gated variants exactly as the Form node defines them.
+			const legacyValues = valuesOf(byNaming('legacy')[0]);
+			expect(legacyValues.some((v) => v.displayName === 'Field Name')).toBe(true);
+
+			// Modern always shows Label + Custom Field Name, free of @version gating.
+			const modernValues = valuesOf(byNaming('modern')[0]);
+			expect(modernValues.some((v) => v.name === 'fieldLabel' && v.displayName === 'Label')).toBe(
+				true,
 			);
 			expect(
-				values.every((v) => v.displayOptions?.show?.['@version'] === undefined),
+				modernValues.some((v) => v.name === 'fieldName' && v.displayName === 'Custom Field Name'),
 			).toBe(true);
+			expect(modernValues.some((v) => v.displayName === 'Field Name')).toBe(false);
+			expect(modernValues.every((v) => v.displayOptions?.show?.['@version'] === undefined)).toBe(
+				true,
+			);
 		});
 
 		it('should include extra options when provided', () => {
@@ -507,6 +520,87 @@ describe('Send and Wait utils tests', () => {
 				buttonLabel: 'Test button',
 				dangerousCustomCss: 'body { background-color: red; }',
 			});
+		});
+
+		it.each(['legacy', undefined])(
+			'should key customForm output by field label when Field Naming is %s',
+			async (formFieldsNaming) => {
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'POST',
+					contentType: 'multipart/form-data',
+				} as any);
+				mockWebhookFunctions.getResponseObject.mockReturnValue({
+					send: vi.fn(),
+				} as any);
+				mockWebhookFunctions.getNode.mockReturnValue({
+					typeVersion: 1.2,
+					type: 'n8n-nodes-base.gmail',
+					name: 'Node',
+				} as unknown as INode);
+				mockWebhookFunctions.getTimezone.mockReturnValue('UTC');
+				mockWebhookFunctions.getBodyData.mockReturnValue({
+					data: { 'field-0': 'test answer' },
+					files: {},
+				});
+				mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+					const params: { [key: string]: any } = {
+						responseType: 'customForm',
+						defineForm: 'fields',
+						formFieldsNaming,
+						'formFields.values': [
+							{ fieldLabel: 'Email Address', fieldName: 'email', fieldType: 'text' },
+						],
+						options: {},
+					};
+					return params[parameterName];
+				});
+
+				const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				const item = (result.workflowData as INodeExecutionData[][])[0][0];
+				const data = item.json.data as Record<string, unknown>;
+				expect(data['Email Address']).toBe('test answer');
+				expect(data.email).toBeUndefined();
+			},
+		);
+
+		it('should key customForm output by custom field name when Field Naming is modern', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'POST',
+				contentType: 'multipart/form-data',
+			} as any);
+			mockWebhookFunctions.getResponseObject.mockReturnValue({
+				send: vi.fn(),
+			} as any);
+			mockWebhookFunctions.getNode.mockReturnValue({
+				typeVersion: 1.2,
+				type: 'n8n-nodes-base.gmail',
+				name: 'Node',
+			} as unknown as INode);
+			mockWebhookFunctions.getTimezone.mockReturnValue('UTC');
+			mockWebhookFunctions.getBodyData.mockReturnValue({
+				data: { 'field-0': 'test answer' },
+				files: {},
+			});
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'customForm',
+					defineForm: 'fields',
+					formFieldsNaming: 'modern',
+					'formFields.values': [
+						{ fieldLabel: 'Email Address', fieldName: 'email', fieldType: 'text' },
+					],
+					options: {},
+				};
+				return params[parameterName];
+			});
+
+			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			const item = (result.workflowData as INodeExecutionData[][])[0][0];
+			const data = item.json.data as Record<string, unknown>;
+			expect(data.email).toBe('test answer');
+			expect(data['Email Address']).toBeUndefined();
 		});
 
 		it('should resolve expressions in HTML fields for customForm GET webhook', async () => {

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -63,6 +63,33 @@ describe('Send and Wait utils tests', () => {
 			);
 		});
 
+		it('should always render modern custom-form fields regardless of host node version', () => {
+			const result = getSendAndWaitProperties([], 'message');
+
+			const customFormProps = result.filter((p) =>
+				(p.displayOptions?.show?.responseType as string[] | undefined)?.includes('customForm'),
+			);
+			const fields = customFormProps.find(
+				(p) => p.name === 'formFields' && p.type === 'fixedCollection',
+			);
+			if (!fields) throw new Error('formFields fixedCollection not found');
+			expect(customFormProps.filter((p) => p.name === 'formFields')).toHaveLength(1);
+
+			const collection = fields.options?.[0] as { values: INodeProperties[] } | undefined;
+			if (!collection) throw new Error('form field values not found');
+			const values = collection.values;
+			expect(values.some((v) => v.name === 'fieldLabel' && v.displayName === 'Label')).toBe(true);
+			expect(
+				values.some((v) => v.name === 'fieldName' && v.displayName === 'Custom Field Name'),
+			).toBe(true);
+			expect(values.some((v) => v.name === 'fieldLabel' && v.displayName === 'Field Name')).toBe(
+				false,
+			);
+			expect(
+				values.every((v) => v.displayOptions?.show?.['@version'] === undefined),
+			).toBe(true);
+		});
+
 		it('should include extra options when provided', () => {
 			const targetProperties: INodeProperties[] = [
 				{

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -47,7 +47,8 @@ type FormResponseTypeOptions = {
 
 const INPUT_FIELD_IDENTIFIER = 'field-0';
 
-// Output identifiers resolve like Form >=2.5: prefer fieldName, fall back to fieldLabel.
+// Used when Field Naming is set to "Label + Custom Field Name"; identifiers resolve
+// like Form >=2.5: prefer fieldName, fall back to fieldLabel.
 const FORM_FIELD_IDENTIFIER_VERSION = 2.5;
 
 const appendAttributionOption: INodeProperties = {
@@ -236,10 +237,46 @@ export function getSendAndWaitProperties(
 				},
 			],
 		},
+		{
+			displayName: 'Field Naming',
+			name: 'formFieldsNaming',
+			type: 'options',
+			default: 'legacy',
+			description: 'How to name form fields and their output keys',
+			displayOptions: {
+				show: {
+					responseType: ['customForm'],
+				},
+			},
+			options: [
+				{
+					name: 'Field Name (legacy)',
+					value: 'legacy',
+					description:
+						'A single Field Name per element, shown as the label and used as the output key',
+				},
+				{
+					name: 'Label + Custom Field Name',
+					value: 'modern',
+					description:
+						'Separate Label and optional Custom Field Name, matching the current Form node; a custom name becomes the output key. Changing this may change existing output keys.',
+				},
+			],
+		},
 		...updateDisplayOptions(
 			{
 				show: {
 					responseType: ['customForm'],
+					formFieldsNaming: ['legacy'],
+				},
+			},
+			formFieldsProperties,
+		),
+		...updateDisplayOptions(
+			{
+				show: {
+					responseType: ['customForm'],
+					formFieldsNaming: ['modern'],
 				},
 			},
 			modernizeFormFieldsVersions(formFieldsProperties),
@@ -507,13 +544,15 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 			};
 		}
 		if (method === 'POST') {
+			const useModernIdentifiers =
+				this.getNodeParameter('formFieldsNaming', 'legacy') === 'modern';
 			const returnItem = await prepareFormReturnItem(
 				this,
 				fields,
 				'production',
 				true,
 				undefined,
-				FORM_FIELD_IDENTIFIER_VERSION,
+				useModernIdentifiers ? FORM_FIELD_IDENTIFIER_VERSION : undefined,
 			);
 			const json = returnItem.json;
 

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -1,6 +1,7 @@
 import isbot from 'isbot';
 import { getHtmlSandboxCSP, isFormHtmlSandboxingDisabled } from 'n8n-core';
 import type {
+	DisplayCondition,
 	FormFieldsParameter,
 	IDataObject,
 	IExecuteFunctions,
@@ -46,6 +47,9 @@ type FormResponseTypeOptions = {
 
 const INPUT_FIELD_IDENTIFIER = 'field-0';
 
+// Output identifiers resolve like Form >=2.5: prefer fieldName, fall back to fieldLabel.
+const FORM_FIELD_IDENTIFIER_VERSION = 2.5;
+
 const appendAttributionOption: INodeProperties = {
 	displayName: 'Append n8n Attribution',
 	name: 'appendAttribution',
@@ -54,6 +58,41 @@ const appendAttributionOption: INodeProperties = {
 	description:
 		'Whether to include the phrase "This message was sent automatically with n8n" to the end of the message',
 };
+// Shared form field definitions gate fields on the Form node's version history; strip
+// that so every channel renders the modern schema (Label + Custom Field Name).
+function hasModernVersionCondition(version: Array<number | DisplayCondition>): boolean {
+	return version.some((entry) => typeof entry === 'object' && 'gte' in entry._cnd);
+}
+
+function modernizeFormFieldsVersions(properties: INodeProperties[]): INodeProperties[] {
+	const walk = (props: INodeProperties[]): INodeProperties[] =>
+		props.flatMap((property) => {
+			const version = property.displayOptions?.show?.['@version'];
+			if (version && !hasModernVersionCondition(version)) return [];
+
+			const displayOptions =
+				property.displayOptions && {
+					...property.displayOptions,
+					show: { ...property.displayOptions.show },
+				};
+			delete displayOptions?.show?.['@version'];
+
+			return [
+				{
+					...property,
+					...(displayOptions ? { displayOptions } : {}),
+					...(Array.isArray(property.options)
+						? {
+								options: property.options.map((option) =>
+									'values' in option ? { ...option, values: walk(option.values) } : option,
+								),
+							}
+						: {}),
+				},
+			];
+		});
+	return walk(properties);
+}
 
 // Operation Properties ----------------------------------------------------------
 export function getSendAndWaitProperties(
@@ -203,7 +242,7 @@ export function getSendAndWaitProperties(
 					responseType: ['customForm'],
 				},
 			},
-			formFieldsProperties,
+			modernizeFormFieldsVersions(formFieldsProperties),
 		),
 
 		{
@@ -468,7 +507,14 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 			};
 		}
 		if (method === 'POST') {
-			const returnItem = await prepareFormReturnItem(this, fields, 'production', true);
+			const returnItem = await prepareFormReturnItem(
+				this,
+				fields,
+				'production',
+				true,
+				undefined,
+				FORM_FIELD_IDENTIFIER_VERSION,
+			);
 			const json = returnItem.json;
 
 			delete json.submittedAt;


### PR DESCRIPTION
## Summary

While setting up a Send and Wait approval flow on Gmail I wanted to collect a few structured answers, so I switched the Response Type to Custom Form. The form editor looked different from the regular Form node: no separate Label and Custom Field Name, just the old single "Field Name" input.

Digging into it, the reason is that all the messaging nodes (Gmail, Slack, Telegram, Teams, Outlook, Discord, WhatsApp, Email Send, Google Chat) reuse `formFieldsProperties` from the Form node, but those shared field definitions carry `@version` display conditions that were written for the Form node's own version history (the field name/label split happened at Form 2.4, "Custom Field Name" arrived at 2.5). Since the conditions end up being evaluated against each *host* node's version — Gmail is at 2.2, Telegram at 1.2, etc. — almost every channel falls back to rendering the pre-2.4 legacy field. Only Slack, which happens to be past 2.5, shows the modern editor.

This PR adds an explicit **Field Naming** option to the Custom Form response type:

- **Field Name (legacy)** (default) — exactly what these nodes show today: a single Field Name per element, used as both label and output key.
- **Label + Custom Field Name** — the modern schema matching the current Form node: separate Label, Element Type, Custom Field Name, Placeholder and Default Value, with output keys preferring the custom name.

The default keeps every existing workflow byte-identical (including edge cases where stored fields carry both keys), while letting anyone opt into the modern editor on any channel — including their existing Gmail/Telegram/WhatsApp nodes.

AI disclosure: this change was developed with the help of an AI coding agent; the investigation, testing and description here are my own.

## How to test

1. Open any workflow with a Gmail (or Telegram / WhatsApp / Email Send) node, choose the **Send and Wait** operation and set **Response Type → Custom Form**.
2. The editor defaults to the legacy single Field Name view. Switch **Field Naming → Label + Custom Field Name**: the Form Elements editor now shows Label, Element Type, Custom Field Name, Placeholder and Default Value, matching the Form / Form Trigger nodes.
3. Set a Label of e.g. "Email Address" and a Custom Field Name of `email`, execute the node and submit the form through the link in the message.
4. The output item should be keyed by `email` (the custom name), not by the label.
5. With Field Naming left on the default legacy value — including in workflows created before this change — output keys are exactly what master produces today.

Regression tests are included:
- `packages/nodes-base/utils/sendAndWait/test/util.test.ts` — asserts the dual-schema embed (legacy untouched, modern stripped of version gating) and that webhook output keys follow the Field Naming option
- `packages/nodes-base/nodes/Form/test/utils.test.ts` — asserts output keying prefers `fieldName` with an explicit version, and falls back to the label otherwise

To see them fail against master: the schema test fails because there is no Field Naming option at all; the webhook tests fail because output is keyed by the label even when a custom field name is set.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #36960

Related context:

- https://github.com/n8n-io/n8n/pull/22304 — the Form Node change that split form name and label (the source of the version gating this PR normalizes)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




