### PR TITLE
fix(core): Keep the API version in the Gemini base URL for agent models

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -64,6 +64,7 @@ vi.mock('@ai-sdk/google', () => ({
 		provider: 'google',
 		modelId: model,
 		apiKey: opts?.apiKey,
+		baseURL: opts?.baseURL,
 		fetch: opts?.fetch,
 		specificationVersion: 'v3',
 	}),
@@ -517,6 +518,41 @@ describe('createModel', () => {
 				unknown
 			>;
 			expect(model.baseURL).toBeUndefined();
+		});
+	});
+
+	describe('google baseURL normalization', () => {
+		const baseURLFor = (creds: Record<string, unknown>) =>
+			(
+				createModel({
+					id: 'google/gemini-3.7-flash',
+					apiKey: 'g-test',
+					...creds,
+				}) as unknown as Record<string, unknown>
+			).baseURL;
+
+		// `googlePalmApi.host` defaults to the bare host, which drops the API
+		// version from every request path — Google then 404s for any model.
+		it('appends the API version to the credential host', () => {
+			expect(baseURLFor({ url: 'https://generativelanguage.googleapis.com' })).toBe(
+				'https://generativelanguage.googleapis.com/v1beta',
+			);
+		});
+
+		it('leaves a baseURL that already targets the API version unchanged', () => {
+			expect(baseURLFor({ url: 'https://generativelanguage.googleapis.com/v1beta' })).toBe(
+				'https://generativelanguage.googleapis.com/v1beta',
+			);
+		});
+
+		it('appends to a proxy host', () => {
+			expect(baseURLFor({ url: 'https://proxy.example/gemini' })).toBe(
+				'https://proxy.example/gemini/v1beta',
+			);
+		});
+
+		it('leaves the SDK default in place when no host is configured', () => {
+			expect(baseURLFor({})).toBeUndefined();
 		});
 	});
 

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -214,7 +214,15 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 	google: {
 		build: (creds, model, fetch) => {
 			const { createGoogle } = require('@ai-sdk/google') as typeof import('@ai-sdk/google');
-			return createGoogle({ ...creds, fetch })(model);
+			// The SDK expects a version-qualified base (its own default ends in
+			// `/v1beta`), but `googlePalmApi.host` stores the bare host — the Gemini
+			// node's SDK appends the API version itself. Passing the host through
+			// unqualified drops the version from every request path, and Google
+			// answers 404 for any model.
+			const normalizedBaseURL = creds.baseURL
+				? ensureUrlPathSuffix(creds.baseURL, '/v1beta')
+				: creds.baseURL;
+			return createGoogle({ ...creds, baseURL: normalizedBaseURL, fetch })(model);
 		},
 	},
 	xai: {


### PR DESCRIPTION
Fixes https://linear.app/n8n/issue/INS-1188 — closes https://github.com/n8n-io/n8n/issues/36354

## Summary

Every Google model returns `404 Not Found` in the agents runtime and in Instance AI, regardless of which model id is configured.

`googlePalmApi.host` stores a **bare** host (`https://generativelanguage.googleapis.com`), because the Gemini node's SDK — `@google/generative-ai`, via `@langchain/google-genai` — has `DEFAULT_API_VERSION = "v1beta"` and appends the API version itself. The credential's own test request does the same (`{{$credentials.host}}/v1beta/models`), which is why it reports "Connection tested successfully".

`model-factory.ts` passed that host straight into `createGoogle()`. But `@ai-sdk/google` treats `baseURL` as **already version-qualified** — its own default is `https://generativelanguage.googleapis.com/v1beta`. The bare host overrode that default and dropped the version from every request path:

```
https://generativelanguage.googleapis.com/models/gemini-3.7-flash:streamGenerateContent
                                          ^^^ no /v1beta  ->  404, empty body, text/html
```

Verified that the path alone is the cause, no credential needed:

| URL | Status |
| --- | --- |
| `…googleapis.com/models/gemini-3.7-flash:streamGenerateContent` | **404** |
| `…googleapis.com/v1beta/models/gemini-3.7-flash:streamGenerateContent` | **403** (auth) |

403 means the path and the model both resolve — the model id was never the problem.

## Fix

Normalize the base URL with `ensureUrlPathSuffix`, exactly as this same file already does for Anthropic (`/v1`), Alibaba (`/compatible-mode/v1`) and MiniMax (`/anthropic/v1`) — all of which have the same mismatch between the stored credential field and what their SDK expects.

This also aligns the agents runtime with what the Gemini node does to the same field, so a proxy or gateway host stays consistent between the two.

## Prior art

This is the same bug class as #33848 (https://linear.app/n8n/issue/AGENT-343), which fixed Anthropic in these exact two files. That ticket's description closed with:

> Other providers mapped the same way (openai, xai, deepseek, cohere, etc.) may need the same audit.

Google was missed in that audit. This completes it.

## Blast radius

Both paths that build a model through `createModel` are affected:

- **Agent builder / agent runs** — `credential-field-mapping.ts` maps `google: (c) => ({ baseURL: c.host })`.
- **Instance AI "Connect a model"** — `instance-ai-settings.service.ts` maps `googlePalmApi: 'host'` into the model config's `url`, which `createModel` accepts as a `baseURL` alias. This is the flow INS-1188 reports, and both the save/test-connection step and subsequent assistant usage fail.

## Scope of the audit

I checked the remaining providers rather than assuming Google was the only one left:

- **cohere** looked suspicious (credential defaults to bare `api.cohere.ai`, SDK default is `api.cohere.com/v2`) but both routes answer 401, so `api.cohere.ai` is a live alias — fine.
- **deepseek** matches its SDK default.
- **nvidia / xai / openrouter / minimax / moonshot** already carry `/v1`.

Google is the only one still affected.

## Review

- `packages/@n8n/agents/src/runtime/model/model-factory.ts` — the fix
- `packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts` — 4 cases (bare host, already-qualified, proxy host, no host configured). The `@ai-sdk/google` test mock did not expose `baseURL`, so it could not have caught this; it now does, matching the anthropic/alibaba/minimax mocks.

## Testing

`@n8n/agents`: 1435 tests pass, lint and typecheck clean.

Not yet verified against a live Gemini credential in the preview — worth a manual check before merge.

## Note on INS-1188's priority

INS-1188 currently sits in Backlog at **Low / S**. The practical impact is that no Google model works at all in either Instance AI or the agent builder, and the failure reads as a credential problem — the reporter of https://linear.app/n8n/issue/INS-1263 had a user revoke and regenerate a valid Gemini key roughly three times. Might be worth re-rating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)