### PR TITLE
feat(core): Resolve node output schemas into generated type definitions

### DIFF
--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-node-defs-cli.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-node-defs-cli.test.ts
@@ -192,6 +192,18 @@ describe('generate-node-defs-cli', () => {
 			const hash2 = computeInputHash('content', '0.1.0');
 			expect(hash1).toBe(hash2);
 		});
+
+		it('should produce different hashes for different schema corpus hashes', () => {
+			const hash1 = computeInputHash('content', '0.1.0', 'schema-hash-a');
+			const hash2 = computeInputHash('content', '0.1.0', 'schema-hash-b');
+			expect(hash1).not.toBe(hash2);
+		});
+
+		it('should default the schema corpus hash to an empty string', () => {
+			const withDefault = computeInputHash('content', '0.1.0');
+			const withExplicitEmpty = computeInputHash('content', '0.1.0', '');
+			expect(withDefault).toBe(withExplicitEmpty);
+		});
 	});
 
 	describe('parallel writes', () => {

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-node-defs-cli.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-node-defs-cli.ts
@@ -19,7 +19,7 @@ import { jsonParse } from 'n8n-workflow';
 import * as path from 'path';
 
 import type { NodeTypeDescription } from './generate-types';
-import { orchestrateGeneration } from './generate-types';
+import { computeSchemaCorpusHash, orchestrateGeneration } from './generate-types';
 
 /** Name of the sentinel file storing the content hash */
 const HASH_SENTINEL_FILE = '.nodes-hash';
@@ -31,11 +31,20 @@ export interface GenerateNodeDefinitionsOptions {
 }
 
 /**
- * Compute a SHA-256 hash of the nodes.json content and SDK package version.
- * Including the SDK version ensures regeneration when generation logic changes.
+ * Compute a SHA-256 hash of the nodes.json content, SDK package version, and
+ * discovered `__schema__` corpus. The corpus hash isn't part of nodes.json, so
+ * without it, editing/adding an output schema wouldn't invalidate the hash-skip.
  */
-export function computeInputHash(content: string, sdkVersion: string): string {
-	return createHash('sha256').update(content).update(sdkVersion).digest('hex');
+export function computeInputHash(
+	content: string,
+	sdkVersion: string,
+	schemaCorpusHash = '',
+): string {
+	return createHash('sha256')
+		.update(content)
+		.update(sdkVersion)
+		.update(schemaCorpusHash)
+		.digest('hex');
 }
 
 /**
@@ -69,7 +78,8 @@ export async function generateNodeDefinitions(
 
 	// Hash-based skip: check if output is already up to date
 	const sdkVersion = getSdkVersion();
-	const inputHash = computeInputHash(content, sdkVersion);
+	const schemaCorpusHash = computeSchemaCorpusHash();
+	const inputHash = computeInputHash(content, sdkVersion, schemaCorpusHash);
 	const hashFilePath = path.join(outputDir, HASH_SENTINEL_FILE);
 
 	try {

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
@@ -5324,7 +5324,7 @@ describe('generate-types', () => {
 			const schema = { type: 'object', properties: { text: { type: 'string' } } };
 
 			try {
-				createTestSchemaDir(`Nested/__TESTCHAINLLM__`, 'v1.9.0', {
+				createTestSchemaDir('Nested/__TESTCHAINLLM__', 'v1.9.0', {
 					'output.json': JSON.stringify(schema),
 				});
 

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
@@ -5231,6 +5231,37 @@ describe('generate-types', () => {
 			}
 		});
 
+		it('fills gaps per file from lower minors when the exact dir is sparse', () => {
+			const nodeName = '__TestPerFileFallback__';
+			const searchSchema = { type: 'object', properties: { matches: { type: 'array' } } };
+			const postSchema = { type: 'object', properties: { ts: { type: 'string' } } };
+			const stalePostSchema = { type: 'object', properties: { old: { type: 'boolean' } } };
+
+			try {
+				// The Slack shape: v2.7.0 exists but only holds message/search.json,
+				// while v2.3.0 holds message/post.json — post must resolve from v2.3.0.
+				createTestSchemaDir(nodeName, 'v2.3.0', {
+					'message/post.json': JSON.stringify(postSchema),
+					'message/search.json': JSON.stringify(stalePostSchema),
+				});
+				createTestSchemaDir(nodeName, 'v2.7.0', {
+					'message/search.json': JSON.stringify(searchSchema),
+				});
+
+				const result = generateTypes.discoverSchemasForNode(
+					`n8n-nodes-base.${nodeName}`,
+					2.7,
+					nodeName,
+				);
+
+				expect(result).toHaveLength(2);
+				expect(result.find((s) => s.operation === 'search')?.schema).toEqual(searchSchema);
+				expect(result.find((s) => s.operation === 'post')?.schema).toEqual(postSchema);
+			} finally {
+				cleanupTestDir(nodeName);
+			}
+		});
+
 		it('never falls forward to a newer major', () => {
 			const nodeName = '__TestNoNewerMajor__';
 
@@ -5285,6 +5316,52 @@ describe('generate-types', () => {
 				});
 			} finally {
 				cleanupTestDir(nodeName);
+			}
+		});
+
+		it('matches schema folders case-insensitively (chainLlm -> ChainLLM)', () => {
+			const nodeName = '__testchainllm__';
+			const schema = { type: 'object', properties: { text: { type: 'string' } } };
+
+			try {
+				createTestSchemaDir(`Nested/__TESTCHAINLLM__`, 'v1.9.0', {
+					'output.json': JSON.stringify(schema),
+				});
+
+				const result = generateTypes.discoverSchemasForNode(
+					`@n8n/n8n-nodes-langchain.${nodeName}`,
+					1.9,
+				);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].schema).toEqual(schema);
+			} finally {
+				cleanupTestDir('Nested');
+			}
+		});
+
+		it('discovers schemas from the current package before falling back to nodes-base', () => {
+			const nodeName = '__TestOwnPackageSchema__';
+			const ownSchema = { type: 'object', properties: { output: { type: 'object' } } };
+			const packageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-root-test-'));
+			const originalCwd = process.cwd();
+
+			try {
+				const schemaDir = path.join(packageDir, 'dist/nodes/chains', nodeName, '__schema__/v1.2.0');
+				fs.mkdirSync(schemaDir, { recursive: true });
+				fs.writeFileSync(path.join(schemaDir, 'output.json'), JSON.stringify(ownSchema));
+
+				process.chdir(packageDir);
+				const result = generateTypes.discoverSchemasForNode(
+					`@n8n/n8n-nodes-langchain.${nodeName}`,
+					1.2,
+				);
+
+				expect(result).toHaveLength(1);
+				expect(result[0]).toEqual({ resource: '', operation: 'output', schema: ownSchema });
+			} finally {
+				process.chdir(originalCwd);
+				fs.rmSync(packageDir, { recursive: true, force: true });
 			}
 		});
 

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
@@ -18,6 +18,7 @@
  * @generated - This file generates code, but is itself manually maintained.
  */
 
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import { deepCopy } from 'n8n-workflow';
 import * as path from 'path';
@@ -37,7 +38,10 @@ import { checkConditions } from '../validation/display-options';
 /** Indentation string for generated code (2 spaces per level) */
 const INDENT = '  ';
 
-const NODES_BASE_TYPES = path.resolve(__dirname, '../../../../nodes-base/dist/types/nodes.json');
+export const NODES_BASE_TYPES = path.resolve(
+	__dirname,
+	'../../../../nodes-base/dist/types/nodes.json',
+);
 const NODES_LANGCHAIN_TYPES = path.resolve(
 	__dirname,
 	'../../../nodes-langchain/dist/types/nodes.json',
@@ -134,7 +138,7 @@ ${prefix} ResourceMapperCommon = { matchingColumns?: string[]; cachedResultName?
 ${prefix} ResourceMapperValue = ResourceMapperCommon & { mappingMode: string; value?: null | Record<string, unknown>; schema?: ResourceMapperField[] };`;
 }
 
-function isCustomApiCall(operation: string): boolean {
+export function isCustomApiCall(operation: string): boolean {
 	return operation === CUSTOM_API_CALL_KEY;
 }
 
@@ -551,13 +555,18 @@ function findNestedSchemaDir(dir: string, targetNames: string[]): string | undef
 		return undefined;
 	}
 
+	// Case-insensitive: node names don't round-trip folder casing reliably
+	// (chainLlm -> ChainLLM), and exact matching only appeared to work on
+	// macOS because APFS ignores case.
+	const targetsLower = targetNames.map((n) => n.toLowerCase());
+
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
 
 		const entryPath = path.join(dir, entry.name);
 
 		// Check if this directory matches our target and has __schema__
-		if (targetNames.includes(entry.name)) {
+		if (targetsLower.includes(entry.name.toLowerCase())) {
 			const schemaPath = path.join(entryPath, '__schema__');
 			if (fs.existsSync(schemaPath)) {
 				return schemaPath;
@@ -575,17 +584,35 @@ function findNestedSchemaDir(dir: string, targetNames: string[]): string | undef
 }
 
 /**
+ * Schema roots to search, in priority order: the package currently being
+ * generated (generate-node-defs-cli runs with CWD = that package, so e.g.
+ * nodes-langchain's own `__schema__` dirs resolve), then nodes-base as the
+ * shared fallback.
+ */
+export function schemaSearchRoots(): string[] {
+	const cwdRoot = path.resolve(process.cwd(), 'dist', 'nodes');
+	if (cwdRoot !== NODES_BASE_DIST && fs.existsSync(cwdRoot)) {
+		return [cwdRoot, NODES_BASE_DIST];
+	}
+	return [NODES_BASE_DIST];
+}
+
+/**
  * Find the schema directory for a node, searching both flat and nested paths
  *
  * @param baseName The base node name (e.g., 'gmail')
  * @returns Path to the __schema__ directory, or undefined if not found
  */
 function findSchemaDirectory(baseName: string, schemaPath?: string): string | undefined {
+	const roots = schemaSearchRoots();
+
 	// If explicit schemaPath is provided, use it directly
 	if (schemaPath) {
-		const explicitPath = path.join(NODES_BASE_DIST, schemaPath, '__schema__');
-		if (fs.existsSync(explicitPath)) {
-			return explicitPath;
+		for (const root of roots) {
+			const explicitPath = path.join(root, schemaPath, '__schema__');
+			if (fs.existsSync(explicitPath)) {
+				return explicitPath;
+			}
 		}
 	}
 
@@ -595,16 +622,32 @@ function findSchemaDirectory(baseName: string, schemaPath?: string): string | un
 		baseName.toUpperCase(), // GMAIL
 	];
 
-	// Try flat paths first (most common case)
-	for (const folderName of possibleNames) {
-		const flatPath = path.join(NODES_BASE_DIST, folderName, '__schema__');
-		if (fs.existsSync(flatPath)) {
-			return flatPath;
+	// Try flat paths first (most common case). Match folder names
+	// case-insensitively — fs.existsSync with a guessed casing only works on
+	// case-insensitive filesystems (macOS), not on Linux CI.
+	const namesLower = possibleNames.map((n) => n.toLowerCase());
+	for (const root of roots) {
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(root, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			if (!entry.isDirectory() || !namesLower.includes(entry.name.toLowerCase())) continue;
+			const flatPath = path.join(root, entry.name, '__schema__');
+			if (fs.existsSync(flatPath)) {
+				return flatPath;
+			}
 		}
 	}
 
 	// Search recursively for nested paths (e.g., Google/Gmail/__schema__)
-	return findNestedSchemaDir(NODES_BASE_DIST, possibleNames);
+	for (const root of roots) {
+		const found = findNestedSchemaDir(root, possibleNames);
+		if (found) return found;
+	}
+	return undefined;
 }
 
 /**
@@ -640,14 +683,24 @@ export function discoverSchemasForNode(
 		return schemas;
 	}
 
-	// Try to find version directory - try exact match first, then closest lower version
-	const versionDir = findVersionDirectory(schemaDir, version);
-	if (!versionDir) {
-		schemaCache.set(cacheKey, schemas);
-		return schemas;
+	// Per-file fallback across version directories: the best-matching dir wins
+	// for every (resource, operation) it covers, and older dirs only fill the
+	// gaps. Without this, a sparse exact-version dir (e.g. Slack v2.7.0 holding
+	// only message/search.json) hides every schema a lower minor already has.
+	const seen = new Set<string>();
+	for (const versionDir of orderedVersionDirectories(schemaDir, version)) {
+		collectSchemasFromVersionDir(versionDir, schemas, seen);
 	}
 
-	// Scan version directory entries
+	schemaCache.set(cacheKey, schemas);
+	return schemas;
+}
+
+function collectSchemasFromVersionDir(
+	versionDir: string,
+	schemas: OutputSchema[],
+	seen: Set<string>,
+): void {
 	try {
 		const entries = fs.readdirSync(versionDir, { withFileTypes: true });
 
@@ -658,6 +711,7 @@ export function discoverSchemasForNode(
 				// `output.<variant>.json` files are context-conditional layout
 				// variants (e.g. with-parser), not operations — skip them here.
 				if (operationName.includes('.')) continue;
+				if (seen.has(`/${operationName}`)) continue;
 				const filePath = path.join(versionDir, entry.name);
 
 				try {
@@ -668,6 +722,7 @@ export function discoverSchemasForNode(
 						operation: operationName,
 						schema,
 					});
+					seen.add(`/${operationName}`);
 				} catch {
 					// Skip invalid JSON files
 				}
@@ -684,6 +739,7 @@ export function discoverSchemasForNode(
 				if (!opEntry.isFile() || !opEntry.name.endsWith('.json')) continue;
 
 				const operationName = opEntry.name.replace('.json', '');
+				if (seen.has(`${entry.name}/${operationName}`)) continue;
 				const schemaPath = path.join(resourceDir, opEntry.name);
 
 				try {
@@ -694,6 +750,7 @@ export function discoverSchemasForNode(
 						operation: operationName,
 						schema,
 					});
+					seen.add(`${entry.name}/${operationName}`);
 				} catch {
 					// Skip invalid JSON files
 				}
@@ -702,14 +759,70 @@ export function discoverSchemasForNode(
 	} catch {
 		// Skip if directory can't be read
 	}
-
-	schemaCache.set(cacheKey, schemas);
-	return schemas;
 }
 
 /** Pad "1" / "2.3" to the on-disk "1.0.0" / "2.3.0" directory format. */
-function padVersion(version: number): string {
+export function padVersion(version: number): string {
 	return String(version).split('.').concat(['0', '0']).slice(0, 3).join('.');
+}
+
+/**
+ * Hash every `__schema__/**\/*.json` file under the given roots (default: the
+ * same roots schema discovery searches). Schema content isn't part of
+ * `nodes.json`, so the build-time hash-skip in generate-node-defs-cli needs
+ * this to notice schema-only changes (e.g. a newly harvested output schema)
+ * and regenerate.
+ */
+export function computeSchemaCorpusHash(baseDirs: string[] = schemaSearchRoots()): string {
+	const hash = createHash('sha256');
+	for (const baseDir of baseDirs) {
+		const files: string[] = [];
+		collectSchemaDirs(baseDir, files);
+		files.sort();
+
+		for (const file of files) {
+			hash.update(path.relative(baseDir, file));
+			hash.update(fs.readFileSync(file));
+		}
+	}
+	return hash.digest('hex');
+}
+
+function collectSchemaDirs(dir: string, results: string[]): void {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const entryPath = path.join(dir, entry.name);
+		if (entry.name === '__schema__') {
+			collectJsonFiles(entryPath, results);
+		} else {
+			collectSchemaDirs(entryPath, results);
+		}
+	}
+}
+
+function collectJsonFiles(dir: string, results: string[]): void {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+
+	for (const entry of entries) {
+		const entryPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			collectJsonFiles(entryPath, results);
+		} else if (entry.name.endsWith('.json')) {
+			results.push(entryPath);
+		}
+	}
 }
 
 /** Parse a `vX.Y.Z` directory name into a comparable [X, Y, Z] tuple. */
@@ -726,26 +839,17 @@ function compareVersionTuplesDesc(a: number[], b: number[]): number {
 }
 
 /**
- * Find the best matching version directory for a given version.
- * Tries an exact full-semver match first (2.3 → v2.3.0), then the nearest
- * same-major dir (closest below, then closest above — a v2.x node must not
- * lose its schemas just because only a higher v2 minor was recorded), then
- * the newest lower-major dir.
+ * Order version directories by how well they match the target version:
+ * exact/nearest same-major below first, then nearest same-major above (a v2.x
+ * node must not lose its schemas just because only a higher v2 minor was
+ * recorded), then lower majors newest-first. Schemas resolve per file across
+ * this list — the first directory covering a (resource, operation) wins.
  *
  * NOTE: unlike n8n-core's runtime resolver this never falls forward to a
  * NEWER major — generated types should not describe a next-generation API
  * shape; converging the two is tracked in the harmonization spec.
- *
- * @param schemaDir Path to the __schema__ directory
- * @param version Target version number
- * @returns Path to version directory, or undefined if not found
  */
-function findVersionDirectory(schemaDir: string, version: number): string | undefined {
-	const exactPath = path.join(schemaDir, `v${padVersion(version)}`);
-	if (fs.existsSync(exactPath)) {
-		return exactPath;
-	}
-
+function orderedVersionDirectories(schemaDir: string, version: number): string[] {
 	const target = padVersion(version).split('.').map(Number);
 	try {
 		const entries = fs.readdirSync(schemaDir, { withFileTypes: true });
@@ -754,25 +858,21 @@ function findVersionDirectory(schemaDir: string, version: number): string | unde
 			.map((e) => ({ name: e.name, tuple: parseVersionDir(e.name) }));
 
 		const sameMajor = versionDirs.filter((v) => v.tuple[0] === target[0]);
-		const best =
-			sameMajor
+		const ordered = [
+			...sameMajor
 				.filter((v) => compareVersionTuplesDesc(v.tuple, target) >= 0)
-				.sort((a, b) => compareVersionTuplesDesc(a.tuple, b.tuple))[0] ??
-			sameMajor
+				.sort((a, b) => compareVersionTuplesDesc(a.tuple, b.tuple)),
+			...sameMajor
 				.filter((v) => compareVersionTuplesDesc(v.tuple, target) < 0)
-				.sort((a, b) => compareVersionTuplesDesc(b.tuple, a.tuple))[0] ??
-			versionDirs
+				.sort((a, b) => compareVersionTuplesDesc(b.tuple, a.tuple)),
+			...versionDirs
 				.filter((v) => v.tuple[0] < target[0])
-				.sort((a, b) => compareVersionTuplesDesc(a.tuple, b.tuple))[0];
-
-		if (best) {
-			return path.join(schemaDir, best.name);
-		}
+				.sort((a, b) => compareVersionTuplesDesc(a.tuple, b.tuple)),
+		];
+		return ordered.map((v) => path.join(schemaDir, v.name));
 	} catch {
-		// Ignore read errors
+		return [];
 	}
-
-	return undefined;
 }
 
 /**

--- a/packages/@n8n/workflow-sdk/src/generate-types/schema-corpus-hash.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/schema-corpus-hash.test.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { computeSchemaCorpusHash } from './generate-types';
+
+function writeSchema(baseDir: string, relativePath: string, content: unknown): void {
+	const filePath = path.join(baseDir, relativePath);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(content));
+}
+
+describe('computeSchemaCorpusHash', () => {
+	let baseDir: string;
+
+	beforeEach(() => {
+		baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-corpus-hash-test-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(baseDir, { recursive: true, force: true });
+	});
+
+	it('returns the same hash for an unchanged corpus', () => {
+		writeSchema(baseDir, 'Widget/__schema__/v1.0.0/item/get.json', { type: 'object' });
+
+		expect(computeSchemaCorpusHash([baseDir])).toBe(computeSchemaCorpusHash([baseDir]));
+	});
+
+	it('changes when a schema file is added', () => {
+		writeSchema(baseDir, 'Widget/__schema__/v1.0.0/item/get.json', { type: 'object' });
+		const before = computeSchemaCorpusHash([baseDir]);
+
+		writeSchema(baseDir, 'Widget/__schema__/v1.0.0/item/create.json', { type: 'object' });
+		const after = computeSchemaCorpusHash([baseDir]);
+
+		expect(after).not.toBe(before);
+	});
+
+	it('changes when a schema file is edited', () => {
+		writeSchema(baseDir, 'Widget/__schema__/v1.0.0/item/get.json', { type: 'object' });
+		const before = computeSchemaCorpusHash([baseDir]);
+
+		writeSchema(baseDir, 'Widget/__schema__/v1.0.0/item/get.json', {
+			type: 'object',
+			properties: { id: { type: 'string' } },
+		});
+		const after = computeSchemaCorpusHash([baseDir]);
+
+		expect(after).not.toBe(before);
+	});
+
+	it('ignores non-schema files outside __schema__ directories', () => {
+		writeSchema(baseDir, 'Widget/__schema__/v1.0.0/item/get.json', { type: 'object' });
+		const before = computeSchemaCorpusHash([baseDir]);
+
+		fs.writeFileSync(path.join(baseDir, 'Widget', 'unrelated.json'), JSON.stringify({ a: 1 }));
+		const after = computeSchemaCorpusHash([baseDir]);
+
+		expect(after).toBe(before);
+	});
+
+	it('returns a stable hash for a missing directory', () => {
+		const missingDir = path.join(baseDir, 'does-not-exist');
+		expect(computeSchemaCorpusHash([missingDir])).toBe(computeSchemaCorpusHash([missingDir]));
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
@@ -14,6 +14,7 @@ export class MicrosoftExcel extends VersionedNodeType {
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Consume the Microsoft Excel API for workbooks stored in OneDrive',
 			defaultVersion: 2.2,
+			schemaPath: 'Microsoft/Excel',
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {


### PR DESCRIPTION

## Summary

Make the output schemas that already ship in node packages actually reach the generated node-definition types the AI workflow builder reads, also fixes multiple problems on the way there:

- Resolve schemas per (resource, operation) across ordered version directories instead of picking one dir and stopping — a sparse exact-version dir (Slack v2.7.0 holding only message/search.json) no longer hides every schema a lower minor already has.
- Discover schemas from the package being generated first, then nodes-base — nodes-langchain nodes (Information Extractor, ChainLLM, …) previously produced zero output types despite shipping __schema__ dirs.
- Match schema folder names case-insensitively (chainLlm -> ChainLLM); exact matching only appeared to work on macOS because APFS ignores case.
- Include the schema corpus in the regeneration hash so schema-only changes invalidate the build-time hash-skip (previously only version update would invalidate the hash but we often add new fields without bumping the version). Probably not a big problem because building n8n deletes all `dist` and there is nothing to be outdated, but if we have some automation that caches the output schemas it would only regenerate the schema with a node version update
- Declare schemaPath on Microsoft Excel, whose nested __schema__ dir was invisible to discovery.


## How to test

### Manual
1. write to AI Assistant: `build a workflow with with MistralAi document extract (read documents on gdrive) passing the data to send a message via slack`
2. answer questions if there are any like use manual trigger etc.
3. observe the tool calls and that `loading node schema` includes `MistralAiV1DocumentExtractTextOutput` (when running locally this was included due to mac FS but in actual images built in CI the output schema file was not found, so test on real staging instance vs stable)
4. observe that the `Writing file` tool call correctly uses `$json.extractedText` and not something hallucinated like `$json.text` on the first call

### Langtracer eval
1. setup evals for AI Assistant as described in the `instance-ai` readme
2. run the `cv-screener-bulk-per-file-fanout` eval from baseline suite f.e. via following command. The `expectation: Output from MistalAI node is passed as ...` test should pass (this only makes sense on non-mac since on mac the path was resolved).
```
 pnpm exec dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai \
  --source langtracer --suite baseline \
  --filter cv-screener-bulk-per-file-fanout --verbose --keep-workflows
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5807/add-output-schema-to-node-types-used-by-workflow-builder


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

