### PR TITLE
feat(API): add startedAfter and startedBefore filters to GET /executions

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -413,23 +413,23 @@ describe('ExecutionRepository', () => {
 			expect(condition.startedAt).toBeUndefined();
 		});
 
-		test('should use MoreThanOrEqual when only startedAfter is provided', () => {
+		test('should use And(MoreThanOrEqual) when only startedAfter is provided', () => {
 			const condition = executionRepository.getFindManyInWorkflowsCondition(workflowIds, {
 				startedAfter,
 			});
 
 			expect(condition.startedAt).toEqual(
-				MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedAfter))),
+				And(MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedAfter)))),
 			);
 		});
 
-		test('should use LessThanOrEqual when only startedBefore is provided', () => {
+		test('should use And(LessThanOrEqual) when only startedBefore is provided', () => {
 			const condition = executionRepository.getFindManyInWorkflowsCondition(workflowIds, {
 				startedBefore,
 			});
 
 			expect(condition.startedAt).toEqual(
-				LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedBefore))),
+				And(LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedBefore)))),
 			);
 		});
 

--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -402,6 +402,52 @@ describe('ExecutionRepository', () => {
 		});
 	});
 
+	describe('getFindManyInWorkflowsCondition', () => {
+		const workflowIds = ['wf-1', 'wf-2'];
+		const startedAfter = '2024-01-01T00:00:00.000Z';
+		const startedBefore = '2024-01-31T23:59:59.999Z';
+
+		test('should not set startedAt when neither startedAfter nor startedBefore is provided', () => {
+			const condition = executionRepository.getFindManyInWorkflowsCondition(workflowIds, {});
+
+			expect(condition.startedAt).toBeUndefined();
+		});
+
+		test('should use MoreThanOrEqual when only startedAfter is provided', () => {
+			const condition = executionRepository.getFindManyInWorkflowsCondition(workflowIds, {
+				startedAfter,
+			});
+
+			expect(condition.startedAt).toEqual(
+				MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedAfter))),
+			);
+		});
+
+		test('should use LessThanOrEqual when only startedBefore is provided', () => {
+			const condition = executionRepository.getFindManyInWorkflowsCondition(workflowIds, {
+				startedBefore,
+			});
+
+			expect(condition.startedAt).toEqual(
+				LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedBefore))),
+			);
+		});
+
+		test('should use And(MoreThanOrEqual, LessThanOrEqual) when both are provided', () => {
+			const condition = executionRepository.getFindManyInWorkflowsCondition(workflowIds, {
+				startedAfter,
+				startedBefore,
+			});
+
+			expect(condition.startedAt).toEqual(
+				And(
+					MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedAfter))),
+					LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(new Date(startedBefore))),
+				),
+			);
+		});
+	});
+
 	describe('updateExistingExecution', () => {
 		test.each(['sqlite', 'postgresdb'] as const)(
 			'should update execution and data in transaction on %s',


### PR DESCRIPTION
Summary                                                                                                                                                
                                                                                                                                                         
  GET /api/v1/executions now accepts startedAfter and startedBefore as optional ISO 8601 date-time query parameters. Both parameters were documented in
  the OpenAPI spec but not implemented, causing the request validator to reject them with a 400 error.                                                   
                                                                                                                                                         
  The fix wires the parameters through the full call stack:                                                                                              
                                                                                                                                                         
  - OpenAPI spec: declares the two query params so express-openapi-validator accepts them                                                                
  - executions.handler: destructures and passes them to the service layer                                                                                
  - execution.service → execution-persistence → execution.repository: types and forwarding at each layer                                                 
  - ExecutionRepository.getFindManyInWorkflowsCondition / countInWorkflows: applies MoreThanOrEqual, LessThanOrEqual, or And(both) on startedAt          
                                                                                                                                                         
  How to test                                                                                                                                            
                                                                                                                                                         
  1. Start n8n with a valid API key.                                                                                                                     
  2. Create a few executions with different start times.                                                                                                 
  3. Call GET /api/v1/executions?startedAfter=<ISO8601>&startedBefore=<ISO8601> with X-N8N-API-KEY.                                                      
  4. Confirm 200 response with only executions in the specified time range.                                                                              
  5. Confirm using only startedAfter or only startedBefore also works correctly.                                                                         
  6. Confirm that previously broken behavior (400 "Unknown query parameter") no longer occurs.                                                           
                                                                                                                                                         
  Related Linear tickets, Github issues, and Community forum posts                                                                                       
                                                                                                                                                         
  closes #37228                                                                                                                                           
                                                                                                                                                         
  Review / Merge checklist                                                                                                                            

  - I have seen this code, I have run this code, and I take responsibility for this code.
  - PR title and summary are descriptive.
  - Docs updated or follow-up ticket created.
  - Tests included.                                                                                                                                      
  - PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

