### PR TITLE
fix(editor): Fix Chat node in-editor test mode with authentication (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -1668,6 +1668,43 @@ describe('CredentialsHelper', () => {
 			expect(result).toEqual(dynamicData);
 		});
 
+		test('should resolve against the identity carried on a test-webhook registration', async () => {
+			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
+			const dynamicData = { apiKey: 'builders-own-key' };
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: dynamicData,
+				isDynamic: true,
+			});
+
+			// A chat trigger test run: the builder's identity was minted at registration and
+			// travelled on the registration, so the manual-mode static fallback is bypassed and
+			// that carrier is what the resolver resolves against.
+			const registrationContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'manual' as const,
+				credentials: 'registration-minted-context',
+			};
+
+			const result = await credentialsHelper.getDecrypted(
+				{ ...mockAdditionalData, executionContext: registrationContext },
+				nodeCredentials,
+				credentialType,
+				'manual',
+				undefined,
+				true,
+			);
+
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				registrationContext,
+				expect.anything(),
+				undefined,
+			);
+			expect(result).toEqual(dynamicData);
+		});
+
 		test('should skip resolution when credentials context is missing (manual mode)', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -2,7 +2,10 @@ import type { Logger } from '@n8n/backend-common';
 import type { WorkflowEntity } from '@n8n/db';
 import { generateNanoId } from '@n8n/db';
 import type * as express from 'express';
+import type { ExecutionContextService } from 'n8n-core';
+import { CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type {
+	INodeParameters,
 	ITaskData,
 	IWorkflowBase,
 	IWebhookData,
@@ -54,6 +57,7 @@ describe('TestWebhooks', () => {
 	const logger = mock<Logger>();
 	const registrations = mock<TestWebhookRegistrationsService>();
 	const webhookService = mock<WebhookService>();
+	const executionContextService = mock<ExecutionContextService>();
 
 	const testWebhooks = new TestWebhooks(
 		logger,
@@ -63,6 +67,7 @@ describe('TestWebhooks', () => {
 		mock(),
 		mock(),
 		webhookService,
+		executionContextService,
 	);
 
 	beforeAll(() => {
@@ -292,6 +297,183 @@ describe('TestWebhooks', () => {
 			// The registration should store the full destinationNode object
 			expect(registrations.register).toHaveBeenCalled();
 			expect(registrations.register.mock.calls[0][0].destinationNode).toEqual(destinationNodeObj);
+		});
+
+		describe('runner identity for end-user credentials', () => {
+			const n8nAuthCookie = 'n8n-auth-jwt';
+			const carrier = 'encrypted-carrier';
+
+			/**
+			 * `availableInChat` is what makes a chat trigger identity-bearing today, per
+			 * `classifyTriggerIdentity`. `authentication` alone does not.
+			 */
+			const IDENTITY_BEARING = { availableInChat: true };
+
+			const chatWorkflow = (parameters: INodeParameters, type = CHAT_TRIGGER_NODE_TYPE) =>
+				mock<Workflow>({
+					id: workflowEntity.id,
+					nodes: {
+						chatTriggerNode: { type, name: 'chatTriggerNode', parameters },
+					},
+					expression: mock<WorkflowExpression>(),
+				});
+
+			const chatWebhook = () =>
+				mock<IWebhookData>({
+					node: 'chatTriggerNode',
+					httpMethod,
+					path: 'original-path',
+					workflowId: workflowEntity.id,
+					userId,
+				});
+
+			beforeEach(() => {
+				executionContextService.buildManualExecutionCredentials.mockResolvedValue(carrier);
+			});
+
+			afterEach(() => {
+				vi.unstubAllEnvs();
+			});
+
+			test('mints and stores the carrier for an identity-bearing chat trigger', async () => {
+				// ARRANGE
+				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
+				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(chatWorkflow(IDENTITY_BEARING));
+				vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([chatWebhook()]);
+
+				// ACT
+				await testWebhooks.needsWebhook({ ...args, chatSessionId: 'session', n8nAuthCookie });
+
+				// ASSERT
+				expect(executionContextService.buildManualExecutionCredentials).toHaveBeenCalledWith(
+					n8nAuthCookie,
+				);
+				expect(registrations.register.mock.calls[0][0].encryptedRunnerIdentity).toBe(carrier);
+			});
+
+			test('mints only once for a trigger that registers several webhooks', async () => {
+				// ARRANGE
+				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
+				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(chatWorkflow(IDENTITY_BEARING));
+				vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([
+					chatWebhook(),
+					chatWebhook(),
+				]);
+
+				// ACT
+				await testWebhooks.needsWebhook({ ...args, n8nAuthCookie });
+
+				// ASSERT
+				expect(executionContextService.buildManualExecutionCredentials).toHaveBeenCalledTimes(1);
+			});
+
+			test.each([
+				{
+					reason: 'the feature flag is off',
+					flag: 'false',
+					parameters: IDENTITY_BEARING,
+					type: CHAT_TRIGGER_NODE_TYPE,
+					cookie: n8nAuthCookie,
+				},
+				{
+					// A `n8nOAuth2` webhook node is identity-bearing too, but establishes its own
+					// stronger carrier while its webhook runs, so this gate stays out of its way.
+					reason: 'the trigger is not a chat trigger',
+					flag: 'true',
+					parameters: { authentication: 'n8nOAuth2' },
+					type: 'n8n-nodes-base.webhook',
+					cookie: n8nAuthCookie,
+				},
+				{
+					// Publish-time validation rejects this pairing with an end-user credential, so
+					// granting it identity in test mode would diverge from production. Expected to
+					// start minting once IAM-1263 makes it identity-bearing.
+					reason: 'the chat trigger is n8nUserAuth but not available in chat',
+					flag: 'true',
+					parameters: { authentication: 'n8nUserAuth' },
+					type: CHAT_TRIGGER_NODE_TYPE,
+					cookie: n8nAuthCookie,
+				},
+				{
+					reason: 'authentication is basicAuth',
+					flag: 'true',
+					parameters: { authentication: 'basicAuth' },
+					type: CHAT_TRIGGER_NODE_TYPE,
+					cookie: n8nAuthCookie,
+				},
+				{
+					reason: 'the chat trigger carries no relevant parameters',
+					flag: 'true',
+					parameters: {},
+					type: CHAT_TRIGGER_NODE_TYPE,
+					cookie: n8nAuthCookie,
+				},
+				{
+					reason: 'availableInChat is an unresolved expression',
+					flag: 'true',
+					parameters: { availableInChat: '={{ $json.inChat }}' },
+					type: CHAT_TRIGGER_NODE_TYPE,
+					cookie: n8nAuthCookie,
+				},
+				{
+					reason: 'no cookie was supplied',
+					flag: 'true',
+					parameters: IDENTITY_BEARING,
+					type: CHAT_TRIGGER_NODE_TYPE,
+					cookie: undefined,
+				},
+			])('does not mint a carrier when $reason', async ({ flag, parameters, type, cookie }) => {
+				// ARRANGE
+				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', flag);
+				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(chatWorkflow(parameters, type));
+				vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([chatWebhook()]);
+
+				// ACT
+				await testWebhooks.needsWebhook({ ...args, n8nAuthCookie: cookie });
+
+				// ASSERT
+				expect(executionContextService.buildManualExecutionCredentials).not.toHaveBeenCalled();
+				expect(registrations.register.mock.calls[0][0].encryptedRunnerIdentity).toBeUndefined();
+			});
+
+			test('stores the carrier only on the chat trigger registration', async () => {
+				// ARRANGE
+				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
+				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(
+					mock<Workflow>({
+						id: workflowEntity.id,
+						nodes: {
+							chatTriggerNode: {
+								type: CHAT_TRIGGER_NODE_TYPE,
+								name: 'chatTriggerNode',
+								parameters: IDENTITY_BEARING,
+							},
+							webhookNode: { type: 'n8n-nodes-base.webhook', name: 'webhookNode' },
+						},
+						expression: mock<WorkflowExpression>(),
+					}),
+				);
+				vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([
+					chatWebhook(),
+					mock<IWebhookData>({
+						node: 'webhookNode',
+						httpMethod,
+						path: 'webhook-path',
+						workflowId: workflowEntity.id,
+						userId,
+					}),
+				]);
+
+				// ACT
+				await testWebhooks.needsWebhook({ ...args, n8nAuthCookie });
+
+				// ASSERT
+				expect(registrations.register.mock.calls[0][0].encryptedRunnerIdentity).toBe(carrier);
+				const webhookNodeCall = registrations.register.mock.calls.find(
+					([registration]) => registration.webhook.node === 'webhookNode',
+				);
+				expect(webhookNodeCall?.[0].encryptedRunnerIdentity).toBeUndefined();
+			});
 		});
 		test.each([
 			{ published: true, withSingleWebhookTrigger: true, shouldThrow: true },

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -1355,7 +1355,12 @@ describe('executeWebhook establishTriggerIdentity', () => {
 	 * run with the caller it just authenticated — what `n8nOAuth2Auth` plus
 	 * `context.establishTriggerIdentity` do in the node.
 	 */
-	const runWithTriggerIdentity = async (resource: ProtectedResource | undefined) => {
+	const runWithTriggerIdentity = async (
+		resource: ProtectedResource | undefined,
+		options: { registrationIdentity?: string; establishesIdentity?: boolean } = {},
+	) => {
+		const { registrationIdentity, establishesIdentity = true } = options;
+
 		resourceRegistry.getByResourceUrl.mockResolvedValue(resource);
 
 		const additionalData = {
@@ -1365,7 +1370,9 @@ describe('executeWebhook establishTriggerIdentity', () => {
 		vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
 
 		webhookService.runWebhook.mockImplementation(async (_workflow, _webhookData, _node, data) => {
-			await data.establishTriggerIdentity!('caller-token', RESOURCE_URL);
+			if (establishesIdentity) {
+				await data.establishTriggerIdentity!('caller-token', RESOURCE_URL);
+			}
 			return { workflowData: [[{ json: {} }]] };
 		});
 
@@ -1405,6 +1412,8 @@ describe('executeWebhook establishTriggerIdentity', () => {
 			mock<WebhookRequest>({ method: 'POST', contentType: undefined }),
 			mock<express.Response>({ headersSent: false }),
 			vi.fn(),
+			undefined,
+			{ encryptedRunnerIdentity: registrationIdentity },
 		);
 
 		return additionalData;
@@ -1454,6 +1463,31 @@ describe('executeWebhook establishTriggerIdentity', () => {
 			undefined,
 			undefined,
 		);
+	});
+
+	it('lets a node override the identity carried on the test-webhook registration', async () => {
+		await runWithTriggerIdentity(resourceWithGrant, {
+			registrationIdentity: 'registration-context',
+		});
+
+		const [runData] = workflowRunner.run.mock.calls[0];
+
+		// The registration carrier is only a fallback: a node that authenticates the caller
+		// itself establishes the stronger sealed carrier, and that is what the run uses.
+		expect(runData.encryptedRunnerIdentity).toBe('sealed-context');
+	});
+
+	it('carries the test-webhook registration identity when no node establishes one', async () => {
+		const additionalData = await runWithTriggerIdentity(resourceWithGrant, {
+			registrationIdentity: 'registration-context',
+			establishesIdentity: false,
+		});
+
+		const [runData] = workflowRunner.run.mock.calls[0];
+
+		expect(executionContextService.buildTriggerIdentityCredentials).not.toHaveBeenCalled();
+		expect(additionalData.encryptedRunnerIdentity).toBe('registration-context');
+		expect(runData.encryptedRunnerIdentity).toBe('registration-context');
 	});
 });
 

--- a/packages/cli/src/webhooks/test-webhook-registrations.service.ts
+++ b/packages/cli/src/webhooks/test-webhook-registrations.service.ts
@@ -21,6 +21,13 @@ export type TestWebhookRegistration = {
 	workflowEntity: IWorkflowBase;
 	destinationNode?: IDestinationNode;
 	webhook: IWebhookData;
+	/**
+	 * Encrypted credential context carrying the identity of the builder who started
+	 * this test run. A manual run normally picks this up from the auth cookie when its
+	 * execution data is built, but a run that waits for a webhook returns before that,
+	 * so the identity has to travel on the registration instead.
+	 */
+	encryptedRunnerIdentity?: string;
 };
 
 // Type guard for TestWebhookRegistration.

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -359,7 +359,9 @@ export class TestWebhooks implements IWebhookManager {
 
 		if (node?.type !== CHAT_TRIGGER_NODE_TYPE) return false;
 
-		return classifyTriggerIdentity(node.type, node.parameters).providesN8nIdentity;
+		return classifyTriggerIdentity(node.type, node.parameters, {
+			isChatOAuth2Enabled: isChatOAuth2Enabled(),
+		}).providesN8nIdentity;
 	}
 
 	/**

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -2,8 +2,13 @@ import { Logger } from '@n8n/backend-common';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import type express from 'express';
-import { InstanceSettings } from 'n8n-core';
-import { WebhookPathTakenError, Workflow } from 'n8n-workflow';
+import { ExecutionContextService, InstanceSettings } from 'n8n-core';
+import {
+	CHAT_TRIGGER_NODE_TYPE,
+	classifyTriggerIdentity,
+	WebhookPathTakenError,
+	Workflow,
+} from 'n8n-workflow';
 import type {
 	IWebhookData,
 	IWorkflowExecuteAdditionalData,
@@ -14,6 +19,7 @@ import type {
 } from 'n8n-workflow';
 
 import { TEST_WEBHOOK_TIMEOUT } from '@/constants';
+import { isChatOAuth2Enabled } from '@/constants/oauth2-triggers';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
 import { SingleWebhookTriggerError } from '@/errors/single-webhook-trigger.error';
@@ -61,6 +67,7 @@ export class TestWebhooks implements IWebhookManager {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly publisher: Publisher,
 		private readonly webhookService: WebhookService,
+		private readonly executionContextService: ExecutionContextService,
 	) {}
 
 	private timeouts: { [webhookKey: string]: NodeJS.Timeout } = {};
@@ -129,7 +136,13 @@ export class TestWebhooks implements IWebhookManager {
 			});
 		}
 
-		const { pushRef, workflowEntity, webhook: testWebhook, destinationNode } = registration;
+		const {
+			pushRef,
+			workflowEntity,
+			webhook: testWebhook,
+			destinationNode,
+			encryptedRunnerIdentity,
+		} = registration;
 
 		const workflow = this.toWorkflow(workflowEntity);
 
@@ -168,6 +181,7 @@ export class TestWebhooks implements IWebhookManager {
 							else resolve(data);
 						},
 						destinationNode,
+						{ encryptedRunnerIdentity },
 					);
 
 					// The workflow did not run as the request was probably setup related
@@ -331,6 +345,50 @@ export class TestWebhooks implements IWebhookManager {
 	}
 
 	/**
+	 * Whether a run started by this node's webhook carries the identity of a specific
+	 * person. Defers to `classifyTriggerIdentity` — the same predicate publish-time
+	 * validation and the editor's compatibility warning use — so test mode can only ever
+	 * grant identity to a configuration production would also accept, and widens on its
+	 * own as that predicate learns new ones.
+	 *
+	 * Scoped to the chat trigger: every other identity-bearing trigger establishes its
+	 * own, stronger carrier while its webhook runs.
+	 */
+	private establishesRunnerIdentity(workflow: Workflow, nodeName: string) {
+		const node = workflow.nodes[nodeName];
+
+		if (node?.type !== CHAT_TRIGGER_NODE_TYPE) return false;
+
+		return classifyTriggerIdentity(node.type, node.parameters).providesN8nIdentity;
+	}
+
+	/**
+	 * The builder's identity, for a test run whose trigger can use end-user credentials —
+	 * they resolve against a specific person, and a run that waits for a webhook never
+	 * reaches the point where a manual execution picks its identity up from the cookie.
+	 *
+	 * Minted here, at the authenticated registration request, rather than read off the
+	 * webhook call later: a `manual-execution` carrier skips the browser-id and endpoint
+	 * checks, so minting one from a cookie presented on an arbitrary cross-site request
+	 * would be CSRF-shaped. Minted once, because the carrier depends only on the cookie
+	 * and a chat trigger registers several webhooks.
+	 */
+	private async mintRunnerIdentity(
+		workflow: Workflow,
+		webhooks: IWebhookData[],
+		n8nAuthCookie?: string,
+	) {
+		if (!n8nAuthCookie || !isChatOAuth2Enabled()) return undefined;
+
+		const anyEstablishesIdentity = webhooks.some((webhook) =>
+			this.establishesRunnerIdentity(workflow, webhook.node),
+		);
+		if (!anyEstablishesIdentity) return undefined;
+
+		return await this.executionContextService.buildManualExecutionCredentials(n8nAuthCookie);
+	}
+
+	/**
 	 * Return whether activating a workflow requires listening for webhook calls.
 	 * For every webhook call to listen for, also activate the webhook.
 	 */
@@ -344,6 +402,7 @@ export class TestWebhooks implements IWebhookManager {
 		triggerToStartFrom?: WorkflowRequest.FullManualExecutionFromKnownTriggerPayload['triggerToStartFrom'];
 		chatSessionId?: string;
 		workflowIsActive?: boolean;
+		n8nAuthCookie?: string;
 	}) {
 		const {
 			userId,
@@ -355,6 +414,7 @@ export class TestWebhooks implements IWebhookManager {
 			triggerToStartFrom,
 			chatSessionId,
 			workflowIsActive,
+			n8nAuthCookie,
 		} = options;
 
 		if (!workflowEntity.id) throw new WorkflowMissingIdError(workflowEntity);
@@ -406,6 +466,12 @@ export class TestWebhooks implements IWebhookManager {
 				timeoutDuration,
 			);
 
+			const encryptedRunnerIdentity = await this.mintRunnerIdentity(
+				workflow,
+				webhooks,
+				n8nAuthCookie,
+			);
+
 			for (const webhook of webhooks) {
 				webhook.path = removeTrailingSlash(webhook.path);
 
@@ -414,7 +480,7 @@ export class TestWebhooks implements IWebhookManager {
 				if (
 					chatSessionId &&
 					webhook.node &&
-					workflow.nodes[webhook.node]?.type === '@n8n/n8n-nodes-langchain.chatTrigger'
+					workflow.nodes[webhook.node]?.type === CHAT_TRIGGER_NODE_TYPE
 				) {
 					// Generate predictable path using workflowId and sessionId (without leading slash to match lookup format)
 					webhook.path = `${workflow.id}/${chatSessionId}`;
@@ -454,6 +520,9 @@ export class TestWebhooks implements IWebhookManager {
 					workflowEntity,
 					destinationNode,
 					webhook: cacheableWebhook as IWebhookData,
+					encryptedRunnerIdentity: this.establishesRunnerIdentity(workflow, webhook.node)
+						? encryptedRunnerIdentity
+						: undefined,
 				};
 
 				try {

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -512,6 +512,15 @@ export async function executeWebhook(
 		data: IWebhookResponseCallbackData | WebhookResponse,
 	) => void,
 	destinationNode?: IDestinationNode,
+	options?: {
+		/**
+		 * Identity of the builder who registered this test webhook, for a manual run that
+		 * had to wait for a webhook and so never reached the point where a manual
+		 * execution normally picks its identity up from the auth cookie. Only a fallback:
+		 * a node that establishes its own carrier below still wins.
+		 */
+		encryptedRunnerIdentity?: string;
+	},
 ): Promise<string | undefined> {
 	// Get the nodeType to know which responseMode is set
 	const nodeType = workflow.nodeTypes.getByNameAndVersion(
@@ -542,6 +551,11 @@ export async function executeWebhook(
 	const additionalData = await WorkflowExecuteAdditionalData.getBase({
 		projectId: project?.id,
 	});
+
+	// Guarded: an absent carrier must not clobber one set elsewhere.
+	if (options?.encryptedRunnerIdentity) {
+		additionalData.encryptedRunnerIdentity = options.encryptedRunnerIdentity;
+	}
 
 	if (executionId) {
 		additionalData.executionId = executionId;

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -333,6 +333,7 @@ export class WorkflowExecutionService {
 					destinationNode: payload.destinationNode,
 					chatSessionId: payload.chatSessionId,
 					workflowIsActive,
+					n8nAuthCookie,
 				}))
 			) {
 				return { waitingForWebhook: true };
@@ -370,6 +371,7 @@ export class WorkflowExecutionService {
 					pushRef,
 					destinationNode: payload.destinationNode,
 					workflowIsActive,
+					n8nAuthCookie,
 				}))
 			) {
 				return { waitingForWebhook: true };

--- a/packages/cli/test/integration/dynamic-credentials.ee/chat-trigger-test-run.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/chat-trigger-test-run.api.test.ts
@@ -1,0 +1,350 @@
+/**
+ * End-user credentials in an editor test run of a Chat Trigger.
+ *
+ * A test run is `executionMode: 'manual'`, and `CredentialsHelper.getDecrypted` skips
+ * dynamic resolution for manual runs unless the execution carries a credential context.
+ * Every other manual run gets one from the builder's auth cookie, but a run that waits
+ * for a webhook returns `{ waitingForWebhook: true }` before that point — so the
+ * identity is minted at registration and travels on the registration instead.
+ *
+ * The whole seam is exercised: the editor's authenticated `POST /rest/workflows/:id/run`
+ * registers the webhook, then a real `WebhookServer` fires it and the workflow runs. The
+ * assertion is a `nock` interceptor that only answers a request bearing the builder's own
+ * per-user token — a match is proof the run resolved against their connection rather than
+ * against the static credential data, which holds no token at all.
+ */
+
+import {
+	createTeamProject,
+	createWorkflow,
+	linkUserToProject,
+	mockInstance,
+	randomCredentialPayload,
+	testDb,
+} from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import type { Project, User, WorkflowEntity } from '@n8n/db';
+import { ExecutionRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { DirectoryLoader } from 'n8n-core';
+import { Cipher, UnrecognizedNodeTypeError } from 'n8n-core';
+import type { INode, INodeType, NodeLoadingDetails } from 'n8n-workflow';
+import { CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import nock from 'nock';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { agent as testAgent } from 'supertest';
+
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { SYSTEM_RESOLVER_ID } from '@/modules/dynamic-credentials.ee/constants';
+import { DynamicCredentialUserEntryStorage } from '@/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-user-entry-storage';
+import { N8nResolverSeeder } from '@/modules/dynamic-credentials.ee/services/n8n-resolver-seeder.service';
+import { CacheService } from '@/services/cache/cache.service';
+import { Telemetry } from '@/telemetry';
+import { WebhookServer } from '@/webhooks/webhook-server';
+
+import { saveCredential } from '../shared/db/credentials';
+import { createOwner } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import { initNodeTypes, setupTestServer } from '../shared/utils';
+import { loadNodesFromDist } from '../shared/utils/node-types-data';
+
+mockInstance(Telemetry);
+
+process.env.N8N_ENV_FEAT_DYNAMIC_CREDENTIALS = 'true';
+process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 = 'true';
+
+const testServer = setupTestServer({
+	endpointGroups: ['workflows', 'credentials'],
+	enabledFeatures: ['feat:sharing', 'feat:dynamicCredentials'],
+	modules: ['dynamic-credentials'],
+});
+
+const HTTP_REQUEST = 'n8n-nodes-base.httpRequest';
+const CREDENTIAL_TYPE = 'googleSheetsOAuth2Api';
+const VENDOR_HOST = 'https://api.example.test';
+const VENDOR_PATH = '/ping';
+const PER_USER_ACCESS_TOKEN = 'builders-own-access-token';
+
+/** Resolves the requested credential types (and everything they extend) out of `nodes-base/dist`. */
+function registerCredentialTypesFromDist(credentialTypeNames: string[]) {
+	const baseDir = path.resolve(__dirname, '../../../../nodes-base');
+	const known = JSON.parse(
+		readFileSync(path.join(baseDir, 'dist/known/credentials.json'), 'utf-8'),
+	) as Record<string, NodeLoadingDetails & { extends?: string[]; supportedNodes?: string[] }>;
+
+	const loadNodesAndCredentials = Container.get(LoadNodesAndCredentials);
+	const pending = [...credentialTypeNames];
+
+	while (pending.length > 0) {
+		const name = pending.shift()!;
+		if (name in loadNodesAndCredentials.loadedCredentials) continue;
+
+		const loadInfo = known[name];
+		if (!loadInfo) throw new Error(`Unknown credential type in dist: ${name}`);
+
+		const CredentialClass = require(path.join(baseDir, loadInfo.sourcePath))[loadInfo.className];
+		loadNodesAndCredentials.loadedCredentials[name] = {
+			type: new CredentialClass(),
+			sourcePath: '',
+		};
+		loadNodesAndCredentials.knownCredentials[name] = {
+			className: loadInfo.className,
+			sourcePath: loadInfo.sourcePath,
+			extends: loadInfo.extends,
+			supportedNodes: loadInfo.supportedNodes,
+		};
+
+		pending.push(...(loadInfo.extends ?? []));
+	}
+}
+
+/**
+ * The real Chat Trigger, out of the langchain package's dist. Required by absolute path
+ * rather than imported (the package exports only its index), and registered under its own
+ * package loader because node types resolve by the package prefix in their name. It has to
+ * be the real node: `executeWebhook` keys its chat-specific seeding on this exact type.
+ */
+function registerChatTrigger() {
+	const distPath = path.resolve(
+		__dirname,
+		'../../../../@n8n/nodes-langchain/dist/nodes/trigger/ChatTrigger/ChatTrigger.node.js',
+	);
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const { ChatTrigger } = require(distPath);
+	const loaded = { type: new ChatTrigger() as INodeType, sourcePath: '' };
+	const [packageName, nodeName] = CHAT_TRIGGER_NODE_TYPE.split('.');
+
+	Container.get(LoadNodesAndCredentials).loaders[packageName] = {
+		getNode: (nodeType: string) => {
+			if (nodeType !== nodeName) throw new UnrecognizedNodeTypeError(packageName, nodeType);
+			return loaded;
+		},
+		known: { nodes: {}, credentials: {} },
+	} as unknown as DirectoryLoader;
+}
+
+let builder: User;
+let teamProject: Project;
+let webhookAgent: SuperAgentTest;
+let webhookTestEndpoint: string;
+
+const chatTriggerNode = (parameters: Record<string, unknown>): INode => ({
+	id: randomUUID(),
+	name: 'When chat message received',
+	type: CHAT_TRIGGER_NODE_TYPE,
+	typeVersion: 1.3,
+	position: [0, 0],
+	webhookId: randomUUID(),
+	parameters: { public: true, mode: 'webhook', options: {}, ...parameters },
+});
+
+/**
+ * `availableInChat` is what `classifyTriggerIdentity` reads to call a chat trigger
+ * identity-bearing, and so what publish-time validation requires before an end-user
+ * credential is allowed on one.
+ */
+const IDENTITY_BEARING = { availableInChat: true };
+
+const httpRequestNode = (credential: { id: string; name: string }): INode => ({
+	id: randomUUID(),
+	name: 'Call the vendor',
+	type: HTTP_REQUEST,
+	typeVersion: 4.2,
+	position: [200, 0],
+	parameters: {
+		method: 'GET',
+		url: `${VENDOR_HOST}${VENDOR_PATH}`,
+		authentication: 'predefinedCredentialType',
+		nodeCredentialType: CREDENTIAL_TYPE,
+		options: {},
+	},
+	credentials: { [CREDENTIAL_TYPE]: { id: credential.id, name: credential.name } },
+});
+
+const createChatWorkflow = async (
+	credential: { id: string; name: string },
+	parameters: Record<string, unknown> = IDENTITY_BEARING,
+) => {
+	const trigger = chatTriggerNode(parameters);
+
+	return await createWorkflow(
+		{
+			active: false,
+			nodes: [trigger, httpRequestNode(credential)],
+			connections: {
+				[trigger.name]: { main: [[{ node: 'Call the vendor', type: 'main', index: 0 }]] },
+			},
+		},
+		teamProject,
+	);
+};
+
+/**
+ * An end-user OAuth2 credential: the shared client fields are static, the token is not —
+ * it lives per user under the resolver, so the static data holds none.
+ */
+const createEndUserCredential = async () =>
+	await saveCredential(
+		{
+			...randomCredentialPayload({ isResolvable: true, type: CREDENTIAL_TYPE }),
+			data: {
+				grantType: 'authorizationCode',
+				clientId: 'shared-client-id',
+				clientSecret: 'shared-client-secret',
+				authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				accessTokenUrl: 'https://oauth2.googleapis.com/token',
+				scope: 'https://www.googleapis.com/auth/drive',
+				authentication: 'body',
+			},
+		},
+		{ project: teamProject, role: 'credential:owner' },
+	);
+
+/** What the connect flow stores: per-user data, encrypted, keyed by n8n user id. */
+const connect = async (credentialId: string, user: User, accessToken = PER_USER_ACCESS_TOKEN) => {
+	const encrypted = await Container.get(Cipher).encryptV2({
+		oauthTokenData: { access_token: accessToken, token_type: 'Bearer' },
+	});
+	await Container.get(DynamicCredentialUserEntryStorage).setCredentialData(
+		credentialId,
+		user.id,
+		SYSTEM_RESOLVER_ID,
+		encrypted,
+		{},
+	);
+};
+
+/** The vendor call, answered only for a request bearing the given token. */
+const mockVendorCall = (accessToken = PER_USER_ACCESS_TOKEN) =>
+	nock(VENDOR_HOST)
+		.get(VENDOR_PATH)
+		.matchHeader('authorization', `Bearer ${accessToken}`)
+		.reply(200, { ok: true });
+
+/** The editor pressing "Open chat": registers the test webhook for this session. */
+const startListening = async (workflow: WorkflowEntity, chatSessionId: string) =>
+	await testServer
+		.authAgentFor(builder)
+		.post(`/workflows/${workflow.id}/run`)
+		.send({ triggerToStartFrom: { name: 'When chat message received' }, chatSessionId });
+
+/** The chat panel sending a message to the test webhook it just registered. */
+const sendChatMessage = async (workflow: WorkflowEntity, chatSessionId: string) =>
+	await webhookAgent
+		.post(`/${webhookTestEndpoint}/${workflow.id}/${chatSessionId}`)
+		.send({ action: 'sendMessage', chatInput: 'hello', sessionId: chatSessionId });
+
+const lastExecutionFor = async (workflowId: string) =>
+	await Container.get(ExecutionRepository).findOne({
+		where: { workflowId },
+		order: { createdAt: 'DESC' },
+		relations: ['executionData'],
+	});
+
+beforeAll(async () => {
+	await initNodeTypes(loadNodesFromDist([HTTP_REQUEST]));
+	registerChatTrigger();
+	registerCredentialTypesFromDist([CREDENTIAL_TYPE]);
+
+	webhookTestEndpoint = Container.get(GlobalConfig).endpoints.webhookTest;
+
+	await Container.get(CacheService).init();
+
+	// `/webhook-test/*` is mounted only when a server opts into test webhooks, which the
+	// production webhook process does not — the editor's own server does.
+	class EditorFacingWebhookServer extends WebhookServer {
+		constructor() {
+			super();
+			this.testWebhooksEnabled = true;
+		}
+	}
+
+	const server = new EditorFacingWebhookServer();
+	await server.start();
+	webhookAgent = testAgent(server.app) as unknown as SuperAgentTest;
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'ExecutionEntity',
+		'SharedWorkflow',
+		'WorkflowEntity',
+		'DynamicCredentialUserEntry',
+		'SharedCredentials',
+		'CredentialsEntity',
+		'DynamicCredentialResolver',
+	]);
+	await Container.get(CacheService).reset();
+	nock.cleanAll();
+
+	// Seeding (not a hand-written row) matters: the resolver's config has to be
+	// encrypted for it to be readable at resolve time.
+	await Container.get(N8nResolverSeeder).seed();
+
+	builder = await createOwner();
+	// End-user credentials live in team projects only.
+	teamProject = await createTeamProject(undefined, builder);
+	await linkUserToProject(builder, teamProject, 'project:admin');
+});
+
+describe('chat trigger test run with end-user credentials', () => {
+	let workflow: WorkflowEntity;
+	let credentialId: string;
+	let chatSessionId: string;
+
+	beforeEach(async () => {
+		const credential = await createEndUserCredential();
+		credentialId = credential.id;
+		workflow = await createChatWorkflow(credential);
+		chatSessionId = randomUUID().replace(/-/g, '');
+	});
+
+	test("runs against the builder's own connection", async () => {
+		await connect(credentialId, builder);
+		const vendorScope = mockVendorCall();
+
+		const listening = await startListening(workflow, chatSessionId);
+		expect(listening.body.data).toEqual({ waitingForWebhook: true });
+
+		const response = await sendChatMessage(workflow, chatSessionId);
+
+		expect(response.statusCode).toBe(200);
+		// The interceptor only matches the builder's own token, so a match proves the run
+		// resolved against their connection rather than the tokenless static data.
+		expect(vendorScope.isDone()).toBe(true);
+	});
+
+	test('tells a builder who has not connected, instead of failing to sign', async () => {
+		const vendorScope = mockVendorCall();
+
+		await startListening(workflow, chatSessionId);
+		await sendChatMessage(workflow, chatSessionId);
+
+		const execution = await lastExecutionFor(workflow.id);
+		const runError = JSON.stringify(execution?.executionData?.data ?? '');
+
+		expect(runError).toContain('is not connected for you');
+		expect(runError).not.toContain('Unable to sign without access token');
+		expect(vendorScope.isDone()).toBe(false);
+	});
+
+	test('carries no identity for a chat trigger that establishes none', async () => {
+		// Without `availableInChat` this configuration cannot be published with an end-user
+		// credential at all, so a test run must not quietly grant it an identity — it keeps
+		// today's fall back to the static credential data, which holds no token, so the
+		// builder's connection is never reached.
+		await connect(credentialId, builder);
+		const vendorScope = mockVendorCall();
+		const noIdentityWorkflow = await createChatWorkflow(
+			{ id: credentialId, name: 'end-user credential' },
+			{ authentication: 'n8nUserAuth' },
+		);
+
+		await startListening(noIdentityWorkflow, chatSessionId);
+		await sendChatMessage(noIdentityWorkflow, chatSessionId);
+
+		expect(vendorScope.isDone()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
As we are now upgrading the n8n user auth setting on the Chat node to provide an identity (which can then be used for things such as end-user credentials) we need to make sure that the 'test' version of this supports them too. 
The 'test' version of a Chat node appears inline within the editor - this is in contrast to other webhook-based nodes, such as Form, where their test mode more similarly mirrors their published mode, i.e. a popup window.

This means that the solution to provide auth for a Chat test is _different_ than for a published Chat workflow. To achieve this here, we attach the users existing n8n-auth identity (encrypted, in the `encryptedRunnerIdentity` option) to their workflow execution so that it can be read when the trigger is executed. It has to be done this way because webhook nodes are triggered as 2 requests, one to register the webhook and one to trigger it, and the trigger webhook is unauthenticated.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
1. Create a chat trigger in a workflow that has end-user credentials used on a node
2. From within the editor, click 'Open chat' which will open the chat in a panel within the workflow editor
3. Type your message
4. The workflow should execute using the current users credentials
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-1262/chat-trigger-run-end-user-credential-auth-in-test-mode-executions
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

