### PR TITLE
fix(core): Surface remaining AI node failures with a useful message and original cause

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
@@ -110,7 +110,9 @@ export async function conversationalAgentExecute(
 			returnData.push({ json: response });
 		} catch (error) {
 			throwIfToolSchema(this, error);
-			const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex);
+			const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex, {
+				enrichNonParserErrors: true,
+			});
 
 			if (this.continueOnFail()) {
 				returnData.push({

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
@@ -118,7 +118,9 @@ export async function reActAgentAgentExecute(
 			returnData.push({ json: response });
 		} catch (error) {
 			throwIfToolSchema(this, error);
-			const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex);
+			const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex, {
+				enrichNonParserErrors: true,
+			});
 			if (this.continueOnFail()) {
 				returnData.push({
 					json: { error: executionError.message },

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -465,7 +465,11 @@ export async function toolsAgentExecute(
 		return [returnData];
 	} catch (error) {
 		failureType = getFailureType(error);
-		throw error;
+		// Failures raised outside the per-item batch handling (model/memory setup,
+		// parameter assertions) are still raw here, so enrich them the same way.
+		throw wrapLangChainParserError(error, this.getNode(), undefined, {
+			enrichNonParserErrors: true,
+		});
 	} finally {
 		applyAgentTracingMetadata(this, {
 			toolCalls,

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -8,7 +8,7 @@ import type {
 } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
 import { getHighlightedResponseKey } from 'n8n-workflow';
-import { getFailureType } from '@utils/output_parsers/langchainParserError';
+import { getFailureType, wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
 
 import { buildExecutionContext, executeBatch, resolveSubAgentRequest } from './helpers';
 import { isExecuteFunctions } from '../../utils';
@@ -149,7 +149,11 @@ export async function toolsAgentExecute(
 		return [returnData];
 	} catch (error) {
 		failureType = getFailureType(error);
-		throw error;
+		// Failures raised outside `executeBatch` (context building, parameter
+		// assertions) are still raw here, so enrich them the same way.
+		throw wrapLangChainParserError(error, this.getNode(), undefined, {
+			enrichNonParserErrors: true,
+		});
 	} finally {
 		if (isExecuteFunctions(this)) {
 			const tracing: ToolsAgentV3TracingMetadata = {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -8,7 +8,10 @@ import type {
 } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
 import { getHighlightedResponseKey } from 'n8n-workflow';
-import { getFailureType, wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
+import {
+	getFailureType,
+	wrapLangChainParserError,
+} from '@utils/output_parsers/langchainParserError';
 
 import { buildExecutionContext, executeBatch, resolveSubAgentRequest } from './helpers';
 import { isExecuteFunctions } from '../../utils';

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ConversationalAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ConversationalAgent.test.ts
@@ -1,0 +1,90 @@
+import type { Tool } from '@langchain/classic/tools';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import * as helpers from '../../../../utils/helpers';
+import { conversationalAgentExecute } from '../agents/ConversationalAgent/execute';
+
+const { mockInitializeAgentExecutor } = vi.hoisted(() => ({
+	mockInitializeAgentExecutor: vi.fn(),
+}));
+
+vi.mock('@langchain/classic/agents', () => ({
+	initializeAgentExecutorWithOptions: mockInitializeAgentExecutor,
+}));
+
+const mockContext = mock<IExecuteFunctions>({ helpers: mock<IExecuteFunctions['helpers']>() });
+
+/** Wires the context so the agent reaches `agentExecutor.invoke` and fails with `error`. */
+function setupFailingAgent(error: unknown) {
+	const mockModel = mock<BaseChatModel>();
+	mockModel.lc_namespace = ['chat_models'];
+
+	mockContext.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.2 }));
+	mockContext.getInputData.mockReturnValue([{ json: { text: 'test input' } }]);
+	mockContext.getInputConnectionData.mockImplementation(async (connectionType) =>
+		connectionType === NodeConnectionTypes.AiLanguageModel ? mockModel : undefined,
+	);
+	mockContext.getNodeParameter.mockImplementation((param, _i, defaultValue) => {
+		if (param === 'text') return 'test input';
+		if (param === 'hasOutputParser') return false;
+		if (param === 'options') return { maxIterations: 10 };
+		return defaultValue;
+	});
+
+	vi.spyOn(helpers, 'getConnectedTools').mockResolvedValue([mock<Tool>()]);
+
+	const invoke = vi.fn().mockRejectedValue(error);
+	mockInitializeAgentExecutor.mockResolvedValue({
+		withConfig: vi.fn().mockReturnValue({ invoke }),
+	});
+}
+
+describe('conversationalAgentExecute', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockContext.logger = {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+		mockContext.getWorkflow.mockReturnValue({ name: 'Test Workflow' } as never);
+		mockContext.getExecutionId.mockReturnValue('exec-123');
+	});
+
+	it('should surface a raw TypeError as a NodeOperationError keeping message and cause', async () => {
+		const original = new TypeError('fetch failed');
+		setupFailingAgent(original);
+		mockContext.continueOnFail.mockReturnValue(false);
+
+		const thrown = await conversationalAgentExecute
+			.call(mockContext, 1.7)
+			.catch((error: NodeOperationError) => error);
+
+		expect(thrown).toBeInstanceOf(NodeOperationError);
+		expect((thrown as NodeOperationError).message).toBe('fetch failed');
+		expect((thrown as NodeOperationError).description).toBe('Original error: TypeError');
+		expect((thrown as NodeOperationError).cause).toBe(original);
+	});
+
+	it('should replace a useless error message with the agent fallback message', async () => {
+		setupFailingAgent(new Error('Error'));
+		mockContext.continueOnFail.mockReturnValue(false);
+
+		await expect(conversationalAgentExecute.call(mockContext, 1.7)).rejects.toThrow(
+			'Agent execution failed',
+		);
+	});
+
+	it('should report the enriched message on the item when continueOnFail is true', async () => {
+		setupFailingAgent(new Error('Error'));
+		mockContext.continueOnFail.mockReturnValue(true);
+
+		const result = await conversationalAgentExecute.call(mockContext, 1.7);
+
+		expect(result[0][0].json.error).toBe('Agent execution failed');
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -7,6 +7,7 @@ import type {
 import { sleep } from '@n8n/utils/sleep';
 import { NodeApiError, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
+import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
 import { getOptionalOutputParser } from '@utils/output_parsers/N8nOutputParser';
 
 // Import from centralized module
@@ -16,6 +17,8 @@ import {
 	getCustomErrorMessage as getCustomOpenAiErrorMessage,
 	isOpenAiError,
 } from '../../vendors/OpenAi/helpers/error-handling';
+
+const CHAIN_FAILURE_FALLBACK_MESSAGE = 'Model execution failed';
 
 /**
  * Basic LLM Chain Node Implementation
@@ -106,14 +109,19 @@ export class ChainLlm implements INodeType {
 							}
 						}
 
+						const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex, {
+							enrichNonParserErrors: true,
+							fallbackMessage: CHAIN_FAILURE_FALLBACK_MESSAGE,
+						});
+
 						if (this.continueOnFail()) {
 							returnData.push({
-								json: { error: error.message },
+								json: { error: executionError.message },
 								pairedItem: { item: itemIndex },
 							});
 							return;
 						}
-						throw new NodeOperationError(this.getNode(), error);
+						throw new NodeOperationError(this.getNode(), executionError);
 					}
 
 					const responses = promiseResult.value;
@@ -152,13 +160,21 @@ export class ChainLlm implements INodeType {
 						}
 					}
 
+					const executionError = wrapLangChainParserError(error, this.getNode(), itemIndex, {
+						enrichNonParserErrors: true,
+						fallbackMessage: CHAIN_FAILURE_FALLBACK_MESSAGE,
+					});
+
 					// Continue on failure if configured
 					if (this.continueOnFail()) {
-						returnData.push({ json: { error: error.message }, pairedItem: { item: itemIndex } });
+						returnData.push({
+							json: { error: executionError.message },
+							pairedItem: { item: itemIndex },
+						});
 						continue;
 					}
 
-					throw error;
+					throw executionError;
 				}
 			}
 		}

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/ChainLlm.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/ChainLlm.node.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { FakeChatModel } from '@langchain/core/utils/testing';
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
-import { NodeApiError, NodeConnectionTypes } from 'n8n-workflow';
+import { NodeApiError, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -185,6 +185,36 @@ describe('ChainLlm Node', () => {
 			const result = await node.execute.call(mockExecuteFunction);
 
 			expect(result).toEqual([[{ json: { error: 'Test error' }, pairedItem: { item: 0 } }]]);
+		});
+
+		it('should surface a raw TypeError as a NodeOperationError keeping message and cause', async () => {
+			(helperModule.getPromptInputByType as Mock).mockReturnValue('Test prompt');
+
+			const error = new TypeError('fetch failed');
+			(executeChainModule.executeChain as Mock).mockRejectedValue(error);
+
+			mockExecuteFunction.continueOnFail.mockReturnValue(false);
+
+			const thrown = await node.execute
+				.call(mockExecuteFunction)
+				.catch((e: NodeOperationError) => e);
+
+			expect(thrown).toBeInstanceOf(NodeOperationError);
+			expect((thrown as NodeOperationError).message).toBe('fetch failed');
+			expect((thrown as NodeOperationError).description).toBe('Original error: TypeError');
+			expect((thrown as NodeOperationError).cause).toBe(error);
+		});
+
+		it('should replace a useless error message with the model fallback message', async () => {
+			(helperModule.getPromptInputByType as Mock).mockReturnValue('Test prompt');
+
+			(executeChainModule.executeChain as Mock).mockRejectedValue(new Error('Error'));
+
+			mockExecuteFunction.continueOnFail.mockReturnValue(true);
+
+			const result = await node.execute.call(mockExecuteFunction);
+
+			expect(result[0][0].json.error).toBe('Model execution failed');
 		});
 
 		it('should handle multiple response items from executeChain', async () => {

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.test.ts
@@ -162,6 +162,29 @@ describe('wrapLangChainParserError', () => {
 			expect(wrapped.message).not.toBe('[object Object]');
 		});
 
+		it('uses a caller-supplied fallback message instead of the agent wording', () => {
+			const cases = [new Error('Error'), new Error(''), { code: 500 }] as const;
+
+			for (const original of cases) {
+				const wrapped = wrapLangChainParserError(original, node, undefined, {
+					enrichNonParserErrors: true,
+					fallbackMessage: 'Model execution failed',
+				});
+
+				expect(wrapped.message).toBe('Model execution failed');
+			}
+		});
+
+		it('keeps a useful original message even when a fallback message is supplied', () => {
+			const wrapped = wrapLangChainParserError(new TypeError('fetch failed'), node, undefined, {
+				enrichNonParserErrors: true,
+				fallbackMessage: 'Model execution failed',
+			});
+
+			expect(wrapped.message).toBe('fetch failed');
+			expect((wrapped as NodeOperationError).description).toBe('Original error: TypeError');
+		});
+
 		it('still wraps parser errors when the option is set', () => {
 			const error = new Error('Failed to parse. Text: "x"');
 

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/langchainParserError.ts
@@ -67,12 +67,13 @@ function wrapAsNodeOperationError(
 	error: unknown,
 	node: INode,
 	itemIndex: number | undefined,
+	fallbackMessage: string,
 ): Error {
 	const className = resolveErrorName(error);
 	const messageProperty = getErrorProperty(error, 'message');
 	const candidateMessage = messageProperty ?? (typeof error === 'string' ? error : undefined);
 	const message = isUselessMessage(candidateMessage, className)
-		? AGENT_FAILURE_FALLBACK_MESSAGE
+		? fallbackMessage
 		: (candidateMessage as string);
 
 	const options = {
@@ -98,23 +99,27 @@ export function wrapLangChainParserError(
 	error: unknown,
 	node: INode,
 	itemIndex?: number,
-	options?: { enrichNonParserErrors?: boolean },
+	options?: { enrichNonParserErrors?: boolean; fallbackMessage?: string },
 ): Error {
 	if (!isLangChainParserError(error)) {
-		// Default: callers that have not opted in (the chain nodes, ReAct and
-		// Conversational agents) keep the error exactly as it was thrown.
+		// Default: callers that have not opted in keep the error exactly as it was thrown.
 		if (!options?.enrichNonParserErrors) {
 			return error instanceof Error
 				? error
 				: new Error(getErrorProperty(error, 'message') ?? String(error));
 		}
 
-		// Opt-in enrichment (Tools Agent, all versions): wrap plain errors so a
-		// useless message like "Error" never reaches the user, and the original
-		// error survives as `cause` for failure-type telemetry. Errors that are
-		// already ours carry a meaningful message, so leave them alone.
+		// Opt-in enrichment: wrap plain errors so a useless message like "Error"
+		// never reaches the user, and the original error survives as `cause` for
+		// failure-type telemetry. Errors that are already ours carry a meaningful
+		// message, so leave them alone.
 		if (error instanceof BaseError) return error;
-		return wrapAsNodeOperationError(error, node, itemIndex);
+		return wrapAsNodeOperationError(
+			error,
+			node,
+			itemIndex,
+			options.fallbackMessage ?? AGENT_FAILURE_FALLBACK_MESSAGE,
+		);
 	}
 
 	const parserOptions = {


### PR DESCRIPTION

## Summary

Follow-up to #36603. 
This PR opts the leftover paths into the same `wrapLangChainParserError(..., { enrichNonParserErrors: true })` treatment, so the real message survives, the original error is kept as `cause` for Sentry `LinkedErrors`, and `level: 'error'` keeps the event from being dropped.

- **Conversational Agent** and **ReAct Agent** — pass `enrichNonParserErrors: true`.
- **Basic LLM Chain** — both the batch and non-batch `catch` blocks now go through the helper. Adds an optional `fallbackMessage` to the helper so this node reports `Model execution failed` rather than the agent wording when the original message is useless.
- **Tools Agent V2 / V3 outer `catch`** — previously `throw error`, which only covers failures raised *outside* the per-item batch handling (execution-context building, parameter assertions). Those are now enriched too. Errors coming out of `executeBatch` are already `BaseError`s and pass through untouched, so there is no double wrapping.

## How to test

1. Start a local HTTP server on a port that accepts TCP and immediately destroys the socket (to force a `TypeError` from the SDK's fetch layer).
2. Build a workflow with a Manual Trigger → **Basic LLM Chain**, with an OpenAI Chat Model connected. Set the model Base URL to that server. Any OpenAI credential works — auth is never checked.
3. Execute. Expected: the Basic LLM Chain node is red, the message is the real transport error (not `Error`), and the description reads `Original error: TypeError`.
4. Repeat with an **AI Agent (v1.x)** node set to Agent type `Conversational Agent` and to `ReAct Agent`.
5. With `On Error → Continue`, the item output should carry the same enriched message rather than a bare class name.

Optional Sentry check: point `N8N_SENTRY_DSN` at a local Kent instance and confirm the event is a `NodeOperationError` at level `error` with the original error attached as a linked exception, not `TypeError: TypeError`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2734

Follow-up to #36603.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
