### PR TITLE
fix(ai-builder): Add several tools of the  same provider via UI

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
@@ -503,33 +503,58 @@ describe('AgentToolsConnectionModalWrapper', () => {
 		expect(uiStore.closeModal).toHaveBeenCalledWith(MODAL_NAME);
 	});
 
-	it('closes the tools modal once an edit to a connected tool is saved', async () => {
+	it('adds another instance of a connected node tool instead of overwriting it', async () => {
+		const existing = toolRef(SLACK.name);
 		const onConfirm = vi.fn();
-		render([toolRef(SLACK.name)], onConfirm);
+		render([existing], onConfirm);
 		await flushPromises();
 
 		const connected = getItems().find((item) => item.status === 'connected');
 		emitConnect(connected!);
 
+		// Activating a connected node-tool row opens the config modal for a NEW
+		// instance (fresh ref, empty parameters) — not an edit of the existing one.
 		const [payload] = (uiStore.openModalWithData as ReturnType<typeof vi.fn>).mock.calls[0];
-		payload.data.onConfirm({ ...toolRef(SLACK.name), name: 'Renamed Slack' });
+		expect(payload.name).toBe('agentToolConfigModal');
+		expect(payload.data.toolRef).toMatchObject({
+			type: 'node',
+			node: { nodeType: SLACK.name, nodeParameters: {} },
+		});
+		expect(payload.data.existingToolNames).toContain(existing.name);
 
-		expect(onConfirm).toHaveBeenCalledTimes(1);
+		const configuredRef: AgentJsonToolRef = {
+			type: 'node',
+			name: 'Slack (1)',
+			node: {
+				nodeType: SLACK.name,
+				nodeTypeVersion: 1,
+				nodeParameters: { resource: 'message' },
+				credentials: { slackApi: { id: 'c-2', name: 'Other Slack' } },
+			},
+		};
+		payload.data.onConfirm(configuredRef);
+
+		expect(onConfirm).toHaveBeenCalledWith({
+			tools: [existing, configuredRef],
+			mcpServers: [],
+		});
 		expect(uiStore.closeModal).toHaveBeenCalledWith(MODAL_NAME);
 	});
 
-	it('removes a connected tool when the config modal asks to', async () => {
+	it('does not remove a connected node tool when activating its row', async () => {
+		const existing = toolRef(SLACK.name);
 		const onConfirm = vi.fn();
-		render([toolRef(SLACK.name)], onConfirm);
+		render([existing], onConfirm);
 		await flushPromises();
 
 		const connected = getItems().find((item) => item.status === 'connected');
 		emitConnect(connected!);
 
+		// The connected row now opens config for a new instance; there is no
+		// remove callback on that flow (removal happens via the capabilities chips).
 		const [payload] = (uiStore.openModalWithData as ReturnType<typeof vi.fn>).mock.calls[0];
-		payload.data.onRemove();
-
-		expect(onConfirm).toHaveBeenCalledWith({ tools: [], mcpServers: [] });
+		expect(payload.data.onRemove).toBeUndefined();
+		expect(onConfirm).not.toHaveBeenCalled();
 	});
 
 	it('appends a configured tool once the config modal saves', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
@@ -975,5 +975,33 @@ describe('AgentToolsConnectionModalWrapper', () => {
 			});
 			expect(uiStore.closeModal).toHaveBeenCalledWith(MODAL_NAME);
 		});
+
+		it('adds another managed instance with the managed credential preselected', async () => {
+			const existing: AgentJsonToolRef = {
+				type: 'node',
+				name: 'Slack',
+				node: {
+					nodeType: SLACK.name,
+					nodeTypeVersion: 1,
+					nodeParameters: {},
+					credentials: { slackApi: { id: null, name: '', __aiGatewayManaged: true } },
+				},
+			};
+			const onConfirm = vi.fn();
+			render([existing], onConfirm);
+			await flushPromises();
+
+			const connected = getItems().find((item) => item.status === 'connected');
+			emitConnect(connected!);
+
+			// Activating a connected managed tool routes through the managed add
+			// path, so the new instance keeps the __aiGatewayManaged credential.
+			const [payload] = (uiStore.openModalWithData as ReturnType<typeof vi.fn>).mock.calls[0];
+			expect(payload.name).toBe('agentToolConfigModal');
+			expect(payload.data.toolRef.node.credentials).toEqual({
+				slackApi: { id: null, name: '', __aiGatewayManaged: true },
+			});
+			expect(payload.data.existingToolNames).toContain(existing.name);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
@@ -823,14 +823,21 @@ function handleRowActivate(item: ToolConnectionItem) {
 			if (!entry) return;
 			// Adding another instance of the same service: editing happens via the
 			// capabilities chips, so activating a connected node-tool row adds a
-			// new instance instead of overwriting the existing tool.
+			// new instance instead of overwriting the existing tool. A connected
+			// n8n Connect managed tool must keep its managed-credential
+			// preselection, so route it through the same managed add path.
 			const { ref } = entry;
 			if (ref.type === 'node') {
 				const nodeType =
 					[...availableToolTypes.value, ...communitySearchToolTypes.value].find(
 						(nt) => nt.name === ref.node.nodeType,
 					) ?? nodeTypesStore.getNodeType(ref.node.nodeType);
-				if (nodeType) void handleAddTool(nodeType);
+				if (nodeType) {
+					const isManaged = Object.values(ref.node.credentials ?? {}).some(
+						(credential) => '__aiGatewayManaged' in credential && credential.__aiGatewayManaged,
+					);
+					void (isManaged ? addManagedNodeTool(nodeType) : handleAddTool(nodeType));
+				}
 				return;
 			}
 			openConfigForToolEntry(entry);

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
@@ -820,7 +820,20 @@ function handleRowActivate(item: ToolConnectionItem) {
 		if (item.id.startsWith('tool:')) {
 			const localId = item.id.slice('tool:'.length);
 			const entry = workingToolEntries.value.find((e) => e.localId === localId);
-			if (entry) openConfigForToolEntry(entry);
+			if (!entry) return;
+			// Adding another instance of the same service: editing happens via the
+			// capabilities chips, so activating a connected node-tool row adds a
+			// new instance instead of overwriting the existing tool.
+			const { ref } = entry;
+			if (ref.type === 'node') {
+				const nodeType =
+					[...availableToolTypes.value, ...communitySearchToolTypes.value].find(
+						(nt) => nt.name === ref.node.nodeType,
+					) ?? nodeTypesStore.getNodeType(ref.node.nodeType);
+				if (nodeType) void handleAddTool(nodeType);
+				return;
+			}
+			openConfigForToolEntry(entry);
 		}
 		return;
 	}


### PR DESCRIPTION
## Summary

Fixes the agent builder so that manually adding a second tool of the same service (ie. two Google Sheets tools) adds a separate tool instead of silently overwriting the existing one.

## How to test

1. Create a blank agent.
2. Add an n8n node tool that requires setup (e.g. Google Sheets) and configure it (operation A, credential). Save so one tool chip appears.
3. Open the tools modal again and click the connected Google Sheets row at the top of the `n8n` tab.
4. Configure a different operation (operation B) and save.
5. Verify two separate Google Sheets tools now exist: the capabilities section groups them into a single "2 Google Sheets" chip; open the chip dropdown to confirm both operations are present and individually editable.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-725

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-docs/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

