### PR TITLE
fix(editor): Fix the published type defects in @n8n/design-system (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/README.md
+++ b/packages/frontend/@n8n/design-system/README.md
@@ -46,6 +46,19 @@ pnpm build:theme
 pnpm watch:theme
 ```
 
+### Check the declarations this package ships
+
+```
+pnpm typecheck:libcheck
+```
+
+`build` runs this after the emit. Consumers compile with `skipLibCheck: true`, so
+a broken `.d.ts` here is invisible to them until they turn it off — at which point
+they cannot fix it. The check compiles `dist/**/*.d.ts` with `skipLibCheck: false`
+and no `paths` mappings, so the declarations resolve their imports the way an
+installed consumer would. It fails on errors in this package's files only, and
+counts the third-party ones (`--verbose` lists them).
+
 ## License
 
 You can find the license information [here](https://github.com/n8n-io/n8n/blob/master/README.md#license)

--- a/packages/frontend/@n8n/design-system/package.json
+++ b/packages/frontend/@n8n/design-system/package.json
@@ -35,9 +35,10 @@
   "scripts": {
     "dev": "pnpm run --dir=../storybook dev",
     "clean": "rimraf dist .turbo",
-    "build": "vite build",
-    "build:unchecked": "pnpm run build",
+    "build": "vite build && pnpm run typecheck:libcheck",
+    "build:unchecked": "vite build",
     "typecheck": "vue-tsc --noEmit",
+    "typecheck:libcheck": "node scripts/check-shipped-types.mjs",
     "typecheck:watch": "vue-tsc --watch --noEmit",
     "test": "vitest run",
     "test:changed": "janitor test-scoped",

--- a/packages/frontend/@n8n/design-system/scripts/check-shipped-types.mjs
+++ b/packages/frontend/@n8n/design-system/scripts/check-shipped-types.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Typechecks the declarations this package emits, and fails on the ones it owns.
+ *
+ * Consumers compile with `skipLibCheck: true`, so a broken `.d.ts` here is
+ * invisible to them until they turn it off — at which point it is unfixable from
+ * their side. This runs as part of `build`, so a regression fails in the only
+ * place that can still fix it.
+ *
+ * `skipLibCheck: false` checks every `.d.ts` in the program, so it also reports
+ * declarations this repo does not write: element-plus 2.4.3 against a newer vue
+ * and csstype, `@vueuse/core` wanting `@types/web-bluetooth`, and a stale
+ * `@types/markdown-it-link-attributes`. Those are dependency-upgrade work, not a
+ * broken package contract, and gating on them would leave the check permanently
+ * red — which is how a check stops being read.
+ *
+ * So the gate is scoped: an error in a file inside this package fails the build;
+ * anything else is counted, and listed under `--verbose`. Third-party noise
+ * going up or down never changes the verdict.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const distDir = resolve(packageDir, 'dist');
+
+if (!existsSync(distDir)) {
+	console.error(`No dist at ${distDir}. Run the build first.`);
+	process.exit(1);
+}
+
+// The local bin rather than `vue-tsc` on PATH, so the script also runs directly
+// (`node scripts/check-shipped-types.mjs`), not only through a pnpm script.
+// vue-tsc rather than tsc: the emitted declarations import each other through
+// `./Foo.vue` specifiers, which plain tsc does not resolve.
+const localBin = resolve(packageDir, 'node_modules/.bin/vue-tsc');
+const { stdout = '', status } = spawnSync(
+	existsSync(localBin) ? localBin : 'vue-tsc',
+	['--noEmit', '-p', 'tsconfig.libcheck.json'],
+	{ cwd: packageDir, encoding: 'utf8' },
+);
+
+/** `path(line,col): error TSxxxx: message`, plus its indented continuation lines. */
+const diagnostics = [];
+for (const line of stdout.split('\n')) {
+	const head = /^(?<file>[^(]+)\((?<line>\d+),(?<col>\d+)\): error (?<code>TS\d+): /.exec(line);
+	if (head) {
+		diagnostics.push({ file: resolve(packageDir, head.groups.file), text: line });
+	} else if (line.trim() && diagnostics.length) {
+		diagnostics.at(-1).text += `\n${line}`;
+	}
+}
+
+const isOurs = (file) => file.startsWith(`${packageDir}/`) && !file.includes('/node_modules/');
+const ours = diagnostics.filter((d) => isOurs(d.file));
+const theirs = diagnostics.filter((d) => !isOurs(d.file));
+
+if (process.argv.includes('--verbose')) {
+	for (const d of theirs) console.log(d.text);
+}
+
+if (ours.length) {
+	for (const d of ours) console.error(d.text);
+	console.error(
+		`\n${ours.length} error(s) in the declarations this package ships. ` +
+			'Fix the source, or add a rewrite in vite.config.mts.',
+	);
+	process.exit(1);
+}
+
+console.log(
+	'Shipped declarations: no errors of our own ' +
+		`(${theirs.length} in third-party declarations, ignored — pass --verbose to list them).`,
+);
+
+// vue-tsc exits non-zero for the ignored errors, and 0 means it ran clean;
+// anything else is a crash we must not swallow.
+if (status !== 0 && !diagnostics.length) {
+	console.error(stdout);
+	console.error(`vue-tsc exited ${status} without reporting a diagnostic.`);
+	process.exit(1);
+}

--- a/packages/frontend/@n8n/design-system/src/components/N8nActionPill/ActionPill.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionPill/ActionPill.vue
@@ -30,7 +30,7 @@ withDefaults(
 );
 
 defineEmits<{
-	click: [event: MouseEvent];
+	click: [payload: MouseEvent];
 }>();
 
 const hovered = ref(false);

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatInput/ChatInput.vue
@@ -64,8 +64,8 @@ const emit = defineEmits<{
 	'update:modelValue': [value: string];
 	submit: [];
 	stop: [];
-	focus: [event: FocusEvent];
-	blur: [event: FocusEvent];
+	focus: [payload: FocusEvent];
+	blur: [payload: FocusEvent];
 	'upgrade-click': [];
 }>();
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nDataTableServer/N8nDataTableServer.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDataTableServer/N8nDataTableServer.vue
@@ -90,7 +90,7 @@ const emit = defineEmits<{
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	'update:options': [payload: TableOptions];
 	// eslint-disable-next-line @typescript-eslint/naming-convention
-	'click:row': [event: MouseEvent, payload: { item: T }];
+	'click:row': [payload: MouseEvent, row: { item: T }];
 }>();
 
 const data = shallowRef<T[]>(props.items.concat());

--- a/packages/frontend/@n8n/design-system/src/components/N8nDialog/Dialog.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDialog/Dialog.vue
@@ -82,10 +82,10 @@ export interface DialogProps {
 }
 
 export interface DialogEmits {
-	escapeKeyDown: [event: KeyboardEvent];
-	interactOutside: [event: Event];
-	openAutoFocus: [event: Event];
-	closeAutoFocus: [event: Event];
+	escapeKeyDown: [payload: KeyboardEvent];
+	interactOutside: [payload: Event];
+	openAutoFocus: [payload: Event];
+	closeAutoFocus: [payload: Event];
 	'update:open': [value: boolean];
 }
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogContent.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDialog/DialogContent.vue
@@ -54,10 +54,10 @@ export interface DialogContentProps {
 }
 
 export interface DialogContentEmits {
-	escapeKeyDown: [event: KeyboardEvent];
-	interactOutside: [event: Event];
-	openAutoFocus: [event: Event];
-	closeAutoFocus: [event: Event];
+	escapeKeyDown: [payload: KeyboardEvent];
+	interactOutside: [payload: Event];
+	openAutoFocus: [payload: Event];
+	closeAutoFocus: [payload: Event];
 }
 
 const props = withDefaults(defineProps<DialogContentProps>(), {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
 	select: [value: T];
 	search: [searchTerm: string, itemId: T];
 	'update:subMenuOpen': [open: boolean];
-	pointermove: [event: PointerEvent];
+	pointermove: [payload: PointerEvent];
 }>();
 
 const $style = useCssModule();

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuSearch.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuSearch.vue
@@ -17,7 +17,7 @@ withDefaults(
 
 const emit = defineEmits<{
 	'update:modelValue': [value: string];
-	keydown: [event: KeyboardEvent];
+	keydown: [payload: KeyboardEvent];
 }>();
 
 const slots = defineSlots<{

--- a/packages/frontend/@n8n/design-system/src/components/N8nHeaderAction/HeaderAction.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHeaderAction/HeaderAction.vue
@@ -34,7 +34,7 @@ withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	click: [event: MouseEvent];
+	click: [payload: MouseEvent];
 }>();
 </script>
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.types.ts
@@ -34,10 +34,10 @@ export interface InputProps {
 export interface InputEmits {
 	'update:modelValue': [value: string];
 	input: [value: string];
-	focus: [event: FocusEvent];
-	blur: [event: FocusEvent];
-	keydown: [event: KeyboardEvent];
-	mousedown: [event: MouseEvent];
+	focus: [payload: FocusEvent];
+	blur: [payload: FocusEvent];
+	keydown: [payload: KeyboardEvent];
+	mousedown: [payload: MouseEvent];
 }
 
 export interface InputSlots {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -8,6 +8,7 @@ import { computed, ref } from 'vue';
 import type { IWhiteList } from 'xss';
 import xss from 'xss';
 
+import type { TaskListsConfig } from './taskLists';
 import { markdownYoutubeEmbed, YOUTUBE_EMBED_SRC_REGEX, type YoutubeEmbedConfig } from './youtube';
 import { toggleCheckbox, serializeAttr } from '../../utils/markdown';
 import N8nLoading from '../N8nLoading';
@@ -20,7 +21,7 @@ interface IImage {
 interface Options {
 	markdown: MarkdownOptions;
 	linkAttributes: markdownLink.Config;
-	tasklists: markdownTaskLists.Config;
+	tasklists: TaskListsConfig;
 	youtube: YoutubeEmbedConfig;
 }
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/taskLists.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/taskLists.ts
@@ -1,0 +1,14 @@
+/**
+ * `markdown-it-task-lists` publishes no types, and DefinitelyTyped has none, so
+ * `src/shims-modules.d.ts` types it with an ambient `declare module`. Ambient
+ * declarations do not reach `dist` — `vite-plugin-dts` emits only module files —
+ * so a public prop type that names the shim's `Config` ships a dangling
+ * reference. This interface is the same shape, in a module the build emits.
+ *
+ * @see https://github.com/revin/markdown-it-task-lists#usage
+ */
+export interface TaskListsConfig {
+	enabled?: boolean;
+	label?: boolean;
+	labelAfter?: boolean;
+}

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.types.ts
@@ -19,7 +19,7 @@ export type N8nMarkdownEditorProps = {
 export type N8nMarkdownEditorEmits = {
 	'update:modelValue': [value: string];
 	input: [value: string];
-	focus: [event: FocusEvent];
+	focus: [payload: FocusEvent];
 	blur: [value: string, event: FocusEvent];
 	ready: [editor: Editor];
 };

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsRow/SettingsRow.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsRow/SettingsRow.vue
@@ -84,7 +84,7 @@ const props = withDefaults(defineProps<SettingsRowProps>(), {
 });
 
 const emit = defineEmits<{
-	click: [event: MouseEvent | KeyboardEvent];
+	click: [payload: MouseEvent | KeyboardEvent];
 }>();
 
 // Declared rather than inferred from `useSlots()`: `slots` is read by a computed

--- a/packages/frontend/@n8n/design-system/src/plugin.ts
+++ b/packages/frontend/@n8n/design-system/src/plugin.ts
@@ -4,7 +4,13 @@ import * as directives from './directives';
 
 export interface N8nPluginOptions {}
 
-export const N8nPlugin: Plugin<N8nPluginOptions> = {
+/**
+ * `Plugin<Options>` reads a non-array `Options` as a single required argument, so
+ * `Plugin<N8nPluginOptions>` forces every caller to write `app.use(N8nPlugin, {})`.
+ * The tuple form makes the argument optional, which is what `app.use(N8nPlugin)`
+ * needs.
+ */
+export const N8nPlugin: Plugin<[options?: N8nPluginOptions]> = {
 	install: (app) => {
 		for (const [name, directive] of Object.entries(directives)) {
 			app.directive(name, directive);

--- a/packages/frontend/@n8n/design-system/src/shims-modules.d.ts
+++ b/packages/frontend/@n8n/design-system/src/shims-modules.d.ts
@@ -1,15 +1,11 @@
 declare module 'markdown-it-task-lists' {
 	import type { PluginWithOptions } from 'markdown-it';
 
-	declare namespace markdownItTaskLists {
-		interface Config {
-			enabled?: boolean;
-			label?: boolean;
-			labelAfter?: boolean;
-		}
-	}
+	// The option shape lives in an emitted module, because public prop types name
+	// it and this file never reaches `dist`.
+	import type { TaskListsConfig } from './components/N8nMarkdown/taskLists';
 
-	declare const markdownItTaskLists: PluginWithOptions<markdownItTaskLists.Config>;
+	declare const markdownItTaskLists: PluginWithOptions<TaskListsConfig>;
 
 	export = markdownItTaskLists;
 }

--- a/packages/frontend/@n8n/design-system/src/v2/components/Checkbox/Checkbox.types.ts
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Checkbox/Checkbox.types.ts
@@ -13,5 +13,5 @@ export type CheckboxSlots = {
 };
 
 export type CheckboxEmits = {
-	change: [event: Event];
+	change: [payload: Event];
 };

--- a/packages/frontend/@n8n/design-system/src/v2/components/InputNumber/InputNumber.types.ts
+++ b/packages/frontend/@n8n/design-system/src/v2/components/InputNumber/InputNumber.types.ts
@@ -13,8 +13,8 @@ export type InputNumberProps = Omit<NumberFieldRootProps, 'formatOptions'> & {
 };
 
 export type InputNumberEmits = NumberFieldRootEmits & {
-	focus: [event: FocusEvent];
-	blur: [event: FocusEvent];
+	focus: [payload: FocusEvent];
+	blur: [payload: FocusEvent];
 };
 
 export type InputNumberControlSlotProps = {

--- a/packages/frontend/@n8n/design-system/tsconfig.libcheck.json
+++ b/packages/frontend/@n8n/design-system/tsconfig.libcheck.json
@@ -1,0 +1,22 @@
+{
+	// Typechecks the declarations this package emits, from the package itself —
+	// deliberately without the `paths` mappings the other configs carry, so
+	// `dist/**/*.d.ts` resolves its imports the way an installed consumer would:
+	// `vue` and the sibling `@n8n/*` packages through node, and nothing through
+	// `src`. `skipLibCheck: false` is the whole point; a real app leaves it on and
+	// therefore never sees these errors until it turns it off.
+	//
+	// Run through `scripts/check-shipped-types.mjs`, which scopes the verdict to
+	// this package's own files. Never extended by another config.
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
+		"types": [],
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": false
+	},
+	"include": ["dist/**/*.d.ts"]
+}

--- a/packages/frontend/@n8n/design-system/vite.config.mts
+++ b/packages/frontend/@n8n/design-system/vite.config.mts
@@ -36,6 +36,62 @@ const externalPackages = [
 const isExternal = (id: string) =>
 	externalPackages.some((name) => id === name || id.startsWith(`${name}/`));
 
+/**
+ * Two rewrites over the declarations `vite-plugin-dts` emits. Both target names
+ * TypeScript prints when it expands a full component instance type — which
+ * happens wherever a component exposes a template ref — and both produce
+ * declarations that no consumer can compile with `skipLibCheck: false`.
+ *
+ * 1. `OnCleanup` is declared in `@vue/reactivity` and only re-exported through
+ *    `@vue/runtime-core`, so TypeScript prints the declaring package. `vue` does
+ *    not re-export the name, and `@vue/reactivity` is not a dependency of this
+ *    package, so the reference resolves nowhere (TS2307, 18 errors over 11
+ *    files). The structural type is identical:
+ *    `export type OnCleanup = (cleanupFn: () => void) => void`.
+ *
+ * 2. `GlobalComponents` and `GlobalDirectives` are augmentable interfaces, so
+ *    they have no index signature and fail the `Record<string, Component>` and
+ *    `Record<string, Directive>` constraints TypeScript itself printed them into
+ *    (TS2344, 9 + 9 errors). Both parameters carry the component's own template
+ *    scope, which no consumer reads, so the constraints themselves are the
+ *    honest replacements.
+ *
+ * The alternative — narrowing every `defineExpose` that leaks an instance type —
+ * removes the expansions at the source. It is the better end state and a much
+ * larger change; `scripts/check-shipped-types.mjs` holds the line either way.
+ */
+const REWRITES = [
+	{
+		from: /import\('@vue\/reactivity'\)\.OnCleanup/g,
+		to: '((cleanupFn: () => void) => void)',
+	},
+	{
+		from: /import\('vue'\)\.GlobalComponents/g,
+		to: "Record<string, import('vue').Component>",
+	},
+	{
+		from: /import\('vue'\)\.GlobalDirectives/g,
+		to: "Record<string, import('vue').Directive>",
+	},
+] as const;
+
+function rewriteEmittedDeclaration(filePath: string, content: string) {
+	let rewritten = content;
+	for (const { from, to } of REWRITES) rewritten = rewritten.replace(from, to);
+
+	// A new name from a package we do not declare would ship the same broken
+	// reference as `OnCleanup` did, and silently. Fail the build instead.
+	const leak = /import\('(@vue\/(?!runtime-core)[^']+)'\)/.exec(rewritten);
+	if (leak) {
+		throw new Error(
+			`${filePath} names "${leak[1]}", which this package does not depend on. ` +
+				'Add a rewrite in vite.config.mts, or declare the dependency.',
+		);
+	}
+
+	return rewritten === content ? undefined : { content: rewritten };
+}
+
 /** Emit stylesheets at the dist root, everything else under `assets/`. */
 const assetFileNames = (name: string) => (asset: { names?: string[] }) =>
 	asset.names?.[0]?.endsWith('.css') ? name : 'assets/[name][extname]';
@@ -140,6 +196,7 @@ export default mergeConfig(
 				// module specifiers and leaves the imports dangling. Rejected in ADR-0002.
 				rollupTypes: false,
 				entryRoot: resolve(__dirname, 'src'),
+				beforeWriteFile: rewriteEmittedDeclaration,
 			}),
 		],
 		resolve: {

--- a/packages/frontend/@n8n/storybook/.storybook/preview.ts
+++ b/packages/frontend/@n8n/storybook/.storybook/preview.ts
@@ -35,7 +35,7 @@ setup((app) => {
 		locale: lang,
 	});
 
-	app.use(N8nPlugin, {});
+	app.use(N8nPlugin);
 });
 
 export const parameters = {

--- a/packages/frontend/editor-ui/src/app/plugins/components.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/components.ts
@@ -10,7 +10,7 @@ export const GlobalComponentsPlugin: Plugin = {
 	install(app) {
 		const messageService = useMessage();
 
-		app.use(N8nPlugin, {});
+		app.use(N8nPlugin);
 
 		app.use(ElLoading);
 


### PR DESCRIPTION
## Summary

Fixes the five type defects in what `@n8n/design-system` publishes, and gates its build on the declarations it emits.

Supersedes and closes #37018, which targeted the `design-system-consumer` harness branch. That harness is a temporary test and never merges, so its base could never merge either, and the gate could not live in it. This PR targets `master`, touches only `@n8n/design-system` (plus dropping the `app.use(N8nPlugin, {})` workaround in its two in-repo consumers), and the gate now lives inside the package it protects.

| # | Defect | Errors | Fix |
| - | ------ | ------ | --- |
| 1 | `app.use(N8nPlugin)` did not typecheck | breaks every consumer | `Plugin<[options?: N8nPluginOptions]>` — `Plugin<Options>` only reads `Options` as a rest tuple when it is an array type, so the object form made the argument required |
| 2 | `@vue/reactivity` named by the shipped types | 18 × TS2307 | `OnCleanup` is declared there and only re-exported through `@vue/runtime-core`; rewritten to its structural type after the emit |
| 3 | `event` as an emit tuple label | 48 × TS2300 | `focus: [event: FocusEvent]` emits `(event: "focus", event: FocusEvent) => void`; all 24 labels are now `payload` |
| 4 | `markdown-it-task-lists` option type unreachable | TS7016 | the shape moves from the ambient shim (never emitted) into `N8nMarkdown/taskLists.ts`, which the build emits |
| 5 | `GlobalComponents` / `GlobalDirectives` fail their own constraints | 9 + 9 × TS2344 | augmentable interfaces carry no index signature; rewritten to the constraints themselves |

Defects 2 and 5 are unsoundness in what vue-tsc prints, not in the source, so they are corrected in a `beforeWriteFile` rewrite in `vite.config.mts`. That hook also fails the build when a new undeclared `@vue/*` package appears in the output, so the next leak is not silent. Narrowing the `defineExpose` calls that leak whole component instance types would remove the expansions at the source — the better end state, and a much larger change.

### The gate

`scripts/check-shipped-types.mjs` + `tsconfig.libcheck.json` compile `dist/**/*.d.ts` with `skipLibCheck: false` and **no** `paths` mappings, so the declarations resolve their imports the way an installed consumer would. It runs as part of `build` — consumers compile with `skipLibCheck: true`, so a broken `.d.ts` is invisible to them until they turn it off, at which point they cannot fix it. Cost: ~5s, because it compiles only the emitted declarations. `build:unchecked` skips it and now earns its name.

The verdict is scoped on purpose. `skipLibCheck: false` also reports 50 errors in declarations this repo does not write — element-plus 2.4.3 against a newer vue and csstype, `@vueuse/core` wanting `@types/web-bluetooth`, a stale `@types/markdown-it-link-attributes`. Those are dependency-upgrade work; gating on them would leave the check permanently red, which is how a check stops being read. It fails on errors in this package's files only and counts the rest (`--verbose` lists them).

## How to test

```sh
pnpm --filter @n8n/design-system build          # the gate runs at the end
pnpm --filter @n8n/design-system typecheck:libcheck --verbose
```

Before: 76 errors in the shipped declarations. After: 0.

The gate was verified to catch every defect class from its new home, not just to pass:

| Reverted | Gate reports |
| -------- | ------------ |
| the `REWRITES` block | 18 × TS2307, 11 × TS2344 |
| one `payload` label back to `event` | 10 × TS2300 |
| `tasklists: TaskListsConfig` back to the ambient shim's `Config` | TS2503 in `Markdown.vue.d.ts` |
| an injected `export type Broken = NoSuchTypeAtAll;` in `dist` | TS2304 |

Also green: `@n8n/design-system` typecheck, lint and 1521 unit tests; `n8n-editor-ui` and `@n8n/storybook` typecheck.

## Related Linear tickets, Github issues, and Community forum posts

Closes #37018.

Touches the same package as #37025, on disjoint files.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

