### PR TITLE
ci: Trial the shared cla-check action alongside the in-repo CLA workflow

### DIFF
--- a/.github/workflows/ci-cla-check-trial.yml
+++ b/.github/workflows/ci-cla-check-trial.yml
@@ -1,0 +1,54 @@
+name: 'CI: CLA Check (trial)'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('CI: CLA Check trial (PR #{0})', inputs.pr_number) || '' }}"
+
+# Temporary shadow run of the released n8n-io/github-actions/cla-check action,
+# compared against the in-repo implementation in ci-cla-check.yml before that
+# workflow switches over. Nothing depends on this workflow; it is safe to delete.
+#
+# Triggers are narrowed so a shadow run leaves no contributor-facing trace:
+# merge_group carries no PR number, so the action's comment and label steps
+# self-skip and only a commit status is written; workflow_dispatch covers the PR
+# path on hand-picked PRs.
+#
+# Every identifier the action can collide on is deliberately distinct from the
+# production one: the status context is required by no ruleset, the comment
+# marker never matches the production comment, and the label is not
+# `cla-signed`, which community-PR triage reads.
+
+on:
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to verify'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  # Distinct prefix from ci-cla-check.yml, so trial and production runs can
+  # never cancel each other.
+  group: >-
+    cla-check-trial-${{ github.event.merge_group.head_sha
+      || github.event.inputs.pr_number
+      || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cla-check-trial:
+    name: Verify CLA signatures (trial)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: n8n-io/github-actions/cla-check@931777df53ace1bdb31d2bf5c63c9f2d27451c35 # cla-check/v1.0.0
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          status-context: 'CLA Check (trial)'
+          comment-marker: '<!-- n8n-cla-check-trial -->'
+          label-name: 'cla-trial-signed'


### PR DESCRIPTION
## Summary

Shadow-runs n8n-io/github-actions/cla-check@cla-check/v1.0.0 next to ci-cla-check.yml before switching that workflow over. Triggers are limited to merge_group and workflow_dispatch, and the status context, comment marker and label name are all distinct from the production ones, so the trial can neither gate a merge nor touch a contributor-facing artifact.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-731


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

