### PR TITLE
ci: Revert SafeChain minimum-package-age skip (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -91,8 +91,6 @@ runs:
       shell: bash
       run: |
         # SafeChain only reads configs from this directory https://github.com/AikidoSec/safe-chain#configuration-options-1
-        # The age exclusions still apply to pnpm/npm runs in later job steps,
-        # which go through the shim without the install step's skip flag.
         mkdir -p "$HOME/.safe-chain"
         cp "${{ github.action_path }}/safe-chain.config.json" "$HOME/.safe-chain/config.json"
 
@@ -172,19 +170,6 @@ runs:
     #
     # `SAFE_CHAIN_LOGGING=verbose` surfaces safe-chain's proxy decisions, which
     # are otherwise buffered (and lost on failure) while pnpm is in flight.
-    #
-    # `--safe-chain-skip-minimum-package-age` disables SafeChain's own 48h
-    # version filtering, which re-parses and rewrites every packument response
-    # (tens of MB for Storybook packages). pnpm natively enforces the stricter
-    # `minimumReleaseAge` from pnpm-workspace.yaml, so the filter is pure
-    # overhead here. Malware blocking stays active. This must be a CLI flag:
-    # SafeChain has no config-file equivalent (verified in 1.5.7 and 1.5.15
-    # sources), and the shim strips all `--safe-chain-*` args before it runs
-    # the real pnpm.
-    #
-    # Not passed on Windows: SafeChain's shims there are `.cmd`/`.ps1`, which
-    # bash does not resolve for a bare `pnpm` — this step runs the real pnpm
-    # unwrapped, and the flag would fail as an unknown pnpm option.
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       id: install-deps
@@ -193,7 +178,6 @@ runs:
         INSTALL_LOG: ${{ runner.temp }}/pnpm-install.log
         PNPM_DIAG_DIR: ${{ runner.temp }}/pnpm-diagnostics
         SAFE_CHAIN_LOGGING: verbose
-        SAFE_CHAIN_SKIP_ARGS: ${{ runner.os != 'Windows' && '--safe-chain-skip-minimum-package-age' || '' }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         # Stable, artifact-name-safe id for the upload step (written first so it
@@ -204,7 +188,6 @@ runs:
 
         set +o pipefail
         timeout --kill-after=30s 600s $INSTALL_COMMAND \
-          $SAFE_CHAIN_SKIP_ARGS \
           --config.logs-dir="$PNPM_DIAG_DIR/pnpm-logs" \
           --reporter=append-only --config.loglevel=info 2>&1 | tee "$INSTALL_LOG"
         rc=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

Reverts #37156. After that change merged, CI installs began failing across jobs on master (for example, run [32981761319](https://github.com/n8n-io/n8n/actions/runs/32981761319)):

```
[WARN] GET https://registry.npmjs.org/@storybook%2Fvue3-vite error (23). Will retry in 10 seconds. 2 retries left.
[ERR_PNPM_BROKEN_METADATA_JSON] The operation was aborted due to timeout
✗ Lockfile failed supply-chain policy check (3776 entries in 4m 14.5s)
```

Mechanism: pnpm's lockfile supply-chain policy check (the native `minimumReleaseAge` verification) fetches package metadata for every lockfile entry after a frozen install. With the skip flag active, SafeChain no longer buffers packument responses — it streams them — and on CI runners the large `@storybook/vue3-vite` packument fetch stalls past pnpm's 60-second fetch timeout on all 3 attempts, which aborts the whole check. Error `(23)` is the `TimeoutError` DOMException code.

Direct comparison on the same lockfile (Lint job):

- Pre-merge: `✓ Lockfile passes supply-chain policies (3776 entries in 41.1s)`
- Post-merge: `✗ Lockfile failed supply-chain policy check (3776 entries in 4m 14.5s)`

A local reproduction of the same setup (safe-chain 1.5.7, skip flag, cold cache, `minimumReleaseAge: 4320`) passes, so the stall is specific to the CI environment (prebuilt SafeChain binary, Blacksmith network path). Reverting restores the known-good buffered behavior while we root-cause the streaming stall.

## How to test

CI on this PR runs the `setup-nodejs` action in every job. The lockfile supply-chain policy check must pass again.

## Related Linear tickets, Github issues, and Community forum posts

Reverts #37156.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

