### PR TITLE
fix(core): Execute waiting nodes deadlocked by cyclic workflows

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-waiting-nodes-cycle.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-waiting-nodes-cycle.test.ts
@@ -1,0 +1,147 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import type { IRun, IWorkflowBase } from 'n8n-workflow';
+import { NodeConnectionTypes, Workflow } from 'n8n-workflow';
+
+import * as Helpers from '@test/helpers';
+
+import { WorkflowExecute } from '../workflow-execute';
+
+/**
+ * Repro for https://github.com/n8n-io/n8n/issues/30662 (CAT-3156).
+ *
+ * Two merge nodes wait for input while a feedback edge makes the graph
+ * cyclic. Each merge node then appears among the other's (transitive)
+ * parents, the waiting-nodes dispatcher skips both forever, and the
+ * execution silently finishes without ever running them.
+ */
+describe('waiting nodes in a cyclic workflow', () => {
+	const nodeTypes = Helpers.NodeTypes();
+
+	const workflowData: Pick<IWorkflowBase, 'nodes' | 'connections'> = {
+		nodes: [
+			{
+				parameters: {},
+				id: '9f62a1a2-0000-0000-0000-000000000001',
+				name: 'Start',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0],
+			},
+			{
+				parameters: {},
+				id: '9f62a1a2-0000-0000-0000-000000000002',
+				name: 'NoOp',
+				type: 'n8n-nodes-base.noOp',
+				typeVersion: 1,
+				position: [200, 0],
+			},
+			{
+				// No conditions -> every item goes to the true branch
+				parameters: {},
+				id: '9f62a1a2-0000-0000-0000-000000000003',
+				name: 'IfBranch',
+				type: 'n8n-nodes-base.if',
+				typeVersion: 1,
+				position: [400, 100],
+			},
+			{
+				parameters: {},
+				id: '9f62a1a2-0000-0000-0000-000000000004',
+				name: 'MergeInner',
+				type: 'n8n-nodes-base.merge',
+				typeVersion: 2.1,
+				position: [600, 100],
+			},
+			{
+				parameters: {},
+				id: '9f62a1a2-0000-0000-0000-000000000005',
+				name: 'MergeOuter',
+				type: 'n8n-nodes-base.merge',
+				typeVersion: 2.1,
+				position: [800, 0],
+			},
+			{
+				// Condition never matches -> nothing is ever sent around the loop,
+				// the edge back to NoOp only exists structurally.
+				parameters: {
+					conditions: {
+						number: [
+							{
+								value1: '={{ $json.counter || 0 }}',
+								operation: 'larger',
+								value2: 3,
+							},
+						],
+					},
+				},
+				id: '9f62a1a2-0000-0000-0000-000000000006',
+				name: 'IfLoop',
+				type: 'n8n-nodes-base.if',
+				typeVersion: 1,
+				position: [1000, 0],
+			},
+		],
+		connections: {
+			Start: {
+				main: [[{ node: 'NoOp', type: NodeConnectionTypes.Main, index: 0 }]],
+			},
+			NoOp: {
+				main: [
+					[
+						{ node: 'MergeOuter', type: NodeConnectionTypes.Main, index: 0 },
+						{ node: 'IfBranch', type: NodeConnectionTypes.Main, index: 0 },
+					],
+				],
+			},
+			IfBranch: {
+				main: [
+					[{ node: 'MergeInner', type: NodeConnectionTypes.Main, index: 0 }],
+					[{ node: 'MergeInner', type: NodeConnectionTypes.Main, index: 1 }],
+				],
+			},
+			MergeInner: {
+				main: [[{ node: 'MergeOuter', type: NodeConnectionTypes.Main, index: 1 }]],
+			},
+			MergeOuter: {
+				main: [[{ node: 'IfLoop', type: NodeConnectionTypes.Main, index: 0 }]],
+			},
+			IfLoop: {
+				main: [[{ node: 'NoOp', type: NodeConnectionTypes.Main, index: 0 }]],
+			},
+		},
+	};
+
+	test('merge nodes still execute when a feedback edge makes the workflow cyclic', async () => {
+		const workflowInstance = new Workflow({
+			id: 'test',
+			nodes: workflowData.nodes,
+			connections: workflowData.connections,
+			active: false,
+			nodeTypes,
+			settings: { executionOrder: 'v1' },
+		});
+
+		const waitPromise = createDeferredPromise<IRun>();
+		const additionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+		const workflowExecute = new WorkflowExecute(additionalData, 'manual');
+
+		await workflowExecute.run({ workflow: workflowInstance });
+		const result = await waitPromise.promise;
+
+		const runData = result.data.resultData.runData;
+		expect(Object.keys(runData)).toEqual([
+			'Start',
+			'NoOp',
+			'IfBranch',
+			'MergeInner',
+			'MergeOuter',
+			'IfLoop',
+		]);
+
+		// MergeInner must run before MergeOuter, as in the acyclic variant
+		expect(runData.MergeInner[0].executionIndex).toBeLessThan(runData.MergeOuter[0].executionIndex);
+		// MergeOuter appends its direct input and MergeInner's output
+		expect(runData.MergeOuter[0].data!.main[0]).toHaveLength(2);
+		expect(result.finished).toEqual(true);
+	});
+});

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -850,6 +850,34 @@ export class WorkflowExecute {
 	}
 
 	/**
+	 * Whether data produced by `from` could still reach `to` without re-running
+	 * a node that already executed. If every path passes through an executed
+	 * node, data from `from` could only arrive in a later loop iteration.
+	 */
+	private canStillDeliverData(workflow: Workflow, from: string, to: string): boolean {
+		const visited = new Set<string>([from]);
+		const queue = [from];
+		while (queue.length) {
+			const current = queue.shift() as string;
+			for (const output of workflow.connectionsBySourceNode[current]?.main ?? []) {
+				for (const connection of output ?? []) {
+					if (connection.node === to) {
+						return true;
+					}
+					if (visited.has(connection.node)) {
+						continue;
+					}
+					visited.add(connection.node);
+					if (this.runExecutionData.resultData.runData[connection.node] === undefined) {
+						queue.push(connection.node);
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Scans `waitingExecution` for a node that can be executed next and moves it
 	 * onto the execution stack. Waiting entries whose received data is all empty
 	 * are removed without being executed. At most one node gets dispatched.
@@ -1014,7 +1042,19 @@ export class WorkflowExecute {
 	 */
 	private dispatchWaitingNode(workflow: Workflow): boolean {
 		const anyWaitingParent = (waitingParents: string[]) => waitingParents.length !== 0;
-		return this.dispatchWaitingNodeWhere(workflow, anyWaitingParent);
+		if (this.dispatchWaitingNodeWhere(workflow, anyWaitingParent)) {
+			return true;
+		}
+
+		// In a cyclic workflow every waiting node can appear among another waiting
+		// node's parents, so the pass above may dispatch nothing at all and the
+		// execution would silently end. Retry, ignoring waiting parents whose data
+		// could only arrive via a later loop iteration. This stays a separate
+		// fallback (rather than the only pass) purely to preserve the dispatch
+		// behavior of workflows that never deadlocked.
+		const deliverableWaitingParent = (waitingParents: string[], nodeName: string) =>
+			waitingParents.some((parent) => this.canStillDeliverData(workflow, parent, nodeName));
+		return this.dispatchWaitingNodeWhere(workflow, deliverableWaitingParent);
 	}
 
 	/**

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -850,6 +850,174 @@ export class WorkflowExecute {
 	}
 
 	/**
+	 * Scans `waitingExecution` for a node that can be executed next and moves it
+	 * onto the execution stack. Waiting entries whose received data is all empty
+	 * are removed without being executed. At most one node gets dispatched.
+	 *
+	 * A node is skipped while `isBlockedByWaitingParents` reports that some of
+	 * its still-waiting parents should be dispatched first.
+	 *
+	 * @returns true if a node was added to the execution stack
+	 */
+	private dispatchWaitingNodeWhere(
+		workflow: Workflow,
+		isBlockedByWaitingParents: (waitingParents: string[], nodeName: string) => boolean,
+	): boolean {
+		let waitingNodes = Object.keys(this.runExecutionData.executionData!.waitingExecution);
+
+		// TODO: Should this also care about workflow position (top-left first?)
+		for (let i = 0; i < waitingNodes.length; i++) {
+			const nodeName = waitingNodes[i];
+
+			const checkNode = workflow.getNode(nodeName);
+			if (!checkNode) {
+				continue;
+			}
+			const nodeType = workflow.nodeTypes.getByNameAndVersion(
+				checkNode.type,
+				checkNode.typeVersion,
+			);
+
+			// Check if the node is only allowed execute if all inputs received data
+			let requiredInputs =
+				workflow.settings.executionOrder === 'v1' ? nodeType.description.requiredInputs : undefined;
+			if (requiredInputs !== undefined) {
+				if (typeof requiredInputs === 'string') {
+					requiredInputs = workflow.expression.getSimpleParameterValue(
+						checkNode,
+						requiredInputs,
+						this.mode,
+						{ $version: checkNode.typeVersion },
+						undefined,
+						[],
+					) as number[];
+				}
+
+				if (
+					(requiredInputs !== undefined &&
+						Array.isArray(requiredInputs) &&
+						requiredInputs.length === nodeType.description.inputs.length) ||
+					requiredInputs === nodeType.description.inputs.length
+				) {
+					// All inputs are required, but not all have data so do not continue
+					continue;
+				}
+			}
+
+			const parentNodes = workflow.getParentNodes(nodeName);
+
+			// Check if input nodes (of same run) got already executed
+			const waitingParents = parentNodes.filter((value) => waitingNodes.includes(value));
+			if (isBlockedByWaitingParents(waitingParents, nodeName)) {
+				// Execute node later as one of its dependencies is still outstanding
+				continue;
+			}
+
+			const runIndexes = Object.keys(
+				this.runExecutionData.executionData!.waitingExecution[nodeName],
+			).sort();
+
+			// The run-index of the earliest outstanding one
+			const firstRunIndex = parseInt(runIndexes[0]);
+
+			// Find all the inputs which received any kind of data, even if it was an empty
+			// array as this shows that the parent nodes executed but they did not have any
+			// data to pass on.
+			const inputsWithData = this.runExecutionData
+				.executionData!.waitingExecution[nodeName][firstRunIndex].main.map((data, index) =>
+					data === null ? null : index,
+				)
+				.filter((data) => data !== null);
+
+			if (requiredInputs !== undefined) {
+				// Certain inputs are required that the node can execute
+
+				if (Array.isArray(requiredInputs)) {
+					// Specific inputs are required (array of input indexes)
+					let inputDataMissing = false;
+					for (const requiredInput of requiredInputs) {
+						if (!inputsWithData.includes(requiredInput)) {
+							inputDataMissing = true;
+							break;
+						}
+					}
+					if (inputDataMissing) {
+						continue;
+					}
+				} else {
+					// A certain amount of inputs are required (amount of inputs)
+					if (inputsWithData.length < requiredInputs) {
+						continue;
+					}
+				}
+			}
+
+			const taskDataMain = this.runExecutionData.executionData!.waitingExecution[nodeName][
+				firstRunIndex
+			].main.map((data) => {
+				// For the inputs for which never any data got received set it to an empty array
+				return data === null ? [] : data;
+			});
+
+			if (taskDataMain.filter((data) => data.length).length !== 0) {
+				// Add the node to be executed
+
+				// Make sure that each input at least receives an empty array
+				if (taskDataMain.length < nodeType.description.inputs.length) {
+					for (; taskDataMain.length < nodeType.description.inputs.length; ) {
+						taskDataMain.push([]);
+					}
+				}
+
+				this.runExecutionData.executionData!.nodeExecutionStack.push({
+					node: workflow.nodes[nodeName],
+					data: {
+						main: taskDataMain,
+					},
+					source:
+						this.runExecutionData.executionData!.waitingExecutionSource![nodeName][firstRunIndex],
+				});
+			}
+
+			// Remove the node from waiting
+			delete this.runExecutionData.executionData!.waitingExecution[nodeName][firstRunIndex];
+			delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName][firstRunIndex];
+
+			if (
+				Object.keys(this.runExecutionData.executionData!.waitingExecution[nodeName]).length === 0
+			) {
+				// No more data left for the node so also delete that one
+				delete this.runExecutionData.executionData!.waitingExecution[nodeName];
+				delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName];
+			}
+
+			if (taskDataMain.filter((data) => data.length).length !== 0) {
+				// Node to execute got found and added to stop
+				return true;
+			} else {
+				// Node to add did not get found, rather an empty one removed so continue with search
+				waitingNodes = Object.keys(this.runExecutionData.executionData!.waitingExecution);
+				// Set counter to start again from the beginning. Set it to -1 as it auto increments
+				// after run. So only like that will we end up again at 0.
+				i = -1;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Dispatches the next waiting node (see `dispatchWaitingNodeWhere`), holding
+	 * back nodes whose (transitive) parents are themselves still waiting.
+	 *
+	 * @returns true if a node was added to the execution stack
+	 */
+	private dispatchWaitingNode(workflow: Workflow): boolean {
+		const anyWaitingParent = (waitingParents: string[]) => waitingParents.length !== 0;
+		return this.dispatchWaitingNodeWhere(workflow, anyWaitingParent);
+	}
+
+	/**
 	 * Checks if everything in the workflow is complete
 	 * and ready to be executed. If it returns null everything
 	 * is fine. If there are issues it returns the issues
@@ -2334,7 +2502,7 @@ export class WorkflowExecute {
 						this.runExecutionData,
 					]);
 
-					let waitingNodes: string[] = Object.keys(
+					const waitingNodes: string[] = Object.keys(
 						this.runExecutionData.executionData!.waitingExecution,
 					);
 
@@ -2345,152 +2513,7 @@ export class WorkflowExecute {
 						// There are no more nodes in the execution stack. Check if there are
 						// waiting nodes that do not require data on all inputs and execute them,
 						// one by one.
-
-						// TODO: Should this also care about workflow position (top-left first?)
-						for (let i = 0; i < waitingNodes.length; i++) {
-							const nodeName = waitingNodes[i];
-
-							const checkNode = workflow.getNode(nodeName);
-							if (!checkNode) {
-								continue;
-							}
-							const nodeType = workflow.nodeTypes.getByNameAndVersion(
-								checkNode.type,
-								checkNode.typeVersion,
-							);
-
-							// Check if the node is only allowed execute if all inputs received data
-							let requiredInputs =
-								workflow.settings.executionOrder === 'v1'
-									? nodeType.description.requiredInputs
-									: undefined;
-							if (requiredInputs !== undefined) {
-								if (typeof requiredInputs === 'string') {
-									requiredInputs = workflow.expression.getSimpleParameterValue(
-										checkNode,
-										requiredInputs,
-										this.mode,
-										{ $version: checkNode.typeVersion },
-										undefined,
-										[],
-									) as number[];
-								}
-
-								if (
-									(requiredInputs !== undefined &&
-										Array.isArray(requiredInputs) &&
-										requiredInputs.length === nodeType.description.inputs.length) ||
-									requiredInputs === nodeType.description.inputs.length
-								) {
-									// All inputs are required, but not all have data so do not continue
-									continue;
-								}
-							}
-
-							const parentNodes = workflow.getParentNodes(nodeName);
-
-							// Check if input nodes (of same run) got already executed
-
-							const parentIsWaiting = parentNodes.some((value) => waitingNodes.includes(value));
-							if (parentIsWaiting) {
-								// Execute node later as one of its dependencies is still outstanding
-								continue;
-							}
-
-							const runIndexes = Object.keys(
-								this.runExecutionData.executionData!.waitingExecution[nodeName],
-							).sort();
-
-							// The run-index of the earliest outstanding one
-							const firstRunIndex = parseInt(runIndexes[0]);
-
-							// Find all the inputs which received any kind of data, even if it was an empty
-							// array as this shows that the parent nodes executed but they did not have any
-							// data to pass on.
-							const inputsWithData = this.runExecutionData
-								.executionData!.waitingExecution[nodeName][firstRunIndex].main.map((data, index) =>
-									data === null ? null : index,
-								)
-								.filter((data) => data !== null);
-
-							if (requiredInputs !== undefined) {
-								// Certain inputs are required that the node can execute
-
-								if (Array.isArray(requiredInputs)) {
-									// Specific inputs are required (array of input indexes)
-									let inputDataMissing = false;
-									for (const requiredInput of requiredInputs) {
-										if (!inputsWithData.includes(requiredInput)) {
-											inputDataMissing = true;
-											break;
-										}
-									}
-									if (inputDataMissing) {
-										continue;
-									}
-								} else {
-									// A certain amount of inputs are required (amount of inputs)
-									if (inputsWithData.length < requiredInputs) {
-										continue;
-									}
-								}
-							}
-
-							const taskDataMain = this.runExecutionData.executionData!.waitingExecution[nodeName][
-								firstRunIndex
-							].main.map((data) => {
-								// For the inputs for which never any data got received set it to an empty array
-								return data === null ? [] : data;
-							});
-
-							if (taskDataMain.filter((data) => data.length).length !== 0) {
-								// Add the node to be executed
-
-								// Make sure that each input at least receives an empty array
-								if (taskDataMain.length < nodeType.description.inputs.length) {
-									for (; taskDataMain.length < nodeType.description.inputs.length; ) {
-										taskDataMain.push([]);
-									}
-								}
-
-								this.runExecutionData.executionData!.nodeExecutionStack.push({
-									node: workflow.nodes[nodeName],
-									data: {
-										main: taskDataMain,
-									},
-									source:
-										this.runExecutionData.executionData!.waitingExecutionSource![nodeName][
-											firstRunIndex
-										],
-								});
-							}
-
-							// Remove the node from waiting
-							delete this.runExecutionData.executionData!.waitingExecution[nodeName][firstRunIndex];
-							delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName][
-								firstRunIndex
-							];
-
-							if (
-								Object.keys(this.runExecutionData.executionData!.waitingExecution[nodeName])
-									.length === 0
-							) {
-								// No more data left for the node so also delete that one
-								delete this.runExecutionData.executionData!.waitingExecution[nodeName];
-								delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName];
-							}
-
-							if (taskDataMain.filter((data) => data.length).length !== 0) {
-								// Node to execute got found and added to stop
-								break;
-							} else {
-								// Node to add did not get found, rather an empty one removed so continue with search
-								waitingNodes = Object.keys(this.runExecutionData.executionData!.waitingExecution);
-								// Set counter to start again from the beginning. Set it to -1 as it auto increments
-								// after run. So only like that will we end up again at 0.
-								i = -1;
-							}
-						}
+						this.dispatchWaitingNode(workflow);
 					}
 				}
 


### PR DESCRIPTION
## Summary

In a cyclic workflow, two multi-input nodes (e.g. Merge) waiting for input can each appear among the other's transitive parents. The waiting-nodes dispatcher skips a node while a parent is still waiting, so it skipped both forever and the execution finished silently without running them or anything downstream.

The dispatcher now runs a fallback pass when the strict pass dispatches nothing: a waiting parent only blocks a node if its data can still reach it without re-running an already executed node (i.e. within the current loop iteration). Acyclic workflows and previously working loops are unaffected — the fallback only engages where execution previously ended silently. The dispatcher loop is extracted into `dispatchWaitingNode` unchanged apart from this check.

## How to test

Run the new test in `packages/core/src/execution-engine/__tests__/workflow-execute-waiting-nodes-cycle.test.ts`, or import the workflow from the linked issue (`test2.json`): with the `No Operation, do nothing6` → `Wait` connection present, both Merge nodes previously never executed; now they run in the same order as the acyclic variant.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3156
- fixes #30662

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

