### PR TITLE
feat(core): Chat trigger publish validation & workflow:execute access control

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -442,6 +442,21 @@ export class ChatTrigger extends Node {
 				},
 			},
 			{
+				displayName: 'Require Workflow Execute Permission',
+				name: 'requireExecuteAccess',
+				type: 'boolean',
+				default: false,
+				displayOptions: {
+					show: {
+						authentication: ['n8nUserAuth'],
+						mode: ['hostedChat'],
+						public: [true],
+					},
+				},
+				description:
+					'Whether the triggering user must also have permission to execute the workflow in the project it belongs to',
+			},
+			{
 				displayName: 'Initial Message(s)',
 				name: 'initialMessages',
 				type: 'string',

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -170,6 +170,22 @@ describe('ChatTrigger Node', () => {
 		});
 	});
 
+	describe('requireExecuteAccess property', () => {
+		it('exposes the toggle, off by default and scoped to n8nUserAuth hosted chat', () => {
+			const requireExecuteParam = chatTrigger.description.properties.find(
+				(property) => property.name === 'requireExecuteAccess',
+			);
+
+			expect(requireExecuteParam).toMatchObject({
+				type: 'boolean',
+				default: false,
+				displayOptions: {
+					show: { authentication: ['n8nUserAuth'], mode: ['hostedChat'], public: [true] },
+				},
+			});
+		});
+	});
+
 	describe('webhook method', () => {
 		it('returns 404 for public chat when instance policy disables public chat', async () => {
 			chatTriggerConfig.disablePublicChat = true;

--- a/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
@@ -1,4 +1,9 @@
-import { createWorkflowWithHistory, setActiveVersion, testDb } from '@n8n/backend-test-utils';
+import {
+	createWorkflowWithHistory,
+	setActiveVersion,
+	shareWorkflowWithUsers,
+	testDb,
+} from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { WebhookRepository, WorkflowRepository } from '@n8n/db';
@@ -10,9 +15,12 @@ import { randomUUID } from 'node:crypto';
 import { createMember, createOwner } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
 
+import { OAuthTokenService } from '@/modules/oauth-server/oauth-token.service';
 import { CacheService } from '@/services/cache/cache.service';
 import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
 import { UrlService } from '@/services/url.service';
+
+import { OAuthClientRepository } from '../database/repositories/oauth-client.repository';
 
 const testServer = setupTestServer({ modules: ['oauth-server', 'mcp'], endpointGroups: ['mcp'] });
 
@@ -34,6 +42,7 @@ const chatTriggerNode = ({
 	mode = 'hostedChat',
 	authentication = 'n8nUserAuth',
 	disabled = false,
+	requireExecuteAccess,
 }: {
 	name?: string;
 	// `null` drops the key entirely, so the "parameter stripped at its default" shape the
@@ -42,6 +51,7 @@ const chatTriggerNode = ({
 	mode?: string | null;
 	authentication?: string | null;
 	disabled?: boolean;
+	requireExecuteAccess?: boolean;
 } = {}): INode => ({
 	id: randomUUID(),
 	name,
@@ -54,6 +64,7 @@ const chatTriggerNode = ({
 		...(isPublic === null ? {} : { public: isPublic }),
 		...(mode === null ? {} : { mode }),
 		...(authentication === null ? {} : { authentication }),
+		...(requireExecuteAccess === undefined ? {} : { requireExecuteAccess }),
 	},
 });
 
@@ -293,14 +304,116 @@ describe('protected resource metadata for chat triggers', () => {
 	});
 });
 
-describe('authorize gate', () => {
-	test('authorizes any authenticated user — there is no execute gate yet', async () => {
+describe('authorize gate (workflow:execute)', () => {
+	test('authorizes the owner but denies a visitor without execute access', async () => {
 		const path = chatPath();
-		await createPublishedChatWorkflow(path, chatTriggerNode());
+		await createPublishedChatWorkflow(path, chatTriggerNode({ requireExecuteAccess: true }));
 
 		const resource = await resolveResource(path);
 
 		await expect(resource?.authorize(owner)).resolves.toBe(true);
+		await expect(resource?.authorize(member)).resolves.toBe(false);
+	});
+
+	test('authorizes a visitor granted execute via a project role', async () => {
+		const path = chatPath();
+		const workflow = await createPublishedChatWorkflow(
+			path,
+			chatTriggerNode({ requireExecuteAccess: true }),
+		);
+		await shareWorkflowWithUsers(workflow, [member]);
+
+		const resource = await resolveResource(path);
+
 		await expect(resource?.authorize(member)).resolves.toBe(true);
+	});
+
+	test('authorizes any authenticated visitor when require-execute is turned off', async () => {
+		const path = chatPath();
+		await createPublishedChatWorkflow(path, chatTriggerNode({ requireExecuteAccess: false }));
+
+		const resource = await resolveResource(path);
+
+		await expect(resource?.authorize(member)).resolves.toBe(true);
+	});
+
+	test('authorizes any authenticated visitor when the parameter is absent', async () => {
+		// `requireExecuteAccess` is opt-in, so an unset parameter means any authenticated
+		// visitor may chat — a trigger whose node never set it stays open.
+		const node = chatTriggerNode();
+		expect(node.parameters.requireExecuteAccess).toBeUndefined();
+		const path = chatPath();
+		await createPublishedChatWorkflow(path, node);
+
+		const resource = await resolveResource(path);
+
+		await expect(resource?.authorize(member)).resolves.toBe(true);
+	});
+});
+
+/**
+ * The same check the chat POST handler and dynamic-credential resolution go through:
+ * holding a token for the chat resource is not enough — the visitor must still have
+ * `workflow:execute` on the workflow behind it.
+ */
+describe('runtime gate: verifyOAuthAccessToken enforces workflow:execute', () => {
+	const mintAccessToken = async (userId: string, resourceUrl: string) => {
+		const tokenService = Container.get(OAuthTokenService);
+		// A registered client is needed only to satisfy the token rows' FK.
+		const clientId = `client-${randomUUID()}`;
+		await Container.get(OAuthClientRepository).save({
+			id: clientId,
+			name: 'Chat resolver tests',
+			redirectUris: ['https://example.com/callback'],
+			grantTypes: ['authorization_code'],
+			tokenEndpointAuthMethod: 'none',
+		});
+		const pair = tokenService.generateTokenPair(userId, clientId, resourceUrl, []);
+		await tokenService.saveTokenPair(pair.accessToken, pair.refreshToken, clientId, userId, []);
+		return pair.accessToken;
+	};
+
+	test('refuses a visitor without execute access on the workflow', async () => {
+		const path = chatPath();
+		await createPublishedChatWorkflow(path, chatTriggerNode({ requireExecuteAccess: true }));
+		const token = await mintAccessToken(member.id, resourceUrlFor(path));
+
+		const result = await Container.get(OAuthTokenService).verifyOAuthAccessToken(
+			token,
+			resourceUrlFor(path),
+		);
+
+		expect(result.user).toBeNull();
+		expect(result.context?.reason).toBe('insufficient_scope');
+	});
+
+	test('allows a visitor granted execute via a project role', async () => {
+		const path = chatPath();
+		const workflow = await createPublishedChatWorkflow(
+			path,
+			chatTriggerNode({ requireExecuteAccess: true }),
+		);
+		await shareWorkflowWithUsers(workflow, [member]);
+		const token = await mintAccessToken(member.id, resourceUrlFor(path));
+
+		const result = await Container.get(OAuthTokenService).verifyOAuthAccessToken(
+			token,
+			resourceUrlFor(path),
+		);
+
+		expect(result.user?.id).toBe(member.id);
+	});
+
+	test('allows the same visitor once require-execute is turned off', async () => {
+		const path = chatPath();
+		await createPublishedChatWorkflow(path, chatTriggerNode({ requireExecuteAccess: false }));
+		const token = await mintAccessToken(member.id, resourceUrlFor(path));
+
+		const result = await Container.get(OAuthTokenService).verifyOAuthAccessToken(
+			token,
+			resourceUrlFor(path),
+		);
+
+		expect(result.user?.id).toBe(member.id);
 	});
 });

--- a/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-test-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-test-resource.resolver.api.test.ts
@@ -1,4 +1,9 @@
-import { createWorkflowWithHistory, setActiveVersion, testDb } from '@n8n/backend-test-utils';
+import {
+	createWorkflowWithHistory,
+	setActiveVersion,
+	shareWorkflowWithUsers,
+	testDb,
+} from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { WebhookRepository } from '@n8n/db';
@@ -43,6 +48,7 @@ const chatTriggerNode = ({
 	mode = 'hostedChat',
 	authentication = 'n8nUserAuth',
 	disabled = false,
+	requireExecuteAccess,
 }: {
 	name?: string;
 	// `null` drops the key entirely, so the "parameter stripped at its default" shape the
@@ -51,6 +57,7 @@ const chatTriggerNode = ({
 	mode?: string | null;
 	authentication?: string | null;
 	disabled?: boolean;
+	requireExecuteAccess?: boolean;
 } = {}): INode => ({
 	id: randomUUID(),
 	name,
@@ -63,6 +70,7 @@ const chatTriggerNode = ({
 		...(isPublic === null ? {} : { public: isPublic }),
 		...(mode === null ? {} : { mode }),
 		...(authentication === null ? {} : { authentication }),
+		...(requireExecuteAccess === undefined ? {} : { requireExecuteAccess }),
 	},
 });
 
@@ -246,17 +254,83 @@ describe('protected resource metadata for test chat triggers', () => {
 	});
 });
 
-describe('authorize gate', () => {
-	test('authorizes any authenticated user — there is no execute gate yet', async () => {
+describe('authorize gate (workflow:execute)', () => {
+	const registerWithWorkflow = async (node: INode) => {
 		const path = chatPath();
-		const node = chatTriggerNode();
 		const workflow = await createWorkflowWithHistory({ active: false, nodes: [node] }, owner);
 		await registerTestWebhook(path, node, { workflowId: workflow.id });
+		return { path, workflow };
+	};
+
+	test('authorizes the owner but denies a visitor without execute access', async () => {
+		const { path } = await registerWithWorkflow(chatTriggerNode({ requireExecuteAccess: true }));
 
 		const resource = await resolveResource(path);
 
 		await expect(resource?.authorize(owner)).resolves.toBe(true);
+		await expect(resource?.authorize(member)).resolves.toBe(false);
+	});
+
+	test('authorizes a visitor granted execute via a project role', async () => {
+		const { path, workflow } = await registerWithWorkflow(
+			chatTriggerNode({ requireExecuteAccess: true }),
+		);
+		await shareWorkflowWithUsers(workflow, [member]);
+
+		const resource = await resolveResource(path);
+
 		await expect(resource?.authorize(member)).resolves.toBe(true);
+	});
+
+	test('authorizes any authenticated visitor when require-execute is turned off', async () => {
+		const { path } = await registerWithWorkflow(chatTriggerNode({ requireExecuteAccess: false }));
+
+		const resource = await resolveResource(path);
+
+		await expect(resource?.authorize(member)).resolves.toBe(true);
+	});
+
+	test('authorizes any authenticated visitor when the parameter is absent', async () => {
+		const node = chatTriggerNode();
+		expect(node.parameters.requireExecuteAccess).toBeUndefined();
+		const { path } = await registerWithWorkflow(node);
+
+		const resource = await resolveResource(path);
+
+		await expect(resource?.authorize(member)).resolves.toBe(true);
+	});
+});
+
+describe('runtime gate: verifyOAuthAccessToken enforces workflow:execute', () => {
+	const mintAccessToken = async (userId: string, resourceUrl: string) => {
+		const tokenService = Container.get(OAuthTokenService);
+		const clientId = `client-${randomUUID()}`;
+		await Container.get(OAuthClientRepository).save({
+			id: clientId,
+			name: 'Chat test resolver tests',
+			redirectUris: ['https://example.com/callback'],
+			grantTypes: ['authorization_code'],
+			tokenEndpointAuthMethod: 'none',
+		});
+		const pair = tokenService.generateTokenPair(userId, clientId, resourceUrl, []);
+		await tokenService.saveTokenPair(pair.accessToken, pair.refreshToken, clientId, userId, []);
+		return pair.accessToken;
+	};
+
+	test('refuses a visitor without execute access on the workflow', async () => {
+		const path = chatPath();
+		const node = chatTriggerNode({ requireExecuteAccess: true });
+		const workflow = await createWorkflowWithHistory({ active: false, nodes: [node] }, owner);
+		await registerTestWebhook(path, node, { workflowId: workflow.id });
+		const token = await mintAccessToken(member.id, testResourceUrlFor(path));
+
+		const result = await Container.get(OAuthTokenService).verifyOAuthAccessToken(
+			token,
+			testResourceUrlFor(path),
+		);
+
+		expect(result.user).toBeNull();
+		expect(result.context?.reason).toBe('insufficient_scope');
 	});
 });
 

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/chat-trigger-resource.base.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/chat-trigger-resource.base.ts
@@ -99,6 +99,10 @@ export abstract class ChatTriggerResourceResolverBase implements ProtectedResour
 		// and the single `redirect_uri` — it has to equal the page the visitor loads.
 		const resourceUrl = `${trimTrailingSlash(this.baseUrl)}/${endpoint}/${path}`;
 		const audiences = [resourceUrl];
+		// Opt-in, unlike the MCP/webhook resolvers' `!== false`: defaulting off preserves the
+		// existing any-authenticated-visitor behaviour, so turning the chat OAuth2 flag on does
+		// not change who may chat with an already-published workflow.
+		const requireExecute = node.parameters.requireExecuteAccess === true;
 		return {
 			// Path included, like the webhook resolver's id: one workflow can hold several chat
 			// triggers, each its own resource.
@@ -109,9 +113,11 @@ export abstract class ChatTriggerResourceResolverBase implements ProtectedResour
 			getAllowedRedirectUris: async () => [resourceUrl],
 			scopes: CHAT_TRIGGER_SCOPES,
 			displayName: workflowName,
-			// No `executeAccessWorkflowId`: today any authenticated visitor may chat, and IAM-1263
-			// owns the opt-in toggle. `uiHints` is IAM-1266's.
-			...triggerResourceGate(this.workflowFinderService, { audiences }),
+			// `uiHints` is IAM-1266's.
+			...triggerResourceGate(this.workflowFinderService, {
+				audiences,
+				executeAccessWorkflowId: requireExecute ? workflowId : undefined,
+			}),
 		};
 	}
 }

--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -888,7 +888,7 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toContain('end-user credentials');
 			expect(result.error).toContain('"My OAuth2"');
 			expect(result.error).toContain(
-				'only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication',
+				'only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication',
 			);
 		});
 
@@ -1239,7 +1239,7 @@ describe('WorkflowValidationService', () => {
 
 				expect(result.isValid).toBe(false);
 				expect(result.error).toBe(
-					'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
+					'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
 				);
 			});
 
@@ -1265,7 +1265,7 @@ describe('WorkflowValidationService', () => {
 
 				expect(result.isValid).toBe(false);
 				expect(result.error).toContain(
-					'only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication',
+					'only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication',
 				);
 			});
 		});
@@ -1273,11 +1273,9 @@ describe('WorkflowValidationService', () => {
 		describe('chat trigger', () => {
 			const CHAT_TRIGGER = '@n8n/n8n-nodes-langchain.chatTrigger';
 
-			const validateWithChatTrigger = async (authentication: string) => {
+			const validateWithChatTrigger = async (parameters: Record<string, unknown>) => {
 				const nodes: INode[] = [
-					createNode('When chat message received', CHAT_TRIGGER, {
-						parameters: { authentication },
-					}),
+					createNode('When chat message received', CHAT_TRIGGER, { parameters }),
 					createNode('HTTP', 'n8n-nodes-base.httpRequest', {
 						credentials: { oAuth2Api: { id: 'cred-1' } },
 					}),
@@ -1296,22 +1294,58 @@ describe('WorkflowValidationService', () => {
 				return await service.validateDynamicCredentials(nodes, mockNodeTypes);
 			};
 
-			// A chat trigger establishes no identity at runtime through `n8nUserAuth`, so
-			// the flag being on must not let publish accept a configuration that would
-			// only fail later, mid-execution.
-			it.each(['n8nUserAuth', 'none', 'basicAuth'])(
+			// A chat trigger establishes no identity at runtime through `none`/`basicAuth`, so
+			// the flag being on must not let publish accept a configuration that would only
+			// fail later, mid-execution.
+			it.each(['none', 'basicAuth'])(
 				'should reject authentication %s even when chat OAuth2 is enabled',
 				async (authentication) => {
 					withChatOAuth2(true);
 
-					const result = await validateWithChatTrigger(authentication);
+					const result = await validateWithChatTrigger({ authentication });
 
 					expect(result.isValid).toBe(false);
 					expect(result.error).toBe(
-						'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
+						'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
 					);
 				},
 			);
+
+			it.each([{}, { mode: 'hostedChat' }])(
+				'should return valid for public n8nUserAuth in hosted-chat mode (%o)',
+				async (modeParams) => {
+					const result = await validateWithChatTrigger({
+						public: true,
+						authentication: 'n8nUserAuth',
+						...modeParams,
+					});
+
+					expect(result.isValid).toBe(true);
+				},
+			);
+
+			// A non-public trigger 404s on every production request and skips auth entirely
+			// in test mode, so it never reaches the code that establishes identity.
+			it('should reject n8nUserAuth in hosted-chat mode when not public', async () => {
+				const result = await validateWithChatTrigger({ authentication: 'n8nUserAuth' });
+
+				expect(result.isValid).toBe(false);
+			});
+
+			// Embedded/webhook-mode chat has no hosted page to run the OAuth2 handshake on, so
+			// `n8nUserAuth` establishes no identity there despite being selected.
+			it('should reject authentication n8nUserAuth in webhook mode', async () => {
+				const result = await validateWithChatTrigger({
+					public: true,
+					authentication: 'n8nUserAuth',
+					mode: 'webhook',
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toBe(
+					'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
+				);
+			});
 		});
 
 		it('should state the identity-extractor requirement for a custom resolver', async () => {
@@ -1355,7 +1389,7 @@ describe('WorkflowValidationService', () => {
 			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
 
 			expect(result.error).toBe(
-				'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
+				'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
 			);
 		});
 

--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -1312,8 +1312,10 @@ describe('WorkflowValidationService', () => {
 			);
 
 			it.each([{}, { mode: 'hostedChat' }])(
-				'should return valid for public n8nUserAuth in hosted-chat mode (%o)',
+				'should return valid for public n8nUserAuth in hosted-chat mode when chat OAuth2 is enabled (%o)',
 				async (modeParams) => {
+					withChatOAuth2(true);
+
 					const result = await validateWithChatTrigger({
 						public: true,
 						authentication: 'n8nUserAuth',
@@ -1323,6 +1325,21 @@ describe('WorkflowValidationService', () => {
 					expect(result.isValid).toBe(true);
 				},
 			);
+
+			// With the flag off (the default), hosted-chat `n8nUserAuth` falls back to a cookie
+			// check that never binds the visitor's identity — publish must not accept an
+			// end-user credential it can't actually resolve at runtime.
+			it('should reject public n8nUserAuth in hosted-chat mode when chat OAuth2 is disabled', async () => {
+				const result = await validateWithChatTrigger({
+					public: true,
+					authentication: 'n8nUserAuth',
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toBe(
+					'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
+				);
+			});
 
 			// A non-public trigger 404s on every production request and skips auth entirely
 			// in test mode, so it never reaches the code that establishes identity.

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -23,6 +23,7 @@ import type {
 } from 'n8n-workflow';
 
 import { STARTING_NODES } from '@/constants';
+import { isChatOAuth2Enabled } from '@/constants/oauth2-triggers';
 import { CredentialTypes } from '@/credential-types';
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { NodeTypes } from '@/node-types';
@@ -481,6 +482,7 @@ export class WorkflowValidationService {
 			const { providesExternalIdentity, providesN8nIdentity } = classifyTriggerIdentity(
 				node.type,
 				node.parameters,
+				{ isChatOAuth2Enabled: isChatOAuth2Enabled() },
 			);
 			allTriggersProvideExternalIdentity &&= providesExternalIdentity;
 			allTriggersProvideN8nIdentity &&= providesN8nIdentity;

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -417,13 +417,14 @@ export class WorkflowValidationService {
 
 	/**
 	 * Describes which trigger configurations the system resolver currently accepts,
-	 * for the publish-error copy. Chat only qualifies when available in Chat Hub — a
-	 * `n8nUserAuth` chat trigger establishes no identity at runtime, so it's not
-	 * listed here regardless of the chat OAuth2 flag; MCP only with n8n user auth
-	 * (OAuth2). Mirrors `classifyTriggerIdentity`.
+	 * for the publish-error copy. Chat qualifies when available in Chat Hub, or with
+	 * `n8nUserAuth` in hosted-chat mode specifically — embedded/webhook-mode chat has
+	 * no page to run the OAuth2 handshake on, so it establishes no identity regardless
+	 * of the chat OAuth2 flag; MCP only with n8n user auth (OAuth2). Mirrors
+	 * `classifyTriggerIdentity`.
 	 */
 	private getN8nUserAuthTriggersList(): string {
-		return 'manual and sub-workflow triggers, chat triggers available in n8n Chat Hub, and MCP, form, or webhook triggers with n8n user authentication';
+		return 'manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication';
 	}
 
 	/** Collects the ids of all credentials referenced by enabled nodes. */

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4368,7 +4368,7 @@
 	"nodeIssues.credentials.notIdentified": "Credentials with name {name} exist for {type}.",
 	"nodeIssues.credentials.notIdentified.hint": "Credentials are not clearly identified. Please select the correct credentials.",
 	"nodeIssues.credentials.privateNotConnected": "'{name}' end-user credential is not connected for you. Connect yours to execute this step manually.",
-	"nodeIssues.credentials.privateRequiresIdentityTriggerWithFormAndWebhook": "End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+	"nodeIssues.credentials.privateRequiresIdentityTriggerWithFormAndWebhook": "End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 	"nodeIssues.credentials.privateRequiresIdentityExtractor": "End-user credentials with this resolver need a trigger that extracts an identity. Configure an identity extractor on the trigger, or switch this credential to Fixed.",
 	"nodeIssues.input.missing": "No node connected to required input \"{inputName}\"",
 	"ndv.trigger.moreInfo": "More info",

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -1182,8 +1182,9 @@ describe('useNodeHelpers()', () => {
 				);
 
 				it.each([undefined, 'hostedChat'])(
-					'does not warn for public n8nUserAuth in hosted-chat mode (mode: %s)',
+					'does not warn for public n8nUserAuth in hosted-chat mode when chat OAuth2 is enabled (mode: %s)',
 					(mode) => {
+						setChatOAuth2(true);
 						mockConnectedPrivateCred(true);
 						mockDocumentStore.workflowTriggerNodes = [
 							buildChatUserAuthTrigger('n8nUserAuth', mode, true),
@@ -1195,6 +1196,23 @@ describe('useNodeHelpers()', () => {
 						expect(result).toBeNull();
 					},
 				);
+
+				// With the flag off (the default), hosted-chat `n8nUserAuth` falls back to a
+				// cookie check that never binds the visitor's identity for credential
+				// resolution — the warning must still show.
+				it('warns for public n8nUserAuth in hosted-chat mode when chat OAuth2 is disabled', () => {
+					mockConnectedPrivateCred(true);
+					mockDocumentStore.workflowTriggerNodes = [
+						buildChatUserAuthTrigger('n8nUserAuth', 'hostedChat', true),
+					];
+
+					const { getNodeCredentialIssues } = useNodeHelpers();
+					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+					expect(result?.credentials?.[NOTION_API]).toEqual([
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					]);
+				});
 
 				// A non-public trigger 404s on every production request and skips auth
 				// entirely in test mode, so it never reaches the code that establishes identity.

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -1041,7 +1041,7 @@ describe('useNodeHelpers()', () => {
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 				expect(result?.credentials?.[NOTION_API]).toEqual([
-					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 				]);
 			});
 
@@ -1070,7 +1070,7 @@ describe('useNodeHelpers()', () => {
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 				expect(result?.credentials?.[NOTION_API]).toEqual([
-					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 				]);
 			});
 
@@ -1084,7 +1084,7 @@ describe('useNodeHelpers()', () => {
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 				expect(result?.credentials?.[NOTION_API]).toEqual([
-					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 				]);
 			});
 
@@ -1139,19 +1139,33 @@ describe('useNodeHelpers()', () => {
 					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 					expect(result?.credentials?.[NOTION_API]).toEqual([
-						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
 			});
 
 			describe('chat trigger n8nUserAuth', () => {
-				const buildChatUserAuthTrigger = (authentication: string) =>
-					buildTriggerNode(CHAT_TRIGGER, { parameters: { authentication } });
+				// `isPublic` has no default: an omitted arg leaves the `public` key out of
+				// `parameters` entirely (the "stripped at its default" shape a saved node can
+				// carry), which a JS default parameter can't express since it also fires for an
+				// explicitly-passed `undefined`.
+				const buildChatUserAuthTrigger = (
+					authentication: string,
+					mode?: string,
+					isPublic?: boolean,
+				) =>
+					buildTriggerNode(CHAT_TRIGGER, {
+						parameters: {
+							...(isPublic === undefined ? {} : { public: isPublic }),
+							authentication,
+							mode,
+						},
+					});
 
-				// A chat trigger establishes no identity at runtime through `n8nUserAuth`, so
-				// the flag being on must not clear this warning — that would tell the
+				// A chat trigger establishes no identity at runtime through `none`/`basicAuth`,
+				// so the flag being on must not clear this warning — that would tell the
 				// builder a fix works when it doesn't.
-				it.each(['n8nUserAuth', 'none', 'basicAuth'])(
+				it.each(['none', 'basicAuth'])(
 					'warns for authentication %s even when chat OAuth2 is enabled',
 					(authentication) => {
 						setChatOAuth2(true);
@@ -1162,10 +1176,60 @@ describe('useNodeHelpers()', () => {
 						const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 						expect(result?.credentials?.[NOTION_API]).toEqual([
-							"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+							"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 						]);
 					},
 				);
+
+				it.each([undefined, 'hostedChat'])(
+					'does not warn for public n8nUserAuth in hosted-chat mode (mode: %s)',
+					(mode) => {
+						mockConnectedPrivateCred(true);
+						mockDocumentStore.workflowTriggerNodes = [
+							buildChatUserAuthTrigger('n8nUserAuth', mode, true),
+						];
+
+						const { getNodeCredentialIssues } = useNodeHelpers();
+						const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+						expect(result).toBeNull();
+					},
+				);
+
+				// A non-public trigger 404s on every production request and skips auth
+				// entirely in test mode, so it never reaches the code that establishes identity.
+				it.each([undefined, false])(
+					'warns for n8nUserAuth in hosted-chat mode when not public (public: %s)',
+					(isPublic) => {
+						mockConnectedPrivateCred(true);
+						mockDocumentStore.workflowTriggerNodes = [
+							buildChatUserAuthTrigger('n8nUserAuth', 'hostedChat', isPublic),
+						];
+
+						const { getNodeCredentialIssues } = useNodeHelpers();
+						const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+						expect(result?.credentials?.[NOTION_API]).toEqual([
+							"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+						]);
+					},
+				);
+
+				// Embedded/webhook-mode chat has no hosted page to run the OAuth2 handshake
+				// on, so `n8nUserAuth` establishes no identity there despite being selected.
+				it('warns for n8nUserAuth in webhook mode', () => {
+					mockConnectedPrivateCred(true);
+					mockDocumentStore.workflowTriggerNodes = [
+						buildChatUserAuthTrigger('n8nUserAuth', 'webhook', true),
+					];
+
+					const { getNodeCredentialIssues } = useNodeHelpers();
+					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+					expect(result?.credentials?.[NOTION_API]).toEqual([
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					]);
+				});
 			});
 
 			it('does not warn when a private credential is used under a Chat Trigger with availableInChat', () => {
@@ -1385,7 +1449,7 @@ describe('useNodeHelpers()', () => {
 					const result = getNodeCredentialIssues(buildGenericAuthNode(), httpRequestWithSslAuth);
 
 					expect(result?.credentials?.[OAUTH2_API]).toEqual([
-						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
 
@@ -1417,7 +1481,7 @@ describe('useNodeHelpers()', () => {
 					const result = getNodeCredentialIssues(buildPredefinedAuthNode(), httpRequestWithSslAuth);
 
 					expect(result?.credentials?.[OAUTH2_API]).toEqual([
-						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -48,6 +48,7 @@ import { EnableNodeToggleCommand } from '@/app/models/history';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useCanvasStore } from '@/app/stores/canvas.store';
+import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { injectWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
@@ -70,6 +71,7 @@ export function useNodeHelpers() {
 	const settingsStore = useSettingsStore();
 	const i18n = useI18n();
 	const canvasStore = useCanvasStore();
+	const { check: envFeatureFlag } = useEnvFeatureFlag();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 	const { isEnabled: isPrivateCredentialsEnabled } = usePrivateCredentials();
@@ -439,6 +441,7 @@ export function useNodeHelpers() {
 			const { providesN8nIdentity, providesExternalIdentity } = classifyTriggerIdentity(
 				trigger.type,
 				trigger.parameters,
+				{ isChatOAuth2Enabled: envFeatureFlag.value('CHAT_TRIGGER_OAUTH2') },
 			);
 			return isSystemResolver ? !providesN8nIdentity : !providesExternalIdentity;
 		});

--- a/packages/workflow/src/trigger-identity.ts
+++ b/packages/workflow/src/trigger-identity.ts
@@ -39,12 +39,20 @@ function hasContextEstablishmentHook(parameters: INodeParameters | undefined): b
 
 /**
  * Whether a Chat Trigger's `n8nUserAuth` establishes the visitor's n8n identity: only in
- * hosted-chat mode (embedded/webhook mode has no page to run the OAuth2 handshake on) and
- * only when public (a non-public trigger never reaches the auth code at all). Absent `mode`
- * counts as `hostedChat`, its default.
+ * hosted-chat mode (embedded/webhook mode has no page to run the OAuth2 handshake on), only
+ * when public (a non-public trigger never reaches the auth code at all), and only when the
+ * chat-trigger OAuth2 pipeline is enabled — with it off, `n8nUserAuth` falls back to a plain
+ * cookie check that authenticates the request but never binds the visitor's identity for
+ * credential resolution (`GenericFunctions.ts`'s `validateAuth`). Absent `mode` counts as
+ * `hostedChat`, its default.
  */
-function isHostedChatUserAuthTrigger(nodeType: string, parameters: INodeParameters | undefined) {
+function isHostedChatUserAuthTrigger(
+	nodeType: string,
+	parameters: INodeParameters | undefined,
+	isChatOAuth2Enabled: boolean,
+) {
 	return (
+		isChatOAuth2Enabled &&
 		nodeType === CHAT_TRIGGER_NODE_TYPE &&
 		parameters?.public === true &&
 		parameters?.authentication === 'n8nUserAuth' &&
@@ -60,10 +68,17 @@ function isHostedChatUserAuthTrigger(nodeType: string, parameters: INodeParamete
  * sync with how the engine establishes identity (`execution-context.ts`,
  * manual/parent inheritance) and the resolvers' identifiers (e.g. `N8NIdentifier`):
  * when a new trigger or identity source is added there, reflect it here too.
+ *
+ * `isChatOAuth2Enabled` mirrors the `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2` opt-in flag: it
+ * gates the Chat Trigger's hosted-chat `n8nUserAuth` branch, since that configuration
+ * only establishes identity through the flagged pipeline. Defaults to `false` so a
+ * caller that forgets to pass it gets the safe (no-identity) answer rather than a false
+ * positive.
  */
 export function classifyTriggerIdentity(
 	nodeType: string,
 	parameters: INodeParameters | undefined,
+	{ isChatOAuth2Enabled = false }: { isChatOAuth2Enabled?: boolean } = {},
 ): TriggerIdentityCapabilities {
 	// Sub-workflows inherit identity from the parent; Chat Hub and MCP-over-n8nOAuth2
 	// inject it. All provide both identity families.
@@ -83,7 +98,7 @@ export function classifyTriggerIdentity(
 	if (
 		isSubWorkflowTrigger ||
 		isChatHubTrigger ||
-		isHostedChatUserAuthTrigger(nodeType, parameters) ||
+		isHostedChatUserAuthTrigger(nodeType, parameters, isChatOAuth2Enabled) ||
 		isMcpTrigger ||
 		isFormTrigger ||
 		isOAuth2Webhook

--- a/packages/workflow/src/trigger-identity.ts
+++ b/packages/workflow/src/trigger-identity.ts
@@ -38,6 +38,21 @@ function hasContextEstablishmentHook(parameters: INodeParameters | undefined): b
 }
 
 /**
+ * Whether a Chat Trigger's `n8nUserAuth` establishes the visitor's n8n identity: only in
+ * hosted-chat mode (embedded/webhook mode has no page to run the OAuth2 handshake on) and
+ * only when public (a non-public trigger never reaches the auth code at all). Absent `mode`
+ * counts as `hostedChat`, its default.
+ */
+function isHostedChatUserAuthTrigger(nodeType: string, parameters: INodeParameters | undefined) {
+	return (
+		nodeType === CHAT_TRIGGER_NODE_TYPE &&
+		parameters?.public === true &&
+		parameters?.authentication === 'n8nUserAuth' &&
+		(parameters?.mode ?? 'hostedChat') === 'hostedChat'
+	);
+}
+
+/**
  * Classifies a single trigger node by the identity it can establish at runtime.
  *
  * Shared by the backend publish-time validation (`WorkflowValidationService`) and
@@ -68,6 +83,7 @@ export function classifyTriggerIdentity(
 	if (
 		isSubWorkflowTrigger ||
 		isChatHubTrigger ||
+		isHostedChatUserAuthTrigger(nodeType, parameters) ||
 		isMcpTrigger ||
 		isFormTrigger ||
 		isOAuth2Webhook

--- a/packages/workflow/test/trigger-identity.test.ts
+++ b/packages/workflow/test/trigger-identity.test.ts
@@ -63,31 +63,61 @@ describe('classifyTriggerIdentity', () => {
 		);
 
 		// Only the hosted-chat page runs the OAuth2 handshake that establishes the
-		// visitor's identity — `mode` absent or explicit defaults to hosted.
+		// visitor's identity — `mode` absent or explicit defaults to hosted. Requires the
+		// chat-trigger OAuth2 flag: with it off, `n8nUserAuth` falls back to a plain cookie
+		// check that never binds the visitor's identity for credential resolution.
 		it.each([{}, { mode: 'hostedChat' }])(
-			'provides both identities for public n8nUserAuth in hosted-chat mode (%o)',
+			'provides both identities for public n8nUserAuth in hosted-chat mode when chat OAuth2 is enabled (%o)',
 			(modeParams) => {
 				expect(
-					classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {
-						public: true,
-						authentication: 'n8nUserAuth',
-						...modeParams,
-					}),
+					classifyTriggerIdentity(
+						CHAT_TRIGGER_NODE_TYPE,
+						{
+							public: true,
+							authentication: 'n8nUserAuth',
+							...modeParams,
+						},
+						{ isChatOAuth2Enabled: true },
+					),
 				).toEqual({ providesN8nIdentity: true, providesExternalIdentity: true });
 			},
 		);
 
+		// With the flag off (the default), the cookie fallback authenticates the request but
+		// never binds the visitor's identity — publish must not advertise identity it can't
+		// actually establish.
+		it.each([{}, { isChatOAuth2Enabled: false }])(
+			'provides no identity for public n8nUserAuth in hosted-chat mode when chat OAuth2 is disabled (%o)',
+			(options) => {
+				expect(
+					classifyTriggerIdentity(
+						CHAT_TRIGGER_NODE_TYPE,
+						{ public: true, authentication: 'n8nUserAuth' },
+						options,
+					),
+				).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
+			},
+		);
+
 		// Embedded/webhook-mode chat has no hosted page to run the OAuth2 handshake on, so
-		// `n8nUserAuth` establishes no identity there despite being selected (IAM-1262/IAM-1272).
-		it('provides no identity for n8nUserAuth in webhook mode', () => {
-			expect(
-				classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {
-					public: true,
-					authentication: 'n8nUserAuth',
-					mode: 'webhook',
-				}),
-			).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
-		});
+		// `n8nUserAuth` establishes no identity there despite being selected (IAM-1262/IAM-1272),
+		// regardless of the chat OAuth2 flag.
+		it.each([{}, { isChatOAuth2Enabled: true }])(
+			'provides no identity for n8nUserAuth in webhook mode (%o)',
+			(options) => {
+				expect(
+					classifyTriggerIdentity(
+						CHAT_TRIGGER_NODE_TYPE,
+						{
+							public: true,
+							authentication: 'n8nUserAuth',
+							mode: 'webhook',
+						},
+						options,
+					),
+				).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
+			},
+		);
 
 		// A non-public trigger 404s on every production request and skips auth entirely in
 		// test mode (`ChatTrigger.node.ts`'s `webhook()`), so it never reaches the code that

--- a/packages/workflow/test/trigger-identity.test.ts
+++ b/packages/workflow/test/trigger-identity.test.ts
@@ -51,15 +51,56 @@ describe('classifyTriggerIdentity', () => {
 			},
 		);
 
-		// A chat trigger establishes no identity at runtime through `n8nUserAuth`,
-		// regardless of the chat OAuth2 flag (which classification ignores).
-		it.each(['n8nUserAuth', 'none', 'basicAuth'])(
+		// A chat trigger establishes no identity at runtime through `none`/`basicAuth`.
+		it.each(['none', 'basicAuth'])(
 			'provides no identity for authentication %s',
 			(authentication) => {
 				expect(classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, { authentication })).toEqual({
 					providesN8nIdentity: false,
 					providesExternalIdentity: false,
 				});
+			},
+		);
+
+		// Only the hosted-chat page runs the OAuth2 handshake that establishes the
+		// visitor's identity — `mode` absent or explicit defaults to hosted.
+		it.each([{}, { mode: 'hostedChat' }])(
+			'provides both identities for public n8nUserAuth in hosted-chat mode (%o)',
+			(modeParams) => {
+				expect(
+					classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {
+						public: true,
+						authentication: 'n8nUserAuth',
+						...modeParams,
+					}),
+				).toEqual({ providesN8nIdentity: true, providesExternalIdentity: true });
+			},
+		);
+
+		// Embedded/webhook-mode chat has no hosted page to run the OAuth2 handshake on, so
+		// `n8nUserAuth` establishes no identity there despite being selected (IAM-1262/IAM-1272).
+		it('provides no identity for n8nUserAuth in webhook mode', () => {
+			expect(
+				classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {
+					public: true,
+					authentication: 'n8nUserAuth',
+					mode: 'webhook',
+				}),
+			).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
+		});
+
+		// A non-public trigger 404s on every production request and skips auth entirely in
+		// test mode (`ChatTrigger.node.ts`'s `webhook()`), so it never reaches the code that
+		// establishes identity — regardless of authentication/mode.
+		it.each([{}, { public: false }])(
+			'provides no identity for n8nUserAuth in hosted-chat mode when not public (%o)',
+			(publicParams) => {
+				expect(
+					classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {
+						authentication: 'n8nUserAuth',
+						...publicParams,
+					}),
+				).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
 			},
 		);
 	});


### PR DESCRIPTION
## Summary

- Adds a `classifyTriggerIdentity` branch so a Chat Trigger with `authentication: n8nUserAuth` in hosted-chat mode (public, `mode: hostedChat`) is recognized as identity-providing — unblocking end-user (resolvable) credentials on it in the editor and at publish time. Scoped to hosted-chat only: `webhook` mode has no page to run the OAuth2 handshake on, so it still establishes no identity there.
- Adds an opt-in "Require Workflow Execute Permission" toggle on Chat Trigger, defaulting off (non-breaking), wired into the existing OAuth grant/`workflow:execute` gate shared with Form/MCP/Webhook triggers.
- Publish validation now rejects a Chat Trigger set to `none`/`basicAuth` with an end-user credential attached downstream — for free, by reusing the same classifier rather than a second check.

## How to test

1. Publish validation / editor warning:
   - Create a workflow with a publicly-published Chat Trigger, `authentication: n8nUserAuth`, mode `Hosted Chat`, with a downstream node using a resolvable (end-user) credential.
   - Confirm the editor no longer warns that the trigger can't carry identity, and the workflow publishes successfully.
   - Switch `authentication` to `none` or `basicAuth` — confirm publish is now rejected with a clear error.
   - Switch `mode` to `Embedded Chat` (`webhook`) — confirm the trigger is still treated as non-identity-providing (publish rejected), since that mode has no working identity pipeline.
2. `workflow:execute` toggle:
   - Enable "Require Workflow Execute Permission" on the trigger.
   - As a non-owner member without `workflow:execute` on the workflow's project, attempting to chat should be denied; a member granted access via project role should succeed.
   - With the toggle off (default), any authenticated visitor can chat, matching today's behavior.
   - Note: an instance Owner/Admin account bypasses this check regardless of the toggle (pre-existing `workflow:execute` scoping behavior, not specific to this change) — test with a `member`-role account to see the gate.
3. Automated tests: `pnpm test` in `packages/workflow`, `packages/cli`, `packages/@n8n/nodes-langchain`, and `packages/frontend/editor-ui` cover the classifier, publish validation, the new node property, and both the production and test-mode OAuth resource resolvers.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1263

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

