### PR TITLE
feat(core)!: Always offload manual executions to workers in queue mode

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -941,7 +941,7 @@ describe('pre-persist context establishment', () => {
 	});
 
 	it('skips establishExecutionContext when nodeExecutionStack has not been populated yet', async () => {
-		// Queue mode with OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true creates
+		// Queue mode creates
 		// the outer IRunExecutionData with `executionData: null`, which
 		// `createRunExecutionData` normalises to an object whose inner
 		// `.executionData` is undefined. The worker establishes context

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -211,9 +211,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 			scopedLogger.debug('Starting main instance in scaling mode');
 			scopedLogger.debug(`Host ID: ${this.instanceSettings.hostId}`);
 
-			if (process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true') {
-				this.needsTaskRunner = false;
-			}
+			this.needsTaskRunner = false;
 		}
 
 		await super.init();

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -1,7 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
-import { GlobalConfig } from '@n8n/config';
-import type { InstanceType } from '@n8n/constants';
 import { InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
@@ -9,15 +7,11 @@ import { DeprecationService } from '../deprecation.service';
 
 describe('DeprecationService', () => {
 	const logger = mock<Logger>();
-	const globalConfig = mockInstance(GlobalConfig, {
-		nodes: { exclude: [] },
-		executions: { mode: 'regular' },
-	});
 	const instanceSettings = mockInstance(InstanceSettings, {
 		instanceType: 'main',
 		isDocker: true,
 	});
-	const deprecationService = new DeprecationService(logger, globalConfig, instanceSettings);
+	const deprecationService = new DeprecationService(logger, instanceSettings);
 
 	beforeEach(() => {
 		// Ignore environment variables coming in from the environment when running
@@ -64,6 +58,8 @@ describe('DeprecationService', () => {
 		['N8N_CONFIG_FILES', '1', true],
 		['N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN', '1', true],
 		['N8N_RUNNERS_ENABLED', '1', true],
+		['OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS', 'true', true],
+		['OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS', undefined, false],
 		['WEBHOOK_URL', 'https://example.com/', true],
 		['N8N_DEFAULT_BINARY_DATA_MODE', 'default', true],
 		['N8N_DEFAULT_BINARY_DATA_MODE', 'filesystem', false],
@@ -80,108 +76,12 @@ describe('DeprecationService', () => {
 		toTest(envVar, value, mustWarn);
 	});
 
-	describe('OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS', () => {
-		const envVar = 'OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS';
-
-		beforeEach(() => {
-			process.env = {};
-		});
-
-		describe('when executions.mode is not queue', () => {
-			test.each<[InstanceType]>([['main'], ['worker'], ['webhook']])(
-				'should not warn for instanceType %s',
-				(instanceType) => {
-					process.env[envVar] = 'false';
-					const service = new DeprecationService(
-						logger,
-						globalConfig,
-						mock<InstanceSettings>({ instanceType, isDocker: true }),
-					);
-					service.warn();
-					expect(logger.warn.mock.lastCall?.[0] ?? '').not.toContain(envVar);
-				},
-			);
-		});
-
-		describe('when executions.mode is queue', () => {
-			const globalConfig = mockInstance(GlobalConfig, {
-				nodes: { exclude: [] },
-				executions: { mode: 'queue' },
-			});
-
-			describe('when instanceType is worker', () => {
-				test.each([
-					['false', 'false'],
-					['empty string', ''],
-				])(`should not warn when ${envVar} is %s`, (_description, envValue) => {
-					process.env[envVar] = envValue;
-					const service = new DeprecationService(
-						logger,
-						globalConfig,
-						mock<InstanceSettings>({ instanceType: 'worker', isDocker: true }),
-					);
-					service.warn();
-					expect(logger.warn.mock.lastCall?.[0] ?? '').not.toContain(envVar);
-				});
-			});
-
-			describe('when instanceType is webhook', () => {
-				test.each([
-					['false', 'false'],
-					['empty string', ''],
-				])(`should not warn when ${envVar} is %s`, (_description, envValue) => {
-					process.env[envVar] = envValue;
-					const service = new DeprecationService(
-						logger,
-						globalConfig,
-						mock<InstanceSettings>({ instanceType: 'webhook', isDocker: true }),
-					);
-					service.warn();
-					expect(logger.warn.mock.lastCall?.[0] ?? '').not.toContain(envVar);
-				});
-			});
-
-			describe('when instanceType is main', () => {
-				test.each([
-					['false', 'false'],
-					['empty string', ''],
-				])(`should warn when ${envVar} is %s`, (_description, envValue) => {
-					process.env[envVar] = envValue;
-					const service = new DeprecationService(logger, globalConfig, instanceSettings);
-					service.warn();
-					expect(logger.warn.mock.lastCall?.[0] ?? '').toContain(envVar);
-				});
-
-				test('should not warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is true', () => {
-					process.env[envVar] = 'true';
-
-					const service = new DeprecationService(logger, globalConfig, instanceSettings);
-					service.warn();
-
-					expect(logger.warn.mock.lastCall?.[0] ?? '').not.toContain(envVar);
-				});
-
-				test('should warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is undefined', () => {
-					delete process.env[envVar];
-
-					const service = new DeprecationService(logger, globalConfig, instanceSettings);
-					service.warn();
-
-					expect(logger.warn).toHaveBeenCalledTimes(1);
-					const warningMessage = logger.warn.mock.calls[0][0];
-					expect(warningMessage).toContain(envVar);
-				});
-			});
-		});
-	});
-
 	describe('running outside a container', () => {
 		const message = 'Running n8n outside a container is deprecated';
 
 		test('should warn when not running in a container', () => {
 			const service = new DeprecationService(
 				logger,
-				globalConfig,
 				mock<InstanceSettings>({ instanceType: 'main', isDocker: false }),
 			);
 			service.warn();
@@ -191,7 +91,6 @@ describe('DeprecationService', () => {
 		test('should not warn when running in a container', () => {
 			const service = new DeprecationService(
 				logger,
-				globalConfig,
 				mock<InstanceSettings>({ instanceType: 'main', isDocker: true }),
 			);
 			service.warn();

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -1,5 +1,4 @@
 import { Logger } from '@n8n/backend-common';
-import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 
@@ -14,15 +13,6 @@ type Deprecation = {
 
 	/** Function to identify the specific value in the env var that is deprecated. */
 	checkValue?: (value?: string) => boolean;
-
-	/** Whether to show a deprecation warning if the env var is missing. */
-	warnIfMissing?: boolean;
-
-	/** Whether a config value is required to trigger a deprecation warning. */
-	matchConfig?: boolean;
-
-	/** Function to run to check whether to disable this deprecation warning. */
-	disableIf?: () => boolean;
 };
 
 const SAFE_TO_REMOVE = 'Remove this environment variable; it is no longer needed.';
@@ -47,12 +37,7 @@ export class DeprecationService {
 		},
 		{
 			envVar: 'OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS',
-			message:
-				'Running manual executions in the main instance in scaling mode is deprecated. Manual executions will be routed to workers in a future version. Please set `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true` to offload manual executions to workers and avoid potential issues in the future. Consider increasing memory available to workers and reducing memory available to main.',
-			checkValue: (value?: string) => value?.toLowerCase() !== 'true' && value !== '1',
-			warnIfMissing: true,
-			matchConfig: this.globalConfig.executions.mode === 'queue',
-			disableIf: () => this.instanceSettings.instanceType !== 'main',
+			message: `In queue mode, manual executions are always routed to workers. ${SAFE_TO_REMOVE}`,
 		},
 		{
 			envVar: 'N8N_EXPRESSION_EVALUATOR',
@@ -110,25 +95,15 @@ export class DeprecationService {
 
 	constructor(
 		private readonly logger: Logger,
-		private readonly globalConfig: GlobalConfig,
 		private readonly instanceSettings: InstanceSettings,
 	) {}
 
 	warn() {
 		this.deprecations.forEach((d) => {
-			if (d.disableIf?.()) {
-				this.state.set(d, { mustWarn: false });
-				return;
-			}
-
 			const envValue = process.env[d.envVar];
 
-			const matchConfig = d.matchConfig === true || d.matchConfig === undefined;
-			const warnIfMissing = d.warnIfMissing !== undefined && envValue === undefined;
-			const checkValue = d.checkValue ? d.checkValue(envValue) : envValue !== undefined;
-
 			this.state.set(d, {
-				mustWarn: matchConfig && (warnIfMissing || checkValue),
+				mustWarn: d.checkValue ? d.checkValue(envValue) : envValue !== undefined,
 			});
 		});
 

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -573,7 +573,7 @@ describe('TestRunnerService', () => {
 			expect(runCallArg).toHaveProperty('forceFullExecutionData', true);
 		});
 
-		test('should call workflowRunner.run with correct data in queue execution mode and manual offload', async () => {
+		test('should call workflowRunner.run with correct data in queue execution mode', async () => {
 			const queueModeConfig = mockInstance(ExecutionsConfig, { mode: 'queue' });
 			const testRunnerService = new TestRunnerService(
 				logger,
@@ -596,7 +596,6 @@ describe('TestRunnerService', () => {
 				workflowCompiler,
 				ownershipService,
 			);
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
 
 			// Create workflow with a trigger node
 			const triggerNodeName = 'Dataset Trigger';
@@ -643,7 +642,7 @@ describe('TestRunnerService', () => {
 			expect(runCallArg).toHaveProperty('workflowData.settings.saveExecutionProgress', false);
 			expect(runCallArg).toHaveProperty('userId', metadata.userId);
 
-			// In queue mode with offloading, executionData.executionData should not exist
+			// In queue mode, executionData.executionData should not exist
 			expect(runCallArg).not.toHaveProperty('executionData.executionData');
 			expect(runCallArg).not.toHaveProperty('executionData.executionData.nodeExecutionStack');
 
@@ -665,9 +664,6 @@ describe('TestRunnerService', () => {
 				operation: 'getRows',
 			});
 			expect(runCallArg).toHaveProperty('forceFullExecutionData', true);
-
-			// after reset
-			delete process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
 		});
 
 		test('should wait for execution to finish and return result', async () => {

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -373,11 +373,7 @@ export class TestRunnerService {
 			},
 		};
 
-		const offloadingManualExecutionsInQueueMode =
-			this.executionsConfig.mode === 'queue' &&
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true';
-
-		if (offloadingManualExecutionsInQueueMode) {
+		if (this.executionsConfig.mode === 'queue') {
 			// Offloading to workers fails if executionData.executionData is present,
 			// so drop just that nested field (keep startData/manualData).
 			// @ts-expect-error - Removing nested executionData property for queue mode

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -4009,41 +4009,34 @@ describe('createExecutionAdapter run()', () => {
 		expect(runData.workflowData.settings?.errorWorkflow).toBe('error-wf-1');
 	});
 
-	it('wraps manual metadata into executionData when offloading to workers so the worker can run it', async () => {
-		const original = process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
-		process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
-		try {
-			const { adapter, mockWorkflowRunner } = createRunAdapterForTests(
-				{
-					id: 'wf-1',
-					// No trigger node: the adapter sets neither startNodes nor executionData,
-					// so an offloaded worker would receive an execution with no run data.
-					nodes: [
-						{
-							id: 'n1',
-							name: 'Set',
-							type: 'n8n-nodes-base.set',
-							typeVersion: 3,
-							position: [0, 0],
-							parameters: {},
-						},
-					],
-					settings: { executionOrder: 'v1' },
-				},
-				{ queueMode: true, execution: makeExecution({ status: 'success' }) },
-			);
+	it('wraps manual metadata into executionData in queue mode so the worker can run it', async () => {
+		const { adapter, mockWorkflowRunner } = createRunAdapterForTests(
+			{
+				id: 'wf-1',
+				// No trigger node: the adapter sets neither startNodes nor executionData,
+				// so an offloaded worker would receive an execution with no run data.
+				nodes: [
+					{
+						id: 'n1',
+						name: 'Set',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [0, 0],
+						parameters: {},
+					},
+				],
+				settings: { executionOrder: 'v1' },
+			},
+			{ queueMode: true, execution: makeExecution({ status: 'success' }) },
+		);
 
-			await adapter.run('wf-1');
+		await adapter.run('wf-1');
 
-			const runData = mockWorkflowRunner.run.mock.calls[0][0];
-			// Offloaded workers reconstruct the run from execution.data (= runData.executionData).
-			// Without this wrapping it is undefined and job-processor throws "without run data".
-			expect(runData.executionData).toBeDefined();
-			expect(runData.executionData?.manualData?.userId).toBe('user-1');
-		} finally {
-			if (original === undefined) delete process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
-			else process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = original;
-		}
+		const runData = mockWorkflowRunner.run.mock.calls[0][0];
+		// Offloaded workers reconstruct the run from execution.data (= runData.executionData).
+		// Without this wrapping it is undefined and job-processor throws "without run data".
+		expect(runData.executionData).toBeDefined();
+		expect(runData.executionData?.manualData?.userId).toBe('user-1');
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1421,12 +1421,9 @@ export class InstanceAiAdapterService {
 				// serialization, so wrap them into `executionData` — mirroring
 				// `workflow-execution.service`. A trigger run already carries its stack in
 				// `executionData`, so only wrap when it's absent.
-				const offloadingManualExecutionsInQueueMode =
-					globalConfig.executions?.mode === 'queue' &&
-					process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true';
 				if (
 					runData.executionMode === 'manual' &&
-					offloadingManualExecutionsInQueueMode &&
+					globalConfig.executions?.mode === 'queue' &&
 					!runData.executionData
 				) {
 					runData.executionData = createRunExecutionData({

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -291,13 +291,7 @@ export class WorkflowRunner {
 			}, STREAMING_HEARTBEAT_INTERVAL_MS);
 		}
 
-		// @TODO: Reduce to true branch once feature is stable
-		const shouldEnqueue =
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
-				? this.executionsConfig.mode === 'queue'
-				: this.executionsConfig.mode === 'queue' && data.executionMode !== 'manual';
-
-		if (shouldEnqueue) {
+		if (this.executionsConfig.mode === 'queue') {
 			await this.enqueueExecution(
 				executionId,
 				workflowId,

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -937,15 +937,12 @@ describe('WorkflowExecutionService', () => {
 		});
 	});
 
-	describe('offloading manual executions to workers', () => {
-		let originalOffloadManualExecutionsToWorkers: string | undefined;
+	describe('manual executions in queue mode', () => {
 		let globalConfigMock: GlobalConfig;
 		let workflowRunnerMock: MockProxy<WorkflowRunner>;
 		let service: WorkflowExecutionService;
 
 		beforeEach(() => {
-			originalOffloadManualExecutionsToWorkers = process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
 			globalConfigMock = mock<GlobalConfig>({ executions: { mode: 'queue' } });
 			workflowRunnerMock = mock<WorkflowRunner>();
 			workflowRunnerMock.run.mockResolvedValue('fake-execution-id');
@@ -972,11 +969,6 @@ describe('WorkflowExecutionService', () => {
 		});
 
 		afterEach(() => {
-			if (originalOffloadManualExecutionsToWorkers === undefined) {
-				delete process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
-			} else {
-				process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = originalOffloadManualExecutionsToWorkers;
-			}
 			vi.clearAllMocks();
 		});
 

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -401,10 +401,6 @@ export class WorkflowExecutionService {
 				? await this.executionContextService.buildManualExecutionCredentials(n8nAuthCookie)
 				: undefined;
 
-			const offloadingManualExecutionsInQueueMode =
-				this.globalConfig.executions.mode === 'queue' &&
-				process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true';
-
 			/**
 			 * Historically, manual executions in scaling mode ran in the main process,
 			 * so some execution details were never persisted in the database.
@@ -412,7 +408,7 @@ export class WorkflowExecutionService {
 			 * Currently, manual executions in scaling mode are offloaded to workers,
 			 * so we persist all details to give workers full access to them.
 			 */
-			if (data.executionMode === 'manual' && offloadingManualExecutionsInQueueMode) {
+			if (data.executionMode === 'manual' && this.globalConfig.executions.mode === 'queue') {
 				data.executionData = createRunExecutionData({
 					startData: {
 						startNodes: data.startNodes,

--- a/packages/testing/containers/services/n8n.ts
+++ b/packages/testing/containers/services/n8n.ts
@@ -113,7 +113,6 @@ function computeEnvironment(options: N8NInstancesOptions): Record<string, string
 
 	if (isQueueMode) {
 		env.EXECUTIONS_MODE = 'queue';
-		env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
 
 		if (mains > 1) {
 			if (!process.env.N8N_LICENSE_ACTIVATION_KEY && !process.env.N8N_LICENSE_CERT) {


### PR DESCRIPTION
## Summary

In queue (scaling) mode, manual executions were run on the main instance unless `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true` was set. This removes the flag and makes offloading to workers the only behavior in queue mode. Regular mode is unaffected.

- Removed the raw `process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS` checks in `workflow-runner.ts`, `workflow-execution.service.ts`, `commands/start.ts`, `test-runner.service.ee.ts`, and `instance-ai.adapter.service.ts` - queue mode alone now triggers the offloading behavior
- Replaced the scaling-mode deprecation warning with a plain "safe to remove" notice for instances that still set the variable, and deleted the now-unused `warnIfMissing`/`matchConfig`/`disableIf` machinery from `DeprecationService`
- The v3 breaking-changes detection rule stays (consistent with other v3 removals)
- Dropped the env var from the containers test harness

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-689

## Review / Merge checklist

- [x] PR title and summary are descriptive. (conventions)
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

