### PR TITLE
ci: Delete the e2e image tarball from the cache after e2e passes (no-changelog)

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -461,10 +461,12 @@ jobs:
       # Not `gh api --method DELETE`: written on Blacksmith runners, where
       # actions/cache is transparently intercepted, so GitHub's cache has no
       # such entry and the REST call would no-op.
+      # Key must track build-n8n-docker/load-n8n-docker; a mismatch makes the
+      # delete a silent no-op rather than a failure.
       - name: Delete the image tarball from the cache
         uses: useblacksmith/cache-delete@941f534fcf46c8d0a89feeceeb0f5377d82dd5e7 # v2
         with:
-          key: n8n-docker-image-standard-${{ github.sha }}
+          key: n8n-docker-image-v2-standard-${{ github.sha }}
 
   # Posts a QA metrics comparison comment on the PR.
   # Runs after all checks so any job can emit metrics before this reports.

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -439,6 +439,33 @@ jobs:
             --channel '#alerts-build' \
             --text "<${PR_URL}|Required Checks failed on the ${HEAD_REF} PR> - the batched fixes stay unpublished until it is green."
 
+  # The tarball is scoped to one run and nothing else deleted it, so it evicted
+  # the entries that are reused across runs (DEVP-912). Gated on the whole run
+  # being green, not just the image consumers: a re-run of a red workflow should
+  # restore the image rather than rebuild it.
+  #
+  # Blacksmith-only rather than following the usual `runs-on` provider switch: off
+  # Blacksmith the tarball lands in GitHub's own cache, which this action does not
+  # address, so there is nothing here to delete.
+  cleanup-docker-image:
+    name: Cleanup Docker image
+    needs: [prepare-docker, e2e-performance, required-checks]
+    if: |
+      always() &&
+      vars.RUNNER_PROVIDER != 'github' &&
+      needs.prepare-docker.result == 'success' &&
+      needs.required-checks.result == 'success' &&
+      (needs.e2e-performance.result == 'success' || needs.e2e-performance.result == 'skipped')
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    steps:
+      # Not `gh api --method DELETE`: written on Blacksmith runners, where
+      # actions/cache is transparently intercepted, so GitHub's cache has no
+      # such entry and the REST call would no-op.
+      - name: Delete the image tarball from the cache
+        uses: useblacksmith/cache-delete@941f534fcf46c8d0a89feeceeb0f5377d82dd5e7 # v2
+        with:
+          key: n8n-docker-image-standard-${{ github.sha }}
+
   # Posts a QA metrics comparison comment on the PR.
   # Runs after all checks so any job can emit metrics before this reports.
   post-qa-metrics-comment:


### PR DESCRIPTION
## Summary

Deletes the e2e Docker image tarball from the cache once e2e passes. One file, +30 lines.

`n8n-docker-image-<variant>-<sha>` is scoped to a single workflow run, but nothing ever deleted it. The Blacksmith Actions cache sat at **99.93% of its 50 GB per-repo limit**, with **28.96 GB across 68 of these entries — 58% of the pool** — so LRU evicted the entries that *are* reused across runs:

- Nothing last used more than ~10 hours ago survived.
- **No arm64 entry existed in either cache**, so the arm64 release build paid **227s of uncached `pnpm install`** every time.

The previous design pushed to `ghcr.io/n8n-io/n8n:ci-<run_id>` and had a `cleanup-ghcr` job. #28798 replaced it with the cache tarball — correctly, since `actions/cache` works from fork PRs where `packages: write` does not — but the cleanup was dropped and never replaced. This restores it.

## Measured

Deleting the 68 entries by hand:

| | Before | After |
|---|---|---|
| pool | **49.89 GB (99.93%)** | **24.11 GB (~48%)** |
| entries | 11,158 | 8,956 |
| `n8n-docker-image-*` | 60 / 25.63 GB | 0 |
| arm64 pnpm entries | **0** | **2** (738 MB, 737 MB) |

The arm64 stores appeared within the hour — the headroom doing what it should. But two tarballs were already back **11 minutes** after the deletion, and they accumulate at roughly **46–62 GB/day** against a 50 GB ceiling. The manual pass buys about one working day; this makes it stick.

## Implementation notes

**Success only.** A red run is the one someone re-runs, and a re-run should restore rather than rebuild. `load-n8n-docker` already falls back to a rebuild on a miss, so a deleted entry costs a rebuild, not a failure.

**`cache-delete`, not `gh api --method DELETE`.** These entries are written on Blacksmith runners where `actions/cache` is transparently intercepted, so they are absent from GitHub's cache (0 of 311 by that key) and the REST call would silently no-op. The action uses the runner's ambient identity — no org-wide token required.

## Considered and rejected: sticky disks

Blacksmith's docs recommend sticky disks for large artefacts, so I built and measured it. On [run 33221674685](https://github.com/n8n-io/n8n/actions/runs/33221674685) all 16 shards hydrated the disk correctly (`transport=sticky-disk result=hit` ×16, run green) — but the load step went from **21–33s to 229–305s**, ~10× slower, roughly an hour of added shard wall-clock per run.

Their "~3s mount vs ~66s restore" figure applies to mounting a filesystem you then use in place. We mount a disk, read a 436 MB tarball off it, and pipe it through `zstd -d | docker load`. The mount is cheap; the read is slower than the colocated cache's parallel download. Reverted; this PR is the cleanup alone.

## Not yet verified

**The job has never executed.** Its gate requires `prepare-docker` to have succeeded, and this PR's diff is `.github/**`-only, so impact selection returns 0/208 specs and e2e skips. `force-e2e` does not help — `skip_tests` is ANDed separately from the label check. First real execution will be on a PR that touches app code.

If it silently no-ops, the result is today's status quo, not something worse.

https://linear.app/n8n/issue/DEVP-912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
