### PR TITLE
fix(core): Apply the SSO expression mapping env var in the provisioning loader

### DIFF
--- a/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-loader.config.ts
@@ -33,7 +33,11 @@ export class InstanceSettingsLoaderConfig {
 	@Env('N8N_SSO_MANAGED_BY_ENV')
 	ssoManagedByEnv: boolean = false;
 
-	/** User role provisioning mode: disabled, instance_role, or instance_and_project_roles. */
+	/**
+	 * Which roles direct-claim provisioning sets: disabled, instance_role, or
+	 * instance_and_project_roles. Ignored when N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING selects
+	 * the expression-mapping strategy instead.
+	 */
 	@Env('N8N_SSO_USER_ROLE_PROVISIONING')
 	ssoUserRoleProvisioning: string = 'disabled';
 

--- a/packages/@n8n/config/src/configs/sso.config.ts
+++ b/packages/@n8n/config/src/configs/sso.config.ts
@@ -51,7 +51,11 @@ class ProvisioningConfig {
 	@Env('N8N_SSO_SCOPES_PROJECTS_ROLES_CLAIM_NAME')
 	scopesProjectsRolesClaimName: string = 'n8n_projects';
 
-	/** Whether to use expression-based role mapping rules instead of direct SSO claim provisioning. */
+	/**
+	 * Whether to use expression-based role mapping rules instead of direct SSO claim
+	 * provisioning. The two are mutually exclusive, and which scopes the rules cover follows
+	 * from the rules themselves rather than from N8N_SSO_USER_ROLE_PROVISIONING.
+	 */
 	@Env('N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING')
 	scopesUseExpressionMapping: boolean = false;
 }

--- a/packages/cli/src/instance-settings-loader/__tests__/sso/provisioning.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/sso/provisioning.instance-settings-loader.test.ts
@@ -11,22 +11,32 @@ describe('ProvisioningInstanceSettingsLoader', () => {
 	const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
 	const settingsRepository = mock<SettingsRepository>();
 
-	const globalConfig = {
-		sso: {
-			provisioning: {
-				scopesName: 'n8n',
-				scopesInstanceRoleClaimName: 'n8n_instance_role',
-				scopesProjectsRolesClaimName: 'n8n_projects',
+	const createGlobalConfig = (scopesUseExpressionMapping = false) =>
+		({
+			sso: {
+				provisioning: {
+					scopesName: 'n8n',
+					scopesInstanceRoleClaimName: 'n8n_instance_role',
+					scopesProjectsRolesClaimName: 'n8n_projects',
+					scopesUseExpressionMapping,
+				},
 			},
-		},
-	} as GlobalConfig;
+		}) as GlobalConfig;
 
-	const createLoader = (configOverrides: Partial<InstanceSettingsLoaderConfig> = {}) => {
+	const createLoader = (
+		configOverrides: Partial<InstanceSettingsLoaderConfig> = {},
+		scopesUseExpressionMapping = false,
+	) => {
 		const config = {
 			ssoUserRoleProvisioning: 'disabled',
 			...configOverrides,
 		} as InstanceSettingsLoaderConfig;
-		return new ProvisioningInstanceSettingsLoader(config, globalConfig, settingsRepository, logger);
+		return new ProvisioningInstanceSettingsLoader(
+			config,
+			createGlobalConfig(scopesUseExpressionMapping),
+			settingsRepository,
+			logger,
+		);
 	};
 
 	beforeEach(() => {
@@ -106,6 +116,78 @@ describe('ProvisioningInstanceSettingsLoader', () => {
 		);
 	});
 
+	describe('N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING', () => {
+		// It is the "role mapping method" dropdown: it picks how claims map to the roles the
+		// mode provisions, and clears the direct-claim flags because the two are exclusive.
+		it.each(['instance_role', 'instance_and_project_roles'] as const)(
+			'should select expression mapping for the %s mode',
+			async (mode) => {
+				const loader = createLoader({ ssoUserRoleProvisioning: mode }, true);
+
+				await loader.apply();
+
+				expect(settingsRepository.upsert).toHaveBeenCalledWith(
+					{
+						key: 'features.provisioning',
+						value: JSON.stringify({
+							scopesProvisionInstanceRole: false,
+							scopesProvisionProjectRoles: false,
+							scopesUseExpressionMapping: true,
+							scopesName: 'n8n',
+							scopesInstanceRoleClaimName: 'n8n_instance_role',
+							scopesProjectsRolesClaimName: 'n8n_projects',
+						}),
+						loadOnStartup: true,
+					},
+					{ conflictPaths: ['key'] },
+				);
+			},
+		);
+
+		it('should stay off for the disabled mode, which assigns roles manually', async () => {
+			const loader = createLoader({ ssoUserRoleProvisioning: 'disabled' }, true);
+
+			await loader.apply();
+
+			const upsertCall = settingsRepository.upsert.mock.calls[0][0] as { value: string };
+			expect(jsonParse(upsertCall.value)).toMatchObject({
+				scopesProvisionInstanceRole: false,
+				scopesProvisionProjectRoles: false,
+				scopesUseExpressionMapping: false,
+			});
+		});
+
+		it('should warn that it has no effect for the disabled mode', async () => {
+			const loader = createLoader({ ssoUserRoleProvisioning: 'disabled' }, true);
+
+			await loader.apply();
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING=true has no effect'),
+			);
+		});
+
+		it('should not warn when the mode provisions roles', async () => {
+			const loader = createLoader({ ssoUserRoleProvisioning: 'instance_role' }, true);
+
+			await loader.apply();
+
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it.each(['disabled', 'instance_role', 'instance_and_project_roles'] as const)(
+			'should leave %s untouched when unset',
+			async (mode) => {
+				const loader = createLoader({ ssoUserRoleProvisioning: mode });
+
+				await loader.apply();
+
+				const upsertCall = settingsRepository.upsert.mock.calls[0][0] as { value: string };
+				expect(jsonParse(upsertCall.value)).toMatchObject({ scopesUseExpressionMapping: false });
+			},
+		);
+	});
+
 	describe('persisted value is consumable by ProvisioningConfigDto', () => {
 		// The loader writes the row that the provisioning service reads back via
 		// ProvisioningConfigDto.parse(). If parse fails the service silently falls
@@ -114,6 +196,17 @@ describe('ProvisioningInstanceSettingsLoader', () => {
 
 		it.each(modes)('round-trips for %s', async (mode) => {
 			const loader = createLoader({ ssoUserRoleProvisioning: mode });
+
+			await loader.apply();
+
+			const upsertCall = settingsRepository.upsert.mock.calls[0][0] as { value: string };
+			const persisted = jsonParse<unknown>(upsertCall.value);
+
+			expect(() => ProvisioningConfigDto.parse(persisted)).not.toThrow();
+		});
+
+		it.each(modes)('round-trips for %s with expression mapping', async (mode) => {
+			const loader = createLoader({ ssoUserRoleProvisioning: mode }, true);
 
 			await loader.apply();
 

--- a/packages/cli/src/instance-settings-loader/loaders/sso/provisioning.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/sso/provisioning.instance-settings-loader.ts
@@ -1,4 +1,8 @@
-import { ProvisioningConfigDto, type ProvisioningMode } from '@n8n/api-types';
+import {
+	ProvisioningConfigDto,
+	type ProvisioningMode,
+	type ProvisioningModeFlags,
+} from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig, InstanceSettingsLoaderConfig } from '@n8n/config';
 import { SettingsRepository } from '@n8n/db';
@@ -14,6 +18,45 @@ const ENV_PROVISIONING_MODES = [
 	'instance_role',
 	'instance_and_project_roles',
 ] as const satisfies readonly ProvisioningMode[];
+
+type EnvProvisioningMode = (typeof ENV_PROVISIONING_MODES)[number];
+
+/**
+ * The two env vars are the two settings dropdowns: the mode picks which roles SSO provisions,
+ * `N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING` picks how claims map to them. Mirrors
+ * `getProvisioningConfigFromDropdowns` in the UI, which collapses the same two choices into
+ * these three flags because the two mapping methods are mutually exclusive code paths.
+ */
+function resolveModeFlags(
+	mode: EnvProvisioningMode,
+	useExpressionMapping: boolean,
+): ProvisioningModeFlags {
+	// Roles assigned by hand, so there is nothing for a mapping method to do — the UI hides
+	// that dropdown entirely for this option.
+	if (mode === 'disabled') {
+		return {
+			scopesProvisionInstanceRole: false,
+			scopesProvisionProjectRoles: false,
+			scopesUseExpressionMapping: false,
+		};
+	}
+
+	// Expression mapping replaces direct-claim provisioning rather than layering on top, so
+	// the scopes it covers follow from the rules that exist, not from the mode.
+	if (useExpressionMapping) {
+		return {
+			scopesProvisionInstanceRole: false,
+			scopesProvisionProjectRoles: false,
+			scopesUseExpressionMapping: true,
+		};
+	}
+
+	return {
+		scopesProvisionInstanceRole: true,
+		scopesProvisionProjectRoles: mode === 'instance_and_project_roles',
+		scopesUseExpressionMapping: false,
+	};
+}
 
 const modeSchema = z.object({
 	ssoUserRoleProvisioning: z.enum(ENV_PROVISIONING_MODES, {
@@ -43,13 +86,16 @@ export class ProvisioningInstanceSettingsLoader {
 		const mode = parsed.data.ssoUserRoleProvisioning;
 		const { provisioning } = this.globalConfig.sso;
 
+		if (provisioning.scopesUseExpressionMapping && mode === 'disabled') {
+			this.logger.warn(
+				'N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING=true has no effect while N8N_SSO_USER_ROLE_PROVISIONING is "disabled", which assigns roles manually. Set it to instance_role or instance_and_project_roles to map roles with rules.',
+			);
+		}
+
 		// Persist the full ProvisioningConfigDto shape. The read path rejects
 		// partial rows and silently falls back to disabled defaults.
 		const value: ProvisioningConfigDto = {
-			scopesProvisionInstanceRole:
-				mode === 'instance_role' || mode === 'instance_and_project_roles',
-			scopesProvisionProjectRoles: mode === 'instance_and_project_roles',
-			scopesUseExpressionMapping: false,
+			...resolveModeFlags(mode, provisioning.scopesUseExpressionMapping),
 			scopesName: provisioning.scopesName,
 			scopesInstanceRoleClaimName: provisioning.scopesInstanceRoleClaimName,
 			scopesProjectsRolesClaimName: provisioning.scopesProjectsRolesClaimName,

--- a/packages/cli/test/integration/provisioning.instance-settings-loader.test.ts
+++ b/packages/cli/test/integration/provisioning.instance-settings-loader.test.ts
@@ -1,0 +1,93 @@
+import { testDb } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import { SettingsRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { ProvisioningInstanceSettingsLoader } from '@/instance-settings-loader/loaders/sso/provisioning.instance-settings-loader';
+import { PROVISIONING_PREFERENCES_DB_KEY } from '@/modules/provisioning.ee/constants';
+import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
+
+beforeAll(async () => {
+	await testDb.init();
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('ProvisioningInstanceSettingsLoader', () => {
+	let originalLoaderConfig: Record<string, unknown>;
+	let originalProvisioningConfig: Record<string, unknown>;
+
+	beforeEach(() => {
+		const globalConfig = Container.get(GlobalConfig);
+		originalLoaderConfig = { ...globalConfig.instanceSettingsLoader };
+		originalProvisioningConfig = { ...globalConfig.sso.provisioning };
+	});
+
+	afterEach(async () => {
+		const globalConfig = Container.get(GlobalConfig);
+		Object.assign(globalConfig.instanceSettingsLoader, originalLoaderConfig);
+		Object.assign(globalConfig.sso.provisioning, originalProvisioningConfig);
+
+		await Container.get(SettingsRepository).delete({ key: PROVISIONING_PREFERENCES_DB_KEY });
+	});
+
+	const applyWith = async (mode: string, scopesUseExpressionMapping = false) => {
+		const globalConfig = Container.get(GlobalConfig);
+		Object.assign(globalConfig.instanceSettingsLoader, {
+			ssoManagedByEnv: true,
+			ssoUserRoleProvisioning: mode,
+		});
+		globalConfig.sso.provisioning.scopesUseExpressionMapping = scopesUseExpressionMapping;
+
+		await Container.get(ProvisioningInstanceSettingsLoader).apply();
+	};
+
+	it('should write a row that ProvisioningService reads back as expression mapping', async () => {
+		await applyWith('instance_and_project_roles', true);
+
+		const provisioningService = Container.get(ProvisioningService);
+		const config = await provisioningService.loadConfig();
+
+		expect(config).toMatchObject({
+			scopesProvisionInstanceRole: false,
+			scopesProvisionProjectRoles: false,
+			scopesUseExpressionMapping: true,
+		});
+	});
+
+	it('should keep expression mapping off for direct-claim modes', async () => {
+		await applyWith('instance_and_project_roles');
+
+		const config = await Container.get(ProvisioningService).loadConfig();
+
+		expect(config).toMatchObject({
+			scopesProvisionInstanceRole: true,
+			scopesProvisionProjectRoles: true,
+			scopesUseExpressionMapping: false,
+		});
+	});
+
+	it('should leave everything off for the disabled mode, which assigns roles manually', async () => {
+		await applyWith('disabled', true);
+
+		const config = await Container.get(ProvisioningService).loadConfig();
+
+		expect(config).toMatchObject({
+			scopesProvisionInstanceRole: false,
+			scopesProvisionProjectRoles: false,
+			scopesUseExpressionMapping: false,
+		});
+	});
+
+	it('should survive a restart, which is what the DB row is for', async () => {
+		await applyWith('instance_role', true);
+		// Second boot with the same env: the row must not flip back to direct-claim.
+		await applyWith('instance_role', true);
+
+		const config = await Container.get(ProvisioningService).loadConfig();
+
+		expect(config.scopesUseExpressionMapping).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

The env-managed provisioning loader hardcoded `scopesUseExpressionMapping: false`, so `N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING` never reached the persisted config. Every restart of an instance with `N8N_SSO_MANAGED_BY_ENV=true` reset expression-based role mapping to off, and the config API is blocked in that mode, so there was no way to turn it on at all.

The loader now derives the three provisioning flags from both env vars. `N8N_SSO_USER_ROLE_PROVISIONING` picks which roles SSO provisions and `N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING` picks how claims map to them, mirroring the two dropdowns in SSO settings:

| `N8N_SSO_USER_ROLE_PROVISIONING` | `N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING` | persisted flags |
|---|---|---|
| `disabled` | either | all `false`, plus a warning when it is `true` |
| `instance_role` | `false` | instance role only |
| `instance_and_project_roles` | `false` | instance and project roles |
| either non-disabled mode | `true` | expression mapping only |

Note this is not the one-line change proposed in the issue. Expression mapping and direct-claim provisioning are mutually exclusive, and `patchConfig()` rejects a config that enables both, so reading the var straight through alongside `instance_and_project_roles` would persist a row the API refuses and the UI can never save back. Expression mapping therefore clears the direct-claim flags, exactly as `getProvisioningConfigFromDropdowns` does in the editor. Which scopes the rules cover still follows from the rules themselves.

Thanks to @abduol-mabrouk for the detailed report and to @Solaris-star for #35080.

## How to test

Provisioning needs an enterprise license with SSO and provisioning entitlements.

1. Start n8n with `N8N_SSO_MANAGED_BY_ENV=true`, `N8N_SSO_OIDC_LOGIN_ENABLED=true` plus your OIDC connection vars, `N8N_SSO_USER_ROLE_PROVISIONING=instance_role` and `N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING=true`.
2. Open **Settings → SSO**. Role mapping method shows **Map rules inside n8n**.
3. Add an instance role rule, for example `{{ $claims.groups.includes('admins') }}` assigning Admin.
4. Restart n8n. The rule and the mapping method both survive. On master the method flips back to **Map rules on your IdP** on every restart.
5. Log in through the IdP as a user matching the rule and confirm the resolved role.
6. Set `N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING=false`, restart, and confirm direct-claim provisioning is used again.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1092

fixes #35076

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

