### PR TITLE
refactor(engine): Extract the shared-secret token helper and add the action token

### DIFF
--- a/packages/@n8n/engine/src/auth/__tests__/action-token.test.ts
+++ b/packages/@n8n/engine/src/auth/__tests__/action-token.test.ts
@@ -1,0 +1,163 @@
+import jwt from 'jsonwebtoken';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	ACTION_TOKEN,
+	InvalidActionTokenError,
+	mintActionToken,
+	verifyActionToken,
+} from '../action-token';
+import { mintIdentityToken } from '../identity-token';
+
+const secret = 'a'.repeat(32);
+
+/** Past every deadline the verifier allows, so one advance covers expiry and max age. */
+const PAST_EVERY_DEADLINE_MS =
+	(ACTION_TOKEN.ttlSeconds + ACTION_TOKEN.clockToleranceSeconds + 1) * 1000;
+
+/**
+ * Signs a token from raw claims, bypassing {@link mintActionToken}. Only for
+ * tokens the data plane cannot mint: a foreign scope, a foreign audience, an
+ * expiry untied to the TTL. Anything the clock can express moves the clock
+ * instead, so these tests do not restate how a real token is built.
+ */
+const signRawToken = (claims: Record<string, unknown>, options: jwt.SignOptions = {}) =>
+	jwt.sign(claims, secret, {
+		algorithm: 'HS256',
+		issuer: ACTION_TOKEN.issuer,
+		audience: ACTION_TOKEN.audience,
+		...options,
+	});
+
+const verify = (token: string) => verifyActionToken(secret, token, 'status:write');
+
+describe('verifyActionToken', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('round trips: accepts a token it minted for the scope', () => {
+		expect(() => verify(mintActionToken(secret, 'status:write'))).not.toThrow();
+	});
+
+	it('rejects an identity token minted for the control plane to data plane direction', () => {
+		const token = mintIdentityToken(secret, { cpId: 'cp-1', tenantId: 'tenant-1' });
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token whose scope is not the required one', () => {
+		// The scope type has one member, so this shape is unreachable through mint.
+		const token = signRawToken(
+			{ scope: 'credential:read' },
+			{ expiresIn: ACTION_TOKEN.ttlSeconds },
+		);
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token without a scope', () => {
+		const token = signRawToken({}, { expiresIn: ACTION_TOKEN.ttlSeconds });
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token signed with a different secret', () => {
+		const token = mintActionToken('b'.repeat(32), 'status:write');
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it.each([
+		['unset', ''],
+		['under-length', 'a'.repeat(31)],
+	])('rejects every token when the verifying secret is %s', (_label, verifyingSecret) => {
+		const token = mintActionToken(secret, 'status:write');
+
+		expect(() => verifyActionToken(verifyingSecret, token, 'status:write')).toThrow(
+			InvalidActionTokenError,
+		);
+	});
+
+	it('accepts a token still inside its lifetime', () => {
+		const token = mintActionToken(secret, 'status:write');
+
+		vi.advanceTimersByTime((ACTION_TOKEN.ttlSeconds - 1) * 1000);
+
+		expect(() => verify(token)).not.toThrow();
+	});
+
+	it('rejects a token once its lifetime has passed', () => {
+		const token = mintActionToken(secret, 'status:write');
+
+		vi.advanceTimersByTime(PAST_EVERY_DEADLINE_MS);
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token minted further ahead than the clock-skew tolerance', () => {
+		const now = Date.now();
+
+		// Minted on a clock that runs ahead of this host by more than it tolerates.
+		vi.setSystemTime(now + (ACTION_TOKEN.clockToleranceSeconds + 60) * 1000);
+		const token = mintActionToken(secret, 'status:write');
+		vi.setSystemTime(now);
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token older than the maximum age even when it has not expired', () => {
+		// `mintActionToken` ties `exp` to the TTL, so only a raw token can outlive it.
+		const token = signRawToken({ scope: 'status:write' }, { expiresIn: '1h' });
+
+		vi.advanceTimersByTime(PAST_EVERY_DEADLINE_MS);
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token without an expiration', () => {
+		const token = signRawToken({ scope: 'status:write' });
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token with the wrong audience', () => {
+		const token = signRawToken(
+			{ scope: 'status:write' },
+			{ audience: 'someone-else', expiresIn: ACTION_TOKEN.ttlSeconds },
+		);
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a token with the wrong issuer', () => {
+		const token = signRawToken(
+			{ scope: 'status:write' },
+			{ issuer: 'someone-else', expiresIn: ACTION_TOKEN.ttlSeconds },
+		);
+
+		expect(() => verify(token)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects an alg: none token', () => {
+		const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+		const payload = Buffer.from(
+			JSON.stringify({
+				scope: 'status:write',
+				iss: ACTION_TOKEN.issuer,
+				aud: ACTION_TOKEN.audience,
+				exp: Math.floor(Date.now() / 1000) + ACTION_TOKEN.ttlSeconds,
+			}),
+		).toString('base64url');
+
+		expect(() => verify(`${header}.${payload}.`)).toThrow(InvalidActionTokenError);
+	});
+
+	it('rejects a non-JWT string', () => {
+		expect(() => verify('not-a-jwt')).toThrow(InvalidActionTokenError);
+	});
+});

--- a/packages/@n8n/engine/src/auth/__tests__/identity-token.test.ts
+++ b/packages/@n8n/engine/src/auth/__tests__/identity-token.test.ts
@@ -2,10 +2,7 @@ import jwt from 'jsonwebtoken';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-	IDENTITY_AUDIENCE,
-	IDENTITY_ISSUER,
-	IDENTITY_TOKEN_CLOCK_TOLERANCE_SECONDS,
-	IDENTITY_TOKEN_TTL_SECONDS,
+	IDENTITY_TOKEN,
 	InvalidIdentityTokenError,
 	mintIdentityToken,
 	SharedSecretIdentityVerifier,
@@ -16,7 +13,7 @@ const caller = { cpId: 'cp-1', tenantId: 'tenant-1' };
 
 /** Past every deadline the verifier allows, so one advance covers expiry and max age. */
 const PAST_EVERY_DEADLINE_MS =
-	(IDENTITY_TOKEN_TTL_SECONDS + IDENTITY_TOKEN_CLOCK_TOLERANCE_SECONDS + 1) * 1000;
+	(IDENTITY_TOKEN.ttlSeconds + IDENTITY_TOKEN.clockToleranceSeconds + 1) * 1000;
 
 /**
  * Signs a token from raw claims, bypassing {@link mintIdentityToken}. Only for
@@ -27,8 +24,8 @@ const PAST_EVERY_DEADLINE_MS =
 const signRawToken = (claims: Record<string, unknown>, options: jwt.SignOptions = {}) =>
 	jwt.sign(claims, secret, {
 		algorithm: 'HS256',
-		issuer: IDENTITY_ISSUER,
-		audience: IDENTITY_AUDIENCE,
+		issuer: IDENTITY_TOKEN.issuer,
+		audience: IDENTITY_TOKEN.audience,
 		...options,
 	});
 
@@ -67,7 +64,7 @@ describe('SharedSecretIdentityVerifier', () => {
 		const token = mintIdentityToken(secret, caller);
 		const verifier = new SharedSecretIdentityVerifier(secret);
 
-		vi.advanceTimersByTime((IDENTITY_TOKEN_TTL_SECONDS - 1) * 1000);
+		vi.advanceTimersByTime((IDENTITY_TOKEN.ttlSeconds - 1) * 1000);
 
 		expect(verifier.verify(token)).toEqual(caller);
 	});
@@ -86,7 +83,7 @@ describe('SharedSecretIdentityVerifier', () => {
 		const verifier = new SharedSecretIdentityVerifier(secret);
 
 		// Minted on a clock that runs ahead of this host by more than it tolerates.
-		vi.setSystemTime(now + (IDENTITY_TOKEN_CLOCK_TOLERANCE_SECONDS + 60) * 1000);
+		vi.setSystemTime(now + (IDENTITY_TOKEN.clockToleranceSeconds + 60) * 1000);
 		const token = mintIdentityToken(secret, caller);
 		vi.setSystemTime(now);
 
@@ -116,7 +113,7 @@ describe('SharedSecretIdentityVerifier', () => {
 	it('rejects a token with the wrong audience', () => {
 		const token = signRawToken(
 			{ sub: caller.cpId, tenant_id: caller.tenantId },
-			{ audience: 'someone-else', expiresIn: IDENTITY_TOKEN_TTL_SECONDS },
+			{ audience: 'someone-else', expiresIn: IDENTITY_TOKEN.ttlSeconds },
 		);
 		const verifier = new SharedSecretIdentityVerifier(secret);
 
@@ -126,7 +123,7 @@ describe('SharedSecretIdentityVerifier', () => {
 	it('rejects a token with the wrong issuer', () => {
 		const token = signRawToken(
 			{ sub: caller.cpId, tenant_id: caller.tenantId },
-			{ issuer: 'someone-else', expiresIn: IDENTITY_TOKEN_TTL_SECONDS },
+			{ issuer: 'someone-else', expiresIn: IDENTITY_TOKEN.ttlSeconds },
 		);
 		const verifier = new SharedSecretIdentityVerifier(secret);
 
@@ -139,9 +136,9 @@ describe('SharedSecretIdentityVerifier', () => {
 			JSON.stringify({
 				sub: caller.cpId,
 				tenant_id: caller.tenantId,
-				iss: IDENTITY_ISSUER,
-				aud: IDENTITY_AUDIENCE,
-				exp: Math.floor(Date.now() / 1000) + IDENTITY_TOKEN_TTL_SECONDS,
+				iss: IDENTITY_TOKEN.issuer,
+				aud: IDENTITY_TOKEN.audience,
+				exp: Math.floor(Date.now() / 1000) + IDENTITY_TOKEN.ttlSeconds,
 			}),
 		).toString('base64url');
 		const token = `${header}.${payload}.`;
@@ -151,7 +148,7 @@ describe('SharedSecretIdentityVerifier', () => {
 	});
 
 	it('rejects a token missing tenant_id', () => {
-		const token = signRawToken({ sub: caller.cpId }, { expiresIn: IDENTITY_TOKEN_TTL_SECONDS });
+		const token = signRawToken({ sub: caller.cpId }, { expiresIn: IDENTITY_TOKEN.ttlSeconds });
 		const verifier = new SharedSecretIdentityVerifier(secret);
 
 		expect(() => verifier.verify(token)).toThrow(InvalidIdentityTokenError);

--- a/packages/@n8n/engine/src/auth/action-token.ts
+++ b/packages/@n8n/engine/src/auth/action-token.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+import {
+	signSharedSecretToken,
+	verifySharedSecretToken,
+	type SharedSecretTokenSpec,
+} from './shared-secret-token';
+
+/**
+ * What an action token authorizes. Scoped rather than blanket: the data plane
+ * reports status and nothing else today, so a leaked token buys nothing more
+ * than that, and the next surface it reaches for gets its own scope.
+ */
+export type ActionScope = 'status:write';
+
+/**
+ * Deliberately the mirror image of the identity token's spec. The swapped
+ * issuer and audience are what stop a token minted for CP → DP being replayed
+ * at a control plane endpoint, and vice versa, even though both are signed with
+ * the same shared secret.
+ */
+export const ACTION_TOKEN: SharedSecretTokenSpec = Object.freeze({
+	issuer: 'n8n-engine-dp',
+	audience: 'n8n-cp',
+	ttlSeconds: 60,
+	clockToleranceSeconds: 30,
+});
+
+const actionClaimsSchema = z.object({
+	scope: z.enum(['status:write']),
+	iat: z.number().int(),
+	exp: z.number().int(),
+});
+
+/** Every rejection path throws this one type, so no caller learns which check failed. */
+export class InvalidActionTokenError extends Error {}
+
+/** Signs an action token {@link verifyActionToken} accepts. The DP → CP direction. */
+export function mintActionToken(secret: string, scope: ActionScope): string {
+	return signSharedSecretToken(ACTION_TOKEN, secret, { scope });
+}
+
+/**
+ * Throws unless the token is trustworthy and carries `requiredScope`. The secret
+ * is read per call, and an unset or under-length one rejects everything.
+ */
+export function verifyActionToken(secret: string, token: string, requiredScope: ActionScope): void {
+	const claims = verifySharedSecretToken(ACTION_TOKEN, secret, token, actionClaimsSchema);
+	if (!claims || claims.scope !== requiredScope) throw new InvalidActionTokenError();
+}

--- a/packages/@n8n/engine/src/auth/identity-token.ts
+++ b/packages/@n8n/engine/src/auth/identity-token.ts
@@ -1,13 +1,22 @@
-import jwt from 'jsonwebtoken';
 import { z } from 'zod';
 
 import type { AuthenticatedCaller, IdentityVerifier } from './identity.types';
+import {
+	MIN_SECRET_LENGTH,
+	signSharedSecretToken,
+	verifySharedSecretToken,
+	type SharedSecretTokenSpec,
+} from './shared-secret-token';
 
-export const IDENTITY_ISSUER = 'n8n-cp';
-export const IDENTITY_AUDIENCE = 'n8n-engine-dp';
-export const IDENTITY_TOKEN_TTL_SECONDS = 60;
-export const IDENTITY_TOKEN_CLOCK_TOLERANCE_SECONDS = 30;
-export const MIN_SECRET_LENGTH = 32;
+export { MIN_SECRET_LENGTH };
+
+/** The token the control plane presents to the engine. */
+export const IDENTITY_TOKEN: SharedSecretTokenSpec = Object.freeze({
+	issuer: 'n8n-cp',
+	audience: 'n8n-engine-dp',
+	ttlSeconds: 60,
+	clockToleranceSeconds: 30,
+});
 
 const identityClaimsSchema = z.object({
 	sub: z.string().min(1),
@@ -21,11 +30,9 @@ export class InvalidIdentityTokenError extends Error {}
 
 /** Signs an identity token the engine's {@link SharedSecretIdentityVerifier} accepts. */
 export function mintIdentityToken(secret: string, caller: AuthenticatedCaller): string {
-	return jwt.sign({ sub: caller.cpId, tenant_id: caller.tenantId }, secret, {
-		algorithm: 'HS256',
-		issuer: IDENTITY_ISSUER,
-		audience: IDENTITY_AUDIENCE,
-		expiresIn: IDENTITY_TOKEN_TTL_SECONDS,
+	return signSharedSecretToken(IDENTITY_TOKEN, secret, {
+		sub: caller.cpId,
+		tenant_id: caller.tenantId,
 	});
 }
 
@@ -38,30 +45,14 @@ export class SharedSecretIdentityVerifier implements IdentityVerifier {
 	}
 
 	verify(token: string): AuthenticatedCaller {
-		const now = Math.floor(Date.now() / 1000);
-		let claims: unknown;
-		try {
-			// `algorithms` is pinned: an unpinned verify accepts whatever `alg` the
-			// token names, including `none`. `clockTolerance` allows for clock skew
-			// between the CP and DP hosts.
-			claims = jwt.verify(token, this.secret, {
-				algorithms: ['HS256'],
-				issuer: IDENTITY_ISSUER,
-				audience: IDENTITY_AUDIENCE,
-				maxAge: IDENTITY_TOKEN_TTL_SECONDS,
-				clockTolerance: IDENTITY_TOKEN_CLOCK_TOLERANCE_SECONDS,
-				clockTimestamp: now,
-			});
-		} catch {
-			throw new InvalidIdentityTokenError();
-		}
+		const claims = verifySharedSecretToken(
+			IDENTITY_TOKEN,
+			this.secret,
+			token,
+			identityClaimsSchema,
+		);
+		if (!claims) throw new InvalidIdentityTokenError();
 
-		const parsed = identityClaimsSchema.safeParse(claims);
-		if (!parsed.success) throw new InvalidIdentityTokenError();
-		if (parsed.data.iat > now + IDENTITY_TOKEN_CLOCK_TOLERANCE_SECONDS) {
-			throw new InvalidIdentityTokenError();
-		}
-
-		return { cpId: parsed.data.sub, tenantId: parsed.data.tenant_id };
+		return { cpId: claims.sub, tenantId: claims.tenant_id };
 	}
 }

--- a/packages/@n8n/engine/src/auth/index.ts
+++ b/packages/@n8n/engine/src/auth/index.ts
@@ -1,9 +1,13 @@
 export { createAuthenticationMiddleware } from './authenticate';
 export {
-	IDENTITY_AUDIENCE,
-	IDENTITY_ISSUER,
-	IDENTITY_TOKEN_CLOCK_TOLERANCE_SECONDS,
-	IDENTITY_TOKEN_TTL_SECONDS,
+	ACTION_TOKEN,
+	InvalidActionTokenError,
+	mintActionToken,
+	verifyActionToken,
+} from './action-token';
+export type { ActionScope } from './action-token';
+export {
+	IDENTITY_TOKEN,
 	InvalidIdentityTokenError,
 	MIN_SECRET_LENGTH,
 	mintIdentityToken,

--- a/packages/@n8n/engine/src/auth/shared-secret-token.ts
+++ b/packages/@n8n/engine/src/auth/shared-secret-token.ts
@@ -1,0 +1,72 @@
+import jwt from 'jsonwebtoken';
+import type { z } from 'zod';
+
+/**
+ * Floor for a shared secret. One value authenticates a whole plane, so a
+ * guessable secret is a full bypass.
+ */
+export const MIN_SECRET_LENGTH = 32;
+
+/** Everything that distinguishes one shared-secret token type from another. */
+export interface SharedSecretTokenSpec {
+	readonly issuer: string;
+	readonly audience: string;
+	readonly ttlSeconds: number;
+	readonly clockToleranceSeconds: number;
+}
+
+export function signSharedSecretToken(
+	spec: SharedSecretTokenSpec,
+	secret: string,
+	claims: object,
+): string {
+	return jwt.sign(claims, secret, {
+		algorithm: 'HS256',
+		issuer: spec.issuer,
+		audience: spec.audience,
+		expiresIn: spec.ttlSeconds,
+	});
+}
+
+/**
+ * The claims the token proves, or `undefined` for any rejection — one outcome
+ * for every failure, so no caller can tell which check failed.
+ *
+ * Fails closed on an under-length secret rather than throwing: a secret can be
+ * generated after the verifying code is constructed, so "not configured yet" and
+ * "token is bad" must look the same to a caller.
+ */
+export function verifySharedSecretToken<T extends { iat: number }>(
+	spec: SharedSecretTokenSpec,
+	secret: string,
+	token: string,
+	schema: z.ZodType<T>,
+): T | undefined {
+	if (!secret || secret.length < MIN_SECRET_LENGTH) return undefined;
+
+	const now = Math.floor(Date.now() / 1000);
+	let claims: unknown;
+	try {
+		// `algorithms` is pinned: an unpinned verify accepts whatever `alg` the
+		// token names, including `none`. `clockTolerance` allows for clock skew
+		// between the CP and DP hosts.
+		claims = jwt.verify(token, secret, {
+			algorithms: ['HS256'],
+			issuer: spec.issuer,
+			audience: spec.audience,
+			maxAge: spec.ttlSeconds,
+			clockTolerance: spec.clockToleranceSeconds,
+			clockTimestamp: now,
+		});
+	} catch {
+		return undefined;
+	}
+
+	const parsed = schema.safeParse(claims);
+	if (!parsed.success) return undefined;
+	// `maxAge` bounds how old a token may be; this bounds how far in the future
+	// it may claim to have been issued.
+	if (parsed.data.iat > now + spec.clockToleranceSeconds) return undefined;
+
+	return parsed.data;
+}


### PR DESCRIPTION
## Summary

**Stack 1/3.** Targets `master`. Followed by
`cat-2919-2-emit-status-updates` → `cat-2919-3-control-plane-server`.

The stack adds execution status updates from DP → CP.

This PR 1/3 adds action token for DP → CP communication and extracts shared parts from identity token.

Nothing consumes the new token yet. This PR is a behaviour-neutral refactor plus a new, unused primitive.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2919

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

