### PR TITLE
fix(Form Node): Improve error messages for invalid form definition JSON

### DIFF
--- a/packages/workflow/src/type-validation.ts
+++ b/packages/workflow/src/type-validation.ts
@@ -203,69 +203,83 @@ const ALLOWED_FIELD_TYPES = [
 	'hiddenField',
 ];
 
+const tryToParseFormFieldOptions = (rawOptions: unknown, index: number): object => {
+	const asObject = Array.isArray(rawOptions) ? { values: rawOptions } : rawOptions;
+
+	const invalidValuesError = new UserError(
+		`Field dropdown in field ${index} has no 'values' property that contains an array of options`,
+	);
+
+	if (typeof asObject !== 'object' || asObject === null) throw invalidValuesError;
+
+	const { values } = asObject as { [key: string]: unknown };
+	if (!Array.isArray(values)) throw invalidValuesError;
+
+	const options: unknown[] = values;
+	for (const [optionIndex, option] of options.entries()) {
+		if (
+			typeof option !== 'object' ||
+			option === null ||
+			Object.keys(option).length !== 1 ||
+			typeof (option as { option?: unknown }).option !== 'string'
+		) {
+			throw new UserError(`Field dropdown in field ${index} has an invalid option ${optionIndex}`);
+		}
+	}
+
+	return asObject;
+};
+
 export const tryToParseJsonToFormFields = (value: unknown): FormFieldsParameter => {
 	const fields: FormFieldsParameter = [];
 
+	let rawFields: Array<{ [key: string]: unknown }>;
 	try {
-		const rawFields = jsonParse<Array<{ [key: string]: unknown }>>(value as string, {
+		rawFields = jsonParse<Array<{ [key: string]: unknown }>>(value as string, {
 			acceptJSObject: true,
 		});
+	} catch (error) {
+		// Keep the engine message, it contains the error position
+		throw new UserError(`Value is not valid JSON: ${(error as Error).message}`);
+	}
 
-		for (const [index, field] of rawFields.entries()) {
-			for (const key of Object.keys(field)) {
-				if (!ALLOWED_FORM_FIELDS_KEYS.includes(key)) {
-					throw new UserError(`Key '${key}' in field ${index} is not valid for form fields`);
-				}
-				if (
-					key !== 'fieldOptions' &&
-					!['string', 'number', 'boolean'].includes(typeof field[key])
-				) {
-					field[key] = String(field[key]);
-				} else if (typeof field[key] === 'string' && key !== 'html') {
-					field[key] = field[key].replace(/</g, '&lt;').replace(/>/g, '&gt;');
-				}
+	if (!Array.isArray(rawFields)) {
+		throw new UserError(
+			`Form fields must be an array of objects, but we got ${getValueDescription(rawFields)}`,
+		);
+	}
 
-				if (key === 'fieldType' && !ALLOWED_FIELD_TYPES.includes(field[key] as string)) {
-					throw new UserError(
-						`Field type '${field[key] as string}' in field ${index} is not valid for form fields`,
-					);
-				}
+	for (const [index, field] of rawFields.entries()) {
+		if (typeof field !== 'object' || field === null || Array.isArray(field)) {
+			throw new UserError(
+				`Field ${index} must be an object, but we got ${getValueDescription(field)}`,
+			);
+		}
 
-				if (key === 'fieldOptions') {
-					if (Array.isArray(field[key])) {
-						field[key] = { values: field[key] };
-					}
-
-					if (
-						typeof field[key] !== 'object' ||
-						!(field[key] as { [key: string]: unknown }).values
-					) {
-						throw new UserError(
-							`Field dropdown in field ${index} does has no 'values' property that contain an array of options`,
-						);
-					}
-
-					for (const [optionIndex, option] of (
-						(field[key] as { [key: string]: unknown }).values as Array<{
-							[key: string]: { option: string };
-						}>
-					).entries()) {
-						if (Object.keys(option).length !== 1 || typeof option.option !== 'string') {
-							throw new UserError(
-								`Field dropdown in field ${index} has an invalid option ${optionIndex}`,
-							);
-						}
-					}
-				}
+		for (const key of Object.keys(field)) {
+			if (!ALLOWED_FORM_FIELDS_KEYS.includes(key)) {
+				throw new UserError(`Key '${key}' in field ${index} is not valid for form fields`);
+			}
+			if (key !== 'fieldOptions' && !['string', 'number', 'boolean'].includes(typeof field[key])) {
+				field[key] = String(field[key]);
+			} else if (typeof field[key] === 'string' && key !== 'html') {
+				field[key] = field[key].replace(/</g, '&lt;').replace(/>/g, '&gt;');
 			}
 
-			fields.push(field as FormFieldsParameter[number]);
-		}
-	} catch (error) {
-		if (error instanceof ApplicationError || error instanceof BaseError) throw error;
+			if (key === 'fieldType' && !ALLOWED_FIELD_TYPES.includes(field[key] as string)) {
+				throw new UserError(
+					`Field type '${field[key] as string}' in field ${index} is not valid for form fields`,
+				);
+			}
 
-		throw new UserError('Value is not valid JSON');
+			if (key === 'fieldOptions') {
+				field[key] = tryToParseFormFieldOptions(field[key], index);
+			}
+		}
+
+		fields.push(field as FormFieldsParameter[number]);
 	}
+
 	return fields;
 };
 

--- a/packages/workflow/test/type-validation.test.ts
+++ b/packages/workflow/test/type-validation.test.ts
@@ -372,6 +372,41 @@ describe('Type Validation', () => {
 			const fields = tryToParseJsonToFormFields(json);
 			expect(fields).toEqual([{ fieldType: 'html', html: '<div>test</div>' }]);
 		});
+
+		it('should include the parse error detail for invalid JSON', () => {
+			const json = '[{"fieldLabel": }]';
+			expect(() => tryToParseJsonToFormFields(json)).toThrowError(/^Value is not valid JSON: .+/);
+		});
+
+		it('should reject valid JSON that is not an array', () => {
+			const json = '{"fieldLabel": "Name"}';
+			expect(() => tryToParseJsonToFormFields(json)).toThrowError(
+				'Form fields must be an array of objects, but we got object',
+			);
+		});
+
+		it('should reject array entries that are not objects', () => {
+			const json = '[null]';
+			expect(() => tryToParseJsonToFormFields(json)).toThrowError(
+				"Field 0 must be an object, but we got 'null'",
+			);
+		});
+
+		it('should reject fieldOptions without a values array', () => {
+			const json =
+				'[{"fieldLabel": "Choice", "fieldType": "dropdown", "fieldOptions": {"values": "not an array"}}]';
+			expect(() => tryToParseJsonToFormFields(json)).toThrowError(
+				"Field dropdown in field 0 has no 'values' property that contains an array of options",
+			);
+		});
+
+		it('should reject dropdown options that are not objects', () => {
+			const json =
+				'[{"fieldLabel": "Choice", "fieldType": "dropdown", "fieldOptions": {"values": [null]}}]';
+			expect(() => tryToParseJsonToFormFields(json)).toThrowError(
+				'Field dropdown in field 0 has an invalid option 0',
+			);
+		});
 	});
 
 	describe('binary', () => {


### PR DESCRIPTION
## Summary

The Form and Form Trigger nodes report each problem in the "Define Form → Using JSON" parameter with the same message: "Value is not valid JSON". This PR makes the messages specific. JSON syntax errors now include the engine detail with the error position (for example `Value is not valid JSON: Expected ',' or ']' after array element in JSON at position 17 (line 1 column 18)`). Valid JSON with an incorrect shape now gets an accurate message: an object instead of an array, a field entry that is not an object, or a `fieldOptions` value without a `values` array. The improved messages show in the NDV parameter issue and in the runtime node error.

## How to test

1. Add a Form Trigger (or Form) node and set "Define Form" to "Using JSON".
2. Enter JSON with a syntax error, for example `[{"fieldLabel": }]`. The parameter issue and the execution error show the parse error position.
3. Enter `{"fieldLabel": "Name"}` (an object, not an array). The error says the form fields must be an array of objects.
4. Enter `[{"fieldLabel": "Choice", "fieldType": "dropdown", "fieldOptions": {"values": "x"}}]`. The error says `values` must contain an array of options.

## Related Linear tickets, Github issues, and Community forum posts

None found.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

