### PR TITLE
fix(editor): Use only server-provided hints for the OAuth consent screen icon

### DIFF
--- a/packages/@n8n/api-types/src/consent.ts
+++ b/packages/@n8n/api-types/src/consent.ts
@@ -1,5 +1,5 @@
 export interface ConsentUiHints {
-	/** design-system icon name (updatedIconSet) for the consent logo tile; omit to keep the client-brand / mcp fallback */
+	/** design-system icon name (updatedIconSet) for the consent logo tile; omit to fall back to the generic mcp icon */
 	icon?: string;
 	/** noun key inserted into first-party consent copy, e.g. 'form' (later 'webhook'); resolved to a localized word on the frontend */
 	consentType?: string;

--- a/packages/cli/src/services/protected-resource.registry.ts
+++ b/packages/cli/src/services/protected-resource.registry.ts
@@ -20,7 +20,7 @@ export interface ProtectedResource {
 	/** Human readable name, for consent screen */
 	displayName?: string;
 
-	/** Presentational hints for the consent screen; omit for the default client-brand treatment. */
+	/** Presentational hints for the consent screen; omit for the default generic MCP icon. */
 	uiHints?: ConsentUiHints;
 
 	/**

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
@@ -187,6 +187,61 @@ describe('OAuthConsentView', () => {
 		);
 	});
 
+	describe('client icon', () => {
+		it('should render the generic MCP icon for a client whose name matches a known brand', async () => {
+			const details = { clientName: 'Claude Code', clientId: 'c1', scopes: [] };
+			consentStore.consentDetails = details;
+			consentStore.fetchConsentDetails.mockImplementation(async () => {
+				consentStore.consentDetails = details;
+				return details;
+			});
+
+			const { getByTestId } = renderComponent();
+			await waitAllPromises();
+
+			expect(getByTestId('consent-client-icon')).toHaveAttribute('data-icon', 'mcp');
+		});
+
+		// Deliberately not a first-party client: the icon follows the resource, not the client.
+		it('should render the icon supplied by the resource', async () => {
+			const details = {
+				clientName: 'Test MCP Client',
+				clientId: 'c1',
+				scopes: [],
+				uiHints: { icon: 'square-pen' },
+			};
+			consentStore.consentDetails = details;
+			consentStore.fetchConsentDetails.mockImplementation(async () => {
+				consentStore.consentDetails = details;
+				return details;
+			});
+
+			const { getByTestId } = renderComponent();
+			await waitAllPromises();
+
+			expect(getByTestId('consent-client-icon')).toHaveAttribute('data-icon', 'square-pen');
+		});
+
+		it('should fall back to the generic MCP icon when the resource hint is blank', async () => {
+			const details = {
+				clientName: 'Test MCP Client',
+				clientId: 'c1',
+				scopes: [],
+				uiHints: { icon: '' },
+			};
+			consentStore.consentDetails = details;
+			consentStore.fetchConsentDetails.mockImplementation(async () => {
+				consentStore.consentDetails = details;
+				return details;
+			});
+
+			const { getByTestId } = renderComponent();
+			await waitAllPromises();
+
+			expect(getByTestId('consent-client-icon')).toHaveAttribute('data-icon', 'mcp');
+		});
+	});
+
 	describe('first-party consent', () => {
 		const firstPartyDetails = {
 			clientName: 'My Form',

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -17,7 +17,6 @@ import {
 	N8nTooltip,
 } from '@n8n/design-system';
 import { MCP_SCOPE_GROUPS } from '@/features/ai/mcpAccess/mcp.constants';
-import { getClientBrand } from '@/features/ai/mcpAccess/clients.utils';
 import { useToast } from '@n8n/composables/useToast';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import ScopesSelector from '@/app/components/scopes/ScopesSelector.vue';
@@ -48,8 +47,6 @@ const errorMessage = computed(() => {
 });
 
 const clientDetails = computed<ConsentDetails | null>(() => consentStore.consentDetails);
-// Known clients get their brand mark on the left tile; unknown ones fall back to the MCP glyph.
-const clientBrandIcon = computed(() => getClientBrand(clientDetails.value?.clientName ?? '').icon);
 // Localized noun for first-party copy, driven by the resource's consentType hint.
 const firstPartyResourceType = computed(() =>
 	i18n.baseText(
@@ -154,19 +151,15 @@ onMounted(async () => {
 	<div :class="$style.overlay">
 		<div :class="$style['consent-dialog']">
 			<header :class="$style.header">
+				<!-- Only the resource's server-side `uiHints` picks this icon; the client's
+				     self-reported name never does. `||` so a blank hint also falls back. -->
 				<div :class="$style.logo">
 					<N8nIcon
-						v-if="clientDetails?.uiHints?.icon"
-						:icon="clientDetails.uiHints.icon"
+						:icon="clientDetails?.uiHints?.icon || 'mcp'"
 						size="large"
 						color="text-dark"
+						data-test-id="consent-client-icon"
 					/>
-					<component
-						:is="clientBrandIcon"
-						v-else-if="clientBrandIcon"
-						:class="$style['brand-icon']"
-					/>
-					<N8nIcon v-else icon="mcp" size="large" color="text-dark" />
 				</div>
 				<!-- Pending-connection connector: a dashed SVG line marching toward the n8n tile
 				     with a slow muted spinner badge. Decorative. -->
@@ -405,13 +398,7 @@ onMounted(async () => {
 	border-radius: var(--radius--xs);
 	background: var(--background--surface);
 	box-shadow: var(--shadow--xs);
-	font-size: var(--font-size--xl);
 	color: var(--text-color--subtle);
-}
-
-.brand-icon {
-	width: 1em;
-	height: 1em;
 }
 
 .connector {


### PR DESCRIPTION
## Summary

The OAuth consent screen chose its header icon by pattern-matching the client's
`client_name` against a list of known brands (Claude, Cursor, VS Code, OpenAI).
That name is self-reported by the client at registration, so the icon carried no
verified meaning on the one screen where the user makes a trust decision.

The tile icon now comes only from the protected resource's server-side
`uiHints`, falling back to the generic MCP glyph. The client name itself still
renders as before, deliberately: it is an honest representation of self-reported
metadata in a way a brand mark is not.

Logos can come back once client identity is verifiable (pre-vetted client IDs,
or Client ID Metadata Documents via ADO-5686), gated on verified clients only.

## Scope

- `OAuthConsentView.vue`: the three-branch icon collapses to one `N8nIcon`
  (`uiHints.icon || 'mcp'`). `getClientBrand`, the `clientBrandIcon` computed and
  the `.brand-icon` / `.logo` `font-size` rules that only existed to size the raw
  brand SVG are gone.
- Two doc comments in `@n8n/api-types` and the protected-resource registry
  still advertised the removed "client-brand fallback"; both now describe the
  actual behavior.
- `getClientBrand` and the four brand SVGs stay: the connected-clients table and
  details modal in Settings still use them. Those list clients the user has
  already approved, so they are not a pre-grant trust surface.

## Related

https://linear.app/n8n/issue/ADO-5784
Follows up on ADO-5758.

## Review notes

`uiHints` is not reachable from client-supplied registration metadata. Its only
producer is the `FORM_TRIGGER_CONSENT_HINTS` constant in
`protected-resource-resolvers/utils.ts`, read server-side in
`oauth-consent.service.ts`.

Each of the three tests kills a distinct mutation, verified locally:
- re-adding a name-derived brand branch → the known-brand test fails
- gating the icon on `isFirstParty` → the resource-icon test fails
- `||` → `??` → the blank-hint test fails

The resource-icon test deliberately sits outside the first-party fixture; inside
it, the `isFirstParty` gating mutation passed silently.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

