### PR TITLE
fix(core): Grant connect access for globally shared end-user credentials

### DIFF
--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -190,6 +190,11 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 			findManyOptions.select = { ...findManyOptions.select, id: true }; // pagination requires id
 		}
 
+		// the credential:connect scope check needs isResolvable whenever isGlobal is selected
+		if (select?.isGlobal && !select?.isResolvable) {
+			findManyOptions.select = { ...findManyOptions.select, isResolvable: true };
+		}
+
 		if (!findManyOptions.select) {
 			findManyOptions.select = defaultSelect;
 			findManyOptions.relations = defaultRelations;

--- a/packages/cli/src/credentials/credentials-finder.service.ts
+++ b/packages/cli/src/credentials/credentials-finder.service.ts
@@ -27,12 +27,25 @@ export class CredentialsFinderService {
 		});
 	}
 
+	private isExactScope(scopes: Scope[], scope: Scope): boolean {
+		return scopes.length === 1 && scopes[0] === scope;
+	}
+
 	/**
 	 * Checks if the scopes allow read-only access to global credentials.
 	 * Global credentials can be accessed with credential:read scope only.
 	 */
 	hasGlobalReadOnlyAccess(scopes: Scope[]): boolean {
-		return scopes.length === 1 && scopes[0] === 'credential:read';
+		return this.isExactScope(scopes, 'credential:read');
+	}
+
+	/**
+	 * Checks if the scopes allow connect access to global credentials. Only
+	 * end-user (resolvable) global credentials grant this — the caller is
+	 * still responsible for checking `isResolvable` on the credential itself.
+	 */
+	hasGlobalConnectAccess(scopes: Scope[]): boolean {
+		return this.isExactScope(scopes, 'credential:connect');
 	}
 
 	/**
@@ -188,6 +201,15 @@ export class CredentialsFinderService {
 			});
 		}
 
+		// End-user credentials shared globally still let the recipient connect
+		// their own account; static global credentials do not.
+		if (this.hasGlobalConnectAccess(scopes)) {
+			const globalCredential = await this.findGlobalCredentialById(credentialsId, {
+				shared: { project: true },
+			});
+			return globalCredential?.isResolvable ? globalCredential : null;
+		}
+
 		return null;
 	}
 
@@ -294,6 +316,18 @@ export class CredentialsFinderService {
 		if (this.hasGlobalReadOnlyAccess(scopes)) {
 			const globalCreds = await this.credentialsRepository.find({
 				where: { id: In(credentialIds), isGlobal: true, usageScope: 'project' },
+				select: ['id'],
+			});
+			for (const gc of globalCreds) result.add(gc.id);
+		} else if (this.hasGlobalConnectAccess(scopes)) {
+			// Only end-user (resolvable) global credentials grant connect access.
+			const globalCreds = await this.credentialsRepository.find({
+				where: {
+					id: In(credentialIds),
+					isGlobal: true,
+					usageScope: 'project',
+					isResolvable: true,
+				},
 				select: ['id'],
 			});
 			for (const gc of globalCreds) result.add(gc.id);

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-connection-status.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-connection-status.service.test.ts
@@ -174,6 +174,7 @@ describe('CredentialConnectionStatusService', () => {
 			em.find.mockResolvedValueOnce([admin]);
 			// Even if the project check returned nothing, admin is retained in-memory
 			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([]);
+			em.find.mockResolvedValueOnce([]); // no globally-connectable credentials
 
 			// ACT
 			await service.cleanupOrphanedEntriesForUsers(['admin-1'], em);
@@ -192,6 +193,7 @@ describe('CredentialConnectionStatusService', () => {
 			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([
 				{ credentialId: CRED_ID, userId: 'sharee-1' },
 			]);
+			em.find.mockResolvedValueOnce([]); // no globally-connectable credentials
 
 			// ACT
 			await service.cleanupOrphanedEntriesForUsers(['sharee-1'], em);
@@ -220,6 +222,7 @@ describe('CredentialConnectionStatusService', () => {
 			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([
 				{ credentialId: CRED_ID, userId: 'member-1' },
 			]);
+			em.find.mockResolvedValueOnce([]); // no globally-connectable credentials
 
 			// ACT
 			await service.cleanupOrphanedEntriesForUsers(['member-1'], em);
@@ -235,6 +238,7 @@ describe('CredentialConnectionStatusService', () => {
 			em.find.mockResolvedValueOnce([member]);
 			// No retained pairs — member was unshared / removed / role downgraded
 			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([]);
+			em.find.mockResolvedValueOnce([]); // no globally-connectable credentials
 
 			// ACT
 			await service.cleanupOrphanedEntriesForUsers(['member-1'], em);
@@ -259,12 +263,46 @@ describe('CredentialConnectionStatusService', () => {
 			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([
 				{ credentialId: CRED_ID, userId: 'member-1' },
 			]);
+			em.find.mockResolvedValueOnce([]); // no globally-connectable credentials
 
 			// ACT
 			await service.cleanupOrphanedEntriesForUsers(['member-1'], em);
 
 			// ASSERT — surviving path keeps the entry
 			expect(repository.deleteByPairs).not.toHaveBeenCalled();
+		});
+
+		it('retains pair for a recipient of a global end-user credential share', async () => {
+			// ARRANGE — no project share at all, only a global (isGlobal + isResolvable) share
+			const recipient = makeUser('recipient-1'); // no global scope
+			em.find.mockResolvedValueOnce([makeEntry(CRED_ID, 'recipient-1')]);
+			em.find.mockResolvedValueOnce([recipient]);
+			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([]);
+			em.find.mockResolvedValueOnce([{ id: CRED_ID }]); // globally-connectable credential
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['recipient-1'], em);
+
+			// ASSERT — global end-user share retains the connection
+			expect(repository.deleteByPairs).not.toHaveBeenCalled();
+		});
+
+		it('deletes pair when the credential is globally shared but not an end-user credential', async () => {
+			// ARRANGE — a static global credential grants no connect access
+			const recipient = makeUser('recipient-1'); // no global scope
+			em.find.mockResolvedValueOnce([makeEntry(CRED_ID, 'recipient-1')]);
+			em.find.mockResolvedValueOnce([recipient]);
+			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([]);
+			em.find.mockResolvedValueOnce([]); // not resolvable, so excluded from the query result
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['recipient-1'], em);
+
+			// ASSERT
+			expect(repository.deleteByPairs).toHaveBeenCalledWith(
+				[{ credentialId: CRED_ID, userId: 'recipient-1' }],
+				em,
+			);
 		});
 
 		it('handles mixed batch: deletes orphaned pair and retains the one with access', async () => {
@@ -283,6 +321,7 @@ describe('CredentialConnectionStatusService', () => {
 			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([
 				{ credentialId: CRED_B, userId: 'user-active' },
 			]);
+			em.find.mockResolvedValueOnce([]); // no globally-connectable credentials
 
 			// ACT
 			await service.cleanupOrphanedEntriesForUsers(['user-lost', 'user-active'], em);

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-connection-status.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-connection-status.service.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import {
+	CredentialsEntity,
 	In,
 	ProjectRelationRepository,
 	SharedCredentialsRepository,
@@ -203,40 +204,68 @@ export class CredentialConnectionStatusService implements ICredentialConnectionS
 		const pairsToCheck = uniquePairs.filter((p) => userById.has(p.userId));
 
 		let projectRetainedKeys = new Set<string>();
+		let globallyConnectableCredentialIds = new Set<string>();
 		if (pairsToCheck.length > 0) {
-			// Credential roles that carry credential:connect — served from the role
-			const validCredRoles = await this.roleService.rolesWithScope(
-				'credential',
-				CREDENTIAL_RETAIN_SCOPE,
-				em,
-			);
-			const projectRetained = await this.sharedCredentialsRepository.findPairsWithCredentialAccess(
-				pairsToCheck,
-				CREDENTIAL_RETAIN_SCOPE,
-				validCredRoles,
-				em,
-			);
+			const credentialIds = [...new Set(pairsToCheck.map((p) => p.credentialId))];
+
+			const [projectRetained, globallyConnectableCredentials] = await Promise.all([
+				// Credential roles that carry credential:connect — served from the role
+				(async () => {
+					const validCredRoles = await this.roleService.rolesWithScope(
+						'credential',
+						CREDENTIAL_RETAIN_SCOPE,
+						em,
+					);
+					return await this.sharedCredentialsRepository.findPairsWithCredentialAccess(
+						pairsToCheck,
+						CREDENTIAL_RETAIN_SCOPE,
+						validCredRoles,
+						em,
+					);
+				})(),
+				// End-user credentials shared globally grant every user connect
+				// access regardless of project membership (see role.service.ts).
+				em.find(CredentialsEntity, {
+					where: {
+						id: In(credentialIds),
+						isGlobal: true,
+						usageScope: 'project',
+						isResolvable: true,
+					},
+					select: ['id'],
+				}),
+			]);
 			projectRetainedKeys = new Set(projectRetained.map(keyOf));
+			globallyConnectableCredentialIds = new Set(globallyConnectableCredentials.map((c) => c.id));
 		}
 
-		const toDelete = this.selectOrphanedPairs(uniquePairs, userById, projectRetainedKeys);
+		const toDelete = this.selectOrphanedPairs(
+			uniquePairs,
+			userById,
+			projectRetainedKeys,
+			globallyConnectableCredentialIds,
+		);
 		if (toDelete.length > 0) {
 			await this.repository.deleteByPairs(toDelete, em);
 		}
 	}
 
 	/**
-	 * A pair is orphaned unless the user retains `credential:connect`.
+	 * A pair is orphaned unless the user retains `credential:connect`, either
+	 * through a global role, a project share, or a global end-user credential
+	 * share.
 	 */
 	private selectOrphanedPairs(
 		pairs: CredentialUserPair[],
 		userById: Map<string, User>,
 		projectRetainedKeys: Set<string>,
+		globallyConnectableCredentialIds: Set<string>,
 	): CredentialUserPair[] {
 		return pairs.filter((pair) => {
 			const user = userById.get(pair.userId);
 			if (!user) return true;
 			if (hasGlobalScope(user, CREDENTIAL_RETAIN_SCOPE)) return false;
+			if (globallyConnectableCredentialIds.has(pair.credentialId)) return false;
 			return !projectRetainedKeys.has(keyOf(pair));
 		});
 	}

--- a/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
+++ b/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
@@ -24,6 +24,7 @@ describe('userHasScopes', () => {
 	let instanceCredentialExistsMock: Mock;
 	let findGlobalCredentialByIdMock: Mock;
 	let hasGlobalReadOnlyAccessMock: Mock;
+	let hasGlobalConnectAccessMock: Mock;
 	let roleServiceMock: Mock;
 	let mockQueryBuilder: any;
 
@@ -34,6 +35,7 @@ describe('userHasScopes', () => {
 		instanceCredentialExistsMock = vi.fn();
 		findGlobalCredentialByIdMock = vi.fn();
 		hasGlobalReadOnlyAccessMock = vi.fn();
+		hasGlobalConnectAccessMock = vi.fn();
 		roleServiceMock = vi.fn();
 
 		Container.set(
@@ -63,6 +65,7 @@ describe('userHasScopes', () => {
 			mock<CredentialsFinderService>({
 				findGlobalCredentialById: findGlobalCredentialByIdMock,
 				hasGlobalReadOnlyAccess: hasGlobalReadOnlyAccessMock,
+				hasGlobalConnectAccess: hasGlobalConnectAccessMock,
 			}),
 		);
 
@@ -99,6 +102,7 @@ describe('userHasScopes', () => {
 		instanceCredentialExistsMock.mockReset();
 		findGlobalCredentialByIdMock.mockReset();
 		hasGlobalReadOnlyAccessMock.mockReset();
+		hasGlobalConnectAccessMock.mockReset();
 		roleServiceMock.mockReset();
 
 		// Default mock responses
@@ -532,6 +536,66 @@ describe('userHasScopes', () => {
 
 			const user = { id: 'userId', scopes: [], role: GLOBAL_MEMBER_ROLE } as unknown as User;
 			const scopes = ['credential:read'] as Scope[];
+
+			const result = await userHasScopes(user, scopes, false, { credentialId });
+
+			expect(result).toBe(false);
+		});
+
+		it('should grant connect access to a global end-user credential when user lacks project access', async () => {
+			const credentialId = 'global-cred-123';
+			roleServiceMock.mockResolvedValue(['credential:owner']);
+			mockQueryBuilder.getRawMany.mockResolvedValue([]); // No project access
+
+			findByCredentialMock.mockResolvedValue([
+				{
+					credentialsId: credentialId,
+					projectId: 'otherProjectId',
+					role: 'credential:owner',
+				},
+			]);
+
+			hasGlobalReadOnlyAccessMock.mockReturnValue(false);
+			hasGlobalConnectAccessMock.mockReturnValue(true);
+			findGlobalCredentialByIdMock.mockResolvedValue({
+				id: credentialId,
+				isGlobal: true,
+				isResolvable: true,
+			});
+
+			const user = { id: 'userId', scopes: [], role: GLOBAL_MEMBER_ROLE } as unknown as User;
+			const scopes = ['credential:connect'] as Scope[];
+
+			const result = await userHasScopes(user, scopes, false, { credentialId });
+
+			expect(hasGlobalConnectAccessMock).toHaveBeenCalledWith(scopes);
+			expect(findGlobalCredentialByIdMock).toHaveBeenCalledWith(credentialId);
+			expect(result).toBe(true);
+		});
+
+		it('should not grant connect access to a global credential that is not an end-user credential', async () => {
+			const credentialId = 'global-cred-123';
+			roleServiceMock.mockResolvedValue(['credential:owner']);
+			mockQueryBuilder.getRawMany.mockResolvedValue([]); // No project access
+
+			findByCredentialMock.mockResolvedValue([
+				{
+					credentialsId: credentialId,
+					projectId: 'otherProjectId',
+					role: 'credential:owner',
+				},
+			]);
+
+			hasGlobalReadOnlyAccessMock.mockReturnValue(false);
+			hasGlobalConnectAccessMock.mockReturnValue(true);
+			findGlobalCredentialByIdMock.mockResolvedValue({
+				id: credentialId,
+				isGlobal: true,
+				isResolvable: false,
+			});
+
+			const user = { id: 'userId', scopes: [], role: GLOBAL_MEMBER_ROLE } as unknown as User;
+			const scopes = ['credential:connect'] as Scope[];
 
 			const result = await userHasScopes(user, scopes, false, { credentialId });
 

--- a/packages/cli/src/permissions.ee/check-access.ts
+++ b/packages/cli/src/permissions.ee/check-access.ts
@@ -25,6 +25,26 @@ const INSTANCE_CREDENTIAL_MANAGEMENT_SCOPES = new Set<Scope>([
 ]);
 
 /**
+ * Global credentials bypass per-recipient sharing rows, so they are checked
+ * separately: read-only access for any global credential, plus connect
+ * access when the credential is an end-user (resolvable) credential.
+ */
+async function hasGlobalCredentialAccess(
+	credentialsFinderService: CredentialsFinderService,
+	credentialId: string,
+	scopes: Scope[],
+): Promise<boolean> {
+	const isReadOnlyRequest = credentialsFinderService.hasGlobalReadOnlyAccess(scopes);
+	const isConnectRequest = credentialsFinderService.hasGlobalConnectAccess(scopes);
+	if (!isReadOnlyRequest && !isConnectRequest) return false;
+
+	const globalCredential = await credentialsFinderService.findGlobalCredentialById(credentialId);
+	if (!globalCredential) return false;
+
+	return isReadOnlyRequest || globalCredential.isResolvable;
+}
+
+/**
  * Check if a user has the required scopes. The check can be:
  *
  * - only for scopes in the user's global role, or
@@ -115,18 +135,8 @@ export async function userHasScopes(
 			return true;
 		}
 
-		// Check for global credentials with read-only access
 		const credentialsFinderService = Container.get(CredentialsFinderService);
-		if (credentialsFinderService.hasGlobalReadOnlyAccess(scopes)) {
-			const globalCredential =
-				await credentialsFinderService.findGlobalCredentialById(credentialId);
-
-			if (globalCredential) {
-				return true;
-			}
-		}
-
-		return false;
+		return await hasGlobalCredentialAccess(credentialsFinderService, credentialId, scopes);
 	}
 
 	if (workflowId) {

--- a/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
@@ -298,6 +298,52 @@ describe('CredentialsFinderService', () => {
 			expect(credential).toEqual(globalCredential);
 		});
 
+		test('should return global end-user credential for credential:connect scope', async () => {
+			const globalCredential = mock<CredentialsEntity>({
+				id: credentialsId,
+				isGlobal: true,
+				isResolvable: true,
+			});
+			sharedCredentialsRepository.findOne.mockResolvedValueOnce(null);
+			credentialsRepository.findOne.mockResolvedValueOnce(globalCredential);
+
+			const credential = await credentialsFinderService.findCredentialForUser(
+				credentialsId,
+				member,
+				['credential:connect' as const],
+			);
+
+			expect(credentialsRepository.findOne).toHaveBeenCalledWith({
+				where: {
+					id: credentialsId,
+					isGlobal: true,
+					usageScope: 'project',
+				},
+				relations: {
+					shared: { project: true },
+				},
+			});
+			expect(credential).toEqual(globalCredential);
+		});
+
+		test('should not grant connect access to a global credential that is not an end-user credential', async () => {
+			const staticGlobalCredential = mock<CredentialsEntity>({
+				id: credentialsId,
+				isGlobal: true,
+				isResolvable: false,
+			});
+			sharedCredentialsRepository.findOne.mockResolvedValueOnce(null);
+			credentialsRepository.findOne.mockResolvedValueOnce(staticGlobalCredential);
+
+			const credential = await credentialsFinderService.findCredentialForUser(
+				credentialsId,
+				member,
+				['credential:connect' as const],
+			);
+
+			expect(credential).toBeNull();
+		});
+
 		test('should not fallback to global credential for write scopes', async () => {
 			sharedCredentialsRepository.findOne.mockResolvedValueOnce(null);
 
@@ -909,6 +955,26 @@ describe('CredentialsFinderService', () => {
 			});
 		});
 
+		test('should include global end-user credentials for connect scope', async () => {
+			const ids = ['cred-1', 'global-1'];
+			sharedCredentialsRepository.find.mockResolvedValueOnce([
+				mock<SharedCredentials>({ credentialsId: 'cred-1' }),
+			]);
+			credentialsRepository.find.mockResolvedValueOnce([
+				mock<CredentialsEntity>({ id: 'global-1' }),
+			]);
+
+			const result = await credentialsFinderService.findCredentialIdsWithScopeForUser(ids, member, [
+				'credential:connect',
+			]);
+
+			expect(result).toEqual(new Set(['cred-1', 'global-1']));
+			expect(credentialsRepository.find).toHaveBeenCalledWith({
+				where: { id: In(ids), isGlobal: true, usageScope: 'project', isResolvable: true },
+				select: ['id'],
+			});
+		});
+
 		test('should not include global credentials for write scopes', async () => {
 			const ids = ['cred-1'];
 			sharedCredentialsRepository.find.mockResolvedValueOnce([
@@ -1166,6 +1232,35 @@ describe('CredentialsFinderService', () => {
 
 		test('should return false for credential:shareGlobally scope', () => {
 			const result = credentialsFinderService.hasGlobalReadOnlyAccess(['credential:shareGlobally']);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('hasGlobalConnectAccess', () => {
+		test('should return true for single credential:connect scope', () => {
+			const result = credentialsFinderService.hasGlobalConnectAccess(['credential:connect']);
+
+			expect(result).toBe(true);
+		});
+
+		test('should return false for multiple scopes including credential:connect', () => {
+			const result = credentialsFinderService.hasGlobalConnectAccess([
+				'credential:connect',
+				'credential:read',
+			]);
+
+			expect(result).toBe(false);
+		});
+
+		test('should return false for single non-connect scope', () => {
+			const result = credentialsFinderService.hasGlobalConnectAccess(['credential:read']);
+
+			expect(result).toBe(false);
+		});
+
+		test('should return false for empty scopes array', () => {
+			const result = credentialsFinderService.hasGlobalConnectAccess([]);
 
 			expect(result).toBe(false);
 		});

--- a/packages/cli/src/services/__tests__/role.service.addScopes.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.addScopes.test.ts
@@ -1,0 +1,88 @@
+import type { LicenseState } from '@n8n/backend-common';
+import { Logger } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
+import type { CredentialsEntity, ScopesField, User } from '@n8n/db';
+import { RoleRepository, ScopeRepository } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import { EventService } from '@/events/event.service';
+import { RoleCacheService } from '@/services/role-cache.service';
+import { RoleDeletionCheckProxy } from '@/services/role-deletion-check-proxy.service';
+import { RoleService } from '@/services/role.service';
+
+describe('RoleService.addScopes', () => {
+	const licenseState = mock<LicenseState>();
+	const roleRepository = mockInstance(RoleRepository);
+	const scopeRepository = mockInstance(ScopeRepository);
+	const roleCacheService = mockInstance(RoleCacheService);
+	const logger = mockInstance(Logger);
+	const roleDeletionCheckProxy = mockInstance(RoleDeletionCheckProxy);
+	const eventService = mockInstance(EventService);
+
+	const roleService = new RoleService(
+		licenseState,
+		roleRepository,
+		scopeRepository,
+		roleCacheService,
+		logger,
+		roleDeletionCheckProxy,
+		eventService,
+	);
+
+	// No global scopes and no project relations, so a global credential's
+	// scopes come entirely from the isGlobal-driven fallback under test.
+	const memberWithNoAccess = { role: { scopes: [] } } as unknown as User;
+
+	const makeGlobalCredential = (isResolvable: boolean) =>
+		({
+			type: 'someNodeCredentialsType',
+			isGlobal: true,
+			isResolvable,
+			shared: [],
+		}) as unknown as CredentialsEntity & ScopesField;
+
+	it('grants credential:read and credential:connect for a global end-user credential', () => {
+		const entity = roleService.addScopes(makeGlobalCredential(true), memberWithNoAccess, []);
+
+		expect(entity.scopes).toEqual(
+			expect.arrayContaining(['credential:read', 'credential:connect']),
+		);
+	});
+
+	it('grants only credential:read for a global static credential', () => {
+		const entity = roleService.addScopes(makeGlobalCredential(false), memberWithNoAccess, []);
+
+		expect(entity.scopes).toContain('credential:read');
+		expect(entity.scopes).not.toContain('credential:connect');
+	});
+
+	it('does not force any scopes onto a non-global credential', () => {
+		const entity = {
+			type: 'someNodeCredentialsType',
+			isGlobal: false,
+			isResolvable: true,
+			shared: [],
+		} as unknown as CredentialsEntity & ScopesField;
+
+		const result = roleService.addScopes(entity, memberWithNoAccess, []);
+
+		expect(result.scopes).toEqual([]);
+	});
+
+	it('does not duplicate credential:connect when already present through a resource role', () => {
+		const entity = {
+			type: 'someNodeCredentialsType',
+			isGlobal: true,
+			isResolvable: true,
+			shared: [],
+		} as unknown as CredentialsEntity & ScopesField;
+		// Owner-level global scope grants credential:connect independently of the isGlobal fallback
+		const owner = {
+			role: { scopes: [{ slug: 'credential:connect' }] },
+		} as unknown as User;
+
+		const result = roleService.addScopes(entity, owner, []);
+
+		expect(result.scopes.filter((s) => s === 'credential:connect')).toHaveLength(1);
+	});
+});

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -394,13 +394,21 @@ export class RoleService {
 		const entityType = isWorkflow ? 'workflow' : 'credential';
 		entity.scopes = this.combineResourceScopes(entityType, user, shared, userProjectRelations);
 
-		if (
-			entityType === 'credential' &&
-			'isGlobal' in entity &&
-			entity.isGlobal &&
-			!entity.scopes.includes('credential:read')
-		) {
-			entity.scopes.push('credential:read');
+		if (entityType === 'credential' && 'isGlobal' in entity && entity.isGlobal) {
+			if (!entity.scopes.includes('credential:read')) {
+				entity.scopes.push('credential:read');
+			}
+
+			// End-user credentials require the recipient to connect their own
+			// account, so a global share must also grant `credential:connect`.
+			// Static credentials stay read-only.
+			if (
+				'isResolvable' in entity &&
+				entity.isResolvable &&
+				!entity.scopes.includes('credential:connect')
+			) {
+				entity.scopes.push('credential:connect');
+			}
 		}
 
 		return entity;

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -402,11 +402,11 @@ export class RoleService {
 			// End-user credentials require the recipient to connect their own
 			// account, so a global share must also grant `credential:connect`.
 			// Static credentials stay read-only.
-			if (
-				'isResolvable' in entity &&
-				entity.isResolvable &&
-				!entity.scopes.includes('credential:connect')
-			) {
+			if (!('isResolvable' in entity)) {
+				throw new UnexpectedError('isResolvable must be selected whenever isGlobal is');
+			}
+
+			if (entity.isResolvable && !entity.scopes.includes('credential:connect')) {
 				entity.scopes.push('credential:connect');
 			}
 		}

--- a/packages/cli/test/integration/services/role.service.test.ts
+++ b/packages/cli/test/integration/services/role.service.test.ts
@@ -1923,6 +1923,7 @@ describe('RoleService', () => {
 				name: 'Global Test Credential',
 				type: 'testCredential',
 				isGlobal: true,
+				isResolvable: false,
 				shared: [
 					{
 						projectId: 'project-1',
@@ -1954,6 +1955,7 @@ describe('RoleService', () => {
 				name: 'Global Test Credential 2',
 				type: 'testCredential',
 				isGlobal: true,
+				isResolvable: false,
 				shared: [],
 			} as any;
 			const userProjectRelations = [] as any[];
@@ -1980,6 +1982,7 @@ describe('RoleService', () => {
 				name: 'Global Test Credential 3',
 				type: 'testCredential',
 				isGlobal: true,
+				isResolvable: false,
 				shared: [
 					{
 						projectId: 'project-1',


### PR DESCRIPTION
## Summary

An end-user credential shared via "all users and projects" (`isGlobal: true`) let recipients see and select the credential in nodes, but never let them connect their own account — the Connect button stayed disabled. Global sharing is a separate code path from named/project sharing that bypasses `SharedCredentials` rows entirely, and every place that granted access through it was hard-coded to read-only, with no way to also grant `credential:connect` for resolvable (end-user) credentials.

This change makes the global-share path connect-aware for end-user credentials specifically, while leaving static global credentials read-only as before:
- Recipients of a globally shared end-user credential now get `credential:connect` in their listed scopes, so the Connect button in the UI is enabled.
- The credential lookups behind OAuth authorization and the "may I use this end-user credential" checks now also recognize a global end-user credential as connect-eligible.
- The background job that prunes per-user OAuth connections when project membership changes now also retains connections made through a global end-user credential share, instead of treating them as orphaned.

## How to test

1. As an instance owner, create an OAuth2 credential and set its type to end-user (resolvable).
2. Share it via "all users and projects" only (no named-user share, no project membership).
3. As a different, non-admin user with no project access to that credential, add a node using it and open the credential dropdown.
4. The credential should be selectable and the Connect button should be enabled; connecting should succeed.
5. Repeat with a *static* (non-end-user) credential shared globally — it should remain read-only/usable as-is, with no Connect option, confirming no regression.


https://github.com/user-attachments/assets/a44aa23f-ccdb-4e36-b04b-701cc0d1fe20



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1270

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

