### PR TITLE
ci: Route SafeChain proxy logging to a file (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -168,8 +168,14 @@ runs:
     #  4. Everything is uploaded as an artifact by the next step, so the full log
     #     survives even when the live console stream is truncated by the runner.
     #
-    # `SAFE_CHAIN_LOGGING=verbose` surfaces safe-chain's proxy decisions, which
-    # are otherwise buffered (and lost on failure) while pnpm is in flight.
+    # SafeChain's proxy decisions go to a file rather than the console. They are
+    # emitted via `writeVerbose`, which always writes to `SAFE_CHAIN_LOG_FILE` but
+    # only reaches the console at `SAFE_CHAIN_LOGGING=verbose` — and there is one
+    # line per HTTP request, so verbose put ~9.5k `Finished proxying request to`
+    # lines in every install (60-76% of the whole job log). Omitting the variable
+    # leaves the console at safe-chain's `normal` default; the file keeps the full
+    # detail (its own default verbosity is `verbose`) and lands in the diagnostics
+    # dir that the next step uploads on install failure.
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       id: install-deps
@@ -177,7 +183,8 @@ runs:
         INSTALL_COMMAND: ${{ inputs.install-command }}
         INSTALL_LOG: ${{ runner.temp }}/pnpm-install.log
         PNPM_DIAG_DIR: ${{ runner.temp }}/pnpm-diagnostics
-        SAFE_CHAIN_LOGGING: verbose
+        SAFE_CHAIN_LOG_FILE: ${{ runner.temp }}/pnpm-diagnostics/safe-chain.log
+        SAFE_CHAIN_LOG_FILE_FORMAT: plain
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         # Stable, artifact-name-safe id for the upload step (written first so it


### PR DESCRIPTION
## Summary

Write safechain output to a file to prevent it clogging the CI UI

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

