### PR TITLE
fix(Gmail Trigger Node): Do not lose queued messages when a fetch fails mid-poll

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -396,6 +396,19 @@ export class GmailTrigger implements INodeType {
 			}
 		};
 
+		// Applied on every path that returns items — including a tick whose error
+		// was swallowed by the catch below, which skips the end of the try block.
+		const simplifyResponseData = async (): Promise<void> => {
+			if (simple && responseData.length > 0) {
+				responseData = this.helpers.returnJsonArray(
+					await simplifyOutput.call(
+						this,
+						responseData.map((item) => item.json),
+					),
+				);
+			}
+		};
+
 		// May only permit a cursor advance when an exhausted page token proved the
 		// window complete. Every path that never completes a listing — the early
 		// pending return (which exits before the advance) or any thrown fetch/list
@@ -438,14 +451,7 @@ export class GmailTrigger implements INodeType {
 
 				// If we still have pending IDs, don't list new messages yet.
 				if ((nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
-					if (simple && responseData.length > 0) {
-						responseData = this.helpers.returnJsonArray(
-							await simplifyOutput.call(
-								this,
-								responseData.map((item) => item.json),
-							),
-						);
-					}
+					await simplifyResponseData();
 					return responseData.length > 0 ? [responseData] : null;
 				}
 			}
@@ -555,15 +561,6 @@ export class GmailTrigger implements INodeType {
 					}
 				}
 			}
-
-			if (simple && responseData.length > 0) {
-				responseData = this.helpers.returnJsonArray(
-					await simplifyOutput.call(
-						this,
-						responseData.map((item) => item.json),
-					),
-				);
-			}
 		} catch (error) {
 			if (this.getMode() === 'manual' || !nodeStaticData.lastTimeChecked) {
 				throw error;
@@ -578,6 +575,8 @@ export class GmailTrigger implements INodeType {
 				},
 			);
 		}
+
+		await simplifyResponseData();
 
 		if (!allFetchedMessages.length) {
 			return null;

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -410,11 +410,15 @@ export class GmailTrigger implements INodeType {
 			const pendingIds = nodeStaticData.pendingMessageIds ?? [];
 			if (shouldLimitMessages && pendingIds.length > 0) {
 				const idsToFetch = pendingIds.slice(0, budget);
-				nodeStaticData.pendingMessageIds = pendingIds.slice(budget);
 				const fetchQs = buildFetchQs();
 
-				for (const id of idsToFetch) {
+				for (const [index, id] of idsToFetch.entries()) {
 					await fetchAndProcessMessage(id, fetchQs);
+					// An id leaves the stored queue only after its fetch succeeded. A
+					// mid-drain throw is swallowed by the catch below, and pending ids sit
+					// behind an already-advanced cursor — removing them up front would
+					// lose the unfetched ones for good.
+					nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
 				}
 
 				budget -= idsToFetch.length;
@@ -432,7 +436,7 @@ export class GmailTrigger implements INodeType {
 				}
 
 				// If we still have pending IDs, don't list new messages yet.
-				if (nodeStaticData.pendingMessageIds.length > 0) {
+				if ((nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
 					if (simple && responseData.length > 0) {
 						responseData = this.helpers.returnJsonArray(
 							await simplifyOutput.call(

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -396,11 +396,12 @@ export class GmailTrigger implements INodeType {
 			}
 		};
 
-		// A poll that never starts listing (early pending return) has no unlisted
-		// remainder, so the default keeps the cursor advance allowed. The list loop
-		// flips this to false on entry; from then on only an exhausted token proves
-		// the window complete.
-		let windowFullyListed = true;
+		// May only permit a cursor advance when an exhausted page token proved the
+		// window complete. Every path that never completes a listing — the early
+		// pending return (which exits before the advance) or any thrown fetch/list
+		// — must leave it pessimistic, or a held cursor would advance past mail
+		// the failed poll never listed.
+		let windowFullyListed = false;
 
 		try {
 			let budget = maxResults;

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -529,9 +529,11 @@ export class GmailTrigger implements INodeType {
 
 			// Take only what fits in the remaining budget, store the rest as pending.
 			let messagesToProcess = messages;
+			let beyondBudgetIds: string[] = [];
 			if (shouldLimitMessages && messages.length > budget) {
 				messagesToProcess = messages.slice(0, budget);
-				nodeStaticData.pendingMessageIds = messages.slice(budget).map((m) => m.id);
+				beyondBudgetIds = messages.slice(budget).map((m) => m.id);
+				nodeStaticData.pendingMessageIds = beyondBudgetIds;
 			}
 
 			if (messagesToProcess.length > 0) {
@@ -539,8 +541,18 @@ export class GmailTrigger implements INodeType {
 				Object.assign(fetchQs, options);
 				delete fetchQs.includeDrafts;
 
-				for (const message of messagesToProcess) {
+				for (const [index, message] of messagesToProcess.entries()) {
 					await fetchAndProcessMessage(message.id, fetchQs);
+					if (shouldLimitMessages) {
+						// An id leaves persisted state only after its fetch succeeded. A
+						// mid-loop throw is swallowed by the catch below, and the cursor can
+						// still advance past every listed id — an unfetched within-budget id
+						// kept in no persisted structure would be lost for good.
+						nodeStaticData.pendingMessageIds = [
+							...messagesToProcess.slice(index + 1).map((m) => m.id),
+							...beyondBudgetIds,
+						];
+					}
 				}
 			}
 

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -402,17 +402,27 @@ export class GmailTrigger implements INodeType {
 
 		// Applied on every path that returns items — including a tick whose error
 		// was swallowed by the catch below, which skips the end of the try block.
-		// A failure here is deliberately not swallowed: the workflow asked for the
-		// simplified shape, and handing it the raw shape instead would break the
-		// fields it reads. The poll fails, the cursor stays put, and the next poll
-		// delivers these messages in the shape that was asked for.
+		// A failure here is swallowed on the same terms as the rest of the poll: the
+		// items go out in the raw shape, as they did before this helper existed.
+		// Refusing to deliver them instead would change what a workflow receives,
+		// which needs a new node version.
 		const simplifyResponseData = async (): Promise<void> => {
-			if (simple && responseData.length > 0) {
+			if (!simple || responseData.length === 0) return;
+
+			try {
 				responseData = this.helpers.returnJsonArray(
 					await simplifyOutput.call(
 						this,
 						responseData.map((item) => item.json),
 					),
+				);
+			} catch (error) {
+				if (this.getMode() === 'manual' || !nodeStaticData.lastTimeChecked) {
+					throw error;
+				}
+				this.logger.error(
+					`Gmail Trigger could not simplify the output of '${node.name}': '${error.description}'`,
+					{ node: node.name, error },
 				);
 			}
 		};

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -402,28 +402,17 @@ export class GmailTrigger implements INodeType {
 
 		// Applied on every path that returns items — including a tick whose error
 		// was swallowed by the catch below, which skips the end of the try block.
-		// Simplifying needs a labels request of its own, and it runs after the
-		// messages are already fetched: a failure there must not cost the tick its
-		// messages or its state update, or a labels outage would stall delivery on
-		// every poll. Deliver the raw shape instead, on the same terms as the poll
-		// body — a manual run or a first poll still fails loudly.
+		// A failure here is deliberately not swallowed: the workflow asked for the
+		// simplified shape, and handing it the raw shape instead would break the
+		// fields it reads. The poll fails, the cursor stays put, and the next poll
+		// delivers these messages in the shape that was asked for.
 		const simplifyResponseData = async (): Promise<void> => {
-			if (!simple || responseData.length === 0) return;
-
-			try {
+			if (simple && responseData.length > 0) {
 				responseData = this.helpers.returnJsonArray(
 					await simplifyOutput.call(
 						this,
 						responseData.map((item) => item.json),
 					),
-				);
-			} catch (error) {
-				if (this.getMode() === 'manual' || !nodeStaticData.lastTimeChecked) {
-					throw error;
-				}
-				this.logger.error(
-					`Gmail Trigger could not simplify the output of '${node.name}': '${error.description}'`,
-					{ node: node.name, error },
 				);
 			}
 		};

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -462,6 +462,14 @@ export class GmailTrigger implements INodeType {
 								`Gmail Trigger cannot fetch message ${id} after ${attempted} attempts; skipping it`,
 								{ node: node.name },
 							);
+							// Giving up has to outlast this poll. An id that only leaves the
+							// set-aside list is in no stored state, so the next scan finds it
+							// again and starts the attempts over. The boundary set is what the
+							// scan already skips, so it goes there.
+							nodeStaticData.possibleDuplicates = [
+								...(nodeStaticData.possibleDuplicates ?? []),
+								id,
+							];
 						} else {
 							stillFailing.push([id, attempted]);
 						}
@@ -637,17 +645,39 @@ export class GmailTrigger implements INodeType {
 				Object.assign(fetchQs, options);
 				delete fetchQs.includeDrafts;
 
+				const scannedButFailed: Array<[string, number]> = [];
+
 				for (const [index, message] of messagesToProcess.entries()) {
-					await fetchAndProcessMessage(message.id, fetchQs);
+					try {
+						await fetchAndProcessMessage(message.id, fetchQs);
+					} catch (error) {
+						// Same rule as the queue drain: set this message aside, count the
+						// attempt, and carry on with the rest of the batch. Letting the
+						// error out here would skip every message behind it and give this
+						// one an attempt that no count remembers.
+						this.logger.warn(`Gmail Trigger could not fetch message ${message.id}; will retry it`, {
+							node: node.name,
+							error,
+						});
+						scannedButFailed.push([message.id, 1]);
+					}
+
 					if (shouldLimitMessages) {
 						// Trim what the queue write above seeded: keep only the ids this loop
-						// has not delivered yet, so a swallowed throw leaves every unfetched
-						// id stored while the cursor may still advance past all of them.
+						// has not handled yet, so a later throw leaves every unhandled id
+						// stored while the cursor may still advance past all of them.
 						nodeStaticData.pendingMessageIds = [
 							...messagesToProcess.slice(index + 1).map((m) => m.id),
 							...beyondBudgetIds,
 						];
 					}
+				}
+
+				if (scannedButFailed.length > 0) {
+					nodeStaticData.failedFetches = [
+						...(nodeStaticData.failedFetches ?? []),
+						...scannedButFailed,
+					];
 				}
 			}
 		} catch (error) {

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -36,12 +36,10 @@ const MAX_LIST_PAGES = 20;
 // Tracked-id count (pending + boundary ids) at which the poll stops holding
 // the cursor and accepts skipping any unlisted remainder.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;
-// Consecutive failed fetches of the same queued message before the poll skips
-// it. Only failures that may be transient are counted, so the bound is generous:
-// a rate-limited or briefly failing message must survive the outage. The count
-// is per node, not per id, which is enough: the queue only moves on a success or
-// a skip, so the failing id stays at its head.
-export const MAX_PENDING_FETCH_ATTEMPTS = 20;
+// Attempts a single message gets before the poll gives up on it. Failures here
+// cannot be told apart from rate limits, which this node does not retry on its
+// own, so a message gets several polls to come back before it is skipped.
+export const MAX_PENDING_FETCH_ATTEMPTS = 10;
 
 export class GmailTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -438,65 +436,98 @@ export class GmailTrigger implements INodeType {
 		try {
 			let budget = maxResults;
 
-			// Process pending messages from a previous poll first. These are IDs
+			// A message whose fetch failed waits in its own list rather than in the
+			// queue, so it can be retried without holding up everything behind it.
+			// Retry those first — they are the oldest — and give up on one only once
+			// it has used up its attempts. A failed fetch carries no message, so it
+			// costs no budget; only a success does.
+			const quarantined = nodeStaticData.failedFetches ?? [];
+			if (shouldLimitMessages && quarantined.length > 0) {
+				// Bounded per tick, and the untried tail moves to the front, so a long
+				// list cannot spend the whole poll on doomed requests or starve its own
+				// later entries.
+				const retryNow = quarantined.slice(0, maxResults);
+				const retryLater = quarantined.slice(maxResults);
+				const stillFailing: Array<[string, number]> = [];
+				const fetchQs = buildFetchQs();
+
+				for (const [id, attempts] of retryNow) {
+					try {
+						await fetchAndProcessMessage(id, fetchQs);
+						budget -= 1;
+					} catch (error) {
+						const attempted = attempts + 1;
+						if (attempted >= MAX_PENDING_FETCH_ATTEMPTS) {
+							this.logger.warn(
+								`Gmail Trigger cannot fetch message ${id} after ${attempted} attempts; skipping it`,
+								{ node: node.name },
+							);
+						} else {
+							stillFailing.push([id, attempted]);
+						}
+					}
+				}
+
+				nodeStaticData.failedFetches = [...retryLater, ...stillFailing];
+			}
+
+			// Process pending messages from a previous poll next. These are IDs
 			// listed but not fetched last time: beyond the maxResults budget, or left
 			// over when a fetch failed mid-poll.
 			const pendingIds = nodeStaticData.pendingMessageIds ?? [];
-			if (shouldLimitMessages && pendingIds.length > 0) {
-				const idsToFetch = pendingIds.slice(0, budget);
+			if (shouldLimitMessages && pendingIds.length > 0 && budget > 0) {
 				const fetchQs = buildFetchQs();
+				const newlyFailed: Array<[string, number]> = [];
 
-				for (const [index, id] of idsToFetch.entries()) {
+				for (const [index, id] of pendingIds.entries()) {
+					// A delivery costs budget, a failure costs a request. Stop on either
+					// count, so a queue full of failures cannot spend the whole poll on
+					// doomed requests.
+					if (budget <= 0 || newlyFailed.length >= maxResults) break;
+
 					try {
 						await fetchAndProcessMessage(id, fetchQs);
+						budget -= 1;
 					} catch (error) {
-						// The queue is drained before any listing and nothing else evicts
-						// from it, so an id that can never be fetched — deleted since it was
-						// listed, or one that always breaks parsing — would block the queue
-						// and every new message behind it. Retry it across polls, since most
-						// failures here pass on their own, and skip it once the bound runs
-						// out. The tick fails either way, as it did before.
-						const attempts = (nodeStaticData.pendingFetchAttempts ?? 0) + 1;
-						if (attempts >= MAX_PENDING_FETCH_ATTEMPTS) {
-							this.logger.warn(
-								`Gmail Trigger cannot fetch message ${id} after ${attempts} attempts; skipping it`,
-								{ node: node.name },
-							);
-							nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
-							nodeStaticData.pendingFetchAttempts = 0;
-						} else {
-							nodeStaticData.pendingFetchAttempts = attempts;
-						}
-						throw error;
+						// Set the message aside instead of ending the tick: the rest of the
+						// queue, and the listing below, must still run. The error is logged
+						// here because it no longer reaches the catch at the end of poll().
+						this.logger.warn(`Gmail Trigger could not fetch message ${id}; will retry it`, {
+							node: node.name,
+							error,
+						});
+						newlyFailed.push([id, 1]);
 					}
 
-					// An id leaves the stored queue only after its fetch succeeded — a
-					// dropped id is in no state and can already sit behind an advanced
-					// cursor, so nothing would ever list it again.
+					// An id leaves the queue once it has been handled either way — it was
+					// delivered, or it now waits in failedFetches. Trimming per iteration
+					// keeps every unhandled id stored, since a later throw is swallowed by
+					// the catch below while the cursor can still advance.
 					nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
-					// Only consecutive failures may add up to a skip.
-					nodeStaticData.pendingFetchAttempts = 0;
 				}
 
-				budget -= idsToFetch.length;
-
-				// Record drained IDs in possibleDuplicates so Gmail's boundary-inclusive
-				// `after:` query can't re-list a message we just emitted and push it back
-				// into pendingMessageIds as overflow. Also covers the early-return path,
-				// where the state update at the end of poll() is skipped.
-				if (allFetchedMessages.length > 0) {
-					const merged = new Set([
-						...(nodeStaticData.possibleDuplicates ?? []),
-						...allFetchedMessages.map((m) => m.id),
-					]);
-					nodeStaticData.possibleDuplicates = Array.from(merged);
+				if (newlyFailed.length > 0) {
+					nodeStaticData.failedFetches = [...(nodeStaticData.failedFetches ?? []), ...newlyFailed];
 				}
+			}
 
-				// If we still have pending IDs, don't list new messages yet.
-				if ((nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
-					await simplifyResponseData();
-					return responseData.length > 0 ? [responseData] : null;
-				}
+			// Record everything fetched so far in possibleDuplicates so Gmail's
+			// boundary-inclusive `after:` query can't re-list a message this tick
+			// already emitted — either below, when the listing repeats a retried id,
+			// or on a later poll. Also covers the early return just after, where the
+			// state update at the end of poll() is skipped.
+			if (shouldLimitMessages && allFetchedMessages.length > 0) {
+				const merged = new Set([
+					...(nodeStaticData.possibleDuplicates ?? []),
+					...allFetchedMessages.map((m) => m.id),
+				]);
+				nodeStaticData.possibleDuplicates = Array.from(merged);
+			}
+
+			// While queued IDs remain, don't list new messages yet.
+			if (shouldLimitMessages && (nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
+				await simplifyResponseData();
+				return responseData.length > 0 ? [responseData] : null;
 			}
 
 			// List new messages from Gmail.
@@ -654,7 +685,8 @@ export class GmailTrigger implements INodeType {
 		if (shouldLimitMessages && !windowFullyListed) {
 			const trackedIds =
 				(nodeStaticData.pendingMessageIds?.length ?? 0) +
-				(nodeStaticData.possibleDuplicates?.length ?? 0);
+				(nodeStaticData.possibleDuplicates?.length ?? 0) +
+				(nodeStaticData.failedFetches?.length ?? 0);
 			if (trackedIds < MAX_TRACKED_BACKLOG_IDS) {
 				// Unlisted older mail exists beyond the page cap. Hold the cursor so later
 				// polls can still list it. The possibleDuplicates update below keeps every

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -36,6 +36,10 @@ const MAX_LIST_PAGES = 20;
 // Tracked-id count (pending + boundary ids) at which the poll stops holding
 // the cursor and accepts skipping any unlisted remainder.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;
+// Consecutive failed fetches of the same queued message before the poll skips
+// it. The count is per node, not per id, which is enough: the queue only moves
+// on a success or a skip, so the failing id stays at its head.
+const MAX_PENDING_FETCH_ATTEMPTS = 3;
 
 export class GmailTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -427,12 +431,35 @@ export class GmailTrigger implements INodeType {
 				const fetchQs = buildFetchQs();
 
 				for (const [index, id] of idsToFetch.entries()) {
-					await fetchAndProcessMessage(id, fetchQs);
+					try {
+						await fetchAndProcessMessage(id, fetchQs);
+					} catch (error) {
+						// The queue is drained before any listing and nothing else evicts
+						// from it, so an id that can never be fetched — deleted since it was
+						// listed, or one that always breaks parsing — would block the queue
+						// and every new message behind it. Retry it a few times, then skip
+						// it and let the tick fail as before.
+						const attempts = (nodeStaticData.pendingFetchAttempts ?? 0) + 1;
+						if (attempts >= MAX_PENDING_FETCH_ATTEMPTS) {
+							this.logger.warn(
+								`Gmail Trigger cannot fetch message ${id} after ${attempts} attempts; skipping it`,
+								{ node: node.name },
+							);
+							nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
+							nodeStaticData.pendingFetchAttempts = 0;
+						} else {
+							nodeStaticData.pendingFetchAttempts = attempts;
+						}
+						throw error;
+					}
+
 					// An id leaves the stored queue only after its fetch succeeded. A
 					// mid-drain throw is swallowed by the catch below, and pending ids sit
 					// behind an already-advanced cursor — removing them up front would
 					// lose the unfetched ones for good.
 					nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
+					// Only consecutive failures may add up to a skip.
+					nodeStaticData.pendingFetchAttempts = 0;
 				}
 
 				budget -= idsToFetch.length;

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -566,7 +566,18 @@ export class GmailTrigger implements INodeType {
 			if (shouldLimitMessages && messages.length > budget) {
 				messagesToProcess = messages.slice(0, budget);
 				beyondBudgetIds = messages.slice(budget).map((m) => m.id);
-				nodeStaticData.pendingMessageIds = beyondBudgetIds;
+			}
+
+			// Queue every listed id before fetching any of them, so a throw on the
+			// first fetch cannot leave ids in no stored state: the loop below trims
+			// this back down as each fetch succeeds. Stays gated on the version
+			// check, or a pre-1.4 node would store a queue its own drain path
+			// ignores until someone bumps its version.
+			if (shouldLimitMessages) {
+				nodeStaticData.pendingMessageIds = [
+					...messagesToProcess.map((m) => m.id),
+					...beyondBudgetIds,
+				];
 			}
 
 			if (messagesToProcess.length > 0) {

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -30,16 +30,16 @@ import type {
 	MessageListResponse,
 } from './types';
 
-// Bounds how many pages one poll scans for new messages. Hitting the cap does
-// not lose mail: the leftover page token makes the poll hold the cursor (see
-// poll below).
+// Bounds how many pages one poll scans for new messages. A leftover page token
+// holds the cursor, so mail beyond the cap stays reachable until a give-up valve
+// decides to skip it.
 const MAX_SCAN_PAGES = 20;
-// Tracked-id count (pending + boundary ids) at which the poll stops holding
-// the cursor and accepts skipping whatever it did not scan.
+// Count of stored ids (queued + boundary + set aside) at which the poll stops
+// holding the cursor and accepts skipping whatever it did not scan.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;
-// Attempts a single message gets before the poll gives up on it. Failures here
-// cannot be told apart from rate limits, which this node does not retry on its
-// own, so a message gets several polls to come back before it is skipped.
+// Attempts one set-aside id gets before the poll drops it with a warning. A
+// failed fetch cannot be told apart from a rate limit, and this node does not
+// retry inside a poll, so an id gets several polls to come back.
 export const MAX_PENDING_FETCH_ATTEMPTS = 10;
 
 export class GmailTrigger implements INodeType {
@@ -438,16 +438,16 @@ export class GmailTrigger implements INodeType {
 
 			// A message whose fetch failed waits in its own list rather than in the
 			// queue, so it can be retried without holding up everything behind it.
-			// Retry those first — they are the oldest — and give up on one only once
-			// it has used up its attempts. A failed fetch carries no message, so it
+			// Retry those first, because they have waited longest, and give up on one
+			// only once it has used up its attempts. A failed fetch carries no message, so it
 			// costs no budget; only a success does.
-			const quarantined = nodeStaticData.failedFetches ?? [];
-			if (shouldLimitMessages && quarantined.length > 0) {
+			const setAside = nodeStaticData.failedFetches ?? [];
+			if (shouldLimitMessages && setAside.length > 0) {
 				// Bounded per tick, and the untried tail moves to the front, so a long
 				// list cannot spend the whole poll on doomed requests or starve its own
 				// later entries.
-				const retryNow = quarantined.slice(0, maxResults);
-				const retryLater = quarantined.slice(maxResults);
+				const retryNow = setAside.slice(0, maxResults);
+				const retryLater = setAside.slice(maxResults);
 				const stillFailing: Array<[string, number]> = [];
 				const fetchQs = buildFetchQs();
 
@@ -499,7 +499,7 @@ export class GmailTrigger implements INodeType {
 					} catch (error) {
 						// Set the message aside instead of ending the tick: the rest of the
 						// queue, and the scan below, must still run. The error is logged
-						// here because it no longer reaches the catch at the end of poll().
+						// here, because this error never reaches the catch at the end of poll().
 						this.logger.warn(`Gmail Trigger could not fetch message ${id}; will retry it`, {
 							node: node.name,
 							error,
@@ -507,10 +507,10 @@ export class GmailTrigger implements INodeType {
 						newlyFailed.push([id, 1]);
 					}
 
-					// An id leaves the queue once it has been handled either way — it was
-					// delivered, or it now waits in failedFetches. Trimming per iteration
-					// keeps every unhandled id stored, since a later throw is swallowed by
-					// the catch below while the cursor can still advance.
+					// Trim per iteration so every id this loop has not handled yet stays
+					// stored: a later throw is swallowed while the cursor can still
+					// advance. A failed id leaves the queue for the set-aside list, which
+					// is written once the loop ends.
 					nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
 				}
 
@@ -519,7 +519,9 @@ export class GmailTrigger implements INodeType {
 				}
 			}
 
-			// While queued IDs remain, don't scan for new messages yet.
+			// While queued ids remain, do not scan: the queue write after a scan replaces
+			// the whole queue, so scanning now would drop the ids this poll could not
+			// reach.
 			if (shouldLimitMessages && (nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
 				await simplifyResponseData();
 
@@ -614,6 +616,9 @@ export class GmailTrigger implements INodeType {
 							{ node: node.name },
 						);
 						nodeStaticData.lastTimeChecked = +now;
+						// The cursor jumped to now, so ids from the old window are no longer
+						// at the boundary. Keeping them would grow the stored-id count for
+						// nothing — every other path merges the set instead.
 						nodeStaticData.possibleDuplicates = [];
 					}
 					return null;
@@ -628,7 +633,7 @@ export class GmailTrigger implements INodeType {
 				beyondBudgetIds = messages.slice(budget).map((m) => m.id);
 			}
 
-			// Queue every listed id before fetching any of them, so a throw on the
+			// Queue every scanned id before fetching any of them, so a throw on the
 			// first fetch cannot leave ids in no stored state: the loop below trims
 			// this back down as each fetch succeeds. Stays gated on the version
 			// check, or a pre-1.4 node would store a queue its own drain path

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -30,11 +30,12 @@ import type {
 	MessageListResponse,
 } from './types';
 
-// Bounds one poll's list requests. Hitting the cap does not lose mail: the
-// leftover page token makes the poll hold the cursor (see poll below).
-const MAX_LIST_PAGES = 20;
+// Bounds how many pages one poll scans for new messages. Hitting the cap does
+// not lose mail: the leftover page token makes the poll hold the cursor (see
+// poll below).
+const MAX_SCAN_PAGES = 20;
 // Tracked-id count (pending + boundary ids) at which the poll stops holding
-// the cursor and accepts skipping any unlisted remainder.
+// the cursor and accepts skipping whatever it did not scan.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;
 // Attempts a single message gets before the poll gives up on it. Failures here
 // cannot be told apart from rate limits, which this node does not retry on its
@@ -428,9 +429,9 @@ export class GmailTrigger implements INodeType {
 		};
 
 		// Pessimistic default: poll() swallows non-manual errors and still runs the
-		// cursor advance below, so a throw before or during listing must leave the
+		// cursor advance below, so a throw before or during the scan must leave the
 		// cursor held. Only an exhausted page token may set this true.
-		let windowFullyListed = false;
+		let windowFullyScanned = false;
 
 		try {
 			let budget = maxResults;
@@ -470,9 +471,9 @@ export class GmailTrigger implements INodeType {
 				nodeStaticData.failedFetches = [...retryLater, ...stillFailing];
 			}
 
-			// Process pending messages from a previous poll next. These are IDs
-			// listed but not fetched last time: beyond the maxResults budget, or left
-			// over when a fetch failed mid-poll.
+			// Process pending messages from a previous poll next. These are IDs a scan
+			// found but no poll fetched: beyond the maxResults budget, or left over when
+			// a fetch failed mid-poll.
 			const pendingIds = nodeStaticData.pendingMessageIds ?? [];
 			if (shouldLimitMessages && pendingIds.length > 0 && budget > 0) {
 				const fetchQs = buildFetchQs();
@@ -489,7 +490,7 @@ export class GmailTrigger implements INodeType {
 						budget -= 1;
 					} catch (error) {
 						// Set the message aside instead of ending the tick: the rest of the
-						// queue, and the listing below, must still run. The error is logged
+						// queue, and the scan below, must still run. The error is logged
 						// here because it no longer reaches the catch at the end of poll().
 						this.logger.warn(`Gmail Trigger could not fetch message ${id}; will retry it`, {
 							node: node.name,
@@ -510,15 +511,13 @@ export class GmailTrigger implements INodeType {
 				}
 			}
 
-			// While queued IDs remain, don't list new messages yet.
+			// While queued IDs remain, don't scan for new messages yet.
 			if (shouldLimitMessages && (nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
 				await simplifyResponseData();
 
 				// This path returns before the state update at the end of poll(), so it
 				// records the boundary itself: Gmail's boundary-inclusive `after:` query
-				// would otherwise re-list what this poll just delivered. It runs after
-				// simplifying, because a poll that fails there delivers nothing and its
-				// ids must stay listable.
+				// would otherwise return again what this poll just delivered.
 				if (allFetchedMessages.length > 0) {
 					const merged = new Set([
 						...(nodeStaticData.possibleDuplicates ?? []),
@@ -530,7 +529,7 @@ export class GmailTrigger implements INodeType {
 				return responseData.length > 0 ? [responseData] : null;
 			}
 
-			// List new messages from Gmail.
+			// Scan Gmail for new messages.
 			const qs: IDataObject = {};
 			const allFilters: GmailTriggerFilters = { ...filters, receivedAfter: startDate };
 
@@ -551,7 +550,7 @@ export class GmailTrigger implements INodeType {
 
 			let messages: ListMessage[] = [];
 			let pageToken: string | undefined;
-			let pagesListed = 0;
+			let pagesScanned = 0;
 			do {
 				const messagesResponse: MessageListResponse = await googleApiRequest.call(
 					this,
@@ -562,12 +561,12 @@ export class GmailTrigger implements INodeType {
 				);
 				messages.push(...(messagesResponse.messages ?? []));
 				pageToken = messagesResponse.nextPageToken;
-				pagesListed++;
-			} while (shouldLimitMessages && pageToken && pagesListed < MAX_LIST_PAGES);
-			// A leftover token means the cap cut the listing short. Gmail lists newest
-			// first, so the remainder is older mail; a cursor moved past it would
-			// never list it again.
-			windowFullyListed = !pageToken;
+				pagesScanned++;
+			} while (shouldLimitMessages && pageToken && pagesScanned < MAX_SCAN_PAGES);
+			// A leftover token means the cap stopped the scan short. Gmail returns
+			// newest first, so the remainder is older mail; a cursor moved past it
+			// would never reach it again.
+			windowFullyScanned = !pageToken;
 
 			// Pagination can repeat an id across pages when the mailbox shifts
 			// between page fetches; one id must map to one delivery.
@@ -579,7 +578,7 @@ export class GmailTrigger implements INodeType {
 
 			// For v1.4+, filter out already-handled messages before fetching to save API
 			// calls. Gmail's `after:` query is inclusive at the second boundary, and a
-			// held cursor re-lists its whole window, so handled messages can reappear.
+			// held cursor re-scans its whole window, so handled messages can reappear.
 			if (shouldLimitMessages) {
 				// Set-aside ids are dropped along with the handled ones: that list
 				// already owns them and retries them every poll, so queueing them here
@@ -597,13 +596,13 @@ export class GmailTrigger implements INodeType {
 				}
 
 				if (!messages.length && !allFetchedMessages.length) {
-					// No-progress valve: the page cap cut the listing short, yet every
-					// reachable id is already tracked. Holding again would repeat this
+					// No-progress valve: the page cap stopped the scan short, yet every id
+					// it reached is already tracked. Holding again would repeat this
 					// tick forever — no backlog progress and no new mail. Give up loudly:
 					// jump the cursor to now and skip what the cap keeps unreachable.
-					if (!windowFullyListed) {
+					if (!windowFullyScanned) {
 						this.logger.warn(
-							'Gmail Trigger backlog cannot progress past the page cap; advancing past unlisted older messages',
+							'Gmail Trigger backlog cannot progress past the page cap; advancing past older messages it could not scan',
 							{ node: node.name },
 						);
 						nodeStaticData.lastTimeChecked = +now;
@@ -692,21 +691,22 @@ export class GmailTrigger implements INodeType {
 		}
 
 		let effectiveLastTimeChecked = Math.floor(Math.max(lastEmailDate, +startDate)) || +startDate;
-		if (shouldLimitMessages && !windowFullyListed) {
+		if (shouldLimitMessages && !windowFullyScanned) {
 			const trackedIds =
 				(nodeStaticData.pendingMessageIds?.length ?? 0) +
 				(nodeStaticData.possibleDuplicates?.length ?? 0) +
 				(nodeStaticData.failedFetches?.length ?? 0);
 			if (trackedIds < MAX_TRACKED_BACKLOG_IDS) {
-				// Unlisted older mail exists beyond the page cap. Hold the cursor so later
-				// polls can still list it. The possibleDuplicates update below keeps every
-				// handled id filterable, so the held-cursor re-list cannot re-emit them.
+				// Older mail sits beyond the page cap, unscanned. Hold the cursor so later
+				// polls can still reach it. The possibleDuplicates update below keeps every
+				// handled id filterable, so a re-scan under a held cursor cannot re-emit
+				// them.
 				effectiveLastTimeChecked = +startDate;
 			} else {
 				// Give-up valve: holding again would grow the tracked-id state without
-				// bound. Advance and accept skipping the unlisted older mail instead.
+				// bound. Advance and accept skipping the unscanned older mail instead.
 				this.logger.warn(
-					`Gmail Trigger backlog exceeds ${MAX_TRACKED_BACKLOG_IDS} tracked ids; advancing past unlisted older messages`,
+					`Gmail Trigger backlog exceeds ${MAX_TRACKED_BACKLOG_IDS} tracked ids; advancing past older messages it could not scan`,
 					{ node: node.name },
 				);
 			}

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -438,16 +438,23 @@ export class GmailTrigger implements INodeType {
 
 			// A message whose fetch failed waits in its own list rather than in the
 			// queue, so it can be retried without holding up everything behind it.
-			// Retry those first, because they have waited longest, and give up on one
-			// only once it has used up its attempts. A failed fetch carries no message, so it
-			// costs no budget; only a success does.
+			// Retry those first, because they have waited longest. A failed fetch
+			// carries no message, so it costs no budget; only a success does.
 			const setAside = nodeStaticData.failedFetches ?? [];
-			if (shouldLimitMessages && setAside.length > 0) {
+			// An id that used up its attempts stays in the list with no attempts left.
+			// That is what makes giving up outlast the poll: the scan below skips every
+			// id in this list, while the boundary set is replaced whenever the cursor
+			// advances. The message was never fetched, so its date is unknown and the
+			// poll cannot tell when the cursor passed it.
+			const retryable = setAside.filter(([, attempts]) => attempts < MAX_PENDING_FETCH_ATTEMPTS);
+			const givenUp = setAside.filter(([, attempts]) => attempts >= MAX_PENDING_FETCH_ATTEMPTS);
+
+			if (shouldLimitMessages && retryable.length > 0) {
 				// Bounded per tick, and the untried tail moves to the front, so a long
 				// list cannot spend the whole poll on doomed requests or starve its own
 				// later entries.
-				const retryNow = setAside.slice(0, maxResults);
-				const retryLater = setAside.slice(maxResults);
+				const retryNow = retryable.slice(0, maxResults);
+				const retryLater = retryable.slice(maxResults);
 				const stillFailing: Array<[string, number]> = [];
 				const fetchQs = buildFetchQs();
 
@@ -462,21 +469,14 @@ export class GmailTrigger implements INodeType {
 								`Gmail Trigger cannot fetch message ${id} after ${attempted} attempts; skipping it`,
 								{ node: node.name },
 							);
-							// Giving up has to outlast this poll. An id that only leaves the
-							// set-aside list is in no stored state, so the next scan finds it
-							// again and starts the attempts over. The boundary set is what the
-							// scan already skips, so it goes there.
-							nodeStaticData.possibleDuplicates = [
-								...(nodeStaticData.possibleDuplicates ?? []),
-								id,
-							];
+							givenUp.push([id, attempted]);
 						} else {
 							stillFailing.push([id, attempted]);
 						}
 					}
 				}
 
-				nodeStaticData.failedFetches = [...retryLater, ...stillFailing];
+				nodeStaticData.failedFetches = [...retryLater, ...stillFailing, ...givenUp];
 			}
 
 			// Process pending messages from a previous poll next. These are IDs a scan

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -37,9 +37,11 @@ const MAX_LIST_PAGES = 20;
 // the cursor and accepts skipping any unlisted remainder.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;
 // Consecutive failed fetches of the same queued message before the poll skips
-// it. The count is per node, not per id, which is enough: the queue only moves
-// on a success or a skip, so the failing id stays at its head.
-const MAX_PENDING_FETCH_ATTEMPTS = 3;
+// it. Only failures that may be transient are counted, so the bound is generous:
+// a rate-limited or briefly failing message must survive the outage. The count
+// is per node, not per id, which is enough: the queue only moves on a success or
+// a skip, so the failing id stays at its head.
+export const MAX_PENDING_FETCH_ATTEMPTS = 20;
 
 export class GmailTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -436,8 +438,9 @@ export class GmailTrigger implements INodeType {
 						// The queue is drained before any listing and nothing else evicts
 						// from it, so an id that can never be fetched — deleted since it was
 						// listed, or one that always breaks parsing — would block the queue
-						// and every new message behind it. Retry it a few times, then skip
-						// it and let the tick fail as before.
+						// and every new message behind it. Retry it across polls, since most
+						// failures here pass on their own, and skip it once the bound runs
+						// out. The tick fails either way, as it did before.
 						const attempts = (nodeStaticData.pendingFetchAttempts ?? 0) + 1;
 						if (attempts >= MAX_PENDING_FETCH_ATTEMPTS) {
 							this.logger.warn(

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -404,13 +404,28 @@ export class GmailTrigger implements INodeType {
 
 		// Applied on every path that returns items — including a tick whose error
 		// was swallowed by the catch below, which skips the end of the try block.
+		// Simplifying needs a labels request of its own, and it runs after the
+		// messages are already fetched: a failure there must not cost the tick its
+		// messages or its state update, or a labels outage would stall delivery on
+		// every poll. Deliver the raw shape instead, on the same terms as the poll
+		// body — a manual run or a first poll still fails loudly.
 		const simplifyResponseData = async (): Promise<void> => {
-			if (simple && responseData.length > 0) {
+			if (!simple || responseData.length === 0) return;
+
+			try {
 				responseData = this.helpers.returnJsonArray(
 					await simplifyOutput.call(
 						this,
 						responseData.map((item) => item.json),
 					),
+				);
+			} catch (error) {
+				if (this.getMode() === 'manual' || !nodeStaticData.lastTimeChecked) {
+					throw error;
+				}
+				this.logger.error(
+					`Gmail Trigger could not simplify the output of '${node.name}': '${error.description}'`,
+					{ node: node.name, error },
 				);
 			}
 		};

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -581,9 +581,15 @@ export class GmailTrigger implements INodeType {
 			// calls. Gmail's `after:` query is inclusive at the second boundary, and a
 			// held cursor re-lists its whole window, so handled messages can reappear.
 			if (shouldLimitMessages) {
-				const possibleDuplicates = new Set(nodeStaticData.possibleDuplicates ?? []);
-				if (possibleDuplicates.size > 0) {
-					messages = messages.filter((m) => !possibleDuplicates.has(m.id));
+				// Set-aside ids are dropped along with the handled ones: that list
+				// already owns them and retries them every poll, so queueing them here
+				// as well would have both paths fetch the same message.
+				const alreadyTracked = new Set([
+					...(nodeStaticData.possibleDuplicates ?? []),
+					...(nodeStaticData.failedFetches ?? []).map(([id]) => id),
+				]);
+				if (alreadyTracked.size > 0) {
+					messages = messages.filter((m) => !alreadyTracked.has(m.id));
 				}
 
 				if (!messages.length && !allFetchedMessages.length) {

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -413,18 +413,17 @@ export class GmailTrigger implements INodeType {
 			}
 		};
 
-		// May only permit a cursor advance when an exhausted page token proved the
-		// window complete. Every path that never completes a listing — the early
-		// pending return (which exits before the advance) or any thrown fetch/list
-		// — must leave it pessimistic, or a held cursor would advance past mail
-		// the failed poll never listed.
+		// Pessimistic default: poll() swallows non-manual errors and still runs the
+		// cursor advance below, so a throw before or during listing must leave the
+		// cursor held. Only an exhausted page token may set this true.
 		let windowFullyListed = false;
 
 		try {
 			let budget = maxResults;
 
-			// Process pending messages from previous poll first.
-			// These are IDs that were listed but not fetched last time due to maxResults.
+			// Process pending messages from a previous poll first. These are IDs
+			// listed but not fetched last time: beyond the maxResults budget, or left
+			// over when a fetch failed mid-poll.
 			const pendingIds = nodeStaticData.pendingMessageIds ?? [];
 			if (shouldLimitMessages && pendingIds.length > 0) {
 				const idsToFetch = pendingIds.slice(0, budget);
@@ -453,10 +452,9 @@ export class GmailTrigger implements INodeType {
 						throw error;
 					}
 
-					// An id leaves the stored queue only after its fetch succeeded. A
-					// mid-drain throw is swallowed by the catch below, and pending ids sit
-					// behind an already-advanced cursor — removing them up front would
-					// lose the unfetched ones for good.
+					// An id leaves the stored queue only after its fetch succeeded — a
+					// dropped id is in no state and can already sit behind an advanced
+					// cursor, so nothing would ever list it again.
 					nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
 					// Only consecutive failures may add up to a skip.
 					nodeStaticData.pendingFetchAttempts = 0;
@@ -505,10 +503,6 @@ export class GmailTrigger implements INodeType {
 			let messages: ListMessage[] = [];
 			let pageToken: string | undefined;
 			let pagesListed = 0;
-			// From here on, an exception mid-loop must read as "not fully listed":
-			// the catch path continues to the cursor advance, and a stale `true`
-			// would skip everything the failed pages never showed.
-			windowFullyListed = false;
 			do {
 				const messagesResponse: MessageListResponse = await googleApiRequest.call(
 					this,
@@ -588,10 +582,9 @@ export class GmailTrigger implements INodeType {
 				for (const [index, message] of messagesToProcess.entries()) {
 					await fetchAndProcessMessage(message.id, fetchQs);
 					if (shouldLimitMessages) {
-						// An id leaves persisted state only after its fetch succeeded. A
-						// mid-loop throw is swallowed by the catch below, and the cursor can
-						// still advance past every listed id — an unfetched within-budget id
-						// kept in no persisted structure would be lost for good.
+						// Trim what the queue write above seeded: keep only the ids this loop
+						// has not delivered yet, so a swallowed throw leaves every unfetched
+						// id stored while the cursor may still advance past all of them.
 						nodeStaticData.pendingMessageIds = [
 							...messagesToProcess.slice(index + 1).map((m) => m.id),
 							...beyondBudgetIds,

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -500,22 +500,23 @@ export class GmailTrigger implements INodeType {
 				}
 			}
 
-			// Record everything fetched so far in possibleDuplicates so Gmail's
-			// boundary-inclusive `after:` query can't re-list a message this tick
-			// already emitted — either below, when the listing repeats a retried id,
-			// or on a later poll. Also covers the early return just after, where the
-			// state update at the end of poll() is skipped.
-			if (shouldLimitMessages && allFetchedMessages.length > 0) {
-				const merged = new Set([
-					...(nodeStaticData.possibleDuplicates ?? []),
-					...allFetchedMessages.map((m) => m.id),
-				]);
-				nodeStaticData.possibleDuplicates = Array.from(merged);
-			}
-
 			// While queued IDs remain, don't list new messages yet.
 			if (shouldLimitMessages && (nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
 				await simplifyResponseData();
+
+				// This path returns before the state update at the end of poll(), so it
+				// records the boundary itself: Gmail's boundary-inclusive `after:` query
+				// would otherwise re-list what this poll just delivered. It runs after
+				// simplifying, because a poll that fails there delivers nothing and its
+				// ids must stay listable.
+				if (allFetchedMessages.length > 0) {
+					const merged = new Set([
+						...(nodeStaticData.possibleDuplicates ?? []),
+						...allFetchedMessages.map((m) => m.id),
+					]);
+					nodeStaticData.possibleDuplicates = Array.from(merged);
+				}
+
 				return responseData.length > 0 ? [responseData] : null;
 			}
 
@@ -576,6 +577,10 @@ export class GmailTrigger implements INodeType {
 				const alreadyTracked = new Set([
 					...(nodeStaticData.possibleDuplicates ?? []),
 					...(nodeStaticData.failedFetches ?? []).map(([id]) => id),
+					// Fetched earlier in this same poll. Kept in memory rather than read
+					// from the boundary set, which is only written once the poll is sure
+					// it can deliver.
+					...allFetchedMessages.map((m) => m.id),
 				]);
 				if (alreadyTracked.size > 0) {
 					messages = messages.filter((m) => !alreadyTracked.has(m.id));

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1642,6 +1642,12 @@ describe('GmailTrigger', () => {
 				.query(true)
 				.reply(200, createMessage({ id, internalDate: String(internalDateMs) }));
 
+		const mockGetError = (id: string) =>
+			nock(baseUrl)
+				.get(`/gmail/v1/users/me/messages/${id}`)
+				.query(true)
+				.reply(500, { error: 'transient' });
+
 		it('should follow nextPageToken and deliver messages from all pages', async () => {
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': { lastTimeChecked: 1000000 },
@@ -1787,6 +1793,39 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
 				expect.arrayContaining(['X', 'P1']),
+			);
+		});
+
+		it('should keep unfetched pending ids when a drain fetch fails', async () => {
+			// A transient error mid-drain is swallowed by poll()'s catch. An id
+			// removed from the stored queue before its fetch would be lost for good:
+			// pending ids sit behind an already-advanced cursor, so no re-list ever
+			// finds them again.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 6_000_000_000,
+					pendingMessageIds: ['1', '2', '3'],
+				},
+			};
+
+			mockLabels();
+			mockGet('1', 1_000_000_000_000);
+			mockGetError('2');
+			// No mock for '3': the throw on '2' must stop the drain before it.
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			// Only the message fetched before the error is delivered...
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// ...and exactly the unfetched ids stay queued for the next poll.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '3']);
+			// The delivered id must leave the queue and join the boundary set,
+			// or the next poll would deliver it twice.
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['1']),
 			);
 		});
 

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1829,6 +1829,32 @@ describe('GmailTrigger', () => {
 			);
 		});
 
+		it('should simplify output when a fetch fails mid-poll', async () => {
+			// A swallowed fetch error must not change the shape of what is
+			// delivered: with Simplify on, the messages fetched before the error
+			// must still come out simplified, not in the raw format.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['1', '2']));
+			mockGet('1', 4_000_000_000_000);
+			mockGetError('2');
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// Simplified shape: labelIds resolved into labels, not left raw.
+			expect(response?.[0]?.[0]?.json.labels).toEqual([
+				{ id: 'testLabelId', name: 'Test Label Name' },
+			]);
+			expect(response?.[0]?.[0]?.json.labelIds).toBeUndefined();
+		});
+
 		it('should keep unfetched new-message ids when a fetch fails after the listing', async () => {
 			// Same invariant as the drain loop, on the new-message side: the window
 			// was fully listed, so the cursor advances past every listed id. A fetch

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1829,6 +1829,43 @@ describe('GmailTrigger', () => {
 			);
 		});
 
+		it('should keep holding the cursor when a drain fetch fails during a held backlog', async () => {
+			// The cursor was held by a previous capped tick, so unlisted older mail
+			// exists beyond the boundary. When a drain fetch throws before any
+			// listing starts, nothing proved the window complete — the drained
+			// message's newer date must not advance the cursor past the unlisted
+			// remainder.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					pendingMessageIds: ['P1', 'P2'],
+					possibleDuplicates: ['X'],
+				},
+			};
+
+			mockLabels();
+			mockGet('P1', 5_000_000_000_000);
+			mockGetError('P2');
+			// No list mocks: the throw precedes listing, so an unexpected list
+			// request must fail loudly.
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			// The message drained before the error is still delivered...
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
+			// ...but the cursor must keep holding: P1's date (5000s) must not
+			// become the new boundary while the window was never listed.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P2']);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['X', 'P1']),
+			);
+		});
+
 		it('should emit a message only once when pages return an overlapping id', async () => {
 			// Gmail pagination can repeat an id across pages when the mailbox shifts
 			// between page fetches. The accumulated list must be deduplicated.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -846,7 +846,7 @@ describe('GmailTrigger', () => {
 			// 1 message with maxResults=5, all fetched — advance normally
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2000000000);
 			// No pending messages
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toBeUndefined();
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
 		});
 
 		it('should not produce duplicates across a 3-poll pending drain cycle', async () => {
@@ -1824,6 +1824,36 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '3']);
 			// The delivered id must leave the queue and join the boundary set,
 			// or the next poll would deliver it twice.
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
+				expect.arrayContaining(['1']),
+			);
+		});
+
+		it('should keep unfetched new-message ids when a fetch fails after the listing', async () => {
+			// Same invariant as the drain loop, on the new-message side: the window
+			// was fully listed, so the cursor advances past every listed id. A fetch
+			// error mid-loop is swallowed — any within-budget id not yet persisted
+			// as pending sits behind the new cursor and is lost for good.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['1', '2', '3', '4']));
+			mockGet('1', 4_000_000_000_000);
+			mockGetError('2');
+			// No mock for '3': the throw on '2' must stop the loop before it.
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 3 } },
+				workflowStaticData,
+			});
+
+			// Only the message fetched before the error is delivered...
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// ...and the unfetched within-budget remainder joins the beyond-budget
+			// tail in the pending queue, order preserved.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '3', '4']);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
 				expect.arrayContaining(['1']),
 			);

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2085,6 +2085,32 @@ describe('GmailTrigger', () => {
 			);
 		});
 
+		it('should not queue a set-aside id that the listing returns again', async () => {
+			// The set-aside list already owns that id and retries it every poll. Also
+			// putting it in the queue would have both lists fetch it, and one poll
+			// could deliver it twice.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					failedFetches: [['X', 1]],
+				},
+			};
+
+			mockLabels();
+			mockGetError('X');
+			mockList(listPage(['A', 'X']));
+			mockGet('A', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['A']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['X', 2]]);
+		});
+
 		it('should retry only as many quarantined ids as one poll allows', async () => {
 			// The list can grow past what a poll should spend on requests, so each
 			// poll takes a slice and moves the rest to the front for the next one.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1922,6 +1922,82 @@ describe('GmailTrigger', () => {
 			);
 		});
 
+		it('should count a failed drain fetch instead of dropping the id right away', async () => {
+			// A transient error must not cost the message: keep it queued and
+			// remember the attempt.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					pendingMessageIds: ['P1', 'P2'],
+				},
+			};
+
+			mockLabels();
+			mockGetError('P1');
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P1', 'P2']);
+			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(1);
+		});
+
+		it('should skip a pending id that keeps failing so the queue can drain', async () => {
+			// A message that can never be fetched — deleted since it was listed, or
+			// one that always breaks parsing — would otherwise be retried before
+			// every listing forever, blocking both the queue and all new mail.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					pendingMessageIds: ['GONE', 'P2'],
+					pendingFetchAttempts: 2,
+				},
+			};
+
+			mockLabels();
+			mockGetError('GONE');
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response).toBeNull();
+			// The unfetchable id is gone from the queue; the rest survives for the
+			// next tick, which can now make progress.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P2']);
+			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(0);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+		});
+
+		it('should forget earlier drain failures once a fetch succeeds', async () => {
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['P1'],
+					pendingFetchAttempts: 2,
+				},
+			};
+
+			mockLabels();
+			mockGet('P1', 2_000_000_000_000);
+			mockList(listPage([]));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
+			// Only consecutive failures may add up to a skip.
+			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(0);
+		});
+
 		it('should emit a message only once when pages return an overlapping id', async () => {
 			// Gmail pagination can repeat an id across pages when the mailbox shifts
 			// between page fetches. The accumulated list must be deduplicated.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1999,6 +1999,32 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 		});
 
+		it('should still deliver messages when the labels lookup for simplifying fails', async () => {
+			// Simplifying needs a labels request of its own. If that fails, the poll
+			// must not stall: a failure that repeats would otherwise block delivery
+			// on every tick. Fall back to the raw shape instead.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Earlier tests can leave unconsumed interceptors behind, and this test
+			// needs the labels lookup to be the one request that fails.
+			nock.cleanAll();
+			nock(baseUrl).get('/gmail/v1/users/me/labels').reply(500, { error: 'transient' });
+			mockList(listPage(['1']));
+			mockGet('1', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// Unsimplified shape: raw labelIds survive because simplifying failed.
+			expect(response?.[0]?.[0]?.json.labelIds).toEqual(['testLabelId']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2_000_000_000);
+		});
+
 		it('should forget earlier drain failures once a fetch succeeds', async () => {
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2054,7 +2054,7 @@ describe('GmailTrigger', () => {
 			// boundary ids plus that one id is exactly the bound, while the boundary
 			// ids alone are not.
 			const initialTimestamp = 1000000;
-			const handled = Array.from({ length: 4998 }, (_, i) => `dup${i}`);
+			const handled = Array.from({ length: 4999 }, (_, i) => `dup${i}`);
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: initialTimestamp,
@@ -2142,6 +2142,34 @@ describe('GmailTrigger', () => {
 				['Q1', 2],
 				['Q2', 2],
 			]);
+		});
+
+		it('should not record ids at the boundary when the poll fails before delivering', async () => {
+			// The poll fetched a message and then failed while simplifying, so it
+			// delivers nothing. Its id must not join the boundary set: the cursor did
+			// not move, so the next poll re-lists that message, and a boundary entry
+			// would filter it out and lose it.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					pendingMessageIds: ['P1', 'P2'],
+				},
+			};
+
+			nock.cleanAll();
+			nock(baseUrl).get('/gmail/v1/users/me/labels').reply(500, { error: 'transient' });
+			mockGet('P1', 2_000_000_000_000);
+
+			await expect(
+				testPollingTriggerNode(GmailTrigger, {
+					node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
+					workflowStaticData,
+				}),
+			).rejects.toThrow();
+
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates ?? []).not.toContain('P1');
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 		});
 
 		it('should deliver nothing when the output cannot be simplified', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -845,8 +845,6 @@ describe('GmailTrigger', () => {
 
 			// 1 message with maxResults=5, all fetched — advance normally
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2000000000);
-			// No pending messages left — the fetch loop always writes the (empty)
-			// remainder, so the key exists
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
 		});
 
@@ -1424,7 +1422,7 @@ describe('GmailTrigger', () => {
 			//
 			// Poll 1: list [3,2,1] → emit [3,2], pending=['1'], lastTimeChecked=3000000000.
 			// Poll 2: drain '1', then list after:3000000000 is boundary-inclusive and
-			//   returns [4,3,2,1]. The pre-fetch filter at GmailTrigger.node.ts:450 only
+			//   returns [4,3,2,1]. The pre-fetch filter only
 			//   knows about possibleDuplicates={3,2}, so '1' falls through to overflow
 			//   and is re-added to pendingMessageIds — even though '1' was just drained.
 			// Poll 3 would then drain '1' again → the observed duplicate.
@@ -1504,8 +1502,8 @@ describe('GmailTrigger', () => {
 
 		it('should not re-emit pending messages drained during an early-return poll', async () => {
 			// Alternative failure path: with maxResults=1 and several same-second msgs,
-			// poll 2 early-returns at GmailTrigger.node.ts:417 because pending is still
-			// non-empty. The early-return skips the state update at lines 504-533, so
+			// poll 2 takes the early return because the queue is still non-empty. That
+			// path skips the state update at the end of poll(), so
 			// possibleDuplicates never records emails drained in poll 2. Poll 3's list
 			// call then finds those same-second emails unchanged in possibleDuplicates
 			// and they get re-queued as pending — causing duplicate emission later.
@@ -1616,11 +1614,12 @@ describe('GmailTrigger', () => {
 		});
 	});
 
-	describe('v1.4 - multi-page backlog pagination', () => {
-		// Contract under test: the scan follows nextPageToken up to 20 pages.
-		// lastTimeChecked advances only when the token was exhausted; otherwise the
-		// cursor holds so older mail it never scanned stays reachable. Give-up valve: once
-		// 5000 ids are already tracked, the poll advances instead of holding again.
+	describe('v1.4 - backlog scan, drain and retry', () => {
+		// Contract under test: the scan follows nextPageToken up to MAX_SCAN_PAGES.
+		// lastTimeChecked advances when the scan exhausted the token, or when a
+		// give-up valve fires: no progress past the cap, or MAX_TRACKED_BACKLOG_IDS
+		// ids already stored. Otherwise the cursor holds, so mail the poll never
+		// scanned stays reachable.
 		const listPage = (ids: string[], nextPageToken?: string): MessageListResponse => ({
 			messages: ids.map((id) => createListMessage({ id })),
 			resultSizeEstimate: ids.length,
@@ -1895,7 +1894,7 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['P2', 1]]);
 			// The cursor must keep holding: P1's date (5e9 s, far past the 1e6
 			// boundary) must not become the new cursor while the window was never
-			// listed.
+			// scanned.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
@@ -1903,7 +1902,7 @@ describe('GmailTrigger', () => {
 			);
 		});
 
-		it('should quarantine a failed id and keep draining the rest of the queue', async () => {
+		it('should set aside a failed id and keep draining the rest of the queue', async () => {
 			// A failed fetch must not stop the tick: the id moves aside, the other
 			// queued ids are still fetched, and the scan still runs so new mail
 			// keeps arriving.
@@ -1958,7 +1957,7 @@ describe('GmailTrigger', () => {
 		});
 
 		it('should not deliver a recovered id twice when the scan re-scans it', async () => {
-			// A quarantined id is still inside the query window, so a held cursor
+			// A set-aside id is still inside the query window, so a held cursor
 			// re-scans it. Once its retry succeeds it must join the boundary set
 			// before the scan runs, or the same tick delivers it twice.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
@@ -2060,7 +2059,7 @@ describe('GmailTrigger', () => {
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['OK1', 'OK2']);
 		});
 
-		it('should count quarantined ids towards the tracked-id bound', async () => {
+		it('should count set-aside ids towards the stored-id bound', async () => {
 			// Set-aside ids are stored state like the queue is, so they must not let a
 			// held cursor grow that state past the bound unnoticed. One retry succeeds
 			// (so the poll reaches its cursor decision) and one stays set aside: 4999
@@ -2133,9 +2132,6 @@ describe('GmailTrigger', () => {
 				'Gmail Trigger': { lastTimeChecked: 1000000 },
 			};
 
-			// Earlier tests can leave unconsumed interceptors behind, and this test
-			// needs the labels lookup to be the one request that fails.
-			nock.cleanAll();
 			nock(baseUrl).get('/gmail/v1/users/me/labels').reply(500, { error: 'transient' });
 			mockList(listPage(['1']));
 			mockGet('1', 2_000_000_000_000);
@@ -2227,7 +2223,7 @@ describe('GmailTrigger', () => {
 			]);
 		});
 
-		it('should retry only as many quarantined ids as one poll allows', async () => {
+		it('should retry only as many set-aside ids as one poll allows', async () => {
 			// The list can grow past what a poll should spend on requests, so each
 			// poll takes a slice and moves the rest to the front for the next one.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -845,7 +845,8 @@ describe('GmailTrigger', () => {
 
 			// 1 message with maxResults=5, all fetched — advance normally
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2000000000);
-			// No pending messages
+			// No pending messages left — the fetch loop always writes the (empty)
+			// remainder, so the key exists
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
 		});
 
@@ -1820,7 +1821,6 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
-			// Simplified shape: labelIds resolved into labels, not left raw.
 			expect(response?.[0]?.[0]?.json.labels).toEqual([
 				{ id: 'testLabelId', name: 'Test Label Name' },
 			]);

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2005,9 +2005,58 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response).toBeNull();
-			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([]);
-			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toContain('GONE');
-			// Not queued for a fetch either: the scan skipped it.
+			// The id stays in the list with no attempts left, which is what the scan
+			// skips — so it is not queued for a fetch either.
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([
+				['GONE', MAX_PENDING_FETCH_ATTEMPTS],
+			]);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
+		});
+
+		it('should keep remembering a given-up id after the cursor moves on', async () => {
+			// The boundary set is replaced whenever the cursor advances, so it cannot
+			// carry a give-up. The message was never fetched, so its date is unknown
+			// and "until the cursor passes it" is not something the poll can decide.
+			// The set-aside list keeps the id instead, which is what the scan skips.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					failedFetches: [['GONE', MAX_PENDING_FETCH_ATTEMPTS - 1]],
+				},
+			};
+
+			mockLabels();
+			mockGetError('GONE');
+			// A deliverable message in the same scan moves the cursor forward.
+			mockList(listPage(['OK']));
+			mockGet('OK', 2_000_000_000_000);
+
+			const first = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(first.response?.[0]?.map((item) => item.json.id)).toEqual(['OK']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2_000_000_000);
+			// The id is still remembered, with no attempts left.
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([
+				['GONE', MAX_PENDING_FETCH_ATTEMPTS],
+			]);
+
+			// Second poll: the scan finds the message again, and the poll must neither
+			// fetch it nor start its attempts over. Its fetch is not mocked.
+			mockLabels();
+			mockList(listPage(['GONE']));
+
+			const second = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(second.response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([
+				['GONE', MAX_PENDING_FETCH_ATTEMPTS],
+			]);
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
 		});
 
@@ -2032,7 +2081,11 @@ describe('GmailTrigger', () => {
 				workflowStaticData,
 			});
 
-			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['FRESH', 1]]);
+			// OLD used up its attempts and is kept with none left; FRESH keeps its own.
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([
+				['OLD', MAX_PENDING_FETCH_ATTEMPTS],
+				['FRESH', 1],
+			]);
 		});
 
 		it('should not spend the delivery budget on failed fetches', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1834,10 +1834,11 @@ describe('GmailTrigger', () => {
 		});
 
 		it('should keep unfetched new-message ids when a fetch fails after the scan', async () => {
-			// Same invariant as the drain loop, on the new-message side: the window
-			// was fully scanned, so the cursor advances past every listed id. A fetch
-			// error mid-loop is swallowed — any within-budget id not yet persisted
-			// as pending sits behind the new cursor and is lost for good.
+			// Same rule as the queue drain, on the newly scanned side. The scan
+			// reached the whole window, so the cursor advances past every id it
+			// found: an id that is in no stored state would sit behind the new
+			// cursor and be lost. A failed id goes to the set-aside list, and the
+			// ids the budget could not reach stay queued.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': { lastTimeChecked: 1000000 },
 			};
@@ -1846,20 +1847,21 @@ describe('GmailTrigger', () => {
 			mockList(listPage(['1', '2', '3', '4']));
 			mockGet('1', 4_000_000_000_000);
 			mockGetError('2');
-			// No mock for '3': the throw on '2' must stop the loop before it.
+			mockGet('3', 3_000_000_000_000);
+			// No mock for '4': it is beyond the budget, so this poll must not fetch it.
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 3 } },
 				workflowStaticData,
 			});
 
-			// Only the message fetched before the error is delivered...
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
-			// ...and the unfetched within-budget remainder joins the beyond-budget
-			// tail in the pending queue, order preserved.
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '3', '4']);
+			// The failure costs only its own message.
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1', '3']);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['2', 1]]);
+			// The beyond-budget tail stays queued.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['4']);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
-				expect.arrayContaining(['1']),
+				expect.arrayContaining(['1', '3']),
 			);
 		});
 
@@ -1978,7 +1980,11 @@ describe('GmailTrigger', () => {
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['Q1', 'NEW']);
 		});
 
-		it('should drop a quarantined id once it has used up its attempts', async () => {
+		it('should stop looking for an id it gave up on', async () => {
+			// Giving up has to outlast the poll. An id that is only removed from the
+			// set-aside list is in no stored state at all, so the next scan finds it
+			// again and the whole round of attempts starts over. Putting it at the
+			// boundary keeps the scan from picking it up while the cursor is held.
 			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -1989,14 +1995,19 @@ describe('GmailTrigger', () => {
 
 			mockLabels();
 			mockGetError('GONE');
-			mockList(listPage([]));
+			// The message is still in the mailbox, so the scan returns it again.
+			mockList(listPage(['GONE']));
 
-			await testPollingTriggerNode(GmailTrigger, {
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
 				workflowStaticData,
 			});
 
+			expect(response).toBeNull();
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toContain('GONE');
+			// Not queued for a fetch either: the scan skipped it.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
 		});
 
 		it('should count attempts per id so a fresh failure is not dropped early', async () => {
@@ -2136,6 +2147,29 @@ describe('GmailTrigger', () => {
 			// Raw labelIds survive, because simplifying failed.
 			expect(response?.[0]?.[0]?.json.labelIds).toEqual(['testLabelId']);
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2_000_000_000);
+		});
+
+		it('should keep fetching the rest of a scanned batch when one fetch fails', async () => {
+			// The scan found several messages. One failing fetch must not cost the
+			// poll the messages behind it, and that failure must count as an attempt
+			// like every other one, so the id does not get a free try.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['A', 'B']));
+			mockGetError('A');
+			mockGet('B', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['B']);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['A', 1]]);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
 		});
 
 		it('should retry only as many quarantined ids as one poll allows', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1654,6 +1654,12 @@ describe('GmailTrigger', () => {
 				.query(true)
 				.reply(500, { error: 'transient' });
 
+		// Several tests here prove a request did NOT happen, so their unconsumed
+		// interceptors must not leak into the next test's requests.
+		afterEach(() => {
+			nock.cleanAll();
+		});
+
 		it('should follow nextPageToken and deliver messages from all pages', async () => {
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': { lastTimeChecked: 1000000 },
@@ -1859,10 +1865,8 @@ describe('GmailTrigger', () => {
 
 		it('should keep holding the cursor when a drain fetch fails during a held backlog', async () => {
 			// The cursor was held by a previous capped tick, so unlisted older mail
-			// exists beyond the boundary. When a drain fetch throws before any
-			// listing starts, nothing proved the window complete — the drained
-			// message's newer date must not advance the cursor past the unlisted
-			// remainder.
+			// exists beyond the boundary. A drain fetch failing must not let the
+			// drained messages' newer dates advance the cursor past that remainder.
 			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -1875,128 +1879,243 @@ describe('GmailTrigger', () => {
 			mockLabels();
 			mockGet('P1', 5_000_000_000_000);
 			mockGetError('P2');
-			// No mock for 'P3' and no list mocks: the throw on 'P2' must stop the
-			// drain before it, and listing must not be reached at all.
+			mockGet('P3', 4_000_000_000_000);
+			// No list mocks: the listing cannot complete, so nothing proves the
+			// window was fully listed.
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
 				workflowStaticData,
 			});
 
-			// The message drained before the error is still delivered...
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
-			// ...but the cursor must keep holding: P1's date (5e9 s, far past the
-			// 1e6 boundary) must not become the new cursor while the window was
-			// never listed.
+			// The failure costs only its own message: the ids around it are drained.
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1', 'P3']);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['P2', 1]]);
+			// The cursor must keep holding: P1's date (5e9 s, far past the 1e6
+			// boundary) must not become the new cursor while the window was never
+			// listed.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
-			// Exactly the unfetched ids stay queued, the delivered one does not.
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P2', 'P3']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
-				expect.arrayContaining(['X', 'P1']),
+				expect.arrayContaining(['X', 'P1', 'P3']),
 			);
 		});
 
-		it('should keep listed ids when the very first new-message fetch fails', async () => {
-			// A drain succeeded earlier in this tick, so the "nothing fetched" guard
-			// cannot save the listing: the cursor advances to the drained message's
-			// date. A listed id older than that date must therefore be queued before
-			// the first fetch, not after it, or it ends up behind the cursor and in
-			// no stored state.
+		it('should quarantine a failed id and keep draining the rest of the queue', async () => {
+			// A failed fetch must not stop the tick: the id moves aside, the other
+			// queued ids are still fetched, and the listing still runs so new mail
+			// keeps arriving.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['BAD', 'OK1'],
+				},
+			};
+
+			mockLabels();
+			mockGetError('BAD');
+			mockGet('OK1', 2_000_000_000_000);
+			mockList(listPage(['NEW']));
+			mockGet('NEW', 3_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['OK1', 'NEW']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
+			// The failed id is tracked on its own, with one attempt against it.
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['BAD', 1]]);
+		});
+
+		it('should retry a quarantined id before the queue and deliver it on success', async () => {
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: 1000000,
 					pendingMessageIds: ['P1'],
+					failedFetches: [['RECOVERED', 2]],
 				},
 			};
 
 			mockLabels();
-			mockGet('P1', 5_000_000_000_000);
-			mockList(listPage(['R1', 'R2']));
-			mockGetError('R1');
+			mockGet('RECOVERED', 2_000_000_000_000);
+			mockGet('P1', 3_000_000_000_000);
+			mockList(listPage([]));
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
 				workflowStaticData,
 			});
 
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['R1', 'R2']);
+			// Quarantined ids are the oldest, so they go first.
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['RECOVERED', 'P1']);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([]);
 		});
 
-		it('should count a failed drain fetch instead of dropping the id right away', async () => {
-			// A transient error must not cost the message: keep it queued and
-			// remember the attempt.
-			const initialTimestamp = 1000000;
-			const workflowStaticData: Record<string, Record<string, unknown>> = {
-				'Gmail Trigger': {
-					lastTimeChecked: initialTimestamp,
-					pendingMessageIds: ['P1', 'P2'],
-				},
-			};
-
-			mockLabels();
-			mockGetError('P1');
-
-			const { response } = await testPollingTriggerNode(GmailTrigger, {
-				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
-				workflowStaticData,
-			});
-
-			expect(response).toBeNull();
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P1', 'P2']);
-			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(1);
-		});
-
-		it('should keep retrying a queued message while the failure may be transient', async () => {
-			// Rate limits and 5xx come and go, and this node never retries a request
-			// itself. Dropping such an id early would lose the message.
+		it('should not deliver a recovered id twice when the listing re-lists it', async () => {
+			// A quarantined id is still inside the query window, so a held cursor
+			// re-lists it. Once its retry succeeds it must join the boundary set
+			// before the listing runs, or the same tick delivers it twice.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: 1000000,
-					pendingMessageIds: ['P1', 'P2'],
-					pendingFetchAttempts: 3,
+					failedFetches: [['Q1', 1]],
 				},
 			};
 
 			mockLabels();
-			mockGetError('P1');
+			mockGet('Q1', 2_000_000_000_000);
+			mockGet('Q1', 2_000_000_000_000);
+			mockList(listPage(['NEW', 'Q1']));
+			mockGet('NEW', 3_000_000_000_000);
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
 				workflowStaticData,
 			});
 
-			expect(response).toBeNull();
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P1', 'P2']);
-			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(4);
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['Q1', 'NEW']);
 		});
 
-		it('should skip a pending id that keeps failing so the queue can drain', async () => {
-			// Even a failure that looks transient has to be given up on eventually,
-			// or one message blocks its queue and all new mail for good.
+		it('should drop a quarantined id once it has used up its attempts', async () => {
 			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: initialTimestamp,
-					pendingMessageIds: ['GONE', 'P2'],
-					pendingFetchAttempts: MAX_PENDING_FETCH_ATTEMPTS - 1,
+					failedFetches: [['GONE', MAX_PENDING_FETCH_ATTEMPTS - 1]],
 				},
 			};
 
 			mockLabels();
 			mockGetError('GONE');
+			mockList(listPage([]));
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([]);
+		});
+
+		it('should count attempts per id so a fresh failure is not dropped early', async () => {
+			// One id is on its last attempt while another fails for the first time.
+			// Only the first may be dropped, or the second loses its retries.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['FRESH'],
+					failedFetches: [['OLD', MAX_PENDING_FETCH_ATTEMPTS - 1]],
+				},
+			};
+
+			mockLabels();
+			mockGetError('OLD');
+			mockGetError('FRESH');
+			mockList(listPage([]));
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['FRESH', 1]]);
+		});
+
+		it('should not spend the delivery budget on failed fetches', async () => {
+			// A failed fetch carries no message, so it must not count against
+			// maxResults — the healthy queued ids still fit in this tick.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['BAD', 'OK1', 'OK2'],
+				},
+			};
+
+			mockLabels();
+			mockGetError('BAD');
+			mockGet('OK1', 2_000_000_000_000);
+			mockGet('OK2', 3_000_000_000_000);
+			mockList(listPage([]));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['OK1', 'OK2']);
+		});
+
+		it('should count quarantined ids towards the tracked-id bound', async () => {
+			// Set-aside ids are stored state like the queue is, so they must not let a
+			// held cursor grow that state past the bound unnoticed. One retry succeeds
+			// (so the poll reaches its cursor decision) and one stays set aside: 4999
+			// boundary ids plus that one id is exactly the bound, while the boundary
+			// ids alone are not.
+			const initialTimestamp = 1000000;
+			const handled = Array.from({ length: 4998 }, (_, i) => `dup${i}`);
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					possibleDuplicates: handled,
+					failedFetches: [
+						['Q1', 1],
+						['Q2', 1],
+					],
+				},
+			};
+
+			mockLabels();
+			mockGet('Q1', 6_000_000_000_000);
+			mockGetError('Q2');
+			// The listing cannot finish — page two is not mocked — so nothing proves
+			// the window complete and the cursor would otherwise hold.
+			mockList(listPage(['n0'], 'token-1'));
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
 				workflowStaticData,
 			});
 
-			expect(response).toBeNull();
-			// The unfetchable id is gone from the queue; the rest survives for the
-			// next tick, which can now make progress.
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P2']);
-			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(0);
-			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['Q1']);
+			// Past the bound, so the poll gives up holding instead of tracking more.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked as number).toBeGreaterThan(
+				initialTimestamp,
+			);
+		});
+
+		it('should retry only as many quarantined ids as one poll allows', async () => {
+			// The list can grow past what a poll should spend on requests, so each
+			// poll takes a slice and moves the rest to the front for the next one.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					failedFetches: [
+						['Q1', 1],
+						['Q2', 1],
+						['Q3', 1],
+					],
+				},
+			};
+
+			mockLabels();
+			mockGetError('Q1');
+			mockGetError('Q2');
+			// No mock for 'Q3': it must not be requested in this poll.
+			mockList(listPage([]));
+
+			await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			// Q3 waits with its count untouched and goes first next poll.
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([
+				['Q3', 1],
+				['Q1', 2],
+				['Q2', 2],
+			]);
 		});
 
 		it('should still deliver messages when the labels lookup for simplifying fails', async () => {
@@ -2023,29 +2142,6 @@ describe('GmailTrigger', () => {
 			// Unsimplified shape: raw labelIds survive because simplifying failed.
 			expect(response?.[0]?.[0]?.json.labelIds).toEqual(['testLabelId']);
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2_000_000_000);
-		});
-
-		it('should forget earlier drain failures once a fetch succeeds', async () => {
-			const workflowStaticData: Record<string, Record<string, unknown>> = {
-				'Gmail Trigger': {
-					lastTimeChecked: 1000000,
-					pendingMessageIds: ['P1'],
-					pendingFetchAttempts: 2,
-				},
-			};
-
-			mockLabels();
-			mockGet('P1', 2_000_000_000_000);
-			mockList(listPage([]));
-
-			const { response } = await testPollingTriggerNode(GmailTrigger, {
-				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
-				workflowStaticData,
-			});
-
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
-			// Only consecutive failures may add up to a skip.
-			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(0);
 		});
 
 		it('should emit a message only once when pages return an overlapping id', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 
 import { testPollingTriggerNode } from '@test/nodes/TriggerHelpers';
 
-import { GmailTrigger } from '../GmailTrigger.node';
+import { GmailTrigger, MAX_PENDING_FETCH_ATTEMPTS } from '../GmailTrigger.node';
 import type { Message, ListMessage, MessageListResponse } from '../types';
 
 vi.mock('mailparser');
@@ -1947,16 +1947,39 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(1);
 		});
 
+		it('should keep retrying a queued message while the failure may be transient', async () => {
+			// Rate limits and 5xx come and go, and this node never retries a request
+			// itself. Dropping such an id early would lose the message.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['P1', 'P2'],
+					pendingFetchAttempts: 3,
+				},
+			};
+
+			mockLabels();
+			mockGetError('P1');
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P1', 'P2']);
+			expect(workflowStaticData['Gmail Trigger'].pendingFetchAttempts).toBe(4);
+		});
+
 		it('should skip a pending id that keeps failing so the queue can drain', async () => {
-			// A message that can never be fetched — deleted since it was listed, or
-			// one that always breaks parsing — would otherwise be retried before
-			// every listing forever, blocking both the queue and all new mail.
+			// Even a failure that looks transient has to be given up on eventually,
+			// or one message blocks its queue and all new mail for good.
 			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: initialTimestamp,
 					pendingMessageIds: ['GONE', 'P2'],
-					pendingFetchAttempts: 2,
+					pendingFetchAttempts: MAX_PENDING_FETCH_ATTEMPTS - 1,
 				},
 			};
 

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1374,7 +1374,7 @@ describe('GmailTrigger', () => {
 		});
 
 		it('should early-return when budget is fully consumed by pending messages', async () => {
-			// maxResults=2, pending has 3 IDs → fetch 2, keep 1 pending, no listing
+			// maxResults=2, pending has 3 IDs → fetch 2, keep 1 pending, no scan
 			nock(baseUrl)
 				.get('/gmail/v1/users/me/labels')
 				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
@@ -1384,7 +1384,7 @@ describe('GmailTrigger', () => {
 			nock(baseUrl)
 				.get(new RegExp('/gmail/v1/users/me/messages/B?.*'))
 				.reply(200, createMessage({ id: 'B', internalDate: '2000000000000' }));
-			// No list mock — listing should NOT happen because budget is exhausted
+			// No list mock — scan should NOT happen because budget is exhausted
 
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -1617,9 +1617,9 @@ describe('GmailTrigger', () => {
 	});
 
 	describe('v1.4 - multi-page backlog pagination', () => {
-		// Contract under test: the list loop follows nextPageToken up to 20 pages.
+		// Contract under test: the scan follows nextPageToken up to 20 pages.
 		// lastTimeChecked advances only when the token was exhausted; otherwise the
-		// cursor holds so unlisted older mail stays reachable. Give-up valve: once
+		// cursor holds so older mail it never scanned stays reachable. Give-up valve: once
 		// 5000 ids are already tracked, the poll advances instead of holding again.
 		const listPage = (ids: string[], nextPageToken?: string): MessageListResponse => ({
 			messages: ids.map((id) => createListMessage({ id })),
@@ -1703,7 +1703,7 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]).toHaveLength(2);
-			// The window was fully listed, so every unfetched id is tracked by id and
+			// The scan reached the whole window, so every unfetched id is tracked by id and
 			// advancing cannot lose anything.
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['4', '3', '2', '1']);
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
@@ -1733,19 +1733,19 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]).toHaveLength(2);
-			// The window was NOT fully listed: unlisted older mail exists beyond the
+			// The scan did NOT reach the whole window: older mail exists beyond the
 			// cap, so the cursor must hold to keep it reachable.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(allIds.slice(2));
-			// Fetched ids join the boundary set so the held-cursor re-list skips them.
+			// Fetched ids join the boundary set so a re-scan under the held cursor skips them.
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
 				expect.arrayContaining(['p0a', 'p0b']),
 			);
 		});
 
-		it('should resume a held backlog and advance once the window is fully listed', async () => {
+		it('should resume a held backlog and advance once the scan reaches the whole window', async () => {
 			// Mid-backlog state: cursor held, one id pending, one handled id at the
-			// boundary. The re-list must skip the handled id, and the exhausted token
+			// boundary. The re-scan must skip the handled id, and the exhausted token
 			// must let the cursor advance again.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -1770,8 +1770,8 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds ?? []).toEqual([]);
 		});
 
-		it('should hold the cursor when listing fails mid-pagination', async () => {
-			// A transient error on page 2 means the window was NOT fully listed.
+		it('should hold the cursor when the scan fails mid-pagination', async () => {
+			// A transient error on page 2 means the window was NOT fully scanned.
 			// Advancing anyway would skip everything the failed pages never showed —
 			// silently, without even the valve's warning.
 			const initialTimestamp = 1000000;
@@ -1786,7 +1786,7 @@ describe('GmailTrigger', () => {
 			mockLabels();
 			// The pending drain succeeds and populates the fetched set...
 			mockGet('P1', 5_000_000_000_000);
-			// ...then listing resumes: page 1 succeeds with a token, page 2 blows up.
+			// ...then scan resumes: page 1 succeeds with a token, page 2 blows up.
 			mockList(listPage(['L1', 'L2'], 'token-1'));
 			nock(baseUrl)
 				.get('/gmail/v1/users/me/messages')
@@ -1833,9 +1833,9 @@ describe('GmailTrigger', () => {
 			expect(response?.[0]?.[0]?.json.labelIds).toBeUndefined();
 		});
 
-		it('should keep unfetched new-message ids when a fetch fails after the listing', async () => {
+		it('should keep unfetched new-message ids when a fetch fails after the scan', async () => {
 			// Same invariant as the drain loop, on the new-message side: the window
-			// was fully listed, so the cursor advances past every listed id. A fetch
+			// was fully scanned, so the cursor advances past every listed id. A fetch
 			// error mid-loop is swallowed — any within-budget id not yet persisted
 			// as pending sits behind the new cursor and is lost for good.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
@@ -1864,7 +1864,7 @@ describe('GmailTrigger', () => {
 		});
 
 		it('should keep holding the cursor when a drain fetch fails during a held backlog', async () => {
-			// The cursor was held by a previous capped tick, so unlisted older mail
+			// The cursor was held by a previous capped tick, so unscanned older mail
 			// exists beyond the boundary. A drain fetch failing must not let the
 			// drained messages' newer dates advance the cursor past that remainder.
 			const initialTimestamp = 1000000;
@@ -1880,8 +1880,8 @@ describe('GmailTrigger', () => {
 			mockGet('P1', 5_000_000_000_000);
 			mockGetError('P2');
 			mockGet('P3', 4_000_000_000_000);
-			// No list mocks: the listing cannot complete, so nothing proves the
-			// window was fully listed.
+			// No scan mocks: the scan cannot complete, so nothing proves the
+			// window was fully scanned.
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
@@ -1903,7 +1903,7 @@ describe('GmailTrigger', () => {
 
 		it('should quarantine a failed id and keep draining the rest of the queue', async () => {
 			// A failed fetch must not stop the tick: the id moves aside, the other
-			// queued ids are still fetched, and the listing still runs so new mail
+			// queued ids are still fetched, and the scan still runs so new mail
 			// keeps arriving.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -1953,10 +1953,10 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([]);
 		});
 
-		it('should not deliver a recovered id twice when the listing re-lists it', async () => {
+		it('should not deliver a recovered id twice when the scan re-scans it', async () => {
 			// A quarantined id is still inside the query window, so a held cursor
-			// re-lists it. Once its retry succeeds it must join the boundary set
-			// before the listing runs, or the same tick delivers it twice.
+			// re-scans it. Once its retry succeeds it must join the boundary set
+			// before the scan runs, or the same tick delivers it twice.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: 1000000,
@@ -2069,7 +2069,7 @@ describe('GmailTrigger', () => {
 			mockLabels();
 			mockGet('Q1', 6_000_000_000_000);
 			mockGetError('Q2');
-			// The listing cannot finish — page two is not mocked — so nothing proves
+			// The scan cannot finish, because page two is not mocked, so nothing proves
 			// the window complete and the cursor would otherwise hold.
 			mockList(listPage(['n0'], 'token-1'));
 
@@ -2085,7 +2085,7 @@ describe('GmailTrigger', () => {
 			);
 		});
 
-		it('should not queue a set-aside id that the listing returns again', async () => {
+		it('should not queue a set-aside id that the scan returns again', async () => {
 			// The set-aside list already owns that id and retries it every poll. Also
 			// putting it in the queue would have both lists fetch it, and one poll
 			// could deliver it twice.
@@ -2222,7 +2222,7 @@ describe('GmailTrigger', () => {
 		});
 
 		it('should give up holding when a capped window makes no progress', async () => {
-			// Every id the cap can reach is already tracked, so re-listing the same
+			// Every id the cap can reach is already tracked, so re-scanning the same
 			// pages can never progress past them. Holding again would repeat this
 			// tick forever: no backlog progress, no new mail, no warning. The poll
 			// must give up instead — advance and start fresh.
@@ -2259,7 +2259,7 @@ describe('GmailTrigger', () => {
 		it('should not paginate on versions before 1.4', async () => {
 			// Pagination is scoped to v1.4+: older versions have no pendingMessageIds
 			// machinery, so following the token there would change their behavior.
-			// Only one list page is mocked — a second list request fails the poll,
+			// Only one page is mocked, so a second page request fails the poll,
 			// and the assertions below catch the resulting empty response.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': { lastTimeChecked: 1000000 },
@@ -2283,7 +2283,7 @@ describe('GmailTrigger', () => {
 		it('should keep the beyond-budget remainder when a drain exactly consumed the budget', async () => {
 			// The drain empties the queue, so there is no early return, but it also
 			// leaves no budget: the fetch loop never runs, and only the pre-fetch
-			// queue write can save what the listing found.
+			// queue write can save what the scan found.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: 1000000,
@@ -2335,7 +2335,7 @@ describe('GmailTrigger', () => {
 			// Cap was hit (20 pages listed, token remaining) but the valve fires:
 			// advance instead of holding.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
-			// The valve skips only unlisted mail; listed-but-unfetched ids stay tracked.
+			// The valve skips only unscanned mail; scanned-but-unfetched ids stay tracked.
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(allIds.slice(2));
 		});
 	});

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2111,6 +2111,33 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['X', 2]]);
 		});
 
+		it('should deliver the raw shape when the labels lookup for simplifying fails', async () => {
+			// Simplifying needs a labels request of its own. A failure there is
+			// swallowed like any other poll error and the items go out unsimplified,
+			// which is what the node did before. Delivering nothing instead would
+			// change what a workflow receives and needs a new node version.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			// Earlier tests can leave unconsumed interceptors behind, and this test
+			// needs the labels lookup to be the one request that fails.
+			nock.cleanAll();
+			nock(baseUrl).get('/gmail/v1/users/me/labels').reply(500, { error: 'transient' });
+			mockList(listPage(['1']));
+			mockGet('1', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// Raw labelIds survive, because simplifying failed.
+			expect(response?.[0]?.[0]?.json.labelIds).toEqual(['testLabelId']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2_000_000_000);
+		});
+
 		it('should retry only as many quarantined ids as one poll allows', async () => {
 			// The list can grow past what a poll should spend on requests, so each
 			// poll takes a slice and moves the rest to the front for the next one.
@@ -2142,62 +2169,6 @@ describe('GmailTrigger', () => {
 				['Q1', 2],
 				['Q2', 2],
 			]);
-		});
-
-		it('should not record ids at the boundary when the poll fails before delivering', async () => {
-			// The poll fetched a message and then failed while simplifying, so it
-			// delivers nothing. Its id must not join the boundary set: the cursor did
-			// not move, so the next poll re-lists that message, and a boundary entry
-			// would filter it out and lose it.
-			const initialTimestamp = 1000000;
-			const workflowStaticData: Record<string, Record<string, unknown>> = {
-				'Gmail Trigger': {
-					lastTimeChecked: initialTimestamp,
-					pendingMessageIds: ['P1', 'P2'],
-				},
-			};
-
-			nock.cleanAll();
-			nock(baseUrl).get('/gmail/v1/users/me/labels').reply(500, { error: 'transient' });
-			mockGet('P1', 2_000_000_000_000);
-
-			await expect(
-				testPollingTriggerNode(GmailTrigger, {
-					node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
-					workflowStaticData,
-				}),
-			).rejects.toThrow();
-
-			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates ?? []).not.toContain('P1');
-			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
-		});
-
-		it('should deliver nothing when the output cannot be simplified', async () => {
-			// The workflow asked for simplified output. If the labels request that
-			// simplifying needs fails, the poll must not hand over the raw shape:
-			// downstream nodes read fields that only the simplified shape has. Fail
-			// the poll instead and leave the cursor alone, so the next poll delivers
-			// these messages in the shape the workflow expects.
-			const initialTimestamp = 1000000;
-			const workflowStaticData: Record<string, Record<string, unknown>> = {
-				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
-			};
-
-			// Earlier tests can leave unconsumed interceptors behind, and this test
-			// needs the labels lookup to be the one request that fails.
-			nock.cleanAll();
-			nock(baseUrl).get('/gmail/v1/users/me/labels').reply(500, { error: 'transient' });
-			mockList(listPage(['1']));
-			mockGet('1', 2_000_000_000_000);
-
-			await expect(
-				testPollingTriggerNode(GmailTrigger, {
-					node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
-					workflowStaticData,
-				}),
-			).rejects.toThrow();
-
-			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 		});
 
 		it('should emit a message only once when pages return an overlapping id', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1931,7 +1931,11 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['BAD', 1]]);
 		});
 
-		it('should retry a quarantined id before the queue and deliver it on success', async () => {
+		it('should retry a set-aside id before the queue and deliver it on success', async () => {
+			// One message fits in this poll, and the set-aside id has waited longest,
+			// so it goes first and spends that one unit of budget. The queued id has
+			// to wait for the next poll — its fetch is not mocked, so a poll that
+			// spent no budget on the retry would fail here.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: 1000000,
@@ -1942,17 +1946,15 @@ describe('GmailTrigger', () => {
 
 			mockLabels();
 			mockGet('RECOVERED', 2_000_000_000_000);
-			mockGet('P1', 3_000_000_000_000);
-			mockList(listPage([]));
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
-				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
 				workflowStaticData,
 			});
 
-			// Quarantined ids are the oldest, so they go first.
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['RECOVERED', 'P1']);
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['RECOVERED']);
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P1']);
 		});
 
 		it('should not deliver a recovered id twice when the scan re-scans it', async () => {
@@ -2170,6 +2172,59 @@ describe('GmailTrigger', () => {
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['B']);
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['A', 1]]);
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual([]);
+		});
+
+		it('should not scan for new messages while the queue still holds ids', async () => {
+			// The queue write after a scan replaces the whole queue, so scanning while
+			// ids are still queued would drop the ones this poll could not reach.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['P1', 'P2'],
+				},
+			};
+
+			mockLabels();
+			mockGet('P1', 2_000_000_000_000);
+			const scanScope = mockList(listPage(['NEW']));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
+			// No scan request went out, and the undrained id survives.
+			expect(scanScope.isDone()).toBe(false);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P2']);
+		});
+
+		it('should stop draining once a poll has spent its attempts on failures', async () => {
+			// Failures cost no budget, so only their own count stops the drain. Without
+			// that stop, one poll would work through a queue full of failures.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['F1', 'F2', 'F3'],
+				},
+			};
+
+			mockLabels();
+			mockGetError('F1');
+			mockGetError('F2');
+			// No mock for 'F3': this poll has used up its attempts before reaching it.
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['F3']);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([
+				['F1', 1],
+				['F2', 1],
+			]);
 		});
 
 		it('should retry only as many quarantined ids as one poll allows', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1401,6 +1401,11 @@ describe('GmailTrigger', () => {
 			expect(response?.[0]).toHaveLength(2);
 			expect(response?.[0]?.[0]?.json?.id).toBe('A');
 			expect(response?.[0]?.[1]?.json?.id).toBe('B');
+			// This path returns before the end of poll(), so it needs its own
+			// simplify step — raw labelIds here would mean unsimplified output.
+			expect(response?.[0]?.[0]?.json.labels).toEqual([
+				{ id: 'testLabelId', name: 'Test Label Name' },
+			]);
 			// One pending ID remains
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['C']);
 			// possibleDuplicates includes the pre-existing entries plus drained IDs so
@@ -1796,39 +1801,6 @@ describe('GmailTrigger', () => {
 			);
 		});
 
-		it('should keep unfetched pending ids when a drain fetch fails', async () => {
-			// A transient error mid-drain is swallowed by poll()'s catch. An id
-			// removed from the stored queue before its fetch would be lost for good:
-			// pending ids sit behind an already-advanced cursor, so no re-list ever
-			// finds them again.
-			const workflowStaticData: Record<string, Record<string, unknown>> = {
-				'Gmail Trigger': {
-					lastTimeChecked: 6_000_000_000,
-					pendingMessageIds: ['1', '2', '3'],
-				},
-			};
-
-			mockLabels();
-			mockGet('1', 1_000_000_000_000);
-			mockGetError('2');
-			// No mock for '3': the throw on '2' must stop the drain before it.
-
-			const { response } = await testPollingTriggerNode(GmailTrigger, {
-				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
-				workflowStaticData,
-			});
-
-			// Only the message fetched before the error is delivered...
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
-			// ...and exactly the unfetched ids stay queued for the next poll.
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '3']);
-			// The delivered id must leave the queue and join the boundary set,
-			// or the next poll would deliver it twice.
-			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
-				expect.arrayContaining(['1']),
-			);
-		});
-
 		it('should simplify output when a fetch fails mid-poll', async () => {
 			// A swallowed fetch error must not change the shape of what is
 			// delivered: with Simplify on, the messages fetched before the error
@@ -1895,7 +1867,7 @@ describe('GmailTrigger', () => {
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
 					lastTimeChecked: initialTimestamp,
-					pendingMessageIds: ['P1', 'P2'],
+					pendingMessageIds: ['P1', 'P2', 'P3'],
 					possibleDuplicates: ['X'],
 				},
 			};
@@ -1903,8 +1875,8 @@ describe('GmailTrigger', () => {
 			mockLabels();
 			mockGet('P1', 5_000_000_000_000);
 			mockGetError('P2');
-			// No list mocks: the throw precedes listing, so an unexpected list
-			// request must fail loudly.
+			// No mock for 'P3' and no list mocks: the throw on 'P2' must stop the
+			// drain before it, and listing must not be reached at all.
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
@@ -1913,10 +1885,12 @@ describe('GmailTrigger', () => {
 
 			// The message drained before the error is still delivered...
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
-			// ...but the cursor must keep holding: P1's date (5000s) must not
-			// become the new boundary while the window was never listed.
+			// ...but the cursor must keep holding: P1's date (5e9 s, far past the
+			// 1e6 boundary) must not become the new cursor while the window was
+			// never listed.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P2']);
+			// Exactly the unfetched ids stay queued, the delivered one does not.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['P2', 'P3']);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(
 				expect.arrayContaining(['X', 'P1']),
 			);
@@ -2129,6 +2103,34 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// The queue belongs to v1.4+; older versions must not persist one their
+			// own drain path would ignore.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toBeUndefined();
+		});
+
+		it('should keep the beyond-budget remainder when a drain exactly consumed the budget', async () => {
+			// The drain empties the queue, so there is no early return, but it also
+			// leaves no budget: the fetch loop never runs, and only the pre-fetch
+			// queue write can save what the listing found.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['P1', 'P2'],
+				},
+			};
+
+			mockLabels();
+			mockGet('P1', 2_000_000_000_000);
+			mockGet('P2', 2_000_000_000_000);
+			mockList(listPage(['1', '2']));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1', 'P2']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1', '2']);
 		});
 
 		it('should give up holding and advance when the tracked-id bound is exceeded', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1922,6 +1922,33 @@ describe('GmailTrigger', () => {
 			);
 		});
 
+		it('should keep listed ids when the very first new-message fetch fails', async () => {
+			// A drain succeeded earlier in this tick, so the "nothing fetched" guard
+			// cannot save the listing: the cursor advances to the drained message's
+			// date. A listed id older than that date must therefore be queued before
+			// the first fetch, not after it, or it ends up behind the cursor and in
+			// no stored state.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					pendingMessageIds: ['P1'],
+				},
+			};
+
+			mockLabels();
+			mockGet('P1', 5_000_000_000_000);
+			mockList(listPage(['R1', 'R2']));
+			mockGetError('R1');
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['R1', 'R2']);
+		});
+
 		it('should count a failed drain fetch instead of dropping the id right away', async () => {
 			// A transient error must not cost the message: keep it queued and
 			// remember the attempt.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2144,12 +2144,15 @@ describe('GmailTrigger', () => {
 			]);
 		});
 
-		it('should still deliver messages when the labels lookup for simplifying fails', async () => {
-			// Simplifying needs a labels request of its own. If that fails, the poll
-			// must not stall: a failure that repeats would otherwise block delivery
-			// on every tick. Fall back to the raw shape instead.
+		it('should deliver nothing when the output cannot be simplified', async () => {
+			// The workflow asked for simplified output. If the labels request that
+			// simplifying needs fails, the poll must not hand over the raw shape:
+			// downstream nodes read fields that only the simplified shape has. Fail
+			// the poll instead and leave the cursor alone, so the next poll delivers
+			// these messages in the shape the workflow expects.
+			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
-				'Gmail Trigger': { lastTimeChecked: 1000000 },
+				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
 			};
 
 			// Earlier tests can leave unconsumed interceptors behind, and this test
@@ -2159,15 +2162,14 @@ describe('GmailTrigger', () => {
 			mockList(listPage(['1']));
 			mockGet('1', 2_000_000_000_000);
 
-			const { response } = await testPollingTriggerNode(GmailTrigger, {
-				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
-				workflowStaticData,
-			});
+			await expect(
+				testPollingTriggerNode(GmailTrigger, {
+					node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+					workflowStaticData,
+				}),
+			).rejects.toThrow();
 
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
-			// Unsimplified shape: raw labelIds survive because simplifying failed.
-			expect(response?.[0]?.[0]?.json.labelIds).toEqual(['testLabelId']);
-			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(2_000_000_000);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 		});
 
 		it('should emit a message only once when pages return an overlapping id', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -58,8 +58,8 @@ export type GmailWorkflowStaticData = {
 	possibleDuplicates?: string[];
 	/** v1.4+: Message IDs remaining from a previous poll that exceeded maxResults */
 	pendingMessageIds?: string[];
-	/** v1.4+: Consecutive failed fetches of the first pending ID; resets on success */
-	pendingFetchAttempts?: number;
+	/** v1.4+: IDs whose fetch failed, with how many attempts each has had so far */
+	failedFetches?: Array<[string, number]>;
 };
 export type GmailWorkflowStaticDataDictionary = Record<string, GmailWorkflowStaticData>;
 

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -58,6 +58,8 @@ export type GmailWorkflowStaticData = {
 	possibleDuplicates?: string[];
 	/** v1.4+: Message IDs remaining from a previous poll that exceeded maxResults */
 	pendingMessageIds?: string[];
+	/** v1.4+: Consecutive failed fetches of the first pending ID; resets on success */
+	pendingFetchAttempts?: number;
 };
 export type GmailWorkflowStaticDataDictionary = Record<string, GmailWorkflowStaticData>;
 


### PR DESCRIPTION
## Summary

Second PR for the Gmail backlog work, on top of the merged #37261.

A Gmail poll works in two phases. First it scans Gmail for the IDs of matching messages, then it fetches those messages. Either phase can fail partway through. In a non-manual poll the node logs the error and carries on to update its stored state. Anything that must survive an error therefore has to be in that state before the error happens. In several places it was not. This PR fixes what a poll loses, and what it stops delivering, when a scan or a fetch fails.

**Nothing is lost when a fetch fails.**

- The queue holds IDs that a scan found but no poll fetched yet. It used to be cut down before fetching. A swallowed error then dropped every ID that was cut but not yet fetched. The queue is now trimmed after each fetch that succeeds.
- Newly found IDs are queued before the first fetch instead of after it. Before, a poll that drained a queued message and then failed on the first message it had just found advanced the cursor past that message and stored it nowhere.
- A poll whose scan stopped short no longer advances the cursor. The flag that records whether the scan reached the whole window now starts pessimistic, so only an exhausted page token can set it.

**The trigger keeps delivering when one message cannot be fetched.**

- Some messages can never be fetched. The message was deleted after it was listed, or it always breaks parsing. Such a message stayed at the head of the queue.
- The queue is drained before the poll scans for new messages, so the poll ended at that message every time. No queued message and no new mail reached the workflow until the ID was finally skipped. At a five-minute poll interval that was over an hour of silence.
- A failed fetch now moves the message to a separate list, and the poll continues. The rest of the queue is fetched. The scan for new mail runs as usual.
- Every following poll retries each entry on that list. Each entry counts its own attempts. After ten attempts the poll gives up on that entry and logs a warning. It keeps the id, with no attempts left, so the scan does not find the message again and start over: the message was never fetched, so the poll cannot know its date and cannot tell when the cursor passed it.
- Only a delivered message spends the per-poll budget. Failed fetches therefore do not displace healthy messages. Each poll also retries only part of the list, so a long list cannot spend the whole poll on requests that fail.
- The scan skips IDs that are on the list. Each message has one owner, so no poll fetches or delivers the same message twice.

**The output keeps its shape after an error.**

- The simplify step used to be the last statement of the poll's `try` block. A swallowed error skipped it, so the messages fetched before the error went out as raw Gmail objects although the workflow asked for simplified output. The step now runs on every path that returns items, including a poll whose error was swallowed.
- Simplifying makes a labels request of its own. A failure there is still swallowed and the items still go out raw, as before: refusing to deliver them would change what a workflow receives, which belongs with a new node version.

Some commits here repair earlier commits in the same PR. They are kept separate so each fix can be read together with its test.

## How to test

```
pnpm --filter n8n-nodes-base test GmailTrigger.test
```

58 tests, all green. The error paths are covered by making a message fetch return 500 at chosen points: the first queued fetch, mid-queue, the first fetch after a scan, and mid-scan. Each test asserts what stays stored and where the cursor ends up.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3870

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI



