### PR TITLE
fix(core): Forward the receiver in the lazy-proxy set trap

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
@@ -532,19 +532,13 @@ describe('createDeepLazyProxy', () => {
 		}
 
 		describe('array proxies', () => {
-			it('index write is applied and visible to later reads', () => {
-				const p = writableArrayProxy();
-				p[0] = 'X';
-				expect(p[0]).toBe('X');
-				expect(p[1]).toBe('b');
-			});
-
 			it('reads never materialize; first write fetches each element exactly once', () => {
 				const p = writableArrayProxy();
 				expect(p[0]).toBe('a');
 				expect(mocks.getArrayElement).toHaveBeenCalledTimes(1);
 
 				p[0] = 'X';
+				expect(p[0]).toBe('X');
 				// materialization fetches the remaining uncached elements (1, 2)
 				expect(mocks.getArrayElement).toHaveBeenCalledTimes(3);
 
@@ -567,20 +561,7 @@ describe('createDeepLazyProxy', () => {
 				expect(p.pop()).toBe('c');
 				expect(p.length).toBe(2);
 				expect(2 in p).toBe(false);
-			});
-
-			it('splice() removes in place with consistent length and contents', () => {
-				const p = writableArrayProxy();
-				expect(p.splice(0, 2)).toEqual(['a', 'b']);
-				expect(p.length).toBe(1);
-				expect([...p]).toEqual(['c']);
-			});
-
-			it('native sort() mutates in place and is visible to later reads', () => {
-				const p = writableArrayProxy([3, 1, 2]);
-				p.sort();
-				expect([...p]).toEqual([1, 2, 3]);
-				expect(p[0]).toBe(1);
+				expect([...p]).toEqual(['a', 'b']);
 			});
 
 			it('delete removes the element without resurrecting it on the next read', () => {
@@ -619,13 +600,6 @@ describe('createDeepLazyProxy', () => {
 		});
 
 		describe('object proxies', () => {
-			it('existing-key write is applied and visible to later reads', () => {
-				const p = writableObjectProxy();
-				p.name = 'Zed';
-				expect(p.name).toBe('Zed');
-				expect(p.email).toBe('a@x');
-			});
-
 			it('new-key write is visible and enumerable', () => {
 				const p = writableObjectProxy();
 				p.extra = 42;
@@ -656,13 +630,16 @@ describe('createDeepLazyProxy', () => {
 				expect(p['__proto__']).toBe(protoValue);
 			});
 
-			it('write fetches each key exactly once; later access stays local', () => {
+			it('write fetches each uncached key exactly once; later access stays local', () => {
 				const p = writableObjectProxy();
+				expect(p.name).toBe('Alice');
 				p.name = 'Zed';
-				const callsAfterWrite = mocks.getValueAtPath.mock.calls.length;
+				// The pre-read cached 'name'; materialization fetched only 'email'.
+				expect(mocks.getValueAtPath).toHaveBeenCalledTimes(2);
+				expect(p.name).toBe('Zed');
 				expect(p.email).toBe('a@x');
 				p.email = 'b@x';
-				expect(mocks.getValueAtPath.mock.calls.length).toBe(callsAfterWrite);
+				expect(mocks.getValueAtPath).toHaveBeenCalledTimes(2);
 			});
 		});
 	});

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
@@ -598,6 +598,14 @@ describe('createDeepLazyProxy', () => {
 				expect(desc).toMatchObject({ writable: true, value: 'X' });
 			});
 
+			it('a write through a derived object lands on the derived object, not the proxy cache', () => {
+				const p = writableArrayProxy();
+				const derived = Object.create(p);
+				derived.foo = 'X';
+				expect(Object.prototype.hasOwnProperty.call(derived, 'foo')).toBe(true);
+				expect(p.foo).toBeUndefined();
+			});
+
 			it('error sentinel during materialization propagates', () => {
 				const sentinel = { __isError: true, name: 'Error', message: 'fetch failed' };
 				mocks.getArrayElement.mockImplementation((_path: string[], idx: number) =>

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
@@ -240,7 +240,6 @@ describe('createDeepLazyProxy', () => {
 
 		it('does not intercept negative indices', () => {
 			const p = proxyWithLargeArray();
-			// -1 is NaN? No, Number('-1') === -1 which is not NaN, but -1 >= 0 is false
 			p.items[-1];
 			expect(mocks.getArrayElement).not.toHaveBeenCalled();
 		});

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -175,9 +175,10 @@ export function createDeepLazyProxy(
 	// per-evaluation context.
 	let materialized = false;
 
-	function fetchAndCacheArrayElement(idx: number): unknown {
+	// `prop` is the already-stringified index — callers have it at hand, and
+	// re-deriving it here would put a String() allocation on the hot read path.
+	function fetchAndCacheArrayElement(idx: number, prop: string): unknown {
 		const t = target as Record<string, unknown>;
-		const prop = String(idx);
 		const element = getArrayElement(basePath, idx);
 		// Primitives (and null) skip `materializeChild`'s metadata checks.
 		if (element === null || typeof element !== 'object') {
@@ -207,7 +208,8 @@ export function createDeepLazyProxy(
 		if (materialized) return;
 		if (isArray) {
 			for (let i = 0; i < arrayLength; i++) {
-				if (!Object.prototype.hasOwnProperty.call(target, String(i))) fetchAndCacheArrayElement(i);
+				const prop = String(i);
+				if (!Object.prototype.hasOwnProperty.call(target, prop)) fetchAndCacheArrayElement(i, prop);
 			}
 			(target as unknown[]).length = arrayLength;
 		} else {
@@ -307,15 +309,18 @@ export function createDeepLazyProxy(
 			if (isArray) {
 				const idx = isInArrayBounds(prop);
 				if (idx === undefined) return undefined;
-				return fetchAndCacheArrayElement(idx);
+				return fetchAndCacheArrayElement(idx, prop);
 			}
 
 			return fetchAndCacheObjectValue(prop);
 		},
 
-		set(_targetObj: any, prop: string | symbol, value: unknown): boolean {
+		set(_targetObj: any, prop: string | symbol, value: unknown, receiver: unknown): boolean {
 			materialize();
-			return Reflect.set(target, prop, value);
+			// Forward the receiver: when the proxy sits on another object's
+			// prototype chain, the write must create an own property on that
+			// object, not land in this proxy's cache.
+			return Reflect.set(target, prop, value, receiver);
 		},
 
 		deleteProperty(_targetObj: any, prop: string | symbol): boolean {

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -99,6 +99,8 @@ export type ProxyMeta = { kind: 'object'; keys?: string[] } | { kind: 'array'; l
  * 2. Metadata indicates type: primitive, object, or array
  * 3. For objects/arrays: Create nested proxy (shape-matched) for lazy loading
  * 4. Cache all fetched values in target to avoid repeated callbacks
+ * 5. On the first write or delete: shallow-materialize into the cache
+ *    (copy-on-write). Mutations stay in the evaluation and never reach the host.
  *
  * Callable host bindings (`$('Foo').first()`, `$items()`, etc.) do not flow
  * through this proxy — they are wired as in-isolate stubs on `target` that
@@ -127,7 +129,8 @@ export function createDeepLazyProxy(
 	const objectKeys = meta?.kind === 'object' ? meta.keys : undefined;
 
 	// Cache for keys fetched from the bridge (root object proxies without known keys).
-	// Shared between ownKeys and getOwnPropertyDescriptor for consistency.
+	// Shared by ownKeys, getOwnPropertyDescriptor, and materialize() so all three
+	// see the same key list.
 	let fetchedKeys: string[] | undefined;
 
 	function resolveObjectKeys(): string[] {
@@ -173,10 +176,15 @@ export function createDeepLazyProxy(
 	// never cross the isolate boundary — the host callback surface is read-only
 	// (getValueAtPath / getArrayElement) — and the mutated copy dies with the
 	// per-evaluation context.
+	// The guard must be in EVERY trap: after mutation, the construction-time
+	// meta (arrayLength, host key list, host `in` checks) is stale — an
+	// unguarded trap would report the pre-push length or resurrect deleted keys.
 	let materialized = false;
 
 	// `prop` is the already-stringified index — callers have it at hand, and
 	// re-deriving it here would put a String() allocation on the hot read path.
+	// Plain assignment is safe here (unlike fetchAndCacheObjectValue): `prop`
+	// is always a canonical index string, never a setter-chain key like '__proto__'.
 	function fetchAndCacheArrayElement(idx: number, prop: string): unknown {
 		const t = target as Record<string, unknown>;
 		const element = getArrayElement(basePath, idx);
@@ -206,6 +214,9 @@ export function createDeepLazyProxy(
 
 	function materialize(): void {
 		if (materialized) return;
+		// Keep cached entries: a cached child proxy can already carry its own
+		// copy-on-write mutations; a re-fetch would create a fresh proxy and
+		// discard them.
 		if (isArray) {
 			for (let i = 0; i < arrayLength; i++) {
 				const prop = String(i);
@@ -301,7 +312,6 @@ export function createDeepLazyProxy(
 				return arrayLength;
 			}
 
-			// Check cache - if already fetched, return cached value
 			if (prop in targetObj) {
 				return targetObj[prop];
 			}
@@ -315,6 +325,10 @@ export function createDeepLazyProxy(
 			return fetchAndCacheObjectValue(prop);
 		},
 
+		// Expression code runs in sloppy mode (the eval wrapper adds no
+		// 'use strict'), so a false result from these traps no-ops silently
+		// instead of throwing. Materialize, then let Reflect apply the
+		// mutation for real.
 		set(_targetObj: any, prop: string | symbol, value: unknown, receiver: unknown): boolean {
 			materialize();
 			// Forward the receiver: when the proxy sits on another object's
@@ -329,8 +343,6 @@ export function createDeepLazyProxy(
 		},
 
 		has(targetObj: any, prop: string | symbol): boolean {
-			// Implement 'in' operator support
-			// Example: '$json' in data
 			if (materialized) return Reflect.has(targetObj, prop);
 
 			// Mirror the get trap: symbol-keyed lookups defer to the target so
@@ -343,12 +355,10 @@ export function createDeepLazyProxy(
 				return isInArrayBounds(prop) !== undefined;
 			}
 
-			// Check cache first
 			if (prop in targetObj) {
 				return true;
 			}
 
-			// Build path and check existence via callback
 			const path = [...basePath, prop];
 			const value = getValueAtPath(path);
 
@@ -356,8 +366,7 @@ export function createDeepLazyProxy(
 			// so the isolate's outer try-catch can serialize them back via __reportError
 			throwIfErrorSentinel(value);
 
-			// Property exists if value is not undefined
-			// Note: null values mean property exists but is null
+			// Note: null values mean the property exists but is null.
 			return value !== undefined;
 		},
 	});

--- a/packages/workflow/test/expression-array-proxy-semantics.test.ts
+++ b/packages/workflow/test/expression-array-proxy-semantics.test.ts
@@ -4,7 +4,9 @@ import * as Helpers from './helpers';
 import type { INodeExecutionData } from '../src/interfaces';
 import { Workflow } from '../src/workflow';
 
-// Engine-parity tests for behaviour of `$json` arrays beyond plain indexed access.
+// Engine-parity tests for `$json` arrays beyond plain indexed access. Return
+// values must match on both engines; mutation persistence intentionally
+// diverges (see the isVm branches below).
 
 describe('Expression — array proxy semantics (engine parity)', () => {
 	const workflow = new Workflow({


### PR DESCRIPTION
## Summary

This fixes an esoteric regression using `Object.create` in expressions:

```js
{{ (() => {
  const local = Object.create($json.config);   // local overlay, shouldn't touch $json
  local.retries = 3;
  return [local.retries, $json.config.retries].join('/');
})() }}
```

Before this would return `3/3` with the copy-on-write approach, e.g. assigning to the new object would also assign to the source. 
But it should return `3/1` and with this PR does.

I don't know if anybody relies on `Object.create` in the wild, but better to be correct.

It also contains some comment improvements and throws out some redundant tests.

<details>
<summary>AI Summary</summary>

Follow-up to #37262 (stacked on its branch so only the delta shows), from a post-implementation review sweep — adversarial review with refutation pass, mutation testing (15/17 kill rate), and a comment audit.

- **Fix: forward the `receiver` in the lazy-proxy `set` trap.** Without it, a write through an object that has the proxy on its prototype chain (`Object.create($json.arr)` is expressible — `SafeObject` allows single-arg `create`) lands in the proxy's cache instead of on that object: verified through the real evaluator, the written key then appears in `Object.keys($json.arr)` for the rest of the evaluation. Scope was evaluation-local (per-evaluation copy-on-write), never host data. Pinned by a new prototype-chain-write test.
- **Perf: keep `String()` off the per-element read path** — the `get` trap already holds the index string; pass it into `fetchAndCacheArrayElement` instead of re-deriving it (CodSpeed flagged `vm: Array Iteration - map 10k items` on the parent PR).
- **Tests: mutation-hardening.** A pre-read plus a pinned bridge-call count now kills the one surviving non-equivalent mutant (materialization silently re-fetching cached keys); four tests whose kill-sets were strict subsets of siblings are folded into those siblings.
- **Docs: comment audit.** Documents the invisible constraints (materialized guard required in every trap; cached-entry skip preserves child proxies' own mutations; sloppy-mode swallows falsy trap results; array vs object caching asymmetry) and removes comments that restated adjacent code.


</details>


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4266

Follow-up to https://github.com/n8n-io/n8n/pull/37262.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

