### PR TITLE
fix(editor): Keep workflows moved out of a folder visible in the source control push modal

### DIFF
--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -56,6 +56,7 @@ export const SourceControlledFileSchema = z.object({
 	isRemoteArchived: z.boolean().optional(),
 	parentFolderId: z.string().nullable().optional(),
 	folderPath: z.array(z.string()).optional(),
+	remoteFolderPath: z.array(z.string()).optional(),
 	owner: ResourceOwnerSchema.optional(), // Resource owner can be a personal email or team information
 	publishingError: z.string().optional(),
 	publishingErrorDetails: workflowPublishBlockedDetailsSchema.optional(),

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -1041,6 +1041,64 @@ describe('getStatus', () => {
 				expect(workflow?.parentFolderId).toBe('local-child');
 				expect(workflow?.folderPath).toEqual(['Local Parent', 'Local Child']);
 			});
+
+			it('exposes the remote folder path for a moved workflow so it stays visible under the source folder', async () => {
+				const local = createWorkflow({
+					id: 'wf-moved-foldered',
+					versionId: 'local-v1',
+					parentFolderId: 'local-child',
+				});
+				const remote = createWorkflow({
+					id: 'wf-moved-foldered',
+					versionId: 'remote-v2',
+					parentFolderId: 'remote-child',
+				});
+
+				sourceControlImportService.getLocalVersionIdsFromDb.mockResolvedValue([local]);
+				sourceControlImportService.getRemoteVersionIdsFromFiles.mockResolvedValue([remote]);
+				sourceControlImportService.getLocalFoldersAndMappingsFromDb.mockResolvedValue({
+					folders: [],
+				});
+				sourceControlImportService.getRemoteFoldersAndMappingsFromFile.mockResolvedValue({
+					folders: [
+						{
+							id: 'remote-child',
+							name: 'Remote Child',
+							parentFolderId: null,
+							homeProjectId: 'project1',
+							createdAt: '2023-01-01T00:00:00.000Z',
+							updatedAt: '2023-01-01T00:00:00.000Z',
+						},
+					],
+				});
+
+				const folderData = new Map([
+					[
+						'local-child',
+						{ id: 'local-child', name: 'Local Child', parentFolder: { id: 'local-parent' } },
+					],
+					['local-parent', { id: 'local-parent', name: 'Local Parent', parentFolder: null }],
+				]);
+				folderRepository.find.mockImplementation(async (options: any) => {
+					if (options?.where?.id?._value) {
+						const ids = options.where.id._value as string[];
+						return ids.map((id: string) => folderData.get(id)).filter(Boolean) as any;
+					}
+					return [];
+				});
+
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'push',
+					verbose: false,
+					preferLocalVersion: true,
+				});
+
+				const workflow = result.find((f) => f.id === 'wf-moved-foldered');
+				expect(workflow).toBeDefined();
+				expect(workflow?.status).toBe('modified');
+				expect(workflow?.folderPath).toEqual(['Local Parent', 'Local Child']);
+				expect(workflow?.remoteFolderPath).toEqual(['Remote Child']);
+			});
 		});
 
 		describe('owner changes', () => {

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -433,6 +433,12 @@ export class SourceControlStatusService {
 				preferredParentFolderId,
 				options.preferLocalVersion ? localFoldersById : remoteFoldersById,
 			);
+			// A move keeps only its new folderPath; expose the prior/remote path too so a
+			// filter on the source folder doesn't hide the pending move.
+			const remoteFolderPath = this.buildFolderPath(
+				remoteWorkflowWithSameId.parentFolderId,
+				remoteFoldersById,
+			);
 
 			const wfModified: SourceControlWorkflowVersionId = {
 				...localWorkflow,
@@ -462,6 +468,7 @@ export class SourceControlStatusService {
 				isRemoteArchived: archivedWorkflowIds.get(wfModified.id) ?? false,
 				parentFolderId: preferredParentFolderId,
 				folderPath: preferredFolderPath,
+				remoteFolderPath,
 				owner: wfModified.owner,
 			});
 		}

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4131,6 +4131,7 @@
 	"settings.sourceControl.modals.push.success.description": "was committed and pushed to your remote repository | were committed and pushed to your remote repository",
 	"settings.sourceControl.modals.push.projectAdmin.callout": "If you want to push workflows from your personal space, move them to a project first.",
 	"settings.sourceControl.modals.push.currentWorkflow": "Current workflow",
+	"settings.sourceControl.modals.push.movedWorkflow": "Moved from {from} to {to}",
 	"settings.sourceControl.status.modified": "Modified",
 	"settings.sourceControl.status.deleted": "Deleted",
 	"settings.sourceControl.status.created": "New",

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -1498,6 +1498,60 @@ describe('SourceControlPushModal', () => {
 			expect(optionLabels).toEqual(['Alpha', 'Prod', 'Prod / Analytics', 'Prod / Billing']);
 		});
 
+		it('keeps a workflow moved out of a folder visible when filtering by its source folder', async () => {
+			// Moved from Production (prior) into Archive (current).
+			const status: SourceControlledFile[] = [
+				{
+					id: 'wf-moved',
+					name: 'Moved workflow',
+					type: 'workflow',
+					status: 'modified',
+					location: 'local',
+					conflict: true,
+					file: '/home/user/.n8n/git/workflows/wf-moved.json',
+					updatedAt: '2024-09-20T10:31:40.000Z',
+					folderPath: ['Archive'],
+					remoteFolderPath: ['Production'],
+				},
+			];
+
+			sourceControlStore.getAggregatedStatus.mockResolvedValue(status);
+
+			const { getByTestId, getAllByTestId, getByText } = renderModal({
+				pinia,
+				props: {
+					data: {
+						eventBus,
+						status,
+					},
+				},
+			});
+
+			await waitFor(() => {
+				expect(getByText('Commit and push changes')).toBeInTheDocument();
+			});
+
+			await waitFor(() => {
+				expect(getAllByTestId('source-control-push-modal-file-checkbox')).toHaveLength(1);
+			});
+
+			await userEvent.click(getByTestId('source-control-filter-dropdown'));
+			const folderSelect = getByTestId('source-control-folder-filter');
+			const folderCombobox = within(folderSelect).getByRole('combobox');
+			await userEvent.click(folderCombobox);
+
+			const dropdownId = folderCombobox.getAttribute('aria-controls');
+			await waitFor(() => {
+				const dropdown = document.getElementById(dropdownId as string);
+				expect(within(dropdown as HTMLElement).getByText('Production')).toBeInTheDocument();
+			});
+
+			const dropdown = document.getElementById(dropdownId as string) as HTMLElement;
+			await userEvent.click(within(dropdown).getByText('Production'));
+
+			expect(getAllByTestId('source-control-push-modal-file-checkbox')).toHaveLength(1);
+		});
+
 		test.each([
 			['credential', 'Credentials'],
 			['workflow', 'Workflows'],

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -356,8 +356,12 @@ const sortedWorkflows = useSourceControlFileList({
 			return true;
 		}
 
-		const workflowPath = (workflow.folderPath ?? []).join('/');
-		return workflowPath === folderFilter || workflowPath.startsWith(`${folderFilter}/`);
+		// Match both the current and prior folder so a moved-out workflow stays visible.
+		const matchesFolder = (path: string[] | undefined) => {
+			const workflowPath = (path ?? []).join('/');
+			return workflowPath === folderFilter || workflowPath.startsWith(`${folderFilter}/`);
+		};
+		return matchesFolder(workflow.folderPath) || matchesFolder(workflow.remoteFolderPath);
 	},
 });
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -531,6 +531,18 @@ function renderUpdatedAt(file: SourceControlledFile) {
 	return formatSourceControlUpdatedAt(file.updatedAt);
 }
 
+// Non-empty only when the workflow's folder changed vs. the remote, i.e. it was moved.
+function renderMovedTooltip(file: SourceControlledFile) {
+	const to = (file.folderPath ?? []).join('/');
+	const from = (file.remoteFolderPath ?? []).join('/');
+	if (file.remoteFolderPath === undefined || from === to) {
+		return '';
+	}
+	return i18n.baseText('settings.sourceControl.modals.push.movedWorkflow', {
+		interpolate: { from: from || '/', to: to || '/' },
+	});
+}
+
 async function onCommitKeyDownEnter() {
 	if (!isSubmitDisabled.value) {
 		await commitAndPush();
@@ -1225,12 +1237,18 @@ onMounted(async () => {
 																	:show-badge-border="false"
 																/>
 															</template>
-															<N8nBadge
-																:theme="getStatusTheme(row.file.status)"
-																style="height: 25px"
+															<N8nTooltip
+																:content="renderMovedTooltip(row.file)"
+																:disabled="!renderMovedTooltip(row.file)"
+																placement="top"
 															>
-																{{ getStatusText(row.file.status) }}
-															</N8nBadge>
+																<N8nBadge
+																	:theme="getStatusTheme(row.file.status)"
+																	style="height: 25px"
+																>
+																	{{ getStatusText(row.file.status) }}
+																</N8nBadge>
+															</N8nTooltip>
 															<template v-if="isWorkflowDiffsEnabled">
 																<N8nTooltip
 																	v-if="row.file.type === SOURCE_CONTROL_FILE_TYPE.workflow"

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
@@ -169,6 +169,28 @@ describe('source control utils', () => {
 			]);
 		});
 
+		it('includes the remote/prior folder of a moved workflow so its source folder stays selectable', () => {
+			const options = buildFolderFilterOptions([
+				{
+					id: 'wf-moved',
+					name: 'Moved workflow',
+					type: 'workflow',
+					status: 'modified',
+					location: 'local',
+					conflict: true,
+					file: '/wf-moved.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Archive'],
+					remoteFolderPath: ['Production'],
+				},
+			]);
+
+			expect(options).toEqual([
+				{ label: 'Archive', value: 'Archive' },
+				{ label: 'Production', value: 'Production' },
+			]);
+		});
+
 		it('returns empty array when workflows have no folder paths', () => {
 			const options = buildFolderFilterOptions([
 				{

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
@@ -215,12 +215,14 @@ export const buildFolderFilterOptions = (workflows: SourceControlledFile[]) => {
 	const folderPathSet = new Set<string>();
 
 	for (const workflow of workflows) {
-		const pathSegments = workflow.folderPath ?? [];
-		let path = '';
+		// Include the prior/remote path so a moved workflow's source folder stays selectable.
+		for (const pathSegments of [workflow.folderPath, workflow.remoteFolderPath]) {
+			let path = '';
 
-		for (const segment of pathSegments) {
-			path = path ? `${path}/${segment}` : segment;
-			folderPathSet.add(path);
+			for (const segment of pathSegments ?? []) {
+				path = path ? `${path}/${segment}` : segment;
+				folderPathSet.add(path);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

When you move a workflow between folders and push it to source control, the push modal folder filter used to hide the moved workflow.

A moved workflow is classified as `modified`. Its `folderPath` was built only from the new (local) folder. The push modal folder filter matched that single path. So when you filtered by the workflow's original folder, the moved workflow disappeared from the list. Nothing showed that a change was hidden. You could push an empty or unrelated set and believe the move was deployed. The pulling instance kept the old location, so the two environments drifted apart.

Deletions did not have this problem: their path was built from the remote folder map, so they stayed visible under the old folder. Moves and deletions behaved in opposite ways in the same view.

This PR makes a moved workflow visible under both folders:

- The status service now also computes the prior **remote** folder path and returns it as `remoteFolderPath` on the `modified` change item.
- `SourceControlledFile` gains an optional `remoteFolderPath: string[]`.
- The push modal folder filter matches **either** the current or the remote path.
- The folder filter options include the remote path, so the now-empty source folder still appears as an option.

## Screenshot

<img width="400" alt="Screenshot 2026-08-26 at 18 06 37" src="https://github.com/user-attachments/assets/be8f5b9e-5fef-4c71-9daf-225ca71e2f11" />

## Demo
https://www.loom.com/share/0cc05987c11f43f399c7097808918aca

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-991

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

