### PR TITLE
feat(Execute Sub-workflow Node)!: Remove "Run once for each item" mode

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.test.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.test.ts
@@ -23,6 +23,7 @@ describe('ExecuteWorkflow', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		executeFunctions.getInputData.mockReturnValue([{ json: { key: 'value' } }]);
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3, parameters: {} } as INode);
 		executeFunctions.getWorkflowDataProxy.mockReturnValue({
 			$workflow: { id: 'workflowId' },
 			$execution: { id: 'executionId' },
@@ -55,60 +56,25 @@ describe('ExecuteWorkflow', () => {
 		expect(mappingPatterns).toContain('convertFieldsToString: true');
 	});
 
-	test('should execute workflow in "each" mode and wait for sub-workflow completion', async () => {
+	test('should throw when a node still carries the removed "each" mode', async () => {
 		executeFunctions.getNodeParameter
 			.mockReturnValueOnce('database') // source
-			.mockReturnValueOnce('each') // mode
 			.mockReturnValueOnce({}) // workflowInputs.value
 			.mockReturnValueOnce([]) // workflowInputs.schema
-			.mockReturnValueOnce(true); // waitForSubWorkflow
+			.mockReturnValueOnce('each'); // mode
 
-		executeFunctions.getInputData.mockReturnValue([{ json: { key: 'value' } }]);
-		executeFunctions.getWorkflowDataProxy.mockReturnValue({
-			$workflow: { id: 'workflowId' },
-			$execution: { id: 'executionId' },
-		} as unknown as IWorkflowDataProxyData);
-		(getWorkflowInfo as Mock).mockResolvedValue({ id: 'subWorkflowId' });
-		(executeFunctions.executeWorkflow as Mock).mockResolvedValue({
-			executionId: 'subExecutionId',
-			data: [[{ json: { key: 'subValue' } }]],
-		});
-
-		const result = await executeWorkflow.execute.call(executeFunctions);
-
-		expect(result).toEqual([
-			[
-				{
-					json: { key: 'subValue' },
-					pairedItem: { item: 0 },
-					metadata: {
-						subExecution: { workflowId: 'subWorkflowId', executionId: 'subExecutionId' },
-					},
-				},
-			],
-		]);
-
-		// Verify shouldResume is set correctly
-		expect(executeFunctions.executeWorkflow).toHaveBeenCalledWith(
-			{ id: 'subWorkflowId' },
-			[{ json: { key: 'value' }, index: 0, pairedItem: { item: 0 }, binary: undefined }],
-			undefined,
-			{
-				parentExecution: {
-					executionId: 'executionId',
-					workflowId: 'workflowId',
-					shouldResume: true,
-				},
-			},
+		await expect(executeWorkflow.execute.call(executeFunctions)).rejects.toThrow(
+			'The "Run once for each item" mode is no longer available',
 		);
+		expect(executeFunctions.executeWorkflow).not.toHaveBeenCalled();
 	});
 
 	test('should execute workflow in "once" mode and not wait for sub-workflow completion', async () => {
 		executeFunctions.getNodeParameter
 			.mockReturnValueOnce('database') // source
-			.mockReturnValueOnce('once') // mode
 			.mockReturnValueOnce({}) // workflowInputs.value
 			.mockReturnValueOnce([]) // workflowInputs.schema
+			.mockReturnValueOnce('once') // mode
 			.mockReturnValueOnce(false); // waitForSubWorkflow
 
 		executeFunctions.getInputData.mockReturnValue([{ json: { key: 'value' } }]);
@@ -141,42 +107,13 @@ describe('ExecuteWorkflow', () => {
 		);
 	});
 
-	test('should handle errors and continue on fail, no items, < 1.3 version', async () => {
+	test('should handle errors and continue on fail in "once" mode', async () => {
 		executeFunctions.getNodeParameter
 			.mockReturnValueOnce('database') // source
-			.mockReturnValueOnce('each') // mode
 			.mockReturnValueOnce({}) // workflowInputs.value
 			.mockReturnValueOnce([]) // workflowInputs.schema
+			.mockReturnValueOnce('once') // mode
 			.mockReturnValueOnce(true); // waitForSubWorkflow
-
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 } as INode);
-
-		(getWorkflowInfo as Mock).mockRejectedValue(new Error('Test error'));
-		(executeFunctions.continueOnFail as Mock).mockReturnValue(true);
-
-		const result = await executeWorkflow.execute.call(executeFunctions);
-
-		expect(result).toEqual([[{ json: { error: 'Test error' }, pairedItem: { item: 0 } }]]);
-	});
-
-	test('should handle errors and continue on fail, multiple items, < 1.3 version', async () => {
-		executeFunctions.getNodeParameter
-			.mockReturnValueOnce('database') // source
-			.mockReturnValueOnce('each') // mode
-			.mockReturnValueOnce({}) // workflowInputs.value (item 0)
-			.mockReturnValueOnce({}) // workflowInputs.value (item 1)
-			.mockReturnValueOnce({}) // workflowInputs.value (item 2)
-			.mockReturnValueOnce([]) // workflowInputs.schema
-			.mockReturnValueOnce(true) // waitForSubWorkflow (item 0)
-			.mockReturnValueOnce(true) // waitForSubWorkflow (item 1)
-			.mockReturnValueOnce(true); // waitForSubWorkflow (item 2)
-
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 } as INode);
-		executeFunctions.getInputData.mockReturnValueOnce([
-			{ json: { key: '1' } },
-			{ json: { key: '2' } },
-			{ json: { key: '3' } },
-		]);
 
 		(getWorkflowInfo as Mock).mockRejectedValue(new Error('Test error'));
 		(executeFunctions.continueOnFail as Mock).mockReturnValue(true);
@@ -184,76 +121,22 @@ describe('ExecuteWorkflow', () => {
 		const result = await executeWorkflow.execute.call(executeFunctions);
 
 		expect(result).toEqual([
-			[{ json: { error: 'Test error' }, pairedItem: { item: 0 }, metadata: undefined }],
-			[{ json: { error: 'Test error' }, pairedItem: { item: 1 }, metadata: undefined }],
-			[{ json: { error: 'Test error' }, pairedItem: { item: 2 }, metadata: undefined }],
-		]);
-	});
-
-	test('should handle errors and continue on fail, no items, >= 1.3 version', async () => {
-		executeFunctions.getNodeParameter
-			.mockReturnValueOnce('database') // source
-			.mockReturnValueOnce('each') // mode
-			.mockReturnValueOnce({}) // workflowInputs.value
-			.mockReturnValueOnce([]) // workflowInputs.schema
-			.mockReturnValueOnce(true); // waitForSubWorkflow
-
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 } as INode);
-
-		(getWorkflowInfo as Mock).mockRejectedValue(new Error('Test error'));
-		(executeFunctions.continueOnFail as Mock).mockReturnValue(true);
-
-		const result = await executeWorkflow.execute.call(executeFunctions);
-
-		expect(result).toEqual([[{ json: { error: 'Test error' }, pairedItem: { item: 0 } }]]);
-	});
-
-	test('should handle errors and continue on fail, multiple items, >= 1.3 version', async () => {
-		executeFunctions.getNodeParameter
-			.mockReturnValueOnce('database') // source
-			.mockReturnValueOnce('each') // mode
-			.mockReturnValueOnce({}) // workflowInputs.value (item 0)
-			.mockReturnValueOnce({}) // workflowInputs.value (item 1)
-			.mockReturnValueOnce({}) // workflowInputs.value (item 2)
-			.mockReturnValueOnce([]) // workflowInputs.schema
-			.mockReturnValueOnce(true) // waitForSubWorkflow (item 0)
-			.mockReturnValueOnce(true) // waitForSubWorkflow (item 1)
-			.mockReturnValueOnce(true); // waitForSubWorkflow (item 2)
-
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 } as INode);
-		executeFunctions.getInputData.mockReturnValueOnce([
-			{ json: { key: '1' } },
-			{ json: { key: '2' } },
-			{ json: { key: '3' } },
-		]);
-
-		(getWorkflowInfo as Mock).mockRejectedValue(new Error('Test error'));
-		(executeFunctions.continueOnFail as Mock).mockReturnValue(true);
-
-		const result = await executeWorkflow.execute.call(executeFunctions);
-
-		expect(result).toEqual([
-			[
-				{ json: { error: 'Test error' }, pairedItem: { item: 0 }, metadata: undefined },
-				{ json: { error: 'Test error' }, pairedItem: { item: 1 }, metadata: undefined },
-				{ json: { error: 'Test error' }, pairedItem: { item: 2 }, metadata: undefined },
-			],
+			// generatePairedItemData is auto-mocked, so pairedItem resolves to undefined here
+			[{ json: { error: 'Test error' }, metadata: undefined, pairedItem: undefined }],
 		]);
 	});
 
 	test('should throw error if not continuing on fail', async () => {
 		executeFunctions.getNodeParameter
 			.mockReturnValueOnce('database') // source
-			.mockReturnValueOnce('each') // mode
 			.mockReturnValueOnce({}) // workflowInputs.value
 			.mockReturnValueOnce([]) // workflowInputs.schema
+			.mockReturnValueOnce('once') // mode
 			.mockReturnValueOnce(true); // waitForSubWorkflow
 
 		(getWorkflowInfo as Mock).mockRejectedValue(new Error('Test error'));
 		(executeFunctions.continueOnFail as Mock).mockReturnValue(false);
 
-		await expect(executeWorkflow.execute.call(executeFunctions)).rejects.toThrow(
-			'Error executing workflow with item at index 0',
-		);
+		await expect(executeWorkflow.execute.call(executeFunctions)).rejects.toThrow('Test error');
 	});
 });

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -20,7 +20,7 @@ export class ExecuteWorkflow implements INodeType {
 		icon: 'node:execute-sub-workflow',
 		iconColor: 'orange-red',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3],
+		version: [1, 1.1, 1.2, 1.3, 1.4],
 		subtitle: '={{"Workflow: " + $parameter["workflowId"]}}',
 		description: 'Execute another workflow',
 		defaults: {
@@ -31,7 +31,6 @@ export class ExecuteWorkflow implements INodeType {
 		builderHint: {
 			extraTypeDefContent: [
 				{
-					displayOptions: { show: { mode: ['once', 'each'] } },
 					content: `<patterns>
 These workflowInputs patterns apply to Execute Workflow node versions 1.2 and newer.
 <pattern title="Child accepts all data">
@@ -295,35 +294,32 @@ workflowInputs: {
 				},
 			},
 			{
+				// Kept as a hidden parameter on the versions that offered the mode:
+				// Workflow construction strips parameters that are not declared (or not
+				// displayed) for the node's version, and the runtime guard in execute()
+				// needs to see a stale 'each' value to fail loudly on it. On 1.4+ the
+				// value is stripped and the node always runs once with all items.
 				displayName: 'Mode',
 				name: 'mode',
-				type: 'options',
+				type: 'hidden',
 				noDataExpression: true,
-				options: [
-					{
-						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
-						name: 'Run once with all items',
-						value: 'once',
-						description: 'Pass all items into a single execution of the sub-workflow',
-					},
-					{
-						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
-						name: 'Run once for each item',
-						value: 'each',
-						description: 'Call the sub-workflow individually for each item',
-					},
-				],
 				default: 'once',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { lte: 1.3 } }],
+					},
+				},
 			},
 			{
 				displayName:
-					'"Run once for each item" is deprecated and will be removed in a future version. To run the sub-workflow once per item, add a "Loop Over Items" node before this node and use "Run once with all items".',
-				name: 'eachModeDeprecationNotice',
+					'The "Run once for each item" mode is no longer available, so this node will fail. Replace it with a new "Execute Sub-workflow" node. To run the sub-workflow once per item, add a "Loop Over Items" node before the new node.',
+				name: 'eachModeRemovedNotice',
 				type: 'notice',
 				default: '',
 				displayOptions: {
 					show: {
 						mode: ['each'],
+						'@version': [{ _cnd: { lte: 1.3 } }],
 					},
 				},
 			},
@@ -351,7 +347,7 @@ workflowInputs: {
 				message:
 					"Note on using an expression for workflow ID: Since this node is set to run once with all items, they will all be sent to the <em>same</em> workflow. That workflow's ID will be calculated by evaluating the expression for the <strong>first input item</strong>.",
 				displayCondition:
-					'={{ $rawParameter.workflowId.startsWith("=") && $parameter.mode === "once" && $nodeVersion >= 1.2 }}',
+					'={{ $rawParameter.workflowId.startsWith("=") && ($nodeVersion >= 1.4 || ($nodeVersion >= 1.2 && $parameter.mode === "once")) }}',
 				whenToDisplay: 'always',
 				location: 'outputPane',
 			},
@@ -364,118 +360,20 @@ workflowInputs: {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const source = this.getNodeParameter('source', 0) as string;
-		const mode = this.getNodeParameter('mode', 0, false) as string;
 		const items = getCurrentWorkflowInputData.call(this);
 
 		const workflowProxy = this.getWorkflowDataProxy(0);
-		const currentWorkflowId = workflowProxy.$workflow.id as string;
 
-		if (mode === 'each') {
-			const returnData: INodeExecutionData[][] = [];
-
-			for (let i = 0; i < items.length; i++) {
-				try {
-					const waitForSubWorkflow = this.getNodeParameter(
-						'options.waitForSubWorkflow',
-						i,
-						true,
-					) as boolean;
-					const workflowInfo = await getWorkflowInfo.call(this, source, i);
-
-					if (waitForSubWorkflow) {
-						const executionResult: ExecuteWorkflowData = await this.executeWorkflow(
-							workflowInfo,
-							[items[i]],
-							undefined,
-							{
-								parentExecution: {
-									executionId: workflowProxy.$execution.id,
-									workflowId: workflowProxy.$workflow.id,
-									shouldResume: waitForSubWorkflow,
-								},
-								executionMode: this.getMode(),
-							},
-						);
-						const workflowResult = executionResult.data as INodeExecutionData[][];
-
-						for (const [outputIndex, outputData] of workflowResult.entries()) {
-							for (const item of outputData) {
-								item.pairedItem = { item: i };
-								item.metadata = {
-									subExecution: {
-										executionId: executionResult.executionId,
-										workflowId: workflowInfo.id ?? currentWorkflowId,
-									},
-								};
-							}
-
-							if (returnData[outputIndex] === undefined) {
-								returnData[outputIndex] = [];
-							}
-
-							returnData[outputIndex].push(...outputData);
-						}
-					} else {
-						const executionResult: ExecuteWorkflowData = await this.executeWorkflow(
-							workflowInfo,
-							[items[i]],
-							undefined,
-							{
-								doNotWaitToFinish: true,
-								parentExecution: {
-									executionId: workflowProxy.$execution.id,
-									workflowId: workflowProxy.$workflow.id,
-									shouldResume: waitForSubWorkflow,
-								},
-								executionMode: this.getMode(),
-							},
-						);
-
-						if (returnData.length === 0) {
-							returnData.push([]);
-						}
-
-						returnData[0].push({
-							...items[i],
-							metadata: {
-								subExecution: {
-									workflowId: workflowInfo.id ?? currentWorkflowId,
-									executionId: executionResult.executionId,
-								},
-							},
-						});
-					}
-				} catch (error) {
-					if (this.continueOnFail()) {
-						const nodeVersion = this.getNode().typeVersion;
-						// In versions < 1.3 using the "Continue (using error output)" mode
-						// the node would return items in extra "error branches" instead of
-						// returning an array of items on the error output. These branches weren't really shown correctly on the UI.
-						// In the fixed >= 1.3 versions the errors are now all output into the single error output as an array of error items.
-						const outputIndex = nodeVersion >= 1.3 ? 0 : i;
-
-						returnData[outputIndex] ??= [];
-						const metadata = parseErrorMetadata(error);
-						returnData[outputIndex].push({
-							json: { error: error.message },
-							pairedItem: { item: i },
-							metadata,
-						});
-						continue;
-					}
-					throw new NodeOperationError(this.getNode(), error, {
-						message: `Error executing workflow with item at index ${i}`,
-						description: error.message,
-						itemIndex: i,
-					});
-				}
-			}
-
-			this.setMetadata({
-				subExecutionsCount: items.length,
-			});
-
-			return returnData;
+		// The mode selection is gone, but nodes saved before its removal may still carry the value
+		if (this.getNodeParameter('mode', 0, 'once') === 'each') {
+			throw new NodeOperationError(
+				this.getNode(),
+				'The "Run once for each item" mode is no longer available',
+				{
+					description:
+						'Replace this node with a new "Execute Sub-workflow" node. To run the sub-workflow once per item, add a "Loop Over Items" node before the new node.',
+				},
+			);
 		} else {
 			try {
 				const waitForSubWorkflow = this.getNodeParameter(

--- a/packages/testing/playwright/pages/components/RunDataPanel.ts
+++ b/packages/testing/playwright/pages/components/RunDataPanel.ts
@@ -103,10 +103,6 @@ export class RunDataPanel {
 		return this.root.locator('table tbody tr').nth(row).locator('td').nth(col);
 	}
 
-	getTbodyCellLink(row: number, col: number) {
-		return this.getTbodyCell(row, col).locator('a');
-	}
-
 	getTableCellSpan(row: number, col: number, dataName: string) {
 		return this.getTbodyCell(row, col).locator(`span[data-name="${dataName}"]`).first();
 	}

--- a/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/debugging.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/debugging.spec.ts
@@ -11,7 +11,7 @@ test.describe(
 		test.beforeEach(async ({ n8n }) => {
 			await n8n.start.fromImportedWorkflow(WORKFLOW_FILE);
 
-			await expect(n8n.canvas.getCanvasNodes()).toHaveCount(11);
+			await expect(n8n.canvas.getCanvasNodes()).toHaveCount(7);
 			await n8n.canvas.clickZoomToFitButton();
 
 			await n8n.canvas.clickExecuteWorkflowButton();
@@ -31,17 +31,6 @@ test.describe(
 
 				await expect(n8n.ndv.outputPanel.getTableHeaders()).toHaveCount(2);
 				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 0)).toHaveText('world Natalie Moore');
-			});
-
-			test('(Run once for each item/ Wait for Sub-workflow completion) param1', async ({ n8n }) => {
-				await n8n.canvas.openNode('Execute Workflow with param1');
-
-				await expect(n8n.ndv.outputPanel.getItemsCount()).toContainText('2 items, 2 sub-execution');
-				await expect(n8n.ndv.outputPanel.getRelatedExecutionLink()).not.toBeAttached();
-
-				await expect(n8n.ndv.outputPanel.getTableHeaders()).toHaveCount(3);
-				await expect(n8n.ndv.outputPanel.getTbodyCellLink(0, 0)).toHaveAttribute('href', /.+/);
-				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 1)).toHaveText('world Natalie Moore');
 			});
 
 			test('(Run once with all items/ Wait for Sub-workflow completion) param2', async ({
@@ -71,32 +60,6 @@ test.describe(
 				await expect(n8n.ndv.outputPanel.getTableHeader(0)).toHaveText('uid');
 				await expect(n8n.ndv.outputPanel.getTableRows()).toHaveCount(3);
 				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 1)).toContainText(
-					'Terry.Dach@hotmail.com',
-				);
-			});
-
-			test('(Run once for each item/ Wait for Sub-workflow completion) param3', async ({ n8n }) => {
-				await n8n.canvas.openNode('Execute Workflow with param3');
-
-				await expect(n8n.ndv.outputPanel.getRunSelectorInput()).toHaveValue(
-					'2 of 2 (3 items, 3 sub-executions)',
-				);
-				await expect(n8n.ndv.outputPanel.getTableHeaders()).toHaveCount(7);
-				await expect(n8n.ndv.outputPanel.getTableHeader(1)).toHaveText('uid');
-				await expect(n8n.ndv.outputPanel.getTableRows()).toHaveCount(4);
-				await expect(n8n.ndv.outputPanel.getTbodyCellLink(0, 0)).toHaveAttribute('href', /.+/);
-				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 2)).toContainText('Jon_Ebert@yahoo.com');
-
-				await n8n.ndv.changeOutputRunSelector('1 of 2 (2 items, 2 sub-executions)');
-				await expect(n8n.ndv.outputPanel.getRunSelectorInput()).toHaveValue(
-					'1 of 2 (2 items, 2 sub-executions)',
-				);
-				await expect(n8n.ndv.outputPanel.getTableHeaders()).toHaveCount(7);
-				await expect(n8n.ndv.outputPanel.getTableHeader(1)).toHaveText('uid');
-				await expect(n8n.ndv.outputPanel.getTableRows()).toHaveCount(3);
-
-				await expect(n8n.ndv.outputPanel.getTbodyCellLink(0, 0)).toHaveAttribute('href', /.+/);
-				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 2)).toContainText(
 					'Terry.Dach@hotmail.com',
 				);
 			});

--- a/packages/testing/playwright/workflows/Subworkflow-debugging-execute-workflow.json
+++ b/packages/testing/playwright/workflows/Subworkflow-debugging-execute-workflow.json
@@ -6,7 +6,7 @@
 		{
 			"parameters": {},
 			"id": "4535ce3e-280e-49b0-8854-373472ec86d1",
-			"name": "When clicking ‘Execute workflow’",
+			"name": "When clicking \u2018Execute workflow\u2019",
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
 			"position": [80, 860]
@@ -22,47 +22,6 @@
 			"type": "n8n-nodes-base.debugHelper",
 			"typeVersion": 1,
 			"position": [280, 860]
-		},
-		{
-			"parameters": {
-				"source": "parameter",
-				"workflowJson": "{\n  \"meta\": {\n    \"instanceId\": \"a786b722078489c1fa382391a9f3476c2784761624deb2dfb4634827256d51a0\"\n  },\n  \"nodes\": [\n    {\n      \"parameters\": {},\n      \"type\": \"n8n-nodes-base.executeWorkflowTrigger\",\n      \"typeVersion\": 1,\n      \"position\": [\n        0,\n        0\n      ],\n      \"id\": \"00600a51-e63a-4b6e-93f5-f01d50a21e0c\",\n      \"name\": \"Execute Workflow Trigger\"\n    },\n    {\n      \"parameters\": {\n        \"assignments\": {\n          \"assignments\": [\n            {\n              \"id\": \"87ff01af-2e28-48da-ae6c-304040200b15\",\n              \"name\": \"hello\",\n              \"value\": \"=world {{ $json.firstname }} {{ $json.lastname }}\",\n              \"type\": \"string\"\n            }\n          ]\n        },\n        \"includeOtherFields\": false,\n        \"options\": {}\n      },\n      \"type\": \"n8n-nodes-base.set\",\n      \"typeVersion\": 3.4,\n      \"position\": [\n        280,\n        0\n      ],\n      \"id\": \"642219a1-d655-4a30-af5c-fcccbb690322\",\n      \"name\": \"Edit Fields\"\n    }\n  ],\n  \"connections\": {\n    \"Execute Workflow Trigger\": {\n      \"main\": [\n        [\n          {\n            \"node\": \"Edit Fields\",\n            \"type\": \"main\",\n            \"index\": 0\n          }\n        ]\n      ]\n    }\n  },\n  \"pinData\": {}\n}",
-				"mode": "each",
-				"options": {
-					"waitForSubWorkflow": false
-				}
-			},
-			"type": "n8n-nodes-base.executeWorkflow",
-			"typeVersion": 1.1,
-			"position": [680, 1540],
-			"id": "f90a25da-dd89-4bf8-8f5b-bf8ee1de0b70",
-			"name": "Execute Workflow with param3"
-		},
-		{
-			"parameters": {
-				"assignments": {
-					"assignments": [
-						{
-							"id": "c93f26bd-3489-467b-909e-6462e1463707",
-							"name": "uid",
-							"value": "={{ $json.uid }}",
-							"type": "string"
-						},
-						{
-							"id": "3dd706ce-d925-4219-8531-ad12369972fe",
-							"name": "email",
-							"value": "={{ $json.email }}",
-							"type": "string"
-						}
-					]
-				},
-				"options": {}
-			},
-			"type": "n8n-nodes-base.set",
-			"typeVersion": 3.4,
-			"position": [900, 1540],
-			"id": "3be57648-3be8-4b0f-abfa-8fdcafee804d",
-			"name": "Edit Fields8"
 		},
 		{
 			"parameters": {
@@ -103,47 +62,6 @@
 			"position": [840, 1220],
 			"id": "9d2a9dda-e2a1-43e8-a66f-a8a555692e5f",
 			"name": "Edit Fields7"
-		},
-		{
-			"parameters": {
-				"source": "parameter",
-				"workflowJson": "{\n  \"meta\": {\n    \"instanceId\": \"a786b722078489c1fa382391a9f3476c2784761624deb2dfb4634827256d51a0\"\n  },\n  \"nodes\": [\n    {\n      \"parameters\": {},\n      \"type\": \"n8n-nodes-base.executeWorkflowTrigger\",\n      \"typeVersion\": 1,\n      \"position\": [\n        0,\n        0\n      ],\n      \"id\": \"00600a51-e63a-4b6e-93f5-f01d50a21e0c\",\n      \"name\": \"Execute Workflow Trigger\"\n    },\n    {\n      \"parameters\": {\n        \"assignments\": {\n          \"assignments\": [\n            {\n              \"id\": \"87ff01af-2e28-48da-ae6c-304040200b15\",\n              \"name\": \"hello\",\n              \"value\": \"=world {{ $json.firstname }} {{ $json.lastname }}\",\n              \"type\": \"string\"\n            }\n          ]\n        },\n        \"includeOtherFields\": false,\n        \"options\": {}\n      },\n      \"type\": \"n8n-nodes-base.set\",\n      \"typeVersion\": 3.4,\n      \"position\": [\n        280,\n        0\n      ],\n      \"id\": \"642219a1-d655-4a30-af5c-fcccbb690322\",\n      \"name\": \"Edit Fields\"\n    }\n  ],\n  \"connections\": {\n    \"Execute Workflow Trigger\": {\n      \"main\": [\n        [\n          {\n            \"node\": \"Edit Fields\",\n            \"type\": \"main\",\n            \"index\": 0\n          }\n        ]\n      ]\n    }\n  },\n  \"pinData\": {}\n}",
-				"mode": "each",
-				"options": {
-					"waitForSubWorkflow": true
-				}
-			},
-			"type": "n8n-nodes-base.executeWorkflow",
-			"typeVersion": 1.1,
-			"position": [560, 900],
-			"id": "07e47f60-622a-484c-ab24-35f6f2280595",
-			"name": "Execute Workflow with param1"
-		},
-		{
-			"parameters": {
-				"assignments": {
-					"assignments": [
-						{
-							"id": "c93f26bd-3489-467b-909e-6462e1463707",
-							"name": "uid",
-							"value": "={{ $json.uid }}",
-							"type": "string"
-						},
-						{
-							"id": "3dd706ce-d925-4219-8531-ad12369972fe",
-							"name": "email",
-							"value": "={{ $json.email }}",
-							"type": "string"
-						}
-					]
-				},
-				"options": {}
-			},
-			"type": "n8n-nodes-base.set",
-			"typeVersion": 3.4,
-			"position": [760, 900],
-			"id": "80563d0a-0bab-444f-a04c-4041a505d78b",
-			"name": "Edit Fields6"
 		},
 		{
 			"parameters": {
@@ -247,7 +165,7 @@
 		}
 	],
 	"connections": {
-		"When clicking ‘Execute workflow’": {
+		"When clicking \u2018Execute workflow\u2019": {
 			"main": [
 				[
 					{
@@ -267,17 +185,7 @@
 			"main": [
 				[
 					{
-						"node": "Execute Workflow with param3",
-						"type": "main",
-						"index": 0
-					},
-					{
 						"node": "Execute Workflow with param2",
-						"type": "main",
-						"index": 0
-					},
-					{
-						"node": "Execute Workflow with param1",
 						"type": "main",
 						"index": 0
 					},
@@ -289,33 +197,11 @@
 				]
 			]
 		},
-		"Execute Workflow with param3": {
-			"main": [
-				[
-					{
-						"node": "Edit Fields8",
-						"type": "main",
-						"index": 0
-					}
-				]
-			]
-		},
 		"Execute Workflow with param2": {
 			"main": [
 				[
 					{
 						"node": "Edit Fields7",
-						"type": "main",
-						"index": 0
-					}
-				]
-			]
-		},
-		"Execute Workflow with param1": {
-			"main": [
-				[
-					{
-						"node": "Edit Fields6",
 						"type": "main",
 						"index": 0
 					}
@@ -338,11 +224,6 @@
 				[
 					{
 						"node": "Execute Workflow with param2",
-						"type": "main",
-						"index": 0
-					},
-					{
-						"node": "Execute Workflow with param3",
 						"type": "main",
 						"index": 0
 					}


### PR DESCRIPTION
## Summary

Removes the "Run once for each item" mode from the Execute Sub-workflow node, per the v3 breaking-changes tracker. This mode does not behave correctly in combination with waiting, and a Loop Over Items node achieves the same behavior.

<img width="2880" height="1800" alt="2" src="https://github.com/user-attachments/assets/25e238e0-beb6-4aad-8ee0-f967bcc27165" />


- Removes the Mode selection from the node panel and adds node version 1.4. The node always runs once with all items.
- On versions 1 to 1.3 — the versions where the mode could legitimately be set — the `mode` parameter is kept as a hidden property, gated to `@version <= 1.3`. This is deliberate: `Workflow` construction rebuilds `node.parameters` from the declared and displayed properties only, so without the declaration a stale `each` value would be stripped and the workflow would silently run as `once`, changing what data the sub-workflow receives. The hidden declaration lets the stored value survive so the node can fail loudly instead.
- A workflow saved with `mode: 'each'` on version <= 1.3 shows a warning notice in the editor and fails at runtime with: *The "Run once for each item" mode is no longer available*, instructing the user to replace the node and add a "Loop Over Items" node before it.
- On version 1.4, `mode` is not declared. A value injected via the API or workflow JSON is stripped during parameter normalization and the node runs once with all items — the standard n8n treatment for parameters that are not part of a node version's contract.
- The v3 breaking-change detection rule (`execute-workflow-each-mode-v3`) and the deprecation notice already shipped on `master`; this PR is only the removal.

### Behavior overview

| Node version | `mode: 'each'` present | Behavior |
|---|---|---|
| <= 1.3 | yes | Editor warning + runtime failure with migration instructions |
| <= 1.3 | no | Runs once with all items |
| 1.4 | injected via API/JSON | Value stripped, runs once with all items |
| 1.4 | no | Runs once with all items |

## How to test

1. On a current release build, create a workflow: Manual Trigger → Execute Sub-workflow with Mode set to "Run once for each item", pointing at any sub-workflow.
2. Start n8n from this branch.
3. Open the node: no Mode field renders, and a warning notice explains that the node uses the removed mode and how to migrate.
4. Execute the workflow: the node fails with the removal error and migration instructions.
5. Save the workflow without changes and execute again: it must still fail (the hidden declaration preserves the stale value through save-time parameter normalization).
6. Create a new Execute Sub-workflow node: it is created at version 1.4 with no Mode field and runs once with all items.

Unit tests cover the removed-mode failure and the `once` paths.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4214

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)