### PR TITLE
feat(core)!: Change task runner task timeout from 5min to 1min

### DIFF
--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -48,11 +48,9 @@ export class TaskRunnersConfig {
 	 * How long (in seconds) a task is allowed to take for completion, else the
 	 * task will be aborted. (In internal mode, the runner will also be
 	 * restarted.) Must be greater than 0.
-	 *
-	 * Kept high for backwards compatibility - n8n v3 will reduce this to `60`
 	 */
 	@Env('N8N_RUNNERS_TASK_TIMEOUT')
-	taskTimeout: number = 5 * Time.minutes.toSeconds;
+	taskTimeout: number = 1 * Time.minutes.toSeconds;
 
 	/**
 	 * How long (in seconds) a task request can wait for a runner to become

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -418,7 +418,7 @@ describe('GlobalConfig', () => {
 			port: 5679,
 			maxOldSpaceSize: '',
 			maxConcurrency: 10,
-			taskTimeout: 300,
+			taskTimeout: 60,
 			taskRequestTimeout: 60,
 			taskAcceptTimeout: 2,
 			heartbeatInterval: 30,

--- a/packages/@n8n/task-runner/src/config/base-runner-config.ts
+++ b/packages/@n8n/task-runner/src/config/base-runner-config.ts
@@ -75,11 +75,9 @@ export class BaseRunnerConfig {
 	 * How long (in seconds) a task is allowed to take for completion, else the
 	 * task will be aborted. (In internal mode, the runner will also be
 	 * restarted.) Must be greater than 0.
-	 *
-	 * Kept high for backwards compatibility - n8n v2 will reduce this to `60`
 	 */
 	@Env('N8N_RUNNERS_TASK_TIMEOUT')
-	taskTimeout: number = 300; // 5 minutes
+	taskTimeout: number = 60; // 1 minute
 
 	@Nested
 	healthcheckServer!: HealthcheckServerConfig;

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -173,23 +173,20 @@ describe('DeprecationService', () => {
 	});
 
 	describe('default-flip warnings', () => {
-		test.each(['N8N_UNVERIFIED_PACKAGES_ENABLED', 'N8N_RUNNERS_TASK_TIMEOUT'])(
-			'should warn when %s is unset',
-			(envVar) => {
-				delete process.env[envVar];
+		test.each(['N8N_UNVERIFIED_PACKAGES_ENABLED'])('should warn when %s is unset', (envVar) => {
+			delete process.env[envVar];
+			deprecationService.warn();
+			expect(logger.warn.mock.lastCall?.[0] ?? '').toContain(envVar);
+		});
+
+		test.each([['N8N_UNVERIFIED_PACKAGES_ENABLED', 'false']])(
+			'should not warn when %s is set explicitly',
+			(envVar, value) => {
+				process.env[envVar] = value;
 				deprecationService.warn();
-				expect(logger.warn.mock.lastCall?.[0] ?? '').toContain(envVar);
+				expect(logger.warn.mock.lastCall?.[0] ?? '').not.toContain(envVar);
 			},
 		);
-
-		test.each([
-			['N8N_UNVERIFIED_PACKAGES_ENABLED', 'false'],
-			['N8N_RUNNERS_TASK_TIMEOUT', '120'],
-		])('should not warn when %s is set explicitly', (envVar, value) => {
-			process.env[envVar] = value;
-			deprecationService.warn();
-			expect(logger.warn.mock.lastCall?.[0] ?? '').not.toContain(envVar);
-		});
 	});
 
 	describe('running outside a container', () => {

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -74,12 +74,6 @@ export class DeprecationService {
 			checkValue: (value?: string) => value === undefined,
 		},
 		{
-			envVar: 'N8N_RUNNERS_TASK_TIMEOUT',
-			message:
-				'The default for this variable will be reduced from 300 (5 minutes) to 60 (1 minute) in a future version. Set it explicitly to keep your current task timeout.',
-			checkValue: (value?: string) => value === undefined,
-		},
-		{
 			envVar: 'N8N_EXPRESSION_ENGINE',
 			message:
 				'The `legacy` expression engine runs expressions without isolation, is no longer considered secure, and will be removed in a future version. Remove this environment variable to use the default `vm` engine.',


### PR DESCRIPTION
## Summary

Reduce the default task runner task timeout from 300 seconds (5 minutes) to 60 seconds (1 minute) for n8n v3.

- `N8N_RUNNERS_TASK_TIMEOUT` now defaults to `60` in both the main config (`@n8n/config`) and the runner config (`@n8n/task-runner`). The Python runner already defaults to `60`.
- Remove the deprecation warning for an unset `N8N_RUNNERS_TASK_TIMEOUT`, because the default flip is now done.
- The v3 breaking-change detection rule (`task-runner-task-timeout.rule.ts`) already exists and stays unchanged.

Users who need longer-running Code node tasks can set `N8N_RUNNERS_TASK_TIMEOUT` explicitly.

## How to test

1. Start n8n without `N8N_RUNNERS_TASK_TIMEOUT` set.
2. Run a Code node task that takes more than 60 seconds (for example, `await new Promise((r) => setTimeout(r, 70_000)); return items;`).
3. The task is aborted after 60 seconds.
4. Set `N8N_RUNNERS_TASK_TIMEOUT=300` and repeat. The task completes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4223

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

