### PR TITLE
test: Wait for task runner registration before executing code in e2e tests (no-changelog)

### DIFF
--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -34,7 +34,6 @@ import { Push } from '@/push';
 import { CacheService } from '@/services/cache/cache.service';
 import { FrontendService } from '@/services/frontend.service';
 import { PasswordUtility } from '@/services/password.utility';
-import { TaskBroker } from '@/task-runners/task-broker/task-broker.service';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
 if (!inE2ETests) {
@@ -204,7 +203,6 @@ export class E2EController {
 		private readonly scheduledJobRepository: ScheduledJobRepository,
 		private readonly pollerStateRepository: PollerStateRepository,
 		private readonly workflowStaticDataService: WorkflowStaticDataService,
-		private readonly taskBroker: TaskBroker,
 	) {
 		license.isLicensed = (feature: BooleanLicenseFeature) => this.enabledFeatures[feature] ?? false;
 
@@ -315,16 +313,6 @@ export class E2EController {
 		const { workflowId, nodeId, secondsAgo } = req.body;
 		await this.scheduledJobRepository.backdateNextRunAt(workflowId, nodeId, secondsAgo);
 		return { success: true };
-	}
-
-	/**
-	 * Number of task runners currently registered with the broker, so a test can
-	 * wait for a runner to be ready instead of racing its startup.
-	 */
-	@Get('/task-runners/count', { skipAuth: true })
-	countTaskRunners() {
-		const count = this.taskBroker.getKnownRunners().size;
-		return { count };
 	}
 
 	@Get('/env-feature-flags', { skipAuth: true })

--- a/packages/testing/containers/helpers/utils.ts
+++ b/packages/testing/containers/helpers/utils.ts
@@ -106,3 +106,54 @@ export async function pollContainerHttpEndpoint(
 		} seconds. Proceeding with caution.`,
 	);
 }
+
+/**
+ * Waits until a container's logs contain `pattern` at least `occurrences` times.
+ * Reads the log stream from the beginning, so a message emitted before the call
+ * still counts. Throws on timeout, since callers use this to establish a
+ * precondition rather than to observe one.
+ *
+ * @param container The started container.
+ * @param pattern The pattern to look for in the container's logs.
+ * @param occurrences How many matching lines to wait for (default: 1).
+ * @param timeoutMs Total timeout in milliseconds (default: 60,000ms).
+ */
+export async function waitForContainerLogMessage(
+	container: StartedTestContainer,
+	pattern: RegExp,
+	occurrences: number = 1,
+	timeoutMs: number = 60000,
+): Promise<void> {
+	const stream = await container.logs({ since: 0 });
+	let seen = 0;
+
+	try {
+		await new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				reject(
+					new Error(
+						`Container ${container.getName()} did not log ${occurrences}x ${String(pattern)} within ${timeoutMs / 1000} seconds (saw ${seen})`,
+					),
+				);
+			}, timeoutMs);
+
+			const finish = (error?: Error) => {
+				clearTimeout(timer);
+				if (error) reject(error);
+				else resolve();
+			};
+
+			stream.on('data', (chunk: Buffer | string) => {
+				for (const line of chunk.toString().split('\n')) {
+					if (pattern.test(line) && ++seen >= occurrences) {
+						finish();
+						return;
+					}
+				}
+			});
+			stream.on('error', finish);
+		});
+	} finally {
+		stream.destroy();
+	}
+}

--- a/packages/testing/containers/helpers/utils.ts
+++ b/packages/testing/containers/helpers/utils.ts
@@ -109,21 +109,23 @@ export async function pollContainerHttpEndpoint(
 
 /**
  * Waits until a container's logs have matched every pattern in `patterns` at
- * least once. Reads the log stream from the beginning, so a message emitted
- * before the call still counts; container names are unique per stack, so a
- * stream never carries lines from an earlier run. Throws on timeout, since
- * callers use this to establish a precondition rather than to observe one.
+ * least once. Throws on timeout, since callers use this to establish a
+ * precondition rather than to observe one.
  *
  * @param container The started container.
  * @param patterns The patterns to look for. Each must match at least one line.
- * @param timeoutMs Total timeout in milliseconds (default: 60,000ms).
+ * @param options.since Unix timestamp in seconds. Only lines logged from then on
+ * count. A reused container carries the logs of the run before it, so a caller
+ * whose precondition must hold for the current run has to pass this.
+ * @param options.timeoutMs Total timeout in milliseconds (default: 60,000ms).
  */
 export async function waitForContainerLogMessages(
 	container: StartedTestContainer,
 	patterns: RegExp[],
-	timeoutMs: number = 60000,
+	options: { since?: number; timeoutMs?: number } = {},
 ): Promise<void> {
-	const stream = await container.logs({ since: 0 });
+	const { since = 0, timeoutMs = 60000 } = options;
+	const stream = await container.logs({ since });
 	const pending = new Set(patterns);
 
 	try {

--- a/packages/testing/containers/helpers/utils.ts
+++ b/packages/testing/containers/helpers/utils.ts
@@ -108,31 +108,31 @@ export async function pollContainerHttpEndpoint(
 }
 
 /**
- * Waits until a container's logs contain `pattern` at least `occurrences` times.
- * Reads the log stream from the beginning, so a message emitted before the call
- * still counts. Throws on timeout, since callers use this to establish a
- * precondition rather than to observe one.
+ * Waits until a container's logs have matched every pattern in `patterns` at
+ * least once. Reads the log stream from the beginning, so a message emitted
+ * before the call still counts; container names are unique per stack, so a
+ * stream never carries lines from an earlier run. Throws on timeout, since
+ * callers use this to establish a precondition rather than to observe one.
  *
  * @param container The started container.
- * @param pattern The pattern to look for in the container's logs.
- * @param occurrences How many matching lines to wait for (default: 1).
+ * @param patterns The patterns to look for. Each must match at least one line.
  * @param timeoutMs Total timeout in milliseconds (default: 60,000ms).
  */
-export async function waitForContainerLogMessage(
+export async function waitForContainerLogMessages(
 	container: StartedTestContainer,
-	pattern: RegExp,
-	occurrences: number = 1,
+	patterns: RegExp[],
 	timeoutMs: number = 60000,
 ): Promise<void> {
 	const stream = await container.logs({ since: 0 });
-	let seen = 0;
+	const pending = new Set(patterns);
 
 	try {
 		await new Promise<void>((resolve, reject) => {
 			const timer = setTimeout(() => {
+				const missing = [...pending].map(String).join(', ');
 				reject(
 					new Error(
-						`Container ${container.getName()} did not log ${occurrences}x ${String(pattern)} within ${timeoutMs / 1000} seconds (saw ${seen})`,
+						`Container ${container.getName()} did not log ${missing} within ${timeoutMs / 1000} seconds`,
 					),
 				);
 			}, timeoutMs);
@@ -143,9 +143,17 @@ export async function waitForContainerLogMessage(
 				else resolve();
 			};
 
+			let partialLine = '';
 			stream.on('data', (chunk: Buffer | string) => {
-				for (const line of chunk.toString().split('\n')) {
-					if (pattern.test(line) && ++seen >= occurrences) {
+				// A chunk can split a line, so hold the trailing fragment back until
+				// the rest of it arrives.
+				const lines = (partialLine + chunk.toString()).split('\n');
+				partialLine = lines.pop() ?? '';
+				for (const line of lines) {
+					for (const pattern of pending) {
+						if (pattern.test(line)) pending.delete(pattern);
+					}
+					if (pending.size === 0) {
 						finish();
 						return;
 					}

--- a/packages/testing/containers/services/task-runner.ts
+++ b/packages/testing/containers/services/task-runner.ts
@@ -43,9 +43,7 @@ export const taskRunner: Service<TaskRunnerResult> = {
 				.withExposedPorts(5680)
 				.withEnvironment({
 					N8N_RUNNERS_AUTH_TOKEN: 'test',
-					// The stack's readiness gate reads the launchers' broker registration
-					// from this container's log, which the launcher prints only at debug.
-					N8N_RUNNERS_LAUNCHER_LOG_LEVEL: 'debug',
+					N8N_RUNNERS_LAUNCHER_LOG_LEVEL: 'debug', // Broker registration is logged at debug, and the stack waits on it
 					N8N_RUNNERS_TASK_BROKER_URI: taskBrokerUri,
 					N8N_RUNNERS_MAX_CONCURRENCY: '5',
 					N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT: '0', // Disabled in tests to prevent cold-start delays
@@ -56,8 +54,7 @@ export const taskRunner: Service<TaskRunnerResult> = {
 					'com.docker.compose.service': 'task-runner',
 				})
 				.withName(`${projectName}-task-runner`)
-				// Not reused across runs: the launchers hold a connection to the broker of
-				// the stack that started them, and do not register with a new one.
+				// Not reused: a launcher stays bound to the broker of the stack that started it
 				.withLogConsumer(consumer)
 				.start();
 

--- a/packages/testing/containers/services/task-runner.ts
+++ b/packages/testing/containers/services/task-runner.ts
@@ -43,6 +43,8 @@ export const taskRunner: Service<TaskRunnerResult> = {
 				.withExposedPorts(5680)
 				.withEnvironment({
 					N8N_RUNNERS_AUTH_TOKEN: 'test',
+					// The stack's readiness gate reads the launchers' broker registration
+					// from this container's log, which the launcher prints only at debug.
 					N8N_RUNNERS_LAUNCHER_LOG_LEVEL: 'debug',
 					N8N_RUNNERS_TASK_BROKER_URI: taskBrokerUri,
 					N8N_RUNNERS_MAX_CONCURRENCY: '5',

--- a/packages/testing/containers/services/task-runner.ts
+++ b/packages/testing/containers/services/task-runner.ts
@@ -56,7 +56,8 @@ export const taskRunner: Service<TaskRunnerResult> = {
 					'com.docker.compose.service': 'task-runner',
 				})
 				.withName(`${projectName}-task-runner`)
-				.withReuse()
+				// Not reused across runs: the launchers hold a connection to the broker of
+				// the stack that started them, and do not register with a new one.
 				.withLogConsumer(consumer)
 				.start();
 

--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -9,10 +9,10 @@ import {
 } from './helpers/utils';
 import { waitForNetworkQuiet } from './network-stabilization';
 import type { LoadBalancerResult } from './services/load-balancer';
-import type { TaskRunnerResult } from './services/task-runner';
 import type { N8NStartupDiagnostics } from './services/n8n';
 import { createN8NInstances, N8NStartupError } from './services/n8n';
 import { helperFactories, services } from './services/registry';
+import type { TaskRunnerResult } from './services/task-runner';
 import type {
 	FileToMount,
 	HelperContext,

--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -224,6 +224,9 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 			return meta?.n8nFilesToMount ?? [];
 		});
 
+		// A registration that counts for this run can only happen once the instances
+		// are up, so this is the earliest log line the readiness gate below may accept.
+		const n8nStartedAtSeconds = Math.floor(Date.now() / 1000);
 		const n8nStartupStart = performance.now();
 		const n8nResult = await createN8NInstances({
 			mains,
@@ -259,13 +262,18 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		// registered before a test executes code, otherwise the first execution races
 		// the registration. Which instance owns the broker varies by topology, so the
 		// runner's own log is the one place the signal is observable. Match each
-		// launcher separately, so one launcher reconnecting cannot stand in for the other.
+		// launcher separately, so one launcher reconnecting cannot stand in for the
+		// other, and only from this run, since a reused container keeps its old logs.
 		const taskRunnerResult = serviceResults.taskRunner as TaskRunnerResult | undefined;
 		if (taskRunnerResult) {
-			await waitForContainerLogMessages(taskRunnerResult.container, [
-				/\[launcher:js\].*Received message `broker:runnerregistered`/,
-				/\[launcher:py\].*Received message `broker:runnerregistered`/,
-			]);
+			await waitForContainerLogMessages(
+				taskRunnerResult.container,
+				[
+					/\[launcher:js\].*Received message `broker:runnerregistered`/,
+					/\[launcher:py\].*Received message `broker:runnerregistered`/,
+				],
+				{ since: n8nStartedAtSeconds },
+			);
 			log('Task runners registered with broker');
 		}
 

--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -5,7 +5,7 @@ import { Network } from 'testcontainers';
 import {
 	createElapsedLogger,
 	pollContainerHttpEndpoint,
-	waitForContainerLogMessage,
+	waitForContainerLogMessages,
 } from './helpers/utils';
 import { waitForNetworkQuiet } from './network-stabilization';
 import type { LoadBalancerResult } from './services/load-balancer';
@@ -255,17 +255,17 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		}
 
 		// The runner container starts before the instance whose broker it dials, so it
-		// can only register once that instance is up. Both launchers must have
+		// can only register once that instance is up. Each launcher must have
 		// registered before a test executes code, otherwise the first execution races
 		// the registration. Which instance owns the broker varies by topology, so the
-		// runner's own log is the one place the signal is observable.
+		// runner's own log is the one place the signal is observable. Match each
+		// launcher separately, so one launcher reconnecting cannot stand in for the other.
 		const taskRunnerResult = serviceResults.taskRunner as TaskRunnerResult | undefined;
 		if (taskRunnerResult) {
-			await waitForContainerLogMessage(
-				taskRunnerResult.container,
-				/Received message `broker:runnerregistered`/,
-				2,
-			);
+			await waitForContainerLogMessages(taskRunnerResult.container, [
+				/\[launcher:js\].*Received message `broker:runnerregistered`/,
+				/\[launcher:py\].*Received message `broker:runnerregistered`/,
+			]);
 			log('Task runners registered with broker');
 		}
 

--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -224,8 +224,7 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 			return meta?.n8nFilesToMount ?? [];
 		});
 
-		// A registration that counts for this run can only happen once the instances
-		// are up, so this is the earliest log line the readiness gate below may accept.
+		// Earliest log line the readiness gate below may accept
 		const n8nStartedAtSeconds = Math.floor(Date.now() / 1000);
 		const n8nStartupStart = performance.now();
 		const n8nResult = await createN8NInstances({

--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -2,9 +2,14 @@ import getPort from 'get-port';
 import type { StartedNetwork, StartedTestContainer, StoppedTestContainer } from 'testcontainers';
 import { Network } from 'testcontainers';
 
-import { createElapsedLogger, pollContainerHttpEndpoint } from './helpers/utils';
+import {
+	createElapsedLogger,
+	pollContainerHttpEndpoint,
+	waitForContainerLogMessage,
+} from './helpers/utils';
 import { waitForNetworkQuiet } from './network-stabilization';
 import type { LoadBalancerResult } from './services/load-balancer';
+import type { TaskRunnerResult } from './services/task-runner';
 import type { N8NStartupDiagnostics } from './services/n8n';
 import { createN8NInstances, N8NStartupError } from './services/n8n';
 import { helperFactories, services } from './services/registry';
@@ -247,6 +252,21 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		if (lbResult) {
 			await pollContainerHttpEndpoint(lbResult.container, '/healthz/readiness');
 			log('Load balancer ready');
+		}
+
+		// The runner container starts before the instance whose broker it dials, so it
+		// can only register once that instance is up. Both launchers must have
+		// registered before a test executes code, otherwise the first execution races
+		// the registration. Which instance owns the broker varies by topology, so the
+		// runner's own log is the one place the signal is observable.
+		const taskRunnerResult = serviceResults.taskRunner as TaskRunnerResult | undefined;
+		if (taskRunnerResult) {
+			await waitForContainerLogMessage(
+				taskRunnerResult.container,
+				/Received message `broker:runnerregistered`/,
+				2,
+			);
+			log('Task runners registered with broker');
 		}
 
 		ctx.baseUrl = baseUrl;

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -277,15 +277,6 @@ export class ApiHelpers {
 		return { consecutiveErrors: data.consecutiveErrors, backoffUntil: data.backoffUntil };
 	}
 
-	async countTaskRunners(): Promise<number> {
-		const response = await this.request.get('/rest/e2e/task-runners/count');
-		if (!response.ok()) {
-			throw new TestError(`Failed to count task runners: ${await response.text()}`);
-		}
-		const { data } = (await response.json()) as { data: { count: number } };
-		return data.count;
-	}
-
 	async clearWorkflowStaticData(workflowId: string): Promise<void> {
 		const response = await this.request.post('/rest/e2e/workflow-static-data/clear', {
 			data: { workflowId },

--- a/packages/testing/playwright/tests/e2e/capabilities/task-runner.spec.ts
+++ b/packages/testing/playwright/tests/e2e/capabilities/task-runner.spec.ts
@@ -13,17 +13,10 @@ test.describe(
 		annotation: [{ type: 'owner', description: 'Catalysts' }],
 	},
 	() => {
-		test('should execute Javascript with task runner enabled', async ({ n8n, api }) => {
+		test('should execute Javascript with task runner enabled', async ({ n8n }) => {
 			await n8n.start.fromBlankCanvas();
 			await n8n.canvas.addNode(MANUAL_TRIGGER_NODE_NAME);
 			await n8n.canvas.addNode(CODE_NODE_NAME, { action: 'Code in JavaScript', closeNDV: true });
-
-			// The server reports itself ready once the runner process is spawned, not
-			// once it has registered with the broker over WebSocket, so wait for an
-			// actual registration before triggering execution.
-			await expect
-				.poll(async () => await api.countTaskRunners(), { timeout: 10_000, intervals: [250] })
-				.toBeGreaterThan(0);
 
 			await n8n.workflowComposer.executeWorkflowAndWaitForNotification(
 				'Workflow executed successfully',


### PR DESCRIPTION
## Summary

The container stack called itself ready as soon as the task runner's port opened.
An open port only proves the launcher process started.
It does not prove the launcher registered with a task broker.
Every workflow execution in a stack's first seconds raced that registration.
`Task Runner > should execute Javascript with task runner enabled` went flaky, and Currents quarantined it.

The stack now waits for both launchers to log `broker:runnerregistered` on the runner container.
The wait runs after the n8n instances start.
It cannot be a container start wait strategy.
The runner container starts before the instance whose broker it dials, so a wait there deadlocks the stack.

Fixing readiness at the source retires the per-test guard from #36212.
That guard could never pass in a topology with a worker.
The runner registers with the worker's broker, but `/rest/e2e/task-runners/count` answers from a main, so the count stayed 0.
The test failed every run in the `queue` and `multi-main` projects.
This PR removes three things:

- The guard
- Its API helper
- The endpoint

Local results, one worker, container stacks:

| Stack | Before | After |
| --- | --- | --- |
| `queue` | JavaScript test fails every run | 2 of 2 pass |
| `sqlite`, JavaScript x12 | 11 of 12 pass, one 18.7s timeout | 12 of 12 pass |

Each run now takes 6.9-8.4s, against 7.2-10.1s before.
No timeout value went up.

## How to test

Build the images, then run the spec in both topologies:

```bash
pnpm build:docker
pnpm --filter=n8n-playwright test:container:sqlite \
  tests/e2e/capabilities/task-runner.spec.ts --repeat-each=12 --workers=1
pnpm --filter=n8n-playwright test:container:queue \
  tests/e2e/capabilities/task-runner.spec.ts --workers=1
```

Keep `--workers=1`.
The default worker count starts one container stack per worker.
That saturates a local Docker VM and produces unrelated `page.goto` timeouts.

The `multi-main` project needs `N8N_LICENSE_ACTIVATION_KEY` or `N8N_LICENSE_CERT`, so CI has to confirm that topology.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4135

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Claude generated
