### PR TITLE
feat(core)!: Change N8N_UNVERIFIED_PACKAGES_ENABLED default to false

### DIFF
--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -172,23 +172,6 @@ describe('DeprecationService', () => {
 		});
 	});
 
-	describe('default-flip warnings', () => {
-		test.each(['N8N_UNVERIFIED_PACKAGES_ENABLED'])('should warn when %s is unset', (envVar) => {
-			delete process.env[envVar];
-			deprecationService.warn();
-			expect(logger.warn.mock.lastCall?.[0] ?? '').toContain(envVar);
-		});
-
-		test.each([['N8N_UNVERIFIED_PACKAGES_ENABLED', 'false']])(
-			'should not warn when %s is set explicitly',
-			(envVar, value) => {
-				process.env[envVar] = value;
-				deprecationService.warn();
-				expect(logger.warn.mock.lastCall?.[0] ?? '').not.toContain(envVar);
-			},
-		);
-	});
-
 	describe('running outside a container', () => {
 		const message = 'Running n8n outside a container is deprecated';
 

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -68,12 +68,6 @@ export class DeprecationService {
 				'Use N8N_WEBHOOK_URL instead, which sets the base URL for both test and production webhooks.',
 		},
 		{
-			envVar: 'N8N_UNVERIFIED_PACKAGES_ENABLED',
-			message:
-				'The default for this variable will change to `false` in a future version. Set it to `true` explicitly to keep installing unverified community packages.',
-			checkValue: (value?: string) => value === undefined,
-		},
-		{
 			envVar: 'N8N_EXPRESSION_ENGINE',
 			message:
 				'The `legacy` expression engine runs expressions without isolation, is no longer considered secure, and will be removed in a future version. Remove this environment variable to use the default `vm` engine.',

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
@@ -54,8 +54,13 @@ beforeAll(async () => {
 
 beforeEach(() => {
 	vi.resetAllMocks();
-	Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
+	// These endpoints predate verified-only mode; run them with unverified packages enabled.
+	Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 	communityPackagesService.withLoadStatus.mockImplementation((packages) => packages);
+});
+
+afterEach(() => {
+	Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
 });
 
 describe('GET /community-packages', () => {
@@ -126,8 +131,7 @@ describe('GET /community-packages', () => {
 		expect(mockedExecuteNpmCommand).not.toHaveBeenCalled();
 	});
 
-	test('should check for updates if packages installed and unverified packages are enabled', async () => {
-		Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
+	test('should check for updates if packages installed', async () => {
 		communityPackagesService.getAllInstalledPackages.mockResolvedValue([mockPackage()]);
 
 		await authAgent.get('/community-packages').expect(200);
@@ -138,7 +142,6 @@ describe('GET /community-packages', () => {
 	});
 
 	test('should report package updates if available', async () => {
-		Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 		const pkg = mockPackage();
 		communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
 

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
@@ -54,7 +54,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
 	vi.resetAllMocks();
-	// These endpoints predate verified-only mode; run them with unverified packages enabled.
+	// Most tests here assert the npm-based update check, which only runs when
+	// unverified packages are enabled - opt in instead of relying on the default.
 	Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 	communityPackagesService.withLoadStatus.mockImplementation((packages) => packages);
 });

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
@@ -59,10 +59,6 @@ beforeEach(() => {
 	communityPackagesService.withLoadStatus.mockImplementation((packages) => packages);
 });
 
-afterEach(() => {
-	Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
-});
-
 describe('GET /community-packages', () => {
 	test('should respond 200 if no nodes are installed', async () => {
 		communityPackagesService.getAllInstalledPackages.mockResolvedValue([]);

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
@@ -4,9 +4,11 @@ vi.mock('../npm-utils', async () => ({
 }));
 
 import { mockInstance } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
 import path from 'path';
 
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { CommunityPackagesConfig } from '@/modules/community-packages/community-packages.config';
 import { CommunityPackagesService } from '@/modules/community-packages/community-packages.service';
 import type { InstalledNodes } from '@/modules/community-packages/installed-nodes.entity';
 import type { InstalledPackages } from '@/modules/community-packages/installed-packages.entity';
@@ -52,6 +54,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
 	vi.resetAllMocks();
+	Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
 	communityPackagesService.withLoadStatus.mockImplementation((packages) => packages);
 });
 
@@ -123,7 +126,8 @@ describe('GET /community-packages', () => {
 		expect(mockedExecuteNpmCommand).not.toHaveBeenCalled();
 	});
 
-	test('should check for updates if packages installed', async () => {
+	test('should check for updates if packages installed and unverified packages are enabled', async () => {
+		Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 		communityPackagesService.getAllInstalledPackages.mockResolvedValue([mockPackage()]);
 
 		await authAgent.get('/community-packages').expect(200);
@@ -134,6 +138,7 @@ describe('GET /community-packages', () => {
 	});
 
 	test('should report package updates if available', async () => {
+		Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 		const pkg = mockPackage();
 		communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
 

--- a/packages/cli/src/modules/community-packages/community-packages.config.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.config.ts
@@ -19,9 +19,9 @@ export class CommunityPackagesConfig {
 	@Env('N8N_REINSTALL_MISSING_PACKAGES')
 	reinstallMissing: boolean = false;
 
-	/** Whether to block installation of not verified packages */
+	/** Whether to allow installing and loading packages not verified by n8n */
 	@Env('N8N_UNVERIFIED_PACKAGES_ENABLED')
-	unverifiedEnabled: boolean = true;
+	unverifiedEnabled: boolean = false;
 
 	/** Whether to enable and show search suggestion of packages verified by n8n */
 	@Env('N8N_VERIFIED_PACKAGES_ENABLED')

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -63,7 +63,8 @@ describe('Community packages (Public API)', () => {
 
 	beforeEach(async () => {
 		vi.resetAllMocks();
-		Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
+		// These endpoints predate verified-only mode; run them with unverified packages enabled.
+		Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 		communityPackagesService.withLoadStatus.mockImplementation((packages) => packages);
 		communityNodeTypesService.findVetted.mockResolvedValue(mockedVettedPackage);
 		await testDb.truncate(['User']);
@@ -74,6 +75,10 @@ describe('Community packages (Public API)', () => {
 		const apiKey = await addApiKey(ownerUser, { scopes });
 		ownerUser.apiKeys = [apiKey];
 		owner = ownerUser;
+	});
+
+	afterEach(() => {
+		Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
 	});
 
 	describe('GET /community-packages', () => {
@@ -119,8 +124,7 @@ describe('Community packages (Public API)', () => {
 			expect(response.body[0].packageName).toBe(pkg.packageName);
 		});
 
-		it('should run npm outdated when packages exist and unverified packages are enabled', async () => {
-			Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
+		it('should run npm outdated when packages exist', async () => {
 			communityPackagesService.getAllInstalledPackages.mockResolvedValue([mockPackage()]);
 			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([]);
 
@@ -133,7 +137,6 @@ describe('Community packages (Public API)', () => {
 		});
 
 		it('should return packages with updateAvailable when outdated', async () => {
-			Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 			const pkg = mockPackage();
 			communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
 

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -77,10 +77,6 @@ describe('Community packages (Public API)', () => {
 		owner = ownerUser;
 	});
 
-	afterEach(() => {
-		Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
-	});
-
 	describe('GET /community-packages', () => {
 		it('should return 401 without API key', async () => {
 			const response = await testServer.publicApiAgentWithoutApiKey().get('/community-packages');

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/modules/community-packages/npm-utils', async () => ({
 import type { CommunityNodeType } from '@n8n/api-types';
 import { mockInstance, testDb } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
 import type { ApiKeyScope } from '@n8n/permissions';
 import { OWNER_API_KEY_SCOPES } from '@n8n/permissions';
 import path from 'node:path';
@@ -16,6 +17,7 @@ import { mock } from 'vitest-mock-extended';
 
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { CommunityNodeTypesService } from '@/modules/community-packages/community-node-types.service';
+import { CommunityPackagesConfig } from '@/modules/community-packages/community-packages.config';
 import { CommunityPackagesService } from '@/modules/community-packages/community-packages.service';
 import { executeNpmCommand } from '@/modules/community-packages/npm-utils';
 
@@ -61,6 +63,7 @@ describe('Community packages (Public API)', () => {
 
 	beforeEach(async () => {
 		vi.resetAllMocks();
+		Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
 		communityPackagesService.withLoadStatus.mockImplementation((packages) => packages);
 		communityNodeTypesService.findVetted.mockResolvedValue(mockedVettedPackage);
 		await testDb.truncate(['User']);
@@ -116,7 +119,8 @@ describe('Community packages (Public API)', () => {
 			expect(response.body[0].packageName).toBe(pkg.packageName);
 		});
 
-		it('should run npm outdated when packages exist', async () => {
+		it('should run npm outdated when packages exist and unverified packages are enabled', async () => {
+			Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 			communityPackagesService.getAllInstalledPackages.mockResolvedValue([mockPackage()]);
 			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([]);
 
@@ -129,6 +133,7 @@ describe('Community packages (Public API)', () => {
 		});
 
 		it('should return packages with updateAvailable when outdated', async () => {
+			Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 			const pkg = mockPackage();
 			communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
 

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -63,7 +63,8 @@ describe('Community packages (Public API)', () => {
 
 	beforeEach(async () => {
 		vi.resetAllMocks();
-		// These endpoints predate verified-only mode; run them with unverified packages enabled.
+		// Most tests here assert the npm-based update check, which only runs when
+		// unverified packages are enabled - opt in instead of relying on the default.
 		Container.get(CommunityPackagesConfig).unverifiedEnabled = true;
 		communityPackagesService.withLoadStatus.mockImplementation((packages) => packages);
 		communityNodeTypesService.findVetted.mockResolvedValue(mockedVettedPackage);

--- a/packages/cli/test/integration/public-api/community-packages.test.ts
+++ b/packages/cli/test/integration/public-api/community-packages.test.ts
@@ -136,6 +136,19 @@ describe('Community packages (Public API)', () => {
 			);
 		});
 
+		it('should not run npm outdated when unverified packages are disabled', async () => {
+			Container.get(CommunityPackagesConfig).unverifiedEnabled = false;
+			const pkg = mockPackage();
+			communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
+			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([pkg]);
+
+			const response = await testServer.publicApiAgentFor(owner).get('/community-packages');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toHaveLength(1);
+			expect(mockedExecuteNpmCommand).not.toHaveBeenCalled();
+		});
+
 		it('should return packages with updateAvailable when outdated', async () => {
 			const pkg = mockPackage();
 			communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);


### PR DESCRIPTION
## Summary

Flips the default of `N8N_UNVERIFIED_PACKAGES_ENABLED` from `true` to `false`, as planned for v3. Unverified community packages are no longer installable or loadable unless the instance explicitly opts in with `N8N_UNVERIFIED_PACKAGES_ENABLED=true`.

Also removes the corresponding default-flip deprecation warning from `DeprecationService` (and its tests), since the flip has now happened on this branch — same pattern as #37042.

The v3 breaking-change detection rule (`unverified-packages-v3`) is left in place, as it reports pre-upgrade impact.

## How to test

- Start n8n without the env var: installing an unverified community package (no checksum) is rejected, and unverified installed packages are not loaded.
- Start with `N8N_UNVERIFIED_PACKAGES_ENABLED=true`: previous behavior is restored.
- Unit tests: `packages/cli` — `src/modules/community-packages`, `src/deprecation`, `src/instance-settings-loader` all pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

