### PR TITLE
fix(Gmail Trigger Node): Do not miss emails when more than 100 arrive between polls

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -30,7 +30,11 @@ import type {
 	MessageListResponse,
 } from './types';
 
+// Bounds one poll's list requests. Hitting the cap does not lose mail: the
+// leftover page token makes the poll hold the cursor (see poll below).
 const MAX_LIST_PAGES = 20;
+// Tracked-id count (pending + boundary ids) at which the poll stops holding
+// the cursor and accepts skipping any unlisted remainder.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;
 
 export class GmailTrigger implements INodeType {
@@ -392,8 +396,10 @@ export class GmailTrigger implements INodeType {
 			}
 		};
 
-		// A poll that never reaches the list loop (early pending return, error) has
-		// no unlisted remainder, so the cursor advance stays allowed by default.
+		// A poll that never starts listing (early pending return) has no unlisted
+		// remainder, so the default keeps the cursor advance allowed. The list loop
+		// flips this to false on entry; from then on only an exhausted token proves
+		// the window complete.
 		let windowFullyListed = true;
 
 		try {
@@ -477,8 +483,9 @@ export class GmailTrigger implements INodeType {
 				pageToken = messagesResponse.nextPageToken;
 				pagesListed++;
 			} while (shouldLimitMessages && pageToken && pagesListed < MAX_LIST_PAGES);
-			// A remaining token means unlisted, older mail exists beyond the page cap;
-			// the cursor advance below must not move past it.
+			// A leftover token means the cap cut the listing short. Gmail lists newest
+			// first, so the remainder is older mail; a cursor moved past it would
+			// never list it again.
 			windowFullyListed = !pageToken;
 
 			// Pagination can repeat an id across pages when the mailbox shifts
@@ -489,9 +496,9 @@ export class GmailTrigger implements INodeType {
 				return null;
 			}
 
-			// For v1.4+, filter out boundary duplicates before fetching to save API calls.
-			// Gmail's `after:` query is inclusive at the second boundary, so messages at
-			// the lastTimeChecked timestamp can reappear.
+			// For v1.4+, filter out already-handled messages before fetching to save API
+			// calls. Gmail's `after:` query is inclusive at the second boundary, and a
+			// held cursor re-lists its whole window, so handled messages can reappear.
 			if (shouldLimitMessages) {
 				const possibleDuplicates = new Set(nodeStaticData.possibleDuplicates ?? []);
 				if (possibleDuplicates.size > 0) {
@@ -572,13 +579,13 @@ export class GmailTrigger implements INodeType {
 				(nodeStaticData.pendingMessageIds?.length ?? 0) +
 				(nodeStaticData.possibleDuplicates?.length ?? 0);
 			if (trackedIds < MAX_TRACKED_BACKLOG_IDS) {
-				// Unlisted older mail exists beyond the page cap. Hold the cursor so the
-				// next windows can still reach it; the merge below keeps every handled id
-				// filterable at the held boundary.
+				// Unlisted older mail exists beyond the page cap. Hold the cursor so later
+				// polls can still list it. The possibleDuplicates update below keeps every
+				// handled id filterable, so the held-cursor re-list cannot re-emit them.
 				effectiveLastTimeChecked = +startDate;
 			} else {
-				// Give-up valve: holding would grow the tracked-id state without bound.
-				// Advance and accept the logged skip instead of wedging the trigger.
+				// Give-up valve: holding again would grow the tracked-id state without
+				// bound. Advance and accept skipping the unlisted older mail instead.
 				this.logger.warn(
 					`Gmail Trigger backlog exceeds ${MAX_TRACKED_BACKLOG_IDS} tracked ids; advancing past unlisted older messages`,
 					{ node: node.name },
@@ -586,8 +593,9 @@ export class GmailTrigger implements INodeType {
 			}
 		}
 
-		// When lastTimeChecked didn't advance (e.g., only older pending messages were processed),
-		// preserve existing possibleDuplicates — they're still at the query boundary.
+		// When lastTimeChecked didn't advance (only older pending messages were
+		// processed, or the cursor is held), preserve existing possibleDuplicates —
+		// they're still at the query boundary.
 		if (effectiveLastTimeChecked === +startDate && nodeStaticData.possibleDuplicates?.length) {
 			const merged = new Set([...nodeStaticData.possibleDuplicates, ...nextPollPossibleDuplicates]);
 			nodeStaticData.possibleDuplicates = Array.from(merged);

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -30,6 +30,9 @@ import type {
 	MessageListResponse,
 } from './types';
 
+const MAX_LIST_PAGES = 20;
+const MAX_TRACKED_BACKLOG_IDS = 5_000;
+
 export class GmailTrigger implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Gmail Trigger',
@@ -389,6 +392,10 @@ export class GmailTrigger implements INodeType {
 			}
 		};
 
+		// A poll that never reaches the list loop (early pending return, error) has
+		// no unlisted remainder, so the cursor advance stays allowed by default.
+		let windowFullyListed = true;
+
 		try {
 			let budget = maxResults;
 
@@ -451,15 +458,24 @@ export class GmailTrigger implements INodeType {
 				}
 			}
 
-			const messagesResponse: MessageListResponse = await googleApiRequest.call(
-				this,
-				'GET',
-				'/gmail/v1/users/me/messages',
-				{},
-				qs,
-			);
-
-			let messages: ListMessage[] = messagesResponse.messages ?? [];
+			let messages: ListMessage[] = [];
+			let pageToken: string | undefined;
+			let pagesListed = 0;
+			do {
+				const messagesResponse: MessageListResponse = await googleApiRequest.call(
+					this,
+					'GET',
+					'/gmail/v1/users/me/messages',
+					{},
+					pageToken ? { ...qs, pageToken } : qs,
+				);
+				messages.push(...(messagesResponse.messages ?? []));
+				pageToken = messagesResponse.nextPageToken;
+				pagesListed++;
+			} while (shouldLimitMessages && pageToken && pagesListed < MAX_LIST_PAGES);
+			// A remaining token means unlisted, older mail exists beyond the page cap;
+			// the cursor advance below must not move past it.
+			windowFullyListed = !pageToken;
 
 			if (!messages.length && !allFetchedMessages.length) {
 				return null;
@@ -542,7 +558,25 @@ export class GmailTrigger implements INodeType {
 			}
 		}
 
-		const effectiveLastTimeChecked = Math.floor(Math.max(lastEmailDate, +startDate)) || +startDate;
+		let effectiveLastTimeChecked = Math.floor(Math.max(lastEmailDate, +startDate)) || +startDate;
+		if (shouldLimitMessages && !windowFullyListed) {
+			const trackedIds =
+				(nodeStaticData.pendingMessageIds?.length ?? 0) +
+				(nodeStaticData.possibleDuplicates?.length ?? 0);
+			if (trackedIds < MAX_TRACKED_BACKLOG_IDS) {
+				// Unlisted older mail exists beyond the page cap. Hold the cursor so the
+				// next windows can still reach it; the merge below keeps every handled id
+				// filterable at the held boundary.
+				effectiveLastTimeChecked = +startDate;
+			} else {
+				// Give-up valve: holding would grow the tracked-id state without bound.
+				// Advance and accept the logged skip instead of wedging the trigger.
+				this.logger.warn(
+					`Gmail Trigger backlog exceeds ${MAX_TRACKED_BACKLOG_IDS} tracked ids; advancing past unlisted older messages`,
+					{ node: node.name },
+				);
+			}
+		}
 
 		// When lastTimeChecked didn't advance (e.g., only older pending messages were processed),
 		// preserve existing possibleDuplicates — they're still at the query boundary.

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -506,6 +506,18 @@ export class GmailTrigger implements INodeType {
 				}
 
 				if (!messages.length && !allFetchedMessages.length) {
+					// No-progress valve: the page cap cut the listing short, yet every
+					// reachable id is already tracked. Holding again would repeat this
+					// tick forever — no backlog progress and no new mail. Give up loudly:
+					// jump the cursor to now and skip what the cap keeps unreachable.
+					if (!windowFullyListed) {
+						this.logger.warn(
+							'Gmail Trigger backlog cannot progress past the page cap; advancing past unlisted older messages',
+							{ node: node.name },
+						);
+						nodeStaticData.lastTimeChecked = +now;
+						nodeStaticData.possibleDuplicates = [];
+					}
 					return null;
 				}
 			}

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -461,6 +461,10 @@ export class GmailTrigger implements INodeType {
 			let messages: ListMessage[] = [];
 			let pageToken: string | undefined;
 			let pagesListed = 0;
+			// From here on, an exception mid-loop must read as "not fully listed":
+			// the catch path continues to the cursor advance, and a stale `true`
+			// would skip everything the failed pages never showed.
+			windowFullyListed = false;
 			do {
 				const messagesResponse: MessageListResponse = await googleApiRequest.call(
 					this,
@@ -476,6 +480,10 @@ export class GmailTrigger implements INodeType {
 			// A remaining token means unlisted, older mail exists beyond the page cap;
 			// the cursor advance below must not move past it.
 			windowFullyListed = !pageToken;
+
+			// Pagination can repeat an id across pages when the mailbox shifts
+			// between page fetches; one id must map to one delivery.
+			messages = Array.from(new Map(messages.map((m) => [m.id, m])).values());
 
 			if (!messages.length && !allFetchedMessages.length) {
 				return null;

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1609,4 +1609,185 @@ describe('GmailTrigger', () => {
 			expect(response?.[0]?.[0]?.json?.id).toBe('1');
 		});
 	});
+
+	describe('v1.4 - multi-page backlog pagination', () => {
+		// Contract under test: the list loop follows nextPageToken up to a page cap
+		// (20 pages). lastTimeChecked advances only when the token was exhausted
+		// (window fully listed) — otherwise the cursor holds so unlisted older mail
+		// cannot be skipped. Give-up valve: when holding would track more than
+		// 5000 ids, advance anyway rather than wedge the trigger.
+		const listPage = (ids: string[], nextPageToken?: string): MessageListResponse => ({
+			messages: ids.map((id) => createListMessage({ id })),
+			resultSizeEstimate: ids.length,
+			...(nextPageToken ? { nextPageToken } : {}),
+		});
+
+		const mockLabels = () =>
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/labels')
+				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+
+		const mockList = (page: MessageListResponse, expectedPageToken?: string) =>
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/messages')
+				.query((q) =>
+					expectedPageToken === undefined
+						? q.pageToken === undefined
+						: q.pageToken === expectedPageToken,
+				)
+				.reply(200, page);
+
+		const mockGet = (id: string, internalDateMs: number) =>
+			nock(baseUrl)
+				.get(`/gmail/v1/users/me/messages/${id}`)
+				.query(true)
+				.reply(200, createMessage({ id, internalDate: String(internalDateMs) }));
+
+		it('should follow nextPageToken and deliver messages from all pages', async () => {
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['6', '5', '4'], 'token-1'));
+			mockList(listPage(['3', '2', '1']), 'token-1');
+			mockGet('6', 6_000_000_000_000);
+			mockGet('5', 5_000_000_000_000);
+			mockGet('4', 4_000_000_000_000);
+			mockGet('3', 3_000_000_000_000);
+			mockGet('2', 2_000_000_000_000);
+			mockGet('1', 1_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+			});
+
+			// Today only page 1 is listed and everything on page 2 is silently lost.
+			expect(response?.[0]).toHaveLength(6);
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['6', '5', '4', '3', '2', '1']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
+		});
+
+		it('should park later pages as pending and still advance when the token was exhausted', async () => {
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['6', '5', '4'], 'token-1'));
+			mockList(listPage(['3', '2', '1']), 'token-1');
+			mockGet('6', 6_000_000_000_000);
+			mockGet('5', 5_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]).toHaveLength(2);
+			// The window was fully listed, so every unfetched id is tracked by id and
+			// advancing cannot lose anything.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['4', '3', '2', '1']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
+		});
+
+		it('should hold lastTimeChecked when the page cap is hit with a token remaining', async () => {
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
+			};
+
+			mockLabels();
+			// 20 pages, every one of them with a continuation token. Page 21 is
+			// deliberately not mocked: requesting it fails the test loudly.
+			const pages = Array.from({ length: 20 }, (_, page) => [`p${page}a`, `p${page}b`]);
+			const allIds = pages.flat();
+			pages.forEach((ids, page) =>
+				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
+			);
+			mockGet('p0a', 6_000_000_000_000);
+			mockGet('p0b', 5_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]).toHaveLength(2);
+			// The window was NOT fully listed: unlisted older mail exists beyond the
+			// cap, so the cursor must hold to keep it reachable.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			// Everything listed but not fetched is parked by id.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(allIds.slice(2));
+			// Fetched ids join the boundary set so the held-cursor re-list skips them.
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['p0a', 'p0b']),
+			);
+		});
+
+		it('should resume a held backlog and advance once the window is fully listed', async () => {
+			// Pin for the resume path: cursor held at T0, one pending id, one already
+			// handled id in the boundary set. The poll drains pending, re-lists under
+			// the held cursor, skips the handled id, fetches the new one, and — with
+			// the token exhausted — finally advances.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['B'],
+					possibleDuplicates: ['A'],
+				},
+			};
+
+			mockLabels();
+			mockGet('B', 2_000_000_000_000);
+			mockList(listPage(['A', 'C']));
+			mockGet('C', 3_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['B', 'C']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3_000_000_000);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
+		});
+
+		it('should give up holding and advance when the tracked-id bound is exceeded', async () => {
+			const initialTimestamp = 1000000;
+			// The boundary set is already at the tracking bound; holding through yet
+			// another capped cycle would grow it further, so the trigger advances and
+			// accepts the (loud) skip instead of wedging forever.
+			const hugeDuplicates = Array.from({ length: 5000 }, (_, i) => `dup${i}`);
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					possibleDuplicates: hugeDuplicates,
+				},
+			};
+
+			mockLabels();
+			const pages = Array.from({ length: 20 }, (_, page) => [`n${page}a`, `n${page}b`]);
+			const allIds = pages.flat();
+			pages.forEach((ids, page) =>
+				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
+			);
+			mockGet('n0a', 6_000_000_000_000);
+			mockGet('n0b', 5_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]).toHaveLength(2);
+			// Cap was hit (20 pages listed, token remaining) but the valve fires:
+			// advance instead of holding.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
+			// Listed-but-unfetched ids stay tracked and drain normally.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(allIds.slice(2));
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1840,6 +1840,27 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['C']);
 		});
 
+		it('should not paginate on versions before 1.4', async () => {
+			// Pagination is scoped to v1.4+: older versions have no pendingMessageIds
+			// machinery, so following the token there would change their behavior.
+			// Only one list page is mocked — a second list request fails the poll,
+			// and the assertions below catch the resulting empty response.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['1'], 'token-1'));
+			mockGet('1', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.3, parameters: { simple: true } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+		});
+
 		it('should give up holding and advance when the tracked-id bound is exceeded', async () => {
 			const initialTimestamp = 1000000;
 			// The boundary set already holds MAX_TRACKED_BACKLOG_IDS ids, so the valve

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1755,6 +1755,94 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
 		});
 
+		it('should hold the cursor when listing fails mid-pagination', async () => {
+			// A transient error on page 2 means the window was NOT fully listed.
+			// Advancing anyway would skip everything the failed pages never showed —
+			// silently, without even the valve's warning.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					pendingMessageIds: ['P1'],
+					possibleDuplicates: ['X'],
+				},
+			};
+
+			mockLabels();
+			// The pending drain succeeds and populates the fetched set...
+			mockGet('P1', 5_000_000_000_000);
+			// ...then listing resumes: page 1 succeeds with a token, page 2 blows up.
+			mockList(listPage(['L1', 'L2'], 'token-1'));
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/messages')
+				.query((q) => q.pageToken === 'token-1')
+				.reply(500, { error: 'transient' });
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			// The drained pending message is still delivered...
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
+			// ...but the cursor must hold: P1's date (5000s) must not become the new
+			// boundary while page 1's ids were never persisted anywhere.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['X', 'P1']),
+			);
+		});
+
+		it('should emit a message only once when pages return an overlapping id', async () => {
+			// Gmail pagination can repeat an id across pages when the mailbox shifts
+			// between page fetches. The accumulated list must be deduplicated.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['A', 'B'], 'token-1'));
+			mockList(listPage(['A', 'C']), 'token-1');
+			// Two interceptors for A: if the code fetches it twice, both are consumed
+			// and the duplicate shows up in the output.
+			mockGet('A', 4_000_000_000_000);
+			mockGet('A', 4_000_000_000_000);
+			mockGet('B', 3_000_000_000_000);
+			mockGet('C', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 4 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['A', 'B', 'C']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(4_000_000_000);
+		});
+
+		it('should not park an already-fetched id as pending when pages overlap', async () => {
+			// Same overlap, tighter budget: the repeated id must not land in the
+			// fetched batch AND next tick's pending queue — that is a cross-tick
+			// duplicate delivery.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['A', 'B'], 'token-1'));
+			mockList(listPage(['A', 'C']), 'token-1');
+			mockGet('A', 4_000_000_000_000);
+			mockGet('B', 3_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['A', 'B']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['C']);
+		});
+
 		it('should give up holding and advance when the tracked-id bound is exceeded', async () => {
 			const initialTimestamp = 1000000;
 			// The boundary set is already at the tracking bound; holding through yet

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1840,6 +1840,41 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['C']);
 		});
 
+		it('should give up holding when a capped window makes no progress', async () => {
+			// Every id the cap can reach is already tracked, so re-listing the same
+			// pages can never progress past them. Holding again would repeat this
+			// tick forever: no backlog progress, no new mail, no warning. The poll
+			// must give up instead — advance and start fresh.
+			const initialTimestamp = 1000000;
+			const pages = Array.from({ length: 20 }, (_, page) => [`h${page}a`, `h${page}b`]);
+			const handledIds = pages.flat();
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					possibleDuplicates: handledIds,
+				},
+			};
+
+			mockLabels();
+			pages.forEach((ids, page) =>
+				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
+			);
+			// No message GET mocks: everything listed is filtered as already handled.
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response).toBeNull();
+			// The cursor must move off the wedged window instead of holding forever.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked as number).toBeGreaterThan(
+				initialTimestamp,
+			);
+			// A fresh boundary has no handled ids to remember.
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual([]);
+		});
+
 		it('should not paginate on versions before 1.4', async () => {
 			// Pagination is scoped to v1.4+: older versions have no pendingMessageIds
 			// machinery, so following the token there would change their behavior.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1611,11 +1611,10 @@ describe('GmailTrigger', () => {
 	});
 
 	describe('v1.4 - multi-page backlog pagination', () => {
-		// Contract under test: the list loop follows nextPageToken up to a page cap
-		// (20 pages). lastTimeChecked advances only when the token was exhausted
-		// (window fully listed) — otherwise the cursor holds so unlisted older mail
-		// cannot be skipped. Give-up valve: when holding would track more than
-		// 5000 ids, advance anyway rather than wedge the trigger.
+		// Contract under test: the list loop follows nextPageToken up to 20 pages.
+		// lastTimeChecked advances only when the token was exhausted; otherwise the
+		// cursor holds so unlisted older mail stays reachable. Give-up valve: once
+		// 5000 ids are already tracked, the poll advances instead of holding again.
 		const listPage = (ids: string[], nextPageToken?: string): MessageListResponse => ({
 			messages: ids.map((id) => createListMessage({ id })),
 			resultSizeEstimate: ids.length,
@@ -1663,7 +1662,6 @@ describe('GmailTrigger', () => {
 				workflowStaticData,
 			});
 
-			// Today only page 1 is listed and everything on page 2 is silently lost.
 			expect(response?.[0]).toHaveLength(6);
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['6', '5', '4', '3', '2', '1']);
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
@@ -1700,8 +1698,9 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			// 20 pages, every one of them with a continuation token. Page 21 is
-			// deliberately not mocked: requesting it fails the test loudly.
+			// 20 pages, every one of them with a continuation token. Page 21 is not
+			// mocked: a loop that overruns the cap hits an unmatched request, poll()
+			// swallows the error and returns null, and the assertions below fail.
 			const pages = Array.from({ length: 20 }, (_, page) => [`p${page}a`, `p${page}b`]);
 			const allIds = pages.flat();
 			pages.forEach((ids, page) =>
@@ -1719,7 +1718,6 @@ describe('GmailTrigger', () => {
 			// The window was NOT fully listed: unlisted older mail exists beyond the
 			// cap, so the cursor must hold to keep it reachable.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
-			// Everything listed but not fetched is parked by id.
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(allIds.slice(2));
 			// Fetched ids join the boundary set so the held-cursor re-list skips them.
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
@@ -1728,10 +1726,9 @@ describe('GmailTrigger', () => {
 		});
 
 		it('should resume a held backlog and advance once the window is fully listed', async () => {
-			// Pin for the resume path: cursor held at T0, one pending id, one already
-			// handled id in the boundary set. The poll drains pending, re-lists under
-			// the held cursor, skips the handled id, fetches the new one, and — with
-			// the token exhausted — finally advances.
+			// Mid-backlog state: cursor held, one id pending, one handled id at the
+			// boundary. The re-list must skip the handled id, and the exhausted token
+			// must let the cursor advance again.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: 1000000,
@@ -1845,9 +1842,8 @@ describe('GmailTrigger', () => {
 
 		it('should give up holding and advance when the tracked-id bound is exceeded', async () => {
 			const initialTimestamp = 1000000;
-			// The boundary set is already at the tracking bound; holding through yet
-			// another capped cycle would grow it further, so the trigger advances and
-			// accepts the (loud) skip instead of wedging forever.
+			// The boundary set already holds MAX_TRACKED_BACKLOG_IDS ids, so the valve
+			// must fire: advance instead of holding again.
 			const hugeDuplicates = Array.from({ length: 5000 }, (_, i) => `dup${i}`);
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -1874,7 +1870,7 @@ describe('GmailTrigger', () => {
 			// Cap was hit (20 pages listed, token remaining) but the valve fires:
 			// advance instead of holding.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
-			// Listed-but-unfetched ids stay tracked and drain normally.
+			// The valve skips only unlisted mail; listed-but-unfetched ids stay tracked.
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(allIds.slice(2));
 		});
 	});


### PR DESCRIPTION
## Summary

Part of Linear CAT-3870 (PR 2 of 3). Fixes silent mail loss on large poll windows.

**The bug.** Each poll listed exactly one page of message ids — roughly the newest 100 of the window — and then advanced its cursor (`lastTimeChecked`) to the newest fetched date. The next poll queries `after:` that cursor, so every message the single page did not show became permanently unreachable: no later query can return it, and Gmail offers no ascending sort to walk a window from the old end. Any poll window with more than ~100 messages (instance downtime, a burst of mail) silently lost everything except the newest page.

**The fix.** The list now follows `nextPageToken`, up to 20 pages per tick (ids-only calls, a few seconds). Ids that were listed but not fetched are parked in the existing `pendingMessageIds` mechanism and delivered over the next ticks, `maxResults` at a time.

**The cursor rule that makes this safe:** `lastTimeChecked` advances only when the page token was exhausted. An exhausted token means every message in the window is either fetched or parked by id — advancing cannot lose anything.

**When the page cap cuts the listing short**, the cursor stays where it was, and the backlog drains across ticks:

1. Each following tick first delivers parked ids (`maxResults` per tick). Every delivered id is also recorded in `possibleDuplicates` while the cursor holds.
2. Once nothing is parked, the tick lists again from the held cursor. Gmail returns the same newest pages; the recorded ids are filtered out before fetching, and whatever remains on those pages is delivered or parked.

**Two give-up valves**, both advance the cursor and log a warning instead of holding:

- **No progress:** a capped listing where every reachable id was already handled — re-listing the same pages can never get past the cap, so holding again would freeze the trigger (no backlog progress, no new mail).
- **State bound:** holding would track more than 5,000 ids in the cursor state.

Net numbers: a held window delivers up to ~2,000 messages (20 pages × ~100 ids) before a valve fires; the previous code delivered ~100 and dropped the rest silently. For a 5,000-message window: before, ~4,900 dropped with no trace; now, ~2,000 delivered and ~3,000 skipped with a warning naming the skip.

Delivery stays bounded at `maxResults` messages per tick — that cap doubles as the memory guard (its original purpose) and does not change here or in the follow-up. What the follow-up PR adds with the engine-provided time budget from #37119 is listing reach (a held backlog can list past this PR's fixed page cap before a valve fires) and an early stop ahead of the poll timeout — not more messages per tick.

## How to test

```
pnpm --filter n8n-nodes-base test GmailTrigger.test
```

New tests cover: multi-page delivery in one tick; cross-page overflow into `pendingMessageIds` with a legitimate advance; cursor hold when the page cap hits with a token remaining; resume of a held backlog to completion; hold on a mid-pagination error; id dedup across overlapping pages (same-tick and via the pending queue); the no-progress valve; the tracked-id valve; and that versions before 1.4 do not paginate.

Manual: activate a Gmail Trigger against an inbox with >100 matching messages and a past `lastTimeChecked`; before this change only the newest ~100 ever arrive, after it the backlog drains across ticks.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3870

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
