### PR TITLE
fix(core): Handle reserved object keys in workflow connections diff

### DIFF
--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
@@ -419,6 +419,29 @@ describe('CreateWorkflowDto', () => {
 				},
 				expectedErrorPath: ['connections'],
 			},
+			{
+				name: 'connections with a "prototype" node name',
+				request: { name: 'Test', nodes: [], connections: { prototype: {} } },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'connections with a "constructor" input name',
+				request: {
+					name: 'Test',
+					nodes: [],
+					connections: { 'Manual Trigger': { constructor: [] } },
+				},
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'connections with a "prototype" input name',
+				request: {
+					name: 'Test',
+					nodes: [],
+					connections: { 'Manual Trigger': { prototype: [] } },
+				},
+				expectedErrorPath: ['connections'],
+			},
 		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
 			const result = CreateWorkflowDto.safeParse(request);
 			expect(result.success).toBe(false);

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
@@ -1,4 +1,4 @@
-import { GROUP_DESCRIPTION_MAX_LENGTH } from 'n8n-workflow';
+import { GROUP_DESCRIPTION_MAX_LENGTH, jsonParse } from 'n8n-workflow';
 
 import { CreateWorkflowDto } from '../create-workflow.dto';
 
@@ -398,6 +398,26 @@ describe('CreateWorkflowDto', () => {
 					],
 				},
 				expectedErrorPath: ['nodeGroups', 0, 'description'],
+			},
+			{
+				name: 'connections with a "__proto__" node name',
+				// jsonParse (unlike an object literal) creates an own-enumerable "__proto__" key.
+				request: { name: 'Test', nodes: [], connections: jsonParse('{"__proto__":{}}') },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'connections with a reserved "constructor" node name',
+				request: { name: 'Test', nodes: [], connections: { constructor: {} } },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'connections with a "__proto__" input name',
+				request: {
+					name: 'Test',
+					nodes: [],
+					connections: jsonParse('{"Manual Trigger":{"__proto__":[[]]}}'),
+				},
+				expectedErrorPath: ['connections'],
 			},
 		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
 			const result = CreateWorkflowDto.safeParse(request);

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
@@ -1,3 +1,5 @@
+import { jsonParse } from 'n8n-workflow';
+
 import { UpdateWorkflowDto } from '../update-workflow.dto';
 
 describe('UpdateWorkflowDto', () => {
@@ -153,6 +155,17 @@ describe('UpdateWorkflowDto', () => {
 			{
 				name: 'connections as array',
 				request: { connections: [] },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'connections with a "__proto__" node name',
+				// A body parsed from JSON carries an own-enumerable "__proto__" key
+				// (unlike an object literal).
+				request: {
+					connections: jsonParse(
+						'{"__proto__":{"someInput":[[{"node":"X","type":"main","index":0}]]},"Manual Trigger":{"main":[[]]}}',
+					),
+				},
 				expectedErrorPath: ['connections'],
 			},
 			{

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -27,8 +27,38 @@ export const workflowNodesSchema = z.custom<INode[]>((val) => Array.isArray(val)
 	message: 'Nodes must be an array',
 });
 
+/**
+ * Keys that resolve through the Object.prototype accessor and must not be used
+ * as dynamic object keys.
+ */
+const FORBIDDEN_CONNECTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Rejects connection payloads whose node names or input names include a key that
+ * would otherwise resolve through the Object.prototype accessor when used as a
+ * dynamic object key.
+ */
+function hasForbiddenConnectionKey(connections: object): boolean {
+	// `connections` is freshly-parsed JSON; treat its values as unknown.
+	const record = connections as Record<string, unknown>;
+	for (const nodeName of Object.keys(record)) {
+		if (FORBIDDEN_CONNECTION_KEYS.has(nodeName)) return true;
+		const inputs = record[nodeName];
+		if (inputs !== null && typeof inputs === 'object') {
+			for (const inputName of Object.keys(inputs)) {
+				if (FORBIDDEN_CONNECTION_KEYS.has(inputName)) return true;
+			}
+		}
+	}
+	return false;
+}
+
 export const workflowConnectionsSchema = z.custom<IConnections>(
-	(val) => typeof val === 'object' && val !== null && !Array.isArray(val),
+	(val: unknown) =>
+		typeof val === 'object' &&
+		val !== null &&
+		!Array.isArray(val) &&
+		!hasForbiddenConnectionKey(val),
 	{
 		message: 'Connections must be an object',
 	},

--- a/packages/workflow/src/connections-diff.ts
+++ b/packages/workflow/src/connections-diff.ts
@@ -32,6 +32,15 @@ function groupByValue(connections: IConnection[]) {
 }
 
 /**
+ * Reads a value only when it is an own property, so an inherited key such as
+ * "__proto__" resolves to `undefined` (via the Object.prototype accessor) rather
+ * than to the prototype object itself.
+ */
+function ownValue<T>(map: Record<string, T>, key: string): T | undefined {
+	return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : undefined;
+}
+
+/**
  * Creates a prototype-less dictionary so a dynamic key such as "__proto__" is
  * stored as an ordinary own key instead of resolving through the
  * Object.prototype accessor.
@@ -50,8 +59,8 @@ export function compareConnections(prev: IConnections, next: IConnections): Conn
 	const allNodeNames = new Set([...Object.keys(prev), ...Object.keys(next)]);
 
 	for (const nodeName of allNodeNames) {
-		const prevNodeConnections = prev[nodeName] ?? {};
-		const nextNodeConnections = next[nodeName] ?? {};
+		const prevNodeConnections = ownValue(prev, nodeName) ?? {};
+		const nextNodeConnections = ownValue(next, nodeName) ?? {};
 
 		// Get all unique input names for this node
 		const allInputNames = new Set([
@@ -60,8 +69,8 @@ export function compareConnections(prev: IConnections, next: IConnections): Conn
 		]);
 
 		for (const inputName of allInputNames) {
-			const prevInputConnections = prevNodeConnections[inputName] ?? [];
-			const nextInputConnections = nextNodeConnections[inputName] ?? [];
+			const prevInputConnections = ownValue(prevNodeConnections, inputName) ?? [];
+			const nextInputConnections = ownValue(nextNodeConnections, inputName) ?? [];
 
 			// Compare each source index
 			const maxLength = Math.max(prevInputConnections.length, nextInputConnections.length);

--- a/packages/workflow/src/connections-diff.ts
+++ b/packages/workflow/src/connections-diff.ts
@@ -31,9 +31,20 @@ function groupByValue(connections: IConnection[]) {
 	return byValue;
 }
 
+/**
+ * Creates a prototype-less dictionary so a dynamic key such as "__proto__" is
+ * stored as an ordinary own key instead of resolving through the
+ * Object.prototype accessor.
+ */
+function nullProtoRecord<T>(): Record<string, T> {
+	return Object.create(null) as Record<string, T>;
+}
+
 export function compareConnections(prev: IConnections, next: IConnections): ConnectionsDiff {
-	const added: Record<string, INodeConnectionsDiff> = {};
-	const removed: Record<string, INodeConnectionsDiff> = {};
+	// Prototype-less accumulators so a node/input name of "__proto__" becomes an
+	// ordinary own key instead of resolving through the Object.prototype accessor.
+	const added: Record<string, INodeConnectionsDiff> = nullProtoRecord<INodeConnectionsDiff>();
+	const removed: Record<string, INodeConnectionsDiff> = nullProtoRecord<INodeConnectionsDiff>();
 
 	// Get all unique node names from both connection objects
 	const allNodeNames = new Set([...Object.keys(prev), ...Object.keys(next)]);
@@ -67,7 +78,7 @@ export function compareConnections(prev: IConnections, next: IConnections): Conn
 				for (const [key, entries] of nextMap) {
 					const kept = prevMap.get(key)?.length ?? 0;
 					for (const value of entries.slice(kept)) {
-						if (!added[nodeName]) added[nodeName] = {};
+						if (!added[nodeName]) added[nodeName] = nullProtoRecord<ConnectionEntry[]>();
 						if (!added[nodeName][inputName]) added[nodeName][inputName] = [];
 
 						added[nodeName][inputName].push({
@@ -81,7 +92,7 @@ export function compareConnections(prev: IConnections, next: IConnections): Conn
 				for (const [key, entries] of prevMap) {
 					const kept = nextMap.get(key)?.length ?? 0;
 					for (const value of entries.slice(kept)) {
-						if (!removed[nodeName]) removed[nodeName] = {};
+						if (!removed[nodeName]) removed[nodeName] = nullProtoRecord<ConnectionEntry[]>();
 						if (!removed[nodeName][inputName]) removed[nodeName][inputName] = [];
 
 						removed[nodeName][inputName].push({

--- a/packages/workflow/test/connections-diff.test.ts
+++ b/packages/workflow/test/connections-diff.test.ts
@@ -618,4 +618,34 @@ describe('compareConnections', () => {
 			expect(result.removed).toEqual({});
 		});
 	});
+
+	// A connections object parsed from JSON can carry an own-enumerable "__proto__"
+	// key (unlike an object literal). Such a node name must be handled as an
+	// ordinary own key rather than resolving through the Object.prototype accessor.
+	describe('reserved object keys as node names', () => {
+		// Always clean up so a regression (which would set the key globally) cannot
+		// leak into the rest of the suite / test process.
+		afterEach(() => {
+			delete (Object.prototype as Record<string, unknown>).n8n_probe_key;
+		});
+
+		it('should treat a "__proto__" node name as an ordinary own key on the diff', () => {
+			// Two versions that differ only in the connections nested under a literal
+			// "__proto__" node.
+			const prev = JSON.parse('{"__proto__":{}}') as IConnections;
+			const next = JSON.parse(
+				'{"__proto__":{"n8n_probe_key":[[{"node":"X","type":"main","index":0}]]}}',
+			) as IConnections;
+
+			expect('n8n_probe_key' in prev).toBe(false);
+
+			const result = compareConnections(prev, next);
+
+			// The added connection under "__proto__" must be recorded as an own
+			// property of the result, never on the shared Object.prototype.
+			expect(({} as Record<string, unknown>).n8n_probe_key).toBeUndefined();
+			expect('n8n_probe_key' in Object.prototype).toBe(false);
+			expect(Object.keys(result.added)).toContain('__proto__');
+		});
+	});
 });

--- a/packages/workflow/test/connections-diff.test.ts
+++ b/packages/workflow/test/connections-diff.test.ts
@@ -622,7 +622,7 @@ describe('compareConnections', () => {
 	// A connections object parsed from JSON can carry an own-enumerable "__proto__"
 	// key (unlike an object literal). Such a node name must be handled as an
 	// ordinary own key rather than resolving through the Object.prototype accessor.
-	describe('reserved object keys as node names', () => {
+	describe('reserved object keys', () => {
 		// Always clean up so a regression (which would set the key globally) cannot
 		// leak into the rest of the suite / test process.
 		afterEach(() => {
@@ -646,6 +646,32 @@ describe('compareConnections', () => {
 			expect(({} as Record<string, unknown>).n8n_probe_key).toBeUndefined();
 			expect('n8n_probe_key' in Object.prototype).toBe(false);
 			expect(Object.keys(result.added)).toContain('__proto__');
+		});
+
+		it('should record a connection added under a "__proto__" input name', () => {
+			const prev = JSON.parse('{"NodeA":{}}') as IConnections;
+			const next = JSON.parse(
+				'{"NodeA":{"__proto__":[[{"node":"NodeB","type":"main","index":0}]]}}',
+			) as IConnections;
+
+			const result = compareConnections(prev, next);
+
+			// The inherited key must not shortcut the length check; the added
+			// connection under the "__proto__" input is recorded on the result.
+			expect(result.added.NodeA?.['__proto__']).toHaveLength(1);
+			expect(result.removed).toEqual({});
+		});
+
+		it('should record a connection removed under a "__proto__" input name', () => {
+			const prev = JSON.parse(
+				'{"NodeA":{"__proto__":[[{"node":"NodeB","type":"main","index":0}]]}}',
+			) as IConnections;
+			const next = JSON.parse('{"NodeA":{}}') as IConnections;
+
+			const result = compareConnections(prev, next);
+
+			expect(result.removed.NodeA?.['__proto__']).toHaveLength(1);
+			expect(result.added).toEqual({});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

A workflow's `connections` object parsed from JSON can carry an own-enumerable `"__proto__"` key (unlike an object literal). The workflow connections diff (`compareConnections`) used the accumulator value itself as an existence check on plain `{}` dictionaries, so such a node name resolved through the `Object.prototype` accessor and the diff wrote onto the shared prototype instead of onto the result object.

Regression tests are included at both layers.

Automated coverage:
- `cd packages/workflow && pnpm test connections-diff`
- `cd packages/@n8n/api-types && pnpm test workflow.dto`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-774

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

