### PR TITLE
feat(core): Wire credentialDecrypt host point (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -19,6 +19,7 @@ import type {
 	IAuthenticateGeneric,
 	ICredentialDataDecryptedObject,
 	ICredentialType,
+	IExecuteData,
 	IHttpRequestHelper,
 	IHttpRequestOptions,
 	INode,
@@ -50,6 +51,7 @@ import type { CredentialsOverwrites } from '@/credentials-overwrites';
 import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import type { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-secrets.config';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { AiGatewayService } from '@/services/ai-gateway.service';
 
 describe('CredentialsHelper', () => {
@@ -60,6 +62,7 @@ describe('CredentialsHelper', () => {
 	const licenseState = mock<LicenseState>();
 	const externalSecretsConfig = mock<ExternalSecretsConfig>();
 	const mockLogger = mock<any>();
+	const policyEnforcementService = mock<PolicyEnforcementService>();
 	// Use a real instance of DynamicCredentialsProxy so setResolverProvider works
 	const dynamicCredentialProxy = new DynamicCredentialsProxy(mockLogger);
 
@@ -81,6 +84,7 @@ describe('CredentialsHelper', () => {
 		licenseState,
 		externalSecretsConfig,
 		mock<AiGatewayService>(),
+		policyEnforcementService,
 	);
 
 	describe('getCredentials', () => {
@@ -179,6 +183,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 
 			const result = await helper.applyDefaultsAndOverwrites(
@@ -232,6 +237,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 
 			await expect(
@@ -275,6 +281,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 			const externalSecretsProxy =
 				mock<NonNullable<IWorkflowExecuteAdditionalData['externalSecretsProxy']>>();
@@ -354,6 +361,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 
 			// Region left at its default: neither `region` nor `url` was persisted.
@@ -413,6 +421,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 
 			const result = await helper.applyDefaultsAndOverwrites(
@@ -455,6 +464,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 
 		const registerType = (credentialType: ICredentialType) =>
@@ -1243,6 +1253,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				aiGatewayService,
+				policyEnforcementService,
 			);
 
 			const syntheticCred = { apiKey: 'mock-jwt', host: 'http://gateway/v1/gateway/google' };
@@ -1288,6 +1299,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				aiGatewayService,
+				policyEnforcementService,
 			);
 
 			const syntheticCred = { apiKey: 'mock-jwt', host: 'http://gateway/v1/gateway/google' };
@@ -1335,6 +1347,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				aiGatewayService,
+				policyEnforcementService,
 			);
 
 			const syntheticCred = {
@@ -1570,6 +1583,7 @@ describe('CredentialsHelper', () => {
 				licenseState,
 				externalSecretsConfig,
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 
 			const result = await helperWithoutProvider.getDecrypted(
@@ -1830,6 +1844,7 @@ describe('CredentialsHelper', () => {
 				mock<LicenseState>(),
 				mock<ExternalSecretsConfig>(),
 				mock<AiGatewayService>(),
+				policyEnforcementService,
 			);
 
 		// The loader sets the class's `supportedNodes` to short names (e.g. "restrictedConsumer");
@@ -2382,6 +2397,140 @@ describe('CredentialsHelper', () => {
 				{ installationId: expressionText, accessToken: 'NEW_TOKEN' },
 			);
 			expect(result).toMatchObject({ accessToken: 'NEW_TOKEN' });
+		});
+	});
+
+	describe('getDecrypted - credentialDecrypt policy enforcement', () => {
+		const nodeCredentials: INodeCredentialsDetails = {
+			id: 'cred-policy',
+			name: 'Policy Test Credential',
+		};
+
+		const credentialEntity = {
+			id: 'cred-policy',
+			name: 'Policy Test Credential',
+			type: 'testApi',
+			data: cipher.encrypt({ apiKey: 'test' }),
+			isResolvable: false,
+			usageScope: 'project',
+		} as CredentialsEntity;
+
+		let helper: CredentialsHelper;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			credentialsRepository.findOneByOrFail.mockResolvedValue(credentialEntity);
+			policyEnforcementService.enforceCredentialDecrypt.mockResolvedValue(mock());
+			helper = new CredentialsHelper(
+				new CredentialTypes(mockNodesAndCredentials),
+				mock(),
+				credentialsRepository,
+				dynamicCredentialProxy,
+				secretsProviderRepository,
+				licenseState,
+				externalSecretsConfig,
+				mock<AiGatewayService>(),
+				policyEnforcementService,
+			);
+		});
+
+		test('calls enforceCredentialDecrypt with the credential, consumer and project context', async () => {
+			const executeData = {
+				node: {
+					name: 'Slack1',
+					type: 'n8n-nodes-base.slack',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				data: {},
+				source: null,
+			} as IExecuteData;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({ projectId: 'proj-1' });
+
+			await helper.getDecrypted(
+				additionalData,
+				nodeCredentials,
+				'testApi',
+				'manual',
+				executeData,
+				true,
+			);
+
+			expect(policyEnforcementService.enforceCredentialDecrypt).toHaveBeenCalledExactlyOnceWith({
+				credentialType: 'testApi',
+				credentialId: 'cred-policy',
+				consumer: { nodeType: 'n8n-nodes-base.slack' },
+				projectId: 'proj-1',
+			});
+		});
+
+		test('passes a null consumer when no node is asking, e.g. a credential test', async () => {
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({ projectId: undefined });
+
+			await helper.getDecrypted(
+				additionalData,
+				nodeCredentials,
+				'testApi',
+				'manual',
+				undefined,
+				true,
+			);
+
+			expect(policyEnforcementService.enforceCredentialDecrypt).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ consumer: null, projectId: null }),
+			);
+		});
+
+		test('resolves the credential before enforcing the policy check', async () => {
+			const callOrder: string[] = [];
+			credentialsRepository.findOneByOrFail.mockImplementation(async () => {
+				callOrder.push('findOneByOrFail');
+				return credentialEntity;
+			});
+			policyEnforcementService.enforceCredentialDecrypt.mockImplementation(async () => {
+				callOrder.push('enforceCredentialDecrypt');
+				return await mock();
+			});
+
+			await helper.getDecrypted(
+				mock<IWorkflowExecuteAdditionalData>(),
+				nodeCredentials,
+				'testApi',
+				'manual',
+				undefined,
+				true,
+			);
+
+			expect(callOrder).toEqual(['findOneByOrFail', 'enforceCredentialDecrypt']);
+		});
+
+		test('blocks decryption when the policy check throws', async () => {
+			const violation = new Error('blocked by policy');
+			policyEnforcementService.enforceCredentialDecrypt.mockRejectedValueOnce(violation);
+
+			await expect(
+				helper.getDecrypted(
+					mock<IWorkflowExecuteAdditionalData>(),
+					nodeCredentials,
+					'testApi',
+					'manual',
+				),
+			).rejects.toThrow(violation);
+		});
+
+		test('decryption behavior is unchanged when the policy check clears', async () => {
+			const result = await helper.getDecrypted(
+				mock<IWorkflowExecuteAdditionalData>(),
+				nodeCredentials,
+				'testApi',
+				'manual',
+				undefined,
+				true,
+			);
+
+			expect(result).toEqual({ apiKey: 'test' });
 		});
 	});
 });

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -271,10 +271,9 @@ describe('WorkflowExecuteAdditionalData', () => {
 				mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
 			);
 
-			// getBase backfills projectId from the workflow owner (mocked to
-			// 'project-id-1' in this describe's beforeEach) when the sub-workflow
-			// call site omits it.
-			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, 'project-id-1');
+			// getBase passes the caller's projectId straight through to getVariables,
+			// which resolves the workflow owner internally when it's missing.
+			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, undefined);
 		});
 
 		describe('credential permission check routing', () => {
@@ -1272,7 +1271,10 @@ describe('WorkflowExecuteAdditionalData', () => {
 				webhookWaiting: '/webhook-waiting/',
 				webhookTest: '/webhook-test/',
 			});
-			vi.spyOn(WorkflowHelpers, 'getVariables').mockResolvedValue(mockVariables);
+			vi.spyOn(WorkflowHelpers, 'getVariables').mockResolvedValue({
+				variables: mockVariables,
+				projectId: undefined,
+			});
 		});
 
 		it('should return base additional data with default values', async () => {
@@ -1343,6 +1345,9 @@ describe('WorkflowExecuteAdditionalData', () => {
 				// mockInstance(OwnershipService), which each Container.set a fresh mock.
 				// Re-bind ours so the source resolves it.
 				Container.set(OwnershipService, ownershipService);
+				// This behavior lives inside the real getVariables, not getBase itself —
+				// undo the outer describe's stub so these tests exercise it for real.
+				vi.mocked(WorkflowHelpers.getVariables).mockRestore();
 			});
 
 			it('backfills projectId from the workflow owner when missing', async () => {

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -271,9 +271,9 @@ describe('WorkflowExecuteAdditionalData', () => {
 				mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
 			);
 
-			// getBase passes the caller's projectId straight through to getVariables,
-			// which resolves the workflow owner internally when it's missing.
-			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, undefined);
+			// getBase backfills projectId from the workflow owner (mocked to
+			// 'project-id-1' in this describe's beforeEach) before calling getVariables.
+			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, 'project-id-1');
 		});
 
 		describe('credential permission check routing', () => {
@@ -1372,12 +1372,10 @@ describe('WorkflowExecuteAdditionalData', () => {
 				expect(additionalData.projectId).toBeUndefined();
 			});
 
-			it('leaves projectId unset when the workflow has no resolvable owning project', async () => {
+			it('rejects when the workflow has no resolvable owning project', async () => {
 				ownershipService.getWorkflowProjectCached.mockRejectedValue(new Error('not found'));
 
-				const additionalData = await getBase({ workflowId: 'workflow-1' });
-
-				expect(additionalData.projectId).toBeUndefined();
+				await expect(getBase({ workflowId: 'workflow-1' })).rejects.toThrow('not found');
 			});
 		});
 	});

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -271,7 +271,10 @@ describe('WorkflowExecuteAdditionalData', () => {
 				mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
 			);
 
-			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, undefined);
+			// getBase backfills projectId from the workflow owner (mocked to
+			// 'project-id-1' in this describe's beforeEach) when the sub-workflow
+			// call site omits it.
+			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, 'project-id-1');
 		});
 
 		describe('credential permission check routing', () => {
@@ -1329,6 +1332,54 @@ describe('WorkflowExecuteAdditionalData', () => {
 			});
 
 			expect(additionalData.workflowSettings).toBe(workflowSettings);
+		});
+
+		describe('projectId resolution', () => {
+			const ownershipService = mockInstance(OwnershipService);
+
+			beforeEach(() => {
+				ownershipService.getWorkflowProjectCached.mockReset();
+				// Both this and the executeWorkflow/executeAgent describes call
+				// mockInstance(OwnershipService), which each Container.set a fresh mock.
+				// Re-bind ours so the source resolves it.
+				Container.set(OwnershipService, ownershipService);
+			});
+
+			it('backfills projectId from the workflow owner when missing', async () => {
+				ownershipService.getWorkflowProjectCached.mockResolvedValue(
+					mock<Project>({ id: 'owning-project-1' }),
+				);
+
+				const additionalData = await getBase({ workflowId: 'workflow-1' });
+
+				expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('workflow-1');
+				expect(additionalData.projectId).toBe('owning-project-1');
+			});
+
+			it('keeps the given projectId untouched when already present', async () => {
+				const additionalData = await getBase({
+					workflowId: 'workflow-1',
+					projectId: 'given-project',
+				});
+
+				expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
+				expect(additionalData.projectId).toBe('given-project');
+			});
+
+			it('leaves projectId unset when workflowId is missing', async () => {
+				const additionalData = await getBase();
+
+				expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
+				expect(additionalData.projectId).toBeUndefined();
+			});
+
+			it('leaves projectId unset when the workflow has no resolvable owning project', async () => {
+				ownershipService.getWorkflowProjectCached.mockRejectedValue(new Error('not found'));
+
+				const additionalData = await getBase({ workflowId: 'workflow-1' });
+
+				expect(additionalData.projectId).toBeUndefined();
+			});
 		});
 	});
 

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -1271,10 +1271,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				webhookWaiting: '/webhook-waiting/',
 				webhookTest: '/webhook-test/',
 			});
-			vi.spyOn(WorkflowHelpers, 'getVariables').mockResolvedValue({
-				variables: mockVariables,
-				projectId: undefined,
-			});
+			vi.spyOn(WorkflowHelpers, 'getVariables').mockResolvedValue(mockVariables);
 		});
 
 		it('should return base additional data with default values', async () => {
@@ -1345,9 +1342,6 @@ describe('WorkflowExecuteAdditionalData', () => {
 				// mockInstance(OwnershipService), which each Container.set a fresh mock.
 				// Re-bind ours so the source resolves it.
 				Container.set(OwnershipService, ownershipService);
-				// This behavior lives inside the real getVariables, not getBase itself —
-				// undo the outer describe's stub so these tests exercise it for real.
-				vi.mocked(WorkflowHelpers.getVariables).mockRestore();
 			});
 
 			it('backfills projectId from the workflow owner when missing', async () => {

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -35,6 +35,11 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { mock } from 'vitest-mock-extended';
 
 describe('workflow-helpers', () => {
+	const ownershipService = mockInstance(OwnershipService);
+	ownershipService.getWorkflowProjectCached.mockResolvedValue(
+		mock<Project>({ id: '1', name: 'project' }),
+	);
+
 	beforeAll(() => {
 		mockInstance(VariablesService, {
 			async getAllCached() {
@@ -64,38 +69,45 @@ describe('workflow-helpers', () => {
 				] as Variables[];
 			},
 		});
-
-		mockInstance(OwnershipService, {
-			async getWorkflowProjectCached(_workflowId: string) {
-				return { id: '1', name: 'project' } as unknown as Project;
-			},
-		});
 	});
 
 	describe('getVariables', () => {
 		it('should return all variables as key-value pairs if no parameters are given', async () => {
-			const variables = await getVariables();
+			const { variables, projectId } = await getVariables();
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2' });
+			expect(projectId).toBeUndefined();
 		});
 
 		it('should return global and project variables if projectId is given', async () => {
-			const variables = await getVariables(undefined, '1');
+			const { variables, projectId } = await getVariables(undefined, '1');
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value1Project', VAR4: 'value4' });
+			expect(projectId).toBe('1');
 		});
 
 		it('should return global and project variables if workflowId is given', async () => {
-			const variables = await getVariables('1');
+			const { variables, projectId } = await getVariables('1');
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value1Project', VAR4: 'value4' });
+			expect(projectId).toBe('1');
 		});
 
 		it('should prioritize passed of projectId over workflowId', async () => {
-			const variables = await getVariables('1', '2');
+			const { variables, projectId } = await getVariables('1', '2');
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2', VAR5: 'value5' });
+			expect(projectId).toBe('2');
 		});
 
 		it('should let a project variable override a same-key global regardless of order', async () => {
-			const variables = await getVariables(undefined, '1');
+			const { variables } = await getVariables(undefined, '1');
 			expect(variables.VAR2).toBe('value1Project');
+		});
+
+		it('should resolve global variables and leave projectId unset when the owning project cannot be resolved', async () => {
+			ownershipService.getWorkflowProjectCached.mockRejectedValueOnce(new Error('not found'));
+
+			const { variables, projectId } = await getVariables('1');
+
+			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2' });
+			expect(projectId).toBeUndefined();
 		});
 	});
 });

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -73,41 +73,36 @@ describe('workflow-helpers', () => {
 
 	describe('getVariables', () => {
 		it('should return all variables as key-value pairs if no parameters are given', async () => {
-			const { variables, projectId } = await getVariables();
+			const variables = await getVariables();
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2' });
-			expect(projectId).toBeUndefined();
 		});
 
 		it('should return global and project variables if projectId is given', async () => {
-			const { variables, projectId } = await getVariables(undefined, '1');
+			const variables = await getVariables(undefined, '1');
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value1Project', VAR4: 'value4' });
-			expect(projectId).toBe('1');
 		});
 
 		it('should return global and project variables if workflowId is given', async () => {
-			const { variables, projectId } = await getVariables('1');
+			const variables = await getVariables('1');
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value1Project', VAR4: 'value4' });
-			expect(projectId).toBe('1');
 		});
 
 		it('should prioritize passed of projectId over workflowId', async () => {
-			const { variables, projectId } = await getVariables('1', '2');
+			const variables = await getVariables('1', '2');
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2', VAR5: 'value5' });
-			expect(projectId).toBe('2');
 		});
 
 		it('should let a project variable override a same-key global regardless of order', async () => {
-			const { variables } = await getVariables(undefined, '1');
+			const variables = await getVariables(undefined, '1');
 			expect(variables.VAR2).toBe('value1Project');
 		});
 
-		it('should resolve global variables and leave projectId unset when the owning project cannot be resolved', async () => {
+		it('should resolve global variables without throwing when the owning project cannot be resolved', async () => {
 			ownershipService.getWorkflowProjectCached.mockRejectedValueOnce(new Error('not found'));
 
-			const { variables, projectId } = await getVariables('1');
+			const variables = await getVariables('1');
 
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2' });
-			expect(projectId).toBeUndefined();
 		});
 	});
 });

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -97,12 +97,10 @@ describe('workflow-helpers', () => {
 			expect(variables.VAR2).toBe('value1Project');
 		});
 
-		it('should resolve global variables without throwing when the owning project cannot be resolved', async () => {
+		it('should reject when the owning project cannot be resolved', async () => {
 			ownershipService.getWorkflowProjectCached.mockRejectedValueOnce(new Error('not found'));
 
-			const variables = await getVariables('1');
-
-			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2' });
+			await expect(getVariables('1')).rejects.toThrow('not found');
 		});
 	});
 });

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -46,6 +46,7 @@ import {
 	MANAGED_OAUTH_PINNED_FIELDS,
 } from '@/oauth/dcr-managed-fields';
 import { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-secrets.config';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { AiGatewayService } from '@/services/ai-gateway.service';
 
 import { RESPONSE_ERROR_MESSAGES } from './constants';
@@ -100,6 +101,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 		private readonly licenseState: LicenseState,
 		private readonly externalSecretsConfig: ExternalSecretsConfig,
 		private readonly aiGatewayService: AiGatewayService,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 	) {
 		super();
 	}
@@ -527,6 +529,15 @@ export class CredentialsHelper extends ICredentialsHelper {
 		}
 
 		const credentialsEntity = await this.getCredentialsEntity(nodeCredentials, type);
+
+		// Validate against the executing project's policy before any decryption happens.
+		await this.policyEnforcementService.enforceCredentialDecrypt({
+			credentialType: type,
+			credentialId: credentialsEntity.id,
+			consumer: executeData ? { nodeType: executeData.node.type } : null,
+			projectId: additionalData.projectId ?? null,
+		});
+
 		const credentials = new Credentials(
 			{ id: credentialsEntity.id, name: credentialsEntity.name },
 			credentialsEntity.type,

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -789,23 +789,13 @@ export async function getBase({
 
 	const globalConfig = Container.get(GlobalConfig);
 
-	// Trigger-fired, webhook, and worker-queued executions build additionalData without
-	// a `projectId` (see the `getBase` callers in `active-workflow-manager`,
-	// `webhooks/*`, and `scaling/job-processor`). Resolve it from the workflow's owning
-	// project so every downstream consumer (e.g. policy enforcement) sees the executing
-	// project, same as `executeAgent` already does locally for its own use.
-	if (!projectId && workflowId) {
-		try {
-			const { OwnershipService } = await import('@/services/ownership.service.js');
-			const project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowId);
-			projectId = project.id;
-		} catch {
-			// No resolvable owning project (e.g. workflow deleted mid-flight) — leave
-			// `projectId` unset, matching today's behavior for callers that omit it.
-		}
-	}
-
-	const variables = await WorkflowHelpers.getVariables(workflowId, projectId);
+	// `getVariables` resolves and returns the workflow's owning project when the caller
+	// passes `workflowId` but not `projectId` — reuse that so every downstream consumer
+	// (e.g. policy enforcement) sees the executing project too, same as `executeAgent`
+	// already does locally for its own use.
+	const variablesResult = await WorkflowHelpers.getVariables(workflowId, projectId);
+	const variables = variablesResult.variables;
+	projectId = variablesResult.projectId;
 
 	const eventService = Container.get(EventService);
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -792,22 +792,16 @@ export async function getBase({
 	// Trigger-fired, webhook, and worker-queued executions build additionalData without
 	// a `projectId`. Resolve it from the workflow's owning project so every downstream
 	// consumer (e.g. policy enforcement) sees the executing project, same as
-	// `executeAgent` already does locally for its own use. Run alongside `getVariables`
-	// (which does an equivalent, safe, cache-backed lookup internally) rather than
-	// awaiting first, so this backfill adds no serial latency.
-	const [variables, ownerProjectDetails] = await Promise.all([
-		WorkflowHelpers.getVariables(workflowId, projectId),
-		projectId || !workflowId
-			? null
-			: (async () => {
-					const { OwnershipService } = await import('@/services/ownership.service.js');
-					return await getWorkflowProjectDetailsSafe(Container.get(OwnershipService), workflowId);
-				})(),
-	]);
-
-	if (!projectId && ownerProjectDetails?.projectId) {
-		projectId = ownerProjectDetails.projectId;
+	// `executeAgent` already does locally for its own use. Left unguarded on purpose,
+	// matching `getVariables`'s own pre-existing lookup below: an unresolvable owner
+	// project fails execution setup, it isn't silently tolerated.
+	if (!projectId && workflowId) {
+		const { OwnershipService } = await import('@/services/ownership.service.js');
+		const project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowId);
+		projectId = project?.id;
 	}
+
+	const variables = await WorkflowHelpers.getVariables(workflowId, projectId);
 
 	const eventService = Container.get(EventService);
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -789,13 +789,25 @@ export async function getBase({
 
 	const globalConfig = Container.get(GlobalConfig);
 
-	// `getVariables` resolves and returns the workflow's owning project when the caller
-	// passes `workflowId` but not `projectId` — reuse that so every downstream consumer
-	// (e.g. policy enforcement) sees the executing project too, same as `executeAgent`
-	// already does locally for its own use.
-	const variablesResult = await WorkflowHelpers.getVariables(workflowId, projectId);
-	const variables = variablesResult.variables;
-	projectId = variablesResult.projectId;
+	// Trigger-fired, webhook, and worker-queued executions build additionalData without
+	// a `projectId`. Resolve it from the workflow's owning project so every downstream
+	// consumer (e.g. policy enforcement) sees the executing project, same as
+	// `executeAgent` already does locally for its own use. Run alongside `getVariables`
+	// (which does an equivalent, safe, cache-backed lookup internally) rather than
+	// awaiting first, so this backfill adds no serial latency.
+	const [variables, ownerProjectDetails] = await Promise.all([
+		WorkflowHelpers.getVariables(workflowId, projectId),
+		projectId || !workflowId
+			? null
+			: (async () => {
+					const { OwnershipService } = await import('@/services/ownership.service.js');
+					return await getWorkflowProjectDetailsSafe(Container.get(OwnershipService), workflowId);
+				})(),
+	]);
+
+	if (!projectId && ownerProjectDetails?.projectId) {
+		projectId = ownerProjectDetails.projectId;
+	}
 
 	const eventService = Container.get(EventService);
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -789,6 +789,22 @@ export async function getBase({
 
 	const globalConfig = Container.get(GlobalConfig);
 
+	// Trigger-fired, webhook, and worker-queued executions build additionalData without
+	// a `projectId` (see the `getBase` callers in `active-workflow-manager`,
+	// `webhooks/*`, and `scaling/job-processor`). Resolve it from the workflow's owning
+	// project so every downstream consumer (e.g. policy enforcement) sees the executing
+	// project, same as `executeAgent` already does locally for its own use.
+	if (!projectId && workflowId) {
+		try {
+			const { OwnershipService } = await import('@/services/ownership.service.js');
+			const project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowId);
+			projectId = project.id;
+		} catch {
+			// No resolvable owning project (e.g. workflow deleted mid-flight) — leave
+			// `projectId` unset, matching today's behavior for callers that omit it.
+		}
+	}
+
 	const variables = await WorkflowHelpers.getVariables(workflowId, projectId);
 
 	const eventService = Container.get(EventService);

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -32,7 +32,6 @@ import { VariablesService } from '@/environments.ee/variables/variables.service.
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 import { OwnershipService } from './services/ownership.service';
-import { getWorkflowProjectDetailsSafe } from './workflows/utils';
 
 export { dropInvalidWorkflowGroups, makeGetNodeTypeForGrouping };
 
@@ -423,19 +422,16 @@ export async function replaceInvalidCredentials<T extends IWorkflowBase>(
 }
 
 export async function getVariables(workflowId?: string, projectId?: string): Promise<IDataObject> {
-	const [variables, ownerProjectDetails] = await Promise.all([
+	const [variables, project] = await Promise.all([
 		Container.get(VariablesService).getAllCached(),
-		// If projectId is not provided, try to get it from workflow. Never throws —
-		// callers need the owning project for scoping, not as a hard dependency.
+		// If projectId is not provided, try to get it from workflow
 		workflowId && !projectId
-			? getWorkflowProjectDetailsSafe(Container.get(OwnershipService), workflowId)
+			? Container.get(OwnershipService).getWorkflowProjectCached(workflowId)
 			: null,
 	]);
 
-	// Either projectId passed or use project resolved from workflow. `projectId` on
-	// the safe result is '' (falsy, not nullish) when resolution failed, so `||`
-	// rather than `??` is needed to fall through to `undefined` in that case.
-	const projectIdToUse = projectId ?? (ownerProjectDetails?.projectId || undefined);
+	// Either projectId passed or use project from workflow
+	const projectIdToUse = projectId ?? project?.id;
 
 	return Object.freeze(resolveVariables(variables, projectIdToUse));
 }

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -32,6 +32,7 @@ import { VariablesService } from '@/environments.ee/variables/variables.service.
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 import { OwnershipService } from './services/ownership.service';
+import { getWorkflowProjectDetailsSafe } from './workflows/utils';
 
 export { dropInvalidWorkflowGroups, makeGetNodeTypeForGrouping };
 
@@ -421,19 +422,28 @@ export async function replaceInvalidCredentials<T extends IWorkflowBase>(
 	return workflow;
 }
 
-export async function getVariables(workflowId?: string, projectId?: string): Promise<IDataObject> {
-	const [variables, project] = await Promise.all([
+export async function getVariables(
+	workflowId?: string,
+	projectId?: string,
+): Promise<{ variables: IDataObject; projectId?: string }> {
+	const [variables, ownerProjectDetails] = await Promise.all([
 		Container.get(VariablesService).getAllCached(),
-		// If projectId is not provided, try to get it from workflow
+		// If projectId is not provided, try to get it from workflow. Never throws —
+		// callers need the owning project for scoping, not as a hard dependency.
 		workflowId && !projectId
-			? Container.get(OwnershipService).getWorkflowProjectCached(workflowId)
+			? getWorkflowProjectDetailsSafe(Container.get(OwnershipService), workflowId)
 			: null,
 	]);
 
-	// Either projectId passed or use project from workflow
-	const projectIdToUse = projectId ?? project?.id;
+	// Either projectId passed or use project resolved from workflow. `projectId` on
+	// the safe result is '' (falsy, not nullish) when resolution failed, so `||`
+	// rather than `??` is needed to fall through to `undefined` in that case.
+	const projectIdToUse = projectId ?? (ownerProjectDetails?.projectId || undefined);
 
-	return Object.freeze(resolveVariables(variables, projectIdToUse));
+	return {
+		variables: Object.freeze(resolveVariables(variables, projectIdToUse)),
+		projectId: projectIdToUse,
+	};
 }
 
 /**

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -422,10 +422,7 @@ export async function replaceInvalidCredentials<T extends IWorkflowBase>(
 	return workflow;
 }
 
-export async function getVariables(
-	workflowId?: string,
-	projectId?: string,
-): Promise<{ variables: IDataObject; projectId?: string }> {
+export async function getVariables(workflowId?: string, projectId?: string): Promise<IDataObject> {
 	const [variables, ownerProjectDetails] = await Promise.all([
 		Container.get(VariablesService).getAllCached(),
 		// If projectId is not provided, try to get it from workflow. Never throws —
@@ -440,10 +437,7 @@ export async function getVariables(
 	// rather than `??` is needed to fall through to `undefined` in that case.
 	const projectIdToUse = projectId ?? (ownerProjectDetails?.projectId || undefined);
 
-	return {
-		variables: Object.freeze(resolveVariables(variables, projectIdToUse)),
-		projectId: projectIdToUse,
-	};
+	return Object.freeze(resolveVariables(variables, projectIdToUse));
 }
 
 /**

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
@@ -100,6 +100,23 @@ describe('HookContext', () => {
 
 			expect(credentials).toEqual({ secret: 'token' });
 		});
+
+		it('should surface the node to the credentials helper', async () => {
+			credentialsHelper.getDecrypted.mockResolvedValue({ secret: 'token' });
+			credentialsHelper.isCredentialUsableByNode.mockReturnValue(true);
+
+			await hookContext.getCredentials<ICredentialDataDecryptedObject>(testCredentialType);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+				additionalData,
+				expect.anything(),
+				testCredentialType,
+				mode,
+				expect.objectContaining({ node }),
+				false,
+				undefined,
+			);
+		});
 	});
 
 	describe('getNodeParameter', () => {

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/load-options-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/load-options-context.test.ts
@@ -95,7 +95,7 @@ describe('LoadOptionsContext', () => {
 				expect.anything(),
 				testCredentialType,
 				'internal',
-				undefined,
+				expect.objectContaining({ node }),
 				false,
 				undefined,
 			);

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
@@ -76,6 +76,24 @@ describe('PollContext', () => {
 
 			expect(credentials).toEqual({ secret: 'token' });
 		});
+
+		it('should surface the node to the credentials helper', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+			credentialsHelper.getDecrypted.mockResolvedValue({ secret: 'token' });
+			credentialsHelper.isCredentialUsableByNode.mockReturnValue(true);
+
+			await pollContext.getCredentials<ICredentialDataDecryptedObject>(testCredentialType);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+				additionalData,
+				expect.anything(),
+				testCredentialType,
+				mode,
+				expect.objectContaining({ node }),
+				false,
+				undefined,
+			);
+		});
 	});
 
 	describe('getNodeParameter', () => {

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/trigger-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/trigger-context.test.ts
@@ -76,6 +76,24 @@ describe('TriggerContext', () => {
 
 			expect(credentials).toEqual({ secret: 'token' });
 		});
+
+		it('should surface the node to the credentials helper', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+			credentialsHelper.getDecrypted.mockResolvedValue({ secret: 'token' });
+			credentialsHelper.isCredentialUsableByNode.mockReturnValue(true);
+
+			await triggerContext.getCredentials<ICredentialDataDecryptedObject>(testCredentialType);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+				additionalData,
+				expect.anything(),
+				testCredentialType,
+				mode,
+				expect.objectContaining({ node }),
+				false,
+				undefined,
+			);
+		});
 	});
 
 	describe('getNodeParameter', () => {

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
@@ -140,6 +140,24 @@ describe('WebhookContext', () => {
 
 			expect(credentials).toEqual({ secret: 'token' });
 		});
+
+		it('should surface the node to the credentials helper', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+			credentialsHelper.getDecrypted.mockResolvedValue({ secret: 'token' });
+			credentialsHelper.isCredentialUsableByNode.mockReturnValue(true);
+
+			await webhookContext.getCredentials<ICredentialDataDecryptedObject>(testCredentialType);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+				additionalData,
+				expect.anything(),
+				testCredentialType,
+				mode,
+				expect.objectContaining({ node }),
+				false,
+				undefined,
+			);
+		});
 	});
 
 	describe('getBodyData', () => {

--- a/packages/core/src/execution-engine/node-execution-context/hook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/hook-context.ts
@@ -1,6 +1,7 @@
 import { UnexpectedError } from 'n8n-workflow';
 import type {
 	ICredentialDataDecryptedObject,
+	IExecuteData,
 	INode,
 	IHookFunctions,
 	IWorkflowExecuteAdditionalData,
@@ -36,7 +37,12 @@ export class HookContext extends NodeExecutionContext implements IHookFunctions 
 	}
 
 	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
-		return await this._getCredentials<T>(type);
+		// No real task run backs a webhook-registration hook, so this only exists to
+		// surface `node` to the credentials helper (e.g. for policy checks) — `data`/
+		// `source` are unused.
+		const executeData: IExecuteData = { data: {}, node: this.node, source: null };
+
+		return await this._getCredentials<T>(type, executeData);
 	}
 
 	getNodeWebhookUrl(name: WebhookType): string | undefined {

--- a/packages/core/src/execution-engine/node-execution-context/load-options-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/load-options-context.ts
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import type {
 	ICredentialDataDecryptedObject,
+	IExecuteData,
 	IGetNodeParameterOptions,
 	INode,
 	ILoadOptionsFunctions,
@@ -44,7 +45,12 @@ export class LoadOptionsContext extends NodeExecutionContext implements ILoadOpt
 	}
 
 	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
-		return await this._getCredentials<T>(type);
+		// No real task run backs design-time parameter loading, so this only exists to
+		// surface `node` to the credentials helper (e.g. for policy checks) — `data`/`source`
+		// are unused.
+		const executeData: IExecuteData = { data: {}, node: this.node, source: null };
+
+		return await this._getCredentials<T>(type, executeData);
 	}
 
 	getCurrentNodeParameter(

--- a/packages/core/src/execution-engine/node-execution-context/poll-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/poll-context.ts
@@ -2,6 +2,7 @@ import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
 	IDataObject,
+	IExecuteData,
 	INode,
 	IPollFunctions,
 	IWorkflowExecuteAdditionalData,
@@ -66,6 +67,10 @@ export class PollContext extends NodeExecutionContext implements IPollFunctions 
 	}
 
 	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
-		return await this._getCredentials<T>(type);
+		// No real task run backs a poll, so this only exists to surface `node` to
+		// the credentials helper (e.g. for policy checks) — `data`/`source` are unused.
+		const executeData: IExecuteData = { data: {}, node: this.node, source: null };
+
+		return await this._getCredentials<T>(type, executeData);
 	}
 }

--- a/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
@@ -1,6 +1,7 @@
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
+	IExecuteData,
 	INode,
 	ITriggerFunctions,
 	IWorkflowExecuteAdditionalData,
@@ -65,6 +66,10 @@ export class TriggerContext extends NodeExecutionContext implements ITriggerFunc
 	}
 
 	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
-		return await this._getCredentials<T>(type);
+		// No real task run backs a trigger, so this only exists to surface `node` to
+		// the credentials helper (e.g. for policy checks) — `data`/`source` are unused.
+		const executeData: IExecuteData = { data: {}, node: this.node, source: null };
+
+		return await this._getCredentials<T>(type, executeData);
 	}
 }

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -99,7 +99,11 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 	}
 
 	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
-		return await this._getCredentials<T>(type);
+		// No real task run backs a webhook call, so this only exists to surface `node`
+		// to the credentials helper (e.g. for policy checks) — `data`/`source` are unused.
+		const executeData: IExecuteData = { data: {}, node: this.node, source: null };
+
+		return await this._getCredentials<T>(type, executeData);
 	}
 
 	getBodyData() {


### PR DESCRIPTION
## Summary

Wires the `credentialDecrypt` enforcement point. `PolicyEnforcementService.enforceCredentialDecrypt` is now called from `CredentialsHelper.getDecrypted`, right after the credential entity is resolved and before any decryption happens. This sits alongside the existing author-side `restrictToSupportedNodes` guard on `CredentialsHelper.isCredentialUsableByNode` without replacing it — that guard stays a separate, static check.

The context passed to the policy is:
- `credentialType` / `credentialId`: from the resolved credential.
- `consumer`: the node type asking for the credential, taken from `executeData.node.type` when present, or `null` when no node is asking (for example, a credential test).
- `projectId`: from `additionalData.projectId`.

The AI Gateway managed-credential branch (`nodeCredentials.__aiGatewayManaged`) is not wired in this PR. It returns a synthetic credential before a `CredentialsEntity` is loaded, so there is no `credentialId` to build a context around.

No policy backend is registered by default, so the proxy clears every decrypt and behavior is unchanged.

## How to test

The gate is a no-op in a default instance, so testing is about proving nothing changed: run any workflow that uses a credential and confirm it executes exactly as before.

```bash
cd packages/cli
pnpm test src/__tests__/credentials-helper.test.ts
pnpm typecheck
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1126

(Replaces #36961, auto-closed when its source branch was renamed to match Linear's suggested branch name.)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)