### PR TITLE
fix(Alibaba Cloud Node): Use async image-generation for Wan 2.6

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/actions/image/generate.operation.ts
@@ -5,11 +5,12 @@ import type {
 	INodeExecutionData,
 } from 'n8n-workflow';
 import { NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
-import { apiRequest, pollTaskResult } from '../../transport';
+
 import type { IImageOptions, IModelStudioRequestBody } from '../../helpers/interfaces';
+import { planWanImage } from '../../helpers/wanImage';
+import { apiRequest, pollTaskResult } from '../../transport';
 import { modelRLC } from '../descriptions';
 
-const WAN_IMAGE_DEFAULT_SIZE = '1280*1280';
 const WAN_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 
 const properties: INodeProperties[] = [
@@ -74,7 +75,7 @@ const properties: INodeProperties[] = [
 	},
 	{
 		displayName:
-			'Wan 2.6 Image is an editing model. Attach 1 to 4 reference images, or use Wan 2.6 T2I for text-only generate.',
+			'Attach reference images for Wan image editing. Use a Wan t2i model for text-only generate.',
 		name: 'wanImageEditNotice',
 		type: 'notice',
 		default: '',
@@ -290,14 +291,6 @@ const displayOptions = {
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
-function isAsyncWanImageModel(model: string): boolean {
-	return model.startsWith('wan') && (model.includes('-t2i') || model.includes('-image'));
-}
-
-function isWanImageEditModel(model: string): boolean {
-	return model.startsWith('wan') && model.includes('-image') && !model.includes('-t2i');
-}
-
 function toImageDataUri(
 	buffer: Buffer,
 	mimeType: string,
@@ -390,66 +383,73 @@ export async function execute(
 	const prompt = this.getNodeParameter('prompt', itemIndex) as string;
 	const imageOptions = this.getNodeParameter('imageOptions', itemIndex, {}) as IImageOptions;
 	const downloadImage = this.getNodeParameter('downloadImage', itemIndex, true) as boolean;
-	const useAsyncWan = isAsyncWanImageModel(model);
-	const useWanEdit = isWanImageEditModel(model);
+	const plan = planWanImage(model);
 
-	const content: Array<{ text?: string; image?: string }> = [{ text: prompt }];
-	if (useWanEdit) {
-		const referenceImages = await resolveReferenceImages(this, itemIndex);
-		if (referenceImages.length === 0) {
+	let referenceImages: string[] = [];
+	if (plan.refs) {
+		referenceImages = await resolveReferenceImages(this, itemIndex);
+		if (plan.refs.required && referenceImages.length === 0) {
 			throw new NodeOperationError(
 				this.getNode(),
-				'Wan 2.6 Image is an editing model and needs 1 to 4 reference images. Use Wan 2.6 T2I for text-only generate.',
+				`This Wan image-edit model needs 1 to ${plan.refs.max} reference images. Use a Wan t2i model for text-only generate.`,
 				{ itemIndex },
 			);
 		}
-		if (referenceImages.length > 4) {
+		if (referenceImages.length > plan.refs.max) {
 			throw new NodeOperationError(
 				this.getNode(),
-				'Wan 2.6 Image accepts at most 4 reference images.',
+				`This Wan image-edit model accepts at most ${plan.refs.max} reference images.`,
 				{ itemIndex },
 			);
 		}
-		for (const image of referenceImages) {
-			content.push({ image });
-		}
+	}
+
+	const parameters: IModelStudioRequestBody['parameters'] = {
+		prompt_extend: imageOptions.promptExtend ?? false,
+	};
+	if (plan.n !== null) {
+		parameters.n = plan.n;
+	}
+	if (plan.defaultSize !== null) {
+		parameters.size = imageOptions.size ?? plan.defaultSize;
+	} else if (imageOptions.size) {
+		parameters.size = imageOptions.size;
 	}
 
 	const body: IModelStudioRequestBody = {
 		model,
-		input: {
-			messages: [
-				{
-					role: 'user',
-					content,
-				},
-			],
-		},
-		parameters: {
-			prompt_extend: imageOptions.promptExtend ?? false,
-		},
+		input:
+			plan.input === 'prompt'
+				? {
+						prompt,
+						...(plan.attachImages === 'input' ? { images: referenceImages } : {}),
+					}
+				: {
+						messages: [
+							{
+								role: 'user',
+								content: [
+									{ text: prompt },
+									...(plan.attachImages === 'content'
+										? referenceImages.map((image) => ({ image }))
+										: []),
+								],
+							},
+						],
+					},
+		parameters,
 	};
 
-	if (useAsyncWan) {
-		body.parameters.n = 1;
-		body.parameters.size = imageOptions.size ?? WAN_IMAGE_DEFAULT_SIZE;
-	} else if (imageOptions.size) {
-		body.parameters.size = imageOptions.size;
-	}
-
 	let response: IDataObject;
-	if (useAsyncWan) {
-		const createResponse = await apiRequest.call(
-			this,
-			'POST',
-			'/api/v1/services/aigc/image-generation/generation',
-			{
-				headers: {
-					'X-DashScope-Async': 'enable',
-				},
-				body,
+	if (!plan.async) {
+		response = await apiRequest.call(this, 'POST', plan.endpoint, { body });
+	} else {
+		const createResponse = await apiRequest.call(this, 'POST', plan.endpoint, {
+			headers: {
+				'X-DashScope-Async': 'enable',
 			},
-		);
+			body,
+		});
 
 		const taskId = createResponse?.output?.task_id as string;
 		if (!taskId) {
@@ -460,15 +460,6 @@ export async function execute(
 		}
 
 		response = await pollTaskResult.call(this, taskId);
-	} else {
-		response = await apiRequest.call(
-			this,
-			'POST',
-			'/api/v1/services/aigc/multimodal-generation/generation',
-			{
-				body,
-			},
-		);
 	}
 
 	const imageUrl = extractGeneratedImageUrl(response);

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/actions/image/generate.operation.ts
@@ -1,8 +1,16 @@
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { updateDisplayOptions } from 'n8n-workflow';
-import { apiRequest } from '../../transport';
+import type {
+	IDataObject,
+	INodeProperties,
+	IExecuteFunctions,
+	INodeExecutionData,
+} from 'n8n-workflow';
+import { NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
+import { apiRequest, pollTaskResult } from '../../transport';
 import type { IImageOptions, IModelStudioRequestBody } from '../../helpers/interfaces';
 import { modelRLC } from '../descriptions';
+
+const WAN_IMAGE_DEFAULT_SIZE = '1280*1280';
+const WAN_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 
 const properties: INodeProperties[] = [
 	{
@@ -24,6 +32,11 @@ const properties: INodeProperties[] = [
 				name: 'Qwen Image Plus',
 				value: 'qwen-image-plus',
 				description: 'Enhanced Qwen image generation model',
+			},
+			{
+				name: 'Wan 2.6 Image',
+				value: 'wan2.6-image',
+				description: 'Wan image editing model. Requires 1 to 4 reference images.',
 			},
 			{
 				name: 'Wan 2.6 T2I',
@@ -60,6 +73,95 @@ const properties: INodeProperties[] = [
 		required: true,
 	},
 	{
+		displayName:
+			'Wan 2.6 Image is an editing model. Attach 1 to 4 reference images, or use Wan 2.6 T2I for text-only generate.',
+		name: 'wanImageEditNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				'/modelId': [{ _cnd: { includes: 'wan' } }],
+			},
+			hide: {
+				'/modelId': [{ _cnd: { includes: '-t2i' } }],
+			},
+		},
+	},
+	{
+		displayName: 'Reference Images',
+		name: 'referenceImages',
+		type: 'fixedCollection',
+		placeholder: 'Add Image',
+		typeOptions: {
+			multipleValues: true,
+			multipleValueButtonText: 'Add Image',
+		},
+		default: {
+			values: [{ inputType: 'url', imageUrl: '', binaryPropertyName: 'data' }],
+		},
+		description: '1 to 4 reference images for Wan image editing',
+		displayOptions: {
+			show: {
+				'/modelId': [{ _cnd: { includes: 'wan' } }],
+			},
+			hide: {
+				'/modelId': [{ _cnd: { includes: '-t2i' } }],
+			},
+		},
+		options: [
+			{
+				displayName: 'Image',
+				name: 'values',
+				values: [
+					{
+						displayName: 'Input Type',
+						name: 'inputType',
+						type: 'options',
+						options: [
+							{
+								name: 'URL',
+								value: 'url',
+							},
+							{
+								name: 'Binary Data',
+								value: 'binary',
+							},
+						],
+						default: 'url',
+					},
+					{
+						displayName: 'Image URL',
+						name: 'imageUrl',
+						type: 'string',
+						default: '',
+						placeholder: 'https://example.com/image.png',
+						displayOptions: {
+							show: {
+								inputType: ['url'],
+							},
+						},
+					},
+					{
+						displayName: 'Input Data Field Name',
+						name: 'binaryPropertyName',
+						type: 'string',
+						default: 'data',
+						placeholder: 'e.g. data',
+						hint: 'The name of the input field containing the binary image data',
+						typeOptions: {
+							binaryDataProperty: true,
+						},
+						displayOptions: {
+							show: {
+								inputType: ['binary'],
+							},
+						},
+					},
+				],
+			},
+		],
+	},
+	{
 		displayName: 'Download Image',
 		name: 'downloadImage',
 		type: 'boolean',
@@ -80,7 +182,7 @@ const properties: INodeProperties[] = [
 				type: 'options',
 				displayOptions: {
 					show: {
-						'/modelId': ['z-image-turbo', 'wan2.6-t2i'],
+						'/modelId': ['z-image-turbo'],
 					},
 				},
 				options: [
@@ -98,6 +200,40 @@ const properties: INodeProperties[] = [
 					},
 				],
 				default: '1024*1024',
+				description: 'The size of the generated image',
+			},
+			{
+				displayName: 'Size',
+				name: 'size',
+				type: 'options',
+				displayOptions: {
+					show: {
+						'/modelId': ['wan2.6-t2i', 'wan2.6-image'],
+					},
+				},
+				options: [
+					{
+						name: '1104x1472 (3:4)',
+						value: '1104*1472',
+					},
+					{
+						name: '1280x1280 (1:1)',
+						value: '1280*1280',
+					},
+					{
+						name: '1472x1104 (4:3)',
+						value: '1472*1104',
+					},
+					{
+						name: '1696x960 (16:9)',
+						value: '1696*960',
+					},
+					{
+						name: '960x1696 (9:16)',
+						value: '960*1696',
+					},
+				],
+				default: '1280*1280',
 				description: 'The size of the generated image',
 			},
 			{
@@ -154,6 +290,94 @@ const displayOptions = {
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
+function isAsyncWanImageModel(model: string): boolean {
+	return model.startsWith('wan') && (model.includes('-t2i') || model.includes('-image'));
+}
+
+function isWanImageEditModel(model: string): boolean {
+	return model.startsWith('wan') && model.includes('-image') && !model.includes('-t2i');
+}
+
+function toImageDataUri(
+	buffer: Buffer,
+	mimeType: string,
+	imageUrl: string,
+	ctx: IExecuteFunctions,
+	itemIndex: number,
+): string {
+	if (buffer.length > WAN_IMAGE_MAX_BYTES) {
+		throw new NodeOperationError(ctx.getNode(), `Reference image exceeds 10 MB: ${imageUrl}`, {
+			itemIndex,
+		});
+	}
+
+	return `data:${mimeType};base64,${buffer.toString('base64')}`;
+}
+
+async function downloadImageAsDataUri(
+	ctx: IExecuteFunctions,
+	imageUrl: string,
+	itemIndex: number,
+): Promise<string> {
+	if (imageUrl.startsWith('data:')) {
+		return imageUrl;
+	}
+
+	const imageResponse = await ctx.helpers.httpRequest({
+		method: 'GET',
+		url: imageUrl,
+		encoding: 'arraybuffer',
+		returnFullResponse: true,
+		headers: {
+			'User-Agent': 'n8n (https://n8n.io)',
+		},
+	});
+	const contentType =
+		(imageResponse.headers?.['content-type'] as string | undefined) ?? 'image/png';
+	const mimeType = contentType.split(';')[0]?.trim() || 'image/png';
+	const buffer = Buffer.from(imageResponse.body as ArrayBuffer);
+	return toImageDataUri(buffer, mimeType, imageUrl, ctx, itemIndex);
+}
+
+async function resolveReferenceImages(
+	ctx: IExecuteFunctions,
+	itemIndex: number,
+): Promise<string[]> {
+	const collection = ctx.getNodeParameter('referenceImages', itemIndex, {}) as {
+		values?: Array<{ inputType?: string; imageUrl?: string; binaryPropertyName?: string }>;
+	};
+	const uris: string[] = [];
+
+	for (const entry of collection.values ?? []) {
+		if (entry.inputType === 'binary') {
+			const propertyName = entry.binaryPropertyName ?? 'data';
+			const binaryData = ctx.helpers.assertBinaryData(itemIndex, propertyName);
+			const buffer = await ctx.helpers.getBinaryDataBuffer(itemIndex, propertyName);
+			const mimeType = binaryData.mimeType ?? 'image/png';
+			uris.push(toImageDataUri(buffer, mimeType, propertyName, ctx, itemIndex));
+		} else if (entry.imageUrl) {
+			uris.push(await downloadImageAsDataUri(ctx, entry.imageUrl, itemIndex));
+		}
+	}
+
+	return uris;
+}
+
+function extractGeneratedImageUrl(response: IDataObject): string {
+	const output = response.output as IDataObject | undefined;
+	const choices = output?.choices as Array<{ message?: { content?: Array<{ image?: string }> } }>;
+	const content = choices?.[0]?.message?.content;
+	if (Array.isArray(content)) {
+		const imagePart = content.find((part) => part?.image);
+		if (imagePart?.image) {
+			return imagePart.image;
+		}
+	}
+
+	const results = output?.results as Array<{ url?: string }>;
+	return results?.[0]?.url ?? '';
+}
+
 export async function execute(
 	this: IExecuteFunctions,
 	itemIndex: number,
@@ -166,6 +390,30 @@ export async function execute(
 	const prompt = this.getNodeParameter('prompt', itemIndex) as string;
 	const imageOptions = this.getNodeParameter('imageOptions', itemIndex, {}) as IImageOptions;
 	const downloadImage = this.getNodeParameter('downloadImage', itemIndex, true) as boolean;
+	const useAsyncWan = isAsyncWanImageModel(model);
+	const useWanEdit = isWanImageEditModel(model);
+
+	const content: Array<{ text?: string; image?: string }> = [{ text: prompt }];
+	if (useWanEdit) {
+		const referenceImages = await resolveReferenceImages(this, itemIndex);
+		if (referenceImages.length === 0) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Wan 2.6 Image is an editing model and needs 1 to 4 reference images. Use Wan 2.6 T2I for text-only generate.',
+				{ itemIndex },
+			);
+		}
+		if (referenceImages.length > 4) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Wan 2.6 Image accepts at most 4 reference images.',
+				{ itemIndex },
+			);
+		}
+		for (const image of referenceImages) {
+			content.push({ image });
+		}
+	}
 
 	const body: IModelStudioRequestBody = {
 		model,
@@ -173,11 +421,7 @@ export async function execute(
 			messages: [
 				{
 					role: 'user',
-					content: [
-						{
-							text: prompt,
-						},
-					],
+					content,
 				},
 			],
 		},
@@ -186,20 +430,48 @@ export async function execute(
 		},
 	};
 
-	if (imageOptions.size) {
+	if (useAsyncWan) {
+		body.parameters.n = 1;
+		body.parameters.size = imageOptions.size ?? WAN_IMAGE_DEFAULT_SIZE;
+	} else if (imageOptions.size) {
 		body.parameters.size = imageOptions.size;
 	}
 
-	const response = await apiRequest.call(
-		this,
-		'POST',
-		'/api/v1/services/aigc/multimodal-generation/generation',
-		{
-			body,
-		},
-	);
+	let response: IDataObject;
+	if (useAsyncWan) {
+		const createResponse = await apiRequest.call(
+			this,
+			'POST',
+			'/api/v1/services/aigc/image-generation/generation',
+			{
+				headers: {
+					'X-DashScope-Async': 'enable',
+				},
+				body,
+			},
+		);
 
-	const imageUrl = (response.output?.choices?.[0]?.message?.content?.[0]?.image as string) || '';
+		const taskId = createResponse?.output?.task_id as string;
+		if (!taskId) {
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to create image generation task: ${createResponse?.message || 'No task_id returned'}`,
+			);
+		}
+
+		response = await pollTaskResult.call(this, taskId);
+	} else {
+		response = await apiRequest.call(
+			this,
+			'POST',
+			'/api/v1/services/aigc/multimodal-generation/generation',
+			{
+				body,
+			},
+		);
+	}
+
+	const imageUrl = extractGeneratedImageUrl(response);
 
 	if (downloadImage && imageUrl) {
 		const imageResponse = await this.helpers.httpRequest({

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/helpers/interfaces.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/helpers/interfaces.ts
@@ -22,6 +22,7 @@ export interface IModelStudioRequestBody {
 	input: {
 		messages?: IMessage[];
 		prompt?: string;
+		images?: string[];
 		img_url?: string;
 		audio_url?: string;
 	};

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/helpers/interfaces.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/helpers/interfaces.ts
@@ -35,6 +35,7 @@ export interface IModelStudioRequestBody {
 		enable_search?: boolean;
 		seed?: number;
 		prompt_extend?: boolean;
+		n?: number;
 		size?: string;
 		duration?: string | number;
 		resolution?: string;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/helpers/wanImage.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/helpers/wanImage.ts
@@ -1,0 +1,109 @@
+const MULTIMODAL_ENDPOINT = '/api/v1/services/aigc/multimodal-generation/generation';
+const IMAGE_GENERATION_ENDPOINT = '/api/v1/services/aigc/image-generation/generation';
+const TEXT2IMAGE_ENDPOINT = '/api/v1/services/aigc/text2image/image-synthesis';
+const IMAGE2IMAGE_ENDPOINT = '/api/v1/services/aigc/image2image/image-synthesis';
+
+const SIZE_2_5_PLUS = '1280*1280';
+const SIZE_2_2_AND_EARLIER = '1024*1024';
+
+export type WanImagePlan = {
+	endpoint: string;
+	async: boolean;
+	input: 'messages' | 'prompt';
+	attachImages: 'content' | 'input' | null;
+	defaultSize: string | null;
+	n: number | null;
+	refs: { max: number; required: boolean } | null;
+};
+
+const SYNC_MULTIMODAL_PLAN: WanImagePlan = {
+	endpoint: MULTIMODAL_ENDPOINT,
+	async: false,
+	input: 'messages',
+	attachImages: null,
+	defaultSize: null,
+	n: null,
+	refs: null,
+};
+
+function normalizeModelId(model: string): string {
+	return model.trim().toLowerCase();
+}
+
+function isWanVideoModel(id: string): boolean {
+	return /(?:^|-)(t2v|i2v)(?:-|$)/.test(id);
+}
+
+function parseWanVersion(id: string): { major: number; minor: number } | null {
+	if (id === 'wanx-v1' || id.startsWith('wanx-v1-')) {
+		return { major: 1, minor: 0 };
+	}
+
+	const match = /^wanx?(\d+)\.(\d+)/.exec(id);
+	if (!match) {
+		return null;
+	}
+
+	return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+function defaultSizeForVersion(version: { major: number; minor: number } | null): string {
+	if (!version || version.major > 2 || (version.major === 2 && version.minor >= 5)) {
+		return SIZE_2_5_PLUS;
+	}
+
+	return SIZE_2_2_AND_EARLIER;
+}
+
+/**
+ * Wan 2.6+ uses `/image-generation/generation`. Wan 2.5 and earlier use
+ * `/text2image/image-synthesis` (t2i) or `/image2image/image-synthesis` (i2i).
+ */
+export function planWanImage(model: string): WanImagePlan {
+	const id = normalizeModelId(model);
+	if (!id.startsWith('wan') || isWanVideoModel(id)) {
+		return SYNC_MULTIMODAL_PLAN;
+	}
+
+	const version = parseWanVersion(id);
+
+	if (id.includes('-i2i')) {
+		return {
+			endpoint: IMAGE2IMAGE_ENDPOINT,
+			async: true,
+			input: 'prompt',
+			attachImages: 'input',
+			defaultSize: defaultSizeForVersion(version),
+			n: 1,
+			refs: { max: 3, required: true },
+		};
+	}
+
+	if (!version) {
+		return SYNC_MULTIMODAL_PLAN;
+	}
+
+	const isNewProtocol = version.major > 2 || (version.major === 2 && version.minor >= 6);
+	if (!isNewProtocol) {
+		return {
+			endpoint: TEXT2IMAGE_ENDPOINT,
+			async: true,
+			input: 'prompt',
+			attachImages: null,
+			defaultSize: defaultSizeForVersion(version),
+			n: 1,
+			refs: null,
+		};
+	}
+
+	const isImageEdit = id.includes('-image') && !id.includes('-t2i');
+	return {
+		endpoint: IMAGE_GENERATION_ENDPOINT,
+		async: true,
+		input: 'messages',
+		attachImages: isImageEdit ? 'content' : null,
+		defaultSize: defaultSizeForVersion(version),
+		n: 1,
+		refs: isImageEdit ? { max: 4, required: version.major === 2 && version.minor === 6 } : null,
+	};
+}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/methods/listSearch.ts
@@ -39,6 +39,7 @@ export async function textModelSearch(
 			!model.includes('-ocr') &&
 			!model.includes('-image') &&
 			!model.includes('-t2i') &&
+			!model.includes('-i2i') &&
 			!model.includes('-t2v') &&
 			!model.includes('-i2v') &&
 			!model.includes('-kf2v') &&
@@ -67,7 +68,7 @@ export async function imageGenerationModelSearch(
 ): Promise<INodeListSearchResult> {
 	return await baseModelSearch.call(
 		this,
-		(model) => model.includes('-image') || model.includes('-t2i'),
+		(model) => model.includes('-image') || model.includes('-t2i') || model.includes('-i2i'),
 		filter,
 	);
 }

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/listSearch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/listSearch.test.ts
@@ -45,6 +45,8 @@ describe('AlibabaCloud listSearch', () => {
 		'qwen-image',
 		'qwen-image-plus',
 		'wan2.6-t2i',
+		'wan2.5-t2i-preview',
+		'wan2.5-i2i-preview',
 		'z-image-turbo',
 		'wan2.6-t2v',
 		'wan2.6-i2v',
@@ -69,6 +71,7 @@ describe('AlibabaCloud listSearch', () => {
 			expect(values).not.toContain('qwen-image');
 			expect(values).not.toContain('wan2.6-t2v');
 			expect(values).not.toContain('wan2.6-i2v');
+			expect(values).not.toContain('wan2.5-i2i-preview');
 		});
 
 		it('should apply search filter', async () => {
@@ -107,6 +110,8 @@ describe('AlibabaCloud listSearch', () => {
 			expect(values).toContain('qwen-image');
 			expect(values).toContain('qwen-image-plus');
 			expect(values).toContain('wan2.6-t2i');
+			expect(values).toContain('wan2.5-t2i-preview');
+			expect(values).toContain('wan2.5-i2i-preview');
 			expect(values).not.toContain('qwen3.5-flash');
 			expect(values).not.toContain('wan2.6-t2v');
 		});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/operations.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/operations.test.ts
@@ -375,6 +375,7 @@ describe('AlicloudModelStudio Operations', () => {
 				usage: { input_tokens: 10 },
 			});
 			expect(result.binary).toBeUndefined();
+			expect(mockPollTaskResult).not.toHaveBeenCalled();
 		});
 
 		it('should auto-download image as binary when downloadImage is true', async () => {
@@ -439,6 +440,168 @@ describe('AlicloudModelStudio Operations', () => {
 					imageUrl: 'https://result.aliyuncs.com/generated.png',
 				}),
 			);
+		});
+
+		it('should use async image-generation and poll for wan2.6-t2i with default size and n=1', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wan2.6-t2i',
+						prompt: 'A flower shop with wooden door',
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			mockApiRequest.mockResolvedValue({
+				output: { task_id: 'wan-t2i-task-1', task_status: 'PENDING' },
+			});
+			mockPollTaskResult.mockResolvedValue({
+				output: {
+					task_status: 'SUCCEEDED',
+					choices: [
+						{
+							message: {
+								content: [{ image: 'https://result.aliyuncs.com/wan-t2i.png', type: 'image' }],
+							},
+						},
+					],
+				},
+				usage: { image_count: 1, size: '1280*1280' },
+			});
+
+			const result = await imageGenerateExecute.call(mockExecuteFunctions, 0);
+
+			expect(mockApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/api/v1/services/aigc/image-generation/generation',
+				expect.objectContaining({
+					headers: { 'X-DashScope-Async': 'enable' },
+					body: expect.objectContaining({
+						model: 'wan2.6-t2i',
+						parameters: expect.objectContaining({
+							n: 1,
+							size: '1280*1280',
+							prompt_extend: false,
+						}),
+					}),
+				}),
+			);
+			expect(mockPollTaskResult).toHaveBeenCalledWith('wan-t2i-task-1');
+			expect(result.json).toEqual({
+				model: 'wan2.6-t2i',
+				imageUrl: 'https://result.aliyuncs.com/wan-t2i.png',
+				usage: { image_count: 1, size: '1280*1280' },
+			});
+		});
+
+		it('should download reference image URLs and send them as data URIs for wan2.6-image', async () => {
+			const deepMock = mockDeep<IExecuteFunctions>();
+			deepMock.getNode.mockReturnValue({ typeVersion: 1 } as any);
+			deepMock.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wan2.6-image',
+						prompt: 'Edit this scene',
+						referenceImages: {
+							values: [{ inputType: 'url', imageUrl: 'https://example.com/ref.jpg' }],
+						},
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+			deepMock.helpers.httpRequest.mockResolvedValue({
+				body: Buffer.from('fake-jpg-data'),
+				headers: { 'content-type': 'image/jpeg' },
+			});
+
+			mockApiRequest.mockResolvedValue({
+				output: { task_id: 'wan-image-task-1', task_status: 'PENDING' },
+			});
+			mockPollTaskResult.mockResolvedValue({
+				output: {
+					task_status: 'SUCCEEDED',
+					choices: [
+						{
+							message: {
+								content: [
+									{ text: 'Here is the edited image' },
+									{ image: 'https://result.aliyuncs.com/wan-image.png', type: 'image' },
+								],
+							},
+						},
+					],
+				},
+				usage: { image_count: 1 },
+			});
+
+			const result = await imageGenerateExecute.call(deepMock, 0);
+
+			expect(deepMock.helpers.httpRequest).toHaveBeenCalledWith(
+				expect.objectContaining({
+					method: 'GET',
+					url: 'https://example.com/ref.jpg',
+					encoding: 'arraybuffer',
+					returnFullResponse: true,
+				}),
+			);
+			expect(mockApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/api/v1/services/aigc/image-generation/generation',
+				expect.objectContaining({
+					headers: { 'X-DashScope-Async': 'enable' },
+					body: expect.objectContaining({
+						model: 'wan2.6-image',
+						input: {
+							messages: [
+								{
+									role: 'user',
+									content: [
+										{ text: 'Edit this scene' },
+										{
+											image: `data:image/jpeg;base64,${Buffer.from('fake-jpg-data').toString('base64')}`,
+										},
+									],
+								},
+							],
+						},
+						parameters: expect.objectContaining({
+							n: 1,
+							size: '1280*1280',
+						}),
+					}),
+				}),
+			);
+			expect(mockPollTaskResult).toHaveBeenCalledWith('wan-image-task-1');
+			expect(result.json).toEqual({
+				model: 'wan2.6-image',
+				imageUrl: 'https://result.aliyuncs.com/wan-image.png',
+				usage: { image_count: 1 },
+			});
+		});
+
+		it('should fail before create when wan2.6-image has no reference images', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wan2.6-image',
+						prompt: 'a cat on a tree',
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			await expect(imageGenerateExecute.call(mockExecuteFunctions, 0)).rejects.toThrow(
+				'Wan 2.6 Image is an editing model and needs 1 to 4 reference images. Use Wan 2.6 T2I for text-only generate.',
+			);
+			expect(mockApiRequest).not.toHaveBeenCalled();
+			expect(mockPollTaskResult).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/operations.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/operations.test.ts
@@ -584,6 +584,230 @@ describe('AlicloudModelStudio Operations', () => {
 			});
 		});
 
+		it('should use old text2image synthesis and input.prompt for wan2.5-t2i-preview', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wan2.5-t2i-preview',
+						prompt: 'A sitting orange cat',
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			mockApiRequest.mockResolvedValue({
+				output: { task_id: 'wan-old-t2i-1', task_status: 'PENDING' },
+			});
+			mockPollTaskResult.mockResolvedValue({
+				output: {
+					task_status: 'SUCCEEDED',
+					results: [{ url: 'https://result.aliyuncs.com/wan-old-t2i.png' }],
+				},
+				usage: { image_count: 1 },
+			});
+
+			const result = await imageGenerateExecute.call(mockExecuteFunctions, 0);
+
+			expect(mockApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/api/v1/services/aigc/text2image/image-synthesis',
+				expect.objectContaining({
+					headers: { 'X-DashScope-Async': 'enable' },
+					body: {
+						model: 'wan2.5-t2i-preview',
+						input: { prompt: 'A sitting orange cat' },
+						parameters: {
+							prompt_extend: false,
+							n: 1,
+							size: '1280*1280',
+						},
+					},
+				}),
+			);
+			expect(mockPollTaskResult).toHaveBeenCalledWith('wan-old-t2i-1');
+			expect(result.json).toEqual({
+				model: 'wan2.5-t2i-preview',
+				imageUrl: 'https://result.aliyuncs.com/wan-old-t2i.png',
+				usage: { image_count: 1 },
+			});
+		});
+
+		it('should default wan2.2-t2i-flash size to 1024*1024 on the old t2i endpoint', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wan2.2-t2i-flash',
+						prompt: 'A flower shop',
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			mockApiRequest.mockResolvedValue({
+				output: { task_id: 'wan-22-1', task_status: 'PENDING' },
+			});
+			mockPollTaskResult.mockResolvedValue({
+				output: {
+					task_status: 'SUCCEEDED',
+					results: [{ url: 'https://result.aliyuncs.com/wan-22.png' }],
+				},
+			});
+
+			await imageGenerateExecute.call(mockExecuteFunctions, 0);
+
+			expect(mockApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/api/v1/services/aigc/text2image/image-synthesis',
+				expect.objectContaining({
+					body: expect.objectContaining({
+						model: 'wan2.2-t2i-flash',
+						input: { prompt: 'A flower shop' },
+						parameters: expect.objectContaining({ size: '1024*1024', n: 1 }),
+					}),
+				}),
+			);
+		});
+
+		it('should route wanx2.1-t2i-plus to the old t2i endpoint', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wanx2.1-t2i-plus',
+						prompt: 'A mountain landscape',
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			mockApiRequest.mockResolvedValue({
+				output: { task_id: 'wanx-21-1', task_status: 'PENDING' },
+			});
+			mockPollTaskResult.mockResolvedValue({
+				output: {
+					task_status: 'SUCCEEDED',
+					results: [{ url: 'https://result.aliyuncs.com/wanx.png' }],
+				},
+			});
+
+			await imageGenerateExecute.call(mockExecuteFunctions, 0);
+
+			expect(mockApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/api/v1/services/aigc/text2image/image-synthesis',
+				expect.objectContaining({
+					body: expect.objectContaining({ model: 'wanx2.1-t2i-plus' }),
+				}),
+			);
+		});
+
+		it('should use old image2image synthesis and input.images for wan2.5-i2i-preview', async () => {
+			const deepMock = mockDeep<IExecuteFunctions>();
+			deepMock.getNode.mockReturnValue({ typeVersion: 1 } as any);
+			deepMock.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wan2.5-i2i-preview',
+						prompt: 'Make it sunset',
+						referenceImages: {
+							values: [{ inputType: 'url', imageUrl: 'https://example.com/ref.jpg' }],
+						},
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+			deepMock.helpers.httpRequest.mockResolvedValue({
+				body: Buffer.from('fake-jpg-data'),
+				headers: { 'content-type': 'image/jpeg' },
+			});
+
+			mockApiRequest.mockResolvedValue({
+				output: { task_id: 'wan-i2i-1', task_status: 'PENDING' },
+			});
+			mockPollTaskResult.mockResolvedValue({
+				output: {
+					task_status: 'SUCCEEDED',
+					results: [{ url: 'https://result.aliyuncs.com/wan-i2i.png' }],
+				},
+			});
+
+			const result = await imageGenerateExecute.call(deepMock, 0);
+
+			expect(mockApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/api/v1/services/aigc/image2image/image-synthesis',
+				expect.objectContaining({
+					headers: { 'X-DashScope-Async': 'enable' },
+					body: {
+						model: 'wan2.5-i2i-preview',
+						input: {
+							prompt: 'Make it sunset',
+							images: [`data:image/jpeg;base64,${Buffer.from('fake-jpg-data').toString('base64')}`],
+						},
+						parameters: {
+							prompt_extend: false,
+							n: 1,
+							size: '1280*1280',
+						},
+					},
+				}),
+			);
+			expect(result.json.imageUrl).toBe('https://result.aliyuncs.com/wan-i2i.png');
+		});
+
+		it('should keep wan2.7-image on the new async endpoint without requiring refs', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'wan2.7-image',
+						prompt: 'A flower shop',
+						imageOptions: {},
+						downloadImage: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			mockApiRequest.mockResolvedValue({
+				output: { task_id: 'wan-27-1', task_status: 'PENDING' },
+			});
+			mockPollTaskResult.mockResolvedValue({
+				output: {
+					task_status: 'SUCCEEDED',
+					choices: [
+						{
+							message: {
+								content: [{ image: 'https://result.aliyuncs.com/wan-27.png', type: 'image' }],
+							},
+						},
+					],
+				},
+			});
+
+			await imageGenerateExecute.call(mockExecuteFunctions, 0);
+
+			expect(mockApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/api/v1/services/aigc/image-generation/generation',
+				expect.objectContaining({
+					body: expect.objectContaining({
+						model: 'wan2.7-image',
+						input: {
+							messages: [{ role: 'user', content: [{ text: 'A flower shop' }] }],
+						},
+					}),
+				}),
+			);
+			expect(mockPollTaskResult).toHaveBeenCalledWith('wan-27-1');
+		});
+
 		it('should fail before create when wan2.6-image has no reference images', async () => {
 			mockExecuteFunctions.getNodeParameter.mockImplementation(
 				(param: string, _index: number, fallback?: any) => {
@@ -598,7 +822,7 @@ describe('AlicloudModelStudio Operations', () => {
 			);
 
 			await expect(imageGenerateExecute.call(mockExecuteFunctions, 0)).rejects.toThrow(
-				'Wan 2.6 Image is an editing model and needs 1 to 4 reference images. Use Wan 2.6 T2I for text-only generate.',
+				'This Wan image-edit model needs 1 to 4 reference images. Use a Wan t2i model for text-only generate.',
 			);
 			expect(mockApiRequest).not.toHaveBeenCalled();
 			expect(mockPollTaskResult).not.toHaveBeenCalled();

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/transport.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/transport.test.ts
@@ -186,7 +186,7 @@ describe('AlicloudModelStudio Transport', () => {
 				NodeOperationError,
 			);
 			await expect(pollTaskResult.call(mockExecuteFunctions, 'task-789', 0)).rejects.toThrow(
-				'Video generation task was canceled',
+				'Task was canceled',
 			);
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/wanImage.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/test/wanImage.test.ts
@@ -1,0 +1,205 @@
+import { planWanImage } from '../helpers/wanImage';
+
+const IMAGE_GENERATION = '/api/v1/services/aigc/image-generation/generation';
+const TEXT2IMAGE = '/api/v1/services/aigc/text2image/image-synthesis';
+const IMAGE2IMAGE = '/api/v1/services/aigc/image2image/image-synthesis';
+const MULTIMODAL = '/api/v1/services/aigc/multimodal-generation/generation';
+
+describe('planWanImage', () => {
+	it.each([
+		[
+			'wan2.6-t2i',
+			{
+				endpoint: IMAGE_GENERATION,
+				async: true,
+				input: 'messages',
+				attachImages: null,
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wan2.6-image',
+			{
+				endpoint: IMAGE_GENERATION,
+				async: true,
+				input: 'messages',
+				attachImages: 'content',
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: { max: 4, required: true },
+			},
+		],
+		[
+			'wan2.7-image',
+			{
+				endpoint: IMAGE_GENERATION,
+				async: true,
+				input: 'messages',
+				attachImages: 'content',
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: { max: 4, required: false },
+			},
+		],
+		[
+			'wan2.7-image-pro',
+			{
+				endpoint: IMAGE_GENERATION,
+				async: true,
+				input: 'messages',
+				attachImages: 'content',
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: { max: 4, required: false },
+			},
+		],
+		[
+			'WAN2.6-T2I',
+			{
+				endpoint: IMAGE_GENERATION,
+				async: true,
+				input: 'messages',
+				attachImages: null,
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wan3.0-t2i',
+			{
+				endpoint: IMAGE_GENERATION,
+				async: true,
+				input: 'messages',
+				attachImages: null,
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wan2.5-t2i-preview',
+			{
+				endpoint: TEXT2IMAGE,
+				async: true,
+				input: 'prompt',
+				attachImages: null,
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wan2.2-t2i-flash',
+			{
+				endpoint: TEXT2IMAGE,
+				async: true,
+				input: 'prompt',
+				attachImages: null,
+				defaultSize: '1024*1024',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wanx2.1-t2i-plus',
+			{
+				endpoint: TEXT2IMAGE,
+				async: true,
+				input: 'prompt',
+				attachImages: null,
+				defaultSize: '1024*1024',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wanx2.0-t2i-turbo',
+			{
+				endpoint: TEXT2IMAGE,
+				async: true,
+				input: 'prompt',
+				attachImages: null,
+				defaultSize: '1024*1024',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wanx-v1',
+			{
+				endpoint: TEXT2IMAGE,
+				async: true,
+				input: 'prompt',
+				attachImages: null,
+				defaultSize: '1024*1024',
+				n: 1,
+				refs: null,
+			},
+		],
+		[
+			'wan2.5-i2i-preview',
+			{
+				endpoint: IMAGE2IMAGE,
+				async: true,
+				input: 'prompt',
+				attachImages: 'input',
+				defaultSize: '1280*1280',
+				n: 1,
+				refs: { max: 3, required: true },
+			},
+		],
+		[
+			'qwen-image',
+			{
+				endpoint: MULTIMODAL,
+				async: false,
+				input: 'messages',
+				attachImages: null,
+				defaultSize: null,
+				n: null,
+				refs: null,
+			},
+		],
+		[
+			'z-image-turbo',
+			{
+				endpoint: MULTIMODAL,
+				async: false,
+				input: 'messages',
+				attachImages: null,
+				defaultSize: null,
+				n: null,
+				refs: null,
+			},
+		],
+		[
+			'wan2.6-t2v',
+			{
+				endpoint: MULTIMODAL,
+				async: false,
+				input: 'messages',
+				attachImages: null,
+				defaultSize: null,
+				n: null,
+				refs: null,
+			},
+		],
+		[
+			'wan2.6-i2v-flash',
+			{
+				endpoint: MULTIMODAL,
+				async: false,
+				input: 'messages',
+				attachImages: null,
+				defaultSize: null,
+				n: null,
+				refs: null,
+			},
+		],
+	] as const)('%s', (model, expected) => {
+		expect(planWanImage(model)).toEqual(expected);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/AlibabaCloud/transport/index.ts
@@ -62,7 +62,7 @@ export async function apiRequest(
  *
  * @param taskId - The task ID returned by the async task creation call.
  * @param pollIntervalMs - Interval between polls in milliseconds. Defaults to 15 seconds.
- * @returns The final task response containing video_url on success.
+ * @returns The final task response on success.
  */
 export async function pollTaskResult(
 	this: IExecuteFunctions,
@@ -77,13 +77,12 @@ export async function pollTaskResult(
 		if (TERMINAL_STATUSES.includes(taskStatus)) {
 			if (taskStatus === 'FAILED') {
 				const errorCode = response?.output?.code || response?.code || 'UNKNOWN';
-				const errorMessage =
-					response?.output?.message || response?.message || 'Video generation task failed';
+				const errorMessage = response?.output?.message || response?.message || 'Task failed';
 				throw new NodeOperationError(this.getNode(), `Task failed: [${errorCode}] ${errorMessage}`);
 			}
 
 			if (taskStatus === 'CANCELED') {
-				throw new NodeOperationError(this.getNode(), 'Video generation task was canceled');
+				throw new NodeOperationError(this.getNode(), 'Task was canceled');
 			}
 
 			// SUCCEEDED


### PR DESCRIPTION
## Summary

Frankfurt only supports async Wan 2.6 image jobs. The node always posted to the sync multimodal endpoint, so `wan2.6-t2i` failed on Connect.

https://www.loom.com/share/88b38dcd2217402bb5a9bedee6f0d4d8

This PR:

- Posts Wan `*-t2i` / `*-image` jobs to `POST /api/v1/services/aigc/image-generation/generation` with `X-DashScope-Async: enable`, then polls `/api/v1/tasks/{id}`.
- Keeps Qwen Image and Z-Image on the sync multimodal path.
- Adds `wan2.6-image` as an edit model. It requires 1 to 4 reference images. The node downloads URL images and sends them as data URIs so Alibaba does not fetch the URL.
- Defaults Wan size to `1280*1280` and sets `n` to `1`.
- Makes poll error messages generic (`Task failed` / `Task was canceled`).

## How to test

1. Use n8n Connect credentials against the Frankfurt MaaS workspace.
2. Run **Image → Generate** with model `wan2.6-t2i` and prompt `a flower shop`. Confirm the node returns an image. Confirm the size is `1280*1280` when Size is unset.
3. Run the same operation with model `wan2.6-image` and no reference images. Confirm the node fails immediately and tells you to use `wan2.6-t2i` or attach images.
4. Run `wan2.6-image` with a Wikimedia (or other hotlink-protected) image URL and an edit prompt. Confirm the node returns an edited image.
5. Run `z-image-turbo` generate. Confirm it still uses sync multimodal and does not poll.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-267

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

