### PR TITLE
fix(core): Add a timeout to the S3 startup connection check

### DIFF
--- a/packages/@n8n/blob-storage/src/object-store/__tests__/object-store.service.test.ts
+++ b/packages/@n8n/blob-storage/src/object-store/__tests__/object-store.service.test.ts
@@ -48,6 +48,7 @@ describe('ObjectStoreService', () => {
 		protocol: 'https',
 		forcePathStyle: true,
 		maxAttempts: 3,
+		connectionTimeoutMs: 10_000,
 	});
 
 	let objectStoreService: ObjectStoreService;
@@ -61,7 +62,23 @@ describe('ObjectStoreService', () => {
 		await objectStoreService.init();
 		mockS3Send.mockClear();
 		logger.error.mockClear();
+		logger.info.mockClear();
 		vi.restoreAllMocks();
+	});
+
+	describe('init()', () => {
+		it('should log the resolved endpoint so a misconfigured host is visible at startup', async () => {
+			s3Config.host = mockHost;
+			s3Config.forcePathStyle = true;
+			mockS3Send.mockResolvedValueOnce({});
+			objectStoreService.setReady(false);
+
+			await objectStoreService.init();
+
+			expect(logger.info).toHaveBeenCalledWith(
+				`S3 binary storage configured: endpoint=https://${mockHost}, bucket=test-bucket, region=us-east-1, forcePathStyle=true`,
+			);
+		});
 	});
 
 	describe('getClientConfig()', () => {
@@ -69,6 +86,7 @@ describe('ObjectStoreService', () => {
 			accessKeyId: s3Config.credentials.accessKey,
 			secretAccessKey: s3Config.credentials.accessSecret,
 		};
+		const requestHandler = { connectionTimeout: 10_000 };
 
 		it('should return client config with endpoint and forcePathStyle when custom host is provided', () => {
 			s3Config.host = 'example.com';
@@ -82,6 +100,7 @@ describe('ObjectStoreService', () => {
 				region: mockBucket.region,
 				credentials,
 				maxAttempts: 3,
+				requestHandler,
 			});
 		});
 
@@ -97,6 +116,7 @@ describe('ObjectStoreService', () => {
 				region: mockBucket.region,
 				credentials,
 				maxAttempts: 3,
+				requestHandler,
 			});
 		});
 
@@ -109,6 +129,7 @@ describe('ObjectStoreService', () => {
 				region: mockBucket.region,
 				credentials,
 				maxAttempts: 3,
+				requestHandler,
 			});
 		});
 
@@ -120,12 +141,23 @@ describe('ObjectStoreService', () => {
 			expect(clientConfig).toEqual({
 				region: mockBucket.region,
 				maxAttempts: 3,
+				requestHandler,
 			});
+		});
+
+		it('should bound connection establishment with the configured timeout', () => {
+			s3Config.connectionTimeoutMs = 2_500;
+
+			const clientConfig = objectStoreService.getClientConfig();
+
+			expect(clientConfig.requestHandler).toEqual({ connectionTimeout: 2_500 });
+
+			s3Config.connectionTimeoutMs = 10_000;
 		});
 	});
 
 	describe('checkConnection()', () => {
-		it('should send a HEAD request to the correct bucket', async () => {
+		it('should send a HEAD request to the correct bucket, with a timeout', async () => {
 			mockS3Send.mockResolvedValueOnce({});
 
 			objectStoreService.setReady(false);
@@ -133,20 +165,25 @@ describe('ObjectStoreService', () => {
 			await objectStoreService.checkConnection();
 
 			const commandCaptor = captor<HeadObjectCommand>();
-			expect(mockS3Send).toHaveBeenCalledWith(commandCaptor);
+			const optionsCaptor = captor<{ abortSignal: AbortSignal }>();
+			expect(mockS3Send).toHaveBeenCalledWith(commandCaptor, optionsCaptor);
 			const command = commandCaptor.value;
 			expect(command).toBeInstanceOf(HeadBucketCommand);
 			expect(command.input).toEqual({ Bucket: 'test-bucket' });
+			expect(optionsCaptor.value.abortSignal).toBeInstanceOf(AbortSignal);
 		});
 
-		it('should throw an error on request failure', async () => {
+		it('should throw an error naming the endpoint on request failure', async () => {
+			s3Config.host = 'example.com';
 			objectStoreService.setReady(false);
 
 			mockS3Send.mockRejectedValueOnce(mockError);
 
 			const promise = objectStoreService.checkConnection();
 
-			await expect(promise).rejects.toThrowError(FAILED_REQUEST_ERROR_MESSAGE);
+			await expect(promise).rejects.toThrowError(
+				`Failed to connect to S3 at https://example.com (bucket: test-bucket): ${mockError.message}.`,
+			);
 		});
 	});
 

--- a/packages/@n8n/blob-storage/src/object-store/__tests__/object-store.service.test.ts
+++ b/packages/@n8n/blob-storage/src/object-store/__tests__/object-store.service.test.ts
@@ -48,7 +48,7 @@ describe('ObjectStoreService', () => {
 		protocol: 'https',
 		forcePathStyle: true,
 		maxAttempts: 3,
-		connectionTimeoutMs: 10_000,
+		startupTimeoutMs: 10_000,
 	});
 
 	let objectStoreService: ObjectStoreService;
@@ -86,8 +86,6 @@ describe('ObjectStoreService', () => {
 			accessKeyId: s3Config.credentials.accessKey,
 			secretAccessKey: s3Config.credentials.accessSecret,
 		};
-		const requestHandler = { connectionTimeout: 10_000 };
-
 		it('should return client config with endpoint and forcePathStyle when custom host is provided', () => {
 			s3Config.host = 'example.com';
 			s3Config.forcePathStyle = true;
@@ -100,7 +98,6 @@ describe('ObjectStoreService', () => {
 				region: mockBucket.region,
 				credentials,
 				maxAttempts: 3,
-				requestHandler,
 			});
 		});
 
@@ -116,7 +113,6 @@ describe('ObjectStoreService', () => {
 				region: mockBucket.region,
 				credentials,
 				maxAttempts: 3,
-				requestHandler,
 			});
 		});
 
@@ -129,7 +125,6 @@ describe('ObjectStoreService', () => {
 				region: mockBucket.region,
 				credentials,
 				maxAttempts: 3,
-				requestHandler,
 			});
 		});
 
@@ -141,18 +136,7 @@ describe('ObjectStoreService', () => {
 			expect(clientConfig).toEqual({
 				region: mockBucket.region,
 				maxAttempts: 3,
-				requestHandler,
 			});
-		});
-
-		it('should bound connection establishment with the configured timeout', () => {
-			s3Config.connectionTimeoutMs = 2_500;
-
-			const clientConfig = objectStoreService.getClientConfig();
-
-			expect(clientConfig.requestHandler).toEqual({ connectionTimeout: 2_500 });
-
-			s3Config.connectionTimeoutMs = 10_000;
 		});
 	});
 
@@ -171,6 +155,19 @@ describe('ObjectStoreService', () => {
 			expect(command).toBeInstanceOf(HeadBucketCommand);
 			expect(command.input).toEqual({ Bucket: 'test-bucket' });
 			expect(optionsCaptor.value.abortSignal).toBeInstanceOf(AbortSignal);
+		});
+
+		it('should not attach an abort signal when the startup timeout is disabled (0)', async () => {
+			s3Config.startupTimeoutMs = 0;
+			mockS3Send.mockResolvedValueOnce({});
+
+			objectStoreService.setReady(false);
+
+			await objectStoreService.checkConnection();
+
+			expect(mockS3Send).toHaveBeenCalledWith(expect.any(HeadBucketCommand), {});
+
+			s3Config.startupTimeoutMs = 10_000;
 		});
 
 		it('should throw an error naming the endpoint on request failure', async () => {

--- a/packages/@n8n/blob-storage/src/object-store/object-store.config.ts
+++ b/packages/@n8n/blob-storage/src/object-store/object-store.config.ts
@@ -1,4 +1,4 @@
-import { Config, Env, Nested } from '@n8n/config';
+import { Config, Env, Nested, nonnegativeIntSchema } from '@n8n/config';
 import { z } from 'zod';
 
 const protocolSchema = z.enum(['http', 'https']);
@@ -57,10 +57,10 @@ export class ObjectStoreConfig {
 
 	/**
 	 * Milliseconds to wait for the startup connection check to the S3 bucket before
-	 * giving up. Also bounds how long any S3 request may spend establishing a socket.
+	 * giving up. Set to 0 to disable the timeout.
 	 */
-	@Env('N8N_EXTERNAL_STORAGE_S3_CONNECTION_TIMEOUT')
-	connectionTimeoutMs: number = 10_000;
+	@Env('N8N_EXTERNAL_STORAGE_S3_STARTUP_TIMEOUT_MS', nonnegativeIntSchema)
+	startupTimeoutMs: number = 10_000;
 
 	@Nested
 	bucket: ObjectStoreBucketConfig = {} as ObjectStoreBucketConfig;

--- a/packages/@n8n/blob-storage/src/object-store/object-store.config.ts
+++ b/packages/@n8n/blob-storage/src/object-store/object-store.config.ts
@@ -55,6 +55,13 @@ export class ObjectStoreConfig {
 	@Env('N8N_EXTERNAL_STORAGE_S3_MAX_ATTEMPTS')
 	maxAttempts: number = 3;
 
+	/**
+	 * Milliseconds to wait for the startup connection check to the S3 bucket before
+	 * giving up. Also bounds how long any S3 request may spend establishing a socket.
+	 */
+	@Env('N8N_EXTERNAL_STORAGE_S3_CONNECTION_TIMEOUT')
+	connectionTimeoutMs: number = 10_000;
+
 	@Nested
 	bucket: ObjectStoreBucketConfig = {} as ObjectStoreBucketConfig;
 

--- a/packages/@n8n/blob-storage/src/object-store/object-store.service.ee.ts
+++ b/packages/@n8n/blob-storage/src/object-store/object-store.service.ee.ts
@@ -56,9 +56,9 @@ export class ObjectStoreService {
 
 	/** This generates the config for the S3Client to make it work in all various auth configurations */
 	getClientConfig() {
-		const { host, bucket, protocol, credentials, maxAttempts } = this.s3Config;
+		const { bucket, credentials, maxAttempts } = this.s3Config;
 		const clientConfig: S3ClientConfig = {};
-		const endpoint = host ? `${protocol}://${host}` : undefined;
+		const { endpoint } = this;
 		if (endpoint) {
 			clientConfig.endpoint = endpoint;
 			clientConfig.forcePathStyle = this.s3Config.forcePathStyle;
@@ -79,7 +79,7 @@ export class ObjectStoreService {
 	async init() {
 		const { bucket, forcePathStyle } = this.s3Config;
 		this.logger.info(
-			`S3 binary storage configured: endpoint=${this.endpoint}, bucket=${this.bucket}, region=${bucket.region || 'none'}, forcePathStyle=${forcePathStyle}`,
+			`S3 binary storage configured: endpoint=${this.endpoint ?? 'default'}, bucket=${this.bucket}, region=${bucket.region || 'none'}, forcePathStyle=${forcePathStyle}`,
 		);
 		await this.checkConnection();
 		this.setReady(true);
@@ -108,7 +108,7 @@ export class ObjectStoreService {
 			);
 		} catch (e) {
 			const error = ensureError(e);
-			const message = `Failed to connect to S3 at ${endpoint} (bucket: ${this.bucket}): ${error.message}. Check that N8N_EXTERNAL_STORAGE_S3_HOST includes the port, that N8N_EXTERNAL_STORAGE_S3_PROTOCOL matches the endpoint, and that the endpoint is reachable.`;
+			const message = `Failed to connect to S3 at ${endpoint ?? 'the default S3 endpoint'} (bucket: ${this.bucket}): ${error.message}. Check that N8N_EXTERNAL_STORAGE_S3_HOST includes the port, that N8N_EXTERNAL_STORAGE_S3_PROTOCOL matches the endpoint, and that the endpoint is reachable.`;
 			this.logger.error(message);
 			throw new UnexpectedError(message, { cause: error });
 		}
@@ -386,10 +386,10 @@ export class ObjectStoreService {
 		}
 	}
 
-	/** Resolved S3 endpoint, or a placeholder when falling back to the AWS default. */
+	/** Custom S3 endpoint, or `undefined` to let the SDK resolve the default. */
 	private get endpoint() {
 		const { host, protocol } = this.s3Config;
-		return host ? `${protocol}://${host}` : 'the AWS default endpoint';
+		return host ? `${protocol}://${host}` : undefined;
 	}
 
 	private handleS3Error(e: unknown): never {

--- a/packages/@n8n/blob-storage/src/object-store/object-store.service.ee.ts
+++ b/packages/@n8n/blob-storage/src/object-store/object-store.service.ee.ts
@@ -56,12 +56,8 @@ export class ObjectStoreService {
 
 	/** This generates the config for the S3Client to make it work in all various auth configurations */
 	getClientConfig() {
-		const { host, bucket, protocol, credentials, maxAttempts, connectionTimeoutMs } = this.s3Config;
-		const clientConfig: S3ClientConfig = {
-			// Passed as options rather than a handler instance so the SDK builds the
-			// handler with its own bundled version.
-			requestHandler: { connectionTimeout: connectionTimeoutMs },
-		};
+		const { host, bucket, protocol, credentials, maxAttempts } = this.s3Config;
+		const clientConfig: S3ClientConfig = {};
 		const endpoint = host ? `${protocol}://${host}` : undefined;
 		if (endpoint) {
 			clientConfig.endpoint = endpoint;
@@ -104,18 +100,17 @@ export class ObjectStoreService {
 		try {
 			this.logger.debug('Checking connection to S3 bucket', { bucket: this.bucket, endpoint });
 			const command = new HeadBucketCommand({ Bucket: this.bucket });
-			// Without an abort signal this hangs indefinitely when the endpoint accepts
-			// the TCP connection but never completes the TLS handshake, which blocks
-			// the rest of startup. The signal bounds all retry attempts together.
-			await this.s3Client.send(command, {
-				abortSignal: AbortSignal.timeout(this.s3Config.connectionTimeoutMs),
-			});
+			const { startupTimeoutMs } = this.s3Config;
+			await this.s3Client.send(
+				command,
+				// NOTE: startupTimeoutMs of 0 means no timeout.
+				startupTimeoutMs > 0 ? { abortSignal: AbortSignal.timeout(startupTimeoutMs) } : {},
+			);
 		} catch (e) {
 			const error = ensureError(e);
-			throw new UnexpectedError(
-				`Failed to connect to S3 at ${endpoint} (bucket: ${this.bucket}): ${error.message}. Check that N8N_EXTERNAL_STORAGE_S3_HOST includes the port, that N8N_EXTERNAL_STORAGE_S3_PROTOCOL matches the endpoint, and that the endpoint is reachable.`,
-				{ cause: error },
-			);
+			const message = `Failed to connect to S3 at ${endpoint} (bucket: ${this.bucket}): ${error.message}. Check that N8N_EXTERNAL_STORAGE_S3_HOST includes the port, that N8N_EXTERNAL_STORAGE_S3_PROTOCOL matches the endpoint, and that the endpoint is reachable.`;
+			this.logger.error(message);
+			throw new UnexpectedError(message, { cause: error });
 		}
 	}
 

--- a/packages/@n8n/blob-storage/src/object-store/object-store.service.ee.ts
+++ b/packages/@n8n/blob-storage/src/object-store/object-store.service.ee.ts
@@ -56,8 +56,12 @@ export class ObjectStoreService {
 
 	/** This generates the config for the S3Client to make it work in all various auth configurations */
 	getClientConfig() {
-		const { host, bucket, protocol, credentials, maxAttempts } = this.s3Config;
-		const clientConfig: S3ClientConfig = {};
+		const { host, bucket, protocol, credentials, maxAttempts, connectionTimeoutMs } = this.s3Config;
+		const clientConfig: S3ClientConfig = {
+			// Passed as options rather than a handler instance so the SDK builds the
+			// handler with its own bundled version.
+			requestHandler: { connectionTimeout: connectionTimeoutMs },
+		};
 		const endpoint = host ? `${protocol}://${host}` : undefined;
 		if (endpoint) {
 			clientConfig.endpoint = endpoint;
@@ -77,6 +81,10 @@ export class ObjectStoreService {
 	}
 
 	async init() {
+		const { bucket, forcePathStyle } = this.s3Config;
+		this.logger.info(
+			`S3 binary storage configured: endpoint=${this.endpoint}, bucket=${this.bucket}, region=${bucket.region || 'none'}, forcePathStyle=${forcePathStyle}`,
+		);
 		await this.checkConnection();
 		this.setReady(true);
 	}
@@ -91,12 +99,23 @@ export class ObjectStoreService {
 	async checkConnection() {
 		if (this.isReady) return;
 
+		const { endpoint } = this;
+
 		try {
-			this.logger.debug('Checking connection to S3 bucket', { bucket: this.bucket });
+			this.logger.debug('Checking connection to S3 bucket', { bucket: this.bucket, endpoint });
 			const command = new HeadBucketCommand({ Bucket: this.bucket });
-			await this.s3Client.send(command);
+			// Without an abort signal this hangs indefinitely when the endpoint accepts
+			// the TCP connection but never completes the TLS handshake, which blocks
+			// the rest of startup. The signal bounds all retry attempts together.
+			await this.s3Client.send(command, {
+				abortSignal: AbortSignal.timeout(this.s3Config.connectionTimeoutMs),
+			});
 		} catch (e) {
-			this.handleS3Error(e);
+			const error = ensureError(e);
+			throw new UnexpectedError(
+				`Failed to connect to S3 at ${endpoint} (bucket: ${this.bucket}): ${error.message}. Check that N8N_EXTERNAL_STORAGE_S3_HOST includes the port, that N8N_EXTERNAL_STORAGE_S3_PROTOCOL matches the endpoint, and that the endpoint is reachable.`,
+				{ cause: error },
+			);
 		}
 	}
 
@@ -370,6 +389,12 @@ export class ObjectStoreService {
 		} catch (e) {
 			this.handleS3Error(e);
 		}
+	}
+
+	/** Resolved S3 endpoint, or a placeholder when falling back to the AWS default. */
+	private get endpoint() {
+		const { host, protocol } = this.s3Config;
+		return host ? `${protocol}://${host}` : 'the AWS default endpoint';
 	}
 
 	private handleS3Error(e: unknown): never {

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -61,6 +61,7 @@ export { DatabaseConfig, SqliteConfig } from './configs/database.config';
 export { InstanceSettingsConfig } from './configs/instance-settings-config';
 export { InstanceSettingsLoaderConfig } from './configs/instance-settings-loader.config';
 export { sampleRateSchema } from './configs/sentry.config';
+export { positiveIntSchema, nonnegativeIntSchema } from './schemas';
 export type { TaskRunnerMode } from './configs/runners.config';
 export { TaskRunnersConfig } from './configs/runners.config';
 export { SecurityConfig } from './configs/security.config';

--- a/packages/@n8n/config/src/schemas.ts
+++ b/packages/@n8n/config/src/schemas.ts
@@ -1,3 +1,4 @@
 import { z } from 'zod';
 
 export const positiveIntSchema = z.number({ coerce: true }).int().positive();
+export const nonnegativeIntSchema = z.number({ coerce: true }).int().nonnegative();


### PR DESCRIPTION
## Summary

Generate an error if we can't connect to S3 for binary data storage. Previously we would just hang forever.

This is a rebase of #29777 (auto-closed as an external contribution) onto the current tree. Credit to @keithrigg, who reported the issue, root-caused it, and wrote the original patch.

## How to test

```bash
# Terminal 1 — TCP listener that accepts but never responds
nc -kl 9999

# Terminal 2 — start n8n pointed at it (protocol defaults to https)
N8N_EXTERNAL_STORAGE_S3_HOST=127.0.0.1:9999 \
N8N_EXTERNAL_STORAGE_S3_BUCKET_NAME=test \
N8N_DEFAULT_BINARY_DATA_MODE=s3 \
pnpm start
```

Before: startup stops after "Registered runner" and never recovers. After: within ~10s it fails with `Failed to connect to S3 at https://127.0.0.1:9999 (bucket: test): Request aborted. Check that N8N_EXTERNAL_STORAGE_S3_HOST includes the port, that N8N_EXTERNAL_STORAGE_S3_PROTOCOL matches the endpoint, and that the endpoint is reachable.`

Unit tests: `cd packages/@n8n/blob-storage && pnpm test object-store.service`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2853

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- New env var `N8N_EXTERNAL_STORAGE_S3_CONNECTION_TIMEOUT` needs a n8n-docs follow-up. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` <!-- Suggest `Backport to Stable`: this is a production-impacting startup hang. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)