### PR TITLE
feat(editor): Add floating Markdown editor toolbar

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.stories.ts
@@ -74,7 +74,7 @@ const meta: Meta<typeof N8nMarkdownEditor> = {
 		},
 		showToolbar: {
 			control: 'select',
-			options: ['never', 'hover', 'always'],
+			options: ['never', 'hover', 'always', 'floating'],
 		},
 		maxHeight: {
 			control: 'text',
@@ -176,6 +176,20 @@ export const AlwaysVisibleToolbar: Story = {
 	args: {
 		...Default.args,
 		showToolbar: 'always',
+	},
+};
+
+export const FloatingToolbar: Story = {
+	args: {
+		...Default.args,
+		showToolbar: 'floating',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Select text in the editor to show the floating toolbar.',
+			},
+		},
 	},
 };
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.test.ts
@@ -3,6 +3,15 @@ import type { Editor } from '@tiptap/core';
 
 import N8nMarkdownEditor from './MarkdownEditor.vue';
 
+vi.mock('@tiptap/vue-3/menus', function mockTiptapMenus() {
+	return {
+		BubbleMenu: {
+			name: 'BubbleMenu',
+			template: '<div data-test-id="markdown-editor-bubble-menu"><slot /></div>',
+		},
+	};
+});
+
 describe('components/N8nMarkdownEditorToolbar', () => {
 	it('renders the toolbar from toggle groups by default', async () => {
 		const wrapper = render(N8nMarkdownEditor, {
@@ -84,6 +93,37 @@ describe('components/N8nMarkdownEditorToolbar', () => {
 
 		await waitFor(() => expect(wrapper.getByTestId('markdown-editor-toolbar')).toBeInTheDocument());
 		expect(wrapper.getByRole('button', { name: 'Text' })).toBeInTheDocument();
+	});
+
+	it('renders the floating toolbar in a TipTap bubble menu', async () => {
+		const wrapper = render(N8nMarkdownEditor, {
+			props: {
+				modelValue: 'Content',
+				showToolbar: 'floating',
+			},
+		});
+
+		await waitFor(() =>
+			expect(wrapper.getByTestId('markdown-editor-bubble-menu')).toBeInTheDocument(),
+		);
+		expect(wrapper.getByTestId('markdown-editor-toolbar')).toHaveClass('floating');
+		expect(wrapper.getByRole('button', { name: 'Bold' })).toBeInTheDocument();
+	});
+
+	it('does not add fixed-toolbar padding for the floating toolbar', async () => {
+		const wrapper = render(N8nMarkdownEditor, {
+			props: {
+				modelValue: 'Content',
+				showToolbar: 'floating',
+			},
+		});
+
+		await waitFor(() =>
+			expect(wrapper.getByTestId('n8n-markdown-editor-content')).toBeInTheDocument(),
+		);
+		expect(wrapper.getByTestId('n8n-markdown-editor-content').parentElement).not.toHaveClass(
+			'padTop',
+		);
 	});
 
 	it('disables toolbar controls when editor is disabled', async () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.types.ts
@@ -1,7 +1,7 @@
 import type { Editor, Extension, EditorOptions } from '@tiptap/core';
 
 export type MarkdownEditorVariant = 'ghost' | 'contained';
-export type MarkdownEditorToolbarMode = 'never' | 'hover' | 'always';
+export type MarkdownEditorToolbarMode = 'never' | 'hover' | 'always' | 'floating';
 
 export type N8nMarkdownEditorProps = {
 	modelValue: string;

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Editor } from '@tiptap/core';
 import { EditorContent } from '@tiptap/vue-3';
+import { BubbleMenu } from '@tiptap/vue-3/menus';
 import { computed, nextTick, ref, watch } from 'vue';
 
 import { useMarkdownEditor } from './composables/useMarkdownEditor';
@@ -26,7 +27,7 @@ const maxHeightStyle = computed(() => ({
 		typeof props.maxHeight === 'number' ? `${props.maxHeight}px` : props.maxHeight,
 }));
 
-const shouldShowToolbar = computed(() => props.showToolbar !== 'never');
+const shouldShowInlineToolbar = computed(() => ['always', 'hover'].includes(props.showToolbar));
 const toolbarMode = computed(() => (props.showToolbar === 'always' ? 'always' : 'hover'));
 const shouldPadContentTop = computed(() => props.showToolbar === 'always');
 
@@ -51,6 +52,20 @@ function getRenderedContentHeight() {
 
 	return renderedContent ? `${renderedContent.clientHeight}px` : undefined;
 }
+
+function getBubbleMenuContainer() {
+	return document.body;
+}
+
+const bubbleMenuOptions = computed(function getBubbleMenuOptions() {
+	return {
+		placement: 'top' as const,
+		offset: 8,
+		flip: true,
+		shift: true,
+		scrollTarget: container.value?.querySelector<HTMLElement>('.n8n-markdown') ?? undefined,
+	};
+});
 
 async function toggleRawMode(value: boolean) {
 	if (value) {
@@ -155,7 +170,7 @@ defineExpose({
 			:class="[$style.content, shouldPadContentTop ? $style.padTop : '']"
 		/>
 		<MarkdownEditorToolbar
-			v-if="shouldShowToolbar && editor"
+			v-if="shouldShowInlineToolbar && editor"
 			:editor="editor"
 			:disabled="props.disabled || props.readonly"
 			:is-raw-mode="isRawMode"
@@ -163,6 +178,22 @@ defineExpose({
 			:variant="props.variant"
 			@update:is-raw-mode="toggleRawMode"
 		/>
+		<BubbleMenu
+			v-if="props.showToolbar === 'floating' && editor && !isRawMode"
+			:editor="editor"
+			:options="bubbleMenuOptions"
+			:append-to="getBubbleMenuContainer"
+			:class="$style.bubbleMenu"
+		>
+			<MarkdownEditorToolbar
+				:editor="editor"
+				:disabled="props.disabled || props.readonly"
+				:is-raw-mode="false"
+				mode="floating"
+				:variant="props.variant"
+				@update:is-raw-mode="toggleRawMode"
+			/>
+		</BubbleMenu>
 	</div>
 </template>
 
@@ -171,7 +202,12 @@ defineExpose({
 </style>
 
 <style lang="scss" module>
+@use '../../css/common/var';
 @use '../../css/mixins/focus';
+
+.bubbleMenu {
+	z-index: var.$index-popper;
+}
 
 .disabled {
 	cursor: not-allowed;

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditorToolbar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditorToolbar.vue
@@ -294,7 +294,11 @@ const setTextStyle = (value: string | number) => {
 </script>
 <template>
 	<div
-		:class="[$style.toolbar, mode === 'always' ? $style.alwaysVisible : '']"
+		:class="[
+			$style.toolbar,
+			mode === 'always' && $style.alwaysVisible,
+			mode === 'floating' && $style.floating,
+		]"
 		data-test-id="markdown-editor-toolbar"
 	>
 		<div
@@ -501,13 +505,32 @@ const setTextStyle = (value: string | number) => {
 
 <style lang="scss" module>
 .toolbar {
+	--n8n-markdown-editor-toolbar--pos-x: 0;
+	--n8n-markdown-editor-toolbar--pos-y: 0;
+
 	position: absolute;
-	inset-inline: 0;
-	top: 0;
+	inset-inline: var(--n8n-markdown-editor-toolbar--pos-x);
+	top: var(--n8n-markdown-editor-toolbar--pos-y);
 	z-index: 1;
 	opacity: 0;
 	visibility: hidden;
 	pointer-events: none;
+}
+.floating {
+	position: static;
+	inset: auto;
+	width: max-content;
+	max-width: calc(100vw - var(--spacing--lg));
+	opacity: 1;
+	visibility: visible;
+	pointer-events: auto;
+
+	.toolbarInner {
+		border: var(--border);
+		border-radius: var(--radius--lg);
+		background-color: var(--background--surface);
+		box-shadow: var(--shadow--md);
+	}
 }
 
 .toolbarInner {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/component-markdown-editor.md
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/component-markdown-editor.md
@@ -33,7 +33,7 @@ A reusable rich-text Markdown editor for editing Markdown-backed content in the 
 - `placeholder?: string` - Placeholder text displayed when the editor is empty. Default: `''`
 - `disabled?: boolean` - When `true`, prevents user interaction and dims the editor. Default: `false`
 - `readonly?: boolean` - When `true`, content can be selected but not edited. Default: `false`
-- `showToolbar?: MarkdownEditorToolbarMode` - Controls toolbar visibility. Values: `'never' | 'hover' | 'always'`. Default: `'always'`
+- `showToolbar?: MarkdownEditorToolbarMode` - Controls toolbar visibility. Values: `'never' | 'hover' | 'always' | 'floating'`. The floating toolbar appears above a non-empty text selection. Default: `'always'`
 - `maxHeight?: string | number` - Maximum editor content height. Number values are treated as pixels. Default: `'480px'`
 - `extensions?: Extension[]` - Optional TipTap extension escape hatch for concrete callsite needs. Default extensions remain design-system managed.
 - `editorProps?: EditorOptions['editorProps']` - Optional TipTap editor props escape hatch.

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentInfoPanel.spec.ts
@@ -195,14 +195,14 @@ describe('AgentInfoPanel', () => {
 		defaultModelHolder.value = null;
 	});
 
-	it('renders instructions as a contained markdown editor', () => {
+	it('renders instructions as a contained markdown editor with a floating toolbar', () => {
 		const wrapper = mountPanel();
 
 		const editor = wrapper.findComponent({ name: 'N8nMarkdownEditor' });
 		expect(editor.props()).toMatchObject({
 			modelValue: '# Role\nHelp users.',
 			variant: 'contained',
-			showToolbar: 'never',
+			showToolbar: 'floating',
 			maxHeight: '360px',
 		});
 		expect(editor.props('placeholder')).toBeUndefined();
@@ -211,12 +211,12 @@ describe('AgentInfoPanel', () => {
 		expect(wrapper.text()).not.toContain('Enter instructions here');
 	});
 
-	it('can show the markdown toolbar above instructions', () => {
+	it('keeps the markdown toolbar floating when the instructions toolbar is enabled', () => {
 		const wrapper = mountPanel('# Role\nHelp users.', { showInstructionsToolbar: true });
 
 		const editor = wrapper.findComponent({ name: 'N8nMarkdownEditor' });
 		expect(editor.props()).toMatchObject({
-			showToolbar: 'always',
+			showToolbar: 'floating',
 			variant: 'contained',
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentInfoPanel.vue
@@ -45,7 +45,6 @@ const props = withDefaults(
 		instructionsMaxHeight?: string;
 		showModel?: boolean;
 		showInstructions?: boolean;
-		showInstructionsToolbar?: boolean;
 		/**
 		 * Emit instructions edits per keystroke instead of debounced. For hosts
 		 * whose updates are cheap local writes (inline agent → node parameter);
@@ -142,10 +141,6 @@ const panelTestId = computed(() => {
 	if (!props.showModel && props.showInstructions) return 'agent-instructions-panel';
 	return 'agent-info-panel';
 });
-
-const instructionsToolbarMode = computed(() =>
-	props.showInstructionsToolbar ? 'always' : 'never',
-);
 
 function onModelChange(selection: AgentModelSelection, source: 'user' | 'auto' = 'user') {
 	const credentialId = effectiveCredentials.value?.[selection.provider];
@@ -324,8 +319,8 @@ function onInstructionsInput(value: string) {
 				:class="$style.instructionsDocument"
 				:model-value="instructions"
 				:disabled="props.disabled"
-				:show-toolbar="instructionsToolbarMode"
 				:max-height="props.instructionsMaxHeight"
+				show-toolbar="floating"
 				variant="contained"
 				data-testid="agent-instructions-document"
 				@update:model-value="onInstructionsInput"


### PR DESCRIPTION
## Summary

Add a floating toolbar mode to `N8nMarkdownEditor`.

* Uses TipTap built-in `<BubbleMenu />` which positions at the correct node
* Adds `floating` variant which disables auto-position and adds floating UI style
* Updates Agent instructions to use `floating` variant 
* Adds tests and stories for new functionality

<!-- linear:table-colwidths:357,356 -->
| **Before** | **After** |
| -- | -- |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/bf6d80d3-26d0-4921-a930-84330490302a/6d16fcc0-e55a-4129-8588-e410f1047b3f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9iZjZkODBkMy0yNmQwLTQ5MjEtYTkzMC04NDMzMDQ5MDMwMmEvNmQxNmZjYzAtZTU1YS00MTI5LTg1ODgtZTQxMGYxMDQ3YjNmIiwiaWF0IjoxNzg3OTA3NTE0LCJleHAiOjE4MTk0NzgwNzR9.9Bih2c0L3kyc8sCsWHkBj5uQWrz6LdaG2cY2GNbF5CY " alt="CleanShot 2026-08-28 at 09.57.04@2x.png" width="1638" data-linear-height="536" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/c9c0afbe-d5bd-4100-95d7-98316d91f8f3/6ff0a8f1-2ca8-415e-8c3c-90fd13d1a3eb?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9jOWMwYWZiZS1kNWJkLTQxMDAtOTVkNy05ODMxNmQ5MWY4ZjMvNmZmMGE4ZjEtMmNhOC00MTVlLThjM2MtOTBmZDEzZDFhM2ViIiwiaWF0IjoxNzg3OTA3NTE0LCJleHAiOjE4MTk0NzgwNzR9.ZSKIB_nTP0opzMJGP5rytHyYG7MKfYXpXH7IVXwsnGs " alt="CleanShot 2026-08-28 at 09.56.17@2x.png" width="1664" data-linear-height="500" /> |

## How to test

1. Open the agent settings.
2. Go to the instructions section.
3. Confirm that the toolbar is not visible by default.
4. Select non-empty text in the instructions editor.
5. Confirm that the toolbar appears above the selection.
6. Clear the selection.
7. Confirm that the toolbar closes.
8. Use the toolbar to format selected text.
9. Confirm that the editor applies the selected format.

## Related Linear tickets, Github issues, and Community forum posts

* [DS-633](https://linear.app/n8n/issue/DS-633)
* [AGENT-750](https://linear.app/n8n/issue/AGENT-750)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)