### PR TITLE
fix(eslint-config): remove unsafe autofix from no-argument-spread rule

### DIFF
--- a/packages/@n8n/eslint-config/src/rules/no-argument-spread.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-argument-spread.test.ts
@@ -15,33 +15,33 @@ ruleTester.run('no-unbounded-argument-spread', NoArgumentSpreadRule, {
 	invalid: [
 		{
 			code: 'fn(...deps)',
-			output: 'fn.apply(undefined, deps)',
-			errors: [{ messageId: 'replaceWithApply' }],
+			output: null, // no autofix: `.apply` fails at the same argument-count limit
+			errors: [{ messageId: 'noUnboundedSpread' }],
 		},
 		{
 			code: 'obj.fn(...deps)',
-			output: 'obj.fn.apply(obj, deps)',
-			errors: [{ messageId: 'replaceWithApply' }],
+			output: null,
+			errors: [{ messageId: 'noUnboundedSpread' }],
 		},
 		{
 			code: 'instance = metadata.factory(...dependencies);',
-			output: 'instance = metadata.factory.apply(metadata, dependencies);',
-			errors: [{ messageId: 'replaceWithApply' }],
+			output: null,
+			errors: [{ messageId: 'noUnboundedSpread' }],
 		},
 		{
 			code: 'new Foo(...deps)',
-			output: 'Reflect.construct(Foo, deps)',
-			errors: [{ messageId: 'replaceWithReflect' }],
+			output: null, // no autofix: `Reflect.construct` fails at the same argument-count limit
+			errors: [{ messageId: 'noUnboundedSpread' }],
 		},
 		{
 			code: 'someFunction(a, ...deps)',
-			output: null, // multiple args — no fix
-			errors: [{ messageId: 'replaceWithApply' }],
+			output: null,
+			errors: [{ messageId: 'noUnboundedSpread' }],
 		},
 		{
 			code: 'new Bar(a, ...deps)',
 			output: null,
-			errors: [{ messageId: 'replaceWithReflect' }],
+			errors: [{ messageId: 'noUnboundedSpread' }],
 		},
 	],
 });

--- a/packages/@n8n/eslint-config/src/rules/no-argument-spread.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-argument-spread.ts
@@ -5,16 +5,11 @@ export const NoArgumentSpreadRule = ESLintUtils.RuleCreator.withoutDocs({
 		type: 'problem',
 		docs: {
 			description:
-				'Avoid spreading potentially large arrays in function or constructor calls — can cause stack overflows. Use `.apply` or `Reflect.construct` instead.',
+				'Avoid spreading potentially large arrays in function or constructor calls — can cause stack overflows.',
 		},
-		fixable: 'code',
 		messages: {
 			noUnboundedSpread:
-				'Avoid spreading an array in function or constructor calls unless known to be small.',
-			replaceWithApply:
-				'Replace `array.push(...largeArray)` with `array.push.apply(array, largeArray)` to avoid potential stack overflows.',
-			replaceWithReflect:
-				'Replace `new Constructor(...args)` with `Reflect.construct(Constructor, args)` to avoid potential stack overflows.',
+				"Avoid spreading an array in a function or constructor call unless it's known to be small. Note that `.apply` / `Reflect.construct` do not avoid this problem — they hit the same engine argument-count limit. If the input can be large, use a loop, `[].concat()`, or chunking instead.",
 		},
 		schema: [],
 	},
@@ -30,30 +25,9 @@ export const NoArgumentSpreadRule = ESLintUtils.RuleCreator.withoutDocs({
 					// Allow spread of inline arrays
 					if (spreadArg.type === 'ArrayExpression') return;
 
-					// Only autofix if it's the sole argument
-					const canFix = node.arguments.length === 1;
-
 					context.report({
 						node,
-						messageId: 'replaceWithApply',
-						fix: canFix
-							? (fixer) => {
-									const source = context.sourceCode;
-
-									if (node.callee.type === 'MemberExpression') {
-										// Preserve `this`
-										const thisText = source.getText(node.callee.object);
-										const calleeText = source.getText(node.callee);
-										const argText = source.getText(spreadArg);
-										return fixer.replaceText(node, `${calleeText}.apply(${thisText}, ${argText})`);
-									} else {
-										// Not a memberexpression, use undefined as thisArg
-										const calleeText = source.getText(node.callee);
-										const argText = source.getText(spreadArg);
-										return fixer.replaceText(node, `${calleeText}.apply(undefined, ${argText})`);
-									}
-								}
-							: null,
+						messageId: 'noUnboundedSpread',
 					});
 				}
 			},
@@ -66,19 +40,9 @@ export const NoArgumentSpreadRule = ESLintUtils.RuleCreator.withoutDocs({
 
 					if (spreadArg.type === 'ArrayExpression') return;
 
-					const canFix = node.arguments.length === 1;
-
 					context.report({
 						node,
-						messageId: 'replaceWithReflect',
-						fix: canFix
-							? (fixer) => {
-									const source = context.sourceCode;
-									const ctorText = source.getText(node.callee);
-									const argText = source.getText(spreadArg);
-									return fixer.replaceText(node, `Reflect.construct(${ctorText}, ${argText})`);
-								}
-							: null,
+						messageId: 'noUnboundedSpread',
 					});
 				}
 			},


### PR DESCRIPTION
Fixes #36927

## What

Removes the autofixes from the `no-argument-spread` rule while keeping the diagnostic itself intact.

## Why

As detailed in #36927, the suggested fixes do not actually prevent stack overflows — they fail at the same argument-count threshold as the spread syntax they replace:

- `arr.push(...items)` → `arr.push.apply(arr, items)`: `Function.prototype.apply` converts its array argument into an argument list internally (ECMA-262 §20.2.3.1), exactly like spread does.
- `new Ctor(...args)` → `Reflect.construct(Ctor, args)`: same story (§28.1.2).

So the autofix traded readable idiomatic code for obscure code without any safety gain, and could silently rewrite code during `eslint --fix`. The reporter's measurements show identical failure limits for both forms.

Since there is no safe mechanical fix, the rule now reports without one, and the message points to genuinely safe alternatives (looping, `[].concat()`, chunking). The old description telling users to "use `.apply` or `Reflect.construct` instead" was removed accordingly.

## Changes

- `no-argument-spread.ts`: dropped `fixable: 'code'`, both fixers, and the `replaceWithApply` / `replaceWithReflect` messages; consolidated into a single `noUnboundedSpread` message with accurate guidance.
- `no-argument-spread.test.ts`: updated expectations — all invalid cases now assert `output: null` (no autofix offered), detection behavior unchanged.

## Verification

- Full RuleTester suite passes (5 valid + 6 invalid cases).
- Detection semantics unchanged: still flags non-inline-array spreads in calls/constructors, still ignores inline arrays and `.apply`/`Reflect.construct` usage.

Happy to also extend the rule to flag `push.apply(...)` patterns as discussed in the issue if maintainers want that as a follow-up.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

