### PR TITLE
feat(core): Add Volcengine Ark as a model provider in Agent Builder

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -433,6 +433,27 @@ describe('createModel', () => {
 			expect(model.supportsStructuredOutputs).toBeUndefined();
 		});
 
+		it('should create model for volcengine with default baseURL', () => {
+			const model = createModel({
+				id: 'volcengine/doubao-seed-2-1-pro-260628',
+				apiKey: 'ark-test',
+			}) as unknown as Record<string, unknown>;
+			expect(model.provider).toBe('volcengine');
+			expect(model.modelId).toBe('doubao-seed-2-1-pro-260628');
+			expect(model.apiKey).toBe('ark-test');
+			expect(model.baseURL).toBe('https://ark.cn-beijing.volces.com/api/v3');
+		});
+
+		it('should allow custom baseURL for volcengine', () => {
+			const model = createModel({
+				id: 'volcengine/doubao-seed-2-1-pro-260628',
+				apiKey: 'ark-test',
+				url: 'https://custom-ark.example.com/api/v3',
+			}) as unknown as Record<string, unknown>;
+			expect(model.provider).toBe('volcengine');
+			expect(model.baseURL).toBe('https://custom-ark.example.com/api/v3');
+		});
+
 		it('should create model for moonshotai', () => {
 			const model = createModel({
 				id: 'moonshotai/kimi-k3',

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -131,7 +131,7 @@ function buildOpenAiCompatible(
 	})(model);
 }
 
-type OpenAiCompatibleProviderId = 'nvidia';
+type OpenAiCompatibleProviderId = 'nvidia' | 'volcengine';
 
 function isOfficialOpenAiBaseUrl(baseURL: string | undefined): boolean {
 	return baseURL?.replace(/\/+$/, '') === 'https://api.openai.com/v1';
@@ -261,6 +261,7 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 		},
 	},
 	nvidia: openAiCompatibleEntry('nvidia', 'https://integrate.api.nvidia.com/v1', {}),
+	volcengine: openAiCompatibleEntry('volcengine', 'https://ark.cn-beijing.volces.com/api/v3', {}),
 	moonshotai: {
 		build: (creds, model, fetch) => {
 			const { createMoonshotAI } =

--- a/packages/@n8n/agents/src/runtime/model/provider-credentials.ts
+++ b/packages/@n8n/agents/src/runtime/model/provider-credentials.ts
@@ -46,6 +46,7 @@ export const PROVIDER_CREDENTIAL_SCHEMAS = {
 	vercel: apiKeyCreds,
 	openrouter: apiKeyCreds,
 	nvidia: apiKeyCreds,
+	volcengine: apiKeyCreds,
 
 	'azure-openai': z.object({
 		apiKey: z.string().optional(),

--- a/packages/@n8n/ai-utilities/src/model-discovery/__tests__/model-discovery.test.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/__tests__/model-discovery.test.ts
@@ -193,6 +193,28 @@ describe('model-discovery', () => {
 		});
 	});
 
+	describe('volcengine', () => {
+		it('keeps only supported Doubao models and drops unverified/test models', async () => {
+			const fetch = mockFetch({
+				data: [
+					{ id: 'doubao-seed-2-1-pro-260628' },
+					{ id: 'test-v1' },
+					{ id: 'doubao-seed-2-1-turbo-260628' },
+					{ id: 'ddd-1.0.0' },
+				],
+			});
+
+			const models = await listModelsForProvider('volcengine', { apiKey: 'key', fetch });
+
+			expect(calledUrl(fetch)).toBe('https://ark.cn-beijing.volces.com/api/v3/models');
+			expect(calledHeaders(fetch).Authorization).toBe('Bearer key');
+			expect(models.map((m) => m.id)).toEqual([
+				'doubao-seed-2-1-pro-260628',
+				'doubao-seed-2-1-turbo-260628',
+			]);
+		});
+	});
+
 	describe.each([
 		['deepseek', 'https://api.deepseek.com/models'],
 		['openrouter', 'https://openrouter.ai/api/v1/models'],
@@ -321,6 +343,7 @@ describe('model-discovery', () => {
 			'openai',
 			'openrouter',
 			'vercel',
+			'volcengine',
 			'xai',
 		]);
 	});

--- a/packages/@n8n/ai-utilities/src/model-discovery/index.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/index.ts
@@ -11,6 +11,7 @@ import { listNvidiaModels } from './providers/nvidia';
 import { listOpenAiModels } from './providers/openai';
 import { listOpenRouterModels } from './providers/openrouter';
 import { listVercelModels } from './providers/vercel';
+import { listVolcengineModels } from './providers/volcengine';
 import { listXaiModels } from './providers/xai';
 import type { ListModelsFn, ListModelsOptions, ProviderModel } from './types';
 
@@ -39,6 +40,7 @@ export const MODEL_DISCOVERY_PROVIDERS: Record<string, ListModelsFn> = {
 	openai: listOpenAiModels,
 	openrouter: listOpenRouterModels,
 	vercel: listVercelModels,
+	volcengine: listVolcengineModels,
 	xai: listXaiModels,
 };
 
@@ -75,6 +77,7 @@ export {
 } from './providers/openai';
 export { listOpenRouterModels } from './providers/openrouter';
 export { listVercelModels } from './providers/vercel';
+export { listVolcengineModels } from './providers/volcengine';
 export { listXaiModels } from './providers/xai';
 export { ensureUrlPathSuffix } from './request';
 export type { ListModelsFn, ListModelsOptions, ProviderModel } from './types';

--- a/packages/@n8n/ai-utilities/src/model-discovery/providers/volcengine.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/providers/volcengine.ts
@@ -1,0 +1,41 @@
+import { baseUrl, bearerHeaders, byName, getJson, idsToModels, type IdItem } from '../request';
+import type { ListModelsFn } from '../types';
+
+const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3';
+
+/**
+ * Verified chat models on Volcengine Ark.
+ * Ark's GET /models returns hundreds of internal/experimental/unreleased items
+ * (e.g. test-v1, ddd-1.0.0, as well as unactivated model IDs that 404 on chat),
+ * so we filter to the verified Doubao Seed chat models.
+ */
+const VOLCENGINE_SUPPORTED_MODELS = new Set([
+	'doubao-seed-2-1-pro-260628',
+	'doubao-seed-2-1-turbo-260628',
+	'doubao-seed-2-0-pro-260215',
+	'doubao-seed-2-0-lite-260428',
+	'doubao-seed-2-0-mini-260428',
+	'doubao-seed-2-0-code-preview-260215',
+	'doubao-seed-1-8-251228',
+	'doubao-seed-1-6-251015',
+	'doubao-seed-1-6-flash-250828',
+	'doubao-seed-1-6-vision-250815',
+	'doubao-seed-character-260628',
+	'doubao-seed-evolving',
+]);
+
+/**
+ * Source: Volcengine Ark `/models` standard bearer listing filtered to supported models.
+ */
+export const listVolcengineModels: ListModelsFn = async (options) => {
+	const data = (await getJson(
+		`${baseUrl(options, DEFAULT_BASE_URL)}/models`,
+		bearerHeaders(options),
+		options,
+		'volcengine',
+	)) as { data?: IdItem[] };
+
+	return idsToModels(data.data ?? [])
+		.filter((model) => VOLCENGINE_SUPPORTED_MODELS.has(model.id))
+		.sort(byName);
+};

--- a/packages/@n8n/api-types/src/agents/model-providers.ts
+++ b/packages/@n8n/api-types/src/agents/model-providers.ts
@@ -15,6 +15,7 @@ export const AGENT_MODEL_PROVIDERS = [
 	'moonshotai',
 	'alibaba',
 	'minimax',
+	'volcengine',
 ] as const;
 
 /** Canonical `provider/model-name` validation shared by API schemas and editor parsing. */
@@ -52,6 +53,7 @@ export const AGENT_MODEL_PROVIDER_CREDENTIAL_TYPES = {
 	moonshotai: ['moonshotApi'],
 	alibaba: ['alibabaCloudApi'],
 	minimax: ['minimaxApi'],
+	volcengine: ['volcengineApi'],
 } as const satisfies Record<AgentModelProvider, readonly [string, ...string[]]>;
 
 /** Credential types for a provider prefix, or `[]` when it is not a model provider. */

--- a/packages/@n8n/api-types/src/agents/provider-capabilities.ts
+++ b/packages/@n8n/api-types/src/agents/provider-capabilities.ts
@@ -166,6 +166,17 @@ export const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		providerTools: [],
 		attachments: NO_ATTACHMENTS,
 	},
+	// Ark accepts `image_url` (data: URLs verified against the live API; images
+	// under 14px per side are rejected). `file_url` is not an accepted
+	// `messages.content.type`, and PDFs sent as `image_url` fail base64
+	// validation, so PDF and audio stay off.
+	volcengine: {
+		thinking: 'reasoningEffort',
+		promptCaching: false,
+		webSearch: false,
+		providerTools: [],
+		attachments: { image: true, pdf: false, audio: false },
+	},
 	cohere: {
 		thinking: false,
 		promptCaching: false,

--- a/packages/@n8n/nodes-langchain/credentials/VolcengineApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/VolcengineApi.credentials.ts
@@ -1,0 +1,48 @@
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class VolcengineApi implements ICredentialType {
+	name = 'volcengineApi';
+
+	displayName = 'Volcengine Ark';
+
+	documentationUrl = 'volcengine';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			required: true,
+			default: '',
+		},
+		{
+			displayName: 'Base URL',
+			name: 'url',
+			type: 'string',
+			default: 'https://ark.cn-beijing.volces.com/api/v3',
+			description: 'Override the default Volcengine Ark endpoint if using a custom region or proxy',
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{ $credentials.url }}',
+			url: '/models',
+		},
+	};
+}

--- a/packages/@n8n/nodes-langchain/credentials/test/VolcengineApi.credentials.test.ts
+++ b/packages/@n8n/nodes-langchain/credentials/test/VolcengineApi.credentials.test.ts
@@ -1,0 +1,25 @@
+import { VolcengineApi } from '../VolcengineApi.credentials';
+
+describe('VolcengineApi Credential', () => {
+	const volcengineApi = new VolcengineApi();
+
+	it('should have correct properties', () => {
+		expect(volcengineApi.name).toBe('volcengineApi');
+		expect(volcengineApi.displayName).toBe('Volcengine Ark');
+		expect(volcengineApi.documentationUrl).toBe('volcengine');
+		expect(volcengineApi.properties).toHaveLength(2);
+		expect(volcengineApi.test.request.baseURL).toBe('={{ $credentials.url }}');
+		expect(volcengineApi.test.request.url).toBe('/models');
+	});
+
+	it('should have correct authentication configuration', () => {
+		expect(volcengineApi.authenticate).toEqual({
+			type: 'generic',
+			properties: {
+				headers: {
+					Authorization: '=Bearer {{$credentials.apiKey}}',
+				},
+			},
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -75,6 +75,7 @@
       "dist/credentials/SearXngApi.credentials.js",
       "dist/credentials/SerpApi.credentials.js",
       "dist/credentials/VercelAiGatewayApi.credentials.js",
+      "dist/credentials/VolcengineApi.credentials.js",
       "dist/credentials/WeaviateApi.credentials.js",
       "dist/credentials/WolframAlphaApi.credentials.js",
       "dist/credentials/XAiApi.credentials.js",

--- a/packages/cli/src/modules/agents/json-config/__tests__/credential-field-mapping.test.ts
+++ b/packages/cli/src/modules/agents/json-config/__tests__/credential-field-mapping.test.ts
@@ -9,6 +9,7 @@ describe('mapCredentialForProvider', () => {
 		['moonshotai', 'https://api.moonshot.cn/v1'],
 		['minimax', 'https://api.minimaxi.com/v1'],
 		['alibaba', 'https://cn-hongkong.dashscope.aliyuncs.com'],
+		['volcengine', 'https://ark.cn-beijing.volces.com/api/v3'],
 	])('%s', (provider, url) => {
 		it("maps the credential's region-derived url onto baseURL", () => {
 			expect(mapCredentialForProvider(provider, { apiKey: 'key', url })).toEqual({

--- a/packages/cli/src/modules/agents/json-config/credential-field-mapping.ts
+++ b/packages/cli/src/modules/agents/json-config/credential-field-mapping.ts
@@ -42,6 +42,8 @@ const PROVIDER_CREDENTIAL_MAPPERS: Record<string, CredMapper> = {
 	minimax: (c) => ({ apiKey: c.apiKey, baseURL: c.url }),
 	// AlibabaCloudApi.credentials.ts → apiKey, url (hidden, region-derived bare host)
 	alibaba: (c) => ({ apiKey: c.apiKey, baseURL: c.url }),
+	// VolcengineApi.credentials.ts → apiKey, url (base URL)
+	volcengine: (c) => ({ apiKey: c.apiKey, baseURL: c.url }),
 
 	// AzureOpenAiApi.credentials.ts            → apiKey, resourceName, apiVersion, endpoint
 	// AzureEntraCognitiveServicesOAuth2Api.credentials.ts → resourceName, apiVersion, endpoint

--- a/packages/cli/src/modules/agents/llm-provider-defaults.ts
+++ b/packages/cli/src/modules/agents/llm-provider-defaults.ts
@@ -80,6 +80,10 @@ export const LLM_PROVIDER_DEFAULTS: Record<string, LlmProviderDefault> = {
 		provider: 'minimax',
 		defaultModel: 'MiniMax-M3',
 	},
+	volcengineApi: {
+		provider: 'volcengine',
+		defaultModel: 'doubao-seed-2-1-pro-260628',
+	},
 };
 
 /** Order in which resolve_llm auto-picks a provider when credentials span multiple providers. */
@@ -98,4 +102,5 @@ export const LLM_PROVIDER_PRIORITY: string[] = [
 	'moonshotai',
 	'alibaba',
 	'minimax',
+	'volcengine',
 ];

--- a/packages/frontend/editor-ui/src/features/agents/model-providers.ts
+++ b/packages/frontend/editor-ui/src/features/agents/model-providers.ts
@@ -54,6 +54,7 @@ export const AGENT_MODEL_PROVIDER_DEFINITIONS = {
 	moonshotai: { displayName: 'Moonshot' },
 	alibaba: { displayName: 'Qwen Cloud' },
 	minimax: { displayName: 'MiniMax' },
+	volcengine: { displayName: 'Volcengine Ark' },
 } satisfies Record<
 	AgentModelProvider,
 	{


### PR DESCRIPTION
## Summary

Adds Volcengine Ark (Doubao) as a model provider for Agent Builder, following the
structure of #36751 (Moonshot / MiniMax / Qwen Cloud).

Ark speaks the OpenAI-compatible schema, so it routes through the existing
`openAiCompatibleEntry` helper instead of pulling in a new SDK — **no dependency
or lockfile changes**.

**Model discovery is filtered, deliberately.** `GET /api/v3/models` returns **523
entries**, most of them internal or unreleased (`test-v1`, `ddd-1.0.0`,
`Model_Example-fc`, `UAT-YML-v1`), so the raw listing is not usable as a
user-facing dropdown. More importantly, presence in `/models` does not imply the
model is callable: `doubao-seed-1-6-thinking-250715` is listed but returns
`404 InvalidEndpointOrModel.NotFound` on chat. So `listVolcengineModels` filters
to an allowlist of 12 IDs, each verified with a real API call.

If you'd prefer a plain static list over filtering a remote response, happy to
switch — the allowlist is already the source of truth either way.

**Capabilities are set from measured behaviour, not documentation:**

| Capability | Value | Evidence |
|---|---|---|
| `thinking` | `'reasoningEffort'` | `reasoning_effort=low` → 61 reasoning tokens, `high` → 107, on `doubao-seed-2-1-pro-260628` |
| `attachments.image` | `true` | `image_url` data URLs accepted; `prompt_tokens` rises 55 → 1353, confirming the image is ingested rather than silently dropped. Ark rejects images under 14px per side |
| `attachments.pdf` | `false` | `file_url` is not an accepted `messages.content.type`; PDFs sent as `image_url` fail base64 validation |
| `attachments.audio` | `false` | not exposed on the chat endpoint |
| `promptCaching`, `webSearch` | `false` | no equivalent control on this endpoint |

## How to test

1. Create a **Volcengine Ark** credential with an Ark API key (get one from the
   [Ark console](https://console.volcengine.com/ark)). Leave Base URL at its
   default `https://ark.cn-beijing.volces.com/api/v3`.
2. Hit **Test** on the credential — it requests `{url}/models`. Verified it
   discriminates: valid key → `200`, bogus key → `401`.
3. In Agent Builder, pick **Volcengine Ark** as the model provider. The model
   dropdown should list exactly these 12 (and none of Ark's internal/test IDs):

   ```
   doubao-seed-1-6-251015               doubao-seed-1-6-flash-250828
   doubao-seed-1-6-vision-250815        doubao-seed-1-8-251228
   doubao-seed-2-0-code-preview-260215  doubao-seed-2-0-lite-260428
   doubao-seed-2-0-mini-260428          doubao-seed-2-0-pro-260215
   doubao-seed-2-1-pro-260628           doubao-seed-2-1-turbo-260628
   doubao-seed-character-260628         doubao-seed-evolving
   ```

4. Run an agent with the default model (`doubao-seed-2-1-pro-260628`) and confirm
   it responds. Attach an image (≥14px per side) to verify vision works.

Tests run locally:

- `@n8n/ai-utilities` model-discovery: **83 passed**
- `@n8n/agents` model-factory: **57 passed**
- `@n8n/api-types` full suite: **1969 passed**
- `cli` credential-field-mapping: **9 passed**
- `@n8n/nodes-langchain` VolcengineApi: **2 passed**

The new discovery test was mutation-checked — removing the `.filter(...)` makes it
fail with `ddd-1.0.0` leaking through, so it genuinely covers the filtering rather
than passing vacuously.

`pnpm --filter @n8n/ai-utilities lint` reports 13 errors, all in
`src/agent-config/` and all present on `master` before this branch (verified by
stashing these changes and re-running). Nothing in `model-discovery` reports, and
this PR adds no `eslint-disable` / `@ts-expect-error`.

## Related Linear tickets, Github issues, and Community forum posts

Related: https://community.n8n.io/t/add-support-for-volcengine-api/146359

That's an existing feature request in the forum's feature-requests category ("current
ai node does not support Volcengine API - a China model provider"). There's also
https://community.n8n.io/t/242534 — a community member maintaining a third-party
VolcEngine Ark chat-model node, which is some signal that the demand is real enough
that people are building it themselves.

Note this PR is not a new node: it touches no `packages/@n8n/nodes-langchain/nodes/`
path. It registers a model provider for Agent Builder (model factory, credential
mapping, provider capabilities, live model discovery, model picker) plus one
credential file — the same file set as #36751, which added Moonshot / MiniMax /
Qwen Cloud and was merged on 2026-08-26.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- happy to open a docs PR — point me at the right page for Agent Builder providers -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (not an urgent fix)

