### PR TITLE
fix(core): Install environment proxy agents in every process type

### DIFF
--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -5,6 +5,8 @@ import { mockInstance } from '@n8n/backend-test-utils';
 import { AuthRolesService, DbConnection, DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { InstanceSettings, BinaryDataConfig, ErrorReporter } from 'n8n-core';
+import http from 'node:http';
+import https from 'node:https';
 
 import { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import { Start } from '../start';
@@ -252,6 +254,26 @@ describe('Start - AuthRolesService initialization', () => {
 			await start.init();
 
 			expect(authRolesService.init).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('init - env proxy agents', () => {
+		it('should install env-proxy global agents when proxy env vars are set', async () => {
+			setupInstanceSettings('main', false, false);
+			const previousHttpAgent = http.globalAgent;
+			const previousHttpsAgent = https.globalAgent;
+			process.env.HTTPS_PROXY = 'http://proxy.host.invalid:3128';
+
+			try {
+				await start.init();
+
+				expect(http.globalAgent.constructor.name).toBe('EnvProxyHttpAgent');
+				expect(https.globalAgent.constructor.name).toBe('EnvProxyHttpsAgent');
+			} finally {
+				delete process.env.HTTPS_PROXY;
+				http.globalAgent = previousHttpAgent;
+				https.globalAgent = previousHttpsAgent;
+			}
 		});
 	});
 

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -9,6 +9,7 @@ import {
 	ModuleRegistry,
 	ModulesConfig,
 } from '@n8n/backend-common';
+import { installGlobalProxyAgent } from '@n8n/backend-network';
 import { AzureBlobConfig, AzureByteStore, ObjectStoreConfig, S3ByteStore } from '@n8n/blob-storage';
 import { GlobalConfig } from '@n8n/config';
 import { LICENSE_FEATURES } from '@n8n/constants';
@@ -98,6 +99,10 @@ export abstract class BaseCommand<F = never> {
 	protected seedsInstanceIdentity = false;
 
 	async init(): Promise<void> {
+		// Every process type (main, worker, webhook, one-off commands) makes outbound
+		// requests, so env-proxy global agents must be installed before any of them.
+		installGlobalProxyAgent();
+
 		this.dbConnection = Container.get(DbConnection);
 		this.errorReporter = Container.get(ErrorReporter);
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,5 +1,4 @@
 import { inDevelopment, inProduction, ModuleRegistry } from '@n8n/backend-common';
-import { installGlobalProxyAgent } from '@n8n/backend-network';
 import { SecurityConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import type { APIRequest, AuthenticatedRequest } from '@n8n/db';
@@ -481,8 +480,6 @@ export class Server extends AbstractServer {
 		} else {
 			this.app.use('/', express.static(staticCacheDir, cacheOptions));
 		}
-
-		installGlobalProxyAgent();
 	}
 
 	private configureSettingsRoute() {


### PR DESCRIPTION
## Summary

`installGlobalProxyAgent()` runs only in the main `Server` startup. Workers, webhook processors and one-off commands never install the env-proxy global agents, so any HTTP client in those processes that relies on default agents ignores `HTTP(S)_PROXY`. This asymmetry caused a production incident: OAuth2 token refreshes bypassed the proxy on workers (fixed surgically in #36996), and it remains a latent trap for any other default-agent client.

This PR moves the install to the first line of `BaseCommand.init()`, so every process type matches the behaviour main has had since 1.117.0 (#20614). The call is removed from `server.ts`; `BaseCommand` is the single source of truth. A production deployment validated the mechanism: a preload that ran this exact call on workers restored proxy routing.

**Release note.** With proxy env vars set, all default-agent HTTP in workers, webhook processors and one-off commands now follows `HTTP(S)_PROXY`/`NO_PROXY`. Deployments that tuned `NO_PROXY` only for main must make sure it also covers internal endpoints reached from workers (localhost, cluster-internal hosts, metadata endpoints). Without proxy env vars, nothing changes.

This is a deliberate behaviour change targeted at the next minor, not a backport candidate.

## How to test

- `pnpm test src/commands/__tests__/start.test.ts` in `packages/cli` — a new test asserts `init()` installs the env-proxy global agents when proxy env vars are set.
- Manual: start a worker with `HTTPS_PROXY` set and run `node -e "console.log(require('https').globalAgent.constructor.name)"` semantics via a debug log — the startup debug log prints "Installing global HTTP proxy agents" in every process type.

## Related Linear tickets, Github issues, and Community forum posts

Companion to #36996 (surgical OAuth2 token request fix). Related: #20614 (original global proxy support on main).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

