### PR TITLE
fix(task-runners): include workflow/execution IDs on task request timeout reports

### DIFF
--- a/packages/cli/src/task-runners/errors/task-request-timeout.error.ts
+++ b/packages/cli/src/task-runners/errors/task-request-timeout.error.ts
@@ -6,12 +6,35 @@ export class TaskRequestTimeoutError extends OperationalError {
 	constructor({
 		elapsedSeconds,
 		isSelfHosted,
+		requestId,
+		workflowId,
+		executionId,
+		nodeId,
+		taskType,
 	}: {
 		elapsedSeconds: number;
 		isSelfHosted: boolean;
+		requestId: string;
+		workflowId?: string;
+		executionId?: string;
+		nodeId?: string;
+		taskType?: string;
 	}) {
 		// Keep the message static so Sentry groups all occurrences as one issue.
-		super('Task request timed out', { extra: { elapsedSeconds } });
+		// level 'error' + shouldReport so ErrorReporter.beforeSend does not drop this
+		// (OperationalError defaults to warning / non-reportable).
+		super('Task request timed out', {
+			level: 'error',
+			shouldReport: true,
+			extra: {
+				elapsedSeconds,
+				requestId,
+				workflowId,
+				executionId,
+				nodeId,
+				taskType,
+			},
+		});
 
 		const description = [
 			`Your Code node task was not matched to a runner within the timeout period (waited ${elapsedSeconds} ${elapsedSeconds === 1 ? 'second' : 'seconds'}). This indicates that the task runner is currently down, or not ready, or at capacity, so it cannot service your task.`,

--- a/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
+++ b/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
@@ -7,6 +7,7 @@ import { mock } from 'vitest-mock-extended';
 import type { EventService } from '@/events/event.service';
 import type { NodeTypes } from '@/node-types';
 import { TaskCancelledError } from '@/task-runners/errors/task-cancelled.error';
+import { TaskRequestTimeoutError } from '@/task-runners/errors/task-request-timeout.error';
 import type { Task } from '@/task-runners/task-managers/task-requester';
 import { TaskRequester } from '@/task-runners/task-managers/task-requester';
 
@@ -177,6 +178,64 @@ describe('TaskRequester', () => {
 
 			await expect(pending).rejects.toBeInstanceOf(TaskCancelledError);
 			expect(capturedRejection).toBeInstanceOf(TaskCancelledError);
+		});
+	});
+
+	describe('requestExpired', () => {
+		it('rejects with TaskRequestTimeoutError including workflow/execution/node IDs and reports them', async () => {
+			const requestId = 'requestId';
+			const workflowId = 'workflowId';
+			const executionId = 'executionId';
+			const nodeId = 'nodeId';
+			const taskType = 'javascript';
+
+			mockGlobalConfig.deployment = { type: 'default' } as GlobalConfig['deployment'];
+			mockTaskRunnersConfig.taskRequestTimeout = 60;
+
+			let capturedRejection: unknown;
+			const pending = new Promise((_, reject) => {
+				instance.requestAcceptRejects.set(requestId, {
+					accept: vi.fn(),
+					reject: (reason) => {
+						capturedRejection = reason;
+						reject(reason);
+					},
+					requestedAt: Date.now() - 5_000,
+					workflowId,
+					executionId,
+					nodeId,
+					taskType,
+				});
+			});
+
+			instance.requestExpired(requestId);
+
+			await expect(pending).rejects.toBeInstanceOf(TaskRequestTimeoutError);
+			expect(capturedRejection).toBeInstanceOf(TaskRequestTimeoutError);
+			expect((capturedRejection as TaskRequestTimeoutError).extra).toMatchObject({
+				requestId,
+				workflowId,
+				executionId,
+				nodeId,
+				taskType,
+				elapsedSeconds: expect.any(Number),
+			});
+			expect((capturedRejection as TaskRequestTimeoutError).shouldReport).toBe(true);
+			expect((capturedRejection as TaskRequestTimeoutError).level).toBe('error');
+			expect(mockErrorReporter.error).toHaveBeenCalledWith(
+				capturedRejection,
+				expect.objectContaining({
+					executionId,
+					extra: expect.objectContaining({
+						timeout: 60,
+						deploymentType: 'default',
+					}),
+					tags: {
+						issue: 'task-runners-timeouts',
+					},
+				}),
+			);
+			expect(instance.requestAcceptRejects.has(requestId)).toBe(false);
 		});
 	});
 });

--- a/packages/cli/src/task-runners/task-managers/task-requester.ts
+++ b/packages/cli/src/task-runners/task-managers/task-requester.ts
@@ -57,7 +57,15 @@ export type RunnerStatus = { available: true } | { available: false; reason?: st
 export abstract class TaskRequester {
 	requestAcceptRejects: Map<
 		string,
-		{ accept: RequestAccept; reject: RequestReject; requestedAt: number }
+		{
+			accept: RequestAccept;
+			reject: RequestReject;
+			requestedAt: number;
+			workflowId?: string;
+			executionId?: string;
+			nodeId: string;
+			taskType: string;
+		}
 	> = new Map();
 
 	taskAcceptRejects: Map<string, { accept: TaskAccept; reject: TaskReject }> = new Map();
@@ -140,6 +148,10 @@ export abstract class TaskRequester {
 				accept: resolve,
 				reject,
 				requestedAt: Date.now(),
+				workflowId: workflow.id,
+				executionId: additionalData.executionId,
+				nodeId: node.id,
+				taskType,
 			});
 		});
 
@@ -306,16 +318,22 @@ export abstract class TaskRequester {
 		if (!acceptReject) return;
 
 		const elapsedSeconds = Math.round((Date.now() - acceptReject.requestedAt) / 1000);
+		const { workflowId, executionId, nodeId, taskType } = acceptReject;
 
 		const error = new TaskRequestTimeoutError({
 			elapsedSeconds,
 			isSelfHosted: this.globalConfig.deployment.type !== 'cloud',
+			requestId,
+			workflowId,
+			executionId,
+			nodeId,
+			taskType,
 		});
 
-		this.errorReporter.error('Task request timed out', {
+		// Report the error object so defaultReport logs e.extra (workflow/execution IDs).
+		this.errorReporter.error(error, {
+			executionId,
 			extra: {
-				requestId,
-				elapsedSeconds,
 				timeout: this.taskRunnersConfig.taskRequestTimeout,
 				deploymentType: this.globalConfig.deployment.type,
 			},


### PR DESCRIPTION
## Summary
`TaskRequester.requestExpired` reports `"Task request timed out"` via `ErrorReporter` with only `requestId` / timeout metadata. At request time we already have `workflow.id`, `additionalData.executionId`, and `node.id`, but they are not stored on the pending-request map, so logs (JSON stdout → Datadog/etc.) cannot answer "which workflow?" for this high-volume error.

## Change
- Persist `workflowId`, `executionId`, `nodeId`, and `taskType` on the pending request entry when `startTask` enqueues.
- Put those fields on `TaskRequestTimeoutError.extra` (keep the static message for Sentry grouping).
- Report the **error object** (not a bare string) so `ErrorReporter.defaultReport` logs `e.extra` as logger metadata, and pass `executionId` in reporting options.

## Motivation
Self-hosted / queue-mode operators correlating runner capacity issues in log platforms need `@metadata.workflowId` / `@metadata.executionId` on this line. The execution already fails with context in the UI; the platform error report does not.

## Test plan
- [x] Unit: `requestExpired` rejects with `TaskRequestTimeoutError` whose `extra` includes `workflowId`, `executionId`, `nodeId`, `requestId`, `taskType`; `ErrorReporter.error` called with that error + `executionId` (`task-manager.test.ts`).
- [x] Manual: force request expiry (no runner / `N8N_RUNNERS_TASK_REQUEST_TIMEOUT=1`) on a Code node; confirm JSON log metadata includes `workflowId`, `executionId`, `nodeId`, `requestId`.
- [x] Confirm Sentry (if enabled) still groups on static message `Task request timed out`.
- [x] Confirm reject path still surfaces `TaskRequestTimeoutError` on the execution.

Fixes https://github.com/n8n-io/n8n/issues/37095


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

