### PR TITLE
fix(editor): Stop autosave retries on permanent errors

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -18,6 +18,7 @@ import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useWorkflowSaveStore } from '@/app/stores/workflowSave.store';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
+import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import { ResponseError } from '@n8n/rest-api-client';
 import { mockedStore } from '@/__tests__/utils';
@@ -1435,7 +1436,7 @@ describe('useWorkflowSaving', () => {
 
 				vi.spyOn(workflowsStore, 'createNewWorkflow').mockRejectedValue(new Error(errorMessage));
 
-				workflowsStore.setWorkflowId(newWorkflowId);
+				mockRoute.params = { workflowId: newWorkflowId };
 				useWorkflowDocumentStore(createWorkflowDocumentId(newWorkflowId)).hydrate(workflow);
 
 				const saveStore = useWorkflowSaveStore();
@@ -1458,6 +1459,56 @@ describe('useWorkflowSaving', () => {
 					}),
 				);
 			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('does not retry autosaved create when a post-create step fails', async () => {
+			vi.useFakeTimers();
+			const newWorkflowId = 'w-autosave-create-post-create-failure';
+			const createdWorkflow = createTestWorkflow({
+				id: 'w-autosave-created-before-post-create-failure',
+				name: 'Named new workflow',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+			});
+			const createSpy = vi
+				.spyOn(workflowsStore, 'createNewWorkflow')
+				.mockResolvedValue(createdWorkflow);
+			const focusPanelSpy = vi
+				.spyOn(useFocusPanelStore(), 'onNewWorkflowSave')
+				.mockImplementation(() => {
+					throw new Error('Focus panel failed');
+				});
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			try {
+				mockRoute.params = { workflowId: newWorkflowId };
+				useWorkflowDocumentStore(createWorkflowDocumentId(newWorkflowId)).hydrate(
+					createTestWorkflow({
+						id: newWorkflowId,
+						name: 'Named new workflow',
+						nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+					}),
+				);
+
+				const saveStore = useWorkflowSaveStore();
+				const { saveCurrentWorkflow } = useWorkflowSaving({
+					router,
+				});
+
+				const result = await saveCurrentWorkflow({}, true, false, true);
+				await vi.advanceTimersByTimeAsync(saveStore.getRetryDelay() + 1);
+
+				expect(result).toBe(false);
+				expect(createSpy).toHaveBeenCalledTimes(1);
+				expect(workflowsListStore.getWorkflowById(createdWorkflow.id)).toEqual(createdWorkflow);
+				expect(saveStore.retryCount).toBe(0);
+				expect(saveStore.isRetrying).toBe(false);
+				expect(saveStore.lastError).toBeNull();
+				expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
+			} finally {
+				focusPanelSpy.mockRestore();
+				consoleErrorSpy.mockRestore();
 				vi.useRealTimers();
 			}
 		});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -1421,6 +1421,47 @@ describe('useWorkflowSaving', () => {
 			}
 		});
 
+		it('retries autosaved create failures that can recover', async () => {
+			vi.useFakeTimers();
+
+			try {
+				const newWorkflowId = 'w-autosave-create-failure';
+				const errorMessage = 'Network timeout';
+				const workflow = createTestWorkflow({
+					id: newWorkflowId,
+					name: 'Named new workflow',
+					nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				});
+
+				vi.spyOn(workflowsStore, 'createNewWorkflow').mockRejectedValue(new Error(errorMessage));
+
+				workflowsStore.setWorkflowId(newWorkflowId);
+				useWorkflowDocumentStore(createWorkflowDocumentId(newWorkflowId)).hydrate(workflow);
+
+				const saveStore = useWorkflowSaveStore();
+				const { saveCurrentWorkflow } = useWorkflowSaving({
+					router,
+				});
+
+				const result = await saveCurrentWorkflow({}, true, false, true);
+
+				expect(result).toBe(false);
+				expect(saveStore.pendingSave).toBeNull();
+				expect(saveStore.retryCount).toBe(1);
+				expect(saveStore.lastError).toBe(errorMessage);
+				expect(saveStore.isRetrying).toBe(true);
+				expect(showMessageSpy).toHaveBeenCalledTimes(1);
+				expect(showMessageSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						message: expect.stringContaining(errorMessage),
+						type: 'error',
+					}),
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it('does not retry autosave after a permanent client error', async () => {
 			const workflow = createTestWorkflow({
 				id: 'w-autosave-client-error',
@@ -1447,6 +1488,60 @@ describe('useWorkflowSaving', () => {
 
 			expect(result).toBe(false);
 			expect(saveStore.pendingSave).toBeNull();
+			expect(saveStore.retryCount).toBe(0);
+			expect(saveStore.isRetrying).toBe(false);
+			expect(saveStore.lastError).toBe(errorMessage);
+		});
+
+		it('uses raw object messages for autosave errors that are not Error instances', async () => {
+			const { workflow } = prepareHydratedWorkflow('w-autosave-raw-node-api-error');
+			const errorMessage = 'Node API request failed';
+
+			vi.spyOn(workflowsStore, 'updateWorkflow').mockRejectedValue({
+				name: 'NodeApiError',
+				message: errorMessage,
+				errorCode: 400,
+			});
+
+			const saveStore = useWorkflowSaveStore();
+			const { saveCurrentWorkflow } = useWorkflowSaving({
+				router,
+			});
+
+			const result = await saveCurrentWorkflow({ id: workflow.id }, true, false, true);
+
+			expect(result).toBe(false);
+			expect(saveStore.retryCount).toBe(0);
+			expect(saveStore.isRetrying).toBe(false);
+			expect(saveStore.lastError).toBe(errorMessage);
+			expect(showMessageSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: errorMessage,
+					type: 'error',
+				}),
+			);
+		});
+
+		it('does not retry autosave after a raw axios permanent client error', async () => {
+			const { workflow } = prepareHydratedWorkflow('w-autosave-raw-axios-error');
+			const errorMessage = 'Request failed with status code 413';
+
+			vi.spyOn(workflowsStore, 'updateWorkflow').mockRejectedValue(
+				Object.assign(new Error(errorMessage), {
+					response: {
+						status: 413,
+					},
+				}),
+			);
+
+			const saveStore = useWorkflowSaveStore();
+			const { saveCurrentWorkflow } = useWorkflowSaving({
+				router,
+			});
+
+			const result = await saveCurrentWorkflow({ id: workflow.id }, true, false, true);
+
+			expect(result).toBe(false);
 			expect(saveStore.retryCount).toBe(0);
 			expect(saveStore.isRetrying).toBe(false);
 			expect(saveStore.lastError).toBe(errorMessage);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -19,6 +19,7 @@ import { useWorkflowSaveStore } from '@/app/stores/workflowSave.store';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
+import { ResponseError } from '@n8n/rest-api-client';
 import { mockedStore } from '@/__tests__/utils';
 import { createTestNode, createTestWorkflow, mockNodeTypeDescription } from '@/__tests__/mocks';
 import { CHAT_TRIGGER_NODE_TYPE, NodeConnectionTypes } from 'n8n-workflow';
@@ -1415,6 +1416,78 @@ describe('useWorkflowSaving', () => {
 				expect(saveStore.retryCount).toBe(initialRetryCount + 1);
 				expect(saveStore.lastError).toBe(errorMessage);
 				expect(saveStore.isRetrying).toBe(true);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('does not retry autosave after a permanent client error', async () => {
+			const workflow = createTestWorkflow({
+				id: 'w-autosave-client-error',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				active: true,
+			});
+			const errorMessage = 'Workflow name is required';
+
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsStore, 'updateWorkflow').mockRejectedValue(
+				new ResponseError(errorMessage, { httpStatusCode: 400 }),
+			);
+
+			workflowsStore.setWorkflowId(workflow.id);
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+
+			const saveStore = useWorkflowSaveStore();
+			const { saveCurrentWorkflow } = useWorkflowSaving({
+				router,
+			});
+
+			const result = await saveCurrentWorkflow({ id: workflow.id }, true, false, true);
+
+			expect(result).toBe(false);
+			expect(saveStore.pendingSave).toBeNull();
+			expect(saveStore.retryCount).toBe(0);
+			expect(saveStore.isRetrying).toBe(false);
+			expect(saveStore.lastError).toBe(errorMessage);
+		});
+
+		it('does not immediately re-arm debounced autosave after a permanent client error', async () => {
+			vi.useFakeTimers();
+
+			try {
+				mockedStore(useSettingsStore).isAutosaveEnabled = true;
+				prepareHydratedWorkflow('w-autosave-client-error-debounced');
+				const updateSpy = vi
+					.spyOn(workflowsStore, 'updateWorkflow')
+					.mockRejectedValue(
+						new ResponseError('Workflow name is required', { httpStatusCode: 400 }),
+					);
+				const saveStore = useWorkflowSaveStore();
+				const uiStore = useUIStore();
+
+				uiStore.markStateDirty();
+
+				const { autoSaveWorkflow } = useWorkflowSaving({ router, ownsAutoSave: true });
+
+				autoSaveWorkflow();
+				expect(saveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
+
+				await vi.advanceTimersByTimeAsync(
+					getDebounceTime(DEBOUNCE_TIME.API.AUTOSAVE_MAX_WAIT) + 1000,
+				);
+
+				expect(updateSpy).toHaveBeenCalledTimes(1);
+				expect(saveStore.autoSaveState).toBe(AutoSaveState.Idle);
+				expect(saveStore.retryCount).toBe(0);
+				expect(saveStore.isRetrying).toBe(false);
+				expect(uiStore.stateIsDirty).toBe(true);
+
+				await vi.advanceTimersByTimeAsync(
+					getDebounceTime(DEBOUNCE_TIME.API.AUTOSAVE_MAX_WAIT) + 1000,
+				);
+
+				expect(updateSpy).toHaveBeenCalledTimes(1);
 			} finally {
 				vi.useRealTimers();
 			}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -21,6 +21,7 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import { useCanvasStore } from '@/app/stores/canvas.store';
 import type { IUpdateInformation, IWorkflowDb } from '@/Interface';
 import type { WorkflowDataCreate, WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
+import { ResponseError } from '@n8n/rest-api-client';
 import { isExpression, type IDataObject } from 'n8n-workflow';
 import { useToast } from '@n8n/composables/useToast';
 import { useExternalHooks } from './useExternalHooks';
@@ -42,6 +43,45 @@ import { useWorkflowSaveStore } from '@/app/stores/workflowSave.store';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { useInvalidNodeGroupCleanup } from '@/app/composables/useInvalidNodeGroupCleanup';
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function getHttpStatusCode(error: unknown): number | undefined {
+	if (error instanceof ResponseError) {
+		return error.httpStatusCode;
+	}
+
+	if (!error || typeof error !== 'object') {
+		return;
+	}
+
+	const { httpStatusCode, errorCode } = error as {
+		httpStatusCode?: unknown;
+		errorCode?: unknown;
+	};
+
+	if (typeof httpStatusCode === 'number') {
+		return httpStatusCode;
+	}
+
+	if (typeof errorCode === 'number' && errorCode >= 400 && errorCode < 600) {
+		return errorCode;
+	}
+
+	return undefined;
+}
+
+function shouldRetryAutoSaveFailure(error: unknown): boolean {
+	const statusCode = getHttpStatusCode(error);
+
+	if (!statusCode) {
+		return true;
+	}
+
+	return [408, 409, 429].includes(statusCode) || statusCode >= 500;
+}
 
 export function useWorkflowSaving({
 	router,
@@ -90,7 +130,8 @@ export function useWorkflowSaving({
 	const currentWorkflowDocumentStore = computed(() =>
 		useWorkflowDocumentStore(createWorkflowDocumentId(workflowId.value)),
 	);
-	const canScheduleAutoSave = computed(() => {
+
+	const canArmAutoSave = computed(() => {
 		// Don't schedule from a read-only canvas, or from an instance that doesn't
 		// own one. Every autosave entry point funnels through here, so a preview
 		// never writes whatever marked it dirty.
@@ -103,6 +144,23 @@ export function useWorkflowSaving({
 			return false;
 		}
 
+		// Don't schedule if we're offline
+		if (!backendConnectionStore.isOnline) {
+			return false;
+		}
+
+		if (!currentWorkflowDocumentStore.value.hydrated) {
+			return false;
+		}
+
+		return true;
+	});
+
+	const canScheduleAutoSave = computed(() => {
+		if (!canArmAutoSave.value) {
+			return false;
+		}
+
 		// Don't schedule if a save is already in progress - the finally block
 		// will reschedule if there are pending changes
 		if (saveStore.pendingSave) {
@@ -111,15 +169,6 @@ export function useWorkflowSaving({
 
 		// Don't schedule if we're waiting for retry backoff to complete
 		if (saveStore.isRetrying) {
-			return false;
-		}
-
-		// Don't schedule if we're offline
-		if (!backendConnectionStore.isOnline) {
-			return false;
-		}
-
-		if (!currentWorkflowDocumentStore.value.hydrated) {
 			return false;
 		}
 
@@ -320,9 +369,10 @@ export function useWorkflowSaving({
 				onSaved?.(false); // Update of existing workflow
 				return true;
 			} catch (error) {
+				const errorMessage = getErrorMessage(error);
 				console.error(error);
 
-				if (error.errorCode === 409) {
+				if (getHttpStatusCode(error) === 409) {
 					telemetry.track('User attempted to save locked workflow', {
 						workflowId: currentWorkflow,
 						sharing_role: getWorkflowProjectRole(currentWorkflow),
@@ -371,8 +421,20 @@ export function useWorkflowSaving({
 
 				// Handle autosave failures with exponential backoff
 				if (autosaved) {
+					if (!shouldRetryAutoSaveFailure(error)) {
+						saveStore.resetRetry();
+						saveStore.setLastError(errorMessage);
+						toast.showMessage({
+							title: i18n.baseText('workflowHelpers.showMessage.title'),
+							message: errorMessage,
+							type: 'error',
+						});
+
+						return false;
+					}
+
 					saveStore.incrementRetry();
-					saveStore.setLastError(error.message);
+					saveStore.setLastError(errorMessage);
 
 					// Schedule retry with exponential backoff
 					const retryDelay = saveStore.getRetryDelay();
@@ -390,7 +452,7 @@ export function useWorkflowSaving({
 						title: i18n.baseText('workflowHelpers.showMessage.title'),
 						message: i18n.baseText('generic.autosave.retrying', {
 							interpolate: {
-								error: error.message,
+								error: errorMessage,
 								retryIn: `${Math.ceil(retryDelay / 1000)}s`,
 							},
 						}),
@@ -403,7 +465,7 @@ export function useWorkflowSaving({
 
 				toast.showMessage({
 					title: i18n.baseText('workflowHelpers.showMessage.title'),
-					message: error.message,
+					message: errorMessage,
 					type: 'error',
 				});
 
@@ -647,14 +709,15 @@ export function useWorkflowSaving({
 			saveStore.setAutoSaveState(AutoSaveState.InProgress);
 
 			void (async () => {
+				let saved = false;
 				try {
-					await saveCurrentWorkflow({}, true, false, true);
+					saved = await saveCurrentWorkflow({}, true, false, true);
 				} finally {
 					if (saveStore.autoSaveState === AutoSaveState.InProgress) {
 						saveStore.setAutoSaveState(AutoSaveState.Idle);
 					}
 					// If changes were made during save, reschedule autosave
-					if (uiStore.stateIsDirty && canScheduleAutoSave.value) {
+					if (saved && uiStore.stateIsDirty && canScheduleAutoSave.value) {
 						saveStore.setAutoSaveState(AutoSaveState.Scheduled);
 						void autoSaveWorkflowDebounced();
 					}
@@ -692,8 +755,8 @@ export function useWorkflowSaving({
 		// else would save what the agent wrote. Mirrors the AI-builder re-arm in
 		// NodeView.
 		// Watch for network coming back online, and for other autosave eligibility
-		// returning after retry backoff, save completion, or document hydration.
-		watch(canScheduleAutoSave, (allowed, wasAllowed) => {
+		// returning after document hydration.
+		watch(canArmAutoSave, (allowed, wasAllowed) => {
 			if (allowed && !wasAllowed && uiStore.stateIsDirty) {
 				scheduleAutoSave();
 			}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -533,6 +533,8 @@ export function useWorkflowSaving({
 		} = {},
 		redirect = true,
 	): Promise<IWorkflowDb['id'] | null> {
+		let createRequestFailed = false;
+
 		try {
 			const currentDocumentStore = useWorkflowDocumentStore(
 				createWorkflowDocumentId(workflowId.value),
@@ -611,7 +613,13 @@ export function useWorkflowSaving({
 				workflowDataRequest.autosaved = autosaved;
 			}
 
-			const workflowData = await workflowsStore.createNewWorkflow(workflowDataRequest);
+			let workflowData: IWorkflowDb;
+			try {
+				workflowData = await workflowsStore.createNewWorkflow(workflowDataRequest);
+			} catch (e) {
+				createRequestFailed = true;
+				throw e;
+			}
 
 			workflowsListStore.addWorkflow(workflowData);
 
@@ -706,8 +714,15 @@ export function useWorkflowSaving({
 			onSaved?.(true); // First save of new workflow
 			return workflowData.id;
 		} catch (e) {
-			if (autosaved) {
+			if (autosaved && createRequestFailed) {
 				throw e;
+			}
+
+			if (autosaved) {
+				// The create request already succeeded; retrying this autosave
+				// would POST the same new workflow again.
+				console.error(e);
+				return null;
 			}
 
 			toast.showMessage({

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -45,7 +45,18 @@ import { useSettingsStore } from '@n8n/stores/settings.store';
 import { useInvalidNodeGroupCleanup } from '@/app/composables/useInvalidNodeGroupCleanup';
 
 function getErrorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	if (error && typeof error === 'object' && 'message' in error) {
+		const { message } = error as { message?: unknown };
+		if (message !== undefined) {
+			return String(message);
+		}
+	}
+
+	return String(error);
 }
 
 function getHttpStatusCode(error: unknown): number | undefined {
@@ -57,13 +68,21 @@ function getHttpStatusCode(error: unknown): number | undefined {
 		return;
 	}
 
-	const { httpStatusCode, errorCode } = error as {
+	const { httpStatusCode, errorCode, response } = error as {
 		httpStatusCode?: unknown;
 		errorCode?: unknown;
+		response?: unknown;
 	};
 
 	if (typeof httpStatusCode === 'number') {
 		return httpStatusCode;
+	}
+
+	if (response && typeof response === 'object') {
+		const { status } = response as { status?: unknown };
+		if (typeof status === 'number') {
+			return status;
+		}
 	}
 
 	if (typeof errorCode === 'number' && errorCode >= 400 && errorCode < 600) {
@@ -290,20 +309,23 @@ export function useWorkflowSaving({
 		}
 
 		const savePromise = (async (): Promise<boolean> => {
-			// Check if workflow needs to be saved as new (doesn't exist in store yet)
-			const existingWorkflow = currentWorkflow
-				? workflowsListStore.getWorkflowById(currentWorkflow)
-				: null;
-			if (!currentWorkflow || !existingWorkflow?.id) {
-				const workflowId = await saveAsNewWorkflow(
-					{ parentFolderId, uiContext, autosaved },
-					redirect,
-				);
-				return !!workflowId;
-			}
+			let isExistingWorkflowSave = false;
 
-			// Workflow exists already so update it
 			try {
+				// Check if workflow needs to be saved as new (doesn't exist in store yet)
+				const existingWorkflow = currentWorkflow
+					? workflowsListStore.getWorkflowById(currentWorkflow)
+					: null;
+				if (!currentWorkflow || !existingWorkflow?.id) {
+					const workflowId = await saveAsNewWorkflow(
+						{ parentFolderId, uiContext, autosaved },
+						redirect,
+					);
+					return !!workflowId;
+				}
+
+				isExistingWorkflowSave = true;
+				// Workflow exists already so update it
 				if (!forceSave && isLoading) {
 					return true;
 				}
@@ -372,7 +394,7 @@ export function useWorkflowSaving({
 				const errorMessage = getErrorMessage(error);
 				console.error(error);
 
-				if (getHttpStatusCode(error) === 409) {
+				if (isExistingWorkflowSave && getHttpStatusCode(error) === 409) {
 					telemetry.track('User attempted to save locked workflow', {
 						workflowId: currentWorkflow,
 						sharing_role: getWorkflowProjectRole(currentWorkflow),
@@ -684,9 +706,13 @@ export function useWorkflowSaving({
 			onSaved?.(true); // First save of new workflow
 			return workflowData.id;
 		} catch (e) {
+			if (autosaved) {
+				throw e;
+			}
+
 			toast.showMessage({
 				title: i18n.baseText('workflowHelpers.showMessage.title'),
-				message: (e as Error).message,
+				message: getErrorMessage(e),
 				type: 'error',
 			});
 


### PR DESCRIPTION
## Summary

Autosave retried every failed save with exponential backoff, including permanent `4xx` validation errors that can never succeed which could lead to 61 Sentry events for a single workflow.

Failures now only retry when transient (`408`/`409`/`429`, `5xx`, or network errors without a status). Other `4xx` errors surface one error toast and recover on the next change.

Also splits `canArmAutoSave` from `canScheduleAutoSave` so long-lived checks stay separate from temporary save state. This lets autosave start again after hydration, reconnect, or leaving read-only mode, without starting again after a failed save just because `pendingSave` cleared.

Part of stack #36969, on top of #36966.

## How to test

1. Temporarily make autosave update fail with a permanent error - e.g. throw a `ResponseError`('Test permanent save error', { httpStatusCode: 400 })` from the workflow update path.
2. Start the app, open an existing workflow, make a small canvas change and wait for autosave.
3. Expected: one autosave request fails, one error toast is shown, and the workflow stays dirty.
4. Wait past the normal retry windows.
5. Expected: no repeated autosave requests are sent for that same 400 failure.
6. Revert the temporary test patch.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5826

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)