### PR TITLE
feat(core): Track waiting workflow tools as background jobs

### DIFF
--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -1141,6 +1141,12 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 		return result.map((r) => r.workflowVersionId);
 	}
 
+	async findStatusesByIds(ids: string[]): Promise<Array<Pick<ExecutionEntity, 'id' | 'status'>>> {
+		if (ids.length === 0) return [];
+
+		return await this.find({ select: ['id', 'status'], where: { id: In(ids) } });
+	}
+
 	async getAllIds() {
 		const executions = await this.find({ select: ['id'], order: { id: 'ASC' } });
 

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -58,6 +58,7 @@ import type {
 } from '../entities/types-db';
 import { TransactionRunner } from '../services/transaction';
 import { applyWorkflowBooleanSettingFilter } from '../utils/apply-workflow-boolean-setting-filter';
+import { chunkIds } from '../utils/chunk-ids';
 import { separate } from '../utils/separate';
 
 class PostgresLiveRowsRetrievalError extends UnexpectedError {
@@ -1142,9 +1143,12 @@ export class ExecutionRepository extends BaseRepository<ExecutionEntity> {
 	}
 
 	async findStatusesByIds(ids: string[]): Promise<Array<Pick<ExecutionEntity, 'id' | 'status'>>> {
-		if (ids.length === 0) return [];
+		const rows: Array<Pick<ExecutionEntity, 'id' | 'status'>> = [];
+		for (const chunk of chunkIds(ids)) {
+			rows.push(...(await this.find({ select: ['id', 'status'], where: { id: In(chunk) } })));
+		}
 
-		return await this.find({ select: ['id', 'status'], where: { id: In(ids) } });
+		return rows;
 	}
 
 	async getAllIds() {

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -594,6 +594,11 @@ export class ExecutionPersistence {
 		});
 	}
 
+	/** Statuses of the given executions in one read; ids that no longer exist are absent. */
+	async findStatusesByIds(ids: string[]): Promise<Array<{ id: string; status: ExecutionStatus }>> {
+		return await this.executionRepository.findStatusesByIds(ids);
+	}
+
 	/** Find executions scoped to the given workflows, with data per `storedAt`. */
 	async findManyInWorkflows(
 		workflowIds: string[],

--- a/packages/cli/src/modules/agents/__tests__/agent-interrupted-execution-sweeper.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-interrupted-execution-sweeper.test.ts
@@ -1,9 +1,9 @@
-import type { AgentsConfig } from '@n8n/config';
 import { mockLogger } from '@n8n/backend-test-utils';
+import type { AgentsConfig } from '@n8n/config';
 import { mock } from 'vitest-mock-extended';
 
-import { AgentInterruptedExecutionSweeper } from '../agent-interrupted-execution-sweeper';
 import type { AgentExecutionService } from '../agent-execution.service';
+import { AgentInterruptedExecutionSweeper } from '../agent-interrupted-execution-sweeper';
 import type { AgentBackgroundJobService } from '../background/agent-background-job.service';
 import type { AgentExecution } from '../entities/agent-execution.entity';
 import type { AgentExecutionRepository } from '../repositories/agent-execution.repository';
@@ -60,15 +60,17 @@ describe('AgentInterruptedExecutionSweeper', () => {
 		expect(executionService.finalizeInterruptedExecution).not.toHaveBeenCalled();
 	});
 
-	it('reconciles background job rows only when the feature is enabled', async () => {
+	it('runs full reconciliation when the feature is on, and still reconciles workflow jobs when it is off', async () => {
 		const disabled = setup();
 		disabled.repository.findRunning.mockResolvedValue([]);
 		await disabled.sweeper.sweep();
 		expect(disabled.backgroundJobService.reconcile).not.toHaveBeenCalled();
+		expect(disabled.backgroundJobService.reconcileWorkflowJobs).toHaveBeenCalled();
 
 		const enabled = setup({ backgroundTasksEnabled: true });
 		enabled.repository.findRunning.mockResolvedValue([]);
 		await enabled.sweeper.sweep();
 		expect(enabled.backgroundJobService.reconcile).toHaveBeenCalled();
+		expect(enabled.backgroundJobService.reconcileWorkflowJobs).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-workflow-tool-resume.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-workflow-tool-resume.service.test.ts
@@ -91,6 +91,8 @@ function afterContext(
 		executionId: 'exec-1',
 		runData: {
 			status,
+			// The engine stamps this only on runs that ended without error or wait.
+			finished: status === 'success',
 			data: { ...data, ...(parentAgentRun ? { parentAgentRun } : {}) },
 		} as IRun,
 	});
@@ -343,16 +345,26 @@ describe('AgentWorkflowToolResumeService → background job settlement', () => {
 		return ctx;
 	}
 
-	it('settles the job with every node’s output serialized', async () => {
+	it('settles the job with only the last node’s output serialized', async () => {
 		const { service, backgroundJobService } = setup();
 
 		await service.handleWorkflowExecuteAfter(afterContextWithOutput('success'));
 
 		expect(backgroundJobService.settleWorkflowJobByExecutionId).toHaveBeenCalledWith('exec-1', {
 			status: 'completed',
-			result: '{"Fetch":[{"page":1}],"Set":[{"ok":true}]}',
+			result: '{"Set":[{"ok":true}]}',
 			error: null,
 		});
+	});
+
+	it('does not settle a success callback for a run that has not finished', async () => {
+		const { service, backgroundJobService } = setup();
+		const ctx = afterContextWithOutput('success');
+		Object.assign(ctx.runData, { finished: false });
+
+		await service.handleWorkflowExecuteAfter(ctx);
+
+		expect(backgroundJobService.settleWorkflowJobByExecutionId).not.toHaveBeenCalled();
 	});
 
 	it('settles a failed execution with its error and no result', async () => {

--- a/packages/cli/src/modules/agents/__tests__/agent-workflow-tool-resume.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-workflow-tool-resume.service.test.ts
@@ -8,11 +8,14 @@ import { createRunExecutionData } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import type { AgentsConfig } from '@n8n/config';
+
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 
 import type { AgentExecutionUpdateBroadcaster } from '../agent-execution-update-broadcaster';
 import type { AgentTestRunService } from '../agent-test-run.service';
 import { AgentWorkflowToolResumeService } from '../agent-workflow-tool-resume.service';
+import type { AgentBackgroundJobService } from '../background/agent-background-job.service';
 import type { AgentChatBridge } from '../integrations/agent-chat-bridge';
 import type { ChatIntegrationService } from '../integrations/chat-integration.service';
 import type { IntegrationMessageContextService } from '../integrations/integration-message-context.service';
@@ -33,7 +36,7 @@ const previewRun: RelatedAgentRun = {
 	userId: 'user-1',
 };
 
-function setup() {
+function setup(options: { backgroundTasksEnabled?: boolean } = {}) {
 	const logger = mock<Logger>();
 	(logger.scoped as Mock).mockReturnValue(logger);
 	const bridge = mock<AgentChatBridge>();
@@ -51,6 +54,10 @@ function setup() {
 		status: 'active',
 		checkpoint: { status: 'suspended' },
 	} as never);
+	const backgroundJobService = mock<AgentBackgroundJobService>();
+	const agentsConfig = mock<AgentsConfig>({
+		backgroundTasksEnabled: options.backgroundTasksEnabled ?? false,
+	});
 	const service = new AgentWorkflowToolResumeService(
 		logger,
 		userRepository,
@@ -61,6 +68,8 @@ function setup() {
 		checkpointStorage,
 		instanceSettings,
 		publisher,
+		backgroundJobService,
+		agentsConfig,
 	);
 	return {
 		service,
@@ -74,6 +83,7 @@ function setup() {
 		publisher,
 		instanceSettings,
 		messageContextService,
+		backgroundJobService,
 	};
 }
 
@@ -325,5 +335,82 @@ describe('AgentWorkflowToolResumeService → preview chat', () => {
 			'Cannot resume preview chat run without its user',
 			expect.objectContaining({ runId: 'run-1' }),
 		);
+	});
+});
+
+describe('AgentWorkflowToolResumeService → background job settlement', () => {
+	/** Like {@link afterContext}, with node output the settle serializes. */
+	function afterContextWithOutput(status: IRun['status']): WorkflowExecuteAfterContext {
+		const ctx = afterContext(status, agentRun);
+		ctx.runData.data.resultData.runData = {
+			Set: [{ data: { main: [[{ json: { ok: true } }]] } } as never],
+		};
+		return ctx;
+	}
+
+	it('settles the job with the serialized last-node output when the feature is on', async () => {
+		const { service, backgroundJobService } = setup({ backgroundTasksEnabled: true });
+
+		await service.handleWorkflowExecuteAfter(afterContextWithOutput('success'));
+
+		expect(backgroundJobService.settleWorkflowJobByExecutionId).toHaveBeenCalledWith('exec-1', {
+			status: 'completed',
+			result: '{"Set":[{"ok":true}]}',
+			error: null,
+		});
+	});
+
+	it('settles a failed execution with its error and no result', async () => {
+		const { service, backgroundJobService } = setup({ backgroundTasksEnabled: true });
+		const ctx = afterContextWithOutput('error');
+		ctx.runData.data.resultData.error = { message: 'boom' } as never;
+
+		await service.handleWorkflowExecuteAfter(ctx);
+
+		expect(backgroundJobService.settleWorkflowJobByExecutionId).toHaveBeenCalledWith('exec-1', {
+			status: 'failed',
+			result: null,
+			error: 'boom',
+		});
+	});
+
+	it('does not settle while the execution is still waiting', async () => {
+		const { service, backgroundJobService } = setup({ backgroundTasksEnabled: true });
+
+		await service.handleWorkflowExecuteAfter(afterContext('waiting', agentRun));
+
+		expect(backgroundJobService.settleWorkflowJobByExecutionId).not.toHaveBeenCalled();
+	});
+
+	it('does not settle when the feature is off', async () => {
+		const { service, backgroundJobService } = setup();
+
+		await service.handleWorkflowExecuteAfter(afterContext('success', agentRun));
+
+		expect(backgroundJobService.settleWorkflowJobByExecutionId).not.toHaveBeenCalled();
+	});
+
+	it('still resumes a suspended run after settling — the two paths coexist', async () => {
+		const { service, bridge, chatIntegrationService, backgroundJobService } = setup({
+			backgroundTasksEnabled: true,
+		});
+		chatIntegrationService.getBridge.mockReturnValue(bridge);
+
+		await service.handleWorkflowExecuteAfter(afterContext('success', agentRun));
+
+		expect(backgroundJobService.settleWorkflowJobByExecutionId).toHaveBeenCalled();
+		expect(bridge.resumeInAgentThread).toHaveBeenCalled();
+	});
+
+	it('never lets a failing settle disturb the resume path', async () => {
+		const { service, bridge, chatIntegrationService, backgroundJobService } = setup({
+			backgroundTasksEnabled: true,
+		});
+		chatIntegrationService.getBridge.mockReturnValue(bridge);
+		backgroundJobService.settleWorkflowJobByExecutionId.mockRejectedValue(new Error('db down'));
+
+		await service.handleWorkflowExecuteAfter(afterContext('success', agentRun));
+
+		expect(bridge.resumeInAgentThread).toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-workflow-tool-resume.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-workflow-tool-resume.service.test.ts
@@ -1,5 +1,5 @@
-import type { Logger } from '@n8n/backend-common';
 import { N8N_CHAT_INTEGRATION_TYPE } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
 import type { User, UserRepository } from '@n8n/db';
 import type { WorkflowExecuteAfterContext } from '@n8n/decorators';
 import type { InstanceSettings } from 'n8n-core';
@@ -7,8 +7,6 @@ import type { IRun, RelatedAgentRun } from 'n8n-workflow';
 import { createRunExecutionData } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
-
-import type { AgentsConfig } from '@n8n/config';
 
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 
@@ -36,7 +34,7 @@ const previewRun: RelatedAgentRun = {
 	userId: 'user-1',
 };
 
-function setup(options: { backgroundTasksEnabled?: boolean } = {}) {
+function setup() {
 	const logger = mock<Logger>();
 	(logger.scoped as Mock).mockReturnValue(logger);
 	const bridge = mock<AgentChatBridge>();
@@ -55,9 +53,6 @@ function setup(options: { backgroundTasksEnabled?: boolean } = {}) {
 		checkpoint: { status: 'suspended' },
 	} as never);
 	const backgroundJobService = mock<AgentBackgroundJobService>();
-	const agentsConfig = mock<AgentsConfig>({
-		backgroundTasksEnabled: options.backgroundTasksEnabled ?? false,
-	});
 	const service = new AgentWorkflowToolResumeService(
 		logger,
 		userRepository,
@@ -69,7 +64,6 @@ function setup(options: { backgroundTasksEnabled?: boolean } = {}) {
 		instanceSettings,
 		publisher,
 		backgroundJobService,
-		agentsConfig,
 	);
 	return {
 		service,
@@ -343,25 +337,26 @@ describe('AgentWorkflowToolResumeService → background job settlement', () => {
 	function afterContextWithOutput(status: IRun['status']): WorkflowExecuteAfterContext {
 		const ctx = afterContext(status, agentRun);
 		ctx.runData.data.resultData.runData = {
+			Fetch: [{ data: { main: [[{ json: { page: 1 } }]] } } as never],
 			Set: [{ data: { main: [[{ json: { ok: true } }]] } } as never],
 		};
 		return ctx;
 	}
 
-	it('settles the job with the serialized last-node output when the feature is on', async () => {
-		const { service, backgroundJobService } = setup({ backgroundTasksEnabled: true });
+	it('settles the job with every node’s output serialized', async () => {
+		const { service, backgroundJobService } = setup();
 
 		await service.handleWorkflowExecuteAfter(afterContextWithOutput('success'));
 
 		expect(backgroundJobService.settleWorkflowJobByExecutionId).toHaveBeenCalledWith('exec-1', {
 			status: 'completed',
-			result: '{"Set":[{"ok":true}]}',
+			result: '{"Fetch":[{"page":1}],"Set":[{"ok":true}]}',
 			error: null,
 		});
 	});
 
 	it('settles a failed execution with its error and no result', async () => {
-		const { service, backgroundJobService } = setup({ backgroundTasksEnabled: true });
+		const { service, backgroundJobService } = setup();
 		const ctx = afterContextWithOutput('error');
 		ctx.runData.data.resultData.error = { message: 'boom' } as never;
 
@@ -375,25 +370,15 @@ describe('AgentWorkflowToolResumeService → background job settlement', () => {
 	});
 
 	it('does not settle while the execution is still waiting', async () => {
-		const { service, backgroundJobService } = setup({ backgroundTasksEnabled: true });
+		const { service, backgroundJobService } = setup();
 
 		await service.handleWorkflowExecuteAfter(afterContext('waiting', agentRun));
 
 		expect(backgroundJobService.settleWorkflowJobByExecutionId).not.toHaveBeenCalled();
 	});
 
-	it('does not settle when the feature is off', async () => {
-		const { service, backgroundJobService } = setup();
-
-		await service.handleWorkflowExecuteAfter(afterContext('success', agentRun));
-
-		expect(backgroundJobService.settleWorkflowJobByExecutionId).not.toHaveBeenCalled();
-	});
-
 	it('still resumes a suspended run after settling — the two paths coexist', async () => {
-		const { service, bridge, chatIntegrationService, backgroundJobService } = setup({
-			backgroundTasksEnabled: true,
-		});
+		const { service, bridge, chatIntegrationService, backgroundJobService } = setup();
 		chatIntegrationService.getBridge.mockReturnValue(bridge);
 
 		await service.handleWorkflowExecuteAfter(afterContext('success', agentRun));
@@ -403,9 +388,7 @@ describe('AgentWorkflowToolResumeService → background job settlement', () => {
 	});
 
 	it('never lets a failing settle disturb the resume path', async () => {
-		const { service, bridge, chatIntegrationService, backgroundJobService } = setup({
-			backgroundTasksEnabled: true,
-		});
+		const { service, bridge, chatIntegrationService, backgroundJobService } = setup();
 		chatIntegrationService.getBridge.mockReturnValue(bridge);
 		backgroundJobService.settleWorkflowJobByExecutionId.mockRejectedValue(new Error('db down'));
 

--- a/packages/cli/src/modules/agents/agent-interrupted-execution-sweeper.ts
+++ b/packages/cli/src/modules/agents/agent-interrupted-execution-sweeper.ts
@@ -55,12 +55,16 @@ export class AgentInterruptedExecutionSweeper {
 		// Background job rows ride along on the same cadence: after abandoned
 		// child executions were marked interrupted above, reconciliation can
 		// settle the job rows that pointed at them (plus timed-out ones).
-		if (this.agentsConfig.backgroundTasksEnabled) {
-			try {
+		// Workflow-job reconciliation runs even with the feature flag off, so
+		// rows created while it was on cannot strand as `running`.
+		try {
+			if (this.agentsConfig.backgroundTasksEnabled) {
 				await this.backgroundJobService.reconcile();
-			} catch (error) {
-				this.logger.error('Failed to reconcile background job rows', { error });
+			} else {
+				await this.backgroundJobService.reconcileWorkflowJobs();
 			}
+		} catch (error) {
+			this.logger.error('Failed to reconcile background job rows', { error });
 		}
 	}
 }

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -467,6 +467,11 @@ export class AgentRuntimeReconstructionService {
 		} = options;
 
 		const toolExecutor = this.secureRuntime.createToolExecutor(toolCodeByName);
+		// Callers that cannot resume a suspended run (agents invoked as workflow
+		// steps) pass supportsHitl false explicitly; otherwise only the top-level
+		// profile can be woken again.
+		const canResume = supportsHitl ?? runtimeProfile === 'top-level';
+
 		const toolResolver = this.makeToolResolver(
 			{
 				projectId,
@@ -478,12 +483,16 @@ export class AgentRuntimeReconstructionService {
 				userId: user?.id,
 				// Sub-agent checkpoints are rejected on resume and inline agents have no
 				// checkpoint storage, so neither can be woken again.
-				supportsHitl: supportsHitl ?? runtimeProfile === 'top-level',
-				// Only the top-level agent backgrounds waiting workflows: a child's job
-				// would nest under its own thread, where no check/cancel tools exist.
-				// Children handle waits the legacy way instead.
+				supportsHitl: canResume,
+				// Only an interactive top-level agent backgrounds waiting workflows: a
+				// child's job would nest under its own thread, where no check/cancel
+				// tools exist, and a top-level agent invoked as a workflow step
+				// (supportsHitl false) has no interactive turn to hand a receipt to.
+				// Everyone else handles waits the legacy way.
 				backgroundTasksEnabled:
-					runtimeProfile === 'top-level' && Container.get(AgentsConfig).backgroundTasksEnabled,
+					runtimeProfile === 'top-level' &&
+					canResume &&
+					Container.get(AgentsConfig).backgroundTasksEnabled,
 			},
 			instrumentation,
 		);

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -479,6 +479,11 @@ export class AgentRuntimeReconstructionService {
 				// Sub-agent checkpoints are rejected on resume and inline agents have no
 				// checkpoint storage, so neither can be woken again.
 				supportsHitl: supportsHitl ?? runtimeProfile === 'top-level',
+				// Only the top-level agent backgrounds waiting workflows: a child's job
+				// would nest under its own thread, where no check/cancel tools exist.
+				// Children handle waits the legacy way instead.
+				backgroundTasksEnabled:
+					runtimeProfile === 'top-level' && Container.get(AgentsConfig).backgroundTasksEnabled,
 			},
 			instrumentation,
 		);
@@ -638,6 +643,7 @@ export class AgentRuntimeReconstructionService {
 			integrationType?: string;
 			userId?: string;
 			supportsHitl: boolean;
+			backgroundTasksEnabled: boolean;
 		},
 		instrumentation?: AgentRuntimeInstrumentation,
 	): ToolResolver {
@@ -649,6 +655,7 @@ export class AgentRuntimeReconstructionService {
 			integrationType,
 			userId,
 			supportsHitl,
+			backgroundTasksEnabled,
 		} = runIdentity;
 		const instrumentToolAdditionalData = instrumentation?.configureToolAdditionalData;
 		return async (ref: AgentJsonToolConfig) => {
@@ -667,6 +674,7 @@ export class AgentRuntimeReconstructionService {
 					integrationType,
 					userId,
 					supportsHitl,
+					backgroundTasksEnabled,
 				});
 			}
 

--- a/packages/cli/src/modules/agents/agent-workflow-tool-resume.service.ts
+++ b/packages/cli/src/modules/agents/agent-workflow-tool-resume.service.ts
@@ -91,14 +91,17 @@ export class AgentWorkflowToolResumeService {
 	 * Settle the background job tracking this execution, carrying a bounded
 	 * serialization of the result — the run data is in memory here, so the job
 	 * row gets its answer without a later read of the executions table. Job
-	 * results always carry every node's output (the truncation cap bounds
-	 * them): the row does not know the tool's `allOutputs` setting, and the
-	 * full data beats silently dropping nodes. A no-op when the execution was
-	 * not backgrounded. Never throws into the execution's lifecycle.
+	 * results carry the last node's output only: the row does not know the
+	 * tool's `allOutputs` setting, so it keeps the tightest projection and the
+	 * execution keeps the full data. A no-op when the execution was not
+	 * backgrounded. Never throws into the execution's lifecycle.
 	 */
 	private async settleBackgroundJob(ctx: WorkflowExecuteAfterContext): Promise<void> {
 		const { status, data } = ctx.runData;
 		if (!isTerminalExecutionStatus(status)) return;
+		// A success callback for a run that has not actually finished must not
+		// seal the job with partial output; reconciliation settles it later.
+		if (status === 'success' && !ctx.runData.finished) return;
 
 		try {
 			const settlementStatus = settlementStatusForExecution(status);
@@ -107,7 +110,7 @@ export class AgentWorkflowToolResumeService {
 				status: settlementStatus,
 				result:
 					settlementStatus === 'completed' && runData
-						? serializeWorkflowJobResult(collectResultData(runData, true))
+						? serializeWorkflowJobResult(collectResultData(runData, false))
 						: null,
 				error: data.resultData?.error?.message ?? null,
 			});

--- a/packages/cli/src/modules/agents/agent-workflow-tool-resume.service.ts
+++ b/packages/cli/src/modules/agents/agent-workflow-tool-resume.service.ts
@@ -1,18 +1,26 @@
 import { Logger } from '@n8n/backend-common';
 import { N8N_CHAT_INTEGRATION_TYPE } from '@n8n/api-types';
+import { AgentsConfig } from '@n8n/config';
 import { UserRepository } from '@n8n/db';
 import { OnLifecycleEvent, OnPubSubEvent, type WorkflowExecuteAfterContext } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 import type { RelatedAgentRun } from 'n8n-workflow';
+import { isTerminalExecutionStatus } from 'n8n-workflow';
 
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 
 import { AgentExecutionUpdateBroadcaster } from './agent-execution-update-broadcaster';
 import { AgentTestRunService } from './agent-test-run.service';
+import {
+	AgentBackgroundJobService,
+	serializeWorkflowJobResult,
+	settlementStatusForExecution,
+} from './background/agent-background-job.service';
 import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
 import { ChatIntegrationService } from './integrations/chat-integration.service';
 import { IntegrationMessageContextService } from './integrations/integration-message-context.service';
+import { collectResultData } from './tools/workflow-tool-factory';
 
 /**
  * Wakes the agent tool call a finished sub-execution belongs to, from the
@@ -32,6 +40,8 @@ export class AgentWorkflowToolResumeService {
 		private readonly checkpointStorage: N8NCheckpointStorage,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly publisher: Publisher,
+		private readonly backgroundJobService: AgentBackgroundJobService,
+		private readonly agentsConfig: AgentsConfig,
 	) {
 		this.logger = this.logger.scoped('agents');
 	}
@@ -42,6 +52,13 @@ export class AgentWorkflowToolResumeService {
 		if (!agentRun) return; // Not a sub-execution started by an agent workflow tool.
 		// Parked at a Wait node, so the workflow has not finished.
 		if (ctx.runData.status === 'waiting') return;
+
+		// A backgrounded execution has a job row instead of a suspended checkpoint;
+		// settling it is a plain DB write, so it happens right here — also on
+		// workers, without the pubsub hop the resume below needs.
+		if (this.agentsConfig.backgroundTasksEnabled) {
+			await this.settleBackgroundJob(ctx);
+		}
 
 		// Every sub-execution carries the marker, but only one that actually parked left
 		// a suspended checkpoint. Without this an ordinary tool call drives a resume
@@ -70,6 +87,36 @@ export class AgentWorkflowToolResumeService {
 		status: string;
 	}): Promise<void> {
 		await this.resumeSafely(agentRun, status);
+	}
+
+	/**
+	 * Settle the background job tracking this execution, carrying a bounded
+	 * serialization of the result — the run data is in memory here, so the job
+	 * row gets its answer without a later read of the executions table. A no-op
+	 * when the execution was not backgrounded. Never throws into the
+	 * execution's lifecycle.
+	 */
+	private async settleBackgroundJob(ctx: WorkflowExecuteAfterContext): Promise<void> {
+		const { status, data } = ctx.runData;
+		if (!isTerminalExecutionStatus(status)) return;
+
+		try {
+			const settlementStatus = settlementStatusForExecution(status);
+			const runData = data.resultData?.runData;
+			await this.backgroundJobService.settleWorkflowJobByExecutionId(ctx.executionId, {
+				status: settlementStatus,
+				result:
+					settlementStatus === 'completed' && runData
+						? serializeWorkflowJobResult(collectResultData(runData, false))
+						: null,
+				error: data.resultData?.error?.message ?? null,
+			});
+		} catch (error) {
+			this.logger.error('Failed to settle workflow background job', {
+				executionId: ctx.executionId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 	}
 
 	/** Never let a failed agent resume disturb the execution that triggered it. */

--- a/packages/cli/src/modules/agents/agent-workflow-tool-resume.service.ts
+++ b/packages/cli/src/modules/agents/agent-workflow-tool-resume.service.ts
@@ -1,6 +1,5 @@
-import { Logger } from '@n8n/backend-common';
 import { N8N_CHAT_INTEGRATION_TYPE } from '@n8n/api-types';
-import { AgentsConfig } from '@n8n/config';
+import { Logger } from '@n8n/backend-common';
 import { UserRepository } from '@n8n/db';
 import { OnLifecycleEvent, OnPubSubEvent, type WorkflowExecuteAfterContext } from '@n8n/decorators';
 import { Service } from '@n8n/di';
@@ -14,13 +13,13 @@ import { AgentExecutionUpdateBroadcaster } from './agent-execution-update-broadc
 import { AgentTestRunService } from './agent-test-run.service';
 import {
 	AgentBackgroundJobService,
+	collectResultData,
 	serializeWorkflowJobResult,
 	settlementStatusForExecution,
 } from './background/agent-background-job.service';
-import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
 import { ChatIntegrationService } from './integrations/chat-integration.service';
 import { IntegrationMessageContextService } from './integrations/integration-message-context.service';
-import { collectResultData } from './tools/workflow-tool-factory';
+import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
 
 /**
  * Wakes the agent tool call a finished sub-execution belongs to, from the
@@ -41,7 +40,6 @@ export class AgentWorkflowToolResumeService {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly publisher: Publisher,
 		private readonly backgroundJobService: AgentBackgroundJobService,
-		private readonly agentsConfig: AgentsConfig,
 	) {
 		this.logger = this.logger.scoped('agents');
 	}
@@ -55,10 +53,10 @@ export class AgentWorkflowToolResumeService {
 
 		// A backgrounded execution has a job row instead of a suspended checkpoint;
 		// settling it is a plain DB write, so it happens right here — also on
-		// workers, without the pubsub hop the resume below needs.
-		if (this.agentsConfig.backgroundTasksEnabled) {
-			await this.settleBackgroundJob(ctx);
-		}
+		// workers, without the pubsub hop the resume below needs. Deliberately
+		// not gated on the feature flag: it is a no-op without a row, and rows
+		// created while the flag was on must settle even after it is turned off.
+		await this.settleBackgroundJob(ctx);
 
 		// Every sub-execution carries the marker, but only one that actually parked left
 		// a suspended checkpoint. Without this an ordinary tool call drives a resume
@@ -92,9 +90,11 @@ export class AgentWorkflowToolResumeService {
 	/**
 	 * Settle the background job tracking this execution, carrying a bounded
 	 * serialization of the result — the run data is in memory here, so the job
-	 * row gets its answer without a later read of the executions table. A no-op
-	 * when the execution was not backgrounded. Never throws into the
-	 * execution's lifecycle.
+	 * row gets its answer without a later read of the executions table. Job
+	 * results always carry every node's output (the truncation cap bounds
+	 * them): the row does not know the tool's `allOutputs` setting, and the
+	 * full data beats silently dropping nodes. A no-op when the execution was
+	 * not backgrounded. Never throws into the execution's lifecycle.
 	 */
 	private async settleBackgroundJob(ctx: WorkflowExecuteAfterContext): Promise<void> {
 		const { status, data } = ctx.runData;
@@ -107,7 +107,7 @@ export class AgentWorkflowToolResumeService {
 				status: settlementStatus,
 				result:
 					settlementStatus === 'completed' && runData
-						? serializeWorkflowJobResult(collectResultData(runData, false))
+						? serializeWorkflowJobResult(collectResultData(runData, true))
 						: null,
 				error: data.resultData?.error?.message ?? null,
 			});

--- a/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import type { Mock } from 'vitest';
+import { WorkflowOperationError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { ExecutionPersistence } from '@/executions/execution-persistence';
@@ -432,7 +433,7 @@ describe('cancel — workflow jobs', () => {
 		Container.reset();
 	});
 
-	it('claims the row and stops the execution', async () => {
+	it('stops the execution, then claims the row', async () => {
 		const { service, jobRepository } = setup();
 		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob()]);
 		const executionService = mock<ExecutionService>();
@@ -441,20 +442,45 @@ describe('cancel — workflow jobs', () => {
 		const outcome = await service.cancel('thread-1', 'wf-job-1');
 
 		expect(outcome).toBe('cancelled');
+		expect(executionService.stop).toHaveBeenCalledWith('exec-1', ['workflow-1']);
 		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith('wf-job-1', {
 			status: 'cancelled',
 		});
-		expect(executionService.stop).toHaveBeenCalledWith('exec-1', ['workflow-1']);
+		expect(executionService.stop.mock.invocationCallOrder[0]).toBeLessThan(
+			jobRepository.settleIfRunning.mock.invocationCallOrder[0],
+		);
 	});
 
-	it('keeps the row cancelled when stopping the finished execution errors', async () => {
+	it('reports already-settled and leaves the row to reconciliation when the execution already finished', async () => {
 		const { service, jobRepository } = setup();
 		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob()]);
 		const executionService = mock<ExecutionService>();
-		executionService.stop.mockRejectedValue(new Error('already finished'));
+		executionService.stop.mockRejectedValue(new WorkflowOperationError('already finished'));
 		Container.set(ExecutionService, executionService);
 
-		expect(await service.cancel('thread-1', 'wf-job-1')).toBe('cancelled');
+		expect(await service.cancel('thread-1', 'wf-job-1')).toBe('already-settled');
+		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
+	});
+
+	it('rethrows an unexpected stop failure with the row still running', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob()]);
+		const executionService = mock<ExecutionService>();
+		executionService.stop.mockRejectedValue(new Error('db down'));
+		Container.set(ExecutionService, executionService);
+
+		await expect(service.cancel('thread-1', 'wf-job-1')).rejects.toThrow('db down');
+		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
+	});
+
+	it('reports already-settled for a row that is no longer running', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob({ status: 'completed' })]);
+		const executionService = mock<ExecutionService>();
+		Container.set(ExecutionService, executionService);
+
+		expect(await service.cancel('thread-1', 'wf-job-1')).toBe('already-settled');
+		expect(executionService.stop).not.toHaveBeenCalled();
 	});
 
 	it('claims a row that lost its execution id without attempting a stop', async () => {

--- a/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
@@ -356,6 +356,10 @@ describe('registerWorkflowJob', () => {
 				workflowId: 'workflow-1',
 			}),
 		);
+		// No timeout: the execution's own lifecycle governs how long it may wait.
+		expect(jobRepository.insertWorkflowJobOrGetExisting.mock.calls[0][0]).not.toHaveProperty(
+			'timeoutAt',
+		);
 		expect(jobRepository.countRunningByParentThread).not.toHaveBeenCalled();
 	});
 
@@ -497,6 +501,24 @@ describe('reconcile — workflow jobs', () => {
 				status: 'failed',
 				error: expect.stringContaining('outcome is unknown'),
 			}),
+		);
+	});
+
+	it('settles with a null result when the finished execution’s data cannot be read', async () => {
+		const { service, jobRepository, executionPersistence } = setup();
+		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
+			kind === 'workflow' ? [makeWorkflowJob()] : [],
+		);
+		executionPersistence.findSingleExecution.mockImplementation(async (_id, options) => {
+			if (options?.includeData) throw new Error('data bundle unreadable');
+			return { status: 'success' } as never;
+		});
+
+		await service.reconcile();
+
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
+			'wf-job-1',
+			expect.objectContaining({ status: 'completed', result: null }),
 		);
 	});
 

--- a/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
@@ -80,7 +80,7 @@ function setup() {
 		publisher,
 		logger,
 	);
-	return { service, jobRepository, executionRepository, executionPersistence, publisher };
+	return { service, jobRepository, executionRepository, executionPersistence, publisher, logger };
 }
 
 const registerParams = {
@@ -462,8 +462,8 @@ describe('cancel — workflow jobs', () => {
 		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
 	});
 
-	it('rethrows an unexpected stop failure with the row still running', async () => {
-		const { service, jobRepository } = setup();
+	it('logs and rethrows an unexpected stop failure with the row still running', async () => {
+		const { service, jobRepository, logger } = setup();
 		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob()]);
 		const executionService = mock<ExecutionService>();
 		executionService.stop.mockRejectedValue(new Error('db down'));
@@ -471,6 +471,10 @@ describe('cancel — workflow jobs', () => {
 
 		await expect(service.cancel('thread-1', 'wf-job-1')).rejects.toThrow('db down');
 		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining('may still be running'),
+			expect.objectContaining({ jobId: 'wf-job-1', executionId: 'exec-1', error: 'db down' }),
+		);
 	});
 
 	it('reports already-settled for a row that is no longer running', async () => {

--- a/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
@@ -63,7 +63,7 @@ function setup() {
 	const logger = mock<Logger>();
 	(logger.scoped as Mock).mockReturnValue(logger);
 
-	jobRepository.countRunningByParentThread.mockResolvedValue(0);
+	jobRepository.countRunningSubAgentsByParentThread.mockResolvedValue(0);
 	jobRepository.insertJob.mockResolvedValue(undefined);
 	jobRepository.insertWorkflowJobOrGetExisting.mockResolvedValue({ inserted: true });
 	jobRepository.settleIfRunning.mockResolvedValue(true);
@@ -107,12 +107,23 @@ describe('registerSubAgentJob', () => {
 
 	it('returns limit-reached when the thread is at the running-job cap', async () => {
 		const { service, jobRepository } = setup();
-		jobRepository.countRunningByParentThread.mockResolvedValue(MAX_RUNNING_JOBS_PER_THREAD);
+		jobRepository.countRunningSubAgentsByParentThread.mockResolvedValue(
+			MAX_RUNNING_JOBS_PER_THREAD,
+		);
 
 		const receipt = await service.registerSubAgentJob(registerParams);
 
 		expect(receipt).toEqual({ status: 'limit-reached' });
 		expect(jobRepository.insertJob).not.toHaveBeenCalled();
+	});
+
+	it('counts only running sub-agent jobs toward the cap', async () => {
+		const { service, jobRepository } = setup();
+
+		const receipt = await service.registerSubAgentJob(registerParams);
+
+		expect(receipt).toEqual({ status: 'started', jobId: 'job-1' });
+		expect(jobRepository.countRunningSubAgentsByParentThread).toHaveBeenCalledWith('thread-1');
 	});
 });
 
@@ -360,7 +371,7 @@ describe('registerWorkflowJob', () => {
 		expect(jobRepository.insertWorkflowJobOrGetExisting.mock.calls[0][0]).not.toHaveProperty(
 			'timeoutAt',
 		);
-		expect(jobRepository.countRunningByParentThread).not.toHaveBeenCalled();
+		expect(jobRepository.countRunningSubAgentsByParentThread).not.toHaveBeenCalled();
 	});
 
 	it('converges a replayed registration on the job already tracking the execution', async () => {
@@ -467,19 +478,18 @@ describe('reconcile — workflow jobs', () => {
 		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
 			kind === 'workflow' ? [makeWorkflowJob()] : [],
 		);
-		executionPersistence.findSingleExecution.mockImplementation(async (_id, options) =>
-			options?.includeData
-				? ({
-						status: 'success',
-						data: {
-							resultData: { runData: { Set: [{ data: { main: [[{ json: { ok: true } }]] } }] } },
-						},
-					} as never)
-				: ({ status: 'success' } as never),
-		);
+		executionPersistence.findStatusesByIds.mockResolvedValue([{ id: 'exec-1', status: 'success' }]);
+		executionPersistence.findSingleExecution.mockResolvedValue({
+			status: 'success',
+			data: {
+				resultData: { runData: { Set: [{ data: { main: [[{ json: { ok: true } }]] } }] } },
+			},
+		} as never);
 
 		await service.reconcile();
 
+		expect(executionPersistence.findStatusesByIds).toHaveBeenCalledTimes(1);
+		expect(executionPersistence.findStatusesByIds).toHaveBeenCalledWith(['exec-1']);
 		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
 			'wf-job-1',
 			expect.objectContaining({ status: 'completed', result: '{"Set":[{"ok":true}]}' }),
@@ -491,7 +501,7 @@ describe('reconcile — workflow jobs', () => {
 		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
 			kind === 'workflow' ? [makeWorkflowJob()] : [],
 		);
-		executionPersistence.findSingleExecution.mockResolvedValue(undefined);
+		executionPersistence.findStatusesByIds.mockResolvedValue([]);
 
 		await service.reconcile();
 
@@ -509,10 +519,8 @@ describe('reconcile — workflow jobs', () => {
 		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
 			kind === 'workflow' ? [makeWorkflowJob()] : [],
 		);
-		executionPersistence.findSingleExecution.mockImplementation(async (_id, options) => {
-			if (options?.includeData) throw new Error('data bundle unreadable');
-			return { status: 'success' } as never;
-		});
+		executionPersistence.findStatusesByIds.mockResolvedValue([{ id: 'exec-1', status: 'success' }]);
+		executionPersistence.findSingleExecution.mockRejectedValue(new Error('data bundle unreadable'));
 
 		await service.reconcile();
 
@@ -522,25 +530,42 @@ describe('reconcile — workflow jobs', () => {
 		);
 	});
 
-	it('still reconciles the rest of the batch when one execution lookup fails', async () => {
+	it('reads all candidate statuses in one batch and settles the rest when one settle fails', async () => {
 		const { service, jobRepository, executionPersistence } = setup();
 		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
 			kind === 'workflow'
 				? [makeWorkflowJob(), makeWorkflowJob({ id: 'wf-job-2', childExecutionId: 'exec-2' })]
 				: [],
 		);
-		executionPersistence.findSingleExecution.mockImplementation(async (id) => {
-			if (id === 'exec-1') throw new Error('db down');
-			return { status: 'error' } as never;
+		executionPersistence.findStatusesByIds.mockResolvedValue([
+			{ id: 'exec-1', status: 'error' },
+			{ id: 'exec-2', status: 'error' },
+		]);
+		jobRepository.settleIfRunning.mockImplementation(async (id) => {
+			if (id === 'wf-job-1') throw new Error('db down');
+			return true;
 		});
 
 		await service.reconcile();
 
-		expect(jobRepository.settleIfRunning).toHaveBeenCalledTimes(1);
+		expect(executionPersistence.findStatusesByIds).toHaveBeenCalledWith(['exec-1', 'exec-2']);
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledTimes(2);
 		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
 			'wf-job-2',
 			expect.objectContaining({ status: 'failed' }),
 		);
+	});
+
+	it('settles nothing when the batched status read fails', async () => {
+		const { service, jobRepository, executionPersistence } = setup();
+		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
+			kind === 'workflow' ? [makeWorkflowJob()] : [],
+		);
+		executionPersistence.findStatusesByIds.mockRejectedValue(new Error('db down'));
+
+		await service.reconcile();
+
+		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
 	});
 
 	it('leaves a still-waiting execution alone — workflow jobs have no timeout', async () => {
@@ -548,7 +573,7 @@ describe('reconcile — workflow jobs', () => {
 		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
 			kind === 'workflow' ? [makeWorkflowJob()] : [],
 		);
-		executionPersistence.findSingleExecution.mockResolvedValue({ status: 'waiting' } as never);
+		executionPersistence.findStatusesByIds.mockResolvedValue([{ id: 'exec-1', status: 'waiting' }]);
 
 		await service.reconcile();
 
@@ -562,7 +587,9 @@ describe('listForThread — workflow jobs', () => {
 		jobRepository.findByParentThread
 			.mockResolvedValueOnce([makeWorkflowJob()])
 			.mockResolvedValueOnce([makeWorkflowJob({ status: 'cancelled' })]);
-		executionPersistence.findSingleExecution.mockResolvedValue({ status: 'canceled' } as never);
+		executionPersistence.findStatusesByIds.mockResolvedValue([
+			{ id: 'exec-1', status: 'canceled' },
+		]);
 
 		const jobs = await service.listForThread('thread-1');
 

--- a/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
@@ -413,6 +413,10 @@ describe('settleWorkflowJobByExecutionId', () => {
 });
 
 describe('cancel — workflow jobs', () => {
+	afterEach(() => {
+		Container.reset();
+	});
+
 	it('claims the row and stops the execution', async () => {
 		const { service, jobRepository } = setup();
 		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob()]);
@@ -437,25 +441,48 @@ describe('cancel — workflow jobs', () => {
 
 		expect(await service.cancel('thread-1', 'wf-job-1')).toBe('cancelled');
 	});
+
+	it('claims a row that lost its execution id without attempting a stop', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.findByParentThread.mockResolvedValue([
+			makeWorkflowJob({ childExecutionId: null }),
+		]);
+		const executionService = mock<ExecutionService>();
+		Container.set(ExecutionService, executionService);
+
+		const outcome = await service.cancel('thread-1', 'wf-job-1');
+
+		expect(outcome).toBe('cancelled');
+		expect(executionService.stop).not.toHaveBeenCalled();
+	});
 });
 
 describe('reconcile — workflow jobs', () => {
-	it('settles a job whose execution already reached a terminal state', async () => {
+	it('settles a job whose execution already reached a terminal state, carrying its output', async () => {
 		const { service, jobRepository, executionPersistence } = setup();
 		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
 			kind === 'workflow' ? [makeWorkflowJob()] : [],
 		);
-		executionPersistence.findSingleExecution.mockResolvedValue({ status: 'success' } as never);
+		executionPersistence.findSingleExecution.mockImplementation(async (_id, options) =>
+			options?.includeData
+				? ({
+						status: 'success',
+						data: {
+							resultData: { runData: { Set: [{ data: { main: [[{ json: { ok: true } }]] } }] } },
+						},
+					} as never)
+				: ({ status: 'success' } as never),
+		);
 
 		await service.reconcile();
 
 		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
 			'wf-job-1',
-			expect.objectContaining({ status: 'completed' }),
+			expect.objectContaining({ status: 'completed', result: '{"Set":[{"ok":true}]}' }),
 		);
 	});
 
-	it('fails a job whose execution no longer exists', async () => {
+	it('fails a job whose execution no longer exists, saying the outcome is unknown', async () => {
 		const { service, jobRepository, executionPersistence } = setup();
 		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
 			kind === 'workflow' ? [makeWorkflowJob()] : [],
@@ -466,7 +493,31 @@ describe('reconcile — workflow jobs', () => {
 
 		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
 			'wf-job-1',
-			expect.objectContaining({ status: 'failed', error: expect.stringContaining('no longer') }),
+			expect.objectContaining({
+				status: 'failed',
+				error: expect.stringContaining('outcome is unknown'),
+			}),
+		);
+	});
+
+	it('still reconciles the rest of the batch when one execution lookup fails', async () => {
+		const { service, jobRepository, executionPersistence } = setup();
+		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
+			kind === 'workflow'
+				? [makeWorkflowJob(), makeWorkflowJob({ id: 'wf-job-2', childExecutionId: 'exec-2' })]
+				: [],
+		);
+		executionPersistence.findSingleExecution.mockImplementation(async (id) => {
+			if (id === 'exec-1') throw new Error('db down');
+			return { status: 'error' } as never;
+		});
+
+		await service.reconcile();
+
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledTimes(1);
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
+			'wf-job-2',
+			expect.objectContaining({ status: 'failed' }),
 		);
 	});
 
@@ -520,5 +571,18 @@ describe('serializeWorkflowJobResult', () => {
 		const oversized = serializeWorkflowJobResult({ Set: ['x'.repeat(20_000)] });
 		expect(oversized?.length).toBeLessThan(WORKFLOW_JOB_RESULT_MAX_CHARS + 100);
 		expect(oversized).toContain('truncated');
+	});
+
+	it('truncates exactly at the cap and leaves a result at the cap untouched', () => {
+		const atCap = { S: 'x'.repeat(WORKFLOW_JOB_RESULT_MAX_CHARS - '{"S":""}'.length) };
+		const atCapSerialized = JSON.stringify(atCap);
+		expect(atCapSerialized.length).toBe(WORKFLOW_JOB_RESULT_MAX_CHARS);
+		expect(serializeWorkflowJobResult(atCap)).toBe(atCapSerialized);
+
+		const overCap = { S: 'x'.repeat(WORKFLOW_JOB_RESULT_MAX_CHARS) };
+		const overCapSerialized = JSON.stringify(overCap);
+		expect(serializeWorkflowJobResult(overCap)).toBe(
+			`${overCapSerialized.slice(0, WORKFLOW_JOB_RESULT_MAX_CHARS)}… [truncated, full data on execution]`,
+		);
 	});
 });

--- a/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
@@ -343,7 +343,7 @@ describe('registerWorkflowJob', () => {
 		executionId: 'exec-1',
 	};
 
-	it('registers a running workflow job keyed to its execution, without a timeout', async () => {
+	it('registers a running workflow job keyed to its execution', async () => {
 		const { service, jobRepository } = setup();
 
 		const receipt = await service.registerWorkflowJob(workflowParams);

--- a/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/agent-background-job.service.test.ts
@@ -1,7 +1,10 @@
 import type { Logger } from '@n8n/backend-common';
+import { Container } from '@n8n/di';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import type { ExecutionPersistence } from '@/executions/execution-persistence';
+import { ExecutionService } from '@/executions/execution.service';
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 
 import type { AgentBackgroundJob } from '../../entities/agent-background-job.entity';
@@ -12,7 +15,23 @@ import {
 	MAX_RUNNING_JOBS_PER_THREAD,
 	SETTLED_JOB_RETENTION_MS,
 	SUB_AGENT_BACKGROUND_TIMEOUT_MS,
+	WORKFLOW_JOB_RESULT_MAX_CHARS,
+	serializeWorkflowJobResult,
+	settlementStatusForExecution,
 } from '../agent-background-job.service';
+
+function makeWorkflowJob(overrides: Partial<AgentBackgroundJob> = {}): AgentBackgroundJob {
+	return makeJob({
+		id: 'wf-job-1',
+		kind: 'workflow',
+		subAgentId: null,
+		childThreadId: null,
+		childExecutionId: 'exec-1',
+		workflowId: 'workflow-1',
+		timeoutAt: null,
+		...overrides,
+	});
+}
 
 function makeJob(overrides: Partial<AgentBackgroundJob> = {}): AgentBackgroundJob {
 	return {
@@ -39,12 +58,14 @@ function makeJob(overrides: Partial<AgentBackgroundJob> = {}): AgentBackgroundJo
 function setup() {
 	const jobRepository = mock<AgentBackgroundJobRepository>();
 	const executionRepository = mock<AgentExecutionRepository>();
+	const executionPersistence = mock<ExecutionPersistence>();
 	const publisher = mock<Publisher>();
 	const logger = mock<Logger>();
 	(logger.scoped as Mock).mockReturnValue(logger);
 
 	jobRepository.countRunningByParentThread.mockResolvedValue(0);
 	jobRepository.insertJob.mockResolvedValue(undefined);
+	jobRepository.insertWorkflowJobOrGetExisting.mockResolvedValue({ inserted: true });
 	jobRepository.settleIfRunning.mockResolvedValue(true);
 	jobRepository.findByParentThread.mockResolvedValue([]);
 	jobRepository.findRunningJobs.mockResolvedValue([]);
@@ -54,10 +75,11 @@ function setup() {
 	const service = new AgentBackgroundJobService(
 		jobRepository,
 		executionRepository,
+		executionPersistence,
 		publisher,
 		logger,
 	);
-	return { service, jobRepository, executionRepository, publisher };
+	return { service, jobRepository, executionRepository, executionPersistence, publisher };
 }
 
 const registerParams = {
@@ -308,5 +330,195 @@ describe('reconcile', () => {
 		await service.reconcile();
 
 		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
+	});
+});
+
+describe('registerWorkflowJob', () => {
+	const workflowParams = {
+		id: 'wf-job-1',
+		parentAgentId: 'agent-1',
+		parentThreadId: 'thread-1',
+		title: 'My Workflow',
+		workflowId: 'workflow-1',
+		executionId: 'exec-1',
+	};
+
+	it('registers a running workflow job keyed to its execution, without a timeout', async () => {
+		const { service, jobRepository } = setup();
+
+		const receipt = await service.registerWorkflowJob(workflowParams);
+
+		expect(receipt).toEqual({ status: 'started', jobId: 'wf-job-1' });
+		expect(jobRepository.insertWorkflowJobOrGetExisting).toHaveBeenCalledWith(
+			expect.objectContaining({
+				kind: 'workflow',
+				childExecutionId: 'exec-1',
+				workflowId: 'workflow-1',
+			}),
+		);
+		expect(jobRepository.countRunningByParentThread).not.toHaveBeenCalled();
+	});
+
+	it('converges a replayed registration on the job already tracking the execution', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.insertWorkflowJobOrGetExisting.mockResolvedValue({
+			inserted: false,
+			existing: makeWorkflowJob({ id: 'wf-existing' }),
+		});
+
+		const receipt = await service.registerWorkflowJob(workflowParams);
+
+		expect(receipt).toEqual({ status: 'started', jobId: 'wf-existing' });
+	});
+
+	it('converges on the existing job even after it settled', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.insertWorkflowJobOrGetExisting.mockResolvedValue({
+			inserted: false,
+			existing: makeWorkflowJob({ id: 'wf-settled', status: 'completed' }),
+		});
+
+		const receipt = await service.registerWorkflowJob(workflowParams);
+
+		expect(receipt).toEqual({ status: 'started', jobId: 'wf-settled' });
+	});
+});
+
+describe('settleWorkflowJobByExecutionId', () => {
+	it('settles the running job tracking the execution', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.findRunningWorkflowJobByExecutionId.mockResolvedValue(makeWorkflowJob());
+
+		const settled = await service.settleWorkflowJobByExecutionId('exec-1', {
+			status: 'completed',
+			result: '{"Set":[{"ok":true}]}',
+		});
+
+		expect(settled).toBe(true);
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith('wf-job-1', {
+			status: 'completed',
+			result: '{"Set":[{"ok":true}]}',
+		});
+	});
+
+	it('is a no-op when no running job tracks the execution', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.findRunningWorkflowJobByExecutionId.mockResolvedValue(null);
+
+		const settled = await service.settleWorkflowJobByExecutionId('exec-1', { status: 'failed' });
+
+		expect(settled).toBe(false);
+		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
+	});
+});
+
+describe('cancel — workflow jobs', () => {
+	it('claims the row and stops the execution', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob()]);
+		const executionService = mock<ExecutionService>();
+		Container.set(ExecutionService, executionService);
+
+		const outcome = await service.cancel('thread-1', 'wf-job-1');
+
+		expect(outcome).toBe('cancelled');
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith('wf-job-1', {
+			status: 'cancelled',
+		});
+		expect(executionService.stop).toHaveBeenCalledWith('exec-1', ['workflow-1']);
+	});
+
+	it('keeps the row cancelled when stopping the finished execution errors', async () => {
+		const { service, jobRepository } = setup();
+		jobRepository.findByParentThread.mockResolvedValue([makeWorkflowJob()]);
+		const executionService = mock<ExecutionService>();
+		executionService.stop.mockRejectedValue(new Error('already finished'));
+		Container.set(ExecutionService, executionService);
+
+		expect(await service.cancel('thread-1', 'wf-job-1')).toBe('cancelled');
+	});
+});
+
+describe('reconcile — workflow jobs', () => {
+	it('settles a job whose execution already reached a terminal state', async () => {
+		const { service, jobRepository, executionPersistence } = setup();
+		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
+			kind === 'workflow' ? [makeWorkflowJob()] : [],
+		);
+		executionPersistence.findSingleExecution.mockResolvedValue({ status: 'success' } as never);
+
+		await service.reconcile();
+
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
+			'wf-job-1',
+			expect.objectContaining({ status: 'completed' }),
+		);
+	});
+
+	it('fails a job whose execution no longer exists', async () => {
+		const { service, jobRepository, executionPersistence } = setup();
+		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
+			kind === 'workflow' ? [makeWorkflowJob()] : [],
+		);
+		executionPersistence.findSingleExecution.mockResolvedValue(undefined);
+
+		await service.reconcile();
+
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
+			'wf-job-1',
+			expect.objectContaining({ status: 'failed', error: expect.stringContaining('no longer') }),
+		);
+	});
+
+	it('leaves a still-waiting execution alone — workflow jobs have no timeout', async () => {
+		const { service, jobRepository, executionPersistence } = setup();
+		jobRepository.findRunningJobs.mockImplementation(async (kind) =>
+			kind === 'workflow' ? [makeWorkflowJob()] : [],
+		);
+		executionPersistence.findSingleExecution.mockResolvedValue({ status: 'waiting' } as never);
+
+		await service.reconcile();
+
+		expect(jobRepository.settleIfRunning).not.toHaveBeenCalled();
+	});
+});
+
+describe('listForThread — workflow jobs', () => {
+	it('settles a running workflow row whose execution finished (settle-on-check)', async () => {
+		const { service, jobRepository, executionPersistence } = setup();
+		jobRepository.findByParentThread
+			.mockResolvedValueOnce([makeWorkflowJob()])
+			.mockResolvedValueOnce([makeWorkflowJob({ status: 'cancelled' })]);
+		executionPersistence.findSingleExecution.mockResolvedValue({ status: 'canceled' } as never);
+
+		const jobs = await service.listForThread('thread-1');
+
+		expect(jobRepository.settleIfRunning).toHaveBeenCalledWith(
+			'wf-job-1',
+			expect.objectContaining({ status: 'cancelled' }),
+		);
+		expect(jobs[0].status).toBe('cancelled');
+		expect(jobs[0].childExecutionId).toBe('exec-1');
+	});
+});
+
+describe('settlementStatusForExecution', () => {
+	it('maps terminal execution statuses onto job settlement statuses', () => {
+		expect(settlementStatusForExecution('success')).toBe('completed');
+		expect(settlementStatusForExecution('canceled')).toBe('cancelled');
+		expect(settlementStatusForExecution('error')).toBe('failed');
+		expect(settlementStatusForExecution('crashed')).toBe('failed');
+	});
+});
+
+describe('serializeWorkflowJobResult', () => {
+	it('serializes result data and bounds its size', () => {
+		expect(serializeWorkflowJobResult(undefined)).toBeNull();
+		expect(serializeWorkflowJobResult({})).toBeNull();
+		expect(serializeWorkflowJobResult({ Set: [{ ok: true }] })).toBe('{"Set":[{"ok":true}]}');
+
+		const oversized = serializeWorkflowJobResult({ Set: ['x'.repeat(20_000)] });
+		expect(oversized?.length).toBeLessThan(WORKFLOW_JOB_RESULT_MAX_CHARS + 100);
+		expect(oversized).toContain('truncated');
 	});
 });

--- a/packages/cli/src/modules/agents/background/__tests__/background-job-tools.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/background-job-tools.test.ts
@@ -27,6 +27,7 @@ function jobView(overrides: Partial<BackgroundJobView> = {}): BackgroundJobView 
 		createdAt: new Date('2026-08-26T10:00:00Z'),
 		timeoutAt: null,
 		settledAt: null,
+		childExecutionId: null,
 		...overrides,
 	};
 }

--- a/packages/cli/src/modules/agents/background/__tests__/background-job-tools.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/background-job-tools.test.ts
@@ -207,6 +207,20 @@ describe('check_background_jobs', () => {
 		});
 	});
 
+	it('surfaces a workflow job’s execution id', async () => {
+		const { jobService, options } = setup();
+		jobService.listForThread.mockResolvedValue([
+			jobView({ kind: 'workflow', childExecutionId: 'exec-1' }),
+		]);
+		const tool = createCheckBackgroundJobsTool(options.jobService);
+
+		const output = await tool.handler!({}, { persistence });
+
+		expect(output).toMatchObject({
+			jobs: [expect.objectContaining({ executionId: 'exec-1' })],
+		});
+	});
+
 	it('truncates oversized results in the echo', async () => {
 		const { jobService, options } = setup();
 		jobService.listForThread.mockResolvedValue([

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -320,13 +320,13 @@ export class AgentBackgroundJobService {
 					});
 					return 'already-settled';
 				}
-				// The tool call fails with this error, but the executor keeps no
-				// server-side record that names the execution that may still run.
+
 				this.logger.error('Failed to stop a workflow job execution — it may still be running', {
 					jobId: job.id,
 					executionId: job.childExecutionId,
 					error: error instanceof Error ? error.message : String(error),
 				});
+
 				throw error;
 			}
 		}

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -2,7 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
-import type { IRunData, ITaskData, TerminalExecutionStatus } from 'n8n-workflow';
+import type { ExecutionStatus, IRunData, ITaskData, TerminalExecutionStatus } from 'n8n-workflow';
 import { isTerminalExecutionStatus, WorkflowOperationError } from 'n8n-workflow';
 
 import { ExecutionPersistence } from '@/executions/execution-persistence';
@@ -17,6 +17,7 @@ import {
 } from '../repositories/agent-background-job.repository';
 import { AgentExecutionRepository } from '../repositories/agent-execution.repository';
 
+/** Bounds live sub-agent runs per thread. Workflow jobs are parked executions and are exempt. */
 export const MAX_RUNNING_JOBS_PER_THREAD = 5;
 export const SUB_AGENT_BACKGROUND_TIMEOUT_MS = 30 * Time.minutes.toMilliseconds;
 export const SETTLED_JOB_RETENTION_MS = 30 * Time.days.toMilliseconds;
@@ -129,13 +130,15 @@ export class AgentBackgroundJobService {
 
 	/**
 	 * Register a sub-agent job. The receipt follows the spawn contract:
-	 * `limit-reached` when the thread already has the maximum running jobs,
-	 * else `started`.
+	 * `limit-reached` when the thread already has the maximum running sub-agent
+	 * jobs, else `started`.
 	 */
 	async registerSubAgentJob(
 		params: Omit<NewSubAgentJob, 'kind' | 'timeoutAt'>,
 	): Promise<BackgroundJobReceipt> {
-		const running = await this.jobRepository.countRunningByParentThread(params.parentThreadId);
+		const running = await this.jobRepository.countRunningSubAgentsByParentThread(
+			params.parentThreadId,
+		);
 		if (running >= MAX_RUNNING_JOBS_PER_THREAD) return { status: 'limit-reached' };
 
 		await this.jobRepository.insertJob({
@@ -335,17 +338,31 @@ export class AgentBackgroundJobService {
 	 */
 	private async settleFinishedWorkflowJobs(jobs: AgentBackgroundJob[]): Promise<boolean> {
 		const candidates = jobs.filter(
-			(job) => job.kind === 'workflow' && job.status === 'running' && job.childExecutionId !== null,
+			(job): job is AgentBackgroundJob & { childExecutionId: string } =>
+				job.kind === 'workflow' && job.status === 'running' && job.childExecutionId !== null,
 		);
+		if (candidates.length === 0) return false;
+
+		let statuses: Map<string, ExecutionStatus>;
+		try {
+			const rows = await this.executionPersistence.findStatusesByIds(
+				candidates.map((job) => job.childExecutionId),
+			);
+			statuses = new Map(rows.map((row) => [row.id, row.status]));
+		} catch (error) {
+			this.logger.error('Failed to read execution statuses for workflow background jobs', {
+				error,
+			});
+			return false;
+		}
 
 		let settledAny = false;
 		for (const job of candidates) {
 			const executionId = job.childExecutionId;
-			if (executionId === null) continue;
+			const executionStatus = statuses.get(executionId);
 
 			try {
-				const execution = await this.executionPersistence.findSingleExecution(executionId);
-				if (!execution) {
+				if (executionStatus === undefined) {
 					settledAny =
 						(await this.settle(job.id, {
 							status: 'failed',
@@ -353,14 +370,14 @@ export class AgentBackgroundJobService {
 						})) || settledAny;
 					continue;
 				}
-				if (!isTerminalExecutionStatus(execution.status)) continue;
+				if (!isTerminalExecutionStatus(executionStatus)) continue;
 
-				const status = settlementStatusForExecution(execution.status);
+				const status = settlementStatusForExecution(executionStatus);
 				settledAny =
 					(await this.settle(job.id, {
 						status,
 						result: status === 'completed' ? await this.loadExecutionResult(executionId) : null,
-						error: execution.status === 'success' ? null : `Execution ${execution.status}`,
+						error: executionStatus === 'success' ? null : `Execution ${executionStatus}`,
 					})) || settledAny;
 			} catch (error) {
 				this.logger.error('Failed to reconcile workflow background job', {

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -376,15 +376,25 @@ export class AgentBackgroundJobService {
 
 	/** Serialized all-node output of a finished execution, for a settle whose run data is not in memory. */
 	private async loadExecutionResult(executionId: string): Promise<string | null> {
-		const execution = await this.executionPersistence.findSingleExecution(executionId, {
-			includeData: true,
-			unflattenData: true,
-		});
+		// A failed data read must not block the settle: workflow jobs have no
+		// timeout, so a row skipped here could stay running forever.
+		try {
+			const execution = await this.executionPersistence.findSingleExecution(executionId, {
+				includeData: true,
+				unflattenData: true,
+			});
 
-		const runData = execution?.data?.resultData?.runData;
-		if (!runData) return null;
+			const runData = execution?.data?.resultData?.runData;
+			if (!runData) return null;
 
-		return serializeWorkflowJobResult(collectResultData(runData, true));
+			return serializeWorkflowJobResult(collectResultData(runData, false));
+		} catch (error) {
+			this.logger.warn('Failed to read a finished execution’s data for its job result', {
+				executionId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return null;
+		}
 	}
 
 	private async failJobsPastTimeout(): Promise<void> {

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -320,6 +320,13 @@ export class AgentBackgroundJobService {
 					});
 					return 'already-settled';
 				}
+				// The tool call fails with this error, but the executor keeps no
+				// server-side record that names the execution that may still run.
+				this.logger.error('Failed to stop a workflow job execution — it may still be running', {
+					jobId: job.id,
+					executionId: job.childExecutionId,
+					error: error instanceof Error ? error.message : String(error),
+				});
 				throw error;
 			}
 		}

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -219,10 +219,11 @@ export class AgentBackgroundJobService {
 	}
 
 	/**
-	 * Claim the row as canceled, then abort the live run. When this process
-	 * holds the handle the abort is direct; otherwise the spawning main is
-	 * reached via pubsub. The row is claimed first either way, so the aborted
-	 * run's own settle write loses to the claim.
+	 * Cancel a job. A sub-agent row is claimed as cancelled first and its live
+	 * run aborted second, so the aborted run's own settle write loses to the
+	 * claim. When this process holds the handle the abort is direct; otherwise
+	 * the spawning main is reached via pubsub. A workflow job stops its
+	 * execution first instead; see `cancelWorkflowJob`.
 	 */
 	async cancel(
 		parentThreadId: string,
@@ -230,14 +231,12 @@ export class AgentBackgroundJobService {
 	): Promise<'cancelled' | 'not-found' | 'already-settled'> {
 		const [job] = await this.jobRepository.findByParentThread(parentThreadId, [jobId]);
 		if (!job) return 'not-found';
+		if (job.status !== 'running') return 'already-settled';
+
+		if (job.kind === 'workflow') return await this.cancelWorkflowJob(job);
 
 		const claimed = await this.jobRepository.settleIfRunning(jobId, { status: 'cancelled' });
 		if (!claimed) return 'already-settled';
-
-		if (job.kind === 'workflow') {
-			await this.stopWorkflowExecution(job);
-			return 'cancelled';
-		}
 
 		const controller = this.abortControllers.get(jobId);
 		if (controller) {
@@ -294,37 +293,41 @@ export class AgentBackgroundJobService {
 	}
 
 	/**
-	 * Cross-process stop of a cancelled workflow job's execution. The job row is
-	 * already claimed, so a stop that finds the execution finished (or gone) is
-	 * not an error worth surfacing to the model — but any other failure means
-	 * the workflow keeps running while the model believes it stopped, so it is
-	 * logged loudly.
+	 * Stop the execution first, then claim the row. A workflow job has no
+	 * timeout, so a row claimed before a failed stop would tell the model the
+	 * workflow stopped while it keeps waiting. An unexpected stop failure is
+	 * rethrown with the row still running, so the cancel can be retried. An
+	 * execution that already finished (or is gone) is left to reconciliation,
+	 * which records its real outcome.
 	 */
-	private async stopWorkflowExecution(job: AgentBackgroundJob): Promise<void> {
-		if (job.childExecutionId === null || job.workflowId === null) return;
-
-		// Lazy: ExecutionService is a heavy dependency this service otherwise
-		// never needs — workers load this class for the settle path alone.
-		const { ExecutionService } = await import('@/executions/execution.service.js');
-		const { MissingExecutionStopError } = await import('@/errors/missing-execution-stop.error.js');
-		try {
-			await Container.get(ExecutionService).stop(job.childExecutionId, [job.workflowId]);
-		} catch (error) {
-			const details = {
-				jobId: job.id,
-				executionId: job.childExecutionId,
-				error: error instanceof Error ? error.message : String(error),
-			};
-			// Already finished or gone — nothing left to stop.
-			if (error instanceof MissingExecutionStopError || error instanceof WorkflowOperationError) {
-				this.logger.debug('Cancelled workflow job execution was already beyond stopping', details);
-			} else {
-				this.logger.error(
-					'Failed to stop a cancelled workflow job execution — it may still be running',
-					details,
-				);
+	private async cancelWorkflowJob(
+		job: AgentBackgroundJob,
+	): Promise<'cancelled' | 'already-settled'> {
+		if (job.childExecutionId !== null && job.workflowId !== null) {
+			// Lazy: ExecutionService is a heavy dependency this service otherwise
+			// never needs — workers load this class for the settle path alone.
+			const { ExecutionService } = await import('@/executions/execution.service.js');
+			const { MissingExecutionStopError } = await import(
+				'@/errors/missing-execution-stop.error.js'
+			);
+			try {
+				await Container.get(ExecutionService).stop(job.childExecutionId, [job.workflowId]);
+			} catch (error) {
+				if (error instanceof MissingExecutionStopError || error instanceof WorkflowOperationError) {
+					this.logger.debug('Workflow job execution was already beyond stopping', {
+						jobId: job.id,
+						executionId: job.childExecutionId,
+					});
+					return 'already-settled';
+				}
+				throw error;
 			}
 		}
+
+		// The stopped execution's settle hook may have written `cancelled` first;
+		// either way the job is cancelled.
+		await this.jobRepository.settleIfRunning(job.id, { status: 'cancelled' });
+		return 'cancelled';
 	}
 
 	/**

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -39,20 +39,17 @@ export type BackgroundJobView = Pick<
 	| 'childExecutionId'
 >;
 
-/** Cap on the result text persisted on a workflow job row at settle. */
+/** Cap on the result text persisted on a workflow job row. */
 export const WORKFLOW_JOB_RESULT_MAX_CHARS = 8000;
 
 /**
  * Error recorded on a job whose execution vanished before its outcome was
- * read. A successful execution is hard-deleted at completion when the
- * workflow's save settings say not to keep it, so a missing execution is NOT
- * evidence of failure — and the wording is the trust boundary that keeps the
- * model from re-running a workflow that may already have completed.
+ * read.
  */
 export const EXECUTION_OUTCOME_UNKNOWN_ERROR =
 	'The workflow execution was not retained (check the workflow’s save settings), so its outcome is unknown — it may have completed. Do not run the workflow again without checking for its effects.';
 
-/** Job settlement status a finished workflow execution maps to. */
+/** Completed workflow execution status -> job status */
 export function settlementStatusForExecution(
 	status: TerminalExecutionStatus,
 ): 'completed' | 'failed' | 'cancelled' {
@@ -68,7 +65,7 @@ function outputItemsFromNodeRuns(nodeRuns: ITaskData[]): unknown[] {
 	return lastRun.data.main.flatMap((items) => items ?? []).map((item) => item.json);
 }
 
-/** Build the resultData map from an execution's runData, scoped by `allOutputs`. */
+/** Build the resultData map from an execution's runData. */
 export function collectResultData(runData: IRunData, allOutputs: boolean): Record<string, unknown> {
 	const resultData: Record<string, unknown> = {};
 
@@ -94,8 +91,7 @@ export function collectResultData(runData: IRunData, allOutputs: boolean): Recor
 }
 
 /**
- * Serialize a workflow's result data for the job row, bounded so a large
- * output cannot bloat the table — the execution itself keeps the full data.
+ * Serialize a workflow's result data for the job row, with truncation.
  */
 export function serializeWorkflowJobResult(
 	resultData: Record<string, unknown> | undefined,
@@ -115,8 +111,7 @@ export function serializeWorkflowJobResult(
 /**
  * Registry of durable background jobs dispatched by top-level agents. The job
  * row is the receipt handed to the model and the single source of truth for
- * status checks — nothing the check tool depends on lives in memory. The
- * in-process abort map only carries live cancellation handles.
+ * status checks.
  */
 @Service()
 export class AgentBackgroundJobService {
@@ -140,9 +135,6 @@ export class AgentBackgroundJobService {
 	async registerSubAgentJob(
 		params: Omit<NewSubAgentJob, 'kind' | 'timeoutAt'>,
 	): Promise<BackgroundJobReceipt> {
-		// ponytail: count-then-insert can briefly admit one job over the cap under
-		// concurrent spawns; the limit is advisory. Wrap in a transaction if it
-		// ever needs to be exact.
 		const running = await this.jobRepository.countRunningByParentThread(params.parentThreadId);
 		if (running >= MAX_RUNNING_JOBS_PER_THREAD) return { status: 'limit-reached' };
 
@@ -151,26 +143,24 @@ export class AgentBackgroundJobService {
 			kind: 'subagent',
 			timeoutAt: new Date(Date.now() + SUB_AGENT_BACKGROUND_TIMEOUT_MS),
 		});
+
 		return { status: 'started', jobId: params.id };
 	}
 
 	/**
 	 * Register a workflow execution parked at a Wait node as a background job.
-	 * The execution is already running either way, so there is no cap check and
-	 * no timeout — its own lifecycle governs. The schema allows exactly one job
-	 * per execution: a concurrent or replayed registration converges on the job
-	 * that won the insert, so the receipt always names the row actually tracking
-	 * the execution.
 	 */
 	async registerWorkflowJob(
 		params: Omit<NewWorkflowJob, 'kind' | 'childExecutionId'> & { executionId: string },
 	): Promise<BackgroundJobReceipt> {
 		const { executionId, ...job } = params;
+
 		const outcome = await this.jobRepository.insertWorkflowJobOrGetExisting({
 			...job,
 			kind: 'workflow',
 			childExecutionId: executionId,
 		});
+
 		return { status: 'started', jobId: outcome.inserted ? params.id : outcome.existing.id };
 	}
 
@@ -200,9 +190,7 @@ export class AgentBackgroundJobService {
 	}
 
 	/**
-	 * Jobs of the given thread, with running rows reconciled first so the model
-	 * gets a truthful answer instead of a forever-running job when the settle
-	 * never ran (crash, restart).
+	 * Jobs of the given thread, with running rows reconciled first.
 	 */
 	async listForThread(parentThreadId: string, ids?: string[]): Promise<BackgroundJobView[]> {
 		let jobs = await this.jobRepository.findByParentThread(parentThreadId, ids);
@@ -228,7 +216,7 @@ export class AgentBackgroundJobService {
 	}
 
 	/**
-	 * Claim the row as cancelled, then abort the live run. When this process
+	 * Claim the row as canceled, then abort the live run. When this process
 	 * holds the handle the abort is direct; otherwise the spawning main is
 	 * reached via pubsub. The row is claimed first either way, so the aborted
 	 * run's own settle write loses to the claim.
@@ -354,6 +342,7 @@ export class AgentBackgroundJobService {
 		for (const job of candidates) {
 			const executionId = job.childExecutionId;
 			if (executionId === null) continue;
+
 			try {
 				const execution = await this.executionPersistence.findSingleExecution(executionId);
 				if (!execution) {
@@ -381,6 +370,7 @@ export class AgentBackgroundJobService {
 				});
 			}
 		}
+
 		return settledAny;
 	}
 
@@ -390,6 +380,7 @@ export class AgentBackgroundJobService {
 			includeData: true,
 			unflattenData: true,
 		});
+
 		const runData = execution?.data?.resultData?.runData;
 		if (!runData) return null;
 
@@ -403,6 +394,7 @@ export class AgentBackgroundJobService {
 			// order would race the aborted run's own settle write. Grab the handle
 			// before settle drops it from the map.
 			const controller = this.abortControllers.get(job.id);
+
 			try {
 				const settled = await this.settle(job.id, {
 					status: 'failed',

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -1,8 +1,11 @@
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { OnPubSubEvent } from '@n8n/decorators';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
+import type { TerminalExecutionStatus } from 'n8n-workflow';
+import { isTerminalExecutionStatus } from 'n8n-workflow';
 
+import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 
 import type { AgentBackgroundJob } from '../entities/agent-background-job.entity';
@@ -10,6 +13,7 @@ import {
 	AgentBackgroundJobRepository,
 	type AgentBackgroundJobSettlement,
 	type NewSubAgentJob,
+	type NewWorkflowJob,
 } from '../repositories/agent-background-job.repository';
 import { AgentExecutionRepository } from '../repositories/agent-execution.repository';
 
@@ -23,8 +27,48 @@ export type BackgroundJobReceipt =
 
 export type BackgroundJobView = Pick<
 	AgentBackgroundJob,
-	'id' | 'kind' | 'title' | 'status' | 'result' | 'error' | 'createdAt' | 'timeoutAt' | 'settledAt'
+	| 'id'
+	| 'kind'
+	| 'title'
+	| 'status'
+	| 'result'
+	| 'error'
+	| 'createdAt'
+	| 'timeoutAt'
+	| 'settledAt'
+	| 'childExecutionId'
 >;
+
+/** Cap on the result text persisted on a workflow job row at settle. */
+export const WORKFLOW_JOB_RESULT_MAX_CHARS = 8000;
+
+/** Job settlement status a finished workflow execution maps to. */
+export function settlementStatusForExecution(
+	status: TerminalExecutionStatus,
+): 'completed' | 'failed' | 'cancelled' {
+	if (status === 'success') return 'completed';
+	if (status === 'canceled') return 'cancelled';
+	return 'failed';
+}
+
+/**
+ * Serialize a workflow's result data for the job row, bounded so a large
+ * output cannot bloat the table — the execution itself keeps the full data.
+ */
+export function serializeWorkflowJobResult(
+	resultData: Record<string, unknown> | undefined,
+): string | null {
+	if (!resultData || Object.keys(resultData).length === 0) return null;
+
+	let serialized: string;
+	try {
+		serialized = JSON.stringify(resultData);
+	} catch {
+		return null;
+	}
+	if (serialized.length <= WORKFLOW_JOB_RESULT_MAX_CHARS) return serialized;
+	return `${serialized.slice(0, WORKFLOW_JOB_RESULT_MAX_CHARS)}… [truncated, full data on execution]`;
+}
 
 /**
  * Registry of durable background jobs dispatched by top-level agents. The job
@@ -39,6 +83,7 @@ export class AgentBackgroundJobService {
 	constructor(
 		private readonly jobRepository: AgentBackgroundJobRepository,
 		private readonly executionRepository: AgentExecutionRepository,
+		private readonly executionPersistence: ExecutionPersistence,
 		private readonly publisher: Publisher,
 		private readonly logger: Logger,
 	) {
@@ -67,6 +112,37 @@ export class AgentBackgroundJobService {
 		return { status: 'started', jobId: params.id };
 	}
 
+	/**
+	 * Register a workflow execution parked at a Wait node as a background job.
+	 * The execution is already running either way, so there is no cap check and
+	 * no timeout — its own lifecycle governs. The schema allows exactly one job
+	 * per execution: a concurrent or replayed registration converges on the job
+	 * that won the insert, so the receipt always names the row actually tracking
+	 * the execution.
+	 */
+	async registerWorkflowJob(
+		params: Omit<NewWorkflowJob, 'kind' | 'childExecutionId'> & { executionId: string },
+	): Promise<BackgroundJobReceipt> {
+		const { executionId, ...job } = params;
+		const outcome = await this.jobRepository.insertWorkflowJobOrGetExisting({
+			...job,
+			kind: 'workflow',
+			childExecutionId: executionId,
+		});
+		return { status: 'started', jobId: outcome.inserted ? params.id : outcome.existing.id };
+	}
+
+	/** Settle the workflow job tracking the given execution; no-op without a running row. */
+	async settleWorkflowJobByExecutionId(
+		executionId: string,
+		settlement: AgentBackgroundJobSettlement,
+	): Promise<boolean> {
+		const job = await this.jobRepository.findRunningWorkflowJobByExecutionId(executionId);
+		if (!job) return false;
+
+		return await this.settle(job.id, settlement);
+	}
+
 	async settle(jobId: string, settlement: AgentBackgroundJobSettlement): Promise<boolean> {
 		try {
 			return await this.jobRepository.settleIfRunning(jobId, settlement);
@@ -89,8 +165,11 @@ export class AgentBackgroundJobService {
 	async listForThread(parentThreadId: string, ids?: string[]): Promise<BackgroundJobView[]> {
 		let jobs = await this.jobRepository.findByParentThread(parentThreadId, ids);
 
-		const reconciled = await this.failOrphanedSubAgentJobs(jobs);
-		if (reconciled) jobs = await this.jobRepository.findByParentThread(parentThreadId, ids);
+		const settledSubAgents = await this.failOrphanedSubAgentJobs(jobs);
+		const settledWorkflows = await this.settleFinishedWorkflowJobs(jobs);
+		if (settledSubAgents || settledWorkflows) {
+			jobs = await this.jobRepository.findByParentThread(parentThreadId, ids);
+		}
 
 		return jobs.map((job) => ({
 			id: job.id,
@@ -102,6 +181,7 @@ export class AgentBackgroundJobService {
 			createdAt: job.createdAt,
 			timeoutAt: job.timeoutAt,
 			settledAt: job.settledAt,
+			childExecutionId: job.childExecutionId,
 		}));
 	}
 
@@ -120,6 +200,11 @@ export class AgentBackgroundJobService {
 
 		const claimed = await this.jobRepository.settleIfRunning(jobId, { status: 'cancelled' });
 		if (!claimed) return 'already-settled';
+
+		if (job.kind === 'workflow') {
+			await this.stopWorkflowExecution(job);
+			return 'cancelled';
+		}
 
 		const controller = this.abortControllers.get(jobId);
 		if (controller) {
@@ -160,8 +245,75 @@ export class AgentBackgroundJobService {
 	async reconcile(): Promise<void> {
 		await this.failJobsPastTimeout();
 		await this.failOrphanedSubAgentJobs(await this.jobRepository.findRunningJobs('subagent'));
+		await this.settleFinishedWorkflowJobs(await this.jobRepository.findRunningJobs('workflow'));
 
 		await this.jobRepository.deleteSettledBefore(new Date(Date.now() - SETTLED_JOB_RETENTION_MS));
+	}
+
+	/**
+	 * Cross-process stop of a cancelled workflow job's execution. The job row is
+	 * already claimed, so a stop that finds the execution finished (or gone) is
+	 * not an error worth surfacing to the model.
+	 */
+	private async stopWorkflowExecution(job: AgentBackgroundJob): Promise<void> {
+		if (job.childExecutionId === null || job.workflowId === null) return;
+
+		// Lazy: ExecutionService is a heavy dependency this service otherwise
+		// never needs — workers load this class for the settle path alone.
+		const { ExecutionService } = await import('@/executions/execution.service.js');
+		try {
+			await Container.get(ExecutionService).stop(job.childExecutionId, [job.workflowId]);
+		} catch (error) {
+			this.logger.debug('Stopping a cancelled workflow job execution did not succeed', {
+				jobId: job.id,
+				executionId: job.childExecutionId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	/**
+	 * Settle running workflow jobs whose execution already reached a terminal
+	 * state — the settle hook never ran (crash) or lost the registration race.
+	 * The result is left empty here; the lifecycle hook is the path that
+	 * captures output. An execution that no longer exists (pruned, deleted)
+	 * fails the job. Returns whether any row was settled.
+	 */
+	private async settleFinishedWorkflowJobs(jobs: AgentBackgroundJob[]): Promise<boolean> {
+		const candidates = jobs.filter(
+			(job) => job.kind === 'workflow' && job.status === 'running' && job.childExecutionId !== null,
+		);
+
+		let settledAny = false;
+		for (const job of candidates) {
+			const executionId = job.childExecutionId;
+			if (executionId === null) continue;
+			try {
+				const execution = await this.executionPersistence.findSingleExecution(executionId);
+				if (!execution) {
+					settledAny =
+						(await this.settle(job.id, {
+							status: 'failed',
+							error: 'The workflow execution no longer exists',
+						})) || settledAny;
+					continue;
+				}
+				if (!isTerminalExecutionStatus(execution.status)) continue;
+
+				settledAny =
+					(await this.settle(job.id, {
+						status: settlementStatusForExecution(execution.status),
+						error: execution.status === 'success' ? null : `Execution ${execution.status}`,
+					})) || settledAny;
+			} catch (error) {
+				this.logger.error('Failed to reconcile workflow background job', {
+					jobId: job.id,
+					executionId,
+					error,
+				});
+			}
+		}
+		return settledAny;
 	}
 
 	private async failJobsPastTimeout(): Promise<void> {

--- a/packages/cli/src/modules/agents/background/agent-background-job.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-background-job.service.ts
@@ -2,8 +2,8 @@ import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
-import type { TerminalExecutionStatus } from 'n8n-workflow';
-import { isTerminalExecutionStatus } from 'n8n-workflow';
+import type { IRunData, ITaskData, TerminalExecutionStatus } from 'n8n-workflow';
+import { isTerminalExecutionStatus, WorkflowOperationError } from 'n8n-workflow';
 
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
@@ -42,6 +42,16 @@ export type BackgroundJobView = Pick<
 /** Cap on the result text persisted on a workflow job row at settle. */
 export const WORKFLOW_JOB_RESULT_MAX_CHARS = 8000;
 
+/**
+ * Error recorded on a job whose execution vanished before its outcome was
+ * read. A successful execution is hard-deleted at completion when the
+ * workflow's save settings say not to keep it, so a missing execution is NOT
+ * evidence of failure — and the wording is the trust boundary that keeps the
+ * model from re-running a workflow that may already have completed.
+ */
+export const EXECUTION_OUTCOME_UNKNOWN_ERROR =
+	'The workflow execution was not retained (check the workflow’s save settings), so its outcome is unknown — it may have completed. Do not run the workflow again without checking for its effects.';
+
 /** Job settlement status a finished workflow execution maps to. */
 export function settlementStatusForExecution(
 	status: TerminalExecutionStatus,
@@ -49,6 +59,38 @@ export function settlementStatusForExecution(
 	if (status === 'success') return 'completed';
 	if (status === 'canceled') return 'cancelled';
 	return 'failed';
+}
+
+/** Extract the JSON items produced by the last run of a node. */
+function outputItemsFromNodeRuns(nodeRuns: ITaskData[]): unknown[] {
+	const lastRun = nodeRuns[nodeRuns.length - 1];
+	if (!lastRun?.data?.main) return [];
+	return lastRun.data.main.flatMap((items) => items ?? []).map((item) => item.json);
+}
+
+/** Build the resultData map from an execution's runData, scoped by `allOutputs`. */
+export function collectResultData(runData: IRunData, allOutputs: boolean): Record<string, unknown> {
+	const resultData: Record<string, unknown> = {};
+
+	if (allOutputs) {
+		for (const [nodeName, nodeRuns] of Object.entries(runData)) {
+			const outputItems = outputItemsFromNodeRuns(nodeRuns);
+			if (outputItems.length > 0) {
+				resultData[nodeName] = outputItems;
+			}
+		}
+		return resultData;
+	}
+
+	const nodeNames = Object.keys(runData);
+	const lastNodeName = nodeNames[nodeNames.length - 1];
+	if (lastNodeName) {
+		const outputItems = outputItemsFromNodeRuns(runData[lastNodeName]);
+		if (outputItems.length > 0) {
+			resultData[lastNodeName] = outputItems;
+		}
+	}
+	return resultData;
 }
 
 /**
@@ -245,6 +287,16 @@ export class AgentBackgroundJobService {
 	async reconcile(): Promise<void> {
 		await this.failJobsPastTimeout();
 		await this.failOrphanedSubAgentJobs(await this.jobRepository.findRunningJobs('subagent'));
+		await this.reconcileWorkflowJobs();
+	}
+
+	/**
+	 * The workflow-job slice of reconciliation. Runs regardless of the feature
+	 * flag — workflow jobs settle from execution state alone, and rows created
+	 * while the flag was on must not strand as `running` after it is turned
+	 * off. Both steps are no-ops when the table has no matching rows.
+	 */
+	async reconcileWorkflowJobs(): Promise<void> {
 		await this.settleFinishedWorkflowJobs(await this.jobRepository.findRunningJobs('workflow'));
 
 		await this.jobRepository.deleteSettledBefore(new Date(Date.now() - SETTLED_JOB_RETENTION_MS));
@@ -253,7 +305,9 @@ export class AgentBackgroundJobService {
 	/**
 	 * Cross-process stop of a cancelled workflow job's execution. The job row is
 	 * already claimed, so a stop that finds the execution finished (or gone) is
-	 * not an error worth surfacing to the model.
+	 * not an error worth surfacing to the model — but any other failure means
+	 * the workflow keeps running while the model believes it stopped, so it is
+	 * logged loudly.
 	 */
 	private async stopWorkflowExecution(job: AgentBackgroundJob): Promise<void> {
 		if (job.childExecutionId === null || job.workflowId === null) return;
@@ -261,23 +315,35 @@ export class AgentBackgroundJobService {
 		// Lazy: ExecutionService is a heavy dependency this service otherwise
 		// never needs — workers load this class for the settle path alone.
 		const { ExecutionService } = await import('@/executions/execution.service.js');
+		const { MissingExecutionStopError } = await import('@/errors/missing-execution-stop.error.js');
 		try {
 			await Container.get(ExecutionService).stop(job.childExecutionId, [job.workflowId]);
 		} catch (error) {
-			this.logger.debug('Stopping a cancelled workflow job execution did not succeed', {
+			const details = {
 				jobId: job.id,
 				executionId: job.childExecutionId,
 				error: error instanceof Error ? error.message : String(error),
-			});
+			};
+			// Already finished or gone — nothing left to stop.
+			if (error instanceof MissingExecutionStopError || error instanceof WorkflowOperationError) {
+				this.logger.debug('Cancelled workflow job execution was already beyond stopping', details);
+			} else {
+				this.logger.error(
+					'Failed to stop a cancelled workflow job execution — it may still be running',
+					details,
+				);
+			}
 		}
 	}
 
 	/**
 	 * Settle running workflow jobs whose execution already reached a terminal
 	 * state — the settle hook never ran (crash) or lost the registration race.
-	 * The result is left empty here; the lifecycle hook is the path that
-	 * captures output. An execution that no longer exists (pruned, deleted)
-	 * fails the job. Returns whether any row was settled.
+	 * A completed execution's output is read back from the executions table so
+	 * whichever writer wins the guarded settle carries the result. An execution
+	 * that no longer exists was hard-deleted per the workflow's save settings,
+	 * which seals the outcome as unknowable — the job fails with wording that
+	 * says so. Returns whether any row was settled.
 	 */
 	private async settleFinishedWorkflowJobs(jobs: AgentBackgroundJob[]): Promise<boolean> {
 		const candidates = jobs.filter(
@@ -294,15 +360,17 @@ export class AgentBackgroundJobService {
 					settledAny =
 						(await this.settle(job.id, {
 							status: 'failed',
-							error: 'The workflow execution no longer exists',
+							error: EXECUTION_OUTCOME_UNKNOWN_ERROR,
 						})) || settledAny;
 					continue;
 				}
 				if (!isTerminalExecutionStatus(execution.status)) continue;
 
+				const status = settlementStatusForExecution(execution.status);
 				settledAny =
 					(await this.settle(job.id, {
-						status: settlementStatusForExecution(execution.status),
+						status,
+						result: status === 'completed' ? await this.loadExecutionResult(executionId) : null,
 						error: execution.status === 'success' ? null : `Execution ${execution.status}`,
 					})) || settledAny;
 			} catch (error) {
@@ -314,6 +382,18 @@ export class AgentBackgroundJobService {
 			}
 		}
 		return settledAny;
+	}
+
+	/** Serialized all-node output of a finished execution, for a settle whose run data is not in memory. */
+	private async loadExecutionResult(executionId: string): Promise<string | null> {
+		const execution = await this.executionPersistence.findSingleExecution(executionId, {
+			includeData: true,
+			unflattenData: true,
+		});
+		const runData = execution?.data?.resultData?.runData;
+		if (!runData) return null;
+
+		return serializeWorkflowJobResult(collectResultData(runData, true));
 	}
 
 	private async failJobsPastTimeout(): Promise<void> {

--- a/packages/cli/src/modules/agents/background/background-job-tools.ts
+++ b/packages/cli/src/modules/agents/background/background-job-tools.ts
@@ -180,6 +180,7 @@ export function createCheckBackgroundJobsTool(jobService: AgentBackgroundJobServ
 					...(job.error !== null ? { error: truncateResult(job.error) } : {}),
 					startedAt: job.createdAt.toISOString(),
 					...(job.timeoutAt !== null ? { timeoutAt: job.timeoutAt.toISOString() } : {}),
+					...(job.childExecutionId !== null ? { executionId: job.childExecutionId } : {}),
 				})),
 				runningCount: jobs.filter((job) => job.status === 'running').length,
 			};

--- a/packages/cli/src/modules/agents/repositories/agent-background-job.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-background-job.repository.ts
@@ -69,8 +69,9 @@ export class AgentBackgroundJobRepository extends Repository<AgentBackgroundJob>
 		throw new OperationalError('Failed to register workflow background job');
 	}
 
-	async countRunningByParentThread(parentThreadId: string): Promise<number> {
-		return await this.count({ where: { parentThreadId, status: 'running' } });
+	/** Running sub-agent jobs only: parked workflow jobs do not count toward the cap. */
+	async countRunningSubAgentsByParentThread(parentThreadId: string): Promise<number> {
+		return await this.count({ where: { parentThreadId, kind: 'subagent', status: 'running' } });
 	}
 
 	async findByParentThread(parentThreadId: string, ids?: string[]): Promise<AgentBackgroundJob[]> {

--- a/packages/cli/src/modules/agents/repositories/agent-background-job.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-background-job.repository.ts
@@ -1,5 +1,6 @@
 import { Service } from '@n8n/di';
 import { DataSource, In, LessThan, Not, Repository } from '@n8n/typeorm';
+import { OperationalError } from 'n8n-workflow';
 
 import {
 	AgentBackgroundJob,
@@ -43,6 +44,37 @@ export class AgentBackgroundJobRepository extends Repository<AgentBackgroundJob>
 
 	async insertJob(job: NewAgentBackgroundJob): Promise<void> {
 		await this.insert({ ...job, status: 'running' });
+	}
+
+	/**
+	 * Insert a workflow job, or read back the job already tracking the same
+	 * execution. The partial unique index on `childExecutionId` makes the
+	 * execution the job's identity: `orIgnore` (`ON CONFLICT DO NOTHING` on
+	 * both supported drivers) lets a concurrent or earlier insert win silently,
+	 * and the readback deliberately ignores status — the identity holds after
+	 * settlement too, so a replayed registration can never start a second
+	 * tracker for a finished execution.
+	 */
+	async insertWorkflowJobOrGetExisting(
+		job: NewWorkflowJob,
+	): Promise<{ inserted: true } | { inserted: false; existing: AgentBackgroundJob }> {
+		await this.createQueryBuilder()
+			.insert()
+			.into(AgentBackgroundJob)
+			.values({ ...job, status: 'running' })
+			.orIgnore()
+			.execute();
+
+		const inserted = await this.existsBy({ id: job.id });
+		if (inserted) return { inserted: true };
+
+		const existing = await this.findOne({ where: { childExecutionId: job.childExecutionId } });
+		if (existing) return { inserted: false, existing };
+
+		// Only the 30-day retention prune deletes rows, so losing the insert
+		// without a readback hit means something outside this code path removed
+		// the winner mid-flight.
+		throw new OperationalError('Failed to register workflow background job');
 	}
 
 	async countRunningByParentThread(parentThreadId: string): Promise<number> {

--- a/packages/cli/src/modules/agents/repositories/agent-background-job.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-background-job.repository.ts
@@ -48,12 +48,7 @@ export class AgentBackgroundJobRepository extends Repository<AgentBackgroundJob>
 
 	/**
 	 * Insert a workflow job, or read back the job already tracking the same
-	 * execution. The partial unique index on `childExecutionId` makes the
-	 * execution the job's identity: `orIgnore` (`ON CONFLICT DO NOTHING` on
-	 * both supported drivers) lets a concurrent or earlier insert win silently,
-	 * and the readback deliberately ignores status — the identity holds after
-	 * settlement too, so a replayed registration can never start a second
-	 * tracker for a finished execution.
+	 * execution.
 	 */
 	async insertWorkflowJobOrGetExisting(
 		job: NewWorkflowJob,
@@ -71,9 +66,6 @@ export class AgentBackgroundJobRepository extends Repository<AgentBackgroundJob>
 		const existing = await this.findOne({ where: { childExecutionId: job.childExecutionId } });
 		if (existing) return { inserted: false, existing };
 
-		// Only the 30-day retention prune deletes rows, so losing the insert
-		// without a readback hit means something outside this code path removed
-		// the winner mid-flight.
 		throw new OperationalError('Failed to register workflow background job');
 	}
 

--- a/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
@@ -1008,6 +1008,21 @@ describe('workflow tool → background job handoff', () => {
 		expect(suspend).not.toHaveBeenCalled();
 	});
 
+	it('settles as outcome-unknown when the execution is pruned between the status and data reads', async () => {
+		setPersistence({ status: 'success' }, undefined);
+		const jobService = setJobService();
+		const tool = await buildBackgroundTool();
+		const { ctx } = makeParentCtx();
+
+		const result = await tool.handler?.({}, ctx);
+
+		expect(jobService.settle).toHaveBeenCalledWith('job-1', {
+			status: 'failed',
+			error: expect.stringContaining('outcome is unknown'),
+		});
+		expect(result).toMatchObject({ status: 'unknown', jobId: 'job-1' });
+	});
+
 	it('points at check_background_jobs when the settle hook already recorded the outcome', async () => {
 		setPersistence(undefined);
 		const jobService = setJobService();

--- a/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
@@ -782,16 +782,16 @@ describe('workflow tool → background job handoff', () => {
 		connections: {},
 	} as unknown as WorkflowEntity;
 
-	const parkedRun = (): IRun => ({
+	const parkedRun = (waitTill = WAIT_INDEFINITELY): IRun => ({
 		mode: 'integrated',
 		status: 'waiting',
 		finished: false,
 		startedAt: new Date(),
 		storedAt: 'db',
-		waitTill: WAIT_INDEFINITELY,
+		waitTill,
 		data: createRunExecutionData({
 			resultData: { runData: {} },
-			waitTill: WAIT_INDEFINITELY,
+			waitTill,
 		}),
 	});
 
@@ -814,10 +814,10 @@ describe('workflow tool → background job handoff', () => {
 		}),
 	});
 
-	const parkedActiveExecutions = () =>
+	const parkedActiveExecutions = (waitTill = WAIT_INDEFINITELY) =>
 		({
 			has: vi.fn().mockReturnValue(true),
-			getPostExecutePromise: vi.fn().mockResolvedValue(parkedRun()),
+			getPostExecutePromise: vi.fn().mockResolvedValue(parkedRun(waitTill)),
 		}) as unknown as ActiveExecutions;
 
 	function setPersistence(...results: unknown[]) {
@@ -838,13 +838,13 @@ describe('workflow tool → background job handoff', () => {
 		return jobService;
 	}
 
-	async function buildBackgroundTool() {
+	async function buildBackgroundTool(waitTill = WAIT_INDEFINITELY) {
 		const workflowLoader = mock<WorkflowToolWorkflowLoader>();
 		workflowLoader.loadWorkflow.mockResolvedValue(waitWorkflow);
 		const tool = await resolveWorkflowTool({ type: 'workflow', workflow: 'Approval workflow' }, {
 			...buildContext(vi.fn().mockResolvedValue('exec-1'), {
 				workflowLoader,
-				activeExecutions: parkedActiveExecutions(),
+				activeExecutions: parkedActiveExecutions(waitTill),
 				agentId: 'agent-1',
 				backgroundTasksEnabled: true,
 			}),
@@ -896,6 +896,23 @@ describe('workflow tool → background job handoff', () => {
 		expect(suspend).not.toHaveBeenCalled();
 		// One recheck read; the inline wait polling stays off.
 		expect(findSingleExecution).toHaveBeenCalledTimes(1);
+	});
+
+	it('polls a wait due soon to completion instead of backgrounding it', async () => {
+		setPersistence(settledInDb());
+		const jobService = setJobService();
+		const tool = await buildBackgroundTool(new Date(Date.now() + 30_000));
+		const { ctx, suspend } = makeParentCtx();
+
+		const result = await tool.handler?.({}, ctx);
+
+		expect(jobService.registerWorkflowJob).not.toHaveBeenCalled();
+		expect(suspend).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			executionId: 'exec-1',
+			status: 'success',
+			data: { Result: [{ approved: true }] },
+		});
 	});
 
 	it('settles inline and returns the real result when the workflow finished during registration', async () => {

--- a/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
@@ -919,6 +919,24 @@ describe('workflow tool → background job handoff', () => {
 		expect(suspend).not.toHaveBeenCalled();
 	});
 
+	it('settles a failed inline finish with its error and no result', async () => {
+		const failed = settledInDb();
+		failed.status = 'error';
+		failed.data.resultData.error = { message: 'boom' } as never;
+		setPersistence(failed);
+		const jobService = setJobService();
+		const tool = await buildBackgroundTool();
+		const { ctx } = makeParentCtx();
+
+		await tool.handler?.({}, ctx);
+
+		expect(jobService.settle).toHaveBeenCalledWith('job-1', {
+			status: 'failed',
+			result: null,
+			error: 'boom',
+		});
+	});
+
 	it('falls back to suspending when the run has no parent identity', async () => {
 		setPersistence({
 			status: 'waiting',
@@ -971,5 +989,21 @@ describe('workflow tool → background job handoff', () => {
 			note: expect.stringContaining('Do not run the workflow again'),
 		});
 		expect(suspend).not.toHaveBeenCalled();
+	});
+
+	it('points at check_background_jobs when the settle hook already recorded the outcome', async () => {
+		setPersistence(undefined);
+		const jobService = setJobService();
+		jobService.settle.mockResolvedValue(false);
+		const tool = await buildBackgroundTool();
+		const { ctx } = makeParentCtx();
+
+		const result = await tool.handler?.({}, ctx);
+
+		expect(result).toMatchObject({
+			status: 'unknown',
+			jobId: 'job-1',
+			note: expect.stringContaining('check_background_jobs'),
+		});
 	});
 });

--- a/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import type { WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -13,11 +14,11 @@ import { createRunExecutionData, WAIT_INDEFINITELY } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { ActiveExecutions } from '@/active-executions';
-import { AgentBackgroundJobService } from '../../background/agent-background-job.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { WebhookResponseRelay } from '@/scaling/webhook-response-relay';
 import type { WorkflowRunner } from '@/workflow-runner';
 
+import { AgentBackgroundJobService } from '../../background/agent-background-job.service';
 import {
 	executeWorkflow,
 	resolveWorkflowTool,
@@ -932,5 +933,43 @@ describe('workflow tool → background job handoff', () => {
 
 		expect(jobService.registerWorkflowJob).not.toHaveBeenCalled();
 		expect(suspend).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to the legacy wait handling when registration fails, instead of erroring', async () => {
+		setPersistence({ status: 'waiting' });
+		const jobService = setJobService();
+		jobService.registerWorkflowJob.mockRejectedValue(new Error('db down'));
+		const logger = mock<Logger>();
+		Container.set(Logger, logger);
+		const tool = await buildBackgroundTool();
+		const { ctx, suspend } = makeParentCtx();
+
+		// The execution is already running: a registration failure must reach the
+		// suspend path, never the model as a tool error it would answer by retrying.
+		await tool.handler?.({}, ctx);
+
+		expect(suspend).toHaveBeenCalledTimes(1);
+		expect(logger.error).toHaveBeenCalled();
+	});
+
+	it('settles the job as outcome-unknown when the finished execution was not retained', async () => {
+		setPersistence(undefined);
+		const jobService = setJobService();
+		const tool = await buildBackgroundTool();
+		const { ctx, suspend } = makeParentCtx();
+
+		const result = await tool.handler?.({}, ctx);
+
+		expect(jobService.settle).toHaveBeenCalledWith('job-1', {
+			status: 'failed',
+			error: expect.stringContaining('outcome is unknown'),
+		});
+		expect(result).toMatchObject({
+			executionId: 'exec-1',
+			status: 'unknown',
+			jobId: 'job-1',
+			note: expect.stringContaining('Do not run the workflow again'),
+		});
+		expect(suspend).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/workflow-tool-factory.test.ts
@@ -13,6 +13,7 @@ import { createRunExecutionData, WAIT_INDEFINITELY } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { ActiveExecutions } from '@/active-executions';
+import { AgentBackgroundJobService } from '../../background/agent-background-job.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { WebhookResponseRelay } from '@/scaling/webhook-response-relay';
 import type { WorkflowRunner } from '@/workflow-runner';
@@ -769,5 +770,167 @@ describe('workflow tool → parentAgentRun stamping', () => {
 		const executionData = await runToolWith(contextExtras, ctx);
 
 		expect(executionData?.parentAgentRun).toBeUndefined();
+	});
+});
+
+describe('workflow tool → background job handoff', () => {
+	const waitWorkflow = {
+		id: 'wf-1',
+		name: 'Approval workflow',
+		nodes: [triggerNode],
+		connections: {},
+	} as unknown as WorkflowEntity;
+
+	const parkedRun = (): IRun => ({
+		mode: 'integrated',
+		status: 'waiting',
+		finished: false,
+		startedAt: new Date(),
+		storedAt: 'db',
+		waitTill: WAIT_INDEFINITELY,
+		data: createRunExecutionData({
+			resultData: { runData: {} },
+			waitTill: WAIT_INDEFINITELY,
+		}),
+	});
+
+	const settledInDb = () => ({
+		status: 'success',
+		data: createRunExecutionData({
+			resultData: {
+				runData: {
+					Result: [
+						{
+							data: { main: [[{ json: { approved: true } }]] },
+							executionIndex: 0,
+							startTime: 0,
+							executionTime: 1,
+							source: [],
+						},
+					],
+				},
+			},
+		}),
+	});
+
+	const parkedActiveExecutions = () =>
+		({
+			has: vi.fn().mockReturnValue(true),
+			getPostExecutePromise: vi.fn().mockResolvedValue(parkedRun()),
+		}) as unknown as ActiveExecutions;
+
+	function setPersistence(...results: unknown[]) {
+		const findSingleExecution = vi.fn();
+		for (const result of results) findSingleExecution.mockResolvedValueOnce(result);
+		findSingleExecution.mockResolvedValue(results[results.length - 1]);
+		Container.set(ExecutionPersistence, {
+			findSingleExecution,
+		} as unknown as ExecutionPersistence);
+		return findSingleExecution;
+	}
+
+	function setJobService() {
+		const jobService = mock<AgentBackgroundJobService>();
+		jobService.registerWorkflowJob.mockResolvedValue({ status: 'started', jobId: 'job-1' });
+		jobService.settle.mockResolvedValue(true);
+		Container.set(AgentBackgroundJobService, jobService);
+		return jobService;
+	}
+
+	async function buildBackgroundTool() {
+		const workflowLoader = mock<WorkflowToolWorkflowLoader>();
+		workflowLoader.loadWorkflow.mockResolvedValue(waitWorkflow);
+		const tool = await resolveWorkflowTool({ type: 'workflow', workflow: 'Approval workflow' }, {
+			...buildContext(vi.fn().mockResolvedValue('exec-1'), {
+				workflowLoader,
+				activeExecutions: parkedActiveExecutions(),
+				agentId: 'agent-1',
+				backgroundTasksEnabled: true,
+			}),
+			executionMode: 'integrated',
+		} as WorkflowToolContext);
+		return tool;
+	}
+
+	function makeParentCtx() {
+		const suspend = vi.fn().mockResolvedValue(undefined);
+		return {
+			ctx: {
+				suspend,
+				runId: 'run-1',
+				toolCallId: 'call-1',
+				persistence: { threadId: 'thread-1', resourceId: 'resource-1' },
+			} as never,
+			suspend,
+		};
+	}
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		Container.reset();
+	});
+
+	it('returns a receipt for a waiting execution instead of polling or suspending', async () => {
+		const findSingleExecution = setPersistence({ status: 'waiting' });
+		const jobService = setJobService();
+		const tool = await buildBackgroundTool();
+		const { ctx, suspend } = makeParentCtx();
+
+		const result = await tool.handler?.({}, ctx);
+
+		expect(result).toMatchObject({
+			executionId: 'exec-1',
+			status: 'running_in_background',
+			jobId: 'job-1',
+			note: expect.stringContaining('check_background_jobs'),
+		});
+		expect(jobService.registerWorkflowJob).toHaveBeenCalledWith({
+			id: expect.any(String),
+			parentAgentId: 'agent-1',
+			parentThreadId: 'thread-1',
+			title: 'Approval workflow',
+			workflowId: 'wf-1',
+			executionId: 'exec-1',
+		});
+		expect(suspend).not.toHaveBeenCalled();
+		// One recheck read; the inline wait polling stays off.
+		expect(findSingleExecution).toHaveBeenCalledTimes(1);
+	});
+
+	it('settles inline and returns the real result when the workflow finished during registration', async () => {
+		setPersistence(settledInDb());
+		const jobService = setJobService();
+		const tool = await buildBackgroundTool();
+		const { ctx, suspend } = makeParentCtx();
+
+		const result = await tool.handler?.({}, ctx);
+
+		expect(jobService.settle).toHaveBeenCalledWith('job-1', {
+			status: 'completed',
+			result: '{"Result":[{"approved":true}]}',
+			error: null,
+		});
+		expect(result).toMatchObject({
+			status: 'success',
+			jobId: 'job-1',
+			data: { Result: [{ approved: true }] },
+		});
+		expect(suspend).not.toHaveBeenCalled();
+	});
+
+	it('falls back to suspending when the run has no parent identity', async () => {
+		setPersistence({
+			status: 'waiting',
+			data: createRunExecutionData({ resultData: { runData: {} } }),
+		});
+		const jobService = setJobService();
+		const tool = await buildBackgroundTool();
+		// No persistence/runId/toolCallId — a job row would be unreachable.
+		const suspend = vi.fn().mockResolvedValue(undefined);
+
+		await tool.handler?.({}, { suspend } as never);
+
+		expect(jobService.registerWorkflowJob).not.toHaveBeenCalled();
+		expect(suspend).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -781,12 +781,18 @@ async function backgroundWaitingExecution(
 		const recheck = await executionPersistence.findSingleExecution(result.executionId);
 
 		if (!recheck) {
-			await jobService.settle(jobId, { status: 'failed', error: EXECUTION_OUTCOME_UNKNOWN_ERROR });
+			const claimed = await jobService.settle(jobId, {
+				status: 'failed',
+				error: EXECUTION_OUTCOME_UNKNOWN_ERROR,
+			});
+			// A lost claim means the settle hook already recorded the real outcome.
 			return {
 				executionId: result.executionId,
 				status: 'unknown',
 				jobId,
-				note: EXECUTION_OUTCOME_UNKNOWN_ERROR,
+				note: claimed
+					? EXECUTION_OUTCOME_UNKNOWN_ERROR
+					: `This run already settled as background job ${jobId} — use check_background_jobs for its outcome.`,
 			};
 		}
 
@@ -802,12 +808,16 @@ async function backgroundWaitingExecution(
 				full?.data,
 				allOutputs,
 			);
-			// The job row carries every node's output regardless of the tool's
-			// `allOutputs` scope, matching the settle hook.
+			// The job row keeps the last node's output for completed runs only,
+			// matching the settle hook's projection.
+			const settlementStatus = settlementStatusForExecution(rawStatus);
 			const runData = full?.data?.resultData?.runData;
 			await jobService.settle(jobId, {
-				status: settlementStatusForExecution(rawStatus),
-				result: runData ? serializeWorkflowJobResult(collectResultData(runData, true)) : null,
+				status: settlementStatus,
+				result:
+					settlementStatus === 'completed' && runData
+						? serializeWorkflowJobResult(collectResultData(runData, false))
+						: null,
 				error: fresh.error ?? null,
 			});
 

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -618,6 +618,7 @@ export async function executeWorkflow(
 /** Map an execution's raw status into the tool's simplified status value. */
 function normaliseExecutionStatus(status: string | undefined): string {
 	if (status === 'error' || status === 'crashed') return 'error';
+	if (status === 'canceled') return 'canceled';
 	if (status === 'running' || status === 'new') return 'running';
 	if (status === 'waiting') return 'waiting';
 	return 'success';
@@ -779,22 +780,7 @@ async function backgroundWaitingExecution(
 
 		const executionPersistence = Container.get(ExecutionPersistence);
 		const recheck = await executionPersistence.findSingleExecution(result.executionId);
-
-		if (!recheck) {
-			const claimed = await jobService.settle(jobId, {
-				status: 'failed',
-				error: EXECUTION_OUTCOME_UNKNOWN_ERROR,
-			});
-			// A lost claim means the settle hook already recorded the real outcome.
-			return {
-				executionId: result.executionId,
-				status: 'unknown',
-				jobId,
-				note: claimed
-					? EXECUTION_OUTCOME_UNKNOWN_ERROR
-					: `This run already settled as background job ${jobId} — use check_background_jobs for its outcome.`,
-			};
-		}
+		if (!recheck) return await settleOutcomeUnknown(jobService, jobId, result.executionId);
 
 		const rawStatus = recheck.status;
 		if (isTerminalExecutionStatus(rawStatus)) {
@@ -802,16 +788,14 @@ async function backgroundWaitingExecution(
 				includeData: true,
 				unflattenData: true,
 			});
-			const fresh = formatResult(
-				result.executionId,
-				full?.status ?? rawStatus,
-				full?.data,
-				allOutputs,
-			);
+			// Pruned between the status read and the data read.
+			if (!full) return await settleOutcomeUnknown(jobService, jobId, result.executionId);
+
+			const fresh = formatResult(result.executionId, full.status, full.data, allOutputs);
 			// The job row keeps the last node's output for completed runs only,
 			// matching the settle hook's projection.
 			const settlementStatus = settlementStatusForExecution(rawStatus);
-			const runData = full?.data?.resultData?.runData;
+			const runData = full.data?.resultData?.runData;
 			await jobService.settle(jobId, {
 				status: settlementStatus,
 				result:
@@ -844,6 +828,26 @@ async function backgroundWaitingExecution(
 		});
 		return undefined;
 	}
+}
+
+/** The execution is gone, so its outcome cannot be known; a lost claim means the settle hook recorded it first. */
+async function settleOutcomeUnknown(
+	jobService: AgentBackgroundJobService,
+	jobId: string,
+	executionId: string,
+): Promise<WorkflowToolResult & { jobId: string }> {
+	const claimed = await jobService.settle(jobId, {
+		status: 'failed',
+		error: EXECUTION_OUTCOME_UNKNOWN_ERROR,
+	});
+	return {
+		executionId,
+		status: 'unknown',
+		jobId,
+		note: claimed
+			? EXECUTION_OUTCOME_UNKNOWN_ERROR
+			: `This run already settled as background job ${jobId} — use check_background_jobs for its outcome.`,
+	};
 }
 
 function isPollableWait(wait: WorkflowWaitState | undefined): wait is { waitTill: Date } {

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -1129,6 +1129,12 @@ async function buildWorkflowTool(
 				};
 			}
 
+			// A wait due within the poll window resolves inline. Only a wait the poll
+			// did not settle is handed to the background.
+			if (result.status === 'waiting') {
+				result = await pollIfDueSoon(result, allOutputs, ctx.abortSignal);
+			}
+
 			if (result.status === 'waiting' && context.backgroundTasksEnabled) {
 				const backgrounded = await backgroundWaitingExecution(
 					result,
@@ -1140,9 +1146,6 @@ async function buildWorkflowTool(
 				if (backgrounded) return backgrounded;
 			}
 
-			if (result.status === 'waiting') {
-				result = await pollIfDueSoon(result, allOutputs, ctx.abortSignal);
-			}
 			if (result.status !== 'waiting' || !supportsHitl) return withoutWaitState(result);
 
 			current ??= await loadCurrentWorkflow(context, reference, triggerType);

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -15,6 +15,7 @@ import { isRecord } from '@n8n/utils/is-record';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { sleep } from '@n8n/utils/sleep';
 import { DateTime } from 'luxon';
+import { v4 as uuid } from 'uuid';
 import type {
 	IDataObject,
 	IExecuteResponsePromiseData,
@@ -46,6 +47,11 @@ import { WebhookResponseRelay } from '@/scaling/webhook-response-relay';
 import type { WorkflowRunner } from '@/workflow-runner';
 
 import type { InstrumentToolAdditionalData } from '../agent-runtime-instrumentation';
+import {
+	AgentBackgroundJobService,
+	serializeWorkflowJobResult,
+	settlementStatusForExecution,
+} from '../background/agent-background-job.service';
 import { sanitizeToolName } from '../json-config/agent-config-composition';
 import type {
 	WorkflowToolWorkflowLoader,
@@ -165,6 +171,8 @@ export interface WorkflowToolContext {
 	userId?: string;
 	/** Whether a suspension can be resumed at all. Defaults to true. */
 	supportsHitl?: boolean;
+	/** When true, an execution parked at a Wait node becomes a background job instead of polling or suspending. */
+	backgroundTasksEnabled?: boolean;
 	/** Eval-only additionalData decoration for the sub-execution — absent on every production path. */
 	instrumentToolAdditionalData?: InstrumentToolAdditionalData;
 }
@@ -622,7 +630,7 @@ function outputItemsFromNodeRuns(nodeRuns: ITaskData[]): unknown[] {
 }
 
 /** Build the resultData map from an execution's runData, scoped by `allOutputs`. */
-function collectResultData(runData: IRunData, allOutputs: boolean): Record<string, unknown> {
+export function collectResultData(runData: IRunData, allOutputs: boolean): Record<string, unknown> {
 	const resultData: Record<string, unknown> = {};
 
 	if (allOutputs) {
@@ -752,6 +760,72 @@ function extractWaitState(data: IRun['data'] | undefined): WorkflowWaitState | u
 function withoutWaitState(result: WorkflowToolExecutionResult): WorkflowToolResult {
 	const { wait: _wait, ...rest } = result;
 	return rest;
+}
+
+/**
+ * Register a waiting execution as a background job and hand the model a
+ * receipt, so the agent stays interactive instead of polling or suspending.
+ * Returns undefined when the run has no parent identity — such a job would be
+ * unreachable by the check tool, so the legacy wait handling takes over.
+ *
+ * Registration races the workflow finishing: a webhook can resume the Wait
+ * node in the gap between observing `waiting` and inserting the row. The
+ * insert-then-recheck order closes it — a finish landing before the insert is
+ * caught by the recheck and settled inline; one landing after it is seen by
+ * the `workflowExecuteAfter` settle hook, which finds the row. Both writers
+ * go through the guarded settle, so the first one wins.
+ */
+async function backgroundWaitingExecution(
+	result: WorkflowToolExecutionResult,
+	context: WorkflowToolRunContext,
+	ctx: WaitToolContext,
+	reference: WorkflowToolWorkflowReference,
+	allOutputs: boolean,
+): Promise<(WorkflowToolResult & { jobId: string }) | undefined> {
+	const agentRun = context.agentRun ?? agentRunOf(context, ctx);
+	if (!agentRun || !reference.workflowId) return undefined;
+
+	const jobService = Container.get(AgentBackgroundJobService);
+	const receipt = await jobService.registerWorkflowJob({
+		id: uuid(),
+		parentAgentId: agentRun.agentId,
+		parentThreadId: agentRun.threadId,
+		title: reference.workflowName,
+		workflowId: reference.workflowId,
+		executionId: result.executionId,
+	});
+
+	// A workflow job never hits the running cap, so the receipt can only be started.
+	if (receipt.status !== 'started') return undefined;
+	const jobId = receipt.jobId;
+
+	const rawStatus = (
+		await Container.get(ExecutionPersistence).findSingleExecution(result.executionId)
+	)?.status;
+
+	if (rawStatus && isTerminalExecutionStatus(rawStatus)) {
+		const fresh = await extractResult(result.executionId, allOutputs);
+		await jobService.settle(jobId, {
+			status: settlementStatusForExecution(rawStatus),
+			result: serializeWorkflowJobResult(fresh.data),
+			error: fresh.error ?? null,
+		});
+
+		return { ...withoutWaitState(fresh), jobId };
+	}
+
+	const continuesAt = result.wait?.waitTill
+		? ` It continues at ${result.wait.waitTill.toISOString()}.`
+		: '';
+
+	return {
+		executionId: result.executionId,
+		status: 'running_in_background',
+		jobId,
+		note:
+			`The "${reference.workflowName}" workflow is paused at a Wait node and now runs as background job ${jobId}.${continuesAt}` +
+			' Use check_background_jobs for the result and cancel_background_job to stop it. Do not start it again.',
+	};
 }
 
 function isPollableWait(wait: WorkflowWaitState | undefined): wait is { waitTill: Date } {
@@ -991,6 +1065,7 @@ async function buildWorkflowTool(
 				data: z.record(z.unknown()).optional(),
 				error: z.string().optional(),
 				note: z.string().optional(),
+				jobId: z.string().optional(),
 			}),
 		)
 		.suspend(WAIT_SUSPEND_SCHEMA)
@@ -1034,6 +1109,17 @@ async function buildWorkflowTool(
 					...withoutWaitState(result),
 					note: 'The user stopped waiting for this workflow. It is still paused — do not start it again.',
 				};
+			}
+
+			if (result.status === 'waiting' && context.backgroundTasksEnabled) {
+				const backgrounded = await backgroundWaitingExecution(
+					result,
+					context,
+					ctx,
+					reference,
+					allOutputs,
+				);
+				if (backgrounded) return backgrounded;
 			}
 
 			if (result.status === 'waiting') {

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -8,6 +8,7 @@ import {
 	type AgentJsonToolConfig,
 	type SUPPORTED_WORKFLOW_TOOL_TRIGGERS,
 } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import type { WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -15,15 +16,12 @@ import { isRecord } from '@n8n/utils/is-record';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { sleep } from '@n8n/utils/sleep';
 import { DateTime } from 'luxon';
-import { v4 as uuid } from 'uuid';
 import type {
 	IDataObject,
 	IExecuteResponsePromiseData,
 	INode,
 	IPinData,
 	IRun,
-	IRunData,
-	ITaskData,
 	IWorkflowExecutionDataProcess,
 	RelatedAgentRun,
 	WorkflowExecuteMode,
@@ -39,6 +37,7 @@ import {
 	WAIT_INDEFINITELY,
 	WEBHOOK_NODE_TYPE,
 } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
 
 import type { ActiveExecutions } from '@/active-executions';
@@ -47,16 +46,18 @@ import { WebhookResponseRelay } from '@/scaling/webhook-response-relay';
 import type { WorkflowRunner } from '@/workflow-runner';
 
 import type { InstrumentToolAdditionalData } from '../agent-runtime-instrumentation';
-import {
-	AgentBackgroundJobService,
-	serializeWorkflowJobResult,
-	settlementStatusForExecution,
-} from '../background/agent-background-job.service';
-import { sanitizeToolName } from '../json-config/agent-config-composition';
 import type {
 	WorkflowToolWorkflowLoader,
 	WorkflowToolWorkflowReference,
 } from './workflow-tool-workflow-loader.service';
+import {
+	AgentBackgroundJobService,
+	collectResultData,
+	EXECUTION_OUTCOME_UNKNOWN_ERROR,
+	serializeWorkflowJobResult,
+	settlementStatusForExecution,
+} from '../background/agent-background-job.service';
+import { sanitizeToolName } from '../json-config/agent-config-composition';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -622,38 +623,6 @@ function normaliseExecutionStatus(status: string | undefined): string {
 	return 'success';
 }
 
-/** Extract the JSON items produced by the last run of a node. */
-function outputItemsFromNodeRuns(nodeRuns: ITaskData[]): unknown[] {
-	const lastRun = nodeRuns[nodeRuns.length - 1];
-	if (!lastRun?.data?.main) return [];
-	return lastRun.data.main.flatMap((items) => items ?? []).map((item) => item.json);
-}
-
-/** Build the resultData map from an execution's runData, scoped by `allOutputs`. */
-export function collectResultData(runData: IRunData, allOutputs: boolean): Record<string, unknown> {
-	const resultData: Record<string, unknown> = {};
-
-	if (allOutputs) {
-		for (const [nodeName, nodeRuns] of Object.entries(runData)) {
-			const outputItems = outputItemsFromNodeRuns(nodeRuns);
-			if (outputItems.length > 0) {
-				resultData[nodeName] = outputItems;
-			}
-		}
-		return resultData;
-	}
-
-	const nodeNames = Object.keys(runData);
-	const lastNodeName = nodeNames[nodeNames.length - 1];
-	if (lastNodeName) {
-		const outputItems = outputItemsFromNodeRuns(runData[lastNodeName]);
-		if (outputItems.length > 0) {
-			resultData[lastNodeName] = outputItems;
-		}
-	}
-	return resultData;
-}
-
 function formatResult(
 	executionId: string,
 	status: string | undefined,
@@ -773,7 +742,15 @@ function withoutWaitState(result: WorkflowToolExecutionResult): WorkflowToolResu
  * insert-then-recheck order closes it — a finish landing before the insert is
  * caught by the recheck and settled inline; one landing after it is seen by
  * the `workflowExecuteAfter` settle hook, which finds the row. Both writers
- * go through the guarded settle, so the first one wins.
+ * go through the guarded settle, so the first one wins. A finish whose
+ * execution the recheck cannot even find was hard-deleted per the workflow's
+ * save settings — the job settles as outcome-unknown right here, since the
+ * settle hook may have fired before the row existed.
+ *
+ * Never throws: the execution is already running either way, so a failure in
+ * here must not surface as a tool error the model would answer by retrying —
+ * that would start a duplicate execution. The legacy poll/suspend handling
+ * takes over instead.
  */
 async function backgroundWaitingExecution(
 	result: WorkflowToolExecutionResult,
@@ -785,47 +762,78 @@ async function backgroundWaitingExecution(
 	const agentRun = context.agentRun ?? agentRunOf(context, ctx);
 	if (!agentRun || !reference.workflowId) return undefined;
 
-	const jobService = Container.get(AgentBackgroundJobService);
-	const receipt = await jobService.registerWorkflowJob({
-		id: uuid(),
-		parentAgentId: agentRun.agentId,
-		parentThreadId: agentRun.threadId,
-		title: reference.workflowName,
-		workflowId: reference.workflowId,
-		executionId: result.executionId,
-	});
-
-	// A workflow job never hits the running cap, so the receipt can only be started.
-	if (receipt.status !== 'started') return undefined;
-	const jobId = receipt.jobId;
-
-	const rawStatus = (
-		await Container.get(ExecutionPersistence).findSingleExecution(result.executionId)
-	)?.status;
-
-	if (rawStatus && isTerminalExecutionStatus(rawStatus)) {
-		const fresh = await extractResult(result.executionId, allOutputs);
-		await jobService.settle(jobId, {
-			status: settlementStatusForExecution(rawStatus),
-			result: serializeWorkflowJobResult(fresh.data),
-			error: fresh.error ?? null,
+	try {
+		const jobService = Container.get(AgentBackgroundJobService);
+		const receipt = await jobService.registerWorkflowJob({
+			id: uuid(),
+			parentAgentId: agentRun.agentId,
+			parentThreadId: agentRun.threadId,
+			title: reference.workflowName,
+			workflowId: reference.workflowId,
+			executionId: result.executionId,
 		});
 
-		return { ...withoutWaitState(fresh), jobId };
+		// A workflow job never hits the running cap, so the receipt can only be started.
+		if (receipt.status !== 'started') return undefined;
+		const jobId = receipt.jobId;
+
+		const executionPersistence = Container.get(ExecutionPersistence);
+		const recheck = await executionPersistence.findSingleExecution(result.executionId);
+
+		if (!recheck) {
+			await jobService.settle(jobId, { status: 'failed', error: EXECUTION_OUTCOME_UNKNOWN_ERROR });
+			return {
+				executionId: result.executionId,
+				status: 'unknown',
+				jobId,
+				note: EXECUTION_OUTCOME_UNKNOWN_ERROR,
+			};
+		}
+
+		const rawStatus = recheck.status;
+		if (isTerminalExecutionStatus(rawStatus)) {
+			const full = await executionPersistence.findSingleExecution(result.executionId, {
+				includeData: true,
+				unflattenData: true,
+			});
+			const fresh = formatResult(
+				result.executionId,
+				full?.status ?? rawStatus,
+				full?.data,
+				allOutputs,
+			);
+			// The job row carries every node's output regardless of the tool's
+			// `allOutputs` scope, matching the settle hook.
+			const runData = full?.data?.resultData?.runData;
+			await jobService.settle(jobId, {
+				status: settlementStatusForExecution(rawStatus),
+				result: runData ? serializeWorkflowJobResult(collectResultData(runData, true)) : null,
+				error: fresh.error ?? null,
+			});
+
+			return { ...withoutWaitState(fresh), jobId };
+		}
+
+		const continuesAt = result.wait?.waitTill
+			? ` It continues at ${result.wait.waitTill.toISOString()}.`
+			: '';
+
+		return {
+			executionId: result.executionId,
+			status: 'running_in_background',
+			jobId,
+			note:
+				`The "${reference.workflowName}" workflow is paused at a Wait node and now runs as background job ${jobId}.${continuesAt}` +
+				' Use check_background_jobs for the result and cancel_background_job to stop it. Do not start it again.',
+		};
+	} catch (error) {
+		Container.get(Logger).error('Failed to background a waiting workflow execution', {
+			executionId: result.executionId,
+			workflowId: reference.workflowId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
 	}
-
-	const continuesAt = result.wait?.waitTill
-		? ` It continues at ${result.wait.waitTill.toISOString()}.`
-		: '';
-
-	return {
-		executionId: result.executionId,
-		status: 'running_in_background',
-		jobId,
-		note:
-			`The "${reference.workflowName}" workflow is paused at a Wait node and now runs as background job ${jobId}.${continuesAt}` +
-			' Use check_background_jobs for the result and cancel_background_job to stop it. Do not start it again.',
-	};
 }
 
 function isPollableWait(wait: WorkflowWaitState | undefined): wait is { waitTill: Date } {


### PR DESCRIPTION
## Summary

Stacked on #37209. 
A workflow tool execution that goes into `waiting` registers a background job (`kind: 'workflow'`) instead of blocking main agent thread.

- **Registration in the tool handler** with insert-then-recheck to close the fast-resume race: a finish landing before the insert is caught by the recheck and returned inline as the real result; one landing after it is seen by the settle hook. The partial unique index on `childExecutionId` makes the execution the job's identity: a replayed registration reads back the existing job — even after settlement — while parallel runs of the same workflow with different inputs each get their own execution and job. A failed registration falls back to the legacy wait handling instead of surfacing a tool error — the execution is already running, and the model answers tool errors by retrying, which would start a duplicate.
- **Settlement rides the existing `workflowExecuteAfter` hook** (before its suspended-checkpoint guard, which would otherwise drop backgrounded executions). It stores a bounded serialization of the last node's output on the job row (completed runs only — the row keeps the tightest projection since it does not know the tool's `allOutputs` setting) — same "answer on the row" contract as sub-agent jobs, and a plain DB write that works on workers with no new pubsub. Pre-flag suspended runs keep resuming through the untouched card path.
- **Workflow jobs have no timeout** — `waitTill` can legitimately be days out; the execution's own lifecycle governs. Reconciliation (settle-on-check and the sweeper) settles rows whose execution finished without the hook running, reading the output back from the execution so whichever writer wins the guarded settle carries the result. An execution that was not retained (save settings, pruning) settles the job as failed with explicit outcome-unknown wording that steers the model away from re-running the workflow. The settle hook and workflow-job reconciliation run regardless of the feature flag — rows created while it was on cannot strand as `running` after it is turned off.
- **Cancel stops the execution** via `ExecutionService.stop`, which already reaches waiting executions (WaitTracker) and other processes in scaling mode. A real stop failure is logged at error level — the workflow may still be running; already-finished executions stay at debug.
- `check_background_jobs` now also reports the workflow `executionId` so results can be traced to the execution.

No schema changes — PR1's table already carries `kind`, the unique `childExecutionId`, and `workflowId`.

## How to test

New unit tests cover registration (including the fallback when it fails), the race close, flag-off regression, the settle hook (incl. error containment), cancel, reconciliation, and the settle-on-check backstop; the full agents module suite passes.

Manually (feature is gated): start n8n with `N8N_ENABLED_MODULES=agents` and `N8N_AGENTS_BACKGROUND_TASKS_ENABLED=true`, create a sub-workflow `executeWorkflowTrigger → Wait (90s) → Set`, attach it as a workflow tool to an agent, and chat: *"Run the tool, don't wait for it."*

Verified end-to-end on an isolated instance: the tool returned `running_in_background` with a job id and the turn ended; a second user message was answered while the workflow waited; when the Wait fired, the job row settled `completed` with the Set node's output and `check_background_jobs` returned it; a follow-up spawn+cancel flipped the job to `cancelled` and the execution to `canceled`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-186

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





