### PR TITLE
docs: Add STE100 writing rule to agent instructions (no-changelog)

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -14,6 +14,9 @@ compatibility:
 
 Create a Linear ticket or GitHub issue for: **$ARGUMENTS**
 
+Write all titles and descriptions in ASD-STE100 Simplified Technical English:
+use short sentences, the active voice, and one instruction for each sentence.
+
 ## Determine Target
 
 Decide where the issue should be created based on user input:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ frontend, and extensible node-based workflow engine.
 ## General Guidelines
 
 - Always use pnpm
+- Write all technical text (code comments, PR descriptions, issue and ticket
+  descriptions, docs) in ASD-STE100 Simplified Technical English: use short
+  sentences, the active voice, and one instruction for each sentence
 - **Secrets on the command line:** if a developer opted into anonymous dev
   metrics (`scripts/dev-metrics`), pnpm command arguments are recorded. Arguments
   of secret-carrying words (`config`, `login`, `publish`, `token`) — whether a


### PR DESCRIPTION
## Summary

Add the ASD-STE100 Simplified Technical English rule to the shared agent instructions:

- `AGENTS.md`: add one bullet to "General Guidelines". It tells agents to write all technical text (code comments, PR descriptions, issue and ticket descriptions, docs) in STE100.
- `.agents/skills/create-issue/SKILL.md`: add the same rule for ticket and issue titles and descriptions.

The `create-pr`, `conventions`, and `content-design` skills already contain this rule with the same phrasing. This PR extends it to issue creation and makes it a global guideline, so it also applies outside skill invocations.

## How to test

Documentation-only change. Read the two changed files and check the wording.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included. (Not applicable: documentation-only change.)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

