### PR TITLE
test(core): Add integration tests for workflowTransfer policy enforcement

### DIFF
--- a/packages/cli/test/integration/policy/workflow-transfer.policy.test.ts
+++ b/packages/cli/test/integration/policy/workflow-transfer.policy.test.ts
@@ -206,9 +206,10 @@ describe('PUT /api/v1/workflows/:id/transfer', () => {
 
 		expect(response.statusCode).toBe(403);
 
-		// `serializePublicApiError` only whitelists `meta.issues`, so the violation list stays
-		// internal on this surface — the public API sees the summary message only.
-		expect(response.body).toEqual({ message: deniedMessage(targetProject.id) });
+		// Status and message only: on master `serializePublicApiError` whitelists `meta.issues`,
+		// so the violation list stays internal on this surface. IAM-1129 adds `violations` to
+		// that whitelist — tighten this to assert the list once that lands.
+		expect(response.body).toMatchObject({ message: deniedMessage(targetProject.id) });
 
 		await expectOwnedBy(workflow, sourceProject);
 	});

--- a/packages/cli/test/integration/policy/workflow-transfer.policy.test.ts
+++ b/packages/cli/test/integration/policy/workflow-transfer.policy.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Pins the `workflowTransfer` host wiring through the real request path. Unit tests mock
+ * `PolicyEnforcementService`, so they prove the service method is called but not that a
+ * registered check actually runs — a removed call site or a new transfer path would look
+ * identical to an allow-all policy.
+ */
+import {
+	createActiveWorkflow,
+	createTeamProject,
+	createWorkflow,
+	getWorkflowSharing,
+	mockInstance,
+	testDb,
+} from '@n8n/backend-test-utils';
+import type { Project, User } from '@n8n/db';
+import type {
+	PolicyCheckResult,
+	RegisteredPolicyCheck,
+	WorkflowTransferContext,
+} from '@n8n/decorators';
+import { PolicyCheck, PolicyCheckMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+
+import { createMemberWithApiKey } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils/';
+
+const CHECK_ID = 'test-target-project-deny';
+const VIOLATION_KIND = 'test-target-project-denied';
+
+const deniedMessage = (projectId: string) => `Transfers into project ${projectId} are blocked`;
+
+/**
+ * The decorator registers the check once per process, so it can't be swapped per test.
+ * Each test instead names the project it wants denied — which is also what keeps the check
+ * from denying the transfers the other tests need to succeed.
+ */
+const deniedTargetProjectIds = new Set<string>();
+
+@PolicyCheck()
+class TargetProjectDenyCheck implements RegisteredPolicyCheck {
+	readonly id = CHECK_ID;
+
+	async onWorkflowTransfer({
+		targetProjectId,
+	}: WorkflowTransferContext): Promise<PolicyCheckResult> {
+		if (targetProjectId === null || !deniedTargetProjectIds.has(targetProjectId)) {
+			return { violations: [] };
+		}
+
+		return {
+			violations: [
+				{
+					kind: VIOLATION_KIND,
+					checkId: this.id,
+					message: deniedMessage(targetProjectId),
+					subject: targetProjectId,
+					subjectType: 'project',
+					scope: 'project',
+				},
+			],
+		};
+	}
+}
+
+const activeWorkflowManager = mockInstance(ActiveWorkflowManager);
+
+const testServer = utils.setupTestServer({
+	endpointGroups: ['workflows', 'publicApi'],
+	enabledFeatures: ['feat:sharing', 'feat:advancedPermissions'],
+	modules: ['policy-infrastructure'],
+});
+
+let member: User;
+let authMemberAgent: SuperAgentTest;
+let publicApiMemberAgent: SuperAgentTest;
+let sourceProject: Project;
+let targetProject: Project;
+
+beforeAll(async () => {
+	// Without this the "allowed" cases below would still pass with the check never registered,
+	// which is exactly the silent allow-all this suite exists to catch.
+	expect(Container.get(PolicyCheckMetadata).getClasses()).toContain(TargetProjectDenyCheck);
+
+	member = await createMemberWithApiKey();
+	authMemberAgent = testServer.authAgentFor(member);
+	publicApiMemberAgent = testServer.publicApiAgentFor(member);
+
+	await utils.initNodeTypes();
+});
+
+beforeEach(async () => {
+	deniedTargetProjectIds.clear();
+	activeWorkflowManager.add.mockReset();
+	activeWorkflowManager.remove.mockReset();
+
+	await testDb.truncate([
+		'WorkflowEntity',
+		'SharedWorkflow',
+		'WorkflowHistory',
+		'WorkflowPublishHistory',
+	]);
+
+	// The member is admin of both, so `workflow:move` and `workflow:create` are never the
+	// reason a transfer fails here.
+	sourceProject = await createTeamProject('Source project', member);
+	targetProject = await createTeamProject('Target project', member);
+});
+
+const expectOwnedBy = async (workflow: IWorkflowBase, project: Project) => {
+	const sharings = await getWorkflowSharing(workflow);
+
+	expect(sharings).toHaveLength(1);
+	expect(sharings[0]).toMatchObject({
+		projectId: project.id,
+		workflowId: workflow.id,
+		role: 'workflow:owner',
+	});
+};
+
+describe('PUT /workflows/:workflowId/transfer', () => {
+	test('blocks the transfer with the structured violation when the target project is denied', async () => {
+		const workflow = await createWorkflow({}, sourceProject);
+		deniedTargetProjectIds.add(targetProject.id);
+
+		const response = await authMemberAgent
+			.put(`/workflows/${workflow.id}/transfer`)
+			.send({ destinationProjectId: targetProject.id })
+			.expect(403);
+
+		expect(response.body).toMatchObject({
+			code: 403,
+			message: deniedMessage(targetProject.id),
+			meta: {
+				violations: [
+					{
+						kind: VIOLATION_KIND,
+						checkId: CHECK_ID,
+						message: deniedMessage(targetProject.id),
+						subject: targetProject.id,
+						subjectType: 'project',
+						scope: 'project',
+					},
+				],
+			},
+		});
+
+		await expectOwnedBy(workflow, sourceProject);
+	});
+
+	test('validates against the target project, not the source', async () => {
+		const workflow = await createWorkflow({}, sourceProject);
+
+		// Only the project the workflow is leaving is denied. Checking the wrong project would
+		// block this transfer and defeat the point of the enforcement point.
+		deniedTargetProjectIds.add(sourceProject.id);
+
+		await authMemberAgent
+			.put(`/workflows/${workflow.id}/transfer`)
+			.send({ destinationProjectId: targetProject.id })
+			.expect(200);
+
+		await expectOwnedBy(workflow, targetProject);
+	});
+
+	test('leaves the workflow untouched when the transfer is blocked', async () => {
+		const workflow = await createActiveWorkflow({}, sourceProject);
+		deniedTargetProjectIds.add(targetProject.id);
+
+		await authMemberAgent
+			.put(`/workflows/${workflow.id}/transfer`)
+			.send({ destinationProjectId: targetProject.id })
+			.expect(403);
+
+		await expectOwnedBy(workflow, sourceProject);
+
+		// Deactivation happens after the check, so a blocked transfer must not take a live
+		// workflow down on its way out.
+		expect(activeWorkflowManager.remove).not.toHaveBeenCalled();
+		expect(activeWorkflowManager.add).not.toHaveBeenCalled();
+	});
+
+	test('transfers as usual when no check objects', async () => {
+		const workflow = await createWorkflow({}, sourceProject);
+
+		await authMemberAgent
+			.put(`/workflows/${workflow.id}/transfer`)
+			.send({ destinationProjectId: targetProject.id })
+			.expect(200);
+
+		await expectOwnedBy(workflow, targetProject);
+	});
+});
+
+describe('PUT /api/v1/workflows/:id/transfer', () => {
+	test('blocks the transfer when the target project is denied', async () => {
+		const workflow = await createWorkflow({}, sourceProject);
+		deniedTargetProjectIds.add(targetProject.id);
+
+		const response = await publicApiMemberAgent
+			.put(`/workflows/${workflow.id}/transfer`)
+			.send({ destinationProjectId: targetProject.id });
+
+		expect(response.statusCode).toBe(403);
+
+		// `serializePublicApiError` only whitelists `meta.issues`, so the violation list stays
+		// internal on this surface — the public API sees the summary message only.
+		expect(response.body).toEqual({ message: deniedMessage(targetProject.id) });
+
+		await expectOwnedBy(workflow, sourceProject);
+	});
+});

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -72,6 +72,7 @@ type ModuleName =
 	| 'source-control'
 	| 'git-connections'
 	| 'token-exchange'
+	| 'policy-infrastructure'
 	| 'workflow-reviews';
 
 export interface SetupProps {


### PR DESCRIPTION
## Summary

Pins the `workflowTransfer` policy enforcement point with integration tests that run through the real request path. The existing unit tests mock `PolicyEnforcementService`, so they prove the service method is called but not that a registered check actually runs — a removed call site or a new transfer path would look identical to an allow-all policy. This PR registers a policy check that denies transfers into a named project, drives it through both the editor REST route and the public API, and asserts the check sees the **target** project rather than the source.

I mutation-tested the suite rather than trusting a green run. Removing the `enforceWorkflowTransfer` call failed the three deny tests and left the two allow tests passing. Swapping `destinationProject.id` for `sourceProject.id` — the exact regression this ticket describes — failed four of five, including the target-versus-source test.

Two notes for reviewers:

- **Relationship to #37077 (IAM-1129).** That PR adds `violations` to the `serializePublicApiError` whitelist. This suite deliberately asserts only the invariant on the public API surface (403 plus the summary message), so it is green both against `master` today and with #37077 applied — I verified both. Once #37077 merges, the assertion can be tightened to check the structured list. The two PRs are independent and can merge in either order.
- **`packages/cli/test/integration/shared/types.ts` carries its own hand-maintained `ModuleName` union**, separate from the one in `@n8n/backend-common`. `policy-infrastructure` was missing from it, so the `modules:` option did not typecheck. One line added.

## How to test

```bash
cd packages/cli
pnpm test:integration test/integration/policy/workflow-transfer.policy.test.ts
```

Five tests pass. `pnpm typecheck` is clean and `eslint --quiet` reports no errors.

The suite enables the `policy-infrastructure` module itself through `setupTestServer`, so no environment variable is needed to run it. On a real instance the module stays opt-in via `N8N_ENABLED_MODULES=policy-infrastructure`.

To watch the tests fail, remove the `policyEnforcementService.enforceWorkflowTransfer` call in `packages/cli/src/workflows/workflow.service.ee.ts`, or change its `targetProjectId` to the source project, and run the suite again.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1132

Parent: https://linear.app/n8n/issue/IAM-1120

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI