### PR TITLE
feat(core): Evaluate content-import policy on workflow import and pull (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -169,6 +169,8 @@ export {
 	SOURCE_CONTROL_FILE_TYPE,
 } from './schemas/source-controlled-file.schema';
 
+export { policyViolationSchema, type PolicyViolation } from './schemas/policy-violation.schema';
+
 export {
 	insightsSummarySchema,
 	type InsightsSummaryType,

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -177,6 +177,11 @@ export {
 } from './schemas/policy-check-failure.schema';
 
 export {
+	contentImportPolicyResultSchema,
+	type ContentImportPolicyResult,
+} from './schemas/content-import-policy-result.schema';
+
+export {
 	insightsSummarySchema,
 	type InsightsSummaryType,
 	type InsightsSummaryUnit,

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -172,6 +172,11 @@ export {
 export { policyViolationSchema, type PolicyViolation } from './schemas/policy-violation.schema';
 
 export {
+	policyCheckFailureSchema,
+	type PolicyCheckFailure,
+} from './schemas/policy-check-failure.schema';
+
+export {
 	insightsSummarySchema,
 	type InsightsSummaryType,
 	type InsightsSummaryUnit,

--- a/packages/@n8n/api-types/src/schemas/content-import-policy-result.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/content-import-policy-result.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+import { policyCheckFailureSchema } from './policy-check-failure.schema';
+import { policyViolationSchema } from './policy-violation.schema';
+
+/**
+ * The content-import policy's advisory result for one artifact — never blocks the import/pull,
+ * per contentImport being `evaluate`, not `enforce`. Bundled as one object (rather than two
+ * sibling fields) because both come from the same evaluation and are read together: a check
+ * that failed to run means a violation may have gone undetected.
+ */
+export const contentImportPolicyResultSchema = z.object({
+	violations: z.array(policyViolationSchema),
+	checkErrors: z.array(policyCheckFailureSchema),
+});
+
+export type ContentImportPolicyResult = z.infer<typeof contentImportPolicyResultSchema>;

--- a/packages/@n8n/api-types/src/schemas/policy-check-failure.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/policy-check-failure.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * A policy check that failed to run. Deliberately vague — error details stay server-side.
+ *
+ * Lands here (instead of aborting the whole evaluation) so one broken check doesn't sink a
+ * whole report — a crash never looks like "nothing to report".
+ */
+export const policyCheckFailureSchema = z.object({
+	checkId: z.string(),
+	correlationId: z.string(),
+});
+
+export type PolicyCheckFailure = z.infer<typeof policyCheckFailureSchema>;

--- a/packages/@n8n/api-types/src/schemas/policy-violation.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/policy-violation.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * One reason something was blocked by a policy check. Mirrors the shape produced by
+ * `PolicyEnforcementService` on the backend (`@n8n/decorators`'s `PolicyViolation`) — kept as
+ * its own schema here since `@n8n/api-types` is the FE/BE contract and doesn't depend on
+ * backend-only packages.
+ */
+export const policyViolationSchema = z.object({
+	kind: z.string(),
+	checkId: z.string(),
+	message: z.string(),
+	subject: z.string().optional(),
+	subjectType: z.string().optional(),
+	scope: z.string().optional(),
+	matchedRuleId: z.string().optional(),
+});
+
+export type PolicyViolation = z.infer<typeof policyViolationSchema>;

--- a/packages/@n8n/api-types/src/schemas/policy-violation.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/policy-violation.schema.ts
@@ -1,18 +1,33 @@
 import { z } from 'zod';
 
 /**
- * One reason something was blocked by a policy check. Mirrors the shape produced by
- * `PolicyEnforcementService` on the backend (`@n8n/decorators`'s `PolicyViolation`) — kept as
- * its own schema here since `@n8n/api-types` is the FE/BE contract and doesn't depend on
- * backend-only packages.
+ * One reason something was blocked by a policy check.
+ *
+ * The same shape is used by the UI, API errors, import reports and the audit log.
+ * `kind`, `subjectType` and `scope` are plain strings rather than enums, so later policy
+ * features can add values without breaking existing readers — which also means readers
+ * must cope with values they don't recognise.
  */
 export const policyViolationSchema = z.object({
+	/** e.g. `'node-type-unavailable'`. Don't assume you know every value. */
 	kind: z.string(),
+
+	/** Id of the check that objected. */
 	checkId: z.string(),
+
+	/** Readable on its own. Don't parse details out of it — use the fields below. */
 	message: z.string(),
+
+	/** What was blocked: a node type name, a credential type name, … */
 	subject: z.string().optional(),
+
+	/** What kind of name `subject` is — node and credential type names can look alike. */
 	subjectType: z.string().optional(),
+
+	/** Which level objected. Usually `'instance'` or `'project'`, but treat it as open. */
 	scope: z.string().optional(),
+
+	/** The rule that decided, if a rule did rather than a fallback default. */
 	matchedRuleId: z.string().optional(),
 });
 

--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { policyViolationSchema } from './policy-violation.schema';
 import { workflowPublishBlockedDetailsSchema } from '../workflow-publish-blocked-details';
 
 const FileTypeSchema = z.enum([
@@ -59,6 +60,8 @@ export const SourceControlledFileSchema = z.object({
 	owner: ResourceOwnerSchema.optional(), // Resource owner can be a personal email or team information
 	publishingError: z.string().optional(),
 	publishingErrorDetails: workflowPublishBlockedDetailsSchema.optional(),
+	/** Advisory only — never blocks the pull. */
+	policyViolations: z.array(policyViolationSchema).optional(),
 });
 
 export type SourceControlledFile = z.infer<typeof SourceControlledFileSchema>;

--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { policyCheckFailureSchema } from './policy-check-failure.schema';
 import { policyViolationSchema } from './policy-violation.schema';
 import { workflowPublishBlockedDetailsSchema } from '../workflow-publish-blocked-details';
 
@@ -62,6 +63,8 @@ export const SourceControlledFileSchema = z.object({
 	publishingErrorDetails: workflowPublishBlockedDetailsSchema.optional(),
 	/** Advisory only — never blocks the pull. */
 	policyViolations: z.array(policyViolationSchema).optional(),
+	/** Checks that failed to run — a violation may have gone undetected. */
+	checkErrors: z.array(policyCheckFailureSchema).optional(),
 });
 
 export type SourceControlledFile = z.infer<typeof SourceControlledFileSchema>;

--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
-import { policyCheckFailureSchema } from './policy-check-failure.schema';
-import { policyViolationSchema } from './policy-violation.schema';
+import { contentImportPolicyResultSchema } from './content-import-policy-result.schema';
 import { workflowPublishBlockedDetailsSchema } from '../workflow-publish-blocked-details';
 
 const FileTypeSchema = z.enum([
@@ -62,9 +61,7 @@ export const SourceControlledFileSchema = z.object({
 	publishingError: z.string().optional(),
 	publishingErrorDetails: workflowPublishBlockedDetailsSchema.optional(),
 	/** Advisory only — never blocks the pull. */
-	policyViolations: z.array(policyViolationSchema).optional(),
-	/** Checks that failed to run — a violation may have gone undetected. */
-	checkErrors: z.array(policyCheckFailureSchema).optional(),
+	contentImportPolicy: contentImportPolicyResultSchema.optional(),
 });
 
 export type SourceControlledFile = z.infer<typeof SourceControlledFileSchema>;

--- a/packages/@n8n/decorators/src/policy-check/policy-check.ts
+++ b/packages/@n8n/decorators/src/policy-check/policy-check.ts
@@ -1,8 +1,8 @@
-import type { PolicyViolation } from '@n8n/api-types';
+import type { PolicyCheckFailure, PolicyViolation } from '@n8n/api-types';
 import type { Constructable } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
 
-export type { PolicyViolation };
+export type { PolicyViolation, PolicyCheckFailure };
 
 /**
  * The points in n8n where a policy can block an action.
@@ -96,12 +96,6 @@ export type PolicyVersionRef = {
 	/** Usually `'instance'` or `'project'`. Open, like {@link PolicyViolation.scope}. */
 	scope: string;
 	version: number;
-};
-
-/** A check that failed to run. Deliberately vague — error details stay server-side. */
-export type PolicyCheckFailure = {
-	checkId: string;
-	correlationId: string;
 };
 
 /**

--- a/packages/@n8n/decorators/src/policy-check/policy-check.ts
+++ b/packages/@n8n/decorators/src/policy-check/policy-check.ts
@@ -1,5 +1,8 @@
+import type { PolicyViolation } from '@n8n/api-types';
 import type { Constructable } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
+
+export type { PolicyViolation };
 
 /**
  * The points in n8n where a policy can block an action.
@@ -86,37 +89,6 @@ export type CredentialDecryptContext = {
 export type ContentImportContext = {
 	readonly workflow: PolicedWorkflow;
 	readonly projectId: string | null;
-};
-
-/**
- * One reason something was blocked.
- *
- * The same shape is used by the UI, API errors, import reports and the audit log.
- * `kind`, `subjectType` and `scope` are plain strings rather than enums, so later policy
- * features can add values without breaking existing readers — which also means readers
- * must cope with values they don't recognise.
- */
-export type PolicyViolation = {
-	/** e.g. `'node-type-unavailable'`. Don't assume you know every value. */
-	kind: string;
-
-	/** Id of the check that objected. */
-	checkId: string;
-
-	/** Readable on its own. Don't parse details out of it — use the fields below. */
-	message: string;
-
-	/** What was blocked: a node type name, a credential type name, … */
-	subject?: string;
-
-	/** What kind of name `subject` is — node and credential type names can look alike. */
-	subjectType?: string;
-
-	/** Which level objected. Usually `'instance'` or `'project'`, but treat it as open. */
-	scope?: string;
-
-	/** The rule that decided, if a rule did rather than a fallback default. */
-	matchedRuleId?: string;
 };
 
 /** A policy version a check read, recorded on the audit log. */

--- a/packages/cli/src/commands/import/__tests__/workflow.test.ts
+++ b/packages/cli/src/commands/import/__tests__/workflow.test.ts
@@ -78,4 +78,55 @@ describe('ImportWorkflowsCommand', () => {
 	test('needs the expression engine', () => {
 		expect(new ImportWorkflowsCommand().needsExpressionEngine).toBe(true);
 	});
+
+	describe('logContentImportViolations', () => {
+		const buildCommandWithLoggerSpy = () => {
+			const command = new ImportWorkflowsCommand();
+			const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+			// @ts-expect-error Protected property
+			command.logger = logger;
+			return { command, logger };
+		};
+
+		it('logs a warning per workflow with violations', () => {
+			const { command, logger } = buildCommandWithLoggerSpy();
+			const violation = { kind: 'node-type-unavailable', checkId: 'test.check', message: 'nope' };
+
+			// @ts-expect-error Private method
+			command.logContentImportViolations([
+				{ workflowId: '1', name: 'Flagged', violations: [violation], checkErrors: [] },
+			]);
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Workflow "Flagged" has 1 content-import policy violation(s)',
+				{ violations: [violation] },
+			);
+		});
+
+		it('logs a warning per workflow with a check that failed to run', () => {
+			const { command, logger } = buildCommandWithLoggerSpy();
+			const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
+
+			// @ts-expect-error Private method
+			command.logContentImportViolations([
+				{ workflowId: '1', name: 'Flaky', violations: [], checkErrors: [checkFailure] },
+			]);
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Workflow "Flaky" has 1 content-import policy check(s) that failed to run',
+				{ checkErrors: [checkFailure] },
+			);
+		});
+
+		it('does not log when there are no violations or check errors', () => {
+			const { command, logger } = buildCommandWithLoggerSpy();
+
+			// @ts-expect-error Private method
+			command.logContentImportViolations([
+				{ workflowId: '1', name: 'Clean', violations: [], checkErrors: [] },
+			]);
+
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/cli/src/commands/import/__tests__/workflow.test.ts
+++ b/packages/cli/src/commands/import/__tests__/workflow.test.ts
@@ -94,7 +94,11 @@ describe('ImportWorkflowsCommand', () => {
 
 			// @ts-expect-error Private method
 			command.logContentImportViolations([
-				{ workflowId: '1', name: 'Flagged', violations: [violation], checkErrors: [] },
+				{
+					workflowId: '1',
+					name: 'Flagged',
+					contentImportPolicy: { violations: [violation], checkErrors: [] },
+				},
 			]);
 
 			expect(logger.warn).toHaveBeenCalledWith(
@@ -109,7 +113,11 @@ describe('ImportWorkflowsCommand', () => {
 
 			// @ts-expect-error Private method
 			command.logContentImportViolations([
-				{ workflowId: '1', name: 'Flaky', violations: [], checkErrors: [checkFailure] },
+				{
+					workflowId: '1',
+					name: 'Flaky',
+					contentImportPolicy: { violations: [], checkErrors: [checkFailure] },
+				},
 			]);
 
 			expect(logger.warn).toHaveBeenCalledWith(
@@ -123,7 +131,11 @@ describe('ImportWorkflowsCommand', () => {
 
 			// @ts-expect-error Private method
 			command.logContentImportViolations([
-				{ workflowId: '1', name: 'Clean', violations: [], checkErrors: [] },
+				{
+					workflowId: '1',
+					name: 'Clean',
+					contentImportPolicy: { violations: [], checkErrors: [] },
+				},
 			]);
 
 			expect(logger.warn).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -151,9 +151,19 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 
 		this.logger.info(`Importing ${workflows.length} workflows...`);
 
-		await Container.get(ImportService).importWorkflows(workflows, project.id, userId, {
-			activeState: flags.activeState,
-		});
+		const { violations } = await Container.get(ImportService).importWorkflows(
+			workflows,
+			project.id,
+			userId,
+			{ activeState: flags.activeState },
+		);
+
+		for (const { name, violations: workflowViolations } of violations) {
+			this.logger.warn(
+				`Workflow "${name}" has ${workflowViolations.length} content-import policy violation(s)`,
+				{ violations: workflowViolations },
+			);
+		}
 
 		this.reportSuccess(workflows.length);
 

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -223,17 +223,17 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 	}
 
 	private logContentImportViolations(violations: WorkflowImportViolations[]) {
-		for (const { name, violations: workflowViolations, checkErrors } of violations) {
-			if (workflowViolations.length) {
+		for (const { name, contentImportPolicy } of violations) {
+			if (contentImportPolicy.violations.length) {
 				this.logger.warn(
-					`Workflow "${name}" has ${workflowViolations.length} content-import policy violation(s)`,
-					{ violations: workflowViolations },
+					`Workflow "${name}" has ${contentImportPolicy.violations.length} content-import policy violation(s)`,
+					{ violations: contentImportPolicy.violations },
 				);
 			}
-			if (checkErrors.length) {
+			if (contentImportPolicy.checkErrors.length) {
 				this.logger.warn(
-					`Workflow "${name}" has ${checkErrors.length} content-import policy check(s) that failed to run`,
-					{ checkErrors },
+					`Workflow "${name}" has ${contentImportPolicy.checkErrors.length} content-import policy check(s) that failed to run`,
+					{ checkErrors: contentImportPolicy.checkErrors },
 				);
 			}
 		}

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -158,11 +158,19 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 			{ activeState: flags.activeState },
 		);
 
-		for (const { name, violations: workflowViolations } of violations) {
-			this.logger.warn(
-				`Workflow "${name}" has ${workflowViolations.length} content-import policy violation(s)`,
-				{ violations: workflowViolations },
-			);
+		for (const { name, violations: workflowViolations, checkErrors } of violations) {
+			if (workflowViolations.length) {
+				this.logger.warn(
+					`Workflow "${name}" has ${workflowViolations.length} content-import policy violation(s)`,
+					{ violations: workflowViolations },
+				);
+			}
+			if (checkErrors.length) {
+				this.logger.warn(
+					`Workflow "${name}" has ${checkErrors.length} content-import policy check(s) that failed to run`,
+					{ checkErrors },
+				);
+			}
 		}
 
 		this.reportSuccess(workflows.length);

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -18,7 +18,7 @@ import { z } from 'zod';
 import { UM_FIX_INSTRUCTION } from '@/constants';
 import { EventService } from '@/events/event.service';
 import type { IWorkflowToImport, IWorkflowWithVersionMetadata } from '@/interfaces';
-import { ImportService } from '@/services/import.service';
+import { ImportService, type WorkflowImportViolations } from '@/services/import.service';
 
 import { BaseCommand } from '../base-command';
 
@@ -158,20 +158,7 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 			{ activeState: flags.activeState },
 		);
 
-		for (const { name, violations: workflowViolations, checkErrors } of violations) {
-			if (workflowViolations.length) {
-				this.logger.warn(
-					`Workflow "${name}" has ${workflowViolations.length} content-import policy violation(s)`,
-					{ violations: workflowViolations },
-				);
-			}
-			if (checkErrors.length) {
-				this.logger.warn(
-					`Workflow "${name}" has ${checkErrors.length} content-import policy check(s) that failed to run`,
-					{ checkErrors },
-				);
-			}
-		}
+		this.logContentImportViolations(violations);
 
 		this.reportSuccess(workflows.length);
 
@@ -233,6 +220,23 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 
 	private reportSuccess(total: number) {
 		this.logger.info(`Successfully imported ${total} ${total === 1 ? 'workflow.' : 'workflows.'}`);
+	}
+
+	private logContentImportViolations(violations: WorkflowImportViolations[]) {
+		for (const { name, violations: workflowViolations, checkErrors } of violations) {
+			if (workflowViolations.length) {
+				this.logger.warn(
+					`Workflow "${name}" has ${workflowViolations.length} content-import policy violation(s)`,
+					{ violations: workflowViolations },
+				);
+			}
+			if (checkErrors.length) {
+				this.logger.warn(
+					`Workflow "${name}" has ${checkErrors.length} content-import policy check(s) that failed to run`,
+					{ checkErrors },
+				);
+			}
+		}
 	}
 
 	private async getWorkflowOwner(workflowId: WorkflowId) {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -1749,6 +1749,20 @@ describe('SourceControlImportService', () => {
 				expect(result[0]).not.toHaveProperty('policyViolations');
 				expect(workflowRepository.upsert).toHaveBeenCalled();
 			});
+
+			it('attaches a failed check to the pull result alongside violations', async () => {
+				const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
+				policyEnforcementService.evaluateContentImport.mockResolvedValueOnce({
+					violations: [],
+					checkErrors: [checkFailure],
+				});
+				const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: '1' })];
+
+				const result = await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+				expect(result).toEqual([expect.objectContaining({ id: '1', checkErrors: [checkFailure] })]);
+				expect(workflowRepository.upsert).toHaveBeenCalled();
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -1,5 +1,6 @@
 import type { SourceControlledFile } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
+import type { PolicyViolation } from '@n8n/decorators';
 import {
 	type Variables,
 	type VariablesRepository,
@@ -1653,6 +1654,98 @@ describe('SourceControlImportService', () => {
 
 				await service.importWorkflowFromWorkFolder(candidates, mockUserId);
 
+				expect(workflowRepository.upsert).toHaveBeenCalled();
+			});
+		});
+
+		describe('content-import policy enforcement', () => {
+			const mockUserId = 'user-id-123';
+			const mockWorkflowFile = '/mock/workflow1.json';
+			const mockWorkflowData = {
+				id: '1',
+				name: 'Workflow 1',
+				active: false,
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Node 1',
+						type: 'n8n-nodes-base.noOp',
+						typeVersion: 1,
+						position: [0, 0],
+						parameters: {},
+					},
+				],
+				connections: {},
+				versionId: 'v1',
+				parentFolderId: null,
+				nodeGroups: [],
+			};
+
+			beforeEach(() => {
+				projectRepository.getPersonalProjectForUserOrFail.mockResolvedValue(
+					Object.assign(new Project(), {
+						id: 'personal-project-id-123',
+						name: 'Personal Project',
+						type: 'personal',
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					}),
+				);
+				workflowRepository.findByIds.mockResolvedValue([]);
+				folderRepository.find.mockResolvedValue([]);
+				sharedWorkflowRepository.findWithFields.mockResolvedValue([]);
+				workflowRepository.upsert.mockResolvedValue({
+					identifiers: [{ id: '1' }],
+					generatedMaps: [],
+					raw: [],
+				});
+				fsReadFile.mockResolvedValueOnce(JSON.stringify(mockWorkflowData));
+			});
+
+			it('evaluates content-import policy for the imported workflow, against the resolved target project', async () => {
+				const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: '1' })];
+
+				await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+				expect(policyEnforcementService.evaluateContentImport).toHaveBeenCalledWith({
+					workflow: {
+						id: mockWorkflowData.id,
+						name: mockWorkflowData.name,
+						nodes: mockWorkflowData.nodes,
+					},
+					projectId: 'personal-project-id-123',
+				});
+			});
+
+			it('attaches violations to the pull result without failing the import', async () => {
+				const violation: PolicyViolation = {
+					kind: 'node-type-unavailable',
+					checkId: 'test.check',
+					message: 'not allowed',
+				};
+				policyEnforcementService.evaluateContentImport.mockResolvedValueOnce({
+					violations: [violation],
+				});
+				const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: '1' })];
+
+				const result = await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+				expect(result).toEqual([
+					expect.objectContaining({ id: '1', policyViolations: [violation] }),
+				]);
+				expect(workflowRepository.upsert).toHaveBeenCalled();
+			});
+
+			it('does not fail the pull when evaluateContentImport throws', async () => {
+				policyEnforcementService.evaluateContentImport.mockRejectedValueOnce(
+					new Error('backend unavailable'),
+				);
+				const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: '1' })];
+
+				const result = await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+				expect(result).toEqual([{ id: '1', name: mockWorkflowFile }]);
+				expect(result[0]).not.toHaveProperty('policyViolations');
 				expect(workflowRepository.upsert).toHaveBeenCalled();
 			});
 		});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -1732,7 +1732,10 @@ describe('SourceControlImportService', () => {
 				const result = await service.importWorkflowFromWorkFolder(candidates, mockUserId);
 
 				expect(result).toEqual([
-					expect.objectContaining({ id: '1', policyViolations: [violation] }),
+					expect.objectContaining({
+						id: '1',
+						contentImportPolicy: { violations: [violation], checkErrors: [] },
+					}),
 				]);
 				expect(workflowRepository.upsert).toHaveBeenCalled();
 			});
@@ -1746,7 +1749,7 @@ describe('SourceControlImportService', () => {
 				const result = await service.importWorkflowFromWorkFolder(candidates, mockUserId);
 
 				expect(result).toEqual([{ id: '1', name: mockWorkflowFile }]);
-				expect(result[0]).not.toHaveProperty('policyViolations');
+				expect(result[0]).not.toHaveProperty('contentImportPolicy');
 				expect(workflowRepository.upsert).toHaveBeenCalled();
 			});
 
@@ -1760,7 +1763,12 @@ describe('SourceControlImportService', () => {
 
 				const result = await service.importWorkflowFromWorkFolder(candidates, mockUserId);
 
-				expect(result).toEqual([expect.objectContaining({ id: '1', checkErrors: [checkFailure] })]);
+				expect(result).toEqual([
+					expect.objectContaining({
+						id: '1',
+						contentImportPolicy: { violations: [], checkErrors: [checkFailure] },
+					}),
+				]);
 				expect(workflowRepository.upsert).toHaveBeenCalled();
 			});
 		});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -85,6 +85,7 @@ describe('SourceControlImportService', () => {
 	const dataTableDDLService = mock<DataTableDDLService>();
 	const redactionEnforcementService = mock<RedactionEnforcementService>();
 	const policyEnforcementService = mock<PolicyEnforcementService>();
+	policyEnforcementService.hasChecksFor.mockReturnValue(true);
 	policyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
 	const dataTableSizeValidator = mock<DataTableSizeValidator>();
 	const activeWorkflowManager = mock<ActiveWorkflowManager>();

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -41,6 +41,7 @@ import type { DataTableDDLService } from '@/modules/data-table/data-table-ddl.se
 import type { DataTableSizeValidator } from '@/modules/data-table/data-table-size-validator.service';
 import type { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import type { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import type { WorkflowMutationHooksProxy } from '@/workflows/workflow-mutation-hooks-proxy.service';
 import type { WorkflowPublishGuardProxy } from '@/workflows/workflow-publish-guard-proxy.service';
@@ -82,6 +83,8 @@ describe('SourceControlImportService', () => {
 	const dataTableColumnRepository = mock<DataTableColumnRepository>();
 	const dataTableDDLService = mock<DataTableDDLService>();
 	const redactionEnforcementService = mock<RedactionEnforcementService>();
+	const policyEnforcementService = mock<PolicyEnforcementService>();
+	policyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
 	const dataTableSizeValidator = mock<DataTableSizeValidator>();
 	const activeWorkflowManager = mock<ActiveWorkflowManager>();
 	const executionPersistence = mock<ExecutionPersistence>();
@@ -125,6 +128,7 @@ describe('SourceControlImportService', () => {
 		dataTableColumnRepository,
 		dataTableDDLService,
 		redactionEnforcementService,
+		policyEnforcementService,
 		dataTableSizeValidator,
 		activeWorkflowManager,
 		executionPersistence,

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -584,6 +584,35 @@ describe('SourceControlService', () => {
 			});
 		});
 
+		it('adds a failed content-import policy check to the pull result', async () => {
+			const user = mock<User>({ id: 'user-1' });
+			const workflowStatus = mock<SourceControlledFile>({
+				id: 'workflow-1',
+				type: 'workflow',
+				status: 'modified',
+				location: 'remote',
+				conflict: false,
+			});
+			mockStatusService.getStatus.mockResolvedValueOnce([workflowStatus]);
+			sourceControlImportService.importWorkflowFromWorkFolder.mockResolvedValue([
+				{
+					id: 'workflow-1',
+					name: 'workflow-1.json',
+					publishingError: undefined,
+					checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+				},
+			]);
+
+			const result = await sourceControlService.pullWorkfolder(user, {
+				force: true,
+				autoPublish: 'none',
+			});
+
+			expect(result.statusResult[0]).toMatchObject({
+				checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+			});
+		});
+
 		it('does not filter locally created credentials', async () => {
 			// ARRANGE
 			const user = mock<User>();

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -551,6 +551,38 @@ describe('SourceControlService', () => {
 			});
 		});
 
+		it('adds content-import policy violations to the pull result', async () => {
+			const user = mock<User>({ id: 'user-1' });
+			const workflowStatus = mock<SourceControlledFile>({
+				id: 'workflow-1',
+				type: 'workflow',
+				status: 'modified',
+				location: 'remote',
+				conflict: false,
+			});
+			mockStatusService.getStatus.mockResolvedValueOnce([workflowStatus]);
+			sourceControlImportService.importWorkflowFromWorkFolder.mockResolvedValue([
+				{
+					id: 'workflow-1',
+					name: 'workflow-1.json',
+					policyViolations: [
+						{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
+					],
+				},
+			]);
+
+			const result = await sourceControlService.pullWorkfolder(user, {
+				force: true,
+				autoPublish: 'none',
+			});
+
+			expect(result.statusResult[0]).toMatchObject({
+				policyViolations: [
+					{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
+				],
+			});
+		});
+
 		it('does not filter locally created credentials', async () => {
 			// ARRANGE
 			const user = mock<User>();

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -565,6 +565,7 @@ describe('SourceControlService', () => {
 				{
 					id: 'workflow-1',
 					name: 'workflow-1.json',
+					publishingError: undefined,
 					policyViolations: [
 						{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
 					],

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -566,9 +566,12 @@ describe('SourceControlService', () => {
 					id: 'workflow-1',
 					name: 'workflow-1.json',
 					publishingError: undefined,
-					policyViolations: [
-						{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
-					],
+					contentImportPolicy: {
+						violations: [
+							{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
+						],
+						checkErrors: [],
+					},
 				},
 			]);
 
@@ -578,9 +581,12 @@ describe('SourceControlService', () => {
 			});
 
 			expect(result.statusResult[0]).toMatchObject({
-				policyViolations: [
-					{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
-				],
+				contentImportPolicy: {
+					violations: [
+						{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
+					],
+					checkErrors: [],
+				},
 			});
 		});
 
@@ -599,7 +605,10 @@ describe('SourceControlService', () => {
 					id: 'workflow-1',
 					name: 'workflow-1.json',
 					publishingError: undefined,
-					checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+					contentImportPolicy: {
+						violations: [],
+						checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+					},
 				},
 			]);
 
@@ -609,7 +618,10 @@ describe('SourceControlService', () => {
 			});
 
 			expect(result.statusResult[0]).toMatchObject({
-				checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+				contentImportPolicy: {
+					violations: [],
+					checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+				},
 			});
 		});
 
@@ -626,10 +638,12 @@ describe('SourceControlService', () => {
 						reason: 'review_pending',
 						workflowReviewRequestId: 'review-1',
 					},
-					policyViolations: [
-						{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
-					],
-					checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+					contentImportPolicy: {
+						violations: [
+							{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
+						],
+						checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+					},
 				},
 			]);
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -613,6 +613,31 @@ describe('SourceControlService', () => {
 			});
 		});
 
+		it('logs violations, check errors and publishing errors for a workflow with no matching status entry, without throwing', async () => {
+			const user = mock<User>({ id: 'user-1' });
+			// No matching SourceControlledFile for 'workflow-missing' in the status result.
+			mockStatusService.getStatus.mockResolvedValueOnce([]);
+			sourceControlImportService.importWorkflowFromWorkFolder.mockResolvedValue([
+				{
+					id: 'workflow-missing',
+					name: 'workflow-missing.json',
+					publishingError: 'Workflow review is open',
+					publishingErrorDetails: {
+						reason: 'review_pending',
+						workflowReviewRequestId: 'review-1',
+					},
+					policyViolations: [
+						{ kind: 'node-type-unavailable', checkId: 'test.check', message: 'not allowed' },
+					],
+					checkErrors: [{ checkId: 'test.check', correlationId: 'corr-1' }],
+				},
+			]);
+
+			await expect(
+				sourceControlService.pullWorkfolder(user, { force: true, autoPublish: 'none' }),
+			).resolves.not.toThrow();
+		});
+
 		it('does not filter locally created credentials', async () => {
 			// ARRANGE
 			const user = mock<User>();

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -1,6 +1,5 @@
 import type { SourceControlledFile, WorkflowPublishBlockedDetails } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import type { ContentImportContext } from '@n8n/decorators';
 import type {
 	FindOptionsWhere,
 	Folder,
@@ -51,6 +50,7 @@ import { DataTable } from '@/modules/data-table/data-table.entity';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { isValidColumnName, isValidDataTableId } from '@/modules/data-table/utils/sql-utils';
 import { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
+import { evaluateContentImportSafely } from '@/policy/evaluate-content-import-safely';
 import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { isUniqueConstraintError } from '@/response-helper';
 import { TagService } from '@/services/tag.service';
@@ -899,23 +899,20 @@ export class SourceControlImportService {
 			(w) => w.workflowId === id && w.role === 'workflow:owner',
 		);
 
-		// Resolved once and reused, so ownership sync and the policy context below always agree.
-		const targetOwnerProject = await this.resolveTargetOwnerProject(owner, personalProject);
-
-		await this.syncResourceOwnership({
+		const targetOwnerProject = await this.syncResourceOwnership({
 			resourceId: id,
 			remoteOwner: owner,
 			localOwner,
 			fallbackProject: personalProject,
 			repository: this.sharedWorkflowRepository,
-			targetOwnerProject,
 		});
 
 		// Advisory only — never blocks the pull, per contentImport being `evaluate`, not `enforce`.
-		const policyViolations = await this.evaluateContentImportSafely({
-			workflow: { id, name: importedWorkflow.name, nodes },
-			projectId: targetOwnerProject.id,
-		});
+		const policyViolations = await evaluateContentImportSafely(
+			this.policyEnforcementService,
+			{ workflow: { id, name: importedWorkflow.name, nodes }, projectId: targetOwnerProject.id },
+			this.logger,
+		);
 
 		// Now publish the workflow if needed (after history is saved)
 		if (shouldPublishAfterImport) {
@@ -935,26 +932,6 @@ export class SourceControlImportService {
 			}),
 			...(policyViolations.length && { policyViolations }),
 		};
-	}
-
-	/**
-	 * `evaluateContentImport` is advisory and documented to never throw, but a pull must never
-	 * fail because of policy regardless — so an unexpected error here is swallowed and treated
-	 * as no violations rather than aborting the pull.
-	 */
-	private async evaluateContentImportSafely(context: ContentImportContext) {
-		try {
-			const { violations } = await this.policyEnforcementService.evaluateContentImport(context);
-			return violations;
-		} catch (error) {
-			this.logger.warn(
-				`Failed to evaluate content-import policy for workflow ${context.workflow.id}`,
-				{
-					error: ensureError(error),
-				},
-			);
-			return [];
-		}
 	}
 
 	private async parseWorkflowFromFile(file: string): Promise<IWorkflowToImport> {
@@ -1987,7 +1964,7 @@ export class SourceControlImportService {
 		repository: SharedWorkflowRepository | SharedCredentialsRepository;
 		transactionManager?: EntityManager;
 		targetOwnerProject?: Project;
-	}): Promise<void> {
+	}): Promise<Project> {
 		targetOwnerProject ??= await this.resolveTargetOwnerProject(remoteOwner, fallbackProject);
 
 		const trx = transactionManager ?? this.workflowRepository.manager;
@@ -2000,6 +1977,8 @@ export class SourceControlImportService {
 
 		// Set new ownership
 		await repository.makeOwner([resourceId], targetOwnerProject.id, trx);
+
+		return targetOwnerProject;
 	}
 
 	private async resolveTargetOwnerProject(

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -908,7 +908,7 @@ export class SourceControlImportService {
 		});
 
 		// Advisory only — never blocks the pull, per contentImport being `evaluate`, not `enforce`.
-		const { violations: policyViolations, checkErrors } = await evaluateContentImportSafely(
+		const contentImportPolicy = await evaluateContentImportSafely(
 			this.policyEnforcementService,
 			{ workflow: { id, name: importedWorkflow.name, nodes }, projectId: targetOwnerProject.id },
 			this.logger,
@@ -930,8 +930,9 @@ export class SourceControlImportService {
 			...(finalPublishingErrorDetails && {
 				publishingErrorDetails: finalPublishingErrorDetails,
 			}),
-			...(policyViolations.length && { policyViolations }),
-			...(checkErrors.length && { checkErrors }),
+			...((contentImportPolicy.violations.length || contentImportPolicy.checkErrors.length) && {
+				contentImportPolicy,
+			}),
 		};
 	}
 

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -908,7 +908,7 @@ export class SourceControlImportService {
 		});
 
 		// Advisory only — never blocks the pull, per contentImport being `evaluate`, not `enforce`.
-		const policyViolations = await evaluateContentImportSafely(
+		const { violations: policyViolations, checkErrors } = await evaluateContentImportSafely(
 			this.policyEnforcementService,
 			{ workflow: { id, name: importedWorkflow.name, nodes }, projectId: targetOwnerProject.id },
 			this.logger,
@@ -931,6 +931,7 @@ export class SourceControlImportService {
 				publishingErrorDetails: finalPublishingErrorDetails,
 			}),
 			...(policyViolations.length && { policyViolations }),
+			...(checkErrors.length && { checkErrors }),
 		};
 	}
 

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -1,5 +1,6 @@
 import type { SourceControlledFile, WorkflowPublishBlockedDetails } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
+import type { ContentImportContext } from '@n8n/decorators';
 import type {
 	FindOptionsWhere,
 	Folder,
@@ -50,6 +51,7 @@ import { DataTable } from '@/modules/data-table/data-table.entity';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { isValidColumnName, isValidDataTableId } from '@/modules/data-table/utils/sql-utils';
 import { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { isUniqueConstraintError } from '@/response-helper';
 import { TagService } from '@/services/tag.service';
 import { assertNever } from '@/utils';
@@ -150,6 +152,7 @@ export class SourceControlImportService {
 		private readonly dataTableColumnRepository: DataTableColumnRepository,
 		private readonly dataTableDDLService: DataTableDDLService,
 		private readonly redactionEnforcementService: RedactionEnforcementService,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 		private readonly dataTableSizeValidator: DataTableSizeValidator,
 		private readonly activeWorkflowManager: ActiveWorkflowManager,
 		private readonly executionPersistence: ExecutionPersistence,
@@ -896,12 +899,22 @@ export class SourceControlImportService {
 			(w) => w.workflowId === id && w.role === 'workflow:owner',
 		);
 
+		// Resolved once and reused, so ownership sync and the policy context below always agree.
+		const targetOwnerProject = await this.resolveTargetOwnerProject(owner, personalProject);
+
 		await this.syncResourceOwnership({
 			resourceId: id,
 			remoteOwner: owner,
 			localOwner,
 			fallbackProject: personalProject,
 			repository: this.sharedWorkflowRepository,
+			targetOwnerProject,
+		});
+
+		// Advisory only — never blocks the pull, per contentImport being `evaluate`, not `enforce`.
+		const policyViolations = await this.evaluateContentImportSafely({
+			workflow: { id, name: importedWorkflow.name, nodes },
+			projectId: targetOwnerProject.id,
 		});
 
 		// Now publish the workflow if needed (after history is saved)
@@ -920,7 +933,28 @@ export class SourceControlImportService {
 			...(finalPublishingErrorDetails && {
 				publishingErrorDetails: finalPublishingErrorDetails,
 			}),
+			...(policyViolations.length && { policyViolations }),
 		};
+	}
+
+	/**
+	 * `evaluateContentImport` is advisory and documented to never throw, but a pull must never
+	 * fail because of policy regardless — so an unexpected error here is swallowed and treated
+	 * as no violations rather than aborting the pull.
+	 */
+	private async evaluateContentImportSafely(context: ContentImportContext) {
+		try {
+			const { violations } = await this.policyEnforcementService.evaluateContentImport(context);
+			return violations;
+		} catch (error) {
+			this.logger.warn(
+				`Failed to evaluate content-import policy for workflow ${context.workflow.id}`,
+				{
+					error: ensureError(error),
+				},
+			);
+			return [];
+		}
 	}
 
 	private async parseWorkflowFromFile(file: string): Promise<IWorkflowToImport> {

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -583,25 +583,26 @@ export class SourceControlService {
 			id,
 			publishingError,
 			publishingErrorDetails,
-			policyViolations,
-			checkErrors,
+			contentImportPolicy,
 		} of workflowImportResults) {
 			const statusItem = statusByWorkflowId.get(id);
 
-			if (policyViolations?.length) {
+			if (contentImportPolicy?.violations.length) {
 				this.logger.warn(
-					`Workflow ${id} has ${policyViolations.length} content-import policy violation(s)`,
-					{ violations: policyViolations },
+					`Workflow ${id} has ${contentImportPolicy.violations.length} content-import policy violation(s)`,
+					{ violations: contentImportPolicy.violations },
 				);
-				if (statusItem) statusItem.policyViolations = policyViolations;
 			}
 
-			if (checkErrors?.length) {
+			if (contentImportPolicy?.checkErrors.length) {
 				this.logger.warn(
-					`Workflow ${id} has ${checkErrors.length} content-import policy check(s) that failed to run`,
-					{ checkErrors },
+					`Workflow ${id} has ${contentImportPolicy.checkErrors.length} content-import policy check(s) that failed to run`,
+					{ checkErrors: contentImportPolicy.checkErrors },
 				);
-				if (statusItem) statusItem.checkErrors = checkErrors;
+			}
+
+			if (contentImportPolicy && statusItem) {
+				statusItem.contentImportPolicy = contentImportPolicy;
 			}
 
 			if (!publishingError && !publishingErrorDetails) continue;

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -590,6 +590,9 @@ export class SourceControlService {
 					`Workflow ${id} has ${policyViolations.length} content-import policy violation(s)`,
 					{ violations: policyViolations },
 				);
+
+				const statusItem = statusByWorkflowId.get(id);
+				if (statusItem) statusItem.policyViolations = policyViolations;
 			}
 
 			if (!publishingError && !publishingErrorDetails) continue;

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -579,7 +579,19 @@ export class SourceControlService {
 			statusResult.filter((item) => item.type === 'workflow').map((item) => [item.id, item]),
 		);
 
-		for (const { id, publishingError, publishingErrorDetails } of workflowImportResults) {
+		for (const {
+			id,
+			publishingError,
+			publishingErrorDetails,
+			policyViolations,
+		} of workflowImportResults) {
+			if (policyViolations?.length) {
+				this.logger.warn(
+					`Workflow ${id} has ${policyViolations.length} content-import policy violation(s)`,
+					{ violations: policyViolations },
+				);
+			}
+
 			if (!publishingError && !publishingErrorDetails) continue;
 
 			const statusItem = statusByWorkflowId.get(id);

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -584,20 +584,28 @@ export class SourceControlService {
 			publishingError,
 			publishingErrorDetails,
 			policyViolations,
+			checkErrors,
 		} of workflowImportResults) {
+			const statusItem = statusByWorkflowId.get(id);
+
 			if (policyViolations?.length) {
 				this.logger.warn(
 					`Workflow ${id} has ${policyViolations.length} content-import policy violation(s)`,
 					{ violations: policyViolations },
 				);
-
-				const statusItem = statusByWorkflowId.get(id);
 				if (statusItem) statusItem.policyViolations = policyViolations;
+			}
+
+			if (checkErrors?.length) {
+				this.logger.warn(
+					`Workflow ${id} has ${checkErrors.length} content-import policy check(s) that failed to run`,
+					{ checkErrors },
+				);
+				if (statusItem) statusItem.checkErrors = checkErrors;
 			}
 
 			if (!publishingError && !publishingErrorDetails) continue;
 
-			const statusItem = statusByWorkflowId.get(id);
 			if (statusItem) {
 				statusItem.publishingError = publishingError;
 				if (publishingErrorDetails) {

--- a/packages/cli/src/modules/source-control.ee/types/import-result.ts
+++ b/packages/cli/src/modules/source-control.ee/types/import-result.ts
@@ -1,11 +1,14 @@
 import type { WorkflowPublishBlockedDetails } from '@n8n/api-types';
 import type { TagEntity, WorkflowTagMapping } from '@n8n/db';
+import type { PolicyViolation } from '@n8n/decorators';
 
 export interface WorkflowImportResult {
 	id: string;
 	name: string;
 	publishingError?: string;
 	publishingErrorDetails?: WorkflowPublishBlockedDetails;
+	/** Advisory only — never blocks the import. */
+	policyViolations?: PolicyViolation[];
 }
 
 export interface ImportResult {

--- a/packages/cli/src/modules/source-control.ee/types/import-result.ts
+++ b/packages/cli/src/modules/source-control.ee/types/import-result.ts
@@ -1,6 +1,6 @@
 import type { WorkflowPublishBlockedDetails } from '@n8n/api-types';
 import type { TagEntity, WorkflowTagMapping } from '@n8n/db';
-import type { PolicyViolation } from '@n8n/decorators';
+import type { PolicyCheckFailure, PolicyViolation } from '@n8n/decorators';
 
 export interface WorkflowImportResult {
 	id: string;
@@ -9,6 +9,8 @@ export interface WorkflowImportResult {
 	publishingErrorDetails?: WorkflowPublishBlockedDetails;
 	/** Advisory only — never blocks the import. */
 	policyViolations?: PolicyViolation[];
+	/** Checks that failed to run — a violation may have gone undetected. */
+	checkErrors?: PolicyCheckFailure[];
 }
 
 export interface ImportResult {

--- a/packages/cli/src/modules/source-control.ee/types/import-result.ts
+++ b/packages/cli/src/modules/source-control.ee/types/import-result.ts
@@ -1,6 +1,5 @@
-import type { WorkflowPublishBlockedDetails } from '@n8n/api-types';
+import type { ContentImportPolicyResult, WorkflowPublishBlockedDetails } from '@n8n/api-types';
 import type { TagEntity, WorkflowTagMapping } from '@n8n/db';
-import type { PolicyCheckFailure, PolicyViolation } from '@n8n/decorators';
 
 export interface WorkflowImportResult {
 	id: string;
@@ -8,9 +7,7 @@ export interface WorkflowImportResult {
 	publishingError?: string;
 	publishingErrorDetails?: WorkflowPublishBlockedDetails;
 	/** Advisory only — never blocks the import. */
-	policyViolations?: PolicyViolation[];
-	/** Checks that failed to run — a violation may have gone undetected. */
-	checkErrors?: PolicyCheckFailure[];
+	contentImportPolicy?: ContentImportPolicyResult;
 }
 
 export interface ImportResult {

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-lifecycle.integration.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-lifecycle.integration.test.ts
@@ -626,6 +626,7 @@ describe('auto-close on source-control pull', () => {
 			mock(), // dataTableColumnRepository
 			mock(), // dataTableDDLService
 			mock(), // redactionEnforcementService
+			mock(), // policyEnforcementService
 			mock(), // dataTableSizeValidator
 			mock(), // activeWorkflowManager
 			mock(), // executionPersistence

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-lifecycle.integration.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-lifecycle.integration.test.ts
@@ -22,6 +22,7 @@ import { mock } from 'vitest-mock-extended';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { EventService } from '@/events/event.service';
 import { SourceControlImportService } from '@/modules/source-control.ee/source-control-import.service.ee';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import { WorkflowPublicationNotifier } from '@/workflows/publication/workflow-publication-notifier';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -626,7 +627,9 @@ describe('auto-close on source-control pull', () => {
 			mock(), // dataTableColumnRepository
 			mock(), // dataTableDDLService
 			mock(), // redactionEnforcementService
-			mock(), // policyEnforcementService
+			mock<PolicyEnforcementService>({
+				evaluateContentImport: async () => ({ violations: [] }),
+			}), // policyEnforcementService
 			mock(), // dataTableSizeValidator
 			mock(), // activeWorkflowManager
 			mock(), // executionPersistence

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-lifecycle.integration.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-lifecycle.integration.test.ts
@@ -628,6 +628,7 @@ describe('auto-close on source-control pull', () => {
 			mock(), // dataTableDDLService
 			mock(), // redactionEnforcementService
 			mock<PolicyEnforcementService>({
+				hasChecksFor: () => true,
 				evaluateContentImport: async () => ({ violations: [] }),
 			}), // policyEnforcementService
 			mock(), // dataTableSizeValidator

--- a/packages/cli/src/policy/__tests__/evaluate-content-import-safely.test.ts
+++ b/packages/cli/src/policy/__tests__/evaluate-content-import-safely.test.ts
@@ -36,7 +36,7 @@ describe('evaluateContentImportSafely', () => {
 		expect(result).toStrictEqual({ violations: [violation], checkErrors: [] });
 	});
 
-	it('returns and logs checkErrors alongside violations', async () => {
+	it('returns checkErrors alongside violations, without logging them itself', async () => {
 		policyEnforcementService.hasChecksFor.mockReturnValue(true);
 		const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
 		policyEnforcementService.evaluateContentImport.mockResolvedValue({
@@ -47,30 +47,9 @@ describe('evaluateContentImportSafely', () => {
 		const result = await evaluateContentImportSafely(policyEnforcementService, context, logger);
 
 		expect(result).toStrictEqual({ violations: [], checkErrors: [checkFailure] });
-		expect(logger.warn).toHaveBeenCalledWith(
-			'1 content-import policy check(s) failed to run for workflow workflow-1',
-			{ checkErrors: [checkFailure] },
-		);
-	});
-
-	it('falls back to "(new)" in the log message for a workflow with no id yet', async () => {
-		policyEnforcementService.hasChecksFor.mockReturnValue(true);
-		const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
-		policyEnforcementService.evaluateContentImport.mockResolvedValue({
-			violations: [],
-			checkErrors: [checkFailure],
-		});
-		const newWorkflowContext: ContentImportContext = {
-			workflow: { id: null, name: 'Brand New', nodes: [] },
-			projectId: 'project-1',
-		};
-
-		await evaluateContentImportSafely(policyEnforcementService, newWorkflowContext, logger);
-
-		expect(logger.warn).toHaveBeenCalledWith(
-			'1 content-import policy check(s) failed to run for workflow (new)',
-			{ checkErrors: [checkFailure] },
-		);
+		// Reporting is the caller's job — each call site already logs checkErrors itself, so
+		// logging them here too would print every failed check twice.
+		expect(logger.warn).not.toHaveBeenCalled();
 	});
 
 	it('does not fail when evaluateContentImport throws, and logs the error', async () => {

--- a/packages/cli/src/policy/__tests__/evaluate-content-import-safely.test.ts
+++ b/packages/cli/src/policy/__tests__/evaluate-content-import-safely.test.ts
@@ -1,0 +1,108 @@
+import { mock } from 'vitest-mock-extended';
+import type { Logger } from '@n8n/backend-common';
+import type { ContentImportContext } from '@n8n/decorators';
+
+import { evaluateContentImportSafely } from '../evaluate-content-import-safely';
+import type { PolicyEnforcementService } from '../policy-enforcement.service';
+
+describe('evaluateContentImportSafely', () => {
+	const logger = mock<Logger>();
+	const policyEnforcementService = mock<PolicyEnforcementService>();
+	const context: ContentImportContext = {
+		workflow: { id: 'workflow-1', name: 'Test Workflow', nodes: [] },
+		projectId: 'project-1',
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('skips evaluation entirely when nothing is registered for contentImport', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(false);
+
+		const result = await evaluateContentImportSafely(policyEnforcementService, context, logger);
+
+		expect(result).toStrictEqual({ violations: [], checkErrors: [] });
+		expect(policyEnforcementService.evaluateContentImport).not.toHaveBeenCalled();
+	});
+
+	it('returns violations from a clean evaluation', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		const violation = { kind: 'node-type-unavailable', checkId: 'test.check', message: 'nope' };
+		policyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [violation] });
+
+		const result = await evaluateContentImportSafely(policyEnforcementService, context, logger);
+
+		expect(result).toStrictEqual({ violations: [violation], checkErrors: [] });
+	});
+
+	it('returns and logs checkErrors alongside violations', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
+		policyEnforcementService.evaluateContentImport.mockResolvedValue({
+			violations: [],
+			checkErrors: [checkFailure],
+		});
+
+		const result = await evaluateContentImportSafely(policyEnforcementService, context, logger);
+
+		expect(result).toStrictEqual({ violations: [], checkErrors: [checkFailure] });
+		expect(logger.warn).toHaveBeenCalledWith(
+			'1 content-import policy check(s) failed to run for workflow workflow-1',
+			{ checkErrors: [checkFailure] },
+		);
+	});
+
+	it('falls back to "(new)" in the log message for a workflow with no id yet', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
+		policyEnforcementService.evaluateContentImport.mockResolvedValue({
+			violations: [],
+			checkErrors: [checkFailure],
+		});
+		const newWorkflowContext: ContentImportContext = {
+			workflow: { id: null, name: 'Brand New', nodes: [] },
+			projectId: 'project-1',
+		};
+
+		await evaluateContentImportSafely(policyEnforcementService, newWorkflowContext, logger);
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			'1 content-import policy check(s) failed to run for workflow (new)',
+			{ checkErrors: [checkFailure] },
+		);
+	});
+
+	it('does not fail when evaluateContentImport throws, and logs the error', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		policyEnforcementService.evaluateContentImport.mockRejectedValue(
+			new Error('backend unavailable'),
+		);
+
+		const result = await evaluateContentImportSafely(policyEnforcementService, context, logger);
+
+		expect(result).toStrictEqual({ violations: [], checkErrors: [] });
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Content-import policy evaluation failed for workflow workflow-1',
+			{ error: expect.any(Error) },
+		);
+	});
+
+	it('falls back to "(new)" in the failure log message for a workflow with no id yet', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		policyEnforcementService.evaluateContentImport.mockRejectedValue(
+			new Error('backend unavailable'),
+		);
+		const newWorkflowContext: ContentImportContext = {
+			workflow: { id: null, name: 'Brand New', nodes: [] },
+			projectId: 'project-1',
+		};
+
+		await evaluateContentImportSafely(policyEnforcementService, newWorkflowContext, logger);
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Content-import policy evaluation failed for workflow (new)',
+			{ error: expect.any(Error) },
+		);
+	});
+});

--- a/packages/cli/src/policy/evaluate-content-import-safely.ts
+++ b/packages/cli/src/policy/evaluate-content-import-safely.ts
@@ -1,14 +1,9 @@
+import type { ContentImportPolicyResult } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
-import type { ContentImportContext, PolicyCheckFailure, PolicyViolation } from '@n8n/decorators';
+import type { ContentImportContext } from '@n8n/decorators';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 
 import type { PolicyEnforcementService } from './policy-enforcement.service';
-
-export type ContentImportPolicyResult = {
-	violations: PolicyViolation[];
-	/** Checks that failed to run — a violation may have gone undetected. */
-	checkErrors: PolicyCheckFailure[];
-};
 
 /**
  * Evaluates the content-import policy for one artifact, never rejecting: `evaluateContentImport`

--- a/packages/cli/src/policy/evaluate-content-import-safely.ts
+++ b/packages/cli/src/policy/evaluate-content-import-safely.ts
@@ -1,0 +1,37 @@
+import type { Logger } from '@n8n/backend-common';
+import type { ContentImportContext, PolicyViolation } from '@n8n/decorators';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
+
+import type { PolicyEnforcementService } from './policy-enforcement.service';
+
+/**
+ * Evaluates the content-import policy for one artifact, never rejecting: `evaluateContentImport`
+ * is documented to never throw, but an import/pull batch must never fail because of policy
+ * regardless of that guarantee holding, so an unexpected error is logged and treated as no
+ * violations rather than propagated.
+ */
+export async function evaluateContentImportSafely(
+	policyEnforcementService: PolicyEnforcementService,
+	context: ContentImportContext,
+	logger: Logger,
+): Promise<PolicyViolation[]> {
+	try {
+		const { violations, checkErrors } =
+			await policyEnforcementService.evaluateContentImport(context);
+
+		if (checkErrors?.length) {
+			logger.warn(
+				`${checkErrors.length} content-import policy check(s) failed to run for workflow ${context.workflow.id ?? '(new)'}`,
+				{ checkErrors },
+			);
+		}
+
+		return violations;
+	} catch (error) {
+		logger.warn(
+			`Content-import policy evaluation failed for workflow ${context.workflow.id ?? '(new)'}`,
+			{ error: ensureError(error) },
+		);
+		return [];
+	}
+}

--- a/packages/cli/src/policy/evaluate-content-import-safely.ts
+++ b/packages/cli/src/policy/evaluate-content-import-safely.ts
@@ -15,6 +15,10 @@ export async function evaluateContentImportSafely(
 	context: ContentImportContext,
 	logger: Logger,
 ): Promise<PolicyViolation[]> {
+	// A feature that is merely absent must not cost anything — same guard as
+	// PolicyLifecycleHandler.onWorkflowExecuteBefore for `workflowStart`.
+	if (!policyEnforcementService.hasChecksFor('contentImport')) return [];
+
 	try {
 		const { violations, checkErrors } =
 			await policyEnforcementService.evaluateContentImport(context);

--- a/packages/cli/src/policy/evaluate-content-import-safely.ts
+++ b/packages/cli/src/policy/evaluate-content-import-safely.ts
@@ -31,13 +31,7 @@ export async function evaluateContentImportSafely(
 		const { violations, checkErrors = [] } =
 			await policyEnforcementService.evaluateContentImport(context);
 
-		if (checkErrors.length) {
-			logger.warn(
-				`${checkErrors.length} content-import policy check(s) failed to run for workflow ${context.workflow.id ?? '(new)'}`,
-				{ checkErrors },
-			);
-		}
-
+		// Reporting checkErrors (like violations) is the caller's call — it already logs both.
 		return { violations, checkErrors };
 	} catch (error) {
 		logger.warn(

--- a/packages/cli/src/policy/evaluate-content-import-safely.ts
+++ b/packages/cli/src/policy/evaluate-content-import-safely.ts
@@ -1,8 +1,14 @@
 import type { Logger } from '@n8n/backend-common';
-import type { ContentImportContext, PolicyViolation } from '@n8n/decorators';
+import type { ContentImportContext, PolicyCheckFailure, PolicyViolation } from '@n8n/decorators';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 
 import type { PolicyEnforcementService } from './policy-enforcement.service';
+
+export type ContentImportPolicyResult = {
+	violations: PolicyViolation[];
+	/** Checks that failed to run — a violation may have gone undetected. */
+	checkErrors: PolicyCheckFailure[];
+};
 
 /**
  * Evaluates the content-import policy for one artifact, never rejecting: `evaluateContentImport`
@@ -14,28 +20,30 @@ export async function evaluateContentImportSafely(
 	policyEnforcementService: PolicyEnforcementService,
 	context: ContentImportContext,
 	logger: Logger,
-): Promise<PolicyViolation[]> {
+): Promise<ContentImportPolicyResult> {
 	// A feature that is merely absent must not cost anything — same guard as
 	// PolicyLifecycleHandler.onWorkflowExecuteBefore for `workflowStart`.
-	if (!policyEnforcementService.hasChecksFor('contentImport')) return [];
+	if (!policyEnforcementService.hasChecksFor('contentImport')) {
+		return { violations: [], checkErrors: [] };
+	}
 
 	try {
-		const { violations, checkErrors } =
+		const { violations, checkErrors = [] } =
 			await policyEnforcementService.evaluateContentImport(context);
 
-		if (checkErrors?.length) {
+		if (checkErrors.length) {
 			logger.warn(
 				`${checkErrors.length} content-import policy check(s) failed to run for workflow ${context.workflow.id ?? '(new)'}`,
 				{ checkErrors },
 			);
 		}
 
-		return violations;
+		return { violations, checkErrors };
 	} catch (error) {
 		logger.warn(
 			`Content-import policy evaluation failed for workflow ${context.workflow.id ?? '(new)'}`,
 			{ error: ensureError(error) },
 		);
-		return [];
+		return { violations: [], checkErrors: [] };
 	}
 }

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -1,6 +1,11 @@
 import type { Mock } from 'vitest';
 import { safeJoinPath, type Logger } from '@n8n/backend-common';
-import type { CredentialsRepository, TagRepository, UserRepository } from '@n8n/db';
+import type {
+	CredentialsRepository,
+	SharedWorkflowRepository,
+	TagRepository,
+	UserRepository,
+} from '@n8n/db';
 import { type DataSource, type EntityManager } from '@n8n/typeorm';
 import { readdir, readFile } from 'fs/promises';
 import { mock } from 'vitest-mock-extended';
@@ -49,6 +54,7 @@ describe('ImportService', () => {
 	let mockUserRepository: UserRepository;
 	let mockWorkflowService: WorkflowService;
 	let mockPolicyEnforcementService: PolicyEnforcementService;
+	let mockSharedWorkflowRepository: SharedWorkflowRepository;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -67,6 +73,10 @@ describe('ImportService', () => {
 		mockPolicyEnforcementService.evaluateContentImport = vi
 			.fn()
 			.mockResolvedValue({ violations: [] });
+		mockSharedWorkflowRepository = mock<SharedWorkflowRepository>();
+		mockSharedWorkflowRepository.findOwnerProjectsByWorkflowIds = vi
+			.fn()
+			.mockResolvedValue(new Map());
 
 		// Set up cipher mock
 		mockCipher.decryptV2 = vi.fn(async (data: string) =>
@@ -121,6 +131,7 @@ describe('ImportService', () => {
 			mockUserRepository,
 			mockWorkflowService,
 			mockPolicyEnforcementService,
+			mockSharedWorkflowRepository,
 		);
 	});
 

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -70,6 +70,7 @@ describe('ImportService', () => {
 		mockUserRepository = mock<UserRepository>();
 		mockWorkflowService = mock<WorkflowService>();
 		mockPolicyEnforcementService = mock<PolicyEnforcementService>();
+		mockPolicyEnforcementService.hasChecksFor = vi.fn().mockReturnValue(true);
 		mockPolicyEnforcementService.evaluateContentImport = vi
 			.fn()
 			.mockResolvedValue({ violations: [] });

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -8,6 +8,7 @@ import type { Cipher } from 'n8n-core';
 
 import type { DataTableDDLService } from '@/modules/data-table/data-table-ddl.service';
 import type { WorkflowIndexService } from '@/modules/workflow-index/workflow-index.service';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { WorkflowService } from '@/workflows/workflow.service';
 
 import { ImportService } from '../import.service';
@@ -47,6 +48,7 @@ describe('ImportService', () => {
 	let mockDataTableDDLService: DataTableDDLService;
 	let mockUserRepository: UserRepository;
 	let mockWorkflowService: WorkflowService;
+	let mockPolicyEnforcementService: PolicyEnforcementService;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -61,6 +63,10 @@ describe('ImportService', () => {
 		mockDataTableDDLService = mock<DataTableDDLService>();
 		mockUserRepository = mock<UserRepository>();
 		mockWorkflowService = mock<WorkflowService>();
+		mockPolicyEnforcementService = mock<PolicyEnforcementService>();
+		mockPolicyEnforcementService.evaluateContentImport = vi
+			.fn()
+			.mockResolvedValue({ violations: [] });
 
 		// Set up cipher mock
 		mockCipher.decryptV2 = vi.fn(async (data: string) =>
@@ -114,6 +120,7 @@ describe('ImportService', () => {
 			mockDataTableDDLService,
 			mockUserRepository,
 			mockWorkflowService,
+			mockPolicyEnforcementService,
 		);
 	});
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -1,5 +1,5 @@
 import { Logger, safeJoinPath } from '@n8n/backend-common';
-import type { PolicyCheckFailure, PolicyViolation } from '@n8n/decorators';
+import type { ContentImportPolicyResult } from '@n8n/api-types';
 import type { TagEntity, ICredentialsDb, User } from '@n8n/db';
 import {
 	Project,
@@ -44,13 +44,11 @@ import { WorkflowService } from '@/workflows/workflow.service';
 
 const DATA_TABLE_ROWS_FILE_PREFIX = 'data_table_user_';
 
-/** Advisory policy violations found for one imported workflow, never blocking the import. */
+/** Advisory content-import policy result for one imported workflow, never blocking the import. */
 export interface WorkflowImportViolations {
 	workflowId: string | null;
 	name: string;
-	violations: PolicyViolation[];
-	/** Checks that failed to run — a violation may have gone undetected. */
-	checkErrors: PolicyCheckFailure[];
+	contentImportPolicy: ContentImportPolicyResult;
 }
 
 @Service()
@@ -165,7 +163,7 @@ export class ImportService {
 			const evaluationProjectId = workflow.id
 				? (existingOwnerProjects.get(workflow.id)?.id ?? projectId)
 				: projectId;
-			const { violations: workflowViolations, checkErrors } = await evaluateContentImportSafely(
+			const contentImportPolicy = await evaluateContentImportSafely(
 				this.policyEnforcementService,
 				{
 					workflow: { id: workflow.id ?? null, name: workflow.name, nodes: workflow.nodes },
@@ -173,12 +171,11 @@ export class ImportService {
 				},
 				this.logger,
 			);
-			if (workflowViolations.length || checkErrors.length) {
+			if (contentImportPolicy.violations.length || contentImportPolicy.checkErrors.length) {
 				violations.push({
 					workflowId: workflow.id ?? null,
 					name: workflow.name,
-					violations: workflowViolations,
-					checkErrors,
+					contentImportPolicy,
 				});
 			}
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -5,6 +5,7 @@ import {
 	Project,
 	WorkflowEntity,
 	SharedWorkflow,
+	SharedWorkflowRepository,
 	WorkflowTagMapping,
 	CredentialsRepository,
 	TagRepository,
@@ -30,6 +31,7 @@ import {
 	toTableName,
 } from '@/modules/data-table/utils/sql-utils';
 import { WorkflowIndexService } from '@/modules/workflow-index/workflow-index.service';
+import { evaluateContentImportSafely } from '@/policy/evaluate-content-import-safely';
 import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { decompressFolder } from '@/utils/compression.util';
 import { validateDbTypeForImportEntities } from '@/utils/validate-database-type';
@@ -83,6 +85,7 @@ export class ImportService {
 		private readonly userRepository: UserRepository,
 		private readonly workflowService: WorkflowService,
 		private readonly policyEnforcementService: PolicyEnforcementService,
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 	) {}
 
 	async initRecords() {
@@ -112,6 +115,8 @@ export class ImportService {
 		const existingWorkflowIds = new Set<string>();
 		const activeVersionIdByWorkflow = new Map<string, string>();
 
+		let existingOwnerProjects = new Map<string, Project>();
+
 		if (workflowIds.length > 0) {
 			const existingWorkflows = await dbManager.find(WorkflowEntity, {
 				where: { id: In(workflowIds) },
@@ -124,6 +129,11 @@ export class ImportService {
 					activeVersionIdByWorkflow.set(id, activeVersionId);
 				}
 			}
+
+			// An existing workflow's policy scope is its own project, not `projectId` — that
+			// param is where a brand-new workflow lands, and re-importing never moves ownership.
+			existingOwnerProjects =
+				await this.sharedWorkflowRepository.findOwnerProjectsByWorkflowIds(workflowIds);
 		}
 
 		const violations: WorkflowImportViolations[] = [];
@@ -145,12 +155,23 @@ export class ImportService {
 			}
 
 			// Advisory only — never blocks the import, per contentImport being `evaluate`, not `enforce`.
-			const decision = await this.evaluateContentImportSafely(workflow, projectId);
-			if (decision.violations.length) {
+			// Use the workflow's own project when it already has one — re-importing never moves it.
+			const evaluationProjectId = workflow.id
+				? (existingOwnerProjects.get(workflow.id)?.id ?? projectId)
+				: projectId;
+			const workflowViolations = await evaluateContentImportSafely(
+				this.policyEnforcementService,
+				{
+					workflow: { id: workflow.id ?? null, name: workflow.name, nodes: workflow.nodes },
+					projectId: evaluationProjectId,
+				},
+				this.logger,
+			);
+			if (workflowViolations.length) {
 				violations.push({
 					workflowId: workflow.id ?? null,
 					name: workflow.name,
-					violations: decision.violations,
+					violations: workflowViolations,
 				});
 			}
 
@@ -250,28 +271,6 @@ export class ImportService {
 		}
 
 		return { violations };
-	}
-
-	/**
-	 * `evaluateContentImport` is advisory and documented to never throw, but a batch import
-	 * must never fail because of policy regardless — so an unexpected error here is swallowed
-	 * and treated as no violations rather than aborting the import.
-	 */
-	private async evaluateContentImportSafely(
-		workflow: IWorkflowWithVersionMetadata,
-		projectId: string,
-	) {
-		try {
-			return await this.policyEnforcementService.evaluateContentImport({
-				workflow: { id: workflow.id ?? null, name: workflow.name, nodes: workflow.nodes },
-				projectId,
-			});
-		} catch (error) {
-			this.logger.warn(`Failed to evaluate content-import policy for "${workflow.name}"`, {
-				error: ensureError(error),
-			});
-			return { violations: [] };
-		}
 	}
 
 	/**

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -1,4 +1,5 @@
 import { Logger, safeJoinPath } from '@n8n/backend-common';
+import type { PolicyViolation } from '@n8n/decorators';
 import type { TagEntity, ICredentialsDb, User } from '@n8n/db';
 import {
 	Project,
@@ -29,6 +30,7 @@ import {
 	toTableName,
 } from '@/modules/data-table/utils/sql-utils';
 import { WorkflowIndexService } from '@/modules/workflow-index/workflow-index.service';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { decompressFolder } from '@/utils/compression.util';
 import { validateDbTypeForImportEntities } from '@/utils/validate-database-type';
 import {
@@ -39,6 +41,13 @@ import {
 import { WorkflowService } from '@/workflows/workflow.service';
 
 const DATA_TABLE_ROWS_FILE_PREFIX = 'data_table_user_';
+
+/** Advisory policy violations found for one imported workflow, never blocking the import. */
+export interface WorkflowImportViolations {
+	workflowId: string | null;
+	name: string;
+	violations: PolicyViolation[];
+}
 
 @Service()
 export class ImportService {
@@ -73,6 +82,7 @@ export class ImportService {
 		private readonly dataTableDDLService: DataTableDDLService,
 		private readonly userRepository: UserRepository,
 		private readonly workflowService: WorkflowService,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 	) {}
 
 	async initRecords() {
@@ -87,7 +97,7 @@ export class ImportService {
 		projectId: string,
 		userId: string,
 		{ activeState = 'false' }: { activeState?: 'false' | 'fromJson' },
-	) {
+	): Promise<{ violations: WorkflowImportViolations[] }> {
 		await this.initRecords();
 
 		const user = await this.userRepository.findOneOrFail({
@@ -116,6 +126,8 @@ export class ImportService {
 			}
 		}
 
+		const violations: WorkflowImportViolations[] = [];
+
 		for (const workflow of workflows) {
 			workflow.nodes.forEach((node) => {
 				this.toNewCredentialFormat(node);
@@ -130,6 +142,16 @@ export class ImportService {
 
 			for (const warning of sanitizeNodeGroupDescriptions(workflow)) {
 				this.logger.warn(`Workflow "${workflow.name}": ${warning}`);
+			}
+
+			// Advisory only — never blocks the import, per contentImport being `evaluate`, not `enforce`.
+			const decision = await this.evaluateContentImportSafely(workflow, projectId);
+			if (decision.violations.length) {
+				violations.push({
+					workflowId: workflow.id ?? null,
+					name: workflow.name,
+					violations: decision.violations,
+				});
 			}
 
 			// Deactivate BEFORE the transaction to prevent orphaned trigger listeners.
@@ -225,6 +247,30 @@ export class ImportService {
 		// workflow-update events during import.
 		for (const workflow of insertedWorkflows) {
 			await this.workflowIndexService.updateIndexForDraft(workflow);
+		}
+
+		return { violations };
+	}
+
+	/**
+	 * `evaluateContentImport` is advisory and documented to never throw, but a batch import
+	 * must never fail because of policy regardless — so an unexpected error here is swallowed
+	 * and treated as no violations rather than aborting the import.
+	 */
+	private async evaluateContentImportSafely(
+		workflow: IWorkflowWithVersionMetadata,
+		projectId: string,
+	) {
+		try {
+			return await this.policyEnforcementService.evaluateContentImport({
+				workflow: { id: workflow.id ?? null, name: workflow.name, nodes: workflow.nodes },
+				projectId,
+			});
+		} catch (error) {
+			this.logger.warn(`Failed to evaluate content-import policy for "${workflow.name}"`, {
+				error: ensureError(error),
+			});
+			return { violations: [] };
 		}
 	}
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -1,5 +1,5 @@
 import { Logger, safeJoinPath } from '@n8n/backend-common';
-import type { PolicyViolation } from '@n8n/decorators';
+import type { PolicyCheckFailure, PolicyViolation } from '@n8n/decorators';
 import type { TagEntity, ICredentialsDb, User } from '@n8n/db';
 import {
 	Project,
@@ -49,6 +49,8 @@ export interface WorkflowImportViolations {
 	workflowId: string | null;
 	name: string;
 	violations: PolicyViolation[];
+	/** Checks that failed to run — a violation may have gone undetected. */
+	checkErrors: PolicyCheckFailure[];
 }
 
 @Service()
@@ -163,7 +165,7 @@ export class ImportService {
 			const evaluationProjectId = workflow.id
 				? (existingOwnerProjects.get(workflow.id)?.id ?? projectId)
 				: projectId;
-			const workflowViolations = await evaluateContentImportSafely(
+			const { violations: workflowViolations, checkErrors } = await evaluateContentImportSafely(
 				this.policyEnforcementService,
 				{
 					workflow: { id: workflow.id ?? null, name: workflow.name, nodes: workflow.nodes },
@@ -171,11 +173,12 @@ export class ImportService {
 				},
 				this.logger,
 			);
-			if (workflowViolations.length) {
+			if (workflowViolations.length || checkErrors.length) {
 				violations.push({
 					workflowId: workflow.id ?? null,
 					name: workflow.name,
 					violations: workflowViolations,
+					checkErrors,
 				});
 			}
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -132,8 +132,12 @@ export class ImportService {
 
 			// An existing workflow's policy scope is its own project, not `projectId` — that
 			// param is where a brand-new workflow lands, and re-importing never moves ownership.
-			existingOwnerProjects =
-				await this.sharedWorkflowRepository.findOwnerProjectsByWorkflowIds(workflowIds);
+			// Skipped when nothing would read it — a feature that is merely absent must not cost
+			// an extra query.
+			if (this.policyEnforcementService.hasChecksFor('contentImport')) {
+				existingOwnerProjects =
+					await this.sharedWorkflowRepository.findOwnerProjectsByWorkflowIds(workflowIds);
+			}
 		}
 
 		const violations: WorkflowImportViolations[] = [];

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -36,7 +36,7 @@ import type { InstanceSettings } from 'n8n-core';
 import * as utils from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 import { readFile } from 'node:fs/promises';
-import type { Mock } from 'vitest';
+import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import type { IWorkflowToImport } from '@/interfaces';
@@ -44,6 +44,7 @@ import { SourceControlContextFactory } from '@/modules/source-control.ee/source-
 import { SourceControlImportService } from '@/modules/source-control.ee/source-control-import.service.ee';
 import { SourceControlScopedService } from '@/modules/source-control.ee/source-control-scoped.service';
 import type { ExportableCredential } from '@/modules/source-control.ee/types/exportable-credential';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import { createFolder } from '@test-integration/db/folders';
 import { assignTagToWorkflow, createTag } from '@test-integration/db/tags';
@@ -77,6 +78,7 @@ describe('SourceControlImportService', () => {
 	let workflowHistoryService: WorkflowHistoryService;
 	let sourceControlContextFactory: SourceControlContextFactory;
 	let sourceControlScopedService: SourceControlScopedService;
+	let mockPolicyEnforcementService: Mocked<PolicyEnforcementService>;
 
 	const cipher = mockInstance(Cipher);
 	const mockFileData = new Map<string, string>();
@@ -97,6 +99,8 @@ describe('SourceControlImportService', () => {
 		workflowHistoryService = Container.get(WorkflowHistoryService);
 		sourceControlContextFactory = Container.get(SourceControlContextFactory);
 		sourceControlScopedService = Container.get(SourceControlScopedService);
+		mockPolicyEnforcementService = mock<PolicyEnforcementService>();
+		mockPolicyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
 		service = new SourceControlImportService(
 			mock(),
 			mock(),
@@ -123,6 +127,7 @@ describe('SourceControlImportService', () => {
 			mock(),
 			mock(),
 			mock(), // redactionEnforcementService
+			mockPolicyEnforcementService,
 			mock(), // dataTableSizeValidator
 			mock(), // activeWorkflowManager
 			mock(), // executionPersistence
@@ -2013,6 +2018,81 @@ describe('SourceControlImportService', () => {
 				const post = await workflowRepository.findOne({ where: { id: workflowId } });
 				expect(post?.active).toBe(false);
 				expect(post?.activeVersionId).toBeNull();
+			});
+		});
+
+		describe('content-import policy', () => {
+			beforeEach(() => {
+				mockPolicyEnforcementService.evaluateContentImport.mockClear();
+				mockPolicyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
+			});
+
+			it('evaluates content-import policy once per imported workflow, with the resolved target project', async () => {
+				const importingUser = await getGlobalOwner();
+				const importingUserProject = await getPersonalProject(importingUser);
+
+				const workflow = makeWorkflowImport();
+				const file = putWorkflowFile(workflow.id, workflow);
+
+				await service.importWorkflowFromWorkFolder(
+					[mock<SourceControlledFile>({ id: workflow.id, file })],
+					importingUser.id,
+				);
+
+				expect(mockPolicyEnforcementService.evaluateContentImport).toHaveBeenCalledTimes(1);
+				expect(mockPolicyEnforcementService.evaluateContentImport).toHaveBeenCalledWith({
+					workflow: { id: workflow.id, name: workflow.name, nodes: workflow.nodes },
+					projectId: importingUserProject.id,
+				});
+			});
+
+			it('does not fail the pull when a violation is returned, and attaches it to the result', async () => {
+				const importingUser = await getGlobalOwner();
+				const violation = {
+					kind: 'node-type-unavailable',
+					checkId: 'test.check',
+					message: 'not allowed',
+				};
+				mockPolicyEnforcementService.evaluateContentImport.mockResolvedValueOnce({
+					violations: [violation],
+				});
+
+				const workflow = makeWorkflowImport();
+				const file = putWorkflowFile(workflow.id, workflow);
+
+				const result = await service.importWorkflowFromWorkFolder(
+					[mock<SourceControlledFile>({ id: workflow.id, file })],
+					importingUser.id,
+				);
+
+				expect(result).toEqual([
+					expect.objectContaining({ id: workflow.id, policyViolations: [violation] }),
+				]);
+				// The pull completes regardless of the violation.
+				await expect(
+					workflowRepository.findOne({ where: { id: workflow.id } }),
+				).resolves.toBeTruthy();
+			});
+
+			it('does not fail the pull when evaluateContentImport throws', async () => {
+				const importingUser = await getGlobalOwner();
+				mockPolicyEnforcementService.evaluateContentImport.mockRejectedValueOnce(
+					new Error('backend unavailable'),
+				);
+
+				const workflow = makeWorkflowImport();
+				const file = putWorkflowFile(workflow.id, workflow);
+
+				const result = await service.importWorkflowFromWorkFolder(
+					[mock<SourceControlledFile>({ id: workflow.id, file })],
+					importingUser.id,
+				);
+
+				expect(result).toEqual([expect.objectContaining({ id: workflow.id })]);
+				expect(result[0]).not.toHaveProperty('policyViolations');
+				await expect(
+					workflowRepository.findOne({ where: { id: workflow.id } }),
+				).resolves.toBeTruthy();
 			});
 		});
 	});

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -2067,7 +2067,10 @@ describe('SourceControlImportService', () => {
 				);
 
 				expect(result).toEqual([
-					expect.objectContaining({ id: workflow.id, policyViolations: [violation] }),
+					expect.objectContaining({
+						id: workflow.id,
+						contentImportPolicy: { violations: [violation], checkErrors: [] },
+					}),
 				]);
 				// The pull completes regardless of the violation.
 				await expect(
@@ -2090,7 +2093,7 @@ describe('SourceControlImportService', () => {
 				);
 
 				expect(result).toEqual([expect.objectContaining({ id: workflow.id })]);
-				expect(result[0]).not.toHaveProperty('policyViolations');
+				expect(result[0]).not.toHaveProperty('contentImportPolicy');
 				await expect(
 					workflowRepository.findOne({ where: { id: workflow.id } }),
 				).resolves.toBeTruthy();

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -100,6 +100,7 @@ describe('SourceControlImportService', () => {
 		sourceControlContextFactory = Container.get(SourceControlContextFactory);
 		sourceControlScopedService = Container.get(SourceControlScopedService);
 		mockPolicyEnforcementService = mock<PolicyEnforcementService>();
+		mockPolicyEnforcementService.hasChecksFor.mockReturnValue(true);
 		mockPolicyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
 		service = new SourceControlImportService(
 			mock(),

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -76,6 +76,7 @@ describe('ImportService', () => {
 			userRepository,
 			mockWorkflowService,
 			mockPolicyEnforcementService,
+			sharedWorkflowRepository,
 		);
 	});
 
@@ -532,6 +533,33 @@ describe('ImportService', () => {
 			// The batch completes for every workflow regardless of the violation.
 			await expect(getWorkflowById(clean.id)).resolves.toBeDefined();
 			await expect(getWorkflowById(flagged.id)).resolves.toBeDefined();
+		});
+
+		test('evaluates an existing workflow against its own project, not the batch projectId', async () => {
+			const member = await createMember();
+			const memberPersonalProject = await getPersonalProject(member);
+			const existingWorkflow = await createWorkflow(undefined, member);
+
+			const workflowToReimport = await getWorkflowById(existingWorkflow.id);
+			if (!workflowToReimport) expect.fail('Expected to find workflow');
+
+			// Simulates the flagless CLI invocation, where `projectId` defaults to the
+			// importing user's own project regardless of who actually owns the workflow.
+			await importService.importWorkflows(
+				[workflowToReimport],
+				ownerPersonalProject.id,
+				owner.id,
+				{},
+			);
+
+			expect(mockPolicyEnforcementService.evaluateContentImport).toHaveBeenCalledWith({
+				workflow: {
+					id: workflowToReimport.id,
+					name: workflowToReimport.name,
+					nodes: workflowToReimport.nodes,
+				},
+				projectId: memberPersonalProject.id,
+			});
 		});
 
 		test('does not fail the import when evaluateContentImport throws', async () => {

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -63,6 +63,7 @@ describe('ImportService', () => {
 		mockWorkflowService = mock<WorkflowService>();
 		mockWorkflowIndexService = mock<WorkflowIndexService>();
 		mockPolicyEnforcementService = mock<PolicyEnforcementService>();
+		mockPolicyEnforcementService.hasChecksFor.mockReturnValue(true);
 		mockPolicyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
 
 		importService = new ImportService(

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -19,12 +19,14 @@ import {
 	UserRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type { PolicyViolation } from '@n8n/decorators';
 import type { INode } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import type { WorkflowIndexService } from '@/modules/workflow-index/workflow-index.service';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { ImportService } from '@/services/import.service';
 import type { WorkflowService } from '@/workflows/workflow.service';
 
@@ -37,6 +39,7 @@ describe('ImportService', () => {
 	let ownerPersonalProject: Project;
 	let mockWorkflowService: Mocked<WorkflowService>;
 	let mockWorkflowIndexService: WorkflowIndexService;
+	let mockPolicyEnforcementService: Mocked<PolicyEnforcementService>;
 
 	let workflowRepository: WorkflowRepository;
 	let sharedWorkflowRepository: SharedWorkflowRepository;
@@ -59,6 +62,8 @@ describe('ImportService', () => {
 
 		mockWorkflowService = mock<WorkflowService>();
 		mockWorkflowIndexService = mock<WorkflowIndexService>();
+		mockPolicyEnforcementService = mock<PolicyEnforcementService>();
+		mockPolicyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
 
 		importService = new ImportService(
 			mock(),
@@ -70,6 +75,7 @@ describe('ImportService', () => {
 			mock(),
 			userRepository,
 			mockWorkflowService,
+			mockPolicyEnforcementService,
 		);
 	});
 
@@ -475,6 +481,74 @@ describe('ImportService', () => {
 				existingWorkflow.id,
 				expect.objectContaining({ source: 'import' }),
 			);
+		});
+	});
+
+	describe('content-import policy', () => {
+		beforeEach(() => {
+			mockPolicyEnforcementService.evaluateContentImport.mockClear();
+			mockPolicyEnforcementService.evaluateContentImport.mockResolvedValue({ violations: [] });
+		});
+
+		test('evaluates content-import policy once per imported workflow, with the workflow and target project', async () => {
+			const first = newWorkflow({ id: uuid(), name: 'First' });
+			const second = newWorkflow({ id: uuid(), name: 'Second' });
+
+			await importService.importWorkflows([first, second], ownerPersonalProject.id, owner.id, {});
+
+			expect(mockPolicyEnforcementService.evaluateContentImport).toHaveBeenCalledTimes(2);
+			expect(mockPolicyEnforcementService.evaluateContentImport).toHaveBeenCalledWith({
+				workflow: { id: first.id, name: first.name, nodes: first.nodes },
+				projectId: ownerPersonalProject.id,
+			});
+			expect(mockPolicyEnforcementService.evaluateContentImport).toHaveBeenCalledWith({
+				workflow: { id: second.id, name: second.name, nodes: second.nodes },
+				projectId: ownerPersonalProject.id,
+			});
+		});
+
+		test('does not fail the import when a violation is returned, and reports it', async () => {
+			const violation: PolicyViolation = {
+				kind: 'node-type-unavailable',
+				checkId: 'test.check',
+				message: 'not allowed',
+			};
+			const clean = newWorkflow({ id: uuid(), name: 'Clean' });
+			const flagged = newWorkflow({ id: uuid(), name: 'Flagged' });
+			mockPolicyEnforcementService.evaluateContentImport.mockImplementation(async ({ workflow }) =>
+				workflow.name === 'Flagged' ? { violations: [violation] } : { violations: [] },
+			);
+
+			const result = await importService.importWorkflows(
+				[clean, flagged],
+				ownerPersonalProject.id,
+				owner.id,
+				{},
+			);
+
+			expect(result.violations).toStrictEqual([
+				{ workflowId: flagged.id, name: 'Flagged', violations: [violation] },
+			]);
+			// The batch completes for every workflow regardless of the violation.
+			await expect(getWorkflowById(clean.id)).resolves.toBeDefined();
+			await expect(getWorkflowById(flagged.id)).resolves.toBeDefined();
+		});
+
+		test('does not fail the import when evaluateContentImport throws', async () => {
+			mockPolicyEnforcementService.evaluateContentImport.mockRejectedValueOnce(
+				new Error('backend unavailable'),
+			);
+			const workflowToImport = newWorkflow();
+
+			const result = await importService.importWorkflows(
+				[workflowToImport],
+				ownerPersonalProject.id,
+				owner.id,
+				{},
+			);
+
+			expect(result.violations).toStrictEqual([]);
+			await expect(getWorkflowById(workflowToImport.id)).resolves.toBeDefined();
 		});
 	});
 });

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -529,7 +529,7 @@ describe('ImportService', () => {
 			);
 
 			expect(result.violations).toStrictEqual([
-				{ workflowId: flagged.id, name: 'Flagged', violations: [violation] },
+				{ workflowId: flagged.id, name: 'Flagged', violations: [violation], checkErrors: [] },
 			]);
 			// The batch completes for every workflow regardless of the violation.
 			await expect(getWorkflowById(clean.id)).resolves.toBeDefined();
@@ -561,6 +561,32 @@ describe('ImportService', () => {
 				},
 				projectId: memberPersonalProject.id,
 			});
+		});
+
+		test('surfaces a failed check alongside violations, without failing the import', async () => {
+			const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
+			const workflowToImport = newWorkflow({ id: uuid(), name: 'Flaky' });
+			mockPolicyEnforcementService.evaluateContentImport.mockResolvedValueOnce({
+				violations: [],
+				checkErrors: [checkFailure],
+			});
+
+			const result = await importService.importWorkflows(
+				[workflowToImport],
+				ownerPersonalProject.id,
+				owner.id,
+				{},
+			);
+
+			expect(result.violations).toStrictEqual([
+				{
+					workflowId: workflowToImport.id,
+					name: 'Flaky',
+					violations: [],
+					checkErrors: [checkFailure],
+				},
+			]);
+			await expect(getWorkflowById(workflowToImport.id)).resolves.toBeDefined();
 		});
 
 		test('does not fail the import when evaluateContentImport throws', async () => {

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -529,7 +529,11 @@ describe('ImportService', () => {
 			);
 
 			expect(result.violations).toStrictEqual([
-				{ workflowId: flagged.id, name: 'Flagged', violations: [violation], checkErrors: [] },
+				{
+					workflowId: flagged.id,
+					name: 'Flagged',
+					contentImportPolicy: { violations: [violation], checkErrors: [] },
+				},
 			]);
 			// The batch completes for every workflow regardless of the violation.
 			await expect(getWorkflowById(clean.id)).resolves.toBeDefined();
@@ -565,8 +569,8 @@ describe('ImportService', () => {
 
 		test('surfaces a failed check alongside violations, without failing the import', async () => {
 			const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
-			// No explicit id: still unassigned when evaluateContentImport runs, exercising the
-			// "(new)" fallback in the failed-check log message.
+			// No explicit id: still unassigned when evaluateContentImport runs, so this also
+			// covers a new workflow reporting a check error.
 			const workflowToImport = newWorkflow({ name: 'Flaky' });
 			mockPolicyEnforcementService.evaluateContentImport.mockResolvedValueOnce({
 				violations: [],
@@ -584,8 +588,7 @@ describe('ImportService', () => {
 				{
 					workflowId: null,
 					name: 'Flaky',
-					violations: [],
-					checkErrors: [checkFailure],
+					contentImportPolicy: { violations: [], checkErrors: [checkFailure] },
 				},
 			]);
 			await expect(getWorkflowById(workflowToImport.id)).resolves.toBeDefined();

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -565,7 +565,9 @@ describe('ImportService', () => {
 
 		test('surfaces a failed check alongside violations, without failing the import', async () => {
 			const checkFailure = { checkId: 'test.check', correlationId: 'corr-1' };
-			const workflowToImport = newWorkflow({ id: uuid(), name: 'Flaky' });
+			// No explicit id: still unassigned when evaluateContentImport runs, exercising the
+			// "(new)" fallback in the failed-check log message.
+			const workflowToImport = newWorkflow({ name: 'Flaky' });
 			mockPolicyEnforcementService.evaluateContentImport.mockResolvedValueOnce({
 				violations: [],
 				checkErrors: [checkFailure],
@@ -580,7 +582,7 @@ describe('ImportService', () => {
 
 			expect(result.violations).toStrictEqual([
 				{
-					workflowId: workflowToImport.id,
+					workflowId: null,
 					name: 'Flaky',
 					violations: [],
 					checkErrors: [checkFailure],


### PR DESCRIPTION
## Summary

Calls `PolicyEnforcementService.evaluateContentImport` (advisory `evaluate`, not `enforce`) per imported artifact from:
- the CLI `import:workflow` command
- the source-control (git) pull path

The check is advisory only — violations are attached to the existing import/pull report structures, and an unexpected error from the check is swallowed, so nothing here can fail the batch.

### Key implementation decisions

- The underlying `PolicyEnforcementService.evaluateContentImport` and `ContentImportContext` already existed (from a prior ticket) — this PR is pure wiring of the two call sites, no new policy logic.
- For the source-control pull path, the target project is resolved once (`resolveTargetOwnerProject`) and reused both for ownership sync and for the policy context's `projectId`, instead of resolving it twice.
- Each call site wraps the advisory check in a narrow try/catch: `evaluateContentImport` is documented to never throw, but the import/pull batch must never fail because of policy regardless of that guarantee holding.

## How to test

- `pnpm --filter n8n import:workflow --input=<file>` — a workflow with a policy violation (once a check is registered) is imported and a warning is logged, without failing the command.
- Trigger a source-control pull with multiple workflow artifacts — the pull completes regardless of individual violations, and `WorkflowImportResult.policyViolations` is populated per artifact when applicable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1127

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>