### PR TITLE
fix(Ldap Node): Escape expression output in the Custom Filter field

### DIFF
--- a/packages/nodes-base/nodes/Ldap/Helpers.ts
+++ b/packages/nodes-base/nodes/Ldap/Helpers.ts
@@ -84,12 +84,19 @@ export function escapeResolvables(
 ): string {
 	// A raw expression-capable value keeps the leading `=` that marks it as an expression
 	let value = rawValue.replace(/^=+/, '');
+	// Everything before this index is already resolved, so it is never rescanned
+	let searchFrom = 0;
 
 	for (const resolvable of getResolvables(value)) {
+		const start = value.indexOf(resolvable, searchFrom);
+		if (start === -1) continue;
+
 		const resolvedValue = escapeValue(String(evaluateExpression(resolvable)));
-		// Replacement function, so `$`-sequences in the resolved value are not
-		// expanded back into unescaped parts of the surrounding filter
-		value = value.replace(resolvable, () => resolvedValue);
+		// Splice by index instead of `String.replace`. That keeps a resolved value
+		// which itself looks like an expression from being substituted again, and
+		// keeps `$` sequences from expanding into the surrounding filter.
+		value = value.slice(0, start) + resolvedValue + value.slice(start + resolvable.length);
+		searchFrom = start + resolvedValue.length;
 	}
 
 	return value;

--- a/packages/nodes-base/nodes/Ldap/Helpers.ts
+++ b/packages/nodes-base/nodes/Ldap/Helpers.ts
@@ -1,6 +1,9 @@
 import { Client } from 'ldapts';
 import type { ClientOptions, Entry } from 'ldapts';
 import type { ICredentialDataDecryptedObject, IDataObject, Logger } from 'n8n-workflow';
+
+import { getResolvables } from '@utils/utilities';
+
 export const BINARY_AD_ATTRIBUTES = ['objectGUID', 'objectSid'];
 
 const resolveEntryBinaryAttributes = (entry: Entry): Entry => {
@@ -64,4 +67,30 @@ export function escapeValue(value: string) {
 		.replace(/\(/g, '\\28')
 		.replace(/\)/g, '\\29')
 		.replace(/\x00/g, '\\00');
+}
+
+/**
+ * Resolves the expressions in a raw, expression-capable filter field and escapes
+ * only what each expression evaluated to.
+ *
+ * The literal text around the expressions is filter syntax the user wrote on
+ * purpose, so it has to reach the server untouched — escaping the whole
+ * resolved string would turn every hand-written `*`, `(` and `)` into a literal
+ * character and break the field.
+ */
+export function escapeResolvables(
+	rawValue: string,
+	evaluateExpression: (resolvable: string) => unknown,
+): string {
+	// A raw expression-capable value keeps the leading `=` that marks it as an expression
+	let value = rawValue.replace(/^=+/, '');
+
+	for (const resolvable of getResolvables(value)) {
+		const resolvedValue = escapeValue(String(evaluateExpression(resolvable)));
+		// Replacement function, so `$`-sequences in the resolved value are not
+		// expanded back into unescaped parts of the surrounding filter
+		value = value.replace(resolvable, () => resolvedValue);
+	}
+
+	return value;
 }

--- a/packages/nodes-base/nodes/Ldap/Ldap.node.ts
+++ b/packages/nodes-base/nodes/Ldap/Ldap.node.ts
@@ -355,7 +355,17 @@ export class Ldap implements INodeType {
 					});
 				} else if (operation === 'search') {
 					const baseDN = this.getNodeParameter('baseDN', itemIndex) as string;
-					let searchFor = this.getNodeParameter('searchFor', itemIndex) as string;
+					const evaluate = (resolvable: string) =>
+						this.evaluateExpression(`${resolvable}`, itemIndex);
+
+					// The object class is spliced into the filter as a fragment, so an
+					// expression in it needs the same per-expression escaping as the filter
+					const rawSearchFor = this.getNodeParameter('searchFor', itemIndex, undefined, {
+						rawExpressions: true,
+					});
+					let searchFor =
+						typeof rawSearchFor === 'string' ? escapeResolvables(rawSearchFor, evaluate) : '';
+
 					const returnAll = this.getNodeParameter('returnAll', itemIndex);
 					const limit = this.getNodeParameter('limit', itemIndex, 0);
 					const options = this.getNodeParameter('options', itemIndex);
@@ -377,9 +387,6 @@ export class Ldap implements INodeType {
 						options.attributes = options.attributes.split(',').map((attribute) => attribute.trim());
 					}
 					options.explicitBufferAttributes = BINARY_AD_ATTRIBUTES;
-
-					const evaluate = (resolvable: string) =>
-						this.evaluateExpression(`${resolvable}`, itemIndex);
 
 					if (searchFor === 'custom') {
 						// Read the filter before expressions are interpolated, so only the

--- a/packages/nodes-base/nodes/Ldap/Ldap.node.ts
+++ b/packages/nodes-base/nodes/Ldap/Ldap.node.ts
@@ -16,11 +16,11 @@ import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import {
 	BINARY_AD_ATTRIBUTES,
 	createLdapClient,
+	escapeResolvables,
 	escapeValue,
 	resolveBinaryAttributes,
 } from './Helpers';
 import { ldapFields } from './LdapDescription';
-import { getResolvables } from '@utils/utilities';
 
 export class Ldap implements INodeType {
 	description: INodeTypeDescription = {
@@ -378,20 +378,24 @@ export class Ldap implements INodeType {
 					}
 					options.explicitBufferAttributes = BINARY_AD_ATTRIBUTES;
 
+					const evaluate = (resolvable: string) =>
+						this.evaluateExpression(`${resolvable}`, itemIndex);
+
 					if (searchFor === 'custom') {
-						searchFor = this.getNodeParameter('customFilter', itemIndex) as string;
-					} else {
-						let searchText = this.getNodeParameter('searchText', itemIndex, undefined, {
+						// Read the filter before expressions are interpolated, so only the
+						// values they resolve to get escaped and the filter syntax the user
+						// wrote stays intact
+						const customFilter = this.getNodeParameter('customFilter', itemIndex, undefined, {
 							rawExpressions: true,
 						}) as string;
-						searchText = searchText.replace(/^=+/, '');
-						const resolvables = getResolvables(searchText);
-						for (const resolvable of resolvables) {
-							const resolvedValue = escapeValue(
-								String(this.evaluateExpression(`${resolvable}`, itemIndex)),
-							);
-							searchText = searchText.replace(resolvable, resolvedValue);
-						}
+						searchFor = escapeResolvables(customFilter, evaluate);
+					} else {
+						const searchText = escapeResolvables(
+							this.getNodeParameter('searchText', itemIndex, undefined, {
+								rawExpressions: true,
+							}) as string,
+							evaluate,
+						);
 
 						const attribute = escapeValue(this.getNodeParameter('attribute', itemIndex) as string);
 						searchFor = `(&${searchFor}(${attribute}=${searchText}))`;

--- a/packages/nodes-base/nodes/Ldap/__tests__/Ldap.node.test.ts
+++ b/packages/nodes-base/nodes/Ldap/__tests__/Ldap.node.test.ts
@@ -422,6 +422,90 @@ describe('Ldap', () => {
 				);
 			});
 		});
+
+		describe('object class', () => {
+			it('should pass a selected object class through unescaped', async () => {
+				mockParameters({ searchText: 'johndoe' });
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(objectclass=person)(cn=johndoe))',
+					}),
+				);
+			});
+
+			it('should escape filter special characters resolved from an expression', async () => {
+				mockParameters({ searchFor: '={{ $json.objectClass }}', searchText: 'johndoe' });
+
+				executeFunctions.evaluateExpression.mockImplementation((expr) => {
+					if (expr === '{{ $json.objectClass }}') return '*)(|(';
+					return expr;
+				});
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&\\2a\\29\\28|\\28(cn=johndoe))',
+					}),
+				);
+			});
+
+			it('should escape only the expression output in a hand-written object class', async () => {
+				mockParameters({
+					searchFor: '=(objectclass={{ $json.objectClass }})',
+					searchText: 'johndoe',
+				});
+
+				executeFunctions.evaluateExpression.mockImplementation((expr) => {
+					if (expr === '{{ $json.objectClass }}') return 'per*son';
+					return expr;
+				});
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(objectclass=per\\2ason)(cn=johndoe))',
+					}),
+				);
+			});
+		});
+
+		describe('raw parameter reads', () => {
+			// Escaping only works on the template, so a dropped `rawExpressions` would
+			// silently hand back a filter n8n has already interpolated
+			it('should read the object class and search text before they are interpolated', async () => {
+				mockParameters({ searchText: 'johndoe' });
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(executeFunctions.getNodeParameter).toHaveBeenCalledWith('searchFor', 0, undefined, {
+					rawExpressions: true,
+				});
+				expect(executeFunctions.getNodeParameter).toHaveBeenCalledWith('searchText', 0, undefined, {
+					rawExpressions: true,
+				});
+			});
+
+			it('should read the custom filter before it is interpolated', async () => {
+				mockParameters({ searchFor: 'custom', customFilter: '(objectclass=*)' });
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(executeFunctions.getNodeParameter).toHaveBeenCalledWith(
+					'customFilter',
+					0,
+					undefined,
+					{ rawExpressions: true },
+				);
+			});
+		});
 	});
 
 	describe('rename', () => {

--- a/packages/nodes-base/nodes/Ldap/__tests__/Ldap.node.test.ts
+++ b/packages/nodes-base/nodes/Ldap/__tests__/Ldap.node.test.ts
@@ -278,6 +278,108 @@ describe('Ldap', () => {
 				}),
 			);
 		});
+
+		describe('custom filter', () => {
+			const customFilterTemplate = '=(&(objectClass=inetOrgPerson)(cn={{ $json.body.username }}))';
+
+			function mockCustomFilter(customFilter: string, resolvedValue?: string) {
+				mockParameters({ searchFor: 'custom', customFilter });
+
+				executeFunctions.evaluateExpression.mockImplementation((expr) => {
+					if (expr === '{{ $json.body.username }}') return resolvedValue;
+					return expr;
+				});
+			}
+
+			it('should not escape a plain value resolved from an expression', async () => {
+				mockCustomFilter(customFilterTemplate, 'alice');
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(objectClass=inetOrgPerson)(cn=alice))',
+					}),
+				);
+			});
+
+			it('should escape filter special characters resolved from an expression', async () => {
+				mockCustomFilter(customFilterTemplate, '*)(|(');
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(objectClass=inetOrgPerson)(cn=\\2a\\29\\28|\\28))',
+					}),
+				);
+			});
+
+			it('should escape a backslash resolved from an expression', async () => {
+				mockCustomFilter(customFilterTemplate, 'domain\\alice');
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(objectClass=inetOrgPerson)(cn=domain\\5calice))',
+					}),
+				);
+			});
+
+			it('should keep a `$` sequence resolved from an expression as a literal value', async () => {
+				// `$'`, `$&` and similar sequences are meaningful to String.replace, so
+				// they must not expand into the surrounding filter syntax
+				mockCustomFilter(customFilterTemplate, "$'");
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: "(&(objectClass=inetOrgPerson)(cn=$'))",
+					}),
+				);
+			});
+
+			it('should pass a static custom filter through unescaped', async () => {
+				mockCustomFilter('(objectclass=*)');
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({ filter: '(objectclass=*)' }),
+				);
+			});
+
+			it('should keep converting hand-escaped special characters in a static custom filter', async () => {
+				mockCustomFilter('(cn=john\\*doe)');
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({ filter: '(cn=john\\2adoe)' }),
+				);
+			});
+
+			it('should keep a wildcard the user typed next to an escaped expression value', async () => {
+				mockCustomFilter('=(&(objectClass=inetOrgPerson)(cn={{ $json.body.username }}*))', 'ali*');
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(objectClass=inetOrgPerson)(cn=ali\\2a*))',
+					}),
+				);
+			});
+		});
 	});
 
 	describe('rename', () => {

--- a/packages/nodes-base/nodes/Ldap/__tests__/Ldap.node.test.ts
+++ b/packages/nodes-base/nodes/Ldap/__tests__/Ldap.node.test.ts
@@ -367,6 +367,48 @@ describe('Ldap', () => {
 				);
 			});
 
+			it('should resolve each expression into its own position', async () => {
+				mockParameters({
+					searchFor: 'custom',
+					customFilter: '=(&(cn={{ $json.a }})(sn={{ $json.b }}))',
+				});
+
+				// The first value looks like the second expression, so a resolved value
+				// must never be rescanned for expressions
+				executeFunctions.evaluateExpression.mockImplementation((expr) => {
+					if (expr === '{{ $json.a }}') return '{{ $json.b }}';
+					if (expr === '{{ $json.b }}') return 'bob';
+					return expr;
+				});
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(cn={{ $json.b }})(sn=bob))',
+					}),
+				);
+			});
+
+			it('should resolve the same expression used more than once', async () => {
+				mockParameters({
+					searchFor: 'custom',
+					customFilter: '=(&(cn={{ $json.a }})(sn={{ $json.a }}))',
+				});
+
+				executeFunctions.evaluateExpression.mockReturnValue('ali*ce');
+
+				await new Ldap().execute.call(executeFunctions);
+
+				expect(mockSearch).toHaveBeenCalledWith(
+					'dc=example,dc=com',
+					expect.objectContaining({
+						filter: '(&(cn=ali\\2ace)(sn=ali\\2ace))',
+					}),
+				);
+			});
+
 			it('should keep a wildcard the user typed next to an escaped expression value', async () => {
 				mockCustomFilter('=(&(objectClass=inetOrgPerson)(cn={{ $json.body.username }}*))', 'ali*');
 


### PR DESCRIPTION
## Summary

The LDAP node's **Custom Filter** field is expression-capable, but it was read after n8n had already substituted the expressions, so whatever an expression resolved to went into `client.search()` verbatim. This PR reads the field as a raw value instead and escapes only what each expression resolves to, so the filter syntax the author wrote — including any `*`, `(`, `)` they escaped by hand — still reaches the server intact. The per-expression escaping that the **Search Text** field already did is now shared as an `escapeResolvables` helper, which splices each resolved value in by index and never rescans the already-resolved part of the filter. That means a resolved value is no longer substituted a second time when it happens to look like another expression, and `$` sequences in a resolved value no longer expand into the surrounding filter.

## How to test

No env vars, license or feature flag needed.

1. Add an LDAP node with **Operation: Search** and **Search For: Custom Filter**.
2. Set the Custom Filter to an expression, e.g. `=(&(objectClass=inetOrgPerson)(cn={{ $json.username }}))`.
3. Run it with `username` set to `alice` — the filter sent is `(&(objectClass=inetOrgPerson)(cn=alice))`, unchanged from before.
4. Run it with `username` set to `a*)(|(` — the filter sent is now `(&(objectClass=inetOrgPerson)(cn=a\2a\29\28|\28))`, so the resolved value is matched as a literal string.
5. Confirm nothing regressed for hand-written filters: a static Custom Filter of `(objectclass=*)` still sends `(objectclass=*)`, and `(cn=john\*doe)` still sends `(cn=john\2adoe)`.

Enable **Debug** on the node to see the filter in the execution log, or read `options.filter` from the LDAP server side.

Unit tests: `cd packages/nodes-base && pnpm test nodes/Ldap` (21 passing).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5816

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


