### PR TITLE
fix(agents): Bind chat resume and open suspensions to the calling user

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -56,6 +56,7 @@ function makeController() {
 		agentExecutionOrchestratorService,
 		agentTestRunService,
 		agentChatAttachmentService,
+		agentsBuilderService,
 		agentsService: {
 			findById: agentsService.findById,
 			getConversationHistory: agentExecutionOrchestratorService.getConversationHistory,
@@ -127,6 +128,7 @@ describe('AgentChatController chat message history', () => {
 
 		const result = await controller.getChatMessages({
 			params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
+			user: { id: 'user-1' },
 		} as never);
 
 		expect(result).toEqual({
@@ -159,8 +161,84 @@ describe('AgentChatController chat message history', () => {
 		await expect(
 			controller.getChatMessages({
 				params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
+				user: { id: 'user-1' },
 			} as never),
 		).rejects.toThrow(NotFoundError);
+	});
+});
+
+describe('AgentChatController suspension and resume binding', () => {
+	const suspendedCheckpoint = (resourceId: string) =>
+		({
+			persistence: { threadId: 'thread-1', resourceId },
+			pendingToolCalls: {
+				'tc-1': {
+					toolCallId: 'tc-1',
+					runId: 'run-1',
+					toolName: 'Code',
+					suspended: true,
+					suspendPayload: { type: 'approval', toolName: 'Code', args: {} },
+				},
+			},
+			messageList: { messages: [] },
+		}) as never;
+
+	it("binds the resumed checkpoint to the calling user's chat memory", async () => {
+		const { controller, agentExecutionOrchestratorService } = makeController();
+		let received: { expectedMemory?: unknown } | undefined;
+		agentExecutionOrchestratorService.resumeForChat.mockImplementation(async function* (config) {
+			received = config;
+			yield* [];
+		});
+
+		await controller.chatResume(
+			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+			makeSseResponse([]),
+			'agent-1',
+			{ runId: 'run-1', toolCallId: 'tc-1', resumeData: { approved: true } } as never,
+		);
+
+		expect(received?.expectedMemory).toEqual({ resourceId: 'draft-chat:user-1' });
+	});
+
+	it("includes open suspensions for the calling user's own checkpoint", async () => {
+		const { controller, agentsService, agentsBuilderService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		agentsService.getConversationHistory.mockResolvedValue([] as never);
+		agentsBuilderService.findOpenCheckpointForThread.mockResolvedValue(
+			suspendedCheckpoint('draft-chat:user-1'),
+		);
+
+		const result = await controller.getChatMessages({
+			params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
+			user: { id: 'user-1' },
+		} as never);
+
+		expect(result.openSuspensions).toEqual([
+			{
+				toolCallId: 'tc-1',
+				runId: 'run-1',
+				suspendPayload: { type: 'approval', toolName: 'Code', args: {} },
+			},
+		]);
+	});
+
+	it("does not surface open suspensions for another user's checkpoint", async () => {
+		const { controller, agentsService, agentsBuilderService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		agentsService.getConversationHistory.mockResolvedValue([
+			{ id: 'execution-1:user', role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+		] as never);
+		agentsBuilderService.findOpenCheckpointForThread.mockResolvedValue(
+			suspendedCheckpoint('draft-chat:someone-else'),
+		);
+
+		const result = await controller.getChatMessages({
+			params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
+			user: { id: 'user-1' },
+		} as never);
+
+		expect(result.openSuspensions).toEqual([]);
 	});
 });
 

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -780,6 +780,7 @@ describe('AgentExecutionOrchestratorService', () => {
 					runId: 'expired-run',
 					toolCallId: 'tc-1',
 					resumeData: { value: 'yes' },
+					expectedMemory: { threadId: 'thread-1' },
 				}),
 			),
 		).rejects.toThrow(UserError);
@@ -799,6 +800,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				runId: 'run-1',
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
+				expectedMemory: { threadId: 'thread-1' },
 				integrationType: 'slack',
 				abortSignal: abortController.signal,
 			}),
@@ -864,6 +866,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				runId: 'run-1',
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
+				expectedMemory: { threadId: 'thread-1' },
 				integrationType: 'slack',
 			}),
 		);
@@ -902,6 +905,7 @@ describe('AgentExecutionOrchestratorService', () => {
 					runId: 'run-1',
 					toolCallId: 'tc-1',
 					resumeData: { value: 'yes' },
+					expectedMemory: { threadId: 'thread-1' },
 					user,
 					usePublishedVersion: false,
 					integrationType: N8N_CHAT_INTEGRATION_TYPE,
@@ -926,6 +930,7 @@ describe('AgentExecutionOrchestratorService', () => {
 					runId: 'run-1',
 					toolCallId: 'tc-1',
 					resumeData: { value: 'yes' },
+					expectedMemory: { threadId: 'thread-1' },
 					integrationType: 'slack',
 				}),
 			),
@@ -953,6 +958,7 @@ describe('AgentExecutionOrchestratorService', () => {
 			runId: 'run-1',
 			toolCallId: 'tc-1',
 			resumeData: { value: 'yes' },
+			expectedMemory: { threadId: 'thread-1' },
 			abortSignal: abortController.signal,
 			onExecutionRecorded: vi.fn(),
 		});
@@ -1069,6 +1075,7 @@ describe('AgentExecutionOrchestratorService', () => {
 					runId: 'child-run-1',
 					toolCallId: 'child-tool-call-1',
 					resumeData: { approved: true },
+					expectedMemory: { threadId: 'thread-1' },
 				}),
 			),
 		).rejects.toThrow('Delegated actions must be resumed through their parent agent');
@@ -1193,6 +1200,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				runId: 'run-1',
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
+				expectedMemory: { threadId: 'thread-1' },
 				integrationType: 'slack',
 			}),
 		);
@@ -1227,6 +1235,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				runId: 'run-1',
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
+				expectedMemory: { threadId: 'thread-1' },
 				integrationType: 'telegram',
 			}),
 		);
@@ -1269,6 +1278,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				runId: 'run-1',
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
+				expectedMemory: { threadId: 'thread-1' },
 				integrationType: 'slack',
 			}),
 		);
@@ -1302,6 +1312,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				runId: 'run-1',
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
+				expectedMemory: { threadId: 'thread-1' },
 				integrationType: 'slack',
 			}),
 		);
@@ -1336,6 +1347,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				runId: 'run-1',
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
+				expectedMemory: { threadId: 'thread-1' },
 				integrationType: 'slack',
 			}),
 		);

--- a/packages/cli/src/modules/agents/agent-chat.controller.ts
+++ b/packages/cli/src/modules/agents/agent-chat.controller.ts
@@ -213,6 +213,9 @@ export class AgentChatController {
 					runId,
 					toolCallId,
 					resumeData,
+					// Bind the checkpoint to the calling user's chat memory so a run id
+					// from another member's conversation cannot be replayed here.
+					expectedMemory: { resourceId: draftChatMemoryResourceId(req.user.id) },
 					user: req.user,
 					usePublishedVersion: false,
 					integrationType: N8N_CHAT_INTEGRATION_TYPE,
@@ -277,11 +280,17 @@ export class AgentChatController {
 			agentId,
 			threadId,
 		);
+		// Open suspensions carry resume coordinates and tool arguments; only the
+		// user whose chat memory owns the checkpoint may see them.
+		const ownCheckpoint =
+			checkpoint?.persistence?.resourceId === draftChatMemoryResourceId(req.user.id)
+				? checkpoint
+				: null;
 		if (!history) {
-			if (checkpoint) return withOpenSuspensions([], checkpoint);
+			if (ownCheckpoint) return withOpenSuspensions([], ownCheckpoint);
 			throw new NotFoundError(`Thread "${threadId}" not found`);
 		}
-		return withOpenSuspensions(history, checkpoint, {
+		return withOpenSuspensions(history, ownCheckpoint, {
 			appendInactiveCheckpointMessages: false,
 		});
 	}

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -91,8 +91,13 @@ export interface ResumeForChatConfig {
 	runId: string;
 	toolCallId: string;
 	resumeData: unknown;
-	/** Expected memory scope used to prevent resuming another user's or thread's checkpoint. */
-	expectedMemory?: Partial<AgentMemoryScope>;
+	/**
+	 * Expected memory scope — binds the resume to a chat's own checkpoint so a
+	 * run id obtained elsewhere cannot be replayed here. Required so callers
+	 * must state what they bind to (draft chat binds the caller's resourceId,
+	 * platform integrations bind the acting thread).
+	 */
+	expectedMemory: Partial<AgentMemoryScope>;
 	/** Identifies the surface that resumed the execution. */
 	source?: string;
 	/**

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-hitl-resume-handler.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-hitl-resume-handler.test.ts
@@ -42,7 +42,10 @@ it.each([
 			'discord:800000000000000001:700000000000000001:600000000000000001',
 		toAgentThreadId: () => ({ id: 'agent-thread-1' }) as never,
 		getPlatformAgentContext: () => ({}),
-		messageContextBridge: { updateLatest: vi.fn().mockResolvedValue(undefined) } as never,
+		messageContextBridge: {
+			updateLatest: vi.fn().mockResolvedValue(undefined),
+			resolveSession: vi.fn().mockResolvedValue(null),
+		} as never,
 		streamConsumer: { consume: vi.fn().mockResolvedValue(undefined) } as never,
 		createResumeExecutionContext: async () => ({}),
 	});

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -84,6 +84,7 @@ interface AgentExecutor {
 		toolCallId: string;
 		resumeData: unknown;
 		integrationType?: string;
+		expectedMemory: { threadId: string };
 	}): AsyncGenerator<StreamChunk>;
 
 	/**

--- a/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
@@ -13,6 +13,7 @@ import { onceStatusHandle } from './agent-chat-integration';
 import type { AgentChatMessageContextBridge } from './agent-chat-message-context';
 import type { AgentChatStreamConsumer } from './agent-chat-stream-consumer';
 import type { CallbackStore } from './callback-store';
+import { toInternalThreadId } from './types';
 import type { InternalThread } from './types';
 
 interface ResumeExecutor {
@@ -23,6 +24,7 @@ interface ResumeExecutor {
 		toolCallId: string;
 		resumeData: unknown;
 		integrationType?: string;
+		expectedMemory: { threadId: string };
 	}): AsyncGenerator<StreamChunk>;
 }
 
@@ -241,6 +243,9 @@ export class AgentChatHitlResumeHandler {
 
 		this.activeResumedRuns.add(runId);
 		try {
+			// Bind the resume to this thread's session so a run id captured in
+			// another conversation cannot be replayed here.
+			const expectedThreadId = await this.resolveMemoryThreadId(thread);
 			const resumeExecutionContext = await this.options.createResumeExecutionContext(thread);
 			const statusHandle = onceStatusHandle(resumeExecutionContext.statusHandle);
 			try {
@@ -251,6 +256,7 @@ export class AgentChatHitlResumeHandler {
 					toolCallId,
 					resumeData,
 					integrationType: this.options.integration.type,
+					expectedMemory: { threadId: expectedThreadId },
 				});
 				await this.options.streamConsumer.consume(stream, thread, {
 					...resumeExecutionContext,
@@ -265,5 +271,17 @@ export class AgentChatHitlResumeHandler {
 		} finally {
 			this.activeResumedRuns.delete(runId);
 		}
+	}
+
+	/**
+	 * The thread a checkpoint parks against — the acting thread, or the session
+	 * it is bound to when a reply continues an earlier session (mirrors the
+	 * binding resolution in `AgentChatBridge.executeAndStream`).
+	 */
+	private async resolveMemoryThreadId(thread: Thread<unknown, unknown>): Promise<string> {
+		const platformThreadId = this.options.resolvePlatformThreadId(thread);
+		const threadId: InternalThread = this.options.toAgentThreadId(platformThreadId);
+		const sessionOrigin = await this.options.messageContextBridge.resolveSession(threadId.id);
+		return sessionOrigin ? toInternalThreadId(sessionOrigin.threadId).id : threadId.id;
 	}
 }


### PR DESCRIPTION
## Summary

Resumes a suspended agent chat checkpoint only when it belongs to the caller's own chat memory, mirroring the binding that `cancelChatRun` already applies.

- `chatResume` now passes the calling user's chat memory scope as the expected checkpoint owner, so a checkpoint from another member's conversation is rejected.
- The expected memory scope is now a **required** parameter of `resumeForChat`, so callers must state what they bind to. Draft chat binds the caller's `resourceId`; platform integrations (Slack, Telegram, Discord, Linear) bind the acting thread's session, including the session-origin resolution used when a reply continues an earlier session.
- `GET /:agentId/chat/:threadId/messages` only surfaces `openSuspensions` for the calling user's own checkpoint. Open suspensions carry resume coordinates and tool arguments, so they are treated as owner-only data.

## How to test

Requires the agents module: `N8N_ENABLED_MODULES=agents` and a team project with two members.

1. As member A, chat with an agent that has a tool with "Require approval" enabled. Let the run suspend.
2. As member B (e.g. `project:viewer`), call `POST /rest/projects/:projectId/agents/v2/:agentId/chat/resume` with A's `runId` and `toolCallId`. The SSE stream must return an error ("does not belong to this chat") and must not execute the tool.
3. As member A, resume the same checkpoint. The resume must succeed and stream the tool result.
4. As member B, call `GET .../chat/:threadId/messages` on A's thread. The `openSuspensions` array must be empty.
5. Regression: platform integration (e.g. Telegram) approval buttons must still resume their own thread's checkpoint. Covered by the recorded and synthetic integration suites.

**Note:** the change is covered by unit and integration tests (the full `src/modules/agents` suite passes: 158 files, 2371 tests), but it has **not yet been validated manually end-to-end** against a running instance. An API-level reproduction script against a local dev server was started but not completed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-741

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

