### PR TITLE
feat(Databricks Node): Support templated MCP registry server URLs (alt design)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
@@ -40,6 +40,7 @@ function createLoadOptionsCtx(params: ParamMap, nodeOverrides?: ParamMap) {
 	ctx.getNodeParameter.mockImplementation((key: string, defaultValue?: unknown) => {
 		return (key in params ? params[key] : defaultValue) as never;
 	});
+	ctx.getCredentials.mockResolvedValue({});
 	return ctx;
 }
 
@@ -58,6 +59,7 @@ function createSupplyDataCtx(params: ParamMap, nodeOverrides?: ParamMap) {
 			return (key in params ? params[key] : defaultValue) as never;
 		},
 	);
+	ctx.getCredentials.mockResolvedValue({});
 	return ctx;
 }
 
@@ -76,6 +78,7 @@ function createExecuteCtx(params: ParamMap, nodeOverrides?: ParamMap) {
 			return (key in params ? params[key] : defaultValue) as never;
 		},
 	);
+	ctx.getCredentials.mockResolvedValue({});
 	return ctx;
 }
 
@@ -137,6 +140,28 @@ describe('McpRegistryClientTool', () => {
 			expect(loadMcpToolOptionsMock).toHaveBeenCalledWith(
 				ctx,
 				expect.objectContaining({ timeout: 60000 }),
+			);
+		});
+
+		it('prefers the credential-resolved serverUrl over the endpointUrl parameter', async () => {
+			const ctx = createLoadOptionsCtx({
+				serverTransport: 'httpStreamable',
+				endpointUrl: '={{$self["host"]}}/api/2.0/mcp/genie',
+				'options.timeout': 30000,
+			});
+			ctx.getCredentials.mockResolvedValue({
+				serverUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+			});
+			loadMcpToolOptionsMock.mockResolvedValue([]);
+
+			const node = new McpRegistryClientTool();
+			await node.methods.loadOptions.getTools.call(ctx);
+
+			expect(loadMcpToolOptionsMock).toHaveBeenCalledWith(
+				ctx,
+				expect.objectContaining({
+					endpointUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+				}),
 			);
 		});
 	});
@@ -211,6 +236,29 @@ describe('McpRegistryClientTool', () => {
 				'No MCP OAuth2 credential type found',
 			);
 		});
+
+		it('prefers the credential-resolved serverUrl over the endpointUrl parameter', async () => {
+			const ctx = createSupplyDataCtx({
+				serverTransport: 'httpStreamable',
+				endpointUrl: '={{$self["host"]}}/api/2.0/mcp/genie',
+				include: 'all',
+			});
+			ctx.getCredentials.mockResolvedValue({
+				serverUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+			});
+			buildMcpToolkitMock.mockResolvedValue({ response: {} } as never);
+
+			const node = new McpRegistryClientTool();
+			await node.supplyData.call(ctx, 0);
+
+			expect(buildMcpToolkitMock).toHaveBeenCalledWith(
+				ctx,
+				0,
+				expect.objectContaining({
+					endpointUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+				}),
+			);
+		});
 	});
 
 	describe('execute', () => {
@@ -238,7 +286,7 @@ describe('McpRegistryClientTool', () => {
 			);
 
 			const resolve = executeMcpToolMock.mock.calls[0][1];
-			expect(resolve(0)).toEqual({
+			await expect(resolve(0)).resolves.toEqual({
 				authentication: 'someServiceMcpOAuth2Api',
 				transport: 'httpStreamable',
 				endpointUrl: 'https://mcp.notion.com/mcp',
@@ -289,6 +337,33 @@ describe('McpRegistryClientTool', () => {
 			const node = new McpRegistryClientTool();
 
 			await expect(node.execute.call(ctx)).rejects.toThrow('No MCP OAuth2 credential type found');
+		});
+
+		it('prefers the credential-resolved serverUrl over the endpointUrl parameter', async () => {
+			const ctx = createExecuteCtx(
+				{
+					serverTransport: 'httpStreamable',
+					endpointUrl: '={{$self["host"]}}/api/2.0/mcp/genie',
+					'options.timeout': 60000,
+					include: 'all',
+					includeTools: [],
+					excludeTools: [],
+				},
+				{ typeVersion: 1.1 },
+			);
+			ctx.getCredentials.mockResolvedValue({
+				serverUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+			});
+			executeMcpToolMock.mockResolvedValue([[]]);
+
+			await new McpRegistryClientTool().execute.call(ctx);
+
+			const resolve = executeMcpToolMock.mock.calls[0][1];
+			await expect(resolve(0)).resolves.toEqual(
+				expect.objectContaining({
+					endpointUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+				}),
+			);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
@@ -23,6 +23,7 @@ import {
 	type McpAuthenticationOption,
 	type McpServerTransport,
 } from '../shared/types';
+import { resolveRegistryEndpointUrl } from '../shared/utils';
 
 /**
  * Nodes from the MCP registry are saved as `@n8n/mcp-registry.<slug>`
@@ -152,10 +153,15 @@ export class McpRegistryClientTool implements INodeType {
 		loadOptions: {
 			async getTools(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const authentication = getCredentialType(this);
+				const endpointUrl = await resolveRegistryEndpointUrl(
+					this,
+					authentication,
+					() => this.getNodeParameter('endpointUrl') as string,
+				);
 				return await loadMcpToolOptions(this, {
 					authentication,
 					transport: this.getNodeParameter('serverTransport') as McpServerTransport,
-					endpointUrl: this.getNodeParameter('endpointUrl') as string,
+					endpointUrl,
 					timeout: this.getNodeParameter('options.timeout', 60000) as number,
 				});
 			},
@@ -163,26 +169,31 @@ export class McpRegistryClientTool implements INodeType {
 	};
 
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
-		return await buildMcpToolkit(this, itemIndex, resolveConfig(this, itemIndex));
+		return await buildMcpToolkit(this, itemIndex, await resolveConfig(this, itemIndex));
 	}
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return await executeMcpTool(this, (itemIndex) => resolveConfig(this, itemIndex), {
+		return await executeMcpTool(this, async (itemIndex) => await resolveConfig(this, itemIndex), {
 			// v1.1+ reuses one MCP session across tool calls within an execution.
 			enableSessionCache: this.getNode().typeVersion >= 1.1,
 		});
 	}
 }
 
-function resolveConfig(
+async function resolveConfig(
 	ctx: ISupplyDataFunctions | IExecuteFunctions,
 	itemIndex: number,
-): ResolvedMcpConfig {
+): Promise<ResolvedMcpConfig> {
 	const authentication = getCredentialType(ctx);
+	const endpointUrl = await resolveRegistryEndpointUrl(
+		ctx,
+		authentication,
+		() => ctx.getNodeParameter('endpointUrl', itemIndex) as string,
+	);
 	return {
 		authentication,
 		transport: ctx.getNodeParameter('serverTransport', itemIndex) as McpServerTransport,
-		endpointUrl: ctx.getNodeParameter('endpointUrl', itemIndex) as string,
+		endpointUrl,
 		timeout: ctx.getNodeParameter('options.timeout', itemIndex, 60000) as number,
 		toolFilter: {
 			mode: ctx.getNodeParameter('include', itemIndex) as McpToolIncludeMode,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
@@ -14,6 +14,7 @@ import {
 	connectMcpClientForCredential,
 	getAuthHeaders,
 	mapToNodeOperationError,
+	resolveRegistryEndpointUrl,
 	tryRefreshOAuth2Token,
 } from '../utils';
 
@@ -842,6 +843,69 @@ describe('utils', () => {
 				expect(egressFilter.validateUrl).toHaveBeenCalledWith('https://mcp.example.com/');
 				expect(mockedProxyFetch).toHaveBeenCalledTimes(1);
 			});
+		});
+	});
+
+	describe('resolveRegistryEndpointUrl', () => {
+		it('prefers the credential-resolved serverUrl for an MCP OAuth2 credential', async () => {
+			const ctx = mockDeep<IExecuteFunctions>();
+			ctx.getCredentials.mockResolvedValue({
+				serverUrl: 'https://acme.cloud.databricks.com/api/2.0/mcp/genie',
+			});
+			const fallback = vi.fn(() => 'ignored');
+
+			const result = await resolveRegistryEndpointUrl(ctx, 'databricksMcpOAuth2Api', fallback);
+
+			expect(result).toBe('https://acme.cloud.databricks.com/api/2.0/mcp/genie');
+			expect(fallback).not.toHaveBeenCalled();
+		});
+
+		it('falls back to the node parameter when the credential has no serverUrl', async () => {
+			const ctx = mockDeep<IExecuteFunctions>();
+			ctx.getCredentials.mockResolvedValue({});
+			const fallback = vi.fn(() => 'https://mcp.example.com/mcp');
+
+			const result = await resolveRegistryEndpointUrl(ctx, 'databricksMcpOAuth2Api', fallback);
+
+			expect(result).toBe('https://mcp.example.com/mcp');
+			expect(fallback).toHaveBeenCalledTimes(1);
+		});
+
+		it('falls back when getCredentials rejects', async () => {
+			const ctx = mockDeep<IExecuteFunctions>();
+			ctx.getCredentials.mockRejectedValue(new Error('not found'));
+			const fallback = vi.fn(() => 'https://mcp.example.com/mcp');
+
+			const result = await resolveRegistryEndpointUrl(ctx, 'databricksMcpOAuth2Api', fallback);
+
+			expect(result).toBe('https://mcp.example.com/mcp');
+		});
+
+		it('never reads credentials for a non-MCP-OAuth2 authentication option, and falls back', async () => {
+			const ctx = mockDeep<IExecuteFunctions>();
+			const fallback = vi.fn(() => 'https://mcp.example.com/mcp');
+
+			const result = await resolveRegistryEndpointUrl(ctx, 'headerAuth', fallback);
+
+			expect(result).toBe('https://mcp.example.com/mcp');
+			expect(ctx.getCredentials).not.toHaveBeenCalled();
+		});
+
+		it('does not call the fallback thunk when a resolved serverUrl is available', async () => {
+			// Regression guard: for a templated registry row the node's own
+			// endpointUrl parameter holds a raw, unresolved `$self` expression
+			// string, evaluating it would be wrong even if its return value is
+			// discarded, so the thunk must stay unevaluated whenever a resolved
+			// serverUrl exists.
+			const ctx = mockDeep<IExecuteFunctions>();
+			ctx.getCredentials.mockResolvedValue({ serverUrl: 'https://acme.databricks.com/mcp' });
+			const fallback = vi.fn(() => {
+				throw new Error('fallback should not be evaluated');
+			});
+
+			await expect(
+				resolveRegistryEndpointUrl(ctx, 'databricksMcpOAuth2Api', fallback),
+			).resolves.toBe('https://acme.databricks.com/mcp');
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
@@ -78,6 +78,7 @@ const OAUTH2_REFRESH_BUFFER_RATIO = 0.1;
 
 type McpOAuth2Credentials = ICredentialDataDecryptedObject & {
 	oauthTokenData?: ClientOAuth2TokenData;
+	serverUrl?: string;
 };
 
 type ConnectMcpClientError =
@@ -526,6 +527,35 @@ export async function connectMcpClientForCredential(
 		onUnauthorized: async (h) => await tryRefreshOAuth2Token(ctx, config.authentication, h),
 		signal: config.signal,
 	});
+}
+
+/**
+ * Registry-derived credentials (see the mcp-registry module) resolve their MCP
+ * endpoint from a synthetic, per-credential `serverUrl` default instead of the
+ * node's `endpointUrl` parameter, so a per-customer host can be filled in via
+ * the credential's own `$self` expression. Only call this from
+ * McpRegistryClientTool: the generic mcpOAuth2Api credential also has a
+ * `serverUrl` field (inherited from oAuth2Api), but it means the unrelated DCR
+ * issuer URL there, not the tool's endpoint.
+ *
+ * `getFallbackEndpointUrl` is a thunk, not a value: for a templated row the
+ * node's own `endpointUrl` parameter holds the raw, unresolved template
+ * (there is no `$self` in node-parameter expressions), so it must never be
+ * evaluated when a resolved `serverUrl` is already available.
+ */
+export async function resolveRegistryEndpointUrl(
+	ctx: IExecuteFunctions | ILoadOptionsFunctions | ISupplyDataFunctions,
+	authentication: McpAuthenticationOption,
+	getFallbackEndpointUrl: () => string,
+): Promise<string> {
+	if (isMcpOAuth2Authentication(authentication)) {
+		const credentials = await ctx
+			.getCredentials<McpOAuth2Credentials>(authentication)
+			.catch(() => null);
+		const serverUrl = credentials?.serverUrl;
+		if (typeof serverUrl === 'string' && serverUrl.length > 0) return serverUrl;
+	}
+	return getFallbackEndpointUrl();
 }
 
 export function isStructuredContent(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/modules/mcp-registry/__tests__/node-description-transform.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/node-description-transform.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../node-description-transform';
 import type { McpRegistryServer } from '../registry/mcp-registry.types';
 import {
+	databricksGenieTemplatedMockServer,
 	gmailDirectExtendMockServer,
 	notionMockServer,
 	slackExtendingMockServer,
@@ -376,6 +377,28 @@ describe('serverToNodeDescription', () => {
 
 			expect(description?.credentials).toEqual([]);
 		});
+
+		it('builds a tile for a templated (=-prefixed) streamable-http remote, unresolved endpointUrl and all', () => {
+			const description = serverToNodeDescription(
+				databricksGenieTemplatedMockServer,
+				baseDescription,
+				(name) => name === 'databricksOAuth2Api',
+			);
+
+			expect(description).not.toBeNull();
+			expect(description?.credentials).toEqual([
+				{ name: 'databricksGenieMcpOAuth2Api', required: true },
+			]);
+
+			// The node's own endpointUrl parameter still gets patched with the raw
+			// template; the runtime never reads it once a credential serverUrl is
+			// resolvable (see McpRegistryClientTool), but the description build
+			// itself does not special-case a templated remote.
+			const endpointUrl = description?.properties.find((p) => p.name === 'endpointUrl');
+			const serverTransport = description?.properties.find((p) => p.name === 'serverTransport');
+			expect(serverTransport?.default).toBe('httpStreamable');
+			expect(endpointUrl?.default).toBe('={{$self["host"].replace(/\\/$/, "")}}/api/2.0/mcp/genie');
+		});
 	});
 });
 
@@ -609,6 +632,71 @@ describe('serverToCredentialDescription', () => {
 
 			expect(description?.extends).toEqual(['mcpOAuth2Api']);
 		});
+
+		it('writes a $self-expression serverUrl and allowedDomains for a templated (=-prefixed) remote', () => {
+			const description = serverToCredentialDescription(
+				databricksGenieTemplatedMockServer,
+				(name) => name === 'databricksOAuth2Api',
+			);
+
+			expect(description).toEqual({
+				name: 'databricksGenieMcpOAuth2Api',
+				displayName: 'Databricks Genie MCP OAuth2',
+				extends: ['databricksOAuth2Api'],
+				icon: 'node:@n8n/mcp-registry.databricksGenie',
+				properties: [
+					{ displayName: 'scope', name: 'scope', type: 'hidden', default: 'genie offline_access' },
+					{
+						displayName: 'grantType',
+						name: 'grantType',
+						type: 'hidden',
+						default: 'authorizationCode',
+					},
+					{
+						displayName: 'customScopes',
+						name: 'customScopes',
+						type: 'hidden',
+						default: false,
+					},
+					{
+						displayName: 'Server URL',
+						name: 'serverUrl',
+						type: 'hidden',
+						default: '={{$self["host"].replace(/\\/$/, "")}}/api/2.0/mcp/genie',
+					},
+					{
+						displayName: 'Allowed HTTP Request Domains',
+						name: 'allowedHttpRequestDomains',
+						type: 'hidden',
+						default: 'domains',
+					},
+					{
+						displayName: 'Allowed Domains',
+						name: 'allowedDomains',
+						type: 'hidden',
+						default: '={{$self["host"].extractDomain()}}',
+					},
+				],
+			});
+		});
+	});
+
+	it('drops the row for a templated remote paired with plain oauth2 auth, no host-bearing field to resolve against', () => {
+		const server: McpRegistryServer = {
+			...notionMockServer,
+			remotes: [{ type: 'streamable-http', url: '={{$self["host"]}}/mcp' }],
+		};
+
+		expect(serverToCredentialDescription(server, isKnownCredentialType)).toBeNull();
+	});
+
+	it('drops the row when the remote type is unrecognised, the back-compat gate for future remote types', () => {
+		const server: McpRegistryServer = {
+			...notionMockServer,
+			remotes: [{ type: 'some-future-remote-type' as never, url: 'https://mcp.notion.com/mcp' }],
+		};
+
+		expect(serverToCredentialDescription(server, isKnownCredentialType)).toBeNull();
 	});
 });
 

--- a/packages/cli/src/modules/mcp-registry/node-description-transform.ts
+++ b/packages/cli/src/modules/mcp-registry/node-description-transform.ts
@@ -1,10 +1,11 @@
 import { camelCase } from 'change-case';
-import type {
-	ICredentialType,
-	INodeCredentialDescription,
-	INodeProperties,
-	INodeTypeDescription,
-	Themed,
+import {
+	isExpression,
+	type ICredentialType,
+	type INodeCredentialDescription,
+	type INodeProperties,
+	type INodeTypeDescription,
+	type Themed,
 } from 'n8n-workflow';
 
 import {
@@ -231,11 +232,11 @@ function getNodeDescriptionCredentials(
 
 /**
  * Pick the connection details from a registry server. `streamable-http` is
- * preferred over `sse`. A remote is templated when its URL starts with `=`,
- * n8n's own convention for "evaluate this as an expression" (the same marker
- * every credential/node parameter default already uses), so no dedicated
- * remote type is needed to flag it. `endpointUrl` is then an unresolved
- * `$self`-expression string, not a literal URL.
+ * preferred over `sse`. A remote is templated when `isExpression` recognizes
+ * its URL, n8n's own convention for "evaluate this as an expression" (the
+ * same marker every credential/node parameter default already uses), so no
+ * dedicated remote type is needed to flag it. `endpointUrl` is then an
+ * unresolved `$self`-expression string, not a literal URL.
  */
 function pickRemote(
 	server: McpRegistryServer,
@@ -245,12 +246,12 @@ function pickRemote(
 		return {
 			transport: 'httpStreamable',
 			endpointUrl: streamable.url,
-			isTemplated: streamable.url.startsWith('='),
+			isTemplated: isExpression(streamable.url),
 		};
 	}
 
 	const sse = server.remotes.find((r) => r.type === 'sse');
-	if (sse) return { transport: 'sse', endpointUrl: sse.url, isTemplated: sse.url.startsWith('=') };
+	if (sse) return { transport: 'sse', endpointUrl: sse.url, isTemplated: isExpression(sse.url) };
 
 	return null;
 }

--- a/packages/cli/src/modules/mcp-registry/node-description-transform.ts
+++ b/packages/cli/src/modules/mcp-registry/node-description-transform.ts
@@ -52,16 +52,24 @@ function getMcpRegistryCredentialHeader(
 	};
 }
 
+type CredentialRemote =
+	| { endpointUrl: string; hostname: string; isTemplated: false }
+	| { endpointUrl: string; isTemplated: true };
+
 /**
- * Picks the server's remote endpoint and parses its hostname.
+ * Picks the server's remote endpoint and parses its hostname. A templated
+ * remote has no hostname to parse yet, it resolves per-credential at runtime.
  */
-function resolveCredentialRemote(
-	server: McpRegistryServer,
-): { endpointUrl: string; hostname: string } | null {
+function resolveCredentialRemote(server: McpRegistryServer): CredentialRemote | null {
 	const remote = pickRemote(server);
 	if (!remote) return null;
+	if (remote.isTemplated) return { endpointUrl: remote.endpointUrl, isTemplated: true };
 	try {
-		return { endpointUrl: remote.endpointUrl, hostname: new URL(remote.endpointUrl).hostname };
+		return {
+			endpointUrl: remote.endpointUrl,
+			hostname: new URL(remote.endpointUrl).hostname,
+			isTemplated: false,
+		};
 	} catch {
 		return null;
 	}
@@ -88,11 +96,14 @@ function buildDomainRestrictionProperties(hostname: string): INodeProperties[] {
 }
 
 /**
- * Registry MCP server → service-specific credential type for OAuth2 auth type
+ * Registry MCP server → service-specific credential type for OAuth2 auth type.
+ * Plain `oauth2` credentials have no user-editable, host-bearing field of
+ * their own to resolve a templated URL against, so templated remotes are
+ * unsupported here and drop the row, same as an unparseable URL.
  */
 function serverToOAuth2CredentialDescription(server: McpRegistryServer): ICredentialType | null {
 	const remote = resolveCredentialRemote(server);
-	if (!remote) return null;
+	if (!remote || remote.isTemplated) return null;
 
 	return {
 		...getMcpRegistryCredentialHeader(server),
@@ -147,7 +158,11 @@ function getValidatedExtendsCredential(
 }
 
 /**
- * Builds a dedicated credential type extending a known n8n credential.
+ * Builds a dedicated credential type extending a known n8n credential. A
+ * templated remote has no literal hostname, so the endpoint and the domain
+ * pin are both written as `$self`-expressions resolved against the parent
+ * credential's own `host` field, the same field the Strapi-authored URL
+ * template itself already depends on.
  */
 function serverToExtendedCredentialDescription(
 	server: McpRegistryServer,
@@ -168,10 +183,29 @@ function serverToExtendedCredentialDescription(
 		}),
 	);
 
+	const serverUrlOverride: INodeProperties[] = remote.isTemplated
+		? [
+				{
+					displayName: 'Server URL',
+					name: 'serverUrl',
+					type: 'hidden',
+					default: remote.endpointUrl,
+				},
+			]
+		: [];
+
+	const allowedDomainsDefault = remote.isTemplated
+		? '={{$self["host"].extractDomain()}}'
+		: remote.hostname;
+
 	return {
 		...getMcpRegistryCredentialHeader(server),
 		extends: [validated.parentType],
-		properties: [...overrideProperties, ...buildDomainRestrictionProperties(remote.hostname)],
+		properties: [
+			...overrideProperties,
+			...serverUrlOverride,
+			...buildDomainRestrictionProperties(allowedDomainsDefault),
+		],
 	};
 }
 
@@ -196,17 +230,27 @@ function getNodeDescriptionCredentials(
 }
 
 /**
- * Pick the connection details from a registry server. Only `streamable-http`
- * and `sse` are supported; `streamable-http` is preferred.
+ * Pick the connection details from a registry server. `streamable-http` is
+ * preferred over `sse`. A remote is templated when its URL starts with `=`,
+ * n8n's own convention for "evaluate this as an expression" (the same marker
+ * every credential/node parameter default already uses), so no dedicated
+ * remote type is needed to flag it. `endpointUrl` is then an unresolved
+ * `$self`-expression string, not a literal URL.
  */
 function pickRemote(
 	server: McpRegistryServer,
-): { transport: 'httpStreamable' | 'sse'; endpointUrl: string } | null {
+): { transport: 'httpStreamable' | 'sse'; endpointUrl: string; isTemplated: boolean } | null {
 	const streamable = server.remotes.find((r) => r.type === 'streamable-http');
-	if (streamable) return { transport: 'httpStreamable', endpointUrl: streamable.url };
+	if (streamable) {
+		return {
+			transport: 'httpStreamable',
+			endpointUrl: streamable.url,
+			isTemplated: streamable.url.startsWith('='),
+		};
+	}
 
 	const sse = server.remotes.find((r) => r.type === 'sse');
-	if (sse) return { transport: 'sse', endpointUrl: sse.url };
+	if (sse) return { transport: 'sse', endpointUrl: sse.url, isTemplated: sse.url.startsWith('=') };
 
 	return null;
 }

--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-search.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-search.test.ts
@@ -85,4 +85,18 @@ describe('searchMcpRegistryServers', () => {
 		const noRemote = server({ slug: 'no-remote', remotes: [] });
 		expect(searchMcpRegistryServers([noRemote], ['no-remote'])).toEqual([]);
 	});
+
+	it('keeps a templated (=-prefixed) streamable-http tile in results, surfacing its unresolved url as-is', () => {
+		const templated = server({
+			slug: 'databricks-genie',
+			title: 'Databricks Genie',
+			remotes: [{ type: 'streamable-http', url: '={{$self["host"]}}/api/2.0/mcp/genie' }],
+		});
+
+		const [result] = searchMcpRegistryServers([templated], ['databricks-genie']);
+
+		expect(result.transport).toBe('streamableHttp');
+		expect(result.url).toBe('={{$self["host"]}}/api/2.0/mcp/genie');
+		expect(result.metadata).toEqual({ nodeTypeName: '@n8n/mcp-registry.databricksGenie' });
+	});
 });

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry-search.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry-search.ts
@@ -25,7 +25,12 @@ export interface McpRegistrySearchResult {
 	metadata: { nodeTypeName: string };
 }
 
-/** Prefer a streamable-http remote, else SSE; null when the server has neither. */
+/**
+ * Prefer a streamable-http remote, else SSE; null when the server has
+ * neither. Consumers key off `metadata.nodeTypeName` / `credentialType` to
+ * wire up a tile, never off this `url` directly, so a templated row's
+ * unresolved `url` string (starting with `=`) is safe to surface as-is.
+ */
 function pickPreferredRemote(
 	server: McpRegistryServer,
 ): { type: 'streamableHttp' | 'sse'; url: string } | null {

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry.types.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry.types.ts
@@ -26,6 +26,10 @@ export const mcpRegistryExtendsCredentialSchema = z.object({
 	authentication: z.enum(['body', 'header']).nullish(),
 	useDynamicClientRegistration: z.boolean().nullish(),
 	serverUrl: z.string().nullish(),
+	// Lets a row that fixes `scope` also hide the parent's "Custom Scopes"
+	// toggle (and its dependent notice/enabledScopes fields), which would
+	// otherwise render with no effect once `scope` is overridden.
+	customScopes: z.boolean().nullish(),
 });
 
 export type McpRegistryExtendsCredential = z.infer<typeof mcpRegistryExtendsCredentialSchema>;

--- a/packages/cli/src/modules/mcp-registry/registry/mock-servers.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mock-servers.ts
@@ -85,6 +85,49 @@ export const gmailDirectExtendMockServer: McpRegistryServer = {
 	},
 };
 
+export const databricksGenieTemplatedMockServer: McpRegistryServer = {
+	name: 'com.databricks/genie-mcp',
+	slug: 'databricks-genie',
+	title: 'Databricks Genie',
+	description: 'Databricks Genie MCP server, resolved per-customer from the workspace host.',
+	tagline: 'Connect to Databricks Genie',
+	version: '1.0.0',
+	updatedAt: '2026-08-20T10:00:00.000Z',
+	icons: [
+		{
+			src: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iNCIgZmlsbD0iI0ZGMzYyMSIvPjwvc3ZnPg==',
+			mimeType: 'image/svg+xml',
+		},
+	],
+	websiteUrl: 'https://databricks.com',
+	authType: 'extendsCredential',
+	remotes: [
+		{
+			// A plain streamable-http remote; the leading `=` is what marks this
+			// as templated (n8n's own "evaluate as expression" convention), not
+			// a dedicated remote type. Trailing slash stripped in case the
+			// customer pastes the host straight from the browser, matching
+			// DatabricksOAuth2Api's own accessTokenUrl/authUrl.
+			type: 'streamable-http',
+			url: '={{$self["host"].replace(/\\/$/, "")}}/api/2.0/mcp/genie',
+		},
+	],
+	tools: [],
+	isOfficial: true,
+	origin: 'registry',
+	status: 'active',
+	extendsCredential: {
+		extends: 'databricksOAuth2Api',
+		scope: 'genie offline_access',
+		grantType: 'authorizationCode',
+		// databricksOAuth2Api already provides a per-host authUrl default, no
+		// override needed. customScopes is hidden here because Genie's scope is
+		// fixed above; without this the parent's "Custom Scopes" toggle and its
+		// dependent fields would render with no effect.
+		customScopes: false,
+	},
+};
+
 export const linearMockServer: McpRegistryServer = {
 	name: 'app.linear/linear',
 	slug: 'linear',


### PR DESCRIPTION
## Summary

**Alternative design, for comparison with #37250. Not intended to merge as-is.**

Same feature as #37250 (Databricks Genie's MCP server URL resolves per-customer from the connecting credential instead of one fixed vendor URL), but without introducing a new `streamable-http-templated` remote type. Instead, a plain `streamable-http`/`sse` remote is treated as templated when its URL starts with `=`, n8n's own existing convention for "evaluate this as an expression" (the same marker every credential/node parameter default already uses).

Backward compatibility holds the same way: an old n8n instance's existing `new URL(...)` parseability check (which predates this ticket) throws on a template string and drops the row cleanly, the same outcome as the dedicated-type approach, just via a different existing guard instead of an unrecognized type string.

Net diff vs #37250: same two commits, only `packages/cli/src/modules/mcp-registry/` differs (the `=`-prefix check replaces the new type everywhere it was referenced). The runtime credential-resolution commit is byte-identical between the two PRs.

## How to test

Same as #37250: seed a registry row with `authType: "extendsCredential"`, `extendsCredential.extends: "databricksOAuth2Api"`, and a `remotes` entry of `{ "type": "streamable-http", "url": "={{$self[\"host\"]}}/api/2.0/mcp/genie" }` (see `databricksGenieTemplatedMockServer` in `packages/cli/src/modules/mcp-registry/registry/mock-servers.ts`), restart the backend, and confirm the Databricks Genie tile/credential behave identically to #37250.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-378

Alternative to #37250, opened for side-by-side comparison of the two design approaches.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. (No docs needed, see #37250)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (not applicable, not an urgent fix)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

