### PR TITLE
fix(API): Return policy violations on a blocked workflow save (no-changelog)

### DIFF
--- a/packages/cli/src/errors/__tests__/http-error-serializers.test.ts
+++ b/packages/cli/src/errors/__tests__/http-error-serializers.test.ts
@@ -9,6 +9,7 @@ import { LicenseEulaRequiredError } from '@/errors/response-errors/license-eula-
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WorkflowPublishBlockedError } from '@/errors/response-errors/workflow-publish-blocked.error';
 import { toImportBlockedError } from '@/modules/n8n-packages/engine/import-blocked.error';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
 
 describe('http-error-serializers', () => {
 	it('serializePublicApiError: minimal message for ResponseError', () => {
@@ -116,6 +117,35 @@ describe('http-error-serializers', () => {
 		const result = serializePublicApiError(descriptor);
 		expect(result.status).toBe(409);
 		expect(result.body).toEqual({ message: expect.stringContaining('Import blocked'), issues });
+	});
+
+	it('both serializers expose policy violations on a 403', () => {
+		const violations = [
+			{
+				kind: 'node-type-unavailable',
+				checkId: 'node-type-availability',
+				message: 'Slack is not available in this project',
+				subject: 'n8n-nodes-base.slack',
+				subjectType: 'nodeType',
+			},
+		];
+		const descriptor = classifyHttpError(new PolicyViolationError([violations[0]]));
+
+		expect(serializePublicApiError(descriptor)).toEqual({
+			status: 403,
+			body: {
+				message: 'Slack is not available in this project',
+				violations,
+			},
+		});
+		expect(serializeInternalRestError(descriptor)).toEqual({
+			status: 403,
+			body: {
+				code: 403,
+				message: 'Slack is not available in this project',
+				meta: { violations },
+			},
+		});
 	});
 
 	it('both serializers map UserError to 400', () => {

--- a/packages/cli/src/errors/http-error-serializers.ts
+++ b/packages/cli/src/errors/http-error-serializers.ts
@@ -26,6 +26,11 @@ export function serializePublicApiError(descriptor: HttpErrorDescriptor): {
 			if (descriptor.meta?.issues !== undefined) {
 				body.issues = descriptor.meta.issues;
 			}
+			// Same reasoning for policy violations: the caller is the one who has to fix
+			// them, so the whole list travels with the response rather than the message alone.
+			if (descriptor.meta?.violations !== undefined) {
+				body.violations = descriptor.meta.violations;
+			}
 			const workflowPublishBlockedDetails = {
 				reason: descriptor.meta?.reason,
 				workflowReviewRequestId: descriptor.meta?.workflowReviewRequestId,

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -7,6 +7,7 @@ import { ResponseError } from '@/errors/response-errors/abstract/response.error'
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
@@ -19,6 +20,11 @@ const handleError = (error: unknown) => {
 		throw new NotFoundError(error.message);
 	}
 	if (error instanceof ResponseError) {
+		throw error;
+	}
+	// Carries its own 403 and the structured violations, neither of which survives being
+	// rewrapped as a bad request.
+	if (error instanceof PolicyViolationError) {
 		throw error;
 	}
 	if (error instanceof Error) {

--- a/packages/cli/test/integration/workflows/workflow-save-policy.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-save-policy.test.ts
@@ -1,0 +1,203 @@
+import { createWorkflow, mockInstance, testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { WorkflowRepository } from '@n8n/db';
+import type { PolicyCheckResult, PolicyViolation, RegisteredPolicyCheck } from '@n8n/decorators';
+import { PolicyCheck, PolicyCheckMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+
+import { cleanupRolesAndScopes } from '../shared/db/roles';
+import { createOwnerWithApiKey } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils/';
+
+/**
+ * Pins the `workflowSave` host wiring on the real request path: a registered check that denies
+ * every save has to block both the editor and the public API, with its violations in the body.
+ * Unit tests construct the services directly, so only this proves the call sites are still there.
+ */
+
+const CHECK_ID = 'integration-test-workflow-save';
+
+const DENIAL: PolicyViolation = {
+	kind: 'test-denial',
+	checkId: CHECK_ID,
+	message: 'Denied by the test policy check',
+	subject: 'n8n-nodes-base.manualTrigger',
+	subjectType: 'nodeType',
+};
+
+/**
+ * `allow` by default: the check registers process-wide when this file is loaded and
+ * `PolicyCheckMetadata` has no unregister, so a leak into another suite has to be a no-op.
+ */
+let mode: 'allow' | 'deny' | 'break' = 'allow';
+
+@PolicyCheck()
+class TestWorkflowSaveCheck implements RegisteredPolicyCheck {
+	readonly id = CHECK_ID;
+
+	async onWorkflowSave(): Promise<PolicyCheckResult> {
+		if (mode === 'break') throw new Error('Test check failed on purpose');
+
+		return await Promise.resolve({ violations: mode === 'deny' ? [DENIAL] : [] });
+	}
+}
+
+const testServer = utils.setupTestServer({
+	endpointGroups: ['workflows', 'publicApi'],
+	modules: ['policy-infrastructure'],
+});
+
+mockInstance(ActiveWorkflowManager);
+
+const triggerNode = {
+	id: 'a4e5d0e6-1a44-4f7e-9b7d-2c6a1f0b3c11',
+	name: 'Manual Trigger',
+	type: 'n8n-nodes-base.manualTrigger',
+	parameters: {},
+	typeVersion: 1,
+	position: [240, 300] as [number, number],
+};
+
+const editorPayload = { name: 'Policed workflow', nodes: [triggerNode], connections: {} };
+const publicApiPayload = { ...editorPayload, settings: { executionOrder: 'v1' } };
+
+let owner: User;
+let editorAgent: SuperAgentTest;
+let publicApiAgent: SuperAgentTest;
+let workflowRepository: WorkflowRepository;
+
+const truncate = async () =>
+	await testDb.truncate([
+		'SharedWorkflow',
+		'ProjectRelation',
+		'Folder',
+		'WebhookEntity',
+		'WorkflowEntity',
+		'WorkflowHistory',
+		'WorkflowPublishHistory',
+		'TagEntity',
+		'Project',
+		'User',
+	]);
+
+beforeAll(async () => {
+	await utils.initNodeTypes();
+	workflowRepository = Container.get(WorkflowRepository);
+
+	// The public API's OpenAPI validator compiles the whole spec on the first authenticated
+	// request that reaches it (~3s). Spend it here, under the 30s hook timeout, so it can't
+	// blow a test's 10s timeout inside `PUT /workflows/:id` — the only validator-served route
+	// this suite uses. The other three routes are served by controllers, which sit in front of
+	// the validator, so they never pay it.
+	await truncate();
+	const warmUpUser = await createOwnerWithApiKey();
+	await testServer.publicApiAgentFor(warmUpUser).put('/workflows/warm-up').send(publicApiPayload);
+});
+
+beforeEach(async () => {
+	mode = 'allow';
+	await truncate();
+	await cleanupRolesAndScopes();
+
+	owner = await createOwnerWithApiKey();
+	editorAgent = testServer.authAgentFor(owner);
+	publicApiAgent = testServer.publicApiAgentFor(owner);
+});
+
+test('registers the test check, so a denial below can only come from it', () => {
+	expect(Container.get(PolicyCheckMetadata).getClasses()).toContain(TestWorkflowSaveCheck);
+});
+
+describe('with a check that denies every save', () => {
+	beforeEach(() => {
+		mode = 'deny';
+	});
+
+	test('editor create fails with 403 and the violations', async () => {
+		const response = await editorAgent.post('/workflows').send(editorPayload);
+
+		expect(response.statusCode).toBe(403);
+		expect(response.body).toMatchObject({
+			code: 403,
+			message: DENIAL.message,
+			meta: { violations: [DENIAL] },
+		});
+		await expect(workflowRepository.count()).resolves.toBe(0);
+	});
+
+	test('editor update fails with 403 and the violations', async () => {
+		const workflow = await createWorkflow({ name: 'Stored name' }, owner);
+
+		const response = await editorAgent
+			.patch(`/workflows/${workflow.id}`)
+			.send({ name: 'Renamed', nodes: [triggerNode], connections: {} });
+
+		expect(response.statusCode).toBe(403);
+		expect(response.body).toMatchObject({
+			code: 403,
+			message: DENIAL.message,
+			meta: { violations: [DENIAL] },
+		});
+		const stored = await workflowRepository.findOneByOrFail({ id: workflow.id });
+		expect(stored.name).toBe('Stored name');
+	});
+
+	test('public API create fails with 403 and the violations', async () => {
+		const response = await publicApiAgent.post('/workflows').send(publicApiPayload);
+
+		expect(response.statusCode).toBe(403);
+		expect(response.body).toEqual({ message: DENIAL.message, violations: [DENIAL] });
+		await expect(workflowRepository.count()).resolves.toBe(0);
+	});
+
+	test('public API update fails with 403 and the violations', async () => {
+		const workflow = await createWorkflow({ name: 'Stored name' }, owner);
+
+		const response = await publicApiAgent
+			.put(`/workflows/${workflow.id}`)
+			.send({ ...publicApiPayload, name: 'Renamed' });
+
+		expect(response.statusCode).toBe(403);
+		expect(response.body).toEqual({ message: DENIAL.message, violations: [DENIAL] });
+		const stored = await workflowRepository.findOneByOrFail({ id: workflow.id });
+		expect(stored.name).toBe('Stored name');
+	});
+});
+
+describe('with the same check reporting nothing', () => {
+	test('editor create succeeds', async () => {
+		const response = await editorAgent.post('/workflows').send(editorPayload);
+
+		expect(response.statusCode).toBe(200);
+		const { data } = response.body as { data: { id: string } };
+		await expect(workflowRepository.findOneByOrFail({ id: data.id })).resolves.toMatchObject({
+			name: editorPayload.name,
+		});
+	});
+
+	test('public API create succeeds', async () => {
+		const response = await publicApiAgent.post('/workflows').send(publicApiPayload);
+
+		expect(response.statusCode).toBe(200);
+		const { id } = response.body as { id: string };
+		await expect(workflowRepository.findOneByOrFail({ id })).resolves.toMatchObject({
+			name: publicApiPayload.name,
+		});
+	});
+});
+
+// A check that didn't answer hasn't said yes: the save is blocked, but nothing about why —
+// an infrastructure fault rendered as a policy rule is something a user would try to satisfy.
+test('a check that breaks blocks the save without leaking violations', async () => {
+	mode = 'break';
+
+	const response = await editorAgent.post('/workflows').send(editorPayload);
+
+	expect(response.statusCode).toBe(503);
+	const { meta } = response.body as { meta: Record<string, unknown> };
+	expect(meta.violations).toBeUndefined();
+	await expect(workflowRepository.count()).resolves.toBe(0);
+});


### PR DESCRIPTION
## Summary

The `workflowSave` policy enforcement point was wired into both save paths, but only unit tests
covered it, and those build the services by hand — so nothing noticed that the public API threw the
violations away twice on the way out. This PR adds an integration suite that registers a real policy
check and drives all four save routes (create and update, editor and public API), and fixes the two
losses the suite exposed: `serializePublicApiError` now passes `meta.violations` through (next to the
existing `meta.issues` passthrough), and the public API workflow update handler lets
`PolicyViolationError` travel untouched instead of rewrapping it as a bad request, which had turned
the 403 into a 400 and dropped `meta` with it. Translating it into a `ForbiddenError` was not an
option: `ResponseError.meta` has no constructor parameter, so the violations would be lost anyway.

| Route | Before | After |
| --- | --- | --- |
| `POST`/`PATCH /rest/workflows` | 403 + `meta.violations` | unchanged |
| `POST /api/v1/workflows` | 403, message only | 403 + `violations[]` |
| `PUT /api/v1/workflows/:id` | **400**, message only | 403 + `violations[]` |

No behaviour change for users today: `policy-infrastructure` is an opt-in module, and with no check
registered every save clears.

## How to test

```bash
cd packages/cli
pnpm test:integration test/integration/workflows/workflow-save-policy.test.ts
pnpm test src/errors/__tests__/http-error-serializers.test.ts
```

The suite is self-contained: it enables the module with
`setupTestServer({ modules: ['policy-infrastructure'] })` and registers its own `@PolicyCheck()`
fixture, so no license or env var is needed. To try it on a live instance instead, start n8n with
`N8N_ENABLED_MODULES=policy-infrastructure` and add a check that returns a violation from
`onWorkflowSave`; saving a workflow in the editor and through `POST /api/v1/workflows` then both
answer 403 with the violation list.

To confirm the two fixes are load-bearing, revert them and re-run the suite: the two public API
tests fail with `expected 400 to be 403` and a message-only body.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1129

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

> Note: the public API OpenAPI spec does not document the 403 for these routes yet. Response
> validation is off (`validateRequests` only), so nothing breaks, but the spec is behind reality —
> worth a follow-up once the policy module reaches GA.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

