### PR TITLE
build: Fix Docker build chain after DHI base drift and the pnpm 11 upgrade

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -32,11 +32,11 @@ jobs:
         # when updating.
         include:
           - node_version: '22'
-            dhi_ref: dhi.io/node:22.23.2-alpine3.24-dev@sha256:a6ac21cfbc4bb746c1cfc6cf1501ec13c961ae71558ff2ac7e021caaaf91a224
-          - node_version: '24.18.1'
-            dhi_ref: dhi.io/node:24.18.1-alpine3.24-dev@sha256:074b5aa92e1ce74cd575214211bbcb8d1550710aec59558da734a67d84d31679
-          - node_version: '26.5.1'
-            dhi_ref: dhi.io/node:26.5.1-alpine3.24-dev@sha256:c4062f85acd1ca91ffb7d15048dcc5f15a922d630e65eb3c3c0dcdcef6ea36d8
+            dhi_ref: dhi.io/node:22.23.2-alpine3.24-dev@sha256:155a95d59244a71e9479e191ff718f03a7197d6829612e0707608be92988cb87
+          - node_version: '24.19.0'
+            dhi_ref: dhi.io/node:24.19.0-alpine3.24-dev@sha256:dc2989ad23938772abaf549ed7bde5d61d70377005229bb55bef94bff40f8bbd
+          - node_version: '26.7.0'
+            dhi_ref: dhi.io/node:26.7.0-alpine3.24-dev@sha256:4b494d89fb26c950ce97865acf45b480dc7a6868fdc2b81c2d66599702eeac3f
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -1,6 +1,6 @@
 # CI passes one DHI reference per published Node version (see the matrix in
 # build-base-image.yml). The default keeps plain `docker build` working.
-ARG DHI_REF=dhi.io/node:24.18.1-alpine3.24-dev@sha256:074b5aa92e1ce74cd575214211bbcb8d1550710aec59558da734a67d84d31679
+ARG DHI_REF=dhi.io/node:24.19.0-alpine3.24-dev@sha256:dc2989ad23938772abaf549ed7bde5d61d70377005229bb55bef94bff40f8bbd
 FROM ${DHI_REF}
 
 # Install all dependencies in a single layer to minimize image size

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,10 @@ hoistPattern:
   - '*'
   - '!typescript'
 allowUnusedPatches: true
+# The docker build trims frontend manifests and deploys with --prod before later
+# scripts run; pnpm 11's pre-run install would reinstall production-only and prune
+# the devDependencies those scripts import.
+verifyDepsBeforeRun: false
 
 pmOnFail: warn
 fund: false

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -10,6 +10,7 @@
 
 import { $, echo, fs, chalk } from 'zx';
 import path from 'path';
+import os from 'os';
 
 // Check if running in a CI environment
 const isCI = process.env.CI === 'true';
@@ -123,14 +124,13 @@ const packageJsonFiles = await $`cd ${config.rootDir} && find . -name "package.j
 -not -path "./compiled/*" \
 -type f`.lines();
 
-// Backup all package.json files
-// This is only needed locally, not in CI
-if (process.env.CI !== 'true') {
-	for (const file of packageJsonFiles) {
-		if (file) {
-			const fullPath = path.join(config.rootDir, file);
-			await fs.copy(fullPath, `${fullPath}.bak`);
-		}
+// Backup all package.json files. The FE trim below mutates them, and pnpm verifies
+// the lockfile before running any later script, which fails until they are restored.
+// Backups live outside the workspace: siblings would be packed into the deployment.
+const packageJsonBackupDir = await fs.mkdtemp(path.join(os.tmpdir(), 'n8n-build-pkgjson-'));
+for (const file of packageJsonFiles) {
+	if (file) {
+		await fs.copy(path.join(config.rootDir, file), path.join(packageJsonBackupDir, file));
 	}
 }
 // Run FE trim script
@@ -303,18 +303,15 @@ if (generateLicenses) {
 }
 
 // Restore package.json files
-// This is only needed locally, not in CI
-if (process.env.CI !== 'true') {
-	for (const file of packageJsonFiles) {
-		if (file) {
-			const fullPath = path.join(config.rootDir, file);
-			const backupPath = `${fullPath}.bak`;
-			if (await fs.pathExists(backupPath)) {
-				await fs.move(backupPath, fullPath, { overwrite: true });
-			}
+for (const file of packageJsonFiles) {
+	if (file) {
+		const backupPath = path.join(packageJsonBackupDir, file);
+		if (await fs.pathExists(backupPath)) {
+			await fs.move(backupPath, path.join(config.rootDir, file), { overwrite: true });
 		}
 	}
 }
+await fs.remove(packageJsonBackupDir);
 
 // Calculate output size
 const compiledAppOutputSize = (await $`du -sh ${config.compiledAppDir} | cut -f1`).stdout.trim();


### PR DESCRIPTION
## Summary

The nightly `Docker Build Smoke Test` has been red since 2026-08-20. Two unrelated causes, the first masking the second.

**1. The base image build could not resolve `busybox-binsh`.** DHI dropped `busybox 1.38.0_git20260724-r5` from their Alpine 3.24 apk repo and delisted the `24.18.1` / `26.5.1` dev tags. Their `busybox` package provides only `cmd:busybox`, so `busybox-binsh` is what supplies the `/bin/sh` that `ca-certificates`, `libheif` and `openssh-server` hard-depend on — and it pins `busybox=<exact version>`, which is checksum-pinned in `/etc/apk/world` and no longer exists in any configured repo:

```
breaks: busybox-binsh-1.37.0_git20260817-r33[busybox=1.37.0_git20260817-r33]
satisfies: world[busybox><Q17qiYKlK9RDwttnUVCN54vOnGybE=]
```

Bumped to DHI's current Alpine 3.24 builds (24.19.0, 26.7.0) with a 22.23.2 digest refresh. `/bin/sh` stays busybox ash; no image content change beyond the Node patch versions.

Rejected alternatives, each tested against a local reproduction: dropping the `busybox-binsh` line (apk re-adds it implicitly for the `/bin/sh` dep), `dash-binsh` / `yash-binsh` (both declare `D:busybox`, so the solver still moves busybox), and unpinning world (apk refuses to downgrade).

**2. pnpm 11 pruned the devDependencies the smoke script needs.** pnpm 11 verifies dependencies before running a script and reinstalls when the tree looks stale. That fires on `pnpm build:docker:smoke`, which runs right after `build-n8n.mjs` has trimmed the frontend manifests and deployed with `--prod`: the reinstall either fails the frozen-lockfile check against the trimmed manifests, or succeeds as a production install and prunes `zx`, which the smoke script imports. Introduced by #36424, which does not touch `docker/images/**` and so never ran this workflow.

- Opt out of the pre-run verification.
- Restore the trimmed manifests in CI too, instead of leaving the working tree mutated. Backups move to a temp dir outside the workspace, since sibling `.bak` files get packed into `compiled/` and would ship inside the image.

## How to test

`Docker Build Smoke Test` passes on this PR — the first green run of the full chain since 2026-08-20.

Base image, against all three refs on both architectures:

```
docker login dhi.io
docker build --platform linux/amd64 -f docker/images/n8n-base/Dockerfile -t base-check .
docker run --rm base-check sh -c 'node -v; gm version | head -1; readlink -f /bin/sh'
```

The pnpm behaviour, emulating the CI sequence:

```
node .github/scripts/trim-fe-packageJson.js
pnpm --filter=n8n --prod --legacy deploy --no-optional /tmp/x
CI=true pnpm build:docker:smoke
```

Before: `ERR_PNPM_OUTDATED_LOCKFILE`, or the script starts and dies on a missing `zx`. After: it runs with dev dependencies intact.

## Notes

The published `n8nio/base:26.5.1` digest that `docker/images/n8n/Dockerfile` pins is untouched, so the n8n image build is unaffected. A follow-up moves it onto `base:26.7.0` once this merge publishes it.

The DHI change is a re-pin, not a structural fix — it recurs on the next DHI busybox roll, until digest bumps are automated (DEVP-266).

Publishing was checked separately and is unaffected: `release-publish.yml` runs no `pnpm run` step after its trim, nested `prepack` scripts do not trip the verification, and packed manifests carry no unresolved `catalog:` / `workspace:` specifiers.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-869
