### PR TITLE
test(core): Support tool-result cleanup in the eval stub workspace (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/stub-workspace.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/stub-workspace.test.ts
@@ -28,6 +28,35 @@ describe('createStubWorkspace', () => {
 		await expect(filesystem().readFile('missing.ts')).rejects.toThrow('No such file');
 	});
 
+	// The runtime offloads oversized tool results to `tool-results/runs/<hash>/`
+	// and clears that directory at the end of every run, calling the filesystem
+	// directly rather than through the exposed tools.
+	describe('tool-result cleanup', () => {
+		const runDirectory = 'tool-results/runs/run-hash';
+
+		it('reports a directory as existing once a file sits under it', async () => {
+			const fs = filesystem();
+			await fs.writeFile(`${runDirectory}/call.result.json`, '{}');
+
+			await expect(fs.exists(runDirectory)).resolves.toBe(true);
+		});
+
+		it('reports a directory that was never written as missing', async () => {
+			await expect(filesystem().exists(runDirectory)).resolves.toBe(false);
+		});
+
+		it('removes every file under the directory it is given, and nothing else', async () => {
+			const fs = filesystem();
+			await fs.writeFile(`${runDirectory}/call.result.json`, '{}');
+			await fs.writeFile('tool-results/runs/other-hash/call.result.json', '{}');
+
+			await fs.rmdir(runDirectory);
+
+			await expect(fs.exists(runDirectory)).resolves.toBe(false);
+			await expect(fs.exists('tool-results/runs/other-hash')).resolves.toBe(true);
+		});
+	});
+
 	it('offers only the tools production exposes', () => {
 		expect(
 			createStubWorkspace()

--- a/packages/@n8n/instance-ai/evaluations/harness/stub-workspace.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/stub-workspace.ts
@@ -4,6 +4,11 @@
 // Without a workspace, `build-workflow` fails its source read with a
 // `code_fixable` remediation telling the agent to write the file with
 // `workspace_write_file` — a tool that only exists when a workspace is attached.
+//
+// Tool exposure is filtered to CORE_WORKSPACE_TOOL_NAMES, but the runtime also
+// calls the filesystem directly for its own bookkeeping — offloading oversized
+// tool results and clearing them at the end of every run — so those operations
+// are implemented rather than rejected.
 // ---------------------------------------------------------------------------
 
 import {
@@ -58,13 +63,29 @@ class InMemoryWorkspaceFilesystem implements WorkspaceFilesystem {
 		await Promise.resolve();
 	}
 
+	async exists(path: string): Promise<boolean> {
+		const key = relativePath(path);
+		if (this.files.has(key)) return await Promise.resolve(true);
+		const prefix = `${key}/`;
+		for (const file of this.files.keys()) {
+			if (file.startsWith(prefix)) return await Promise.resolve(true);
+		}
+		return await Promise.resolve(false);
+	}
+
+	async rmdir(path: string): Promise<void> {
+		const prefix = `${relativePath(path)}/`;
+		for (const file of this.files.keys()) {
+			if (file.startsWith(prefix)) this.files.delete(file);
+		}
+		await Promise.resolve();
+	}
+
 	appendFile = unreachable;
 	deleteFile = unreachable;
 	copyFile = unreachable;
 	moveFile = unreachable;
-	rmdir = unreachable;
 	readdir = unreachable;
-	exists = unreachable;
 	stat = unreachable;
 }
 


### PR DESCRIPTION
## Summary

The agent runtime clears a run's offloaded tool results when the run ends. `AgentRuntime.cleanupRun` calls `removeToolResultRun`, which calls `exists` and then `rmdir` on the workspace filesystem directly — not through the exposed workspace tools.

Lack of this lead to the `Instance AI Discovery Eval ✅` checks to 
<img width="944" height="601" alt="image" src="https://github.com/user-attachments/assets/955083a1-a979-4e4e-a64f-67a928d7e737" />
produce this kind of noise.

The in-memory stub filesystem that the discovery evals attach implemented only `readFile`, `writeFile` and `mkdir`. Every other method rejected with `Stub workspace exposes only CORE_WORKSPACE_TOOL_NAMES`. The runtime catches that rejection and logs a warning, so no eval failed, but each trial printed a 25-line stack trace. A 17-scenario × 3-trial run printed 51 of them. The traces crowd out the real result lines in the PR comment the discovery workflow posts.

This PR implements `exists` and `rmdir` on the stub:

- `exists` returns true if the path is a file, or if any file sits under it. This matches the "directories are implicit" model that `mkdir` already uses.
- `rmdir` drops every entry under the given prefix.

The other methods stay unreachable. Only tools call them, and `getTools()` still filters to `CORE_WORKSPACE_TOOL_NAMES`. The rejection therefore keeps its value: if the runtime starts to call one of them directly, the eval fails loudly instead of silently doing nothing. `reconcileToolResultRuns` needs `readdir` and `stat`, but only `AgentWorkspaceService` in `packages/cli` calls it today.

The cleanup call came in with #36203.

## How to test

Check the output of  `Instance AI Discovery Eval ✅`  on this PR, which now doesnt error.

Unit tests:

```bash
cd packages/@n8n/instance-ai
pnpm test evaluations/__tests__/stub-workspace.test.ts
```

Full discovery evals, which need `ANTHROPIC_API_KEY`:

```bash
cd packages/@n8n/instance-ai
pnpm eval:discovery --filter config-evals-skill-loading
```

Before this change, each trial prints a `Failed to clean up agent run tool results` stack trace. After it, the output holds only the scenario lines and the pass rate.

## Related Linear tickets, Github issues, and Community forum posts

No ticket. Found in the discovery eval output on https://github.com/n8n-io/n8n/pull/37177#issuecomment-5429531631.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

