### PR TITLE
fix(core): Lay out SDK workflow groups as collapsed chips

### DIFF
--- a/packages/@n8n/workflow-sdk/src/node-groups.test.ts
+++ b/packages/@n8n/workflow-sdk/src/node-groups.test.ts
@@ -1,9 +1,15 @@
-import { GROUP_DESCRIPTION_MAX_LENGTH, MANUAL_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import {
+	GROUP_DESCRIPTION_MAX_LENGTH,
+	GROUP_HEADER_WIDTH_COLLAPSED,
+	MANUAL_TRIGGER_NODE_TYPE,
+	computeGroupFrameRects,
+} from 'n8n-workflow';
 
 import { generateWorkflowCode } from './codegen';
 import { parseWorkflowCodeToBuilder } from './codegen/parse-workflow-code';
 import type { GroupOptions, WorkflowJSON } from './types/base';
 import { workflow } from './workflow-builder';
+import { DEFAULT_NODE_SIZE, NODE_X_SPACING } from './workflow-builder/constants';
 import { node, trigger } from './workflow-builder/node-builders/node-builder';
 import { generateDeterministicGroupId } from './workflow-builder/string-utils';
 
@@ -31,6 +37,31 @@ function buildGroupedWorkflow(options?: GroupOptions) {
 		.to(fetchNode)
 		.to(transform)
 		.group('Ingestion', [fetchNode, transform], options);
+}
+
+function collapsedGroupRectFromJson(json: WorkflowJSON, memberNames: string[]) {
+	const boxes = memberNames.map((name) => {
+		const member = json.nodes.find((candidate) => candidate.name === name);
+		if (!member) throw new Error(`Missing node ${name}`);
+
+		return {
+			x: member.position[0],
+			y: member.position[1],
+			width: DEFAULT_NODE_SIZE[0],
+			height: DEFAULT_NODE_SIZE[1],
+		};
+	});
+	const minX = Math.min(...boxes.map((box) => box.x));
+	const minY = Math.min(...boxes.map((box) => box.y));
+	const maxX = Math.max(...boxes.map((box) => box.x + box.width));
+	const maxY = Math.max(...boxes.map((box) => box.y + box.height));
+
+	return computeGroupFrameRects({
+		x: minX,
+		y: minY,
+		width: maxX - minX,
+		height: maxY - minY,
+	}).collapsed;
 }
 
 describe('SDK node groups', () => {
@@ -71,6 +102,34 @@ describe('SDK node groups', () => {
 			});
 			const json = workflow(WF_ID, 'wf').add(start).toJSON();
 			expect(json.nodeGroups).toBeUndefined();
+		});
+
+		it('uses collapsed group chips for tidy-up positions', () => {
+			const start = trigger({
+				type: MANUAL_TRIGGER_NODE_TYPE,
+				version: 1,
+				config: { name: 'Start' },
+			});
+			const intakeA = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'A' } });
+			const intakeB = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'B' } });
+			const deliverA = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'C' } });
+			const deliverB = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'D' } });
+
+			const json = workflow(WF_ID, 'wf')
+				.add(start)
+				.to(intakeA)
+				.to(intakeB)
+				.to(deliverA)
+				.to(deliverB)
+				.group('Intake', [intakeA, intakeB])
+				.group('Deliver', [deliverA, deliverB])
+				.toJSON({ tidyUp: true });
+
+			const intakeChip = collapsedGroupRectFromJson(json, ['A', 'B']);
+			const deliverChip = collapsedGroupRectFromJson(json, ['C', 'D']);
+
+			expect(deliverChip.y).toBe(intakeChip.y);
+			expect(deliverChip.x - intakeChip.x).toBe(GROUP_HEADER_WIDTH_COLLAPSED + NODE_X_SPACING);
 		});
 	});
 
@@ -235,6 +294,40 @@ describe('SDK node groups', () => {
 			// The source id is carried through, not re-derived — round-trip is lossless.
 			expect(json.nodeGroups).toEqual([
 				{ id: 'random-uuid', name: 'G', nodeIds: ['id-a', 'id-b'] },
+			]);
+		});
+
+		it('leaves explicit node positions untouched on a tidy-up round-trip with groups', () => {
+			const source: WorkflowJSON = {
+				id: WF_ID,
+				name: 'wf',
+				nodes: [
+					{
+						id: 'id-a',
+						name: 'A',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [80, 160],
+						parameters: {},
+					},
+					{
+						id: 'id-b',
+						name: 'B',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [240, 160],
+						parameters: {},
+					},
+				],
+				connections: { A: { main: [[{ node: 'B', type: 'main', index: 0 }]] } },
+				nodeGroups: [{ id: 'random-uuid', name: 'G', nodeIds: ['id-a', 'id-b'] }],
+			};
+
+			const json = workflow.fromJSON(source).toJSON({ tidyUp: true });
+
+			expect(json.nodes.map(({ name, position }) => [name, position])).toEqual([
+				['A', [80, 160]],
+				['B', [240, 160]],
 			]);
 		});
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/group-layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/group-layout-utils.ts
@@ -1,0 +1,410 @@
+import dagre from '@dagrejs/dagre';
+import {
+	GROUP_HEADER_HEIGHT,
+	GROUP_HEADER_WIDTH_COLLAPSED,
+	GROUP_PADDING_X,
+	GROUP_PADDING_Y_TOP,
+} from 'n8n-workflow';
+
+import { STICKY_NODE_TYPE } from './constants';
+import { isAnchoredStickyNote, type GraphNode } from '../types/base';
+
+export interface LayoutNodeGroup {
+	name: string;
+	memberKeys: string[];
+}
+
+interface BoundingBox {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+interface GroupLayoutGeometry {
+	compositeBoundingBox: (boxes: BoundingBox[]) => BoundingBox;
+	snapToGrid: (value: number) => number;
+}
+
+interface GroupStickyGeometry {
+	declaresOwnWidth: (graphNode: GraphNode) => boolean;
+	declaresOwnHeight: (graphNode: GraphNode) => boolean;
+	wrappingBoxFor: (anchorBoxes: BoundingBox[]) => BoundingBox | undefined;
+}
+
+export interface EligibleLayoutGroup {
+	chipId: string;
+	name: string;
+	memberKeys: Set<string>;
+	nonStickyMemberKeys: string[];
+	stickyMemberKeys: string[];
+	interiorBoxesByNodeId: Map<string, BoundingBox>;
+}
+
+// ---------------------------------------------------------------------------
+// Group chip substitution
+// ---------------------------------------------------------------------------
+//
+// New groups open collapsed in the editor. Server-side layout has no rendered
+// group chip yet, so it substitutes a temporary chip-sized node before dagre
+// layout, then writes the hidden member positions back under that chip.
+//
+// Frontend counterpart: useCanvasLayout keeps collapsed CanvasGroupNodes in
+// the dagre graph and moves their hidden members by the chip delta afterwards.
+
+/**
+ * Converts a collapsed group chip position into the member origin that yields that chip.
+ */
+function memberRectOriginForChip(chipTopLeft: { x: number; y: number }): { x: number; y: number } {
+	return {
+		x: chipTopLeft.x + GROUP_PADDING_X,
+		y: chipTopLeft.y + GROUP_HEADER_HEIGHT + GROUP_PADDING_Y_TOP,
+	};
+}
+
+/**
+ * Collects each AI parent plus its connected AI config nodes in the parent graph.
+ * Frontend counterpart: useCanvasLayout's getAllConnectedAiConfigNodes.
+ */
+function getAiSubtreeNodeIds(
+	parentGraph: dagre.graphlib.Graph,
+	aiParentNames: Set<string>,
+	getAiConfigNodeIds: (aiParentName: string) => string[],
+): Array<Set<string>> {
+	return [...aiParentNames]
+		.filter((aiParentName) => parentGraph.hasNode(aiParentName))
+		.map((aiParentName) => new Set([aiParentName, ...getAiConfigNodeIds(aiParentName)]));
+}
+
+/**
+ * Checks whether a candidate group would replace only part of an AI subtree.
+ */
+function splitsAiSubtree(memberKeys: Set<string>, aiSubtreeNodeIds: Array<Set<string>>): boolean {
+	for (const subtree of aiSubtreeNodeIds) {
+		let membersInside = 0;
+		for (const nodeId of subtree) {
+			if (memberKeys.has(nodeId)) membersInside++;
+		}
+
+		if (membersInside > 0 && membersInside < subtree.size) return true;
+	}
+
+	return false;
+}
+
+/**
+ * Counts resolved non-sticky group memberships so overlapping groups degrade together.
+ */
+function countNonStickyGroupMemberships(
+	groups: readonly LayoutNodeGroup[] | undefined,
+	nodes: ReadonlyMap<string, GraphNode>,
+	nonStickySet: Set<string>,
+): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const group of groups ?? []) {
+		const groupNonStickyMembers = new Set(
+			group.memberKeys.filter((memberKey) => nodes.has(memberKey) && nonStickySet.has(memberKey)),
+		);
+
+		for (const memberKey of groupNonStickyMembers) {
+			counts.set(memberKey, (counts.get(memberKey) ?? 0) + 1);
+		}
+	}
+	return counts;
+}
+
+/**
+ * Re-bases an isolated group member layout so its top-left corner starts at group-local origin.
+ */
+function normalizeGroupInteriorBoxes(
+	boxesByNodeId: Map<string, BoundingBox>,
+	compositeBoundingBox: (boxes: BoundingBox[]) => BoundingBox,
+): Map<string, BoundingBox> {
+	if (boxesByNodeId.size === 0) return boxesByNodeId;
+
+	const boundingBox = compositeBoundingBox([...boxesByNodeId.values()]);
+	return new Map(
+		[...boxesByNodeId].map(([nodeId, box]) => [
+			nodeId,
+			{ ...box, x: box.x - boundingBox.x, y: box.y - boundingBox.y },
+		]),
+	);
+}
+
+/**
+ * Lays out a group's non-sticky members in isolation and normalizes them to group-local space.
+ */
+function layoutGroupInterior(
+	memberKeys: string[],
+	getGroupInteriorBoxes: (memberKeys: string[]) => Map<string, BoundingBox>,
+	compositeBoundingBox: (boxes: BoundingBox[]) => BoundingBox,
+): Map<string, BoundingBox> {
+	return normalizeGroupInteriorBoxes(getGroupInteriorBoxes(memberKeys), compositeBoundingBox);
+}
+
+/**
+ * Creates a temporary dagre node id for a synthetic collapsed group chip.
+ * Frontend counterpart: createCanvasGroupNodeId, but it uses real persisted group ids.
+ */
+function createGroupChipId(index: number, parentGraph: dagre.graphlib.Graph): string {
+	// Synthetic ids must not collide with authored node names in the layout graph.
+	let chipId = `__n8n_group_chip_${index}__`;
+	while (parentGraph.hasNode(chipId)) {
+		chipId = `_${chipId}`;
+	}
+	return chipId;
+}
+
+/**
+ * Selects groups that can safely enter dagre as collapsed chips and precomputes their interiors.
+ * Frontend counterpart: getTargetData already receives collapsed group chip nodes from view state.
+ */
+export function resolveEligibleLayoutGroups({
+	groups,
+	nodes,
+	nonStickySet,
+	parentGraph,
+	aiParentNames,
+	getAiConfigNodeIds,
+	getGroupInteriorBoxes,
+	compositeBoundingBox,
+}: {
+	groups: readonly LayoutNodeGroup[] | undefined;
+	nodes: ReadonlyMap<string, GraphNode>;
+	nonStickySet: Set<string>;
+	parentGraph: dagre.graphlib.Graph;
+	aiParentNames: Set<string>;
+	getAiConfigNodeIds: (aiParentName: string) => string[];
+	getGroupInteriorBoxes: (memberKeys: string[]) => Map<string, BoundingBox>;
+	compositeBoundingBox: (boxes: BoundingBox[]) => BoundingBox;
+}): EligibleLayoutGroup[] {
+	const membershipCounts = countNonStickyGroupMemberships(groups, nodes, nonStickySet);
+	const aiSubtreeNodeIds = getAiSubtreeNodeIds(parentGraph, aiParentNames, getAiConfigNodeIds);
+	const eligibleGroups: EligibleLayoutGroup[] = [];
+
+	for (const [index, group] of (groups ?? []).entries()) {
+		const memberKeys = new Set(group.memberKeys.filter((memberKey) => nodes.has(memberKey)));
+		const nonStickyMemberKeys = [...memberKeys].filter((memberKey) => nonStickySet.has(memberKey));
+		if (nonStickyMemberKeys.length === 0) continue;
+
+		const hasOverlappingMember = nonStickyMemberKeys.some(
+			(memberKey) => (membershipCounts.get(memberKey) ?? 0) > 1,
+		);
+		// Invalid overlapping groups fall back together. Picking one would move the shared node.
+		if (hasOverlappingMember) continue;
+
+		const hasExplicitlyPositionedMember = nonStickyMemberKeys.some(
+			(memberKey) => nodes.get(memberKey)?.instance.config?.position !== undefined,
+		);
+		if (hasExplicitlyPositionedMember) continue;
+
+		if (splitsAiSubtree(new Set(nonStickyMemberKeys), aiSubtreeNodeIds)) continue;
+
+		const interiorBoxesByNodeId = layoutGroupInterior(
+			nonStickyMemberKeys,
+			getGroupInteriorBoxes,
+			compositeBoundingBox,
+		);
+		if (interiorBoxesByNodeId.size === 0) continue;
+
+		eligibleGroups.push({
+			chipId: createGroupChipId(index, parentGraph),
+			name: group.name,
+			memberKeys,
+			nonStickyMemberKeys,
+			stickyMemberKeys: [...memberKeys].filter(
+				(memberKey) => nodes.get(memberKey)?.instance.type === STICKY_NODE_TYPE,
+			),
+			interiorBoxesByNodeId,
+		});
+	}
+
+	return eligibleGroups;
+}
+
+/**
+ * Builds the dagre parent graph with eligible group members replaced by chip placeholders.
+ * Frontend counterparts: getTargetData and remapCollapsedGroupConnections.
+ */
+export function createGroupedParentGraph(
+	parentGraph: dagre.graphlib.Graph,
+	eligibleGroups: EligibleLayoutGroup[],
+): dagre.graphlib.Graph {
+	if (eligibleGroups.length === 0) return parentGraph;
+
+	const graph = new dagre.graphlib.Graph();
+	graph.setGraph(parentGraph.graph());
+	graph.setDefaultEdgeLabel(() => ({}));
+
+	const chipIdByMember = new Map<string, string>();
+	for (const group of eligibleGroups) {
+		for (const memberKey of group.nonStickyMemberKeys) {
+			chipIdByMember.set(memberKey, group.chipId);
+		}
+	}
+
+	for (const nodeId of parentGraph.nodes()) {
+		if (chipIdByMember.has(nodeId)) continue;
+		graph.setNode(nodeId, parentGraph.node(nodeId));
+	}
+
+	for (const group of eligibleGroups) {
+		graph.setNode(group.chipId, {
+			width: GROUP_HEADER_WIDTH_COLLAPSED,
+			height: GROUP_HEADER_HEIGHT,
+		});
+	}
+
+	const emittedEdges = new Set<string>();
+	for (const edge of parentGraph.edges()) {
+		const source = chipIdByMember.get(edge.v) ?? edge.v;
+		const target = chipIdByMember.get(edge.w) ?? edge.w;
+		if (source === target || !graph.hasNode(source) || !graph.hasNode(target)) continue;
+
+		const edgeKey = `${source}\0${target}`;
+		if (emittedEdges.has(edgeKey)) continue;
+		emittedEdges.add(edgeKey);
+		graph.setEdge(source, target, parentGraph.edge(edge));
+	}
+
+	return graph;
+}
+
+/**
+ * Moves group member boxes from local group coordinates into final workflow coordinates.
+ * Frontend counterpart: useCanvasLayout translates hidden members by the chip delta.
+ */
+function offsetGroupMemberBoxes(
+	boxesByNodeId: ReadonlyMap<string, BoundingBox>,
+	offset: { x: number; y: number },
+): Map<string, BoundingBox> {
+	return new Map(
+		[...boxesByNodeId].map(([nodeId, box]) => [
+			nodeId,
+			{ ...box, x: box.x + offset.x, y: box.y + offset.y },
+		]),
+	);
+}
+
+/**
+ * Snaps box origins after chip-to-member translation so the derived group chip stays grid-aligned.
+ */
+function snapGroupMemberBoxes(
+	boxesByNodeId: ReadonlyMap<string, BoundingBox>,
+	snapToGrid: (value: number) => number,
+): Map<string, BoundingBox> {
+	return new Map(
+		[...boxesByNodeId].map(([nodeId, box]) => [
+			nodeId,
+			{ ...box, x: snapToGrid(box.x), y: snapToGrid(box.y) },
+		]),
+	);
+}
+
+/**
+ * Predicts member-sticky boxes that depend only on grouped anchors.
+ * Frontend counterpart: useCanvasMapping.groups measures real sticky nodes for computeGroupFrameRects.
+ */
+function deterministicMemberStickyBoxes(
+	group: EligibleLayoutGroup,
+	nodes: ReadonlyMap<string, GraphNode>,
+	nameById: ReadonlyMap<string, string>,
+	memberBoxesByNodeId: ReadonlyMap<string, BoundingBox>,
+	{ declaresOwnHeight, declaresOwnWidth, wrappingBoxFor }: GroupStickyGeometry,
+): BoundingBox[] | undefined {
+	const stickyBoxes: BoundingBox[] = [];
+
+	for (const stickyName of group.stickyMemberKeys) {
+		const graphNode = nodes.get(stickyName);
+		if (!graphNode) continue;
+
+		if (
+			graphNode.instance.config?.position !== undefined ||
+			declaresOwnWidth(graphNode) ||
+			declaresOwnHeight(graphNode) ||
+			!isAnchoredStickyNote(graphNode.instance)
+		) {
+			return undefined;
+		}
+
+		const anchorBoxes: BoundingBox[] = [];
+		for (const anchorId of graphNode.instance.stickyAnchorIds) {
+			const anchorName = nameById.get(anchorId);
+			if (!anchorName || !group.memberKeys.has(anchorName)) return undefined;
+
+			const anchorBox = memberBoxesByNodeId.get(anchorName);
+			if (!anchorBox) return undefined;
+
+			anchorBoxes.push(anchorBox);
+		}
+
+		const stickyBox = wrappingBoxFor(anchorBoxes);
+		if (!stickyBox) return undefined;
+
+		stickyBoxes.push(stickyBox);
+	}
+
+	return stickyBoxes;
+}
+
+/**
+ * Replaces synthetic chip boxes with member boxes positioned under each collapsed chip.
+ * Frontend counterpart: useCanvasLayout moves hidden group members, then removes the chip box.
+ */
+export function reExpandLayoutGroups({
+	eligibleGroups,
+	boundingBoxByNodeId,
+	nodes,
+	nameById,
+	geometry,
+	stickyGeometry,
+}: {
+	eligibleGroups: EligibleLayoutGroup[];
+	boundingBoxByNodeId: Map<string, BoundingBox>;
+	nodes: ReadonlyMap<string, GraphNode>;
+	nameById: ReadonlyMap<string, string>;
+	geometry: GroupLayoutGeometry;
+	stickyGeometry: GroupStickyGeometry;
+}): void {
+	const { compositeBoundingBox, snapToGrid } = geometry;
+
+	for (const group of eligibleGroups) {
+		const chipBox = boundingBoxByNodeId.get(group.chipId);
+		if (!chipBox) continue;
+
+		const memberOrigin = memberRectOriginForChip(chipBox);
+		let offset = memberOrigin;
+
+		const memberBoxesAtOrigin = offsetGroupMemberBoxes(group.interiorBoxesByNodeId, memberOrigin);
+		const snappedMemberBoxesAtOrigin = snapGroupMemberBoxes(memberBoxesAtOrigin, snapToGrid);
+		const stickyBoxes = deterministicMemberStickyBoxes(
+			group,
+			nodes,
+			nameById,
+			snappedMemberBoxesAtOrigin,
+			stickyGeometry,
+		);
+
+		if (stickyBoxes && stickyBoxes.length > 0) {
+			const inclusiveBox = compositeBoundingBox([
+				...snappedMemberBoxesAtOrigin.values(),
+				...stickyBoxes,
+			]);
+			// Align the snapped, sticky-inclusive bbox with the member origin the chip expects.
+			offset = {
+				x: memberOrigin.x + snapToGrid(memberOrigin.x) - inclusiveBox.x,
+				y: memberOrigin.y + snapToGrid(memberOrigin.y) - inclusiveBox.y,
+			};
+		}
+
+		for (const [memberKey, box] of group.interiorBoxesByNodeId) {
+			boundingBoxByNodeId.set(memberKey, {
+				...box,
+				x: box.x + offset.x,
+				y: box.y + offset.y,
+			});
+		}
+
+		boundingBoxByNodeId.delete(group.chipId);
+	}
+}

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -2,15 +2,22 @@
  * Tests for layout utility functions (BFS and Dagre)
  */
 
+import { GROUP_HEADER_WIDTH_COLLAPSED, computeGroupFrameRects } from 'n8n-workflow';
+
 import {
 	GRID_SIZE,
 	STICKY_NODE_TYPE,
 	NODE_SPACING_X,
+	NODE_X_SPACING,
 	START_X,
 	DEFAULT_Y,
 	DEFAULT_NODE_SIZE,
 } from './constants';
-import { calculateNodePositions, calculateNodePositionsDagre } from './layout-utils';
+import {
+	calculateNodePositions,
+	calculateNodePositionsDagre,
+	resolveStickyGeometry,
+} from './layout-utils';
 import type { GraphNode, ConnectionTarget } from '../types/base';
 
 // Helper to create connection targets
@@ -31,6 +38,7 @@ function createGraphNode(
 ): GraphNode {
 	return {
 		instance: {
+			id: name,
 			type,
 			name,
 			version,
@@ -66,6 +74,55 @@ function makeAiConns(
 
 function isGridAligned(pos: [number, number]): boolean {
 	return pos[0] % GRID_SIZE === 0 && pos[1] % GRID_SIZE === 0;
+}
+
+function collapsedGroupRect(
+	positions: ReadonlyMap<string, [number, number]>,
+	memberNames: string[],
+): { x: number; y: number; width: number; height: number } {
+	const memberBoxes = memberNames.map((name) => {
+		const position = positions.get(name);
+		if (!position) throw new Error(`Missing position for ${name}`);
+		return {
+			x: position[0],
+			y: position[1],
+			width: DEFAULT_NODE_SIZE[0],
+			height: DEFAULT_NODE_SIZE[1],
+		};
+	});
+	return collapsedGroupRectFromBoxes(memberBoxes);
+}
+
+function collapsedGroupRectFromBoxes(
+	boxes: Array<{ x: number; y: number; width: number; height: number }>,
+): {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+} {
+	const minX = Math.min(...boxes.map((box) => box.x));
+	const minY = Math.min(...boxes.map((box) => box.y));
+	const maxX = Math.max(...boxes.map((box) => box.x + box.width));
+	const maxY = Math.max(...boxes.map((box) => box.y + box.height));
+
+	return computeGroupFrameRects({
+		x: minX,
+		y: minY,
+		width: maxX - minX,
+		height: maxY - minY,
+	}).collapsed;
+}
+
+function createAnchoredSticky(name: string, anchorIds: string[]): GraphNode {
+	const sticky = createGraphNode(name, STICKY_NODE_TYPE);
+	return {
+		...sticky,
+		instance: {
+			...sticky.instance,
+			stickyAnchorIds: anchorIds,
+		} as GraphNode['instance'],
+	};
 }
 
 // ===========================================================================
@@ -363,6 +420,303 @@ describe('calculateNodePositionsDagre', () => {
 			);
 
 			expect(() => calculateNodePositionsDagre(nodes)).not.toThrow();
+		});
+	});
+
+	describe('node groups', () => {
+		it('lays out chained groups as collapsed chips', () => {
+			const nodes = new Map<string, GraphNode>();
+
+			nodes.set(
+				'Start',
+				createGraphNode(
+					'Start',
+					'n8n-nodes-base.manualTrigger',
+					makeMainConns([[0, [makeTarget('Normalize')]]]),
+				),
+			);
+			nodes.set(
+				'Normalize',
+				createGraphNode(
+					'Normalize',
+					'n8n-nodes-base.set',
+					makeMainConns([[0, [makeTarget('Filter')]]]),
+				),
+			);
+			nodes.set(
+				'Filter',
+				createGraphNode(
+					'Filter',
+					'n8n-nodes-base.if',
+					makeMainConns([[0, [makeTarget('Format')]]]),
+				),
+			);
+			nodes.set(
+				'Format',
+				createGraphNode(
+					'Format',
+					'n8n-nodes-base.set',
+					makeMainConns([
+						[0, [makeTarget('Slack')]],
+						[1, [makeTarget('Gmail')]],
+					]),
+				),
+			);
+			nodes.set('Slack', createGraphNode('Slack', 'n8n-nodes-base.slack'));
+			nodes.set('Gmail', createGraphNode('Gmail', 'n8n-nodes-base.gmail'));
+
+			const positions = calculateNodePositionsDagre(nodes, [
+				{ name: 'Intake', memberKeys: ['Normalize', 'Filter'] },
+				{ name: 'Deliver', memberKeys: ['Format', 'Slack', 'Gmail'] },
+			]);
+
+			const intakeChip = collapsedGroupRect(positions, ['Normalize', 'Filter']);
+			const deliverChip = collapsedGroupRect(positions, ['Format', 'Slack', 'Gmail']);
+
+			expect(deliverChip.y).toBe(intakeChip.y);
+			expect(deliverChip.x - intakeChip.x).toBe(GROUP_HEADER_WIDTH_COLLAPSED + NODE_X_SPACING);
+		});
+
+		it('lays out AI config nodes inside a group interior', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'Start',
+				createGraphNode(
+					'Start',
+					'n8n-nodes-base.manualTrigger',
+					makeMainConns([[0, [makeTarget('Agent')]]]),
+				),
+			);
+			nodes.set(
+				'Agent',
+				createGraphNode(
+					'Agent',
+					'@n8n/n8n-nodes-langchain.agent',
+					makeMainConns([[0, [makeTarget('Done')]]]),
+				),
+			);
+			nodes.set('Done', createGraphNode('Done', 'n8n-nodes-base.set'));
+			nodes.set(
+				'OpenAI Model',
+				createGraphNode(
+					'OpenAI Model',
+					'@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					makeAiConns('Agent', 'ai_languageModel'),
+				),
+			);
+			nodes.set(
+				'Calculator',
+				createGraphNode(
+					'Calculator',
+					'@n8n/n8n-nodes-langchain.toolCalculator',
+					makeAiConns('Agent', 'ai_tool'),
+				),
+			);
+
+			const positions = calculateNodePositionsDagre(nodes, [
+				{ name: 'AI', memberKeys: ['Agent', 'OpenAI Model', 'Calculator'] },
+			]);
+
+			const agentPos = positions.get('Agent')!;
+			const modelPos = positions.get('OpenAI Model')!;
+			const calculatorPos = positions.get('Calculator')!;
+			const donePos = positions.get('Done')!;
+
+			expect(modelPos[1]).toBeGreaterThanOrEqual(agentPos[1]);
+			expect(calculatorPos[1]).toBeGreaterThanOrEqual(agentPos[1]);
+			expect(donePos[0]).toBeGreaterThan(agentPos[0]);
+		});
+
+		it('aligns grouped chips when a member sticky wraps the group nodes', () => {
+			const nodes = new Map<string, GraphNode>();
+
+			nodes.set(
+				'Start',
+				createGraphNode(
+					'Start',
+					'n8n-nodes-base.manualTrigger',
+					makeMainConns([[0, [makeTarget('A')]]]),
+				),
+			);
+			nodes.set(
+				'A',
+				createGraphNode('A', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('B')]]])),
+			);
+			nodes.set(
+				'B',
+				createGraphNode('B', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('C')]]])),
+			);
+			nodes.set(
+				'C',
+				createGraphNode('C', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('D')]]])),
+			);
+			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
+			nodes.set('Note', createAnchoredSticky('Note', ['A', 'B']));
+
+			const positions = calculateNodePositionsDagre(nodes, [
+				{ name: 'With note', memberKeys: ['A', 'B', 'Note'] },
+				{ name: 'Plain', memberKeys: ['C', 'D'] },
+			]);
+			const stickyGeometry = resolveStickyGeometry(nodes, positions);
+			const noteGeometry = stickyGeometry.get('Note');
+			expect(noteGeometry?.size).toBeDefined();
+
+			const noteBox = {
+				x: noteGeometry!.position[0],
+				y: noteGeometry!.position[1],
+				width: noteGeometry!.size!.width,
+				height: noteGeometry!.size!.height,
+			};
+			const firstChip = collapsedGroupRectFromBoxes([
+				...['A', 'B'].map((name) => {
+					const position = positions.get(name)!;
+					return {
+						x: position[0],
+						y: position[1],
+						width: DEFAULT_NODE_SIZE[0],
+						height: DEFAULT_NODE_SIZE[1],
+					};
+				}),
+				noteBox,
+			]);
+			const secondChip = collapsedGroupRect(positions, ['C', 'D']);
+
+			expect(secondChip.y).toBe(firstChip.y);
+			expect(secondChip.x - firstChip.x).toBe(GROUP_HEADER_WIDTH_COLLAPSED + NODE_X_SPACING);
+		});
+
+		it('falls back to legacy layout when a group member has an explicit position', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'A',
+				createGraphNode(
+					'A',
+					'n8n-nodes-base.set',
+					makeMainConns([[0, [makeTarget('B')]]]),
+					[500, 600],
+				),
+			);
+			nodes.set('B', createGraphNode('B', 'n8n-nodes-base.set'));
+
+			const legacyPositions = calculateNodePositionsDagre(nodes);
+			const groupedPositions = calculateNodePositionsDagre(nodes, [
+				{ name: 'Positioned', memberKeys: ['A', 'B'] },
+			]);
+
+			expect(groupedPositions).toEqual(legacyPositions);
+			expect(groupedPositions.has('A')).toBe(false);
+		});
+
+		it('skips sticky-only groups', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'A',
+				createGraphNode('A', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('B')]]])),
+			);
+			nodes.set('B', createGraphNode('B', 'n8n-nodes-base.set'));
+			nodes.set('Note', createGraphNode('Note', STICKY_NODE_TYPE, undefined, [5000, 5000]));
+
+			const legacyPositions = calculateNodePositionsDagre(nodes);
+			const groupedPositions = calculateNodePositionsDagre(nodes, [
+				{ name: 'Only note', memberKeys: ['Note'] },
+			]);
+
+			expect(groupedPositions).toEqual(legacyPositions);
+		});
+
+		it('skips groups whose members do not resolve', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'A',
+				createGraphNode('A', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('B')]]])),
+			);
+			nodes.set('B', createGraphNode('B', 'n8n-nodes-base.set'));
+
+			const legacyPositions = calculateNodePositionsDagre(nodes);
+			const groupedPositions = calculateNodePositionsDagre(nodes, [
+				{ name: 'Ghosts', memberKeys: ['Ghost A', 'Ghost B'] },
+			]);
+
+			expect(groupedPositions).toEqual(legacyPositions);
+		});
+
+		it('falls back for all groups that share a non-sticky member', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'A',
+				createGraphNode('A', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('B')]]])),
+			);
+			nodes.set(
+				'B',
+				createGraphNode('B', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('C')]]])),
+			);
+			nodes.set('C', createGraphNode('C', 'n8n-nodes-base.set'));
+
+			const legacyPositions = calculateNodePositionsDagre(nodes);
+			const groupedPositions = calculateNodePositionsDagre(nodes, [
+				{ name: 'First', memberKeys: ['A', 'B'] },
+				{ name: 'Second', memberKeys: ['B', 'C'] },
+			]);
+
+			expect(groupedPositions).toEqual(legacyPositions);
+		});
+
+		it('lets an invalid group bridge otherwise disconnected components through its chip', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'A',
+				createGraphNode('A', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('B')]]])),
+			);
+			nodes.set('B', createGraphNode('B', 'n8n-nodes-base.set'));
+			nodes.set(
+				'C',
+				createGraphNode('C', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('D')]]])),
+			);
+			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
+
+			const positions = calculateNodePositionsDagre(nodes, [
+				{ name: 'Bridge', memberKeys: ['B', 'C'] },
+			]);
+
+			const chip = collapsedGroupRect(positions, ['B', 'C']);
+			expect(positions.get('D')![0]).toBeGreaterThan(chip.x);
+			expect(chip.x).toBeGreaterThan(positions.get('A')![0]);
+			expect(positions.get('D')![1]).toBe(positions.get('A')![1]);
+		});
+
+		it('handles multiple crossing edges around a group chip', () => {
+			const nodes = new Map<string, GraphNode>();
+			nodes.set(
+				'A',
+				createGraphNode('A', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('B')]]])),
+			);
+			nodes.set(
+				'C',
+				createGraphNode('C', 'n8n-nodes-base.set', makeMainConns([[0, [makeTarget('B')]]])),
+			);
+			nodes.set(
+				'B',
+				createGraphNode(
+					'B',
+					'n8n-nodes-base.set',
+					makeMainConns([
+						[0, [makeTarget('D')]],
+						[1, [makeTarget('E')]],
+					]),
+				),
+			);
+			nodes.set('D', createGraphNode('D', 'n8n-nodes-base.set'));
+			nodes.set('E', createGraphNode('E', 'n8n-nodes-base.set'));
+
+			const positions = calculateNodePositionsDagre(nodes, [
+				{ name: 'Many edges', memberKeys: ['B'] },
+			]);
+
+			const chip = collapsedGroupRect(positions, ['B']);
+			expect(positions.get('B')).toBeDefined();
+			expect(positions.get('D')![0]).toBeGreaterThan(chip.x);
+			expect(positions.get('E')![0]).toBeGreaterThan(chip.x);
+			expect(chip.x).toBeGreaterThan(Math.min(positions.get('A')![0], positions.get('C')![0]));
 		});
 	});
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -341,6 +341,29 @@ describe('calculateNodePositionsDagre', () => {
 			expect(isGridAligned(modelPos)).toBe(true);
 			expect(isGridAligned(calcPos)).toBe(true);
 		});
+
+		it('handles cycles in AI config references', () => {
+			const nodes = new Map<string, GraphNode>();
+
+			nodes.set(
+				'Agent',
+				createGraphNode(
+					'Agent',
+					'@n8n/n8n-nodes-langchain.agent',
+					makeAiConns('Calculator', 'ai_tool'),
+				),
+			);
+			nodes.set(
+				'Calculator',
+				createGraphNode(
+					'Calculator',
+					'@n8n/n8n-nodes-langchain.toolCalculator',
+					makeAiConns('Agent', 'ai_tool'),
+				),
+			);
+
+			expect(() => calculateNodePositionsDagre(nodes)).not.toThrow();
+		});
 	});
 
 	describe('explicit positions', () => {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -176,11 +176,15 @@ function getAllConnectedAiConfigNodes(
 	graph: dagre.graphlib.Graph,
 	rootId: string,
 	aiConfigNames: Set<string>,
+	visited = new Set<string>(),
 ): string[] {
 	const predecessors = (graph.predecessors(rootId) as unknown as string[]) ?? [];
 	return predecessors
-		.filter((id) => aiConfigNames.has(id))
-		.flatMap((id) => [id, ...getAllConnectedAiConfigNodes(graph, id, aiConfigNames)]);
+		.filter((id) => aiConfigNames.has(id) && !visited.has(id))
+		.flatMap((id) => {
+			visited.add(id);
+			return [id, ...getAllConnectedAiConfigNodes(graph, id, aiConfigNames, visited)];
+		});
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -33,8 +33,16 @@ import {
 	STICKY_HEADER_HEIGHT,
 	MAX_STICKY_SEPARATION_STEPS,
 } from './constants';
+import {
+	createGroupedParentGraph,
+	reExpandLayoutGroups,
+	resolveEligibleLayoutGroups,
+	type LayoutNodeGroup,
+} from './group-layout-utils';
 import { parseVersion } from './string-utils';
 import { isAnchoredStickyNote, type GraphNode } from '../types/base';
+
+export type { LayoutNodeGroup } from './group-layout-utils';
 
 // ===========================================================================
 // BFS Layout (default)
@@ -623,6 +631,9 @@ function wrappingBoxFor(anchorBoxes: BoundingBox[]): BoundingBox | undefined {
 	};
 }
 
+/**
+ * Resolves stored node ids from groups and sticky anchors to the map keys used by this layout.
+ */
 function mapNodeIdsToKeys(nodes: ReadonlyMap<string, GraphNode>): Map<string, string> {
 	const nameById = new Map<string, string>();
 	for (const [name, graphNode] of nodes) {
@@ -753,10 +764,14 @@ export function resolveStickyGeometry(
  * Calculate positions for nodes using Dagre hierarchical layout.
  * Mirrors the frontend's useCanvasLayout algorithm.
  *
+ * When groups are passed, eligible groups enter dagre as collapsed chip placeholders,
+ * matching the editor's collapsed-group tidy-up path.
+ *
  * Only sets positions for nodes without explicit config.position.
  */
 export function calculateNodePositionsDagre(
 	nodes: ReadonlyMap<string, GraphNode>,
+	groups: readonly LayoutNodeGroup[] = [],
 ): Map<string, [number, number]> {
 	const positions = new Map<string, [number, number]>();
 
@@ -817,11 +832,35 @@ export function calculateNodePositionsDagre(
 		}
 	}
 
-	// Divide into disconnected subgraphs
-	const components = dagre.graphlib.alg.components(parentGraph);
+	// Groups and sticky anchors refer to persisted node ids; layout maps are keyed by node name.
+	const nameById = mapNodeIdsToKeys(nodes);
+
+	// Select groups that can safely enter dagre as collapsed chips.
+	const eligibleGroups = resolveEligibleLayoutGroups({
+		groups,
+		nodes,
+		nonStickySet,
+		parentGraph,
+		aiParentNames,
+		getAiConfigNodeIds: (aiParentName) =>
+			getAllConnectedAiConfigNodes(parentGraph, aiParentName, aiConfigNames),
+		getGroupInteriorBoxes: (memberKeys) => {
+			const layout = layoutConnectedSubgraph(memberKeys, parentGraph, aiParentNames, aiConfigNames);
+			const boxes = collectSubgraphBoundingBoxes(layout);
+			topAlignAiSubtrees(layout.aiGraphs, boxes);
+			return boxes;
+		},
+		compositeBoundingBox,
+	});
+
+	// Replace eligible group members with collapsed chip placeholders before dagre layout.
+	const layoutGraph = createGroupedParentGraph(parentGraph, eligibleGroups);
+
+	// Divide the chip-aware graph into disconnected subgraphs.
+	const components = dagre.graphlib.alg.components(layoutGraph);
 
 	const subgraphs = components.map((nodeIds) =>
-		layoutConnectedSubgraph(nodeIds, parentGraph, aiParentNames, aiConfigNames),
+		layoutConnectedSubgraph(nodeIds, layoutGraph, aiParentNames, aiConfigNames),
 	);
 
 	// Arrange subgraphs vertically (skip composite layout for single subgraph)
@@ -859,6 +898,16 @@ export function calculateNodePositionsDagre(
 		subgraphs.flatMap(({ aiGraphs }) => aiGraphs),
 		boundingBoxByNodeId,
 	);
+
+	// Convert dagre's chip positions back into real hidden group member positions.
+	reExpandLayoutGroups({
+		eligibleGroups,
+		boundingBoxByNodeId,
+		nodes,
+		nameById,
+		geometry: { compositeBoundingBox, snapToGrid },
+		stickyGeometry: { declaresOwnHeight, declaresOwnWidth, wrappingBoxFor },
+	});
 
 	// Snap to grid and build result (skip nodes with explicit positions)
 	for (const [name, box] of boundingBoxByNodeId) {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -20,6 +20,7 @@ import {
 	calculateNodePositions,
 	calculateNodePositionsDagre,
 	resolveStickyGeometry,
+	type LayoutNodeGroup,
 	type StickyGeometry,
 } from '../../layout-utils';
 import {
@@ -228,6 +229,22 @@ function serializeNodeConnections(
 	return nodeConnections;
 }
 
+function resolveLayoutNodeGroups(ctx: SerializerContext): LayoutNodeGroup[] {
+	if (!ctx.nodeGroups?.length) return [];
+
+	const mapKeyById = new Map<string, string>();
+	for (const [mapKey, graphNode] of ctx.nodes) {
+		mapKeyById.set(graphNode.instance.id, mapKey);
+	}
+
+	return ctx.nodeGroups.map((group) => ({
+		name: group.name,
+		memberKeys: group.memberIds
+			.map((memberId) => mapKeyById.get(memberId))
+			.filter((memberKey): memberKey is string => memberKey !== undefined),
+	}));
+}
+
 /**
  * Serializer for the standard n8n workflow JSON format.
  *
@@ -244,7 +261,7 @@ export const jsonSerializer: SerializerPlugin<WorkflowJSON> = {
 
 		// Calculate positions for nodes without explicit positions
 		const nodePositions = ctx.tidyUp
-			? calculateNodePositionsDagre(ctx.nodes)
+			? calculateNodePositionsDagre(ctx.nodes, resolveLayoutNodeGroups(ctx))
 			: calculateNodePositions(ctx.nodes);
 
 		// Sticky notes are placed last: their box depends on where their anchors landed


### PR DESCRIPTION
## Summary

- Pass SDK `nodeGroups` into dagre tidy-up.
- Resolve eligible groups, substitute collapsed chip nodes before dagre layout and write member positions back under each chip after layout.
- Keep ambiguous groups on the existing layout path, including groups with explicit member positions, sticky-only groups, unresolved members, overlapping non-sticky members and partial AI subtrees.

## How to test

- Use an MCP client connected to a local instance with canvas groups enabled, or use the Instance AI assistant.
- Create a workflow with this prompt:

```text
Create a workflow named "ADO-5798 layout check".
It starts with a Webhook trigger. Keep the trigger outside of any group.
Then add three stages, each in its own canvas group.

Group "Intake" contains a Set node that normalizes incoming fields, then an If node that filters out invalid payloads.
Group "Enrich" contains an HTTP Request node that fetches customer data, then an AI Agent with an OpenAI chat model attached that summarizes it.
Group "Deliver" contains a Set node that formats the response, then sends it to both a Slack node and a Gmail node in parallel. Use two outputs of the Set node, not a chain.

Use placeholder credentials everywhere. Do not ask follow-up questions.
```

- Open the created workflow in the editor without clicking **Tidy up**.
- Confirm the Webhook trigger and the three collapsed group chips form one row.
- Confirm the "Deliver" chip does not sit higher or farther away than the other group chips.
- Expand each group.
- Confirm the member nodes have a sensible layout inside the expanded frame.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5798

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
