### PR TITLE
fix(core)!: Check all node outputs when using "Always Output Data" before adding an empty object

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -96,6 +96,69 @@ describe('processRunExecutionData', () => {
 		expect(result.data.resultData.runData).toMatchObject({ node: [{ data: taskDataConnection }] });
 	});
 
+	describe('alwaysOutputData', () => {
+		const multiOutputNode: INodeType = {
+			...passThroughNode,
+			description: { ...passThroughNode.description, outputs: ['main', 'main'] },
+		};
+
+		const runWorkflowWithNodeOutput = async (nodeType: INodeType) => {
+			const trigger = createNodeData({ name: 'trigger', type: types.passThrough });
+			const node = {
+				...createNodeData({ name: 'node', type: 'multiOutput' }),
+				alwaysOutputData: true,
+			};
+			const nodeTypes = NodeTypes({
+				...nodeTypeArguments,
+				multiOutput: { type: nodeType, sourcePath: '' },
+			});
+			const workflow = new DirectedGraph()
+				.addNodes(trigger, node)
+				.addConnections({ from: trigger, to: node })
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const executionData = createRunExecutionData({
+				startData: { startNodes: [{ name: trigger.name, sourceData: null }] },
+				executionData: {
+					nodeExecutionStack: [
+						{ data: { main: [[{ json: { foo: 1 } }]] }, node: trigger, source: null },
+					],
+				},
+			});
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+			const result = await workflowExecute.processRunExecutionData(workflow);
+			return result.data.resultData.runData.node[0].data?.main;
+		};
+
+		test('does not add an empty item to the first output when another output has data', async () => {
+			const nodeType = modifyNode(multiOutputNode)
+				.return([[], [{ json: { routed: true } }]])
+				.done();
+
+			const main = await runWorkflowWithNodeOutput(nodeType);
+
+			expect(main?.[0]).toEqual([]);
+			expect(main?.[1]).toMatchObject([{ json: { routed: true } }]);
+		});
+
+		test('adds an empty item to the first output when every output is empty', async () => {
+			const nodeType = modifyNode(multiOutputNode).return([[], []]).done();
+
+			const main = await runWorkflowWithNodeOutput(nodeType);
+
+			expect(main?.[0]).toMatchObject([{ json: {} }]);
+		});
+
+		test('adds an empty item when a single-output node returns no data', async () => {
+			const nodeType = modifyNode(passThroughNode).return([[]]).done();
+
+			const main = await runWorkflowWithNodeOutput(nodeType);
+
+			expect(main?.[0]).toMatchObject([{ json: {} }]);
+		});
+	});
+
 	test('calls the right hooks in the right order', async () => {
 		// ARRANGE
 		const node1 = createNodeData({ name: 'node1', type: types.passThrough });

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -147,7 +147,8 @@ describe('processRunExecutionData', () => {
 
 			const main = await runWorkflowWithNodeOutput(nodeType);
 
-			expect(main?.[0]).toMatchObject([{ json: {} }]);
+expect(main?.[0]).toMatchObject([{ json: {} }]);
+			expect(main?.[1]).toEqual([]);
 		});
 
 		test('adds an empty item when a single-output node returns no data', async () => {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -147,7 +147,7 @@ describe('processRunExecutionData', () => {
 
 			const main = await runWorkflowWithNodeOutput(nodeType);
 
-expect(main?.[0]).toMatchObject([{ json: {} }]);
+			expect(main?.[0]).toMatchObject([{ json: {} }]);
 			expect(main?.[1]).toEqual([]);
 		});
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1940,7 +1940,10 @@ export class WorkflowExecute {
 								this.runExecutionData.resultData.lastNodeExecuted = executionData.node.name;
 							}
 
-							if (!nodeSuccessData?.[0]?.[0]) {
+							const noOutputData =
+								!nodeSuccessData || nodeSuccessData.every((outputData) => !outputData?.length);
+
+							if (noOutputData) {
 								if (executionData.node.alwaysOutputData === true) {
 									const pairedItem: IPairedItemData[] = [];
 


### PR DESCRIPTION
## Summary

On nodes with multiple outputs, "Always Output Data" adds an empty item to the first output even when another output produced data. This misroutes items (see the linked issue: a Switch node evaluates a condition correctly but routes the item to the wrong lane).

This PR changes the behavior: the engine now checks all outputs. It adds the empty item to the first output only when every output is empty. Single-output nodes keep the same behavior as before.

This re-lands the behavior from #17602, which was reverted in #18577 because it broke workflows on v1/v2. It now ships as a v3 breaking change. The detection rule `always-output-data-multi-output-v3` (#33553) already flags affected workflows.

**BREAKING CHANGE:** With "Always Output Data" enabled on a node with multiple outputs, an empty item is added to the first output only when all outputs are empty, instead of whenever the first output is empty.

## How to test

1. Create a workflow: Manual Trigger → IF node with "Always Output Data" enabled.
2. Set the IF condition so items go to the **false** branch.
3. Execute the workflow.
4. Before this change: the true branch shows one empty item and the false branch shows the routed item. After this change: only the false branch has the item.

Unit tests cover the three cases in `workflow-execute-process-process-run-execution-data.test.ts`:
- Multi-output node with data on a later output: no empty item is added.
- Multi-output node with all outputs empty: an empty item is added to the first output.
- Single-output node with no data: an empty item is added (unchanged behavior).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-3296
- closes https://github.com/n8n-io/n8n/issues/14334
- Original fix #17602, revert #18577, breaking-change detection rule #33553

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. (conventions)
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

