### PR TITLE
test(editor): Add a minimal Vite consumer harness for @n8n/design-system

### DIFF
--- a/packages/frontend/design-system-consumer/README.md
+++ b/packages/frontend/design-system-consumer/README.md
@@ -1,0 +1,60 @@
+# design-system-consumer
+
+A minimal Vite + Vue app that consumes `@n8n/design-system` **the way a project outside
+this monorepo would**: through the package `exports` map, with no source aliases, no
+`unplugin-icons`, no `lucideIconsPlugin`, and no SCSS `additionalData` injection.
+
+`editor-ui` cannot answer the consumption question, because its `vite.config.mts` aliases
+every `@n8n/*` package to its `src/`. This app deliberately has none of that, so anything
+it cannot resolve is a real gap in the package contract.
+
+## Run it
+
+```sh
+pnpm --filter @n8n/design-system build   # the package ships a dist; it must exist first
+pnpm --filter design-system-consumer build
+pnpm --filter design-system-consumer dev
+```
+
+## Scripts
+
+| Script                | What it proves                                                        |
+| --------------------- | --------------------------------------------------------------------- |
+| `build`               | Components, both CSS entries, the `./css/*` SCSS subpath, fonts, and the `./icons/lucide` entry all resolve and bundle. |
+| `typecheck`           | Consumer code typechecks against the shipped `.d.ts` with `skipLibCheck: true` — the setting real apps use (it is `true` in Vue's own `create-vue` template). |
+| `typecheck:libcheck`  | Diagnostic probe with `skipLibCheck: false`, which checks the shipped declarations *themselves*. **Currently fails**; see below. It is not a gate. |
+
+## What the app exercises
+
+- `@n8n/design-system` — 20 components and 3 exported types, from the barrel.
+- `@n8n/design-system/plugin` — `N8nPlugin`, which registers the directives.
+- `@n8n/design-system/icons/lucide` — `loadLucideIconBody` + `IconBodyLoaderKey`. The
+  `anvil` icon is in the app on purpose: it is *not* in the bundled icon set, so it renders
+  only when this entry works.
+- `@n8n/design-system/style.css` and `/theme.css` — component CSS and the token/reset/font layer.
+- `@n8n/design-system/css/mixins/breakpoints` — the shipped SCSS sources, `@use`d from `src/styles.scss`.
+
+## Known defects in the package (as of 2.36.0)
+
+These are the reasons `typecheck:libcheck` fails. None of them stop the app from building
+or rendering.
+
+1. **`app.use(N8nPlugin)` does not typecheck.** `N8nPlugin` is declared
+   `Plugin<N8nPluginOptions>` in `src/plugin.ts`, and Vue reads that single object as a
+   one-element tuple, so the options argument becomes required. Callers must write
+   `app.use(N8nPlugin, {})`. See the comment in `src/main.ts`.
+2. **`@vue/reactivity` is an undeclared dependency of the shipped types** (18 errors).
+   11 emitted `.d.ts` files reference `import('@vue/reactivity').OnCleanup`, but
+   `@vue/reactivity` is neither a `dependency` nor a `peerDependency`.
+3. **`event` as an emit tuple label breaks the emitted declarations** (48 errors, TS2300).
+   `focus: [event: FocusEvent]` emits as `(event: "focus", event: FocusEvent) => void` —
+   a duplicate identifier. Sources: `src/components/N8nInput/Input.types.ts`,
+   `src/v2/components/InputNumber/InputNumber.types.ts`,
+   `src/components/N8nMarkdownEditor/MarkdownEditor.types.ts`,
+   `src/v2/components/Checkbox/Checkbox.types.ts`.
+4. **The ambient shims are not shipped.** `src/shims-modules.d.ts` (declares
+   `markdown-it-task-lists`) and `src/shims-vue.d.ts` (`$style` on
+   `ComponentCustomProperties`) are absent from `dist` — `vite-plugin-dts` does not emit
+   ambient-only files.
+5. **`GlobalComponents` is passed where `Record<string, Component>` is required**
+   (9 errors, TS2344) in the emitted declarations.

--- a/packages/frontend/design-system-consumer/README.md
+++ b/packages/frontend/design-system-consumer/README.md
@@ -27,12 +27,56 @@ pnpm --filter design-system-consumer dev
 ## What the app exercises
 
 - `@n8n/design-system` — 20 components and 3 exported types, from the barrel.
-- `@n8n/design-system/plugin` — `N8nPlugin`, which registers the directives.
+- `@n8n/design-system/plugin` — `N8nPlugin`, which registers the directives. It is not
+  optional: 10 components render text through `v-n8n-html` and render an empty span
+  without it.
 - `@n8n/design-system/icons/lucide` — `loadLucideIconBody` + `IconBodyLoaderKey`. The
   `anvil` icon is in the app on purpose: it is *not* in the bundled icon set, so it renders
   only when this entry works.
 - `@n8n/design-system/style.css` and `/theme.css` — component CSS and the token/reset/font layer.
 - `@n8n/design-system/css/mixins/breakpoints` — the shipped SCSS sources, `@use`d from `src/styles.scss`.
+
+## Out-of-repo verification (2026-08-25)
+
+This app resolves `@n8n/design-system` through a workspace link. To close that gap, the
+same app was rebuilt twice **outside the monorepo**, with `npm` and with `pnpm`, against
+tarballs rather than the workspace:
+
+| Install                                                | Result |
+| ------------------------------------------------------ | ------ |
+| `npm i @n8n/design-system@2.35.3` (the published `latest`) | Builds, typechecks, renders. |
+| `npm i ./n8n-design-system-2.36.0.tgz` (`pnpm pack` of this branch) | Builds, typechecks, renders. |
+| `pnpm i ./n8n-design-system-2.36.0.tgz`, `node-linker=isolated` | Builds, typechecks, renders. |
+
+Findings that only an out-of-repo install can show:
+
+1. **The directives are load-bearing, and they fail silently.** 10 components render text
+   through `v-n8n-html` (`N8nNotice`, `N8nTooltip`, `N8nEmptyState`, `N8nInputLabel`,
+   `N8nTabs`, `N8nSticky`, `N8nInfoAccordion`, `N8nCommandBar`, and 2 `AskAssistantChat`
+   messages). Without the directive, Vue renders an **empty** span: no error, no console
+   warning in a production build. A consumer sees blank notices and blank empty-state
+   descriptions and has nothing to search for.
+2. **`./plugin` — the only documented way to register them — is absent from the published
+   version.** `2.35.3` exports `.`, `./icons/lucide`, `./style.css`, `./theme.css`,
+   `./css/*` and `./package.json`; `import '@n8n/design-system/plugin'` fails with
+   `ERR_PACKAGE_PATH_NOT_EXPORTED`. On `2.35.3` a consumer must register the directive by
+   hand: `app.directive('n8nHtml', n8nHtml)`, with `n8nHtml` taken from the barrel. The
+   `./plugin` subpath lands in `2.36.0`.
+3. **`IconBodyLoaderKey` moved.** `2.35.3` exports it from the barrel only; `2.36.0` also
+   re-exports it from `./icons/lucide`. Code written against `2.36.0` does not build on
+   `2.35.3`.
+4. **Every `exports` target is present in the tarball**, `pnpm pack` rewrites all
+   `workspace:*` and `catalog:` specifiers to fixed versions, and the fonts resolve from
+   `dist/assets`. `npm pack` must not be used to publish this package — it would ship
+   `workspace:*` unresolved.
+5. **An external install costs \~400 MB / \~236 packages**, and pulls
+   `@n8n/composables` → `n8n-workflow` → `@n8n/expression-runtime` → `isolated-vm`, a
+   native addon that needs a C++ toolchain. The browser bundle imports only
+   `@n8n/composables/useDeviceSupport`, `@n8n/frontend-utils/htmlUtils`,
+   `@n8n/utils/event-bus` and `@n8n/utils/string/truncate`.
+6. **`skipLibCheck: false` reports 61 errors in 11 shipped `.d.ts` files** out of repo
+   (48 TS2300, 9 TS2344, 4 TS7016) — the same defects listed below, minus the
+   `@vue/reactivity` ones, which did not reproduce in either out-of-repo tree.
 
 ## Known defects in the package (as of 2.36.0)
 
@@ -43,9 +87,11 @@ or rendering.
    `Plugin<N8nPluginOptions>` in `src/plugin.ts`, and Vue reads that single object as a
    one-element tuple, so the options argument becomes required. Callers must write
    `app.use(N8nPlugin, {})`. See the comment in `src/main.ts`.
-2. **`@vue/reactivity` is an undeclared dependency of the shipped types** (18 errors).
-   11 emitted `.d.ts` files reference `import('@vue/reactivity').OnCleanup`, but
-   `@vue/reactivity` is neither a `dependency` nor a `peerDependency`.
+2. **`@vue/reactivity` is an undeclared dependency of the shipped types** (18 errors
+   in this workspace; 0 in the two out-of-repo trees measured above). 11 emitted `.d.ts`
+   files reference `import('@vue/reactivity').OnCleanup`, but `@vue/reactivity` is neither
+   a `dependency` nor a `peerDependency`. Whether it fires depends on where the installer
+   places `@vue/reactivity`.
 3. **`event` as an emit tuple label breaks the emitted declarations** (48 errors, TS2300).
    `focus: [event: FocusEvent]` emits as `(event: "focus", event: FocusEvent) => void` —
    a duplicate identifier. Sources: `src/components/N8nInput/Input.types.ts`,

--- a/packages/frontend/design-system-consumer/index.html
+++ b/packages/frontend/design-system-consumer/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>@n8n/design-system consumer harness</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/main.ts"></script>
+	</body>
+</html>

--- a/packages/frontend/design-system-consumer/package.json
+++ b/packages/frontend/design-system-consumer/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "design-system-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Contract harness: a minimal Vite app that consumes @n8n/design-system the way an out-of-repo project would \u2014 through the package exports map, with no source aliases.",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview --port 4399",
+    "typecheck": "vue-tsc --noEmit",
+    "typecheck:libcheck": "vue-tsc --noEmit -p tsconfig.libcheck.json"
+  },
+  "dependencies": {
+    "@n8n/design-system": "workspace:*",
+    "vue": "catalog:frontend"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "catalog:frontend",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vue-tsc": "catalog:frontend"
+  }
+}

--- a/packages/frontend/design-system-consumer/src/App.vue
+++ b/packages/frontend/design-system-consumer/src/App.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import {
+	N8nBadge,
+	N8nButton,
+	N8nCallout,
+	N8nCard,
+	N8nCheckbox,
+	N8nEmptyState,
+	N8nHeading,
+	N8nIcon,
+	N8nIconButton,
+	N8nInput,
+	N8nInputLabel,
+	N8nNotice,
+	N8nOption,
+	N8nSelect,
+	N8nSpinner,
+	N8nTabs,
+	N8nTag,
+	N8nText,
+	N8nTooltip,
+	locale,
+} from '@n8n/design-system';
+import type { ButtonVariant, CalloutTheme, TextSize } from '@n8n/design-system';
+import { ref } from 'vue';
+
+// Typed against the package's own exported types, not `any`. A broken `.d.ts`
+// fails `pnpm typecheck` here rather than in a consumer's product code.
+const themes: CalloutTheme[] = ['info', 'success', 'warning', 'danger'];
+const buttonVariants: ButtonVariant[] = [
+	'solid',
+	'subtle',
+	'ghost',
+	'outline',
+	'destructive',
+	'success',
+];
+const textSize: TextSize = 'medium';
+
+const name = ref('');
+const fruit = ref('apple');
+const agreed = ref(false);
+const tab = ref('overview');
+
+// The barrel exports the locale singleton; calling it proves the module
+// initialises outside the editor-ui app context.
+const localeSample = locale.t('generic.retry', {});
+</script>
+
+<template>
+	<main class="harness-page">
+		<N8nHeading size="xlarge" bold>@n8n/design-system consumer harness</N8nHeading>
+		<N8nText :size="textSize" color="text-light">
+			Resolved through the package exports map only. locale.t() returned:
+			<code>{{ localeSample }}</code>
+		</N8nText>
+
+		<section>
+			<N8nHeading size="medium" bold>Buttons</N8nHeading>
+			<div class="harness-row">
+				<N8nButton
+					v-for="variant in buttonVariants"
+					:key="variant"
+					:variant="variant"
+					:label="variant"
+				/>
+				<N8nButton variant="solid" label="Loading" loading />
+				<N8nButton variant="solid" label="Disabled" disabled />
+				<N8nIconButton icon="plus" variant="subtle" aria-label="Add" />
+			</div>
+		</section>
+
+		<section>
+			<N8nHeading size="medium" bold>Icons</N8nHeading>
+			<div class="harness-row">
+				<N8nIcon icon="house" size="large" />
+				<N8nIcon icon="triangle-alert" size="large" color="warning" />
+				<N8nIcon icon="circle-check" size="large" color="success" />
+				<N8nSpinner size="medium" />
+				<!-- `anvil` is NOT in the bundled icon set, so it renders only when the app
+				     provides a loader from `@n8n/design-system/icons/lucide`. It is the
+				     regression case for that entry point. -->
+				<N8nIcon icon="anvil" size="xlarge" />
+			</div>
+		</section>
+
+		<section>
+			<N8nHeading size="medium" bold>Form controls</N8nHeading>
+			<div class="harness-row">
+				<N8nInputLabel label="Name">
+					<N8nInput v-model="name" placeholder="Type here" />
+				</N8nInputLabel>
+				<N8nInputLabel label="Fruit">
+					<N8nSelect v-model="fruit">
+						<N8nOption value="apple" label="Apple" />
+						<N8nOption value="pear" label="Pear" />
+					</N8nSelect>
+				</N8nInputLabel>
+				<N8nCheckbox v-model="agreed" label="I agree" />
+			</div>
+		</section>
+
+		<section>
+			<N8nHeading size="medium" bold>Callouts and feedback</N8nHeading>
+			<N8nCallout v-for="theme in themes" :key="theme" :theme="theme">
+				A {{ theme }} callout.
+			</N8nCallout>
+			<N8nNotice content="A notice rendered from dist." />
+		</section>
+
+		<section>
+			<N8nHeading size="medium" bold>Data display</N8nHeading>
+			<N8nTabs
+				v-model="tab"
+				:options="[
+					{ value: 'overview', label: 'Overview' },
+					{ value: 'usage', label: 'Usage' },
+				]"
+			/>
+			<div class="harness-row">
+				<N8nBadge theme="primary">Badge</N8nBadge>
+				<N8nTag text="tag" />
+				<N8nTooltip content="Tooltip content">
+					<N8nText size="small">Hover me</N8nText>
+				</N8nTooltip>
+			</div>
+			<N8nCard>
+				<N8nText size="small">A card body.</N8nText>
+			</N8nCard>
+			<N8nEmptyState heading="Nothing here" description="An empty state from the package." />
+		</section>
+	</main>
+</template>

--- a/packages/frontend/design-system-consumer/src/main.ts
+++ b/packages/frontend/design-system-consumer/src/main.ts
@@ -1,0 +1,21 @@
+// Every specifier below is a bare package subpath. If any of them needs an alias,
+// a Vite plugin, or a `sass` `includePaths` entry to resolve, the package is not
+// consumable outside this monorepo — which is the whole question this app answers.
+import '@n8n/design-system/style.css';
+import '@n8n/design-system/theme.css';
+import './styles.scss';
+
+import { IconBodyLoaderKey, loadLucideIconBody } from '@n8n/design-system/icons/lucide';
+import { N8nPlugin } from '@n8n/design-system/plugin';
+import { createApp } from 'vue';
+
+import App from './App.vue';
+
+const app = createApp(App);
+// `app.use(N8nPlugin)` — the conventional call — does not typecheck: N8nPlugin is
+// declared `Plugin<N8nPluginOptions>`, and Vue's `Plugin<Options extends unknown[]>`
+// reads that single object as a one-element tuple, so the options argument becomes
+// required. Passing `{}` is the workaround editor-ui also uses.
+app.use(N8nPlugin, {});
+app.provide(IconBodyLoaderKey, loadLucideIconBody);
+app.mount('#app');

--- a/packages/frontend/design-system-consumer/src/styles.scss
+++ b/packages/frontend/design-system-consumer/src/styles.scss
@@ -1,0 +1,21 @@
+// The SCSS sources ship next to the compiled CSS, so a consumer with its own sass
+// toolchain can reach the mixins and token maps. Proves the `./css/*` export.
+@use '@n8n/design-system/css/mixins/breakpoints' as breakpoints;
+
+.harness-page {
+	padding: var(--spacing--lg);
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--lg);
+
+	@include breakpoints.breakpoint('sm-and-down') {
+		padding: var(--spacing--2xs);
+	}
+}
+
+.harness-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--spacing--2xs);
+}

--- a/packages/frontend/design-system-consumer/tsconfig.json
+++ b/packages/frontend/design-system-consumer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
+		"types": ["vite/client"],
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"jsx": "preserve"
+	},
+	"include": ["src/**/*.ts", "src/**/*.vue", "vite.config.mts"]
+}

--- a/packages/frontend/design-system-consumer/tsconfig.libcheck.json
+++ b/packages/frontend/design-system-consumer/tsconfig.libcheck.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		// The default `typecheck` runs with `skipLibCheck: true`, which is what a real
+		// consumer app uses (it is `true` in Vue's own `create-vue` template). This
+		// config turns it off to check the *shipped declarations themselves*. It is a
+		// diagnostic probe, not a gate: it currently fails, and the failures are
+		// catalogued in README.md.
+		"skipLibCheck": false
+	}
+}

--- a/packages/frontend/design-system-consumer/vite.config.mts
+++ b/packages/frontend/design-system-consumer/vite.config.mts
@@ -1,0 +1,13 @@
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+/**
+ * Deliberately bare. No `resolve.alias` for `@n8n/*`, no icon plugin, no SCSS
+ * `additionalData` — the point of this app is to prove `@n8n/design-system`
+ * resolves and renders through its published `exports` map alone, exactly as it
+ * would in a repo that has no n8n build machinery.
+ */
+export default defineConfig({
+	plugins: [vue()],
+	build: { outDir: 'dist' },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5900,6 +5900,28 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(supports-color@8.1.1)(utf-8-validate@5.0.10))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
 
+  packages/frontend/design-system-consumer:
+    dependencies:
+      '@n8n/design-system':
+        specifier: workspace:*
+        version: link:../@n8n/design-system
+      vue:
+        specifier: catalog:frontend
+        version: 3.5.26(typescript@6.0.2)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: catalog:frontend
+        version: 6.0.8(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)
+      vue-tsc:
+        specifier: ^2.2.8
+        version: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@6.0.2)
+
   packages/frontend/editor-ui:
     dependencies:
       '@codemirror/autocomplete':


### PR DESCRIPTION
## Summary

`editor-ui` cannot tell us whether `@n8n/design-system` is consumable by anything else, because its `vite.config.mts` aliases every `@n8n/*` package to its `src/`. This PR adds `packages/frontend/design-system-consumer`: a minimal Vite + Vue app that resolves the package **only through its published `exports` map** — no aliases, no `unplugin-icons`, no `lucideIconsPlugin`, no SCSS `additionalData`. Anything it cannot resolve is a real gap in the package contract.

## Verdict

**The package is consumable.** From `dist`, with nothing but `vue` and `@vitejs/plugin-vue` in the consumer:

- 20 components render correctly at 320 / 768 / 1440, with zero runtime console errors.
- Both CSS entries work — `style.css` (components) and `theme.css` (tokens, reset, `@font-face`, element-plus overrides). Fonts resolve; the `base: './'` decision in the library's vite config is doing its job.
- `./icons/lucide` works end-to-end without registering any Vite plugin. The harness renders `anvil`, which is deliberately *not* in the bundled icon set, so it only appears when that entry resolves and loads its bucket chunk.
- `./css/*` ships the SCSS sources and they are `@use`-able — `src/styles.scss` pulls `css/mixins/breakpoints` and its media query lands in the output CSS.
- Types resolve, and consumer code typechecks under `skipLibCheck: true`.

## Defects found

One affects consumer code:

- **`app.use(N8nPlugin)` does not typecheck.** `N8nPlugin` is declared `Plugin<N8nPluginOptions>`; Vue reads that single object as a one-element tuple, so the options argument becomes required. Callers must write `app.use(N8nPlugin, {})` — which is what `editor-ui/src/app/plugins/components.ts:13` already does.

Four are in the shipped declarations, and surface only when the consumer lib-checks them (76 errors across 11 `.d.ts` files):

- `@vue/reactivity` is referenced by 11 emitted `.d.ts` files but is neither a `dependency` nor a `peerDependency` (18 errors).
- `event` used as an emit tuple label emits as `(event: "focus", event: FocusEvent) => void` — a duplicate identifier (48 errors).
- The ambient shims `src/shims-modules.d.ts` and `src/shims-vue.d.ts` are not emitted into `dist`, so `markdown-it-task-lists` is untyped downstream.
- `GlobalComponents` is passed where `Record<string, Component>` is required (9 errors).

The harness `README.md` catalogues all five with file references.

## How this is wired into CI

- `typecheck` — runs with `skipLibCheck: true`, which is what a real app uses (it is `true` in Vue's own `create-vue` template). **Green**, and it is the regression gate.
- `build` — **green**.
- `typecheck:libcheck` — a separate diagnostic probe with `skipLibCheck: false` that checks the shipped declarations themselves. It currently fails on the four defects above and is deliberately **not** part of `typecheck`, so it does not gate CI. It becomes the gate once those are fixed.

The package declares no `lint` or `test` script, so turbo skips those tasks for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

