### PR TITLE
fix(editor): Show error when eligible reviewers fail to load

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4704,6 +4704,7 @@
 	"workflowReviews.submitForReview.submit": "Submit",
 	"workflowReviews.submitForReview.error.title": "Workflow couldn't be submitted for review",
 	"workflowReviews.submitForReview.error.save": "Save the workflow and try again.",
+	"workflowReviews.submitForReview.error.loadReviewers": "Couldn't load reviewers",
 	"workflowReviews.updateReview.title": "Submit latest changes to existing review",
 	"workflowReviews.updateReview.description": "This workflow already has an {review}. Submit latest changes to the existing review, to get them approved.",
 	"workflowReviews.updateReview.description.review": "open review",

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
@@ -487,16 +487,18 @@ describe('WorkflowSubmitForReviewDialog', () => {
 		expect(getByTestId('workflow-review-submit-button')).toBeEnabled();
 	});
 
-	it('keeps submission blocked when loading the reviewers fails', async () => {
-		vi.mocked(fetchEligibleReviewers).mockRejectedValue(new Error('nope'));
+	it('shows error toast and keeps submission blocked when loading the reviewers fails', async () => {
+		const error = new Error('nope');
+		vi.mocked(fetchEligibleReviewers).mockRejectedValue(error);
 		const { getByTestId, goToStep2 } = await renderDialog();
-		await goToStep2();
 
+		await waitFor(() => expect(mockShowError).toHaveBeenCalledWith(error, expect.any(String)));
+
+		await goToStep2();
 		await userEvent.type(getByTestId('workflow-review-title-input'), 'Review payments');
 
 		expect(getByTestId('workflow-review-submit-button')).toBeDisabled();
 		expect(createWorkflowReviewRequest).not.toHaveBeenCalled();
-		expect(mockShowError).not.toHaveBeenCalled();
 	});
 
 	it('closes and hands off to the update-review flow when an open review conflicts', async () => {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
@@ -501,6 +501,22 @@ describe('WorkflowSubmitForReviewDialog', () => {
 		expect(createWorkflowReviewRequest).not.toHaveBeenCalled();
 	});
 
+	it('stays silent when the reviewer load fails after the dialog has closed', async () => {
+		let rejectLoad!: (error: unknown) => void;
+		const pendingLoad = new Promise<never>((_resolve, reject) => {
+			rejectLoad = reject;
+		});
+		vi.mocked(fetchEligibleReviewers).mockReturnValue(pendingLoad);
+		const { rerender, flushSave } = await renderDialog();
+
+		// Close before the in-flight load settles, then let it fail.
+		await rerender({ open: false, workflowId: 'workflow-1', flushSave });
+		rejectLoad(new Error('nope'));
+		await pendingLoad.catch(() => {});
+
+		expect(mockShowError).not.toHaveBeenCalled();
+	});
+
 	it('closes and hands off to the update-review flow when an open review conflicts', async () => {
 		vi.mocked(createWorkflowReviewRequest).mockRejectedValue(
 			new ResponseError('Conflict', {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
@@ -113,7 +113,11 @@ const loadEligibleReviewers = async () => {
 watch(
 	() => props.open,
 	(isOpen) => {
-		if (!isOpen) return;
+		if (!isOpen) {
+			// Invalidate any in-flight load so it can't toast after the dialog closes.
+			loadReviewersSequence++;
+			return;
+		}
 
 		step.value = 1;
 		reviewTitle.value = '';

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
@@ -101,9 +101,10 @@ const loadEligibleReviewers = async () => {
 		});
 		if (sequence !== loadReviewersSequence) return;
 		eligibleReviewers.value = data;
-	} catch {
+	} catch (error) {
 		if (sequence !== loadReviewersSequence) return;
 		eligibleReviewers.value = [];
+		toast.showError(error, i18n.baseText('workflowReviews.submitForReview.error.loadReviewers'));
 	} finally {
 		if (sequence === loadReviewersSequence) isLoadingReviewers.value = false;
 	}


### PR DESCRIPTION
## Summary

The submit-for-review dialog failed silently when it could not load the list of eligible reviewers. The picker went empty, submit stayed disabled, and the user got no explanation.

This change makes the reviewer load surface an error notification, matching how submit itself already reports failures. Submit stays blocked until a later load succeeds. Stale in-flight loads still stay silent after the dialog closes or a newer load starts.

## How to test

1. Open **Publish → Submit for review** on a workflow.
2. Make `GET /workflow-review-requests/eligible-reviewers` fail (network error or 5xx).
3. Confirm an error notification appears ("Couldn't load reviewers").
4. Confirm the reviewer field is empty and submit stays disabled.
5. Fix the endpoint and reopen the dialog. Confirm reviewers load and submit becomes available.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-1078

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

