### PR TITLE
fix(core): Scope active workflow IDs to the requesting user's projects

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
@@ -141,4 +141,86 @@ describe('SharedWorkflowRepository', () => {
 			expect(result).toEqual([first, last]);
 		});
 	});
+
+	describe('findWorkflowIdsInProjects', () => {
+		it('returns an empty set without querying when there are no workflow ids', async () => {
+			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects([], ['project-1']);
+
+			expect(result).toEqual(new Set());
+			expect(entityManager.find).not.toHaveBeenCalled();
+		});
+
+		it('returns an empty set without querying when there are no project ids', async () => {
+			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(['workflow-1'], []);
+
+			expect(result).toEqual(new Set());
+			expect(entityManager.find).not.toHaveBeenCalled();
+		});
+
+		it('filters by both workflow and project, and returns each id once', async () => {
+			entityManager.find.mockResolvedValueOnce([
+				mock<SharedWorkflow>({ workflowId: 'workflow-1' }),
+				// Same workflow shared with two of the projects, so it is returned twice.
+				mock<SharedWorkflow>({ workflowId: 'workflow-1' }),
+				mock<SharedWorkflow>({ workflowId: 'workflow-2' }),
+			]);
+
+			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(
+				['workflow-1', 'workflow-2', 'workflow-3'],
+				['project-1', 'project-2'],
+			);
+
+			expect(entityManager.find).toHaveBeenCalledWith(SharedWorkflow, {
+				select: { workflowId: true },
+				where: {
+					workflowId: In(['workflow-1', 'workflow-2', 'workflow-3']),
+					projectId: In(['project-1', 'project-2']),
+				},
+			});
+			expect(result).toEqual(new Set(['workflow-1', 'workflow-2']));
+		});
+
+		it('chunks the workflow ids and applies the project filter to every chunk', async () => {
+			entityManager.find
+				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-0' })])
+				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-10000' })]);
+			const workflowIds = Array.from({ length: 10_001 }, (_, index) => `workflow-${index}`);
+
+			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(workflowIds, [
+				'project-1',
+			]);
+
+			expect(entityManager.find).toHaveBeenCalledTimes(2);
+			expect(entityManager.find).toHaveBeenNthCalledWith(2, SharedWorkflow, {
+				select: { workflowId: true },
+				where: {
+					workflowId: In(['workflow-10000']),
+					projectId: In(['project-1']),
+				},
+			});
+			expect(result).toEqual(new Set(['workflow-0', 'workflow-10000']));
+		});
+
+		it('chunks the project ids and merges the results across project chunks', async () => {
+			entityManager.find
+				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-1' })])
+				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-2' })]);
+			const projectIds = Array.from({ length: 10_001 }, (_, index) => `project-${index}`);
+
+			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(
+				['workflow-1', 'workflow-2'],
+				projectIds,
+			);
+
+			expect(entityManager.find).toHaveBeenCalledTimes(2);
+			expect(entityManager.find).toHaveBeenNthCalledWith(2, SharedWorkflow, {
+				select: { workflowId: true },
+				where: {
+					workflowId: In(['workflow-1', 'workflow-2']),
+					projectId: In(['project-10000']),
+				},
+			});
+			expect(result).toEqual(new Set(['workflow-1', 'workflow-2']));
+		});
+	});
 });

--- a/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
@@ -142,85 +142,79 @@ describe('SharedWorkflowRepository', () => {
 		});
 	});
 
-	describe('findWorkflowIdsInProjects', () => {
+	describe('findWorkflowIdsInUserProjects', () => {
 		it('returns an empty set without querying when there are no workflow ids', async () => {
-			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects([], ['project-1']);
+			const result = await sharedWorkflowRepository.findWorkflowIdsInUserProjects([], 'user-1', [
+				'project:admin',
+			]);
 
 			expect(result).toEqual(new Set());
 			expect(entityManager.find).not.toHaveBeenCalled();
 		});
 
-		it('returns an empty set without querying when there are no project ids', async () => {
-			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(['workflow-1'], []);
+		it('returns an empty set without querying when no project role carries the scope', async () => {
+			const result = await sharedWorkflowRepository.findWorkflowIdsInUserProjects(
+				['workflow-1'],
+				'user-1',
+				[],
+			);
 
 			expect(result).toEqual(new Set());
 			expect(entityManager.find).not.toHaveBeenCalled();
 		});
 
-		it('filters by both workflow and project, and returns each id once', async () => {
+		it('joins through the project relation and returns each id once', async () => {
 			entityManager.find.mockResolvedValueOnce([
 				mock<SharedWorkflow>({ workflowId: 'workflow-1' }),
-				// Same workflow shared with two of the projects, so it is returned twice.
+				// Same workflow reachable through two of the user's projects.
 				mock<SharedWorkflow>({ workflowId: 'workflow-1' }),
 				mock<SharedWorkflow>({ workflowId: 'workflow-2' }),
 			]);
 
-			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(
+			const result = await sharedWorkflowRepository.findWorkflowIdsInUserProjects(
 				['workflow-1', 'workflow-2', 'workflow-3'],
-				['project-1', 'project-2'],
+				'user-1',
+				['project:admin', 'project:viewer'],
 			);
 
 			expect(entityManager.find).toHaveBeenCalledWith(SharedWorkflow, {
 				select: { workflowId: true },
 				where: {
 					workflowId: In(['workflow-1', 'workflow-2', 'workflow-3']),
-					projectId: In(['project-1', 'project-2']),
+					project: {
+						projectRelations: {
+							userId: 'user-1',
+							role: { slug: In(['project:admin', 'project:viewer']) },
+						},
+					},
 				},
 			});
 			expect(result).toEqual(new Set(['workflow-1', 'workflow-2']));
 		});
 
-		it('chunks the workflow ids and applies the project filter to every chunk', async () => {
+		it('chunks the workflow ids and issues one query per chunk', async () => {
 			entityManager.find
 				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-0' })])
 				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-10000' })]);
 			const workflowIds = Array.from({ length: 10_001 }, (_, index) => `workflow-${index}`);
 
-			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(workflowIds, [
-				'project-1',
-			]);
-
-			expect(entityManager.find).toHaveBeenCalledTimes(2);
-			expect(entityManager.find).toHaveBeenNthCalledWith(2, SharedWorkflow, {
-				select: { workflowId: true },
-				where: {
-					workflowId: In(['workflow-10000']),
-					projectId: In(['project-1']),
-				},
-			});
-			expect(result).toEqual(new Set(['workflow-0', 'workflow-10000']));
-		});
-
-		it('chunks the project ids and merges the results across project chunks', async () => {
-			entityManager.find
-				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-1' })])
-				.mockResolvedValueOnce([mock<SharedWorkflow>({ workflowId: 'workflow-2' })]);
-			const projectIds = Array.from({ length: 10_001 }, (_, index) => `project-${index}`);
-
-			const result = await sharedWorkflowRepository.findWorkflowIdsInProjects(
-				['workflow-1', 'workflow-2'],
-				projectIds,
+			const result = await sharedWorkflowRepository.findWorkflowIdsInUserProjects(
+				workflowIds,
+				'user-1',
+				['project:admin'],
 			);
 
 			expect(entityManager.find).toHaveBeenCalledTimes(2);
 			expect(entityManager.find).toHaveBeenNthCalledWith(2, SharedWorkflow, {
 				select: { workflowId: true },
 				where: {
-					workflowId: In(['workflow-1', 'workflow-2']),
-					projectId: In(['project-10000']),
+					workflowId: In(['workflow-10000']),
+					project: {
+						projectRelations: { userId: 'user-1', role: { slug: In(['project:admin']) } },
+					},
 				},
 			});
-			expect(result).toEqual(new Set(['workflow-1', 'workflow-2']));
+			expect(result).toEqual(new Set(['workflow-0', 'workflow-10000']));
 		});
 	});
 });

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -25,14 +25,28 @@ export class SharedWorkflowRepository extends BaseRepository<SharedWorkflow> {
 		super(SharedWorkflow, dataSource.manager, transactionRunner);
 	}
 
-	async getSharedWorkflowIds(workflowIds: string[]) {
-		const sharedWorkflows = await this.find({
-			select: ['workflowId'],
-			where: {
-				workflowId: In(workflowIds),
-			},
-		});
-		return sharedWorkflows.map((sharing) => sharing.workflowId);
+	/**
+	 * Returns workflow IDs that have any sharing row
+	 * in one of the projects the caller is allowed to list.
+	 */
+	async findWorkflowIdsInProjects(
+		workflowIds: string[],
+		projectIds: string[],
+	): Promise<Set<string>> {
+		if (workflowIds.length === 0 || projectIds.length === 0) return new Set();
+
+		const found = new Set<string>();
+		for (const chunk of chunkIds(workflowIds)) {
+			const rows = await this.find({
+				select: { workflowId: true },
+				where: { workflowId: In(chunk), projectId: In(projectIds) },
+			});
+			for (const row of rows) {
+				found.add(row.workflowId);
+			}
+		}
+
+		return found;
 	}
 
 	async findByWorkflowIds(workflowIds: string[]) {

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -35,14 +35,17 @@ export class SharedWorkflowRepository extends BaseRepository<SharedWorkflow> {
 	): Promise<Set<string>> {
 		if (workflowIds.length === 0 || projectIds.length === 0) return new Set();
 
+		// Chunk both filters to keep each IN clause within database parameter limits
 		const found = new Set<string>();
-		for (const chunk of chunkIds(workflowIds)) {
-			const rows = await this.find({
-				select: { workflowId: true },
-				where: { workflowId: In(chunk), projectId: In(projectIds) },
-			});
-			for (const row of rows) {
-				found.add(row.workflowId);
+		for (const workflowChunk of chunkIds(workflowIds)) {
+			for (const projectChunk of chunkIds(projectIds)) {
+				const rows = await this.find({
+					select: { workflowId: true },
+					where: { workflowId: In(workflowChunk), projectId: In(projectChunk) },
+				});
+				for (const row of rows) {
+					found.add(row.workflowId);
+				}
 			}
 		}
 

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -26,26 +26,27 @@ export class SharedWorkflowRepository extends BaseRepository<SharedWorkflow> {
 	}
 
 	/**
-	 * Returns workflow IDs that have any sharing row
-	 * in one of the projects the caller is allowed to list.
+	 * SharedWorkflow maps workflows to projects, so user access is checked through
+	 * project relations with the supplied project roles.
 	 */
-	async findWorkflowIdsInProjects(
+	async findWorkflowIdsInUserProjects(
 		workflowIds: string[],
-		projectIds: string[],
+		userId: string,
+		projectRoleSlugs: string[],
 	): Promise<Set<string>> {
-		if (workflowIds.length === 0 || projectIds.length === 0) return new Set();
+		if (workflowIds.length === 0 || projectRoleSlugs.length === 0) return new Set();
 
-		// Chunk both filters to keep each IN clause within database parameter limits
 		const found = new Set<string>();
-		for (const workflowChunk of chunkIds(workflowIds)) {
-			for (const projectChunk of chunkIds(projectIds)) {
-				const rows = await this.find({
-					select: { workflowId: true },
-					where: { workflowId: In(workflowChunk), projectId: In(projectChunk) },
-				});
-				for (const row of rows) {
-					found.add(row.workflowId);
-				}
+		for (const chunk of chunkIds(workflowIds)) {
+			const rows = await this.find({
+				select: { workflowId: true },
+				where: {
+					workflowId: In(chunk),
+					project: { projectRelations: { userId, role: { slug: In(projectRoleSlugs) } } },
+				},
+			});
+			for (const row of rows) {
+				found.add(row.workflowId);
 			}
 		}
 

--- a/packages/cli/src/permissions.ee/__tests__/project-scope.service.test.ts
+++ b/packages/cli/src/permissions.ee/__tests__/project-scope.service.test.ts
@@ -23,6 +23,29 @@ describe('ProjectScopeService', () => {
 		vi.clearAllMocks();
 	});
 
+	describe('getProjectRoleSlugs', () => {
+		it('returns no project role restriction when the user has the global scope', async () => {
+			const result = await service.getProjectRoleSlugs(makeUser(['agent:update']), [
+				'agent:update',
+			]);
+
+			expect(result).toBeNull();
+			expect(roleService.rolesWithScope).not.toHaveBeenCalled();
+			expect(projectRelationRepository.getAccessibleProjectsByRoles).not.toHaveBeenCalled();
+		});
+
+		it('resolves project roles that grant the scope', async () => {
+			roleService.rolesWithScope.mockResolvedValue(['project:admin', 'project:editor']);
+
+			const result = await service.getProjectRoleSlugs(makeUser(), ['agent:update']);
+
+			expect(roleService.rolesWithScope).toHaveBeenCalledOnce();
+			expect(roleService.rolesWithScope).toHaveBeenCalledWith('project', ['agent:update']);
+			expect(projectRelationRepository.getAccessibleProjectsByRoles).not.toHaveBeenCalled();
+			expect(result).toEqual(['project:admin', 'project:editor']);
+		});
+	});
+
 	it('returns no project restriction when the user has the global scope', async () => {
 		const result = await service.getProjectIds(makeUser(['agent:update']), ['agent:update']);
 

--- a/packages/cli/src/permissions.ee/project-scope.service.ts
+++ b/packages/cli/src/permissions.ee/project-scope.service.ts
@@ -5,7 +5,7 @@ import { hasGlobalScope, type Scope } from '@n8n/permissions';
 import { RoleService } from '@/services/role.service';
 
 /**
- * Resolves the project restriction for a scope-aware query.
+ * Resolves the project roles, or the project IDs, that restrict a scope-aware query.
  * `null` means the user's global role grants access to every project.
  */
 @Service()
@@ -15,10 +15,16 @@ export class ProjectScopeService {
 		private readonly projectRelationRepository: ProjectRelationRepository,
 	) {}
 
-	async getProjectIds(user: User, scopes: Scope[]): Promise<string[] | null> {
+	async getProjectRoleSlugs(user: User, scopes: Scope[]): Promise<string[] | null> {
 		if (hasGlobalScope(user, scopes, { mode: 'allOf' })) return null;
 
-		const roles = await this.roleService.rolesWithScope('project', scopes);
+		return await this.roleService.rolesWithScope('project', scopes);
+	}
+
+	async getProjectIds(user: User, scopes: Scope[]): Promise<string[] | null> {
+		const roles = await this.getProjectRoleSlugs(user, scopes);
+		if (roles === null) return null;
+
 		return await this.projectRelationRepository.getAccessibleProjectsByRoles(user.id, roles);
 	}
 }

--- a/packages/cli/src/services/__tests__/active-workflows.service.test.ts
+++ b/packages/cli/src/services/__tests__/active-workflows.service.test.ts
@@ -43,32 +43,36 @@ describe('ActiveWorkflowsService', () => {
 			workflowRepository.getActiveIds.mockResolvedValue(activeIds);
 		});
 
-		it('should return all workflow ids when the user can list workflows in every project', async () => {
+		it('should return all workflow ids when the user can list workflows globally', async () => {
 			user.role = GLOBAL_ADMIN_ROLE;
-			projectScopeService.getProjectIds.mockResolvedValue(null);
+			projectScopeService.getProjectRoleSlugs.mockResolvedValue(null);
 			const ids = await service.getAllActiveIdsFor(user);
 
 			expect(ids).toEqual(['2', '3', '4']);
-			expect(sharedWorkflowRepository.findWorkflowIdsInProjects).not.toHaveBeenCalled();
+			expect(projectScopeService.getProjectRoleSlugs).toHaveBeenCalledWith(user, ['workflow:list']);
+			expect(sharedWorkflowRepository.findWorkflowIdsInUserProjects).not.toHaveBeenCalled();
 		});
 
 		it('should filter out workflow ids that the user cannot list', async () => {
 			user.role = GLOBAL_MEMBER_ROLE;
-			projectScopeService.getProjectIds.mockResolvedValue(['project-1']);
-			sharedWorkflowRepository.findWorkflowIdsInProjects.mockResolvedValue(new Set(['3']));
+			user.id = 'user-1';
+			projectScopeService.getProjectRoleSlugs.mockResolvedValue(['project:admin']);
+			sharedWorkflowRepository.findWorkflowIdsInUserProjects.mockResolvedValue(new Set(['3']));
 			const ids = await service.getAllActiveIdsFor(user);
 
 			expect(ids).toEqual(['3']);
-			expect(projectScopeService.getProjectIds).toHaveBeenCalledWith(user, ['workflow:list']);
-			expect(sharedWorkflowRepository.findWorkflowIdsInProjects).toHaveBeenCalledWith(activeIds, [
-				'project-1',
-			]);
+			expect(projectScopeService.getProjectRoleSlugs).toHaveBeenCalledWith(user, ['workflow:list']);
+			expect(sharedWorkflowRepository.findWorkflowIdsInUserProjects).toHaveBeenCalledWith(
+				activeIds,
+				'user-1',
+				['project:admin'],
+			);
 		});
 
-		it('should return no ids when the user can list workflows in no project', async () => {
+		it('should return no ids when the user cannot list workflows in any project', async () => {
 			user.role = GLOBAL_MEMBER_ROLE;
-			projectScopeService.getProjectIds.mockResolvedValue([]);
-			sharedWorkflowRepository.findWorkflowIdsInProjects.mockResolvedValue(new Set());
+			projectScopeService.getProjectRoleSlugs.mockResolvedValue([]);
+			sharedWorkflowRepository.findWorkflowIdsInUserProjects.mockResolvedValue(new Set());
 			const ids = await service.getAllActiveIdsFor(user);
 
 			expect(ids).toEqual([]);

--- a/packages/cli/src/services/__tests__/active-workflows.service.test.ts
+++ b/packages/cli/src/services/__tests__/active-workflows.service.test.ts
@@ -4,6 +4,7 @@ import { mock } from 'vitest-mock-extended';
 
 import type { ActivationErrorsService } from '@/activation-errors.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import type { ProjectScopeService } from '@/permissions.ee/project-scope.service';
 import { ActiveWorkflowsService } from '@/services/active-workflows.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -13,12 +14,14 @@ describe('ActiveWorkflowsService', () => {
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const activationErrorsService = mock<ActivationErrorsService>();
+	const projectScopeService = mock<ProjectScopeService>();
 	const service = new ActiveWorkflowsService(
 		mock(),
 		workflowRepository,
 		sharedWorkflowRepository,
 		activationErrorsService,
 		workflowFinderService,
+		projectScopeService,
 	);
 	const activeIds = ['1', '2', '3', '4'];
 
@@ -40,21 +43,35 @@ describe('ActiveWorkflowsService', () => {
 			workflowRepository.getActiveIds.mockResolvedValue(activeIds);
 		});
 
-		it('should return all workflow ids when user has full access', async () => {
+		it('should return all workflow ids when the user can list workflows in every project', async () => {
 			user.role = GLOBAL_ADMIN_ROLE;
+			projectScopeService.getProjectIds.mockResolvedValue(null);
 			const ids = await service.getAllActiveIdsFor(user);
 
 			expect(ids).toEqual(['2', '3', '4']);
-			expect(sharedWorkflowRepository.getSharedWorkflowIds).not.toHaveBeenCalled();
+			expect(sharedWorkflowRepository.findWorkflowIdsInProjects).not.toHaveBeenCalled();
 		});
 
-		it('should filter out workflow ids that the user does not have access to', async () => {
+		it('should filter out workflow ids that the user cannot list', async () => {
 			user.role = GLOBAL_MEMBER_ROLE;
-			sharedWorkflowRepository.getSharedWorkflowIds.mockResolvedValue(['3']);
+			projectScopeService.getProjectIds.mockResolvedValue(['project-1']);
+			sharedWorkflowRepository.findWorkflowIdsInProjects.mockResolvedValue(new Set(['3']));
 			const ids = await service.getAllActiveIdsFor(user);
 
 			expect(ids).toEqual(['3']);
-			expect(sharedWorkflowRepository.getSharedWorkflowIds).toHaveBeenCalledWith(activeIds);
+			expect(projectScopeService.getProjectIds).toHaveBeenCalledWith(user, ['workflow:list']);
+			expect(sharedWorkflowRepository.findWorkflowIdsInProjects).toHaveBeenCalledWith(activeIds, [
+				'project-1',
+			]);
+		});
+
+		it('should return no ids when the user can list workflows in no project', async () => {
+			user.role = GLOBAL_MEMBER_ROLE;
+			projectScopeService.getProjectIds.mockResolvedValue([]);
+			sharedWorkflowRepository.findWorkflowIdsInProjects.mockResolvedValue(new Set());
+			const ids = await service.getAllActiveIdsFor(user);
+
+			expect(ids).toEqual([]);
 		});
 	});
 

--- a/packages/cli/src/services/active-workflows.service.ts
+++ b/packages/cli/src/services/active-workflows.service.ts
@@ -28,16 +28,17 @@ export class ActiveWorkflowsService {
 	async getAllActiveIdsFor(user: User) {
 		const activationErrors = await this.activationErrorsService.getAll();
 		const activeWorkflowIds = await this.workflowRepository.getActiveIds();
-
-		const projectIds = await this.projectScopeService.getProjectIds(user, ['workflow:list']);
+		const projectRoleSlugs = await this.projectScopeService.getProjectRoleSlugs(user, [
+			'workflow:list',
+		]);
 
 		const listableWorkflowIds =
-			// `null` means the user's global role can list workflows in every project
-			projectIds === null
+			projectRoleSlugs === null
 				? new Set(activeWorkflowIds)
-				: await this.sharedWorkflowRepository.findWorkflowIdsInProjects(
+				: await this.sharedWorkflowRepository.findWorkflowIdsInUserProjects(
 						activeWorkflowIds,
-						projectIds,
+						user.id,
+						projectRoleSlugs,
 					);
 
 		return activeWorkflowIds.filter(

--- a/packages/cli/src/services/active-workflows.service.ts
+++ b/packages/cli/src/services/active-workflows.service.ts
@@ -2,10 +2,10 @@ import { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { SharedWorkflowRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { hasGlobalScope } from '@n8n/permissions';
 
 import { ActivationErrorsService } from '@/activation-errors.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ProjectScopeService } from '@/permissions.ee/project-scope.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 @Service()
@@ -16,6 +16,7 @@ export class ActiveWorkflowsService {
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly activationErrorsService: ActivationErrorsService,
 		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly projectScopeService: ProjectScopeService,
 	) {}
 
 	async getAllActiveIdsInStorage() {
@@ -28,14 +29,20 @@ export class ActiveWorkflowsService {
 		const activationErrors = await this.activationErrorsService.getAll();
 		const activeWorkflowIds = await this.workflowRepository.getActiveIds();
 
-		const hasFullAccess = hasGlobalScope(user, 'workflow:list');
-		if (hasFullAccess) {
-			return activeWorkflowIds.filter((workflowId) => !activationErrors[workflowId]);
-		}
+		const projectIds = await this.projectScopeService.getProjectIds(user, ['workflow:list']);
 
-		const sharedWorkflowIds =
-			await this.sharedWorkflowRepository.getSharedWorkflowIds(activeWorkflowIds);
-		return sharedWorkflowIds.filter((workflowId) => !activationErrors[workflowId]);
+		const listableWorkflowIds =
+			// `null` means the user's global role can list workflows in every project
+			projectIds === null
+				? new Set(activeWorkflowIds)
+				: await this.sharedWorkflowRepository.findWorkflowIdsInProjects(
+						activeWorkflowIds,
+						projectIds,
+					);
+
+		return activeWorkflowIds.filter(
+			(workflowId) => listableWorkflowIds.has(workflowId) && !activationErrors[workflowId],
+		);
 	}
 
 	async getActivationError(workflowId: string, user: User) {

--- a/packages/cli/test/integration/active-workflows.api.test.ts
+++ b/packages/cli/test/integration/active-workflows.api.test.ts
@@ -1,0 +1,98 @@
+import {
+	createActiveWorkflow,
+	createTeamProject,
+	linkUserToProject,
+	shareWorkflowWithProjects,
+	shareWorkflowWithUsers,
+	testDb,
+} from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+
+import { createMember, createOwner } from './shared/db/users';
+import type { SuperAgentTest } from './shared/types';
+import * as utils from './shared/utils/';
+
+let owner: User;
+let member: User;
+let anotherMember: User;
+let authOwnerAgent: SuperAgentTest;
+let authMemberAgent: SuperAgentTest;
+
+const testServer = utils.setupTestServer({ endpointGroups: ['activeWorkflows'] });
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'WorkflowEntity',
+		'SharedWorkflow',
+		'WorkflowHistory',
+		'ProjectRelation',
+		'Project',
+		'User',
+	]);
+
+	owner = await createOwner();
+	member = await createMember();
+	anotherMember = await createMember();
+	authOwnerAgent = testServer.authAgentFor(owner);
+	authMemberAgent = testServer.authAgentFor(member);
+});
+
+describe('GET /active-workflows', () => {
+	it('returns every active workflow id to a global owner', async () => {
+		const firstWorkflow = await createActiveWorkflow({}, member);
+		const secondWorkflow = await createActiveWorkflow({}, anotherMember);
+
+		const response = await authOwnerAgent.get('/active-workflows').expect(200);
+
+		expect(response.body.data).toEqual(
+			expect.arrayContaining([firstWorkflow.id, secondWorkflow.id]),
+		);
+		expect(response.body.data).toHaveLength(2);
+	});
+
+	it('returns only active workflow ids the member can list', async () => {
+		const ownWorkflow = await createActiveWorkflow({}, member);
+
+		const sharedWorkflow = await createActiveWorkflow({}, anotherMember);
+		await shareWorkflowWithUsers(sharedWorkflow, [member]);
+
+		const teamProject = await createTeamProject('Team Project', anotherMember);
+		await linkUserToProject(member, teamProject, 'project:viewer');
+		const teamWorkflow = await createActiveWorkflow({}, teamProject);
+
+		const inaccessiblePersonalWorkflow = await createActiveWorkflow({}, anotherMember);
+		const inaccessibleProject = await createTeamProject('Other Team Project', anotherMember);
+		const inaccessibleProjectWorkflow = await createActiveWorkflow({}, inaccessibleProject);
+
+		const response = await authMemberAgent.get('/active-workflows').expect(200);
+
+		expect(response.body.data).toHaveLength(3);
+		expect(response.body.data).toEqual(
+			expect.arrayContaining([ownWorkflow.id, sharedWorkflow.id, teamWorkflow.id]),
+		);
+		expect(response.body.data).not.toContain(inaccessiblePersonalWorkflow.id);
+		expect(response.body.data).not.toContain(inaccessibleProjectWorkflow.id);
+	});
+
+	// `project:chatUser` is the only built-in project role without `workflow:list`
+	it('does not return active workflow ids from a project the member belongs to but cannot list', async () => {
+		const chatOnlyProject = await createTeamProject('Chat Only Project', anotherMember);
+		await linkUserToProject(member, chatOnlyProject, 'project:chatUser');
+		const chatOnlyWorkflow = await createActiveWorkflow({}, chatOnlyProject);
+
+		const response = await authMemberAgent.get('/active-workflows').expect(200);
+
+		expect(response.body.data).toEqual([]);
+		expect(response.body.data).not.toContain(chatOnlyWorkflow.id);
+	});
+
+	it('returns an active workflow id once when it is shared with several projects the member can list', async () => {
+		const workflow = await createActiveWorkflow({}, member);
+		const teamProject = await createTeamProject('Team Project', member);
+		await shareWorkflowWithProjects(workflow, [{ project: teamProject, role: 'workflow:editor' }]);
+
+		const response = await authMemberAgent.get('/active-workflows').expect(200);
+
+		expect(response.body.data).toEqual([workflow.id]);
+	});
+});

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -8,6 +8,7 @@ import type TestAgent from 'supertest/lib/agent';
 import type { LicenseMocker } from './license';
 
 type EndpointGroup =
+	| 'activeWorkflows'
 	| 'health'
 	| 'me'
 	| 'users'

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -198,6 +198,10 @@ export const setupTestServer = ({
 		if (endpointGroups.length) {
 			for (const group of endpointGroups) {
 				switch (group) {
+					case 'activeWorkflows':
+						await import('@/controllers/active-workflows.controller.js');
+						break;
+
 					case 'annotationTags':
 						await import('@/controllers/annotation-tags.controller.ee.js');
 						break;


### PR DESCRIPTION
## Summary

This PR scopes active workflow ID lookup to projects where the requesting user can list workflows.

It keeps global workflow list access unchanged, and uses project-level workflow list access for regular users.

## How to test

- Create a member user on the same instance
- Share a workflow with them (via a project) and publish it. Make sure you have other workflows that are not shared.
- Send a request to `/rest/active-workflows` - see only one shared workflow id there

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-959

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
