### PR TITLE
feat(core)!: Remove in-memory binary data storage mode

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -118,7 +118,7 @@ export interface FrontendSettings {
 	authCookie: {
 		secure: boolean;
 	};
-	binaryDataMode: 'default' | 'filesystem' | 's3' | 'azure' | 'database';
+	binaryDataMode: 'filesystem' | 's3' | 'azure' | 'database';
 	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev' | 'rc';
 	n8nMetadata?: {
 		userId?: string;

--- a/packages/@n8n/workflow-sdk/src/prompts/best-practices/guides/data-extraction.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/best-practices/guides/data-extraction.ts
@@ -31,7 +31,7 @@ When working with large amounts of information, n8n's display can be hard to vie
 
 ## Large File Handling
 
-Process files in batches or use sub-workflows to avoid memory issues. For large binary files, consider enabling filesystem mode (N8N_DEFAULT_BINARY_DATA_MODE=filesystem) if self-hosted, to store binary data on disk instead of memory.
+Process files in batches or use sub-workflows to avoid memory issues. Binary data is stored on disk (filesystem mode) by default when self-hosted; N8N_DEFAULT_BINARY_DATA_MODE can select another store such as s3.
 
 Processing too many items or large files at once can crash your instance. Always batch or split processing for large datasets to manage memory effectively.
 

--- a/packages/cli/src/controllers/binary-data.controller.ts
+++ b/packages/cli/src/controllers/binary-data.controller.ts
@@ -3,12 +3,7 @@ import type { AuthenticatedRequest } from '@n8n/db';
 import { Get, Query, RestController } from '@n8n/decorators';
 import { Request, Response } from 'express';
 import { JsonWebTokenError } from 'jsonwebtoken';
-import {
-	BinaryDataService,
-	FileNotFoundError,
-	getHtmlSandboxCSP,
-	isValidNonDefaultMode,
-} from 'n8n-core';
+import { BinaryDataService, FileNotFoundError, getHtmlSandboxCSP, isStoredMode } from 'n8n-core';
 
 import { BinaryDataAccessService } from '@/binary-data/binary-data-access.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -68,7 +63,7 @@ export class BinaryDataController {
 
 		const mode = binaryDataId.substring(0, separatorIndex);
 
-		if (!isValidNonDefaultMode(mode)) {
+		if (!isStoredMode(mode)) {
 			throw new BadRequestError('Invalid binary data mode');
 		}
 

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -76,7 +76,7 @@ export class DeprecationService {
 		{
 			envVar: 'N8N_DEFAULT_BINARY_DATA_MODE',
 			message:
-				'In-memory binary data storage (`default` mode) will be removed in a future version. Switch to `filesystem`, `s3`, or `database`.',
+				'In-memory binary data storage (`default` mode) has been removed. This value is now ignored and n8n falls back to `filesystem` mode (`database` in scaling mode). Remove this environment variable or set it to `filesystem`, `s3`, or `database`.',
 			checkValue: (value?: string) => value === 'default',
 		},
 		{

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -147,8 +147,8 @@ describe('TelemetryEventRelay', () => {
 		instanceSettingsLoader: getDefaultInstanceSettingsLoaderConfig(),
 	});
 	const binaryDataConfig = mock<BinaryDataConfig>({
-		mode: 'default',
-		availableModes: ['default', 'filesystem', 's3'],
+		mode: 'filesystem',
+		availableModes: ['filesystem', 's3'],
 	});
 	const instanceSettings = mockInstance(InstanceSettings, { isDocker: false, n8nFolder: '/test' });
 	const workflowRepository = mock<WorkflowRepository>();
@@ -2700,7 +2700,7 @@ describe('TelemetryEventRelay', () => {
 						metrics_category_workflow_info: false,
 						metrics_enabled: true,
 					},
-					n8n_binary_data_mode: 'default',
+					n8n_binary_data_mode: 'filesystem',
 					n8n_deployment_type: 'default',
 					saml_enabled: false,
 					smtp_set_up: true,

--- a/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
@@ -293,10 +293,8 @@ for (const mode of ['filesystem', 's3'] as const) {
 	});
 }
 
-describe('on default mode', () => {
+describe('on non-webhook execution mode', () => {
 	it('should do nothing', async () => {
-		Container.get(BinaryDataConfig).mode = 'default';
-
 		const executionId = '999';
 
 		const run = toIRun({

--- a/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
+++ b/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import type { BinaryData } from 'n8n-core';
-import { BinaryDataConfig, BinaryDataService } from 'n8n-core';
+import { BinaryDataService } from 'n8n-core';
 import type { IBinaryData, IRun, WorkflowExecuteMode } from 'n8n-workflow';
 
 /**
@@ -66,7 +66,7 @@ export async function restoreBinaryDataId(
 	executionId: string,
 	workflowExecutionMode: WorkflowExecuteMode,
 ) {
-	if (workflowExecutionMode !== 'webhook' || Container.get(BinaryDataConfig).mode === 'default') {
+	if (workflowExecutionMode !== 'webhook') {
 		return;
 	}
 

--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/binary-data-storage.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/binary-data-storage.rule.test.ts
@@ -13,9 +13,13 @@ describe('BinaryDataStorageRule', () => {
 		rule = new BinaryDataStorageRule(binaryDataConfig, executionsConfig);
 	});
 
+	afterEach(() => {
+		delete process.env.N8N_DEFAULT_BINARY_DATA_MODE;
+	});
+
 	describe('detect()', () => {
-		it('should not be affected if mode is not default', async () => {
-			binaryDataConfig.mode = 'filesystem';
+		it('should not be affected if env var is not set to default', async () => {
+			process.env.N8N_DEFAULT_BINARY_DATA_MODE = 'filesystem';
 			executionsConfig.mode = 'regular';
 			const result = await rule.detect();
 
@@ -23,8 +27,8 @@ describe('BinaryDataStorageRule', () => {
 			expect(result.instanceIssues).toHaveLength(0);
 		});
 
-		it('should be affected if mode is default and execution mode is regular', async () => {
-			binaryDataConfig.mode = 'default';
+		it('should be affected if env var is default and execution mode is regular', async () => {
+			process.env.N8N_DEFAULT_BINARY_DATA_MODE = 'default';
 			executionsConfig.mode = 'regular';
 			const result = await rule.detect();
 
@@ -35,8 +39,8 @@ describe('BinaryDataStorageRule', () => {
 			expect(result.recommendations[0].action).toBe('Ensure adequate disk space');
 		});
 
-		it('should be affected if mode is default and execution mode is queue', async () => {
-			binaryDataConfig.mode = 'default';
+		it('should be affected if env var is default and execution mode is queue', async () => {
+			process.env.N8N_DEFAULT_BINARY_DATA_MODE = 'default';
 			executionsConfig.mode = 'queue';
 			const result = await rule.detect();
 

--- a/packages/cli/src/modules/breaking-changes/rules/v2/binary-data-storage.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/binary-data-storage.rule.ts
@@ -32,7 +32,9 @@ export class BinaryDataStorageRule implements IBreakingChangeInstanceRule {
 	}
 
 	async detect(): Promise<InstanceDetectionReport> {
-		if (this.config.mode !== 'default') {
+		// read the env var directly - `default` is no longer a valid config value,
+		// so `BinaryDataConfig.mode` can never hold it
+		if (process.env.N8N_DEFAULT_BINARY_DATA_MODE !== 'default') {
 			return {
 				isAffected: false,
 				instanceIssues: [],

--- a/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/in-memory-binary-data.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/in-memory-binary-data.rule.test.ts
@@ -1,21 +1,17 @@
-import type { BinaryDataConfig } from 'n8n-core';
-import { mock } from 'vitest-mock-extended';
-
 import { InMemoryBinaryDataRule } from '../in-memory-binary-data.rule';
 
 describe('InMemoryBinaryDataRule', () => {
-	let rule: InMemoryBinaryDataRule;
-	const binaryDataConfig: BinaryDataConfig = mock<BinaryDataConfig>();
+	const rule = new InMemoryBinaryDataRule();
 
-	beforeEach(() => {
-		rule = new InMemoryBinaryDataRule(binaryDataConfig);
+	afterEach(() => {
+		delete process.env.N8N_DEFAULT_BINARY_DATA_MODE;
 	});
 
 	describe('detect()', () => {
-		it.each(['filesystem', 's3', 'database'] as const)(
-			'should not be affected in %s mode',
+		it.each(['filesystem', 's3', 'database', undefined])(
+			'should not be affected when env var is %s',
 			async (mode) => {
-				binaryDataConfig.mode = mode;
+				if (mode) process.env.N8N_DEFAULT_BINARY_DATA_MODE = mode;
 
 				const result = await rule.detect();
 
@@ -24,8 +20,8 @@ describe('InMemoryBinaryDataRule', () => {
 			},
 		);
 
-		it('should be affected in default (in-memory) mode', async () => {
-			binaryDataConfig.mode = 'default';
+		it('should be affected when env var is set to removed default (in-memory) mode', async () => {
+			process.env.N8N_DEFAULT_BINARY_DATA_MODE = 'default';
 
 			const result = await rule.detect();
 

--- a/packages/cli/src/modules/breaking-changes/rules/v3/in-memory-binary-data.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/in-memory-binary-data.rule.ts
@@ -1,5 +1,4 @@
 import { BreakingChangeRule } from '@n8n/decorators';
-import { BinaryDataConfig } from 'n8n-core';
 
 import type {
 	BreakingChangeRuleMetadata,
@@ -10,8 +9,6 @@ import { BreakingChangeCategory } from '../../types';
 
 @BreakingChangeRule({ version: 'v3' })
 export class InMemoryBinaryDataRule implements IBreakingChangeInstanceRule {
-	constructor(private readonly binaryDataConfig: BinaryDataConfig) {}
-
 	id: string = 'in-memory-binary-data-v3';
 
 	getMetadata(): BreakingChangeRuleMetadata {
@@ -26,7 +23,9 @@ export class InMemoryBinaryDataRule implements IBreakingChangeInstanceRule {
 	}
 
 	async detect(): Promise<InstanceDetectionReport> {
-		if (this.binaryDataConfig.mode !== 'default') {
+		// read the env var directly - `default` is no longer a valid config value,
+		// so `BinaryDataConfig.mode` can never hold it
+		if (process.env.N8N_DEFAULT_BINARY_DATA_MODE !== 'default') {
 			return { isAffected: false, instanceIssues: [], recommendations: [] };
 		}
 

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -2245,7 +2245,6 @@ describe('JobProcessor', () => {
 			const relay = new WebhookResponseRelay(
 				logger,
 				binaryDataService,
-				mock<BinaryDataConfig>({ mode }),
 				mock<ExecutionsConfig>({
 					webhookResponseRelaySizeMaxMiB,
 					webhookResponseRelayOffloadEnabled: true,
@@ -2259,7 +2258,7 @@ describe('JobProcessor', () => {
 		const processJobAndCaptureHooks = async (
 			webhookResponseRelaySizeMaxMiB: number,
 			jobData: Partial<Job['data']> = {},
-			mode: BinaryDataConfig['mode'] = 'default',
+			mode: BinaryDataConfig['mode'] = 'filesystem',
 		) => {
 			const { relay, binaryDataService } = buildRelay(webhookResponseRelaySizeMaxMiB, mode);
 			const executionPersistence = mock<ExecutionPersistence>();
@@ -2336,19 +2335,6 @@ describe('JobProcessor', () => {
 					}),
 				}),
 			);
-		});
-
-		it('should refuse to relay a response over the size limit without a store', async () => {
-			const { hooks, job } = await processJobAndCaptureHooks(1);
-			const relayedBefore = (job.progress as Mock).mock.calls.length;
-
-			await expect(
-				hooks.runHook('sendResponse', [
-					{ body: { blob: 'x'.repeat(2 * 1024 * 1024) }, headers: {}, statusCode: 200 },
-				]),
-			).rejects.toThrow(WebhookResponseTooLargeError);
-
-			expect((job.progress as Mock).mock.calls).toHaveLength(relayedBefore);
 		});
 
 		it('should offload an MCP response over the size limit and relay a reference', async () => {

--- a/packages/cli/src/scaling/__tests__/webhook-response-relay.test.ts
+++ b/packages/cli/src/scaling/__tests__/webhook-response-relay.test.ts
@@ -52,7 +52,6 @@ const buildRelay = ({
 	const relay = new WebhookResponseRelay(
 		logger,
 		binaryDataService,
-		mock<BinaryDataConfig>({ mode }),
 		mock<ExecutionsConfig>({
 			webhookResponseRelaySizeMaxMiB: SIZE_MAX_IN_MIB,
 			webhookResponseRelayOffloadEnabled: offloadEnabled,
@@ -342,40 +341,6 @@ describe('WebhookResponseRelay', () => {
 
 			expect(bodyOf(prepared)).toEqual({ [ENCODED_BUFFER_KEY]: 'aGVsbG8=' });
 			expect(binaryDataService.store).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('prepare, over the limit without a store', () => {
-		it.each([
-			['a Buffer body', Buffer.alloc(3 * ONE_MIB)],
-			['a string body', 'x'.repeat(3 * ONE_MIB)],
-			['a multi-byte string body', 'é'.repeat(2 * ONE_MIB)],
-			['a JSON body', { blob: 'x'.repeat(3 * ONE_MIB) }],
-			['a JSON body nested in an array', { items: [{ blob: 'x'.repeat(3 * ONE_MIB) }] }],
-		])('rejects %s where bytes are only kept in memory', async (_label, body) => {
-			const { relay, binaryDataService } = buildRelay({ mode: 'default' });
-
-			await expect(relay.prepare(fullResponse(body), ctx)).rejects.toThrow(
-				WebhookResponseTooLargeError,
-			);
-			expect(binaryDataService.store).not.toHaveBeenCalled();
-		});
-
-		it('names the limit and both ways out', async () => {
-			const { relay } = buildRelay({ mode: 'default' });
-
-			const error = await relay
-				.prepare(fullResponse('x'.repeat(3 * ONE_MIB)), ctx)
-				.catch((e: WebhookResponseTooLargeError) => e);
-
-			expect((error as WebhookResponseTooLargeError).message).not.toContain('MiB');
-			expect((error as WebhookResponseTooLargeError).description).toContain('The limit is 2 MiB');
-			expect((error as WebhookResponseTooLargeError).description).toContain(
-				'N8N_DEFAULT_BINARY_DATA_MODE',
-			);
-			expect((error as WebhookResponseTooLargeError).description).toContain(
-				'N8N_WEBHOOK_RESPONSE_RELAY_SIZE_MAX',
-			);
 		});
 	});
 

--- a/packages/cli/src/scaling/webhook-response-relay.ts
+++ b/packages/cli/src/scaling/webhook-response-relay.ts
@@ -13,7 +13,7 @@ import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { jsonSizeExceeds } from '@n8n/utils/json/json-size-exceeds';
-import { BinaryDataConfig, BinaryDataService, FileLocation, FileTooLargeError } from 'n8n-core';
+import { BinaryDataService, FileLocation, FileTooLargeError } from 'n8n-core';
 import type { BinaryData } from 'n8n-core';
 import { BINARY_ENCODING, jsonParse, OperationalError } from 'n8n-workflow';
 import type {
@@ -40,16 +40,6 @@ export const ENCODED_BUFFER_KEY = '__@N8nEncodedBuffer@__';
  */
 export const OFFLOADED_BODY_KIND_KEY = '__@N8nOffloadedBodyKind@__';
 
-/**
- * The one mode with nowhere to offload a body to: it keeps bytes in memory, so a
- * body stored in it would travel inline after all.
- *
- * Every other mode has a store, and whether main reaches it is the deployment's to
- * get right: a store only the instance that wrote the body can read surfaces when
- * main reads it back, rather than being refused up front.
- */
-const IN_MEMORY_MODE: BinaryDataConfig['mode'] = 'default';
-
 /** What Express sets on a string body sent inline through `res.send`. */
 const INLINE_STRING_CONTENT_TYPE = 'text/html; charset=utf-8';
 
@@ -65,8 +55,6 @@ const OFFLOAD_DISABLED_GUIDANCE =
 
 const BINARY_DATA_DOCS_LINK =
 	"<a href='https://docs.n8n.io/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/binary-data' target='_blank'>in the docs</a>";
-
-const NO_STORE_GUIDANCE = `In scaling mode a response over this size is stored for the main instance to stream, which the in-memory binary-data mode cannot do. Set N8N_DEFAULT_BINARY_DATA_MODE to a mode with a store, or raise N8N_WEBHOOK_RESPONSE_RELAY_SIZE_MAX. The modes are described ${BINARY_DATA_DOCS_LINK}.`;
 
 const UNREADABLE_BODY_GUIDANCE = `A response over N8N_WEBHOOK_RESPONSE_RELAY_SIZE_MAX is stored by the instance that produced it, so N8N_DEFAULT_BINARY_DATA_MODE has to name a store every instance can read. The modes are described ${BINARY_DATA_DOCS_LINK}.`;
 
@@ -117,7 +105,6 @@ export class WebhookResponseRelay {
 	constructor(
 		private readonly logger: Logger,
 		private readonly binaryDataService: BinaryDataService,
-		private readonly binaryDataConfig: BinaryDataConfig,
 		private readonly executionsConfig: ExecutionsConfig,
 	) {
 		this.logger = this.logger.scoped('scaling');
@@ -262,19 +249,12 @@ export class WebhookResponseRelay {
 	/**
 	 * Asserts that a body over the limit has somewhere to be offloaded to.
 	 *
-	 * @throws {WebhookResponseTooLargeError} When offload is turned off, or when the
-	 * binary-data mode keeps bytes in memory.
+	 * @throws {WebhookResponseTooLargeError} When offload is turned off.
 	 */
 	private assertOffloadAvailable(): void {
 		if (!this.executionsConfig.webhookResponseRelayOffloadEnabled) {
 			throw new WebhookResponseTooLargeError(TOO_LARGE_MESSAGE, {
 				description: withInlineLimit(OFFLOAD_DISABLED_GUIDANCE, this.maxInlineMib),
-			});
-		}
-
-		if (this.binaryDataConfig.mode === IN_MEMORY_MODE) {
-			throw new WebhookResponseTooLargeError(TOO_LARGE_MESSAGE, {
-				description: withInlineLimit(NO_STORE_GUIDANCE, this.maxInlineMib),
 			});
 		}
 	}

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -106,8 +106,8 @@ describe('FrontendService', () => {
 	});
 
 	const binaryDataConfig = mock<BinaryDataConfig>({
-		mode: 'default',
-		availableModes: ['default'],
+		mode: 'filesystem',
+		availableModes: ['filesystem'],
 	});
 
 	const credentialTypes = mock<CredentialTypes>({

--- a/packages/cli/test/integration/shared/utils/index.ts
+++ b/packages/cli/test/integration/shared/utils/index.ts
@@ -21,6 +21,9 @@ import { ScheduleTrigger } from 'n8n-nodes-base/nodes/Schedule/ScheduleTrigger.n
 import { Set } from 'n8n-nodes-base/nodes/Set/Set.node';
 import { Webhook as WebhookNode } from 'n8n-nodes-base/nodes/Webhook/Webhook.node';
 import type { INodeProperties, INodeType, INodeTypeData, INode } from 'n8n-workflow';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type request from 'supertest';
 import { v4 as uuid } from 'uuid';
 import { mock } from 'vitest-mock-extended';
@@ -176,11 +179,11 @@ export async function initNodeTypes(customNodes?: INodeTypeData) {
 /**
  * Initialize a BinaryDataService for test runs.
  */
-export async function initBinaryDataService(mode: 'default' | 'filesystem' = 'default') {
+export async function initBinaryDataService() {
 	const config = mock<BinaryDataConfig>({
-		mode,
-		availableModes: [mode],
-		localStoragePath: '',
+		mode: 'filesystem',
+		availableModes: ['filesystem'],
+		localStoragePath: mkdtempSync(join(tmpdir(), 'n8n-binary-data-')),
 	});
 	const logger = mock<Logger>();
 	const errorReporter = mock<ErrorReporter>();

--- a/packages/core/nodes-testing/inline-binary-data-service.ts
+++ b/packages/core/nodes-testing/inline-binary-data-service.ts
@@ -1,0 +1,47 @@
+import { binaryToBuffer } from '@n8n/backend-network';
+import type { IBinaryData } from 'n8n-workflow';
+import { BINARY_ENCODING } from 'n8n-workflow';
+import { readFile, stat } from 'node:fs/promises';
+import prettyBytes from 'pretty-bytes';
+import type { Readable } from 'stream';
+
+import { mock } from './mock-extended';
+import type { BinaryData } from '../dist/binary-data';
+import { BinaryDataService } from '../dist/binary-data';
+
+/**
+ * Keeps binary data inline (base64 in `data`, no id) instead of writing it to
+ * a store, so workflow test fixtures can assert binary payloads without disk
+ * IO or a per-test storage path.
+ */
+export class InlineBinaryDataService extends BinaryDataService {
+	constructor() {
+		super(mock(), mock(), mock());
+	}
+
+	override async store(
+		_location: BinaryData.FileLocation,
+		bufferOrStream: Buffer | Readable,
+		binaryData: IBinaryData,
+	) {
+		const buffer = await binaryToBuffer(bufferOrStream);
+		binaryData.data = buffer.toString(BINARY_ENCODING);
+		binaryData.fileSize = prettyBytes(buffer.length);
+		binaryData.bytes = buffer.length;
+
+		return binaryData;
+	}
+
+	override async copyBinaryFile(
+		_location: BinaryData.FileLocation,
+		binaryData: IBinaryData,
+		filePath: string,
+	) {
+		const { size } = await stat(filePath);
+		binaryData.fileSize = prettyBytes(size);
+		binaryData.bytes = size;
+		binaryData.data = await readFile(filePath, { encoding: BINARY_ENCODING });
+
+		return binaryData;
+	}
+}

--- a/packages/core/nodes-testing/node-test-harness.ts
+++ b/packages/core/nodes-testing/node-test-harness.ts
@@ -18,10 +18,14 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { expect } from 'vitest';
 
+import { Container } from '@n8n/di';
+
+import { BinaryDataService } from '../dist/binary-data';
 import { ExecutionLifecycleHooks } from '../dist/execution-engine/execution-lifecycle-hooks';
 import { WorkflowExecute } from '../dist/execution-engine/workflow-execute';
 import { CredentialTypes } from './credential-types';
 import { CredentialsHelper } from './credentials-helper';
+import { InlineBinaryDataService } from './inline-binary-data-service';
 import { LoadNodesAndCredentials } from './load-nodes-and-credentials';
 import { NodeTypes } from './node-types';
 
@@ -54,7 +58,10 @@ export class NodeTestHarness {
 		this.packagePaths.unshift(this.packageDir);
 
 		beforeAll(() => this.ensureNodesLoaded(), 30_000);
-		beforeEach(() => nock.disableNetConnect());
+		beforeEach(() => {
+			nock.disableNetConnect();
+			Container.set(BinaryDataService, new InlineBinaryDataService());
+		});
 	}
 
 	readWorkflowJSON(filePath: string) {

--- a/packages/core/src/binary-data/__tests__/binary-data.config.test.ts
+++ b/packages/core/src/binary-data/__tests__/binary-data.config.test.ts
@@ -66,6 +66,17 @@ describe('BinaryDataConfig', () => {
 		);
 	});
 
+	it('should fallback to filesystem for removed in-memory `default` mode', () => {
+		process.env.N8N_DEFAULT_BINARY_DATA_MODE = 'default';
+
+		const config = Container.get(BinaryDataConfig);
+
+		expect(config.mode).toEqual('filesystem');
+		expect(console.warn).toHaveBeenCalledWith(
+			expect.stringContaining('Invalid value for N8N_DEFAULT_BINARY_DATA_MODE'),
+		);
+	});
+
 	describe('dbMaxFileSize', () => {
 		it('should coerce string env variable to number', () => {
 			process.env.N8N_BINARY_DATA_DATABASE_MAX_FILE_SIZE = '1024';

--- a/packages/core/src/binary-data/binary-data.config.ts
+++ b/packages/core/src/binary-data/binary-data.config.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { InstanceSettings } from '@/instance-settings';
 import { StorageConfig } from '@/storage.config';
 
-export const BINARY_DATA_MODES = ['default', 'filesystem', 's3', 'azure', 'database'] as const;
+export const BINARY_DATA_MODES = ['filesystem', 's3', 'azure', 'database'] as const;
 
 const binaryDataModesSchema = z.enum(BINARY_DATA_MODES);
 

--- a/packages/core/src/binary-data/binary-data.service.ts
+++ b/packages/core/src/binary-data/binary-data.service.ts
@@ -1,12 +1,10 @@
 import { Logger } from '@n8n/backend-common';
-import { binaryToBuffer } from '@n8n/backend-network';
 import { FsByteStore } from '@n8n/blob-storage';
 import { Service } from '@n8n/di';
 import jwt from 'jsonwebtoken';
 import type { StringValue as TimeUnitValue } from 'ms';
 import { BINARY_ENCODING, UnexpectedError } from 'n8n-workflow';
 import type { INodeExecutionData, IBinaryData } from 'n8n-workflow';
-import { readFile, stat } from 'node:fs/promises';
 import prettyBytes from 'pretty-bytes';
 import type { Readable } from 'stream';
 
@@ -51,7 +49,7 @@ export class BinaryDataService {
 
 	createSignedToken(binaryData: IBinaryData, expiresIn: TimeUnitValue = '1 day') {
 		if (!binaryData.id) {
-			throw new UnexpectedError('URL signing is not available in memory mode');
+			throw new UnexpectedError('URL signing is not available for inline binary data');
 		}
 
 		const signingPayload: BinaryData.SigningPayload = {
@@ -73,16 +71,7 @@ export class BinaryDataService {
 		binaryData: IBinaryData,
 		filePath: string,
 	) {
-		const manager = this.managers[this.mode];
-
-		if (!manager) {
-			const { size } = await stat(filePath);
-			binaryData.fileSize = prettyBytes(size);
-			binaryData.bytes = size;
-			binaryData.data = await readFile(filePath, { encoding: BINARY_ENCODING });
-
-			return binaryData;
-		}
+		const manager = this.getManager(this.mode);
 
 		const metadata = {
 			fileName: binaryData.fileName,
@@ -104,16 +93,7 @@ export class BinaryDataService {
 		bufferOrStream: Buffer | Readable,
 		binaryData: IBinaryData,
 	) {
-		const manager = this.managers[this.mode];
-
-		if (!manager) {
-			const buffer = await binaryToBuffer(bufferOrStream);
-			binaryData.data = buffer.toString(BINARY_ENCODING);
-			binaryData.fileSize = prettyBytes(buffer.length);
-			binaryData.bytes = buffer.length;
-
-			return binaryData;
-		}
+		const manager = this.getManager(this.mode);
 
 		const metadata = {
 			fileName: binaryData.fileName,

--- a/packages/core/src/binary-data/index.ts
+++ b/packages/core/src/binary-data/index.ts
@@ -2,4 +2,4 @@ export * from './binary-data.service';
 export { BinaryDataBlobManager, getExecutionIdFromFileId } from './blob.manager';
 export { BinaryDataConfig } from './binary-data.config';
 export type * from './types';
-export { isStoredMode as isValidNonDefaultMode, FileLocation } from './utils';
+export { isStoredMode, FileLocation } from './utils';

--- a/packages/core/src/binary-data/types.ts
+++ b/packages/core/src/binary-data/types.ts
@@ -21,9 +21,9 @@ export namespace BinaryData {
 
 	/**
 	 * Binary data mode in binary data ID in stored execution data. Both legacy
-	 * and upgraded modes may be present, except default in-memory mode.
+	 * and upgraded modes may be present.
 	 */
-	export type StoredMode = Exclude<ConfigMode | UpgradedMode, 'default'>;
+	export type StoredMode = ConfigMode | UpgradedMode;
 
 	export type Metadata = BlobMetadata;
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
@@ -8,7 +8,7 @@ import type {
 	ITaskDataConnections,
 	IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
-import { BINARY_MODE_COMBINED } from 'n8n-workflow';
+import { BINARY_ENCODING, BINARY_MODE_COMBINED } from 'n8n-workflow';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Readable } from 'stream';
@@ -100,6 +100,31 @@ describe('test binary data helper methods', () => {
 		]);
 
 		// Now, lets fetch our data! The item will be item index 0.
+		const getBinaryDataBufferResponse: Buffer = await getBinaryDataBuffer(
+			taskDataConnectionsInput,
+			0,
+			'data',
+			0,
+		);
+
+		expect(getBinaryDataBufferResponse).toEqual(inputData);
+	});
+
+	test('getBinaryDataBuffer(...) should read inline base64 data when binary data has no id', async () => {
+		await binaryDataService.init();
+
+		// Pinned data and executions stored under the removed in-memory mode
+		// carry inline base64 in `data` with no id - they must stay readable.
+		const inputData: Buffer = Buffer.from('This is some binary data', 'utf8');
+		const inlineBinaryData: IBinaryData = {
+			mimeType: 'txt',
+			data: inputData.toString(BINARY_ENCODING),
+		};
+
+		const taskDataConnectionsInput: ITaskDataConnections = {
+			main: [[{ json: {}, binary: { data: inlineBinaryData } }]],
+		};
+
 		const getBinaryDataBufferResponse: Buffer = await getBinaryDataBuffer(
 			taskDataConnectionsInput,
 			0,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
@@ -42,8 +42,8 @@ const bufferToIncomingMessage = (buffer: Buffer, encoding = 'utf-8') => {
 describe('test binary data helper methods', () => {
 	const temporaryDir = mkdtempSync(join(tmpdir(), 'n8n'));
 	const binaryDataConfig = mock<BinaryDataConfig>({
-		mode: 'default',
-		availableModes: ['default', 'filesystem'],
+		mode: 'filesystem',
+		availableModes: ['filesystem'],
 		localStoragePath: temporaryDir,
 	});
 	const errorReporter = mock<ErrorReporter>();
@@ -54,53 +54,6 @@ describe('test binary data helper methods', () => {
 		vi.resetAllMocks();
 		binaryDataService = new BinaryDataService(binaryDataConfig, errorReporter, logger);
 		Container.set(BinaryDataService, binaryDataService);
-	});
-
-	test("test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'default' mode", async () => {
-		// Setup a 'default' binary data manager instance
-		binaryDataConfig.mode = 'default';
-		await binaryDataService.init();
-
-		// Set our binary data buffer
-		const inputData: Buffer = Buffer.from('This is some binary data', 'utf8');
-		const setBinaryDataBufferResponse: IBinaryData = await setBinaryDataBuffer(
-			{
-				mimeType: 'txt',
-				data: 'This should be overwritten by the actual payload in the response',
-			},
-			inputData,
-			'workflowId',
-			'executionId',
-		);
-
-		// Expect our return object to contain the base64 encoding of the input data, as it should be stored in memory.
-		expect(setBinaryDataBufferResponse.data).toEqual(inputData.toString('base64'));
-
-		// Now, re-fetch our data.
-		// An ITaskDataConnections object is used to share data between nodes. The top level property, 'main', represents the successful output object from a previous node.
-		const taskDataConnectionsInput: ITaskDataConnections = {
-			main: [],
-		};
-
-		// We add an input set, with one item at index 0, to this input. It contains an empty json payload and our binary data.
-		taskDataConnectionsInput.main.push([
-			{
-				json: {},
-				binary: {
-					data: setBinaryDataBufferResponse,
-				},
-			},
-		]);
-
-		// Now, lets fetch our data! The item will be item index 0.
-		const getBinaryDataBufferResponse: Buffer = await getBinaryDataBuffer(
-			taskDataConnectionsInput,
-			0,
-			'data',
-			0,
-		);
-
-		expect(getBinaryDataBufferResponse).toEqual(inputData);
 	});
 
 	test("test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'filesystem' mode", async () => {
@@ -158,25 +111,6 @@ describe('test binary data helper methods', () => {
 	});
 
 	describe('getBinaryDataBuffer with IBinaryData parameter', () => {
-		it('should return buffer when passed IBinaryData directly in default mode', async () => {
-			binaryDataConfig.mode = 'default';
-			await binaryDataService.init();
-
-			const inputBuffer = Buffer.from('direct binary data', 'utf8');
-			const binaryData = await setBinaryDataBuffer(
-				{ mimeType: 'application/octet-stream', data: '' },
-				inputBuffer,
-				workflowId,
-				executionId,
-			);
-
-			// Empty input data since we're passing binary data directly
-			const inputData: ITaskDataConnections = { main: [] };
-
-			const result = await getBinaryDataBuffer(inputData, 0, binaryData, 0);
-			expect(result).toEqual(inputBuffer);
-		});
-
 		it('should return buffer when passed IBinaryData directly in filesystem mode', async () => {
 			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
@@ -196,7 +130,7 @@ describe('test binary data helper methods', () => {
 		});
 
 		it('should handle IBinaryData with different mime types', async () => {
-			binaryDataConfig.mode = 'default';
+			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
 
 			const jsonBuffer = Buffer.from('{"test": "json"}', 'utf8');
@@ -214,7 +148,7 @@ describe('test binary data helper methods', () => {
 		});
 
 		it('should handle IBinaryData with all properties', async () => {
-			binaryDataConfig.mode = 'default';
+			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
 
 			const inputBuffer = Buffer.from('comprehensive test data', 'utf8');
@@ -239,7 +173,7 @@ describe('test binary data helper methods', () => {
 		});
 
 		it('should handle empty buffer with IBinaryData', async () => {
-			binaryDataConfig.mode = 'default';
+			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
 
 			const emptyBuffer = Buffer.alloc(0);
@@ -258,7 +192,7 @@ describe('test binary data helper methods', () => {
 		});
 
 		it('should handle large binary data with IBinaryData', async () => {
-			binaryDataConfig.mode = 'default';
+			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
 
 			// Create a 1MB buffer
@@ -280,7 +214,7 @@ describe('test binary data helper methods', () => {
 		}, 20000);
 
 		it('should handle binary data with special characters using IBinaryData', async () => {
-			binaryDataConfig.mode = 'default';
+			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
 
 			const specialBuffer = Buffer.from('Hello 世界! 🚀 Special chars: àáâãäå', 'utf8');
@@ -334,7 +268,7 @@ describe('test binary data helper methods', () => {
 
 	describe('getBinaryDataBuffer with combined binary mode', () => {
 		beforeEach(async () => {
-			binaryDataConfig.mode = 'default';
+			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
 		});
 
@@ -544,7 +478,7 @@ describe('test binary data helper methods', () => {
 
 	describe('getBinaryDataBuffer with separate binary mode', () => {
 		beforeEach(async () => {
-			binaryDataConfig.mode = 'default';
+			binaryDataConfig.mode = 'filesystem';
 			await binaryDataService.init();
 		});
 

--- a/packages/core/src/utils/__tests__/convert-binary-data.test.ts
+++ b/packages/core/src/utils/__tests__/convert-binary-data.test.ts
@@ -1,8 +1,6 @@
-import { Container } from '@n8n/di';
 import type { IBinaryData, IRunNodeResponse } from 'n8n-workflow';
 import { BINARY_ENCODING, BINARY_IN_JSON_PROPERTY, BINARY_MODE_COMBINED } from 'n8n-workflow';
 
-import type { BinaryDataConfig } from '../../binary-data/binary-data.config';
 import * as binaryHelperFunctions from '../../execution-engine/node-execution-context/utils/binary-helper-functions';
 import { convertBinaryData } from '../convert-binary-data';
 
@@ -11,11 +9,9 @@ vi.mock('../../execution-engine/node-execution-context/utils/binary-helper-funct
 describe('convertBinaryData', () => {
 	const workflowId = 'test-workflow-id';
 	const executionId = 'test-execution-id';
-	const mockBinaryDataConfig = { mode: 'default' } as BinaryDataConfig;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.spyOn(Container, 'get').mockReturnValue(mockBinaryDataConfig);
 	});
 
 	afterEach(() => {
@@ -24,8 +20,6 @@ describe('convertBinaryData', () => {
 
 	describe('early returns', () => {
 		it('should return unchanged data when binaryMode is not "combined"', async () => {
-			mockBinaryDataConfig.mode = 'filesystem';
-
 			const responseData: IRunNodeResponse = {
 				data: [[{ json: { test: 'data' } }]],
 			};
@@ -35,26 +29,7 @@ describe('convertBinaryData', () => {
 			expect(result).toBe(responseData);
 		});
 
-		it('should return unchanged data when mode is "default"', async () => {
-			mockBinaryDataConfig.mode = 'default';
-
-			const responseData: IRunNodeResponse = {
-				data: [[{ json: { test: 'data' } }]],
-			};
-
-			const result = await convertBinaryData(
-				workflowId,
-				executionId,
-				responseData,
-				BINARY_MODE_COMBINED,
-			);
-
-			expect(result).toBe(responseData);
-		});
-
 		it('should return unchanged data when responseData has no data', async () => {
-			mockBinaryDataConfig.mode = 'filesystem';
-
 			const responseData: IRunNodeResponse = {
 				data: [],
 			};
@@ -71,10 +46,6 @@ describe('convertBinaryData', () => {
 	});
 
 	describe('binary data conversion', () => {
-		beforeEach(() => {
-			mockBinaryDataConfig.mode = 'filesystem';
-		});
-
 		it('should handle items without binary data', async () => {
 			const responseData: IRunNodeResponse = {
 				data: [[{ json: { test: 'data' } }]],

--- a/packages/core/src/utils/convert-binary-data.ts
+++ b/packages/core/src/utils/convert-binary-data.ts
@@ -1,4 +1,3 @@
-import { Container } from '@n8n/di';
 import type { IBinaryKeyData, IRunNodeResponse, WorkflowSettingsBinaryMode } from 'n8n-workflow';
 import {
 	BINARY_ENCODING,
@@ -7,7 +6,6 @@ import {
 	UnexpectedError,
 } from 'n8n-workflow';
 
-import { BinaryDataConfig } from '../binary-data/binary-data.config';
 import { prepareBinaryData } from '../execution-engine/node-execution-context/utils/binary-helper-functions';
 
 export async function convertBinaryData(
@@ -16,8 +14,7 @@ export async function convertBinaryData(
 	responseData: IRunNodeResponse,
 	binaryMode: WorkflowSettingsBinaryMode | undefined,
 ) {
-	const { mode } = Container.get(BinaryDataConfig);
-	if (binaryMode !== BINARY_MODE_COMBINED || mode === 'default') return responseData;
+	if (binaryMode !== BINARY_MODE_COMBINED) return responseData;
 
 	if (!responseData.data?.length) return responseData;
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4574,8 +4574,6 @@
 	"workflowRun.showError.title": "Problem running workflow",
 	"workflowRun.showError.payloadTooLarge": "Please execute the whole workflow, rather than just the node. (Existing execution data is too large.)",
 	"workflowRun.showError.resolveOutstandingIssues": "Please resolve outstanding issues before you activate it",
-	"workflowRun.showError.unsupportedExecutionLogic.title": "Unsupported Execution Logic",
-	"workflowRun.showError.unsupportedExecutionLogic.description": "Execution Logic \"v2\" is not supported when filesystem mode is \"default\". Please change the Execution Logic to \"v1\" in workflow settings and update expressions accordingly.",
 	"workflowRun.showWarning.noChatResponseNodes.title": "No response node detected",
 	"workflowRun.showWarning.noChatResponseNodes.description": "Add a Chat or Respond to Webhook node to send a reply, or change the response mode in the Chat Trigger.",
 	"workflowRun.showMessage.message": "Please fix them before executing",

--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -35,7 +35,7 @@ export type RootStoreState = {
 	urlBaseEditor: string;
 	urlBaseWebhookTest: string;
 	instanceId: string;
-	binaryDataMode: 'default' | 'filesystem' | 's3' | 'azure' | 'database';
+	binaryDataMode: 'filesystem' | 's3' | 'azure' | 'database';
 };
 
 export const useRootStore = defineStore(STORES.ROOT, () => {
@@ -64,7 +64,7 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		urlBaseEditor: 'http://localhost:5678',
 		urlBaseWebhookTest: 'http://localhost:5678/',
 		instanceId: '',
-		binaryDataMode: 'default',
+		binaryDataMode: 'filesystem',
 	});
 
 	// ---------------------------------------------------------------------------

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -146,7 +146,7 @@ export const defaultSettings: FrontendSettings = {
 	banners: {
 		dismissed: [],
 	},
-	binaryDataMode: 'default',
+	binaryDataMode: 'filesystem',
 	previewMode: false,
 	mfa: {
 		enabled: false,

--- a/packages/frontend/editor-ui/src/app/composables/__snapshots__/useDebugInfo.test.ts.snap
+++ b/packages/frontend/editor-ui/src/app/composables/__snapshots__/useDebugInfo.test.ts.snap
@@ -21,7 +21,7 @@ exports[`useDebugInfo > should generate debug info 1`] = `
 - error: none
 - progress: true
 - manual: true
-- binaryMode: memory
+- binaryMode: filesystem
 
 ## pruning
 

--- a/packages/frontend/editor-ui/src/app/composables/useDebugInfo.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDebugInfo.test.ts
@@ -31,7 +31,7 @@ const MOCK_BASE_SETTINGS: RecursivePartial<ReturnType<typeof useSettingsStoreTyp
 	saveDataErrorExecution: 'none',
 	saveDataProgressExecution: true,
 	saveManualExecutions: true,
-	binaryDataMode: 'default',
+	binaryDataMode: 'filesystem',
 	pruning: {
 		isEnabled: true,
 		maxAge: 24,

--- a/packages/frontend/editor-ui/src/app/composables/useDebugInfo.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDebugInfo.ts
@@ -118,8 +118,7 @@ export function useDebugInfo() {
 			error: settingsStore.saveDataErrorExecution,
 			progress: settingsStore.saveDataProgressExecution,
 			manual: settingsStore.saveManualExecutions,
-			binaryMode:
-				settingsStore.binaryDataMode === 'default' ? 'memory' : settingsStore.binaryDataMode,
+			binaryMode: settingsStore.binaryDataMode,
 		};
 	};
 

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -3,7 +3,7 @@ import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import { useRouter } from 'vue-router';
 import type router from 'vue-router';
-import { BINARY_MODE_COMBINED, ExpressionError, NodeConnectionTypes } from 'n8n-workflow';
+import { ExpressionError, NodeConnectionTypes } from 'n8n-workflow';
 import type {
 	IPinData,
 	IRunData,
@@ -35,7 +35,6 @@ import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import { createTestNode, createTestWorkflow } from '@/__tests__/mocks';
 import { waitFor } from '@testing-library/vue';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
-import { useRootStore } from '@n8n/stores/useRootStore';
 import { useI18n } from '@n8n/i18n';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
@@ -594,32 +593,6 @@ describe('useRunWorkflow({ router })', () => {
 				await runWorkflow({});
 
 				expect(workflowSaving.saveCurrentWorkflow).toHaveBeenCalledWith({ id: '456' });
-			});
-		});
-
-		it('should prevent execution and show error when binary mode is "combined" with filesystem mode "default"', async () => {
-			const pinia = createTestingPinia({ stubActions: false });
-			setActivePinia(pinia);
-			const toast = useToast();
-			const rootStore = useRootStore();
-			const { runWorkflow } = useRunWorkflow({ router });
-
-			vi.mocked(rootStore).binaryDataMode = 'default';
-			mockDocumentStore.serialize.mockReturnValue({
-				id: 'workflowId',
-				nodes: [],
-				settings: {
-					binaryMode: BINARY_MODE_COMBINED,
-				},
-			} as unknown as WorkflowData);
-
-			const result = await runWorkflow({});
-
-			expect(result).toBeUndefined();
-			expect(toast.showMessage).toHaveBeenCalledWith({
-				title: useI18n().baseText('workflowRun.showError.unsupportedExecutionLogic.title'),
-				message: useI18n().baseText('workflowRun.showError.unsupportedExecutionLogic.description'),
-				type: 'error',
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -15,12 +15,7 @@ import type {
 	IWorkflowBase,
 	IDestinationNode,
 } from 'n8n-workflow';
-import {
-	createRunExecutionData,
-	NodeConnectionTypes,
-	TelemetryHelpers,
-	BINARY_MODE_COMBINED,
-} from 'n8n-workflow';
+import { createRunExecutionData, NodeConnectionTypes, TelemetryHelpers } from 'n8n-workflow';
 import { retry } from '@n8n/utils/retry';
 import { until } from '@vueuse/core';
 import { computed, getCurrentInstance, type Ref } from 'vue';
@@ -215,18 +210,6 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			}
 
 			const workflowData = workflowDocumentStore.value.serialize();
-
-			if (
-				rootStore.binaryDataMode === 'default' &&
-				workflowData.settings?.binaryMode === BINARY_MODE_COMBINED
-			) {
-				toast.showMessage({
-					title: i18n.baseText('workflowRun.showError.unsupportedExecutionLogic.title'),
-					message: i18n.baseText('workflowRun.showError.unsupportedExecutionLogic.description'),
-					type: 'error',
-				});
-				return undefined;
-			}
 
 			const consolidatedData = consolidateRunDataAndStartNodes(
 				directParentNodes,


### PR DESCRIPTION
## Summary

Removes the deprecated in-memory binary data storage mode (`default`) for v3.

- `default` is removed from `BINARY_DATA_MODES`. If `N8N_DEFAULT_BINARY_DATA_MODE=default` is still set, the config validation logs a warning and falls back to the default mode: `filesystem` in regular mode, `database` in scaling mode. The instance starts normally, so no customer action is required.
- The in-memory write fallbacks in `BinaryDataService.store()` and `copyBinaryFile()` are removed. Every write path now produces a binary data id. A missing manager now throws `InvalidManagerError` instead of silently keeping bytes in memory.
- The id-less read fallback in `getAsBuffer()` stays. Pinned data and executions saved under the old mode still carry inline base64, and they must remain readable.
- Dead `mode === 'default'` branches are removed from `convert-binary-data.ts`, `restore-binary-data-id.ts`, and the webhook response relay (including its "mode with no store" error copy).
- The v3 and v2 breaking-change detection rules now read `process.env.N8N_DEFAULT_BINARY_DATA_MODE` directly, because `BinaryDataConfig.mode` can no longer hold `default`.
- The startup deprecation warning now states that the mode has been removed and the value is ignored.
- Frontend: the `binaryDataMode` union is narrowed in `@n8n/api-types` and `useRootStore`, the "Execution Logic v2 is not supported in default mode" run guard is removed with its i18n keys, and `useDebugInfo` no longer relabels the mode as `memory`.
- `isValidNonDefaultMode` is renamed back to `isStoredMode`.

## How to test

1. Start n8n with `N8N_DEFAULT_BINARY_DATA_MODE=default`.
2. Check the startup logs: a warning states the value is invalid and a deprecation notice states the mode has been removed.
3. Run a workflow that produces binary data (e.g. HTTP Request downloading a file). The binary data is written to the filesystem store and the item carries a `filesystem-v2:` id.
4. Start n8n without the env var: `filesystem` is used in regular mode, `database` in queue mode, as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4217

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. In case of a breaking change, the PR title includes `!`.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

