### PR TITLE
fix(editor): Close add-channel modal on outside click

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
@@ -35,6 +35,7 @@ const connectedCredentials = ref<Record<string, string>>({});
 const selectedCredentials = ref<Record<string, string>>({});
 const loadingMap = ref<Record<string, boolean>>({});
 const runtimeErrors = ref<Record<string, string>>({});
+const credentialModalOpen = ref(false);
 
 vi.mock('@n8n/i18n', () => ({
 	useI18n: () => ({ baseText: (key: string) => key }),
@@ -168,7 +169,7 @@ vi.mock('../composables/useAgentChannelSetup', () => ({
 		selectedCredentials,
 		credentialsLoading: ref(false),
 		credentialPermissions: ref({ create: true }),
-		credentialModalOpen: ref(false),
+		credentialModalOpen,
 		getChannelCredentialId: (type?: string | null) =>
 			type ? (selectedCredentials.value[type] ?? connectedCredentials.value[type] ?? '') : '',
 		getCredentials: () => [
@@ -195,9 +196,19 @@ function mountModal(view: ChannelView = 'example_setup', isPublished = false) {
 			stubs: {
 				Dialog: {
 					props: ['open', 'showCloseButton'],
-					emits: ['update:open'],
+					emits: ['update:open', 'interactOutside'],
+					methods: {
+						// Mirrors reka-ui's own DismissableLayer: an outside click fires
+						// `interact-outside` first, and only dismisses if that event
+						// wasn't prevented.
+						clickOutside() {
+							const event = new Event('interact-outside', { cancelable: true });
+							this.$emit('interactOutside', event);
+							if (!event.defaultPrevented) this.$emit('update:open', false);
+						},
+					},
 					template:
-						'<div v-if="open"><button data-testid="close-dialog" @click="$emit(\'update:open\', false)" /><slot /></div>',
+						'<div v-if="open"><button data-testid="close-dialog" @click="$emit(\'update:open\', false)" /><button data-testid="click-outside" @click="clickOutside" /><slot /></div>',
 				},
 				DialogHeader: { template: '<div><slot /></div>' },
 				DialogTitle: { template: '<h3><slot /></h3>' },
@@ -248,6 +259,7 @@ describe('AgentChannelModal', () => {
 		selectedCredentials.value = {};
 		loadingMap.value = {};
 		runtimeErrors.value = {};
+		credentialModalOpen.value = false;
 		mocks.connect.mockImplementation(async (type: string, credentialId: string) => {
 			statuses.value[type] = 'connected';
 			connectedCredentials.value[type] = credentialId;
@@ -415,6 +427,48 @@ describe('AgentChannelModal', () => {
 			expect(mocks.showError).toHaveBeenCalled();
 			expect(mocks.connect).not.toHaveBeenCalled();
 			expect(wrapper.emitted('update:open')).toBeUndefined();
+		});
+	});
+
+	describe('outside click', () => {
+		it('closes the modal', async () => {
+			const wrapper = mountModal('list');
+			await flushPromises();
+
+			await wrapper.get('[data-testid="click-outside"]').trigger('click');
+
+			expect(wrapper.emitted('update:open')).toEqual([[false]]);
+		});
+
+		it('is ignored while the nested credential modal is open', async () => {
+			credentialModalOpen.value = true;
+			const wrapper = mountModal('list');
+			await flushPromises();
+
+			await wrapper.get('[data-testid="click-outside"]').trigger('click');
+
+			expect(wrapper.emitted('update:open')).toBeUndefined();
+		});
+
+		it('is ignored while an action is in flight', async () => {
+			let release: () => void = () => {};
+			mocks.ensureAgentPersisted.mockImplementation(
+				async () =>
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					}),
+			);
+			selectedCredentials.value.example = 'credential-new';
+			const wrapper = mountModal('example_setup');
+			await flushPromises();
+
+			await wrapper.get('[data-testid="connect-channel"]').trigger('click');
+			await wrapper.get('[data-testid="click-outside"]').trigger('click');
+
+			expect(wrapper.emitted('update:open')).toBeUndefined();
+
+			release();
+			await flushPromises();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
@@ -333,6 +333,11 @@ function handleModalOpenUpdate(isOpen: boolean) {
 	emit('update:open', isOpen);
 }
 
+// Only block outside-close while the teleported credential modal is open.
+function handleInteractOutside(event: Event) {
+	if (credentialModalOpen.value) event.preventDefault();
+}
+
 async function persistAgent(): Promise<boolean> {
 	try {
 		await props.ensureAgentPersisted?.();
@@ -525,7 +530,7 @@ watch(
 		:trap-focus="!credentialModalOpen"
 		:disable-outside-pointer-events="!credentialModalOpen"
 		:show-close-button="false"
-		@interact-outside="(e) => e.preventDefault()"
+		@interact-outside="handleInteractOutside"
 		@update:open="handleModalOpenUpdate"
 	>
 		<FocusScope


### PR DESCRIPTION
## Summary

The agent channel modal always called `event.preventDefault()` on outside clicks, which blocked the dialog's built-in close-on-outside-click behavior entirely. It now only suppresses that when the nested credential-picker modal is open, matching the existing pattern in `AgentToolConfigModal.vue`.

## How to test

1. Open an agent, click **Add channel** (or click an existing configured channel to open its edit view).
2. Click outside the modal.
3. Modal should close.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-722


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

