### PR TITLE
ci: Fix pnpm install timeouts by caching pnpm metadata and skipping redundant SafeChain age filtering

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -87,6 +87,34 @@ runs:
             mkdir -p "$PNPM_STORE_PATH"
         fi
 
+    # pnpm 11 re-applies minimumReleaseAge/trustPolicy to every lockfile entry
+    # on each install — frozen installs included — by fetching registry
+    # metadata for the full tree (pnpm/pnpm#12114). setup-node's `cache: pnpm`
+    # only persists the content-addressable store, not the metadata cache, so
+    # every job paid that sweep over the network and one slow fetch could
+    # stall past the install timeout. `pnpm cache path` (pnpm >= 11.21) is the
+    # metadata cache incl. the lockfile-verification log, which lets a job
+    # skip the re-check for an unchanged lockfile. Keyed on the lockfile;
+    # restore-keys let a changed lockfile start from the nearest cache and
+    # revalidate only the delta (304s renew cached entries).
+    - name: Locate pnpm Metadata Cache
+      if: ${{ inputs.install-command != '' }}
+      id: pnpm-metadata
+      shell: bash
+      run: |
+        dir="$(pnpm cache path)"
+        mkdir -p "$dir"
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+    - name: Restore pnpm Metadata Cache
+      if: ${{ inputs.install-command != '' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ${{ steps.pnpm-metadata.outputs.dir }}
+        key: pnpm-metadata-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          pnpm-metadata-v1-${{ runner.os }}-${{ runner.arch }}-
+
     - name: Configure SafeChain
       shell: bash
       run: |
@@ -170,6 +198,12 @@ runs:
     #
     # `SAFE_CHAIN_LOGGING=verbose` surfaces safe-chain's proxy decisions, which
     # are otherwise buffered (and lost on failure) while pnpm is in flight.
+    #
+    # `--safe-chain-skip-minimum-package-age` is consumed by the SafeChain shim
+    # (never reaches pnpm) and turns off only its version-age filtering: pnpm
+    # natively enforces a stricter `minimumReleaseAge`, while SafeChain's
+    # filter forces full packuments (tens of MB for e.g. Storybook) by
+    # rewriting the Accept header. Malware blocking is unaffected.
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       id: install-deps
@@ -188,6 +222,7 @@ runs:
 
         set +o pipefail
         timeout --kill-after=30s 600s $INSTALL_COMMAND \
+          --safe-chain-skip-minimum-package-age \
           --config.logs-dir="$PNPM_DIAG_DIR/pnpm-logs" \
           --reporter=append-only --config.loglevel=info 2>&1 | tee "$INSTALL_LOG"
         rc=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

Since the pnpm 11 migration (#36424), `Install & Build` jobs across unrelated PRs fail with `pnpm install failed (exit 124)` — the 600s timeout in `setup-nodejs`.

Root cause: pnpm 11 re-applies `minimumReleaseAge`/`trustPolicy` to every lockfile entry on each install, frozen installs included (pnpm/pnpm#12114). This fetches registry metadata for the full tree (~3,600 packages) after linking. The SafeChain proxy makes the sweep heavier: its own age filter rewrites the `Accept` header from the abbreviated format to `application/json`, which forces full packuments (tens of MB for e.g. Storybook). One slow fetch then enters pnpm's long retry backoff and the job stalls past the timeout. Example failure: run 32975736437 — linking done in ~30s, then a stuck `@storybook/vue3-vite` metadata fetch until the kill.

Two changes to the `setup-nodejs` action:

1. **Persist the pnpm metadata cache across jobs.** `setup-node`'s `cache: pnpm` only persists the content-addressable store. The metadata cache (`pnpm cache path`, pnpm ≥ 11.21) also holds the lockfile-verification log. With it cached, an unchanged lockfile skips the re-verification completely. A changed lockfile restores the nearest cache via `restore-keys` and revalidates only the delta. The key follows `cache-dependency-path`, so the scoped `.github/scripts` installs keep a separate small cache.

2. **Skip SafeChain's minimum-package-age filtering for the install step.** The install command now passes `--safe-chain-skip-minimum-package-age`. The SafeChain shim consumes this flag; it never reaches pnpm. pnpm natively enforces a stricter `minimumReleaseAge` (72h vs SafeChain's 48h), so the filter is redundant — and it is what forces the full-packument downloads. SafeChain malware blocking runs unconditionally and is unaffected. Done via the flag, not `safe-chain.config.json`: at the pinned SafeChain 1.5.7 the config can only lower the threshold, and even `minimumPackageAgeHours: 0` keeps the expensive `Accept`-header rewrite.

Deliberately **not** done: `trustLockfile: true` (the workaround in pnpm/pnpm#12114). pnpm's docs warn against it when outside collaborators can edit the lockfile, which applies to this repository.

## How to test

CI on this PR exercises the change directly:
- First run populates the metadata cache; the `Install & Build` job must pass.
- Re-run (or a follow-up push) must show a `pnpm-metadata-…` cache hit in `Restore pnpm Metadata Cache` and no per-package `Safe-chain: … was removed (minimumPackageAgeInHours setting)` lines in the install log.
- Install wall time should drop back toward the pre-pnpm-11 level.

## Related Linear tickets, Github issues, and Community forum posts

- Upstream regression: https://github.com/pnpm/pnpm/issues/12114
- Introduced by the pnpm 11 migration: #36424

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

