### PR TITLE
fix(core): Share one time budget across nested expression evaluations

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -784,10 +784,11 @@ describe('Integration: nested evaluation time budget', () => {
 		);
 		const elapsed = Date.now() - start;
 
-		expect(framesEvaluated).toBeGreaterThan(1);
-		// Tight enough to catch a first nested frame that restarts the budget,
-		// which would land at roughly twice the limit.
-		expect(elapsed).toBeLessThan(TIMEOUT_MS * 1.25);
+		// Frame count is the load-independent signal: at BURN_MS per frame the
+		// budget affords exactly two before it runs out. A frame that restarted
+		// the budget would buy at least one more, whatever the host overhead.
+		expect(framesEvaluated).toBe(2);
+		expect(elapsed).toBeLessThan(TIMEOUT_MS * 1.5);
 	});
 
 	it('shares the budget across sequential nested evaluations', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -2,6 +2,7 @@ import { DateTime, Duration, Interval } from 'luxon';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+import type { WorkflowData } from '../types';
 import { TimeoutError, MemoryLimitError } from '../types';
 
 describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
@@ -729,5 +730,65 @@ describe('Integration: Concurrent execution pooling', () => {
 		expect(result).toBe('replenished');
 
 		await evaluator.release(caller2);
+	});
+});
+
+describe('Integration: nested evaluation time budget', () => {
+	const TIMEOUT_MS = 400;
+	const BURN_MS = 150;
+	const DEPTH = 8;
+
+	let evaluator: ExpressionEvaluator;
+	const caller = {};
+
+	beforeAll(async () => {
+		evaluator = new ExpressionEvaluator({
+			createBridge: () => new IsolatedVmBridge({ timeout: TIMEOUT_MS }),
+			maxCodeCacheSize: 1024,
+		});
+		await evaluator.initialize();
+		await evaluator.acquire(caller);
+	});
+
+	afterAll(async () => {
+		await evaluator.release(caller);
+		await evaluator.dispose();
+	});
+
+	/**
+	 * Spends `BURN_MS` inside the isolate, then hands the next depth down to
+	 * `$evaluateExpression`; depth 0 spins forever. The remaining depth travels
+	 * as the expression argument (a nested `{{ }}` literal would terminate the
+	 * enclosing template), and the host callback turns it back into a template.
+	 */
+	const frame = (depth: number): string =>
+		depth === 0
+			? '{{ (function() { while (true) {} })() }}'
+			: `{{ (function() { var s = Date.now(); while (Date.now() - s < ${BURN_MS}) {} return $evaluateExpression("${depth - 1}"); })() }}`;
+
+	it('bounds a chain of nested evaluations to a single time budget', () => {
+		let framesEvaluated = 0;
+		const data: WorkflowData = {
+			$evaluateExpression: (depth: string) => {
+				framesEvaluated++;
+				return evaluator.evaluate(frame(Number(depth)), data, caller);
+			},
+		};
+
+		const start = Date.now();
+		expect(() => evaluator.evaluate(frame(DEPTH), data, caller)).toThrow(/timed out/);
+		const elapsed = Date.now() - start;
+
+		expect(framesEvaluated).toBeGreaterThan(1);
+		expect(elapsed).toBeLessThan(TIMEOUT_MS * 2);
+	});
+
+	it('gives a single evaluation the full budget', () => {
+		const start = Date.now();
+		expect(() => evaluator.evaluate(frame(0), {}, caller)).toThrow(TimeoutError);
+		const elapsed = Date.now() - start;
+
+		expect(elapsed).toBeGreaterThanOrEqual(TIMEOUT_MS * 0.8);
+		expect(elapsed).toBeLessThan(TIMEOUT_MS * 2);
 	});
 });

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -630,6 +630,9 @@ describe('Integration: IsolatedVmBridge error handling', () => {
 		await bridge.initialize();
 		try {
 			expect(() => bridge.execute('while(true){}', {})).toThrow(TimeoutError);
+			// A spent budget must be rejected before entering the isolate, which
+			// reads a non-positive timeout as no timeout at all.
+			expect(() => bridge.execute('return 1;', {}, { elapsedMs: 100 })).toThrow(TimeoutError);
 		} finally {
 			await bridge.dispose();
 		}
@@ -776,16 +779,39 @@ describe('Integration: nested evaluation time budget', () => {
 		};
 
 		const start = Date.now();
-		expect(() => evaluator.evaluate(frame(DEPTH), data, caller)).toThrow(/timed out/);
+		expect(() => evaluator.evaluate(frame(DEPTH), data, caller)).toThrow(
+			`Nested expressions timed out after sharing the ${TIMEOUT_MS}ms limit`,
+		);
 		const elapsed = Date.now() - start;
 
 		expect(framesEvaluated).toBeGreaterThan(1);
-		expect(elapsed).toBeLessThan(TIMEOUT_MS * 2);
+		// Tight enough to catch a first nested frame that restarts the budget,
+		// which would land at roughly twice the limit.
+		expect(elapsed).toBeLessThan(TIMEOUT_MS * 1.25);
+	});
+
+	it('shares the budget across sequential nested evaluations', () => {
+		const burn = `{{ (function() { var s = Date.now(); while (Date.now() - s < ${BURN_MS}) {} return 1; })() }}`;
+		const data: WorkflowData = {
+			$evaluateExpression: () => evaluator.evaluate(burn, {}, caller),
+		};
+
+		// Siblings draw on the same budget, so the later ones run out; each
+		// getting a fresh one would let the pair complete.
+		expect(() =>
+			evaluator.evaluate(
+				'{{ $evaluateExpression("a") + $evaluateExpression("a") + $evaluateExpression("a") }}',
+				data,
+				caller,
+			),
+		).toThrow(/timed out/);
 	});
 
 	it('gives a single evaluation the full budget', () => {
 		const start = Date.now();
-		expect(() => evaluator.evaluate(frame(0), {}, caller)).toThrow(TimeoutError);
+		expect(() => evaluator.evaluate(frame(0), {}, caller)).toThrow(
+			`Expression timed out after ${TIMEOUT_MS}ms`,
+		);
 		const elapsed = Date.now() - start;
 
 		expect(elapsed).toBeGreaterThanOrEqual(TIMEOUT_MS * 0.8);

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -660,8 +660,9 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * Handler for `$evaluateExpression(expression, itemIndex?)`. Forwards
 	 * the string to the host's nested-evaluation helper, which re-enters
 	 * the expression engine on the inner expression. Under the VM engine
-	 * this round-trips through the bridge again on a fresh evaluation
-	 * cycle, which is the same shape the legacy engine supports.
+	 * this round-trips through the bridge again as a new evaluation on the
+	 * enclosing call's time budget, which is the same shape the legacy
+	 * engine supports.
 	 *
 	 * @private
 	 */
@@ -709,7 +710,8 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 *    from the closure-scoped references.
 	 *
 	 * Each call gets its own closure, so nested and concurrent evaluations
-	 * cannot interfere with each other.
+	 * cannot see each other's data. Time is the exception: a nested call runs
+	 * on what is left of the enclosing call's budget (see `elapsedMs`).
 	 *
 	 * @param code - JavaScript expression to evaluate
 	 * @param data - Workflow data (e.g., { $json: {...}, $runIndex: 0 })
@@ -722,13 +724,18 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		}
 
 		// A nested call runs on what is left of the configured timeout, so the
-		// whole chain it belongs to shares one budget.
+		// chain shares one budget: subtracting elapsed makes every frame's
+		// deadline the same instant. A configured timeout of 0 means "no limit",
+		// so there is nothing to share. A positive elapsed is the only nested
+		// case that needs handling — a frame that has spent nothing is owed the
+		// full timeout anyway.
 		const elapsedMs = options?.elapsedMs ?? 0;
 		const nested = elapsedMs > 0 && this.config.timeout > 0;
 		let timeout = this.config.timeout;
 		if (nested) {
-			// isolated-vm reads a non-positive timeout as "no timeout" and rejects
-			// fractional values, so an exhausted budget stops here instead.
+			// isolated-vm rejects a fractional timeout and reads 0 or less as "no
+			// timeout at all", so truncate, and fail here rather than pass on a
+			// budget that is already gone.
 			timeout = Math.trunc(this.config.timeout - elapsedMs);
 			if (timeout <= 0) throw this.timeoutError(true);
 		}

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -721,6 +721,18 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			throw new Error('Bridge not initialized. Call initialize() first.');
 		}
 
+		// A nested call runs on what is left of the configured timeout, so the
+		// whole chain it belongs to shares one budget.
+		const elapsedMs = options?.elapsedMs ?? 0;
+		const nested = elapsedMs > 0 && this.config.timeout > 0;
+		let timeout = this.config.timeout;
+		if (nested) {
+			// isolated-vm reads a non-positive timeout as "no timeout" and rejects
+			// fractional values, so an exhausted budget stops here instead.
+			timeout = Math.trunc(this.config.timeout - elapsedMs);
+			if (timeout <= 0) throw this.timeoutError(true);
+		}
+
 		// Host callbacks are ivm.Callback instances: inside the isolate they
 		// arrive as plain functions with structured-clone marshaling, so the
 		// runtime invokes them directly. Callbacks are GC-managed; there is no
@@ -773,7 +785,7 @@ try {
 			const result = this.context.evalClosureSync(
 				wrappedCode,
 				[getValueAtPath, getArrayElement, callHost],
-				{ result: { copy: true }, timeout: this.config.timeout },
+				{ result: { copy: true }, timeout },
 			);
 
 			if (isErrorSentinel(result)) {
@@ -797,7 +809,7 @@ try {
 			}
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			if (errorMessage.includes('Script execution timed out')) {
-				throw new TimeoutError(`Expression timed out after ${this.config.timeout}ms`, {});
+				throw this.timeoutError(nested);
 			}
 			if (errorMessage.includes('memory limit')) {
 				throw new MemoryLimitError(
@@ -807,6 +819,19 @@ try {
 			}
 			throw new Error(`Expression evaluation failed: ${errorMessage}`);
 		}
+	}
+
+	/**
+	 * Always names the configured limit, never the reduced budget a nested call
+	 * ran on — reporting "timed out after 137ms" would misstate the limit.
+	 */
+	private timeoutError(nested: boolean): TimeoutError {
+		return new TimeoutError(
+			nested
+				? `Nested expressions timed out after sharing the ${this.config.timeout}ms limit`
+				: `Expression timed out after ${this.config.timeout}ms`,
+			{},
+		);
 	}
 
 	/**

--- a/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
@@ -47,6 +47,16 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 
 	private bridgesByCaller = new WeakMap<object, RuntimeBridge>();
 
+	/**
+	 * Depth of the evaluation chain currently in progress, and when it started.
+	 * An expression can evaluate another one (`$evaluateExpression`), which
+	 * re-enters `evaluate()` through a synchronous host callback; the whole
+	 * chain runs on the time budget the outermost call started with.
+	 */
+	private chainDepth = 0;
+
+	private chainStart = 0;
+
 	private readonly createBridge: () => Promise<RuntimeBridge>;
 
 	constructor(config: EvaluatorConfig) {
@@ -120,15 +130,22 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 		const { observability } = this.config;
 		const start = performance.now();
 
+		const nested = this.chainDepth > 0;
+		if (!nested) this.chainStart = start;
+		this.chainDepth++;
+
 		try {
 			const result = bridge.execute(transformedCode, data, {
 				timezone: options?.timezone,
+				elapsedMs: nested ? start - this.chainStart : undefined,
 			});
 			recordOutcome(observability, start, 'success');
 			return result;
 		} catch (error) {
 			recordOutcome(observability, start, 'error', error);
 			throw error;
+		} finally {
+			this.chainDepth--;
 		}
 	}
 

--- a/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
@@ -52,6 +52,11 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 	 * An expression can evaluate another one (`$evaluateExpression`), which
 	 * re-enters `evaluate()` through a synchronous host callback; the whole
 	 * chain runs on the time budget the outermost call started with.
+	 *
+	 * This is correct only while the whole path stays synchronous. Both fields
+	 * belong to the instance, so two chains that overlap would corrupt them. If
+	 * a host callback or `bridge.execute()` becomes async, pass the budget in
+	 * the call arguments instead.
 	 */
 	private chainDepth = 0;
 

--- a/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
@@ -129,26 +129,32 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 
 		const bridge = this.getBridge(caller);
 
-		// Transform template expression → sanitized JavaScript (cached)
-		const transformedCode = this.getTransformedCode(expression);
-
-		const { observability } = this.config;
-		const start = performance.now();
-
+		// Anchor the chain's clock before transformation, so that parsing an
+		// uncached expression counts against the shared budget instead of
+		// escaping it. Transformation runs inside the try to keep the depth
+		// counter balanced if it throws.
 		const nested = this.chainDepth > 0;
-		if (!nested) this.chainStart = start;
+		if (!nested) this.chainStart = performance.now();
 		this.chainDepth++;
 
 		try {
-			const result = bridge.execute(transformedCode, data, {
-				timezone: options?.timezone,
-				elapsedMs: nested ? start - this.chainStart : undefined,
-			});
-			recordOutcome(observability, start, 'success');
-			return result;
-		} catch (error) {
-			recordOutcome(observability, start, 'error', error);
-			throw error;
+			// Transform template expression → sanitized JavaScript (cached)
+			const transformedCode = this.getTransformedCode(expression);
+
+			const { observability } = this.config;
+			const start = performance.now();
+
+			try {
+				const result = bridge.execute(transformedCode, data, {
+					timezone: options?.timezone,
+					elapsedMs: nested ? start - this.chainStart : undefined,
+				});
+				recordOutcome(observability, start, 'success');
+				return result;
+			} catch (error) {
+				recordOutcome(observability, start, 'error', error);
+				throw error;
+			}
 		} finally {
 			this.chainDepth--;
 		}

--- a/packages/@n8n/expression-runtime/src/types/bridge.ts
+++ b/packages/@n8n/expression-runtime/src/types/bridge.ts
@@ -101,4 +101,11 @@ export interface ExecuteOptions {
 	 * Sets luxon Settings.defaultZone inside the isolate before execution.
 	 */
 	timezone?: string;
+
+	/**
+	 * Milliseconds already spent by the chain of evaluations this call belongs
+	 * to. Subtracted from the configured timeout so a chain shares one budget
+	 * instead of each call starting a fresh one. Omit for a standalone call.
+	 */
+	elapsedMs?: number;
 }

--- a/packages/@n8n/expression-runtime/src/types/bridge.ts
+++ b/packages/@n8n/expression-runtime/src/types/bridge.ts
@@ -71,7 +71,9 @@ export interface BridgeConfig {
 	memoryLimit?: number;
 
 	/**
-	 * Timeout in milliseconds for expression execution.
+	 * Timeout in milliseconds for one expression evaluation. A chain of nested
+	 * evaluations (`$evaluateExpression`) shares this limit; a nested call does
+	 * not get a new one.
 	 * Default: 5000ms
 	 */
 	timeout?: number;


### PR DESCRIPTION
## Summary

`N8N_EXPRESSION_ENGINE_TIMEOUT` (default 5000ms) is documented and intended as the limit for one expression evaluation, and it was enforced per call into the isolate. But `$evaluateExpression` lets an expression evaluate another one, and that nested evaluation re-entered the engine with a **fresh, full timeout** — so the limit bounded a single frame rather than the evaluation as a whole.

Measured before this change, with the limit set to 1000ms and each frame spending 400ms before recursing:

| Nesting depth | Total | Multiple of the limit |
|---|---|---|
| 2 | 1814ms | 1.81x |
| 5 | 3002ms | 3.00x |
| 10 | 5003ms | 5.00x |
| 20 | 9003ms | 9.00x |

Growth is linear in depth (`total ≈ (depth-1) × per-frame + limit`) and there is no depth cap, so the effective ceiling was set by expression length rather than by config. It behaves the same whether frames share one isolate or land on different ones.

The reason the outer limit never intervened: while an isolate sits in a host callback it is outside JS execution, so V8 never services its pending termination. Only the innermost frame's own timer fires.

### What this changes

The evaluator now records when the outermost evaluation began and passes the elapsed time to each nested call, which runs on what is left. Subtracting elapsed makes every frame in a chain share one deadline, so a whole chain is bounded by one configured limit. An already-spent budget is rejected before entering the isolate.

After the change, the same measurement stays at 1.00–1.01x at depths 1, 2, 5, 10, 20 and 40.

Two details worth a reviewer's attention:

- **Elapsed time is passed, not a timeout override.** `ExpressionEvaluator` has no access to the configured value — it only holds a `createBridge` factory, and `bridgeTimeout` goes straight into the bridge constructor. Passing elapsed keeps the limit in one place and lets the error message always name the configured limit rather than the reduced remainder.
- **An exhausted budget fails fast instead of clamping to 1ms.** isolated-vm reads a non-positive timeout as *no timeout at all* and rejects fractional values, hence the truncation and the early throw. Clamping would hand every past-deadline frame another millisecond.

### Deliberately out of scope

- A single frame making one very slow host call can still overrun the limit by that call's duration — while the guest is in a host callback, termination cannot be serviced. This change stops that time from *multiplying* across a chain, but does not bound one frame's own host time.
- Repeated top-level evaluations still each get a full budget; that is the documented per-evaluation semantics.
- `N8N_EXPRESSION_ENGINE_TIMEOUT=0` continues to mean "no limit", nested frames included.
- No nesting depth cap is added; the bound here is on time.

## How to test

```bash
pnpm --filter @n8n/expression-runtime test src/__tests__/integration.test.ts
```

`Integration: nested evaluation time budget` covers the chain bound, sibling evaluations sharing one budget, and a standalone evaluation still receiving the full limit. 355/355 pass in the package.

The assertions were checked against deliberate breaking changes to confirm they have teeth — reverting the fix, restarting the budget on the first nested frame, removing the counter unwind, and reversing the subtraction each fail at least one test.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3392

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

