### PR TITLE
fix(core): Stage libatomic into the distroless runners image

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -277,6 +277,22 @@ jobs:
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_distroless_tags }}
 
+      - name: Runners interpreters smoke check
+        # The runtime stages assemble node/python by copying binaries across images,
+        # so a missing shared library only surfaces at exec time. Runs the exact
+        # interpreter paths the launcher config (n8n-task-runners.json) uses.
+        if: needs.determine-build-context.outputs.push_enabled == 'true'
+        env:
+          RUNNERS_TAGS: ${{ steps.determine-tags.outputs.runners_tags }}
+          RUNNERS_DISTROLESS_TAGS: ${{ steps.determine-tags.outputs.runners_distroless_tags }}
+        run: |
+          for TAGS in "$RUNNERS_TAGS" "$RUNNERS_DISTROLESS_TAGS"; do
+            IMAGE_TAG=$(echo "$TAGS" | cut -d',' -f1)
+            docker pull "$IMAGE_TAG"
+            docker run --rm --entrypoint /usr/local/bin/node "$IMAGE_TAG" --version
+            docker run --rm --entrypoint /opt/runners/task-runner-python/.venv/bin/python "$IMAGE_TAG" --version
+          done
+
   create_multi_arch_manifest:
     name: Create Multi-Arch Manifest
     needs: [determine-build-context, build-and-push-docker]

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -164,6 +164,10 @@ COPY --from=python-runner-builder /usr/lib/*-linux-gnu* /runtime/usr/lib/
 # Copy Node.js runtime
 COPY --from=node-debian /usr/local/bin/node /runtime/usr/local/bin/node
 
+# Node 26+ links against libatomic, which neither the python image above nor
+# the distroless cc base provides, so stage it from the node image.
+COPY --from=node-debian /usr/lib/*-linux-gnu*/libatomic.so.1* /runtime/usr/lib/
+
 # Copy task runners
 COPY --from=javascript-runner-builder /app/task-runner-javascript /runtime/opt/runners/task-runner-javascript
 COPY --from=python-runner-builder /app/task-runner-python /runtime/opt/runners/task-runner-python


### PR DESCRIPTION
## Summary

On 2.37.x, every JS Code node task fails with "Your Code node task was not matched to a runner within the timeout period". The launcher logs show the cause:

```
ERROR [runner:js] /usr/local/bin/node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
ERROR [launcher:js] Runner process exited with error: exit status 127
```

The distroless runners image copies the bare `node` binary from `node:26.5.1-bookworm-slim` and stages its glibc libraries from the python builder image. Node 26 links against `libatomic.so.1` (Node 24 did not). Neither the python image nor the `distroless/cc-debian13` base provides that library, so the JS runner exits with code 127 on every launch and no Code node task is ever matched. The Python runner is unaffected. The Node 26 bump reached the runners images in #36702 with 2.37.0.

This PR:
- Stages `libatomic.so.1` from the node image into the distroless runtime.
- Adds a smoke step to the Docker build workflow that runs both runner interpreters (`node --version`, venv `python --version`) in the built runners images, at the exact paths `n8n-task-runners.json` launches them from. A missing shared library now fails the build instead of the runner.

The Alpine runners image does not need the fix: its musl Node 26 build does not link libatomic (verified on amd64 and arm64).

## How to test

Verified with a minimal reproduction of the runtime assembly:

```dockerfile
FROM node:26.5.1-bookworm-slim AS node-debian
FROM gcr.io/distroless/cc-debian13:latest
COPY --from=node-debian /usr/local/bin/node /usr/local/bin/node
# COPY --from=node-debian /usr/lib/*-linux-gnu*/libatomic.so.1* /usr/lib/
ENTRYPOINT ["/usr/local/bin/node", "--version"]
```

Without the commented line, the container fails with the exact error above. With it, it prints `v26.5.1`.

Full check: build the distroless runners image (`docker build -f docker/images/runners/Dockerfile.distroless .` after `pnpm build:docker`), then run `docker run --rm --entrypoint /usr/local/bin/node <image> --version`. On a deployed instance, run a workflow with a Manual Trigger and a JS Code node; it executes instead of timing out after ~60s.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4242

Fixes #37064, fixes #37062, fixes #37037, fixes #36989

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

