### PR TITLE
test(editor): Update approval status label format in review round trip test

### DIFF
--- a/packages/testing/playwright/tests/e2e/workflow-reviews/review-round-trip.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflow-reviews/review-round-trip.spec.ts
@@ -113,7 +113,7 @@ test.describe(
 			await reviewerN8n.workflowReviews.approve('Looks good now');
 			await expect(reviewerN8n.workflowReviews.getSelectedRequestStatus()).toHaveAttribute(
 				'aria-label',
-				'Closed • Approved',
+				'Closed | Approved',
 			);
 			// Deciding refetches the review, so this summary has to appear on its own
 			await expect(reviewerN8n.workflowReviews.getClosedCallout()).toBeVisible();


### PR DESCRIPTION
## Summary

Two commits were out of sync:
- 846bb4bab8c (#36906) added the spec asserting aria-label = Closed • Approved
- f3481c70c11 (#37005) changed the separator to a pipe and deleted the workflowReviews.status.combinedLabel i18n key that produced the bullet

## Related Linear tickets, Github issues, and Community forum posts

LIGO-1033

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
