### PR TITLE
feat(core): Serialize mid-poll emit hand-offs and report their dispatches (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
-import type { WorkflowsConfig } from '@n8n/config';
+import type { GlobalConfig, WorkflowsConfig } from '@n8n/config';
 import type { Project, WorkflowEntity, WorkflowHistory, WorkflowRepository } from '@n8n/db';
 import type { UpdateResult } from '@n8n/typeorm';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
@@ -441,6 +441,7 @@ describe('ActiveWorkflowManager', () => {
 				ownershipService,
 				mock(), // nodeTypes
 				pollCursorService,
+				mock<GlobalConfig>({ scheduler: { pollTimeoutSeconds: 45, leaseDurationSeconds: 60 } }),
 			);
 
 			activeWorkflowManager = new ActiveWorkflowManager(

--- a/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
@@ -190,6 +190,7 @@ describe('PollTriggerTaskHandler', () => {
 				triggerNode,
 				{ taskId: 'task-1', leaseEpoch: 1 },
 				undefined,
+				expect.any(Function),
 			);
 			expect(triggersAndPollers.runPollFunction).toHaveBeenCalledWith(
 				workflow,
@@ -212,6 +213,7 @@ describe('PollTriggerTaskHandler', () => {
 				triggerNode,
 				{ taskId: 'task-1', leaseEpoch: 1 },
 				{ lastItemId: 'prefetched' },
+				expect.any(Function),
 			);
 		});
 
@@ -242,6 +244,59 @@ describe('PollTriggerTaskHandler', () => {
 			expect(onDispatch).not.toHaveBeenCalled();
 			// The isolate is released on this path too, not just the happy path.
 			expect(releaseIsolate).toHaveBeenCalledTimes(1);
+		});
+
+		test('reports a dispatch when poll() returned null after emitting mid-poll', async () => {
+			triggersAndPollers.runPollFunction.mockImplementation(async () => {
+				// The factory reports each handed-off mid-poll emit through the callback
+				// the handler passed into createPollExecutionContext.
+				const onDispatched = triggerExecutionContextFactory.createPollExecutionContext.mock
+					.calls[0][4] as (() => void) | undefined;
+				onDispatched?.();
+				return null;
+			});
+
+			const decision = await handler.execute(buildTask(), report);
+
+			expect(decision).toBe(report.dispatched());
+			expect(onDispatch).toHaveBeenCalled();
+			// The end-of-poll emit stays unused; the mid-poll emits already dispatched.
+			expect(pollFunctions.__emit).not.toHaveBeenCalled();
+			// A staged advance made after the last emit still commits on this path.
+			expect(pollFunctions.__commitCursor).toHaveBeenCalled();
+		});
+
+		test('stamps the dispatch marker while the poll is still running, not only at its end', async () => {
+			triggersAndPollers.runPollFunction.mockImplementation(async () => {
+				const onDispatched = triggerExecutionContextFactory.createPollExecutionContext.mock
+					.calls[0][4] as (() => void) | undefined;
+				onDispatched?.();
+				// The marker must be stamped the moment the emit hands off: if the
+				// process dies before poll() returns, the occurrence must not be
+				// retried and duplicate the execution.
+				expect(onDispatch).toHaveBeenCalledTimes(1);
+				return null;
+			});
+
+			const decision = await handler.execute(buildTask(), report);
+
+			expect(decision).toBe(report.dispatched());
+		});
+
+		test('still reports a dispatch when the trailing cursor commit fails after mid-poll emits', async () => {
+			triggersAndPollers.runPollFunction.mockImplementation(async () => {
+				const onDispatched = triggerExecutionContextFactory.createPollExecutionContext.mock
+					.calls[0][4] as (() => void) | undefined;
+				onDispatched?.();
+				return null;
+			});
+			pollFunctions.__commitCursor.mockRejectedValue(new Error('poller state write failed'));
+
+			const decision = await handler.execute(buildTask(), report);
+
+			// The executions were handed off mid-poll; a failed trailing cursor write
+			// must not downgrade the occurrence to retry-safe.
+			expect(decision).toBe(report.dispatched());
 		});
 
 		test('discards the result and reports no dispatch when the workflow was deactivated during poll()', async () => {

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -47,7 +47,8 @@ function timeoutAfter(ms: number): { timedOut: Promise<typeof TIMED_OUT>; cancel
 }
 
 /**
- * Runs a due poll occurrence's `poll()` once and dispatches only when it returns new data.
+ * Runs a due poll occurrence's `poll()` once and dispatches when it hands data off —
+ * through mid-poll `__emit` calls or the returned batch.
  * Carries no `deduplicationKey`: under the at-least-once scheduler contract an occurrence
  * can run twice, later cursor write wins; tolerable since two polls can legitimately differ anyway.
  */
@@ -110,12 +111,21 @@ export class PollTriggerTaskHandler implements TaskHandler {
 
 		const node = this.resolveTriggerNode(workflowData, nodeId, task);
 
+		let midPollDispatched = false;
 		const { workflow, pollFunctions } =
 			await this.triggerExecutionContextFactory.createPollExecutionContext(
 				workflowData,
 				node,
 				{ taskId: task.id, leaseEpoch: task.leaseEpoch },
 				state?.cursor,
+				() => {
+					// Stamped the moment an emit hands off: a throw later in this tick must
+					// not retry the occurrence and duplicate the run. The marker is permanent,
+					// so a discard path returning notDispatched() cannot downgrade it; the
+					// flag only steers the decision when poll() returns null.
+					midPollDispatched = true;
+					report.dispatched();
+				},
 			);
 
 		// Poll and hand-off share one staging scope, so a cursor staged here can only
@@ -135,9 +145,9 @@ export class PollTriggerTaskHandler implements TaskHandler {
 			try {
 				// `poll()` takes no abort signal, so the deadline abandons it rather than
 				// cancelling it: the call keeps running until it settles on its own, and its
-				// outcome is discarded. The cursor never moves on that path (it only moves
-				// through the staged commit or __emit below), so an abandoned tick leaves
-				// the poll window untouched for the next occurrence to cover.
+				// outcome is discarded. The staged cursor cannot commit on that path; batches
+				// the node already emitted mid-poll were handed off with their own advances,
+				// and the next occurrence covers the rest of the window.
 				const deadline = timeoutAfter(this.pollTimeoutMs);
 				const poll = this.triggersAndPollers.runPollFunction(workflow, node, pollFunctions);
 				// Deliberately not chained: keeps an abandoned poll's eventual rejection from
@@ -156,9 +166,10 @@ export class PollTriggerTaskHandler implements TaskHandler {
 							nodeId,
 							pollTimeoutMs: this.pollTimeoutMs,
 						});
-						// Not routed to the error workflow: an abandoned poll produces no run, and
-						// an error run is one. It does count as a poll failure, so a source that
-						// keeps hanging is re-polled at a widening interval like any failing source.
+						// Not routed to the error workflow: the timeout itself failed no run —
+						// anything emitted before the deadline was handed off normally. It does
+						// count as a poll failure, so a source that keeps hanging is re-polled
+						// at a widening interval like any failing source.
 						const isActive = await this.workflowRepository.isActive(workflowId).catch(() => true);
 						if (isActive) {
 							await this.pollBackoffService.recordFailure({
@@ -204,9 +215,9 @@ export class PollTriggerTaskHandler implements TaskHandler {
 					return report.dispatched();
 				}
 
-				// A poll with no items may still have moved its cursor, committed here on
-				// its own. Active state is re-read first so a workflow deactivated mid-poll
-				// doesn't get its cursor moved.
+				// A poll that returned nothing may still have staged a cursor advance — on
+				// its own, or after its last mid-poll emit — committed here. Active state is
+				// re-read first so a workflow deactivated mid-poll doesn't get its cursor moved.
 				try {
 					if (await this.workflowRepository.isActive(workflowId))
 						await commitStagedCursor(pollFunctions);
@@ -222,6 +233,22 @@ export class PollTriggerTaskHandler implements TaskHandler {
 					);
 				}
 
+				// Checked after the cursor commit on purpose: the commit must still run on
+				// this path, and a failed commit must not downgrade an occurrence whose
+				// executions were already handed off.
+				if (midPollDispatched) {
+					this.logger.debug(
+						'Poll returned no new data; mid-poll emits already dispatched executions',
+						{
+							taskId: task.id,
+							jobId: task.jobId,
+							workflowId,
+							nodeId,
+						},
+					);
+					return report.dispatched();
+				}
+
 				this.logger.debug('Poll returned no new data; nothing to hand off', {
 					taskId: task.id,
 					jobId: task.jobId,
@@ -232,7 +259,8 @@ export class PollTriggerTaskHandler implements TaskHandler {
 			} catch (error) {
 				// Routed to the error workflow instead of rethrown, which would retry and
 				// dead-letter without ever running it. __emitError commits no cursor, so
-				// the cursor holds and the next tick retries the same window.
+				// anything not yet handed off holds and the next tick re-covers it from
+				// the last committed advance.
 				if (!polled) {
 					const isActive = await this.workflowRepository.isActive(workflowId).catch(() => true);
 					if (isActive) {

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
 import type { Project, WorkflowEntity } from '@n8n/db';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
@@ -97,6 +98,7 @@ describe('TriggerExecutionContextFactory', () => {
 			ownershipService,
 			nodeTypes,
 			pollCursorService,
+			mock<GlobalConfig>({ scheduler: { pollTimeoutSeconds: 45, leaseDurationSeconds: 60 } }),
 		);
 	});
 
@@ -997,6 +999,69 @@ describe('TriggerExecutionContextFactory', () => {
 			expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(2);
 			const cursors = workflowExecutionService.runPolledWorkflow.mock.calls.map((call) => call[5]);
 			expect(cursors).toEqual([{ lastItemId: 'fast' }, { lastItemId: 'slow' }]);
+		});
+
+		describe('getPollBudgetMs', () => {
+			const buildBudgetContext = (
+				pollTimeoutSeconds: number,
+				leaseDurationSeconds: number,
+				fence?: { taskId: string; leaseEpoch: number },
+			) => {
+				const globalConfig = mock<GlobalConfig>({
+					scheduler: { pollTimeoutSeconds, leaseDurationSeconds },
+				});
+				const budgetFactory = new TriggerExecutionContextFactory(
+					mock<Logger>({ scoped: vi.fn().mockReturnValue(scopedLogger) }),
+					errorReporter,
+					activeExecutions,
+					eventService,
+					executionService,
+					workflowStaticDataService,
+					workflowExecutionService,
+					storageConfig,
+					workflowPublishedDataService,
+					scheduleTriggerJobRegistrar,
+					ownershipService,
+					nodeTypes,
+					pollCursorService,
+					globalConfig,
+				);
+				const getPollFunctions = budgetFactory.getExecutePollFunctions(
+					mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+					additionalData,
+					mode,
+					activation,
+					async () => mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+					fence,
+				);
+				return getPollFunctions(workflow, node, additionalData, mode, activation);
+			};
+
+			const fence = { taskId: 'task-1', leaseEpoch: 1 };
+
+			// Budget = min(poll timeout, lease duration) minus a margin of
+			// max(20%, 5s), so a node that exhausts it still finishes its
+			// in-flight batch before the engine abandons the tick.
+			test.each([
+				{ pollTimeoutSeconds: 45, leaseDurationSeconds: 60, expected: 36_000 },
+				{ pollTimeoutSeconds: 100, leaseDurationSeconds: 60, expected: 48_000 },
+				// The margin never eats more than half the ceiling, so a tiny (but
+				// schema-valid) timeout still yields a positive budget.
+				{ pollTimeoutSeconds: 4, leaseDurationSeconds: 60, expected: 2_000 },
+			])(
+				'derives $expected ms from a $pollTimeoutSeconds s timeout under a $leaseDurationSeconds s lease',
+				({ pollTimeoutSeconds, leaseDurationSeconds, expected }) => {
+					const budgetContext = buildBudgetContext(pollTimeoutSeconds, leaseDurationSeconds, fence);
+					expect(budgetContext.getPollBudgetMs()).toBe(expected);
+				},
+			);
+
+			test('keeps the generous PollContext default for a poll that runs without a lease', () => {
+				// The legacy in-memory path has no poll timeout and no lease, so the
+				// scheduler-derived budget must not apply there.
+				const budgetContext = buildBudgetContext(45, 60);
+				expect(budgetContext.getPollBudgetMs()).toBe(300_000);
+			});
 		});
 
 		test('throws when the node reads its static data outside of a poll', () => {

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1001,6 +1001,161 @@ describe('TriggerExecutionContextFactory', () => {
 			expect(cursors).toEqual([{ lastItemId: 'fast' }, { lastItemId: 'slow' }]);
 		});
 
+		describe('mid-poll emits', () => {
+			const unhandled: unknown[] = [];
+			const captureUnhandled = (reason: unknown) => unhandled.push(reason);
+
+			beforeEach(() => {
+				unhandled.length = 0;
+				process.on('unhandledRejection', captureUnhandled);
+			});
+
+			afterEach(() => {
+				process.off('unhandledRejection', captureUnhandled);
+			});
+
+			test('starts the next emit commit only after the previous one settled', async () => {
+				const firstRun = createDeferredPromise<string>();
+				workflowExecutionService.runPolledWorkflow
+					.mockReturnValueOnce(firstRun.promise)
+					.mockResolvedValueOnce('exec-2');
+
+				await context.__runPoll(async () => {
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+					context.__emit(pollData);
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'b' });
+					context.__emit(pollData);
+				});
+				await sleep(0);
+
+				// The first commit is still in flight, so the second must not have started:
+				// the cursor write is last-write-wins, and an out-of-order commit would
+				// regress the cursor to the earlier batch.
+				expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(1);
+
+				firstRun.resolve('exec-1');
+				await sleep(0);
+
+				expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(2);
+				expect(unhandled).toEqual([]);
+			});
+
+			test('captures each emit cursor delta when the node calls __emit, not when its commit runs', async () => {
+				await context.__runPoll(async () => {
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+					context.__emit(pollData);
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'b' });
+					context.__emit(pollData);
+				});
+				await sleep(0);
+
+				const cursors = workflowExecutionService.runPolledWorkflow.mock.calls.map(
+					(call) => call[5],
+				);
+				expect(cursors).toEqual([{ lastItemId: 'a' }, { lastItemId: 'b' }]);
+			});
+
+			test('runs the next emit commit even when the previous one rejected', async () => {
+				workflowExecutionService.runPolledWorkflow
+					.mockRejectedValueOnce(new UnexpectedError('db down'))
+					.mockResolvedValueOnce('exec-2');
+
+				await context.__runPoll(async () => {
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+					context.__emit(pollData);
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'b' });
+					context.__emit(pollData);
+				});
+				await sleep(0);
+				await new Promise((resolve) => setImmediate(resolve));
+
+				expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(2);
+				expect(scopedLogger.error).toHaveBeenCalled();
+				expect(unhandled).toEqual([]);
+			});
+
+			const buildDispatchContext = (onDispatched: () => void) => {
+				const getPollFunctions = factory.getExecutePollFunctions(
+					mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+					additionalData,
+					mode,
+					activation,
+					async () => mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+					undefined,
+					undefined,
+					onDispatched,
+				);
+				return getPollFunctions(
+					workflow,
+					node,
+					additionalData,
+					mode,
+					activation,
+				) as RunnablePollFunctions;
+			};
+
+			test('notifies onDispatched once per handed-off emit, skipping fenced-out ones', async () => {
+				const onDispatched = vi.fn();
+				const dispatchContext = buildDispatchContext(onDispatched);
+
+				// The first emit is fenced out (no execution row), the second hands off.
+				workflowExecutionService.runPolledWorkflow
+					.mockResolvedValueOnce(undefined)
+					.mockResolvedValueOnce('exec-polled');
+
+				await dispatchContext.__runPoll(async () => {
+					Object.assign(dispatchContext.getWorkflowStaticData('node'), { lastItemId: 'a' });
+					dispatchContext.__emit(pollData);
+					Object.assign(dispatchContext.getWorkflowStaticData('node'), { lastItemId: 'b' });
+					dispatchContext.__emit(pollData);
+				});
+				await sleep(0);
+
+				expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(2);
+				expect(onDispatched).toHaveBeenCalledTimes(1);
+			});
+
+			test('does not notify onDispatched when every emit was fenced out', async () => {
+				const onDispatched = vi.fn();
+				const dispatchContext = buildDispatchContext(onDispatched);
+
+				workflowExecutionService.runPolledWorkflow.mockResolvedValue(undefined);
+
+				await dispatchContext.__runPoll(async () => {
+					Object.assign(dispatchContext.getWorkflowStaticData('node'), { lastItemId: 'a' });
+					dispatchContext.__emit(pollData);
+				});
+				await sleep(0);
+
+				expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(1);
+				expect(onDispatched).not.toHaveBeenCalled();
+			});
+
+			test('does not queue a later poll emit behind an earlier poll unsettled commit', async () => {
+				const firstRun = createDeferredPromise<string>();
+				workflowExecutionService.runPolledWorkflow
+					.mockReturnValueOnce(firstRun.promise)
+					.mockResolvedValueOnce('exec-2');
+
+				await context.__runPoll(async () => {
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+					context.__emit(pollData);
+				});
+				await sleep(0);
+
+				// The legacy activation path reuses one context for every tick, so a
+				// hung hand-off from one tick must not defer the next tick's dispatch.
+				// firstRun is left unresolved on purpose.
+				await context.__runPoll(async () => {
+					Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'b' });
+					context.__emit(pollData);
+				});
+				await sleep(0);
+
+				expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledTimes(2);
+			});
+		});
+
 		describe('getPollBudgetMs', () => {
 			const buildBudgetContext = (
 				pollTimeoutSeconds: number,
@@ -1416,6 +1571,7 @@ describe('TriggerExecutionContextFactory', () => {
 				expect.any(Function),
 				undefined,
 				undefined,
+				undefined,
 			);
 
 			expect(getPollFunctions).toHaveBeenCalledWith(
@@ -1449,6 +1605,7 @@ describe('TriggerExecutionContextFactory', () => {
 				expect.any(Function),
 				fence,
 				undefined,
+				undefined,
 			);
 		});
 
@@ -1475,6 +1632,7 @@ describe('TriggerExecutionContextFactory', () => {
 				expect.any(Function),
 				fence,
 				prefetched,
+				undefined,
 			);
 		});
 

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -1,4 +1,6 @@
 import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
 import type { IWorkflowDb, PollerCursor, PollLeaseFence } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
@@ -79,6 +81,7 @@ export class TriggerExecutionContextFactory {
 		private readonly ownershipService: OwnershipService,
 		private readonly nodeTypes: NodeTypes,
 		private readonly pollCursorService: PollCursorService,
+		private readonly globalConfig: GlobalConfig,
 	) {
 		this.logger = this.logger.scoped(['workflow-activation']);
 	}
@@ -279,6 +282,17 @@ export class TriggerExecutionContextFactory {
 		prefetchedCursor?: PollerCursor,
 	): IGetExecutePollFunctions {
 		return (workflow: Workflow, node: INode) => {
+			// A poll must finish inside both the handler's abandon deadline and the task
+			// lease; past either, its commits are fenced out or discarded. The margin —
+			// 20%, at least 5s, at most half the ceiling — leaves room for the trailing
+			// hand-off and cursor commit.
+			const ceilingMs =
+				Math.min(
+					this.globalConfig.scheduler.pollTimeoutSeconds,
+					this.globalConfig.scheduler.leaseDurationSeconds,
+				) * Time.seconds.toMilliseconds;
+			const marginMs = Math.min(Math.max(0.2 * ceilingMs, 5_000), ceilingMs / 2);
+			const pollBudgetMs = ceilingMs - marginMs;
 			// A poll's staged snapshot lives in an async scope entered per poll, rather
 			// than in a variable per node: only the poll that staged it can commit it, and
 			// two overlapping polls of the same node never share a slot. An unmigrated
@@ -410,6 +424,9 @@ export class TriggerExecutionContextFactory {
 				__commitCursor,
 				__runPoll,
 				resolveNodeStaticData,
+				// Only a leased (durable) poll is bounded by the timeout and lease; a
+				// legacy in-memory poll keeps PollContext's generous default.
+				fence ? () => pollBudgetMs : undefined,
 			);
 		};
 	}

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -280,8 +280,15 @@ export class TriggerExecutionContextFactory {
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
 		fence?: PollLeaseFence,
 		prefetchedCursor?: PollerCursor,
+		// Optional: the legacy activation paths register poll functions without a
+		// dispatch reporter, so only the durable task handler passes a callback.
+		onDispatched?: () => void,
 	): IGetExecutePollFunctions {
 		return (workflow: Workflow, node: INode) => {
+			// Hand-offs from one poll run strictly in emit order: each commit is a
+			// last-write-wins cursor write, so two in flight at once could land out of
+			// order and move the cursor backwards.
+			let emitChain: Promise<unknown> = Promise.resolve();
 			// A poll must finish inside both the handler's abandon deadline and the task
 			// lease; past either, its commits are fenced out or discarded. The margin —
 			// 20%, at least 5s, at most half the ceiling — leaves room for the trailing
@@ -303,6 +310,9 @@ export class TriggerExecutionContextFactory {
 			>();
 
 			const __runPoll = async <T>(poll: () => Promise<T>): Promise<T> => {
+				// Fresh chain per poll: the legacy activation path reuses this context
+				// across ticks, and one tick's hung hand-off must not defer the next's.
+				emitChain = Promise.resolve();
 				const resolved = await this.pollCursorService.resolveCursor(
 					workflowData.id,
 					node.id,
@@ -344,11 +354,16 @@ export class TriggerExecutionContextFactory {
 				// data, or an unmigrated node's own bucket, which still doubles as its cursor.
 				void this.workflowStaticDataService.saveStaticData(workflow);
 
+				// Only the hand-off waits on the chain. The cursor and static data were
+				// captured above, synchronously: they must reflect what the node had staged
+				// at this emit, not what it stages while earlier hand-offs drain.
+				//
 				// TODO(CAT-3202): resolves workflow data via callback so we
 				// can feature-flag between in-memory data and the published data
 				// service. Once the flag is removed, we'll call the service directly.
-				const executePromise = resolveWorkflowData().then(async (freshWorkflowData) =>
-					cursor === null
+				const executePromise = emitChain.then(async () => {
+					const freshWorkflowData = await resolveWorkflowData();
+					return cursor === null
 						? await this.workflowExecutionService.runWorkflow(
 								freshWorkflowData,
 								node,
@@ -366,8 +381,18 @@ export class TriggerExecutionContextFactory {
 								cursor,
 								responsePromise,
 								fence,
-							),
-				);
+							);
+				});
+				// The swallowed copy keeps the chain alive and quiet: a failed hand-off must
+				// not block later emits, and its rejection is already reported through
+				// executePromise (done promise and failure log below).
+				emitChain = executePromise
+					.then((executionId) => {
+						// No id: the fence rejected the commit or the hand-off failed before
+						// creating an execution. Nothing ran, so it does not count as a dispatch.
+						if (executionId) onDispatched?.();
+					})
+					.catch(() => {});
 
 				if (donePromise) this.settleDonePromise(executePromise, donePromise);
 
@@ -441,6 +466,7 @@ export class TriggerExecutionContextFactory {
 		node: INode,
 		fence?: PollLeaseFence,
 		prefetchedCursor?: PollerCursor,
+		onDispatched?: () => void,
 	): Promise<{ workflow: Workflow; pollFunctions: IPollFunctions }> {
 		const workflow = new Workflow({
 			id: workflowData.id,
@@ -469,6 +495,7 @@ export class TriggerExecutionContextFactory {
 			resolveWorkflowData,
 			fence,
 			prefetchedCursor,
+			onDispatched,
 		);
 		// getPollFunctions already closed over these; its signature still requires them.
 		const pollFunctions = getPollFunctions(workflow, node, additionalData, 'trigger', 'update');

--- a/packages/cli/test/integration/database/repositories/poller-state.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/poller-state.repository.test.ts
@@ -1,8 +1,16 @@
-import { createWorkflow, testDb } from '@n8n/backend-test-utils';
+import {
+	createWorkflow,
+	createWorkflowWithHistory,
+	setActiveVersion,
+	testDb,
+} from '@n8n/backend-test-utils';
 import {
 	type PollerCursor,
 	PollerStateRepository,
+	ScheduledJobRepository,
+	ScheduledTaskRepository,
 	TransactionRunner,
+	WorkflowPublishedVersionRepository,
 	WorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -240,6 +248,82 @@ describe('PollerStateRepository', () => {
 			).rejects.toThrow('execution insert failed');
 
 			expect(await repository.findCursor(workflowId, 'node-1')).toEqual({ lastItemId: 'a' });
+		});
+
+		// Deactivation deprovisions the node's scheduled jobs; the running task row
+		// must cascade away with its job so the lease fence rejects any commit a
+		// still-running poll attempts afterwards (e.g. a mid-poll emit).
+		describe('fence after the job was deprovisioned', () => {
+			let jobRepository: ScheduledJobRepository;
+			let taskRepository: ScheduledTaskRepository;
+
+			beforeAll(() => {
+				jobRepository = Container.get(ScheduledJobRepository);
+				taskRepository = Container.get(ScheduledTaskRepository);
+			});
+
+			beforeEach(async () => {
+				await testDb.truncate(['ScheduledTask', 'ScheduledJob']);
+			});
+
+			it('rejects the advance once deprovisioning cascaded the running task away', async () => {
+				// scheduled_job.workflowId FKs to workflow_published_version, which itself
+				// FKs to workflow_history, so a job insert needs all three rows in place.
+				const published = await createWorkflowWithHistory({});
+				await setActiveVersion(published.id, published.versionId);
+				await Container.get(WorkflowPublishedVersionRepository).setPublishedVersion(
+					published.id,
+					published.versionId,
+				);
+
+				const job = await jobRepository.save(
+					jobRepository.create({
+						name: 'poll-node-1',
+						workflowId: published.id,
+						nodeId: 'node-1',
+						taskType: 'pollTrigger',
+						payload: {},
+						kind: 'interval',
+						intervalSeconds: 60,
+						enabled: true,
+						nextRunAt: new Date('2026-01-01T00:00:00.000Z'),
+						maxAttempts: 1,
+					}),
+				);
+				const task = await taskRepository.save(
+					taskRepository.create({
+						jobId: job.id,
+						taskType: 'pollTrigger',
+						payload: {},
+						scheduledFor: new Date('2026-06-01T00:00:00.000Z'),
+						runAt: new Date('2026-06-01T00:00:00.000Z'),
+						status: 'running',
+						attempts: 1,
+						maxAttempts: 1,
+						leaseEpoch: 1,
+						leaseExpiresAt: new Date(Date.now() + 60_000),
+					}),
+				);
+				const fence = { taskId: task.id, leaseEpoch: 1 };
+				await seed('node-1', { lastItemId: 'a' }, published.id);
+
+				// While the poll holds its lease, the fenced advance lands.
+				await expect(
+					repository.advanceCursor(published.id, 'node-1', { lastItemId: 'b' }, {}, fence),
+				).resolves.toBe(true);
+
+				// The same call deactivation's deprovision makes.
+				await jobRepository.deleteByWorkflowNode(jobRepository.manager, published.id, 'node-1');
+
+				// The running task row is gone with its job, not orphaned.
+				await expect(taskRepository.findOneBy({ id: task.id })).resolves.toBeNull();
+
+				// A late commit from the still-running poll is fenced out, cursor untouched.
+				await expect(
+					repository.advanceCursor(published.id, 'node-1', { lastItemId: 'c' }, {}, fence),
+				).resolves.toBe(false);
+				expect(await repository.findCursor(published.id, 'node-1')).toEqual({ lastItemId: 'b' });
+			});
 		});
 
 		it('does not touch the stored failure counters', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
@@ -65,6 +65,29 @@ describe('PollContext', () => {
 		});
 	});
 
+	describe('getPollBudgetMs', () => {
+		it('returns a five-minute default when the engine provided no budget', () => {
+			expect(pollContext.getPollBudgetMs()).toBe(300_000);
+		});
+
+		it('returns the budget provided by the engine', () => {
+			const context = new PollContext(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				activation,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				() => 36_000,
+			);
+			expect(context.getPollBudgetMs()).toBe(36_000);
+		});
+	});
+
 	describe('getCredentials', () => {
 		it('should get decrypted credentials', async () => {
 			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);

--- a/packages/core/src/execution-engine/node-execution-context/poll-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/poll-context.ts
@@ -1,3 +1,4 @@
+import { Time } from '@n8n/constants';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
@@ -45,6 +46,11 @@ export class PollContext extends NodeExecutionContext implements IPollFunctions 
 		// staging scope (e.g. a manual test run).
 		private readonly resolveNodeStaticData: () => IDataObject = () =>
 			this.workflow.getStaticData('node', this.node),
+		// Generous fallback for polls that run outside the durable scheduler (e.g. a
+		// manual test run): no lease bounds them, but nodes still size their fetch
+		// loop from a finite budget.
+		readonly getPollBudgetMs: IPollFunctions['getPollBudgetMs'] = () =>
+			5 * Time.minutes.toMilliseconds,
 	) {
 		super(workflow, node, additionalData, mode);
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1417,6 +1417,12 @@ export interface IPollFunctions
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 		donePromise?: IDeferredPromise<IRun | undefined>,
 	): void;
+	/**
+	 * Milliseconds this poll may spend before the engine abandons the tick.
+	 * A node draining a large backlog should stop fetching before the budget
+	 * runs out, return what it has, and leave the rest to the next poll.
+	 */
+	getPollBudgetMs(): number;
 	__emitError(error: Error, responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>): void;
 	getNodeParameter(
 		parameterName: string,


### PR DESCRIPTION
## Summary

Stacked on #37119 (poll time budget); extracted from it to keep that PR focused.

Any poll node may legally call `__emit` more than once during one `poll()`. Two latent problems in that path, both now fixed:

**Out-of-order commits could move the cursor backwards.** Each emit's hand-off commits the node's cursor delta atomically with its execution, but the hand-offs were fire-and-forget and the cursor write is a lease-fenced, last-write-wins UPDATE. Two commits in flight at once could land out of order: the cursor would regress to an earlier batch and the next tick would re-fetch data an execution already received. Hand-offs from one poll now run through a chain, in emit order. The chain resets when a poll starts, because the legacy activation path builds one poll context at activation and reuses it every tick — a shared chain would queue each tick's dispatches behind the previous tick's, and one hung hand-off would stall the node's executions forever while `poll()` keeps running on schedule.

**The scheduler was not told about mid-poll dispatches.** A tick that emitted executions mid-poll and then returned `null` was recorded as "no new data". The factory now notifies the durable task handler of each hand-off (only when the commit produced an execution — a fence-rejected commit dispatches nothing), and the handler stamps the occurrence dispatched at that instant, so a throw later in the tick cannot retry an occurrence whose executions already started.

Note: the flagship node work for CAT-3870 uses time-boxed accumulate-and-return (one emit per tick via the normal return path), so no built-in node exercises this machinery yet. It hardens a surface that community nodes can already reach today.

## How to test

```
pnpm --filter n8n test src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
pnpm --filter n8n test src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
```

Covered: commit ordering under a slow first hand-off, chain reset across polls of one context, failure isolation (a rejected hand-off does not block later emits, no unhandled rejections), synchronous cursor-delta capture, onDispatched only for handed-off emits (fenced-out emits excluded), dispatch decision and marker stamped while the poll is still in flight, and the trailing-cursor-commit-fails case.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3870

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

