### PR TITLE
refactor(editor): Refine workflow review feed formatting

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5532,7 +5532,6 @@
 	"workflowReviews.sidebar.error": "Couldn't load reviews",
 	"workflowReviews.status.open": "Open",
 	"workflowReviews.status.closed": "Closed",
-	"workflowReviews.status.combinedLabel": "{state} • {decision}",
 	"workflowReviews.decision.pending": "Waiting for review",
 	"workflowReviews.decision.changes_requested": "Changes requested",
 	"workflowReviews.decision.approved": "Approved",

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailMetadata.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailMetadata.test.ts
@@ -97,7 +97,7 @@ describe('WorkflowReviewDetailMetadata', () => {
 		});
 
 		expect(getByTestId('workflow-review-detail-status-card')).toHaveTextContent(
-			'Open • Waiting for review',
+			'Open | Waiting for review',
 		);
 		expect(getByText('Riley Reviewer')).toBeInTheDocument();
 		expect(queryByText('reviewer@example.com')).not.toBeInTheDocument();
@@ -149,7 +149,7 @@ describe('WorkflowReviewDetailMetadata', () => {
 		});
 
 		expect(getByTestId('workflow-review-detail-status-card')).toHaveTextContent(
-			'Closed • Approved',
+			'Closed | Approved',
 		);
 	});
 
@@ -160,7 +160,7 @@ describe('WorkflowReviewDetailMetadata', () => {
 		});
 
 		expect(getByTestId('workflow-review-detail-status-card')).toHaveTextContent(
-			'Closed • No decision',
+			'Closed | No decision',
 		);
 	});
 
@@ -170,7 +170,7 @@ describe('WorkflowReviewDetailMetadata', () => {
 		});
 
 		expect(getByTestId('workflow-review-detail-status-card')).toHaveTextContent(
-			'Closed • Changes requested',
+			'Closed | Changes requested',
 		);
 	});
 
@@ -180,7 +180,7 @@ describe('WorkflowReviewDetailMetadata', () => {
 		});
 
 		expect(getByTestId('workflow-review-detail-status-card')).toHaveTextContent(
-			'Open • Changes requested',
+			'Open | Changes requested',
 		);
 	});
 

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailMetadata.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailMetadata.vue
@@ -24,8 +24,8 @@ const otherAuthors = computed(() =>
 	props.review.authors.filter((author) => author.id !== props.review.requester?.id),
 );
 
-const statusSummary = computed(
-	() => getWorkflowReviewStatusDisplay(i18n, props.review.state, props.review.decision).label,
+const statusSummary = computed(() =>
+	getWorkflowReviewStatusDisplay(i18n, props.review.state, props.review.decision),
 );
 </script>
 
@@ -39,7 +39,11 @@ const statusSummary = computed(
 			</template>
 			<div :class="$style.status">
 				<WorkflowReviewStatusDot :state="review.state" :decision="review.decision" decorative />
-				<N8nText size="medium">{{ statusSummary }}</N8nText>
+				<N8nText size="medium">
+					{{ statusSummary.stateLabel }}
+					<span aria-hidden="true" :class="$style.statusSeparator">|</span>
+					{{ statusSummary.decisionLabel }}
+				</N8nText>
 			</div>
 		</N8nCard>
 
@@ -169,6 +173,11 @@ const statusSummary = computed(
 	flex-direction: column;
 	gap: var(--spacing--2xs);
 	min-width: 0;
+}
+
+.statusSeparator {
+	margin-inline: var(--spacing--3xs);
+	color: var(--text-color--subtler);
 }
 
 .peopleCard {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
@@ -149,7 +149,6 @@ const tabOptions = computed(() => [
 								v-else
 								color="text-light"
 								size="medium"
-								:class="$style.noDescription"
 								data-test-id="workflow-review-no-description"
 							>
 								{{ i18n.baseText('workflowReviews.detail.activity.noDescription') }}
@@ -292,10 +291,6 @@ const tabOptions = computed(() => [
 .description {
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
-}
-
-.noDescription {
-	font-style: italic;
 }
 
 .decisionActions {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewRequestsSidebar.test.ts
@@ -116,14 +116,14 @@ describe('WorkflowReviewRequestsSidebar', () => {
 
 	describe('cards', () => {
 		it.each([
-			{ state: 'open' as const, decision: 'pending' as const, label: 'Open • Waiting for review' },
+			{ state: 'open' as const, decision: 'pending' as const, label: 'Open | Waiting for review' },
 			{
 				state: 'open' as const,
 				decision: 'changes_requested' as const,
-				label: 'Open • Changes requested',
+				label: 'Open | Changes requested',
 			},
-			{ state: 'closed' as const, decision: 'approved' as const, label: 'Closed • Approved' },
-			{ state: 'closed' as const, decision: 'pending' as const, label: 'Closed • No decision' },
+			{ state: 'closed' as const, decision: 'approved' as const, label: 'Closed | Approved' },
+			{ state: 'closed' as const, decision: 'pending' as const, label: 'Closed | No decision' },
 		])('maps $state + $decision to the "$label" status indicator', ({ state, decision, label }) => {
 			const props =
 				state === 'closed'

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewStatusDot.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewStatusDot.vue
@@ -28,7 +28,11 @@ const status = computed(() => getWorkflowReviewStatusDisplay(i18n, props.state, 
 	<div
 		:class="[$style.dot, $style[status.colorClass], size === 'small' && $style.small]"
 		data-test-id="workflow-review-request-status-dot"
-		v-bind="decorative ? { 'aria-hidden': 'true' } : { role: 'img', 'aria-label': status.label }"
+		v-bind="
+			decorative
+				? { 'aria-hidden': 'true' }
+				: { role: 'img', 'aria-label': `${status.stateLabel} | ${status.decisionLabel}` }
+		"
 	/>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/activity-entries/WorkflowReviewActivityComment.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/activity-entries/WorkflowReviewActivityComment.vue
@@ -36,7 +36,7 @@ function authorName(message: WorkflowReviewActivityMessage): string {
 					>
 						{{ authorName(message) }}
 					</N8nText>
-					<N8nText size="small" color="text-light">
+					<N8nText size="medium" color="text-light">
 						<time
 							:datetime="message.createdAt"
 							data-test-id="workflow-review-activity-comment-time"
@@ -58,7 +58,7 @@ function authorName(message: WorkflowReviewActivityMessage): string {
 				<N8nText
 					v-else
 					size="medium"
-					color="text-light"
+					color="text-dark"
 					:class="[$style.body, $style.line]"
 					data-test-id="workflow-review-activity-comment-body"
 				>
@@ -101,7 +101,7 @@ function authorName(message: WorkflowReviewActivityMessage): string {
 }
 
 .timeStamp {
-	padding-left: var(--spacing--3xs);
+	padding-left: var(--spacing--4xs);
 }
 
 .body {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/activity-entries/WorkflowReviewActivityEventEntry.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/activity-entries/WorkflowReviewActivityEventEntry.vue
@@ -236,7 +236,7 @@ const actorName = computed(() =>
 				<N8nText
 					v-if="content.namesActor"
 					size="medium"
-					color="text-base"
+					color="text-dark"
 					:class="$style.line"
 					data-test-id="workflow-review-activity-actor"
 				>
@@ -247,7 +247,7 @@ const actorName = computed(() =>
 				</N8nText>
 				<N8nText
 					size="medium"
-					color="text-base"
+					color="text-light"
 					:class="$style.line"
 					:data-test-id="content.testId"
 				>
@@ -269,7 +269,7 @@ const actorName = computed(() =>
 						>
 					</I18nT>
 				</N8nText>
-				<N8nText size="small" color="text-light" :class="$style.timeStamp">
+				<N8nText size="medium" color="text-light" :class="$style.timeStamp">
 					<time :datetime="entry.createdAt">
 						<TimeAgo :date="entry.createdAt" />
 					</time>
@@ -278,7 +278,7 @@ const actorName = computed(() =>
 			<N8nText
 				v-if="content.note"
 				size="medium"
-				color="text-light"
+				color="text-dark"
 				:class="[$style.body, $style.line]"
 				data-test-id="workflow-review-activity-note"
 			>
@@ -320,6 +320,7 @@ const actorName = computed(() =>
 
 .separator {
 	margin-inline: var(--spacing--3xs);
+	color: var(--text-color--disabled);
 }
 
 .unknownWorkflow {
@@ -327,7 +328,7 @@ const actorName = computed(() =>
 }
 
 .timeStamp {
-	padding-left: var(--spacing--3xs);
+	padding-left: var(--spacing--4xs);
 }
 
 /* A decision that carries a note sits in a card, as a comment always does. */

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/activity-entries/WorkflowReviewActivityWorkflowLink.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/activity-entries/WorkflowReviewActivityWorkflowLink.vue
@@ -27,9 +27,10 @@ const label = computed(() =>
 </template>
 
 <style lang="scss" module>
-/* Inline with the sentence; the offset optically centres the icon on the text. */
 .icon {
+	margin-left: var(--spacing--4xs);
 	margin-right: var(--spacing--4xs);
+	/* Inline with the sentence; the offset optically centres the icon on the text. */
 	vertical-align: -0.15em;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/workflowReviewStatus.utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/workflowReviewStatus.utils.ts
@@ -2,8 +2,8 @@ import type { WorkflowReviewRequestDecision, WorkflowReviewRequestState } from '
 import type { BaseTextKey, useI18n } from '@n8n/i18n';
 
 export type WorkflowReviewStatusDisplay = {
-	/** The shared `<state> • <decision>` label. */
-	label: string;
+	/** The state half alone, for surfaces that compose the two halves themselves. */
+	stateLabel: string;
 	/** The decision half alone, for surfaces where the state is implied. */
 	decisionLabel: string;
 	/** Color class of {@link WorkflowReviewStatusDot}. */
@@ -27,12 +27,7 @@ export function getWorkflowReviewStatusDisplay(
 			: (`workflowReviews.decision.${decision}` as BaseTextKey);
 
 	const decisionLabel = i18n.baseText(decisionKey);
-	const label = i18n.baseText('workflowReviews.status.combinedLabel', {
-		interpolate: {
-			state: i18n.baseText(`workflowReviews.status.${state}` as BaseTextKey),
-			decision: decisionLabel,
-		},
-	});
+	const stateLabel = i18n.baseText(`workflowReviews.status.${state}` as BaseTextKey);
 
 	const colorClass =
 		state === 'open'
@@ -45,5 +40,5 @@ export function getWorkflowReviewStatusDisplay(
 				? 'approved'
 				: 'closed';
 
-	return { label, decisionLabel, colorClass };
+	return { stateLabel, decisionLabel, colorClass };
 }


### PR DESCRIPTION
## Summary

- Refine the workflow review detail and activity feed presentation.
- Separate review state and decision labels with a vertical separator.
- Update text colors, sizes, spacing, and workflow-link icon alignment.
- Remove the obsolete combined status translation key.

<details><summary>activity feed before vs after</summary>
<p>

<img width="1566" height="356" alt="CleanShot 2026-08-25 at 12 16 59@2x" src="https://github.com/user-attachments/assets/1c1d927c-fb63-46b2-a0dd-f0e2c4dce339" />


<img width="1566" height="356" alt="CleanShot 2026-08-25 at 12 00 33@2x" src="https://github.com/user-attachments/assets/f5556ebb-0d38-42d9-b2a5-0f653464ed46" />

</p>
</details> 

<details><summary>meta status card before vs after</summary>
<p>

<img width="612" height="170" alt="CleanShot 2026-08-25 at 12 17 03@2x" src="https://github.com/user-attachments/assets/dfd402fb-9e62-4e15-8ac1-816bb7d9fda0" />

<img width="622" height="168" alt="CleanShot 2026-08-25 at 12 00 21@2x" src="https://github.com/user-attachments/assets/75763946-3a45-4b5a-bd38-bc2730f7d693" />

</p>
</details> 

## How to test

From `packages/frontend/editor-ui`, run the focused workflow review tests:

```bash
pnpm test src/features/workflow-reviews/components/WorkflowReviewDetailMetadata.test.ts src/features/workflow-reviews/components/WorkflowReviewDetailTabs.test.ts src/features/workflow-reviews/components/activity-entries/WorkflowReviewActivityComment.test.ts src/features/workflow-reviews/components/WorkflowReviewActivityFeed.test.ts
```

Run `pnpm lint` and `pnpm typecheck` from the same package.

Open the workflow reviews view and check the detail metadata and activity feed styling.

## Related Linear tickets, Github issues, and Community forum posts

No related ticket or issue was provided.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

This PR refines workflow review feed formatting and status presentation. It updates labels, text styling, spacing, icon alignment, and related tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

