### PR TITLE
test(core): Pin accepted review/publish race outcomes (no-changelog)

### DIFF
--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-requests.controller.integration.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-requests.controller.integration.test.ts
@@ -25,6 +25,8 @@ import { v4 as uuid } from 'uuid';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import { WorkflowValidationService } from '@/workflows/workflow-validation.service';
+import { WorkflowService } from '@/workflows/workflow.service';
+import { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 import { createAdmin, createMember, createOwner, createUser } from '@test-integration/db/users';
 import { createWorkflowHistoryItem } from '@test-integration/db/workflow-history';
 import type { SuperAgentTest } from '@test-integration/types';
@@ -926,6 +928,147 @@ describe('publishing a workflow under review', () => {
 
 		await ownerAgent.post(`/workflows/${workflow.id}/deactivate`).send({}).expect(200);
 
+		expect(
+			(await workflowEntityRepository.findOneByOrFail({ id: workflow.id })).activeVersionId,
+		).toBeNull();
+	});
+});
+
+/**
+ * The approval commits under the review lock, but auto-publish runs after it is
+ * released. Workflow mutations are deliberately not serialized behind that lock,
+ * so they can land in the gap. These pin the accepted outcomes: the approval
+ * stands and the publish that lost the race is reported as a failure.
+ */
+describe('a workflow mutation racing the auto-publish of an approval', () => {
+	/** Run `raceAction` in the gap between the committed approval and auto-publish. */
+	function raceBeforeAutoPublish(raceAction: () => Promise<unknown>) {
+		const workflowService = Container.get(WorkflowService);
+		const activate = workflowService.activateWorkflow.bind(workflowService);
+		vi.spyOn(workflowService, 'activateWorkflow').mockImplementationOnce(async (...args) => {
+			await raceAction();
+			return await activate(...args);
+		});
+	}
+
+	test('an archive that lands in the gap leaves an approved review and a failed auto-publish', async () => {
+		const { workflow, versionId } = await createReviewableWorkflow();
+		const request = await createOpenReview(workflow.id, versionId);
+
+		raceBeforeAutoPublish(
+			async () => await ownerAgent.post(`/workflows/${workflow.id}/archive`).expect(200),
+		);
+
+		const response = await ownerAgent
+			.post(`/workflow-review-requests/${request.id}/decision`)
+			.send({ decision: 'approved' })
+			.expect(200);
+
+		expect(response.body.data).toMatchObject({
+			state: 'closed',
+			decision: 'approved',
+			autoPublish: { status: 'failed', message: 'Cannot activate an archived workflow.' },
+		});
+
+		// The archive found the review already closed, so it left the approval alone.
+		const closed = await requestRepository.findById(request.id, {});
+		expect(closed).toMatchObject({ state: 'closed', decision: 'approved' });
+
+		const archived = await workflowEntityRepository.findOneByOrFail({ id: workflow.id });
+		expect(archived.isArchived).toBe(true);
+		expect(archived.activeVersionId).toBeNull();
+
+		// Publishing stays blocked by the archival itself, not by the closed review.
+		await ownerAgent.post(`/workflows/${workflow.id}/activate`).send({ versionId }).expect(400);
+	});
+
+	test('a transfer that lands in the gap leaves an approved review and a failed auto-publish', async () => {
+		const versionId = uuid();
+		const workflow = await createWorkflow({}, teamProject);
+		await createWorkflowHistoryItem(workflow.id, { versionId });
+
+		// The requester publishes on approval, so it must be someone who loses access
+		// when the workflow moves — the deciding owner never does.
+		const request = await requestRepository.createRequest(
+			{ projectId: teamProject.id, title: 'Review before publishing', createdById: member.id },
+			{},
+		);
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: request.id,
+				workflowId: workflow.id,
+				workflowVersionId: versionId,
+			},
+			{},
+		);
+		await authorRepository.addAuthor(
+			{ workflowReviewRequestId: request.id, userId: member.id },
+			{},
+		);
+
+		const destination = await createTeamProject('Elsewhere', await createMember());
+		raceBeforeAutoPublish(
+			async () =>
+				await Container.get(EnterpriseWorkflowService).transferWorkflow(
+					owner,
+					workflow.id,
+					destination.id,
+				),
+		);
+
+		const response = await ownerAgent
+			.post(`/workflow-review-requests/${request.id}/decision`)
+			.send({ decision: 'approved' })
+			.expect(200);
+
+		expect(response.body.data).toMatchObject({
+			state: 'closed',
+			decision: 'approved',
+			autoPublish: {
+				status: 'failed',
+				message:
+					'You do not have permission to activate this workflow. Ask the owner to share it with you.',
+			},
+		});
+
+		expect(await requestRepository.findById(request.id, {})).toMatchObject({
+			state: 'closed',
+			decision: 'approved',
+		});
+		expect(
+			(await workflowEntityRepository.findOneByOrFail({ id: workflow.id })).activeVersionId,
+		).toBeNull();
+	});
+
+	test('a review created in the gap blocks the auto-publish without failing the decision', async () => {
+		const { workflow, versionId } = await createReviewableWorkflow();
+		const request = await createOpenReview(workflow.id, versionId);
+
+		let racingRequestId = '';
+		raceBeforeAutoPublish(async () => {
+			racingRequestId = (await createOpenReview(workflow.id, versionId)).id;
+		});
+
+		const response = await ownerAgent
+			.post(`/workflow-review-requests/${request.id}/decision`)
+			.send({ decision: 'approved' })
+			.expect(200);
+
+		expect(response.body.data).toMatchObject({
+			state: 'closed',
+			decision: 'approved',
+			autoPublish: {
+				status: 'failed',
+				message:
+					"Workflow can't be published while its review is open. Submit this version to the review, or wait for the review to close.",
+			},
+		});
+
+		// The new review is untouched and still guards the workflow.
+		expect(await requestRepository.findOpenRequestForWorkflow(workflow.id, {})).toMatchObject({
+			id: racingRequestId,
+			state: 'open',
+		});
 		expect(
 			(await workflowEntityRepository.findOneByOrFail({ id: workflow.id })).activeVersionId,
 		).toBeNull();

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -886,6 +886,13 @@ export class WorkflowService {
 
 		// re-applying the already-published version (e.g. a settings-only update)
 		// publishes no new version, so the review gate must not block it.
+		//
+		// This check is deliberately not serialized with review mutations: putting
+		// publishing behind the review feature's global lock would slow down a core
+		// workflow operation for every instance. A review opened just after this
+		// passes, or just before an approval's auto-publish reaches it, therefore
+		// races — accepted, because both outcomes degrade gracefully (the approval
+		// stands and auto-publish reports `failed`).`.
 		if (versionIdToActivate !== previousActiveVersionId) {
 			await this.workflowPublishGuard.assertCanPublish(workflowId);
 		}


### PR DESCRIPTION
## Summary

The backend review found narrow race windows between review mutations and workflow mutations. The team accepted them: they degrade gracefully, and serializing them would put core workflow operations behind the review feature's global lock. This PR pins the accepted outcomes with tests, so a later refactor cannot change them without a test failure.

The approval commits under the review lock, but the auto-publish runs after the lock is released. A workflow mutation can land in that gap. Three integration tests cover it:

1. **An archive lands in the gap.** The request stays `closed` / `approved`. The auto-publish reports `{ status: 'failed', message: 'Cannot activate an archived workflow.' }`. A later manual publish is still refused, because the workflow is archived — not because of the review.
2. **A transfer lands in the gap.** The request stays `closed` / `approved`. The requester loses publish access in the new project, so the auto-publish reports `failed`. The workflow stays unpublished.
3. **A new review is created in the gap.** The decision still returns 200. The publish guard blocks the auto-publish, which reports `failed` with the `review_pending` message. The new review stays open, and the workflow stays unpublished.

The tests wrap `WorkflowService.activateWorkflow` one time. The racing mutation commits in the real gap, and the real publish path then runs. No behaviour is mocked away.

This PR also adds a comment at the publish guard in `workflow.service.ts`. The comment records why the guard is not serialized with review mutations, and points to the tests.

No production behaviour changes.

## How to test

Run the test file:

```bash
cd packages/cli
pnpm test:integration src/modules/workflow-reviews.ee/__tests__/workflow-review-requests.controller.integration.test.ts
```

All 172 tests pass. The three new tests are in the describe block `a workflow mutation racing the auto-publish of an approval`.

The workflow reviews feature needs the `workflow-reviews` module, the `feat:workflowReviews` license feature, and the instance review policy. The test server sets all three up.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-1038

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

