### PR TITLE
refactor(core): Spike a declarative trigger-identity capability (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -111,6 +111,15 @@ export class McpTrigger extends Node {
 		],
 		outputs: [],
 		sensitiveOutputFields: ['headers.authorization', 'headers.cookie'],
+		triggerIdentity: {
+			establishes: true,
+			mergeStrategy: 'index-merge',
+			// Calls context.checkTriggerCredentialStatus() itself, from
+			// getConnectedToolsRespectingCredentialGate — it needs the gate
+			// result mid-flow, to decide whether to expose a placeholder
+			// "connect credentials" tool instead of the real tool list.
+			gate: 'manual',
+		},
 		credentials: [
 			{
 				// eslint-disable-next-line n8n-nodes-base/node-class-description-credentials-name-unsuffixed

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -112,13 +112,18 @@ export class McpTrigger extends Node {
 		outputs: [],
 		sensitiveOutputFields: ['headers.authorization', 'headers.cookie'],
 		triggerIdentity: {
-			establishes: true,
+			establishes: (node) => node.parameters?.authentication === 'n8nOAuth2',
 			mergeStrategy: 'index-merge',
 			// Calls context.checkTriggerCredentialStatus() itself, from
 			// getConnectedToolsRespectingCredentialGate — it needs the gate
 			// result mid-flow, to decide whether to expose a placeholder
 			// "connect credentials" tool instead of the real tool list.
 			gate: 'manual',
+		},
+		// Needed regardless of auth mode: getConnectedTools() connects MCP Client
+		// sub-nodes eagerly, which requires execution data to exist up front.
+		triggerExecutionSeeding: {
+			mergeStrategy: 'index-merge',
 		},
 		credentials: [
 			{

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -14,6 +14,7 @@ import {
 } from 'n8n-workflow';
 import type {
 	IDataObject,
+	INode,
 	IWebhookFunctions,
 	IWebhookResponseData,
 	INodeTypeDescription,
@@ -39,7 +40,11 @@ import {
 	isShellInnerRequest,
 } from './shell';
 import { createPage, createShellPage } from './templates';
-import { assertValidLoadPreviousSessionOption, type ChatFrameIdentity } from './types';
+import {
+	assertValidLoadPreviousSessionOption,
+	type AuthenticationChatOption,
+	type ChatFrameIdentity,
+} from './types';
 
 const isPublicChatTriggerDisabled = () => Container.get(ChatTriggerConfig).disablePublicChat;
 const allowFileUploadsOption: INodeProperties = {
@@ -277,6 +282,21 @@ export class ChatTrigger extends Node {
 			];
 		 })() }}`,
 		outputs: [NodeConnectionTypes.Main],
+		triggerIdentity: {
+			establishes: (node: INode) => {
+				const authentication = node.parameters?.authentication as
+					| AuthenticationChatOption
+					| undefined;
+				const mode =
+					(node.parameters?.mode as 'hostedChat' | 'webhook' | undefined) ?? 'hostedChat';
+				return authentication === 'n8nUserAuth' && mode === 'hostedChat';
+			},
+			mergeStrategy: 'index-merge',
+			gate: 'manual',
+		},
+		triggerExecutionSeeding: {
+			mergeStrategy: 'index-merge',
+		},
 		builderHint: {
 			searchHint:
 				"Pair with `@n8n/n8n-nodes-langchain.agent` for chatbot workflows. Reply delivery is controlled by `options.responseMode` — `streaming` (Agent streams directly to widget) is simplest and preferred. For `lastNode` mode, the workflow's last-executed node MUST output `{ output: '<reply>' }` — typically the Agent itself or a Set node re-shaping data; ending the chain with a Data Table insert, HTTP Request, or other side-effect node will fail. Put logging or persistence on a parallel branch, not inline after the Agent.",

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Microsoft/MicrosoftAgent365Trigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Microsoft/MicrosoftAgent365Trigger.node.ts
@@ -48,6 +48,13 @@ export class MicrosoftAgent365Trigger implements INodeType {
 			}}`,
 		outputs: [NodeConnectionTypes.Main],
 		triggerPanel: false,
+		// Needs its execution stack pre-seeded before webhook() runs (see
+		// `TriggerExecutionSeeding`), but authenticates the caller via Bot
+		// Framework JWT (authorizeJWT below) rather than n8n's identity system —
+		// no `triggerIdentity` capability here.
+		triggerExecutionSeeding: {
+			mergeStrategy: 'index-merge',
+		},
 		webhooks: [
 			{
 				name: 'default',

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -621,23 +621,32 @@ describe('prepareExecutionData', () => {
 	});
 
 	// Mirrors the real `triggerIdentity` / `triggerExecutionSeeding` declarations
-	// on Webhook.node.ts, McpTrigger.node.ts, and MicrosoftAgent365Trigger.node.ts.
-	// Chat Trigger isn't migrated yet, so it's deliberately absent here too —
-	// `reconcileSeededExecutionStack` still special-cases it directly.
+	// on Webhook.node.ts, McpTrigger.node.ts, MicrosoftAgent365Trigger.node.ts, and
+	// ChatTrigger.node.ts. Chat declares both: `triggerIdentity` (conditional on
+	// n8nUserAuth + hostedChat) and a sibling unconditional `triggerExecutionSeeding`,
+	// since every Chat execution needs stack pre-seeding regardless of auth mode.
 	const nodeTypes = {
 		getByNameAndVersion: vi.fn((type: string) =>
 			mock<INodeType>({
 				description: {
 					triggerIdentity:
-						type === WEBHOOK_NODE_TYPE || type === MCP_TRIGGER_NODE_TYPE
+						type === WEBHOOK_NODE_TYPE ||
+						type === MCP_TRIGGER_NODE_TYPE ||
+						type === CHAT_TRIGGER_NODE_TYPE
 							? {
-									establishes: (node: INode) => node.parameters?.authentication === 'n8nOAuth2',
+									establishes: (node: INode) =>
+										type === CHAT_TRIGGER_NODE_TYPE
+											? node.parameters?.authentication === 'n8nUserAuth' &&
+												(node.parameters?.mode ?? 'hostedChat') === 'hostedChat'
+											: node.parameters?.authentication === 'n8nOAuth2',
 									mergeStrategy: type === WEBHOOK_NODE_TYPE ? 'replace' : 'index-merge',
 									gate: type === WEBHOOK_NODE_TYPE ? 'reactive' : 'manual',
 								}
 							: undefined,
 					triggerExecutionSeeding:
-						type === MICROSOFT_AGENT365_TRIGGER_NODE_TYPE || type === MCP_TRIGGER_NODE_TYPE
+						type === MICROSOFT_AGENT365_TRIGGER_NODE_TYPE ||
+						type === MCP_TRIGGER_NODE_TYPE ||
+						type === CHAT_TRIGGER_NODE_TYPE
 							? { mergeStrategy: 'index-merge' }
 							: undefined,
 				},

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -629,17 +629,15 @@ describe('prepareExecutionData', () => {
 			mock<INodeType>({
 				description: {
 					triggerIdentity:
-						type === WEBHOOK_NODE_TYPE
+						type === WEBHOOK_NODE_TYPE || type === MCP_TRIGGER_NODE_TYPE
 							? {
 									establishes: (node: INode) => node.parameters?.authentication === 'n8nOAuth2',
-									mergeStrategy: 'replace',
-									gate: 'reactive',
+									mergeStrategy: type === WEBHOOK_NODE_TYPE ? 'replace' : 'index-merge',
+									gate: type === WEBHOOK_NODE_TYPE ? 'reactive' : 'manual',
 								}
-							: type === MCP_TRIGGER_NODE_TYPE
-								? { establishes: true, mergeStrategy: 'index-merge', gate: 'manual' }
-								: undefined,
+							: undefined,
 					triggerExecutionSeeding:
-						type === MICROSOFT_AGENT365_TRIGGER_NODE_TYPE
+						type === MICROSOFT_AGENT365_TRIGGER_NODE_TYPE || type === MCP_TRIGGER_NODE_TYPE
 							? { mergeStrategy: 'index-merge' }
 							: undefined,
 				},

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -20,6 +20,7 @@ import type {
 	Workflow,
 	INode,
 	INodeType,
+	INodeTypes,
 	IDataObject,
 	IWebhookResponseData,
 	IN8nHttpFullResponse,
@@ -619,8 +620,36 @@ describe('prepareExecutionData', () => {
 		pinData: { nodeA: [{ json: { pinned: true } }] },
 	});
 
+	// Mirrors the real `triggerIdentity` / `triggerExecutionSeeding` declarations
+	// on Webhook.node.ts, McpTrigger.node.ts, and MicrosoftAgent365Trigger.node.ts.
+	// Chat Trigger isn't migrated yet, so it's deliberately absent here too —
+	// `reconcileSeededExecutionStack` still special-cases it directly.
+	const nodeTypes = {
+		getByNameAndVersion: vi.fn((type: string) =>
+			mock<INodeType>({
+				description: {
+					triggerIdentity:
+						type === WEBHOOK_NODE_TYPE
+							? {
+									establishes: (node: INode) => node.parameters?.authentication === 'n8nOAuth2',
+									mergeStrategy: 'replace',
+									gate: 'reactive',
+								}
+							: type === MCP_TRIGGER_NODE_TYPE
+								? { establishes: true, mergeStrategy: 'index-merge', gate: 'manual' }
+								: undefined,
+					triggerExecutionSeeding:
+						type === MICROSOFT_AGENT365_TRIGGER_NODE_TYPE
+							? { mergeStrategy: 'index-merge' }
+							: undefined,
+				},
+			}),
+		),
+	} as unknown as INodeTypes;
+
 	test('should create new execution data when not provided', () => {
 		const { runExecutionData, pinData } = prepareExecutionData(
+			nodeTypes,
 			'manual',
 			workflowStartNode,
 			webhookResultData,
@@ -654,6 +683,7 @@ describe('prepareExecutionData', () => {
 		} as IRunExecutionData;
 
 		prepareExecutionData(
+			nodeTypes,
 			'manual',
 			workflowStartNode,
 			webhookResultData,
@@ -668,6 +698,7 @@ describe('prepareExecutionData', () => {
 
 	test('should set destination node when provided', () => {
 		const { runExecutionData } = prepareExecutionData(
+			nodeTypes,
 			'manual',
 			workflowStartNode,
 			webhookResultData,
@@ -690,6 +721,7 @@ describe('prepareExecutionData', () => {
 		};
 
 		const { runExecutionData } = prepareExecutionData(
+			nodeTypes,
 			'manual',
 			workflowStartNode,
 			webhookResultData,
@@ -702,6 +734,7 @@ describe('prepareExecutionData', () => {
 
 	test('should set pinData when execution mode is manual', () => {
 		const { runExecutionData, pinData } = prepareExecutionData(
+			nodeTypes,
 			'manual',
 			workflowStartNode,
 			webhookResultData,
@@ -718,6 +751,7 @@ describe('prepareExecutionData', () => {
 
 	test('should not set pinData when execution mode is not manual or evaluation', () => {
 		const { runExecutionData, pinData } = prepareExecutionData(
+			nodeTypes,
 			'webhook',
 			workflowStartNode,
 			webhookResultData,
@@ -734,6 +768,7 @@ describe('prepareExecutionData', () => {
 
 	test('should populate manualData.userId for manual executions when userId is provided', () => {
 		const { runExecutionData } = prepareExecutionData(
+			nodeTypes,
 			'manual',
 			workflowStartNode,
 			webhookResultData,
@@ -750,6 +785,7 @@ describe('prepareExecutionData', () => {
 
 	test('should not populate manualData when userId is undefined', () => {
 		const { runExecutionData } = prepareExecutionData(
+			nodeTypes,
 			'manual',
 			workflowStartNode,
 			webhookResultData,
@@ -766,6 +802,7 @@ describe('prepareExecutionData', () => {
 
 	test('should not populate manualData for non-manual execution modes', () => {
 		const { runExecutionData } = prepareExecutionData(
+			nodeTypes,
 			'webhook',
 			workflowStartNode,
 			webhookResultData,
@@ -814,6 +851,7 @@ describe('prepareExecutionData', () => {
 				} as IRunExecutionData;
 
 				const { runExecutionData } = prepareExecutionData(
+					nodeTypes,
 					'trigger',
 					seededTriggerNode,
 					webhookResultData,
@@ -842,6 +880,7 @@ describe('prepareExecutionData', () => {
 			});
 
 			const { runExecutionData } = prepareExecutionData(
+				nodeTypes,
 				'trigger',
 				microsoftAgentNode,
 				webhookResultData,
@@ -874,6 +913,7 @@ describe('prepareExecutionData', () => {
 			} as IRunExecutionData;
 
 			const { runExecutionData } = prepareExecutionData(
+				nodeTypes,
 				'trigger',
 				microsoftAgentNode,
 				webhookResultData,
@@ -913,6 +953,7 @@ describe('prepareExecutionData', () => {
 			} as IRunExecutionData;
 
 			const { runExecutionData } = prepareExecutionData(
+				nodeTypes,
 				'trigger',
 				regularNode,
 				webhookResultData,
@@ -965,6 +1006,7 @@ describe('prepareExecutionData', () => {
 			} as IRunExecutionData;
 
 			const { runExecutionData } = prepareExecutionData(
+				nodeTypes,
 				'trigger',
 				identityWebhookNode,
 				webhookResultData,
@@ -1021,6 +1063,7 @@ describe('prepareExecutionData', () => {
 			};
 
 			const { runExecutionData } = prepareExecutionData(
+				nodeTypes,
 				'trigger',
 				identityWebhookNode,
 				multiMethodResult,
@@ -1062,6 +1105,7 @@ describe('prepareExecutionData', () => {
 			} as IRunExecutionData;
 
 			const { runExecutionData } = prepareExecutionData(
+				nodeTypes,
 				'trigger',
 				microsoftAgentNode,
 				webhookResultData,
@@ -1200,9 +1244,19 @@ describe('executeWebhook credential-status gate', () => {
 			id: WORKFLOW_ID,
 			name: 'Test Workflow',
 			nodeTypes: {
-				getByNameAndVersion: vi
-					.fn()
-					.mockReturnValue(mock<INodeType>({ description: { name: 'webhook' } })),
+				getByNameAndVersion: vi.fn().mockReturnValue(
+					mock<INodeType>({
+						description: {
+							name: 'webhook',
+							// Mirrors Webhook.node.ts's real declaration.
+							triggerIdentity: {
+								establishes: (node: INode) => node.parameters?.authentication === 'n8nOAuth2',
+								mergeStrategy: 'replace',
+								gate: 'reactive',
+							},
+						},
+					}),
+				),
 			},
 			expression: {
 				getSimpleParameterValue: vi.fn().mockReturnValue('onReceived'),
@@ -1387,9 +1441,19 @@ describe('executeWebhook establishTriggerIdentity', () => {
 			id: WORKFLOW_ID,
 			name: 'Test Workflow',
 			nodeTypes: {
-				getByNameAndVersion: vi
-					.fn()
-					.mockReturnValue(mock<INodeType>({ description: { name: 'webhook' } })),
+				getByNameAndVersion: vi.fn().mockReturnValue(
+					mock<INodeType>({
+						description: {
+							name: 'webhook',
+							// Mirrors Webhook.node.ts's real declaration.
+							triggerIdentity: {
+								establishes: (node: INode) => node.parameters?.authentication === 'n8nOAuth2',
+								mergeStrategy: 'replace',
+								gate: 'reactive',
+							},
+						},
+					}),
+				),
 			},
 			expression: {
 				getSimpleParameterValue: vi.fn().mockReturnValue('onReceived'),

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -390,11 +390,8 @@ export function setupResponseNodePromise(
  * Reads the start node's declared `triggerIdentity` capability (see
  * `TriggerIdentityCapability` in n8n-workflow), resolving the `establishes`
  * predicate against this node instance's parameters where it's a function
- * (e.g. the Webhook node's opt-in "n8n User Auth (OAuth2)" mode).
- *
- * TEMPORARY: Chat Trigger hasn't been migrated to declare this capability yet
- * (tracked separately, alongside IAM-1259) and keeps its historical hardcoded
- * treatment below wherever this returns `undefined` for it.
+ * (e.g. the Webhook node's opt-in "n8n User Auth (OAuth2)" mode, or Chat
+ * Trigger's n8nUserAuth + hostedChat combination).
  */
 function getTriggerIdentityCapability(nodeTypes: INodeTypes, workflowStartNode: INode) {
 	const { description } = nodeTypes.getByNameAndVersion(
@@ -418,8 +415,6 @@ function getTriggerIdentityCapability(nodeTypes: INodeTypes, workflowStartNode: 
  * declare bare `triggerExecutionSeeding` for the same stack-timing need
  * without establishing identity (e.g. Agent365, which authenticates the
  * caller via Bot Framework JWT rather than n8n's identity/credential system).
- *
- * TEMPORARY: Chat Trigger isn't migrated yet — see `getTriggerIdentityCapability`.
  */
 function getExecutionSeedingCapability(
 	nodeTypes: INodeTypes,
@@ -456,12 +451,6 @@ function reconcileSeededExecutionStack(
 ): void {
 	const executionData = runExecutionData?.executionData;
 	if (!executionData?.nodeExecutionStack) return;
-
-	// TEMPORARY: Chat Trigger isn't migrated to declare a capability yet.
-	if (workflowStartNode.type === CHAT_TRIGGER_NODE_TYPE) {
-		merge(executionData.nodeExecutionStack, nodeExecutionStack);
-		return;
-	}
 
 	const seeding = getExecutionSeedingCapability(nodeTypes, workflowStartNode);
 	if (!seeding) return;
@@ -753,11 +742,7 @@ export async function executeWebhook(
 		await parseRequestBody(req, workflowStartNode, workflow, executionMode, additionalKeys);
 
 		// TODO: remove this hack, and make sure that execution data is properly created before the MCP trigger is executed
-		if (
-			// TEMPORARY: Chat Trigger isn't migrated to declare a capability yet.
-			workflowStartNode.type === CHAT_TRIGGER_NODE_TYPE ||
-			getExecutionSeedingCapability(workflow.nodeTypes, workflowStartNode)
-		) {
+		if (getExecutionSeedingCapability(workflow.nodeTypes, workflowStartNode)) {
 			// Initialize the data of the webhook node
 			const nodeExecutionStack: IExecuteData[] = [];
 			nodeExecutionStack.push({

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -25,6 +25,7 @@ import type {
 	IExecuteResponsePromiseData,
 	IN8nHttpFullResponse,
 	INode,
+	INodeTypes,
 	IPinData,
 	IRunExecutionData,
 	IWebhookData,
@@ -34,6 +35,7 @@ import type {
 	WebhookResponseMode,
 	OAuth2FailureReason,
 	OAuthResourceGrant,
+	TriggerExecutionSeeding,
 	Workflow,
 	WorkflowExecuteMode,
 	IWorkflowExecutionDataProcess,
@@ -47,13 +49,11 @@ import {
 	ExecutionCancelledError,
 	FORM_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,
-	MICROSOFT_AGENT365_TRIGGER_NODE_TYPE,
 	NodeOperationError,
 	OperationalError,
 	tryToParseUrl,
 	UnexpectedError,
 	WAIT_NODE_TYPE,
-	WEBHOOK_NODE_TYPE,
 	WorkflowConfigurationError,
 } from 'n8n-workflow';
 import { finished } from 'stream/promises';
@@ -387,36 +387,69 @@ export function setupResponseNodePromise(
 }
 
 /**
- * Predicate (not an action): checks whether the start node will establish a
- * triggering-user identity from within its `webhook()` method (via
- * `context.establishTriggerIdentity`). Such nodes need their `runExecutionData`
- * created before the webhook runs, and the webhook output merged into the seeded
- * execution stack afterwards.
+ * Reads the start node's declared `triggerIdentity` capability (see
+ * `TriggerIdentityCapability` in n8n-workflow), resolving the `establishes`
+ * predicate against this node instance's parameters where it's a function
+ * (e.g. the Webhook node's opt-in "n8n User Auth (OAuth2)" mode).
  *
- * The Webhook node does this only when its opt-in "n8n User Auth (OAuth2)" mode
- * (`n8nOAuth2`) is selected; the MCP / chat / Agent365 triggers always do.
+ * TEMPORARY: Chat Trigger hasn't been migrated to declare this capability yet
+ * (tracked separately, alongside IAM-1259) and keeps its historical hardcoded
+ * treatment below wherever this returns `undefined` for it.
  */
-function shouldEstablishTriggerIdentity(workflowStartNode: INode): boolean {
-	return (
-		workflowStartNode.type === WEBHOOK_NODE_TYPE &&
-		workflowStartNode.parameters?.authentication === 'n8nOAuth2'
+function getTriggerIdentityCapability(nodeTypes: INodeTypes, workflowStartNode: INode) {
+	const { description } = nodeTypes.getByNameAndVersion(
+		workflowStartNode.type,
+		workflowStartNode.typeVersion,
 	);
+	const capability = description.triggerIdentity;
+	if (!capability) return undefined;
+
+	const establishes =
+		typeof capability.establishes === 'function'
+			? capability.establishes(workflowStartNode)
+			: capability.establishes;
+
+	return establishes ? capability : undefined;
+}
+
+/**
+ * Resolves how a pre-seeded execution stack should be reconciled: identity
+ * establishment (`triggerIdentity`) implies seeding; a node can otherwise
+ * declare bare `triggerExecutionSeeding` for the same stack-timing need
+ * without establishing identity (e.g. Agent365, which authenticates the
+ * caller via Bot Framework JWT rather than n8n's identity/credential system).
+ *
+ * TEMPORARY: Chat Trigger isn't migrated yet — see `getTriggerIdentityCapability`.
+ */
+function getExecutionSeedingCapability(
+	nodeTypes: INodeTypes,
+	workflowStartNode: INode,
+): TriggerExecutionSeeding | undefined {
+	const identityCapability = getTriggerIdentityCapability(nodeTypes, workflowStartNode);
+	if (identityCapability) return identityCapability;
+
+	const { description } = nodeTypes.getByNameAndVersion(
+		workflowStartNode.type,
+		workflowStartNode.typeVersion,
+	);
+	return description.triggerExecutionSeeding;
 }
 
 /**
  * Reconciles a pre-seeded execution stack (identity/context trigger flows) with the
  * webhook node's real output. No-op unless the start node seeded execution data.
  *
- * - MCP / chat / Agent365 (single-output triggers): index-merge the webhook output
- *   into the seeded item so seeded input data is preserved.
- * - n8n Identity webhook: the identity was already established from the seeded
- *   placeholder during the node's `webhook()` call (credentials now live on
- *   `executionData.runtimeData`, a sibling that survives the reassignment). Replace
- *   the seeded stack with the real output instead of index-merging — a naive merge
- *   keeps the empty placeholder in output slot 0 and would spuriously fire that
- *   branch on multi-method webhooks.
+ * - Index-merge (single-output triggers, e.g. MCP, Agent365): fold the webhook
+ *   output into the seeded item so seeded input data is preserved.
+ * - Replace (e.g. n8n Identity webhook): the identity was already established
+ *   from the seeded placeholder during the node's `webhook()` call (credentials
+ *   now live on `executionData.runtimeData`, a sibling that survives the
+ *   reassignment). Replace the seeded stack with the real output instead of
+ *   index-merging — a naive merge keeps the empty placeholder in output slot 0
+ *   and would spuriously fire that branch on multi-method webhooks.
  */
 function reconcileSeededExecutionStack(
+	nodeTypes: INodeTypes,
 	workflowStartNode: INode,
 	runExecutionData: IRunExecutionData | undefined,
 	nodeExecutionStack: IExecuteData[],
@@ -424,18 +457,24 @@ function reconcileSeededExecutionStack(
 	const executionData = runExecutionData?.executionData;
 	if (!executionData?.nodeExecutionStack) return;
 
-	if (
-		[MCP_TRIGGER_NODE_TYPE, MICROSOFT_AGENT365_TRIGGER_NODE_TYPE, CHAT_TRIGGER_NODE_TYPE].includes(
-			workflowStartNode.type,
-		)
-	) {
+	// TEMPORARY: Chat Trigger isn't migrated to declare a capability yet.
+	if (workflowStartNode.type === CHAT_TRIGGER_NODE_TYPE) {
 		merge(executionData.nodeExecutionStack, nodeExecutionStack);
-	} else if (shouldEstablishTriggerIdentity(workflowStartNode)) {
+		return;
+	}
+
+	const seeding = getExecutionSeedingCapability(nodeTypes, workflowStartNode);
+	if (!seeding) return;
+
+	if (seeding.mergeStrategy === 'index-merge') {
+		merge(executionData.nodeExecutionStack, nodeExecutionStack);
+	} else {
 		executionData.nodeExecutionStack = nodeExecutionStack;
 	}
 }
 
 export function prepareExecutionData(
+	nodeTypes: INodeTypes,
 	executionMode: WorkflowExecuteMode,
 	workflowStartNode: INode,
 	webhookResultData: IWebhookResponseData,
@@ -457,7 +496,7 @@ export function prepareExecutionData(
 		},
 	];
 
-	reconcileSeededExecutionStack(workflowStartNode, runExecutionData, nodeExecutionStack);
+	reconcileSeededExecutionStack(nodeTypes, workflowStartNode, runExecutionData, nodeExecutionStack);
 
 	runExecutionData ??= createRunExecutionData({
 		executionData: {
@@ -715,12 +754,9 @@ export async function executeWebhook(
 
 		// TODO: remove this hack, and make sure that execution data is properly created before the MCP trigger is executed
 		if (
-			[
-				MCP_TRIGGER_NODE_TYPE,
-				MICROSOFT_AGENT365_TRIGGER_NODE_TYPE,
-				CHAT_TRIGGER_NODE_TYPE,
-			].includes(workflowStartNode.type) ||
-			shouldEstablishTriggerIdentity(workflowStartNode)
+			// TEMPORARY: Chat Trigger isn't migrated to declare a capability yet.
+			workflowStartNode.type === CHAT_TRIGGER_NODE_TYPE ||
+			getExecutionSeedingCapability(workflow.nodeTypes, workflowStartNode)
 		) {
 			// Initialize the data of the webhook node
 			const nodeExecutionStack: IExecuteData[] = [];
@@ -845,7 +881,11 @@ export async function executeWebhook(
 		// user's resolvable (private) credentials are still unconnected, responding
 		// 428 Precondition Required with the missing-credential list and a signed
 		// connect link for each.
-		if (!didSendResponse && !res.headersSent && shouldEstablishTriggerIdentity(workflowStartNode)) {
+		if (
+			!didSendResponse &&
+			!res.headersSent &&
+			getTriggerIdentityCapability(workflow.nodeTypes, workflowStartNode)?.gate === 'reactive'
+		) {
 			const credentialGate = await additionalData.checkTriggerCredentialStatus?.();
 			if (credentialGate && !credentialGate.readyToExecute) {
 				responseCallback(null, {
@@ -863,6 +903,7 @@ export async function executeWebhook(
 
 		// Prepare execution data
 		const { runExecutionData: preparedRunExecutionData, pinData } = prepareExecutionData(
+			workflow.nodeTypes,
 			executionMode,
 			workflowStartNode,
 			webhookResultData,

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -75,6 +75,11 @@ export class Webhook extends Node {
 		credentials: credentialsProperty(this.authPropertyName),
 		webhooks: [defaultWebhookDescription],
 		sensitiveOutputFields: ['headers.authorization', 'headers.cookie'],
+		triggerIdentity: {
+			establishes: (node) => node.parameters?.authentication === 'n8nOAuth2',
+			mergeStrategy: 'replace',
+			gate: 'reactive',
+		},
 		properties: [
 			{
 				displayName: 'Allow Multiple HTTP Methods',

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1184,6 +1184,39 @@ export type CredentialCheckResult = {
 	credentials: CredentialCheckStatus[];
 };
 
+/**
+ * How a pre-seeded execution stack (created before a trigger's `webhook()`
+ * method runs) is reconciled with the trigger's real output once it's known.
+ */
+export type TriggerExecutionSeeding = {
+	/**
+	 * Single-output triggers: index-merge the real output into the seeded
+	 * item so whatever the seed carried (e.g. identity metadata) survives.
+	 */
+	mergeStrategy: 'index-merge' | 'replace';
+};
+
+/**
+ * Declares that this node type can establish a triggering end-user's identity
+ * from within its `webhook()` method (via `context.establishTriggerIdentity`),
+ * for end-user credential resolution. Implies execution-stack pre-seeding —
+ * the identity has to be attached before the trigger's real output exists.
+ */
+export interface TriggerIdentityCapability extends TriggerExecutionSeeding {
+	/**
+	 * Whether this node instance establishes identity for this run. A function
+	 * lets a node's own parameters decide (e.g. Webhook's "Authentication"
+	 * dropdown); `true` means it always does.
+	 */
+	establishes: boolean | ((node: INode) => boolean);
+	/**
+	 * 'reactive': the CLI's webhook-handling code calls
+	 * `checkTriggerCredentialStatus()` on the node's behalf, once, before the
+	 * execution is created. 'manual': the node's own code calls it itself.
+	 */
+	gate: 'reactive' | 'manual';
+}
+
 export type DynamicCredentialCheckProxyProvider = {
 	checkCredentialStatus(
 		workflowId: string,
@@ -3021,6 +3054,18 @@ export interface INodeTypeDescription extends INodeTypeBaseDescription {
 	 * permissions and are never revealable.
 	 */
 	sensitiveOutputFields?: string[];
+	/**
+	 * This node establishes a triggering end-user's identity for credential
+	 * resolution. See `TriggerIdentityCapability`.
+	 */
+	triggerIdentity?: TriggerIdentityCapability;
+	/**
+	 * This node needs its execution stack pre-seeded before `webhook()` runs,
+	 * for reasons other than establishing identity (e.g. needing an execution
+	 * reference available up front). Nodes with `triggerIdentity` don't need
+	 * this separately — identity establishment implies seeding.
+	 */
+	triggerExecutionSeeding?: TriggerExecutionSeeding;
 }
 
 export type TriggerPanelDefinition = {


### PR DESCRIPTION
## Summary

Proof-of-concept: replaces the hardcoded node-type lists in `webhook-helpers.ts` (`shouldEstablishTriggerIdentity` / `reconcileSeededExecutionStack`) with a capability a node declares on its own `INodeTypeDescription`:

- `triggerIdentity` — establishes end-user identity (gate style, merge strategy)
- `triggerExecutionSeeding` — needs stack pre-seeding without establishing identity

Migrated: Webhook (`n8nOAuth2` mode), MCP Trigger, Microsoft Agent 365 Trigger (seeding-only — it authenticates via Bot Framework JWT, not n8n's identity system, a discrepancy from the removed code comment).

Deliberately **not** migrated: Chat Trigger — left on its old hardcoded branch, out of scope while IAM-1259 work is in flight. IAM-1264 (gate every message send on credential readiness) is the natural ticket to pair with Chat's migration.

**Not for merging as-is** — this proves the concept compiles and existing tests pass unchanged. Open questions (node-type lookup cost, whether `establishes` as a function is the right shape), not resolved here.

## How to test

Existing webhook-helpers test suite passes unchanged; no new behavior to manually test yet — this is a design spike.

## Related Linear tickets, Github issues, and Community forum posts

Related context: IAM-1259, IAM-1264 (not directly implementing either).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

