### PR TITLE
fix(Microsoft Entra ID Node): Validate and encode user and group IDs before sending them to Graph (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
@@ -27,8 +27,6 @@ import { validateUserTargetId, type UserTargetMessages } from '../GenericFunctio
 const ID_FORMAT_HINT = 'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315';
 
 const ENTRA_USER_MESSAGES: UserTargetMessages = {
-	// Unreachable through the shared validator, which `validateEntraUserId` only calls once the
-	// value is known to be non-empty. Kept because the interface requires it.
 	required: {
 		message: 'The user is empty',
 		description: `Select a user from the list, or set the ID. ${ID_FORMAT_HINT}, or a user principal name e.g. jane@contoso.com.`,
@@ -58,7 +56,7 @@ const ENTRA_GROUP_MESSAGES: Pick<UserTargetMessages, 'required' | 'invalid'> = {
  * Validates a user ID before it is encoded into a Graph URL path. Graph accepts either an object
  * ID or a user principal name, guests included. The value is validated untrimmed, because the URL
  * interpolates it untrimmed. Both accepted alphabets are closed under substring, so no substring
- * of an accepted ID can contain `/ \ ? % #` and change the request path.
+ * of an accepted ID can contain `/ \ ? % #`.
  *
  * Exported for tests. Production callers must go through the `preSend` wrappers below, which also
  * refuse a stored extraction rule.
@@ -107,11 +105,31 @@ function readEntraId(this: IExecuteSingleFunctions, name: 'user' | 'group'): str
 	return String(this.getNodeParameter(name, undefined, { extractValue: true }) ?? '');
 }
 
+/**
+ * Last-mile check on the path that is about to be sent. Encoding keeps every other character
+ * inside its segment, but a bare `.` or `..` segment still re-points the request, and the URL is
+ * composed from its own read of the parameter. No Graph path has a `.` or `..` segment, so this
+ * refuses nothing legitimate.
+ */
+function assertNoDotSegment(
+	this: IExecuteSingleFunctions,
+	url: string | undefined,
+	copy: { message: string; description: string },
+): void {
+	const segments = (url ?? '').split('?')[0].split('/');
+	if (segments.some((segment) => segment === '.' || segment === '..')) {
+		throw new NodeOperationError(this.getNode(), copy.message, {
+			description: copy.description,
+		});
+	}
+}
+
 export async function validateUserPreSend(
 	this: IExecuteSingleFunctions,
 	requestOptions: IHttpRequestOptions,
 ): Promise<IHttpRequestOptions> {
 	validateEntraUserId(readEntraId.call(this, 'user'), this.getNode());
+	assertNoDotSegment.call(this, requestOptions.url, ENTRA_USER_MESSAGES.invalid);
 	return requestOptions;
 }
 
@@ -120,6 +138,7 @@ export async function validateGroupPreSend(
 	requestOptions: IHttpRequestOptions,
 ): Promise<IHttpRequestOptions> {
 	validateEntraGroupId(readEntraId.call(this, 'group'), this.getNode());
+	assertNoDotSegment.call(this, requestOptions.url, ENTRA_GROUP_MESSAGES.invalid);
 	return requestOptions;
 }
 
@@ -140,14 +159,19 @@ async function resolveGraphTarget(
 			? credentials.graphApiBaseUrl
 			: 'https://graph.microsoft.com'
 	).replace(/\/+$/, '');
-	if (!URL.canParse(baseUrl)) {
+	// `URL.origin` is the string "null" for a scheme without a defined origin, which would make
+	// the comparison below pass for any host.
+	if (!URL.canParse(baseUrl) || new URL(baseUrl).origin === 'null') {
 		throw new NodeOperationError(this.getNode(), 'The Graph API base URL is not a valid URL', {
 			description:
 				'Set a full URL on the credential, e.g. https://graph.microsoft.com, and try again.',
 		});
 	}
 	const target = url ?? `${baseUrl}/v1.0${endpoint}`;
-	if (!URL.canParse(target) || new URL(target).origin !== new URL(baseUrl).origin) {
+	if (!URL.canParse(target)) {
+		throw new NodeOperationError(this.getNode(), 'The request URL is not a valid URL');
+	}
+	if (new URL(target).origin !== new URL(baseUrl).origin) {
 		throw new NodeOperationError(
 			this.getNode(),
 			'Refusing to send credentials to an unexpected host',

--- a/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
@@ -6,15 +6,106 @@ import type {
 	IHttpRequestMethods,
 	IHttpRequestOptions,
 	ILoadOptionsFunctions,
+	INode,
 	IRequestOptions,
 	INodeExecutionData,
 	IN8nHttpFullResponse,
 	INodePropertyOptions,
 	INodeListSearchResult,
 	INodeListSearchItems,
+	PreSendAction,
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError, sanitizeXmlName } from 'n8n-workflow';
 import { parseStringPromise } from 'xml2js';
+
+import { validateUserTargetId, type UserTargetMessages } from '../GenericFunctions';
+
+const ID_FORMAT_HINT = 'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315';
+
+const OBJECT_ID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+
+const ENTRA_USER_MESSAGES: UserTargetMessages = {
+	required: {
+		message: 'The user is empty',
+		description: `Select a user from the list, or set the ID. ${ID_FORMAT_HINT}, or a user principal name e.g. jane@contoso.com.`,
+	},
+	dotsOnly: {
+		message: 'The user ID is invalid',
+		description: `${ID_FORMAT_HINT}.`,
+	},
+	invalid: {
+		message: 'The user ID is invalid',
+		description: `${ID_FORMAT_HINT}, or a user principal name e.g. jane@contoso.com.`,
+	},
+};
+
+const ENTRA_GROUP_MESSAGES = {
+	required: {
+		message: 'The group is empty',
+		description: `Select a group from the list, or set the ID. ${ID_FORMAT_HINT}.`,
+	},
+	invalid: {
+		message: 'The group ID is invalid',
+		description: `${ID_FORMAT_HINT}. Groups are addressed by object ID, not by name or email address.`,
+	},
+};
+
+/**
+ * Validates a user ID before it is encoded into a Graph URL path. Graph accepts either an object
+ * ID or a user principal name, guests included. The value is validated untrimmed, because the URL
+ * interpolates it untrimmed. Both accepted alphabets are closed under substring, so no substring
+ * of an accepted ID can contain `/ \ ? % #` and change the request path.
+ */
+export function validateEntraUserId(id: unknown, node: INode): void {
+	const value = String(id ?? '');
+	if (value.trim() === '') {
+		throw new NodeOperationError(node, ENTRA_USER_MESSAGES.required.message, {
+			description: ENTRA_USER_MESSAGES.required.description,
+		});
+	}
+	validateUserTargetId(value, node, ENTRA_USER_MESSAGES);
+}
+
+/** Graph resolves `/groups/{id}` and `/directoryObjects/{id}` by object ID only. */
+export function validateEntraGroupId(id: unknown, node: INode): void {
+	const value = String(id ?? '');
+	if (value.trim() === '') {
+		throw new NodeOperationError(node, ENTRA_GROUP_MESSAGES.required.message, {
+			description: ENTRA_GROUP_MESSAGES.required.description,
+		});
+	}
+	if (!OBJECT_ID.test(value)) {
+		throw new NodeOperationError(node, ENTRA_GROUP_MESSAGES.invalid.message, {
+			description: ENTRA_GROUP_MESSAGES.invalid.description,
+		});
+	}
+}
+
+/**
+ * Reads an ID the way the routing layer does. A `$parameter[...]` URL template applies a stored
+ * `__regex` while `extractValue` applies the mode's own rule, so a stored `__regex` would put a
+ * substring in the URL that this guard never saw. No Entra mode declares `extractValue`, so
+ * refusing a stored `__regex` refuses nothing legitimate.
+ */
+function readEntraId(this: IExecuteSingleFunctions, name: 'user' | 'group'): unknown {
+	const stored = this.getNodeParameter(name);
+	if (typeof stored === 'object' && stored !== null && '__regex' in stored) {
+		throw new NodeOperationError(this.getNode(), `The ${name} ID is invalid`, {
+			description: 'Remove the ID extraction rule from this field and set the ID directly.',
+		});
+	}
+	return this.getNodeParameter(name, undefined, { extractValue: true });
+}
+
+export const validateUserPreSend: PreSendAction = async function (requestOptions) {
+	validateEntraUserId(readEntraId.call(this, 'user'), this.getNode());
+	return requestOptions;
+};
+
+export const validateGroupPreSend: PreSendAction = async function (requestOptions) {
+	validateEntraGroupId(readEntraId.call(this, 'group'), this.getNode());
+	return requestOptions;
+};
 
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,

--- a/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
@@ -13,7 +13,7 @@ import type {
 	INodeListSearchResult,
 	INodeListSearchItems,
 } from 'n8n-workflow';
-import { NodeApiError, sanitizeXmlName } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError, sanitizeXmlName } from 'n8n-workflow';
 import { parseStringPromise } from 'xml2js';
 
 export async function microsoftApiRequest(
@@ -31,9 +31,20 @@ export async function microsoftApiRequest(
 			? credentials.graphApiBaseUrl
 			: 'https://graph.microsoft.com'
 	).replace(/\/+$/, '');
+	// An explicit `url` (e.g. a next-page link from Graph) is used verbatim,
+	// but it must stay on the credential's Graph host: the bearer token must
+	// never travel to an unexpected origin. Graph's own @odata.nextLink is
+	// always same-origin, so nothing legitimate is refused.
+	const target = url ?? `${baseUrl}/v1.0${endpoint}`;
+	if (new URL(target).origin !== new URL(baseUrl).origin) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Refusing to send credentials to an unexpected host',
+		);
+	}
 	const options: IHttpRequestOptions = {
 		method,
-		url: url ?? `${baseUrl}/v1.0${endpoint}`,
+		url: target,
 		json: true,
 		headers,
 		body,
@@ -63,10 +74,21 @@ export async function microsoftApiPaginateRequest(
 			? credentials.graphApiBaseUrl
 			: 'https://graph.microsoft.com'
 	).replace(/\/+$/, '');
+	// An explicit `url` (e.g. a next-page link from Graph) is used verbatim,
+	// but it must stay on the credential's Graph host: the bearer token must
+	// never travel to an unexpected origin. Graph's own @odata.nextLink is
+	// always same-origin, so nothing legitimate is refused.
+	const target = url ?? `${baseUrl}/v1.0${endpoint}`;
+	if (new URL(target).origin !== new URL(baseUrl).origin) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Refusing to send credentials to an unexpected host',
+		);
+	}
 	// Todo: IHttpRequestOptions doesn't have uri property which is required for requestWithAuthenticationPaginated
 	const options: IRequestOptions = {
 		method,
-		uri: url ?? `${baseUrl}/v1.0${endpoint}`,
+		uri: target,
 		json: true,
 		headers,
 		body,

--- a/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
@@ -13,18 +13,22 @@ import type {
 	INodePropertyOptions,
 	INodeListSearchResult,
 	INodeListSearchItems,
-	PreSendAction,
 } from 'n8n-workflow';
-import { NodeApiError, NodeOperationError, sanitizeXmlName } from 'n8n-workflow';
+import {
+	isResourceLocatorValue,
+	NodeApiError,
+	NodeOperationError,
+	sanitizeXmlName,
+} from 'n8n-workflow';
 import { parseStringPromise } from 'xml2js';
 
 import { validateUserTargetId, type UserTargetMessages } from '../GenericFunctions';
 
 const ID_FORMAT_HINT = 'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315';
 
-const OBJECT_ID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
-
 const ENTRA_USER_MESSAGES: UserTargetMessages = {
+	// Unreachable through the shared validator, which `validateEntraUserId` only calls once the
+	// value is known to be non-empty. Kept because the interface requires it.
 	required: {
 		message: 'The user is empty',
 		description: `Select a user from the list, or set the ID. ${ID_FORMAT_HINT}, or a user principal name e.g. jane@contoso.com.`,
@@ -35,11 +39,11 @@ const ENTRA_USER_MESSAGES: UserTargetMessages = {
 	},
 	invalid: {
 		message: 'The user ID is invalid',
-		description: `${ID_FORMAT_HINT}, or a user principal name e.g. jane@contoso.com.`,
+		description: `${ID_FORMAT_HINT}, or a user principal name e.g. jane@contoso.com. Enter it as it appears in Entra, not URL-encoded.`,
 	},
 };
 
-const ENTRA_GROUP_MESSAGES = {
+const ENTRA_GROUP_MESSAGES: Pick<UserTargetMessages, 'required' | 'invalid'> = {
 	required: {
 		message: 'The group is empty',
 		description: `Select a group from the list, or set the ID. ${ID_FORMAT_HINT}.`,
@@ -55,26 +59,32 @@ const ENTRA_GROUP_MESSAGES = {
  * ID or a user principal name, guests included. The value is validated untrimmed, because the URL
  * interpolates it untrimmed. Both accepted alphabets are closed under substring, so no substring
  * of an accepted ID can contain `/ \ ? % #` and change the request path.
+ *
+ * Exported for tests. Production callers must go through the `preSend` wrappers below, which also
+ * refuse a stored extraction rule.
  */
-export function validateEntraUserId(id: unknown, node: INode): void {
-	const value = String(id ?? '');
-	if (value.trim() === '') {
+export function validateEntraUserId(id: string, node: INode): void {
+	if (id.trim() === '') {
 		throw new NodeOperationError(node, ENTRA_USER_MESSAGES.required.message, {
 			description: ENTRA_USER_MESSAGES.required.description,
 		});
 	}
-	validateUserTargetId(value, node, ENTRA_USER_MESSAGES);
+	validateUserTargetId(id, node, ENTRA_USER_MESSAGES);
 }
 
-/** Graph resolves `/groups/{id}` and `/directoryObjects/{id}` by object ID only. */
-export function validateEntraGroupId(id: unknown, node: INode): void {
-	const value = String(id ?? '');
-	if (value.trim() === '') {
+const GROUP_OBJECT_ID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+
+/**
+ * Graph resolves `/groups/{id}` and `/directoryObjects/{id}` by object ID only. Exported for
+ * tests, same caveat as {@link validateEntraUserId}.
+ */
+export function validateEntraGroupId(id: string, node: INode): void {
+	if (id.trim() === '') {
 		throw new NodeOperationError(node, ENTRA_GROUP_MESSAGES.required.message, {
 			description: ENTRA_GROUP_MESSAGES.required.description,
 		});
 	}
-	if (!OBJECT_ID.test(value)) {
+	if (!GROUP_OBJECT_ID.test(id)) {
 		throw new NodeOperationError(node, ENTRA_GROUP_MESSAGES.invalid.message, {
 			description: ENTRA_GROUP_MESSAGES.invalid.description,
 		});
@@ -82,30 +92,36 @@ export function validateEntraGroupId(id: unknown, node: INode): void {
 }
 
 /**
- * Reads an ID the way the routing layer does. A `$parameter[...]` URL template applies a stored
- * `__regex` while `extractValue` applies the mode's own rule, so a stored `__regex` would put a
- * substring in the URL that this guard never saw. No Entra mode declares `extractValue`, so
- * refusing a stored `__regex` refuses nothing legitimate.
+ * Reads an ID the way the routing layer does, so the guard sees what the URL will interpolate.
+ * A stored `__regex` is refused because the two readers apply it differently: `$parameter[...]`
+ * honours it, `extractValue` does not. No Entra mode declares `extractValue`, so nothing
+ * legitimate ever carries one.
  */
-function readEntraId(this: IExecuteSingleFunctions, name: 'user' | 'group'): unknown {
+function readEntraId(this: IExecuteSingleFunctions, name: 'user' | 'group'): string {
 	const stored = this.getNodeParameter(name);
-	if (typeof stored === 'object' && stored !== null && '__regex' in stored) {
+	if (isResourceLocatorValue(stored) && stored.__regex) {
 		throw new NodeOperationError(this.getNode(), `The ${name} ID is invalid`, {
 			description: 'Remove the ID extraction rule from this field and set the ID directly.',
 		});
 	}
-	return this.getNodeParameter(name, undefined, { extractValue: true });
+	return String(this.getNodeParameter(name, undefined, { extractValue: true }) ?? '');
 }
 
-export const validateUserPreSend: PreSendAction = async function (requestOptions) {
+export async function validateUserPreSend(
+	this: IExecuteSingleFunctions,
+	requestOptions: IHttpRequestOptions,
+): Promise<IHttpRequestOptions> {
 	validateEntraUserId(readEntraId.call(this, 'user'), this.getNode());
 	return requestOptions;
-};
+}
 
-export const validateGroupPreSend: PreSendAction = async function (requestOptions) {
+export async function validateGroupPreSend(
+	this: IExecuteSingleFunctions,
+	requestOptions: IHttpRequestOptions,
+): Promise<IHttpRequestOptions> {
 	validateEntraGroupId(readEntraId.call(this, 'group'), this.getNode());
 	return requestOptions;
-};
+}
 
 /**
  * Resolves the URL a request is sent to. An explicit `url` (e.g. a next-page link from Graph) is

--- a/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/GenericFunctions.ts
@@ -107,6 +107,39 @@ export const validateGroupPreSend: PreSendAction = async function (requestOption
 	return requestOptions;
 };
 
+/**
+ * Resolves the URL a request is sent to. An explicit `url` (e.g. a next-page link from Graph) is
+ * used verbatim, but only after it is confirmed to be on the credential's Graph host: the bearer
+ * token must never travel to an unexpected origin. Graph's own @odata.nextLink is always
+ * same-origin, so nothing legitimate is refused.
+ */
+async function resolveGraphTarget(
+	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
+	endpoint: string,
+	url?: string,
+): Promise<string> {
+	const credentials = await this.getCredentials('microsoftEntraOAuth2Api');
+	const baseUrl = (
+		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
+			? credentials.graphApiBaseUrl
+			: 'https://graph.microsoft.com'
+	).replace(/\/+$/, '');
+	if (!URL.canParse(baseUrl)) {
+		throw new NodeOperationError(this.getNode(), 'The Graph API base URL is not a valid URL', {
+			description:
+				'Set a full URL on the credential, e.g. https://graph.microsoft.com, and try again.',
+		});
+	}
+	const target = url ?? `${baseUrl}/v1.0${endpoint}`;
+	if (!URL.canParse(target) || new URL(target).origin !== new URL(baseUrl).origin) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Refusing to send credentials to an unexpected host',
+		);
+	}
+	return target;
+}
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
@@ -116,23 +149,7 @@ export async function microsoftApiRequest(
 	headers?: IDataObject,
 	url?: string,
 ): Promise<any> {
-	const credentials = await this.getCredentials('microsoftEntraOAuth2Api');
-	const baseUrl = (
-		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
-			? credentials.graphApiBaseUrl
-			: 'https://graph.microsoft.com'
-	).replace(/\/+$/, '');
-	// An explicit `url` (e.g. a next-page link from Graph) is used verbatim,
-	// but it must stay on the credential's Graph host: the bearer token must
-	// never travel to an unexpected origin. Graph's own @odata.nextLink is
-	// always same-origin, so nothing legitimate is refused.
-	const target = url ?? `${baseUrl}/v1.0${endpoint}`;
-	if (new URL(target).origin !== new URL(baseUrl).origin) {
-		throw new NodeOperationError(
-			this.getNode(),
-			'Refusing to send credentials to an unexpected host',
-		);
-	}
+	const target = await resolveGraphTarget.call(this, endpoint, url);
 	const options: IHttpRequestOptions = {
 		method,
 		url: target,
@@ -159,23 +176,7 @@ export async function microsoftApiPaginateRequest(
 	url?: string,
 	itemIndex: number = 0,
 ): Promise<IDataObject[]> {
-	const credentials = await this.getCredentials('microsoftEntraOAuth2Api');
-	const baseUrl = (
-		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
-			? credentials.graphApiBaseUrl
-			: 'https://graph.microsoft.com'
-	).replace(/\/+$/, '');
-	// An explicit `url` (e.g. a next-page link from Graph) is used verbatim,
-	// but it must stay on the credential's Graph host: the bearer token must
-	// never travel to an unexpected origin. Graph's own @odata.nextLink is
-	// always same-origin, so nothing legitimate is refused.
-	const target = url ?? `${baseUrl}/v1.0${endpoint}`;
-	if (new URL(target).origin !== new URL(baseUrl).origin) {
-		throw new NodeOperationError(
-			this.getNode(),
-			'Refusing to send credentials to an unexpected host',
-		);
-	}
+	const target = await resolveGraphTarget.call(this, endpoint, url);
 	// Todo: IHttpRequestOptions doesn't have uri property which is required for requestWithAuthenticationPaginated
 	const options: IRequestOptions = {
 		method,

--- a/packages/nodes-base/nodes/Microsoft/Entra/descriptions/GroupDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/descriptions/GroupDescription.ts
@@ -48,7 +48,7 @@ export const groupOperations: INodeProperties[] = [
 					request: {
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 						method: 'DELETE',
-						url: '=/groups/{{ $parameter["group"] }}',
+						url: '=/groups/{{ encodeURIComponent($parameter["group"]) }}',
 					},
 					output: {
 						postReceive: [
@@ -72,7 +72,7 @@ export const groupOperations: INodeProperties[] = [
 					request: {
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 						method: 'GET',
-						url: '=/groups/{{ $parameter["group"] }}',
+						url: '=/groups/{{ encodeURIComponent($parameter["group"]) }}',
 					},
 					output: {
 						postReceive: [handleErrorPostReceive],
@@ -112,7 +112,7 @@ export const groupOperations: INodeProperties[] = [
 					request: {
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 						method: 'PATCH',
-						url: '=/groups/{{ $parameter["group"] }}',
+						url: '=/groups/{{ encodeURIComponent($parameter["group"]) }}',
 					},
 					output: {
 						postReceive: [

--- a/packages/nodes-base/nodes/Microsoft/Entra/descriptions/GroupDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/descriptions/GroupDescription.ts
@@ -545,11 +545,20 @@ const createFields: INodeProperties[] = [
 								}
 
 								try {
-									await microsoftApiRequest.call(this, 'PATCH', `/groups/${groupId}`, body);
+									await microsoftApiRequest.call(
+										this,
+										'PATCH',
+										`/groups/${encodeURIComponent(groupId)}`,
+										body,
+									);
 									merge(item.json, body);
 								} catch (error) {
 									try {
-										await microsoftApiRequest.call(this, 'DELETE', `/groups/${groupId}`);
+										await microsoftApiRequest.call(
+											this,
+											'DELETE',
+											`/groups/${encodeURIComponent(groupId)}`,
+										);
 									} catch {}
 									throw error;
 								}
@@ -1178,7 +1187,12 @@ const updateFields: INodeProperties[] = [
 								const body: IDataObject = {
 									...separateFields,
 								};
-								await microsoftApiRequest.call(this, 'PATCH', `/groups/${groupId}`, body);
+								await microsoftApiRequest.call(
+									this,
+									'PATCH',
+									`/groups/${encodeURIComponent(groupId)}`,
+									body,
+								);
 							}
 						}
 						return items;

--- a/packages/nodes-base/nodes/Microsoft/Entra/descriptions/GroupDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/descriptions/GroupDescription.ts
@@ -10,7 +10,11 @@ import type {
 import { NodeOperationError } from 'n8n-workflow';
 
 import { ignoreHttpStatusErrorsConfig } from './common';
-import { handleErrorPostReceive, microsoftApiRequest } from '../GenericFunctions';
+import {
+	handleErrorPostReceive,
+	microsoftApiRequest,
+	validateGroupPreSend,
+} from '../GenericFunctions';
 
 export const groupOperations: INodeProperties[] = [
 	{
@@ -592,6 +596,11 @@ const deleteFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateGroupPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 ];
@@ -628,6 +637,11 @@ const getFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateGroupPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 	{
@@ -901,6 +915,11 @@ const updateFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateGroupPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 	{

--- a/packages/nodes-base/nodes/Microsoft/Entra/descriptions/UserDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/descriptions/UserDescription.ts
@@ -914,16 +914,30 @@ const createFields: INodeProperties[] = [
 
 								try {
 									if (Object.keys(separateBody).length) {
-										await microsoftApiRequest.call(this, 'PATCH', `/users/${userId}`, separateBody);
+										await microsoftApiRequest.call(
+											this,
+											'PATCH',
+											`/users/${encodeURIComponent(userId)}`,
+											separateBody,
+										);
 										merge(item.json, separateBody);
 									}
 									if (Object.keys(body).length) {
-										await microsoftApiRequest.call(this, 'PATCH', `/users/${userId}`, body);
+										await microsoftApiRequest.call(
+											this,
+											'PATCH',
+											`/users/${encodeURIComponent(userId)}`,
+											body,
+										);
 										merge(item.json, body);
 									}
 								} catch (error) {
 									try {
-										await microsoftApiRequest.call(this, 'DELETE', `/users/${userId}`);
+										await microsoftApiRequest.call(
+											this,
+											'DELETE',
+											`/users/${encodeURIComponent(userId)}`,
+										);
 									} catch {}
 									throw error;
 								}
@@ -2124,7 +2138,12 @@ const updateFields: INodeProperties[] = [
 								if (body.birthday) {
 									body.birthday = (body.birthday as DateTime).toUTC().toISO();
 								}
-								await microsoftApiRequest.call(this, 'PATCH', `/users/${userId}`, body);
+								await microsoftApiRequest.call(
+									this,
+									'PATCH',
+									`/users/${encodeURIComponent(userId)}`,
+									body,
+								);
 							}
 						}
 						return items;

--- a/packages/nodes-base/nodes/Microsoft/Entra/descriptions/UserDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/descriptions/UserDescription.ts
@@ -11,7 +11,12 @@ import {
 } from 'n8n-workflow';
 
 import { ignoreHttpStatusErrorsConfig } from './common';
-import { handleErrorPostReceive, microsoftApiRequest } from '../GenericFunctions';
+import {
+	handleErrorPostReceive,
+	microsoftApiRequest,
+	validateGroupPreSend,
+	validateUserPreSend,
+} from '../GenericFunctions';
 
 export const userOperations: INodeProperties[] = [
 	{
@@ -215,6 +220,11 @@ const addGroupFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateGroupPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 	{
@@ -250,6 +260,7 @@ const addGroupFields: INodeProperties[] = [
 		required: true,
 		routing: {
 			send: {
+				preSend: [validateUserPreSend],
 				property: '@odata.id',
 				propertyInDotNotation: false,
 				type: 'body',
@@ -959,6 +970,11 @@ const deleteFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateUserPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 ];
@@ -995,6 +1011,11 @@ const getFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateUserPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 	{
@@ -1253,6 +1274,11 @@ const removeGroupFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateGroupPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 	{
@@ -1286,6 +1312,11 @@ const removeGroupFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateUserPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 ];
@@ -1322,6 +1353,11 @@ const updateFields: INodeProperties[] = [
 			},
 		],
 		required: true,
+		routing: {
+			send: {
+				preSend: [validateUserPreSend],
+			},
+		},
 		type: 'resourceLocator',
 	},
 	{

--- a/packages/nodes-base/nodes/Microsoft/Entra/descriptions/UserDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/descriptions/UserDescription.ts
@@ -32,7 +32,7 @@ export const userOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'POST',
-						url: '=/groups/{{ $parameter["group"] }}/members/$ref',
+						url: '=/groups/{{ encodeURIComponent($parameter["group"]) }}/members/$ref',
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 					},
 					output: {
@@ -72,7 +72,7 @@ export const userOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'DELETE',
-						url: '=/users/{{ $parameter["user"] }}',
+						url: '=/users/{{ encodeURIComponent($parameter["user"]) }}',
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 					},
 					output: {
@@ -96,7 +96,7 @@ export const userOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'GET',
-						url: '=/users/{{ $parameter["user"] }}',
+						url: '=/users/{{ encodeURIComponent($parameter["user"]) }}',
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 					},
 					output: {
@@ -137,7 +137,7 @@ export const userOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'DELETE',
-						url: '=/groups/{{ $parameter["group"] }}/members/{{ $parameter["user"] }}/$ref',
+						url: '=/groups/{{ encodeURIComponent($parameter["group"]) }}/members/{{ encodeURIComponent($parameter["user"]) }}/$ref',
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 					},
 					output: {
@@ -161,7 +161,7 @@ export const userOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'PATCH',
-						url: '=/users/{{ $parameter["user"] }}',
+						url: '=/users/{{ encodeURIComponent($parameter["user"]) }}',
 						ignoreHttpStatusErrors: ignoreHttpStatusErrorsConfig,
 					},
 					output: {
@@ -254,7 +254,7 @@ const addGroupFields: INodeProperties[] = [
 				propertyInDotNotation: false,
 				type: 'body',
 				value:
-					'={{ ($credentials.graphApiBaseUrl || "https://graph.microsoft.com").replace(/\\/+$/, "") }}/v1.0/directoryObjects/{{ $value }}',
+					'={{ ($credentials.graphApiBaseUrl || "https://graph.microsoft.com").replace(/\\/+$/, "") }}/v1.0/directoryObjects/{{ encodeURIComponent($value) }}',
 			},
 		},
 		type: 'resourceLocator',

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
@@ -347,7 +347,37 @@ describe('Microsoft Entra GenericFunctions', () => {
 			);
 		});
 
-		it('microsoftApiRequest rejects a URL override on another host', async () => {
+		it('microsoftApiPaginateRequest keeps a URL override on the credential host', async () => {
+			mockRequestWithAuthenticationPaginated.mockResolvedValue([{ body: { value: [] } }]);
+
+			await microsoftApiPaginateRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/groups',
+				{},
+				undefined,
+				undefined,
+				'https://graph.microsoft.com/v1.0/groups?$skiptoken=abc',
+			);
+
+			expect(mockRequestWithAuthenticationPaginated).toHaveBeenCalledWith(
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/groups?$skiptoken=abc',
+				}),
+				0,
+				expect.any(Object),
+				'microsoftEntraOAuth2Api',
+			);
+		});
+
+		it.each([
+			['another host', 'https://not-graph.example.com/v1.0/groups'],
+			['a userinfo prefix', 'https://graph.microsoft.com@not-graph.example.com/v1.0/groups'],
+			['a plain-text scheme', 'http://graph.microsoft.com/v1.0/groups'],
+			['a lookalike host', 'https://graph.microsoft.com.not-graph.example.com/v1.0/groups'],
+			['a scheme-relative URL', '//not-graph.example.com/v1.0/groups'],
+			['a URL that cannot be parsed', 'not a url'],
+		])('microsoftApiRequest rejects a URL override with %s', async (_label, url) => {
 			await expect(
 				microsoftApiRequest.call(
 					mockExecuteFunctions,
@@ -356,9 +386,38 @@ describe('Microsoft Entra GenericFunctions', () => {
 					{},
 					undefined,
 					undefined,
-					'https://not-graph.example.com/v1.0/groups',
+					url,
 				),
 			).rejects.toThrow('Refusing to send credentials to an unexpected host');
+
+			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('microsoftApiRequest keeps an explicit default port on the credential host', async () => {
+			mockRequestWithAuthentication.mockResolvedValue({ value: [] });
+
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/groups',
+				{},
+				undefined,
+				undefined,
+				'https://graph.microsoft.com:443/v1.0/groups',
+			);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalled();
+		});
+
+		it('microsoftApiRequest rejects a base URL that is not a full URL', async () => {
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				oauthTokenData: { access_token: 'test-access-token' },
+				graphApiBaseUrl: 'graph.microsoft.com',
+			});
+
+			await expect(
+				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/groups'),
+			).rejects.toThrow('The Graph API base URL is not a valid URL');
 
 			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 		});

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
@@ -1,7 +1,20 @@
 import { mockDeep } from 'vitest-mock-extended';
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	IExecuteSingleFunctions,
+	IHttpRequestOptions,
+	INode,
+} from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 
-import { microsoftApiRequest, microsoftApiPaginateRequest } from '../GenericFunctions';
+import {
+	microsoftApiRequest,
+	microsoftApiPaginateRequest,
+	validateEntraGroupId,
+	validateEntraUserId,
+	validateGroupPreSend,
+	validateUserPreSend,
+} from '../GenericFunctions';
 import type { Mock, Mocked } from 'vitest';
 
 describe('Microsoft Entra GenericFunctions', () => {
@@ -364,6 +377,165 @@ describe('Microsoft Entra GenericFunctions', () => {
 			).rejects.toThrow('Refusing to send credentials to an unexpected host');
 
 			expect(mockRequestWithAuthenticationPaginated).not.toHaveBeenCalled();
+		});
+	});
+
+	// The shared `validateUserTargetId` table in nodes/Microsoft/test covers the accepted and
+	// rejected UPN alphabet, so these only cover what Entra adds on top of it.
+	describe('validateEntraUserId', () => {
+		it.each([
+			['a GUID', '02bd9fd6-8f93-4758-87c3-1fb73740a315'],
+			['a UPN', 'jane@contoso.com'],
+			['a guest UPN', 'user_contoso.com#EXT#@tenant.onmicrosoft.com'],
+		])('accepts %s', (_label, id) => {
+			expect(() => validateEntraUserId(id, mockNode)).not.toThrow();
+		});
+
+		it.each([
+			['a GUID with surrounding spaces', ' 02bd9fd6-8f93-4758-87c3-1fb73740a315 '],
+			['a UPN with a trailing space', 'jane@contoso.com '],
+			['a UPN with a percent-encoded at sign', 'jane%40contoso.com'],
+		])('rejects %s', (_label, id) => {
+			expect(() => validateEntraUserId(id, mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('reports an empty value as empty', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateEntraUserId('', mockNode);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The user is empty');
+			expect(caught?.description).toBe(
+				'Select a user from the list, or set the ID. The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315, or a user principal name e.g. jane@contoso.com.',
+			);
+		});
+
+		it('reports a dots-only value without the UPN hint', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateEntraUserId('..', mockNode);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The user ID is invalid');
+			expect(caught?.description).toBe(
+				'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315.',
+			);
+		});
+
+		it('reports an unrecognised value with the UPN hint', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateEntraUserId('jane', mockNode);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The user ID is invalid');
+			expect(caught?.description).toBe(
+				'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315, or a user principal name e.g. jane@contoso.com.',
+			);
+		});
+	});
+
+	describe('validateEntraGroupId', () => {
+		it.each([
+			['a lowercase GUID', 'a8eb60e3-0145-4d7e-85ef-c6259784761b'],
+			['an uppercase GUID', 'A8EB60E3-0145-4D7E-85EF-C6259784761B'],
+		])('accepts %s', (_label, id) => {
+			expect(() => validateEntraGroupId(id, mockNode)).not.toThrow();
+		});
+
+		it.each([
+			['a UPN', 'jane@contoso.com'],
+			['a mail nickname', 'sales-team'],
+			['a GUID with surrounding spaces', ' a8eb60e3-0145-4d7e-85ef-c6259784761b '],
+			['an empty value', ''],
+			['two dots', '..'],
+			['a forward slash', 'a8eb60e3-0145-4d7e-85ef-c6259784761b/members'],
+			['a question mark', 'a8eb60e3-0145-4d7e-85ef-c6259784761b?x=1'],
+			['a hash', 'a8eb60e3-0145-4d7e-85ef-c6259784761b#x'],
+			['a percent-encoded dot pair', '%2e%2e'],
+		])('rejects %s', (_label, id) => {
+			expect(() => validateEntraGroupId(id, mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('reports an empty value as empty', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateEntraGroupId('', mockNode);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The group is empty');
+			expect(caught?.description).toBe(
+				'Select a group from the list, or set the ID. The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315.',
+			);
+		});
+
+		it('tells the user that a group is addressed by object ID', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateEntraGroupId('sales-team', mockNode);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The group ID is invalid');
+			expect(caught?.description).toBe(
+				'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315. Groups are addressed by object ID, not by name or email address.',
+			);
+		});
+	});
+
+	describe.each([
+		['validateUserPreSend', validateUserPreSend, 'user', '87d349ed-44d7-43e1-9a83-5f2406dee5bd'],
+		['validateGroupPreSend', validateGroupPreSend, 'group', 'a8eb60e3-0145-4d7e-85ef-c6259784761b'],
+	])('%s', (_label, preSend, parameterName, validId) => {
+		const requestOptions = { url: 'https://graph.microsoft.com/v1.0/users' } as IHttpRequestOptions;
+
+		const context = (stored: unknown, extracted: unknown) => {
+			const single = mockDeep<IExecuteSingleFunctions>();
+			single.getNode.mockReturnValue(mockNode);
+			single.getNodeParameter.mockImplementation(((
+				name: string,
+				_fallbackValue: unknown,
+				options?: { extractValue?: boolean },
+			) => {
+				if (name !== parameterName) return undefined;
+				return options?.extractValue ? extracted : stored;
+			}) as never);
+			return single;
+		};
+
+		it('passes the request options through for a valid ID', async () => {
+			const single = context({ __rl: true, mode: 'id', value: validId }, validId);
+
+			await expect(preSend.call(single, requestOptions)).resolves.toBe(requestOptions);
+		});
+
+		it('throws for an ID containing a slash', async () => {
+			const single = context(
+				{ __rl: true, mode: 'id', value: `${validId}/members` },
+				`${validId}/members`,
+			);
+
+			await expect(preSend.call(single, requestOptions)).rejects.toThrow(NodeOperationError);
+		});
+
+		it('throws when the stored value carries an extraction rule', async () => {
+			const single = context({ __rl: true, mode: 'id', value: validId, __regex: '(.*)' }, validId);
+
+			let caught: NodeOperationError | undefined;
+			try {
+				await preSend.call(single, requestOptions);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe(`The ${parameterName} ID is invalid`);
+			expect(caught?.description).toBe(
+				'Remove the ID extraction rule from this field and set the ID directly.',
+			);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
@@ -302,4 +302,68 @@ describe('Microsoft Entra GenericFunctions', () => {
 			});
 		});
 	});
+
+	describe('same-origin URL override', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				oauthTokenData: {
+					access_token: 'test-access-token',
+				},
+				graphApiBaseUrl: 'https://graph.microsoft.com',
+			});
+		});
+
+		it('microsoftApiRequest keeps a URL override on the credential host', async () => {
+			mockRequestWithAuthentication.mockResolvedValue({ value: [] });
+
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/groups',
+				{},
+				undefined,
+				undefined,
+				'https://graph.microsoft.com/v1.0/groups?$skiptoken=abc',
+			);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraOAuth2Api',
+				expect.objectContaining({
+					url: 'https://graph.microsoft.com/v1.0/groups?$skiptoken=abc',
+				}),
+			);
+		});
+
+		it('microsoftApiRequest rejects a URL override on another host', async () => {
+			await expect(
+				microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/groups',
+					{},
+					undefined,
+					undefined,
+					'https://not-graph.example.com/v1.0/groups',
+				),
+			).rejects.toThrow('Refusing to send credentials to an unexpected host');
+
+			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('microsoftApiPaginateRequest rejects a URL override on another host', async () => {
+			await expect(
+				microsoftApiPaginateRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/groups',
+					{},
+					undefined,
+					undefined,
+					'https://not-graph.example.com/v1.0/groups',
+				),
+			).rejects.toThrow('Refusing to send credentials to an unexpected host');
+
+			expect(mockRequestWithAuthenticationPaginated).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
@@ -347,36 +347,11 @@ describe('Microsoft Entra GenericFunctions', () => {
 			);
 		});
 
-		it('microsoftApiPaginateRequest keeps a URL override on the credential host', async () => {
-			mockRequestWithAuthenticationPaginated.mockResolvedValue([{ body: { value: [] } }]);
-
-			await microsoftApiPaginateRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/groups',
-				{},
-				undefined,
-				undefined,
-				'https://graph.microsoft.com/v1.0/groups?$skiptoken=abc',
-			);
-
-			expect(mockRequestWithAuthenticationPaginated).toHaveBeenCalledWith(
-				expect.objectContaining({
-					uri: 'https://graph.microsoft.com/v1.0/groups?$skiptoken=abc',
-				}),
-				0,
-				expect.any(Object),
-				'microsoftEntraOAuth2Api',
-			);
-		});
-
 		it.each([
 			['another host', 'https://not-graph.example.com/v1.0/groups'],
 			['a userinfo prefix', 'https://graph.microsoft.com@not-graph.example.com/v1.0/groups'],
 			['a plain-text scheme', 'http://graph.microsoft.com/v1.0/groups'],
 			['a lookalike host', 'https://graph.microsoft.com.not-graph.example.com/v1.0/groups'],
-			['a scheme-relative URL', '//not-graph.example.com/v1.0/groups'],
-			['a URL that cannot be parsed', 'not a url'],
 		])('microsoftApiRequest rejects a URL override with %s', async (_label, url) => {
 			await expect(
 				microsoftApiRequest.call(
@@ -389,6 +364,35 @@ describe('Microsoft Entra GenericFunctions', () => {
 					url,
 				),
 			).rejects.toThrow('Refusing to send credentials to an unexpected host');
+
+			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('microsoftApiRequest rejects a URL override that is not a full URL', async () => {
+			await expect(
+				microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/groups',
+					{},
+					undefined,
+					undefined,
+					'//not-graph.example.com/v1.0/groups',
+				),
+			).rejects.toThrow('The request URL is not a valid URL');
+
+			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('microsoftApiRequest rejects a base URL with no defined origin', async () => {
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				oauthTokenData: { access_token: 'test-access-token' },
+				graphApiBaseUrl: 'foo://graph.microsoft.com',
+			});
+
+			await expect(
+				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/groups'),
+			).rejects.toThrow('The Graph API base URL is not a valid URL');
 
 			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 		});
@@ -442,6 +446,12 @@ describe('Microsoft Entra GenericFunctions', () => {
 	// The shared `validateUserTargetId` table in nodes/Microsoft/test covers the accepted and
 	// rejected UPN alphabet, so these only cover what Entra adds on top of it.
 	describe('validateEntraUserId', () => {
+		it('accepts an uppercase GUID', () => {
+			expect(() =>
+				validateEntraUserId('87D349ED-44D7-43E1-9A83-5F2406DEE5BD', mockNode),
+			).not.toThrow();
+		});
+
 		it.each([
 			['a GUID with surrounding spaces', ' 02bd9fd6-8f93-4758-87c3-1fb73740a315 '],
 			['a UPN with a percent-encoded at sign', 'jane%40contoso.com'],
@@ -539,6 +549,19 @@ describe('Microsoft Entra GenericFunctions', () => {
 
 			await expect(preSend.call(single, requestOptions)).rejects.toThrow(NodeOperationError);
 		});
+
+		// The routing layer composes the URL from its own read of the parameter, so the two can
+		// disagree. The harness cannot express that divergence, so it is covered here.
+		it.each([['..'], ['.']])(
+			'throws when the composed path has a "%s" segment',
+			async (segment) => {
+				const single = context({ __rl: true, mode: 'id', value: validId }, validId);
+
+				await expect(
+					preSend.call(single, { url: `/users/${segment}` } as IHttpRequestOptions),
+				).rejects.toThrow(NodeOperationError);
+			},
+		);
 
 		it('throws when the stored value carries an extraction rule', async () => {
 			const single = context({ __rl: true, mode: 'id', value: validId, __regex: '(.*)' }, validId);

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/GenericFunctions.test.ts
@@ -443,16 +443,7 @@ describe('Microsoft Entra GenericFunctions', () => {
 	// rejected UPN alphabet, so these only cover what Entra adds on top of it.
 	describe('validateEntraUserId', () => {
 		it.each([
-			['a GUID', '02bd9fd6-8f93-4758-87c3-1fb73740a315'],
-			['a UPN', 'jane@contoso.com'],
-			['a guest UPN', 'user_contoso.com#EXT#@tenant.onmicrosoft.com'],
-		])('accepts %s', (_label, id) => {
-			expect(() => validateEntraUserId(id, mockNode)).not.toThrow();
-		});
-
-		it.each([
 			['a GUID with surrounding spaces', ' 02bd9fd6-8f93-4758-87c3-1fb73740a315 '],
-			['a UPN with a trailing space', 'jane@contoso.com '],
 			['a UPN with a percent-encoded at sign', 'jane%40contoso.com'],
 		])('rejects %s', (_label, id) => {
 			expect(() => validateEntraUserId(id, mockNode)).toThrow(NodeOperationError);
@@ -470,32 +461,6 @@ describe('Microsoft Entra GenericFunctions', () => {
 				'Select a user from the list, or set the ID. The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315, or a user principal name e.g. jane@contoso.com.',
 			);
 		});
-
-		it('reports a dots-only value without the UPN hint', () => {
-			let caught: NodeOperationError | undefined;
-			try {
-				validateEntraUserId('..', mockNode);
-			} catch (error) {
-				caught = error as NodeOperationError;
-			}
-			expect(caught?.message).toBe('The user ID is invalid');
-			expect(caught?.description).toBe(
-				'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315.',
-			);
-		});
-
-		it('reports an unrecognised value with the UPN hint', () => {
-			let caught: NodeOperationError | undefined;
-			try {
-				validateEntraUserId('jane', mockNode);
-			} catch (error) {
-				caught = error as NodeOperationError;
-			}
-			expect(caught?.message).toBe('The user ID is invalid');
-			expect(caught?.description).toBe(
-				'The ID should be in the format e.g. 02bd9fd6-8f93-4758-87c3-1fb73740a315, or a user principal name e.g. jane@contoso.com.',
-			);
-		});
 	});
 
 	describe('validateEntraGroupId', () => {
@@ -507,15 +472,8 @@ describe('Microsoft Entra GenericFunctions', () => {
 		});
 
 		it.each([
-			['a UPN', 'jane@contoso.com'],
-			['a mail nickname', 'sales-team'],
-			['a GUID with surrounding spaces', ' a8eb60e3-0145-4d7e-85ef-c6259784761b '],
-			['an empty value', ''],
 			['two dots', '..'],
 			['a forward slash', 'a8eb60e3-0145-4d7e-85ef-c6259784761b/members'],
-			['a question mark', 'a8eb60e3-0145-4d7e-85ef-c6259784761b?x=1'],
-			['a hash', 'a8eb60e3-0145-4d7e-85ef-c6259784761b#x'],
-			['a percent-encoded dot pair', '%2e%2e'],
 		])('rejects %s', (_label, id) => {
 			expect(() => validateEntraGroupId(id, mockNode)).toThrow(NodeOperationError);
 		});

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/GroupDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/GroupDescription.test.ts
@@ -1,9 +1,13 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import { NodeConnectionTypes, type WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
-import type { Mock } from 'vitest';
 
-import { microsoftEntraApiResponse, microsoftEntraNodeResponse } from './mocks';
+import {
+	entraGroupGuid,
+	entraWorkflow,
+	expectNoGraphRequests,
+	microsoftEntraApiResponse,
+	microsoftEntraNodeResponse,
+} from './mocks';
 
 describe('Microsoft Entra Node', () => {
 	const baseUrl = 'https://graph.microsoft.com/v1.0';
@@ -750,77 +754,17 @@ describe('Microsoft Entra Node', () => {
 	});
 
 	describe('Rejected group IDs', () => {
-		let graphRequests: Mock;
-
-		beforeEach(() => {
-			// Any request reaching Graph fails the case: a rejected ID must never be sent.
-			graphRequests = vi.fn().mockReturnValue({});
-			for (const method of ['GET', 'POST', 'PATCH', 'DELETE'] as const) {
-				nock('https://graph.microsoft.com')
-					.persist()
-					.intercept(/.*/, method)
-					.reply(200, graphRequests);
-			}
-		});
-
-		afterEach(() => {
-			const requestsSeen = graphRequests.mock.calls.length;
-			nock.cleanAll();
-			expect(requestsSeen, 'a rejected ID must never reach Graph').toBe(0);
-		});
+		expectNoGraphRequests();
 
 		testHarness.setupTest({
 			description: 'should reject a group ID containing a slash',
 			input: {
-				workflowData: {
-					nodes: [
-						{
-							parameters: {},
-							id: '416e4fc1-5055-4e61-854e-a6265256ac26',
-							name: 'When clicking ‘Execute workflow’',
-							type: 'n8n-nodes-base.manualTrigger',
-							position: [820, 380],
-							typeVersion: 1,
-						},
-						{
-							parameters: {
-								resource: 'group',
-								operation: 'get',
-								group: {
-									__rl: true,
-									value: 'a8eb60e3-0145-4d7e-85ef-c6259784761b/members',
-									mode: 'id',
-								},
-								output: 'raw',
-								requestOptions: {},
-							},
-							type: 'n8n-nodes-base.microsoftEntra',
-							typeVersion: 1,
-							position: [220, 0],
-							id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
-							name: 'Microsoft Entra ID',
-							credentials: {
-								microsoftEntraOAuth2Api: {
-									id: 'Hot2KwSMSoSmMVqd',
-									name: 'Microsoft Entra ID (Azure Active Directory) account',
-								},
-							},
-						},
-					],
-					connections: {
-						'When clicking ‘Execute workflow’': {
-							main: [
-								[
-									{
-										node: 'Microsoft Entra ID',
-										type: NodeConnectionTypes.Main,
-										index: 0,
-									},
-								],
-							],
-						},
-					},
-				},
+				workflowData: entraWorkflow({
+					resource: 'group',
+					operation: 'get',
+					group: { __rl: true, mode: 'id', value: `${entraGroupGuid}/members` },
+					output: 'raw',
+				}),
 			},
 			output: { nodeData: {}, error: 'The group ID is invalid' },
 		});

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/GroupDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/GroupDescription.test.ts
@@ -1,5 +1,7 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import { NodeConnectionTypes, type WorkflowTestData } from 'n8n-workflow';
+import nock from 'nock';
+import type { Mock } from 'vitest';
 
 import { microsoftEntraApiResponse, microsoftEntraNodeResponse } from './mocks';
 
@@ -745,5 +747,82 @@ describe('Microsoft Entra Node', () => {
 		for (const testData of tests) {
 			testHarness.setupTest(testData);
 		}
+	});
+
+	describe('Rejected group IDs', () => {
+		let graphRequests: Mock;
+
+		beforeEach(() => {
+			// Any request reaching Graph fails the case: a rejected ID must never be sent.
+			graphRequests = vi.fn().mockReturnValue({});
+			for (const method of ['GET', 'POST', 'PATCH', 'DELETE'] as const) {
+				nock('https://graph.microsoft.com')
+					.persist()
+					.intercept(/.*/, method)
+					.reply(200, graphRequests);
+			}
+		});
+
+		afterEach(() => {
+			const requestsSeen = graphRequests.mock.calls.length;
+			nock.cleanAll();
+			expect(requestsSeen, 'a rejected ID must never reach Graph').toBe(0);
+		});
+
+		testHarness.setupTest({
+			description: 'should reject a group ID containing a slash',
+			input: {
+				workflowData: {
+					nodes: [
+						{
+							parameters: {},
+							id: '416e4fc1-5055-4e61-854e-a6265256ac26',
+							name: 'When clicking ‘Execute workflow’',
+							type: 'n8n-nodes-base.manualTrigger',
+							position: [820, 380],
+							typeVersion: 1,
+						},
+						{
+							parameters: {
+								resource: 'group',
+								operation: 'get',
+								group: {
+									__rl: true,
+									value: 'a8eb60e3-0145-4d7e-85ef-c6259784761b/members',
+									mode: 'id',
+								},
+								output: 'raw',
+								requestOptions: {},
+							},
+							type: 'n8n-nodes-base.microsoftEntra',
+							typeVersion: 1,
+							position: [220, 0],
+							id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
+							name: 'Microsoft Entra ID',
+							credentials: {
+								microsoftEntraOAuth2Api: {
+									id: 'Hot2KwSMSoSmMVqd',
+									name: 'Microsoft Entra ID (Azure Active Directory) account',
+								},
+							},
+						},
+					],
+					connections: {
+						'When clicking ‘Execute workflow’': {
+							main: [
+								[
+									{
+										node: 'Microsoft Entra ID',
+										type: NodeConnectionTypes.Main,
+										index: 0,
+									},
+								],
+							],
+						},
+					},
+				},
+			},
+			output: { nodeData: {}, error: 'The group ID is invalid' },
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
@@ -111,6 +111,60 @@ describe('Microsoft Entra Node', () => {
 		}
 	});
 
+	describe('Path ID wiring', () => {
+		const { properties } = new MicrosoftEntra().description;
+		const resourceLocators = properties.filter((property) => property.type === 'resourceLocator');
+
+		// Derived from the sinks rather than hardcoded, so a new ID in a URL template fails here
+		// until it is guarded too.
+		const interpolatedIds = new Set(
+			properties
+				.flatMap((property) => property.options ?? [])
+				.flatMap((option) =>
+					'routing' in option && typeof option.routing?.request?.url === 'string'
+						? [option.routing.request.url]
+						: [],
+				)
+				.flatMap((url) => [...url.matchAll(/\$parameter\["([^"]+)"\]/g)].map(([, name]) => name)),
+		);
+
+		it('interpolates only the user and group IDs into request URLs', () => {
+			expect([...interpolatedIds].sort()).toEqual(['group', 'user']);
+		});
+
+		it('guards every parameter interpolated into a request URL', () => {
+			for (const name of interpolatedIds) {
+				const matching = resourceLocators.filter((property) => property.name === name);
+				expect(matching.length, name).toBeGreaterThan(0);
+				for (const property of matching) {
+					expect(property.routing?.send?.preSend, property.displayName).toHaveLength(1);
+				}
+			}
+		});
+
+		it('guards every resource locator', () => {
+			for (const property of resourceLocators) {
+				expect(property.routing?.send?.preSend, property.displayName).toHaveLength(1);
+			}
+		});
+
+		it('has ten resource locators', () => {
+			expect(resourceLocators).toHaveLength(10);
+		});
+
+		it('still composes the @odata.id body when adding a user to a group', () => {
+			const addGroupUser = properties.find(
+				(property) =>
+					property.name === 'user' &&
+					property.displayOptions?.show?.operation?.includes('addGroup'),
+			);
+
+			expect(addGroupUser?.routing?.send?.property).toBe('@odata.id');
+			expect(addGroupUser?.routing?.send?.value).toContain('directoryObjects');
+			expect(addGroupUser?.routing?.send?.preSend).toHaveLength(1);
+		});
+	});
+
 	describe('HTTP status handling', () => {
 		it('handles non-authentication errors in the node error handler', async () => {
 			const axiosRequest = convertN8nRequestToAxios({

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
@@ -9,14 +9,16 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import nock from 'nock';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import type { MockInstance } from 'vitest';
 
 import { microsoftEntraApiResponse, microsoftEntraNodeResponse } from './mocks';
 import { MicrosoftEntra } from '../MicrosoftEntra.node';
 import { ignoreHttpStatusErrorsConfig } from '../descriptions/common';
-import { handleErrorPostReceive } from '../GenericFunctions';
+import {
+	handleErrorPostReceive,
+	validateGroupPreSend,
+	validateUserPreSend,
+} from '../GenericFunctions';
 
 describe('Microsoft Entra Node', () => {
 	const testHarness = new NodeTestHarness();
@@ -133,10 +135,6 @@ describe('Microsoft Entra Node', () => {
 			),
 		);
 
-		const descriptionSources = ['UserDescription.ts', 'GroupDescription.ts'].map((file) =>
-			readFileSync(join(__dirname, '..', 'descriptions', file), 'utf-8'),
-		);
-
 		it('interpolates only the user and group IDs into request URLs', () => {
 			expect([...interpolatedIds].sort()).toEqual(['group', 'user']);
 		});
@@ -152,24 +150,16 @@ describe('Microsoft Entra Node', () => {
 
 		it('guards every resource locator', () => {
 			for (const property of resourceLocators) {
-				expect(property.routing?.send?.preSend, property.displayName).toHaveLength(1);
+				expect(property.routing?.send?.preSend, property.displayName).toContain(
+					property.name === 'user' ? validateUserPreSend : validateGroupPreSend,
+				);
 			}
 		});
 
 		it('encodes every parameter interpolated into a request URL', () => {
 			for (const url of routingUrls) {
-				const unwrapped = url.replace(/encodeURIComponent\(\$parameter\["[^"]+"\]\)/g, '');
+				const unwrapped = url.replace(/encodeURIComponent\(\s*\$parameter\["[^"]+"\]\s*\)/g, '');
 				expect(unwrapped, url).not.toContain('$parameter[');
-			}
-		});
-
-		// The programmatic follow-up requests build their path with a template literal, which the
-		// description object above cannot see.
-		it('encodes every ID interpolated into a follow-up request path', () => {
-			for (const source of descriptionSources) {
-				for (const [line] of source.matchAll(/`\/(?:users|groups)\/\$\{[^}]*\}`/g)) {
-					expect(line).toContain('encodeURIComponent(');
-				}
 			}
 		});
 
@@ -195,10 +185,10 @@ describe('Microsoft Entra Node', () => {
 			);
 
 			expect(addGroupUser?.routing?.send?.property).toBe('@odata.id');
-			expect(addGroupUser?.routing?.send?.value).toBe(
-				'={{ ($credentials.graphApiBaseUrl || "https://graph.microsoft.com").replace(/\\/+$/, "") }}/v1.0/directoryObjects/{{ encodeURIComponent($value) }}',
+			expect(addGroupUser?.routing?.send?.value).toContain(
+				'directoryObjects/{{ encodeURIComponent($value) }}',
 			);
-			expect(addGroupUser?.routing?.send?.preSend).toHaveLength(1);
+			expect(addGroupUser?.routing?.send?.preSend).toContain(validateUserPreSend);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
@@ -9,6 +9,8 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import nock from 'nock';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { MockInstance } from 'vitest';
 
 import { microsoftEntraApiResponse, microsoftEntraNodeResponse } from './mocks';
@@ -115,30 +117,36 @@ describe('Microsoft Entra Node', () => {
 		const { properties } = new MicrosoftEntra().description;
 		const resourceLocators = properties.filter((property) => property.type === 'resourceLocator');
 
+		const routingUrls = properties
+			.flatMap((property) => property.options ?? [])
+			.flatMap((option) =>
+				'routing' in option && typeof option.routing?.request?.url === 'string'
+					? [option.routing.request.url]
+					: [],
+			);
+
 		// Derived from the sinks rather than hardcoded, so a new ID in a URL template fails here
 		// until it is guarded too.
 		const interpolatedIds = new Set(
-			properties
-				.flatMap((property) => property.options ?? [])
-				.flatMap((option) =>
-					'routing' in option && typeof option.routing?.request?.url === 'string'
-						? [option.routing.request.url]
-						: [],
-				)
-				.flatMap((url) => [...url.matchAll(/\$parameter\["([^"]+)"\]/g)].map(([, name]) => name)),
+			routingUrls.flatMap((url) =>
+				[...url.matchAll(/\$parameter\["([^"]+)"\]/g)].map(([, name]) => name),
+			),
+		);
+
+		const descriptionSources = ['UserDescription.ts', 'GroupDescription.ts'].map((file) =>
+			readFileSync(join(__dirname, '..', 'descriptions', file), 'utf-8'),
 		);
 
 		it('interpolates only the user and group IDs into request URLs', () => {
 			expect([...interpolatedIds].sort()).toEqual(['group', 'user']);
 		});
 
-		it('guards every parameter interpolated into a request URL', () => {
+		it('has a resource locator for every parameter interpolated into a request URL', () => {
 			for (const name of interpolatedIds) {
-				const matching = resourceLocators.filter((property) => property.name === name);
-				expect(matching.length, name).toBeGreaterThan(0);
-				for (const property of matching) {
-					expect(property.routing?.send?.preSend, property.displayName).toHaveLength(1);
-				}
+				expect(
+					resourceLocators.filter((property) => property.name === name).length,
+					name,
+				).toBeGreaterThan(0);
 			}
 		});
 
@@ -148,8 +156,35 @@ describe('Microsoft Entra Node', () => {
 			}
 		});
 
-		it('has ten resource locators', () => {
-			expect(resourceLocators).toHaveLength(10);
+		it('encodes every parameter interpolated into a request URL', () => {
+			for (const url of routingUrls) {
+				const unwrapped = url.replace(/encodeURIComponent\(\$parameter\["[^"]+"\]\)/g, '');
+				expect(unwrapped, url).not.toContain('$parameter[');
+			}
+		});
+
+		// The programmatic follow-up requests build their path with a template literal, which the
+		// description object above cannot see.
+		it('encodes every ID interpolated into a follow-up request path', () => {
+			for (const source of descriptionSources) {
+				for (const [line] of source.matchAll(/`\/(?:users|groups)\/\$\{[^}]*\}`/g)) {
+					expect(line).toContain('encodeURIComponent(');
+				}
+			}
+		});
+
+		// The guard reads the ID with `extractValue`, while the URL template reads it through
+		// `$parameter`, which additionally applies a stored `__regex`. Declaring `extractValue` on a
+		// mode would split the two readings apart.
+		it('declares no extractValue on any resource locator mode', () => {
+			for (const property of resourceLocators) {
+				for (const mode of property.modes ?? []) {
+					expect(
+						mode.extractValue,
+						`${property.displayName} / ${mode.displayName}`,
+					).toBeUndefined();
+				}
+			}
 		});
 
 		it('still composes the @odata.id body when adding a user to a group', () => {
@@ -160,7 +195,9 @@ describe('Microsoft Entra Node', () => {
 			);
 
 			expect(addGroupUser?.routing?.send?.property).toBe('@odata.id');
-			expect(addGroupUser?.routing?.send?.value).toContain('directoryObjects');
+			expect(addGroupUser?.routing?.send?.value).toBe(
+				'={{ ($credentials.graphApiBaseUrl || "https://graph.microsoft.com").replace(/\\/+$/, "") }}/v1.0/directoryObjects/{{ encodeURIComponent($value) }}',
+			);
 			expect(addGroupUser?.routing?.send?.preSend).toHaveLength(1);
 		});
 	});

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
@@ -1,7 +1,51 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
-import { NodeConnectionTypes, type WorkflowTestData } from 'n8n-workflow';
+import {
+	NodeConnectionTypes,
+	NodeHelpers,
+	type INodeParameters,
+	type WorkflowTestData,
+} from 'n8n-workflow';
+import nock from 'nock';
+import type { Mock } from 'vitest';
 
 import { microsoftEntraApiResponse, microsoftEntraNodeResponse } from './mocks';
+import { MicrosoftEntra } from '../MicrosoftEntra.node';
+
+const guid = '87d349ed-44d7-43e1-9a83-5f2406dee5bd';
+const groupGuid = 'a8eb60e3-0145-4d7e-85ef-c6259784761b';
+
+// A manual trigger feeding one Microsoft Entra ID node, so a case only has to state its parameters.
+const entraWorkflow = (parameters: INodeParameters): WorkflowTestData['input']['workflowData'] => ({
+	nodes: [
+		{
+			parameters: {},
+			id: '416e4fc1-5055-4e61-854e-a6265256ac26',
+			name: 'When clicking ‘Execute workflow’',
+			type: 'n8n-nodes-base.manualTrigger',
+			position: [820, 380],
+			typeVersion: 1,
+		},
+		{
+			parameters: { requestOptions: {}, ...parameters },
+			type: 'n8n-nodes-base.microsoftEntra',
+			typeVersion: 1,
+			position: [220, 0],
+			id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
+			name: 'Microsoft Entra ID',
+			credentials: {
+				microsoftEntraOAuth2Api: {
+					id: 'Hot2KwSMSoSmMVqd',
+					name: 'Microsoft Entra ID (Azure Active Directory) account',
+				},
+			},
+		},
+	],
+	connections: {
+		'When clicking ‘Execute workflow’': {
+			main: [[{ node: 'Microsoft Entra ID', type: NodeConnectionTypes.Main, index: 0 }]],
+		},
+	},
+});
 
 describe('Microsoft Entra Node', () => {
 	const testHarness = new NodeTestHarness();
@@ -1127,5 +1171,240 @@ describe('Microsoft Entra Node', () => {
 		for (const testData of tests) {
 			testHarness.setupTest(testData);
 		}
+	});
+
+	describe('Accepted user IDs', () => {
+		const deleteUser = (
+			description: string,
+			user: INodeParameters,
+			path: string,
+		): WorkflowTestData => ({
+			description,
+			input: {
+				workflowData: entraWorkflow({
+					resource: 'user',
+					operation: 'delete',
+					user,
+					options: {},
+				}),
+			},
+			output: { nodeData: { 'Microsoft Entra ID': [microsoftEntraNodeResponse.deleteUser] } },
+			nock: {
+				baseUrl,
+				mocks: [{ method: 'delete', path, statusCode: 204, responseBody: {} }],
+			},
+		});
+
+		const tests: WorkflowTestData[] = [
+			deleteUser(
+				'should delete a user addressed by an expression-driven UPN',
+				{ __rl: true, mode: 'id', value: '={{ "john.doe@contoso.com" }}' },
+				'/users/john.doe%40contoso.com',
+			),
+			deleteUser(
+				'should delete a guest user addressed by UPN',
+				{ __rl: true, mode: 'id', value: 'user_contoso.com#EXT#@tenant.onmicrosoft.com' },
+				'/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com',
+			),
+			deleteUser(
+				'should delete a user addressed by UPN',
+				{ __rl: true, mode: 'id', value: 'jane@contoso.com' },
+				'/users/jane%40contoso.com',
+			),
+			deleteUser(
+				'should delete a user picked from the list',
+				{ __rl: true, mode: 'list', value: guid },
+				`/users/${guid}`,
+			),
+			deleteUser(
+				'should delete a user addressed by an uppercase ID',
+				{ __rl: true, mode: 'id', value: guid.toUpperCase() },
+				`/users/${guid.toUpperCase()}`,
+			),
+		];
+
+		for (const testData of tests) {
+			testHarness.setupTest(testData);
+		}
+	});
+
+	describe('Rejected user IDs', () => {
+		let graphRequests: Mock;
+
+		beforeEach(() => {
+			// Any request reaching Graph fails the case: a rejected ID must never be sent.
+			graphRequests = vi.fn().mockReturnValue({});
+			for (const method of ['GET', 'POST', 'PATCH', 'DELETE'] as const) {
+				nock('https://graph.microsoft.com')
+					.persist()
+					.intercept(/.*/, method)
+					.reply(200, graphRequests);
+			}
+		});
+
+		afterEach(() => {
+			const requestsSeen = graphRequests.mock.calls.length;
+			nock.cleanAll();
+			expect(requestsSeen, 'a rejected ID must never reach Graph').toBe(0);
+		});
+
+		const tests: WorkflowTestData[] = [
+			{
+				description: 'should reject an expression-driven ID containing a slash',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'get',
+						user: { __rl: true, mode: 'id', value: '={{ "a/b" }}' },
+						output: 'raw',
+					}),
+				},
+				output: { nodeData: {}, error: 'The user ID is invalid' },
+			},
+			{
+				description: 'should reject an ID containing a slash on a two-ID operation',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'removeGroup',
+						group: { __rl: true, mode: 'id', value: groupGuid },
+						user: { __rl: true, mode: 'id', value: `${guid}/manager` },
+					}),
+				},
+				output: { nodeData: {}, error: 'The user ID is invalid' },
+			},
+			{
+				description: 'should reject an ID that only reaches the request body',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'addGroup',
+						group: { __rl: true, mode: 'id', value: groupGuid },
+						user: { __rl: true, mode: 'id', value: `${guid}/manager` },
+					}),
+				},
+				output: { nodeData: {}, error: 'The user ID is invalid' },
+			},
+			{
+				description: 'should reject a blank user',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'get',
+						user: { __rl: true, mode: 'id', value: ' ' },
+						output: 'raw',
+					}),
+				},
+				output: { nodeData: {}, error: 'The user is empty' },
+			},
+		];
+
+		for (const testData of tests) {
+			testHarness.setupTest(testData);
+		}
+
+		// An empty or absent resource locator never reaches the request: the workflow refuses to
+		// start because the parameter is required.
+		it.each([
+			['an empty user', { __rl: true, mode: 'list', value: '' }],
+			['a user that was never set', undefined],
+		])('reports %s as a node issue', (_label, user) => {
+			const node = new MicrosoftEntra();
+			const [, entra] = entraWorkflow({
+				resource: 'user',
+				operation: 'get',
+				output: 'raw',
+				...(user ? { user } : {}),
+			}).nodes;
+
+			const issues = NodeHelpers.getNodeParametersIssues(
+				node.description.properties,
+				entra,
+				node.description,
+			);
+
+			expect(issues?.parameters?.user).toEqual(['Parameter "User to Get" is required.']);
+		});
+	});
+
+	describe('Per-item validation', () => {
+		afterEach(() => {
+			nock.cleanAll();
+		});
+
+		testHarness.setupTest(
+			{
+				description: 'should delete the valid user and fail only the item with an invalid ID',
+				input: {
+					workflowData: {
+						nodes: [
+							{
+								parameters: {},
+								id: '416e4fc1-5055-4e61-854e-a6265256ac26',
+								name: 'When clicking ‘Execute workflow’',
+								type: 'n8n-nodes-base.manualTrigger',
+								position: [820, 380],
+								typeVersion: 1,
+							},
+							{
+								parameters: { data: JSON.stringify([{ id: guid }, { id: `${guid}/manager` }]) },
+								id: '2c1e0f0e-6d0c-4a2e-9a8f-6b2a1c0d3e4f',
+								name: 'Test Data',
+								type: 'n8n-nodes-testing.testData',
+								position: [20, 0],
+								typeVersion: 1,
+							},
+							{
+								parameters: {
+									resource: 'user',
+									operation: 'delete',
+									user: { __rl: true, mode: 'id', value: '={{ $json.id }}' },
+									options: {},
+									requestOptions: {},
+								},
+								type: 'n8n-nodes-base.microsoftEntra',
+								typeVersion: 1,
+								position: [220, 0],
+								id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
+								name: 'Microsoft Entra ID',
+								onError: 'continueRegularOutput',
+								credentials: {
+									microsoftEntraOAuth2Api: {
+										id: 'Hot2KwSMSoSmMVqd',
+										name: 'Microsoft Entra ID (Azure Active Directory) account',
+									},
+								},
+							},
+						],
+						connections: {
+							'When clicking ‘Execute workflow’': {
+								main: [[{ node: 'Test Data', type: NodeConnectionTypes.Main, index: 0 }]],
+							},
+							'Test Data': {
+								main: [[{ node: 'Microsoft Entra ID', type: NodeConnectionTypes.Main, index: 0 }]],
+							},
+						},
+					},
+				},
+				output: {
+					nodeData: {
+						'Microsoft Entra ID': [
+							[
+								{ json: { deleted: true } },
+								{
+									json: { error: 'The user ID is invalid' },
+									error: expect.objectContaining({ message: 'The user ID is invalid' }),
+								},
+							],
+						],
+					},
+				},
+				nock: {
+					baseUrl,
+					mocks: [{ method: 'delete', path: `/users/${guid}`, statusCode: 204, responseBody: {} }],
+				},
+			},
+			{ customAssertions: () => expect(nock.isDone()).toBe(true) },
+		);
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
@@ -1343,6 +1343,20 @@ describe('Microsoft Entra Node', () => {
 				output: { nodeData: {}, error: 'The user ID is invalid' },
 			},
 			{
+				// A legitimate UPN whose extracted substring is `..`, i.e. the one case the guard's
+				// own substring reasoning does not cover.
+				description: 'should reject a user carrying an ID extraction rule',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'get',
+						user: { __rl: true, mode: 'id', value: 'a..b@contoso.com', __regex: '(\\.\\.)' },
+						output: 'raw',
+					}),
+				},
+				output: { nodeData: {}, error: 'The user ID is invalid' },
+			},
+			{
 				description: 'should reject a blank user',
 				input: {
 					workflowData: entraWorkflow({

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
@@ -5,8 +5,6 @@ import {
 	type INodeParameters,
 	type WorkflowTestData,
 } from 'n8n-workflow';
-import nock from 'nock';
-
 import {
 	entraGroupGuid as groupGuid,
 	entraGuid as guid,
@@ -1186,11 +1184,6 @@ describe('Microsoft Entra Node', () => {
 				{ __rl: true, mode: 'list', value: guid },
 				`/users/${guid}`,
 			),
-			deleteUser(
-				'should delete a user addressed by an uppercase ID',
-				{ __rl: true, mode: 'id', value: guid.toUpperCase() },
-				`/users/${guid.toUpperCase()}`,
-			),
 			{
 				description: 'should get a guest user addressed by UPN',
 				input: {
@@ -1401,10 +1394,6 @@ describe('Microsoft Entra Node', () => {
 	});
 
 	describe('Per-item validation', () => {
-		afterEach(() => {
-			nock.cleanAll();
-		});
-
 		testHarness.setupTest({
 			description: 'should delete the valid user and fail only the item with an invalid ID',
 			input: {

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
@@ -1174,6 +1174,11 @@ describe('Microsoft Entra Node', () => {
 	});
 
 	describe('Accepted user IDs', () => {
+		// Only the user templates can carry a UPN. The five group templates take a GUID, which
+		// encodes to itself, so there is nothing falsifiable to assert for them.
+		const guestUpn = 'user_contoso.com#EXT#@tenant.onmicrosoft.com';
+		const guestPath = '/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com';
+
 		const deleteUser = (
 			description: string,
 			user: INodeParameters,
@@ -1203,13 +1208,8 @@ describe('Microsoft Entra Node', () => {
 			),
 			deleteUser(
 				'should delete a guest user addressed by UPN',
-				{ __rl: true, mode: 'id', value: 'user_contoso.com#EXT#@tenant.onmicrosoft.com' },
-				'/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com',
-			),
-			deleteUser(
-				'should delete a user addressed by UPN',
-				{ __rl: true, mode: 'id', value: 'jane@contoso.com' },
-				'/users/jane%40contoso.com',
+				{ __rl: true, mode: 'id', value: guestUpn },
+				guestPath,
 			),
 			deleteUser(
 				'should delete a user picked from the list',
@@ -1221,6 +1221,63 @@ describe('Microsoft Entra Node', () => {
 				{ __rl: true, mode: 'id', value: guid.toUpperCase() },
 				`/users/${guid.toUpperCase()}`,
 			),
+			{
+				description: 'should get a guest user addressed by UPN',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'get',
+						user: { __rl: true, mode: 'id', value: guestUpn },
+						output: 'fields',
+						fields: [],
+					}),
+				},
+				output: { nodeData: { 'Microsoft Entra ID': [microsoftEntraNodeResponse.getUser] } },
+				nock: {
+					baseUrl,
+					mocks: [
+						{
+							method: 'get',
+							path: `${guestPath}?$select=id`,
+							statusCode: 200,
+							responseBody: microsoftEntraApiResponse.getUser,
+						},
+					],
+				},
+			},
+			{
+				// `update` sends a second, programmatic PATCH for the fields Graph only accepts on
+				// their own, so the ID reaches a Graph path twice.
+				description: 'should update a guest user on both of its requests',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'update',
+						user: { __rl: true, mode: 'id', value: guestUpn },
+						updateFields: { city: 'New York', aboutMe: 'About me' },
+					}),
+				},
+				output: { nodeData: { 'Microsoft Entra ID': [microsoftEntraNodeResponse.updateUser] } },
+				nock: {
+					baseUrl,
+					mocks: [
+						{
+							method: 'patch',
+							path: guestPath,
+							statusCode: 204,
+							requestBody: { city: 'New York' },
+							responseBody: {},
+						},
+						{
+							method: 'patch',
+							path: guestPath,
+							statusCode: 204,
+							requestBody: { aboutMe: 'About me' },
+							responseBody: {},
+						},
+					],
+				},
+			},
 		];
 
 		for (const testData of tests) {

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
@@ -1246,6 +1246,34 @@ describe('Microsoft Entra Node', () => {
 				},
 			},
 			{
+				description: 'should add a user addressed by UPN to a group',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'addGroup',
+						group: { __rl: true, mode: 'id', value: groupGuid },
+						user: { __rl: true, mode: 'id', value: 'jane@contoso.com' },
+					}),
+				},
+				output: {
+					nodeData: { 'Microsoft Entra ID': [microsoftEntraNodeResponse.addUserToGroup] },
+				},
+				nock: {
+					baseUrl,
+					mocks: [
+						{
+							method: 'post',
+							path: `/groups/${groupGuid}/members/$ref`,
+							statusCode: 204,
+							requestBody: {
+								'@odata.id': 'https://graph.microsoft.com/v1.0/directoryObjects/jane%40contoso.com',
+							},
+							responseBody: {},
+						},
+					],
+				},
+			},
+			{
 				// `update` sends a second, programmatic PATCH for the fields Graph only accepts on
 				// their own, so the ID reaches a Graph path twice.
 				description: 'should update a guest user on both of its requests',

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/UserDescription.test.ts
@@ -6,46 +6,16 @@ import {
 	type WorkflowTestData,
 } from 'n8n-workflow';
 import nock from 'nock';
-import type { Mock } from 'vitest';
 
-import { microsoftEntraApiResponse, microsoftEntraNodeResponse } from './mocks';
+import {
+	entraGroupGuid as groupGuid,
+	entraGuid as guid,
+	entraWorkflow,
+	expectNoGraphRequests,
+	microsoftEntraApiResponse,
+	microsoftEntraNodeResponse,
+} from './mocks';
 import { MicrosoftEntra } from '../MicrosoftEntra.node';
-
-const guid = '87d349ed-44d7-43e1-9a83-5f2406dee5bd';
-const groupGuid = 'a8eb60e3-0145-4d7e-85ef-c6259784761b';
-
-// A manual trigger feeding one Microsoft Entra ID node, so a case only has to state its parameters.
-const entraWorkflow = (parameters: INodeParameters): WorkflowTestData['input']['workflowData'] => ({
-	nodes: [
-		{
-			parameters: {},
-			id: '416e4fc1-5055-4e61-854e-a6265256ac26',
-			name: 'When clicking ‘Execute workflow’',
-			type: 'n8n-nodes-base.manualTrigger',
-			position: [820, 380],
-			typeVersion: 1,
-		},
-		{
-			parameters: { requestOptions: {}, ...parameters },
-			type: 'n8n-nodes-base.microsoftEntra',
-			typeVersion: 1,
-			position: [220, 0],
-			id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
-			name: 'Microsoft Entra ID',
-			credentials: {
-				microsoftEntraOAuth2Api: {
-					id: 'Hot2KwSMSoSmMVqd',
-					name: 'Microsoft Entra ID (Azure Active Directory) account',
-				},
-			},
-		},
-	],
-	connections: {
-		'When clicking ‘Execute workflow’': {
-			main: [[{ node: 'Microsoft Entra ID', type: NodeConnectionTypes.Main, index: 0 }]],
-		},
-	},
-});
 
 describe('Microsoft Entra Node', () => {
 	const testHarness = new NodeTestHarness();
@@ -1314,24 +1284,7 @@ describe('Microsoft Entra Node', () => {
 	});
 
 	describe('Rejected user IDs', () => {
-		let graphRequests: Mock;
-
-		beforeEach(() => {
-			// Any request reaching Graph fails the case: a rejected ID must never be sent.
-			graphRequests = vi.fn().mockReturnValue({});
-			for (const method of ['GET', 'POST', 'PATCH', 'DELETE'] as const) {
-				nock('https://graph.microsoft.com')
-					.persist()
-					.intercept(/.*/, method)
-					.reply(200, graphRequests);
-			}
-		});
-
-		afterEach(() => {
-			const requestsSeen = graphRequests.mock.calls.length;
-			nock.cleanAll();
-			expect(requestsSeen, 'a rejected ID must never reach Graph').toBe(0);
-		});
+		expectNoGraphRequests();
 
 		const tests: WorkflowTestData[] = [
 			{
@@ -1357,6 +1310,30 @@ describe('Microsoft Entra Node', () => {
 					}),
 				},
 				output: { nodeData: {}, error: 'The user ID is invalid' },
+			},
+			{
+				description: 'should reject a group ID containing a slash on a two-ID operation',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'removeGroup',
+						group: { __rl: true, mode: 'id', value: `${groupGuid}/members` },
+						user: { __rl: true, mode: 'id', value: guid },
+					}),
+				},
+				output: { nodeData: {}, error: 'The group ID is invalid' },
+			},
+			{
+				description: 'should reject a group ID containing a slash when adding to a group',
+				input: {
+					workflowData: entraWorkflow({
+						resource: 'user',
+						operation: 'addGroup',
+						group: { __rl: true, mode: 'id', value: `${groupGuid}/members` },
+						user: { __rl: true, mode: 'id', value: guid },
+					}),
+				},
+				output: { nodeData: {}, error: 'The group ID is invalid' },
 			},
 			{
 				description: 'should reject an ID that only reaches the request body',
@@ -1404,16 +1381,13 @@ describe('Microsoft Entra Node', () => {
 
 		// An empty or absent resource locator never reaches the request: the workflow refuses to
 		// start because the parameter is required.
-		it.each([
-			['an empty user', { __rl: true, mode: 'list', value: '' }],
-			['a user that was never set', undefined],
-		])('reports %s as a node issue', (_label, user) => {
+		it('reports an empty user as a node issue', () => {
 			const node = new MicrosoftEntra();
 			const [, entra] = entraWorkflow({
 				resource: 'user',
 				operation: 'get',
 				output: 'raw',
-				...(user ? { user } : {}),
+				user: { __rl: true, mode: 'list', value: '' },
 			}).nodes;
 
 			const issues = NodeHelpers.getNodeParametersIssues(
@@ -1431,79 +1405,76 @@ describe('Microsoft Entra Node', () => {
 			nock.cleanAll();
 		});
 
-		testHarness.setupTest(
-			{
-				description: 'should delete the valid user and fail only the item with an invalid ID',
-				input: {
-					workflowData: {
-						nodes: [
-							{
-								parameters: {},
-								id: '416e4fc1-5055-4e61-854e-a6265256ac26',
-								name: 'When clicking ‘Execute workflow’',
-								type: 'n8n-nodes-base.manualTrigger',
-								position: [820, 380],
-								typeVersion: 1,
+		testHarness.setupTest({
+			description: 'should delete the valid user and fail only the item with an invalid ID',
+			input: {
+				workflowData: {
+					nodes: [
+						{
+							parameters: {},
+							id: '416e4fc1-5055-4e61-854e-a6265256ac26',
+							name: 'When clicking ‘Execute workflow’',
+							type: 'n8n-nodes-base.manualTrigger',
+							position: [820, 380],
+							typeVersion: 1,
+						},
+						{
+							parameters: { data: JSON.stringify([{ id: guid }, { id: `${guid}/manager` }]) },
+							id: '2c1e0f0e-6d0c-4a2e-9a8f-6b2a1c0d3e4f',
+							name: 'Test Data',
+							type: 'n8n-nodes-testing.testData',
+							position: [20, 0],
+							typeVersion: 1,
+						},
+						{
+							parameters: {
+								resource: 'user',
+								operation: 'delete',
+								user: { __rl: true, mode: 'id', value: '={{ $json.id }}' },
+								options: {},
+								requestOptions: {},
 							},
-							{
-								parameters: { data: JSON.stringify([{ id: guid }, { id: `${guid}/manager` }]) },
-								id: '2c1e0f0e-6d0c-4a2e-9a8f-6b2a1c0d3e4f',
-								name: 'Test Data',
-								type: 'n8n-nodes-testing.testData',
-								position: [20, 0],
-								typeVersion: 1,
-							},
-							{
-								parameters: {
-									resource: 'user',
-									operation: 'delete',
-									user: { __rl: true, mode: 'id', value: '={{ $json.id }}' },
-									options: {},
-									requestOptions: {},
-								},
-								type: 'n8n-nodes-base.microsoftEntra',
-								typeVersion: 1,
-								position: [220, 0],
-								id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
-								name: 'Microsoft Entra ID',
-								onError: 'continueRegularOutput',
-								credentials: {
-									microsoftEntraOAuth2Api: {
-										id: 'Hot2KwSMSoSmMVqd',
-										name: 'Microsoft Entra ID (Azure Active Directory) account',
-									},
+							type: 'n8n-nodes-base.microsoftEntra',
+							typeVersion: 1,
+							position: [220, 0],
+							id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
+							name: 'Microsoft Entra ID',
+							onError: 'continueRegularOutput',
+							credentials: {
+								microsoftEntraOAuth2Api: {
+									id: 'Hot2KwSMSoSmMVqd',
+									name: 'Microsoft Entra ID (Azure Active Directory) account',
 								},
 							},
-						],
-						connections: {
-							'When clicking ‘Execute workflow’': {
-								main: [[{ node: 'Test Data', type: NodeConnectionTypes.Main, index: 0 }]],
-							},
-							'Test Data': {
-								main: [[{ node: 'Microsoft Entra ID', type: NodeConnectionTypes.Main, index: 0 }]],
-							},
+						},
+					],
+					connections: {
+						'When clicking ‘Execute workflow’': {
+							main: [[{ node: 'Test Data', type: NodeConnectionTypes.Main, index: 0 }]],
+						},
+						'Test Data': {
+							main: [[{ node: 'Microsoft Entra ID', type: NodeConnectionTypes.Main, index: 0 }]],
 						},
 					},
 				},
-				output: {
-					nodeData: {
-						'Microsoft Entra ID': [
-							[
-								{ json: { deleted: true } },
-								{
-									json: { error: 'The user ID is invalid' },
-									error: expect.objectContaining({ message: 'The user ID is invalid' }),
-								},
-							],
+			},
+			output: {
+				nodeData: {
+					'Microsoft Entra ID': [
+						[
+							{ json: { deleted: true } },
+							{
+								json: { error: 'The user ID is invalid' },
+								error: expect.objectContaining({ message: 'The user ID is invalid' }),
+							},
 						],
-					},
-				},
-				nock: {
-					baseUrl,
-					mocks: [{ method: 'delete', path: `/users/${guid}`, statusCode: 204, responseBody: {} }],
+					],
 				},
 			},
-			{ customAssertions: () => expect(nock.isDone()).toBe(true) },
-		);
+			nock: {
+				baseUrl,
+				mocks: [{ method: 'delete', path: `/users/${guid}`, statusCode: 204, responseBody: {} }],
+			},
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/mocks.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/mocks.ts
@@ -1,4 +1,66 @@
 /* eslint-disable n8n-nodes-base/node-param-display-name-miscased */
+import { NodeConnectionTypes, type INodeParameters, type WorkflowTestData } from 'n8n-workflow';
+import nock from 'nock';
+import type { Mock } from 'vitest';
+
+export const entraGuid = '87d349ed-44d7-43e1-9a83-5f2406dee5bd';
+export const entraGroupGuid = 'a8eb60e3-0145-4d7e-85ef-c6259784761b';
+
+/** A manual trigger feeding one Microsoft Entra ID node, so a case only has to state parameters. */
+export const entraWorkflow = (
+	parameters: INodeParameters,
+): WorkflowTestData['input']['workflowData'] => ({
+	nodes: [
+		{
+			parameters: {},
+			id: '416e4fc1-5055-4e61-854e-a6265256ac26',
+			name: 'When clicking ‘Execute workflow’',
+			type: 'n8n-nodes-base.manualTrigger',
+			position: [820, 380],
+			typeVersion: 1,
+		},
+		{
+			parameters: { requestOptions: {}, ...parameters },
+			type: 'n8n-nodes-base.microsoftEntra',
+			typeVersion: 1,
+			position: [220, 0],
+			id: '3429f7f2-dfca-4b72-8913-43a582e96e66',
+			name: 'Microsoft Entra ID',
+			credentials: {
+				microsoftEntraOAuth2Api: {
+					id: 'Hot2KwSMSoSmMVqd',
+					name: 'Microsoft Entra ID (Azure Active Directory) account',
+				},
+			},
+		},
+	],
+	connections: {
+		'When clicking ‘Execute workflow’': {
+			main: [[{ node: 'Microsoft Entra ID', type: NodeConnectionTypes.Main, index: 0 }]],
+		},
+	},
+});
+
+/**
+ * Catches every request to the Graph host for the surrounding describe block and fails the case
+ * if one arrives. A rejected ID must never be sent.
+ */
+export const expectNoGraphRequests = () => {
+	let requests: Mock;
+
+	beforeEach(() => {
+		requests = vi.fn().mockReturnValue({});
+		for (const method of ['GET', 'POST', 'PATCH', 'DELETE'] as const) {
+			nock('https://graph.microsoft.com').persist().intercept(/.*/, method).reply(200, requests);
+		}
+	});
+
+	afterEach(() => {
+		const requestsSeen = requests.mock.calls.length;
+		nock.cleanAll();
+		expect(requestsSeen, 'a rejected ID must never reach Graph').toBe(0);
+	});
+};
 
 export const microsoftEntraApiResponse = {
 	postGroup: {


### PR DESCRIPTION
## Summary

The Microsoft Entra ID node built Graph URLs by interpolating resource-locator ID values into the path with no shape check and no encoding. This PR makes both halves of the repo's existing rule hold in this node (see the contract already written at `nodes/Microsoft/GenericFunctions.ts:28-36`): validate the ID shape first, then encode it.

Four changes:

1. **Validate.** A `routing.send.preSend` guard on each of the ten `user` / `group` resource locators. Entra is a purely declarative node, so `preSend` is the only hook that runs after the URL is interpolated and before the request is sent. `user` reuses the shared `validateUserTargetId` (object ID or user principal name, guests included); `group` gets a local object-ID-only check, since Graph resolves `/groups/{id}` and `/directoryObjects/{id}` by object ID only and the node's own error copy already says so.
2. **Encode.** Every ID interpolated into a Graph path is now wrapped in `encodeURIComponent`: the eight declarative `routing.request.url` templates, the `@odata.id` body value, and the seven programmatic follow-up request paths inside the `postReceive` hooks.
3. **Keep an explicit request URL on the credential host.** `microsoftApiRequest` and `microsoftApiPaginateRequest` accept an explicit `url` that was used verbatim. `getGroups` / `getUsers` pass a caller-supplied `paginationToken` straight into it, so this now resolves through one helper that confirms the target is on the credential's Graph origin and rejects an unparsable one with an actionable message instead of a raw `TypeError`. This is a separate concern from the ID handling and lives in its own commit (`3b34fb664b`, `fe8d829a01`) if you would rather it were split out.
4. **Reject a dot path segment on the composed request URL.** Encoding contains every other character inside its path segment; a bare `.` or `..` survives encoding unchanged. This is the only check here that inspects the outgoing request rather than re-reading a parameter, which makes it the piece that is robust to the parameter being re-read.

### Behaviour changes a user may notice

- **Guest users now work.** A UPN containing `#EXT#` could not previously reach Graph intact from this node, because the `#` ended the path when the URL was parsed. It is now encoded, matching what Outlook, OneDrive and To Do already do.
- A percent-encoded value such as `jane%40contoso.com` is now rejected. It happened to work before, because Graph decoded it. The error copy tells the user to enter the ID as it appears in Entra. No supported entry point produces this form: both resource locators expose only "From list" and "By ID", there is no "By URL" mode, and both list pickers emit object IDs.
- An ID with leading or trailing whitespace is now rejected rather than sent. The value is validated untrimmed because the URL interpolates it untrimmed.

## How to test

1. Add a Microsoft Entra ID credential and a **Microsoft Entra ID** node, resource **User**.
2. **User > Get**, set the user field to **By ID**, and try each of: a plain object ID, a user principal name (`jane@contoso.com`), and a guest UPN (`user_contoso.com#EXT#@tenant.onmicrosoft.com`). All three should resolve; the last two appear percent-encoded on the wire.
3. Set the field to an expression such as `={{ "a/b" }}`. The node should fail with "The user ID is invalid" and issue no request.
4. **User > Update** on a guest UPN with one of `aboutMe`, `interests`, `mySite`, `schools` or `skills` set. This operation issues a second PATCH; both requests should target the same encoded path. Before this PR the second one was truncated at the `#` and targeted a different user.
5. **Group > Get** with a group name or email instead of an object ID should be rejected with "The group ID is invalid".

Automated: `cd packages/nodes-base && pnpm test nodes/Microsoft/Entra` (88 tests) and `pnpm test nodes/Microsoft/test/GenericFunctions.test.ts` (36). The whole `nodes/Microsoft` tree passes at 1510.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5498

## Notes for the reviewer

- **Scope is the Entra node only.** The same ID handling is being fixed in Microsoft Outlook, Excel and SharePoint as separate PRs on this ticket, per the team's per-node PR rule. Entra went first because its requests are directory-scoped and include `PATCH` and `DELETE`.
- **Encoding is applied at five sites where it is provably a no-op** (values that are always an object ID from a Graph response). Kept deliberately so "every ID interpolated into a Graph path is encoded" is checkable at every call site rather than requiring each future reader to re-derive provenance. A wiring test enforces it.
- **The guard refuses a stored `__regex`** on a resource-locator value. `$parameter[...]` honours a stored `__regex` while `extractValue` does not, so the two readers could otherwise disagree. No Entra mode declares `extractValue`; a test asserts that stays true, because adding one would make the editor write a `__regex` that it never removes.
- **Not changed here:** the OData `$search` / `$filter` string literals in `GenericFunctions.ts` interpolate the list-picker search text without escaping a quote. It is a real correctness bug for any name containing an apostrophe, but it is a query-string value against a collection the same caller can already list, so it is not part of this change. Happy to file it as a follow-up.
- `microsoftApiPaginateRequest` has no production callers anywhere in the repo. It is guarded rather than deleted, since removing an exported symbol would widen this diff.
- The guard runs per item. Under `Continue on Fail`, a rejected item does not stop a sibling item's request from being sent, which a test pins.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

