### PR TITLE
refactor(core): Share node group geometry with editor

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.test.ts
@@ -20,7 +20,7 @@ import {
 	GROUP_PADDING_Y_BOTTOM,
 	GROUP_PADDING_Y_TOP,
 } from '../stores/canvasNodeGroups.constants';
-import { GRID_SIZE } from '@/app/utils/nodeViewUtils';
+import { DEFAULT_NODE_SIZE, GRID_SIZE } from '@/app/utils/nodeViewUtils';
 import { STICKY_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { createNodeExecutionSnapshot } from '../__tests__/utils';
 
@@ -62,6 +62,10 @@ function snapshotGetter(byId: Record<string, Partial<NodeExecutionSnapshot>> = {
 describe('computeGroupFrameRects', () => {
 	// Coordinates intentionally off the grid so an accidental snap() would surface.
 	const nodesRect = { x: 317, y: 213, width: 396, height: 120 };
+
+	it('keeps the group header height aligned with the default node height', () => {
+		expect(GROUP_HEADER_HEIGHT).toBe(DEFAULT_NODE_SIZE[1]);
+	});
 
 	it('anchors both rects at the same unsnapped top-left, offset by padding and header', () => {
 		const { collapsed, expanded } = computeGroupFrameRects(nodesRect);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.ts
@@ -1,7 +1,11 @@
-import type { ExecutionStatus, IWorkflowGroup } from 'n8n-workflow';
+import {
+	computeGroupFrameRects,
+	type ExecutionStatus,
+	type IWorkflowGroup,
+	type NodeGroupRect,
+} from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
 import type {
-	BoundingBox,
 	CanvasConnection,
 	CanvasGroupNode,
 	CanvasGroupNodeData,
@@ -16,23 +20,15 @@ import {
 } from '../canvas.types';
 import {
 	GROUP_HEADER_HEIGHT,
-	GROUP_HEADER_WIDTH_COLLAPSED,
 	GROUP_NODE_Z_INDEX_COLLAPSED,
 	GROUP_NODE_Z_INDEX_EXPANDED,
-	GROUP_PADDING_X,
-	GROUP_PADDING_Y_BOTTOM,
-	GROUP_PADDING_Y_TOP,
 } from '../stores/canvasNodeGroups.constants';
 import { applyOffset, createCanvasConnectionId } from '../canvas.utils';
 import { DEFAULT_NODE_SIZE, GRID_SIZE } from '@/app/utils/nodeViewUtils';
 import { STICKY_NODE_TYPE } from '@/app/constants/nodeTypes';
 
-export interface NodesRect {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-}
+export type NodesRect = NodeGroupRect;
+export { computeGroupFrameRects };
 
 /**
  * Size lookup for nodes that aren't the default size
@@ -59,28 +55,6 @@ function resolveNodeDimensions(
 	return {
 		width: supplied?.width ?? sticky?.width ?? DEFAULT_NODE_SIZE[0],
 		height: supplied?.height ?? sticky?.height ?? DEFAULT_NODE_SIZE[1],
-	};
-}
-
-/**
- * Collapsed (chip) and expanded frame rects for a group, in unsnapped store
- * space. Expanded width is floored at the chip width so a tight cluster never
- * shrinks the frame below it.
- */
-export function computeGroupFrameRects(nodesRect: NodesRect): {
-	collapsed: BoundingBox;
-	expanded: BoundingBox;
-} {
-	const x = nodesRect.x - GROUP_PADDING_X;
-	const y = nodesRect.y - GROUP_PADDING_Y_TOP - GROUP_HEADER_HEIGHT;
-	return {
-		collapsed: { x, y, width: GROUP_HEADER_WIDTH_COLLAPSED, height: GROUP_HEADER_HEIGHT },
-		expanded: {
-			x,
-			y,
-			width: Math.max(nodesRect.width + 2 * GROUP_PADDING_X, GROUP_HEADER_WIDTH_COLLAPSED),
-			height: GROUP_HEADER_HEIGHT + nodesRect.height + GROUP_PADDING_Y_TOP + GROUP_PADDING_Y_BOTTOM,
-		},
 	};
 }
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/stores/canvasNodeGroups.constants.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/stores/canvasNodeGroups.constants.ts
@@ -1,12 +1,10 @@
-import { DEFAULT_NODE_SIZE } from '@/app/utils/nodeViewUtils';
-
-export const GROUP_PADDING_X = 56;
-export const GROUP_PADDING_Y_TOP = 40;
-export const GROUP_PADDING_Y_BOTTOM = 88;
-/** Matches node height */
-export const GROUP_HEADER_HEIGHT = DEFAULT_NODE_SIZE[1];
-/** Fixed width when collapsed; also the minimum width when expanded. */
-export const GROUP_HEADER_WIDTH_COLLAPSED = 400;
+export {
+	GROUP_PADDING_X,
+	GROUP_PADDING_Y_TOP,
+	GROUP_PADDING_Y_BOTTOM,
+	GROUP_HEADER_WIDTH_COLLAPSED,
+	GROUP_HEADER_HEIGHT,
+} from 'n8n-workflow';
 /** Character cap on a group description; shared with the backend so validation matches. */
 export { GROUP_DESCRIPTION_MAX_LENGTH } from 'n8n-workflow';
 /** Below this zoom level all group descriptions and their affordances are hidden. */

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -37,6 +37,7 @@ export * from './from-ai-parse-utils';
 export * from './node-helpers';
 export * from './node-validation';
 export * from './node-grouping-validation';
+export * from './node-group-geometry';
 export * from './mcp-helpers';
 export * from './tool-helpers';
 export * from './trigger-credential-gate';

--- a/packages/workflow/src/node-group-geometry.ts
+++ b/packages/workflow/src/node-group-geometry.ts
@@ -1,0 +1,36 @@
+export interface NodeGroupRect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface NodeGroupFrameRects {
+	collapsed: NodeGroupRect;
+	expanded: NodeGroupRect;
+}
+
+export const GROUP_PADDING_X = 56;
+export const GROUP_PADDING_Y_TOP = 40;
+export const GROUP_PADDING_Y_BOTTOM = 88;
+/** Must match the canvas default node height. */
+export const GROUP_HEADER_HEIGHT = 96;
+/** Fixed width when collapsed; also the minimum width when expanded. */
+export const GROUP_HEADER_WIDTH_COLLAPSED = 400;
+
+/**
+ * Collapsed chip and expanded frame rects for a group, in unsnapped canvas space.
+ */
+export function computeGroupFrameRects(nodesRect: NodeGroupRect): NodeGroupFrameRects {
+	const x = nodesRect.x - GROUP_PADDING_X;
+	const y = nodesRect.y - GROUP_PADDING_Y_TOP - GROUP_HEADER_HEIGHT;
+	return {
+		collapsed: { x, y, width: GROUP_HEADER_WIDTH_COLLAPSED, height: GROUP_HEADER_HEIGHT },
+		expanded: {
+			x,
+			y,
+			width: Math.max(nodesRect.width + 2 * GROUP_PADDING_X, GROUP_HEADER_WIDTH_COLLAPSED),
+			height: GROUP_HEADER_HEIGHT + nodesRect.height + GROUP_PADDING_Y_TOP + GROUP_PADDING_Y_BOTTOM,
+		},
+	};
+}

--- a/packages/workflow/test/node-group-geometry.test.ts
+++ b/packages/workflow/test/node-group-geometry.test.ts
@@ -1,0 +1,38 @@
+import {
+	GROUP_HEADER_HEIGHT,
+	GROUP_HEADER_WIDTH_COLLAPSED,
+	GROUP_PADDING_X,
+	GROUP_PADDING_Y_BOTTOM,
+	GROUP_PADDING_Y_TOP,
+	computeGroupFrameRects,
+} from '../src/node-group-geometry';
+
+describe('node group geometry', () => {
+	it('computes collapsed and expanded group frames from member bounds', () => {
+		const nodesRect = { x: 120, y: 240, width: 320, height: 180 };
+		const { collapsed, expanded } = computeGroupFrameRects(nodesRect);
+
+		expect(collapsed).toEqual({
+			x: nodesRect.x - GROUP_PADDING_X,
+			y: nodesRect.y - GROUP_PADDING_Y_TOP - GROUP_HEADER_HEIGHT,
+			width: GROUP_HEADER_WIDTH_COLLAPSED,
+			height: GROUP_HEADER_HEIGHT,
+		});
+		expect(expanded).toEqual({
+			x: collapsed.x,
+			y: collapsed.y,
+			width: nodesRect.width + 2 * GROUP_PADDING_X,
+			height: GROUP_HEADER_HEIGHT + nodesRect.height + GROUP_PADDING_Y_TOP + GROUP_PADDING_Y_BOTTOM,
+		});
+	});
+
+	it('floors expanded width at the collapsed chip width', () => {
+		const { expanded } = computeGroupFrameRects({ x: 0, y: 0, width: 10, height: 100 });
+
+		expect(expanded.width).toBe(GROUP_HEADER_WIDTH_COLLAPSED);
+	});
+
+	it('keeps the shared header height aligned with the canvas default node height', () => {
+		expect(GROUP_HEADER_HEIGHT).toBe(96);
+	});
+});


### PR DESCRIPTION
## Summary

- Move shared group geometry from the editor into `n8n-workflow`.
- Export `computeGroupFrameRects` and the group spacing constants from `n8n-workflow`.
- Update the editor group mapping code to use the shared geometry so frontend rendering and SDK tidy-up can use the same chip dimensions.

## How to test

This should not change the current editor behavior.
- Create a workflow with a few connected nodes.
- Create a group around some of them.
- Collapse and expand the group.
- Move the group and move one grouped node.
- Confirm the collapsed chip, expanded frame, title bar, and member positions behave as they do on `master`.
- Confirm there is no visible size change or jump caused by the shared geometry move.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5798

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
