### PR TITLE
fix(editor): Correct community node docs link interpolation key

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsTabs.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsTabs.vue
@@ -104,7 +104,7 @@ const options = computed(() => {
 			align: 'right',
 			tooltip: i18n.baseText('generic.communityNode.tooltip', {
 				interpolate: {
-					docUrl: COMMUNITY_NODES_INSTALLATION_DOCS_URL,
+					docURL: COMMUNITY_NODES_INSTALLATION_DOCS_URL,
 					packageName: packageName.value,
 				},
 			}),


### PR DESCRIPTION
## Summary

The community node tooltip's "Learn more" link was broken: the locale string interpolates `{docURL}`, but the component was passing a `docUrl` (lowercase `url`) key, so the placeholder was never substituted and the link pointed at the literal `{docURL}` text instead of the installation docs.

Fixes the interpolation key in `NodeSettingsTabs.vue` to match the locale string casing.

## How to test

1. Install any community node package.
2. Open a node from that package in the NDV.
3. Hover the community-node icon/tag in the node settings tabs to reveal the tooltip.
4. Click "Learn more" — it should navigate to the community nodes installation docs instead of showing a broken/literal link.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-2497

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

