### PR TITLE
refactor(editor): Extract workflow save failure handling

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -190,6 +190,68 @@ export function useWorkflowSaving({
 		return false;
 	}
 
+	async function handleConflictSaveFailure({
+		error,
+		errorMessage,
+		currentWorkflow,
+		id,
+		redirect,
+		autosaved,
+	}: {
+		error: unknown;
+		errorMessage: string;
+		currentWorkflow: string;
+		id: string | undefined;
+		redirect: boolean;
+		autosaved: boolean;
+	}): Promise<boolean> {
+		telemetry.track('User attempted to save locked workflow', {
+			workflowId: currentWorkflow,
+			sharing_role: getWorkflowProjectRole(currentWorkflow),
+		});
+
+		// Hide modal if we already showed it
+		// So that user could explore the workflow
+		if (!saveStore.conflictModalShown) {
+			if (autosaved) {
+				saveStore.setConflictModalShown(true);
+			}
+
+			const url = router.resolve({
+				name: VIEWS.WORKFLOW,
+				params: { workflowId: currentWorkflow },
+			}).href;
+
+			const overwrite = await message.confirm(
+				i18n.baseText('workflows.concurrentChanges.confirmMessage.message', {
+					interpolate: {
+						url,
+					},
+				}),
+				i18n.baseText('workflows.concurrentChanges.confirmMessage.title'),
+				{
+					confirmButtonText: i18n.baseText(
+						'workflows.concurrentChanges.confirmMessage.confirmButtonText',
+					),
+					cancelButtonText: i18n.baseText(
+						'workflows.concurrentChanges.confirmMessage.cancelButtonText',
+					),
+				},
+			);
+
+			if (overwrite === MODAL_CONFIRM) {
+				return await saveCurrentWorkflow({ id }, redirect, true);
+			}
+		}
+
+		// For autosaves, use retry logic so we still communicate autosave stopped working.
+		if (autosaved) {
+			return handleAutoSaveFailure(error, errorMessage);
+		}
+
+		return false;
+	}
+
 	// Preview hosts (template, workflow history, execution) render the real canvas
 	// and scope their subtree read-only through the editor context. The context is
 	// injected, so it only resolves inside a component — fall back to no context
@@ -445,50 +507,14 @@ export function useWorkflowSaving({
 				console.error(error);
 
 				if (isExistingWorkflowSave && getHttpStatusCode(error) === 409) {
-					telemetry.track('User attempted to save locked workflow', {
-						workflowId: currentWorkflow,
-						sharing_role: getWorkflowProjectRole(currentWorkflow),
+					return await handleConflictSaveFailure({
+						error,
+						errorMessage,
+						currentWorkflow,
+						id,
+						redirect,
+						autosaved,
 					});
-
-					// Hide modal if we already showed it
-					// So that user could explore the workflow
-					if (!saveStore.conflictModalShown) {
-						if (autosaved) {
-							saveStore.setConflictModalShown(true);
-						}
-
-						const url = router.resolve({
-							name: VIEWS.WORKFLOW,
-							params: { workflowId: currentWorkflow },
-						}).href;
-
-						const overwrite = await message.confirm(
-							i18n.baseText('workflows.concurrentChanges.confirmMessage.message', {
-								interpolate: {
-									url,
-								},
-							}),
-							i18n.baseText('workflows.concurrentChanges.confirmMessage.title'),
-							{
-								confirmButtonText: i18n.baseText(
-									'workflows.concurrentChanges.confirmMessage.confirmButtonText',
-								),
-								cancelButtonText: i18n.baseText(
-									'workflows.concurrentChanges.confirmMessage.cancelButtonText',
-								),
-							},
-						);
-
-						if (overwrite === MODAL_CONFIRM) {
-							return await saveCurrentWorkflow({ id }, redirect, true);
-						}
-					}
-
-					// For autosaves, fall through to retry logic below
-					// As we want to still communicate autosave stopped working
-					if (!autosaved) {
-						return false;
-					}
 				}
 
 				if (autosaved) {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -157,6 +157,39 @@ export function useWorkflowSaving({
 		});
 	}
 
+	function scheduleAutoSaveRetry(retryDelay: number) {
+		saveStore.setRetrying(true);
+
+		setTimeout(() => {
+			saveStore.setRetrying(false);
+			// Trigger autosave again if workflow is still dirty
+			if (uiStore.stateIsDirty) {
+				scheduleAutoSave();
+			}
+		}, retryDelay);
+	}
+
+	function handleAutoSaveFailure(error: unknown, errorMessage: string): false {
+		// Handle autosave failures with exponential backoff
+		if (!shouldRetryAutoSaveFailure(error)) {
+			saveStore.resetRetry();
+			saveStore.setLastError(errorMessage);
+			showSaveErrorToast(errorMessage);
+
+			return false;
+		}
+
+		saveStore.incrementRetry();
+		saveStore.setLastError(errorMessage);
+
+		// Schedule retry with exponential backoff
+		const retryDelay = saveStore.getRetryDelay();
+		scheduleAutoSaveRetry(retryDelay);
+		showSaveErrorToast(errorMessage, retryDelay);
+
+		return false;
+	}
+
 	// Preview hosts (template, workflow history, execution) render the real canvas
 	// and scope their subtree read-only through the editor context. The context is
 	// injected, so it only resolves inside a component — fall back to no context
@@ -458,34 +491,8 @@ export function useWorkflowSaving({
 					}
 				}
 
-				// Handle autosave failures with exponential backoff
 				if (autosaved) {
-					if (!shouldRetryAutoSaveFailure(error)) {
-						saveStore.resetRetry();
-						saveStore.setLastError(errorMessage);
-						showSaveErrorToast(errorMessage);
-
-						return false;
-					}
-
-					saveStore.incrementRetry();
-					saveStore.setLastError(errorMessage);
-
-					// Schedule retry with exponential backoff
-					const retryDelay = saveStore.getRetryDelay();
-					saveStore.setRetrying(true);
-
-					setTimeout(() => {
-						saveStore.setRetrying(false);
-						// Trigger autosave again if workflow is still dirty
-						if (uiStore.stateIsDirty) {
-							scheduleAutoSave();
-						}
-					}, retryDelay);
-
-					showSaveErrorToast(errorMessage, retryDelay);
-
-					return false;
+					return handleAutoSaveFailure(error, errorMessage);
 				}
 
 				showSaveErrorToast(errorMessage);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -140,6 +140,23 @@ export function useWorkflowSaving({
 	const workflowId = useWorkflowId();
 	const { removeInvalidNodeGroups } = useInvalidNodeGroupCleanup();
 
+	function showSaveErrorToast(errorMessage: string, retryDelay?: number) {
+		toast.showMessage({
+			title: i18n.baseText('workflowHelpers.showMessage.title'),
+			message:
+				retryDelay === undefined
+					? errorMessage
+					: i18n.baseText('generic.autosave.retrying', {
+							interpolate: {
+								error: errorMessage,
+								retryIn: `${Math.ceil(retryDelay / 1000)}s`,
+							},
+						}),
+			type: 'error',
+			...(retryDelay === undefined ? {} : { duration: retryDelay }),
+		});
+	}
+
 	// Preview hosts (template, workflow history, execution) render the real canvas
 	// and scope their subtree read-only through the editor context. The context is
 	// injected, so it only resolves inside a component — fall back to no context
@@ -446,11 +463,7 @@ export function useWorkflowSaving({
 					if (!shouldRetryAutoSaveFailure(error)) {
 						saveStore.resetRetry();
 						saveStore.setLastError(errorMessage);
-						toast.showMessage({
-							title: i18n.baseText('workflowHelpers.showMessage.title'),
-							message: errorMessage,
-							type: 'error',
-						});
+						showSaveErrorToast(errorMessage);
 
 						return false;
 					}
@@ -470,26 +483,12 @@ export function useWorkflowSaving({
 						}
 					}, retryDelay);
 
-					toast.showMessage({
-						title: i18n.baseText('workflowHelpers.showMessage.title'),
-						message: i18n.baseText('generic.autosave.retrying', {
-							interpolate: {
-								error: errorMessage,
-								retryIn: `${Math.ceil(retryDelay / 1000)}s`,
-							},
-						}),
-						type: 'error',
-						duration: retryDelay,
-					});
+					showSaveErrorToast(errorMessage, retryDelay);
 
 					return false;
 				}
 
-				toast.showMessage({
-					title: i18n.baseText('workflowHelpers.showMessage.title'),
-					message: errorMessage,
-					type: 'error',
-				});
+				showSaveErrorToast(errorMessage);
 
 				return false;
 			}
@@ -725,11 +724,7 @@ export function useWorkflowSaving({
 				return null;
 			}
 
-			toast.showMessage({
-				title: i18n.baseText('workflowHelpers.showMessage.title'),
-				message: getErrorMessage(e),
-				type: 'error',
-			});
+			showSaveErrorToast(getErrorMessage(e));
 
 			return null;
 		}


### PR DESCRIPTION
## Summary

Pure refactor, no behavior change. `saveCurrentWorkflow`'s catch block handled everything inline; each concern moves into its own helper:

- `showSaveErrorToast` — the shared save-error toast, with an optional retry countdown
- `handleAutoSaveFailure` / `scheduleAutoSaveRetry` — autosave retry scheduling with backoff
- `handleConflictSaveFailure` — the 409 conflict flow

Top of stack [#36969](https://github.com/n8n-io/n8n/pull/36969), on top of #[36967](https://github.com/n8n-io/n8n/pull/36967), which introduced the retry policy this code reshapes.

## How to test

Covered by the existing suite in `useWorkflowSaving.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/ADO-5827

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
