### PR TITLE
fix(core): Return a single not-found message when disconnecting a credential

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -30,6 +30,8 @@ import { getDynamicCredentialMiddlewares } from './utils';
 
 const dynamicCredentialsConfig = Container.get(DynamicCredentialsConfig);
 
+const NO_CONNECTION_TO_DISCONNECT = 'No connection to disconnect';
+
 @RestController('/credentials')
 export class DynamicCredentialsController {
 	constructor(
@@ -313,7 +315,7 @@ export class DynamicCredentialsController {
 		const credential = await this.credentialsFinderService.findById(credentialId);
 
 		if (!credential) {
-			throw new NotFoundError('Credential not found');
+			throw new NotFoundError(NO_CONNECTION_TO_DISCONNECT);
 		}
 
 		const affected = await this.credentialConnectionStatusService.deleteMyConnection(
@@ -322,7 +324,7 @@ export class DynamicCredentialsController {
 		);
 
 		if (affected === 0) {
-			throw new NotFoundError('No connection to disconnect');
+			throw new NotFoundError(NO_CONNECTION_TO_DISCONNECT);
 		}
 
 		this.eventService.emit('credentials-user-disconnected', {

--- a/packages/cli/test/integration/dynamic-credentials.ee/my-connection.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/my-connection.api.test.ts
@@ -125,10 +125,29 @@ describe('DELETE /credentials/:credentialId/my-connection', () => {
 	test('returns 404 when no entry exists for the running user', async () => {
 		const credential = await saveResolvableCredential();
 
-		await testServer
+		const response = await testServer
 			.authAgentFor(memberA)
 			.delete(`/credentials/${credential.id}/my-connection`)
 			.expect(404);
+
+		expect(response.body.message).toBe('No connection to disconnect');
+	});
+
+	test('returns the same 404 body when the credential id is unknown', async () => {
+		const credential = await saveResolvableCredential();
+
+		const missingConnection = await testServer
+			.authAgentFor(memberA)
+			.delete(`/credentials/${credential.id}/my-connection`)
+			.expect(404);
+
+		const unknownCredential = await testServer
+			.authAgentFor(memberA)
+			.delete('/credentials/00000000-0000-4000-8000-000000000000/my-connection')
+			.expect(404);
+
+		expect(unknownCredential.body.message).toBe(missingConnection.body.message);
+		expect(unknownCredential.body.code).toBe(missingConnection.body.code);
 	});
 
 	test('returns 404 on repeat call (entry already deleted)', async () => {


### PR DESCRIPTION
## Summary

- Return one 404 message from `DELETE /credentials/:credentialId/my-connection` when the credential is missing and when the caller has no connection to remove.
- Keep the early return when the credential does not exist, so the handler does not run the delete query in that case.

## How to test

This endpoint is part of the dynamic credentials module. Enable that module on an enterprise instance (`N8N_ENABLED_MODULES` / `feat:dynamicCredentials`).

1. Sign in, connect a per-user OAuth connection, then disconnect it. Expect HTTP 204.
2. Disconnect again with no stored connection. Expect HTTP 404 with message `No connection to disconnect`.
3. Call the same endpoint with an unknown credential id. Expect HTTP 404 with the same message.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1017

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

