### PR TITLE
fix(editor): Restore parameter expression toggle layout

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nSegmentControl/SegmentControl.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSegmentControl/SegmentControl.vue
@@ -153,59 +153,61 @@ function onUpdate(raw: AcceptableValue) {
 .segmentControl {
 	@include input-mixin.size-variables('medium');
 
-	--segment-control--padding: var(--spacing--5xs);
-	--segment-control--font-size: var(--font-size--2xs);
-	--segment-control--item-padding: 0 var(--spacing--xs);
+	--n8n-segment-control--padding: var(--spacing--5xs);
+	--n8n-segment-control--font-size: var(--font-size--2xs);
+	--n8n-segment-control--item-padding: 0 var(--spacing--xs);
+	--n8n-segment-control--height: var(--input--height);
 
 	display: inline-flex;
 	align-items: stretch;
-	height: var(--input--height);
+	height: var(--n8n-segment-control--height);
 	line-height: 1;
 	vertical-align: middle;
 	background-color: var(--color--foreground);
-	padding: var(--segment-control--padding);
+	padding: var(--n8n-segment-control--padding);
 	border-radius: var(--radius--2xs);
 }
 
 .mini {
 	@include input-mixin.size-variables('mini');
 
-	--segment-control--font-size: var(--font-size--3xs);
-	--segment-control--item-padding: 0 var(--spacing--2xs);
+	--n8n-segment-control--font-size: var(--font-size--3xs);
+	--n8n-segment-control--item-padding: 0 var(--spacing--2xs);
 }
 
 .small {
 	@include input-mixin.size-variables('small');
 
-	--segment-control--font-size: var(--font-size--3xs);
-	--segment-control--item-padding: 0 var(--spacing--2xs);
+	--n8n-segment-control--font-size: var(--font-size--3xs);
+	--n8n-segment-control--item-padding: 0 var(--spacing--2xs);
 }
 
 .default {
 	@include input-mixin.size-variables('medium');
 
-	--segment-control--font-size: var(--font-size--2xs);
-	--segment-control--item-padding: 0 var(--spacing--xs);
+	--n8n-segment-control--font-size: var(--font-size--2xs);
+	--n8n-segment-control--item-padding: 0 var(--spacing--xs);
 }
 
 .large {
 	@include input-mixin.size-variables('large');
 
-	--segment-control--font-size: var(--font-size--xs);
-	--segment-control--item-padding: 0 var(--spacing--xs);
+	--n8n-segment-control--font-size: var(--font-size--xs);
+	--n8n-segment-control--item-padding: 0 var(--spacing--xs);
 }
 
 .xlarge {
 	@include input-mixin.size-variables('xlarge');
 
-	--segment-control--font-size: var(--font-size--sm);
-	--segment-control--item-padding: 0 var(--spacing--sm);
+	--n8n-segment-control--font-size: var(--font-size--sm);
+	--n8n-segment-control--item-padding: 0 var(--spacing--sm);
 }
 
 .group {
 	display: flex;
 	align-items: stretch;
 	flex: 1;
+	height: 100%;
 	width: 100%;
 	gap: var(--spacing--5xs);
 }

--- a/packages/frontend/@n8n/design-system/src/components/N8nSegmentControl/SegmentControlItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSegmentControl/SegmentControlItem.vue
@@ -35,8 +35,6 @@ withDefaults(defineProps<SegmentControlItemProps>(), {
 @use '../../css/mixins/focus';
 
 .item {
-	--segment-control--item-height: calc(var(--input--height) - 2 * var(--segment-control--padding));
-
 	position: relative;
 	appearance: none;
 	display: inline-flex;
@@ -46,9 +44,9 @@ withDefaults(defineProps<SegmentControlItemProps>(), {
 	flex: 1;
 	border-radius: var(--radius--3xs);
 	background: transparent;
-	height: var(--segment-control--item-height);
-	padding: var(--segment-control--item-padding);
-	font-size: var(--segment-control--font-size);
+	height: 100%;
+	padding: var(--n8n-segment-control--item-padding);
+	font-size: var(--n8n-segment-control--font-size);
 	font-weight: var(--font-weight--medium);
 	line-height: 1;
 	color: var(--text-color--subtle);
@@ -99,7 +97,7 @@ withDefaults(defineProps<SegmentControlItemProps>(), {
 }
 
 .square {
-	width: var(--segment-control--item-height);
+	aspect-ratio: 1/1;
 	padding: 0;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.test.ts
@@ -37,6 +37,34 @@ describe('ParameterOptions', () => {
 		expect(getByTestId('radio-button-expression')).toBeInTheDocument();
 	});
 
+	it('renders compact controls in the parameter options row', () => {
+		const { container, getByTestId } = renderComponent(ParameterOptions, {
+			props: {
+				parameter: DEFAULT_PARAMETER,
+				value: 'manual',
+				isReadOnly: false,
+				showDelete: true,
+				onDelete: vi.fn(),
+			},
+			global: {
+				stubs: {
+					N8nActionToggle: {
+						props: ['size'],
+						template: '<div data-test-id="action-toggle" :data-size="size" />',
+					},
+					N8nIconButton: {
+						props: ['size'],
+						template: '<button v-bind="$attrs" :data-size="size" />',
+					},
+				},
+			},
+		});
+
+		expect(container.querySelector('.n8n-segment-control')).toHaveClass('mini');
+		expect(getByTestId('action-toggle')).toHaveAttribute('data-size', 'xsmall');
+		expect(getByTestId('parameter-delete-button')).toHaveAttribute('data-size', 'xsmall');
+	});
+
 	it("doesn't render expression with showExpression set to false", () => {
 		const { getByTestId, queryByTestId } = renderComponent(ParameterOptions, {
 			props: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.vue
@@ -194,7 +194,7 @@ const onViewSelected = (selected: string) => {
 			<N8nIconButton
 				variant="ghost"
 				v-if="canBeOpenedInFocusPanel"
-				size="small"
+				size="xsmall"
 				icon-size="large"
 				icon="panel-right"
 				:class="$style.focusButton"
@@ -207,7 +207,7 @@ const onViewSelected = (selected: string) => {
 				<N8nActionToggle
 					v-if="shouldShowOptions"
 					placement="bottom-end"
-					size="small"
+					size="xsmall"
 					theme="dark"
 					icon-size="large"
 					:actions="actions"
@@ -219,7 +219,7 @@ const onViewSelected = (selected: string) => {
 
 			<N8nSegmentControl
 				v-if="shouldShowExpressionSelector"
-				size="small"
+				size="mini"
 				:class="$style.expressionSwitch"
 				:model-value="selectedView"
 				:disabled="isReadOnly"
@@ -233,7 +233,7 @@ const onViewSelected = (selected: string) => {
 			<N8nIconButton
 				variant="ghost"
 				v-if="showDelete && onDelete"
-				size="small"
+				size="xsmall"
 				icon-size="large"
 				icon="trash-2"
 				:class="$style.deleteButton"
@@ -248,8 +248,8 @@ const onViewSelected = (selected: string) => {
 <style lang="scss" module>
 .container {
 	display: flex;
-	min-height: var(--parameter-input-options--height, 22px);
-	max-height: var(--parameter-input-options--height, 22px);
+	min-height: var(--parameter-input-options--height, 24px);
+	max-height: var(--parameter-input-options--height, 24px);
 	overflow: hidden;
 }
 
@@ -267,6 +267,7 @@ const onViewSelected = (selected: string) => {
 }
 
 .expressionSwitch {
+	--n8n-segment-control--height: 24px;
 	margin-right: var(--spacing--4xs);
 }
 


### PR DESCRIPTION
## Summary

Restore the Fixed and Expression toggle layout in the node details view. 

Because of changes to \`N8nSegmentControl\` in [#34447](<https://github.com/n8n-io/n8n/pull/34447>) the components size was breaking out of its clipped container, cutting off the top and bottom.

* Adds correct size variant `mini` to `N8nSegmentControl` in `ParameterOptions`
* Updates container height to `24px` to meet W3 clickable guidelines
* Refactors how height is managed in `N8nSegmentControl` to make it easier to override callers in future
* Adds regression test for the compact control sizes.

<!-- linear:table-colwidths:357,356 -->
| **Before** | **After** |
| -- | -- |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/d7a073e6-df0d-476e-9e33-68f3ab96e771/e296d81e-d718-49da-aa91-b48b8a4b3a6b?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9kN2EwNzNlNi1kZjBkLTQ3NmUtOWUzMy02OGYzYWI5NmU3NzEvZTI5NmQ4MWUtZDcxOC00OWRhLWFhOTEtYjQ4YjhhNGIzYTZiIiwiaWF0IjoxNzg3OTA4OTI5LCJleHAiOjE4MTk0Nzk0ODl9.bdUrncH1ZbcnnjCefYBcBUdqdd5eImwnGTNOH2IuEDk " alt="image.png" width="4064" data-linear-height="2334" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/afd1c21a-eef6-4297-a4d4-2ec13c2c5ee1/a5b83b0e-714a-4deb-acf5-a83d95817318?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9hZmQxYzIxYS1lZWY2LTQyOTctYTRkNC0yZWMxM2MyYzVlZTEvYTViODNiMGUtNzE0YS00ZGViLWFjZjUtYTgzZDk1ODE3MzE4IiwiaWF0IjoxNzg3OTA4OTI5LCJleHAiOjE4MTk0Nzk0ODl9.DcRFWTwLmaaKNerBNJeGggzIIyogaboxsnconNxcdvM " alt="CleanShot 2026-08-28 at 10.21.47@2x.png" width="842" data-linear-height="588" /> |

## How to test

1. Open a workflow with a node that has a parameter input.
2. Open the node details view.
3. Confirm that the Fixed and Expression toggle has the correct height and alignment.
4. Select Fixed and Expression.
5. Confirm that each option works as expected.
6. Run `pnpm test src/features/ndv/parameters/components/ParameterOptions.test.ts` from `packages/frontend/editor-ui`.

## Related Linear tickets, Github issues, and Community forum posts

[ADO-5849](https://linear.app/n8n/issue/ADO-5849)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [X] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)