### PR TITLE
test: Fix broken remediation guard narration assertion (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts
@@ -253,20 +253,17 @@ test.describe(
 						'When the build result reports that setup is required before verification, open the workflow setup card with workflows(action="setup") and stop editing.',
 				);
 
-				// The skill-opening narration is surfaced transiently in the thinking
-				// trace while the orchestrator loads the workflow-builder skill, then
-				// collapses once the build completes. Assert it while the run is still
-				// in progress — before awaiting the terminal setup card.
-				await expect(
-					n8n.instanceAi.getAssistantMessageText('Opening skill: workflow-builder'),
-				).toBeVisible({ timeout: 540_000 });
-
 				await expect(n8n.instanceAi.workflowSetup.getCard()).toBeVisible({ timeout: 540_000 });
 				await expect(n8n.instanceAi.getAssistantMessageText(TERMINAL_FALLBACK_TEXT)).toHaveCount(0);
 
 				const events = getLatestRecordingEvents(await getTraceEvents(api, testInfo));
 				const summary = summarizeRemediationTrace(events);
 				const buildCalls = getToolCalls(events, 'build-workflow');
+				// Since #36808 the skill-opening narration lives inside the collapsed
+				// thinking block, so the skill load is only assertable from the trace.
+				const skillLoads = getToolCalls(events, 'load_skill').filter(
+					(event) => event.input?.skillId === 'workflow-builder',
+				);
 				const setupCalls = getToolEvents(events, 'workflows').filter(
 					(event) =>
 						event.input?.action === 'setup' && event.input.workflowId === summary.workflowId,
@@ -287,6 +284,7 @@ test.describe(
 					fallbackNarrationSeen: false,
 				});
 				expect(summary.postBuildRemediationSubmitsUsed).toBeLessThanOrEqual(2);
+				expect(skillLoads.length).toBeGreaterThan(0);
 				expect(buildCalls.find((event) => event.agentRole === 'orchestrator')).toMatchObject({
 					agentRole: 'orchestrator',
 					stepId: expect.any(Number),

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts
@@ -259,11 +259,6 @@ test.describe(
 				const events = getLatestRecordingEvents(await getTraceEvents(api, testInfo));
 				const summary = summarizeRemediationTrace(events);
 				const buildCalls = getToolCalls(events, 'build-workflow');
-				// Since #36808 the skill-opening narration lives inside the collapsed
-				// thinking block, so the skill load is only assertable from the trace.
-				const skillLoads = getToolCalls(events, 'load_skill').filter(
-					(event) => event.input?.skillId === 'workflow-builder',
-				);
 				const setupCalls = getToolEvents(events, 'workflows').filter(
 					(event) =>
 						event.input?.action === 'setup' && event.input.workflowId === summary.workflowId,
@@ -284,7 +279,6 @@ test.describe(
 					fallbackNarrationSeen: false,
 				});
 				expect(summary.postBuildRemediationSubmitsUsed).toBeLessThanOrEqual(2);
-				expect(skillLoads.length).toBeGreaterThan(0);
 				expect(buildCalls.find((event) => event.agentRole === 'orchestrator')).toMatchObject({
 					agentRole: 'orchestrator',
 					stepId: expect.any(Number),


### PR DESCRIPTION
## Summary

The remediation guard test asserts that the `Opening skill: workflow-builder` narration is visible as assistant-message text. Since #36808 that narration stays inside the collapsed thinking block, where it only flashes as a status line while the skill loads, so the assertion times out and the test fails. 

No pipeline caught this. The coverage nightly skips this spec (no proxy harness), so the impact map never selects it on PRs. The new `-pc` e2e nightly ran it first and [failed on it](https://github.com/n8n-io/n8n/actions/runs/32954718343). 

Hence let's drop the narration assertion. The skill-path fact stays covered by the test's existing trace assertions: `usedLegacyBuilderTool: false` and the orchestrator `build-workflow` call check.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4147/run-nightly-e2e-against-the-pc-image

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
