### PR TITLE
fix(API): Skip projectRelations eager-load in GET /credentials

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -148,7 +148,7 @@ describe('CredentialsRepository', () => {
 			expect(callArg!.order).toBeUndefined();
 		});
 
-		it('should honor a caller-provided relations array (API-22)', async () => {
+		it('should honor a caller-provided relations array', async () => {
 			entityManager.findAndCount.mockResolvedValueOnce([[], 0]);
 
 			await credentialsRepository.findManyAndCount({

--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -3,11 +3,13 @@ import type { EntityManager, SelectQueryBuilder } from '@n8n/typeorm';
 import { In, Not, QueryFailedError } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
+import type { User } from '../../entities';
 import { CredentialsEntity } from '../../entities';
 import { TypeOrmTransaction } from '../../services/typeorm-transaction';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { CredentialsRepository } from '../credentials.repository';
 import { InstanceCredentialAssignmentRepository } from '../instance-credential-assignment.repository';
+import { SharedCredentialsRepository } from '../shared-credentials.repository';
 
 describe('CredentialsRepository', () => {
 	const entityManager = mockEntityManager(CredentialsEntity);
@@ -138,12 +140,23 @@ describe('CredentialsRepository', () => {
 			expect(callArg).toBeDefined();
 			expect(callArg!.take).toBe(10);
 			expect(callArg!.select).toBeDefined();
-			expect(callArg!.relations).toEqual([
-				'shared',
-				'shared.project',
-				'shared.project.projectRelations',
-			]);
+			expect(callArg!.relations).toEqual({
+				shared: { project: { projectRelations: true } },
+			});
 			expect(callArg!.order).toBeUndefined();
+		});
+
+		it('should honor a caller-provided relations tree', async () => {
+			entityManager.findAndCount.mockResolvedValueOnce([[], 0]);
+
+			await credentialsRepository.findManyAndCount({
+				take: 10,
+				skip: 0,
+				relations: { shared: { project: true } },
+			});
+
+			const callArg = entityManager.findAndCount.mock.calls[0]?.[1];
+			expect(callArg?.relations).toEqual({ shared: { project: true } });
 		});
 
 		it('should apply credentialIds filter when provided', async () => {
@@ -186,6 +199,63 @@ describe('CredentialsRepository', () => {
 
 			const callArg = entityManager.findAndCount.mock.calls[0]?.[1];
 			expect(callArg?.order).toBeUndefined();
+		});
+	});
+
+	describe('getManyAndCountWithSharingSubquery', () => {
+		function mockQueryBuilder() {
+			const qb = mock<SelectQueryBuilder<CredentialsEntity>>();
+			qb.andWhere.mockReturnValue(qb);
+			qb.setParameters.mockReturnValue(qb);
+			qb.select.mockReturnValue(qb);
+			qb.addSelect.mockReturnValue(qb);
+			qb.leftJoinAndSelect.mockReturnValue(qb);
+			qb.addOrderBy.mockReturnValue(qb);
+			qb.take.mockReturnValue(qb);
+			qb.skip.mockReturnValue(qb);
+			qb.getMany.mockResolvedValue([]);
+			qb.getCount.mockResolvedValue(0);
+			return qb;
+		}
+
+		beforeEach(() => {
+			const subquery = mock<SelectQueryBuilder<CredentialsEntity>>();
+			subquery.getQuery.mockReturnValue('SELECT sc.credentialsId FROM shared_credentials sc');
+			subquery.getParameters.mockReturnValue({});
+			vi.spyOn(
+				Container.get(SharedCredentialsRepository),
+				'buildSharedCredentialIdsSubquery',
+			).mockReturnValue(subquery);
+		});
+
+		it('eager-loads projectRelations by default', async () => {
+			const qb = mockQueryBuilder();
+			vi.spyOn(credentialsRepository, 'createQueryBuilder').mockReturnValue(qb);
+
+			await credentialsRepository.getManyAndCountWithSharingSubquery(mock<User>(), {}, {});
+
+			expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
+				'project.projectRelations',
+				'projectRelations',
+			);
+		});
+
+		it('skips projectRelations when the caller passes a narrower relations tree', async () => {
+			const qb = mockQueryBuilder();
+			vi.spyOn(credentialsRepository, 'createQueryBuilder').mockReturnValue(qb);
+
+			await credentialsRepository.getManyAndCountWithSharingSubquery(
+				mock<User>(),
+				{},
+				{ relations: { shared: { project: true } } },
+			);
+
+			expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('credential.shared', 'shared');
+			expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('shared.project', 'project');
+			expect(qb.leftJoinAndSelect).not.toHaveBeenCalledWith(
+				'project.projectRelations',
+				expect.anything(),
+			);
 		});
 	});
 

--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -3,13 +3,11 @@ import type { EntityManager, SelectQueryBuilder } from '@n8n/typeorm';
 import { In, Not, QueryFailedError } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
-import type { User } from '../../entities';
 import { CredentialsEntity } from '../../entities';
 import { TypeOrmTransaction } from '../../services/typeorm-transaction';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { CredentialsRepository } from '../credentials.repository';
 import { InstanceCredentialAssignmentRepository } from '../instance-credential-assignment.repository';
-import { SharedCredentialsRepository } from '../shared-credentials.repository';
 
 describe('CredentialsRepository', () => {
 	const entityManager = mockEntityManager(CredentialsEntity);
@@ -201,63 +199,6 @@ describe('CredentialsRepository', () => {
 
 			const callArg = entityManager.findAndCount.mock.calls[0]?.[1];
 			expect(callArg?.order).toBeUndefined();
-		});
-	});
-
-	describe('getManyAndCountWithSharingSubquery', () => {
-		function mockQueryBuilder() {
-			const qb = mock<SelectQueryBuilder<CredentialsEntity>>();
-			qb.andWhere.mockReturnValue(qb);
-			qb.setParameters.mockReturnValue(qb);
-			qb.select.mockReturnValue(qb);
-			qb.addSelect.mockReturnValue(qb);
-			qb.leftJoinAndSelect.mockReturnValue(qb);
-			qb.addOrderBy.mockReturnValue(qb);
-			qb.take.mockReturnValue(qb);
-			qb.skip.mockReturnValue(qb);
-			qb.getMany.mockResolvedValue([]);
-			qb.getCount.mockResolvedValue(0);
-			return qb;
-		}
-
-		beforeEach(() => {
-			const subquery = mock<SelectQueryBuilder<CredentialsEntity>>();
-			subquery.getQuery.mockReturnValue('SELECT sc.credentialsId FROM shared_credentials sc');
-			subquery.getParameters.mockReturnValue({});
-			vi.spyOn(
-				Container.get(SharedCredentialsRepository),
-				'buildSharedCredentialIdsSubquery',
-			).mockReturnValue(subquery);
-		});
-
-		it('eager-loads projectRelations by default', async () => {
-			const qb = mockQueryBuilder();
-			vi.spyOn(credentialsRepository, 'createQueryBuilder').mockReturnValue(qb);
-
-			await credentialsRepository.getManyAndCountWithSharingSubquery(mock<User>(), {}, {});
-
-			expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
-				'project.projectRelations',
-				'projectRelations',
-			);
-		});
-
-		it('skips projectRelations when the caller passes a narrower relations array', async () => {
-			const qb = mockQueryBuilder();
-			vi.spyOn(credentialsRepository, 'createQueryBuilder').mockReturnValue(qb);
-
-			await credentialsRepository.getManyAndCountWithSharingSubquery(
-				mock<User>(),
-				{},
-				{ relations: ['shared', 'shared.project'] },
-			);
-
-			expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('credential.shared', 'shared');
-			expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('shared.project', 'project');
-			expect(qb.leftJoinAndSelect).not.toHaveBeenCalledWith(
-				'project.projectRelations',
-				expect.anything(),
-			);
 		});
 	});
 

--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -140,23 +140,25 @@ describe('CredentialsRepository', () => {
 			expect(callArg).toBeDefined();
 			expect(callArg!.take).toBe(10);
 			expect(callArg!.select).toBeDefined();
-			expect(callArg!.relations).toEqual({
-				shared: { project: { projectRelations: true } },
-			});
+			expect(callArg!.relations).toEqual([
+				'shared',
+				'shared.project',
+				'shared.project.projectRelations',
+			]);
 			expect(callArg!.order).toBeUndefined();
 		});
 
-		it('should honor a caller-provided relations tree', async () => {
+		it('should honor a caller-provided relations array (API-22)', async () => {
 			entityManager.findAndCount.mockResolvedValueOnce([[], 0]);
 
 			await credentialsRepository.findManyAndCount({
 				take: 10,
 				skip: 0,
-				relations: { shared: { project: true } },
+				relations: ['shared', 'shared.project'],
 			});
 
 			const callArg = entityManager.findAndCount.mock.calls[0]?.[1];
-			expect(callArg?.relations).toEqual({ shared: { project: true } });
+			expect(callArg?.relations).toEqual(['shared', 'shared.project']);
 		});
 
 		it('should apply credentialIds filter when provided', async () => {
@@ -240,14 +242,14 @@ describe('CredentialsRepository', () => {
 			);
 		});
 
-		it('skips projectRelations when the caller passes a narrower relations tree', async () => {
+		it('skips projectRelations when the caller passes a narrower relations array', async () => {
 			const qb = mockQueryBuilder();
 			vi.spyOn(credentialsRepository, 'createQueryBuilder').mockReturnValue(qb);
 
 			await credentialsRepository.getManyAndCountWithSharingSubquery(
 				mock<User>(),
 				{},
-				{ relations: { shared: { project: true } } },
+				{ relations: ['shared', 'shared.project'] },
 			);
 
 			expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('credential.shared', 'shared');

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -1,6 +1,6 @@
 import { Container, Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
-import type { FindManyOptions, FindOptionsRelations, SelectQueryBuilder } from '@n8n/typeorm';
+import type { FindManyOptions, SelectQueryBuilder } from '@n8n/typeorm';
 import { DataSource, In, Like, Not, QueryFailedError } from '@n8n/typeorm';
 
 import { CredentialsEntity, type User } from '../entities';
@@ -18,14 +18,21 @@ import { parseListQuerySortBy } from '../utils/list-query-sort';
 
 const SORTABLE_COLUMNS = new Set(['id', 'name', 'createdAt', 'updatedAt']);
 
-const DEFAULT_CREDENTIAL_RELATIONS: FindOptionsRelations<CredentialsEntity> = {
-	shared: { project: { projectRelations: true } },
-};
+export type CredentialSharingRelation =
+	| 'shared'
+	| 'shared.project'
+	| 'shared.project.projectRelations';
+
+const DEFAULT_CREDENTIAL_RELATIONS: CredentialSharingRelation[] = [
+	'shared',
+	'shared.project',
+	'shared.project.projectRelations',
+];
 
 type CredentialsListQueryOptions = ListQuery.Options & {
 	includeData?: boolean;
 	user?: User;
-	relations?: FindOptionsRelations<CredentialsEntity>;
+	relations?: CredentialSharingRelation[];
 };
 
 @Service()
@@ -528,18 +535,14 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 			qb.addSelect('credential.data');
 		}
 
-		// Apply relations. Walk the typed `relations` tree by hand
-		// and decide which joins to add. We need to discern boolean 'true' from objects.
+		// Apply relations.
 		if (!options.select) {
-			const relationsTree = options.relations ?? DEFAULT_CREDENTIAL_RELATIONS;
-			const sharedRel = relationsTree.shared;
-			if (sharedRel) {
+			const relations = options.relations ?? DEFAULT_CREDENTIAL_RELATIONS;
+			if (relations.includes('shared')) {
 				qb.leftJoinAndSelect('credential.shared', 'shared');
-				const projectRel = sharedRel === true ? undefined : sharedRel.project;
-				if (projectRel) {
+				if (relations.includes('shared.project')) {
 					qb.leftJoinAndSelect('shared.project', 'project');
-					const projectRelationsRel = projectRel === true ? undefined : projectRel.projectRelations;
-					if (projectRelationsRel) {
+					if (relations.includes('shared.project.projectRelations')) {
 						qb.leftJoinAndSelect('project.projectRelations', 'projectRelations');
 					}
 				}

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -1,6 +1,6 @@
 import { Container, Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
-import type { FindManyOptions, SelectQueryBuilder } from '@n8n/typeorm';
+import type { FindManyOptions, FindOptionsRelations, SelectQueryBuilder } from '@n8n/typeorm';
 import { DataSource, In, Like, Not, QueryFailedError } from '@n8n/typeorm';
 
 import { CredentialsEntity, type User } from '../entities';
@@ -18,9 +18,14 @@ import { parseListQuerySortBy } from '../utils/list-query-sort';
 
 const SORTABLE_COLUMNS = new Set(['id', 'name', 'createdAt', 'updatedAt']);
 
+const DEFAULT_CREDENTIAL_RELATIONS: FindOptionsRelations<CredentialsEntity> = {
+	shared: { project: { projectRelations: true } },
+};
+
 type CredentialsListQueryOptions = ListQuery.Options & {
 	includeData?: boolean;
 	user?: User;
+	relations?: FindOptionsRelations<CredentialsEntity>;
 };
 
 @Service()
@@ -149,7 +154,7 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 
 		type Select = Array<keyof CredentialsEntity>;
 
-		const defaultRelations = ['shared', 'shared.project', 'shared.project.projectRelations'];
+		const relations = listQueryOptions?.relations ?? DEFAULT_CREDENTIAL_RELATIONS;
 		const defaultSelect: Select = [
 			'id',
 			'name',
@@ -165,7 +170,7 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 		if (!listQueryOptions) {
 			return {
 				select: defaultSelect,
-				relations: defaultRelations,
+				relations,
 			} as FindManyOptions<CredentialsEntity>;
 		}
 
@@ -197,7 +202,7 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 
 		if (!findManyOptions.select) {
 			findManyOptions.select = defaultSelect;
-			findManyOptions.relations = defaultRelations;
+			findManyOptions.relations = relations;
 		}
 
 		if (sortBy) {
@@ -523,12 +528,22 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 			qb.addSelect('credential.data');
 		}
 
-		// Apply relations
+		// Apply relations. Walk the typed `relations` tree by hand
+		// and decide which joins to add. We need to discern boolean 'true' from objects.
 		if (!options.select) {
-			// Only add relations if using default select
-			qb.leftJoinAndSelect('credential.shared', 'shared')
-				.leftJoinAndSelect('shared.project', 'project')
-				.leftJoinAndSelect('project.projectRelations', 'projectRelations');
+			const relationsTree = options.relations ?? DEFAULT_CREDENTIAL_RELATIONS;
+			const sharedRel = relationsTree.shared;
+			if (sharedRel) {
+				qb.leftJoinAndSelect('credential.shared', 'shared');
+				const projectRel = sharedRel === true ? undefined : sharedRel.project;
+				if (projectRel) {
+					qb.leftJoinAndSelect('shared.project', 'project');
+					const projectRelationsRel = projectRel === true ? undefined : projectRel.projectRelations;
+					if (projectRelationsRel) {
+						qb.leftJoinAndSelect('project.projectRelations', 'projectRelations');
+					}
+				}
+			}
 		}
 
 		if (options.sortBy) {

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -535,18 +535,11 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 			qb.addSelect('credential.data');
 		}
 
-		// Apply relations.
+		// Apply relations
 		if (!options.select) {
-			const relations = options.relations ?? DEFAULT_CREDENTIAL_RELATIONS;
-			if (relations.includes('shared')) {
-				qb.leftJoinAndSelect('credential.shared', 'shared');
-				if (relations.includes('shared.project')) {
-					qb.leftJoinAndSelect('shared.project', 'project');
-					if (relations.includes('shared.project.projectRelations')) {
-						qb.leftJoinAndSelect('project.projectRelations', 'projectRelations');
-					}
-				}
-			}
+			qb.leftJoinAndSelect('credential.shared', 'shared')
+				.leftJoinAndSelect('shared.project', 'project')
+				.leftJoinAndSelect('project.projectRelations', 'projectRelations');
 		}
 
 		if (options.sortBy) {

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -10,7 +10,7 @@ export { AuthIdentityRepository } from './auth-identity.repository';
 export { AuthProviderSyncHistoryRepository } from './auth-provider-sync-history.repository';
 export { BaseRepository } from './base-repository';
 export { BinaryDataRepository } from './binary-data.repository';
-export { CredentialsRepository } from './credentials.repository';
+export { CredentialsRepository, type CredentialSharingRelation } from './credentials.repository';
 export { CredentialDependencyRepository } from './credential-dependency.repository';
 export {
 	DeploymentKeyRepository,

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -108,7 +108,9 @@ type PrepareUpdateDataOptions = {
 };
 
 type GetManyOptions = {
-	listQueryOptions?: ListQuery.Options;
+	listQueryOptions?: ListQuery.Options & {
+		relations?: FindOptionsRelations<CredentialsEntity>;
+	};
 	includeScopes?: boolean;
 	includeData?: boolean;
 	onlySharedWithMe?: boolean;

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -19,6 +19,7 @@ import type {
 	ICredentialsDb,
 	ScopesField,
 	OperationContext,
+	CredentialSharingRelation,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
@@ -109,7 +110,7 @@ type PrepareUpdateDataOptions = {
 
 type GetManyOptions = {
 	listQueryOptions?: ListQuery.Options & {
-		relations?: FindOptionsRelations<CredentialsEntity>;
+		relations?: CredentialSharingRelation[];
 	};
 	includeScopes?: boolean;
 	includeData?: boolean;

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
@@ -131,6 +131,8 @@ const credentialsHandlers: CredentialsHandlers = {
 						take: limit,
 						skip: offset,
 						sortBy: 'createdAt:desc',
+						// skip eager-loading shared.project.projectRelations to avoid query fan-out
+						relations: { shared: { project: true } },
 					},
 				},
 			);

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
@@ -132,7 +132,7 @@ const credentialsHandlers: CredentialsHandlers = {
 						skip: offset,
 						sortBy: 'createdAt:desc',
 						// skip eager-loading shared.project.projectRelations to avoid query fan-out
-						relations: { shared: { project: true } },
+						relations: ['shared', 'shared.project'],
 					},
 				},
 			);

--- a/packages/cli/test/integration/public-api/credentials.test.ts
+++ b/packages/cli/test/integration/public-api/credentials.test.ts
@@ -374,6 +374,25 @@ describe('GET /credentials', () => {
 		);
 	});
 
+	test('should return correct shared info for a credential in a team project with multiple members', async () => {
+		const teamProject = await createTeamProject('multi-member-project', owner);
+		await linkUserToProject(member, teamProject, 'project:editor');
+		const saved = await saveCredential(dbCredential(), { project: teamProject });
+
+		const response = await authOwnerAgent.get('/credentials');
+
+		expect(response.statusCode).toBe(200);
+		const item = response.body.data.find((c: { id: string }) => c.id === saved.id);
+		expect(item).toBeDefined();
+		expect(item.shared).toEqual([
+			expect.objectContaining({
+				id: teamProject.id,
+				name: teamProject.name,
+				role: 'credential:owner',
+			}),
+		]);
+	});
+
 	test('should return empty list when no credentials exist', async () => {
 		const response = await authOwnerAgent.get('/credentials');
 


### PR DESCRIPTION
## Summary

Public API endpoint `GET /api/v1/credentials` eager-loaded `shared.project.projectRelations` even though nothing in the response reads project membership. That relation fans the query out by every member of every project a credential is shared to, dominating both DB and hydration cost at scale.

This PR adjusts the underlying `CredentialsListQueryOptions` to accept an override of a subset of credentials relations and the `CredentialsRepository.toFindManyOptions` method to override relations if provided. Within the Public API handler, we omit the `shared.project.projectRelations` relation to avoid query fan-out and reduced performance with large credential, project and project membership sets.

## How to test
Found in comment on Linear ticket.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-22

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

