### PR TITLE
fix(editor): Register v-n8n-html in the design-system components that use it (no-changelog)

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,21 @@
+# ADRs
+
+An ADR records a decision **after** it has been made — what was decided, by whom, why, and the
+consequences, good and bad. Decisions taken against a recommendation are recorded with the same care,
+with the reasoning and a revisit trigger. So are decisions *not* to do something.
+
+## Conventions
+
+- Filename `NNNN-slug.md`, four digits, allocated in order and never reused. The sequence is shared
+  with nothing else; see the numbering note in `../rfcs/README.md`.
+- Nygard format: Context · Decision · Consequences (good and bad) · Revisit trigger.
+- Filed within a day of the decision, never a week. Paperwork never blocks the work.
+- **ADRs are immutable.** A decision that changes gets a new ADR that supersedes the old one; the old
+  record keeps its text and gains a `Superseded by ADR-NNNN` line. Never edit an ADR's substance —
+  an edited record is a record that lies about what was known at the time.
+- Claims are labelled `verified`, `inferred` or `assumed`, with the source. Dissent is preserved, not
+  smoothed over.
+
+## Index
+
+*Empty. RFC-0001 is awaiting a ruling; its ADR is filed when the ruling lands.*

--- a/docs/rfcs/0001-design-system-external-install-weight.md
+++ b/docs/rfcs/0001-design-system-external-install-weight.md
@@ -1,0 +1,320 @@
+# RFC-0001: Cut the external install weight of `@n8n/design-system`
+
+Status: **Draft — awaiting decision**
+Author: index · Reviewers: Alex Grozav (decider), sigma (implementer) · Class: **2** (expensive to reverse) · Comment window closes: **2026-08-28**
+
+Source issue: N8N-303. Evidence base: N8N-296, [PR #37011](https://github.com/n8n-io/n8n/pull/37011), commit `8e65884`.
+
+## Problem
+
+A project outside this monorepo that installs `@n8n/design-system` to use its Vue components gets a
+**351 MB, 312-package** `node_modules`. The tree includes `isolated-vm` (a native addon),
+`@sentry/node`, 14 `@sentry/*` + `@opentelemetry/*` packages, `ssh2`, `axios` and `recast`.
+
+None of that is reachable from any code path a browser consumer executes. Verified against the
+published `2.35.3` artifacts: `n8n-workflow` and `@n8n/api-types` appear in **zero** runtime
+(`.mjs`/`.cjs`) files of `@n8n/composables` and `@n8n/i18n` — only in `.d.mts`/`.d.cts`
+declarations and source maps.
+
+Why now: N8N-296 established that an external install works. This is the next barrier, and it is a
+number, not a taste call.
+
+### Why the 4 subpaths pull the whole chain
+
+The published `dist` of `@n8n/design-system` externalises everything the manifest declares
+(`vite.config.mts`, `isExternal`), so exactly four bare specifiers survive into the bundle:
+
+| Subpath in `dist` | Owning package | That package's dependency cost |
+|---|---|---|
+| `@n8n/composables/useDeviceSupport` | `@n8n/composables` | **the whole chain** |
+| `@n8n/frontend-utils/htmlUtils` | `@n8n/frontend-utils` | `vue`, `xss` |
+| `@n8n/utils/event-bus` | `@n8n/utils` | `@n8n/constants`, `nanoid` |
+| `@n8n/utils/string/truncate` | `@n8n/utils` | ditto |
+
+**npm resolves dependencies per package, not per subpath.** `dist/useDeviceSupport.mjs` imports only
+`vue` — but importing that one subpath installs all nine of `@n8n/composables`' declared
+dependencies, transitively. `exports: { "./*": … }` gives you subpath *resolution*; it gives you no
+subpath *dependency scoping*. No bundler, tree-shaker or `sideEffects` flag changes what the
+installer puts on disk.
+
+The chain, then:
+
+```
+@n8n/design-system
+└── @n8n/composables            ← 1 import site, 1 component, 46 lines
+    ├── n8n-workflow            ← type-only, 0 runtime references
+    │   └── @n8n/expression-runtime → isolated-vm  (+ @sentry/node, ssh2, axios, recast, @codemirror/autocomplete)
+    ├── @n8n/api-types          ← type-only, 0 runtime references
+    │   └── n8n-workflow
+    └── @n8n/i18n               ← real runtime import, in useToast only
+        └── n8n-workflow        ← type-only, 0 runtime references
+```
+
+### Measured cost of each edge
+
+Method: scratch `npm install` per tree, npm 11.x, macOS arm64, `--ignore-scripts` on the per-edge
+probes. Size = `du -sm node_modules`. Count = `package-lock.json` `packages` keys minus the root.
+Verified, 2026-08-25.
+
+| Tree | Disk | Packages |
+|---|---|---|
+| `@n8n/design-system@2.35.3` — what a consumer gets today | **351 MB** | **312** |
+| …with the `@n8n/composables` dependency removed | 207 MB | 157 |
+| **Delta — the `@n8n/composables` edge** | **144 MB** | **155** |
+| `@n8n/composables@1.26.3` alone | 162 MB | 192 |
+| …its browser-only deps only (`@vueuse/core`, `lodash`, `vue`, `vue-router`, `@n8n/frontend-utils`, `@n8n/frontend-constants`) | 26 MB | 35 |
+| **Delta — the type-only backend chain inside composables** | **136 MB** | **157** |
+| `@n8n/i18n@2.36.3` alone | 153 MB | 178 |
+| `@n8n/api-types@1.36.3` alone | 136 MB | 157 |
+| `n8n-workflow@2.36.3` alone | 129 MB | 151 |
+| `@n8n/expression-runtime@0.27.1` alone | 52 MB | 78 |
+| `@sentry/node` alone | 57 MB | 33 |
+| `isolated-vm@7.0.1` alone | 21 MB | 2 |
+| `@n8n/tournament` alone | 7 MB | 45 |
+| `@n8n/frontend-utils@0.4.0` alone | 19 MB | 27 |
+| `@n8n/utils@1.44.0` alone | 2 MB | 3 |
+
+Heaviest single packages in today's 351 MB tree: `element-plus` 110 MB, `@sentry/*` 30 MB,
+`isolated-vm` 21 MB, `@opentelemetry/*` 21 MB, `reka-ui` 16 MB, `@tiptap/*` 15 MB,
+`highlight.js` 10 MB.
+
+Three corrections to the premises in N8N-303, all verified:
+
+1. **The measurement differs.** 351 MB / 312 packages here, against the ~400 MB / ~236 packages
+   recorded in N8N-296. Disk figures vary with npm version and platform; the two package counts
+   cannot both be right for the same resolver. Treat this table as the baseline, and re-run the
+   commands above before accepting a fix.
+2. **`isolated-vm` does not require a C++ toolchain on the common platforms.** `7.0.1` ships
+   prebuilt binaries via `node-gyp-build` for `darwin-arm64`, `linux-x64`, `linux-arm64`
+   (glibc and musl) and `win32-x64`; the install used them and compiled nothing. A toolchain is the
+   *fallback* — it fires on `darwin-x64` (absent from the prebuild set) and on any unlisted
+   ABI. The prebuilds are also why the package costs 21 MB: 15 MB of it is binaries for platforms
+   the consumer does not run.
+3. **`isolated-vm` is not the expensive part.** It is 21 MB of the 144 MB the composables edge adds.
+   Removing it alone fixes 15% of the problem.
+
+The cost driver is not size, and not the native addon. It is **three type-only import statements
+declared as runtime dependencies**:
+
+- `packages/frontend/@n8n/composables/src/registries/telemetryRegistry.ts:1,3` — `import type` from
+  `@n8n/api-types` (`ITelemetrySettings`) and `n8n-workflow` (`IDataObject`,
+  `ITelemetryTrackProperties`, `NodeParameterValueType`).
+- `packages/frontend/@n8n/i18n/src/index.ts:2` — `import type` from `n8n-workflow`
+  (`INodeProperties`, `INodePropertyCollection`, `INodePropertyOptions`).
+
+Two of 16 non-test source files in `@n8n/composables` touch the heavy packages. One of 5 in
+`@n8n/i18n`. Seven type identifiers, total.
+
+## Options considered
+
+### Option A — Fix the declarations: sink the 7 types, drop the runtime edges (recommended)
+
+Move the seven type identifiers into a package with no heavy dependencies —
+`@n8n/frontend-constants` (zero dependencies today) is the natural host — and demote `n8n-workflow`
+and `@n8n/api-types` from `dependencies` to `devDependencies` in `@n8n/composables` and `@n8n/i18n`.
+
+The case for it: **this pattern already ships in the same package.** `@n8n/composables` declares
+`@n8n/telemetry` in `devDependencies`, its types are referenced by the published
+`dist/telemetryRegistry.d.mts`, and the package is absent from the installed tree — three external
+installs in N8N-296 built, typechecked and rendered anyway. The mechanism is proven here, not
+borrowed.
+
+It fixes the problem for **every** consumer of `@n8n/composables` and `@n8n/i18n`, not only for
+design-system: `@n8n/stores`, `packages/modules/instance-registry/frontend`, `@n8n/storybook` and any
+future published frontend package inherit the fix. It is a manifest and import change; no component
+behaviour moves, no public component API changes.
+
+Measured, not projected: a tree with `@n8n/composables` and `@n8n/i18n` present and only the
+type-only edges removed installs at **210 MB / 163 packages**, with no `isolated-vm`, no
+`n8n-workflow`, no `@sentry/*` and no `@opentelemetry/*`.
+
+Costs and risks:
+
+- **`skipLibCheck: false` consumers regress.** A demoted `devDependency` leaves the shipped `.d.ts`
+  referencing a package that is not installed. Sinking the seven types is what keeps this from
+  happening — the demotion alone would not. N8N-296 already records 61 errors in 11 shipped `.d.ts`
+  files under `skipLibCheck: false`; this option must not add to that count, and the acceptance test
+  is the existing `typecheck:libcheck` probe.
+- Type identity changes. `@n8n/i18n`'s exported types stop being `n8n-workflow`'s
+  `INodeProperties` and become a structurally identical copy. Structural typing means callers
+  compile; anything relying on nominal identity or on declaration merging does not. In-repo
+  consumers are behind the workspace, so this is caught at typecheck, not at runtime.
+- The seven types now have two homes and can drift. Mitigation: a type-level assertion test in
+  `n8n-workflow` that the sunk copies still match, or generate one from the other.
+- Does not touch `element-plus` (110 MB), so the tree stays large in absolute terms.
+
+Reversibility: **Class 2.** No new public package name, no data migration. Unwinding is re-promoting
+two dependency entries and moving seven types back — days, not weeks, and semver-visible.
+
+### Option B — Sink `useDeviceSupport` out of `@n8n/composables`
+
+Move the 46-line `useDeviceSupport` composable into `@n8n/frontend-utils` (`vue` + `xss`) or into
+design-system itself, and delete `@n8n/composables` from design-system's dependencies.
+
+The case for it: it is the smallest possible change that hits the headline number, and it fixes a
+real layering violation. `@n8n/design-system` is L1 in the frontend-modularization layering; pulling
+an L2 composable package inverts the layers. `useDeviceSupport` has no dependency beyond `vue` —
+`dist/useDeviceSupport.mjs` imports `computed` and `ref` and nothing else — so it does not belong in
+a package that reaches for `n8n-workflow`. 19 files across the repo import it, so a re-export keeps
+the move mechanical.
+
+Measured result: **207 MB / 157 packages** — 3 MB and 6 packages better than Option A.
+
+Costs and risks:
+
+- It fixes design-system only. `@n8n/stores` and the instance-registry frontend keep the 144 MB
+  chain. The next published frontend package hits the same wall.
+- Design-system regains a dependency on `@n8n/composables` the first time a component wants any
+  other composable from it, and the problem returns silently. Enforcement is needed either way, and
+  Option A makes the enforcement unnecessary.
+- If the target is design-system itself, the honest comparison is 207 vs 210 MB. That is not a
+  reason to choose it.
+
+Reversibility: **Class 1.** Move a file back.
+
+### Option C — Invert `useDeviceSupport` behind a consumer-supplied interface
+
+`N8nKeyboardShortcut` takes platform information through `provide`/`inject` or a prop, with a
+default. Design-system declares no dependency for it.
+
+The case for it: it is the correct shape for a design system in general. Platform detection is host
+knowledge, and a component library that reads `navigator.userAgent` directly is untestable in the
+host's own way and wrong inside an iframe or an SSR pass. Reka-ui and design-system both already use
+injection keys, so the pattern is in the codebase.
+
+Costs and risks: it is a public API change to a shipped component for a 46-line internal helper, and
+the default implementation still has to live somewhere — so it does not remove the code, only adds a
+seam. It buys nothing that Option A or B does not, at higher consumer cost. Correct in principle,
+disproportionate here.
+
+Reversibility: Class 2 — a shipped component contract.
+
+### Option D — Make the heavy edge optional
+
+Declare `isolated-vm` an `optionalDependency` of `@n8n/expression-runtime`, and/or `n8n-workflow` an
+optional `peerDependency` of `@n8n/composables`.
+
+The case for it: it is a one-line manifest change per edge, needs no code move, and `optionalDependencies`
+exists for exactly this — a dependency the package can run without.
+
+Costs and risks: it does not work here. `isolated-vm` is 21 MB of the 144 MB; the remaining 123 MB
+is `@sentry/*`, `@opentelemetry/*`, `axios`, `ssh2`, `recast` and `@codemirror/autocomplete`, all
+reached through `n8n-workflow`. And `@n8n/expression-runtime` genuinely cannot run without
+`isolated-vm` — declaring it optional makes the manifest state something false, and moves a hard
+install failure to a soft runtime failure inside the backend, where it matters most. An optional
+`peerDependency` on `n8n-workflow` is closer to honest but still lies about a package whose
+`.d.ts` needs those types; Option A is the same idea done correctly, with the types sunk instead of
+left dangling.
+
+Reversibility: Class 1, but the failure it creates is Class 3 in blast radius.
+
+### Option E — Split `@n8n/composables` into browser-only and n8n-aware halves
+
+`@n8n/composables` (browser-only: 14 of 16 source files) and `@n8n/composables-n8n` (`useToast`,
+`telemetryRegistry`).
+
+The case for it: it is the structurally durable answer, it publishes an explicit layer boundary
+rather than relying on discipline, and it makes the layering rule enforceable by the package graph
+instead of by review.
+
+Costs and risks: a new published package name is a **Class 3** commitment, and it prices at weeks
+against Option A's days. It also solves a problem that only two files have. Worth revisiting if the
+count of n8n-aware composables grows past a handful; not worth it for two.
+
+Reversibility: **Class 3.** A published name is not withdrawn cleanly.
+
+### Option F — Status quo
+
+Document the install cost in the design-system README and move on.
+
+The case for it: nobody outside the monorepo consumes this package today, so the cost is theoretical.
+The team's frontend-modularization roadmap has 4–6 person-weeks of Wave 0 ahead of it, and this is
+not on that critical path.
+
+Costs and risks: the cost is theoretical only until the first external consumer, at which point it
+is a first-impression failure — a UI component library that installs a native addon and an OTel
+distribution reads as unmaintained. Option A is days of work. The asymmetry is the argument against
+waiting.
+
+## Trade-off summary
+
+| | A: fix declarations | B: sink the composable | C: invert | D: optional edge | E: split package | F: status quo |
+|---|---|---|---|---|---|---|
+| Result (disk / packages) | 210 MB / 163 ᵐ | 207 MB / 157 ᵐ | 207 MB / 157 ᵐ | 330 MB / 310 ᵖ | 210 MB / 163 ᵐ | 351 MB / 312 ᵐ |
+| Native addon gone | yes | yes | yes | on disk yes, correctness no | yes | no |
+| Delivery cost | 2–3 days | 0.5–1 day | 3–4 days | 1 hour | 2–3 weeks | 0 |
+| Fixes it for other consumers | **yes** | no | no | partly | yes | no |
+| Operational cost (the 2 a.m. cost) | type drift between two homes | design-system re-acquires the edge unnoticed | consumers must wire a provider | backend fails at runtime, not at install | one more package to version | first external consumer bounces |
+| Reversibility | Class 2 | Class 1 | Class 2 | Class 1 (bad failure mode) | **Class 3** | — |
+| Risk & blast radius | `skipLibCheck: false` consumers | low | shipped component API | **backend correctness** | publishing surface | reputational |
+
+ᵐ measured · ᵖ projected (today's tree minus `isolated-vm`; not installed)
+
+## Recommendation
+
+**Option A**, with **Option B** taken alongside it as cheap layering hygiene.
+
+Option A is the only candidate that removes the cause rather than one of its symptoms. The 144 MB is
+installed because two packages declare a compile-time need as a runtime dependency; the fix is to
+stop declaring it. It fixes every consumer of those two packages at once, the pattern already ships
+in the same package (`@n8n/telemetry` in `devDependencies`), and it stays a two-way door. Option B
+costs half a day on top, closes the layering inversion that let design-system reach into L2 in the
+first place, and takes the number to 207 MB.
+
+**The strongest argument against it:** Option A buys 141 of the 144 MB that Option B buys alone, for
+four times the effort — and Option B is a Class 1 change while Option A is Class 2 and touches
+`@n8n/i18n`, a package with 178 packages of its own transitive weight and consumers throughout the
+frontend. If the goal is only "make design-system installable", B is the disciplined minimum and A
+is scope creep. The recommendation rests on a claim that is not measured: that a second published
+frontend package will hit this same edge. That claim is the thing to argue with.
+
+### Target
+
+| Metric | Today | Target | Stretch |
+|---|---|---|---|
+| Disk | 351 MB | **≤ 215 MB** | ≤ 110 MB |
+| Packages | 312 | **≤ 165** | ≤ 90 |
+| Native addons | 1 (`isolated-vm`) | **0** | 0 |
+| `@sentry/*` + `@opentelemetry/*` packages | 14 | **0** | 0 |
+| Server-only packages (`ssh2`, `axios`, `recast`, `@codemirror/*`) | present | **absent** | absent |
+
+The target is the measured Option A tree plus headroom, not a projection. The zero-count rows are
+the real gate: they are binary, they do not drift with npm versions, and they are the part a consumer
+notices. The stretch column needs `element-plus` (110 MB, 31% of today's tree and 52% of the target
+tree) addressed — a direct design-system dependency, unrelated to this chain, and out of scope here.
+File it separately.
+
+## Open questions
+
+| # | Question | Owner | Resolve by |
+|---|---|---|---|
+| 1 | Where do the 7 sunk types live — `@n8n/frontend-constants`, `@n8n/utils`, or a new types-only package (which makes this Class 3)? | Alex Grozav | at decision |
+| 2 | Is `skipLibCheck: false` a contract we support for external consumers? If yes, Option A must sink the types and cannot merely demote; if no, the demotion alone suffices and this drops to ~1 day. N8N-296 records 61 pre-existing errors, which suggests the answer is already "no". | Alex Grozav | at decision |
+| 3 | Why did N8N-296 measure 236 packages against 312 here? Two resolvers cannot both be right. | sigma | before implementation |
+| 4 | Does any external consumer target `darwin-x64`? It is the one common platform with no `isolated-vm` prebuild, and the only place today's tree needs a compiler. | sigma | before implementation |
+| 5 | Should design-system's dependency on `@n8n/composables` be barred by lint after Option B, so it cannot return unnoticed? | Alex Grozav | after decision |
+
+## Decision log
+
+*Awaiting the Operator's ruling. Per the ADR contract an ADR records a decision already made, so
+none is filed yet. On a ruling for Option A or B the class is 2 or 1 and an ADR follows within a day;
+a ruling for Option E is Class 3 (a new published package name) and its ADR needs explicit Operator
+sign-off in the same record.*
+
+## Reproducing the measurements
+
+```sh
+# baseline
+mkdir base && cd base && npm init -y
+npm install @n8n/design-system@2.35.3 --no-audit --no-fund
+du -sm node_modules
+node -e "console.log(Object.keys(require('./package-lock.json').packages).length-1)"
+
+# which specifiers actually survive into the shipped bundle
+grep -rhoE '@n8n/[a-z-]+(/[a-zA-Z0-9/_-]+)?' node_modules/@n8n/design-system/dist --include='*.js' | sort -u
+
+# proof the heavy packages are referenced only by declarations
+grep -rln 'n8n-workflow' node_modules/@n8n/composables/dist node_modules/@n8n/i18n/dist
+
+# per-edge cost: install each package alone into its own scratch tree, then subtract
+```

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,29 @@
+# RFCs
+
+An RFC makes a decision arguable in writing before it is expensive in code. It carries the problem,
+every live option steelmanned, a trade-off table, one recommendation and the open questions. The RFC
+argues; the Operator decides; an ADR in `docs/adrs/` records the ruling.
+
+## Conventions
+
+- Filename `NNNN-slug.md`, four digits, allocated in order and never reused.
+- `Status:` is one of `Draft`, `In review`, `Decided`, `Superseded by RFC-NNNN`.
+- `Class:` sizes the process — 1 two-way door (a paragraph in the issue is usually enough),
+  2 expensive to reverse (RFC + a 2-day window), 3 one-way door (RFC + a 3-day window + explicit
+  Operator sign-off).
+- The comment window is in the header and is defended. An RFC without a clock is a parking lot.
+- Superseded RFCs stay in the repo with a pointer forward. The archive is the point.
+
+## Index
+
+| # | Title | Status | Class | Decided |
+|---|---|---|---|---|
+| [0001](./0001-design-system-external-install-weight.md) | Cut the external install weight of `@n8n/design-system` | Draft — awaiting decision | 2 | — |
+
+## Note on numbering
+
+This is the first repo-level RFC or ADR archive. Two earlier sequences exist outside it and do not
+share its numbers: `packages/frontend/@n8n/design-system/vite.config.mts:140` cites an unfiled
+`ADR-0002`, and `packages/@n8n/instance-ai/docs/` cites `ADR-002` and `ADR-003` for that package
+only. Neither has a filed record here. When those are backfilled, renumber them into this sequence
+rather than adopting their old numbers.

--- a/packages/frontend/@n8n/design-system/src/__tests__/directive-independence.test.ts
+++ b/packages/frontend/@n8n/design-system/src/__tests__/directive-independence.test.ts
@@ -1,0 +1,148 @@
+import { render, waitFor } from '@testing-library/vue';
+import { config } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+import BlockMessage from '../components/AskAssistantChat/messages/BlockMessage.vue';
+import TextMessage from '../components/AskAssistantChat/messages/TextMessage.vue';
+import CommandBarItem from '../components/N8nCommandBar/CommandBarItem.vue';
+import EmptyState from '../components/N8nEmptyState/EmptyState.vue';
+import InfoAccordion from '../components/N8nInfoAccordion/InfoAccordion.vue';
+import InputLabel from '../components/N8nInputLabel/InputLabel.vue';
+import Notice from '../components/N8nNotice/Notice.vue';
+import Sticky from '../components/N8nSticky/Sticky.vue';
+import Tabs from '../components/N8nTabs/Tabs.vue';
+import Tooltip from '../components/N8nTooltip/Tooltip.vue';
+import type { ChatUI } from '../types/assistant';
+
+/**
+ * Every component that renders text through `v-n8n-html` must render that text
+ * for a consumer who never installed `N8nPlugin`. A missing global directive
+ * used to produce an empty element, with no error and no console warning in a
+ * production build.
+ *
+ * `src/__tests__/setup.ts` installs `N8nPlugin` for the whole suite, which is
+ * what hid the defect. This file renders without it.
+ */
+
+const suitePlugins = config.global.plugins;
+
+beforeAll(() => {
+	config.global.plugins = [];
+});
+afterAll(() => {
+	config.global.plugins = suitePlugins;
+});
+
+beforeEach(() => {
+	setActivePinia(createPinia());
+});
+
+// N8nInputLabel and N8nTabs put their `v-n8n-html` element in the tooltip
+// content slot. The stub renders that slot without the hover choreography, so
+// the assertion stays about the directive and not about Reka UI open state.
+const openTooltip = {
+	N8nTooltip: {
+		template: '<div><slot /><slot name="content" /></div>',
+	},
+};
+
+const assistantMessage = (content: string): ChatUI.TextMessage & { id: string; read: boolean } => ({
+	id: 'msg-1',
+	role: 'assistant',
+	type: 'text',
+	content,
+	read: true,
+});
+
+describe.each([
+	['N8nNotice', () => render(Notice, { props: { content: 'notice content' } }), 'notice content'],
+	[
+		'N8nEmptyState',
+		() => render(EmptyState, { props: { description: 'empty state description' } }),
+		'empty state description',
+	],
+	[
+		'N8nInfoAccordion',
+		() =>
+			render(InfoAccordion, {
+				props: { description: 'accordion description', initiallyExpanded: true },
+			}),
+		'accordion description',
+	],
+	[
+		'N8nTooltip',
+		() =>
+			render(Tooltip, {
+				props: { content: 'tooltip content', visible: true, teleported: false },
+				slots: { default: 'trigger' },
+			}),
+		'tooltip content',
+	],
+	[
+		'N8nInputLabel',
+		() =>
+			render(InputLabel, {
+				props: { label: 'label', tooltipText: 'input label tooltip' },
+				global: { stubs: openTooltip },
+			}),
+		'input label tooltip',
+	],
+	[
+		'N8nTabs',
+		() =>
+			render(Tabs, {
+				props: { options: [{ value: 'a', label: 'A', tooltip: 'tab tooltip' }] },
+				global: { stubs: openTooltip },
+			}),
+		'tab tooltip',
+	],
+	[
+		'N8nSticky',
+		() => render(Sticky, { props: { modelValue: 'note', editMode: true } }),
+		// `sticky.markdownHint` is a link, so the label is the only visible text.
+		'Markdown',
+	],
+	[
+		'N8nCommandBar',
+		() =>
+			render(CommandBarItem, {
+				props: {
+					item: { id: '1', title: 'command', icon: { html: '<span>icon html</span>' } },
+					isSelected: false,
+				},
+			}),
+		'icon html',
+	],
+	[
+		'AskAssistantChat TextMessage',
+		() =>
+			render(TextMessage, {
+				props: { message: assistantMessage('assistant text'), isFirstOfRole: true },
+			}),
+		'assistant text',
+	],
+	[
+		'AskAssistantChat BlockMessage',
+		() =>
+			render(BlockMessage, {
+				props: {
+					message: {
+						id: 'msg-2',
+						role: 'assistant',
+						type: 'block',
+						title: 'title',
+						content: 'block body',
+						read: true,
+					},
+					isFirstOfRole: true,
+				},
+			}),
+		'block body',
+	],
+])('%s without a globally registered directive', (_name, renderComponent, expected) => {
+	it(`renders "${'%s'}" text`.replace('%s', expected), async () => {
+		const { container } = renderComponent();
+		// N8nInfoAccordion expands and Reka UI mounts tooltip content after mount.
+		await waitFor(() => expect(container.textContent).toContain(expected));
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/BlockMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/BlockMessage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import BaseMessage from './BaseMessage.vue';
 import { useMarkdown } from './useMarkdown';
+import { n8nHtml as vN8nHtml } from '../../../directives';
 import type { ChatUI, RatingFeedback } from '../../../types/assistant';
 import BlinkingCursor from '../../BlinkingCursor/BlinkingCursor.vue';
 

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
@@ -4,6 +4,7 @@ import { computed, ref, onMounted, nextTick, watch } from 'vue';
 import BaseMessage from './BaseMessage.vue';
 import { useMarkdown } from './useMarkdown';
 import { useI18n } from '../../../composables/useI18n';
+import { n8nHtml as vN8nHtml } from '../../../directives';
 import type { ChatUI, RatingFeedback } from '../../../types/assistant';
 import BlinkingCursor from '../../BlinkingCursor/BlinkingCursor.vue';
 import N8nButton from '../../N8nButton';

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBarItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBarItem.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 
 import type { CommandBarItem } from './types';
+import { n8nHtml as vN8nHtml } from '../../directives';
 
 const props = defineProps<{
 	item: CommandBarItem;

--- a/packages/frontend/@n8n/design-system/src/components/N8nEmptyState/EmptyState.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nEmptyState/EmptyState.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import EmptyStateIconCards from './EmptyStateIconCards.vue';
 import type { EmptyStateIconCards as EmptyStateIconCardsIcon } from './types';
+import { n8nHtml as vN8nHtml } from '../../directives';
 import type { ButtonVariant } from '../../types/button';
 import N8nButton from '../N8nButton';
 import N8nCallout, { type CalloutTheme } from '../N8nCallout';

--- a/packages/frontend/@n8n/design-system/src/components/N8nInfoAccordion/InfoAccordion.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInfoAccordion/InfoAccordion.vue
@@ -2,6 +2,7 @@
 import { createEventBus, type EventBus } from '@n8n/utils/event-bus';
 import { onMounted, ref } from 'vue';
 
+import { n8nHtml as vN8nHtml } from '../../directives';
 import type { IconColor } from '../../types/icon';
 import N8nIcon from '../N8nIcon';
 import { type IconName } from '../N8nIcon/icons';

--- a/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { n8nHtml as vN8nHtml } from '../../directives';
 import type { TextColor } from '../../types/text';
 import N8nIcon from '../N8nIcon';
 import N8nText from '../N8nText';

--- a/packages/frontend/@n8n/design-system/src/components/N8nNotice/Notice.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNotice/Notice.vue
@@ -3,6 +3,7 @@ import sanitize from 'sanitize-html';
 import { computed, ref, useCssModule } from 'vue';
 
 import N8nText from '../../components/N8nText';
+import { n8nHtml as vN8nHtml } from '../../directives';
 import { uid } from '../../utils';
 
 interface NoticeProps {

--- a/packages/frontend/@n8n/design-system/src/components/N8nSticky/Sticky.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSticky/Sticky.vue
@@ -4,6 +4,7 @@ import { computed, ref, watch } from 'vue';
 import { defaultStickyProps } from './constants';
 import type { StickyProps } from './types';
 import { useI18n } from '../../composables/useI18n';
+import { n8nHtml as vN8nHtml } from '../../directives';
 import {
 	isValidHexColor,
 	adjustColorLightness,

--- a/packages/frontend/@n8n/design-system/src/components/N8nTabs/Tabs.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTabs/Tabs.vue
@@ -2,6 +2,7 @@
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 
+import { n8nHtml as vN8nHtml } from '../../directives';
 import type { TabOptions } from '../../types';
 import N8nIcon from '../N8nIcon';
 import type { TabsProps } from './Tabs.types';

--- a/packages/frontend/@n8n/design-system/src/components/N8nTabs/Tabs.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTabs/Tabs.vue
@@ -2,10 +2,10 @@
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 
+import type { TabsProps } from './Tabs.types';
 import { n8nHtml as vN8nHtml } from '../../directives';
 import type { TabOptions } from '../../types';
 import N8nIcon from '../N8nIcon';
-import type { TabsProps } from './Tabs.types';
 import Tag from '../N8nTag/Tag.vue';
 import N8nTooltip from '../N8nTooltip';
 import PreviewTag from '../PreviewTag/PreviewTag.vue';

--- a/packages/frontend/@n8n/design-system/src/directives/n8n-html.registration.test.ts
+++ b/packages/frontend/@n8n/design-system/src/directives/n8n-html.registration.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `v-n8n-html` renders the text of ten components. A consumer that does not
+ * install `N8nPlugin` used to get an empty element, with no error and no
+ * console warning in a production build — the package's most basic path
+ * failing in silence.
+ *
+ * The fix is local registration: the component imports the directive, so the
+ * import graph carries it and no consumer can miss it. This test keeps that
+ * true for every component added later.
+ */
+
+// vitest runs with the package root as cwd; import.meta.url is an http URL under jsdom.
+const SRC = join(process.cwd(), 'src');
+
+const LOCAL_REGISTRATION = "import { n8nHtml as vN8nHtml } from '<relative>/directives';";
+
+const vueFilesUnder = (dir: string): string[] =>
+	readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) return vueFilesUnder(path);
+		return entry.name.endsWith('.vue') ? [path] : [];
+	});
+
+const scriptOf = (source: string) => source.slice(0, source.indexOf('<template'));
+
+describe('v-n8n-html registration', () => {
+	const users = vueFilesUnder(SRC)
+		.map((path) => ({ path, source: readFileSync(path, 'utf8') }))
+		.filter(({ source }) => source.includes('v-n8n-html'));
+
+	it('finds the components that use the directive', () => {
+		// Guards the walker itself: an empty list would make the check below vacuous.
+		expect(users.length).toBeGreaterThan(0);
+	});
+
+	it.each(users.map(({ path, source }) => [path.slice(SRC.length + 1), source]))(
+		'%s registers the directive locally',
+		(relativePath, source) => {
+			expect(
+				scriptOf(source).includes('vN8nHtml'),
+				`${relativePath} uses v-n8n-html but does not register it.\n` +
+					'Without local registration the element renders empty for any consumer that ' +
+					'did not install N8nPlugin, with no error.\n' +
+					`Add to the script block: ${LOCAL_REGISTRATION}`,
+			).toBe(true);
+		},
+	);
+});

--- a/packages/frontend/@n8n/design-system/src/directives/n8n-html.registration.test.ts
+++ b/packages/frontend/@n8n/design-system/src/directives/n8n-html.registration.test.ts
@@ -24,7 +24,22 @@ const vueFilesUnder = (dir: string): string[] =>
 		return entry.name.endsWith('.vue') ? [path] : [];
 	});
 
-const scriptOf = (source: string) => source.slice(0, source.indexOf('<template'));
+/** Every `<script>` block, in either block order, so a template-first SFC is read too. */
+const scriptOf = (source: string) =>
+	[...source.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/g)].map(([, body]) => body).join('\n');
+
+/** `://` is excluded so a URL in a string is not mistaken for a line comment. */
+const withoutComments = (script: string) =>
+	script.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
+
+/**
+ * The name must be bound by a real `import ... from '...'`. A mention in a comment
+ * or a commented-out import does not register anything, so neither may pass.
+ */
+export const registersDirective = (source: string) =>
+	/\bimport\b[^;]*\bvN8nHtml\b[^;]*\bfrom\b\s*['"][^'"]+['"]/.test(
+		withoutComments(scriptOf(source)),
+	);
 
 describe('v-n8n-html registration', () => {
 	const users = vueFilesUnder(SRC)
@@ -40,7 +55,7 @@ describe('v-n8n-html registration', () => {
 		'%s registers the directive locally',
 		(relativePath, source) => {
 			expect(
-				scriptOf(source).includes('vN8nHtml'),
+				registersDirective(source),
 				`${relativePath} uses v-n8n-html but does not register it.\n` +
 					'Without local registration the element renders empty for any consumer that ' +
 					'did not install N8nPlugin, with no error.\n' +
@@ -48,4 +63,41 @@ describe('v-n8n-html registration', () => {
 			).toBe(true);
 		},
 	);
+});
+
+describe('registersDirective', () => {
+	const IMPORT = "import { n8nHtml as vN8nHtml } from '../../directives';";
+	const TEMPLATE = '<template><span v-n8n-html="text" /></template>';
+
+	it.each([
+		['script first', `<script setup lang="ts">\n${IMPORT}\n</script>\n${TEMPLATE}`],
+		['template first', `${TEMPLATE}\n<script setup lang="ts">\n${IMPORT}\n</script>`],
+		[
+			'two script blocks',
+			`<script lang="ts">\nexport default {};\n</script>\n<script setup lang="ts">\n${IMPORT}\n</script>\n${TEMPLATE}`,
+		],
+		[
+			'multi-line import',
+			`<script setup lang="ts">\nimport {\n\tn8nHtml as vN8nHtml,\n} from '../../directives';\n</script>\n${TEMPLATE}`,
+		],
+	])('accepts a real import (%s)', (_name, source) => {
+		expect(registersDirective(source)).toBe(true);
+	});
+
+	it.each([
+		['no script block', TEMPLATE],
+		['line-commented import', `<script setup lang="ts">\n// ${IMPORT}\n</script>\n${TEMPLATE}`],
+		['block-commented import', `<script setup lang="ts">\n/* ${IMPORT} */\n</script>\n${TEMPLATE}`],
+		[
+			'a mention of the name only',
+			`<script setup lang="ts">\n// TODO: register vN8nHtml here later\n</script>\n${TEMPLATE}`,
+		],
+	])('rejects a non-import (%s)', (_name, source) => {
+		expect(registersDirective(source)).toBe(false);
+	});
+
+	it('is not fooled by a URL in a string', () => {
+		const source = `<script setup lang="ts">\nconst docs = 'https://n8n.io';\n${IMPORT}\n</script>\n${TEMPLATE}`;
+		expect(registersDirective(source)).toBe(true);
+	});
 });

--- a/packages/frontend/@n8n/design-system/src/directives/n8n-html.test.ts
+++ b/packages/frontend/@n8n/design-system/src/directives/n8n-html.test.ts
@@ -28,6 +28,18 @@ describe('Directive n8n-html', () => {
 		);
 	});
 
+	it('should render nothing for a nullish value', async () => {
+		const { html } = render(TestComponent, {
+			props: { html: undefined },
+			global: {
+				directives: {
+					n8nHtml,
+				},
+			},
+		});
+		expect(html()).toBe('<div></div>');
+	});
+
 	it('should not touch safe html', async () => {
 		const { html } = render(TestComponent, {
 			props: {

--- a/packages/frontend/@n8n/design-system/src/directives/n8n-html.ts
+++ b/packages/frontend/@n8n/design-system/src/directives/n8n-html.ts
@@ -7,6 +7,13 @@ import type { DirectiveBinding, FunctionDirective } from 'vue';
  * Usage:
  * In your Vue template, use the directive `v-n8n-html` passing the unsafe HTML.
  *
+ * Register it locally in the component that uses it:
+ * `import { n8nHtml as vN8nHtml } from '../../directives';`
+ *
+ * Do not rely on the global registration from `N8nPlugin`. A consumer that
+ * installed no plugin gets an empty element, with no error and no console
+ * warning in a production build. `n8n-html.registration.test.ts` guards this.
+ *
  * Example:
  * <p v-n8n-html="'<a href="https://site.com" onclick="alert(1)">link</a>'">
  *
@@ -28,11 +35,14 @@ const configuredSanitize = (html: string) =>
 		},
 	});
 
-export const n8nHtml: FunctionDirective<HTMLElement, string> = (
+// Nullish is accepted because the bound value is usually an optional prop.
+// Local registration type-checks the binding, and `string` alone would push a
+// `?? ''` onto every call site instead of handling it once, here.
+export const n8nHtml: FunctionDirective<HTMLElement, string | null | undefined> = (
 	el: HTMLElement,
-	binding: DirectiveBinding<string>,
+	binding: DirectiveBinding<string | null | undefined>,
 ) => {
 	if (binding.value !== binding.oldValue) {
-		el.innerHTML = configuredSanitize(binding.value);
+		el.innerHTML = configuredSanitize(binding.value ?? '');
 	}
 };


### PR DESCRIPTION
## Summary

Ten `@n8n/design-system` components render their text through `v-n8n-html`. The directive was only registered globally, by `N8nPlugin`. A consumer that did not install the plugin got an **empty element** — no error, and no console warning in a production build. My first external build of the package showed a blank `N8nNotice` and a blank `N8nEmptyState` description, with nothing to search for. The repo could not see it, because `editor-ui` installs the plugin.

### Technique: local registration (acceptance option 2)

Each component now imports the directive, so the import graph carries it and no consumer can miss it:

```ts
import { n8nHtml as vN8nHtml } from '../../directives';
```

`N8nTooltip` already did this, and `N8nIcon` does the same for `v-svg-content`. The other nine components follow the pattern that was already in the package — nine added lines, no new API.

I did not pick the warn-once option (3). A warning tells the consumer about a failure that still happens; local registration removes the failure. I did not remove the global registration either: `editor-ui` uses `v-n8n-html` in its own templates, so `N8nPlugin` keeps registering it.

### A type mismatch the fix surfaced

Local registration type-checks the bound value, which flagged three call sites that pass an optional prop (`InfoAccordion` ×2, `Tabs` ×1). **Verified:** `sanitize-html` returns `''` for `undefined` and `null`, so this was a type mismatch and not a second render defect. The directive now accepts nullish and handles it once, instead of a `?? ''` on every call site.

### Tests — two layers, failing for different reasons

| File | What it catches |
| --- | --- |
| `src/__tests__/directive-independence.test.ts` | Renders **all ten** components with `config.global.plugins` emptied and asserts the text is present. The consumer's view. On master, 9 of 10 render empty. |
| `src/directives/n8n-html.registration.test.ts` | Walks every `.vue` file and fails when one uses `v-n8n-html` without importing it. Covers components added later, which a fixed list of render cases cannot. |

The render test also records why the defect survived for so long: `src/__tests__/setup.ts` installs `N8nPlugin` for the whole suite, so every other test in the package sees the directive.

The structural test names the file and the fix:

```
AssertionError: components/N8nNotice/Notice.vue uses v-n8n-html but does not register it.
Without local registration the element renders empty for any consumer that did not
install N8nPlugin, with no error.
Add to the script block: import { n8nHtml as vN8nHtml } from '<relative>/directives';
```

## How to test

```bash
pnpm --filter @n8n/design-system test    # 129 files, 1543 tests
pnpm --filter @n8n/design-system typecheck
pnpm --filter @n8n/design-system lint
```

To see the defect, check out the parent commit and run the render test:

```bash
git checkout HEAD~1 -- packages/frontend/@n8n/design-system/src/components
pnpm --filter @n8n/design-system vitest run src/__tests__/directive-independence.test.ts
# 9 failed | 1 passed — the pass is N8nTooltip, which was already correct
```

Also verified locally: `turbo run typecheck --filter=n8n-editor-ui --filter=@n8n/storybook` passes, and `turbo run build --filter=@n8n/design-system` passes. (The `v2/.../ComboboxItem.vue` diagnostic in the build log is pre-existing on master, unrelated to this change.)

## Related Linear tickets, Github issues, and Community forum posts

Found by the out-of-repo consumption verification in #37011 (commit `8e65884`). Multica issue N8N-302.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- The rule lives in the directive's docblock and is enforced by a test; consumer-facing setup docs are covered by the N8N-300 PR. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

