### PR TITLE
docs: Stop hardcoding pnpm version in CONTRIBUTING (no-changelog)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ If you already have VS Code and Docker installed, you can click [here](https://v
 
 #### pnpm
 
-[pnpm](https://pnpm.io/) version 10.22 or newer is required for development purposes. We recommend installing it with [corepack](#corepack).
+[pnpm](https://pnpm.io/) is required for development purposes. The required version is pinned in the `packageManager` field of the root [`package.json`](package.json). We recommend installing it with [corepack](#corepack).
 
 ##### pnpm workspaces
 
@@ -96,12 +96,14 @@ We recommend enabling [Node.js corepack](https://nodejs.org/docs/latest-v16.x/ap
 
 ```bash
 corepack enable
-corepack prepare pnpm@10.22.0 --activate
+corepack install
 ```
+
+`corepack install` reads the pinned version from `package.json` and installs it, so this never needs to be updated when the pinned pnpm version changes.
 
 **IMPORTANT**: If you have installed Node.js via homebrew, you'll need to run `brew install corepack`, since homebrew explicitly removes `npm` and `corepack` from [the `node` formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/node.rb#L66).
 
-**IMPORTANT**: If you are on windows, you'd need to run `corepack enable` and `corepack prepare --activate` in a terminal as an administrator.
+**IMPORTANT**: If you are on windows, you'd need to run `corepack enable` and `corepack install` in a terminal as an administrator.
 
 #### Build tools
 


### PR DESCRIPTION
## Summary

CONTRIBUTING.md hardcoded a specific pnpm version (10.22) in prose and in the `corepack prepare pnpm@10.22.0 --activate` setup command. This drifted out of sync after `package.json`'s `packageManager`/`engines.pnpm` fields were bumped to `11.22.0` and nothing kept the two in sync.

This points the docs at the `packageManager` field in `package.json` instead of a hardcoded number, and switches the setup command to `corepack install`, which reads that field automatically — so this file won't need updating on future pnpm version bumps.

## How to test

Run the updated commands from a clean checkout:

```bash
corepack enable
corepack install
```

Confirm the installed pnpm version matches the `packageManager` field in the root `package.json`.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)