### PR TITLE
fix(editor): Show an activity indicator while the AI Assistant is still working

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/AgentTimeline.activity.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/AgentTimeline.activity.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { createThreadComponentRenderer } from './createThreadComponentRenderer';
+import AgentTimeline from '../components/AgentTimeline.vue';
+import { ACTIVITY_INDICATOR_DELAY_MS } from '../agentTimeline.utils';
+import type { InstanceAiAgentNode } from '@n8n/api-types';
+
+const renderComponent = createThreadComponentRenderer(AgentTimeline, {
+	global: {
+		stubs: {
+			InstanceAiMarkdown: { template: '<span>{{ content }}</span>', props: ['content'] },
+		},
+	},
+});
+
+/** Answer-length narration — past TAIL_NARRATION_MAX_LENGTH, so it promotes out. */
+const PLAN = 'I found your new BigQuery credential and got the Supabase node definitions. '.repeat(
+	4,
+);
+
+function agentNode(text: string): InstanceAiAgentNode {
+	return {
+		agentId: 'a1',
+		status: 'active',
+		toolCalls: [],
+		children: [],
+		timeline: [
+			{ type: 'reasoning', responseId: 'r1', content: 'Checking the credential type.' },
+			{ type: 'text', responseId: 'r1', content: text },
+		],
+	} as unknown as InstanceAiAgentNode;
+}
+
+function indicatorText(container: Element): string | undefined {
+	return container
+		.querySelector('[data-test-id="timeline-activity-indicator"]')
+		?.textContent?.replace(/\s+/g, ' ')
+		.trim();
+}
+
+describe('AgentTimeline activity indicator', () => {
+	beforeEach(() => {
+		createTestingPinia({ stubActions: false });
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('surfaces a counting indicator when a committed answer settles the block mid-run', async () => {
+		// INS-1224: the transcript claimed done while the composer stayed on stop.
+		const { container } = renderComponent({ props: { agentNode: agentNode(PLAN) } });
+
+		await vi.advanceTimersByTimeAsync(ACTIVITY_INDICATOR_DELAY_MS + 4_000);
+		expect(indicatorText(container)).toBe('Thinking · 9s');
+	});
+
+	it('stays hidden while the run is only briefly quiet', async () => {
+		// A run wrapping up after its last token would otherwise put "Thinking"
+		// under every answer longer than the narration cap.
+		const { container } = renderComponent({ props: { agentNode: agentNode(PLAN) } });
+
+		await vi.advanceTimersByTimeAsync(ACTIVITY_INDICATOR_DELAY_MS - 1_000);
+		expect(indicatorText(container)).toBeUndefined();
+	});
+
+	it('restarts the clock while text is still streaming into the tail entry', async () => {
+		// Guards the progressToken wiring: the tail entry's identity never changes
+		// as it grows, so without it the stall would be overstated by however long
+		// the answer took to write.
+		const { container, rerender } = renderComponent({ props: { agentNode: agentNode(PLAN) } });
+
+		await vi.advanceTimersByTimeAsync(ACTIVITY_INDICATOR_DELAY_MS + 4_000);
+		expect(indicatorText(container)).toBe('Thinking · 9s');
+
+		await rerender({ agentNode: agentNode(`${PLAN} My plan for Code-node elimination:`) });
+		expect(indicatorText(container)).toBeUndefined();
+
+		await vi.advanceTimersByTimeAsync(ACTIVITY_INDICATOR_DELAY_MS);
+		expect(indicatorText(container)).toBe('Thinking · 5s');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/TimelineActivityIndicator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/TimelineActivityIndicator.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { createThreadComponentRenderer } from './createThreadComponentRenderer';
+import TimelineActivityIndicator from '../components/TimelineActivityIndicator.vue';
+
+const renderComponent = createThreadComponentRenderer(TimelineActivityIndicator);
+
+describe('TimelineActivityIndicator', () => {
+	beforeEach(() => {
+		createTestingPinia();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('renders a live indicator', () => {
+		const { getByTestId } = renderComponent();
+		expect(getByTestId('timeline-activity-indicator')).toBeInTheDocument();
+	});
+
+	it('counts up so the user can see the run is still going', async () => {
+		const { getByTestId } = renderComponent();
+		const indicator = getByTestId('timeline-activity-indicator');
+
+		expect(indicator).toHaveTextContent('Thinking');
+		expect(indicator).not.toHaveTextContent('·');
+
+		await vi.advanceTimersByTimeAsync(3_000);
+		expect(indicator).toHaveTextContent('Thinking · 3s');
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(indicator).toHaveTextContent('Thinking · 1m 3s');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/TimelineActivityIndicator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/TimelineActivityIndicator.test.ts
@@ -2,12 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { createThreadComponentRenderer } from './createThreadComponentRenderer';
 import TimelineActivityIndicator from '../components/TimelineActivityIndicator.vue';
+import { ACTIVITY_INDICATOR_DELAY_MS } from '../agentTimeline.utils';
 
 const renderComponent = createThreadComponentRenderer(TimelineActivityIndicator);
 
+const TEST_ID = 'timeline-activity-indicator';
+
 describe('TimelineActivityIndicator', () => {
 	beforeEach(() => {
-		createTestingPinia();
+		createTestingPinia({ stubActions: false });
 		vi.useFakeTimers();
 	});
 
@@ -15,22 +18,63 @@ describe('TimelineActivityIndicator', () => {
 		vi.useRealTimers();
 	});
 
-	it('renders a live indicator', () => {
-		const { getByTestId } = renderComponent();
-		expect(getByTestId('timeline-activity-indicator')).toBeInTheDocument();
+	it('stays hidden through a short silence', async () => {
+		// The tail of a streamed answer and a run wrapping up both go quiet for a
+		// second or two; flagging those would put "Thinking" under every reply.
+		const { queryByTestId } = renderComponent({ props: { progressToken: 'run-1:2:100' } });
+
+		await vi.advanceTimersByTimeAsync(ACTIVITY_INDICATOR_DELAY_MS - 1_000);
+		expect(queryByTestId(TEST_ID)).toBeNull();
 	});
 
-	it('counts up so the user can see the run is still going', async () => {
-		const { getByTestId } = renderComponent();
-		const indicator = getByTestId('timeline-activity-indicator');
+	it('appears once the silence is worth reporting, and counts up', async () => {
+		const { queryByTestId } = renderComponent({ props: { progressToken: 'run-1:2:100' } });
 
-		expect(indicator).toHaveTextContent('Thinking');
-		expect(indicator).not.toHaveTextContent('·');
-
-		await vi.advanceTimersByTimeAsync(3_000);
-		expect(indicator).toHaveTextContent('Thinking · 3s');
+		await vi.advanceTimersByTimeAsync(ACTIVITY_INDICATOR_DELAY_MS);
+		expect(queryByTestId(TEST_ID)).toHaveTextContent('Thinking · 5s');
 
 		await vi.advanceTimersByTimeAsync(60_000);
-		expect(indicator).toHaveTextContent('Thinking · 1m 3s');
+		expect(queryByTestId(TEST_ID)).toHaveTextContent('Thinking · 1m 5s');
+	});
+
+	it('restarts the clock and hides again when the run advances', async () => {
+		// Text still streaming into the tail entry is progress, not dead time.
+		const { queryByTestId, rerender } = renderComponent({
+			props: { progressToken: 'run-1:2:100' },
+		});
+
+		await vi.advanceTimersByTimeAsync(9_000);
+		expect(queryByTestId(TEST_ID)).toHaveTextContent('Thinking · 9s');
+
+		await rerender({ progressToken: 'run-1:2:140' });
+		expect(queryByTestId(TEST_ID)).toBeNull();
+
+		await vi.advanceTimersByTimeAsync(ACTIVITY_INDICATOR_DELAY_MS);
+		expect(queryByTestId(TEST_ID)).toHaveTextContent('Thinking · 5s');
+	});
+
+	it('restarts the clock for a follow-up run in the same message group', async () => {
+		// The timeline is unchanged across the handover, so only the run id moves.
+		const { queryByTestId, rerender } = renderComponent({
+			props: { progressToken: 'run-1:2:100' },
+		});
+
+		await vi.advanceTimersByTimeAsync(40_000);
+		expect(queryByTestId(TEST_ID)).toHaveTextContent('Thinking · 40s');
+
+		await rerender({ progressToken: 'run-2:2:100' });
+		expect(queryByTestId(TEST_ID)).toBeNull();
+	});
+
+	it('keeps counting while nothing advances', async () => {
+		const { queryByTestId, rerender } = renderComponent({
+			props: { progressToken: 'run-1:2:100' },
+		});
+
+		await vi.advanceTimersByTimeAsync(20_000);
+		await rerender({ progressToken: 'run-1:2:100' });
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(queryByTestId(TEST_ID)).toHaveTextContent('Thinking · 21s');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
@@ -396,7 +396,12 @@ describe('buildTimelineBlocks', () => {
 		const longText = 'This is the final answer. '.repeat(10); // > 200 chars
 		const blocks = blocksOf([reasoning('r1'), text(longText, 'r1')], [], 'active');
 
-		expect(blocks.map((b) => b.type)).toEqual(['thinking', 'text']);
+		// The trailing 'activity' block is the run's live-state indicator, not
+		// part of the promotion under test.
+		expect(blocks.filter((b) => b.type !== 'activity').map((b) => b.type)).toEqual([
+			'thinking',
+			'text',
+		]);
 	});
 
 	test('short streaming tail text of a later response stays inside the block', () => {
@@ -653,11 +658,32 @@ describe('buildTimelineBlocks', () => {
 
 	test('trailing text past the narration cap settles the thinking block', () => {
 		// Answer-length text is a committed answer — a block still "thinking"
-		// behind a streaming answer reads as lag.
+		// behind a streaming answer reads as lag. A standalone indicator carries
+		// the run's live state instead (see the next test).
 		const longAnswer = 'A'.repeat(240) + '.';
 		const blocks = blocksOf([reasoning('r1'), text(longAnswer, 'r2')], [], 'active');
-		expect(blocks.map((b) => b.type)).toEqual(['thinking', 'text']);
+		expect(blocks.map((b) => b.type)).toEqual(['thinking', 'text', 'activity']);
 		expect(blocks[0].type === 'thinking' && blocks[0].active).toBe(false);
+	});
+
+	test('a settled block behind a committed answer still surfaces an activity indicator', () => {
+		// INS-1224: the model wrote a long plan and then went quiet for ~53s while
+		// generating a tool call. Nothing in the transcript moved, yet the composer
+		// stayed in stop-mode — the UI claimed done and busy at the same time.
+		const longAnswer = 'A'.repeat(240) + '.';
+		const blocks = blocksOf([reasoning('r1'), text(longAnswer, 'r2')], [], 'active');
+		expect(blocks.at(-1)?.type).toBe('activity');
+	});
+
+	test('no activity indicator once the run settles', () => {
+		const longAnswer = 'A'.repeat(240) + '.';
+		const blocks = blocksOf([reasoning('r1'), text(longAnswer, 'r2')], [], 'completed');
+		expect(blocks.map((b) => b.type)).toEqual(['thinking', 'text']);
+	});
+
+	test('no activity indicator while a thinking block is already active', () => {
+		const blocks = blocksOf([reasoning('r1'), text('Answer...', 'r2')], [], 'active');
+		expect(blocks.some((b) => b.type === 'activity')).toBe(false);
 	});
 
 	test('real user-facing interruptions settle the thinking block immediately', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
@@ -16,6 +16,19 @@ const INVISIBLE_RENDER_HINTS = new Set(['data-table', 'eval-setup']);
  *  beyond it, it is likely the final answer and renders outside the block. */
 const TAIL_NARRATION_MAX_LENGTH = 200;
 
+/**
+ * How long the transcript must stay quiet before the activity indicator shows.
+ *
+ * Short silences are normal — the tail of a streamed answer, a run wrapping up
+ * after its last token — and calling those "Thinking" is noise on every reply.
+ * A real stall is an order of magnitude longer: a provider that buffers tool
+ * calls goes quiet for 10s on a 4.5KB write and ~53s on a 20KB one (INS-1224).
+ *
+ * A threshold rather than a signal, because the client cannot tell the two
+ * apart on its own; the server knowing it is mid-generation would replace this.
+ */
+export const ACTIVITY_INDICATOR_DELAY_MS = 5_000;
+
 type TextEntry = Extract<InstanceAiTimelineEntry, { type: 'text' }>;
 
 /**

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
@@ -35,7 +35,8 @@ export type TimelineBlock =
 	| { type: 'plan-review'; key: string; toolCall: InstanceAiToolCallState }
 	| { type: 'mcp-connect'; key: string; toolCall: InstanceAiToolCallState }
 	| { type: 'questions'; key: string; toolCall: InstanceAiToolCallState }
-	| { type: 'child'; key: string; child: InstanceAiAgentNode };
+	| { type: 'child'; key: string; child: InstanceAiAgentNode }
+	| { type: 'activity'; key: string };
 
 type ToolCallKind =
 	| 'hidden'
@@ -230,14 +231,30 @@ export function buildTimelineBlocks(
 	// that outgrew the narration cap: it is a committed answer, so keeping the
 	// block behind it "thinking" reads as lag.
 	if (agentStatus === 'active') {
+		let activated = false;
+		let settledByNarrationCap = false;
 		for (let i = blocks.length - 1; i >= 0; i--) {
 			const block = blocks[i];
 			if (block.type === 'thinking') {
 				block.active = true;
+				activated = true;
 				break;
 			}
 			if (block.type !== 'text') break;
-			if (block.entry.content.length > TAIL_NARRATION_MAX_LENGTH) break;
+			if (block.entry.content.length > TAIL_NARRATION_MAX_LENGTH) {
+				settledByNarrationCap = true;
+				break;
+			}
+		}
+		// A committed answer settles the block behind it, but the run is still
+		// going — and with a provider that emits nothing while it generates a
+		// tool call, the next trace entry can be a minute away. Without this the
+		// transcript reads as finished while the composer still shows stop
+		// (INS-1224). Only the narration-cap exit gets an indicator: the other
+		// exits are cards, questions and child agents, which carry their own
+		// state or are waiting on the user.
+		if (!activated && settledByNarrationCap) {
+			blocks.push({ type: 'activity', key: 'activity' });
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
@@ -114,6 +114,20 @@ const childrenById = computed(() => {
 	return map;
 });
 
+/**
+ * Changes whenever the run visibly advances: a new run, a new timeline entry,
+ * or the tail entry growing. Drives the activity indicator's clock — an
+ * entry-derived key can't, because the tail entry's identity is stable while
+ * its content streams.
+ */
+const progressToken = computed(() => {
+	const entries = timelineEntries.value;
+	const tail = entries.at(-1);
+	const tailSize =
+		tail && (tail.type === 'text' || tail.type === 'reasoning') ? tail.content.length : 0;
+	return `${thread.activeRunId}:${entries.length}:${tailSize}`;
+});
+
 const renderBlocks = computed(() =>
 	buildTimelineBlocks(
 		timelineEntries.value,
@@ -298,6 +312,7 @@ function mapTaskItemsToPlannedTasks(tasks?: TaskList): PlannedTaskArg[] | undefi
 			<!-- The run is live but a committed answer settled the block behind it -->
 			<TimelineActivityIndicator
 				v-else-if="block.type === 'activity' && !thread.isAwaitingConfirmation"
+				:progress-token="progressToken"
 			/>
 
 			<!-- Child agent — flat section -->

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
@@ -23,6 +23,7 @@ import InstanceAiMcpConnect from './InstanceAiMcpConnect.vue';
 import PlanReviewPanel, { type PlannedTaskArg, type PlanReviewStatus } from './PlanReviewPanel.vue';
 import TaskChecklist from './TaskChecklist.vue';
 import ThinkingBlock from './ThinkingBlock.vue';
+import TimelineActivityIndicator from './TimelineActivityIndicator.vue';
 import TimelineTextSegment from './TimelineTextSegment.vue';
 
 const i18n = useI18n();
@@ -293,6 +294,11 @@ function mapTaskItemsToPlannedTasks(tasks?: TaskList): PlannedTaskArg[] | undefi
 
 			<!-- Answered questions (read-only after resolution) -->
 			<AnsweredQuestions v-else-if="block.type === 'questions'" :tool-call="block.toolCall" />
+
+			<!-- The run is live but a committed answer settled the block behind it -->
+			<TimelineActivityIndicator
+				v-else-if="block.type === 'activity' && !thread.isAwaitingConfirmation"
+			/>
 
 			<!-- Child agent — flat section -->
 			<template v-else-if="block.type === 'child'">

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/TimelineActivityIndicator.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/TimelineActivityIndicator.vue
@@ -1,20 +1,41 @@
 <script lang="ts" setup>
 import { N8nAiActivityStep } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
-import { computed, onUnmounted, ref } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
+import { ACTIVITY_INDICATOR_DELAY_MS } from '../agentTimeline.utils';
+
+const props = defineProps<{
+	/**
+	 * Changes whenever the run visibly advances. Wall clock is the only signal
+	 * available — coalesced text carries no timestamp (INS-1257) — so the caller
+	 * tells us when to start over.
+	 */
+	progressToken: string;
+}>();
 
 const i18n = useI18n();
 
 /**
- * Wall clock since the indicator mounted, mirroring how AiThinkingBlock counts:
- * event timestamps can't be used here because the whole point of this block is
- * that no event has arrived. What matters is that something visibly advances
- * while the model is quiet.
+ * Time since the run last showed any sign of life, not since this component
+ * mounted: the tail entry keeps growing while text streams, and counting that
+ * as dead time overstates the stall.
+ *
+ * Reset rather than remount. Progress arrives one delta at a time, so keying
+ * the component on it would rebuild it once per token.
  */
-const mountedAt = Date.now();
+let since = Date.now();
 const elapsedSec = ref(0);
+
+watch(
+	() => props.progressToken,
+	() => {
+		since = Date.now();
+		elapsedSec.value = 0;
+	},
+);
+
 const ticker = setInterval(() => {
-	elapsedSec.value = Math.floor((Date.now() - mountedAt) / 1000);
+	elapsedSec.value = Math.floor((Date.now() - since) / 1000);
 }, 1000);
 
 onUnmounted(() => clearInterval(ticker));
@@ -24,14 +45,17 @@ function formatDuration(totalSec: number): string {
 	return `${Math.floor(totalSec / 60)}m ${totalSec % 60}s`;
 }
 
-const label = computed(() => {
-	const active = i18n.baseText('ai.thinking.active');
-	return elapsedSec.value >= 1 ? `${active} · ${formatDuration(elapsedSec.value)}` : active;
-});
+/** Held back until the silence is long enough to be worth reporting. */
+const visible = computed(() => elapsedSec.value * 1000 >= ACTIVITY_INDICATOR_DELAY_MS);
+
+const label = computed(
+	() => `${i18n.baseText('ai.thinking.active')} · ${formatDuration(elapsedSec.value)}`,
+);
 </script>
 
 <template>
 	<N8nAiActivityStep
+		v-if="visible"
 		:label="label"
 		loading
 		:has-content="false"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/TimelineActivityIndicator.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/TimelineActivityIndicator.vue
@@ -1,0 +1,40 @@
+<script lang="ts" setup>
+import { N8nAiActivityStep } from '@n8n/design-system';
+import { useI18n } from '@n8n/i18n';
+import { computed, onUnmounted, ref } from 'vue';
+
+const i18n = useI18n();
+
+/**
+ * Wall clock since the indicator mounted, mirroring how AiThinkingBlock counts:
+ * event timestamps can't be used here because the whole point of this block is
+ * that no event has arrived. What matters is that something visibly advances
+ * while the model is quiet.
+ */
+const mountedAt = Date.now();
+const elapsedSec = ref(0);
+const ticker = setInterval(() => {
+	elapsedSec.value = Math.floor((Date.now() - mountedAt) / 1000);
+}, 1000);
+
+onUnmounted(() => clearInterval(ticker));
+
+function formatDuration(totalSec: number): string {
+	if (totalSec < 60) return `${totalSec}s`;
+	return `${Math.floor(totalSec / 60)}m ${totalSec % 60}s`;
+}
+
+const label = computed(() => {
+	const active = i18n.baseText('ai.thinking.active');
+	return elapsedSec.value >= 1 ? `${active} · ${formatDuration(elapsedSec.value)}` : active;
+});
+</script>
+
+<template>
+	<N8nAiActivityStep
+		:label="label"
+		loading
+		:has-content="false"
+		data-test-id="timeline-activity-indicator"
+	/>
+</template>


### PR DESCRIPTION
## Summary

The AI Assistant transcript could claim it was finished while the run was still live: the thinking block settled to "Thought for 33s", the model's last message rendered as a completed answer, and nothing moved — yet the composer stayed on the stop button, so the user couldn't type either.

Reported on internal with a **53-second** dead window. Root cause is two things meeting:

1. `buildTimelineBlocks` refuses to mark a thinking block active behind trailing text over `TAIL_NARRATION_MAX_LENGTH` (200 chars) — a deliberate choice, since a block still "thinking" behind a committed answer reads as lag. With a long plan narration, that leaves **no** active block anywhere.
2. The orchestrator was on `kimi-k3` via `moonshotai` — an OpenAI-compatible chat endpoint that ships tool calls whole. Measured over 232 tool calls on the reported thread, `tool-input-start` lands **0.04 s** on average before the finished `tool-call`, so it is useless as a progress signal. A 20 KB `workspace_write_file` took 56.7 s to generate and published nothing for ~53 s of it.

(1) is the necessary condition — without it, silence renders as a ticking "Thinking… 53s", which is slow but legible. (2) only sets the duration. So this PR fixes (1).

Trailing text still promotes out of the block — that part was right, and burying an answer in a collapsed block would be worse. What changes is that the block behind it no longer swallows the run's live state: a standalone activity row carries it until the next trace entry arrives.

Rendered output for the reported timeline, 47 s in:

```
[instance-ai-thinking-block]   Thought for 33s              ← collapsed, settled
                               I found your new BigQuery credential (gs_BQ_cred)…
                               My plan for Code-node elimination: …
[timeline-activity-indicator]  ◌ Thinking · 47s             ← new
```

The indicator reuses the existing `ai.thinking.active` string, so there is no new copy to translate. On Anthropic and the OpenAI Responses API it will rarely be visible — both emit `tool-input-start` before any argument bytes, so the block reactivates within a second.

### Known trade-off, worth a reviewer's opinion

A run stays `active` until `run-finish`, so while the model streams its *final* answer the indicator appears beneath it and ticks for a few seconds before the run ends. That's honest, but it is a milder version of the lag reading the original guard was written to prevent.

The alternative is a grace period — reveal the indicator only after N seconds with no visible progress, resetting whenever the tail text grows. Normal streaming answers would never show it; only genuine stalls would. ~20 more lines. Happy to add it in this PR if reviewers prefer that.

## How to test

Needs a model whose provider buffers tool calls — `kimi-k3` via `moonshotai` could reproduce this, but getting to this condition was hard.

1. Point Instance AI at `kimi-k3` and enable the sandbox.
2. Prompt: *"Before you start, write out your full plan in detail. Then build me a workflow with at least 12 nodes…"* — the plan gives the >200-char narration, the node count gives a large `workspace_write_file`.
3. **Before:** once the plan finishes streaming, the transcript goes completely still — settled "Thought for Xs", plan text, nothing else — while the composer shows stop.
4. **After:** a `Thinking · Xs` row sits below the plan and counts up until the tool call lands, at which point it hands off to the thinking block showing "Writing file · …".

The window scales with the tool-call payload — roughly 3 s fixed plus ~1.5 ms per byte, so ~10 s for a 4.5 KB write and ~53 s for a 20 KB one. Small builds may only stall for a few seconds.

Unit coverage: `agentTimeline.utils.test.ts` (indicator present behind a committed answer, absent once the run settles, absent while a thinking block is already active) and `TimelineActivityIndicator.test.ts` (renders, counts up).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1224

A proper solution would be to surface progress *during* tool-call generation, so the label can say "Writing file" instead of "Thinking". Blocked on determining whether moonshot streams arguments at all or buffers the whole `tool_calls` array.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

