### PR TITLE
build: Keep dev dependencies intact through the Docker build chain

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,10 @@ hoistPattern:
   - '*'
   - '!typescript'
 allowUnusedPatches: true
+# The docker build trims frontend manifests and deploys with --prod before later
+# scripts run; pnpm 11's pre-run install would reinstall production-only and prune
+# the devDependencies those scripts import.
+verifyDepsBeforeRun: false
 
 pmOnFail: warn
 fund: false

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -10,6 +10,7 @@
 
 import { $, echo, fs, chalk } from 'zx';
 import path from 'path';
+import os from 'os';
 
 // Check if running in a CI environment
 const isCI = process.env.CI === 'true';
@@ -123,14 +124,13 @@ const packageJsonFiles = await $`cd ${config.rootDir} && find . -name "package.j
 -not -path "./compiled/*" \
 -type f`.lines();
 
-// Backup all package.json files
-// This is only needed locally, not in CI
-if (process.env.CI !== 'true') {
-	for (const file of packageJsonFiles) {
-		if (file) {
-			const fullPath = path.join(config.rootDir, file);
-			await fs.copy(fullPath, `${fullPath}.bak`);
-		}
+// Backup all package.json files. The FE trim below mutates them, and pnpm verifies
+// the lockfile before running any later script, which fails until they are restored.
+// Backups live outside the workspace: siblings would be packed into the deployment.
+const packageJsonBackupDir = await fs.mkdtemp(path.join(os.tmpdir(), 'n8n-build-pkgjson-'));
+for (const file of packageJsonFiles) {
+	if (file) {
+		await fs.copy(path.join(config.rootDir, file), path.join(packageJsonBackupDir, file));
 	}
 }
 // Run FE trim script
@@ -303,18 +303,15 @@ if (generateLicenses) {
 }
 
 // Restore package.json files
-// This is only needed locally, not in CI
-if (process.env.CI !== 'true') {
-	for (const file of packageJsonFiles) {
-		if (file) {
-			const fullPath = path.join(config.rootDir, file);
-			const backupPath = `${fullPath}.bak`;
-			if (await fs.pathExists(backupPath)) {
-				await fs.move(backupPath, fullPath, { overwrite: true });
-			}
+for (const file of packageJsonFiles) {
+	if (file) {
+		const backupPath = path.join(packageJsonBackupDir, file);
+		if (await fs.pathExists(backupPath)) {
+			await fs.move(backupPath, path.join(config.rootDir, file), { overwrite: true });
 		}
 	}
 }
+await fs.remove(packageJsonBackupDir);
 
 // Calculate output size
 const compiledAppOutputSize = (await $`du -sh ${config.compiledAppDir} | cut -f1`).stdout.trim();


### PR DESCRIPTION
## Summary

Stacked on #36984.

pnpm 11 verifies dependencies before running a script and reinstalls when the tree looks stale. In the Docker chain that fires on `pnpm build:docker:smoke`, which runs right after `build-n8n.mjs` has trimmed the frontend manifests and deployed with `--prod`. The reinstall then either fails the frozen-lockfile check against the trimmed manifests, or succeeds as a production install and prunes the devDependencies the smoke script imports (`zx`).

- Opt out of the pre-run verification.
- Restore the trimmed manifests in CI too, instead of leaving the working tree mutated. Backups move to a temp dir outside the workspace, since sibling `.bak` files get packed into `compiled/` and would ship inside the image.

## How to test

Emulate the CI sequence:

```
node .github/scripts/trim-fe-packageJson.js
pnpm --filter=n8n --prod --legacy deploy --no-optional /tmp/x
CI=true pnpm build:docker:smoke
```

Before: `ERR_PNPM_OUTDATED_LOCKFILE`, or the script starts and dies on a missing `zx`. After: the script runs with dev dependencies intact.

The 100-manifest backup/restore round trip leaves the tree clean with no stray `.bak`. The deploy produces only `@n8n/ai-utilities` x2, matching `KNOWN_DUPLICATED`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-869


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

