### PR TITLE
fix(core): Thread execution id through dynamic-credential storage

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -1055,6 +1055,7 @@ describe('CredentialsHelper', () => {
 					workflowSettings: {
 						credentialResolverId: 'workflow-resolver-123',
 					},
+					executionId: 'exec-123',
 				} as IWorkflowExecuteAdditionalData;
 
 				// Act
@@ -1065,7 +1066,10 @@ describe('CredentialsHelper', () => {
 					additionalDataWithCredentials,
 				);
 
-				// Assert: Should use dynamic proxy, NOT direct database update
+				// Assert: Should use dynamic proxy, NOT direct database update, and forward the
+				// execution id so a context already bound to this execution (via
+				// `maybeBindExecutionId`) passes the resolver's replay check the same way
+				// `resolveIfNeeded` already does.
 				expect(storeOAuthTokenDataSpy).toHaveBeenCalledWith(
 					{
 						id: 'cred-789',
@@ -1078,6 +1082,7 @@ describe('CredentialsHelper', () => {
 					additionalDataWithCredentials.executionContext,
 					existingCredentialData,
 					additionalDataWithCredentials.workflowSettings,
+					'exec-123',
 				);
 				expect(credentialsRepository.update).not.toHaveBeenCalled();
 			});
@@ -1129,6 +1134,7 @@ describe('CredentialsHelper', () => {
 						additionalDataWithCredentials.executionContext,
 						existingCredentialData,
 						additionalDataWithCredentials.workflowSettings,
+						undefined,
 					);
 					expect(credentialsRepository.update).not.toHaveBeenCalled();
 				} finally {

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -799,6 +799,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 				additionalData.executionContext,
 				staticData,
 				additionalData.workflowSettings,
+				additionalData.executionId,
 			);
 			return;
 		}

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -169,6 +169,7 @@ describe('DynamicCredentialsProxy', () => {
 				credentialContext,
 				undefined,
 				undefined,
+				undefined,
 			);
 		});
 
@@ -192,6 +193,32 @@ describe('DynamicCredentialsProxy', () => {
 				credentialContext,
 				staticData,
 				workflowSettings,
+				undefined,
+			);
+		});
+
+		it('forwards executionId to the storage provider, so a context bound to this execution passes the resolver replay check', async () => {
+			const staticData = { clientId: 'static-client-id' };
+			const workflowSettings: IWorkflowSettings = { executionTimeout: 300 };
+
+			proxy.setStorageProvider(mockStorageProvider);
+
+			await proxy.storeIfNeeded(
+				credentialMetadata,
+				dynamicData,
+				credentialContext,
+				staticData,
+				workflowSettings,
+				'exec-123',
+			);
+
+			expect(mockStorageProvider.storeIfNeeded).toHaveBeenCalledWith(
+				credentialMetadata,
+				dynamicData,
+				credentialContext,
+				staticData,
+				workflowSettings,
+				'exec-123',
 			);
 		});
 	});

--- a/packages/cli/src/credentials/dynamic-credential-storage.interface.ts
+++ b/packages/cli/src/credentials/dynamic-credential-storage.interface.ts
@@ -33,6 +33,9 @@ export interface IDynamicCredentialStorageProvider {
 	 * @param credentialContext Identity and metadata for scoping storage
 	 * @param staticData Static credential data from database (e.g., clientId, clientSecret)
 	 * @param workflowSettings Workflow settings with fallback resolver ID
+	 * @param executionId The current execution, so a context sealed and bound to an
+	 * execution (see `ExecutionContextService.maybeBindExecutionId`) can pass the
+	 * resolver's replay check the same way `resolveIfNeeded` already does.
 	 */
 	storeIfNeeded(
 		credentialStoreMetadata: CredentialStoreMetadata,
@@ -40,5 +43,6 @@ export interface IDynamicCredentialStorageProvider {
 		credentialContext: ICredentialContext,
 		staticData?: ICredentialDataDecryptedObject,
 		workflowSettings?: IWorkflowSettings,
+		executionId?: string,
 	): Promise<void>;
 }

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -92,6 +92,7 @@ export class DynamicCredentialsProxy
 		credentialContext: ICredentialContext,
 		staticData?: ICredentialDataDecryptedObject,
 		workflowSettings?: IWorkflowSettings,
+		executionId?: string,
 	): Promise<void> {
 		if (!this.storageProvider) {
 			if (credentialStoreMetadata.isResolvable) {
@@ -108,6 +109,7 @@ export class DynamicCredentialsProxy
 			credentialContext,
 			staticData,
 			workflowSettings,
+			executionId,
 		);
 	}
 
@@ -120,6 +122,7 @@ export class DynamicCredentialsProxy
 		executionContext: IExecutionContext | undefined,
 		staticData: ICredentialDataDecryptedObject,
 		workflowSettings?: IWorkflowSettings,
+		executionId?: string,
 	): Promise<void> {
 		if (!credentialStoreMetadata.isResolvable || !credentialStoreMetadata.resolverId) {
 			return;
@@ -149,6 +152,7 @@ export class DynamicCredentialsProxy
 			credentialContext,
 			staticData,
 			workflowSettings,
+			executionId,
 		);
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
@@ -220,6 +220,7 @@ describe('DynamicCredentialStorageService', () => {
 						resolverName: 'test-resolver',
 						resolverId: 'resolver-456',
 					}),
+					undefined,
 				);
 
 				expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -228,6 +229,33 @@ describe('DynamicCredentialStorageService', () => {
 						credentialId: 'cred-123',
 						resolverId: 'resolver-456',
 					}),
+				);
+			});
+
+			it('forwards executionId to the resolver, so a context bound to this execution passes the replay check', async () => {
+				const metadata = createMockCredentialMetadata();
+				const resolverEntity = createMockResolverEntity();
+				const mockResolver = createMockResolver();
+
+				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+				mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ prefix: 'test' }));
+
+				await service.storeIfNeeded(
+					metadata,
+					dynamicData,
+					credentialContext,
+					staticData,
+					undefined,
+					'exec-123',
+				);
+
+				expect(mockResolver.setSecret).toHaveBeenCalledWith(
+					'cred-123',
+					credentialContext,
+					expect.any(Object),
+					expect.any(Object),
+					'exec-123',
 				);
 			});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
@@ -37,6 +37,7 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 		credentialContext: ICredentialContext,
 		staticData?: ICredentialDataDecryptedObject,
 		workflowSettings?: IWorkflowSettings,
+		executionId?: string,
 	): Promise<void> {
 		try {
 			if (!credentialStoreMetadata.isResolvable) {
@@ -92,11 +93,17 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 				}
 			}
 
-			await resolver.setSecret(credentialStoreMetadata.id, credentialContext, mergedDynamicData, {
-				configuration: resolverConfig,
-				resolverName: resolverEntity.name,
-				resolverId: resolverEntity.id,
-			});
+			await resolver.setSecret(
+				credentialStoreMetadata.id,
+				credentialContext,
+				mergedDynamicData,
+				{
+					configuration: resolverConfig,
+					resolverName: resolverEntity.name,
+					resolverId: resolverEntity.id,
+				},
+				executionId,
+			);
 
 			this.logger.debug('Successfully stored dynamic credentials', {
 				credentialId: credentialStoreMetadata.id,


### PR DESCRIPTION
## Summary

When a resolvable (end-user) OAuth2 credential's access token expires mid-execution and needs refreshing, the refresh against the provider (e.g. Google) succeeds but persisting the refreshed token back to n8n's per-user storage crashes with `Sealed identity is not valid for this execution`. Once this happens, the credential is stuck: the old expired token never gets replaced, so it fails again on every subsequent execution.

**This affects Chat Trigger and MCP Trigger**

- **Form Trigger / Webhook n8nOAuth2**: re-verify the n8n identity token fresh, every single time. Simple, but only works because these are typically short, single-request interactions.
- **Chat Trigger / MCP Trigger**: verify the n8n identity token *once*, then seal that decision and stamp it to the specific execution — so a long-running conversation or a workflow paused at a `Wait` node doesn't fail later just because the original identity token's own short TTL elapsed in the meantime. Re-checking that stamp requires knowing *which execution* is asking.

The bug is specifically in that stamp-check: the code path that persists a refreshed downstream token never told it which execution was asking, so the check always failed for any resolvable credential behind Chat or MCP identity, unconditionally, not just occasionally. Form/Webhook never hit this at all, since they never take the "stamped" path in the first place.

## How to test

Live repro (no waiting out a real token expiry): connect a resolvable OAuth2 credential (e.g. Gmail) behind a Chat or MCP trigger, then corrupt only the stored `access_token` (leaving `refresh_token` valid) so the next API call gets a genuine `401` and forces a real refresh-and-persist cycle. Before the fix: crashes with `Failed to store end-user credential data for "<credential>"` / `Sealed identity is not valid for this execution`. After: refreshes and saves cleanly.

Automated coverage: `pnpm test dynamic-credentials-proxy dynamic-credential-storage.service credentials-helper.test` in `packages/cli` — asserts the execution id is forwarded end-to-end from the caller through to the resolver's `setSecret` call.

## Related Linear tickets, Github issues, and Community forum posts

Found while testing [IAM-1263](https://linear.app/n8n/issue/IAM-1263) (chat trigger publish validation), which was the first configuration to reach this pre-existing, generic bug in the dynamic-credentials storage pipeline. No existing Linear ticket covers this specific issue as of writing.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)