### PR TITLE
feat(core): Give poll triggers an engine-derived time budget (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
-import type { WorkflowsConfig } from '@n8n/config';
+import type { GlobalConfig, WorkflowsConfig } from '@n8n/config';
 import type { Project, WorkflowEntity, WorkflowHistory, WorkflowRepository } from '@n8n/db';
 import type { UpdateResult } from '@n8n/typeorm';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
@@ -441,6 +441,7 @@ describe('ActiveWorkflowManager', () => {
 				ownershipService,
 				mock(), // nodeTypes
 				pollCursorService,
+				mock<GlobalConfig>({ scheduler: { pollTimeoutSeconds: 45, leaseDurationSeconds: 60 } }),
 			);
 
 			activeWorkflowManager = new ActiveWorkflowManager(

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
 import type { Project, WorkflowEntity } from '@n8n/db';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
@@ -97,6 +98,7 @@ describe('TriggerExecutionContextFactory', () => {
 			ownershipService,
 			nodeTypes,
 			pollCursorService,
+			mock<GlobalConfig>({ scheduler: { pollTimeoutSeconds: 45, leaseDurationSeconds: 60 } }),
 		);
 	});
 
@@ -997,6 +999,69 @@ describe('TriggerExecutionContextFactory', () => {
 			expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(2);
 			const cursors = workflowExecutionService.runPolledWorkflow.mock.calls.map((call) => call[5]);
 			expect(cursors).toEqual([{ lastItemId: 'fast' }, { lastItemId: 'slow' }]);
+		});
+
+		describe('getPollBudgetMs', () => {
+			const buildBudgetContext = (
+				pollTimeoutSeconds: number,
+				leaseDurationSeconds: number,
+				fence?: { taskId: string; leaseEpoch: number },
+			) => {
+				const globalConfig = mock<GlobalConfig>({
+					scheduler: { pollTimeoutSeconds, leaseDurationSeconds },
+				});
+				const budgetFactory = new TriggerExecutionContextFactory(
+					mock<Logger>({ scoped: vi.fn().mockReturnValue(scopedLogger) }),
+					errorReporter,
+					activeExecutions,
+					eventService,
+					executionService,
+					workflowStaticDataService,
+					workflowExecutionService,
+					storageConfig,
+					workflowPublishedDataService,
+					scheduleTriggerJobRegistrar,
+					ownershipService,
+					nodeTypes,
+					pollCursorService,
+					globalConfig,
+				);
+				const getPollFunctions = budgetFactory.getExecutePollFunctions(
+					mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+					additionalData,
+					mode,
+					activation,
+					async () => mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+					fence,
+				);
+				return getPollFunctions(workflow, node, additionalData, mode, activation);
+			};
+
+			const fence = { taskId: 'task-1', leaseEpoch: 1 };
+
+			// Budget = min(poll timeout, lease duration) minus a margin of
+			// max(20%, 5s), so a node that exhausts it still finishes its
+			// in-flight batch before the engine abandons the tick.
+			test.each([
+				{ pollTimeoutSeconds: 45, leaseDurationSeconds: 60, expected: 36_000 },
+				{ pollTimeoutSeconds: 100, leaseDurationSeconds: 60, expected: 48_000 },
+				// The margin never eats more than half the ceiling, so a tiny (but
+				// schema-valid) timeout still yields a positive budget.
+				{ pollTimeoutSeconds: 4, leaseDurationSeconds: 60, expected: 2_000 },
+			])(
+				'derives $expected ms from a $pollTimeoutSeconds s timeout under a $leaseDurationSeconds s lease',
+				({ pollTimeoutSeconds, leaseDurationSeconds, expected }) => {
+					const budgetContext = buildBudgetContext(pollTimeoutSeconds, leaseDurationSeconds, fence);
+					expect(budgetContext.getPollBudgetMs()).toBe(expected);
+				},
+			);
+
+			test('keeps the generous PollContext default for a poll that runs without a lease', () => {
+				// The legacy in-memory path has no poll timeout and no lease, so the
+				// scheduler-derived budget must not apply there.
+				const budgetContext = buildBudgetContext(45, 60);
+				expect(budgetContext.getPollBudgetMs()).toBe(300_000);
+			});
 		});
 
 		test('throws when the node reads its static data outside of a poll', () => {

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -1,4 +1,6 @@
 import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
 import type { IWorkflowDb, PollerCursor, PollLeaseFence } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
@@ -79,6 +81,7 @@ export class TriggerExecutionContextFactory {
 		private readonly ownershipService: OwnershipService,
 		private readonly nodeTypes: NodeTypes,
 		private readonly pollCursorService: PollCursorService,
+		private readonly globalConfig: GlobalConfig,
 	) {
 		this.logger = this.logger.scoped(['workflow-activation']);
 	}
@@ -279,6 +282,17 @@ export class TriggerExecutionContextFactory {
 		prefetchedCursor?: PollerCursor,
 	): IGetExecutePollFunctions {
 		return (workflow: Workflow, node: INode) => {
+			// A poll must finish inside both the handler's abandon deadline and the task
+			// lease; past either, its commits are fenced out or discarded. The margin —
+			// 20%, at least 5s, at most half the ceiling — leaves room for the trailing
+			// hand-off and cursor commit.
+			const ceilingMs =
+				Math.min(
+					this.globalConfig.scheduler.pollTimeoutSeconds,
+					this.globalConfig.scheduler.leaseDurationSeconds,
+				) * Time.seconds.toMilliseconds;
+			const marginMs = Math.min(Math.max(0.2 * ceilingMs, 5_000), ceilingMs / 2);
+			const pollBudgetMs = ceilingMs - marginMs;
 			// A poll's staged snapshot lives in an async scope entered per poll, rather
 			// than in a variable per node: only the poll that staged it can commit it, and
 			// two overlapping polls of the same node never share a slot. An unmigrated
@@ -410,6 +424,9 @@ export class TriggerExecutionContextFactory {
 				__commitCursor,
 				__runPoll,
 				resolveNodeStaticData,
+				// Only a leased (durable) poll is bounded by the timeout and lease; a
+				// legacy in-memory poll keeps PollContext's generous default.
+				fence ? () => pollBudgetMs : undefined,
 			);
 		};
 	}

--- a/packages/cli/test/integration/database/repositories/poller-state.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/poller-state.repository.test.ts
@@ -1,8 +1,16 @@
-import { createWorkflow, testDb } from '@n8n/backend-test-utils';
+import {
+	createWorkflow,
+	createWorkflowWithHistory,
+	setActiveVersion,
+	testDb,
+} from '@n8n/backend-test-utils';
 import {
 	type PollerCursor,
 	PollerStateRepository,
+	ScheduledJobRepository,
+	ScheduledTaskRepository,
 	TransactionRunner,
+	WorkflowPublishedVersionRepository,
 	WorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -240,6 +248,82 @@ describe('PollerStateRepository', () => {
 			).rejects.toThrow('execution insert failed');
 
 			expect(await repository.findCursor(workflowId, 'node-1')).toEqual({ lastItemId: 'a' });
+		});
+
+		// Deactivation deprovisions the node's scheduled jobs; the running task row
+		// must cascade away with its job so the lease fence rejects any commit a
+		// still-running poll attempts afterwards (e.g. a mid-poll emit).
+		describe('fence after the job was deprovisioned', () => {
+			let jobRepository: ScheduledJobRepository;
+			let taskRepository: ScheduledTaskRepository;
+
+			beforeAll(() => {
+				jobRepository = Container.get(ScheduledJobRepository);
+				taskRepository = Container.get(ScheduledTaskRepository);
+			});
+
+			beforeEach(async () => {
+				await testDb.truncate(['ScheduledTask', 'ScheduledJob']);
+			});
+
+			it('rejects the advance once deprovisioning cascaded the running task away', async () => {
+				// scheduled_job.workflowId FKs to workflow_published_version, which itself
+				// FKs to workflow_history, so a job insert needs all three rows in place.
+				const published = await createWorkflowWithHistory({});
+				await setActiveVersion(published.id, published.versionId);
+				await Container.get(WorkflowPublishedVersionRepository).setPublishedVersion(
+					published.id,
+					published.versionId,
+				);
+
+				const job = await jobRepository.save(
+					jobRepository.create({
+						name: 'poll-node-1',
+						workflowId: published.id,
+						nodeId: 'node-1',
+						taskType: 'pollTrigger',
+						payload: {},
+						kind: 'interval',
+						intervalSeconds: 60,
+						enabled: true,
+						nextRunAt: new Date('2026-01-01T00:00:00.000Z'),
+						maxAttempts: 1,
+					}),
+				);
+				const task = await taskRepository.save(
+					taskRepository.create({
+						jobId: job.id,
+						taskType: 'pollTrigger',
+						payload: {},
+						scheduledFor: new Date('2026-06-01T00:00:00.000Z'),
+						runAt: new Date('2026-06-01T00:00:00.000Z'),
+						status: 'running',
+						attempts: 1,
+						maxAttempts: 1,
+						leaseEpoch: 1,
+						leaseExpiresAt: new Date(Date.now() + 60_000),
+					}),
+				);
+				const fence = { taskId: task.id, leaseEpoch: 1 };
+				await seed('node-1', { lastItemId: 'a' }, published.id);
+
+				// While the poll holds its lease, the fenced advance lands.
+				await expect(
+					repository.advanceCursor(published.id, 'node-1', { lastItemId: 'b' }, {}, fence),
+				).resolves.toBe(true);
+
+				// The same call deactivation's deprovision makes.
+				await jobRepository.deleteByWorkflowNode(jobRepository.manager, published.id, 'node-1');
+
+				// The running task row is gone with its job, not orphaned.
+				await expect(taskRepository.findOneBy({ id: task.id })).resolves.toBeNull();
+
+				// A late commit from the still-running poll is fenced out, cursor untouched.
+				await expect(
+					repository.advanceCursor(published.id, 'node-1', { lastItemId: 'c' }, {}, fence),
+				).resolves.toBe(false);
+				expect(await repository.findCursor(published.id, 'node-1')).toEqual({ lastItemId: 'b' });
+			});
 		});
 
 		it('does not touch the stored failure counters', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
@@ -65,6 +65,29 @@ describe('PollContext', () => {
 		});
 	});
 
+	describe('getPollBudgetMs', () => {
+		it('returns a five-minute default when the engine provided no budget', () => {
+			expect(pollContext.getPollBudgetMs()).toBe(300_000);
+		});
+
+		it('returns the budget provided by the engine', () => {
+			const context = new PollContext(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				activation,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				() => 36_000,
+			);
+			expect(context.getPollBudgetMs()).toBe(36_000);
+		});
+	});
+
 	describe('getCredentials', () => {
 		it('should get decrypted credentials', async () => {
 			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);

--- a/packages/core/src/execution-engine/node-execution-context/poll-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/poll-context.ts
@@ -1,3 +1,4 @@
+import { Time } from '@n8n/constants';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
@@ -45,6 +46,11 @@ export class PollContext extends NodeExecutionContext implements IPollFunctions 
 		// staging scope (e.g. a manual test run).
 		private readonly resolveNodeStaticData: () => IDataObject = () =>
 			this.workflow.getStaticData('node', this.node),
+		// Generous fallback for polls that run outside the durable scheduler (e.g. a
+		// manual test run): no lease bounds them, but nodes still size their fetch
+		// loop from a finite budget.
+		readonly getPollBudgetMs: IPollFunctions['getPollBudgetMs'] = () =>
+			5 * Time.minutes.toMilliseconds,
 	) {
 		super(workflow, node, additionalData, mode);
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1417,6 +1417,12 @@ export interface IPollFunctions
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 		donePromise?: IDeferredPromise<IRun | undefined>,
 	): void;
+	/**
+	 * Milliseconds this poll may spend before the engine abandons the tick.
+	 * A node draining a large backlog should stop fetching before the budget
+	 * runs out, return what it has, and leave the rest to the next poll.
+	 */
+	getPollBudgetMs(): number;
 	__emitError(error: Error, responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>): void;
 	getNodeParameter(
 		parameterName: string,


### PR DESCRIPTION
## Summary

Groundwork for the fetch-volume cap on poll triggers (Linear CAT-3870). The design for the node side is **time-boxed accumulate-and-return**: a node fetches page after page until it is caught up, its time budget is spent, or its item cap (memory guard) is hit — then it advances its cursor to the last fetched item and returns everything as one batch. The remainder is picked up next tick. This PR gives nodes the missing piece: knowing the time budget.

**`getPollBudgetMs()` on `IPollFunctions`.** A poll under the durable scheduler must finish before the engine abandons the tick (`N8N_SCHEDULER_POLL_TIMEOUT`, default 45s) and before its task lease expires (default 60s). The engine derives the budget from live config — `min(timeout, lease)` minus a margin (20%, at least 5s, at most half the ceiling, reserved for the trailing hand-off and cursor commit) — because a constant baked into node code would silently misbehave when an operator lowers the timeout. Only leased (durable) polls get the derived budget; legacy in-memory polls have no timeout and no lease, so they keep a generous five-minute default. The addition is the only interface change; nodes that do not call it lose nothing.

**Deactivation safety, pinned.** A real-database test proves the existing lease fence covers deactivation: deprovisioning deletes the node's scheduled jobs, the running task row cascades away with its job, and the fence rejects any commit a still-running poll attempts afterwards.

No behavior change for existing nodes; nothing calls the budget yet. The mid-poll `__emit` hardening that used to live in this PR moved to #37163 (stacked on this branch) to keep this one focused.

## How to test

```
pnpm --filter n8n test src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
pnpm --filter n8n test:integration test/integration/database/repositories/poller-state.repository.test.ts
pnpm --filter n8n-core test src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
```

Covered: budget derivation from config (including the small-timeout floor), the no-lease fallback to the default, the PollContext default and engine-provided values, and the deprovision → cascade → fence-rejection chain on a real database.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3870

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)