### PR TITLE
test: Fix community nodes install e2e test after unverified packages default change (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/settings/community-nodes/community-nodes.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/community-nodes/community-nodes.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '../../../../fixtures/base';
 
+// Unverified package installs are disabled by default; this spec covers the install flow
+test.use({
+	capability: { env: { N8N_UNVERIFIED_PACKAGES_ENABLED: 'true' } },
+});
+
 const MOCK_PACKAGE = {
 	createdAt: '2024-07-22T19:08:06.505Z',
 	updatedAt: '2024-07-22T19:08:06.505Z',


### PR DESCRIPTION
## Summary

#37084 changed the default of `N8N_UNVERIFIED_PACKAGES_ENABLED` to `false`. With that default, the community nodes settings page disables the Install button, so the e2e spec `tests/e2e/settings/community-nodes/community-nodes.spec.ts` fails on `3.x` (it times out when it tries to click the button).

The failure did not appear on the PR itself because PR CI selects e2e specs with impact analysis. A config default change maps to no specs, so CI skipped the full e2e job. The full suite on `3.x` then surfaced the failure.

This PR opts the spec into the previous behavior with `test.use({ capability: { env: { N8N_UNVERIFIED_PACKAGES_ENABLED: 'true' } } })`. The spec gets its own container stack with the env var set, and the install/update/uninstall flow stays covered.

## How to test

Run the spec in container mode:

```
pnpm --filter=n8n-playwright test:container:multi-main:e2e tests/e2e/settings/community-nodes/community-nodes.spec.ts
```

Note: the capability env only applies in container mode. A `test:local` run against `N8N_BASE_URL` needs `N8N_UNVERIFIED_PACKAGES_ENABLED=true` set on the dev instance.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #37084.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

