### PR TITLE
fix(editor): Set max resize height for decision input

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDecisionPopover.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDecisionPopover.vue
@@ -126,6 +126,7 @@ async function onComment() {
 					:rows="3"
 					:maxlength="WORKFLOW_REVIEW_TEXT_MAX_LENGTH"
 					:placeholder="i18n.baseText('workflowReviews.detail.activity.composer.placeholder')"
+					:class="$style.input"
 					data-test-id="workflow-review-decision-note"
 				/>
 				<div :class="$style.actions">
@@ -186,6 +187,12 @@ async function onComment() {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--xs);
+}
+
+.input {
+	:global(textarea) {
+		max-height: 50dvh;
+	}
 }
 
 .actions {


### PR DESCRIPTION
## Summary

Set a maximum height on the workflow review decision note textarea. This keeps the popover usable when the input is resized.

## How to test

1. Open a workflow review decision popover.
2. Resize the decision note textarea.
3. Confirm that it does not grow beyond 50% of the viewport height.
4. Confirm that the existing row and character limits still work.

Automated tests were not run for this focused CSS change.

## Related Linear tickets, Github issues, and Community forum posts

None provided.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

This PR caps the resizable decision input height to improve popover usability.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

