### PR TITLE
feat(core): Add flag to run system tasks on the durable scheduler (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
@@ -44,6 +44,7 @@ describe('SchedulerConfig', () => {
 			expect(scheduler.maxAttempts).toBe(5);
 			expect(scheduler.enabledForPollTriggers).toBe(false);
 			expect(scheduler.pollTimeoutSeconds).toBe(45);
+			expect(scheduler.enabledForSystemTasks).toBe(false);
 		});
 	});
 
@@ -75,6 +76,7 @@ describe('SchedulerConfig', () => {
 			vi.stubEnv('N8N_SCHEDULER_MAX_ATTEMPTS', '3');
 			vi.stubEnv('N8N_SCHEDULER_POLL_TRIGGERS_ENABLED', 'true');
 			vi.stubEnv('N8N_SCHEDULER_POLL_TIMEOUT', '30');
+			vi.stubEnv('N8N_SCHEDULER_SYSTEM_TASKS_ENABLED', 'true');
 
 			const { scheduler } = Container.get(GlobalConfig);
 
@@ -96,6 +98,7 @@ describe('SchedulerConfig', () => {
 			expect(scheduler.maxAttempts).toBe(3);
 			expect(scheduler.enabledForPollTriggers).toBe(true);
 			expect(scheduler.pollTimeoutSeconds).toBe(30);
+			expect(scheduler.enabledForSystemTasks).toBe(true);
 		});
 
 		it('should expose the durable-scheduler skip escape hatch via env', () => {

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -303,6 +303,21 @@ export class SchedulerConfig {
 	durableCursorsEnabled: boolean = false;
 
 	/**
+	 * Whether n8n's internal maintenance jobs (for example pruning old executions,
+	 * compacting insights data, or renewing the license) are scheduled by the
+	 * durable scheduler instead of n8n's in-process timers. Off by default;
+	 * requires {@link enabled} to also be on.
+	 *
+	 * In a multi-instance setup, only turn this on once every instance runs a
+	 * version of n8n that supports it. While older and newer versions run side by
+	 * side (for example during a rolling deploy), the older instances still run
+	 * these jobs on their own timers, so the same job could run twice at the
+	 * same time.
+	 */
+	@Env('N8N_SCHEDULER_SYSTEM_TASKS_ENABLED')
+	enabledForSystemTasks: boolean = false;
+
+	/**
 	 * Temporary escape hatch for the durable-scheduler rollout (preview to GA).
 	 * Off by default; intended to be removed once the durable scheduler is GA.
 	 *

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -483,6 +483,7 @@ describe('GlobalConfig', () => {
 			maxAttempts: 5,
 			misfireGraceSeconds: 60,
 			durableCursorsEnabled: false,
+			enabledForSystemTasks: false,
 		},
 		evaluation: {
 			collectionsEnabled: false,


### PR DESCRIPTION
## Summary

Add the `N8N_SCHEDULER_SYSTEM_TASKS_ENABLED` flag to the scheduler config (`enabledForSystemTasks`, default `false`).

The flag will let operators move n8n's internal maintenance jobs (execution pruning, insights compaction, license renewal, and similar) from in-process timers to the durable scheduler. 

No code consumes the flag yet.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4156

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

