### PR TITLE
perf(core): Reduce package import memory

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
@@ -29,6 +29,7 @@ import {
 	buildEntityPackageBuffer,
 	dataTableRequirement,
 	serializedDataTable,
+	serializedProject,
 	serializedWorkflowWithDataTable,
 } from './fixtures/package-fixtures';
 import { buildWorkflowReferencingDataTables } from './utils/test-builders';
@@ -164,6 +165,60 @@ describe('workflow package import — with data tables', () => {
 				{},
 			);
 			expect(rowCount).toBe(0);
+		});
+
+		it('reuses bundled table schemas across projects', async () => {
+			licenseMocker.enable('feat:projectRole:admin');
+			licenseMocker.setQuota('quota:maxTeamProjects', -1);
+			const firstTable = serializedDataTable({ id: 'dtsourcea', name: 'Customers' });
+			const secondTable = serializedDataTable({ id: 'dtsourceb', name: 'Orders' });
+			const firstWorkflow = serializedWorkflowWithDataTable({
+				id: 'WFA',
+				name: 'Customers workflow',
+				dataTableId: firstTable.id,
+			});
+			const secondWorkflow = serializedWorkflowWithDataTable({
+				id: 'WFB',
+				name: 'Orders workflow',
+				dataTableId: secondTable.id,
+			});
+			const packageBuffer = await buildEntityPackageBuffer({
+				projects: [
+					{
+						target: 'projects/alpha',
+						project: serializedProject({ id: 'P1', name: 'alpha' }),
+					},
+					{
+						target: 'projects/beta',
+						project: serializedProject({ id: 'P2', name: 'beta' }),
+					},
+				],
+				workflows: [
+					{ target: 'projects/alpha/workflows/customers', workflow: firstWorkflow },
+					{ target: 'projects/beta/workflows/orders', workflow: secondWorkflow },
+				],
+				dataTables: [
+					{ target: 'projects/alpha/data-tables/customers', dataTable: firstTable },
+					{ target: 'projects/beta/data-tables/orders', dataTable: secondTable },
+				],
+				manifestExtras: {
+					requirements: {
+						dataTables: [
+							dataTableRequirement(firstTable, [firstWorkflow.id]),
+							dataTableRequirement(secondTable, [secondWorkflow.id]),
+						],
+					},
+				},
+			});
+
+			try {
+				await service.importPackage(importPackageRequest({ user: owner, packageBuffer }));
+
+				expect((await tablesInProject('P1')).map(({ id }) => id)).toEqual([firstTable.id]);
+				expect((await tablesInProject('P2')).map(({ id }) => id)).toEqual([secondTable.id]);
+			} finally {
+				licenseMocker.reset();
+			}
 		});
 
 		it('handles a package mixing matched and created tables', async () => {

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-package.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-package.integration.test.ts
@@ -34,6 +34,7 @@ import { createMember, createOwner } from '@test-integration/db/users';
 import { LicenseMocker } from '@test-integration/license';
 import { initNodeTypes } from '@test-integration/utils';
 
+import { TarPackageReader } from '../io/tar/tar-package-reader';
 import { TarPackageWriter } from '../io/tar/tar-package-writer';
 import { N8nPackagesService } from '../n8n-packages.service';
 import { importPackageRequest } from './fixtures/import-request';
@@ -180,23 +181,29 @@ describe('Package import batch validation', () => {
 			serializedWorkflow({ id: 'wf-source-1', name: 'First' }),
 			serializedWorkflow({ id: 'wf-source-2', name: 'Second' }),
 		]);
+		const releaseAllFiles = vi.spyOn(TarPackageReader.prototype, 'releaseAllFiles');
 
-		const result = await importPackage({
-			user: owner,
-			packageBuffer: tarBuffer,
-		});
+		try {
+			const result = await importPackage({
+				user: owner,
+				packageBuffer: tarBuffer,
+			});
 
-		expect(result.workflows).toHaveLength(2);
-		expect(result.bindings.credentials).toEqual({});
+			expect(releaseAllFiles).toHaveBeenCalledOnce();
+			expect(result.workflows).toHaveLength(2);
+			expect(result.bindings.credentials).toEqual({});
 
-		const workflowRepo = Container.get(WorkflowRepository);
-		const sharedRepo = Container.get(SharedWorkflowRepository);
+			const workflowRepo = Container.get(WorkflowRepository);
+			const sharedRepo = Container.get(SharedWorkflowRepository);
 
-		expect(await workflowRepo.count()).toBe(2);
-		expect(await sharedRepo.count({ where: { projectId: personalProject.id } })).toBe(2);
+			expect(await workflowRepo.count()).toBe(2);
+			expect(await sharedRepo.count({ where: { projectId: personalProject.id } })).toBe(2);
 
-		const allWorkflows = await workflowRepo.find({ order: { name: 'ASC' } });
-		expect(allWorkflows.map((w) => w.sourceWorkflowId)).toEqual(['wf-source-1', 'wf-source-2']);
+			const allWorkflows = await workflowRepo.find({ order: { name: 'ASC' } });
+			expect(allWorkflows.map((w) => w.sourceWorkflowId)).toEqual(['wf-source-1', 'wf-source-2']);
+		} finally {
+			releaseAllFiles.mockRestore();
+		}
 	});
 });
 

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-projects.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-projects.integration.test.ts
@@ -35,6 +35,7 @@ import { createProjectVariable, createVariable } from '@test-integration/db/vari
 import { LicenseMocker } from '@test-integration/license';
 import { initNodeTypes } from '@test-integration/utils';
 
+import { TarPackageReader } from '../io/tar/tar-package-reader';
 import { N8nPackagesService } from '../n8n-packages.service';
 import { importPackageRequest } from './fixtures/import-request';
 import type {
@@ -165,12 +166,18 @@ describe('project shell import', () => {
 				{ target: 'projects/stilton', project: serializedProject({ id: 'P2', name: 'stilton' }) },
 			],
 		});
+		const releaseAllFiles = vi.spyOn(TarPackageReader.prototype, 'releaseAllFiles');
 
-		const result = await importProjects(owner, packageBuffer);
+		try {
+			const result = await importProjects(owner, packageBuffer);
 
-		expect(result.projects.map((p) => p.localId).sort()).toEqual(['P1', 'P2']);
-		expect(await findProject('P1')).not.toBeNull();
-		expect(await findProject('P2')).not.toBeNull();
+			expect(releaseAllFiles).toHaveBeenCalledOnce();
+			expect(result.projects.map((p) => p.localId).sort()).toEqual(['P1', 'P2']);
+			expect(await findProject('P1')).not.toBeNull();
+			expect(await findProject('P2')).not.toBeNull();
+		} finally {
+			releaseAllFiles.mockRestore();
+		}
 	});
 
 	it('creates two distinct projects that share a name but differ by id', async () => {

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/n8n-package-parser.project.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/n8n-package-parser.project.test.ts
@@ -76,4 +76,44 @@ describe('N8nPackageParser.getProjects — custom span attributes', () => {
 
 		expect(readManifest).toHaveBeenCalledOnce();
 	});
+
+	it('reads and releases data table schemas only once', async () => {
+		const path = 'data-tables/orders/data-table.json';
+		const files: Record<string, unknown> = {
+			[path]: { id: 'dtsource1', name: 'Orders', columns: [] },
+		};
+		const reader = {
+			...makeReader(
+				{
+					...baseManifest(),
+					dataTables: [{ id: 'dtsource1', name: 'Orders', target: 'data-tables/orders' }],
+				},
+				files,
+			),
+			releaseFile: vi.fn((releasedPath: string) => {
+				delete files[releasedPath];
+			}),
+		};
+		const readFile = vi.spyOn(reader, 'readFile');
+
+		await parser.getDataTables(reader);
+		await parser.getDataTables(reader);
+
+		expect(readFile).toHaveBeenCalledOnce();
+		expect(reader.releaseFile).toHaveBeenCalledExactlyOnceWith(path);
+	});
+
+	it('releases malformed JSON files', async () => {
+		const path = 'projects/billing/project.json';
+		const releaseFile = vi.fn();
+		const reader: PackageReader = {
+			readManifest: async () => await Promise.resolve(baseManifest()),
+			readFile: async () => await Promise.resolve(Buffer.from('{not-json')),
+			releaseFile,
+			listEntries: async () => await Promise.resolve([path]),
+		};
+
+		await expect(parser.getProjects(reader)).rejects.toThrow(/not valid JSON/i);
+		expect(releaseFile).toHaveBeenCalledExactlyOnceWith(path);
+	});
 });

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/n8n-package-parser.project.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/n8n-package-parser.project.test.ts
@@ -66,4 +66,14 @@ describe('N8nPackageParser.getProjects — custom span attributes', () => {
 
 		expect(project.customTelemetryTags).toBeUndefined();
 	});
+
+	it('validates each package manifest only once', async () => {
+		const reader = makeReader(baseManifest(), {});
+		const readManifest = vi.spyOn(reader, 'readManifest');
+
+		await parser.getManifest(reader);
+		await parser.getManifest(reader);
+
+		expect(readManifest).toHaveBeenCalledOnce();
+	});
 });

--- a/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
@@ -83,6 +83,8 @@ export interface ImportOrchestrationInput {
 	subWorkflowRequirements?: PackageWorkflowRequirement[];
 }
 
+type ImportPlanInput = Omit<ImportOrchestrationInput, 'folders' | 'workflows'>;
+
 /**
  * Everything one scope's {@link ImportOrchestrator.apply} wrote, before the package-wide publish
  * sweep runs. Telemetry consumes this shape directly — it only reads statuses and ids.
@@ -101,7 +103,7 @@ export interface ImportContentResult {
 }
 
 export interface ImportPlan {
-	input: ImportOrchestrationInput;
+	input: ImportPlanInput;
 	folderContext: FolderImportContext;
 	credentialPlan: CredentialResolution;
 	workflowPlan: WorkflowImportPlan;
@@ -188,16 +190,9 @@ export class ImportOrchestrator {
 	}
 
 	async plan(input: ImportOrchestrationInput): Promise<ImportPlan> {
-		const {
-			context,
-			folders,
-			workflows,
-			credentialRequest,
-			dataTableRequest,
-			variableRequest,
-			tagRequest,
-			options,
-		} = input;
+		const { folders, workflows, ...planInput } = input;
+		const { context, credentialRequest, dataTableRequest, variableRequest, tagRequest, options } =
+			planInput;
 
 		await this.workflowPublisher.assertCanPublish(
 			context.user,
@@ -261,7 +256,7 @@ export class ImportOrchestrator {
 		});
 
 		return {
-			input,
+			input: planInput,
 			folderContext,
 			credentialPlan,
 			workflowPlan,

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -34,6 +34,10 @@ import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
  */
 @Service()
 export class N8nPackageParser {
+	private readonly manifests = new WeakMap<PackageReader, Promise<PackageManifest>>();
+
+	private readonly dataTables = new WeakMap<PackageReader, Promise<SerializedDataTable[]>>();
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly nodeTypes: NodeTypes,
@@ -41,6 +45,15 @@ export class N8nPackageParser {
 	) {}
 
 	async getManifest(reader: PackageReader): Promise<PackageManifest> {
+		let manifest = this.manifests.get(reader);
+		if (!manifest) {
+			manifest = this.parseManifest(reader);
+			this.manifests.set(reader, manifest);
+		}
+		return await manifest;
+	}
+
+	private async parseManifest(reader: PackageReader): Promise<PackageManifest> {
 		try {
 			return packageManifestSchema.parse(await reader.readManifest());
 		} catch (error) {
@@ -75,6 +88,15 @@ export class N8nPackageParser {
 
 	/** Reads the package's data table schemas. */
 	async getDataTables(reader: PackageReader): Promise<SerializedDataTable[]> {
+		let dataTables = this.dataTables.get(reader);
+		if (!dataTables) {
+			dataTables = this.readDataTables(reader);
+			this.dataTables.set(reader, dataTables);
+		}
+		return await dataTables;
+	}
+
+	private async readDataTables(reader: PackageReader): Promise<SerializedDataTable[]> {
 		const manifest = await this.getManifest(reader);
 
 		const dataTables: SerializedDataTable[] = [];
@@ -290,8 +312,12 @@ export class N8nPackageParser {
 			});
 		}
 
-		return jsonParse<T>(content.toString('utf-8'), {
-			errorMessage: `Package ${label} file at ${path} is not valid JSON.`,
-		});
+		try {
+			return jsonParse<T>(content.toString('utf-8'), {
+				errorMessage: `Package ${label} file at ${path} is not valid JSON.`,
+			});
+		} finally {
+			reader.releaseFile?.(path);
+		}
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
@@ -113,6 +113,7 @@ export class ProjectPackageImporter {
 			const plan = await this.importOrchestrator.plan(input);
 			planned.push({ project, plan });
 		}
+		reader.releaseAllFiles?.();
 
 		assertTagWritesAllowed(
 			request.apiKeyScopes,

--- a/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
@@ -129,6 +129,7 @@ export class WorkflowPackageImporter {
 			options: request,
 			subWorkflowRequirements: identifyRequirements(manifest.requirements?.workflows, workflows),
 		});
+		reader.releaseAllFiles?.();
 
 		assertTagWritesAllowed(request.apiKeyScopes, [plan.tagPlan]);
 		await this.importOrchestrator.assertNotBlocked([plan], { apiKeyScopes: request.apiKeyScopes });

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-importer.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-importer.test.ts
@@ -111,6 +111,11 @@ describe('WorkflowImporter.apply', () => {
 			'existing-update',
 			{ publicApi: true, source: 'import' },
 		);
+		expect(items[0].entity).toBe(created);
+		expect(items[1].entity).toBe(updated);
+		expect(items[1].existing?.nodes).toBe(updated.nodes);
+		expect(items[1].existing?.parentFolder).toBe(existingUpdate.parentFolder);
+		expect(items[2].entity).toBe(existingSkip);
 	});
 
 	it('does not prepare a batch context when no workflows are created', async () => {

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-importer.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-importer.test.ts
@@ -8,9 +8,10 @@ import type {
 } from '@/workflows/workflow-creation.service';
 import type { WorkflowService } from '@/workflows/workflow.service';
 
-import type { PackageImportBindings } from '../../../n8n-packages.types';
+import type { ImportWorkflowProperties, PackageImportBindings } from '../../../n8n-packages.types';
 import type { WorkflowImportMatchService } from '../workflow-import-match.service';
 import type {
+	PreparedWorkflow,
 	WorkflowImportContext,
 	WorkflowImportPlan,
 	WorkflowPlanItem,
@@ -32,6 +33,45 @@ const context = {
 	folderId: 'fallback-folder',
 	droppedTagIds: new Set<string>(),
 } as WorkflowImportContext;
+
+describe('WorkflowImporter.plan', () => {
+	it('transfers ownership of prepared workflow entities to the plan', async () => {
+		const findBySourceWorkflowIds = vi
+			.fn<WorkflowImportMatchService['findBySourceWorkflowIds']>()
+			.mockResolvedValue(new Map());
+		const findOwningProjectsByWorkflowId = vi
+			.fn<WorkflowImportMatchService['findOwningProjectsByWorkflowId']>()
+			.mockResolvedValue(new Map());
+		const importer = new WorkflowImporter(
+			mock<WorkflowImportMatchService>({
+				findBySourceWorkflowIds,
+				findOwningProjectsByWorkflowId,
+			}),
+			mock<WorkflowCreationService>(),
+			mock<WorkflowService>(),
+		);
+		const entity = makeWorkflow('source');
+		const prepared: PreparedWorkflow[] = [
+			{
+				entity,
+				sourceWorkflowId: 'source',
+				parentFolderId: null,
+				sourcePublished: false,
+			},
+		];
+		const options = {
+			workflowConflictPolicy: 'new-version',
+			workflowPublishingPolicy: 'preserve-published-state',
+			workflowIdPolicy: 'new',
+			missingNodeTypeMode: 'fail',
+		} satisfies ImportWorkflowProperties;
+
+		const plan = await importer.plan(context, prepared, options);
+
+		expect(prepared).toEqual([]);
+		expect(plan.items[0].entity).toBe(entity);
+	});
+});
 
 describe('WorkflowImporter.apply', () => {
 	it('prepares one batch context and passes it only to created workflows', async () => {

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
@@ -1,4 +1,4 @@
-import { WorkflowEntity } from '@n8n/db';
+import type { WorkflowEntity } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import {
@@ -182,6 +182,7 @@ export class WorkflowImporter {
 		batchContext: WorkflowCreateBatchContext | undefined,
 	): Promise<PersistedWorkflowOutcome> {
 		if (item.action === 'skip') {
+			item.entity = item.existing;
 			return {
 				status: 'skipped',
 				workflow: item.existing,
@@ -189,9 +190,18 @@ export class WorkflowImporter {
 			};
 		}
 
+		const workflow = await this.persistWorkflow(context, item, bindings, batchContext);
+		// Planning is complete, so point the plan at the saved workflow instead of
+		// retaining the package and target node graphs beside the persisted one.
+		item.entity = workflow;
+		if (item.action === 'update') {
+			workflow.parentFolder ??= item.existing.parentFolder;
+			item.existing = workflow;
+		}
+
 		return {
 			status: item.action === 'create' ? 'created' : 'updated',
-			workflow: await this.persistWorkflow(context, item, bindings, batchContext),
+			workflow,
 			sourceWorkflowId: item.sourceWorkflowId,
 			item,
 		};
@@ -236,17 +246,13 @@ export function collectPlannedWorkflowBindings(items: WorkflowPlanItem[]): Impor
 	return new Map(items.map((item) => [item.sourceWorkflowId, planItemTargetId(item)]));
 }
 
-/** Clones package content for persistence without mutating the import plan. */
+/** Applies resolved bindings after planning, when the package entity is no longer read as source data. */
 function prepareEntityForPersist(
 	source: WorkflowEntity,
 	bindings: PackageImportBindings,
 	decidedId?: string,
 ): WorkflowEntity {
-	const entity = Object.assign(new WorkflowEntity(), source, {
-		nodes: structuredClone(source.nodes),
-		...(source.settings ? { settings: structuredClone(source.settings) } : {}),
-		...(decidedId !== undefined ? { id: decidedId } : {}),
-	});
+	const entity = Object.assign(source, decidedId !== undefined ? { id: decidedId } : {});
 	applyCredentialBindingsInPlace(entity, bindings.credentials);
 	for (const reference of workflowReferences) reference.apply(entity, bindings);
 	return entity;

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
@@ -109,6 +109,8 @@ export class WorkflowImporter {
 		}
 
 		const idConflicts = await this.collectIdConflicts(sourceCreateIds);
+		// Plan items take ownership of the entities so each source graph can be released after apply.
+		prepared.length = 0;
 
 		return { items, conflicts, idConflicts, folderConflicts };
 	}

--- a/packages/cli/src/modules/n8n-packages/io/__tests__/tar-package-reader.test.ts
+++ b/packages/cli/src/modules/n8n-packages/io/__tests__/tar-package-reader.test.ts
@@ -68,6 +68,19 @@ describe('TarPackageReader', () => {
 			);
 		});
 
+		it('returns the cached manifest to concurrent readers', async () => {
+			const manifest = { packageFormatVersion: '1' };
+			const buffer = await buildPackage((writer) => {
+				writer.writeFile('manifest.json', JSON.stringify(manifest));
+			});
+			const reader = new TarPackageReader(buffer, DEFAULT_LIMITS);
+
+			await expect(Promise.all([reader.readManifest(), reader.readManifest()])).resolves.toEqual([
+				manifest,
+				manifest,
+			]);
+		});
+
 		it('releases file content without changing the package entry list', async () => {
 			const entryPath = 'workflows/a/workflow.json';
 			const buffer = await buildPackage((writer) => {
@@ -78,6 +91,21 @@ describe('TarPackageReader', () => {
 
 			await reader.readManifest();
 			reader.releaseFile(entryPath);
+
+			await expect(reader.readFile(entryPath)).rejects.toThrow(/does not contain entry/i);
+			await expect(reader.listEntries()).resolves.toContain(entryPath);
+		});
+
+		it('releases all file content without changing the package entry list', async () => {
+			const entryPath = 'credentials/a/credential.json';
+			const buffer = await buildPackage((writer) => {
+				writer.writeFile('manifest.json', '{"packageFormatVersion":"1"}');
+				writer.writeFile(entryPath, '{}');
+			});
+			const reader = new TarPackageReader(buffer, DEFAULT_LIMITS);
+
+			await reader.readManifest();
+			reader.releaseAllFiles();
 
 			await expect(reader.readFile(entryPath)).rejects.toThrow(/does not contain entry/i);
 			await expect(reader.listEntries()).resolves.toContain(entryPath);

--- a/packages/cli/src/modules/n8n-packages/io/__tests__/tar-package-reader.test.ts
+++ b/packages/cli/src/modules/n8n-packages/io/__tests__/tar-package-reader.test.ts
@@ -67,6 +67,21 @@ describe('TarPackageReader', () => {
 				]),
 			);
 		});
+
+		it('releases file content without changing the package entry list', async () => {
+			const entryPath = 'workflows/a/workflow.json';
+			const buffer = await buildPackage((writer) => {
+				writer.writeFile('manifest.json', '{"packageFormatVersion":"1"}');
+				writer.writeFile(entryPath, '{}');
+			});
+			const reader = new TarPackageReader(buffer, DEFAULT_LIMITS);
+
+			await reader.readManifest();
+			reader.releaseFile(entryPath);
+
+			await expect(reader.readFile(entryPath)).rejects.toThrow(/does not contain entry/i);
+			await expect(reader.listEntries()).resolves.toContain(entryPath);
+		});
 	});
 
 	describe('manifest gating', () => {

--- a/packages/cli/src/modules/n8n-packages/io/package-reader.ts
+++ b/packages/cli/src/modules/n8n-packages/io/package-reader.ts
@@ -3,5 +3,6 @@ import type { PackageManifest } from '../spec/manifest.schema';
 export interface PackageReader {
 	readManifest(): Promise<PackageManifest>;
 	readFile(path: string): Promise<Buffer>;
+	releaseFile?(path: string): void;
 	listEntries(): Promise<string[]>;
 }

--- a/packages/cli/src/modules/n8n-packages/io/package-reader.ts
+++ b/packages/cli/src/modules/n8n-packages/io/package-reader.ts
@@ -4,5 +4,6 @@ export interface PackageReader {
 	readManifest(): Promise<PackageManifest>;
 	readFile(path: string): Promise<Buffer>;
 	releaseFile?(path: string): void;
+	releaseAllFiles?(): void;
 	listEntries(): Promise<string[]>;
 }

--- a/packages/cli/src/modules/n8n-packages/io/tar/tar-package-reader.ts
+++ b/packages/cli/src/modules/n8n-packages/io/tar/tar-package-reader.ts
@@ -20,19 +20,29 @@ export interface TarReaderLimits {
 export class TarPackageReader implements PackageReader {
 	private entries: Map<string, Buffer> | null = null;
 
+	private loading: Promise<Map<string, Buffer>> | null = null;
+
+	private manifest: PackageManifest | null = null;
+
+	private entryPaths: string[] | null = null;
+
 	constructor(
-		private readonly buffer: Buffer,
+		private buffer: Buffer | null,
 		private readonly limits: TarReaderLimits,
 	) {}
 
 	async readManifest(): Promise<PackageManifest> {
+		if (this.manifest) return this.manifest;
+
 		const entries = await this.load();
 		const manifest = entries.get(MANIFEST_PATH);
 		if (!manifest) {
 			throw new BadRequestError('Package is missing manifest.json');
 		}
 		try {
-			return jsonParse<PackageManifest>(manifest.toString('utf-8'));
+			this.manifest = jsonParse<PackageManifest>(manifest.toString('utf-8'));
+			entries.delete(MANIFEST_PATH);
+			return this.manifest;
 		} catch {
 			throw new BadRequestError('Package manifest is not valid JSON');
 		}
@@ -47,14 +57,20 @@ export class TarPackageReader implements PackageReader {
 		return content;
 	}
 
+	releaseFile(entryPath: string): void {
+		this.entries?.delete(entryPath);
+	}
+
 	async listEntries(): Promise<string[]> {
-		const entries = await this.load();
-		return Array.from(entries.keys());
+		await this.load();
+		return [...(this.entryPaths ?? [])];
 	}
 
 	private async load(): Promise<Map<string, Buffer>> {
 		if (this.entries) return this.entries;
-		this.entries = await this.parse();
+		this.loading ??= this.parse();
+		this.entries = await this.loading;
+		this.entryPaths = Array.from(this.entries.keys());
 		return this.entries;
 	}
 
@@ -90,6 +106,11 @@ export class TarPackageReader implements PackageReader {
 	}
 
 	private async parse(): Promise<Map<string, Buffer>> {
+		const source = this.buffer;
+		if (!source) {
+			throw new BadRequestError('Package archive is no longer available');
+		}
+
 		const { maxEntries, maxEntryBytes, maxUncompressedBytes } = this.limits;
 		const entries = new Map<string, Buffer>();
 		let totalUncompressedBytes = 0;
@@ -187,7 +208,11 @@ export class TarPackageReader implements PackageReader {
 			parser.on('end', () => {
 				if (!aborted) resolve(entries);
 			});
-			parser.end(this.buffer);
+			try {
+				parser.end(source);
+			} finally {
+				this.buffer = null;
+			}
 		});
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/io/tar/tar-package-reader.ts
+++ b/packages/cli/src/modules/n8n-packages/io/tar/tar-package-reader.ts
@@ -35,6 +35,8 @@ export class TarPackageReader implements PackageReader {
 		if (this.manifest) return this.manifest;
 
 		const entries = await this.load();
+		if (this.manifest) return this.manifest;
+
 		const manifest = entries.get(MANIFEST_PATH);
 		if (!manifest) {
 			throw new BadRequestError('Package is missing manifest.json');
@@ -59,6 +61,10 @@ export class TarPackageReader implements PackageReader {
 
 	releaseFile(entryPath: string): void {
 		this.entries?.delete(entryPath);
+	}
+
+	releaseAllFiles(): void {
+		this.entries?.clear();
 	}
 
 	async listEntries(): Promise<string[]> {

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.config.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.config.ts
@@ -14,7 +14,7 @@ export class PackageImportConfig {
 
 	/** Maximum number of entries in a package. */
 	@Env('N8N_IMPORT_MAX_ENTRIES')
-	maxEntries: number = 5_000;
+	maxEntries: number = 20_000;
 
 	/** Maximum length in characters of a single entry path. */
 	@Env('N8N_IMPORT_MAX_PATH_LENGTH')

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.config.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.config.ts
@@ -14,7 +14,7 @@ export class PackageImportConfig {
 
 	/** Maximum number of entries in a package. */
 	@Env('N8N_IMPORT_MAX_ENTRIES')
-	maxEntries: number = 20_000;
+	maxEntries: number = 5_000;
 
 	/** Maximum length in characters of a single entry path. */
 	@Env('N8N_IMPORT_MAX_PATH_LENGTH')

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -348,8 +348,17 @@ export class N8nPackagesService {
 		};
 	}
 
-	async importPackage(request: ImportPackageRequest): Promise<ImportResult> {
-		const reader = new TarPackageReader(request.packageBuffer, this.packageImportConfig);
+	// Keep the upload buffer out of the long-lived async import frame.
+	// eslint-disable-next-line @typescript-eslint/promise-function-async
+	importPackage({ packageBuffer, ...request }: ImportPackageRequest): Promise<ImportResult> {
+		const reader = new TarPackageReader(packageBuffer, this.packageImportConfig);
+		return this.importPackageFromReader(request, reader);
+	}
+
+	private async importPackageFromReader(
+		request: Omit<ImportPackageRequest, 'packageBuffer'>,
+		reader: TarPackageReader,
+	): Promise<ImportResult> {
 		const manifest = await this.packageParser.getManifest(reader);
 		if (isProjectPackage(manifest)) {
 			if (request.variableParentPolicy !== undefined) {

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -268,7 +268,8 @@ export type ResolvedImportFolderProperties = ImportFolderProperties & {
 };
 
 /** An import request every importer can read without re-deriving what the caller omitted. */
-export type ResolvedImportPackageRequest = ImportPackageRequest & ResolvedImportFolderProperties;
+export type ResolvedImportPackageRequest = Omit<ImportPackageRequest, 'packageBuffer'> &
+	ResolvedImportFolderProperties;
 
 export type ImportFolderProperties = {
 	/**

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -617,16 +617,19 @@ describe('n8n-packages handler', () => {
 			const result = { package: {}, workflows: [], bindings: {}, credentials: {} };
 			mockService.importPackage.mockResolvedValue(result as never);
 			const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
+			const packageBuffer = Buffer.from('tar-bytes');
+			const files = [{ fieldname: 'package', buffer: packageBuffer } as Express.Multer.File];
 
 			const caught = await runImport(
-				makeImportRequest({ workflowConflictPolicy: undefined }, ['workflow:import']),
+				makeImportRequest({ workflowConflictPolicy: undefined }, ['workflow:import'], files),
 				res,
 			);
 
 			expect(caught).toBeUndefined();
 			expect(mockService.importPackage).toHaveBeenCalledWith(
-				expect.objectContaining({ workflowConflictPolicy: 'new-version' }),
+				expect.objectContaining({ packageBuffer, workflowConflictPolicy: 'new-version' }),
 			);
+			expect(files[0].buffer).toHaveLength(0);
 			expect(mockEventService.emit).not.toHaveBeenCalled();
 		});
 

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -224,7 +224,7 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 					variableParentPolicy: payload.data.variableParentPolicy,
 					tagMissingMode: payload.data.tagMissingMode,
 					tagConflictPolicy: payload.data.tagConflictPolicy,
-					packageBuffer: packageFile.buffer,
+					packageBuffer: takePackageBuffer(packageFile),
 				});
 				return res.status(200).json(result);
 			} catch (error) {
@@ -239,5 +239,11 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 		},
 	],
 };
+
+function takePackageBuffer(file: Express.Multer.File): Buffer {
+	const buffer = file.buffer;
+	file.buffer = Buffer.alloc(0);
+	return buffer;
+}
 
 export = n8nPackagesHandlers;


### PR DESCRIPTION
## Summary

- Release the compressed package buffer and consumed archive entries during import.
- Reuse parsed manifests, data table schemas, and persisted workflow graphs.
- Increase the default package entry limit from 5,000 to 20,000 while keeping byte limits unchanged.

## How to test

1. Run `pnpm test src/modules/n8n-packages/io/__tests__/tar-package-reader.test.ts src/modules/n8n-packages/engine/__tests__/n8n-package-parser.project.test.ts src/modules/n8n-packages/entities/workflow/__tests__/workflow-importer.test.ts src/modules/n8n-packages/entities/workflow/__tests__/workflow-publisher.test.ts` from `packages/cli`.
2. Run `pnpm test:integration src/modules/n8n-packages/__tests__/import-package.integration.test.ts src/modules/n8n-packages/__tests__/import-projects.integration.test.ts` from `packages/cli`.
3. Run `pnpm typecheck` from `packages/cli`.
4. Import a package with more than 5,000 and no more than 20,000 archive entries.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/LIGO-1025
- Stacked on https://github.com/n8n-io/n8n/pull/36949

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

