### PR TITLE
chore: Rename instance-ai owner team to ai-assistant (no-changelog)

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -19,7 +19,7 @@ packages/@n8n/errors/                                   @n8n-io/catalysts
 packages/@n8n/constants/                                @n8n-io/catalysts
 packages/@n8n/utils/                                    @n8n-io/catalysts
 packages/@n8n/api-types/                                @n8n-io/catalysts
-packages/@n8n/workflow-sdk/                             @n8n-io/instance-ai
+packages/@n8n/workflow-sdk/                             @n8n-io/ai-assistant
 packages/@n8n/task-runner/                              @n8n-io/catalysts
 packages/@n8n/task-runner-python/                       @n8n-io/catalysts
 packages/@n8n/expression-runtime/                       @n8n-io/catalysts
@@ -103,7 +103,7 @@ packages/cli/src/modules/workflow-builder/              @n8n-io/ai
 packages/cli/src/modules/mcp/                           @n8n-io/adore
 packages/cli/src/modules/quick-connect/                 @n8n-io/ai
 packages/cli/src/modules/chat-hub/                      @n8n-io/ai
-packages/cli/src/modules/instance-ai/                   @n8n-io/instance-ai
+packages/cli/src/modules/instance-ai/                   @n8n-io/ai-assistant
 
 packages/cli/src/modules/community-packages/            @n8n-io/nodes
 
@@ -182,7 +182,7 @@ packages/@n8n/stylelint-config/                         @n8n-io/qa-dx
 
 # AI
 
-packages/@n8n/instance-ai/                              @n8n-io/instance-ai
+packages/@n8n/instance-ai/                              @n8n-io/ai-assistant
 packages/@n8n/nodes-langchain/                          @n8n-io/ai
 packages/@n8n/ai-utilities/                             @n8n-io/ai
 packages/@n8n/ai-node-sdk/                              @n8n-io/ai


### PR DESCRIPTION
## Summary

Rename the owner team `@n8n-io/instance-ai` to `@n8n-io/ai-assistant` in `.github/OWNERS`. This updates the three entries that the team owns: `packages/@n8n/workflow-sdk/`, `packages/cli/src/modules/instance-ai/`, and `packages/@n8n/instance-ai/`. The path names do not change.

## How to test

Not applicable — review ownership change only.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

