### PR TITLE
fix(Baserow Node): Handle missing filter values

### DIFF
--- a/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
@@ -74,10 +74,10 @@ function isFullyFormattedMultiStepValue(value: string): boolean {
  */
 export function formatBaserowFilterValue(
 	operator: string,
-	value: string,
+	value?: string,
 	timezone = 'UTC',
 ): string {
-	const trimmed = value.trim();
+	const trimmed = value?.trim() ?? '';
 
 	if (!trimmed) {
 		if (DEPRECATED_TIMEZONE_ONLY_OPERATORS.has(operator)) {

--- a/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
@@ -74,10 +74,10 @@ function isFullyFormattedMultiStepValue(value: string): boolean {
  */
 export function formatBaserowFilterValue(
 	operator: string,
-	value?: string,
+	value?: unknown,
 	timezone = 'UTC',
 ): string {
-	const trimmed = value?.trim() ?? '';
+	const trimmed = String(value ?? '').trim();
 
 	if (!trimmed) {
 		if (DEPRECATED_TIMEZONE_ONLY_OPERATORS.has(operator)) {

--- a/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import type {
 	IDataObject,
 	IExecuteFunctions,
@@ -6,7 +7,7 @@ import type {
 	IRequestOptions,
 	JsonObject,
 } from 'n8n-workflow';
-import { NodeApiError } from 'n8n-workflow';
+import { NodeApiError, UserError } from 'n8n-workflow';
 
 import type { BaserowCredentials, LoadedResource } from './types';
 
@@ -77,7 +78,19 @@ export function formatBaserowFilterValue(
 	value?: unknown,
 	timezone = 'UTC',
 ): string {
-	const trimmed = String(value ?? '').trim();
+	let normalizedValue: string;
+	if (value === undefined || value === null) {
+		normalizedValue = '';
+	} else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+		normalizedValue = String(value);
+	} else if (DateTime.isDateTime(value) && value.isValid) {
+		normalizedValue = value.toISO() ?? '';
+	} else {
+		throw new UserError(
+			'Baserow filter values must be strings, numbers, booleans, or valid DateTime values',
+		);
+	}
+	const trimmed = normalizedValue.trim();
 
 	if (!trimmed) {
 		if (DEPRECATED_TIMEZONE_ONLY_OPERATORS.has(operator)) {

--- a/packages/nodes-base/nodes/Baserow/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Baserow/__tests__/GenericFunctions.test.ts
@@ -129,6 +129,10 @@ describe('Baserow > GenericFunctions', () => {
 	});
 
 	describe('formatBaserowFilterValue', () => {
+		it('should treat a missing value as empty', () => {
+			expect(formatBaserowFilterValue('equal', undefined)).toBe('');
+		});
+
 		it('should format plain ISO date for date_is_after', () => {
 			expect(formatBaserowFilterValue('date_is_after', '2026-06-17')).toBe(
 				'UTC?2026-06-17?exact_date',

--- a/packages/nodes-base/nodes/Baserow/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Baserow/__tests__/GenericFunctions.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable n8n-nodes-base/node-param-display-name-miscased */
 import { DateTime } from 'luxon';
-import { NodeApiError } from 'n8n-workflow';
+import { NodeApiError, UserError } from 'n8n-workflow';
 
 import {
 	baserowApiRequest,
@@ -155,6 +155,41 @@ describe('Baserow > GenericFunctions', () => {
 			const value = DateTime.fromISO('2026-06-17T12:30:00.000Z', { zone: 'UTC' });
 			expect(formatBaserowFilterValue('date_after_or_equal', value)).toBe(
 				'2026-06-17T12:30:00.000Z',
+			);
+		});
+
+		it.each([
+			{ name: 'plain objects', value: { id: 252284 } },
+			{ name: 'arrays', value: [252284] },
+			{ name: 'symbols', value: Symbol('filter') },
+			{ name: 'functions', value: () => 'filter' },
+		])('should reject $name as filter values', ({ value }) => {
+			expect(() => formatBaserowFilterValue('equal', value)).toThrow(UserError);
+			expect(() => formatBaserowFilterValue('equal', value)).toThrow(
+				'Baserow filter values must be strings, numbers, booleans, or valid DateTime values',
+			);
+		});
+
+		it('should reject objects without invoking their string conversion', () => {
+			const toString = vi.fn(() => {
+				throw new Error('Unexpected string conversion');
+			});
+
+			expect(() => formatBaserowFilterValue('equal', { toString })).toThrow(UserError);
+			expect(toString).not.toHaveBeenCalled();
+		});
+
+		it('should reject invalid Luxon DateTime values', () => {
+			const value = DateTime.invalid('Invalid filter date');
+
+			expect(() => formatBaserowFilterValue('date_after_or_equal', value)).toThrow(UserError);
+		});
+
+		it('should preserve the offset of Luxon DateTime expressions', () => {
+			const value = DateTime.fromISO('2026-06-17T12:30:00.000+05:30', { setZone: true });
+
+			expect(formatBaserowFilterValue('date_after_or_equal', value)).toBe(
+				'2026-06-17T12:30:00.000+05:30',
 			);
 		});
 

--- a/packages/nodes-base/nodes/Baserow/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Baserow/__tests__/GenericFunctions.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable n8n-nodes-base/node-param-display-name-miscased */
+import { DateTime } from 'luxon';
 import { NodeApiError } from 'n8n-workflow';
 
 import {
@@ -131,6 +132,44 @@ describe('Baserow > GenericFunctions', () => {
 	describe('formatBaserowFilterValue', () => {
 		it('should treat a missing value as empty', () => {
 			expect(formatBaserowFilterValue('equal', undefined)).toBe('');
+		});
+
+		it.each([undefined, null])('should preserve empty-value formatting for %s', (value) => {
+			expect(formatBaserowFilterValue('equal', value)).toBe('');
+			expect(formatBaserowFilterValue('date_is_after', value)).toBe('');
+			expect(formatBaserowFilterValue('date_equals_today', value, 'Europe/Berlin')).toBe(
+				'Europe/Berlin',
+			);
+		});
+
+		it.each([
+			{ value: 252284, expected: '252284' },
+			{ value: 0, expected: '0' },
+			{ value: true, expected: 'true' },
+			{ value: false, expected: 'false' },
+		])('should stringify scalar filter value $value', ({ value, expected }) => {
+			expect(formatBaserowFilterValue('equal', value)).toBe(expected);
+		});
+
+		it('should preserve ISO timestamps from Luxon DateTime expressions', () => {
+			const value = DateTime.fromISO('2026-06-17T12:30:00.000Z', { zone: 'UTC' });
+			expect(formatBaserowFilterValue('date_after_or_equal', value)).toBe(
+				'2026-06-17T12:30:00.000Z',
+			);
+		});
+
+		it('should format numeric days for multi-step date filters', () => {
+			expect(formatBaserowFilterValue('date_is_within', 30)).toBe('UTC?30?nr_days_from_now');
+		});
+
+		it('should format numeric days for deprecated date filters', () => {
+			expect(formatBaserowFilterValue('date_within_days', 0, 'Europe/Berlin')).toBe(
+				'Europe/Berlin?0',
+			);
+		});
+
+		it('should continue trimming string filter values', () => {
+			expect(formatBaserowFilterValue('equal', '  foo  ')).toBe('foo');
 		});
 
 		it('should format plain ISO date for date_is_after', () => {


### PR DESCRIPTION
## Summary

Baserow filters can contain missing values or non-string expression results. Calling `.trim()` directly on those values makes otherwise valid requests fail.

Normalize `undefined` and `null` to an empty string, convert numbers and booleans to strings, and serialize valid Luxon `DateTime` values with `toISO()`. Reject unsupported values with a clear `UserError` instead of silently sending values such as `[object Object]` to Baserow. Existing date-operator and timezone formatting is preserved.

Regression coverage includes missing values across date operators, numeric and boolean expressions, valid DateTime values and timezone offsets, unsupported types, invalid DateTime values, and objects with custom string conversion.

## How to test

From `packages/nodes-base`:

```sh
pnpm test nodes/Baserow
pnpm build
pnpm typecheck
NODE_OPTIONS=--max-old-space-size=8192 pnpm lint
```

Validation on this branch: all 49 Baserow tests pass across 3 files; the package build, typecheck, and lint pass. Lint reports existing schema-version warnings for unrelated nodes.

The added validation tests fail against the previous PR implementation. The full helper test file also reproduces failures against the latest upstream `master` helper.

Manual verification steps: in a Baserow **Get Many** node, try filters whose values resolve to `undefined`, a number, a boolean, and a valid Luxon DateTime. Confirm that an object-valued expression produces a clear validation error.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #36165

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

