### PR TITLE
fix(API): Adapt binary data endpoint

### DIFF
--- a/packages/@n8n/db/src/repositories/binary-data.repository.ts
+++ b/packages/@n8n/db/src/repositories/binary-data.repository.ts
@@ -3,6 +3,7 @@ import { Service } from '@n8n/di';
 import { DataSource, In, Repository } from '@n8n/typeorm';
 
 import { BinaryDataFile } from '../entities';
+import type { SourceType } from '../entities';
 import { dbType } from '../entities/abstract-entity';
 
 @Service()
@@ -19,6 +20,15 @@ export class BinaryDataRepository extends Repository<BinaryDataFile> {
 		const file = await this.findOne({ where: { fileId }, select: ['data'] });
 
 		return file?.data ?? null;
+	}
+
+	/** Source that a stored file belongs to, or null when the row is gone. */
+	async findSourceByFileId(
+		fileId: string,
+	): Promise<{ sourceType: SourceType; sourceId: string } | null> {
+		const file = await this.findOne({ where: { fileId }, select: ['sourceType', 'sourceId'] });
+
+		return file ? { sourceType: file.sourceType, sourceId: file.sourceId } : null;
 	}
 
 	async deleteByFileIds(fileIds: string[]): Promise<void> {

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -262,6 +262,20 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 		};
 	}
 
+	/** Whether the execution exists and belongs to one of the given workflows. */
+	async existsForAccessibleWorkflows(
+		executionId: string,
+		accessibleWorkflowIds: string[],
+	): Promise<boolean> {
+		if (accessibleWorkflowIds.length === 0) return false;
+
+		return await this.exists({
+			where: { id: executionId, workflowId: In(accessibleWorkflowIds) },
+			// Manual executions with saving off are soft-deleted but stay downloadable.
+			withDeleted: true,
+		});
+	}
+
 	async findSingleExecution(
 		id: string,
 		options?: {

--- a/packages/cli/src/binary-data/__tests__/binary-data-access.service.test.ts
+++ b/packages/cli/src/binary-data/__tests__/binary-data-access.service.test.ts
@@ -1,0 +1,101 @@
+import type { BinaryDataRepository, ExecutionRepository, User } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+
+import { BinaryDataAccessService } from '../binary-data-access.service';
+
+describe('BinaryDataAccessService', () => {
+	const workflowSharingService = mock<WorkflowSharingService>();
+	const executionRepository = mock<ExecutionRepository>();
+	const binaryDataRepository = mock<BinaryDataRepository>();
+	const service = new BinaryDataAccessService(
+		workflowSharingService,
+		executionRepository,
+		binaryDataRepository,
+	);
+
+	const user = mock<User>();
+	const uuid = '2c3f1e5a-0b6d-4c8e-9f11-abc123def456';
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	describe('hasReadAccess', () => {
+		describe('resolves the execution from a path-format id', () => {
+			test.each(['filesystem', 'filesystem-v2', 's3', 'azure'])('for mode %s', async (mode) => {
+				workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf1']);
+				executionRepository.existsForAccessibleWorkflows.mockResolvedValue(true);
+
+				const id = `${mode}:workflows/wf1/executions/exec1/binary_data/${uuid}`;
+				const result = await service.hasReadAccess(user, id);
+
+				expect(result).toBe(true);
+				expect(workflowSharingService.getSharedWorkflowIds).toHaveBeenCalledWith(user, {
+					scopes: ['workflow:read'],
+				});
+				expect(executionRepository.existsForAccessibleWorkflows).toHaveBeenCalledWith('exec1', [
+					'wf1',
+				]);
+				expect(binaryDataRepository.findSourceByFileId).not.toHaveBeenCalled();
+			});
+		});
+
+		test('denies when the execution is not in an accessible workflow', async () => {
+			workflowSharingService.getSharedWorkflowIds.mockResolvedValue([]);
+			executionRepository.existsForAccessibleWorkflows.mockResolvedValue(false);
+
+			const id = `filesystem-v2:workflows/wf1/executions/exec1/binary_data/${uuid}`;
+			expect(await service.hasReadAccess(user, id)).toBe(false);
+		});
+
+		test('resolves the execution from a database row', async () => {
+			binaryDataRepository.findSourceByFileId.mockResolvedValue({
+				sourceType: 'execution',
+				sourceId: 'exec9',
+			});
+			workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf9']);
+			executionRepository.existsForAccessibleWorkflows.mockResolvedValue(true);
+
+			const result = await service.hasReadAccess(user, `database:${uuid}`);
+
+			expect(result).toBe(true);
+			expect(binaryDataRepository.findSourceByFileId).toHaveBeenCalledWith(uuid);
+			expect(executionRepository.existsForAccessibleWorkflows).toHaveBeenCalledWith('exec9', [
+				'wf9',
+			]);
+		});
+
+		test('denies a database row that is not an execution', async () => {
+			binaryDataRepository.findSourceByFileId.mockResolvedValue({
+				sourceType: 'chat_message_attachment',
+				sourceId: 'msg1',
+			});
+
+			expect(await service.hasReadAccess(user, `database:${uuid}`)).toBe(false);
+			expect(workflowSharingService.getSharedWorkflowIds).not.toHaveBeenCalled();
+			expect(executionRepository.existsForAccessibleWorkflows).not.toHaveBeenCalled();
+		});
+
+		test('denies a database row that is gone', async () => {
+			binaryDataRepository.findSourceByFileId.mockResolvedValue(null);
+
+			expect(await service.hasReadAccess(user, `database:${uuid}`)).toBe(false);
+			expect(executionRepository.existsForAccessibleWorkflows).not.toHaveBeenCalled();
+		});
+
+		test('denies a custom (non-execution) path id', async () => {
+			const id = `filesystem-v2:chat-hub/sessions/s1/messages/m1/binary_data/${uuid}`;
+
+			expect(await service.hasReadAccess(user, id)).toBe(false);
+			expect(workflowSharingService.getSharedWorkflowIds).not.toHaveBeenCalled();
+			expect(executionRepository.existsForAccessibleWorkflows).not.toHaveBeenCalled();
+		});
+
+		test('denies a malformed id without a mode separator', async () => {
+			expect(await service.hasReadAccess(user, 'no-separator')).toBe(false);
+			expect(workflowSharingService.getSharedWorkflowIds).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/binary-data/binary-data-access.service.ts
+++ b/packages/cli/src/binary-data/binary-data-access.service.ts
@@ -1,0 +1,55 @@
+import type { User } from '@n8n/db';
+import { BinaryDataRepository, ExecutionRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { getExecutionIdFromFileId } from 'n8n-core';
+
+import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+
+/**
+ * Authorizes access to binary data. A binary belongs to an execution, so access
+ * derives from `workflow:read` on that execution's workflow.
+ */
+@Service()
+export class BinaryDataAccessService {
+	constructor(
+		private readonly workflowSharingService: WorkflowSharingService,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly binaryDataRepository: BinaryDataRepository,
+	) {}
+
+	/** Whether `user` may read the execution that owns `binaryDataId`. */
+	async hasReadAccess(user: User, binaryDataId: string): Promise<boolean> {
+		const executionId = await this.resolveExecutionId(binaryDataId);
+		if (!executionId) return false;
+
+		const accessibleWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
+			scopes: ['workflow:read'],
+		});
+
+		return await this.executionRepository.existsForAccessibleWorkflows(
+			executionId,
+			accessibleWorkflowIds,
+		);
+	}
+
+	/**
+	 * Resolve the execution a binary belongs to, or null for binaries not tied to
+	 * an execution (custom sources) or IDs that cannot be mapped to one.
+	 */
+	private async resolveExecutionId(binaryDataId: string): Promise<string | null> {
+		const separatorIndex = binaryDataId.indexOf(':');
+		if (separatorIndex === -1) return null;
+
+		const mode = binaryDataId.substring(0, separatorIndex);
+		const fileId = binaryDataId.substring(separatorIndex + 1);
+
+		// database mode stores a bare uuid; the row carries the source
+		if (mode === 'database') {
+			const source = await this.binaryDataRepository.findSourceByFileId(fileId);
+			return source?.sourceType === 'execution' ? source.sourceId : null;
+		}
+
+		// filesystem / filesystem-v2 / s3 / azure embed the execution in the path
+		return getExecutionIdFromFileId(fileId);
+	}
+}

--- a/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
@@ -1,22 +1,27 @@
 import type { BinaryDataQueryDto, BinaryDataSignedQueryDto } from '@n8n/api-types';
-import type { Request, Response } from 'express';
+import type { AuthenticatedRequest } from '@n8n/db';
+import type { Response } from 'express';
 import { JsonWebTokenError } from 'jsonwebtoken';
 import type { BinaryDataService } from 'n8n-core';
 import { FileNotFoundError } from 'n8n-core';
 import type { Readable } from 'node:stream';
 import { mock } from 'vitest-mock-extended';
 
+import type { BinaryDataAccessService } from '@/binary-data/binary-data-access.service';
+
 import { BinaryDataController } from '../binary-data.controller';
 
 describe('BinaryDataController', () => {
-	const request = mock<Request>();
+	const request = mock<AuthenticatedRequest>();
 	const response = mock<Response>();
 	const binaryDataService = mock<BinaryDataService>();
-	const controller = new BinaryDataController(binaryDataService);
+	const binaryDataAccessService = mock<BinaryDataAccessService>();
+	const controller = new BinaryDataController(binaryDataService, binaryDataAccessService);
 
 	beforeEach(() => {
 		vi.resetAllMocks();
 		response.status.mockReturnThis();
+		binaryDataAccessService.hasReadAccess.mockResolvedValue(true);
 	});
 
 	describe('get', () => {
@@ -153,6 +158,24 @@ describe('BinaryDataController', () => {
 			expect(binaryDataService.getAsStream).toHaveBeenCalledWith('filesystem:123');
 		});
 
+		it('should return 404 when the user cannot access the binary', async () => {
+			const query = {
+				id: 'filesystem:123',
+				action: 'view',
+				mimeType: 'image/jpeg',
+			} as BinaryDataQueryDto;
+			binaryDataAccessService.hasReadAccess.mockResolvedValue(false);
+
+			await controller.get(request, response, query);
+
+			expect(binaryDataAccessService.hasReadAccess).toHaveBeenCalledWith(
+				request.user,
+				'filesystem:123',
+			);
+			expect(response.status).toHaveBeenCalledWith(404);
+			expect(binaryDataService.getAsStream).not.toHaveBeenCalled();
+		});
+
 		describe('with malicious binary data IDs', () => {
 			it.each([
 				['filesystem:'],
@@ -161,6 +184,11 @@ describe('BinaryDataController', () => {
 				['filesystem-v2:/'],
 				['filesystem://'],
 				['filesystem-v2://'],
+				['filesystem:workflows/a/executions/b/binary_data/../../../../etc/passwd'],
+				['filesystem:workflows/a/executions/b/binary_data/../../c/executions/d/binary_data/uuid'],
+				['filesystem-v2:workflows/a/executions/b/binary_data/../../../secret'],
+				['filesystem:workflows/a/executions/b/binary_data/..\\..\\..\\..\\etc\\passwd'],
+				['filesystem-v2:workflows\\a\\executions\\b\\binary_data\\..\\..\\..\\secret'],
 			])('should return 400 for ID "%s"', async (maliciousId) => {
 				const query = { id: maliciousId, action: 'download' } as BinaryDataQueryDto;
 
@@ -168,6 +196,8 @@ describe('BinaryDataController', () => {
 
 				expect(response.status).toHaveBeenCalledWith(400);
 				expect(response.end).toHaveBeenCalledWith('Malformed binary data ID');
+				expect(binaryDataAccessService.hasReadAccess).not.toHaveBeenCalled();
+				expect(binaryDataService.getAsStream).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/cli/src/controllers/binary-data.controller.ts
+++ b/packages/cli/src/controllers/binary-data.controller.ts
@@ -1,4 +1,5 @@
 import { BinaryDataQueryDto, BinaryDataSignedQueryDto, ViewableMimeTypes } from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
 import { Get, Query, RestController } from '@n8n/decorators';
 import { Request, Response } from 'express';
 import { JsonWebTokenError } from 'jsonwebtoken';
@@ -9,20 +10,27 @@ import {
 	isValidNonDefaultMode,
 } from 'n8n-core';
 
+import { BinaryDataAccessService } from '@/binary-data/binary-data-access.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 
 @RestController('/binary-data')
 export class BinaryDataController {
-	constructor(private readonly binaryDataService: BinaryDataService) {}
+	constructor(
+		private readonly binaryDataService: BinaryDataService,
+		private readonly binaryDataAccessService: BinaryDataAccessService,
+	) {}
 
 	@Get('/')
 	async get(
-		_: Request,
+		req: AuthenticatedRequest,
 		res: Response,
 		@Query { id: binaryDataId, action, fileName, mimeType }: BinaryDataQueryDto,
 	) {
 		try {
 			this.validateBinaryDataId(binaryDataId);
+			if (!(await this.binaryDataAccessService.hasReadAccess(req.user, binaryDataId))) {
+				return res.status(404).end();
+			}
 			await this.setContentHeaders(binaryDataId, action, res, fileName, mimeType);
 			return await this.binaryDataService.getAsStream(binaryDataId);
 		} catch (error) {
@@ -67,6 +75,13 @@ export class BinaryDataController {
 		const path = binaryDataId.substring(separatorIndex + 1);
 
 		if (path === '' || path === '/' || path === '//') {
+			throw new BadRequestError('Malformed binary data ID');
+		}
+
+		// Reject `..` segments: the reader resolves the whole path, so traversal
+		// could read another execution's file after the authz check matched a prefix.
+		// Split on both separators so backslash traversal is caught on Windows too.
+		if (path.split(/[/\\]/).includes('..')) {
 			throw new BadRequestError('Malformed binary data ID');
 		}
 	}

--- a/packages/cli/test/integration/binary-data.api.test.ts
+++ b/packages/cli/test/integration/binary-data.api.test.ts
@@ -1,9 +1,17 @@
-import { mockInstance } from '@n8n/backend-test-utils';
+import {
+	createWorkflow,
+	mockInstance,
+	shareWorkflowWithUsers,
+	testDb,
+} from '@n8n/backend-test-utils';
+import { BinaryDataRepository, ExecutionRepository, type User } from '@n8n/db';
+import { Container } from '@n8n/di';
 import { BinaryDataService, FileNotFoundError } from 'n8n-core';
 import fsp from 'node:fs/promises';
 import { Readable } from 'node:stream';
 
-import { createOwner } from './shared/db/users';
+import { createSuccessfulExecution } from './shared/db/executions';
+import { createMember, createOwner } from './shared/db/users';
 import type { SuperAgentTest } from './shared/types';
 import { setupTestServer } from './shared/utils';
 
@@ -15,28 +23,35 @@ const throwFileNotFound = () => {
 
 const binaryDataService = mockInstance(BinaryDataService);
 const testServer = setupTestServer({ endpointGroups: ['binaryData'] });
-let authOwnerAgent: SuperAgentTest;
-
-beforeAll(async () => {
-	const owner = await createOwner();
-	authOwnerAgent = testServer.authAgentFor(owner);
-});
 
 afterEach(() => {
 	vi.restoreAllMocks();
 });
 
 describe('GET /binary-data', () => {
-	const fileId = '599c5f84007-7d14-4b63-8f1e-d726098d0cc0';
-	const fsBinaryDataId = `filesystem:${fileId}`;
-	const s3BinaryDataId = `s3:${fileId}`;
-	const binaryFilePath = `/Users/john/.n8n/binaryData/${fileId}`;
+	const binaryFilePath = '/Users/john/.n8n/binaryData/599c5f84007-7d14-4b63-8f1e-d726098d0cc0';
 	const mimeType = 'text/plain';
 	const fileName = 'test.txt';
 	const buffer = Buffer.from('content');
 	const mockStream = new Readable();
 	mockStream.push(buffer);
 	mockStream.push(null);
+
+	let authOwnerAgent: SuperAgentTest;
+	// Path-format ids backed by an execution the owner can read (authorization gate).
+	let fsBinaryDataId: string;
+	let s3BinaryDataId: string;
+
+	beforeAll(async () => {
+		const owner = await createOwner();
+		authOwnerAgent = testServer.authAgentFor(owner);
+
+		const workflow = await createWorkflow({}, owner);
+		const execution = await createSuccessfulExecution(workflow);
+		const fileId = `workflows/${workflow.id}/executions/${execution.id}/binary_data/599c5f84007-7d14-4b63-8f1e-d726098d0cc0`;
+		fsBinaryDataId = `filesystem:${fileId}`;
+		s3BinaryDataId = `s3:${fileId}`;
+	});
 
 	describe('should reject on missing or invalid binary data ID', () => {
 		test.each([['view'], ['download']])('on request to %s', async (action) => {
@@ -159,6 +174,157 @@ describe('GET /binary-data', () => {
 					mimeType,
 					action,
 				})
+				.expect(404);
+		});
+	});
+});
+
+describe('GET /binary-data (execution ownership)', () => {
+	const uuid = '2c3f1e5a-0b6d-4c8e-9f11-abc123def456';
+	const mimeType = 'text/plain';
+	const fileName = 'test.txt';
+	const buffer = Buffer.from('secret');
+
+	let victim: User;
+	let attacker: User;
+
+	const executionBinaryId = (workflowId: string, executionId: string) =>
+		`filesystem-v2:workflows/${workflowId}/executions/${executionId}/binary_data/${uuid}`;
+
+	beforeEach(async () => {
+		await testDb.truncate(['ExecutionEntity', 'WorkflowEntity', 'SharedWorkflow']);
+		victim = await createMember();
+		attacker = await createMember();
+
+		const stream = new Readable();
+		stream.push(buffer);
+		stream.push(null);
+		binaryDataService.getAsStream.mockResolvedValue(stream);
+	});
+
+	test('lets the owner download a binary from their own execution', async () => {
+		const workflow = await createWorkflow({}, victim);
+		const execution = await createSuccessfulExecution(workflow);
+
+		await testServer
+			.authAgentFor(victim)
+			.get('/binary-data')
+			.query({
+				id: executionBinaryId(workflow.id, execution.id),
+				action: 'download',
+				fileName,
+				mimeType,
+			})
+			.expect(200);
+	});
+
+	test('does not let a user download a binary from an execution they cannot access', async () => {
+		const workflow = await createWorkflow({}, victim);
+		const execution = await createSuccessfulExecution(workflow);
+
+		await testServer
+			.authAgentFor(attacker)
+			.get('/binary-data')
+			.query({
+				id: executionBinaryId(workflow.id, execution.id),
+				action: 'download',
+				fileName,
+				mimeType,
+			})
+			.expect(404);
+	});
+
+	test('rejects a path-traversal id that points into an execution the user cannot access', async () => {
+		const attackerWorkflow = await createWorkflow({}, attacker);
+		const attackerExecution = await createSuccessfulExecution(attackerWorkflow);
+		const victimWorkflow = await createWorkflow({}, victim);
+		const victimExecution = await createSuccessfulExecution(victimWorkflow);
+
+		const traversalId =
+			`filesystem-v2:workflows/${attackerWorkflow.id}/executions/${attackerExecution.id}/binary_data/` +
+			`../../../../workflows/${victimWorkflow.id}/executions/${victimExecution.id}/binary_data/${uuid}`;
+
+		await testServer
+			.authAgentFor(attacker)
+			.get('/binary-data')
+			.query({ id: traversalId, action: 'download', fileName, mimeType })
+			.expect(400);
+	});
+
+	test('lets the owner download a binary from their own soft-deleted execution', async () => {
+		const workflow = await createWorkflow({}, victim);
+		const execution = await createSuccessfulExecution(workflow);
+		// Manual executions with saving off are soft-deleted but stay downloadable.
+		await Container.get(ExecutionRepository).softDelete(execution.id);
+
+		await testServer
+			.authAgentFor(victim)
+			.get('/binary-data')
+			.query({
+				id: executionBinaryId(workflow.id, execution.id),
+				action: 'download',
+				fileName,
+				mimeType,
+			})
+			.expect(200);
+	});
+
+	test('lets a user download a binary from an execution shared with them', async () => {
+		const workflow = await createWorkflow({}, victim);
+		await shareWorkflowWithUsers(workflow, [attacker]);
+		const execution = await createSuccessfulExecution(workflow);
+
+		await testServer
+			.authAgentFor(attacker)
+			.get('/binary-data')
+			.query({
+				id: executionBinaryId(workflow.id, execution.id),
+				action: 'download',
+				fileName,
+				mimeType,
+			})
+			.expect(200);
+	});
+
+	describe('database mode', () => {
+		const storeExecutionBinary = async (executionId: string) => {
+			await Container.get(BinaryDataRepository).insert({
+				fileId: uuid,
+				sourceType: 'execution',
+				sourceId: executionId,
+				data: buffer,
+				mimeType,
+				fileName,
+				fileSize: buffer.length,
+			});
+			return `database:${uuid}`;
+		};
+
+		beforeEach(async () => {
+			await testDb.truncate(['BinaryDataFile']);
+		});
+
+		test('lets the owner download a binary from their own execution', async () => {
+			const workflow = await createWorkflow({}, victim);
+			const execution = await createSuccessfulExecution(workflow);
+			const id = await storeExecutionBinary(execution.id);
+
+			await testServer
+				.authAgentFor(victim)
+				.get('/binary-data')
+				.query({ id, action: 'download', fileName, mimeType })
+				.expect(200);
+		});
+
+		test('does not let a user download a binary from an execution they cannot access', async () => {
+			const workflow = await createWorkflow({}, victim);
+			const execution = await createSuccessfulExecution(workflow);
+			const id = await storeExecutionBinary(execution.id);
+
+			await testServer
+				.authAgentFor(attacker)
+				.get('/binary-data')
+				.query({ id, action: 'download', fileName, mimeType })
 				.expect(404);
 		});
 	});

--- a/packages/core/src/binary-data/blob.manager.ts
+++ b/packages/core/src/binary-data/blob.manager.ts
@@ -10,7 +10,14 @@ import type { BinaryData } from './types';
 import { FileLocation } from './utils';
 import { FileNotFoundError } from '../errors/file-not-found.error';
 
+/** Captures `workflowId` (group 1) and `executionId` (group 2) from an execution fileId. */
 const EXECUTION_PATH_MATCHER = /^workflows\/([^/]+)\/executions\/([^/]+)\/binary_data\//;
+
+/** Execution id encoded in a path-format fileId, or null for non-execution paths. */
+export function getExecutionIdFromFileId(fileId: string): string | null {
+	const match = fileId.match(EXECUTION_PATH_MATCHER);
+	return match ? match[2] : null;
+}
 
 /**
  * Stores binary data as blobs via a {@link ByteStore}.

--- a/packages/core/src/binary-data/index.ts
+++ b/packages/core/src/binary-data/index.ts
@@ -1,5 +1,5 @@
 export * from './binary-data.service';
-export { BinaryDataBlobManager } from './blob.manager';
+export { BinaryDataBlobManager, getExecutionIdFromFileId } from './blob.manager';
 export { BinaryDataConfig } from './binary-data.config';
 export type * from './types';
 export { isStoredMode as isValidNonDefaultMode, FileLocation } from './utils';


### PR DESCRIPTION
## Summary

Adapts the logic in `GET /rest/binary-data` endpoint to locate the file to return.

## Related Links

- Linear: https://linear.app/n8n/issue/IAM-845

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

