### PR TITLE
feat(Cal.com Node): Add action node for bookings and event types

### DIFF
--- a/packages/nodes-base/nodes/Cal/Cal.node.json
+++ b/packages/nodes-base/nodes/Cal/Cal.node.json
@@ -1,0 +1,18 @@
+{
+	"node": "n8n-nodes-base.cal",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["Productivity"],
+	"resources": {
+		"credentialDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/credentials/cal/"
+			}
+		],
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.cal/"
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Cal/Cal.node.ts
+++ b/packages/nodes-base/nodes/Cal/Cal.node.ts
@@ -1,0 +1,66 @@
+import { NodeConnectionTypes, type INodeType, type INodeTypeDescription } from 'n8n-workflow';
+
+import {
+	bookingFields,
+	bookingOperations,
+	eventTypeFields,
+	eventTypeOperations,
+} from './descriptions';
+
+export class Cal implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Cal.com',
+		name: 'cal',
+		icon: { light: 'file:cal.svg', dark: 'file:cal.dark.svg' },
+		group: ['transform'],
+		version: 1,
+		subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
+		description: 'Consume the Cal.com API',
+		defaults: {
+			name: 'Cal.com',
+		},
+		usableAsTool: true,
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
+		credentials: [
+			{
+				name: 'calApi',
+				required: true,
+			},
+		],
+		requestDefaults: {
+			// `host` is part of the existing Cal credential, so the same node
+			// serves Cal.com cloud and self-hosted instances.
+			baseURL: '={{ $credentials.host }}/v2',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			// `cal-api-version` is deliberately not set here. The stamp differs
+			// per endpoint, so each operation sets its own.
+		},
+		properties: [
+			{
+				displayName: 'Resource',
+				name: 'resource',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Booking',
+						value: 'booking',
+					},
+					{
+						name: 'Event Type',
+						value: 'eventType',
+					},
+				],
+				default: 'booking',
+			},
+			...bookingOperations,
+			...bookingFields,
+			...eventTypeOperations,
+			...eventTypeFields,
+		],
+	};
+}

--- a/packages/nodes-base/nodes/Cal/Cal.node.ts
+++ b/packages/nodes-base/nodes/Cal/Cal.node.ts
@@ -30,8 +30,12 @@ export class Cal implements INodeType {
 		],
 		requestDefaults: {
 			// `host` is part of the existing Cal credential, so the same node
-			// serves Cal.com cloud and self-hosted instances.
-			baseURL: '={{ $credentials.host }}/v2',
+			// serves Cal.com cloud and self-hosted instances. The trailing slash
+			// is stripped because `/v2` is appended here rather than passed as a
+			// relative URL, so a host saved as `https://cal.example.com/` would
+			// otherwise request `//v2/...` and 404 on some installations.
+			baseURL:
+				'={{ $credentials.host.endsWith("/") ? $credentials.host.slice(0, -1) : $credentials.host }}/v2',
 			headers: {
 				Accept: 'application/json',
 				'Content-Type': 'application/json',

--- a/packages/nodes-base/nodes/Cal/descriptions/BookingDescription.ts
+++ b/packages/nodes-base/nodes/Cal/descriptions/BookingDescription.ts
@@ -1,0 +1,265 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+const showOnlyForBookings = {
+	resource: ['booking'],
+};
+
+// The Cal.com API v2 pins breaking changes to a date-stamped header rather than
+// the URL, and the stamp differs per endpoint, so it is set per operation
+// instead of in `requestDefaults`. `/bookings` requires 2024-08-13; sending the
+// event-type stamp here returns the pre-2024-08-13 response shape.
+const BOOKINGS_API_VERSION = '2024-08-13';
+
+export const bookingOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: showOnlyForBookings,
+		},
+		options: [
+			{
+				name: 'Cancel',
+				value: 'cancel',
+				action: 'Cancel a booking',
+				description: 'Cancel an existing booking',
+				routing: {
+					request: {
+						method: 'POST',
+						url: '=/bookings/{{ $parameter.bookingUid }}/cancel',
+						headers: { 'cal-api-version': BOOKINGS_API_VERSION },
+					},
+					output: {
+						postReceive: [
+							{
+								type: 'rootProperty',
+								properties: {
+									property: 'data',
+								},
+							},
+						],
+					},
+				},
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				action: 'Get a booking',
+				description: 'Retrieve a single booking by its UID',
+				routing: {
+					request: {
+						method: 'GET',
+						url: '=/bookings/{{ $parameter.bookingUid }}',
+						headers: { 'cal-api-version': BOOKINGS_API_VERSION },
+					},
+					output: {
+						postReceive: [
+							{
+								type: 'rootProperty',
+								properties: {
+									property: 'data',
+								},
+							},
+						],
+					},
+				},
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				action: 'Get many bookings',
+				description: 'Retrieve many bookings',
+				routing: {
+					request: {
+						method: 'GET',
+						url: '/bookings',
+						headers: { 'cal-api-version': BOOKINGS_API_VERSION },
+					},
+					output: {
+						postReceive: [
+							{
+								type: 'rootProperty',
+								properties: {
+									property: 'data',
+								},
+							},
+						],
+					},
+					operations: {
+						pagination: {
+							type: 'offset',
+							properties: {
+								limitParameter: 'take',
+								offsetParameter: 'skip',
+								pageSize: 100,
+								type: 'query',
+							},
+						},
+					},
+				},
+			},
+		],
+		default: 'getAll',
+	},
+];
+
+const bookingGetAllFields: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				...showOnlyForBookings,
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+		routing: {
+			send: {
+				paginate: '={{ $value }}',
+			},
+		},
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		typeOptions: {
+			minValue: 1,
+		},
+		displayOptions: {
+			show: {
+				...showOnlyForBookings,
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		default: 50,
+		description: 'Max number of results to return',
+		routing: {
+			send: {
+				type: 'query',
+				property: 'take',
+			},
+		},
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'collection',
+		placeholder: 'Add Filter',
+		displayOptions: {
+			show: {
+				...showOnlyForBookings,
+				operation: ['getAll'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Attendee Email',
+				name: 'attendeeEmail',
+				type: 'string',
+				placeholder: 'name@email.com',
+				default: '',
+				description: 'Only return bookings whose attendee has this email address',
+				routing: {
+					send: {
+						type: 'query',
+						property: 'attendeeEmail',
+					},
+				},
+			},
+			{
+				displayName: 'Status',
+				name: 'status',
+				type: 'options',
+				options: [
+					{
+						name: 'Cancelled',
+						value: 'cancelled',
+					},
+					{
+						name: 'Past',
+						value: 'past',
+					},
+					{
+						name: 'Upcoming',
+						value: 'upcoming',
+					},
+				],
+				default: 'upcoming',
+				description: 'Only return bookings with this status',
+				routing: {
+					send: {
+						type: 'query',
+						property: 'status',
+					},
+				},
+			},
+		],
+	},
+];
+
+const bookingGetFields: INodeProperties[] = [
+	{
+		displayName: 'Booking UID',
+		name: 'bookingUid',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				...showOnlyForBookings,
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description: 'UID of the booking to retrieve',
+	},
+];
+
+const bookingCancelFields: INodeProperties[] = [
+	{
+		displayName: 'Booking UID',
+		name: 'bookingUid',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				...showOnlyForBookings,
+				operation: ['cancel'],
+			},
+		},
+		default: '',
+		description: 'UID of the booking to cancel',
+	},
+	{
+		displayName: 'Cancellation Reason',
+		name: 'cancellationReason',
+		type: 'string',
+		displayOptions: {
+			show: {
+				...showOnlyForBookings,
+				operation: ['cancel'],
+			},
+		},
+		default: '',
+		description: 'Reason for the cancellation, shown to the attendee',
+		routing: {
+			send: {
+				type: 'body',
+				property: 'cancellationReason',
+			},
+		},
+	},
+];
+
+export const bookingFields: INodeProperties[] = [
+	...bookingGetAllFields,
+	...bookingGetFields,
+	...bookingCancelFields,
+];

--- a/packages/nodes-base/nodes/Cal/descriptions/EventTypeDescription.ts
+++ b/packages/nodes-base/nodes/Cal/descriptions/EventTypeDescription.ts
@@ -1,0 +1,126 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+const showOnlyForEventTypes = {
+	resource: ['eventType'],
+};
+
+// `/event-types` is not on the same API-version stamp as `/bookings`: it returns
+// 404 for 2024-08-13 and expects 2024-06-14, which is why the header is set per
+// operation rather than in `requestDefaults`.
+const EVENT_TYPES_API_VERSION = '2024-06-14';
+
+export const eventTypeOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: showOnlyForEventTypes,
+		},
+		options: [
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				action: 'Get many event types',
+				description: 'Retrieve the event types that can be booked on this account',
+				routing: {
+					request: {
+						method: 'GET',
+						url: '/event-types',
+						headers: { 'cal-api-version': EVENT_TYPES_API_VERSION },
+					},
+					output: {
+						postReceive: [
+							{
+								type: 'rootProperty',
+								properties: {
+									property: 'data',
+								},
+							},
+						],
+					},
+				},
+			},
+		],
+		default: 'getAll',
+	},
+];
+
+const eventTypeGetAllFields: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				...showOnlyForEventTypes,
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		// `/event-types` returns the full set in one response and takes no
+		// offset parameters, so the limit is applied to the returned items
+		// rather than sent to the API.
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		typeOptions: {
+			minValue: 1,
+		},
+		displayOptions: {
+			show: {
+				...showOnlyForEventTypes,
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		default: 50,
+		description: 'Max number of results to return',
+		routing: {
+			output: {
+				postReceive: [
+					{
+						type: 'limit',
+						properties: {
+							maxResults: '={{ $value }}',
+						},
+					},
+				],
+			},
+		},
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'collection',
+		placeholder: 'Add Filter',
+		displayOptions: {
+			show: {
+				...showOnlyForEventTypes,
+				operation: ['getAll'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Username',
+				name: 'username',
+				type: 'string',
+				default: '',
+				description: 'Only return event types belonging to this Cal.com username',
+				routing: {
+					send: {
+						type: 'query',
+						property: 'username',
+					},
+				},
+			},
+		],
+	},
+];
+
+export const eventTypeFields: INodeProperties[] = [...eventTypeGetAllFields];

--- a/packages/nodes-base/nodes/Cal/descriptions/index.ts
+++ b/packages/nodes-base/nodes/Cal/descriptions/index.ts
@@ -1,0 +1,2 @@
+export { bookingFields, bookingOperations } from './BookingDescription';
+export { eventTypeFields, eventTypeOperations } from './EventTypeDescription';

--- a/packages/nodes-base/nodes/Cal/test/Cal.node.test.ts
+++ b/packages/nodes-base/nodes/Cal/test/Cal.node.test.ts
@@ -1,0 +1,105 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+const BASE_URL = 'https://api.cal.com';
+
+const credentials = {
+	calApi: {
+		apiKey: 'test-api-key',
+		host: BASE_URL,
+	},
+};
+
+const bookingOne = {
+	uid: 'bk_one',
+	title: '30 Min Meeting between Tai and Ada',
+	status: 'upcoming',
+	start: '2026-09-01T01:00:00.000Z',
+	end: '2026-09-01T01:30:00.000Z',
+	attendees: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
+};
+
+const bookingTwo = {
+	uid: 'bk_two',
+	title: 'Intro Call between Tai and Grace',
+	status: 'upcoming',
+	start: '2026-09-02T03:00:00.000Z',
+	end: '2026-09-02T03:30:00.000Z',
+	attendees: [{ name: 'Grace Hopper', email: 'grace@example.com' }],
+};
+
+describe('Cal.com Node', () => {
+	describe('Booking', () => {
+		beforeEach(() => {
+			// `take` comes from the Limit field; `skip` is absent because
+			// pagination is off when Return All is false.
+			nock(BASE_URL)
+				.get('/v2/bookings')
+				.query({ status: 'upcoming', take: '2' })
+				.matchHeader('cal-api-version', '2024-08-13')
+				.reply(200, {
+					status: 'success',
+					data: [bookingOne, bookingTwo],
+					pagination: { totalItems: 2, remainingItems: 0 },
+				});
+
+			// Return All switches on offset pagination, which sends the page size
+			// as `take` and starts at `skip=0`. A short page ends the run.
+			nock(BASE_URL)
+				.get('/v2/bookings')
+				.query({ status: 'upcoming', take: '100', skip: '0' })
+				.matchHeader('cal-api-version', '2024-08-13')
+				.reply(200, {
+					status: 'success',
+					data: [bookingOne, bookingTwo],
+					pagination: { totalItems: 2, remainingItems: 0 },
+				});
+
+			nock(BASE_URL)
+				.get('/v2/bookings/bk_one')
+				.matchHeader('cal-api-version', '2024-08-13')
+				.reply(200, { status: 'success', data: bookingOne });
+
+			nock(BASE_URL)
+				.post('/v2/bookings/bk_one/cancel', { cancellationReason: 'Rescheduling' })
+				.matchHeader('cal-api-version', '2024-08-13')
+				.reply(200, {
+					status: 'success',
+					data: { uid: 'bk_one', status: 'cancelled', cancellationReason: 'Rescheduling' },
+				});
+		});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: [
+				'getAllBookings.workflow.json',
+				'getAllBookingsReturnAll.workflow.json',
+				'getBooking.workflow.json',
+				'cancelBooking.workflow.json',
+			],
+			credentials,
+		});
+	});
+
+	describe('Event Type', () => {
+		beforeEach(() => {
+			// `/event-types` rejects the 2024-08-13 stamp that `/bookings` requires,
+			// so the version header is pinned separately here.
+			nock(BASE_URL)
+				.get('/v2/event-types')
+				.query({ username: 'tai' })
+				.matchHeader('cal-api-version', '2024-06-14')
+				.reply(200, {
+					status: 'success',
+					data: [
+						{ id: 1001, title: '30 Min Meeting', slug: '30min', lengthInMinutes: 30 },
+						{ id: 1002, title: '60 Min Meeting', slug: '60min', lengthInMinutes: 60 },
+					],
+				});
+		});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['getAllEventTypes.workflow.json'],
+			credentials,
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Cal/test/Cal.node.test.ts
+++ b/packages/nodes-base/nodes/Cal/test/Cal.node.test.ts
@@ -80,6 +80,27 @@ describe('Cal.com Node', () => {
 		});
 	});
 
+	describe('Self-hosted host with a trailing slash', () => {
+		beforeEach(() => {
+			nock(BASE_URL)
+				.get('/v2/bookings/bk_one')
+				.matchHeader('cal-api-version', '2024-08-13')
+				.reply(200, { status: 'success', data: bookingOne });
+		});
+
+		// `/v2` is appended to the credential host, so a host saved with a
+		// trailing slash would request `//v2/bookings/...` without the strip.
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['getBookingTrailingSlashHost.workflow.json'],
+			credentials: {
+				calApi: {
+					apiKey: 'test-api-key',
+					host: `${BASE_URL}/`,
+				},
+			},
+		});
+	});
+
 	describe('Event Type', () => {
 		beforeEach(() => {
 			// `/event-types` rejects the 2024-08-13 stamp that `/bookings` requires,

--- a/packages/nodes-base/nodes/Cal/test/cancelBooking.workflow.json
+++ b/packages/nodes-base/nodes/Cal/test/cancelBooking.workflow.json
@@ -1,0 +1,36 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"resource": "booking",
+				"operation": "cancel",
+				"bookingUid": "bk_one",
+				"cancellationReason": "Rescheduling",
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.cal",
+			"typeVersion": 1,
+			"position": [200, 200],
+			"id": "aa11bb22-cc33-4dd4-8ee5-ff6600112233",
+			"name": "Cal.com",
+			"credentials": {
+				"calApi": {
+					"id": "testId",
+					"name": "Cal account"
+				}
+			}
+		}
+	],
+	"connections": {},
+	"pinData": {
+		"Cal.com": [
+			{
+				"json": {
+					"uid": "bk_one",
+					"status": "cancelled",
+					"cancellationReason": "Rescheduling"
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Cal/test/getAllBookings.workflow.json
+++ b/packages/nodes-base/nodes/Cal/test/getAllBookings.workflow.json
@@ -1,0 +1,62 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"resource": "booking",
+				"operation": "getAll",
+				"returnAll": false,
+				"limit": 2,
+				"filters": {
+					"status": "upcoming"
+				},
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.cal",
+			"typeVersion": 1,
+			"position": [200, 200],
+			"id": "8a5a5c3e-6f8e-4a9f-9a9d-1f1f2a3b4c5d",
+			"name": "Cal.com",
+			"credentials": {
+				"calApi": {
+					"id": "testId",
+					"name": "Cal account"
+				}
+			}
+		}
+	],
+	"connections": {},
+	"pinData": {
+		"Cal.com": [
+			{
+				"json": {
+					"uid": "bk_one",
+					"title": "30 Min Meeting between Tai and Ada",
+					"status": "upcoming",
+					"start": "2026-09-01T01:00:00.000Z",
+					"end": "2026-09-01T01:30:00.000Z",
+					"attendees": [
+						{
+							"name": "Ada Lovelace",
+							"email": "ada@example.com"
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"uid": "bk_two",
+					"title": "Intro Call between Tai and Grace",
+					"status": "upcoming",
+					"start": "2026-09-02T03:00:00.000Z",
+					"end": "2026-09-02T03:30:00.000Z",
+					"attendees": [
+						{
+							"name": "Grace Hopper",
+							"email": "grace@example.com"
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Cal/test/getAllBookingsReturnAll.workflow.json
+++ b/packages/nodes-base/nodes/Cal/test/getAllBookingsReturnAll.workflow.json
@@ -1,0 +1,61 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"resource": "booking",
+				"operation": "getAll",
+				"returnAll": true,
+				"filters": {
+					"status": "upcoming"
+				},
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.cal",
+			"typeVersion": 1,
+			"position": [200, 200],
+			"id": "8a5a5c3e-6f8e-4a9f-9a9d-1f1f2a3b4c5d",
+			"name": "Cal.com",
+			"credentials": {
+				"calApi": {
+					"id": "testId",
+					"name": "Cal account"
+				}
+			}
+		}
+	],
+	"connections": {},
+	"pinData": {
+		"Cal.com": [
+			{
+				"json": {
+					"uid": "bk_one",
+					"title": "30 Min Meeting between Tai and Ada",
+					"status": "upcoming",
+					"start": "2026-09-01T01:00:00.000Z",
+					"end": "2026-09-01T01:30:00.000Z",
+					"attendees": [
+						{
+							"name": "Ada Lovelace",
+							"email": "ada@example.com"
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"uid": "bk_two",
+					"title": "Intro Call between Tai and Grace",
+					"status": "upcoming",
+					"start": "2026-09-02T03:00:00.000Z",
+					"end": "2026-09-02T03:30:00.000Z",
+					"attendees": [
+						{
+							"name": "Grace Hopper",
+							"email": "grace@example.com"
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Cal/test/getAllEventTypes.workflow.json
+++ b/packages/nodes-base/nodes/Cal/test/getAllEventTypes.workflow.json
@@ -1,0 +1,40 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"resource": "eventType",
+				"operation": "getAll",
+				"returnAll": false,
+				"limit": 1,
+				"filters": {
+					"username": "tai"
+				},
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.cal",
+			"typeVersion": 1,
+			"position": [200, 200],
+			"id": "dd44ee55-ff66-4778-8899-aabbccddeeff",
+			"name": "Cal.com",
+			"credentials": {
+				"calApi": {
+					"id": "testId",
+					"name": "Cal account"
+				}
+			}
+		}
+	],
+	"connections": {},
+	"pinData": {
+		"Cal.com": [
+			{
+				"json": {
+					"id": 1001,
+					"title": "30 Min Meeting",
+					"slug": "30min",
+					"lengthInMinutes": 30
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Cal/test/getBooking.workflow.json
+++ b/packages/nodes-base/nodes/Cal/test/getBooking.workflow.json
@@ -1,0 +1,43 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"resource": "booking",
+				"operation": "get",
+				"bookingUid": "bk_one",
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.cal",
+			"typeVersion": 1,
+			"position": [200, 200],
+			"id": "3c2b1a09-8877-4655-9433-2211aabbccdd",
+			"name": "Cal.com",
+			"credentials": {
+				"calApi": {
+					"id": "testId",
+					"name": "Cal account"
+				}
+			}
+		}
+	],
+	"connections": {},
+	"pinData": {
+		"Cal.com": [
+			{
+				"json": {
+					"uid": "bk_one",
+					"title": "30 Min Meeting between Tai and Ada",
+					"status": "upcoming",
+					"start": "2026-09-01T01:00:00.000Z",
+					"end": "2026-09-01T01:30:00.000Z",
+					"attendees": [
+						{
+							"name": "Ada Lovelace",
+							"email": "ada@example.com"
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Cal/test/getBookingTrailingSlashHost.workflow.json
+++ b/packages/nodes-base/nodes/Cal/test/getBookingTrailingSlashHost.workflow.json
@@ -1,0 +1,43 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"resource": "booking",
+				"operation": "get",
+				"bookingUid": "bk_one",
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.cal",
+			"typeVersion": 1,
+			"position": [200, 200],
+			"id": "bb22cc33-dd44-4ee5-9ff6-001122334455",
+			"name": "Cal.com",
+			"credentials": {
+				"calApi": {
+					"id": "testId",
+					"name": "Cal account"
+				}
+			}
+		}
+	],
+	"connections": {},
+	"pinData": {
+		"Cal.com": [
+			{
+				"json": {
+					"uid": "bk_one",
+					"title": "30 Min Meeting between Tai and Ada",
+					"status": "upcoming",
+					"start": "2026-09-01T01:00:00.000Z",
+					"end": "2026-09-01T01:30:00.000Z",
+					"attendees": [
+						{
+							"name": "Ada Lovelace",
+							"email": "ada@example.com"
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -488,6 +488,7 @@
       "dist/nodes/Box/BoxTrigger.node.js",
       "dist/nodes/Brandfetch/Brandfetch.node.js",
       "dist/nodes/Bubble/Bubble.node.js",
+      "dist/nodes/Cal/Cal.node.js",
       "dist/nodes/Cal/CalTrigger.node.js",
       "dist/nodes/Calendly/CalendlyTrigger.node.js",
       "dist/nodes/Chargebee/Chargebee.node.js",


### PR DESCRIPTION
Related: https://community.n8n.io/t/nos-para-o-cal-com-principalmente-para-ferramentas-de-agentes-de-ia/82539

## Summary

Adds a Cal.com **action** node to `nodes-base`, alongside the existing `CalTrigger`.

n8n currently supports Cal.com as a webhook trigger only — `packages/nodes-base/package.json` registers a single Cal entry, `dist/nodes/Cal/CalTrigger.node.js`, and there is no `Cal.node.js`. A workflow can be *woken* by a Cal.com booking but cannot read, look up, or cancel one.

This PR adds `Cal.node.ts`: declarative, `usableAsTool`, covering

| Resource | Operations |
|---|---|
| Booking | Get Many, Get, Cancel |
| Event Type | Get Many |

against Cal API v2.

**It reuses the existing `calApi` credential.** No new credential type, and no change to `CalTrigger` or `GenericFunctions.ts`. `calApi` already carries `host`, so the same node serves Cal.com cloud and self-hosted instances.

## Two API details worth flagging

Both were found against the live API and neither is in the Cal.com docs. They are the reason two things in this PR look unusual, so they're called out in code comments as well:

1. **`cal-api-version` cannot be set globally.** `/bookings` requires `2024-08-13`. `/event-types` returns **404** for that stamp and requires `2024-06-14`. The header is therefore set per operation rather than in `requestDefaults`.
2. **Responses are wrapped as `{status, data, pagination}`.** Without `rootProperty: data`, the node emits one item holding the whole envelope instead of one item per record.

## Pagination

`Return All` on bookings uses offset pagination over `take`/`skip`. `/event-types` takes no offset parameters and returns the full set in one response, so its limit is applied to the returned items via a `limit` post-receive action instead of being sent to the API.

## Tests

Five `NodeTestHarness` workflows under `nodes/Cal/test/`, with nock mocks that assert the per-endpoint `cal-api-version` header — that's the part most likely to regress silently, since the wrong stamp 404s rather than returning a different shape.

```
✓ nodes/Cal/test/Cal.node.test.ts (5 tests)
Test Files  8 passed (8)     # incl. the existing Cal + Calendly trigger suites
     Tests  50 passed (50)
```

`pnpm --filter n8n-nodes-base typecheck` and `eslint nodes/Cal` both pass (0 errors). The only lint warnings are the camelCase naming rule firing on HTTP header names — `CalTriggerV2.node.ts` already carries the identical warning.

## Context

Opened at the request of the nodes team, cc @garritfra, following the community-node review of `n8n-nodes-calcom`. That package was rejected under the no-duplicate-node rule against `packages/nodes-base/nodes/Cal/`; on review the team confirmed the gap was the missing action node and invited a PR against `nodes-base` instead. I'll deprecate the standalone package if this lands.

## Open questions for review

- Happy to widen or narrow the operation list — this is the set already verified against the live API, not an opinion about where to stop.
- If you'd prefer the descriptions flat in `nodes/Cal/` rather than in `descriptions/`, say the word; I followed the `Gong`/`Microsoft Entra` layout.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

