### PR TITLE
chore: Stop persisting derived fields in the code-health baseline (no-changelog)

### DIFF
--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -1,7 +1,5 @@
 {
 	"version": 1,
-	"generated": "2026-08-24T09:15:32.266Z",
-	"totalViolations": 184,
 	"violations": {
 		"packages/@n8n/ai-workflow-builder.ee/package.json": [
 			{

--- a/packages/testing/janitor/src/core/baseline.test.ts
+++ b/packages/testing/janitor/src/core/baseline.test.ts
@@ -90,8 +90,6 @@ describe('baseline', () => {
 		it('round-trips baseline to disk', () => {
 			const baseline: BaselineFile = {
 				version: 1,
-				generated: '2024-01-01T00:00:00Z',
-				totalViolations: 2,
 				violations: {
 					'pages/TestPage.ts': [
 						{ rule: 'dead-code', line: 10, message: 'Unused method', hash: 'abc123' },
@@ -117,8 +115,6 @@ describe('baseline', () => {
 	describe('filterNewViolations', () => {
 		const baseline: BaselineFile = {
 			version: 1,
-			generated: '2024-01-01T00:00:00Z',
-			totalViolations: 1,
 			violations: {
 				'pages/TestPage.ts': [
 					{

--- a/packages/testing/janitor/src/core/baseline.test.ts
+++ b/packages/testing/janitor/src/core/baseline.test.ts
@@ -102,7 +102,6 @@ describe('baseline', () => {
 
 			expect(loaded).not.toBeNull();
 			expect(loaded!.version).toBe(1);
-			expect(loaded!.totalViolations).toBe(2);
 			expect(loaded!.violations['pages/TestPage.ts']).toHaveLength(1);
 		});
 

--- a/packages/testing/janitor/src/core/baseline.ts
+++ b/packages/testing/janitor/src/core/baseline.ts
@@ -53,5 +53,5 @@ export function filterReportByBaseline(
 
 export function formatBaselineInfo(baseline: BaselineFile): string {
 	const fileCount = Object.keys(baseline.violations).length;
-	return `Baseline loaded (${baseline.totalViolations} known violations from ${baseline.generated})\n  Files with violations: ${fileCount}`;
+	return `Baseline loaded (${baseline.totalViolations} known violations)\n  Files with violations: ${fileCount}`;
 }

--- a/packages/testing/janitor/src/core/baseline.ts
+++ b/packages/testing/janitor/src/core/baseline.ts
@@ -53,6 +53,9 @@ export function filterReportByBaseline(
 
 export function formatBaselineInfo(baseline: BaselineFile): string {
 	const fileCount = Object.keys(baseline.violations).length;
-	const totalViolations = Object.values(baseline.violations).reduce((sum, entries) => sum + entries.length, 0);
+	const totalViolations = Object.values(baseline.violations).reduce(
+		(sum, entries) => sum + entries.length,
+		0,
+	);
 	return `Baseline loaded (${totalViolations} known violations)\n  Files with violations: ${fileCount}`;
 }

--- a/packages/testing/janitor/src/core/baseline.ts
+++ b/packages/testing/janitor/src/core/baseline.ts
@@ -53,5 +53,6 @@ export function filterReportByBaseline(
 
 export function formatBaselineInfo(baseline: BaselineFile): string {
 	const fileCount = Object.keys(baseline.violations).length;
-	return `Baseline loaded (${baseline.totalViolations} known violations)\n  Files with violations: ${fileCount}`;
+	const totalViolations = Object.values(baseline.violations).reduce((sum, entries) => sum + entries.length, 0);
+	return `Baseline loaded (${totalViolations} known violations)\n  Files with violations: ${fileCount}`;
 }

--- a/packages/testing/janitor/src/core/tcr-executor.test.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.test.ts
@@ -349,8 +349,6 @@ describe('TcrExecutor', () => {
 			// Create and commit a baseline file first
 			const baseline: BaselineFile = {
 				version: 1,
-				generated: new Date().toISOString(),
-				totalViolations: 0,
 				violations: {},
 			};
 			saveBaseline(baseline, tempDir);
@@ -376,8 +374,6 @@ describe('TcrExecutor', () => {
 			// Create and commit a baseline file
 			const baseline: BaselineFile = {
 				version: 1,
-				generated: new Date().toISOString(),
-				totalViolations: 0,
 				violations: {},
 			};
 			saveBaseline(baseline, tempDir);
@@ -407,8 +403,6 @@ describe('TcrExecutor', () => {
 			// Create baseline with this violation
 			const baseline: BaselineFile = {
 				version: 1,
-				generated: new Date().toISOString(),
-				totalViolations: 1,
 				violations: {
 					'pages/PageA.ts': [
 						{

--- a/packages/testing/rules-engine/src/baseline.test.ts
+++ b/packages/testing/rules-engine/src/baseline.test.ts
@@ -78,7 +78,25 @@ describe('baseline', () => {
 		const loaded = loadBaseline(filePath);
 
 		expect(loaded).not.toBeNull();
-		expect(loaded!.totalViolations).toBe(1);
+		expect(loaded!.version).toBe(1);
+		expect(loaded!.violations['src/a.ts']).toHaveLength(1);
+		expect(loaded!.violations['src/a.ts'][0].hash).toBe(baseline.violations['src/a.ts'][0].hash);
+	});
+
+	// These sat at the top of the file, so two branches that both refreshed the baseline
+	// conflicted there on every merge even when their entries merged cleanly.
+	it('does not persist the derived timestamp and total', () => {
+		const report = makeReport([
+			{ file: '/root/src/a.ts', rule: 'test-rule', message: 'bad thing' },
+		]);
+		const baseline = generateBaseline(report, '/root');
+		const filePath = path.join(tmpDir, 'baseline.json');
+
+		saveBaseline(baseline, filePath);
+
+		const persisted = fs.readFileSync(filePath, 'utf-8');
+		expect(persisted).not.toContain('"generated"');
+		expect(persisted).not.toContain('"totalViolations"');
 	});
 
 	it('returns null for missing baseline', () => {

--- a/packages/testing/rules-engine/src/baseline.ts
+++ b/packages/testing/rules-engine/src/baseline.ts
@@ -15,9 +15,9 @@ export interface BaselineEntry {
 
 export interface BaselineFile {
 	version: number;
-	generated: string;
-	totalViolations: number;
 	violations: Record<string, BaselineEntry[]>;
+	/** Size of the merged set, for the CLI summary. Not persisted — see `saveBaseline`. */
+	totalViolations?: number;
 }
 
 function hashViolation(violation: Violation, rootDir: string): string {
@@ -87,16 +87,17 @@ export function generateBaseline(
 		}
 	}
 
-	return {
-		version: BASELINE_VERSION,
-		generated: new Date().toISOString(),
-		totalViolations: seen.size,
-		violations,
-	};
+	return { version: BASELINE_VERSION, totalViolations: seen.size, violations };
 }
 
+/**
+ * Persist only the fields that are read back. A write timestamp and a running total are
+ * derived data, but they sit at the top of the file, so two branches that both refreshed
+ * the baseline conflict there on every merge even when their entries merge cleanly.
+ */
 export function saveBaseline(baseline: BaselineFile, filePath: string): void {
-	fs.writeFileSync(filePath, JSON.stringify(baseline, null, '\t') + '\n');
+	const { version, violations } = baseline;
+	fs.writeFileSync(filePath, JSON.stringify({ version, violations }, null, '\t') + '\n');
 }
 
 function isInBaseline(violation: Violation, baseline: BaselineFile, rootDir: string): boolean {


### PR DESCRIPTION
## Summary

`generated` and `totalViolations` sat at the top of `.code-health-baseline.json` and were rewritten on every refresh, so two branches that both refreshed it conflicted on those two lines even when their entries merged cleanly. That was the whole conflict in #37079.

Neither is read back: `generated` has no readers, and the persisted `totalViolations` is only echoed in the log line of the run that computed it (`code-health/src/cli.ts:71`). Filtering matches on `hash` alone. `saveBaseline` now writes `version` and `violations` only; the count stays in memory for the CLI summary.

## How to test

- `pnpm --filter=@n8n/code-health check` → exit 0, 0 violations; filtering unaffected.
- A refresh on an unchanged tree is now byte-identical (previously every refresh produced a diff).
- Replaying #37079's three-way merge with the new format: `git merge-file` exits 0, no markers, 187 entries — identical set to the correct three-way set merge.

## Related Linear tickets, Github issues, and Community forum posts

No ticket. Follow-up from #37072 / #37079. Related: https://linear.app/n8n/issue/DEVP-6

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

