### PR TITLE
fix(core): Prevent OpenTelemetry disable from failing when OTLP collector is unreachable

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/otel.service.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel.service.test.ts
@@ -192,6 +192,14 @@ describe('OtelService', () => {
 		it('does not throw when called before init', async () => {
 			await expect(service.shutdown()).resolves.not.toThrow();
 		});
+
+		it('does not throw when the SDK shutdown rejects (e.g. exporter flush failure)', async () => {
+			otelSettingsService.loadSettings.mockResolvedValue(enabledSettings);
+			await service.init();
+			shutdown.mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:9'));
+
+			await expect(service.shutdown()).resolves.not.toThrow();
+		});
 	});
 
 	describe('diagnostics logger', () => {

--- a/packages/cli/src/modules/otel/otel.service.ts
+++ b/packages/cli/src/modules/otel/otel.service.ts
@@ -112,16 +112,24 @@ export class OtelService {
 	}
 
 	async shutdown(): Promise<void> {
-		await this.sdk?.shutdown();
-		this.sdk = undefined;
+		try {
+			await this.sdk?.shutdown();
+		} catch (error) {
+			this.logger.warn(
+				'Failed to cleanly shut down OpenTelemetry SDK (exporter flush may have failed)',
+				{ error: error instanceof Error ? error.message : String(error) },
+			);
+		} finally {
+			this.sdk = undefined;
 
-		// Unregister the global providers so the next NodeSDK.start() can register
-		// new ones. Without this, OTel's allowOverride=false guard blocks
-		// re-registration and the restart silently fails.
-		trace?.disable();
-		context?.disable();
-		propagation?.disable();
-		metrics?.disable();
+			// Unregister the global providers so the next NodeSDK.start() can register
+			// new ones. Without this, OTel's allowOverride=false guard blocks
+			// re-registration and the restart silently fails.
+			trace?.disable();
+			context?.disable();
+			propagation?.disable();
+			metrics?.disable();
+		}
 	}
 
 	private startSdk(settings: OtelConfig): string {


### PR DESCRIPTION
## Summary

Disabling OpenTelemetry could return HTTP 500 when the configured OTLP collector was unreachable or slow. The SDK shutdown flushes any pending spans to the collector. That flush could time out or fail with a connection error, and the failure was not handled. The failure blocked the response and skipped cleanup of the OpenTelemetry global providers.

This PR makes shutdown resilient to exporter failures:
- `OtelService.shutdown()` now catches a failed SDK shutdown, logs a warning, and still runs its cleanup (`sdk = undefined` and unregistering the trace/context/propagation/metrics globals) in a `finally` block. Cleanup must always run so a later restart can re-register the SDK.
- The production trace exporter now sets a bounded `timeoutMillis` (reusing the existing `startupConnectivityTimeoutMs` setting), matching the timeout already applied to the test-trace exporter. This prevents a slow/unresponsive collector from stalling shutdown for an unbounded time.

## How to test

1. Go to **Settings → OpenTelemetry**.
2. Set the OTLP endpoint to an address that is unreachable or slow to respond (for example, a port with nothing listening).
3. Turn off **Only trace production executions**, then save.
4. Click **Enable**.
5. Run any workflow once, so a span is queued for export.
6. Click **Enabled → Disable** shortly after (before the exporter's periodic auto-flush, ~5s, has already drained the queue on its own).

Before this change: the request returns HTTP 500 and the toggle can get out of sync with the actual (disabled) backend state.
After this change: the request succeeds and OpenTelemetry is disabled cleanly, regardless of collector reachability.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-945

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

