### PR TITLE
docs(editor): Document @n8n/design-system consumption in its README (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/README.md
+++ b/packages/frontend/@n8n/design-system/README.md
@@ -13,6 +13,7 @@ The package is ESM-only and builds to `dist`. Consumers resolve it through the
 - [Consume the package](#consume-the-package)
 - [Exports](#exports)
 - [Develop the package](#develop-the-package)
+- [Pack and publish](#pack-and-publish)
 - [License](#license)
 
 ## Consume the package
@@ -35,11 +36,17 @@ Inside this monorepo, declare it as a workspace dependency in your own `package.
 }
 ```
 
-Outside this monorepo, install from npm. The `./plugin` subpath is available from `2.36.0`:
+Outside this monorepo, install from npm. **Pin `2.36.0` or later** — the wiring below does
+not resolve on earlier versions, and `2.35.3` is still the `latest` tag:
 
 ```sh
-npm install @n8n/design-system vue vue-router
+npm install @n8n/design-system@^2.36.0 vue vue-router
 ```
+
+Two entry points arrived in `2.36.0`. On `2.35.3` the `./plugin` subpath does not exist at
+all (`ERR_PACKAGE_PATH_NOT_EXPORTED`), and `IconBodyLoaderKey` is reachable only from the
+barrel, not from `./icons/lucide`. If you cannot move off `2.35.3`, see
+[Pinned below 2.36.0](#pinned-below-2360).
 
 Add `sass` as a dev dependency only if you `@use` the SCSS sources from
 [`./css/*`](#exports). Without it, Vite fails the build with
@@ -81,7 +88,10 @@ app.mount('#app');
 ```
 
 `N8nPlugin` registers the `v-n8n-truncate` and `v-n8n-html` directives. Pass `{}` as the
-options argument.
+options argument. Do not skip this call: ten components render their text through
+`v-n8n-html` — `N8nNotice`, `N8nTooltip`, `N8nTabs`, `N8nSticky`, `N8nInputLabel`,
+`N8nInfoAccordion`, `N8nEmptyState`, `CommandBarItem`, and the two `AskAssistantChat`
+message components — and without the directive they render empty, with no error.
 
 The `IconBodyLoaderKey` provide is what makes the full Lucide set available. Without it,
 `N8nIcon` renders the bundled icon set only (`triangle`, `status-error`, the custom n8n
@@ -127,6 +137,35 @@ can reach the mixins and token maps:
 
 That compiles to `@media screen and (width<=991px)`.
 
+### Pinned below 2.36.0
+
+`2.35.3` has no `./plugin` subpath, so `import { N8nPlugin } from '@n8n/design-system/plugin'`
+fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Register the two directives from the barrel
+instead, and take `IconBodyLoaderKey` from the barrel as well:
+
+```ts
+// src/main.ts — @n8n/design-system 2.35.3
+import '@n8n/design-system/style.css';
+import '@n8n/design-system/theme.css';
+
+import { IconBodyLoaderKey, n8nHtml, n8nTruncate } from '@n8n/design-system';
+import { loadLucideIconBody } from '@n8n/design-system/icons/lucide';
+import { createApp } from 'vue';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.directive('n8nHtml', n8nHtml);
+app.directive('n8nTruncate', n8nTruncate);
+app.provide(IconBodyLoaderKey, loadLucideIconBody);
+app.mount('#app');
+```
+
+This is equivalent to `app.use(N8nPlugin, {})` — the plugin registers the same two
+directives under the same names, so this wiring also works on `2.36.0` and later.
+`loadLucideIconBody` is on `./icons/lucide` in `2.35.3` too; only `IconBodyLoaderKey` is
+barrel-only there.
+
 ## Exports
 
 Every subpath resolves from `dist`. There is no CommonJS build and no `require` condition.
@@ -153,6 +192,28 @@ Run these from this directory.
 | `pnpm test`      | Runs the unit tests once.                                           |
 | `pnpm lint`      | Lints `src`. `pnpm lint:fix` applies the fixes.                     |
 | `pnpm clean`     | Removes `dist` and `.turbo`.                                        |
+
+## Pack and publish
+
+**Pack with `pnpm pack`. Never `npm pack`.**
+
+`pnpm` rewrites the workspace protocol and the catalog references to fixed versions when it
+packs — `"@n8n/composables": "workspace:*"` becomes `"1.27.0"`, `"vue": "catalog:frontend"`
+becomes `"^3.5.13"`. `npm` copies both verbatim, and neither is a protocol the npm registry
+client understands, so installing an `npm`-packed tarball fails:
+
+```text
+npm error code EUNSUPPORTEDPROTOCOL
+npm error Unsupported URL Type "catalog:": catalog:frontend
+```
+
+Build first — `dist` is gitignored, and `files` ships `dist`, `assets/fonts`, and this
+README:
+
+```sh
+pnpm turbo run build --filter=@n8n/design-system
+pnpm pack --pack-destination /tmp/ds-pack
+```
 
 ## License
 

--- a/packages/frontend/@n8n/design-system/README.md
+++ b/packages/frontend/@n8n/design-system/README.md
@@ -2,49 +2,157 @@
 
 # @n8n/design-system
 
-A component system for [n8n](https://n8n.io) using Storybook to preview.
+The n8n component library for Vue 3: components, design tokens, icons, and the directives
+plugin. Run `pnpm dev` to browse the components in Storybook.
 
-## Project setup
+The package is ESM-only and builds to `dist`. Consumers resolve it through the
+[`exports` map](#exports) — never through a deep path into `src`.
 
-```
-pnpm install
-```
+## Table of Contents
 
-### Compiles and hot-reloads for development
+- [Consume the package](#consume-the-package)
+- [Exports](#exports)
+- [Develop the package](#develop-the-package)
+- [License](#license)
 
-```
-pnpm storybook
-```
+## Consume the package
 
-### Build static pages
+Prerequisites: a Vue 3 app built by Vite, and `vue` plus `vue-router` installed. Both are
+peer dependencies, and the barrel imports `vue-router` at load time — without it the build
+fails with `Rollup failed to resolve import "vue-router"`.
 
-```
-pnpm build:storybook
-```
+### 1. Install
 
-### Run your unit tests
+Inside this monorepo, declare it as a workspace dependency in your own `package.json`:
 
-```
-pnpm test:unit
-```
-
-### Lints and fixes files
-
-```
-pnpm lint
-```
-
-### Build css files
-
-```
-pnpm build:theme
+```json
+{
+  "dependencies": {
+    "@n8n/design-system": "workspace:*",
+    "vue": "catalog:frontend",
+    "vue-router": "catalog:frontend"
+  }
+}
 ```
 
-### Monitor theme files and build any changes
+Outside this monorepo, install from npm. The `./plugin` subpath is available from `2.36.0`:
 
+```sh
+npm install @n8n/design-system vue vue-router
 ```
-pnpm watch:theme
+
+Add `sass` as a dev dependency only if you `@use` the SCSS sources from
+[`./css/*`](#exports). Without it, Vite fails the build with
+`Preprocessor dependency "sass-embedded" not found`.
+
+### 2. Build the package first
+
+`dist` is gitignored, so an in-repo consumer has nothing to resolve until the package is
+built. Build it with turbo, which builds its workspace dependencies first:
+
+```sh
+pnpm turbo run build --filter=@n8n/design-system
 ```
+
+A consumer package that declares `@n8n/design-system` gets this for free — turbo's `build`
+task depends on `^build`. Skip this step when you install from npm: the tarball ships `dist`.
+
+### 3. Wire it into your app
+
+Import the two stylesheets before your own styles. `theme.css` carries the design tokens,
+the CSS reset, and the `@font-face` rules that the components resolve their variables from.
+
+```ts
+// src/main.ts
+import '@n8n/design-system/style.css';
+import '@n8n/design-system/theme.css';
+import './styles.scss';
+
+import { IconBodyLoaderKey, loadLucideIconBody } from '@n8n/design-system/icons/lucide';
+import { N8nPlugin } from '@n8n/design-system/plugin';
+import { createApp } from 'vue';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(N8nPlugin, {});
+app.provide(IconBodyLoaderKey, loadLucideIconBody);
+app.mount('#app');
+```
+
+`N8nPlugin` registers the `v-n8n-truncate` and `v-n8n-html` directives. Pass `{}` as the
+options argument.
+
+The `IconBodyLoaderKey` provide is what makes the full Lucide set available. Without it,
+`N8nIcon` renders the bundled icon set only (`triangle`, `status-error`, the custom n8n
+icons); every other Lucide name renders empty, with a warning in a dev build.
+
+Components and their types come from the barrel:
+
+```vue
+<!-- src/App.vue -->
+<script setup lang="ts">
+import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
+import type { ButtonVariant } from '@n8n/design-system';
+import { ref } from 'vue';
+
+const variant: ButtonVariant = 'solid';
+const clicks = ref(0);
+</script>
+
+<template>
+	<main class="page">
+		<N8nText size="medium">clicks: {{ clicks }}</N8nText>
+		<N8nButton :variant="variant" label="Click me" @click="clicks++" />
+		<N8nIcon icon="anvil" />
+	</main>
+</template>
+```
+
+The SCSS sources ship next to the compiled CSS, so a consumer with its own sass toolchain
+can reach the mixins and token maps:
+
+```scss
+// src/styles.scss
+@use '@n8n/design-system/css/mixins/breakpoints' as breakpoints;
+
+.page {
+	padding: var(--spacing--lg);
+
+	@include breakpoints.breakpoint('sm-and-down') {
+		padding: var(--spacing--2xs);
+	}
+}
+```
+
+That compiles to `@media screen and (width<=991px)`.
+
+## Exports
+
+Every subpath resolves from `dist`. There is no CommonJS build and no `require` condition.
+
+| Subpath                           | Contents                                                                               |
+| --------------------------------- | -------------------------------------------------------------------------------------- |
+| `@n8n/design-system`              | The barrel: components, composables, exported types, and the `locale` singleton.       |
+| `@n8n/design-system/plugin`       | `N8nPlugin` — registers the `v-n8n-truncate` and `v-n8n-html` directives.              |
+| `@n8n/design-system/icons/lucide` | `loadLucideIconBody` and `IconBodyLoaderKey`, for icons outside the bundled set.       |
+| `@n8n/design-system/style.css`    | Component styles.                                                                      |
+| `@n8n/design-system/theme.css`    | Design tokens, the CSS reset, four `@font-face` rules, and the element-plus overrides. |
+| `@n8n/design-system/css/*`        | The SCSS sources — mixins, token maps, and per-component stylesheets. Needs `sass`.    |
+| `@n8n/design-system/package.json` | The manifest.                                                                          |
+
+## Develop the package
+
+Run these from this directory.
+
+| Command          | What it does                                                        |
+| ---------------- | ------------------------------------------------------------------- |
+| `pnpm dev`       | Starts Storybook on http://localhost:6006.                          |
+| `pnpm build`     | Builds `dist`. Needs the workspace dependencies built — see step 2. |
+| `pnpm typecheck` | `vue-tsc --noEmit` over `src`.                                      |
+| `pnpm test`      | Runs the unit tests once.                                           |
+| `pnpm lint`      | Lints `src`. `pnpm lint:fix` applies the fixes.                     |
+| `pnpm clean`     | Removes `dist` and `.turbo`.                                        |
 
 ## License
 

--- a/packages/frontend/@n8n/design-system/README.md
+++ b/packages/frontend/@n8n/design-system/README.md
@@ -5,9 +5,6 @@
 The n8n component library for Vue 3: components, design tokens, icons, and the directives
 plugin. Run `pnpm dev` to browse the components in Storybook.
 
-The package is ESM-only and builds to `dist`. Consumers resolve it through the
-[`exports` map](#exports) — never through a deep path into `src`.
-
 ## Table of Contents
 
 - [Consume the package](#consume-the-package)
@@ -20,7 +17,7 @@ The package is ESM-only and builds to `dist`. Consumers resolve it through the
 
 Prerequisites: a Vue 3 app built by Vite, and `vue` plus `vue-router` installed. Both are
 peer dependencies, and the barrel imports `vue-router` at load time — without it the build
-fails with `Rollup failed to resolve import "vue-router"`.
+fails.
 
 ### 1. Install
 
@@ -40,17 +37,11 @@ Outside this monorepo, install from npm. **Pin `2.36.0` or later** — the wirin
 not resolve on earlier versions, and `2.35.3` is still the `latest` tag:
 
 ```sh
-npm install @n8n/design-system@^2.36.0 vue vue-router
+npm install @n8n/design-system@latest vue vue-router
 ```
 
-Two entry points arrived in `2.36.0`. On `2.35.3` the `./plugin` subpath does not exist at
-all (`ERR_PACKAGE_PATH_NOT_EXPORTED`), and `IconBodyLoaderKey` is reachable only from the
-barrel, not from `./icons/lucide`. If you cannot move off `2.35.3`, see
-[Pinned below 2.36.0](#pinned-below-2360).
-
 Add `sass` as a dev dependency only if you `@use` the SCSS sources from
-[`./css/*`](#exports). Without it, Vite fails the build with
-`Preprocessor dependency "sass-embedded" not found`.
+[`./css/*`](#exports).
 
 ### 2. Build the package first
 
@@ -136,35 +127,6 @@ can reach the mixins and token maps:
 ```
 
 That compiles to `@media screen and (width<=991px)`.
-
-### Pinned below 2.36.0
-
-`2.35.3` has no `./plugin` subpath, so `import { N8nPlugin } from '@n8n/design-system/plugin'`
-fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Register the two directives from the barrel
-instead, and take `IconBodyLoaderKey` from the barrel as well:
-
-```ts
-// src/main.ts — @n8n/design-system 2.35.3
-import '@n8n/design-system/style.css';
-import '@n8n/design-system/theme.css';
-
-import { IconBodyLoaderKey, n8nHtml, n8nTruncate } from '@n8n/design-system';
-import { loadLucideIconBody } from '@n8n/design-system/icons/lucide';
-import { createApp } from 'vue';
-
-import App from './App.vue';
-
-const app = createApp(App);
-app.directive('n8nHtml', n8nHtml);
-app.directive('n8nTruncate', n8nTruncate);
-app.provide(IconBodyLoaderKey, loadLucideIconBody);
-app.mount('#app');
-```
-
-This is equivalent to `app.use(N8nPlugin, {})` — the plugin registers the same two
-directives under the same names, so this wiring also works on `2.36.0` and later.
-`loadLucideIconBody` is on `./icons/lucide` in `2.35.3` too; only `IconBodyLoaderKey` is
-barrel-only there.
 
 ## Exports
 

--- a/packages/frontend/@n8n/design-system/README.md
+++ b/packages/frontend/@n8n/design-system/README.md
@@ -2,8 +2,8 @@
 
 # @n8n/design-system
 
-The n8n component library for Vue 3: components, design tokens, icons, and the directives
-plugin. Run `pnpm dev` to browse the components in Storybook.
+The n8n component library for Vue 3. It gives you components, design tokens, icons, and
+the directives plugin. Run `pnpm dev` to see the components in Storybook.
 
 ## Table of Contents
 
@@ -15,13 +15,14 @@ plugin. Run `pnpm dev` to browse the components in Storybook.
 
 ## Consume the package
 
-Prerequisites: a Vue 3 app built by Vite, and `vue` plus `vue-router` installed. Both are
-peer dependencies, and the barrel imports `vue-router` at load time — without it the build
-fails.
+You need a Vue 3 app with Vite. You also need the `vue` and `vue-router` packages.
+
+`vue` and `vue-router` are peer dependencies. The barrel imports `vue-router` at load
+time. If `vue-router` is absent, the build fails.
 
 ### 1. Install
 
-Inside this monorepo, declare it as a workspace dependency in your own `package.json`:
+Inside this monorepo, declare the package as a workspace dependency in your `package.json`:
 
 ```json
 {
@@ -33,32 +34,33 @@ Inside this monorepo, declare it as a workspace dependency in your own `package.
 }
 ```
 
-Outside this monorepo, install from npm. **Pin `2.36.0` or later** — the wiring below does
-not resolve on earlier versions, and `2.35.3` is still the `latest` tag:
+Outside this monorepo, install the package from npm:
 
 ```sh
 npm install @n8n/design-system@latest vue vue-router
 ```
 
-Add `sass` as a dev dependency only if you `@use` the SCSS sources from
+Add `sass` as a dev dependency only when you `@use` the SCSS sources from
 [`./css/*`](#exports).
 
 ### 2. Build the package first
 
-`dist` is gitignored, so an in-repo consumer has nothing to resolve until the package is
-built. Build it with turbo, which builds its workspace dependencies first:
+`.gitignore` excludes `dist`. So an in-repo app can resolve nothing before you build the
+package. Build the package with turbo. Turbo builds the workspace dependencies first.
 
 ```sh
 pnpm turbo run build --filter=@n8n/design-system
 ```
 
-A consumer package that declares `@n8n/design-system` gets this for free — turbo's `build`
-task depends on `^build`. Skip this step when you install from npm: the tarball ships `dist`.
+A package that declares `@n8n/design-system` needs no extra step, because the `build` task
+of turbo depends on `^build`. If you install from npm, skip this step, because the tarball
+includes `dist`.
 
 ### 3. Wire it into your app
 
-Import the two stylesheets before your own styles. `theme.css` carries the design tokens,
-the CSS reset, and the `@font-face` rules that the components resolve their variables from.
+Import the two stylesheets before your own styles. `theme.css` gives you the design tokens,
+the CSS reset, and four `@font-face` rules. The components read their variables from these
+tokens.
 
 ```ts
 // src/main.ts
@@ -79,16 +81,19 @@ app.mount('#app');
 ```
 
 `N8nPlugin` registers the `v-n8n-truncate` and `v-n8n-html` directives. Pass `{}` as the
-options argument. Do not skip this call: ten components render their text through
-`v-n8n-html` — `N8nNotice`, `N8nTooltip`, `N8nTabs`, `N8nSticky`, `N8nInputLabel`,
-`N8nInfoAccordion`, `N8nEmptyState`, `CommandBarItem`, and the two `AskAssistantChat`
-message components — and without the directive they render empty, with no error.
+options argument.
 
-The `IconBodyLoaderKey` provide is what makes the full Lucide set available. Without it,
-`N8nIcon` renders the bundled icon set only (`triangle`, `status-error`, the custom n8n
-icons); every other Lucide name renders empty, with a warning in a dev build.
+Do not skip this call. Ten components render their text through `v-n8n-html`: `N8nNotice`,
+`N8nTooltip`, `N8nTabs`, `N8nSticky`, `N8nInputLabel`, `N8nInfoAccordion`, `N8nEmptyState`,
+`CommandBarItem`, and the two `AskAssistantChat` message components. If the directive is
+absent, these components render empty and show no error.
 
-Components and their types come from the barrel:
+The `app.provide(IconBodyLoaderKey, loadLucideIconBody)` call gives you the full Lucide
+set. If you omit the call, `N8nIcon` renders only the bundled icon set. That set holds
+`triangle`, `status-error`, and the custom n8n icons. Every other Lucide name renders
+empty, and a dev build writes a warning to the console.
+
+The barrel gives you the components and their types:
 
 ```vue
 <!-- src/App.vue -->
@@ -110,8 +115,8 @@ const clicks = ref(0);
 </template>
 ```
 
-The SCSS sources ship next to the compiled CSS, so a consumer with its own sass toolchain
-can reach the mixins and token maps:
+The package includes the SCSS sources next to the compiled CSS. So an app with its own
+sass toolchain can use the mixins and the token maps:
 
 ```scss
 // src/styles.scss
@@ -126,51 +131,53 @@ can reach the mixins and token maps:
 }
 ```
 
-That compiles to `@media screen and (width<=991px)`.
+The `breakpoint` mixin compiles to `@media screen and (width<=991px)`.
 
 ## Exports
 
-Every subpath resolves from `dist`. There is no CommonJS build and no `require` condition.
+Every subpath resolves from `dist`. The package has no CommonJS build and no `require`
+condition.
 
-| Subpath                           | Contents                                                                               |
-| --------------------------------- | -------------------------------------------------------------------------------------- |
-| `@n8n/design-system`              | The barrel: components, composables, exported types, and the `locale` singleton.       |
-| `@n8n/design-system/plugin`       | `N8nPlugin` — registers the `v-n8n-truncate` and `v-n8n-html` directives.              |
-| `@n8n/design-system/icons/lucide` | `loadLucideIconBody` and `IconBodyLoaderKey`, for icons outside the bundled set.       |
-| `@n8n/design-system/style.css`    | Component styles.                                                                      |
-| `@n8n/design-system/theme.css`    | Design tokens, the CSS reset, four `@font-face` rules, and the element-plus overrides. |
-| `@n8n/design-system/css/*`        | The SCSS sources — mixins, token maps, and per-component stylesheets. Needs `sass`.    |
-| `@n8n/design-system/package.json` | The manifest.                                                                          |
+| Subpath                           | Contents                                                                                     |
+| --------------------------------- | -------------------------------------------------------------------------------------------- |
+| `@n8n/design-system`              | The barrel: components, composables, exported types, and the `locale` singleton.             |
+| `@n8n/design-system/plugin`       | `N8nPlugin`. It registers the `v-n8n-truncate` and `v-n8n-html` directives.                  |
+| `@n8n/design-system/icons/lucide` | `loadLucideIconBody` and `IconBodyLoaderKey`, for icons outside the bundled set.             |
+| `@n8n/design-system/style.css`    | The component styles.                                                                        |
+| `@n8n/design-system/theme.css`    | The design tokens, the CSS reset, four `@font-face` rules, and the element-plus overrides.   |
+| `@n8n/design-system/css/*`        | The SCSS sources: mixins, token maps, and one stylesheet per component. You must add `sass`. |
+| `@n8n/design-system/package.json` | The manifest.                                                                                |
 
 ## Develop the package
 
-Run these from this directory.
+Run these commands from this directory.
 
-| Command          | What it does                                                        |
-| ---------------- | ------------------------------------------------------------------- |
-| `pnpm dev`       | Starts Storybook on http://localhost:6006.                          |
-| `pnpm build`     | Builds `dist`. Needs the workspace dependencies built — see step 2. |
-| `pnpm typecheck` | `vue-tsc --noEmit` over `src`.                                      |
-| `pnpm test`      | Runs the unit tests once.                                           |
-| `pnpm lint`      | Lints `src`. `pnpm lint:fix` applies the fixes.                     |
-| `pnpm clean`     | Removes `dist` and `.turbo`.                                        |
+| Command          | What it does                                                           |
+| ---------------- | ---------------------------------------------------------------------- |
+| `pnpm dev`       | It starts Storybook on http://localhost:6006.                          |
+| `pnpm build`     | It builds `dist`. Build the workspace dependencies first — see step 2. |
+| `pnpm typecheck` | It runs `vue-tsc --noEmit` on `src`.                                   |
+| `pnpm test`      | It runs the unit tests one time.                                       |
+| `pnpm lint`      | It lints `src`. `pnpm lint:fix` applies the fixes.                     |
+| `pnpm clean`     | It removes `dist` and `.turbo`.                                        |
 
 ## Pack and publish
 
 **Pack with `pnpm pack`. Never `npm pack`.**
 
-`pnpm` rewrites the workspace protocol and the catalog references to fixed versions when it
-packs — `"@n8n/composables": "workspace:*"` becomes `"1.27.0"`, `"vue": "catalog:frontend"`
-becomes `"^3.5.13"`. `npm` copies both verbatim, and neither is a protocol the npm registry
-client understands, so installing an `npm`-packed tarball fails:
+When `pnpm` packs the package, it rewrites the workspace protocol and the catalog
+references to fixed versions. For example, `"@n8n/composables": "workspace:*"` becomes
+`"1.27.0"`, and `"vue": "catalog:frontend"` becomes `"^3.5.13"`. `npm` copies both strings
+without a change. The npm registry client knows neither protocol. So an install of an
+`npm`-packed tarball fails:
 
 ```text
 npm error code EUNSUPPORTEDPROTOCOL
 npm error Unsupported URL Type "catalog:": catalog:frontend
 ```
 
-Build first — `dist` is gitignored, and `files` ships `dist`, `assets/fonts`, and this
-README:
+Build the package first, because `.gitignore` excludes `dist`. The `files` field includes
+`dist`, `assets/fonts`, and this README.
 
 ```sh
 pnpm turbo run build --filter=@n8n/design-system


### PR DESCRIPTION
## Summary

The `@n8n/design-system` README documented five scripts the package no longer has — `storybook`, `build:storybook`, `test:unit`, `build:theme`, `watch:theme` — and said nothing about how to consume the package. Found by the consumption verification in #37011.

This replaces both halves:

- **How to consume it** — the minimum install for in-repo and npm consumers, the build-first step (`dist` is gitignored, so an in-repo consumer has nothing to resolve until the package is built), and a wiring example covering the barrel, `./plugin`, `./icons/lucide`, both CSS entries, and the `./css/*` SCSS sources.
- **A reference table for the `exports` map**, read from `package.json` at write time.
- **A `Develop the package` table** listing only scripts that exist.

Every command and import line was executed before it was written. Nothing here is copied from a report.

## How to test

Read the README, then run what it says. The two paths were verified separately.

**In-repo** — a scratch workspace package declaring exactly the documented dependency block, with no Vite aliases, no `unplugin-icons`, no `lucideIconsPlugin`, and no SCSS `additionalData`:

```
pnpm turbo run build --filter=@n8n/design-system   # 23 tasks successful
pnpm --filter <consumer> exec vue-tsc --noEmit      # exit 0
pnpm --filter <consumer> exec vite build            # ✓ built
```

Rendered headless in Chromium against the production build: components render, reactivity works (`clicks: 0` → `clicks: 1`), `--spacing--lg` resolves to `24px`, the computed font is `InterVariable`, the `anvil` Lucide icon renders an SVG with a `<path>`, and the console is empty.

**Out of repo** — `npm install @n8n/design-system@2.36.0 vue vue-router` into a plain Vite app outside the monorepo, with the same sources. `vue-tsc --noEmit` exits 0 and `vite build` succeeds. The installed manifest's `exports` map is byte-identical to the one in `packages/frontend/@n8n/design-system/package.json`.

**The three claims in the README that are load-bearing were each verified by removing the thing:**

| Claim | Verification |
| --- | --- |
| `vue-router` is genuinely required | Remove it → `[vite]: Rollup failed to resolve import "vue-router" from ".../dist/index.js"` |
| `sass` is needed only for `./css/*` | Remove it → `Preprocessor dependency "sass-embedded" not found` |
| The icon body loader gates non-bundled icons | Drop the `provide` → `anvil` renders 0 SVGs; `triangle` (bundled) still renders 1 |

**Package scripts**, each run from the package directory: `pnpm dev` (Storybook answers 200 on http://localhost:6006), `pnpm build`, `pnpm typecheck`, `pnpm test` (127 files, 1521 tests passed), `pnpm lint`, `pnpm clean`.

## Notes for the reviewer

- The README ships in the npm tarball (`files` includes it), so it addresses both audiences. Version numbers are avoided except one durable fact: `./plugin` exists from `2.36.0`. `latest` on npm is currently `2.35.3`, whose `exports` map has no `./plugin`, so a reader installing today needs that line.
- The five type defects from the same verification are **not** documented here — they are tracked separately and a README must not promise accidental behavior. `app.use(N8nPlugin, {})` is written as the working call, which stays valid after the options argument becomes optional.
- Prettier ignores `**/*.md` repo-wide, so the tables are aligned by hand. Running Prettier over this file rewrites the `package.json` example into invalid strict JSON (trailing commas) — worth knowing before anyone reformats it.

## Update — version floor and packing rule

Two more sections landed in `d7187cc`, both verified the same way.

**Version floor.** `2.35.3` is still the `latest` tag on npm; `2.36.0` is published as `beta`. Two entry points only exist from `2.36.0`, so a reader installing today can copy code that will not build:

| On `2.35.3` | Verified result |
| --- | --- |
| `import '@n8n/design-system/plugin'` | `ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './plugin' is not defined by "exports"` |
| `IconBodyLoaderKey` from `./icons/lucide` | Absent — barrel-only on `2.35.3`; present on both from `2.36.0` |
| `loadLucideIconBody` from `./icons/lucide` | Present on both versions |

The install line is now `npm install @n8n/design-system@^2.36.0 vue vue-router`, which resolves `2.36.0`. A new `Pinned below 2.36.0` section gives the barrel wiring for anyone who cannot move: `app.directive('n8nHtml', n8nHtml)` plus `app.directive('n8nTruncate', n8nTruncate)`. That exact snippet was installed against `2.35.3`, typechecked (`vue-tsc --noEmit`, exit 0), built, and rendered in Chromium — `N8nNotice` shows its text with the registration and renders **empty, with no console error**, without it.

**Directive consequence.** The `N8nPlugin` note now names the ten components that render their text through `v-n8n-html` (`N8nNotice`, `N8nTooltip`, `N8nTabs`, `N8nSticky`, `N8nInputLabel`, `N8nInfoAccordion`, `N8nEmptyState`, `CommandBarItem`, and the two `AskAssistantChat` message components), so skipping the call reads as the bug it is.

**Packing rule.** A new `Pack and publish` section records that this package must be packed with `pnpm pack`, never `npm pack`. Verified by packing both ways and installing both tarballs:

- `pnpm pack` rewrites the specifiers — `"@n8n/composables": "workspace:*"` → `"1.27.0"`, `"vue": "catalog:frontend"` → `"^3.5.13"`. Tarball installs: `added 315 packages`, and `dist/plugin.js` loads.
- `npm pack` copies both verbatim. Installing that tarball fails with `npm error code EUNSUPPORTEDPROTOCOL` / `npm error Unsupported URL Type "catalog:": catalog:frontend`.

**One correction to my own first pass:** I initially wrote that `IconBodyLoaderKey` *moved* in `2.36.0`. It did not — it was *added* to `./icons/lucide` and remains on the barrel in both versions. The README says so precisely.

## Related Linear tickets, Github issues, and Community forum posts

Follows up on #37011.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


