### PR TITLE
feat(editor): Align workflow and agent header menus

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { computed, onBeforeUnmount, onMounted, ref, useCssModule, useTemplateRef } from 'vue';
-import { type ActionDropdownItem, N8nActionDropdown } from '@n8n/design-system';
+import { N8nDropdownMenu, N8nIconButton, type DropdownMenuItemProps } from '@n8n/design-system';
 import WorkflowProductionChecklist from '@/app/components/WorkflowProductionChecklist.vue';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client';
 import { useToast } from '@n8n/composables/useToast';
@@ -88,6 +88,17 @@ const isSharingEnabled = computed(
 	() => settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing],
 );
 
+function addWorkflowMenuTestIds(
+	item: DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS>,
+): DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS> {
+	return {
+		...item,
+		testId: `workflow-menu-item-${item.id}`,
+		class: [item.class, item.disabled ? 'disabled' : undefined],
+		children: item.children?.map(addWorkflowMenuTestIds),
+	};
+}
+
 function handleFileImport() {
 	const inputRef = importFileRef.value;
 	if (inputRef?.files && inputRef.files.length !== 0) {
@@ -114,7 +125,7 @@ function handleFileImport() {
 	}
 }
 
-const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTIONS>>>(() => {
+const workflowMenuItems = computed<Array<DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS>>>(() => {
 	const canEdit =
 		(props.workflowPermissions.update === true &&
 			!collaborationReadOnly.value &&
@@ -122,7 +133,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 			!sourceControlStore.preferences.branchReadOnly) ||
 		props.isNewWorkflow;
 
-	const nameAndMetadata: Array<ActionDropdownItem<WORKFLOW_MENU_ACTIONS>> = [];
+	const nameAndMetadata: Array<DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS>> = [];
 
 	if (
 		!collaborationReadOnly.value &&
@@ -132,6 +143,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		nameAndMetadata.push({
 			id: WORKFLOW_MENU_ACTIONS.RENAME,
 			label: locale.baseText('generic.rename'),
+			icon: { type: 'icon', value: 'pencil' },
 			disabled: props.workflowPermissions.update !== true,
 		});
 	}
@@ -140,6 +152,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		nameAndMetadata.push({
 			id: WORKFLOW_MENU_ACTIONS.EDIT_DESCRIPTION,
 			label: locale.baseText('menuActions.editDescriptionAndTags'),
+			icon: { type: 'icon', value: 'tags' },
 			disabled: !props.id,
 		});
 	}
@@ -149,15 +162,17 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		label: favoritesStore.isFavorite(props.id, 'workflow')
 			? locale.baseText('favorites.remove')
 			: locale.baseText('favorites.add'),
+		icon: { type: 'icon', value: 'star' },
 		disabled: props.isNewWorkflow,
 	});
 
-	const organization: Array<ActionDropdownItem<WORKFLOW_MENU_ACTIONS>> = [];
+	const organization: Array<DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS>> = [];
 
 	if (props.workflowPermissions.move && projectsStore.isTeamProjectFeatureEnabled) {
 		organization.push({
 			id: WORKFLOW_MENU_ACTIONS.CHANGE_OWNER,
 			label: locale.baseText('workflows.item.changeOwner'),
+			icon: { type: 'icon', value: 'corner-up-right' },
 			disabled: props.isNewWorkflow,
 		});
 	}
@@ -166,6 +181,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		organization.push({
 			id: WORKFLOW_MENU_ACTIONS.DUPLICATE,
 			label: locale.baseText('menuActions.duplicate'),
+			icon: { type: 'icon', value: 'copy' },
 			disabled: !props.id,
 		});
 	}
@@ -174,13 +190,15 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		organization.push({
 			id: WORKFLOW_MENU_ACTIONS.SHARE,
 			label: locale.baseText('workflowDetails.share'),
+			icon: { type: 'icon', value: 'share' },
 		});
 	}
 
-	const importExport: Array<ActionDropdownItem<WORKFLOW_MENU_ACTIONS>> = [
+	const importExport: Array<DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS>> = [
 		{
 			id: WORKFLOW_MENU_ACTIONS.DOWNLOAD,
 			label: locale.baseText('menuActions.exportJson'),
+			icon: { type: 'icon', value: 'download' },
 		},
 	];
 
@@ -188,16 +206,19 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		importExport.push({
 			id: WORKFLOW_MENU_ACTIONS.IMPORT,
 			label: locale.baseText('menuActions.import'),
+			icon: { type: 'icon', value: 'upload' },
 			disabled: onExecutionsTab.value,
 			children: [
 				{
 					id: WORKFLOW_MENU_ACTIONS.IMPORT_FROM_URL,
 					label: locale.baseText('menuActions.importFromUrl'),
+					icon: { type: 'icon', value: 'link' },
 					disabled: onExecutionsTab.value,
 				},
 				{
 					id: WORKFLOW_MENU_ACTIONS.IMPORT_FROM_FILE,
 					label: locale.baseText('menuActions.importFromFile'),
+					icon: { type: 'icon', value: 'file-input' },
 					disabled: onExecutionsTab.value,
 				},
 			],
@@ -208,6 +229,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		importExport.push({
 			id: WORKFLOW_MENU_ACTIONS.PUSH,
 			label: locale.baseText('menuActions.push'),
+			icon: { type: 'icon', value: 'git-branch' },
 			disabled:
 				!sourceControlStore.isEnterpriseSourceControlEnabled ||
 				onExecutionsTab.value ||
@@ -215,15 +237,17 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		});
 	}
 
-	const workflowTools: Array<ActionDropdownItem<WORKFLOW_MENU_ACTIONS>> = [
+	const workflowTools: Array<DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS>> = [
 		{
 			id: WORKFLOW_MENU_ACTIONS.VERSION_HISTORY,
 			label: locale.baseText('menuActions.versionHistory'),
+			icon: { type: 'icon', value: 'history' },
 			disabled: props.isNewWorkflow,
 		},
 		{
 			id: WORKFLOW_MENU_ACTIONS.SETTINGS,
 			label: locale.baseText('generic.settings'),
+			icon: { type: 'icon', value: 'settings' },
 			disabled: props.isNewWorkflow,
 		},
 	];
@@ -232,10 +256,11 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		workflowTools.push({
 			id: WORKFLOW_MENU_ACTIONS.PRODUCTION_CHECKLIST,
 			label: locale.baseText('menuActions.productionChecklist'),
+			icon: { type: 'icon', value: 'list-checks' },
 		});
 	}
 
-	const lifecycle: Array<ActionDropdownItem<WORKFLOW_MENU_ACTIONS>> = [];
+	const lifecycle: Array<DropdownMenuItemProps<WORKFLOW_MENU_ACTIONS>> = [];
 
 	if (
 		(props.workflowPermissions.delete === true &&
@@ -247,20 +272,23 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 			lifecycle.push({
 				id: WORKFLOW_MENU_ACTIONS.UNARCHIVE,
 				label: locale.baseText('menuActions.unarchive'),
+				icon: { type: 'icon', value: 'archive-restore' },
 				disabled: props.isNewWorkflow,
 			});
 			lifecycle.push({
 				id: WORKFLOW_MENU_ACTIONS.DELETE,
 				label: locale.baseText('menuActions.delete'),
+				icon: { type: 'icon', value: 'trash-2' },
 				disabled: props.isNewWorkflow,
-				customClass: $style.deleteItem,
+				class: $style.deleteItem,
 			});
 		} else {
 			lifecycle.push({
 				id: WORKFLOW_MENU_ACTIONS.ARCHIVE,
 				label: locale.baseText('menuActions.archive'),
+				icon: { type: 'icon', value: 'archive' },
 				disabled: props.isNewWorkflow,
-				customClass: $style.deleteItem,
+				class: $style.deleteItem,
 			});
 		}
 	}
@@ -270,9 +298,11 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 	);
 
 	// A separator above the first item of every group but the first.
-	return groups.flatMap((group, index) =>
-		index === 0 ? group : group.map((item, i) => (i === 0 ? { ...item, divided: true } : item)),
-	);
+	return groups
+		.flatMap((group, index) =>
+			index === 0 ? group : group.map((item, i) => (i === 0 ? { ...item, divided: true } : item)),
+		)
+		.map(addWorkflowMenuTestIds);
 });
 
 function openDescriptionAndTagsModal(): void {
@@ -493,14 +523,24 @@ defineExpose({
 		<span :class="$style.checklistAnchor">
 			<WorkflowProductionChecklist v-if="!isNewWorkflow" ref="productionChecklist" hide-trigger />
 		</span>
-		<N8nActionDropdown
+		<N8nDropdownMenu
 			:items="workflowMenuItems"
 			data-test-id="workflow-menu"
+			content-test-id="workflow-menu"
 			placement="bottom-start"
-			activator-icon-size="large"
 			max-height="var(--reka-dropdown-menu-content-available-height)"
 			@select="onWorkflowMenuSelect"
-		/>
+		>
+			<template #trigger>
+				<N8nIconButton
+					variant="ghost"
+					size="medium"
+					icon="ellipsis"
+					icon-size="large"
+					:aria-label="locale.baseText('node.moreActions')"
+				/>
+			</template>
+		</N8nDropdownMenu>
 	</div>
 </template>
 <style lang="scss" module>

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
@@ -280,7 +280,7 @@ const workflowMenuItems = computed<Array<DropdownMenuItemProps<WORKFLOW_MENU_ACT
 				label: locale.baseText('menuActions.delete'),
 				icon: { type: 'icon', value: 'trash-2' },
 				disabled: props.isNewWorkflow,
-				class: $style.deleteItem,
+				class: $style.destructiveItem,
 			});
 		} else {
 			lifecycle.push({
@@ -288,7 +288,7 @@ const workflowMenuItems = computed<Array<DropdownMenuItemProps<WORKFLOW_MENU_ACT
 				label: locale.baseText('menuActions.archive'),
 				icon: { type: 'icon', value: 'archive' },
 				disabled: props.isNewWorkflow,
-				class: $style.deleteItem,
+				class: $style.destructiveItem,
 			});
 		}
 	}
@@ -544,8 +544,9 @@ defineExpose({
 	</div>
 </template>
 <style lang="scss" module>
-.deleteItem {
-	color: var(--color--danger);
+.destructiveItem,
+.destructiveItem * {
+	color: var(--text-color--danger) !important;
 }
 .group {
 	display: flex;

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
@@ -93,15 +93,17 @@ import AgentBuilderHeader from '../components/AgentBuilderHeader.vue';
 
 type DropdownStubWrapper = VueWrapper<{
 	items: Array<{ id: string; label?: string; disabled?: boolean }>;
+	extraPopperClass?: string;
 	$options: unknown;
 	$emit: (event: 'select', value: string) => void;
 }>;
 
+function getDropdown(wrapper: ReturnType<typeof mountHeader>, testId: string) {
+	return wrapper.getComponent(`[data-testid="${testId}"]`) as DropdownStubWrapper;
+}
+
 function getSwitcherOptions(wrapper: ReturnType<typeof mountHeader>) {
-	const switcher = wrapper.findComponent(
-		'[data-testid="agent-header-switcher"]',
-	) as DropdownStubWrapper;
-	return switcher.vm.items;
+	return getDropdown(wrapper, 'agent-header-switcher').vm.items;
 }
 
 const baseAgent = {
@@ -203,8 +205,8 @@ describe('AgentBuilderHeader', () => {
 
 	it('widens the header action menu so labels are readable from the icon trigger', () => {
 		const wrapper = mountHeader({ headerActions: [{ id: 'delete', label: 'Delete agent' }] });
-		const action = wrapper.getComponent('[data-testid="agent-header-actions"]');
-		expect(action.props('extraPopperClass')).toBeTruthy();
+		const action = getDropdown(wrapper, 'agent-header-actions');
+		expect(action.vm.extraPopperClass).toBeTruthy();
 	});
 
 	it('hides the action dropdown when no header actions are available', () => {
@@ -289,7 +291,7 @@ describe('AgentBuilderHeader', () => {
 
 	it('forwards header-action from the action menu', () => {
 		const wrapper = mountHeader({ headerActions: [{ id: 'delete', label: 'Delete' }] });
-		const action = wrapper.getComponent('[data-testid="agent-header-actions"]');
+		const action = getDropdown(wrapper, 'agent-header-actions');
 		action.vm.$emit('select', 'delete');
 		expect(wrapper.emitted('header-action')).toEqual([['delete']]);
 	});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
@@ -72,13 +72,13 @@ vi.mock('@n8n/design-system', () => ({
 	N8nDropdownMenu: {
 		name: 'N8nDropdownMenu',
 		template: '<div v-bind="$attrs"><slot name="trigger" /><slot name="footer" /></div>',
-		props: ['items'],
+		props: ['items', 'placement', 'extraPopperClass'],
 		emits: ['select'],
 	},
 	'n8n-dropdown-menu': {
 		name: 'N8nDropdownMenu',
 		template: '<div v-bind="$attrs"><slot name="trigger" /><slot name="footer" /></div>',
-		props: ['items'],
+		props: ['items', 'placement', 'extraPopperClass'],
 		emits: ['select'],
 	},
 	N8nActionDropdown: {
@@ -197,13 +197,13 @@ describe('AgentBuilderHeader', () => {
 
 	it('uses the horizontal dots action menu icon', () => {
 		const wrapper = mountHeader({ headerActions: [{ id: 'delete', label: 'Delete' }] });
-		const action = wrapper.findComponent({ name: 'ActionDropdown' });
-		expect(action.props('activatorIcon')).toBe('ellipsis');
+		const action = wrapper.get('[data-testid="agent-header-actions"]');
+		expect(action.get('button').attributes('data-icon')).toBe('ellipsis');
 	});
 
 	it('widens the header action menu so labels are readable from the icon trigger', () => {
 		const wrapper = mountHeader({ headerActions: [{ id: 'delete', label: 'Delete agent' }] });
-		const action = wrapper.findComponent({ name: 'ActionDropdown' });
+		const action = wrapper.getComponent('[data-testid="agent-header-actions"]');
 		expect(action.props('extraPopperClass')).toBeTruthy();
 	});
 
@@ -287,9 +287,9 @@ describe('AgentBuilderHeader', () => {
 		expect(wrapper.emitted('reverted')).toBeTruthy();
 	});
 
-	it('forwards header-action from the action dropdown', async () => {
+	it('forwards header-action from the action menu', () => {
 		const wrapper = mountHeader({ headerActions: [{ id: 'delete', label: 'Delete' }] });
-		const action = wrapper.findComponent({ name: 'ActionDropdown' });
+		const action = wrapper.getComponent('[data-testid="agent-header-actions"]');
 		action.vm.$emit('select', 'delete');
 		expect(wrapper.emitted('header-action')).toEqual([['delete']]);
 	});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
@@ -10,7 +10,6 @@ import { computed, onMounted } from 'vue';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
 import type { AgentConfigValidationIssue } from '@n8n/api-types';
 import {
-	N8nActionDropdown,
 	N8nBreadcrumbs,
 	N8nButton,
 	N8nDropdownMenu,
@@ -39,7 +38,6 @@ const props = defineProps<{
 	headerActions: Array<ActionDropdownItem<string>>;
 	saveStatus?: 'idle' | 'saving' | 'saved';
 	beforeRevertToPublished?: () => Promise<void> | void;
-	isVersionHistoryOpen?: boolean;
 	artifactMode?: boolean;
 	isPreviewOpen?: boolean;
 	/** True while the AI is actively building/mutating this agent in artifact mode — disables publish/revert/unpublish without hiding them. */
@@ -137,7 +135,16 @@ function onPreviewClick() {
 // Disabled until the agent has at least one publish history row. The flag
 // is set by the backend (see AgentsService.hasPublishHistory) so it stays
 // true after an unpublish, when activeVersionId is null but rows persist.
-const isVersionHistoryDisabled = computed(() => !props.agent?.hasPublishHistory);
+const menuItems = computed<Array<DropdownMenuItemProps<string>>>(() =>
+	props.headerActions.map((action) => ({
+		...action,
+		icon: { type: 'icon', value: action.icon ?? 'file' },
+	})),
+);
+
+function onMenuSelect(id: string) {
+	emit('header-action', id);
+}
 </script>
 
 <template>
@@ -180,6 +187,24 @@ const isVersionHistoryDisabled = computed(() => !props.agent?.hasPublishHistory)
 									@select="onCreateAgent"
 								/>
 							</div>
+						</template>
+					</N8nDropdownMenu>
+					<N8nDropdownMenu
+						v-if="!props.artifactMode && menuItems.length > 0"
+						:items="menuItems"
+						placement="bottom-start"
+						:extra-popper-class="$style.headerActionsMenu"
+						data-testid="agent-header-actions"
+						@select="onMenuSelect"
+					>
+						<template #trigger>
+							<N8nButton
+								variant="ghost"
+								size="medium"
+								icon="ellipsis"
+								icon-only
+								:aria-label="i18n.baseText('node.moreActions')"
+							/>
 						</template>
 					</N8nDropdownMenu>
 				</template>
@@ -226,34 +251,6 @@ const isVersionHistoryDisabled = computed(() => !props.agent?.hasPublishHistory)
 				@published="(a: AgentResource) => emit('published', a)"
 				@unpublished="(a: AgentResource) => emit('unpublished', a)"
 				@reverted="(a: AgentResource) => emit('reverted', a)"
-			/>
-			<N8nTooltip v-if="!props.artifactMode" placement="bottom">
-				<template #content>
-					<span v-if="isVersionHistoryDisabled">{{
-						i18n.baseText('agents.versionHistory.button.tooltip.empty')
-					}}</span>
-					<span v-else>{{ i18n.baseText('agents.versionHistory.title') }}</span>
-				</template>
-				<N8nButton
-					variant="ghost"
-					size="medium"
-					icon="history"
-					icon-only
-					:class="{ [$style.activeButton]: isVersionHistoryOpen }"
-					:disabled="isVersionHistoryDisabled"
-					:aria-label="i18n.baseText('agents.versionHistory.button.ariaLabel')"
-					data-testid="agent-header-version-history-btn"
-					@click="emit('toggle-version-history')"
-				/>
-			</N8nTooltip>
-			<N8nActionDropdown
-				v-if="!props.artifactMode && headerActions.length > 0"
-				:items="headerActions"
-				activator-icon="ellipsis"
-				activator-size="medium"
-				:extra-popper-class="$style.headerActionsMenu"
-				data-testid="agent-header-actions"
-				@select="(item: string) => emit('header-action', item)"
 			/>
 		</div>
 	</header>
@@ -340,10 +337,6 @@ const isVersionHistoryDisabled = computed(() => !props.agent?.hasPublishHistory)
 	font-size: var(--font-size--2xs);
 	color: var(--text-color--subtle);
 	user-select: none;
-}
-
-.activeButton {
-	background-color: var(--background--active);
 }
 
 .headerActionsMenu {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
@@ -132,15 +132,28 @@ function onPreviewClick() {
 	if (!isPreviewDisabled.value) emit('open-preview');
 }
 
-// Disabled until the agent has at least one publish history row. The flag
-// is set by the backend (see AgentsService.hasPublishHistory) so it stays
-// true after an unpublish, when activeVersionId is null but rows persist.
-const menuItems = computed<Array<DropdownMenuItemProps<string>>>(() =>
-	props.headerActions.map((action) => ({
-		...action,
+/**
+ * Converts an action item and its children to the dropdown menu format.
+ */
+function toMenuItem(
+	action: ActionDropdownItem<string>,
+): DropdownMenuItemProps<string, ActionDropdownItem<string>> {
+	return {
+		id: action.id,
+		label: action.label,
+		testId: action.testId,
 		icon: { type: 'icon', value: action.icon ?? 'file' },
+		disabled: action.disabled,
+		divided: action.divided,
+		checked: action.checked,
 		class: action.id === 'delete' ? $style.destructiveItem : undefined,
-	})),
+		data: action,
+		children: action.children?.map(toMenuItem),
+	};
+}
+
+const menuItems = computed<Array<DropdownMenuItemProps<string, ActionDropdownItem<string>>>>(() =>
+	props.headerActions.map(toMenuItem),
 );
 
 function onMenuSelect(id: string) {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
@@ -6,7 +6,7 @@
  * Navigation intents are emitted as events, except for the project breadcrumb
  * which links back to the owning project/personal page.
  */
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, useCssModule } from 'vue';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
 import type { AgentConfigValidationIssue } from '@n8n/api-types';
 import {
@@ -16,7 +16,6 @@ import {
 	N8nDropdownMenuItem,
 	N8nIcon,
 	N8nToggle,
-	N8nTooltip,
 } from '@n8n/design-system';
 import type { PathItem } from '@n8n/design-system';
 import type { DropdownMenuItemProps } from '@n8n/design-system';
@@ -60,6 +59,7 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const router = useRouter();
+const $style = useCssModule();
 
 const { list: agentsList, ensureLoaded } = useProjectAgentsList(computed(() => props.projectId));
 onMounted(() => {
@@ -139,6 +139,7 @@ const menuItems = computed<Array<DropdownMenuItemProps<string>>>(() =>
 	props.headerActions.map((action) => ({
 		...action,
 		icon: { type: 'icon', value: action.icon ?? 'file' },
+		class: action.id === 'delete' ? $style.destructiveItem : undefined,
 	})),
 );
 
@@ -341,5 +342,10 @@ function onMenuSelect(id: string) {
 
 .headerActionsMenu {
 	--n8n--dropdown-menu-width: var(--spacing--5xl);
+}
+
+.destructiveItem,
+.destructiveItem * {
+	color: var(--text-color--danger) !important;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -1231,6 +1231,15 @@ const headerActions = computed(() => {
 		});
 	}
 
+	actions.push({
+		id: 'version-history',
+		label: locale.baseText('agents.versionHistory.title'),
+		icon: 'history',
+		disabled: !agent.value?.hasPublishHistory,
+		checked: isVersionHistoryOpen.value,
+		divided: true,
+	});
+
 	if (canDeleteAgent.value) {
 		actions.push({
 			id: 'delete',
@@ -1280,6 +1289,10 @@ function openImportJsonModal() {
 }
 
 async function onHeaderAction(action: string) {
+	if (action === 'version-history') {
+		onToggleVersionHistory();
+		return;
+	}
 	if (action === 'export-json') {
 		await exportAgentJson();
 		return;
@@ -1819,7 +1832,6 @@ function onSwitchAgent(nextAgentId: string) {
 			:header-actions="headerActions"
 			:save-status="saveStatus"
 			:before-revert-to-published="settleAutosave"
-			:is-version-history-open="isVersionHistoryOpen"
 			:artifact-mode="isArtifactMode"
 			:editing-locked="props.artifactEditingLocked"
 			:config-validation-status="configValidation?.status ?? null"
@@ -1833,7 +1845,6 @@ function onSwitchAgent(nextAgentId: string) {
 			@unpublished="onUnpublished"
 			@reverted="onReverted"
 			@switch-agent="onSwitchAgent"
-			@toggle-version-history="onToggleVersionHistory"
 		/>
 		<div
 			ref="builderContainer"


### PR DESCRIPTION
## Summary

* Move the agent actions menu next to the agent name.
* Move agent version history into the actions menu.
* update the workflow and agent menus to use the current dropdown component.
* Add icons and item groups to make both menus consistent.

<!-- linear:table-colwidths:362,362 -->
| **Before** | **After** |
| -- | -- |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/c0ad2a27-081d-4862-a028-44bdfe4a1379/efde32d1-820d-4545-9ce5-02bc2883158f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9jMGFkMmEyNy0wODFkLTQ4NjItYTAyOC00NGJkZmU0YTEzNzkvZWZkZTMyZDEtODIwZC00NTQ1LTljZTUtMDJiYzI4ODMxNThmIiwiaWF0IjoxNzg3OTE5MjQ5LCJleHAiOjE4MTk0ODk4MDl9.bo8ldOIZg7htk5_6muccTUnYlaQKbvYiCUmzIoX0_Ug " alt="CleanShot 2026-08-28 at 13.13.59@2x.png" width="586" data-linear-height="446" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/13fcf2e4-c4d3-4b25-82ce-391ea18cbb82/2c5739b7-95cd-4963-877e-4a3b2a4d3d2c?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi8xM2ZjZjJlNC1jNGQzLTRiMjUtODJjZS0zOTFlYTE4Y2JiODIvMmM1NzM5YjctOTVjZC00OTYzLTg3N2UtNGEzYjJhNGQzZDJjIiwiaWF0IjoxNzg3OTE5MjQ5LCJleHAiOjE4MTk0ODk4MDl9.QZPe0D2vcX2oe0L9TNXF8YsKY1oyWly_CqmM8lc-PJk " alt="CleanShot 2026-08-28 at 13.13.09@2x.png" width="414" data-linear-height="526" /> |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/c3bf9f5d-c5b5-4a2f-b6ee-5401c767a18b/713900e2-46f0-451e-82ba-eb3b1e11ae3d?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9jM2JmOWY1ZC1jNWI1LTRhMmYtYjZlZS01NDAxYzc2N2ExOGIvNzEzOTAwZTItNDZmMC00NTFlLTgyYmEtZWIzYjFlMTFhZTNkIiwiaWF0IjoxNzg3OTE5MjQ5LCJleHAiOjE4MTk0ODk4MDl9.wVOc-7GygLLuA79hOBZwVnAMfw3hO68QgMCpJ0TvtkA " alt="CleanShot 2026-08-28 at 13.12.11@2x.png" width="504" data-linear-height="1096" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/1975cd5e-8ba3-4460-ba4e-0582b0a250c9/c3602f54-9c9e-4157-80c8-3c9b7814b69e?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi8xOTc1Y2Q1ZS04YmEzLTQ0NjAtYmE0ZS0wNTgyYjBhMjUwYzkvYzM2MDJmNTQtOWM5ZS00MTU3LTgwYzgtM2M5Yjc4MTRiNjllIiwiaWF0IjoxNzg3OTE5MjQ5LCJleHAiOjE4MTk0ODk4MDl9.a92xe212pFMNlukErOxZAb54ol7DM_YKCAvOgrZYQ8I " alt="CleanShot 2026-08-28 at 13.13.34@2x.png" width="500" data-linear-height="1138" /> |

## How to test

1. Open a workflow.
2. Confirm that the actions menu is next to the workflow name.
3. Open the menu and confirm that each action has the correct icon and group.
4. Open an agent.
5. Confirm that the actions menu is next to the agent name.
6. Open the menu and confirm that version history is in the menu.
7. Confirm that version history is disabled when the agent has no publish history.
8. Confirm that import, export, favorite, and delete actions still work when available.

## Related Linear tickets, Github issues, and Community forum posts

[AGENT-738](https://linear.app/n8n/issue/AGENT-738)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)