### PR TITLE
feat(core): Run system tasks from the registry (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -52,6 +52,7 @@ export const LOG_SCOPES = [
 	'poll-trigger',
 	'metrics',
 	'scheduler',
+	'system-tasks',
 	'enqueued-execution-recovery',
 	'engine-v2',
 	'policy',

--- a/packages/@n8n/decorators/src/system-task/__tests__/run-options.test.ts
+++ b/packages/@n8n/decorators/src/system-task/__tests__/run-options.test.ts
@@ -63,12 +63,20 @@ it.each([
 
 it('should keep the defaults for the fields a task does not override', () => {
 	const options = resolveSystemTaskRunOptions(
-		taskWith({ effects: 'non-idempotent', maxAttempts: 10 }),
+		taskWith({ effects: 'non-idempotent', misfireGraceSeconds: 5 }),
 	);
 
 	expect(options).toEqual({
 		misfirePolicy: ScheduledJobMisfirePolicy.Skip,
-		misfireGraceSeconds: 60,
-		maxAttempts: 10,
+		misfireGraceSeconds: 5,
+		maxAttempts: 1,
 	});
+});
+
+it('should refuse to retry non-idempotent work that asked for more attempts', () => {
+	const options = resolveSystemTaskRunOptions(
+		taskWith({ effects: 'non-idempotent', maxAttempts: 10 }),
+	);
+
+	expect(options.maxAttempts).toBe(1);
 });

--- a/packages/@n8n/decorators/src/system-task/system-task.ts
+++ b/packages/@n8n/decorators/src/system-task/system-task.ts
@@ -60,8 +60,13 @@ export interface SystemTask {
 	 */
 	readonly maxAttempts?: number;
 
-	/** Executes one occurrence of the task. */
-	run(): Promise<void>;
+	/**
+	 * Executes one occurrence of the task. `signal` aborts when the run should
+	 * stop early: the instance is shutting down or, for a run on the in-memory
+	 * timer, leadership was lost. Honoring it is optional, but a run that
+	 * ignores it delays stepdown and shutdown until it settles.
+	 */
+	run(signal: AbortSignal): Promise<void>;
 }
 
 /** How a task's occurrences are retried and how late they may still run. */

--- a/packages/@n8n/decorators/src/system-task/system-task.ts
+++ b/packages/@n8n/decorators/src/system-task/system-task.ts
@@ -40,6 +40,13 @@ export interface SystemTask {
 	readonly durable: boolean;
 
 	/**
+	 * Runs one occurrence as soon as this instance becomes the leader, on top
+	 * of the scheduled occurrences. In-memory timers only: ignored for a
+	 * durable run.
+	 */
+	readonly runOnTakeover?: boolean;
+
+	/**
 	 * Overrides what happens to occurrences that missed their grace window.
 	 * Defaults to `coalesce` for idempotent work and `skip` otherwise.
 	 */

--- a/packages/@n8n/decorators/src/system-task/system-task.ts
+++ b/packages/@n8n/decorators/src/system-task/system-task.ts
@@ -47,6 +47,13 @@ export interface SystemTask {
 	readonly runOnTakeover?: boolean;
 
 	/**
+	 * How long after a failed run an earlier retry occurrence runs, instead of
+	 * waiting for the next scheduled one. In-memory timers only, and only
+	 * honored for idempotent work. Durable runs retry via `maxAttempts`.
+	 */
+	readonly retryDelaySeconds?: number;
+
+	/**
 	 * Overrides what happens to occurrences that missed their grace window.
 	 * Defaults to `coalesce` for idempotent work and `skip` otherwise.
 	 */

--- a/packages/@n8n/decorators/src/system-task/system-task.ts
+++ b/packages/@n8n/decorators/src/system-task/system-task.ts
@@ -50,6 +50,7 @@ export interface SystemTask {
 	 * How long after a failed run an earlier retry occurrence runs, instead of
 	 * waiting for the next scheduled one. In-memory timers only, and only
 	 * honored for idempotent work. Durable runs retry via `maxAttempts`.
+	 * An integer of at least 1, capped at what a timeout honors (about 24 days).
 	 */
 	readonly retryDelaySeconds?: number;
 

--- a/packages/@n8n/decorators/src/system-task/system-task.ts
+++ b/packages/@n8n/decorators/src/system-task/system-task.ts
@@ -55,7 +55,8 @@ export interface SystemTask {
 
 	/**
 	 * Overrides how many times an occurrence is attempted before it is given up on.
-	 * Defaults to 3 for idempotent work and 1 otherwise.
+	 * Defaults to 3 for idempotent work. Ignored for non-idempotent work, which is
+	 * always kept to a single attempt.
 	 */
 	readonly maxAttempts?: number;
 
@@ -94,7 +95,8 @@ const SYSTEM_TASK_RUN_OPTION_DEFAULTS: Record<
 /**
  * Resolves the run options a task is scheduled with, and rejects values the
  * scheduler cannot store. A task's own overrides win over the defaults its
- * effects imply.
+ * effects imply, except for `maxAttempts` on non-idempotent work, which stays
+ * at a single attempt.
  */
 export function resolveSystemTaskRunOptions(task: SystemTask): SystemTaskRunOptions {
 	const defaults = SYSTEM_TASK_RUN_OPTION_DEFAULTS[task.effects];
@@ -102,7 +104,7 @@ export function resolveSystemTaskRunOptions(task: SystemTask): SystemTaskRunOpti
 	const options = {
 		misfirePolicy: task.misfirePolicy ?? defaults.misfirePolicy,
 		misfireGraceSeconds: task.misfireGraceSeconds ?? DEFAULT_MISFIRE_GRACE_SECONDS,
-		maxAttempts: task.maxAttempts ?? defaults.maxAttempts,
+		maxAttempts: task.effects === 'non-idempotent' ? 1 : (task.maxAttempts ?? defaults.maxAttempts),
 	};
 
 	// Both end up in `int` columns, where a fractional value is rounded and anything

--- a/packages/@n8n/scheduler/src/core/index.ts
+++ b/packages/@n8n/scheduler/src/core/index.ts
@@ -16,6 +16,7 @@ export type {
 	Schedule,
 } from './types';
 export { computeFirstRunAt, computeNextRunAt } from './recurrence/next-run';
+export { scheduleFromDefinition } from './recurrence/resolve';
 export { validateSchedule } from './recurrence/validate';
 
 export {

--- a/packages/@n8n/scheduler/src/core/recurrence/__tests__/resolve.test.ts
+++ b/packages/@n8n/scheduler/src/core/recurrence/__tests__/resolve.test.ts
@@ -1,6 +1,8 @@
+import type { ScheduleDefinition } from '@n8n/constants';
+
 import { CorruptStorageRowError } from '../../errors';
 import type { ScheduledJob } from '../../types';
-import { resolveSchedule } from '../resolve';
+import { resolveSchedule, scheduleFromDefinition } from '../resolve';
 
 const DEFAULT_TZ = 'America/New_York';
 
@@ -155,5 +157,50 @@ describe('resolveSchedule', () => {
 	it('throws on a kind outside the enum (a corrupt row)', () => {
 		const corrupt = makeJob({ kind: 'weekly' as ScheduledJob['kind'] });
 		expect(() => resolveSchedule(corrupt, DEFAULT_TZ)).toThrow(CorruptStorageRowError);
+	});
+});
+
+describe('scheduleFromDefinition', () => {
+	it('resolves a cron definition with no timezone to the instance default', () => {
+		const schedule = scheduleFromDefinition(
+			{ kind: 'cron', cronExpression: '0 * * * *', timezone: null },
+			DEFAULT_TZ,
+		);
+
+		expect(schedule).toEqual({
+			kind: 'cron',
+			cronExpression: '0 * * * *',
+			timezone: DEFAULT_TZ,
+		});
+	});
+
+	it('keeps an explicit timezone', () => {
+		const schedule = scheduleFromDefinition(
+			{
+				kind: 'recurring_cron',
+				cronExpression: '0 0 * * *',
+				timezone: 'UTC',
+				recurrenceUnit: 'days',
+				recurrenceSize: 3,
+			},
+			DEFAULT_TZ,
+		);
+
+		expect(schedule).toMatchObject({ timezone: 'UTC' });
+	});
+
+	it('passes an interval definition through', () => {
+		const definition: ScheduleDefinition = { kind: 'interval', intervalSeconds: 30 };
+
+		expect(scheduleFromDefinition(definition, DEFAULT_TZ)).toEqual(definition);
+	});
+
+	it('passes a one_off definition through', () => {
+		const definition: ScheduleDefinition = {
+			kind: 'one_off',
+			fireAt: new Date('2026-06-01T12:00:00.000Z'),
+		};
+
+		expect(scheduleFromDefinition(definition, DEFAULT_TZ)).toEqual(definition);
 	});
 });

--- a/packages/@n8n/scheduler/src/core/recurrence/resolve.ts
+++ b/packages/@n8n/scheduler/src/core/recurrence/resolve.ts
@@ -1,3 +1,6 @@
+import type { ScheduleDefinition } from '@n8n/constants';
+import type { CronExpression } from 'n8n-workflow';
+
 import { CorruptStorageRowError } from '../errors';
 import type { Schedule, ScheduledJob } from '../types';
 import { resolveCron } from './kinds/cron';
@@ -34,5 +37,30 @@ export function resolveSchedule(job: ScheduledJob, defaultTimezone: string): Sch
 				`scheduled_job ${job.id} has unknown kind '${String(exhaustive)}'`,
 			);
 		}
+	}
+}
+
+/**
+ * Builds the schedule a definition describes, filling a missing timezone with
+ * the instance default.
+ * @param definition The schedule definition.
+ * @param defaultTimezone Instance default for a definition with no timezone.
+ * @returns The schedule for that definition.
+ */
+export function scheduleFromDefinition(
+	definition: ScheduleDefinition,
+	defaultTimezone: string,
+): Schedule {
+	switch (definition.kind) {
+		case 'interval':
+		case 'one_off':
+			return definition;
+		case 'cron':
+		case 'recurring_cron':
+			return {
+				...definition,
+				cronExpression: definition.cronExpression as CronExpression,
+				timezone: definition.timezone ?? defaultTimezone,
+			};
 	}
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -38,6 +38,7 @@ import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import { DurableScheduler } from '@/scheduling/durable-scheduler';
 import { PollJobProvider } from '@/scheduling/poll-trigger-node/poll-job-provider';
+import { SystemTaskRunner } from '@/scheduling/system-tasks/system-task-runner';
 import { Server } from '@/server';
 import { JwtService } from '@/services/jwt.service';
 import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
@@ -423,6 +424,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		Container.get(WorkflowHistoryCompactionService).init();
 		Container.get(WorkflowStatisticsRollupService).init();
 		Container.get(N8NCheckpointStorage).init();
+		Container.get(SystemTaskRunner).init();
 		Container.get(DurableScheduler).start();
 
 		if (this.globalConfig.executions.mode === 'regular') {

--- a/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
@@ -272,6 +272,23 @@ describe('DurableScheduler', () => {
 		});
 	});
 
+	describe('isActive', () => {
+		it('is true on a main when the scheduler is enabled', () => {
+			const { scheduler } = makeScheduler({ enabled: true, instanceType: 'main' });
+
+			expect(scheduler.isActive()).toBe(true);
+		});
+
+		it.each([
+			{ case: 'the scheduler is disabled', enabled: false, instanceType: 'main' },
+			{ case: 'the instance is not a main', enabled: true, instanceType: 'webhook' },
+		])('is false when $case', ({ enabled, instanceType }) => {
+			const { scheduler } = makeScheduler({ enabled, instanceType });
+
+			expect(scheduler.isActive()).toBe(false);
+		});
+	});
+
 	describe('registerTaskHandler', () => {
 		it('delegates to the inner scheduler when active', () => {
 			const { scheduler, inner } = makeScheduler();

--- a/packages/cli/src/scheduling/durable-scheduler.ts
+++ b/packages/cli/src/scheduling/durable-scheduler.ts
@@ -99,6 +99,10 @@ export class DurableScheduler implements Scheduler {
 		this.registerTaskHandler(pollTriggerTaskHandler.taskType, pollTriggerTaskHandler);
 	}
 
+	isActive(): boolean {
+		return this.scheduler !== undefined;
+	}
+
 	registerTaskHandler(taskType: string, handler: TaskHandler): void {
 		if (this.scheduler === undefined) {
 			this.logger.debug(

--- a/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
@@ -11,6 +11,8 @@ export class DummySystemTask implements SystemTask {
 
 	durable = false;
 
+	runOnTakeover = false;
+
 	runCount = 0;
 
 	/** How a run settles. Replace it to make a run fail or to hold it open. */

--- a/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
@@ -1,0 +1,28 @@
+import { SystemTask } from '@n8n/decorators';
+import type { SystemTaskEffects, SystemTaskSchedule } from '@n8n/decorators';
+
+@SystemTask()
+export class DummySystemTask implements SystemTask {
+	name = 'dummy';
+
+	schedule: SystemTaskSchedule = { kind: 'interval', intervalSeconds: 60 };
+
+	effects: SystemTaskEffects = 'idempotent';
+
+	durable = false;
+
+	runCount = 0;
+
+	/** How a run settles. Replace it to make a run fail or to hold it open. */
+	onRun: () => Promise<void> = async () => {};
+
+	async run(): Promise<void> {
+		this.runCount++;
+		await this.onRun();
+	}
+}
+
+@SystemTask()
+export class OtherDummySystemTask extends DummySystemTask {
+	name = 'other-dummy';
+}

--- a/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
@@ -13,6 +13,8 @@ export class DummySystemTask implements SystemTask {
 
 	runOnTakeover = false;
 
+	retryDelaySeconds?: number;
+
 	runCount = 0;
 
 	/** How a run settles. Replace it to make a run fail or to hold it open. */

--- a/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/dummy.task.ts
@@ -14,11 +14,11 @@ export class DummySystemTask implements SystemTask {
 	runCount = 0;
 
 	/** How a run settles. Replace it to make a run fail or to hold it open. */
-	onRun: () => Promise<void> = async () => {};
+	onRun: (signal: AbortSignal) => Promise<void> = async () => {};
 
-	async run(): Promise<void> {
+	async run(signal: AbortSignal): Promise<void> {
 		this.runCount++;
-		await this.onRun();
+		await this.onRun(signal);
 	}
 }
 

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-handler.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-handler.test.ts
@@ -1,0 +1,95 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { ClaimedTask, DispatchReporter } from '@n8n/scheduler';
+import { createDispatchReporter } from '@n8n/scheduler';
+import { mock } from 'vitest-mock-extended';
+
+import { SystemTaskHandler } from '../system-task-handler';
+import { DummySystemTask } from './dummy.task';
+
+describe('SystemTaskHandler', () => {
+	const claimed = mock<ClaimedTask>({ id: 'task-1', jobId: 2 });
+
+	function setup(effects: DummySystemTask['effects']) {
+		const task = new DummySystemTask();
+		task.effects = effects;
+		const report = mock<DispatchReporter>();
+		const onRunError = vi.fn();
+		const handler = new SystemTaskHandler(task, mockLogger(), onRunError);
+		return { task, report, handler, onRunError };
+	}
+
+	it('runs the task', async () => {
+		const { task, report, handler } = setup('idempotent');
+
+		await handler.execute(claimed, report);
+
+		expect(task.runCount).toBe(1);
+	});
+
+	it('leaves idempotent work retryable', async () => {
+		const { report, handler } = setup('idempotent');
+
+		await handler.execute(claimed, report);
+
+		expect(report.notDispatched).toHaveBeenCalled();
+		expect(report.dispatched).not.toHaveBeenCalled();
+	});
+
+	it('marks non-idempotent work dispatched before it runs', async () => {
+		const { task, report, handler } = setup('non-idempotent');
+		task.onRun = async () => {
+			expect(report.dispatched).toHaveBeenCalled();
+		};
+
+		await handler.execute(claimed, report);
+
+		expect(task.runCount).toBe(1);
+		expect(report.notDispatched).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ effects: 'idempotent', decision: 'notDispatched' },
+		{ effects: 'non-idempotent', decision: 'dispatched' },
+	] as const)('returns the $decision token for $effects work', async ({ effects, decision }) => {
+		const task = new DummySystemTask();
+		task.effects = effects;
+		const report = createDispatchReporter(vi.fn());
+		const handler = new SystemTaskHandler(task, mockLogger(), vi.fn());
+
+		const returned = await handler.execute(claimed, report);
+
+		expect(returned).toBe(report[decision]());
+	});
+
+	it('lets a failing run reach the executor', async () => {
+		const { task, report, handler } = setup('idempotent');
+		task.onRun = async () => {
+			throw new Error('failed');
+		};
+
+		await expect(handler.execute(claimed, report)).rejects.toThrow('failed');
+	});
+
+	it.each(['idempotent', 'non-idempotent'] as const)(
+		'reports a failing run of %s work, which the executor would not',
+		async (effects) => {
+			const { task, report, handler, onRunError } = setup(effects);
+			const error = new Error('failed');
+			task.onRun = async () => {
+				throw error;
+			};
+
+			await expect(handler.execute(claimed, report)).rejects.toThrow(error);
+
+			expect(onRunError).toHaveBeenCalledWith(error);
+		},
+	);
+
+	it('does not report a run that succeeds', async () => {
+		const { report, handler, onRunError } = setup('idempotent');
+
+		await handler.execute(claimed, report);
+
+		expect(onRunError).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-handler.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-handler.test.ts
@@ -14,8 +14,9 @@ describe('SystemTaskHandler', () => {
 		task.effects = effects;
 		const report = mock<DispatchReporter>();
 		const onRunError = vi.fn();
-		const handler = new SystemTaskHandler(task, mockLogger(), onRunError);
-		return { task, report, handler, onRunError };
+		const shutdownSignal = new AbortController().signal;
+		const handler = new SystemTaskHandler(task, shutdownSignal, mockLogger(), onRunError);
+		return { task, report, handler, onRunError, shutdownSignal };
 	}
 
 	it('runs the task', async () => {
@@ -24,6 +25,18 @@ describe('SystemTaskHandler', () => {
 		await handler.execute(claimed, report);
 
 		expect(task.runCount).toBe(1);
+	});
+
+	it('hands the shutdown signal to the run', async () => {
+		const { task, report, handler, shutdownSignal } = setup('idempotent');
+		let seenSignal: AbortSignal | undefined;
+		task.onRun = async (signal) => {
+			seenSignal = signal;
+		};
+
+		await handler.execute(claimed, report);
+
+		expect(seenSignal).toBe(shutdownSignal);
 	});
 
 	it('leaves idempotent work retryable', async () => {
@@ -54,7 +67,12 @@ describe('SystemTaskHandler', () => {
 		const task = new DummySystemTask();
 		task.effects = effects;
 		const report = createDispatchReporter(vi.fn());
-		const handler = new SystemTaskHandler(task, mockLogger(), vi.fn());
+		const handler = new SystemTaskHandler(
+			task,
+			new AbortController().signal,
+			mockLogger(),
+			vi.fn(),
+		);
 
 		const returned = await handler.execute(claimed, report);
 

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-handler.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-handler.test.ts
@@ -14,9 +14,21 @@ describe('SystemTaskHandler', () => {
 		task.effects = effects;
 		const report = mock<DispatchReporter>();
 		const onRunError = vi.fn();
-		const shutdownSignal = new AbortController().signal;
-		const handler = new SystemTaskHandler(task, shutdownSignal, mockLogger(), onRunError);
-		return { task, report, handler, onRunError, shutdownSignal };
+		const shutdownController = new AbortController();
+		const handler = new SystemTaskHandler(
+			task,
+			shutdownController.signal,
+			mockLogger(),
+			onRunError,
+		);
+		return {
+			task,
+			report,
+			handler,
+			onRunError,
+			shutdownController,
+			shutdownSignal: shutdownController.signal,
+		};
 	}
 
 	it('runs the task', async () => {
@@ -102,6 +114,20 @@ describe('SystemTaskHandler', () => {
 			expect(onRunError).toHaveBeenCalledWith(error);
 		},
 	);
+
+	it('does not report a run that rejects once shutdown aborted its signal', async () => {
+		const { task, report, handler, onRunError, shutdownController } = setup('idempotent');
+		task.onRun = async (signal) =>
+			await new Promise<void>((_, reject) => {
+				signal.addEventListener('abort', () => reject(new Error('aborted')));
+			});
+
+		const executing = handler.execute(claimed, report);
+		shutdownController.abort();
+
+		await expect(executing).rejects.toThrow();
+		expect(onRunError).not.toHaveBeenCalled();
+	});
 
 	it('does not report a run that succeeds', async () => {
 		const { report, handler, onRunError } = setup('idempotent');

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
@@ -376,6 +376,22 @@ describe('SystemTaskRunner', () => {
 			await stopping;
 		});
 
+		it('does not report a run that rejects once stepdown aborted its signal', async () => {
+			const { runner, metadata, errorReporter, logger } = setup();
+			dummy.onRun = async (signal) =>
+				await new Promise<void>((_, reject) => {
+					signal.addEventListener('abort', () => reject(new Error('aborted')));
+				});
+			metadata.register(DummySystemTask);
+			runner.init();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			await runner.stopTimers();
+
+			expect(errorReporter.error).not.toHaveBeenCalled();
+			expect(logger.error).not.toHaveBeenCalled();
+		});
+
 		it('hands the runs of a later takeover a fresh signal', async () => {
 			const { runner, metadata } = setup();
 			const runSignals: AbortSignal[] = [];

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
@@ -223,6 +223,67 @@ describe('SystemTaskRunner', () => {
 			});
 		});
 
+		it('retries a failed run sooner when the task asks for it', async () => {
+			const { runner, metadata } = setup();
+			dummy.retryDelaySeconds = 5;
+			dummy.onRun = async () => {
+				if (dummy.runCount === 1) {
+					throw new Error('failed');
+				}
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+			expect(dummy.runCount).toBe(1);
+
+			await vi.advanceTimersByTimeAsync(5 * Time.seconds.toMilliseconds);
+			expect(dummy.runCount).toBe(2);
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS - 5 * Time.seconds.toMilliseconds);
+			expect(dummy.runCount).toBe(3);
+		});
+
+		it('keeps retrying while the runs keep failing', async () => {
+			const { runner, metadata } = setup();
+			dummy.retryDelaySeconds = 5;
+			dummy.onRun = async () => {
+				throw new Error('failed');
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS + 10 * Time.seconds.toMilliseconds);
+
+			expect(dummy.runCount).toBe(3);
+		});
+
+		it('does not retry a successful run', async () => {
+			const { runner, metadata } = setup();
+			dummy.retryDelaySeconds = 5;
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS + 30 * Time.seconds.toMilliseconds);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('does not retry non-idempotent work', async () => {
+			const { runner, metadata } = setup();
+			dummy.effects = 'non-idempotent';
+			dummy.retryDelaySeconds = 5;
+			dummy.onRun = async () => {
+				throw new Error('failed');
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS + 30 * Time.seconds.toMilliseconds);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
 		it('logs a failing run as well as reporting it', async () => {
 			const { runner, metadata, logger } = setup();
 			const error = new Error('failed');
@@ -332,6 +393,22 @@ describe('SystemTaskRunner', () => {
 			expect(runSignals).toHaveLength(2);
 			expect(runSignals[0].aborted).toBe(true);
 			expect(runSignals[1].aborted).toBe(false);
+		});
+
+		it('drops a pending retry on stepdown', async () => {
+			const { runner, metadata } = setup();
+			dummy.retryDelaySeconds = 5;
+			dummy.onRun = async () => {
+				throw new Error('failed');
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			await runner.stopTimers();
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(1);
 		});
 
 		it('starts the timers again on a later takeover', async () => {

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
@@ -583,6 +583,31 @@ describe('SystemTaskRunner', () => {
 			expect(dummy.runCount).toBe(1);
 		});
 
+		it.each([0, -5, 2.5, NaN, Infinity, 2_147_484])(
+			'rejects a task declaring a retry delay of %s',
+			(retryDelaySeconds) => {
+				dummy.retryDelaySeconds = retryDelaySeconds;
+				const { runner, metadata } = setup();
+				metadata.register(DummySystemTask);
+
+				expect(() => runner.init()).toThrow(
+					expect.objectContaining({
+						cause: expect.objectContaining({
+							message: expect.stringContaining('out-of-range retry delay'),
+						}),
+					}),
+				);
+			},
+		);
+
+		it('accepts the longest retry delay a timeout honors', () => {
+			dummy.retryDelaySeconds = 2_147_483;
+			const { runner, metadata } = setup();
+			metadata.register(DummySystemTask);
+
+			expect(() => runner.init()).not.toThrow();
+		});
+
 		it('rejects two tasks registered under the same name', () => {
 			const other = new OtherDummySystemTask();
 			other.name = dummy.name;

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
@@ -111,6 +111,51 @@ describe('SystemTaskRunner', () => {
 			expect(dummy.runCount).toBe(1);
 		});
 
+		it('runs a takeover task at once when the timers start', async () => {
+			const { runner, metadata } = setup({ isLeader: true });
+			dummy.runOnTakeover = true;
+			metadata.register(DummySystemTask);
+
+			runner.init();
+			expect(dummy.runCount).toBe(1);
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+			expect(dummy.runCount).toBe(2);
+		});
+
+		it('runs a takeover task registered after takeover at once', () => {
+			const { runner, metadata } = setup({ isLeader: true });
+			dummy.runOnTakeover = true;
+			runner.init();
+
+			metadata.register(DummySystemTask);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('does not run a takeover task on a follower', async () => {
+			const { runner, metadata } = setup({ isLeader: false });
+			dummy.runOnTakeover = true;
+			metadata.register(DummySystemTask);
+
+			runner.init();
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(0);
+		});
+
+		it('runs a takeover task again on a later takeover', async () => {
+			const { runner, metadata } = setup({ isLeader: true });
+			dummy.runOnTakeover = true;
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await runner.stopTimers();
+			runner.startTimers();
+
+			expect(dummy.runCount).toBe(2);
+		});
+
 		it('skips an occurrence while the previous run is still going', async () => {
 			const { runner, metadata, logger } = setup();
 			dummy.onRun = async () => await new Promise<void>(() => {});

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
@@ -269,6 +269,27 @@ describe('SystemTaskRunner', () => {
 			expect(dummy.runCount).toBe(1);
 		});
 
+		it('drops a pending retry once a newer occurrence runs', async () => {
+			const { runner, metadata } = setup();
+			dummy.retryDelaySeconds = 90;
+			dummy.onRun = async () => {
+				if (dummy.runCount === 1) {
+					throw new Error('failed');
+				}
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+			expect(dummy.runCount).toBe(1);
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+			expect(dummy.runCount).toBe(2);
+
+			await vi.advanceTimersByTimeAsync(45 * Time.seconds.toMilliseconds);
+			expect(dummy.runCount).toBe(2);
+		});
+
 		it('does not retry non-idempotent work', async () => {
 			const { runner, metadata } = setup();
 			dummy.effects = 'non-idempotent';

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
@@ -248,6 +248,47 @@ describe('SystemTaskRunner', () => {
 			expect(dummy.runCount).toBe(1);
 		});
 
+		it('aborts the signal of the run in flight on stepdown', async () => {
+			const { runner, metadata } = setup();
+			let runSignal: AbortSignal | undefined;
+			let releaseRun = () => {};
+			dummy.onRun = async (signal) => {
+				runSignal = signal;
+				await new Promise<void>((resolve) => {
+					releaseRun = resolve;
+				});
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+			expect(runSignal?.aborted).toBe(false);
+
+			const stopping = runner.stopTimers();
+
+			expect(runSignal?.aborted).toBe(true);
+			releaseRun();
+			await stopping;
+		});
+
+		it('hands the runs of a later takeover a fresh signal', async () => {
+			const { runner, metadata } = setup();
+			const runSignals: AbortSignal[] = [];
+			dummy.onRun = async (signal) => {
+				runSignals.push(signal);
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			await runner.stopTimers();
+			runner.startTimers();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			expect(runSignals).toHaveLength(2);
+			expect(runSignals[0].aborted).toBe(true);
+			expect(runSignals[1].aborted).toBe(false);
+		});
+
 		it('starts the timers again on a later takeover', async () => {
 			const { runner, metadata } = setup();
 			metadata.register(DummySystemTask);
@@ -341,6 +382,31 @@ describe('SystemTaskRunner', () => {
 				shouldBeLogged: false,
 				shouldIsolate: true,
 			});
+		});
+
+		it('aborts the signal of a durable run on shutdown', async () => {
+			dummy.durable = true;
+			const { runner, metadata, durableScheduler } = setup(durably);
+			let runSignal: AbortSignal | undefined;
+			let releaseRun = () => {};
+			dummy.onRun = async (signal) => {
+				runSignal = signal;
+				await new Promise<void>((resolve) => {
+					releaseRun = resolve;
+				});
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			const [, handler] = durableScheduler.registerTaskHandler.mock.calls[0];
+			const executing = handler.execute(mock<ClaimedTask>(), createDispatchReporter(vi.fn()));
+			expect(runSignal?.aborted).toBe(false);
+
+			await runner.shutdown();
+
+			expect(runSignal?.aborted).toBe(true);
+			releaseRun();
+			await executing;
 		});
 
 		it.each([

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-runner.test.ts
@@ -1,0 +1,399 @@
+import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
+import { SystemTaskMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { ClaimedTask } from '@n8n/scheduler';
+import { createDispatchReporter } from '@n8n/scheduler';
+import type { ErrorReporter, InstanceSettings } from 'n8n-core';
+import { mock } from 'vitest-mock-extended';
+
+import type { DurableScheduler } from '../../durable-scheduler';
+import { SystemTaskHandler } from '../system-task-handler';
+import { SystemTaskRunner } from '../system-task-runner';
+import { DummySystemTask, OtherDummySystemTask } from './dummy.task';
+
+const START = new Date('2026-01-01T00:00:00.000Z');
+const ONE_INTERVAL_MS = 60 * Time.seconds.toMilliseconds;
+
+describe('SystemTaskRunner', () => {
+	let dummy: DummySystemTask;
+
+	function setup({
+		isLeader = true,
+		schedulerActive = false,
+		enabledForSystemTasks = false,
+		instanceRole = 'leader' as InstanceSettings['instanceRole'],
+	} = {}) {
+		const logger = mock<Logger>();
+		const metadata = new SystemTaskMetadata();
+		const durableScheduler = mock<DurableScheduler>();
+		durableScheduler.isActive.mockReturnValue(schedulerActive);
+		const errorReporter = mock<ErrorReporter>();
+		const runner = new SystemTaskRunner(
+			mock<Logger>({ scoped: vi.fn().mockReturnValue(logger) }),
+			metadata,
+			durableScheduler,
+			mock<GlobalConfig>({
+				generic: { timezone: 'UTC' },
+				scheduler: { enabledForSystemTasks },
+			}),
+			mock<InstanceSettings>({ isLeader, instanceRole }),
+			errorReporter,
+		);
+
+		return { runner, metadata, durableScheduler, errorReporter, logger };
+	}
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(START);
+		dummy = new DummySystemTask();
+		Container.set(DummySystemTask, dummy);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		Container.reset();
+	});
+
+	describe('in-memory timers', () => {
+		it('fires a task registered before it took over the registry', async () => {
+			const { runner, metadata } = setup({ isLeader: true });
+			metadata.register(DummySystemTask);
+
+			runner.init();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('fires a task registered after it took over the registry', async () => {
+			const { runner, metadata } = setup({ isLeader: true });
+			runner.init();
+
+			metadata.register(DummySystemTask);
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('does not fire on a follower', async () => {
+			const { runner, metadata } = setup({ isLeader: false });
+			metadata.register(DummySystemTask);
+
+			runner.init();
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(0);
+		});
+
+		it('starts firing on leader takeover', async () => {
+			const { runner, metadata } = setup({ isLeader: false });
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			runner.startTimers();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('leaves a running timer alone when leadership is announced again', async () => {
+			const { runner, metadata } = setup();
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS / 2);
+			runner.startTimers();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS / 2);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('skips an occurrence while the previous run is still going', async () => {
+			const { runner, metadata, logger } = setup();
+			dummy.onRun = async () => await new Promise<void>(() => {});
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(2 * ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(1);
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Skipped'), {
+				name: 'dummy',
+			});
+		});
+
+		it('warns once per stuck run, not once per skipped occurrence', async () => {
+			const { runner, metadata, logger } = setup();
+			dummy.onRun = async () => await new Promise<void>(() => {});
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+
+			const skipWarnings = logger.warn.mock.calls.filter(([message]) =>
+				message.includes('Skipped'),
+			);
+			expect(skipWarnings).toHaveLength(1);
+		});
+
+		it('warns again once a later run gets stuck', async () => {
+			const { runner, metadata, logger } = setup();
+			let releaseRun = () => {};
+			dummy.onRun = async () =>
+				await new Promise<void>((resolve) => {
+					releaseRun = resolve;
+				});
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(2 * ONE_INTERVAL_MS);
+			releaseRun();
+			await vi.advanceTimersByTimeAsync(2 * ONE_INTERVAL_MS);
+
+			const skipWarnings = logger.warn.mock.calls.filter(([message]) =>
+				message.includes('Skipped'),
+			);
+			expect(skipWarnings).toHaveLength(2);
+		});
+
+		it('reports a failing run and keeps the cadence', async () => {
+			const { runner, metadata, errorReporter } = setup();
+			const error = new Error('failed');
+			dummy.onRun = async () => {
+				throw error;
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(2 * ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(2);
+			expect(errorReporter.error).toHaveBeenCalledWith(error, {
+				extra: { systemTask: 'dummy' },
+				shouldBeLogged: false,
+				shouldIsolate: true,
+			});
+		});
+
+		it('logs a failing run as well as reporting it', async () => {
+			const { runner, metadata, logger } = setup();
+			const error = new Error('failed');
+			dummy.onRun = async () => {
+				throw error;
+			};
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('run failed'), {
+				name: 'dummy',
+				error,
+			});
+		});
+
+		it('logs and reports a schedule it cannot plan', async () => {
+			const { runner, metadata, logger, errorReporter } = setup();
+			dummy.schedule = { kind: 'cron', cronExpression: 'not-a-cron', timezone: 'UTC' };
+			metadata.register(DummySystemTask);
+
+			runner.init();
+
+			expect(logger.error).toHaveBeenCalledWith(
+				expect.stringContaining('will not run'),
+				expect.objectContaining({ name: 'dummy' }),
+			);
+			expect(errorReporter.error).toHaveBeenCalledWith(
+				expect.any(Error),
+				expect.objectContaining({ extra: { systemTask: 'dummy' } }),
+			);
+		});
+	});
+
+	describe('leadership and shutdown', () => {
+		it('refuses to init before the instance role is resolved', () => {
+			const { runner, metadata } = setup({ instanceRole: 'unset' });
+			metadata.register(DummySystemTask);
+
+			expect(() => runner.init()).toThrow('Instance role is not set');
+		});
+
+		it('stops the timers on stepdown, awaiting the run in flight', async () => {
+			const { runner, metadata } = setup();
+			let releaseRun = () => {};
+			dummy.onRun = async () =>
+				await new Promise<void>((resolve) => {
+					releaseRun = resolve;
+				});
+			metadata.register(DummySystemTask);
+			runner.init();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			const stopping = runner.stopTimers();
+			let stopped = false;
+			void stopping.then(() => {
+				stopped = true;
+			});
+			await Promise.resolve();
+			expect(stopped).toBe(false);
+
+			releaseRun();
+			await stopping;
+			expect(stopped).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('starts the timers again on a later takeover', async () => {
+			const { runner, metadata } = setup();
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await runner.stopTimers();
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+			expect(dummy.runCount).toBe(0);
+
+			runner.startTimers();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('does not start the timers again after shutdown', async () => {
+			const { runner, metadata } = setup();
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			await runner.shutdown();
+			runner.startTimers();
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+
+			expect(dummy.runCount).toBe(0);
+		});
+	});
+
+	describe('routing', () => {
+		const durably = { schedulerActive: true, enabledForSystemTasks: true };
+
+		it('hands a durable task to the durable scheduler', async () => {
+			dummy.durable = true;
+			const { runner, metadata, durableScheduler } = setup(durably);
+			metadata.register(DummySystemTask);
+
+			runner.init();
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+
+			expect(durableScheduler.registerTaskHandler).toHaveBeenCalledWith(
+				'system:dummy',
+				expect.any(SystemTaskHandler),
+			);
+			expect(dummy.runCount).toBe(0);
+		});
+
+		it('hands a durable task registered after it took over the registry to the scheduler', async () => {
+			dummy.durable = true;
+			const { runner, metadata, durableScheduler } = setup(durably);
+			runner.init();
+
+			metadata.register(DummySystemTask);
+			await vi.advanceTimersByTimeAsync(10 * ONE_INTERVAL_MS);
+
+			expect(durableScheduler.registerTaskHandler).toHaveBeenCalledWith(
+				'system:dummy',
+				expect.any(SystemTaskHandler),
+			);
+			expect(dummy.runCount).toBe(0);
+		});
+
+		it('warns that a task handed to the scheduler has no occurrences yet', () => {
+			dummy.durable = true;
+			const { runner, metadata, logger } = setup(durably);
+			metadata.register(DummySystemTask);
+
+			runner.init();
+
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('will not run'), {
+				name: 'dummy',
+			});
+		});
+
+		it('reports a failing durable run, which the executor would not', async () => {
+			dummy.durable = true;
+			const error = new Error('failed');
+			dummy.onRun = async () => {
+				throw error;
+			};
+			const { runner, metadata, durableScheduler, errorReporter } = setup(durably);
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			const [, handler] = durableScheduler.registerTaskHandler.mock.calls[0];
+			await expect(
+				handler.execute(mock<ClaimedTask>(), createDispatchReporter(vi.fn())),
+			).rejects.toThrow(error);
+
+			expect(errorReporter.error).toHaveBeenCalledWith(error, {
+				extra: { systemTask: 'dummy' },
+				shouldBeLogged: false,
+				shouldIsolate: true,
+			});
+		});
+
+		it.each([
+			{
+				case: 'the durable scheduler is inactive',
+				schedulerActive: false,
+				enabledForSystemTasks: true,
+			},
+			{ case: 'the system-task flag is off', schedulerActive: true, enabledForSystemTasks: false },
+		])(
+			'keeps a durable task on its timer while $case',
+			async ({ schedulerActive, enabledForSystemTasks }) => {
+				dummy.durable = true;
+				const { runner, metadata, durableScheduler } = setup({
+					schedulerActive,
+					enabledForSystemTasks,
+				});
+				metadata.register(DummySystemTask);
+
+				runner.init();
+				await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+				expect(durableScheduler.registerTaskHandler).not.toHaveBeenCalled();
+				expect(dummy.runCount).toBe(1);
+			},
+		);
+
+		it('keeps a task that has not migrated on its timer', async () => {
+			const { runner, metadata, durableScheduler } = setup(durably);
+			metadata.register(DummySystemTask);
+
+			runner.init();
+			await vi.advanceTimersByTimeAsync(ONE_INTERVAL_MS);
+
+			expect(durableScheduler.registerTaskHandler).not.toHaveBeenCalled();
+			expect(dummy.runCount).toBe(1);
+		});
+
+		it('rejects two tasks registered under the same name', () => {
+			const other = new OtherDummySystemTask();
+			other.name = dummy.name;
+			Container.set(OtherDummySystemTask, other);
+			const { runner, metadata } = setup();
+			metadata.register(DummySystemTask);
+			runner.init();
+
+			expect(() => metadata.register(OtherDummySystemTask)).toThrow(
+				expect.objectContaining({
+					cause: expect.objectContaining({
+						message: expect.stringContaining('more than once'),
+					}),
+				}),
+			);
+		});
+	});
+});

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-timer.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-timer.test.ts
@@ -160,6 +160,17 @@ describe('SystemTaskTimer', () => {
 		expect(onFire).not.toHaveBeenCalled();
 	});
 
+	it('does not keep the process alive while waiting', () => {
+		const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+		const timer = createTimer({ kind: 'interval', intervalSeconds: 60 });
+
+		timer.start(new Date());
+
+		const pending = setTimeoutSpy.mock.results.at(-1)?.value as NodeJS.Timeout;
+		expect(pending.hasRef()).toBe(false);
+		setTimeoutSpy.mockRestore();
+	});
+
 	it('stops firing once stopped', () => {
 		const timer = createTimer({ kind: 'interval', intervalSeconds: 60 });
 

--- a/packages/cli/src/scheduling/system-tasks/__tests__/system-task-timer.test.ts
+++ b/packages/cli/src/scheduling/system-tasks/__tests__/system-task-timer.test.ts
@@ -1,0 +1,200 @@
+import { Time } from '@n8n/constants';
+import type { SystemTaskSchedule } from '@n8n/decorators';
+import { scheduleFromDefinition } from '@n8n/scheduler';
+
+import { SystemTaskTimer } from '../system-task-timer';
+
+const START = new Date('2026-01-01T00:00:00.000Z');
+
+/** The longest delay Node's `setTimeout` accepts before it fires straight away. */
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
+describe('SystemTaskTimer', () => {
+	const onFire = vi.fn();
+	const onPlanError = vi.fn();
+
+	function createTimer(schedule: SystemTaskSchedule) {
+		return new SystemTaskTimer(scheduleFromDefinition(schedule, 'UTC'), onFire, onPlanError);
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.setSystemTime(START);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('fires on every occurrence of an interval schedule', () => {
+		const timer = createTimer({ kind: 'interval', intervalSeconds: 60 });
+
+		timer.start(new Date());
+
+		vi.advanceTimersByTime(59 * Time.seconds.toMilliseconds);
+		expect(onFire).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1 * Time.seconds.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(3 * 60 * Time.seconds.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(4);
+	});
+
+	it('fires on every occurrence of a cron schedule', () => {
+		const timer = createTimer({ kind: 'cron', cronExpression: '0 0 * * * *', timezone: 'UTC' });
+
+		timer.start(new Date());
+
+		vi.advanceTimersByTime(59 * Time.minutes.toMilliseconds);
+		expect(onFire).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1 * Time.minutes.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(1 * Time.hours.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(2);
+	});
+
+	it('seeds a recurring cron at its next cron instant, not a stride away', () => {
+		const timer = createTimer({
+			kind: 'recurring_cron',
+			cronExpression: '0 0 * * *',
+			timezone: 'UTC',
+			recurrenceUnit: 'days',
+			recurrenceSize: 3,
+		});
+
+		timer.start(new Date());
+
+		// The every-N rule has no previous fire to count from yet, so the first fire
+		// is the next cron instant.
+		vi.advanceTimersByTime(1 * Time.days.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(1);
+
+		// From there the rule applies: three days on from the fire, not from the start.
+		vi.advanceTimersByTime(2 * Time.days.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(1 * Time.days.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(2);
+	});
+
+	it('coalesces the occurrences a stalled process slept through', () => {
+		let clock = START.getTime();
+		const timer = new SystemTaskTimer(
+			scheduleFromDefinition({ kind: 'interval', intervalSeconds: 60 }, 'UTC'),
+			onFire,
+			onPlanError,
+			() => clock,
+		);
+
+		timer.start(new Date(clock));
+
+		// An hour of occurrences goes by with the event loop blocked: the wall clock
+		// moved on, the callback only runs once the loop is free again.
+		clock = START.getTime() + Time.hours.toMilliseconds;
+		vi.advanceTimersByTime(60 * Time.seconds.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(1);
+
+		// The cadence resumes from there rather than replaying the backlog.
+		vi.advanceTimersByTime(59 * Time.seconds.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(1 * Time.seconds.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(2);
+	});
+
+	it('hops to the horizon instead of firing at once when the next fire is far off', () => {
+		const timer = createTimer({ kind: 'interval', intervalSeconds: 40 * Time.days.toSeconds });
+
+		timer.start(new Date());
+
+		vi.advanceTimersByTime(MAX_TIMEOUT_MS);
+		expect(onFire).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(40 * Time.days.toMilliseconds - MAX_TIMEOUT_MS);
+		expect(onFire).toHaveBeenCalledTimes(1);
+	});
+
+	it('still fires an occurrence the process slept through during a horizon hop', () => {
+		let clock = START.getTime();
+		const timer = new SystemTaskTimer(
+			scheduleFromDefinition(
+				{ kind: 'interval', intervalSeconds: 40 * Time.days.toSeconds },
+				'UTC',
+			),
+			onFire,
+			onPlanError,
+			() => clock,
+		);
+
+		timer.start(new Date(clock));
+
+		// The fire time passes while the hop is pending, so the hop's callback finds
+		// it already behind: the occurrence is late, not skipped.
+		clock = START.getTime() + 50 * Time.days.toMilliseconds;
+		vi.advanceTimersByTime(MAX_TIMEOUT_MS + 1);
+
+		expect(onFire).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports a schedule it cannot plan and stays stopped', () => {
+		const timer = createTimer({ kind: 'cron', cronExpression: 'not-a-cron', timezone: 'UTC' });
+
+		timer.start(new Date());
+
+		expect(onPlanError).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(10 * Time.days.toMilliseconds);
+		expect(onFire).not.toHaveBeenCalled();
+	});
+
+	it('reports a fire time past the representable date range and stays stopped', () => {
+		const timer = createTimer({ kind: 'interval', intervalSeconds: Number.MAX_SAFE_INTEGER });
+
+		timer.start(new Date());
+
+		expect(onPlanError).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(10 * Time.days.toMilliseconds);
+		expect(onFire).not.toHaveBeenCalled();
+	});
+
+	it('stops firing once stopped', () => {
+		const timer = createTimer({ kind: 'interval', intervalSeconds: 60 });
+
+		timer.start(new Date());
+		timer.stop();
+
+		vi.advanceTimersByTime(10 * 60 * Time.seconds.toMilliseconds);
+		expect(onFire).not.toHaveBeenCalled();
+	});
+
+	it('replaces a running timer on restart, rather than firing twice', () => {
+		const timer = createTimer({ kind: 'interval', intervalSeconds: 60 });
+
+		timer.start(new Date());
+		vi.advanceTimersByTime(30 * Time.seconds.toMilliseconds);
+		timer.start(new Date());
+
+		vi.advanceTimersByTime(30 * Time.seconds.toMilliseconds);
+		expect(onFire).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(30 * Time.seconds.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the cadence after a fire throws', () => {
+		const timer = createTimer({ kind: 'interval', intervalSeconds: 60 });
+		onFire.mockImplementationOnce(() => {
+			throw new Error('failed');
+		});
+
+		timer.start(new Date());
+
+		expect(() => vi.advanceTimersByTime(60 * Time.seconds.toMilliseconds)).toThrow('failed');
+
+		vi.advanceTimersByTime(60 * Time.seconds.toMilliseconds);
+		expect(onFire).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/cli/src/scheduling/system-tasks/system-task-handler.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-handler.ts
@@ -1,0 +1,37 @@
+import type { Logger } from '@n8n/backend-common';
+import type { SystemTask } from '@n8n/decorators';
+import type { ClaimedTask, DispatchDecision, DispatchReporter, TaskHandler } from '@n8n/scheduler';
+
+/**
+ * Runs one durable occurrence of a system task.
+ *
+ * Errors propagate: the executor is what retries the occurrence or gives up on
+ * it, following the attempt limit carried by the occurrence's job row.
+ */
+export class SystemTaskHandler implements TaskHandler {
+	constructor(
+		private readonly systemTask: SystemTask,
+		private readonly logger: Logger,
+		private readonly onRunError: (error: unknown) => void,
+	) {}
+
+	async execute(task: ClaimedTask, report: DispatchReporter): Promise<DispatchDecision> {
+		const decision =
+			this.systemTask.effects === 'non-idempotent' ? report.dispatched() : report.notDispatched();
+
+		try {
+			await this.systemTask.run();
+		} catch (error) {
+			this.onRunError(error);
+			throw error;
+		}
+
+		this.logger.debug('Ran a system task occurrence', {
+			name: this.systemTask.name,
+			taskId: task.id,
+			jobId: task.jobId,
+		});
+
+		return decision;
+	}
+}

--- a/packages/cli/src/scheduling/system-tasks/system-task-handler.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-handler.ts
@@ -24,7 +24,12 @@ export class SystemTaskHandler implements TaskHandler {
 		try {
 			await this.systemTask.run(this.shutdownSignal);
 		} catch (error) {
-			this.onRunError(error);
+			// A rejection after shutdown aborted the signal is the task honoring
+			// the abort, not a failure. It still propagates so the executor keeps
+			// deciding the occurrence's fate.
+			if (!this.shutdownSignal.aborted) {
+				this.onRunError(error);
+			}
 			throw error;
 		}
 

--- a/packages/cli/src/scheduling/system-tasks/system-task-handler.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-handler.ts
@@ -3,7 +3,8 @@ import type { SystemTask } from '@n8n/decorators';
 import type { ClaimedTask, DispatchDecision, DispatchReporter, TaskHandler } from '@n8n/scheduler';
 
 /**
- * Runs one durable occurrence of a system task.
+ * Runs one durable occurrence of a system task, handing it `shutdownSignal` so
+ * it can stop early when the instance shuts down.
  *
  * Errors propagate: the executor is what retries the occurrence or gives up on
  * it, following the attempt limit carried by the occurrence's job row.
@@ -11,6 +12,7 @@ import type { ClaimedTask, DispatchDecision, DispatchReporter, TaskHandler } fro
 export class SystemTaskHandler implements TaskHandler {
 	constructor(
 		private readonly systemTask: SystemTask,
+		private readonly shutdownSignal: AbortSignal,
 		private readonly logger: Logger,
 		private readonly onRunError: (error: unknown) => void,
 	) {}
@@ -20,7 +22,7 @@ export class SystemTaskHandler implements TaskHandler {
 			this.systemTask.effects === 'non-idempotent' ? report.dispatched() : report.notDispatched();
 
 		try {
-			await this.systemTask.run();
+			await this.systemTask.run(this.shutdownSignal);
 		} catch (error) {
 			this.onRunError(error);
 			throw error;

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
 import type { SystemTask, SystemTaskClass } from '@n8n/decorators';
 import {
 	OnLeaderStepdown,
@@ -27,6 +28,7 @@ type RoutedTask = {
 	task: SystemTask;
 	timer?: SystemTaskTimer;
 	inFlightRun?: InFlightRun;
+	retryTimer?: NodeJS.Timeout;
 };
 
 /**
@@ -109,8 +111,10 @@ export class SystemTaskRunner {
 	async stopTimers(): Promise<void> {
 		this.timersStarted = false;
 		this.inMemoryRunsController.abort();
-		for (const { timer } of this.inMemoryTasks()) {
-			timer.stop();
+		for (const routed of this.inMemoryTasks()) {
+			routed.timer.stop();
+			clearTimeout(routed.retryTimer);
+			routed.retryTimer = undefined;
 		}
 		this.logger.debug('Stopped the in-memory system task timers');
 		await Promise.all(this.inFlightRuns());
@@ -228,7 +232,7 @@ export class SystemTaskRunner {
 			}
 		} else {
 			const inFlightRun: InFlightRun = {
-				promise: this.runOnce(task).finally(() => {
+				promise: this.runOnce(routed).finally(() => {
 					if (routed.inFlightRun === inFlightRun) {
 						routed.inFlightRun = undefined;
 					}
@@ -241,12 +245,26 @@ export class SystemTaskRunner {
 		}
 	}
 
-	private async runOnce(task: SystemTask): Promise<void> {
+	private async runOnce(routed: RoutedTask): Promise<void> {
 		try {
-			await task.run(this.inMemoryRunsController.signal);
+			await routed.task.run(this.inMemoryRunsController.signal);
 		} catch (error) {
-			this.reportFailure('A system task run failed', task, error);
+			this.reportFailure('A system task run failed', routed.task, error);
+			this.scheduleRetry(routed);
 		}
+	}
+
+	private scheduleRetry(routed: RoutedTask): void {
+		const { retryDelaySeconds, effects } = routed.task;
+		if (retryDelaySeconds === undefined || effects === 'non-idempotent' || !this.timersStarted) {
+			return;
+		}
+
+		clearTimeout(routed.retryTimer);
+		routed.retryTimer = setTimeout(() => {
+			void this.run(routed);
+		}, retryDelaySeconds * Time.seconds.toMilliseconds);
+		routed.retryTimer.unref();
 	}
 
 	private reportFailure(message: string, task: SystemTask, error: unknown): void {

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -246,11 +246,16 @@ export class SystemTaskRunner {
 	}
 
 	private async runOnce(routed: RoutedTask): Promise<void> {
+		const { signal } = this.inMemoryRunsController;
 		try {
-			await routed.task.run(this.inMemoryRunsController.signal);
+			await routed.task.run(signal);
 		} catch (error) {
-			this.reportFailure('A system task run failed', routed.task, error);
-			this.scheduleRetry(routed);
+			// A rejection after the run's signal aborted is the task honoring the
+			// abort, not a failure.
+			if (!signal.aborted) {
+				this.reportFailure('A system task run failed', routed.task, error);
+				this.scheduleRetry(routed);
+			}
 		}
 	}
 

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -51,6 +51,10 @@ export class SystemTaskRunner {
 
 	private isShuttingDown = false;
 
+	private inMemoryRunsController = new AbortController();
+
+	private readonly shutdownController = new AbortController();
+
 	constructor(
 		logger: Logger,
 		private readonly metadata: SystemTaskMetadata,
@@ -86,6 +90,7 @@ export class SystemTaskRunner {
 	startTimers(): void {
 		if (!this.isShuttingDown && !this.timersStarted) {
 			this.timersStarted = true;
+			this.inMemoryRunsController = new AbortController();
 			const from = new Date();
 			const timers = this.inMemoryTimers();
 			for (const timer of timers) {
@@ -98,6 +103,7 @@ export class SystemTaskRunner {
 	@OnLeaderStepdown()
 	async stopTimers(): Promise<void> {
 		this.timersStarted = false;
+		this.inMemoryRunsController.abort();
 		for (const timer of this.inMemoryTimers()) {
 			timer.stop();
 		}
@@ -118,6 +124,7 @@ export class SystemTaskRunner {
 	@OnShutdown()
 	async shutdown(): Promise<void> {
 		this.isShuttingDown = true;
+		this.shutdownController.abort();
 		await this.stopTimers();
 	}
 
@@ -148,7 +155,7 @@ export class SystemTaskRunner {
 		if (this.runsDurably(task)) {
 			this.durableScheduler.registerTaskHandler(
 				systemTaskType(task.name),
-				new SystemTaskHandler(task, this.logger, (error) =>
+				new SystemTaskHandler(task, this.shutdownController.signal, this.logger, (error) =>
 					this.reportFailure('A durable system task run failed', task, error),
 				),
 			);
@@ -226,7 +233,7 @@ export class SystemTaskRunner {
 
 	private async runOnce(task: SystemTask): Promise<void> {
 		try {
-			await task.run();
+			await task.run(this.inMemoryRunsController.signal);
 		} catch (error) {
 			this.reportFailure('A system task run failed', task, error);
 		}

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -253,6 +253,10 @@ export class SystemTaskRunner {
 				});
 			}
 		} else {
+			// A newer occurrence runs the same work, so it supersedes a pending retry.
+			clearTimeout(routed.retryTimer);
+			routed.retryTimer = undefined;
+
 			const inFlightRun: InFlightRun = {
 				promise: this.runOnce(routed).finally(() => {
 					if (routed.inFlightRun === inFlightRun) {

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -1,0 +1,243 @@
+import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import type { SystemTask, SystemTaskClass } from '@n8n/decorators';
+import {
+	OnLeaderStepdown,
+	OnLeaderTakeover,
+	OnShutdown,
+	SystemTaskMetadata,
+} from '@n8n/decorators';
+import { Container, Service } from '@n8n/di';
+import { scheduleFromDefinition } from '@n8n/scheduler';
+import { ErrorReporter, InstanceSettings } from 'n8n-core';
+import { UnexpectedError } from 'n8n-workflow';
+import { strict } from 'node:assert';
+
+import { DurableScheduler } from '../durable-scheduler';
+import { SystemTaskHandler } from './system-task-handler';
+import { SystemTaskTimer } from './system-task-timer';
+import { systemTaskType } from './system-task-type';
+
+type InFlightRun = {
+	promise: Promise<void>;
+	skipWarned: boolean;
+};
+
+type RoutedTask = {
+	task: SystemTask;
+	timer?: SystemTaskTimer;
+	inFlightRun?: InFlightRun;
+};
+
+/**
+ * The single owner of the system tasks' run loop: it consumes the registry and
+ * routes each task to the mode it runs in.
+ *
+ * - A task marked durable, on a main with the durable scheduler and its
+ *   system-task flag on, is handed to the database-backed queue: it gets a
+ *   {@link SystemTaskHandler} registered under its task type, so occurrences
+ *   claimed for that type are dispatched to it.
+ * - Every other task runs from an in-memory timer on the leader.
+ */
+@Service()
+export class SystemTaskRunner {
+	private readonly routedTasksByName = new Map<string, RoutedTask>();
+
+	private readonly logger: Logger;
+
+	private initialized = false;
+
+	private timersStarted = false;
+
+	private isShuttingDown = false;
+
+	constructor(
+		logger: Logger,
+		private readonly metadata: SystemTaskMetadata,
+		private readonly durableScheduler: DurableScheduler,
+		private readonly globalConfig: GlobalConfig,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly errorReporter: ErrorReporter,
+	) {
+		this.logger = logger.scoped('system-tasks');
+	}
+
+	/**
+	 * Take ownership of the registry: route every task registered so far and
+	 * every one registered later, then start the in-memory timers if this
+	 * instance is already the leader. Later leadership changes arrive through
+	 * {@link startTimers} and {@link stopTimers}.
+	 */
+	init(): void {
+		strict(this.instanceSettings.instanceRole !== 'unset', 'Instance role is not set');
+
+		if (!this.initialized) {
+			this.initialized = true;
+
+			this.metadata.subscribe((taskClass) => this.route(taskClass));
+
+			if (this.instanceSettings.isLeader) {
+				this.startTimers();
+			}
+		}
+	}
+
+	@OnLeaderTakeover()
+	startTimers(): void {
+		if (!this.isShuttingDown && !this.timersStarted) {
+			this.timersStarted = true;
+			const from = new Date();
+			const timers = this.inMemoryTimers();
+			for (const timer of timers) {
+				timer.start(from);
+			}
+			this.logger.debug('Started the in-memory system task timers', { count: timers.length });
+		}
+	}
+
+	@OnLeaderStepdown()
+	async stopTimers(): Promise<void> {
+		this.timersStarted = false;
+		for (const timer of this.inMemoryTimers()) {
+			timer.stop();
+		}
+		this.logger.debug('Stopped the in-memory system task timers');
+		await Promise.all(this.inFlightRuns());
+	}
+
+	private inMemoryTimers(): SystemTaskTimer[] {
+		return [...this.routedTasksByName.values()].flatMap(({ timer }) => (timer ? [timer] : []));
+	}
+
+	private inFlightRuns(): Array<Promise<void>> {
+		return [...this.routedTasksByName.values()].flatMap(({ inFlightRun }) =>
+			inFlightRun ? [inFlightRun.promise] : [],
+		);
+	}
+
+	@OnShutdown()
+	async shutdown(): Promise<void> {
+		this.isShuttingDown = true;
+		await this.stopTimers();
+	}
+
+	/**
+	 * Resolve a registered class and give its task a mode. Resolving eagerly is
+	 * safe: `@SystemTask()` makes the class injectable before it registers, and
+	 * the name and schedule the routing needs live on the instance.
+	 *
+	 * @throws {UnexpectedError} When a name is registered more than once, whether by
+	 * two tasks claiming it or by one task's module being loaded twice. It surfaces
+	 * out of {@link init} for a task registered before it, and out of the task's own
+	 * `@SystemTask()` decorator for one registered after. Either way the runner is
+	 * left half-routed and startup fails, which is the point: a duplicate name is a
+	 * coding mistake.
+	 */
+	private route(taskClass: SystemTaskClass): void {
+		const task = Container.get(taskClass);
+
+		if (this.routedTasksByName.has(task.name)) {
+			throw new UnexpectedError('A system task name is registered more than once', {
+				extra: { name: task.name },
+			});
+		}
+
+		const routed: RoutedTask = { task };
+		this.routedTasksByName.set(task.name, routed);
+
+		if (this.runsDurably(task)) {
+			this.durableScheduler.registerTaskHandler(
+				systemTaskType(task.name),
+				new SystemTaskHandler(task, this.logger, (error) =>
+					this.reportFailure('A durable system task run failed', task, error),
+				),
+			);
+			// Warn rather than debug while nothing provisions the occurrences: an
+			// operator who turns the flag on otherwise sees the task simply stop.
+			this.logger.warn(
+				'System task handed to the durable scheduler, which does not provision its occurrences yet, so it will not run',
+				{ name: task.name },
+			);
+		} else {
+			routed.timer = this.createTimer(routed);
+			this.logger.debug('System task will run on an in-memory timer', { name: task.name });
+
+			if (this.timersStarted) {
+				routed.timer.start(new Date());
+			}
+		}
+	}
+
+	private runsDurably(task: SystemTask): boolean {
+		return (
+			task.durable &&
+			this.globalConfig.scheduler.enabledForSystemTasks &&
+			this.durableScheduler.isActive()
+		);
+	}
+
+	private createTimer(routed: RoutedTask): SystemTaskTimer {
+		const { task } = routed;
+		const schedule = scheduleFromDefinition(task.schedule, this.globalConfig.generic.timezone);
+
+		return new SystemTaskTimer(
+			schedule,
+			() => {
+				void this.run(routed);
+			},
+			(error) =>
+				this.reportFailure(
+					'Could not plan a system task schedule, so the task will not run',
+					task,
+					error,
+				),
+		);
+	}
+
+	/**
+	 * Run one occurrence in memory, at most one at a time per task: a run that
+	 * outlasts its own cadence skips the next occurrence instead of overlapping
+	 * itself.
+	 */
+	private async run(routed: RoutedTask): Promise<void> {
+		const { task } = routed;
+
+		if (routed.inFlightRun) {
+			if (!routed.inFlightRun.skipWarned) {
+				routed.inFlightRun.skipWarned = true;
+				this.logger.warn('Skipped a system task occurrence, its previous run is still going', {
+					name: task.name,
+				});
+			}
+		} else {
+			const inFlightRun: InFlightRun = {
+				promise: this.runOnce(task).finally(() => {
+					if (routed.inFlightRun === inFlightRun) {
+						routed.inFlightRun = undefined;
+					}
+				}),
+				skipWarned: false,
+			};
+			routed.inFlightRun = inFlightRun;
+
+			await inFlightRun.promise;
+		}
+	}
+
+	private async runOnce(task: SystemTask): Promise<void> {
+		try {
+			await task.run();
+		} catch (error) {
+			this.reportFailure('A system task run failed', task, error);
+		}
+	}
+
+	private reportFailure(message: string, task: SystemTask, error: unknown): void {
+		this.logger.error(message, { name: task.name, error });
+		this.errorReporter.error(error, {
+			extra: { systemTask: task.name },
+			shouldBeLogged: false,
+			shouldIsolate: true,
+		});
+	}
+}

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -19,6 +19,12 @@ import { SystemTaskHandler } from './system-task-handler';
 import { SystemTaskTimer } from './system-task-timer';
 import { systemTaskType } from './system-task-type';
 
+/**
+ * Longest retry delay whose millisecond value still fits the signed 32-bit
+ * range a timeout honors. Node fires anything outside it after about 1 ms.
+ */
+const MAX_RETRY_DELAY_SECONDS = Math.floor((2 ** 31 - 1) / Time.seconds.toMilliseconds);
+
 type InFlightRun = {
 	promise: Promise<void>;
 	skipWarned: boolean;
@@ -150,6 +156,10 @@ export class SystemTaskRunner {
 	 * `@SystemTask()` decorator for one registered after. Either way the runner is
 	 * left half-routed and startup fails, which is the point: a duplicate name is a
 	 * coding mistake.
+	 *
+	 * @throws {UnexpectedError} When a task declares a `retryDelaySeconds` that is
+	 * not an integer between 1 and {@link MAX_RETRY_DELAY_SECONDS}. A timeout would
+	 * silently turn such a delay into an immediate retry.
 	 */
 	private route(taskClass: SystemTaskClass): void {
 		const task = Container.get(taskClass);
@@ -157,6 +167,18 @@ export class SystemTaskRunner {
 		if (this.routedTasksByName.has(task.name)) {
 			throw new UnexpectedError('A system task name is registered more than once', {
 				extra: { name: task.name },
+			});
+		}
+
+		const { retryDelaySeconds } = task;
+		if (
+			retryDelaySeconds !== undefined &&
+			(!Number.isInteger(retryDelaySeconds) ||
+				retryDelaySeconds < 1 ||
+				retryDelaySeconds > MAX_RETRY_DELAY_SECONDS)
+		) {
+			throw new UnexpectedError('A system task declares an out-of-range retry delay', {
+				extra: { name: task.name, retryDelaySeconds },
 			});
 		}
 

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -92,11 +92,16 @@ export class SystemTaskRunner {
 			this.timersStarted = true;
 			this.inMemoryRunsController = new AbortController();
 			const from = new Date();
-			const timers = this.inMemoryTimers();
-			for (const timer of timers) {
-				timer.start(from);
+			const inMemoryTasks = this.inMemoryTasks();
+			for (const routed of inMemoryTasks) {
+				routed.timer.start(from);
+				if (routed.task.runOnTakeover) {
+					void this.run(routed);
+				}
 			}
-			this.logger.debug('Started the in-memory system task timers', { count: timers.length });
+			this.logger.debug('Started the in-memory system task timers', {
+				count: inMemoryTasks.length,
+			});
 		}
 	}
 
@@ -104,15 +109,17 @@ export class SystemTaskRunner {
 	async stopTimers(): Promise<void> {
 		this.timersStarted = false;
 		this.inMemoryRunsController.abort();
-		for (const timer of this.inMemoryTimers()) {
+		for (const { timer } of this.inMemoryTasks()) {
 			timer.stop();
 		}
 		this.logger.debug('Stopped the in-memory system task timers');
 		await Promise.all(this.inFlightRuns());
 	}
 
-	private inMemoryTimers(): SystemTaskTimer[] {
-		return [...this.routedTasksByName.values()].flatMap(({ timer }) => (timer ? [timer] : []));
+	private inMemoryTasks(): Array<RoutedTask & { timer: SystemTaskTimer }> {
+		return [...this.routedTasksByName.values()].filter(
+			(routed): routed is RoutedTask & { timer: SystemTaskTimer } => routed.timer !== undefined,
+		);
 	}
 
 	private inFlightRuns(): Array<Promise<void>> {
@@ -171,6 +178,9 @@ export class SystemTaskRunner {
 
 			if (this.timersStarted) {
 				routed.timer.start(new Date());
+				if (task.runOnTakeover) {
+					void this.run(routed);
+				}
 			}
 		}
 	}

--- a/packages/cli/src/scheduling/system-tasks/system-task-timer.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-timer.ts
@@ -1,0 +1,95 @@
+import type { Schedule } from '@n8n/scheduler';
+import { computeFirstRunAt, computeNextRunAt } from '@n8n/scheduler';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
+import { UnexpectedError } from 'n8n-workflow';
+
+/**
+ * Node fires a timeout longer than this straight away (the delay is a signed
+ * 32-bit millisecond value), so a longer wait is split into hops.
+ */
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
+/**
+ * One task's in-memory cadence: a chained timeout firing `onFire` at every
+ * occurrence of `schedule`.
+ *
+ * Occurrences the process slept through are coalesced: the timer fires once and
+ * resumes from now, rather than replaying the whole backlog.
+ *
+ * @remarks Temporary: removed once every task runs on the durable scheduler
+ */
+export class SystemTaskTimer {
+	private timer: NodeJS.Timeout | undefined;
+
+	constructor(
+		private readonly schedule: Schedule,
+		private readonly onFire: () => void,
+		private readonly onPlanError: (error: Error) => void,
+		private readonly now: () => number = Date.now,
+	) {}
+
+	start(from: Date): void {
+		this.stop();
+		this.arm(from, true);
+	}
+
+	stop(): void {
+		clearTimeout(this.timer);
+		this.timer = undefined;
+	}
+
+	private arm(after: Date, isFirst: boolean): void {
+		let next: Date | null;
+		try {
+			next = isFirst
+				? computeFirstRunAt(this.schedule, after)
+				: computeNextRunAt(this.schedule, after);
+		} catch (error) {
+			this.timer = undefined;
+			this.onPlanError(ensureError(error));
+			return;
+		}
+
+		if (next === null) {
+			this.timer = undefined;
+			return;
+		}
+
+		const fireAtMs = next.getTime();
+
+		if (!Number.isFinite(fireAtMs)) {
+			this.timer = undefined;
+			this.onPlanError(
+				new UnexpectedError('A system task schedule plans past the representable date range'),
+			);
+			return;
+		}
+
+		const delayMs = fireAtMs - this.now();
+
+		if (delayMs < 0) {
+			this.arm(new Date(this.now()), true);
+			return;
+		}
+
+		this.waitFor(next, delayMs);
+	}
+
+	private waitFor(fireAt: Date, delayMs: number): void {
+		if (delayMs > MAX_TIMEOUT_MS) {
+			this.timer = setTimeout(
+				() => this.waitFor(fireAt, fireAt.getTime() - this.now()),
+				MAX_TIMEOUT_MS,
+			);
+			return;
+		}
+
+		this.timer = setTimeout(
+			() => {
+				this.arm(fireAt, false);
+				this.onFire();
+			},
+			Math.max(0, delayMs),
+		);
+	}
+}

--- a/packages/cli/src/scheduling/system-tasks/system-task-timer.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-timer.ts
@@ -16,6 +16,8 @@ const MAX_TIMEOUT_MS = 2 ** 31 - 1;
  * Occurrences the process slept through are coalesced: the timer fires once and
  * resumes from now, rather than replaying the whole backlog.
  *
+ * The pending timeout is unref'd, so it never keeps the process alive on its own.
+ *
  * @remarks Temporary: removed once every task runs on the durable scheduler
  */
 export class SystemTaskTimer {
@@ -81,15 +83,16 @@ export class SystemTaskTimer {
 				() => this.waitFor(fireAt, fireAt.getTime() - this.now()),
 				MAX_TIMEOUT_MS,
 			);
-			return;
+		} else {
+			this.timer = setTimeout(
+				() => {
+					this.arm(fireAt, false);
+					this.onFire();
+				},
+				Math.max(0, delayMs),
+			);
 		}
 
-		this.timer = setTimeout(
-			() => {
-				this.arm(fireAt, false);
-				this.onFire();
-			},
-			Math.max(0, delayMs),
-		);
+		this.timer.unref();
 	}
 }

--- a/packages/cli/src/scheduling/system-tasks/system-task-type.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-type.ts
@@ -1,0 +1,7 @@
+/**
+ * The task type of a system task's durable job.
+ * One type per task, rather than a single `system` type for all of them.
+ */
+export function systemTaskType(taskName: string): string {
+	return `system:${taskName}`;
+}


### PR DESCRIPTION
## Summary

A1 added the `SystemTask` contract and its registry. 
Nothing consumed the registry, so a registered task never ran.
This PR adds the consumer.

`SystemTaskRunner` is the single owner of the system tasks' run loop. It subscribes to `SystemTaskMetadata` and gives every registered task a mode.

No production task carries `@SystemTask()` yet. 
The PR ships a test-only dummy task.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4153

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

