### PR TITLE
feat(Databricks Node): Support templated MCP registry server URLs

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
@@ -91,6 +91,7 @@ describe('McpRegistryClientTool', () => {
 							endpointUrl: 'https://mcp.notion.com/mcp',
 							endpointHostname: 'mcp.notion.com',
 							transport: 'httpStreamable',
+							isTemplated: false,
 						}
 					: undefined,
 			prepareConnection: ({ connection }) => ({
@@ -331,6 +332,7 @@ describe('McpRegistryClientTool', () => {
 						endpointUrl: 'https://mcp.notion.com/mcp',
 						endpointHostname: 'mcp.notion.com',
 						transport: 'httpStreamable',
+						isTemplated: false,
 					},
 					credentialData: { oauthTokenData: { access_token: 'token' } },
 				}),

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
@@ -97,9 +97,14 @@ describe('McpRegistryClientTool', () => {
 			prepareConnection: ({ connection }) => ({
 				ok: true,
 				value: {
-					...connection,
+					nodeTypeName: connection.nodeTypeName,
+					credentialType: connection.credentialType,
+					transport: connection.transport,
+					endpointUrl: connection.isTemplated
+						? 'https://mcp.notion.com/mcp'
+						: connection.endpointUrl,
 					headers: { authorization: 'Bearer test' },
-					allowedDomains: connection.endpointHostname,
+					allowedDomains: connection.isTemplated ? 'mcp.notion.com' : connection.endpointHostname,
 				},
 			}),
 		});

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
@@ -3,6 +3,7 @@ import {
 	type ILoadOptionsFunctions,
 	type INodeExecutionData,
 	type INodePropertyOptions,
+	getConfiguredEndpointUrl,
 	NodeConnectionTypes,
 	type INodeType,
 	type INodeTypeDescription,
@@ -184,7 +185,7 @@ export class McpRegistryClientTool implements INodeType {
 				return await loadMcpToolOptions(this, {
 					authentication,
 					transport: connection.transport,
-					endpointUrl: connection.endpointUrl,
+					endpointUrl: getConfiguredEndpointUrl(connection),
 					registryCredential: {
 						connection,
 						prepareConnection: (input) => McpRegistryClientTool.prepareConnection(input),
@@ -216,7 +217,7 @@ function resolveConfig(
 	return {
 		authentication,
 		transport: connection.transport,
-		endpointUrl: connection.endpointUrl,
+		endpointUrl: getConfiguredEndpointUrl(connection),
 		registryCredential: {
 			connection,
 			prepareConnection: (input) => McpRegistryClientTool.prepareConnection(input),

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
@@ -849,6 +849,7 @@ describe('utils', () => {
 					endpointUrl: 'https://example.com/mcp',
 					endpointHostname: 'example.com',
 					transport: 'httpStreamable' as const,
+					isTemplated: false,
 				};
 				const prepareConnection = vi.fn((input: PrepareMcpRegistryConnectionInput) => ({
 					ok: true as const,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
@@ -6,6 +6,7 @@ import { createResultError, createResultOk } from '@n8n/utils/result';
 import type {
 	IExecuteFunctions,
 	INode,
+	LiteralMcpRegistryConnection,
 	NodeEgressFilter,
 	PrepareMcpRegistryConnectionInput,
 } from 'n8n-workflow';
@@ -843,12 +844,12 @@ describe('utils', () => {
 					access_token: 'refreshed-token',
 				});
 				ctx.helpers.getSecureEgressFilter.mockReturnValue(createTestEgressFilter());
-				const connection = {
+				const connection: LiteralMcpRegistryConnection = {
 					nodeTypeName: '@n8n/mcp-registry.test',
-					credentialType: 'testMcpOAuth2Api' as const,
+					credentialType: 'testMcpOAuth2Api',
 					endpointUrl: 'https://example.com/mcp',
 					endpointHostname: 'example.com',
-					transport: 'httpStreamable' as const,
+					transport: 'httpStreamable',
 					isTemplated: false,
 				};
 				const prepareConnection = vi.fn((input: PrepareMcpRegistryConnectionInput) => ({

--- a/packages/cli/src/modules/agents/builder/__tests__/resolve-integration.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/resolve-integration.tool.test.ts
@@ -23,6 +23,7 @@ const notionResult: McpRegistrySearchResult = {
 	credentialType: 'notionMcpOAuth2Api',
 	tools: [],
 	metadata: { nodeTypeName: '@n8n/mcp-registry.notion' },
+	isTemplated: false,
 };
 
 describe('buildResolveIntegrationTool', () => {

--- a/packages/cli/src/modules/agents/builder/__tests__/search-mcp-servers.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/search-mcp-servers.tool.test.ts
@@ -29,6 +29,7 @@ const notionResult: McpRegistrySearchResult = {
 		{ name: 'notion-create-pages', title: 'Create pages in Markdown' },
 	],
 	metadata: { nodeTypeName: '@n8n/mcp-registry.notion' },
+	isTemplated: false,
 };
 
 describe('buildSearchMcpServersTool', () => {

--- a/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
+++ b/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
@@ -692,26 +692,6 @@ describe('listMcpServerTools', () => {
 		closeMock.mockResolvedValue(undefined);
 	});
 
-	it('reports a connection failure instead of an empty tool list', async () => {
-		// The SDK drops a server that fails to connect rather than throwing, so
-		// the failure only reaches us through `onConnectionFailed`.
-		listToolsMock.mockImplementation(async () => {
-			const [configs] = mcpClientCtor.mock.calls[0] as [
-				Array<{ onConnectionFailed?: (e: { server: string; error: string }) => void }>,
-			];
-			configs[0].onConnectionFailed?.({
-				server: 'srv',
-				error: 'Credential type "x" does not contain an OAuth2 access token',
-			});
-			return [];
-		});
-
-		await expect(listMcpServerTools(makeServer(), deps())).rejects.toThrow(
-			'does not contain an OAuth2 access token',
-		);
-		expect(closeMock).toHaveBeenCalled();
-	});
-
 	it('returns name/description pairs (empty description fallback) and closes the client', async () => {
 		listToolsMock.mockResolvedValue([
 			{ name: 'echo', description: 'Echoes input' },

--- a/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
+++ b/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
@@ -631,6 +631,47 @@ describe('buildMcpClientForServer — unresolvable credential', () => {
 		);
 		expect(proxyFetchMock).not.toHaveBeenCalled();
 	});
+
+	it('keeps a templated URL parseable so the credential error is what surfaces', async () => {
+		const credentialProvider = mock<CredentialProvider>();
+		// No `oauthTokenData`, so `prepareMcpRegistryConnection` rejects before it
+		// substitutes the URL, leaving the raw `$self`-expression behind.
+		credentialProvider.resolve.mockResolvedValue({ host: 'https://tenant.test' } as never);
+		const oauthService = mock<OauthService>();
+
+		const templatedUrl = '={{$self["host"]}}/api/2.0/mcp/genie';
+
+		await buildMcpClientForServer(
+			makeServer({
+				url: templatedUrl,
+				authentication: 'databricksGenieMcpOAuth2Api' as never,
+				credential: 'cred-1',
+				metadata: { nodeTypeName: '@n8n/mcp-registry.databricksGenie' },
+			}),
+			{
+				credentialProvider,
+				oauthService,
+				projectId: 'proj-1',
+				proxyFetch,
+				resolveRegistryConnection: async () => ({
+					nodeTypeName: '@n8n/mcp-registry.databricksGenie',
+					credentialType: 'databricksGenieMcpOAuth2Api',
+					endpointUrl: templatedUrl,
+					endpointHostname: '',
+					transport: 'httpStreamable',
+					isTemplated: true,
+				}),
+			},
+		);
+
+		const [configs] = mcpClientCtor.mock.calls[0] as [Array<{ url: string; fetch: typeof fetch }>];
+		expect(configs[0].url).not.toBe(templatedUrl);
+		expect(() => new URL(configs[0].url)).not.toThrow();
+		await expect(configs[0].fetch(configs[0].url)).rejects.toThrow(
+			'does not contain an OAuth2 access token',
+		);
+		expect(proxyFetchMock).not.toHaveBeenCalled();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -650,6 +691,26 @@ describe('listMcpServerTools', () => {
 		listToolsMock.mockReset();
 		closeMock.mockReset();
 		closeMock.mockResolvedValue(undefined);
+	});
+
+	it('reports a connection failure instead of an empty tool list', async () => {
+		// The SDK drops a server that fails to connect rather than throwing, so
+		// the failure only reaches us through `onConnectionFailed`.
+		listToolsMock.mockImplementation(async () => {
+			const [configs] = mcpClientCtor.mock.calls[0] as [
+				Array<{ onConnectionFailed?: (e: { server: string; error: string }) => void }>,
+			];
+			configs[0].onConnectionFailed?.({
+				server: 'srv',
+				error: 'Credential type "x" does not contain an OAuth2 access token',
+			});
+			return [];
+		});
+
+		await expect(listMcpServerTools(makeServer(), deps())).rejects.toThrow(
+			'does not contain an OAuth2 access token',
+		);
+		expect(closeMock).toHaveBeenCalled();
 	});
 
 	it('returns name/description pairs (empty description fallback) and closes the client', async () => {

--- a/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
+++ b/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
@@ -440,6 +440,7 @@ describe('buildMcpClientForServer — service-specific McpOAuth2Api refresh', ()
 					endpointUrl: 'https://example.test/mcp',
 					endpointHostname: 'example.test',
 					transport: 'httpStreamable',
+					isTemplated: false,
 				}),
 			},
 		);

--- a/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
+++ b/packages/cli/src/modules/agents/json-config/__tests__/mcp-client-factory.test.ts
@@ -656,8 +656,7 @@ describe('buildMcpClientForServer — unresolvable credential', () => {
 				resolveRegistryConnection: async () => ({
 					nodeTypeName: '@n8n/mcp-registry.databricksGenie',
 					credentialType: 'databricksGenieMcpOAuth2Api',
-					endpointUrl: templatedUrl,
-					endpointHostname: '',
+					urlTemplate: templatedUrl,
 					transport: 'httpStreamable',
 					isTemplated: true,
 				}),

--- a/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
+++ b/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
@@ -156,30 +156,39 @@ export async function buildMcpClientForServer(
 
 	// An unresolved credential fails at connect time so the real reason travels
 	// the SDK's connection-failure channel (surfaced as a `warning` chunk);
-	// connecting unauthenticated returns an opaque 401/403 instead. Rejecting
-	// rather than throwing keeps both `promise-function-async` and
-	// `require-await` satisfied.
-	const authFetch: typeof fetch = credentialError
-		? async () =>
-				await Promise.reject(
-					new OperationalError(
-						`Could not resolve the credential for MCP server "${server.name}": ${credentialError.message}`,
-					),
-				)
-		: createAuthFetch({
-				baseFetch: proxyFetch,
-				initialHeaders,
-				onUnauthorized,
-				allowedDomains,
-			});
+	// connecting unauthenticated returns an opaque 401/403 instead.
+	//
+	// The url and the fetch are chosen together on purpose. A templated registry
+	// URL is still an unresolved `$self`-expression when the credential fails,
+	// and the SDK rejects that URL before it ever calls fetch, so the real cause
+	// would be replaced by an opaque "Invalid URL". The placeholder keeps the
+	// connect on the path where the rejecting fetch reports the real reason, and
+	// is only ever paired with that fetch, which sends no request.
+	const { url, fetch: authFetch } = credentialError
+		? {
+				url: UNRESOLVED_CREDENTIAL_URL,
+				// Rejecting rather than throwing keeps both `promise-function-async`
+				// and `require-await` satisfied.
+				fetch: (async () =>
+					await Promise.reject(
+						new OperationalError(
+							`Could not resolve the credential for MCP server "${server.name}": ${credentialError.message}`,
+						),
+					)) as typeof fetch,
+			}
+		: {
+				url: runtimeUrl,
+				fetch: createAuthFetch({
+					baseFetch: proxyFetch,
+					initialHeaders,
+					onUnauthorized,
+					allowedDomains,
+				}),
+			};
 
 	const sdkServerConfig: McpServerConfig = {
 		name: server.name,
-		// A templated registry URL is still an unresolved `$self`-expression when
-		// the credential fails, and the SDK rejects it with an opaque "Invalid URL"
-		// before `authFetch` runs, hiding the real cause. A parseable placeholder
-		// keeps the connect on the path where `authFetch` reports it.
-		url: credentialError ? UNRESOLVED_CREDENTIAL_URL : runtimeUrl,
+		url,
 		transport: runtimeTransport,
 		fetch: authFetch,
 		toolFilter: server.toolFilter,

--- a/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
+++ b/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
@@ -217,20 +217,9 @@ export async function listMcpServerTools(
 	deps: BuildMcpClientDeps,
 ): Promise<Array<{ name: string; description: string }>> {
 	let client: McpClient | undefined;
-	// A server that fails to connect contributes no tools rather than throwing,
-	// so without this an auth or endpoint failure verifies as a healthy server
-	// with an empty tool list. Verification has to report the real reason.
-	let connectionError: string | undefined;
 	try {
-		client = await buildMcpClientForServer(server, {
-			...deps,
-			onConnectionFailed: (event) => {
-				connectionError = event.error;
-				deps.onConnectionFailed?.(event);
-			},
-		});
+		client = await buildMcpClientForServer(server, deps);
 		const tools = await client.listTools();
-		if (connectionError !== undefined) throw new OperationalError(connectionError);
 		return tools.map((tool) => ({ name: tool.name, description: tool.description ?? '' }));
 	} finally {
 		await client?.close().catch(() => {});

--- a/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
+++ b/packages/cli/src/modules/agents/json-config/mcp-client-factory.ts
@@ -85,6 +85,9 @@ export interface BuildMcpClientDeps {
 	onToolCallSettled?: McpServerConfig['onToolCallSettled'];
 }
 
+/** Stand-in for a URL that could not be built. `.invalid` never resolves (RFC 2606), and `authFetch` rejects before any request is sent. */
+const UNRESOLVED_CREDENTIAL_URL = 'https://credential-unresolved.invalid/';
+
 /**
  * Build a connected-but-lazy SDK `McpClient` for a single JSON-config MCP
  * server entry. The returned client opens its transport on first use
@@ -172,7 +175,11 @@ export async function buildMcpClientForServer(
 
 	const sdkServerConfig: McpServerConfig = {
 		name: server.name,
-		url: runtimeUrl,
+		// A templated registry URL is still an unresolved `$self`-expression when
+		// the credential fails, and the SDK rejects it with an opaque "Invalid URL"
+		// before `authFetch` runs, hiding the real cause. A parseable placeholder
+		// keeps the connect on the path where `authFetch` reports it.
+		url: credentialError ? UNRESOLVED_CREDENTIAL_URL : runtimeUrl,
 		transport: runtimeTransport,
 		fetch: authFetch,
 		toolFilter: server.toolFilter,
@@ -201,9 +208,20 @@ export async function listMcpServerTools(
 	deps: BuildMcpClientDeps,
 ): Promise<Array<{ name: string; description: string }>> {
 	let client: McpClient | undefined;
+	// A server that fails to connect contributes no tools rather than throwing,
+	// so without this an auth or endpoint failure verifies as a healthy server
+	// with an empty tool list. Verification has to report the real reason.
+	let connectionError: string | undefined;
 	try {
-		client = await buildMcpClientForServer(server, deps);
+		client = await buildMcpClientForServer(server, {
+			...deps,
+			onConnectionFailed: (event) => {
+				connectionError = event.error;
+				deps.onConnectionFailed?.(event);
+			},
+		});
 		const tools = await client.listTools();
+		if (connectionError !== undefined) throw new OperationalError(connectionError);
 		return tools.map((tool) => ({ name: tool.name, description: tool.description ?? '' }));
 	} finally {
 		await client?.close().catch(() => {});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -4565,6 +4565,15 @@ describe('MCP registry discovery', () => {
 			credentialType: 'googleDriveMcpOAuth2Api',
 			tools: [{ name: 'list_files', title: 'List files' }],
 			metadata: { nodeTypeName: '@n8n/mcp-registry.googleDrive' },
+			isTemplated: false,
+		};
+		const templatedHit = {
+			...registryHit,
+			slug: 'databricks-genie',
+			name: 'databricksGenie',
+			title: 'Databricks Genie',
+			url: '={{$self["host"]}}/api/2.0/mcp/genie',
+			isTemplated: true,
 		};
 
 		it('is absent from the context unless the gate passed', () => {
@@ -4606,6 +4615,28 @@ describe('MCP registry discovery', () => {
 			const results = await context.mcpService!.search(['drive', 'notion']);
 
 			expect(results.map((result) => result.slug)).toEqual(['notion']);
+		});
+
+		// This path cannot resolve a templated url, so `createConnection` refuses
+		// such a row. Offering it would end at a credential picker and an error.
+		it('drops a templated server from search results', async () => {
+			stubContainer({
+				registrySearch: vi.fn().mockResolvedValue([registryHit, templatedHit]),
+			});
+			const context = createAdapter().createContext(user, { mcpConnectionsEnabled: true });
+
+			const results = await context.mcpService!.search(['drive', 'genie']);
+
+			expect(results.map((result) => result.slug)).toEqual(['google-drive']);
+		});
+
+		it('drops a templated server from an exact slug lookup', async () => {
+			stubContainer({
+				registryResolveBySlugs: vi.fn().mockResolvedValue([templatedHit]),
+			});
+			const context = createAdapter().createContext(user, { mcpConnectionsEnabled: true });
+
+			expect(await context.mcpService!.getServers(['databricks-genie'])).toEqual([]);
 		});
 
 		it('resolves exact slugs through the same summary shape', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -499,14 +499,19 @@ export class InstanceAiAdapterService {
 	}
 
 	private createMcpAdapter(user: User): InstanceAiMcpService {
+		// Templated rows are dropped rather than offered: this path reads credentials
+		// without resolving expressions, so `createConnection` refuses them. Offering
+		// one would walk the user to a credential picker and then an error.
 		const toSummaries = (servers: McpRegistrySearchResult[]): McpRegistryServerSummary[] =>
-			servers.map((server) => ({
-				slug: server.slug,
-				title: server.title,
-				description: server.description,
-				credentialType: server.credentialType,
-				tools: server.tools.map((tool) => tool.name),
-			}));
+			servers
+				.filter((server) => !server.isTemplated)
+				.map((server) => ({
+					slug: server.slug,
+					title: server.title,
+					description: server.description,
+					credentialType: server.credentialType,
+					tools: server.tools.map((tool) => tool.name),
+				}));
 
 		return {
 			/** Connected servers are filtered out: `connected` answers what the user has,

--- a/packages/cli/src/modules/instance-ai/mcp/__tests__/instance-ai-mcp-registry.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/mcp/__tests__/instance-ai-mcp-registry.service.test.ts
@@ -7,6 +7,7 @@ import { mock } from 'vitest-mock-extended';
 
 import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import type { CredentialsService } from '@/credentials/credentials.service';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { EventService } from '@/events/event.service';
@@ -875,6 +876,26 @@ describe('InstanceAiMcpRegistryService', () => {
 				'instance-ai-mcp-registry-connection-created',
 				{ userId: user.id, serverSlug: 'linear' },
 			);
+		});
+
+		it('refuses a server whose URL is a template', async () => {
+			// This path cannot resolve the template, so the connection would persist
+			// and read as connected while `getRegistryMcpServers` skips it.
+			const { service, connectionRepository, mcpRegistryService, credentialsFinderService } =
+				createService();
+			mcpRegistryService.get.mockResolvedValue(
+				makeRegistryServer('genie', {
+					remotes: [
+						{ type: 'streamable-http-templated', url: '={{$self["host"]}}/api/2.0/mcp/genie' },
+					],
+				}),
+			);
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(credential);
+
+			await expect(
+				service.createConnection(user, { serverSlug: 'genie', credentialId: 'cred-1' }),
+			).rejects.toBeInstanceOf(BadRequestError);
+			expect(connectionRepository.save).not.toHaveBeenCalled();
 		});
 
 		it('throws NotFoundError when the server slug is unknown', async () => {

--- a/packages/cli/src/modules/instance-ai/mcp/__tests__/instance-ai-mcp-registry.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/mcp/__tests__/instance-ai-mcp-registry.service.test.ts
@@ -280,6 +280,30 @@ describe('InstanceAiMcpRegistryService', () => {
 		);
 	});
 
+	it('skips connections whose server URL is a template', async () => {
+		// This path decrypts the credential without resolving expressions, so the
+		// template would stay unresolved. The row is dropped instead of offered.
+		const { service, connectionRepository, mcpRegistryService, logger } = createService();
+		connectionRepository.findBy.mockResolvedValue([
+			{ id: '3', userId: user.id, serverSlug: 'genie', credentialId: credential.id },
+		] as InstanceAiMcpRegistryConnection[]);
+		mcpRegistryService.getBySlugs.mockResolvedValue([
+			makeRegistryServer('genie', {
+				remotes: [
+					{ type: 'streamable-http-templated', url: '={{$self["host"]}}/api/2.0/mcp/genie' },
+				],
+			}),
+		]);
+
+		const result = await service.getRegistryMcpServers(user);
+
+		expect(result).toEqual([]);
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Skipping MCP registry connection with a templated server URL',
+			expect.objectContaining({ connectionId: '3', serverSlug: 'genie' }),
+		);
+	});
+
 	it('does not attach custom fetch for non-oauth servers', async () => {
 		const {
 			service,

--- a/packages/cli/src/modules/instance-ai/mcp/instance-ai-mcp-registry.service.ts
+++ b/packages/cli/src/modules/instance-ai/mcp/instance-ai-mcp-registry.service.ts
@@ -11,7 +11,7 @@ import { OutboundHttp } from '@n8n/backend-network';
 import { isUniqueConstraintError, type CredentialsEntity, type User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { McpServerConfig } from '@n8n/instance-ai';
-import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import type { ICredentialDataDecryptedObject, LiteralMcpRegistryConnection } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
 
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
@@ -40,7 +40,8 @@ interface ResolvedRegistryServer {
 	serverSlug: string;
 	credentialId: string;
 	authType: McpRegistryServer['authType'];
-	connection: NonNullable<ReturnType<typeof resolveMcpRegistryConnection>>;
+	/** Never templated: this path cannot resolve a template, so those are skipped. */
+	connection: LiteralMcpRegistryConnection;
 }
 
 const MCP_REGISTRY_SERVER_PREFIX = 'mcp_';
@@ -394,6 +395,18 @@ export class InstanceAiMcpRegistryService {
 		const connection = resolveMcpRegistryConnection(server);
 		if (!connection) {
 			this.logger.warn('Skipping MCP registry connection without supported remote transport', {
+				connectionId,
+				serverSlug,
+				credentialId,
+			});
+			return null;
+		}
+
+		// This path reads the credential without resolving expressions, so a
+		// templated row's URL would stay an unresolved template. Skipping keeps
+		// the row out of the picker instead of offering a connection that breaks.
+		if (connection.isTemplated) {
+			this.logger.warn('Skipping MCP registry connection with a templated server URL', {
 				connectionId,
 				serverSlug,
 				credentialId,

--- a/packages/cli/src/modules/instance-ai/mcp/instance-ai-mcp-registry.service.ts
+++ b/packages/cli/src/modules/instance-ai/mcp/instance-ai-mcp-registry.service.ts
@@ -16,6 +16,7 @@ import { randomUUID } from 'node:crypto';
 
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
@@ -138,6 +139,15 @@ export class InstanceAiMcpRegistryService {
 		const server = await this.mcpRegistryService.get(input.serverSlug);
 		if (!server) {
 			throw new NotFoundError(`Unknown MCP registry server: ${input.serverSlug}`);
+		}
+
+		// This path cannot resolve a templated server URL, so `getRegistryMcpServers`
+		// skips such a row at load time. Reject it here too, otherwise the connection
+		// persists and reads as connected while contributing nothing.
+		if (resolveMcpRegistryConnection(server)?.isTemplated) {
+			throw new BadRequestError(
+				`MCP registry server "${input.serverSlug}" cannot be connected here`,
+			);
 		}
 
 		// v1 invariant: at most one connection per (user, serverSlug). To switch

--- a/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-connection.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-connection.test.ts
@@ -18,8 +18,7 @@ const connection: McpRegistryConnection = {
 const templatedConnection: McpRegistryConnection = {
 	nodeTypeName: '@n8n/mcp-registry.example',
 	credentialType: 'exampleMcpOAuth2Api',
-	endpointUrl: '={{$self["host"]}}/api/2.0/mcp/genie',
-	endpointHostname: '',
+	urlTemplate: '={{$self["host"]}}/api/2.0/mcp/genie',
 	transport: 'httpStreamable',
 	isTemplated: true,
 };
@@ -57,8 +56,7 @@ describe('resolveMcpRegistryConnection', () => {
 		expect(result).toEqual({
 			nodeTypeName: '@n8n/mcp-registry.notion',
 			credentialType: 'notionMcpOAuth2Api',
-			endpointUrl: '={{$self["host"]}}/api/2.0/mcp/genie',
-			endpointHostname: '',
+			urlTemplate: '={{$self["host"]}}/api/2.0/mcp/genie',
 			transport: 'httpStreamable',
 			isTemplated: true,
 		});
@@ -73,7 +71,7 @@ describe('resolveMcpRegistryConnection', () => {
 			],
 		});
 
-		expect(result).toMatchObject({ isTemplated: true, endpointUrl: '={{$self["host"]}}/mcp' });
+		expect(result).toMatchObject({ isTemplated: true, urlTemplate: '={{$self["host"]}}/mcp' });
 	});
 });
 
@@ -103,30 +101,56 @@ describe('prepareMcpRegistryConnection', () => {
 		expect(result).toEqual({
 			ok: true,
 			value: {
-				...connection,
+				nodeTypeName: connection.nodeTypeName,
+				credentialType: connection.credentialType,
+				transport: connection.transport,
+				endpointUrl: 'https://example.com/mcp',
 				headers: { Authorization: 'Bearer refreshed-token' },
 				allowedDomains: 'example.com',
 			},
 		});
 	});
 
-	it('resolves a templated connection from the credential serverUrl and allowedDomains', () => {
+	it('resolves a templated connection and pins the domain to the resolved host', () => {
 		const result = prepareMcpRegistryConnection({
 			connection: templatedConnection,
 			credentialData: {
 				oauthTokenData: { access_token: 'token' },
 				serverUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
-				allowedDomains: 'acme.cloud.databricks.com',
+				// Deliberately disagrees with serverUrl: the pin follows the URL
+				// actually called, never a separate field that can drift from it.
+				allowedDomains: 'attacker.test',
 			},
 		});
 
 		expect(result).toEqual({
 			ok: true,
 			value: {
-				...templatedConnection,
+				nodeTypeName: templatedConnection.nodeTypeName,
+				credentialType: templatedConnection.credentialType,
+				transport: templatedConnection.transport,
 				headers: { Authorization: 'Bearer token' },
 				endpointUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
 				allowedDomains: 'acme.cloud.databricks.com',
+			},
+		});
+	});
+
+	it.each([
+		['an unresolved template', '={{$self["host"]}}/api/2.0/mcp/genie'],
+		['a non-URL string', 'not-a-url'],
+		['a non-HTTP scheme', 'file:///etc/passwd'],
+	])('rejects a templated connection whose serverUrl is %s', (_label, serverUrl) => {
+		const result = prepareMcpRegistryConnection({
+			connection: templatedConnection,
+			credentialData: { oauthTokenData: { access_token: 'token' }, serverUrl },
+		});
+
+		expect(result).toEqual({
+			ok: false,
+			error: {
+				code: 'unresolved_server_url',
+				message: 'Credential type "exampleMcpOAuth2Api" did not resolve a server URL',
 			},
 		});
 	});

--- a/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-connection.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-connection.test.ts
@@ -12,6 +12,16 @@ const connection: McpRegistryConnection = {
 	endpointUrl: 'https://example.com/mcp',
 	endpointHostname: 'example.com',
 	transport: 'httpStreamable',
+	isTemplated: false,
+};
+
+const templatedConnection: McpRegistryConnection = {
+	nodeTypeName: '@n8n/mcp-registry.example',
+	credentialType: 'exampleMcpOAuth2Api',
+	endpointUrl: '={{$self["host"]}}/api/2.0/mcp/genie',
+	endpointHostname: '',
+	transport: 'httpStreamable',
+	isTemplated: true,
 };
 
 describe('resolveMcpRegistryConnection', () => {
@@ -36,6 +46,34 @@ describe('resolveMcpRegistryConnection', () => {
 				remotes: [{ type: 'streamable-http', url: 'not a url' }],
 			}),
 		).toBeNull();
+	});
+
+	it('resolves a templated remote without parsing it as a URL', () => {
+		const result = resolveMcpRegistryConnection({
+			...notionMockServer,
+			remotes: [{ type: 'streamable-http-templated', url: '={{$self["host"]}}/api/2.0/mcp/genie' }],
+		});
+
+		expect(result).toEqual({
+			nodeTypeName: '@n8n/mcp-registry.notion',
+			credentialType: 'notionMcpOAuth2Api',
+			endpointUrl: '={{$self["host"]}}/api/2.0/mcp/genie',
+			endpointHostname: '',
+			transport: 'httpStreamable',
+			isTemplated: true,
+		});
+	});
+
+	it('prefers a templated streamable-http remote over sse', () => {
+		const result = resolveMcpRegistryConnection({
+			...notionMockServer,
+			remotes: [
+				{ type: 'sse', url: 'https://mcp.notion.com/sse' },
+				{ type: 'streamable-http-templated', url: '={{$self["host"]}}/mcp' },
+			],
+		});
+
+		expect(result).toMatchObject({ isTemplated: true, endpointUrl: '={{$self["host"]}}/mcp' });
 	});
 });
 
@@ -68,6 +106,42 @@ describe('prepareMcpRegistryConnection', () => {
 				...connection,
 				headers: { Authorization: 'Bearer refreshed-token' },
 				allowedDomains: 'example.com',
+			},
+		});
+	});
+
+	it('resolves a templated connection from the credential serverUrl and allowedDomains', () => {
+		const result = prepareMcpRegistryConnection({
+			connection: templatedConnection,
+			credentialData: {
+				oauthTokenData: { access_token: 'token' },
+				serverUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+				allowedDomains: 'acme.cloud.databricks.com',
+			},
+		});
+
+		expect(result).toEqual({
+			ok: true,
+			value: {
+				...templatedConnection,
+				headers: { Authorization: 'Bearer token' },
+				endpointUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+				allowedDomains: 'acme.cloud.databricks.com',
+			},
+		});
+	});
+
+	it('rejects a templated connection when the credential has no resolved serverUrl', () => {
+		const result = prepareMcpRegistryConnection({
+			connection: templatedConnection,
+			credentialData: { oauthTokenData: { access_token: 'token' } },
+		});
+
+		expect(result).toEqual({
+			ok: false,
+			error: {
+				code: 'unresolved_server_url',
+				message: 'Credential type "exampleMcpOAuth2Api" did not resolve a server URL',
 			},
 		});
 	});

--- a/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry.controller.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry.controller.test.ts
@@ -2,7 +2,11 @@ import { mock } from 'vitest-mock-extended';
 
 import { McpRegistryController } from '../mcp-registry.controller';
 import type { McpRegistryService } from '../registry/mcp-registry.service';
-import { linearMockServer, notionMockServer } from '../registry/mock-servers';
+import {
+	databricksGenieTemplatedMockServer,
+	linearMockServer,
+	notionMockServer,
+} from '../registry/mock-servers';
 
 describe('McpRegistryController', () => {
 	const service = mock<McpRegistryService>();
@@ -33,6 +37,16 @@ describe('McpRegistryController', () => {
 			// Internal transport URLs must not leak.
 			expect(notion).not.toHaveProperty('remotes');
 			expect(notion).not.toHaveProperty('origin');
+		});
+
+		it('drops a server whose URL is a template', async () => {
+			// Instance AI fills its connection picker from here and cannot resolve a
+			// template, so offering the row would end at a refused connection.
+			service.getAll.mockResolvedValue([notionMockServer, databricksGenieTemplatedMockServer]);
+
+			const result = await controller.listServers();
+
+			expect(result.map((s) => s.slug)).toEqual(['notion']);
 		});
 
 		it('returns an empty array when the registry has no servers', async () => {

--- a/packages/cli/src/modules/mcp-registry/__tests__/node-description-transform.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/node-description-transform.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../node-description-transform';
 import type { McpRegistryServer } from '../registry/mcp-registry.types';
 import {
+	databricksGenieTemplatedMockServer,
 	gmailDirectExtendMockServer,
 	notionMockServer,
 	slackExtendingMockServer,
@@ -376,6 +377,28 @@ describe('serverToNodeDescription', () => {
 
 			expect(description?.credentials).toEqual([]);
 		});
+
+		it('builds a tile for a templated streamable-http-templated remote, unresolved endpointUrl and all', () => {
+			const description = serverToNodeDescription(
+				databricksGenieTemplatedMockServer,
+				baseDescription,
+				(name) => name === 'databricksOAuth2Api',
+			);
+
+			expect(description).not.toBeNull();
+			expect(description?.credentials).toEqual([
+				{ name: 'databricksGenieMcpOAuth2Api', required: true },
+			]);
+
+			// The node's own endpointUrl parameter still gets patched with the raw
+			// template; the runtime never reads it once a credential serverUrl is
+			// resolvable (see McpRegistryClientTool), but the description build
+			// itself does not special-case a templated remote.
+			const endpointUrl = description?.properties.find((p) => p.name === 'endpointUrl');
+			const serverTransport = description?.properties.find((p) => p.name === 'serverTransport');
+			expect(serverTransport?.default).toBe('httpStreamable');
+			expect(endpointUrl?.default).toBe('={{$self["host"].replace(/\\/$/, "")}}/api/2.0/mcp/genie');
+		});
 	});
 });
 
@@ -608,6 +631,133 @@ describe('serverToCredentialDescription', () => {
 			const description = serverToCredentialDescription(server, isKnownCredentialType);
 
 			expect(description?.extends).toEqual(['mcpOAuth2Api']);
+		});
+
+		it('writes a $self-expression serverUrl and allowedDomains for a streamable-http-templated remote', () => {
+			const description = serverToCredentialDescription(
+				databricksGenieTemplatedMockServer,
+				(name) => name === 'databricksOAuth2Api',
+			);
+
+			expect(description).toEqual({
+				name: 'databricksGenieMcpOAuth2Api',
+				displayName: 'Databricks Genie MCP OAuth2',
+				extends: ['databricksOAuth2Api'],
+				icon: 'node:@n8n/mcp-registry.databricksGenie',
+				properties: [
+					{ displayName: 'scope', name: 'scope', type: 'hidden', default: 'genie offline_access' },
+					{
+						displayName: 'grantType',
+						name: 'grantType',
+						type: 'hidden',
+						default: 'authorizationCode',
+					},
+					{
+						displayName: 'customScopes',
+						name: 'customScopes',
+						type: 'hidden',
+						default: false,
+					},
+					{
+						displayName: 'Server URL',
+						name: 'serverUrl',
+						type: 'hidden',
+						default: '={{$self["host"].replace(/\\/$/, "")}}/api/2.0/mcp/genie',
+					},
+					{
+						displayName: 'Allowed HTTP Request Domains',
+						name: 'allowedHttpRequestDomains',
+						type: 'hidden',
+						default: 'domains',
+					},
+					{
+						displayName: 'Allowed Domains',
+						name: 'allowedDomains',
+						type: 'hidden',
+						default: '={{$self["host"].extractDomain()}}',
+					},
+				],
+			});
+		});
+	});
+
+	it('drops the row for a templated remote paired with plain oauth2 auth, no host-bearing field to resolve against', () => {
+		const server: McpRegistryServer = {
+			...notionMockServer,
+			remotes: [{ type: 'streamable-http-templated', url: '={{$self["host"]}}/mcp' }],
+		};
+
+		expect(serverToCredentialDescription(server, isKnownCredentialType)).toBeNull();
+	});
+
+	it('drops the row when the remote type is unrecognised, the back-compat gate for future remote types', () => {
+		const server: McpRegistryServer = {
+			...notionMockServer,
+			remotes: [{ type: 'some-future-remote-type' as never, url: 'https://mcp.notion.com/mcp' }],
+		};
+
+		expect(serverToCredentialDescription(server, isKnownCredentialType)).toBeNull();
+	});
+
+	describe('back-compat: an old n8n instance loading a streamable-http-templated row', () => {
+		/**
+		 * Verbatim snapshot of pickRemote/resolveCredentialRemote as they shipped
+		 * before this ticket (commit e60c43112c3, the tip this feature branched
+		 * from). Neither function knows about `streamable-http-templated`, so this
+		 * proves the exact pre-existing code drops the row, not a stand-in that
+		 * merely resembles it. Two independent guards do the dropping, checked
+		 * separately below: the unrecognised-type match in pickRemote, and the
+		 * new URL() parse in resolveCredentialRemote, so a future change to
+		 * either one alone still leaves old instances safe.
+		 */
+		function oldPickRemote(
+			server: McpRegistryServer,
+		): { transport: 'httpStreamable' | 'sse'; endpointUrl: string } | null {
+			const streamable = server.remotes.find((r) => r.type === 'streamable-http');
+			if (streamable) return { transport: 'httpStreamable', endpointUrl: streamable.url };
+
+			const sse = server.remotes.find((r) => r.type === 'sse');
+			if (sse) return { transport: 'sse', endpointUrl: sse.url };
+
+			return null;
+		}
+
+		function oldResolveCredentialRemote(
+			server: McpRegistryServer,
+		): { endpointUrl: string; hostname: string } | null {
+			const remote = oldPickRemote(server);
+			if (!remote) return null;
+			try {
+				return { endpointUrl: remote.endpointUrl, hostname: new URL(remote.endpointUrl).hostname };
+			} catch {
+				return null;
+			}
+		}
+
+		it('old pickRemote never matches streamable-http-templated, so the row is invisible to it', () => {
+			expect(oldPickRemote(databricksGenieTemplatedMockServer)).toBeNull();
+		});
+
+		it('even if a row used the plain streamable-http type with a template-string url, new URL() rejects it independently', () => {
+			const serverWithOldTypeName: McpRegistryServer = {
+				...databricksGenieTemplatedMockServer,
+				remotes: databricksGenieTemplatedMockServer.remotes.map((remote) => ({
+					...remote,
+					type: 'streamable-http',
+				})),
+			};
+
+			expect(oldResolveCredentialRemote(serverWithOldTypeName)).toBeNull();
+		});
+
+		it('the current, patched code builds a tile old code could never build for the same row', () => {
+			expect(
+				serverToCredentialDescription(
+					databricksGenieTemplatedMockServer,
+					(name) => name === 'databricksOAuth2Api',
+				),
+			).not.toBeNull(); // current code DOES build a tile once the parent credential is known...
+			expect(oldPickRemote(databricksGenieTemplatedMockServer)).toBeNull(); // ...but old code drops it regardless
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp-registry/mcp-registry-connection.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry-connection.ts
@@ -24,18 +24,37 @@ export function resolveMcpRegistryConnection(
 	server: McpRegistryServer,
 ): McpRegistryConnection | null {
 	const remote =
-		server.remotes.find(({ type }) => type === 'streamable-http') ??
-		server.remotes.find(({ type }) => type === 'sse');
+		server.remotes.find(
+			({ type }) => type === 'streamable-http' || type === 'streamable-http-templated',
+		) ?? server.remotes.find(({ type }) => type === 'sse');
 	if (!remote) return null;
+
+	const nodeTypeName = `${MCP_REGISTRY_PACKAGE_NAME}.${camelCase(server.slug)}`;
+	const credentialType = getMcpRegistryCredentialTypeName(server);
+
+	// A templated remote's url is an unresolved `$self`-expression, not a
+	// literal URL, resolves per-credential once `prepareMcpRegistryConnection`
+	// has the decrypted credential data.
+	if (remote.type === 'streamable-http-templated') {
+		return {
+			nodeTypeName,
+			credentialType,
+			endpointUrl: remote.url,
+			endpointHostname: '',
+			transport: 'httpStreamable',
+			isTemplated: true,
+		};
+	}
 
 	try {
 		const endpoint = new URL(remote.url);
 		return {
-			nodeTypeName: `${MCP_REGISTRY_PACKAGE_NAME}.${camelCase(server.slug)}`,
-			credentialType: getMcpRegistryCredentialTypeName(server),
+			nodeTypeName,
+			credentialType,
 			endpointUrl: endpoint.toString(),
 			endpointHostname: endpoint.hostname,
 			transport: remote.type === 'streamable-http' ? 'httpStreamable' : 'sse',
+			isTemplated: false,
 		};
 	} catch {
 		return null;
@@ -57,6 +76,25 @@ export function prepareMcpRegistryConnection({
 				code: 'missing_access_token',
 				message: `Credential type "${connection.credentialType}" does not contain an OAuth2 access token`,
 			},
+		};
+	}
+
+	if (connection.isTemplated) {
+		const serverUrl = credentialData.serverUrl;
+		if (typeof serverUrl !== 'string' || serverUrl.length === 0) {
+			return {
+				ok: false,
+				error: {
+					code: 'unresolved_server_url',
+					message: `Credential type "${connection.credentialType}" did not resolve a server URL`,
+				},
+			};
+		}
+		const allowedDomains =
+			typeof credentialData.allowedDomains === 'string' ? credentialData.allowedDomains : '';
+		return {
+			ok: true,
+			value: { ...connection, endpointUrl: serverUrl, headers, allowedDomains },
 		};
 	}
 

--- a/packages/cli/src/modules/mcp-registry/mcp-registry-connection.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry-connection.ts
@@ -1,5 +1,6 @@
 import { camelCase } from 'change-case';
 import {
+	getConfiguredEndpointUrl,
 	getMcpAuthHeaders,
 	type McpOAuth2CredentialType,
 	type McpRegistryConnection,
@@ -8,6 +9,8 @@ import {
 } from 'n8n-workflow';
 
 import type { McpRegistryServer } from './registry/mcp-registry.types';
+
+export { getConfiguredEndpointUrl };
 
 export const MCP_REGISTRY_PACKAGE_NAME = '@n8n/mcp-registry';
 export const LANGCHAIN_PACKAGE_NAME = '@n8n/n8n-nodes-langchain';
@@ -39,8 +42,7 @@ export function resolveMcpRegistryConnection(
 		return {
 			nodeTypeName,
 			credentialType,
-			endpointUrl: remote.url,
-			endpointHostname: '',
+			urlTemplate: remote.url,
 			transport: 'httpStreamable',
 			isTemplated: true,
 		};
@@ -79,9 +81,15 @@ export function prepareMcpRegistryConnection({
 		};
 	}
 
+	const { nodeTypeName, credentialType, transport } = connection;
+
 	if (connection.isTemplated) {
 		const serverUrl = credentialData.serverUrl;
-		if (typeof serverUrl !== 'string' || serverUrl.length === 0) {
+		// An unresolved expression is still a non-empty string, so the URL has to
+		// be parsed here. Otherwise it travels on and fails far from its cause.
+		const endpoint =
+			typeof serverUrl === 'string' && serverUrl.length > 0 ? parseUrl(serverUrl) : undefined;
+		if (!endpoint) {
 			return {
 				ok: false,
 				error: {
@@ -90,22 +98,41 @@ export function prepareMcpRegistryConnection({
 				},
 			};
 		}
-		const allowedDomains =
-			typeof credentialData.allowedDomains === 'string' ? credentialData.allowedDomains : '';
 		return {
 			ok: true,
-			value: { ...connection, endpointUrl: serverUrl, headers, allowedDomains },
+			value: {
+				nodeTypeName,
+				credentialType,
+				transport,
+				endpointUrl: endpoint.toString(),
+				headers,
+				// Pinned to the host actually being called, so the restriction can
+				// never guard a different host than the request goes to.
+				allowedDomains: endpoint.hostname,
+			},
 		};
 	}
 
 	return {
 		ok: true,
 		value: {
-			...connection,
+			nodeTypeName,
+			credentialType,
+			transport,
+			endpointUrl: connection.endpointUrl,
 			headers,
 			allowedDomains: connection.endpointHostname,
 		},
 	};
+}
+
+function parseUrl(value: string): URL | undefined {
+	try {
+		const url = new URL(value);
+		return /^https?:$/.test(url.protocol) ? url : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 export function toAgentMcpTransport(

--- a/packages/cli/src/modules/mcp-registry/mcp-registry.controller.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry.controller.ts
@@ -1,6 +1,7 @@
 import type { McpRegistryServerResponse } from '@n8n/api-types';
 import { Get, RestController } from '@n8n/decorators';
 
+import { resolveMcpRegistryConnection } from './mcp-registry-connection';
 import { getMcpRegistryCredentialTypeName } from './node-description-transform';
 import { McpRegistryService } from './registry/mcp-registry.service';
 import type { McpRegistryServer } from './registry/mcp-registry.types';
@@ -9,10 +10,17 @@ import type { McpRegistryServer } from './registry/mcp-registry.types';
 export class McpRegistryController {
 	constructor(private readonly service: McpRegistryService) {}
 
+	/**
+	 * Only Instance AI reads this, to fill its tool-connection picker. A
+	 * templated row is dropped: that path cannot resolve the template, so
+	 * `createConnection` refuses it and offering it leads nowhere.
+	 */
 	@Get('/servers')
 	async listServers(): Promise<McpRegistryServerResponse[]> {
 		const servers = await this.service.getAll({ includeDeprecated: false });
-		return servers.map(toResponse);
+		return servers
+			.filter((server) => !resolveMcpRegistryConnection(server)?.isTemplated)
+			.map(toResponse);
 	}
 }
 

--- a/packages/cli/src/modules/mcp-registry/node-description-transform.ts
+++ b/packages/cli/src/modules/mcp-registry/node-description-transform.ts
@@ -11,6 +11,7 @@ import {
 	getMcpRegistryCredentialTypeName,
 	MCP_BASE_OAUTH2_CREDENTIAL_NAME,
 	MCP_REGISTRY_PACKAGE_NAME,
+	getConfiguredEndpointUrl,
 	resolveMcpRegistryConnection,
 } from './mcp-registry-connection';
 import {
@@ -53,22 +54,6 @@ function getMcpRegistryCredentialHeader(
 	};
 }
 
-type CredentialRemote =
-	| { endpointUrl: string; hostname: string; isTemplated: false }
-	| { endpointUrl: string; isTemplated: true };
-
-/**
- * Picks the server's remote endpoint. A templated remote has no hostname to
- * parse yet, it resolves per-credential at runtime.
- */
-function resolveCredentialRemote(server: McpRegistryServer): CredentialRemote | null {
-	const connection = resolveMcpRegistryConnection(server);
-	if (!connection) return null;
-	return connection.isTemplated
-		? { endpointUrl: connection.endpointUrl, isTemplated: true }
-		: { endpointUrl: connection.endpointUrl, hostname: connection.endpointHostname, isTemplated: false };
-}
-
 /**
  * Locks the synthetic credential's HTTP requests to the MCP server's hostname.
  */
@@ -96,7 +81,7 @@ function buildDomainRestrictionProperties(hostname: string): INodeProperties[] {
  * unsupported here and drop the row, same as an unparseable URL.
  */
 function serverToOAuth2CredentialDescription(server: McpRegistryServer): ICredentialType | null {
-	const remote = resolveCredentialRemote(server);
+	const remote = resolveMcpRegistryConnection(server);
 	if (!remote || remote.isTemplated) return null;
 
 	return {
@@ -113,7 +98,7 @@ function serverToOAuth2CredentialDescription(server: McpRegistryServer): ICreden
 				displayName: 'Server URL',
 				name: 'serverUrl',
 				type: 'hidden',
-				default: remote.endpointUrl,
+				default: getConfiguredEndpointUrl(remote),
 			},
 			{
 				displayName: 'Resource URL',
@@ -121,7 +106,7 @@ function serverToOAuth2CredentialDescription(server: McpRegistryServer): ICreden
 				type: 'hidden',
 				default: '',
 			},
-			...buildDomainRestrictionProperties(remote.hostname),
+			...buildDomainRestrictionProperties(remote.endpointHostname),
 		],
 	};
 }
@@ -165,7 +150,7 @@ function serverToExtendedCredentialDescription(
 	const validated = getValidatedExtendsCredential(server, isKnownCredentialType);
 	if (!validated) return null;
 
-	const remote = resolveCredentialRemote(server);
+	const remote = resolveMcpRegistryConnection(server);
 	if (!remote) return null;
 
 	const overrideProperties: INodeProperties[] = Object.entries(validated.overrides).map(
@@ -181,13 +166,13 @@ function serverToExtendedCredentialDescription(
 		displayName: 'Server URL',
 		name: 'serverUrl',
 		type: 'hidden',
-		default: remote.endpointUrl,
+		default: getConfiguredEndpointUrl(remote),
 	};
 	const serverUrlOverride = remote.isTemplated ? [serverUrlProperty] : [];
 
 	const allowedDomainsDefault = remote.isTemplated
 		? '={{$self["host"].extractDomain()}}'
-		: remote.hostname;
+		: remote.endpointHostname;
 
 	return {
 		...getMcpRegistryCredentialHeader(server),
@@ -321,7 +306,7 @@ export function serverToNodeDescription(
 	description.properties = withRemoteDefaults(
 		description.properties,
 		connection.transport,
-		connection.endpointUrl,
+		getConfiguredEndpointUrl(connection),
 	);
 	description.builderHint = {
 		...description.builderHint,

--- a/packages/cli/src/modules/mcp-registry/node-description-transform.ts
+++ b/packages/cli/src/modules/mcp-registry/node-description-transform.ts
@@ -53,16 +53,20 @@ function getMcpRegistryCredentialHeader(
 	};
 }
 
+type CredentialRemote =
+	| { endpointUrl: string; hostname: string; isTemplated: false }
+	| { endpointUrl: string; isTemplated: true };
+
 /**
- * Picks the server's remote endpoint and parses its hostname.
+ * Picks the server's remote endpoint. A templated remote has no hostname to
+ * parse yet, it resolves per-credential at runtime.
  */
-function resolveCredentialRemote(
-	server: McpRegistryServer,
-): { endpointUrl: string; hostname: string } | null {
+function resolveCredentialRemote(server: McpRegistryServer): CredentialRemote | null {
 	const connection = resolveMcpRegistryConnection(server);
-	return connection
-		? { endpointUrl: connection.endpointUrl, hostname: connection.endpointHostname }
-		: null;
+	if (!connection) return null;
+	return connection.isTemplated
+		? { endpointUrl: connection.endpointUrl, isTemplated: true }
+		: { endpointUrl: connection.endpointUrl, hostname: connection.endpointHostname, isTemplated: false };
 }
 
 /**
@@ -86,11 +90,14 @@ function buildDomainRestrictionProperties(hostname: string): INodeProperties[] {
 }
 
 /**
- * Registry MCP server → service-specific credential type for OAuth2 auth type
+ * Registry MCP server → service-specific credential type for OAuth2 auth type.
+ * Plain `oauth2` credentials have no user-editable, host-bearing field of
+ * their own to resolve a templated URL against, so templated remotes are
+ * unsupported here and drop the row, same as an unparseable URL.
  */
 function serverToOAuth2CredentialDescription(server: McpRegistryServer): ICredentialType | null {
 	const remote = resolveCredentialRemote(server);
-	if (!remote) return null;
+	if (!remote || remote.isTemplated) return null;
 
 	return {
 		...getMcpRegistryCredentialHeader(server),
@@ -145,7 +152,11 @@ function getValidatedExtendsCredential(
 }
 
 /**
- * Builds a dedicated credential type extending a known n8n credential.
+ * Builds a dedicated credential type extending a known n8n credential. A
+ * templated remote has no literal hostname, so the endpoint and the domain
+ * pin are both written as `$self`-expressions resolved against the parent
+ * credential's own `host` field, the same field the Strapi-authored URL
+ * template itself already depends on.
  */
 function serverToExtendedCredentialDescription(
 	server: McpRegistryServer,
@@ -166,10 +177,26 @@ function serverToExtendedCredentialDescription(
 		}),
 	);
 
+	const serverUrlProperty: INodeProperties = {
+		displayName: 'Server URL',
+		name: 'serverUrl',
+		type: 'hidden',
+		default: remote.endpointUrl,
+	};
+	const serverUrlOverride = remote.isTemplated ? [serverUrlProperty] : [];
+
+	const allowedDomainsDefault = remote.isTemplated
+		? '={{$self["host"].extractDomain()}}'
+		: remote.hostname;
+
 	return {
 		...getMcpRegistryCredentialHeader(server),
 		extends: [validated.parentType],
-		properties: [...overrideProperties, ...buildDomainRestrictionProperties(remote.hostname)],
+		properties: [
+			...overrideProperties,
+			...serverUrlOverride,
+			...buildDomainRestrictionProperties(allowedDomainsDefault),
+		],
 	};
 }
 

--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-search.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-search.test.ts
@@ -47,6 +47,7 @@ describe('searchMcpRegistryServers', () => {
 			credentialType: 'githubMcpOAuth2Api',
 			tools: [{ name: 'create_issue', title: 'Create issue' }],
 			metadata: { nodeTypeName: '@n8n/mcp-registry.github' },
+			isTemplated: false,
 		});
 	});
 
@@ -98,5 +99,13 @@ describe('searchMcpRegistryServers', () => {
 		expect(result.transport).toBe('streamableHttp');
 		expect(result.url).toBe('={{$self["host"]}}/api/2.0/mcp/genie');
 		expect(result.metadata).toEqual({ nodeTypeName: '@n8n/mcp-registry.databricksGenie' });
+		// Marks the url as unresolved so a consumer that cannot resolve it can skip.
+		expect(result.isTemplated).toBe(true);
+	});
+
+	it('marks a literal tile as not templated', () => {
+		const [result] = searchMcpRegistryServers([server({ slug: 'notion' })], ['notion']);
+
+		expect(result.isTemplated).toBe(false);
 	});
 });

--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-search.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-search.test.ts
@@ -85,4 +85,18 @@ describe('searchMcpRegistryServers', () => {
 		const noRemote = server({ slug: 'no-remote', remotes: [] });
 		expect(searchMcpRegistryServers([noRemote], ['no-remote'])).toEqual([]);
 	});
+
+	it('keeps a streamable-http-templated tile in results, surfacing its unresolved url as-is', () => {
+		const templated = server({
+			slug: 'databricks-genie',
+			title: 'Databricks Genie',
+			remotes: [{ type: 'streamable-http-templated', url: '={{$self["host"]}}/api/2.0/mcp/genie' }],
+		});
+
+		const [result] = searchMcpRegistryServers([templated], ['databricks-genie']);
+
+		expect(result.transport).toBe('streamableHttp');
+		expect(result.url).toBe('={{$self["host"]}}/api/2.0/mcp/genie');
+		expect(result.metadata).toEqual({ nodeTypeName: '@n8n/mcp-registry.databricksGenie' });
+	});
 });

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry-search.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry-search.ts
@@ -7,7 +7,11 @@
 import { camelCase } from 'change-case';
 
 import type { McpRegistryServer } from './mcp-registry.types';
-import { resolveMcpRegistryConnection, toAgentMcpTransport } from '../mcp-registry-connection';
+import {
+	getConfiguredEndpointUrl,
+	resolveMcpRegistryConnection,
+	toAgentMcpTransport,
+} from '../mcp-registry-connection';
 
 export interface McpRegistrySearchResult {
 	slug: string;
@@ -30,7 +34,7 @@ function toSearchResult(server: McpRegistryServer): McpRegistrySearchResult | nu
 		name: camelCase(server.slug),
 		title: server.title,
 		description: server.tagline,
-		url: connection.endpointUrl,
+		url: getConfiguredEndpointUrl(connection),
 		transport: toAgentMcpTransport(connection.transport),
 		authentication: connection.credentialType,
 		credentialType: connection.credentialType,

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry-search.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry-search.ts
@@ -24,6 +24,9 @@ export interface McpRegistrySearchResult {
 	credentialType: string;
 	tools: Array<{ name: string; title?: string }>;
 	metadata: { nodeTypeName: string };
+	/** `url` is an unresolved `$self`-expression, not a literal endpoint. Consumers
+	 *  that cannot resolve it against a credential have to skip the row. */
+	isTemplated: boolean;
 }
 
 function toSearchResult(server: McpRegistryServer): McpRegistrySearchResult | null {
@@ -43,6 +46,7 @@ function toSearchResult(server: McpRegistryServer): McpRegistrySearchResult | nu
 			...(tool.title ? { title: tool.title } : {}),
 		})),
 		metadata: { nodeTypeName: connection.nodeTypeName },
+		isTemplated: connection.isTemplated === true,
 	};
 }
 

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry.types.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry.types.ts
@@ -26,6 +26,10 @@ export const mcpRegistryExtendsCredentialSchema = z.object({
 	authentication: z.enum(['body', 'header']).nullish(),
 	useDynamicClientRegistration: z.boolean().nullish(),
 	serverUrl: z.string().nullish(),
+	// Lets a row that fixes `scope` also hide the parent's "Custom Scopes"
+	// toggle (and its dependent notice/enabledScopes fields), which would
+	// otherwise render with no effect once `scope` is overridden.
+	customScopes: z.boolean().nullish(),
 });
 
 export type McpRegistryExtendsCredential = z.infer<typeof mcpRegistryExtendsCredentialSchema>;
@@ -60,7 +64,7 @@ export type McpRegistryIcon = {
 	theme?: 'light' | 'dark';
 };
 
-export type McpRegistryRemoteType = 'streamable-http' | 'sse';
+export type McpRegistryRemoteType = 'streamable-http' | 'sse' | 'streamable-http-templated';
 
 export type McpRegistryRemote = {
 	type: McpRegistryRemoteType;

--- a/packages/cli/src/modules/mcp-registry/registry/mock-servers.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mock-servers.ts
@@ -85,6 +85,46 @@ export const gmailDirectExtendMockServer: McpRegistryServer = {
 	},
 };
 
+export const databricksGenieTemplatedMockServer: McpRegistryServer = {
+	name: 'com.databricks/genie-mcp',
+	slug: 'databricks-genie',
+	title: 'Databricks Genie',
+	description: 'Databricks Genie MCP server, resolved per-customer from the workspace host.',
+	tagline: 'Connect to Databricks Genie',
+	version: '1.0.0',
+	updatedAt: '2026-08-20T10:00:00.000Z',
+	icons: [
+		{
+			src: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iNCIgZmlsbD0iI0ZGMzYyMSIvPjwvc3ZnPg==',
+			mimeType: 'image/svg+xml',
+		},
+	],
+	websiteUrl: 'https://databricks.com',
+	authType: 'extendsCredential',
+	remotes: [
+		{
+			type: 'streamable-http-templated',
+			// Trailing slash stripped in case the customer pastes the host straight
+			// from the browser, matching DatabricksOAuth2Api's own accessTokenUrl/authUrl.
+			url: '={{$self["host"].replace(/\\/$/, "")}}/api/2.0/mcp/genie',
+		},
+	],
+	tools: [],
+	isOfficial: true,
+	origin: 'registry',
+	status: 'active',
+	extendsCredential: {
+		extends: 'databricksOAuth2Api',
+		scope: 'genie offline_access',
+		grantType: 'authorizationCode',
+		// databricksOAuth2Api already provides a per-host authUrl default, no
+		// override needed. customScopes is hidden here because Genie's scope is
+		// fixed above; without this the parent's "Custom Scopes" toggle and its
+		// dependent fields would render with no effect.
+		customScopes: false,
+	},
+};
+
 export const linearMockServer: McpRegistryServer = {
 	name: 'app.linear/linear',
 	slug: 'linear',

--- a/packages/cli/src/modules/mcp/__tests__/agent-tools.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/agent-tools.service.test.ts
@@ -1645,6 +1645,40 @@ describe('McpAgentToolsService', () => {
 			});
 			expect(listMcpServerToolsMock).not.toHaveBeenCalled();
 		});
+
+		it('accepts a templated registry URL and passes it through for resolution', async () => {
+			outboundHttp.transport.mockReturnValue({ asCustomFetch: () => vi.fn() } as never);
+			listMcpServerToolsMock.mockResolvedValue([{ name: 'genie_ask', description: 'Ask' }]);
+			const templatedUrl = '={{$self["host"]}}/api/2.0/mcp/genie';
+
+			const result = await callTool('verify_agent_mcp_server', {
+				...input,
+				url: templatedUrl,
+				metadata: { nodeTypeName: '@n8n/mcp-registry.databricksGenie' },
+			});
+
+			expect(listMcpServerToolsMock).toHaveBeenCalledWith(
+				expect.objectContaining({ url: templatedUrl }),
+				expect.objectContaining({ projectId: 'project-1' }),
+			);
+			expect(result.structuredContent).toEqual({
+				ok: true,
+				tools: [{ name: 'genie_ask', description: 'Ask' }],
+			});
+		});
+
+		it('rejects a templated URL with no registry node to resolve it', async () => {
+			const result = await callTool('verify_agent_mcp_server', {
+				...input,
+				url: '={{$self["host"]}}/api/2.0/mcp/genie',
+			});
+
+			expect(result.isError).toBe(true);
+			expect(result.structuredContent).toMatchObject({
+				error: 'A templated server URL needs metadata.nodeTypeName so the registry can resolve it',
+			});
+			expect(listMcpServerToolsMock).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('get_agent', () => {

--- a/packages/cli/src/modules/mcp/tools/agents/agent-tools.service.ts
+++ b/packages/cli/src/modules/mcp/tools/agents/agent-tools.service.ts
@@ -138,6 +138,13 @@ const httpUrlSchema = z
 	.url()
 	.refine((value) => /^https?:\/\//i.test(value), { message: 'Must be a valid HTTP(S) URL' });
 
+/**
+ * A registry server's endpoint can be an unresolved `$self`-expression instead
+ * of a literal URL. The registry connection substitutes it per-credential
+ * before the connection is opened, so it only validates as a URL after that.
+ */
+const mcpEndpointUrlSchema = z.union([httpUrlSchema, z.string().startsWith('=')]);
+
 const agentIdentityShape = {
 	agentId: z.string().min(1).describe('Agent ID'),
 } satisfies z.ZodRawShape;
@@ -302,7 +309,9 @@ const verifyMcpServerInput = {
 		.min(1)
 		.max(64)
 		.regex(/^[a-zA-Z0-9_-]+$/),
-	url: httpUrlSchema.describe('HTTP(S) MCP server endpoint'),
+	url: mcpEndpointUrlSchema.describe(
+		'HTTP(S) MCP server endpoint, or a registry `$self`-expression when metadata.nodeTypeName is set',
+	),
 	transport: z.enum(['sse', 'streamableHttp']).optional().default('streamableHttp'),
 	authentication: z
 		.union([McpAuthenticationSchemaTypes, z.string().endsWith('McpOAuth2Api')])
@@ -1603,6 +1612,11 @@ export class McpAgentToolsService {
 
 	private async verifyMcpServer(user: User, input: VerifyMcpServerInput) {
 		await this.assertScope(user, input.projectId, 'agent:read');
+		if (input.url.startsWith('=') && !input.metadata?.nodeTypeName) {
+			throw new UserError(
+				'A templated server URL needs metadata.nodeTypeName so the registry can resolve it',
+			);
+		}
 		const credentialProvider = this.credentialProvider(user, input.projectId);
 		if (input.authentication !== 'none') {
 			if (!input.credential) {

--- a/packages/workflow/src/mcp-helpers.ts
+++ b/packages/workflow/src/mcp-helpers.ts
@@ -5,19 +5,40 @@ import type { ICredentialDataDecryptedObject } from './interfaces';
 /** Covers `mcpOAuth2Api` and registry-specific variants like `notionMcpOAuth2Api`. */
 export type McpOAuth2CredentialType = 'mcpOAuth2Api' | `${string}McpOAuth2Api`;
 
-export interface McpRegistryConnection {
+interface McpRegistryConnectionBase {
 	nodeTypeName: string;
 	credentialType: McpOAuth2CredentialType;
+	transport: 'httpStreamable' | 'sse';
+}
+
+/** A row whose endpoint is a literal URL, known before any credential is read. */
+export interface LiteralMcpRegistryConnection extends McpRegistryConnectionBase {
+	isTemplated?: false;
 	endpointUrl: string;
 	endpointHostname: string;
-	transport: 'httpStreamable' | 'sse';
-	/**
-	 * `true` when `endpointUrl` is an unresolved `$self`-expression template
-	 * (e.g. `={{$self["host"]}}/api/2.0/mcp/genie`) rather than a literal URL.
-	 * `endpointHostname` is empty in that case; `prepareMcpRegistryConnection`
-	 * resolves the real endpoint and domain from the credential's own data.
-	 */
-	isTemplated: boolean;
+}
+
+/**
+ * A row whose endpoint is a `$self`-expression (e.g.
+ * `={{$self["host"]}}/api/2.0/mcp/genie`) rather than a URL. It only becomes
+ * one once `prepareMcpRegistryConnection` resolves it against the credential,
+ * so it deliberately has no `endpointUrl` to read by mistake.
+ */
+export interface TemplatedMcpRegistryConnection extends McpRegistryConnectionBase {
+	isTemplated: true;
+	urlTemplate: string;
+}
+
+export type McpRegistryConnection = LiteralMcpRegistryConnection | TemplatedMcpRegistryConnection;
+
+/**
+ * The endpoint as the registry configured it: a literal URL, or the unresolved
+ * template for a templated row. Only for describing the row (node defaults,
+ * search results). Anything that opens a connection needs the resolved URL from
+ * `prepareMcpRegistryConnection`.
+ */
+export function getConfiguredEndpointUrl(connection: McpRegistryConnection): string {
+	return connection.isTemplated ? connection.urlTemplate : connection.endpointUrl;
 }
 
 export interface PrepareMcpRegistryConnectionInput {
@@ -29,8 +50,14 @@ export interface PrepareMcpRegistryConnectionInput {
 export type PrepareMcpRegistryConnectionResult =
 	| {
 			ok: true;
-			value: McpRegistryConnection & {
+			value: {
+				nodeTypeName: string;
+				credentialType: McpOAuth2CredentialType;
+				transport: 'httpStreamable' | 'sse';
+				/** Always a literal URL, templated or not. */
+				endpointUrl: string;
 				headers: Record<string, string>;
+				/** Host the credential is pinned to, taken from `endpointUrl`. */
 				allowedDomains: string;
 			};
 	  }

--- a/packages/workflow/src/mcp-helpers.ts
+++ b/packages/workflow/src/mcp-helpers.ts
@@ -11,6 +11,13 @@ export interface McpRegistryConnection {
 	endpointUrl: string;
 	endpointHostname: string;
 	transport: 'httpStreamable' | 'sse';
+	/**
+	 * `true` when `endpointUrl` is an unresolved `$self`-expression template
+	 * (e.g. `={{$self["host"]}}/api/2.0/mcp/genie`) rather than a literal URL.
+	 * `endpointHostname` is empty in that case; `prepareMcpRegistryConnection`
+	 * resolves the real endpoint and domain from the credential's own data.
+	 */
+	isTemplated: boolean;
 }
 
 export interface PrepareMcpRegistryConnectionInput {
@@ -30,7 +37,7 @@ export type PrepareMcpRegistryConnectionResult =
 	| {
 			ok: false;
 			error: {
-				code: 'missing_access_token' | 'not_registered';
+				code: 'missing_access_token' | 'not_registered' | 'unresolved_server_url';
 				message: string;
 			};
 	  };


### PR DESCRIPTION
## Summary

Every Databricks customer has their own workspace host. So the Genie MCP server URL cannot be one fixed link for everyone, it has to fill in from each customer's own credential.

This PR adds a new remote type, `streamable-http-templated`. A registry row using it can write its URL as a template, like `={{$self["host"]}}/api/2.0/mcp/genie`. n8n fills in the real host at connect time, from the credential the customer already set up.

This also fixes the URL to work with a recent refactor from another engineer that centralized how the MCP registry resolves connections. Because of that shared code, this fix now works automatically in every place that uses the registry: the workflow node, the AI Assistant's tool for adding MCP servers, and Agents that use a registry-based MCP tool.

Old n8n versions that do not know about this new remote type just skip the row. No crash, no broken tile, no feature flag needed.

## How to test

1. Add a registry row with `authType: "extendsCredential"`, `extendsCredential.extends: "databricksOAuth2Api"`, and a remote of `{ "type": "streamable-http-templated", "url": "={{$self[\"host\"]}}/api/2.0/mcp/genie" }`. See `databricksGenieTemplatedMockServer` in `packages/cli/src/modules/mcp-registry/registry/mock-servers.ts` for the exact shape.
2. Restart the backend so it picks up the row.
3. Search "Databricks Genie" in the nodes panel, add it, and create its credential with a workspace Host.
4. Check the credential only asks for Host, Client ID, and Client Secret. Confirm the tool connects to `{host}/api/2.0/mcp/genie`.

Already tested live against a real Databricks workspace. The URL resolves to the right host and the request reaches Databricks.

Not yet tested: adding this tile through the AI Assistant chat, and running a saved Agent that uses it. Both should work already since they share the same fix, but this still needs to be checked by hand before merge.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-378

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. (No docs needed: internal registry plumbing, no node becomes visible until ENT-377/ENT-387 land)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (not applicable, not an urgent fix)
