### PR TITLE
fix(Chat Trigger Node): Apply authentication to test webhook requests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -885,10 +885,10 @@ export class ChatTrigger extends Node {
 		const bodyData = ctx.getBodyData() ?? {};
 
 		try {
-			// The editor's canvas chat can't supply webhook credentials, and test webhooks
-			// are only ever registered through an authenticated editor session, so auth is
-			// only enforced for production executions.
-			if (mode !== 'test') {
+			// The editor's canvas chat can't supply webhook credentials, so its session-scoped
+			// test route (flagged by the backend at registration) is exempt from auth. Every
+			// other request — production or sessionless test — enforces the configured auth.
+			if (mode !== 'test' || !ctx.isChatSessionTest()) {
 				await validateAuth(ctx);
 			}
 		} catch (error) {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -321,8 +321,15 @@ describe('ChatTrigger Node', () => {
 			});
 		});
 
-		it('skips auth validation for manual (test) executions', async () => {
+		it('enforces auth for manual executions outside the canvas chat session route', async () => {
 			mockContext.getMode.mockReturnValue('manual');
+			mockContext.isChatSessionTest.mockReturnValue(false);
+			mockContext.getNode.mockReturnValue({
+				name: 'Chat Trigger',
+				type: 'n8n-nodes-langchain.chatTrigger',
+				typeVersion: 1,
+				webhookId: 'abc123',
+			} as INode);
 			mockContext.getNodeParameter.mockImplementation(
 				(
 					paramName: string,
@@ -336,15 +343,15 @@ describe('ChatTrigger Node', () => {
 					return defaultValue;
 				},
 			);
+			vi.mocked(validateAuth).mockRejectedValueOnce(new ChatTriggerAuthorizationError(401));
 
 			const result = await chatTrigger.webhook(mockContext);
 
-			expect(validateAuth).not.toHaveBeenCalled();
-			expect(mockResponse.writeHead).not.toHaveBeenCalledWith(401, expect.anything());
-			expect(result).toEqual({
-				webhookResponse: { status: 200 },
-				workflowData: expect.any(Array),
+			expect(validateAuth).toHaveBeenCalledWith(mockContext);
+			expect(mockResponse.writeHead).toHaveBeenCalledWith(401, {
+				'www-authenticate': 'Basic realm="Webhook abc123"',
 			});
+			expect(result).toEqual({ noWebhookResponse: true });
 		});
 
 		it('still enforces auth validation for production executions', async () => {

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -486,6 +486,8 @@ export class TestWebhooks implements IWebhookManager {
 				) {
 					// Generate predictable path using workflowId and sessionId (without leading slash to match lookup format)
 					webhook.path = `${workflow.id}/${chatSessionId}`;
+					// Only this session-scoped canvas route may skip the Chat Trigger's configured auth
+					webhook.isChatSessionTest = true;
 				}
 
 				const key = this.registrations.toKey(webhook);

--- a/packages/cli/test/integration/chat-trigger-test-webhook-auth.api.test.ts
+++ b/packages/cli/test/integration/chat-trigger-test-webhook-auth.api.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Authentication on Chat Trigger test webhooks (`/webhook-test/...`).
+ *
+ * A Chat Trigger's configured authentication applies to its test webhook the same way
+ * it does in production. The one exemption is the editor's canvas chat: its registration
+ * is rewritten to the session-scoped `{workflowId}/{chatSessionId}` route and flagged as
+ * such by the backend, and only that flagged registration runs without webhook
+ * credentials. A rejected request responds before any execution starts and leaves the
+ * one-shot registration in place for a later authorized request.
+ */
+
+import {
+	createWorkflow,
+	mockInstance,
+	randomCredentialPayload,
+	testDb,
+} from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import type { User } from '@n8n/db';
+import { ExecutionRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { DirectoryLoader } from 'n8n-core';
+import { UnrecognizedNodeTypeError } from 'n8n-core';
+import type { INode, INodeType } from 'n8n-workflow';
+import { CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { agent as testAgent } from 'supertest';
+
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { CacheService } from '@/services/cache/cache.service';
+import { Telemetry } from '@/telemetry';
+import { TestWebhooks } from '@/webhooks/test-webhooks';
+import { WebhookServer } from '@/webhooks/webhook-server';
+
+import { saveCredential } from './shared/db/credentials';
+import { createOwner } from './shared/db/users';
+import type { SuperAgentTest } from './shared/types';
+import { initCredentialsTypes, setupTestServer } from './shared/utils';
+
+mockInstance(Telemetry);
+
+const testServer = setupTestServer({ endpointGroups: ['workflows'] });
+
+const TRIGGER_NAME = 'When chat message received';
+const BASIC_AUTH_USER = 'chat-user';
+const BASIC_AUTH_PASSWORD = 'chat-password';
+
+/**
+ * The real Chat Trigger, out of the langchain package's dist. Required by absolute path
+ * rather than imported (the package exports only its index), and registered under its own
+ * package loader because node types resolve by the package prefix in their name. It has to
+ * be the real node: its `webhook()` method is what applies the configured authentication.
+ */
+function registerChatTrigger() {
+	const distPath = path.resolve(
+		__dirname,
+		'../../../@n8n/nodes-langchain/dist/nodes/trigger/ChatTrigger/ChatTrigger.node.js',
+	);
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { ChatTrigger } = require(distPath) as { ChatTrigger: new () => INodeType };
+	const loaded = { type: new ChatTrigger(), sourcePath: '' };
+	const [packageName, nodeName] = CHAT_TRIGGER_NODE_TYPE.split('.');
+
+	Container.get(LoadNodesAndCredentials).loaders[packageName] = {
+		getNode: (nodeType: string) => {
+			if (nodeType !== nodeName) throw new UnrecognizedNodeTypeError(packageName, nodeType);
+			return loaded;
+		},
+		known: { nodes: {}, credentials: {} },
+	} as unknown as DirectoryLoader;
+}
+
+let builder: User;
+let webhookAgent: SuperAgentTest;
+let webhookTestEndpoint: string;
+
+const chatTriggerNode = (
+	parameters: Record<string, unknown>,
+	credential?: { id: string; name: string },
+): INode => ({
+	id: randomUUID(),
+	name: TRIGGER_NAME,
+	type: CHAT_TRIGGER_NODE_TYPE,
+	typeVersion: 1.3,
+	position: [0, 0],
+	webhookId: randomUUID(),
+	parameters: { public: true, mode: 'hostedChat', options: {}, ...parameters },
+	...(credential ? { credentials: { httpBasicAuth: credential } } : {}),
+});
+
+const createChatWorkflow = async (trigger: INode) =>
+	await createWorkflow({ active: false, nodes: [trigger], connections: {} }, builder);
+
+const createBasicAuthCredential = async () =>
+	await saveCredential(
+		{
+			...randomCredentialPayload({ type: 'httpBasicAuth' }),
+			data: { user: BASIC_AUTH_USER, password: BASIC_AUTH_PASSWORD },
+		},
+		{ user: builder, role: 'credential:owner' },
+	);
+
+/** The editor registering the test webhook for this workflow's chat trigger. */
+const startListening = async (workflowId: string, chatSessionId?: string) =>
+	await testServer
+		.authAgentFor(builder)
+		.post(`/workflows/${workflowId}/run`)
+		.send({
+			triggerToStartFrom: { name: TRIGGER_NAME },
+			...(chatSessionId ? { chatSessionId } : {}),
+		});
+
+const chatMessage = (sessionId = 'test-session') => ({
+	action: 'sendMessage',
+	chatInput: 'hello',
+	sessionId,
+});
+
+const lastExecutionFor = async (workflowId: string) =>
+	await Container.get(ExecutionRepository).findOne({
+		where: { workflowId },
+		order: { createdAt: 'DESC' },
+	});
+
+beforeAll(async () => {
+	registerChatTrigger();
+	await initCredentialsTypes();
+
+	webhookTestEndpoint = Container.get(GlobalConfig).endpoints.webhookTest;
+
+	await Container.get(CacheService).init();
+
+	// `/webhook-test/*` is mounted only when a server opts into test webhooks, which the
+	// production webhook process does not — the editor's own server does.
+	class EditorFacingWebhookServer extends WebhookServer {
+		constructor() {
+			super();
+			this.testWebhooksEnabled = true;
+		}
+	}
+
+	const server = new EditorFacingWebhookServer();
+	await server.start();
+	webhookAgent = testAgent(server.app) as unknown as SuperAgentTest;
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'ExecutionEntity',
+		'SharedWorkflow',
+		'WorkflowEntity',
+		'SharedCredentials',
+		'CredentialsEntity',
+	]);
+	await Container.get(CacheService).reset();
+
+	builder = await createOwner();
+});
+
+describe('chat trigger test webhooks', () => {
+	test('enforces Basic Auth without clearing the pending test webhook', async () => {
+		await webhookAgent
+			.post(`/${webhookTestEndpoint}/${randomUUID()}/chat`)
+			.send(chatMessage())
+			.expect(404);
+
+		const credential = await createBasicAuthCredential();
+		const trigger = chatTriggerNode(
+			{ authentication: 'basicAuth' },
+			{ id: credential.id, name: credential.name },
+		);
+		const workflow = await createChatWorkflow(trigger);
+
+		const listening = await startListening(workflow.id);
+		expect(listening.body.data).toEqual({ waitingForWebhook: true });
+
+		const url = `/${webhookTestEndpoint}/${trigger.webhookId}/chat`;
+
+		await webhookAgent.post(url).send(chatMessage()).expect(401);
+		await webhookAgent
+			.post(url)
+			.auth(BASIC_AUTH_USER, 'not-the-password')
+			.send(chatMessage())
+			.expect(403);
+
+		// Rejected requests neither ran the workflow nor consumed the registration,
+		// so the same registration still answers an authorized request.
+		const authorized = await webhookAgent
+			.post(url)
+			.auth(BASIC_AUTH_USER, BASIC_AUTH_PASSWORD)
+			.send(chatMessage());
+		expect(authorized.statusCode).toBe(200);
+
+		const execution = await lastExecutionFor(workflow.id);
+		expect(execution?.mode).toBe('manual');
+		expect(execution?.status).toBe('success');
+
+		// The successful request consumed the one-shot registration.
+		await webhookAgent
+			.post(url)
+			.auth(BASIC_AUTH_USER, BASIC_AUTH_PASSWORD)
+			.send(chatMessage())
+			.expect(404);
+	});
+
+	test('requires an n8n session for user-authenticated test webhooks', async () => {
+		const trigger = chatTriggerNode({ authentication: 'n8nUserAuth' });
+		const workflow = await createChatWorkflow(trigger);
+
+		const listening = await startListening(workflow.id);
+		expect(listening.body.data).toEqual({ waitingForWebhook: true });
+
+		await webhookAgent
+			.post(`/${webhookTestEndpoint}/${trigger.webhookId}/chat`)
+			.send(chatMessage())
+			.expect(401);
+
+		const executionCount = await Container.get(ExecutionRepository).count({
+			where: { workflowId: workflow.id },
+		});
+		expect(executionCount).toBe(0);
+
+		// Disarm the pending registration's timeout so the suite exits cleanly.
+		await Container.get(TestWebhooks).cancelWebhook(workflow.id);
+	});
+
+	test('allows the editor chat session route without webhook credentials', async () => {
+		const credential = await createBasicAuthCredential();
+		const trigger = chatTriggerNode(
+			{ authentication: 'basicAuth' },
+			{ id: credential.id, name: credential.name },
+		);
+		const workflow = await createChatWorkflow(trigger);
+		const chatSessionId = randomUUID().replace(/-/g, '');
+
+		const listening = await startListening(workflow.id, chatSessionId);
+		expect(listening.body.data).toEqual({ waitingForWebhook: true });
+
+		const response = await webhookAgent
+			.post(`/${webhookTestEndpoint}/${workflow.id}/${chatSessionId}`)
+			.send(chatMessage(chatSessionId));
+
+		expect(response.statusCode).toBe(200);
+
+		const execution = await lastExecutionFor(workflow.id);
+		expect(execution?.mode).toBe('manual');
+		expect(execution?.status).toBe('success');
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -170,6 +170,10 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		return this.webhookData.webhookDescription.name;
 	}
 
+	isChatSessionTest() {
+		return this.webhookData.isChatSessionTest === true;
+	}
+
 	logHitlResponse(payload: { approved: boolean; authorized: boolean }) {
 		this.additionalData.logHitlResponse?.({
 			...payload,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1584,6 +1584,8 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	getRequestObject(): express.Request;
 	getResponseObject(): express.Response;
 	getWebhookName(): string;
+	/** Whether this request arrived on the editor's session-scoped canvas chat test route. */
+	isChatSessionTest(): boolean;
 	validateCookieAuth(cookieValue: string): Promise<IUser>;
 	/** Emits telemetry for an advanced HITL response actioned via this webhook. */
 	logHitlResponse(payload: { approved: boolean; authorized: boolean }): void;
@@ -3068,6 +3070,13 @@ export interface IWebhookData {
 	workflowExecuteAdditionalData: IWorkflowExecuteAdditionalData;
 	webhookId?: string;
 	isTest?: boolean;
+	/**
+	 * Set when this test webhook was registered for the editor's canvas chat session
+	 * (path rewritten to `{workflowId}/{chatSessionId}`). Lets the Chat Trigger skip
+	 * webhook auth for that trusted, session-scoped route only — every other test
+	 * request still enforces the configured authentication.
+	 */
+	isChatSessionTest?: boolean;
 	userId?: string;
 	staticData?: Workflow['staticData'];
 }


### PR DESCRIPTION
## Summary

- Apply configured Chat Trigger authentication to standard test webhook requests.
- Keep the editor canvas chat route credential-free through a backend-owned session marker.
- Preserve pending one-shot registrations after rejected requests and add real HTTP regression coverage.

## How to test

1. Create a workflow with a public Chat Trigger and Basic Auth.
2. Start a test execution without a chat session ID.
3. Send requests with missing, incorrect, and correct credentials. Confirm the responses are 401, 403, and 200.
4. Send the authorized request again. Confirm the consumed test webhook returns 404.
5. Open the editor canvas chat for the same protected trigger. Confirm it can send a message without a webhook Authorization header.

Automated checks completed:

- `pnpm build`
- `pnpm test nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts` in `packages/@n8n/nodes-langchain`
- `pnpm test:integration test/integration/chat-trigger-test-webhook-auth.api.test.ts` in `packages/cli`
- Affected package typechecks for `workflow`, `core`, `cli`, and `@n8n/nodes-langchain`
- Changed-file lint checks

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5536

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

