### PR TITLE
feat(Gmail Trigger Node): Finish each poll within its time budget

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -417,10 +417,13 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			});
 
 			// A fetched message is progress, whether it came from the pending queue or
-			// a fresh scan, so the no-progress run starts over. Unconditional, unlike
-			// the clear in the scan path: a poll that fetched anything writes the
-			// boundary set below in any case, so this write costs no extra save.
-			nodeStaticData.noProgressTicks = 0;
+			// a fresh scan, so the no-progress run starts over. Gated like the queue
+			// write: a legacy node must not store state its own paths ignore. No value
+			// check here, unlike the clear in the scan path — a poll that fetched
+			// something saves its state in any case.
+			if (shouldLimitMessages) {
+				nodeStaticData.noProgressTicks = 0;
+			}
 
 			if (!includeDrafts && fullMessage.labelIds?.includes('DRAFT')) {
 				return;

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -41,9 +41,11 @@ const MAX_TRACKED_BACKLOG_IDS = 5_000;
 // failed fetch cannot be told apart from a rate limit, and this node does not
 // retry inside a poll, so an id gets several polls to come back.
 export const MAX_PENDING_FETCH_ATTEMPTS = 10;
-// Consecutive polls that reach nothing new before the no-progress valve fires.
-// More than one sample is needed: one slow response can stop a scan short where
-// the next poll, with a fresh budget, reaches further.
+// The no-progress valve fires on this many consecutive polls that reach nothing
+// new. More than one sample is needed: one slow response can stop a scan short
+// where the next poll, with a fresh budget, reaches further. A window the page
+// cap wedges waits the same run, so it needs this many polls to give up where it
+// used to give up on the first.
 const MAX_NO_PROGRESS_TICKS = 3;
 
 export class GmailTrigger implements INodeType {
@@ -415,7 +417,9 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			});
 
 			// A fetched message is progress, whether it came from the pending queue or
-			// a fresh scan, so the no-progress run starts over.
+			// a fresh scan, so the no-progress run starts over. Unconditional, unlike
+			// the clear in the scan path: a poll that fetched anything writes the
+			// boundary set below in any case, so this write costs no extra save.
 			nodeStaticData.noProgressTicks = 0;
 
 			if (!includeDrafts && fullMessage.labelIds?.includes('DRAFT')) {
@@ -489,9 +493,9 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			const givenUp = setAside.filter(([, attempts]) => attempts >= MAX_PENDING_FETCH_ATTEMPTS);
 
 			if (shouldLimitMessages && retryable.length > 0) {
-				// Bounded per tick, and the untried tail moves to the front, so a long
-				// list cannot spend the whole poll on doomed requests or starve its own
-				// later entries.
+				// Bounded per tick. Ids this poll did not reach come first, then the
+				// untried tail, so a long list cannot spend the whole poll on doomed
+				// requests or starve its own later entries.
 				const retryNow = retryable.slice(0, maxResults);
 				const retryLater = retryable.slice(maxResults);
 				const stillFailing: Array<[string, number]> = [];
@@ -533,8 +537,9 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			}
 
 			// Process pending messages from a previous poll next. These are IDs a scan
-			// found but no poll fetched: beyond the maxResults budget, past this poll's
-			// time budget, or left over when a fetch failed mid-poll.
+			// found but no poll fetched: beyond the maxResults budget, past the time
+			// budget of the poll that scanned them, or left over when a fetch failed
+			// mid-poll.
 			const pendingIds = nodeStaticData.pendingMessageIds ?? [];
 			if (shouldLimitMessages && pendingIds.length > 0 && budget > 0) {
 				const fetchQs = buildFetchQs();
@@ -565,7 +570,10 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 					// advance. A failed id leaves the queue for the set-aside list, which
 					// is written once the loop ends.
 					nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
-					// Checked after the fetch so every tick handles at least one id.
+					// Checked after the fetch, and after the trim above, so every poll
+					// handles at least one id and the id it just delivered leaves the queue.
+					// A break above the trim re-delivers it: this drain does not filter
+					// against the boundary set.
 					if (Date.now() >= pollDeadline) break;
 				}
 
@@ -652,7 +660,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			messages = Array.from(new Map(messages.map((m) => [m.id, m])).values());
 
 			// An empty page set is not an early return: Gmail ends a list only by
-			// dropping the page token, so this must reach the no-progress valve below.
+			// dropping the page token, so on v1.4+ this must reach the no-progress valve
+			// below. Every other version falls through to the same null return.
 
 			// For v1.4+, filter out already-handled messages before fetching to save API
 			// calls. Gmail's `after:` query is inclusive at the second boundary, and a
@@ -759,7 +768,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 							...messagesToProcess.slice(index + 1).map((m) => m.id),
 							...beyondBudgetIds,
 						];
-						// Checked after the fetch so every tick fetches at least one message.
+						// Checked after the fetch, and after the trim above, so every poll
+						// fetches at least one message and no delivered id stays queued.
 						if (Date.now() >= pollDeadline) break;
 					}
 				}

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -685,6 +685,12 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 					messages = messages.filter((m) => !alreadyTracked.has(m.id));
 				}
 
+				// Reaching an id no poll has handled proves the window is not wedged, so
+				// the run starts over even if every fetch below fails.
+				if (messages.length > 0 && nodeStaticData.noProgressTicks) {
+					nodeStaticData.noProgressTicks = 0;
+				}
+
 				if (!messages.length && !allFetchedMessages.length) {
 					// No-progress valve: the scan was stopped short, yet every id it
 					// reached is already tracked. One such poll proves little — a slow

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -647,13 +647,13 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				}
 
 				if (!messages.length && !allFetchedMessages.length) {
-					// No-progress valve: the page cap stopped the scan short, yet every id
-					// it reached is already tracked. Holding again would repeat this
+					// No-progress valve: the budget or the cap stopped the scan short, yet
+					// every id it reached is already tracked. Holding again would repeat this
 					// tick forever — no backlog progress and no new mail. Give up loudly:
-					// jump the cursor to now and skip what the cap keeps unreachable.
+					// jump the cursor to now and skip what stays out of reach.
 					if (!windowFullyScanned) {
 						this.logger.warn(
-							'Gmail Trigger backlog cannot progress past the page cap; advancing past older messages it could not scan',
+							"Gmail Trigger backlog cannot progress within one poll's reach; advancing past older messages it could not scan",
 							{ node: node.name },
 						);
 						nodeStaticData.lastTimeChecked = +now;
@@ -666,7 +666,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				}
 			}
 
-			// Take only what fits in the remaining budget, store the rest as pending.
+			// Take only what fits in the remaining maxResults budget, store the rest
+			// as pending.
 			let messagesToProcess = messages;
 			let beyondBudgetIds: string[] = [];
 			if (shouldLimitMessages && messages.length > budget) {

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -651,9 +651,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			// between page fetches; one id must map to one delivery.
 			messages = Array.from(new Map(messages.map((m) => [m.id, m])).values());
 
-			if (!messages.length && !allFetchedMessages.length) {
-				return null;
-			}
+			// An empty page set is not an early return: Gmail ends a list only by
+			// dropping the page token, so this must reach the no-progress valve below.
 
 			// For v1.4+, filter out already-handled messages before fetching to save API
 			// calls. Gmail's `after:` query is inclusive at the second boundary, and a

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -345,6 +345,9 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 		const simple = this.getNodeParameter('simple') as boolean;
 
 		const shouldLimitMessages = node.typeVersion >= 1.4 && this.getMode() !== 'manual';
+		// How far this tick may reach before it must return — bounds listing and
+		// fetching time, not delivery volume (maxResults stays the per-tick bound).
+		const pollDeadline = Date.now() + this.getPollBudgetMs();
 		const maxResults = shouldLimitMessages
 			? (this.getNodeParameter('maxResults', 10) as number)
 			: Infinity;
@@ -536,6 +539,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 					// advance. A failed id leaves the queue for the set-aside list, which
 					// is written once the loop ends.
 					nodeStaticData.pendingMessageIds = pendingIds.slice(index + 1);
+					// Checked after the fetch so every tick handles at least one id.
+					if (Date.now() >= pollDeadline) break;
 				}
 
 				if (newlyFailed.length > 0) {
@@ -543,10 +548,16 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				}
 			}
 
-			// While queued ids remain, do not scan: the queue write after a scan replaces
-			// the whole queue, so scanning now would drop the ids this poll could not
-			// reach.
-			if (shouldLimitMessages && (nodeStaticData.pendingMessageIds?.length ?? 0) > 0) {
+			// While queued ids remain — or fetching them used up this poll's budget —
+			// do not scan: the queue write after a scan replaces the whole queue, so
+			// scanning now would drop the ids this poll could not reach. A poll that
+			// fetched nothing still scans, so an already-spent budget cannot stop every
+			// poll from making progress.
+			if (
+				shouldLimitMessages &&
+				((nodeStaticData.pendingMessageIds?.length ?? 0) > 0 ||
+					(allFetchedMessages.length > 0 && Date.now() >= pollDeadline))
+			) {
 				await simplifyResponseData();
 
 				// This path returns before the state update at the end of poll(), so it
@@ -596,10 +607,15 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				messages.push(...(messagesResponse.messages ?? []));
 				pageToken = messagesResponse.nextPageToken;
 				pagesScanned++;
-			} while (shouldLimitMessages && pageToken && pagesScanned < MAX_SCAN_PAGES);
-			// A leftover token means the cap stopped the scan short. Gmail returns
-			// newest first, so the remainder is older mail; a cursor moved past it
-			// would never reach it again.
+			} while (
+				shouldLimitMessages &&
+				pageToken &&
+				pagesScanned < MAX_SCAN_PAGES &&
+				Date.now() < pollDeadline
+			);
+			// A leftover token means the time budget or the cap stopped the scan short.
+			// Gmail returns newest first, so the remainder is older mail; a cursor moved
+			// past it would never reach it again.
 			windowFullyScanned = !pageToken;
 
 			// Pagination can repeat an id across pages when the mailbox shifts
@@ -699,6 +715,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 							...messagesToProcess.slice(index + 1).map((m) => m.id),
 							...beyondBudgetIds,
 						];
+						// Checked after the fetch so every tick fetches at least one message.
+						if (Date.now() >= pollDeadline) break;
 					}
 				}
 

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -42,6 +42,10 @@ const MAX_TRACKED_BACKLOG_IDS = 5_000;
 // failed fetch cannot be told apart from a rate limit, and this node does not
 // retry inside a poll, so an id gets several polls to come back.
 export const MAX_PENDING_FETCH_ATTEMPTS = 10;
+// Consecutive polls that reach nothing new before the no-progress valve fires.
+// More than one sample is needed: one slow response can stop a scan short where
+// the next poll, with a fresh budget, reaches further.
+const MAX_NO_PROGRESS_TICKS = 3;
 
 export class GmailTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -409,6 +413,10 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				date: getEmailDateAsSeconds(fullMessage),
 			});
 
+			// A fetched message is progress, whether it came from the pending queue or
+			// a fresh listing, so the no-progress run starts over.
+			nodeStaticData.noProgressTicks = 0;
+
 			if (!includeDrafts && fullMessage.labelIds?.includes('DRAFT')) {
 				return;
 			}
@@ -647,11 +655,18 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				}
 
 				if (!messages.length && !allFetchedMessages.length) {
-					// No-progress valve: the budget or the cap stopped the scan short, yet
-					// every id it reached is already tracked. Holding again would repeat this
-					// tick forever — no backlog progress and no new mail. Give up loudly:
-					// jump the cursor to now and skip what stays out of reach.
+					// No-progress valve: the scan was stopped short, yet every id it
+					// reached is already tracked. One such poll proves little — a slow
+					// response can stop a scan short where the next poll, with a fresh
+					// budget, reaches further. Only a run of them means the window is
+					// wedged; then give up loudly: jump the cursor to now and skip what
+					// stays out of reach.
 					if (!windowFullyScanned) {
+						const noProgressTicks = (nodeStaticData.noProgressTicks ?? 0) + 1;
+						if (noProgressTicks < MAX_NO_PROGRESS_TICKS) {
+							nodeStaticData.noProgressTicks = noProgressTicks;
+							return null;
+						}
 						this.logger.warn(
 							"Gmail Trigger backlog cannot progress within one poll's reach; advancing past older messages it could not scan",
 							{ node: node.name },
@@ -661,6 +676,7 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 						// at the boundary. Keeping them would grow the stored-id count for
 						// nothing — every other path merges the set instead.
 						nodeStaticData.possibleDuplicates = [];
+						nodeStaticData.noProgressTicks = 0;
 					}
 					return null;
 				}

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -352,6 +352,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 		const shouldLimitMessages = node.typeVersion >= 1.4 && this.getMode() !== 'manual';
 		// How far this tick may reach before it must return — bounds listing and
 		// fetching time, not delivery volume (maxResults stays the per-tick bound).
+		// Only consulted on shouldLimitMessages paths; pre-1.4 and manual polls are
+		// unchanged.
 		const pollDeadline = Date.now() + this.getPollBudgetMs();
 		const maxResults = shouldLimitMessages
 			? (this.getNodeParameter('maxResults', 10) as number)
@@ -470,6 +472,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 		let windowFullyScanned = false;
 
 		try {
+			// Item-count budget (remaining maxResults) — distinct from the time
+			// budget behind pollDeadline.
 			let budget = maxResults;
 
 			// A message whose fetch failed waits in its own list rather than in the
@@ -516,8 +520,8 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			}
 
 			// Process pending messages from a previous poll next. These are IDs a scan
-			// found but no poll fetched: beyond the maxResults budget, or left over when
-			// a fetch failed mid-poll.
+			// found but no poll fetched: beyond the maxResults budget, past this poll's
+			// time budget, or left over when a fetch failed mid-poll.
 			const pendingIds = nodeStaticData.pendingMessageIds ?? [];
 			if (shouldLimitMessages && pendingIds.length > 0 && budget > 0) {
 				const fetchQs = buildFetchQs();
@@ -605,6 +609,9 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			let messages: ListMessage[] = [];
 			let pageToken: string | undefined;
 			let pagesScanned = 0;
+			// The deadline sits in the loop condition: the do-while always scans page
+			// one, so an already-spent budget still makes progress (mirrors the fetch
+			// loops).
 			do {
 				const messagesResponse: MessageListResponse = await googleApiRequest.call(
 					this,

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -30,10 +30,11 @@ import type {
 	MessageListResponse,
 } from './types';
 
-// Bounds how many pages one poll scans for new messages. A leftover page token
-// holds the cursor, so mail beyond the cap stays reachable until a give-up valve
-// decides to skip it.
-const MAX_SCAN_PAGES = 20;
+// Runaway backstop for how many pages one poll scans: the poll time budget is
+// the working bound on how far a scan reaches. A leftover page token holds the
+// cursor, so mail beyond the cap stays reachable until a give-up valve decides to
+// skip it.
+export const MAX_SCAN_PAGES = 500;
 // Count of stored ids (queued + boundary + set aside) at which the poll stops
 // holding the cursor and accepts skipping whatever it did not scan.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -349,7 +349,7 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 		const simple = this.getNodeParameter('simple') as boolean;
 
 		const shouldLimitMessages = node.typeVersion >= 1.4 && this.getMode() !== 'manual';
-		// How far this tick may reach before it must return — bounds listing and
+		// How far this tick may reach before it must return — bounds scanning and
 		// fetching time, not delivery volume (maxResults stays the per-tick bound).
 		// Only consulted on shouldLimitMessages paths; pre-1.4 and manual polls are
 		// unchanged.
@@ -415,7 +415,7 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 			});
 
 			// A fetched message is progress, whether it came from the pending queue or
-			// a fresh listing, so the no-progress run starts over.
+			// a fresh scan, so the no-progress run starts over.
 			nodeStaticData.noProgressTicks = 0;
 
 			if (!includeDrafts && fullMessage.labelIds?.includes('DRAFT')) {
@@ -576,9 +576,9 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 
 			// While queued ids remain — or fetching them used up this poll's budget —
 			// do not scan: the queue write after a scan replaces the whole queue, so
-			// scanning now would drop the ids this poll could not reach. A poll that
-			// fetched nothing still scans, so an already-spent budget cannot stop every
-			// poll from making progress.
+			// scanning now would drop the ids this poll could not reach. The budget
+			// clause needs a fetch of its own, so a spent budget alone never keeps a
+			// poll from scanning — only a queue that still holds ids does.
 			if (
 				shouldLimitMessages &&
 				((nodeStaticData.pendingMessageIds?.length ?? 0) > 0 ||
@@ -818,10 +818,10 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				(nodeStaticData.possibleDuplicates?.length ?? 0) +
 				(nodeStaticData.failedFetches?.length ?? 0);
 			if (trackedIds < MAX_TRACKED_BACKLOG_IDS) {
-				// Older mail sits beyond the page cap, unscanned. Hold the cursor so later
-				// polls can still reach it. The possibleDuplicates update below keeps every
-				// handled id filterable, so a re-scan under a held cursor cannot re-emit
-				// them.
+				// Older mail sits past where the scan stopped, at the page cap or at the
+				// time budget. Hold the cursor so later polls can still reach it. The
+				// possibleDuplicates update below keeps every handled id filterable, so a
+				// re-scan under a held cursor cannot re-emit them.
 				effectiveLastTimeChecked = +startDate;
 			} else {
 				// Give-up valve: holding again would grow the tracked-id state without

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -697,6 +697,13 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 						// nothing — every other path merges the set instead.
 						nodeStaticData.possibleDuplicates = [];
 						nodeStaticData.noProgressTicks = 0;
+					} else if (nodeStaticData.noProgressTicks) {
+						// The scan exhausted the token, so nothing is out of reach and the
+						// window is not wedged. Without this, a quiet poll between two slow
+						// ones keeps the count and the run no longer has to be consecutive.
+						// Only written when there is a count to clear: an idle node polls
+						// this path every tick, and any write marks the static data dirty.
+						nodeStaticData.noProgressTicks = 0;
 					}
 					return null;
 				}

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -497,8 +497,10 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 				const retryLater = retryable.slice(maxResults);
 				const stillFailing: Array<[string, number]> = [];
 				const fetchQs = buildFetchQs();
+				let retried = 0;
 
 				for (const [id, attempts] of retryNow) {
+					retried += 1;
 					try {
 						await fetchAndProcessMessage(id, fetchQs);
 						budget -= 1;
@@ -514,9 +516,21 @@ When this trigger feeds an action that creates records (tasks, rows, tickets, me
 							stillFailing.push([id, attempted]);
 						}
 					}
+
+					// Checked after the fetch so every poll retries at least one id. This
+					// pass runs before the queue and the scan, so without it a slow set of
+					// retries could spend the whole poll.
+					if (Date.now() >= pollDeadline) break;
 				}
 
-				nodeStaticData.failedFetches = [...retryLater, ...stillFailing, ...givenUp];
+				// Ids this poll did not reach keep their counts and go to the front, so
+				// the next poll starts with them.
+				nodeStaticData.failedFetches = [
+					...retryNow.slice(retried),
+					...retryLater,
+					...stillFailing,
+					...givenUp,
+				];
 			}
 
 			// Process pending messages from a previous poll next. These are IDs a scan

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -30,11 +30,10 @@ import type {
 	MessageListResponse,
 } from './types';
 
-// Runaway backstop for how many pages one poll scans: the poll time budget is
-// the working bound on how far a scan reaches. A leftover page token holds the
-// cursor, so mail beyond the cap stays reachable until a give-up valve decides to
-// skip it.
-export const MAX_SCAN_PAGES = 500;
+// Bounds how many pages one poll scans for new messages. A leftover page token
+// holds the cursor, so mail beyond the cap stays reachable until a give-up valve
+// decides to skip it.
+const MAX_SCAN_PAGES = 20;
 // Count of stored ids (queued + boundary + set aside) at which the poll stops
 // holding the cursor and accepts skipping whatever it did not scan.
 const MAX_TRACKED_BACKLOG_IDS = 5_000;

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2772,6 +2772,37 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger']).not.toHaveProperty('noProgressTicks');
 		});
 
+		it('should clear the no-progress count when a scan reaches new ids that all fail', async () => {
+			// The scan found an id no poll has handled, so the window is not wedged.
+			// The valve must not count this poll towards a give-up, and must not keep
+			// a count an earlier poll left behind, even though every fetch failed.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					noProgressTicks: 2,
+				},
+			};
+
+			mockLabels();
+			// Page 2 is not mocked: the spent budget must stop the scan at page 1.
+			mockList(listPage(['N1'], 'token-1'));
+			mockGetError('N1');
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(0);
+			// Nothing was delivered, so the cursor stays and the id waits in the
+			// set-aside list.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['N1', 1]]);
+		});
+
 		it('should give up once consecutive ticks keep making no progress', async () => {
 			// Repeated no-progress ticks are no longer one unlucky sample: the
 			// window is wedged, so give up loudly rather than hold forever.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1588,29 +1588,42 @@ describe('GmailTrigger', () => {
 			expect(pending).not.toContain('1');
 		});
 
-		it('should not apply limit in manual mode', async () => {
+		it('should apply neither the limit nor the poll budget in manual mode', async () => {
+			// Both are scoped to non-manual polls. Two messages are listed with a
+			// limit of one and a spent time budget, so a poll that honours either one
+			// delivers a single message and fails the assertions below.
 			const messageListResponse: MessageListResponse = {
-				messages: [createListMessage({ id: '1' })],
-				resultSizeEstimate: 1,
+				messages: [createListMessage({ id: '1' }), createListMessage({ id: '2' })],
+				resultSizeEstimate: 2,
+			};
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {},
 			};
 
 			nock(baseUrl)
 				.get('/gmail/v1/users/me/labels')
 				.reply(200, { labels: [{ id: 'testLabelId', name: 'Test Label Name' }] });
+			nock(baseUrl).get('/gmail/v1/users/me/messages').query(true).reply(200, messageListResponse);
 			nock(baseUrl)
-				.get(new RegExp('/gmail/v1/users/me/messages?.*'))
-				.reply(200, messageListResponse);
-			nock(baseUrl)
-				.get(new RegExp('/gmail/v1/users/me/messages/1?.*'))
+				.get('/gmail/v1/users/me/messages/1')
+				.query(true)
 				.reply(200, createMessage({ id: '1' }));
+			nock(baseUrl)
+				.get('/gmail/v1/users/me/messages/2')
+				.query(true)
+				.reply(200, createMessage({ id: '2' }));
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				mode: 'manual',
-				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 1 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
 			});
 
-			expect(response).toHaveLength(1);
-			expect(response?.[0]?.[0]?.json?.id).toBe('1');
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1', '2']);
+			// The queue belongs to non-manual polls; a manual one must not persist a
+			// queue that its own drain path skips.
+			expect(workflowStaticData['Gmail Trigger']).not.toHaveProperty('pendingMessageIds');
 		});
 	});
 

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -1621,9 +1621,10 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1', '2']);
-			// The queue belongs to non-manual polls; a manual one must not persist a
-			// queue that its own drain path skips.
+			// The queue and the no-progress count belong to non-manual polls; a manual
+			// one must not persist state that its own paths skip.
 			expect(workflowStaticData['Gmail Trigger']).not.toHaveProperty('pendingMessageIds');
+			expect(workflowStaticData['Gmail Trigger']).not.toHaveProperty('noProgressTicks');
 		});
 	});
 
@@ -2434,8 +2435,9 @@ describe('GmailTrigger', () => {
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1', '2']);
 			// The queue belongs to v1.4+; older versions must not persist one their
-			// own drain path would ignore.
+			// own drain path would ignore. The same holds for the no-progress count.
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toBeUndefined();
+			expect(workflowStaticData['Gmail Trigger']).not.toHaveProperty('noProgressTicks');
 		});
 
 		it('should keep the beyond-budget remainder when a drain exactly consumed the budget', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 
 import { testPollingTriggerNode } from '@test/nodes/TriggerHelpers';
 
-import { GmailTrigger, MAX_LIST_PAGES, MAX_PENDING_FETCH_ATTEMPTS } from '../GmailTrigger.node';
+import { GmailTrigger, MAX_SCAN_PAGES, MAX_PENDING_FETCH_ATTEMPTS } from '../GmailTrigger.node';
 import type { Message, ListMessage, MessageListResponse } from '../types';
 
 vi.mock('mailparser');
@@ -1720,7 +1720,7 @@ describe('GmailTrigger', () => {
 			// after the cap is not mocked: a loop that overruns the cap hits an
 			// unmatched request, poll() swallows the error and returns null, and the
 			// assertions below fail.
-			const pages = Array.from({ length: MAX_LIST_PAGES }, (_, page) => [`p${page}a`, `p${page}b`]);
+			const pages = Array.from({ length: MAX_SCAN_PAGES }, (_, page) => [`p${page}a`, `p${page}b`]);
 			const allIds = pages.flat();
 			pages.forEach((ids, page) =>
 				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
@@ -2367,7 +2367,7 @@ describe('GmailTrigger', () => {
 			// forever: no backlog progress, no new mail, no warning. Two polls already
 			// found nothing, so this one must give up — advance and start fresh.
 			const initialTimestamp = 1000000;
-			const pages = Array.from({ length: MAX_LIST_PAGES }, (_, page) => [`h${page}a`, `h${page}b`]);
+			const pages = Array.from({ length: MAX_SCAN_PAGES }, (_, page) => [`h${page}a`, `h${page}b`]);
 			const handledIds = pages.flat();
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -2502,6 +2502,35 @@ describe('GmailTrigger', () => {
 			// cursor must hold so the unlisted remainder stays reachable.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['1']);
+		});
+
+		it('should stop retrying set-aside ids when the poll budget is exhausted', async () => {
+			// The retry pass runs before everything else, so without a deadline of its
+			// own it could spend the whole poll on retries and leave nothing for the
+			// queue or the scan.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					failedFetches: [
+						['Q1', 1],
+						['Q2', 1],
+					],
+				},
+			};
+
+			mockLabels();
+			mockGet('Q1', 2_000_000_000_000);
+			// No mock for 'Q2': this poll must stop before reaching it.
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 5 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			// One retry always happens, and the untouched entry keeps its count.
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['Q1']);
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['Q2', 1]]);
 		});
 
 		it('should stop draining pending ids when the poll budget is exhausted', async () => {
@@ -2681,7 +2710,7 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			const pages = Array.from({ length: MAX_LIST_PAGES }, (_, page) => [`n${page}a`, `n${page}b`]);
+			const pages = Array.from({ length: MAX_SCAN_PAGES }, (_, page) => [`n${page}a`, `n${page}b`]);
 			const allIds = pages.flat();
 			pages.forEach((ids, page) =>
 				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 
 import { testPollingTriggerNode } from '@test/nodes/TriggerHelpers';
 
-import { GmailTrigger, MAX_SCAN_PAGES, MAX_PENDING_FETCH_ATTEMPTS } from '../GmailTrigger.node';
+import { GmailTrigger, MAX_PENDING_FETCH_ATTEMPTS } from '../GmailTrigger.node';
 import type { Message, ListMessage, MessageListResponse } from '../types';
 
 vi.mock('mailparser');
@@ -1615,8 +1615,8 @@ describe('GmailTrigger', () => {
 	});
 
 	describe('v1.4 - backlog scan, drain and retry', () => {
-		// Contract under test: the scan follows nextPageToken until the poll's time
-		// budget runs out, with MAX_SCAN_PAGES as a runaway backstop. lastTimeChecked
+		// Contract under test: the scan follows nextPageToken up to MAX_SCAN_PAGES
+		// pages, or until the poll's time budget runs out. lastTimeChecked
 		// advances when the scan exhausted the token, or when a give-up valve fires:
 		// no progress past the reach of one poll, or MAX_TRACKED_BACKLOG_IDS ids
 		// already stored. Otherwise the cursor holds, so mail the poll never scanned
@@ -1716,11 +1716,10 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			// Cap-many pages, every one of them with a continuation token. The page
-			// after the cap is not mocked: a loop that overruns the cap hits an
-			// unmatched request, poll() swallows the error and returns null, and the
-			// assertions below fail.
-			const pages = Array.from({ length: MAX_SCAN_PAGES }, (_, page) => [`p${page}a`, `p${page}b`]);
+			// 20 pages, every one of them with a continuation token. Page 21 is not
+			// mocked: a loop that overruns the cap hits an unmatched request, poll()
+			// swallows the error and returns null, and the assertions below fail.
+			const pages = Array.from({ length: 20 }, (_, page) => [`p${page}a`, `p${page}b`]);
 			const allIds = pages.flat();
 			pages.forEach((ids, page) =>
 				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
@@ -2367,7 +2366,7 @@ describe('GmailTrigger', () => {
 			// forever: no backlog progress, no new mail, no warning. Two polls already
 			// found nothing, so this one must give up — advance and start fresh.
 			const initialTimestamp = 1000000;
-			const pages = Array.from({ length: MAX_SCAN_PAGES }, (_, page) => [`h${page}a`, `h${page}b`]);
+			const pages = Array.from({ length: 20 }, (_, page) => [`h${page}a`, `h${page}b`]);
 			const handledIds = pages.flat();
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -2444,38 +2443,6 @@ describe('GmailTrigger', () => {
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1', 'P2']);
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1', '2']);
-		});
-
-		it('should list a window larger than 20 pages when the budget allows', async () => {
-			const workflowStaticData: Record<string, Record<string, unknown>> = {
-				'Gmail Trigger': { lastTimeChecked: 1000000 },
-			};
-
-			mockLabels();
-			// Listing reach is bounded by the time budget, not a fixed page count:
-			// 21 pages (one past the old 20-page cap) are walked to token
-			// exhaustion, so unfetched ids park as pending and the cursor can
-			// advance.
-			const pages = Array.from({ length: 21 }, (_, page) => [`q${page}`]);
-			pages.forEach((ids, page) =>
-				mockList(
-					listPage(ids, page === pages.length - 1 ? undefined : `token-${page + 1}`),
-					page === 0 ? undefined : `token-${page}`,
-				),
-			);
-			mockGet('q0', 6_000_000_000_000);
-			mockGet('q1', 5_000_000_000_000);
-
-			const { response } = await testPollingTriggerNode(GmailTrigger, {
-				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
-				workflowStaticData,
-			});
-
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['q0', 'q1']);
-			// Token exhausted: every unfetched id is tracked as pending, so the
-			// cursor advances instead of holding.
-			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(pages.flat().slice(2));
-			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
 		});
 
 		it('should stop listing when the poll budget is exhausted and hold the cursor', async () => {
@@ -2710,7 +2677,7 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			const pages = Array.from({ length: MAX_SCAN_PAGES }, (_, page) => [`n${page}a`, `n${page}b`]);
+			const pages = Array.from({ length: 20 }, (_, page) => [`n${page}a`, `n${page}b`]);
 			const allIds = pages.flat();
 			pages.forEach((ids, page) =>
 				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
@@ -2724,7 +2691,7 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]).toHaveLength(2);
-			// The cap cut the listing short (token remaining) but the valve fires:
+			// Cap was hit (20 pages listed, token remaining) but the valve fires:
 			// advance instead of holding.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
 			// The valve skips only unscanned mail; scanned-but-unfetched ids stay tracked.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -3,7 +3,11 @@ import nock from 'nock';
 
 import { testPollingTriggerNode } from '@test/nodes/TriggerHelpers';
 
-import { GmailTrigger, MAX_PENDING_FETCH_ATTEMPTS } from '../GmailTrigger.node';
+import {
+	GmailTrigger,
+	MAX_LIST_PAGES,
+	MAX_PENDING_FETCH_ATTEMPTS,
+} from '../GmailTrigger.node';
 import type { Message, ListMessage, MessageListResponse } from '../types';
 
 vi.mock('mailparser');
@@ -1615,11 +1619,12 @@ describe('GmailTrigger', () => {
 	});
 
 	describe('v1.4 - backlog scan, drain and retry', () => {
-		// Contract under test: the scan follows nextPageToken up to MAX_SCAN_PAGES.
-		// lastTimeChecked advances when the scan exhausted the token, or when a
-		// give-up valve fires: no progress past the cap, or MAX_TRACKED_BACKLOG_IDS
-		// ids already stored. Otherwise the cursor holds, so mail the poll never
-		// scanned stays reachable.
+		// Contract under test: the scan follows nextPageToken until the poll's time
+		// budget runs out, with MAX_SCAN_PAGES as a runaway backstop. lastTimeChecked
+		// advances when the scan exhausted the token, or when a give-up valve fires:
+		// no progress past the reach of one poll, or MAX_TRACKED_BACKLOG_IDS ids
+		// already stored. Otherwise the cursor holds, so mail the poll never scanned
+		// stays reachable.
 		const listPage = (ids: string[], nextPageToken?: string): MessageListResponse => ({
 			messages: ids.map((id) => createListMessage({ id })),
 			resultSizeEstimate: ids.length,
@@ -1715,10 +1720,11 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			// 20 pages, every one of them with a continuation token. Page 21 is not
-			// mocked: a loop that overruns the cap hits an unmatched request, poll()
-			// swallows the error and returns null, and the assertions below fail.
-			const pages = Array.from({ length: 20 }, (_, page) => [`p${page}a`, `p${page}b`]);
+			// Cap-many pages, every one of them with a continuation token. The page
+			// after the cap is not mocked: a loop that overruns the cap hits an
+			// unmatched request, poll() swallows the error and returns null, and the
+			// assertions below fail.
+			const pages = Array.from({ length: MAX_LIST_PAGES }, (_, page) => [`p${page}a`, `p${page}b`]);
 			const allIds = pages.flat();
 			pages.forEach((ids, page) =>
 				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
@@ -2365,7 +2371,7 @@ describe('GmailTrigger', () => {
 			// tick forever: no backlog progress, no new mail, no warning. The poll
 			// must give up instead — advance and start fresh.
 			const initialTimestamp = 1000000;
-			const pages = Array.from({ length: 20 }, (_, page) => [`h${page}a`, `h${page}b`]);
+			const pages = Array.from({ length: MAX_LIST_PAGES }, (_, page) => [`h${page}a`, `h${page}b`]);
 			const handledIds = pages.flat();
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -2441,6 +2447,37 @@ describe('GmailTrigger', () => {
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['P1', 'P2']);
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1', '2']);
+		});
+
+		it('should list a window larger than 20 pages when the budget allows', async () => {
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			// The time budget, not a small page cap, bounds listing reach: a
+			// 21-page window must be walked to token exhaustion so the cursor
+			// can advance without losing the unlisted remainder.
+			const pages = Array.from({ length: 21 }, (_, page) => [`q${page}`]);
+			pages.forEach((ids, page) =>
+				mockList(
+					listPage(ids, page === pages.length - 1 ? undefined : `token-${page + 1}`),
+					page === 0 ? undefined : `token-${page}`,
+				),
+			);
+			mockGet('q0', 6_000_000_000_000);
+			mockGet('q1', 5_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['q0', 'q1']);
+			// Token exhausted: every unfetched id is tracked as pending, so the
+			// cursor advances instead of holding.
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(pages.flat().slice(2));
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
 		});
 
 		it('should stop listing when the poll budget is exhausted and hold the cursor', async () => {
@@ -2565,7 +2602,7 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			const pages = Array.from({ length: 20 }, (_, page) => [`n${page}a`, `n${page}b`]);
+			const pages = Array.from({ length: MAX_LIST_PAGES }, (_, page) => [`n${page}a`, `n${page}b`]);
 			const allIds = pages.flat();
 			pages.forEach((ids, page) =>
 				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
@@ -2579,7 +2616,7 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]).toHaveLength(2);
-			// Cap was hit (20 pages listed, token remaining) but the valve fires:
+			// The cap cut the listing short (token remaining) but the valve fires:
 			// advance instead of holding.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
 			// The valve skips only unscanned mail; scanned-but-unfetched ids stay tracked.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2678,6 +2678,32 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(2);
 		});
 
+		it('should count an empty page with a leftover token as no progress', async () => {
+			// Gmail's only documented end-of-list signal is a missing page token, so a
+			// page with no messages does not mean the window is finished. A poll that
+			// stopped inside such a page reached nothing, which the valve must count.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
+			};
+
+			mockLabels();
+			// No `messages` key at all, which is the shape Gmail sends for an empty
+			// page, plus a token that says the list goes on.
+			mockList({ resultSizeEstimate: 0, nextPageToken: 'token-1' });
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(1);
+			// The scan stopped short, so the cursor must stay where it was.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+		});
+
 		it('should clear the no-progress count once a scan reaches the whole window', async () => {
 			// A scan that exhausted the page token proves nothing is out of reach, so
 			// the window is not wedged. Without this, a quiet poll between two slow

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2443,6 +2443,115 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1', '2']);
 		});
 
+		it('should stop listing when the poll budget is exhausted and hold the cursor', async () => {
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
+			};
+
+			mockLabels();
+			// Only page 1 is mocked: a poll that keeps listing past the exhausted
+			// budget hits an unmatched request, the error is swallowed, and the
+			// assertions below catch the resulting empty response.
+			mockList(listPage(['1'], 'token-1'));
+			mockGet('1', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// A budget stop cuts the listing short like the page cap does: the
+			// cursor must hold so the unlisted remainder stays reachable.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['1']);
+		});
+
+		it('should stop draining pending ids when the poll budget is exhausted', async () => {
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					pendingMessageIds: ['a', 'b', 'c'],
+				},
+			};
+
+			mockLabels();
+			mockGet('a', 2_000_000_000_000);
+			mockGet('b', 3_000_000_000_000);
+			mockGet('c', 4_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			// One fetch always happens (progress guarantee); the rest of the queue
+			// must survive for the next tick instead of being drained past the budget.
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['a']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['b', 'c']);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['a']);
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+		});
+
+		it('should not start listing when the pending drain consumed the poll budget', async () => {
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					pendingMessageIds: ['a'],
+				},
+			};
+
+			mockLabels();
+			mockGet('a', 2_000_000_000_000);
+			// A new message is listable, but the drain used up the budget: a poll
+			// that lists anyway would deliver it and fail the assertions below.
+			mockList(listPage(['z']));
+			mockGet('z', 3_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['a']);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['a']);
+			// No listing happened, so there is nothing new to advance past.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+		});
+
+		it('should park listed messages as pending when the poll budget is exhausted mid-fetch', async () => {
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': { lastTimeChecked: 1000000 },
+			};
+
+			mockLabels();
+			mockList(listPage(['3', '2', '1']));
+			mockGet('3', 3_000_000_000_000);
+			mockGet('2', 2_000_000_000_000);
+			mockGet('1', 1_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			// One fetch always happens (progress guarantee); the rest fit the
+			// maxResults budget but not the time budget, so they park as pending.
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['3']);
+			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '1']);
+			// The window was fully listed and the unfetched ids are tracked, so
+			// advancing the cursor loses nothing.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3_000_000_000);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['3']);
+		});
+
 		it('should give up holding and advance when the tracked-id bound is exceeded', async () => {
 			const initialTimestamp = 1000000;
 			// The boundary set already holds MAX_TRACKED_BACKLOG_IDS ids, so the valve

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2678,6 +2678,35 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(2);
 		});
 
+		it('should clear the no-progress count once a scan reaches the whole window', async () => {
+			// A scan that exhausted the page token proves nothing is out of reach, so
+			// the window is not wedged. Without this, a quiet poll between two slow
+			// ones keeps the count, and slow ticks weeks apart add up to a give-up.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					possibleDuplicates: ['A'],
+					noProgressTicks: 2,
+				},
+			};
+
+			mockLabels();
+			// One page, no continuation token, and its only id is already handled.
+			mockList(listPage(['A']));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(0);
+			// Nothing new arrived, so the cursor and the boundary set stay as they were.
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['A']);
+		});
+
 		it('should give up once consecutive ticks keep making no progress', async () => {
 			// Repeated no-progress ticks are no longer one unlucky sample: the
 			// window is wedged, so give up loudly rather than hold forever.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -735,7 +735,7 @@ describe('GmailTrigger', () => {
 
 		it('should pick up pending messages on subsequent poll', async () => {
 			// Simulates poll 2: pending IDs from previous poll are fetched directly,
-			// then new messages are listed.
+			// then the poll scans for new messages.
 			const newMessageListResponse: MessageListResponse = {
 				messages: [],
 				resultSizeEstimate: 0,
@@ -1616,11 +1616,12 @@ describe('GmailTrigger', () => {
 
 	describe('v1.4 - backlog scan, drain and retry', () => {
 		// Contract under test: the scan follows nextPageToken up to MAX_SCAN_PAGES
-		// pages, or until the poll's time budget runs out. lastTimeChecked
-		// advances when the scan exhausted the token, or when a give-up valve fires:
-		// no progress past the reach of one poll, or MAX_TRACKED_BACKLOG_IDS ids
-		// already stored. Otherwise the cursor holds, so mail the poll never scanned
-		// stays reachable.
+		// pages, or until the poll's time budget runs out. lastTimeChecked advances
+		// when the scan exhausted the token, or when a give-up valve fires: a run of
+		// polls that each reach nothing new, or MAX_TRACKED_BACKLOG_IDS ids already
+		// stored. Otherwise the cursor holds, so mail the poll never scanned stays
+		// reachable. Tests that pass `pollBudgetMs: 0` start the poll with its time
+		// budget already spent, so every deadline check fires at its first chance.
 		const listPage = (ids: string[], nextPageToken?: string): MessageListResponse => ({
 			messages: ids.map((id) => createListMessage({ id })),
 			resultSizeEstimate: ids.length,
@@ -2360,7 +2361,7 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['C']);
 		});
 
-		it('should give up holding when a capped window makes no progress', async () => {
+		it('should give up holding when a capped window makes no progress on repeated polls', async () => {
 			// Every id the cap can reach is already tracked, so re-scanning the same
 			// pages can never progress past them. Holding on would repeat this poll
 			// forever: no backlog progress, no new mail, no warning. Two polls already
@@ -2380,7 +2381,7 @@ describe('GmailTrigger', () => {
 			pages.forEach((ids, page) =>
 				mockList(listPage(ids, `token-${page + 1}`), page === 0 ? undefined : `token-${page}`),
 			);
-			// No message GET mocks: everything listed is filtered as already handled.
+			// No message GET mocks: everything the scan reached is filtered as already handled.
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
@@ -2449,14 +2450,14 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['1', '2']);
 		});
 
-		it('should stop listing when the poll budget is exhausted and hold the cursor', async () => {
+		it('should stop scanning when the poll budget is exhausted and hold the cursor', async () => {
 			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': { lastTimeChecked: initialTimestamp },
 			};
 
 			mockLabels();
-			// Only page 1 is mocked: a poll that keeps listing past the exhausted
+			// Only page 1 is mocked: a poll that keeps scanning past the exhausted
 			// budget hits an unmatched request, the error is swallowed, and the
 			// assertions below catch the resulting empty response.
 			mockList(listPage(['1'], 'token-1'));
@@ -2469,7 +2470,7 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
-			// A budget stop cuts the listing short like the page cap does: the
+			// A budget stop cuts the scan short like the page cap does: the
 			// cursor must hold so the unlisted remainder stays reachable.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['1']);
@@ -2566,7 +2567,7 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 		});
 
-		it('should not start listing when the pending drain consumed the poll budget', async () => {
+		it('should not start scanning when the pending drain consumed the poll budget', async () => {
 			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -2578,7 +2579,7 @@ describe('GmailTrigger', () => {
 			mockLabels();
 			mockGet('a', 2_000_000_000_000);
 			// A new message is listable, but the drain used up the budget: a poll
-			// that lists anyway would deliver it and fail the assertions below.
+			// that scans anyway would deliver it and fail the assertions below.
 			mockList(listPage(['z']));
 			mockGet('z', 3_000_000_000_000);
 
@@ -2590,11 +2591,11 @@ describe('GmailTrigger', () => {
 
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['a']);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['a']);
-			// No listing happened, so there is nothing new to advance past.
+			// No scan happened, so there is nothing new to advance past.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 		});
 
-		it('should park listed messages as pending when the poll budget is exhausted mid-fetch', async () => {
+		it('should park scanned messages as pending when the poll budget is exhausted mid-fetch', async () => {
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': { lastTimeChecked: 1000000 },
 			};
@@ -2615,16 +2616,16 @@ describe('GmailTrigger', () => {
 			// maxResults budget but not the time budget, so they park as pending.
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['3']);
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toEqual(['2', '1']);
-			// The window was fully listed and the unfetched ids are tracked, so
+			// The window was fully scanned and the unfetched ids are tracked, so
 			// advancing the cursor loses nothing.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3_000_000_000);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['3']);
 		});
 
 		it('should hold instead of giving up when a single tick makes no progress', async () => {
-			// A budget-truncated listing is transient: the next tick gets a fresh
+			// A budget-truncated scan is transient: the next tick gets a fresh
 			// budget and may reach further. Giving up on this one sample would skip
-			// mail that a normal tick would have listed.
+			// mail that a normal tick would have scanned.
 			const initialTimestamp = 1000000;
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
 				'Gmail Trigger': {
@@ -2835,7 +2836,7 @@ describe('GmailTrigger', () => {
 			});
 
 			expect(response?.[0]).toHaveLength(2);
-			// Cap was hit (20 pages listed, token remaining) but the valve fires:
+			// Cap was hit (20 pages scanned, token remaining) but the valve fires:
 			// advance instead of holding.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(6_000_000_000);
 			// The valve skips only unscanned mail; scanned-but-unfetched ids stay tracked.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2367,9 +2367,9 @@ describe('GmailTrigger', () => {
 
 		it('should give up holding when a capped window makes no progress', async () => {
 			// Every id the cap can reach is already tracked, so re-scanning the same
-			// pages can never progress past them. Holding again would repeat this
-			// tick forever: no backlog progress, no new mail, no warning. The poll
-			// must give up instead — advance and start fresh.
+			// pages can never progress past them. Holding on would repeat this poll
+			// forever: no backlog progress, no new mail, no warning. Two polls already
+			// found nothing, so this one must give up — advance and start fresh.
 			const initialTimestamp = 1000000;
 			const pages = Array.from({ length: MAX_LIST_PAGES }, (_, page) => [`h${page}a`, `h${page}b`]);
 			const handledIds = pages.flat();
@@ -2377,6 +2377,7 @@ describe('GmailTrigger', () => {
 				'Gmail Trigger': {
 					lastTimeChecked: initialTimestamp,
 					possibleDuplicates: handledIds,
+					noProgressTicks: 2,
 				},
 			};
 
@@ -2587,6 +2588,87 @@ describe('GmailTrigger', () => {
 			// advancing the cursor loses nothing.
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(3_000_000_000);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['3']);
+		});
+
+		it('should hold instead of giving up when a single tick makes no progress', async () => {
+			// A budget-truncated listing is transient: the next tick gets a fresh
+			// budget and may reach further. Giving up on this one sample would skip
+			// mail that a normal tick would have listed.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					possibleDuplicates: ['A'],
+				},
+			};
+
+			mockLabels();
+			// Page 1 is all-handled and the budget stops the walk there. Page 2 is
+			// not mocked: this tick must not reach it.
+			mockList(listPage(['A'], 'token-1'));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['A']);
+			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(1);
+		});
+
+		it('should give up once consecutive ticks keep making no progress', async () => {
+			// Repeated no-progress ticks are no longer one unlucky sample: the
+			// window is wedged, so give up loudly rather than hold forever.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					possibleDuplicates: ['A'],
+					noProgressTicks: 2,
+				},
+			};
+
+			mockLabels();
+			mockList(listPage(['A'], 'token-1'));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked as number).toBeGreaterThan(
+				initialTimestamp,
+			);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual([]);
+			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(0);
+		});
+
+		it('should clear the no-progress count once a tick delivers again', async () => {
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					noProgressTicks: 2,
+				},
+			};
+
+			mockLabels();
+			mockList(listPage(['1']));
+			mockGet('1', 2_000_000_000_000);
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			// The count must not carry over, or two unrelated slow ticks weeks apart
+			// would add up to a give-up.
+			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(0);
 		});
 
 		it('should give up holding and advance when the tracked-id bound is exceeded', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2396,9 +2396,11 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual([]);
 		});
 
-		it('should not paginate on versions before 1.4', async () => {
-			// Pagination is scoped to v1.4+: older versions have no pendingMessageIds
-			// machinery, so following the token there would change their behavior.
+		it('should ignore the page token and the poll budget on versions before 1.4', async () => {
+			// Both are scoped to v1.4+: older versions have no pendingMessageIds
+			// machinery. Following the token there would change their behavior, and a
+			// stop on the budget would drop the messages the poll did not fetch while
+			// the cursor advances past them.
 			// Only one page is mocked, so a second page request fails the poll,
 			// and the assertions below catch the resulting empty response.
 			const workflowStaticData: Record<string, Record<string, unknown>> = {
@@ -2406,15 +2408,17 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			mockList(listPage(['1'], 'token-1'));
+			mockList(listPage(['1', '2'], 'token-1'));
 			mockGet('1', 2_000_000_000_000);
+			mockGet('2', 3_000_000_000_000);
 
 			const { response } = await testPollingTriggerNode(GmailTrigger, {
 				node: { typeVersion: 1.3, parameters: { simple: true } },
 				workflowStaticData,
+				pollBudgetMs: 0,
 			});
 
-			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1']);
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['1', '2']);
 			// The queue belongs to v1.4+; older versions must not persist one their
 			// own drain path would ignore.
 			expect(workflowStaticData['Gmail Trigger'].pendingMessageIds).toBeUndefined();
@@ -2498,6 +2502,40 @@ describe('GmailTrigger', () => {
 			// One retry always happens, and the untouched entry keeps its count.
 			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['Q1']);
 			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([['Q2', 1]]);
+		});
+
+		it('should keep unreached retry ids in front of the ids it never scheduled', async () => {
+			// The retry pass rebuilds its list from several parts. Ids this poll could
+			// not reach must come before ids it never scheduled, or the next poll
+			// retries the back of the list and the front waits again.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					failedFetches: [
+						['Q1', 1],
+						['Q2', 2],
+						['Q3', 3],
+					],
+				},
+			};
+
+			mockLabels();
+			mockGet('Q1', 2_000_000_000_000);
+			// No mock for 'Q2': the budget must stop this poll before it reaches it.
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 2 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response?.[0]?.map((item) => item.json.id)).toEqual(['Q1']);
+			// maxResults scheduled 'Q1' and 'Q2' for this poll and left 'Q3' out, so
+			// the unreached 'Q2' keeps the front.
+			expect(workflowStaticData['Gmail Trigger'].failedFetches).toEqual([
+				['Q2', 2],
+				['Q3', 3],
+			]);
 		});
 
 		it('should stop draining pending ids when the poll budget is exhausted', async () => {
@@ -2610,6 +2648,34 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['A']);
 			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(1);
+		});
+
+		it('should still hold when a second tick makes no progress', async () => {
+			// The valve needs a run of ticks, not a pair: two scans can both stop
+			// short where the next one reaches further. A shorter run would skip mail
+			// after two slow ticks.
+			const initialTimestamp = 1000000;
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: initialTimestamp,
+					possibleDuplicates: ['A'],
+					noProgressTicks: 1,
+				},
+			};
+
+			mockLabels();
+			mockList(listPage(['A'], 'token-1'));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+				pollBudgetMs: 0,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger'].lastTimeChecked).toBe(initialTimestamp);
+			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['A']);
+			expect(workflowStaticData['Gmail Trigger'].noProgressTicks).toBe(2);
 		});
 
 		it('should give up once consecutive ticks keep making no progress', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2733,6 +2733,29 @@ describe('GmailTrigger', () => {
 			expect(workflowStaticData['Gmail Trigger'].possibleDuplicates).toEqual(['A']);
 		});
 
+		it('should not write the no-progress count when a quiet poll has nothing to clear', async () => {
+			// An idle node reaches this path on every tick. Any write to the static
+			// data marks it dirty and has it saved again, so a poll with no count to
+			// clear must leave the field alone.
+			const workflowStaticData: Record<string, Record<string, unknown>> = {
+				'Gmail Trigger': {
+					lastTimeChecked: 1000000,
+					possibleDuplicates: ['A'],
+				},
+			};
+
+			mockLabels();
+			mockList(listPage(['A']));
+
+			const { response } = await testPollingTriggerNode(GmailTrigger, {
+				node: { typeVersion: 1.4, parameters: { simple: true, maxResults: 10 } },
+				workflowStaticData,
+			});
+
+			expect(response).toBeNull();
+			expect(workflowStaticData['Gmail Trigger']).not.toHaveProperty('noProgressTicks');
+		});
+
 		it('should give up once consecutive ticks keep making no progress', async () => {
 			// Repeated no-progress ticks are no longer one unlucky sample: the
 			// window is wedged, so give up loudly rather than hold forever.

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -2456,9 +2456,10 @@ describe('GmailTrigger', () => {
 			};
 
 			mockLabels();
-			// The time budget, not a small page cap, bounds listing reach: a
-			// 21-page window must be walked to token exhaustion so the cursor
-			// can advance without losing the unlisted remainder.
+			// Listing reach is bounded by the time budget, not a fixed page count:
+			// 21 pages (one past the old 20-page cap) are walked to token
+			// exhaustion, so unfetched ids park as pending and the cursor can
+			// advance.
 			const pages = Array.from({ length: 21 }, (_, page) => [`q${page}`]);
 			pages.forEach((ids, page) =>
 				mockList(

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -3,11 +3,7 @@ import nock from 'nock';
 
 import { testPollingTriggerNode } from '@test/nodes/TriggerHelpers';
 
-import {
-	GmailTrigger,
-	MAX_LIST_PAGES,
-	MAX_PENDING_FETCH_ATTEMPTS,
-} from '../GmailTrigger.node';
+import { GmailTrigger, MAX_LIST_PAGES, MAX_PENDING_FETCH_ATTEMPTS } from '../GmailTrigger.node';
 import type { Message, ListMessage, MessageListResponse } from '../types';
 
 vi.mock('mailparser');

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -61,8 +61,9 @@ export type GmailWorkflowStaticData = {
 	/** v1.4+: IDs whose fetch failed, with how many attempts each has had so far */
 	failedFetches?: Array<[string, number]>;
 	/**
-	 * v1.4+: Consecutive polls whose scan stopped short and reached nothing new;
-	 * a delivery or a full scan clears it
+	 * Consecutive polls whose scan stopped short and reached nothing new. Any
+	 * fetched message clears it, delivered or filtered out. A scan that exhausted
+	 * the page token clears it too. Only v1.4+ reads it.
 	 */
 	noProgressTicks?: number;
 };

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -60,6 +60,8 @@ export type GmailWorkflowStaticData = {
 	pendingMessageIds?: string[];
 	/** v1.4+: IDs whose fetch failed, with how many attempts each has had so far */
 	failedFetches?: Array<[string, number]>;
+	/** v1.4+: Consecutive polls that listed nothing new; resets as soon as one fetches */
+	noProgressTicks?: number;
 };
 export type GmailWorkflowStaticDataDictionary = Record<string, GmailWorkflowStaticData>;
 

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -60,7 +60,10 @@ export type GmailWorkflowStaticData = {
 	pendingMessageIds?: string[];
 	/** v1.4+: IDs whose fetch failed, with how many attempts each has had so far */
 	failedFetches?: Array<[string, number]>;
-	/** v1.4+: Consecutive polls that listed nothing new; a delivery or a full scan clears it */
+	/**
+	 * v1.4+: Consecutive polls whose scan stopped short and reached nothing new;
+	 * a delivery or a full scan clears it
+	 */
 	noProgressTicks?: number;
 };
 export type GmailWorkflowStaticDataDictionary = Record<string, GmailWorkflowStaticData>;

--- a/packages/nodes-base/nodes/Google/Gmail/types.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/types.ts
@@ -60,7 +60,7 @@ export type GmailWorkflowStaticData = {
 	pendingMessageIds?: string[];
 	/** v1.4+: IDs whose fetch failed, with how many attempts each has had so far */
 	failedFetches?: Array<[string, number]>;
-	/** v1.4+: Consecutive polls that listed nothing new; resets as soon as one fetches */
+	/** v1.4+: Consecutive polls that listed nothing new; a delivery or a full scan clears it */
 	noProgressTicks?: number;
 };
 export type GmailWorkflowStaticDataDictionary = Record<string, GmailWorkflowStaticData>;

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -323,8 +323,9 @@ export async function testPollingTriggerNode(
 	(additionalData as unknown as Record<string, unknown>).evalLlmMockHandler = undefined;
 
 	const { pollBudgetMs } = options;
-	// Defaults for __emit, __emitError, __commitCursor, __runPoll,
-	// resolveNodeStaticData — only the poll-budget getter is overridden.
+	// Each undefined keeps a PollContext default: __emit, __emitError,
+	// __commitCursor, __runPoll, resolveNodeStaticData. The poll-budget getter is
+	// the only constructor argument this helper sets.
 	const pollContext = new PollContext(
 		workflow,
 		node,

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -323,6 +323,8 @@ export async function testPollingTriggerNode(
 	(additionalData as unknown as Record<string, unknown>).evalLlmMockHandler = undefined;
 
 	const { pollBudgetMs } = options;
+	// Defaults for __emit, __emitError, __commitCursor, __runPoll,
+	// resolveNodeStaticData — only the poll-budget getter is overridden.
 	const pollContext = new PollContext(
 		workflow,
 		node,

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -63,7 +63,10 @@ type TestWebhookTriggerNodeOptions = TestTriggerNodeOptions & {
 	headerData?: IncomingHttpHeaders;
 };
 
-type TestPollingTriggerNodeOptions = TestTriggerNodeOptions & {};
+type TestPollingTriggerNodeOptions = TestTriggerNodeOptions & {
+	/** Overrides the poll time budget the context reports (default: 5 minutes). */
+	pollBudgetMs?: number;
+};
 
 function getNodeVersion(Trigger: new () => VersionedNodeType, version?: number) {
 	const instance = new Trigger();
@@ -319,7 +322,20 @@ export async function testPollingTriggerNode(
 	// don't take the eval-mock code path.
 	(additionalData as unknown as Record<string, unknown>).evalLlmMockHandler = undefined;
 
-	const pollContext = new PollContext(workflow, node, additionalData, mode, 'init');
+	const { pollBudgetMs } = options;
+	const pollContext = new PollContext(
+		workflow,
+		node,
+		additionalData,
+		mode,
+		'init',
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		pollBudgetMs === undefined ? undefined : () => pollBudgetMs,
+	);
 
 	pollContext.getNode = () => node;
 	pollContext.getCredentials = async <T extends object = ICredentialDataDecryptedObject>() =>


### PR DESCRIPTION
## Summary

A poll over a large Gmail backlog can run longer than the scheduler allows. The engine then abandons the tick and discards the work it did. This PR makes the trigger stop on its own before that happens.

The trigger reads the time budget the engine reports and turns it into a deadline at the start of each poll. Five phases check that deadline: the retry pass over set-aside ids, the queue drain, the gate before the scan, the scan itself, and the fetch of newly scanned messages. Each check runs after at least one request, so every poll makes progress.

A budget stop behaves like the page-cap stop that already exists. Either the cursor holds, or the scanned-but-unfetched ids stay in the queue. The next poll continues where this one stopped. No mail is skipped.

### Two related fixes

**The no-progress valve gave up too early.** The valve advances the cursor past mail a poll could not reach. One truncated scan used to be enough to fire it. That was safe while only the page cap could cut a scan short, because a repeated scan of the same window gives the same result. A slow response is different: the next poll, with a fresh budget, may reach further, and giving up would skip the rest of the window for good. The valve now needs three polls in a row that reach nothing new. Any fetched message clears the count, and so does a scan that reaches the end of the window.

**An empty page ended the scan.** Gmail marks the end of a list only by dropping the page token, so a page with no messages does not mean the window is finished. A poll that collected no ids used to return at once. That skipped the valve and left no trace of the stop. The poll now pages until the token is gone, the page cap is reached, or the budget runs out.

### What this PR does not change

- How many messages one execution carries. `maxResults` stays the bound, as a memory guard.
- The page cap. It stays at 20 pages.
- Polls on version 1.3 and older, and manual runs. Every deadline check sits behind the same version gate as the pagination.

## How to test

```
pnpm --filter n8n-nodes-base test GmailTrigger.test
```

71 tests, all green. The budget tests inject a zero budget through the test helper, so they are deterministic without fake timers.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3870

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
