### PR TITLE
build: Order nodes-base lint after its own build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -34,6 +34,14 @@
 		"lint": {
 			"dependsOn": ["^build", "@n8n/eslint-config#build"]
 		},
+		// `nodes-base`'s lint script also runs validate-load-options-methods and
+		// validate-schema-versions, which read `dist/methods/*.json` and `dist/nodes`
+		// from its OWN build. `^build` alone does not order that build first, so the
+		// two validators fail with "Failed to find methods to validate" whenever turbo
+		// happens to schedule the lint before the build.
+		"n8n-nodes-base#lint": {
+			"dependsOn": ["^build", "build", "@n8n/eslint-config#build"]
+		},
 		"lint:fix": {},
 		"lint:styles": {
 			"dependsOn": ["@n8n/stylelint-config#build"]


### PR DESCRIPTION
> **Closed as superseded — not abandoned.** The same fix reached `master` independently in
> `a6a28834a3c` (part of #37408, 2026-08-31). `turbo.json` there declares
> `"n8n-nodes-base#lint": { "dependsOn": ["^build", "build", "@n8n/eslint-config#build"] }`
> — byte-identical to this PR's array. Keeping this open would only add a conflict on the
> same three lines.
>
> The diagnosis below is the part that did not land, and it is why the `"build"` entry is
> not a duplicate of `"^build"`. Do not remove it: `^build` orders the *dependencies'*
> builds, never the package's own, and `nodes-base`'s lint script reads `dist/methods/*.json`
> and `dist/nodes` from its own build. Deleting it returns an intermittent failure whose
> message names metadata generation, not task ordering:
> `Failed to find methods to validate. Please run npm run n8n-generate-metadata first.`
>
> Original description follows.

---

## Summary

`n8n-nodes-base`'s `lint` script is not only ESLint:

```
eslint nodes credentials utils test --quiet
  && node ./scripts/validate-load-options-methods.js
  && node ./scripts/validate-schema-versions.js
```

Both validators read the package's **own** build output — `dist/methods/referenced.json`,
`dist/methods/defined.json` and `dist/nodes`. The shared `lint` task declares
`["^build", "@n8n/eslint-config#build"]`, which orders the *dependencies'* builds only.
`n8n-nodes-base#build` is never ordered before `n8n-nodes-base#lint`.

Verified with turbo 2.9.15 on `master`:

```
$ turbo run lint --filter=n8n-nodes-base --dry=json
n8n-nodes-base#lint deps = [ ...14 dependency builds..., @n8n/eslint-config#build ]
# n8n-nodes-base#build is absent
```

In a full `pnpm lint:ci` run the build is in the graph anyway (7 dependents), so
scheduling order has hidden this. When turbo happens to start the lint first, the job
fails with a message that names neither lint nor the real cause:

```
Failed to find methods to validate. Please run `npm run n8n-generate-metadata` first.
Failed:    n8n-nodes-base#lint
```

Seen on [run 33155240042](https://github.com/n8n-io/n8n/actions/runs/33155240042/job/98797219725),
where `n8n-nodes-base:build` completed *after* `n8n-nodes-base:lint`. In four green runs
sampled the same day, the build completed first every time. The lint task hash is identical
(`92af8c95ad8220e6`) in the failing run and in a green run on the same base, so no input
changed — only the order.

`turbo run lint --filter=n8n-nodes-base` on a clean tree fails 100% of the time for the
same reason.

## The change

One package-scoped task override in `turbo.json`, so only `nodes-base` pays the ordering
edge. `n8n-nodes-base#build` already runs in the same graph, so this adds no work — it
only constrains order.

## How to test

```bash
turbo run lint --filter=n8n-nodes-base --dry=json | jq '.tasks[] | select(.taskId=="n8n-nodes-base#lint") | .dependencies'
# now contains "n8n-nodes-base#build"

# end to end, on a clean tree:
pnpm turbo run lint --filter=n8n-nodes-base
```

## Related Linear tickets, Github issues, and Community forum posts

Surfaced while triaging `Lint / Lint` on #37030.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


