### PR TITLE
ci: Skip SafeChain minimum-package-age filtering in CI installs (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -181,6 +181,10 @@ runs:
     # SafeChain has no config-file equivalent (verified in 1.5.7 and 1.5.15
     # sources), and the shim strips all `--safe-chain-*` args before it runs
     # the real pnpm.
+    #
+    # Not passed on Windows: SafeChain's shims there are `.cmd`/`.ps1`, which
+    # bash does not resolve for a bare `pnpm` — this step runs the real pnpm
+    # unwrapped, and the flag would fail as an unknown pnpm option.
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       id: install-deps
@@ -189,6 +193,7 @@ runs:
         INSTALL_LOG: ${{ runner.temp }}/pnpm-install.log
         PNPM_DIAG_DIR: ${{ runner.temp }}/pnpm-diagnostics
         SAFE_CHAIN_LOGGING: verbose
+        SAFE_CHAIN_SKIP_ARGS: ${{ runner.os != 'Windows' && '--safe-chain-skip-minimum-package-age' || '' }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         # Stable, artifact-name-safe id for the upload step (written first so it
@@ -199,7 +204,7 @@ runs:
 
         set +o pipefail
         timeout --kill-after=30s 600s $INSTALL_COMMAND \
-          --safe-chain-skip-minimum-package-age \
+          $SAFE_CHAIN_SKIP_ARGS \
           --config.logs-dir="$PNPM_DIAG_DIR/pnpm-logs" \
           --reporter=append-only --config.loglevel=info 2>&1 | tee "$INSTALL_LOG"
         rc=${PIPESTATUS[0]}

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -91,6 +91,8 @@ runs:
       shell: bash
       run: |
         # SafeChain only reads configs from this directory https://github.com/AikidoSec/safe-chain#configuration-options-1
+        # The age exclusions still apply to pnpm/npm runs in later job steps,
+        # which go through the shim without the install step's skip flag.
         mkdir -p "$HOME/.safe-chain"
         cp "${{ github.action_path }}/safe-chain.config.json" "$HOME/.safe-chain/config.json"
 
@@ -170,6 +172,15 @@ runs:
     #
     # `SAFE_CHAIN_LOGGING=verbose` surfaces safe-chain's proxy decisions, which
     # are otherwise buffered (and lost on failure) while pnpm is in flight.
+    #
+    # `--safe-chain-skip-minimum-package-age` disables SafeChain's own 48h
+    # version filtering, which re-parses and rewrites every packument response
+    # (tens of MB for Storybook packages). pnpm natively enforces the stricter
+    # `minimumReleaseAge` from pnpm-workspace.yaml, so the filter is pure
+    # overhead here. Malware blocking stays active. This must be a CLI flag:
+    # SafeChain has no config-file equivalent (verified in 1.5.7 and 1.5.15
+    # sources), and the shim strips all `--safe-chain-*` args before it runs
+    # the real pnpm.
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       id: install-deps
@@ -188,6 +199,7 @@ runs:
 
         set +o pipefail
         timeout --kill-after=30s 600s $INSTALL_COMMAND \
+          --safe-chain-skip-minimum-package-age \
           --config.logs-dir="$PNPM_DIAG_DIR/pnpm-logs" \
           --reporter=append-only --config.loglevel=info 2>&1 | tee "$INSTALL_LOG"
         rc=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

pnpm natively enforces `minimumReleaseAge: 4320` (72h) from `pnpm-workspace.yaml`. On top of that stricter native check, SafeChain applies its own 48h minimum-age filter: it forces full packument responses (it changes the `Accept` header away from the compact `install-v1` format) and re-parses and rewrites each response. For large packages (for example, Storybook) a packument is tens of MB, so this is pure overhead on a small runner.

This PR adds `--safe-chain-skip-minimum-package-age` to the install invocation in the `setup-nodejs` action. This disables only the minimum-age path (the `Accept` header rewrite, the JSON parse/filter, and the tarball new-package fallback). Malware blocking stays active — that is the part pnpm does not replicate.

Notes:

- SafeChain has no config-file or env-var equivalent for the skip toggle (verified in the 1.5.7 and 1.5.15 sources; `skipMinimumPackageAge()` reads only the CLI argument). `minimumPackageAgeHours: 0` in the config would not help: the interceptor would still force full packuments and parse each response.
- The SafeChain shim strips all `--safe-chain-*` arguments before it runs the real pnpm, and the action verifies the shim is active before the install step, so the flag never reaches an unwrapped pnpm.
- The flag is not passed on Windows runners: SafeChain's shims there are `.cmd`/`.ps1` files, which bash does not resolve for a bare `pnpm`. The install step runs the real pnpm unwrapped on Windows, so the flag fails as an unknown pnpm option.
- `safe-chain.config.json` keeps its `minimumPackageAgeExclusions`: later job steps run pnpm/npm through the shim without the skip flag, so the exclusions still apply there.

## How to test

CI on this PR exercises the change directly: the `setup-nodejs` action runs in every job. Installs must succeed, and with `SAFE_CHAIN_LOGGING=verbose` the install log no longer shows packument modification decisions.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


