### PR TITLE
ci: Release fixer

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -362,8 +362,9 @@ the runtime `N8N_VERSION`. Every other package keeps its version, so the publish
 step skips the ones already on npm and publishes whichever ones the failed run
 never reached.
 
-It refuses to run unless `n8n@X.Y.Z` is on npm and `n8n@X.Y.(Z+1)` is not.
-Dispatch with `force: true` to skip that check when the registry is unreliable.
+It refuses to run unless `n8n@X.Y.Z` is on npm and `n8n@X.Y.(Z+1)` is not. That
+check fails closed: if the registry can't be reached, the run stops rather than
+guessing. Dispatch with `force: true` to skip it.
 
 The burned version stays on npm. Deprecate it by hand once the re-release is
 out: `npm deprecate n8n@X.Y.Z "Failed release, use X.Y.(Z+1)"`.

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -340,12 +340,41 @@ test-workflows-pr-comment.yml
 └────────────────────────────────────────────────────────────────────────────┘
 ```
 
+### Recovering a failed release
+
+If the pipeline publishes `n8n@X.Y.Z` to npm and then fails, that version is
+burned — npm versions are immutable. Recovery depends on how far it got:
+
+| Failure point | Recovery |
+|---|---|
+| Before `n8n` reached npm | **Re-run failed jobs** on the original run. Sub-packages publish before `n8n` and `pnpm publish -r` skips versions already on npm, so a retry is safe. |
+| After `n8n` reached npm | Dispatch **`release-recreate-failed-release.yml`** with `failed-version: X.Y.Z`. |
+
+`release-recreate-failed-release.yml` checks out `release/X.Y.Z`, bumps only the
+root and `packages/cli` versions to `X.Y.(Z+1)`, pushes `release/X.Y.(Z+1)` from
+the same commit, and opens an auto-merging `release-pr/X.Y.(Z+1)`. Merging it
+fires `release-publish.yml` as normal — `release-publish.yml` has no
+`workflow_dispatch`, so a release PR is the only way to re-drive it.
+
+Only those two `package.json` files move: the root version drives every publish
+output (git tag, Docker tags, GitHub Release, SBOM) and `packages/cli` drives
+the runtime `N8N_VERSION`. Every other package keeps its version, so the publish
+step skips the ones already on npm and publishes whichever ones the failed run
+never reached.
+
+It refuses to run unless `n8n@X.Y.Z` is on npm and `n8n@X.Y.(Z+1)` is not.
+Dispatch with `force: true` to skip that check when the registry is unreliable.
+
+The burned version stays on npm. Deprecate it by hand once the re-release is
+out: `npm deprecate n8n@X.Y.Z "Failed release, use X.Y.(Z+1)"`.
+
 ### Other Release Workflows
 
-| Workflow                         | Trigger            | Purpose                                        |
-|----------------------------------|--------------------|------------------------------------------------|
-| `release-standalone-package.yml` | Manual dispatch    | Release individual packages (@n8n/codemirror-lang, @n8n/create-node, etc.) |
-| `create-patch-release-branch.yml`| Manual dispatch    | Cherry-pick commits for patch releases         |
+| Workflow                                  | Trigger         | Purpose                                        |
+|-------------------------------------------|-----------------|------------------------------------------------|
+| `release-standalone-package.yml`           | Manual dispatch | Release individual packages (@n8n/codemirror-lang, @n8n/create-node, etc.) |
+| `release-create-patch-pr.yml`              | Manual dispatch | Open a patch release PR for one track          |
+| `release-recreate-failed-release.yml`      | Manual dispatch | Re-release a version whose publish failed after it reached npm |
 
 ---
 
@@ -504,6 +533,7 @@ Scripts in `.github/scripts/`:
 |-------------------------------|----------------------------|-------------------------|
 | `bump-versions.mjs`           | Calculate next version     | `release-create-pr.yml` |
 | `update-changelog.mjs`        | Generate CHANGELOG         | `release-create-pr.yml` |
+| `prepare-rerelease.mjs`       | Bump root + cli for a re-release | `release-recreate-failed-release.yml` |
 | `trim-fe-packageJson.js`      | Strip frontend devDeps     | `release-publish.yml`   |
 | `ensure-provenance-fields.mjs`| Add license/author fields  | `release-publish.yml`   |
 

--- a/.github/scripts/prepare-rerelease.mjs
+++ b/.github/scripts/prepare-rerelease.mjs
@@ -1,0 +1,185 @@
+/**
+ * Prepares a re-release of a version whose publish pipeline failed after the
+ * version was already on npm. npm versions are immutable, so the only way
+ * forward is a new patch version built from identical code.
+ *
+ * Bumps only the root and `packages/cli` package.json files: the root version
+ * drives every publish output (git tag, Docker tags, GitHub Release, SBOM) and
+ * `packages/cli` drives the runtime `N8N_VERSION`. Every other package keeps
+ * its version, so `pnpm publish -r` skips the ones already on npm and publishes
+ * whichever ones the failed run never got to.
+ *
+ * Env:
+ *   FAILED_VERSION        required, e.g. "2.27.2"
+ *   SKIP_REGISTRY_CHECK   set to skip the npm registry safety check
+ *
+ * Prints the new version to stdout; diagnostics go to stderr, since the
+ * caller captures stdout.
+ */
+import semver from 'semver';
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { ensureEnvVar } from './github-helpers.mjs';
+
+const REGISTRY = 'https://registry.npmjs.org';
+const RELEASE_PACKAGE_FILES = ['package.json', 'packages/cli/package.json'];
+
+/**
+ * All three versions must agree. Equality with `failedVersion` is the
+ * load-bearing check: it proves we are on `release/<failedVersion>` *and* that
+ * its release PR was merged (the bump commit only lands on merge).
+ *
+ * @param {string} rootVersion
+ * @param {string} cliVersion
+ * @param {string} failedVersion
+ */
+export function assertRereleaseTarget(rootVersion, cliVersion, failedVersion) {
+	if (!semver.valid(failedVersion)) {
+		throw new Error(`FAILED_VERSION is not a valid semver: ${failedVersion}`);
+	}
+
+	// `semver.inc('2.28.0-rc.1', 'patch')` returns 2.28.0, which would collide.
+	if (semver.prerelease(failedVersion)) {
+		throw new Error(
+			`Re-releasing a prerelease is not supported: ${failedVersion}. Re-run the failed jobs instead.`,
+		);
+	}
+
+	if (rootVersion !== cliVersion) {
+		throw new Error(
+			`Root package.json (${rootVersion}) and packages/cli/package.json (${cliVersion}) disagree. Fix them before re-releasing.`,
+		);
+	}
+
+	if (rootVersion !== failedVersion) {
+		throw new Error(
+			`Checked-out tree is at ${rootVersion}, expected ${failedVersion}. Either the wrong branch is checked out, or the ${failedVersion} release PR was never merged — in which case nothing was published and no re-release is needed.`,
+		);
+	}
+}
+
+/**
+ * @param {string} failedVersion
+ * @returns {string}
+ */
+export function computeRereleaseVersion(failedVersion) {
+	const next = semver.inc(failedVersion, 'patch');
+	if (!next) throw new Error(`Could not increment ${failedVersion}`);
+	return next;
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} version
+ * @param {typeof fetch} fetchImpl
+ * @returns {Promise<boolean | null>} null when the registry could not be reached
+ */
+export async function isPublished(packageName, version, fetchImpl = fetch) {
+	const url = `${REGISTRY}/${packageName.replace('/', '%2f')}/${version}`;
+	try {
+		const response = await fetchImpl(url, { method: 'GET' });
+		if (response.status === 200) return true;
+		if (response.status === 404) return false;
+		console.error(`::warning::Unexpected HTTP ${response.status} from ${url}. Skipping check.`);
+		return null;
+	} catch (error) {
+		console.error(`::warning::Could not reach the npm registry: ${error.message}. Skipping check.`);
+		return null;
+	}
+}
+
+/**
+ * A re-release is only warranted when the failed version is already burned on
+ * npm and the next one is still free.
+ *
+ * @param {string} failedVersion
+ * @param {string} nextVersion
+ * @param {typeof fetch} [fetchImpl]
+ */
+export async function assertRereleaseIsWarranted(failedVersion, nextVersion, fetchImpl) {
+	const [failedIsPublished, nextIsPublished] = await Promise.all([
+		isPublished('n8n', failedVersion, fetchImpl),
+		isPublished('n8n', nextVersion, fetchImpl),
+	]);
+
+	if (failedIsPublished === false) {
+		throw new Error(
+			`n8n@${failedVersion} is not on npm, so that version is not burned. Re-run the failed jobs of the original release instead. Pass force to override.`,
+		);
+	}
+
+	if (nextIsPublished === true) {
+		throw new Error(
+			`n8n@${nextVersion} is already on npm. Re-release from ${nextVersion} instead of ${failedVersion}.`,
+		);
+	}
+}
+
+/**
+ * @param {string} failedVersion
+ * @param {string} nextVersion
+ * @param {string} date ISO date, e.g. "2026-08-27"
+ */
+export function buildChangelogEntry(failedVersion, nextVersion, date) {
+	const compareUrl = `https://github.com/n8n-io/n8n/compare/n8n@${failedVersion}...n8n@${nextVersion}`;
+	return [
+		`## [${nextVersion}](${compareUrl}) (${date})`,
+		'',
+		`Re-release of ${failedVersion}, whose publish pipeline failed after the version was already on npm. No code changes.`,
+		'',
+	].join('\n');
+}
+
+async function prepareRerelease() {
+	const rootDir = process.cwd();
+	const failedVersion = ensureEnvVar('FAILED_VERSION');
+
+	const [rootPkg, cliPkg] = await Promise.all(
+		RELEASE_PACKAGE_FILES.map(async (file) =>
+			JSON.parse(await readFile(resolve(rootDir, file), 'utf-8')),
+		),
+	);
+
+	assertRereleaseTarget(rootPkg.version, cliPkg.version, failedVersion);
+
+	const nextVersion = computeRereleaseVersion(failedVersion);
+
+	if (process.env.SKIP_REGISTRY_CHECK) {
+		console.error('::warning::Skipping the npm registry check for this re-release.');
+	} else {
+		await assertRereleaseIsWarranted(failedVersion, nextVersion);
+	}
+
+	for (const [file, pkg] of [
+		[RELEASE_PACKAGE_FILES[0], rootPkg],
+		[RELEASE_PACKAGE_FILES[1], cliPkg],
+	]) {
+		pkg.version = nextVersion;
+		await writeFile(resolve(rootDir, file), JSON.stringify(pkg, null, 2) + '\n');
+	}
+
+	const entry = buildChangelogEntry(
+		failedVersion,
+		nextVersion,
+		new Date().toISOString().slice(0, 10),
+	);
+
+	// Same two files the normal release writes: the per-version one becomes the
+	// PR body, the full one keeps published version history complete.
+	const versionChangelogFile = resolve(rootDir, `CHANGELOG-${nextVersion}.md`);
+	const fullChangelogFile = resolve(rootDir, 'CHANGELOG.md');
+	await writeFile(versionChangelogFile, entry);
+	await writeFile(fullChangelogFile, entry + '\n\n' + (await readFile(fullChangelogFile, 'utf-8')));
+
+	console.log(nextVersion);
+}
+
+// only run when executed directly, not when imported by tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		await prepareRerelease();
+	} catch (error) {
+		console.error(error);
+		process.exit(1);
+	}
+}

--- a/.github/scripts/prepare-rerelease.mjs
+++ b/.github/scripts/prepare-rerelease.mjs
@@ -80,17 +80,18 @@ export async function isPublished(packageName, version, fetchImpl = fetch) {
 		const response = await fetchImpl(url, { method: 'GET' });
 		if (response.status === 200) return true;
 		if (response.status === 404) return false;
-		console.error(`::warning::Unexpected HTTP ${response.status} from ${url}. Skipping check.`);
+		console.error(`::warning::Unexpected HTTP ${response.status} from ${url}`);
 		return null;
 	} catch (error) {
-		console.error(`::warning::Could not reach the npm registry: ${error.message}. Skipping check.`);
+		console.error(`::warning::Could not reach the npm registry: ${error.message}`);
 		return null;
 	}
 }
 
 /**
  * A re-release is only warranted when the failed version is already burned on
- * npm and the next one is still free.
+ * npm and the next one is still free. An inconclusive lookup fails the check —
+ * `force` is the way past it, not a guess.
  *
  * @param {string} failedVersion
  * @param {string} nextVersion
@@ -102,13 +103,19 @@ export async function assertRereleaseIsWarranted(failedVersion, nextVersion, fet
 		isPublished('n8n', nextVersion, fetchImpl),
 	]);
 
-	if (failedIsPublished === false) {
+	if (failedIsPublished === null || nextIsPublished === null) {
 		throw new Error(
-			`n8n@${failedVersion} is not on npm, so that version is not burned. Re-run the failed jobs of the original release instead. Pass force to override.`,
+			`Could not determine what is published on npm, so ${nextVersion} cannot be confirmed as free. Retry, or dispatch with force to skip this check.`,
 		);
 	}
 
-	if (nextIsPublished === true) {
+	if (!failedIsPublished) {
+		throw new Error(
+			`n8n@${failedVersion} is not on npm, so that version is not burned. Re-run the failed jobs of the original release instead, or dispatch with force to override.`,
+		);
+	}
+
+	if (nextIsPublished) {
 		throw new Error(
 			`n8n@${nextVersion} is already on npm. Re-release from ${nextVersion} instead of ${failedVersion}.`,
 		);

--- a/.github/scripts/prepare-rerelease.test.mjs
+++ b/.github/scripts/prepare-rerelease.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * Run these tests with:
+ *
+ * node --test ./.github/scripts/prepare-rerelease.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	assertRereleaseTarget,
+	computeRereleaseVersion,
+	isPublished,
+	assertRereleaseIsWarranted,
+	buildChangelogEntry,
+} from './prepare-rerelease.mjs';
+
+/** @param {Record<string, number>} statusByVersion */
+function fakeFetch(statusByVersion) {
+	return async (/** @type {string} */ url) => {
+		const version = url.split('/').pop();
+		const status = statusByVersion[version];
+		if (status === undefined) throw new Error(`unexpected version requested: ${version}`);
+		return { status };
+	};
+}
+
+describe('assertRereleaseTarget', () => {
+	it('accepts a tree that sits exactly on the failed version', () => {
+		assert.doesNotThrow(() => assertRereleaseTarget('2.27.2', '2.27.2', '2.27.2'));
+	});
+
+	it('rejects an invalid FAILED_VERSION', () => {
+		assert.throws(() => assertRereleaseTarget('2.27.2', '2.27.2', 'release/2.27.2'), {
+			message: /not a valid semver/,
+		});
+	});
+
+	it('rejects a prerelease, which would not increment to a free version', () => {
+		assert.throws(() => assertRereleaseTarget('2.28.0-rc.1', '2.28.0-rc.1', '2.28.0-rc.1'), {
+			message: /prerelease is not supported/,
+		});
+	});
+
+	it('rejects a root/cli version mismatch', () => {
+		assert.throws(() => assertRereleaseTarget('2.27.2', '2.27.1', '2.27.2'), {
+			message: /disagree/,
+		});
+	});
+
+	it('rejects a tree that is not on the failed version', () => {
+		assert.throws(() => assertRereleaseTarget('2.28.0', '2.28.0', '2.27.2'), {
+			message: /Checked-out tree is at 2\.28\.0, expected 2\.27\.2/,
+		});
+	});
+});
+
+describe('computeRereleaseVersion', () => {
+	it('increments the patch', () => {
+		assert.equal(computeRereleaseVersion('2.27.2'), '2.27.3');
+	});
+
+	it('increments a .0 patch', () => {
+		assert.equal(computeRereleaseVersion('2.28.0'), '2.28.1');
+	});
+
+	it('handles multi-digit versions', () => {
+		assert.equal(computeRereleaseVersion('10.20.30'), '10.20.31');
+	});
+});
+
+describe('isPublished', () => {
+	it('reports 200 as published', async () => {
+		assert.equal(await isPublished('n8n', '2.27.2', fakeFetch({ '2.27.2': 200 })), true);
+	});
+
+	it('reports 404 as not published', async () => {
+		assert.equal(await isPublished('n8n', '2.27.3', fakeFetch({ '2.27.3': 404 })), false);
+	});
+
+	it('returns null on an unexpected status', async () => {
+		assert.equal(await isPublished('n8n', '2.27.3', fakeFetch({ '2.27.3': 500 })), null);
+	});
+
+	it('returns null when the registry is unreachable', async () => {
+		const failing = async () => {
+			throw new Error('ENOTFOUND');
+		};
+		assert.equal(await isPublished('n8n', '2.27.3', failing), null);
+	});
+
+	it('encodes a scoped package name', async () => {
+		let requested;
+		await isPublished('@n8n/db', '1.0.0', async (url) => {
+			requested = url;
+			return { status: 200 };
+		});
+		assert.equal(requested, 'https://registry.npmjs.org/@n8n%2fdb/1.0.0');
+	});
+});
+
+describe('assertRereleaseIsWarranted', () => {
+	it('passes when the failed version is burned and the next one is free', async () => {
+		await assert.doesNotReject(
+			assertRereleaseIsWarranted('2.27.2', '2.27.3', fakeFetch({ '2.27.2': 200, '2.27.3': 404 })),
+		);
+	});
+
+	it('rejects when the failed version was never published', async () => {
+		await assert.rejects(
+			assertRereleaseIsWarranted('2.27.2', '2.27.3', fakeFetch({ '2.27.2': 404, '2.27.3': 404 })),
+			{ message: /is not on npm/ },
+		);
+	});
+
+	it('rejects when the next version is already taken', async () => {
+		await assert.rejects(
+			assertRereleaseIsWarranted('2.27.2', '2.27.3', fakeFetch({ '2.27.2': 200, '2.27.3': 200 })),
+			{ message: /2\.27\.3 is already on npm/ },
+		);
+	});
+
+	it('passes when the registry is unreachable', async () => {
+		const failing = async () => {
+			throw new Error('ENOTFOUND');
+		};
+		await assert.doesNotReject(assertRereleaseIsWarranted('2.27.2', '2.27.3', failing));
+	});
+});
+
+describe('buildChangelogEntry', () => {
+	it('renders a patch-level heading with a compare link', () => {
+		const entry = buildChangelogEntry('2.27.2', '2.27.3', '2026-08-27');
+		assert.equal(
+			entry.split('\n')[0],
+			'## [2.27.3](https://github.com/n8n-io/n8n/compare/n8n@2.27.2...n8n@2.27.3) (2026-08-27)',
+		);
+		assert.match(entry, /Re-release of 2\.27\.2/);
+		assert.ok(entry.endsWith('\n'));
+	});
+});

--- a/.github/scripts/prepare-rerelease.test.mjs
+++ b/.github/scripts/prepare-rerelease.test.mjs
@@ -119,11 +119,20 @@ describe('assertRereleaseIsWarranted', () => {
 		);
 	});
 
-	it('passes when the registry is unreachable', async () => {
+	it('fails closed when the registry is unreachable', async () => {
 		const failing = async () => {
 			throw new Error('ENOTFOUND');
 		};
-		await assert.doesNotReject(assertRereleaseIsWarranted('2.27.2', '2.27.3', failing));
+		await assert.rejects(assertRereleaseIsWarranted('2.27.2', '2.27.3', failing), {
+			message: /Could not determine what is published/,
+		});
+	});
+
+	it('fails closed on an unexpected registry status', async () => {
+		await assert.rejects(
+			assertRereleaseIsWarranted('2.27.2', '2.27.3', fakeFetch({ '2.27.2': 200, '2.27.3': 500 })),
+			{ message: /Could not determine what is published/ },
+		);
 	});
 });
 

--- a/.github/workflows/release-recreate-failed-release.yml
+++ b/.github/workflows/release-recreate-failed-release.yml
@@ -1,0 +1,166 @@
+name: 'Release: Recreate failed release'
+run-name: 'Release: Recreate failed release ${{ inputs.failed-version }}'
+
+# Recovery path for a release that published to npm and then died. npm versions
+# are immutable, so the burned version is skipped and the identical code is
+# re-released under the next patch. `release-publish.yml` only fires on a PR
+# merged into `release/*`, so a new release branch + PR is the only way to
+# re-drive it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      failed-version:
+        description: 'Version whose release pipeline failed after it reached npm (e.g. 2.27.2)'
+        required: true
+        type: string
+      force:
+        description: 'Skip the npm registry check (use when the registry is unreliable)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  recreate-release-pr:
+    name: Recreate release PR
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    timeout-minutes: 10
+
+    outputs:
+      pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      next-release: ${{ steps.prepare.outputs.next-release }}
+
+    steps:
+      - name: Validate the failed version
+        env:
+          FAILED_VERSION: ${{ inputs.failed-version }}
+        # The value is interpolated into git refs, so it is validated before it
+        # ever reaches a command.
+        run: |
+          if [[ ! "$FAILED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::'$FAILED_VERSION' is not a plain X.Y.Z version"
+            exit 1
+          fi
+
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      # Checkout of the failed release branch via a separate step to prevent
+      # unsafe actions/checkout ref usage.
+      # poutine: untrusted_checkout_exec
+      - name: Switch to the failed release branch
+        env:
+          FAILED_VERSION: ${{ inputs.failed-version }}
+        run: git checkout "release/$FAILED_VERSION"
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
+
+      - name: Bump the root and cli versions
+        id: prepare
+        # Assign first: a command substitution nested in another command's
+        # arguments (e.g. `echo "X=$(node …)"`) discards the script's exit code.
+        shell: bash
+        env:
+          FAILED_VERSION: ${{ inputs.failed-version }}
+          SKIP_REGISTRY_CHECK: ${{ inputs.force && '1' || '' }}
+        run: |
+          NEXT_RELEASE="$(node .github/scripts/prepare-rerelease.mjs)"
+          if [ -z "$NEXT_RELEASE" ]; then
+            echo "::error::prepare-rerelease.mjs produced no version"
+            exit 1
+          fi
+          echo "NEXT_RELEASE=$NEXT_RELEASE" >> "$GITHUB_ENV"
+          echo "next-release=$NEXT_RELEASE" >> "$GITHUB_OUTPUT"
+
+      # Not force-pushed: an existing release branch means someone already
+      # started this recovery, and resetting it silently would be worse.
+      - name: Push the new release branch
+        env:
+          FAILED_VERSION: ${{ inputs.failed-version }}
+        run: |
+          git push origin \
+            "refs/remotes/origin/release/${FAILED_VERSION}:refs/heads/release/${NEXT_RELEASE}"
+
+      - name: Generate PR body
+        id: generate-body
+        run: |
+          set -e
+          CHANGELOG_FILE="CHANGELOG-${NEXT_RELEASE}.md"
+          DELIMITER="EOF_$(uuidgen)"
+
+          {
+            echo "content<<${DELIMITER}"
+            cat "${CHANGELOG_FILE}"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create the PR
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        id: create-pr
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          base: 'release/${{ env.NEXT_RELEASE }}'
+          branch: 'release-pr/${{ env.NEXT_RELEASE }}'
+          commit-message: ':rocket: Release ${{ env.NEXT_RELEASE }}'
+          delete-branch: true
+          labels: release,release:patch,automation:release
+          title: ':rocket: Release ${{ env.NEXT_RELEASE }}'
+          body: ${{ steps.generate-body.outputs.content }}
+
+  approve-and-automerge:
+    needs: [recreate-release-pr]
+    if: |
+      needs.recreate-release-pr.outputs.pull-request-number != ''
+    uses: ./.github/workflows/util-approve-and-set-automerge.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets: inherit
+    with:
+      pull-request-number: ${{ needs.recreate-release-pr.outputs.pull-request-number }}
+
+  notify-slack:
+    name: Notify Slack
+    needs: [recreate-release-pr]
+    if: needs.recreate-release-pr.outputs.pull-request-number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts/slack
+          sparse-checkout-cone-mode: false
+      - name: Notify Slack
+        env:
+          SLACK_TOKEN: ${{ secrets.RELEASE_HELPER_SLACK_TOKEN }}
+          FAILED_VERSION: ${{ inputs.failed-version }}
+          NEXT_RELEASE: ${{ needs.recreate-release-pr.outputs.next-release }}
+          PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ needs.recreate-release-pr.outputs.pull-request-number }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel C036AELNMV0 \
+            --text ":lifebuoy: Recreating failed release *${FAILED_VERSION}* as *${NEXT_RELEASE}*. <${PR_URL}|View PR> — it auto-merges once checks pass; close it to cancel."

--- a/.github/workflows/release-recreate-failed-release.yml
+++ b/.github/workflows/release-recreate-failed-release.yml
@@ -23,6 +23,12 @@ on:
 permissions:
   contents: read
 
+# Queue a double-dispatch rather than interleaving two pushes of the same
+# branch. Not cancel-in-progress: killing a run mid-push is worse than waiting.
+concurrency:
+  group: recreate-failed-release-${{ inputs.failed-version }}
+  cancel-in-progress: false
+
 jobs:
   recreate-release-pr:
     name: Recreate release PR
@@ -56,12 +62,19 @@ jobs:
         with:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          # Scope the installation token to only what this recovery needs.
+          permission-contents: write # push the new release branch
+          permission-pull-requests: write # open the release PR
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
+          # Don't persist the token in .git/config (avoids leaking it via artifacts);
+          # the branch push uses an explicit token URL and create-pull-request
+          # pushes with its own token input.
+          persist-credentials: false
 
       # Checkout of the failed release branch via a separate step to prevent
       # unsafe actions/checkout ref usage.
@@ -100,8 +113,9 @@ jobs:
       - name: Push the new release branch
         env:
           FAILED_VERSION: ${{ inputs.failed-version }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          git push origin \
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "refs/remotes/origin/release/${FAILED_VERSION}:refs/heads/release/${NEXT_RELEASE}"
 
       - name: Generate PR body
@@ -134,7 +148,9 @@ jobs:
     needs: [recreate-release-pr]
     if: |
       needs.recreate-release-pr.outputs.pull-request-number != ''
-    uses: ./.github/workflows/util-approve-and-set-automerge.yml
+    # inherit, not named secrets: the callee's app credentials live on the
+    # `release` environment, which a caller cannot read to forward.
+    uses: ./.github/workflows/util-approve-and-set-automerge.yml # zizmor: ignore[secrets-inherit]
     permissions:
       contents: write
       pull-requests: write
@@ -154,6 +170,7 @@ jobs:
         with:
           sparse-checkout: .github/scripts/slack
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - name: Notify Slack
         env:
           SLACK_TOKEN: ${{ secrets.RELEASE_HELPER_SLACK_TOKEN }}


### PR DESCRIPTION
## Summary

Implement an emergency valve, where we are able to, without much manual intervention, release a new version as a patch release. 

Previously, we had to trigger a patch release, open the PR branch, manually bump package versions and change merge targets. This PR not aims to do all of those steps without human input (other than triggering it)

This makes it so that fixing a borken release pipeline isn't blocked behind repository admins, but is runnable by anyone in the organization.


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

