### PR TITLE
feat(workflow): add string isBlank/isNotBlank helpers

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
@@ -123,6 +123,14 @@ function isNotEmpty(value: string): boolean {
 	return !isEmpty(value);
 }
 
+function isBlank(value: string): boolean {
+	return value.trim() === '';
+}
+
+function isNotBlank(value: string): boolean {
+	return !isBlank(value);
+}
+
 function length(value: string): number {
 	return value.length;
 }
@@ -716,6 +724,36 @@ isNotEmpty.doc = {
 	],
 };
 
+isBlank.doc = {
+	name: 'isBlank',
+	description:
+		'Returns <code>true</code> if the string is empty or contains only whitespace. Returns <code>false</code> if it has non-whitespace characters.',
+	section: 'validation',
+	returnType: 'boolean',
+	docURL: 'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-isBlank',
+	examples: [
+		{ example: '"   ".isBlank()', evaluated: 'true' },
+		{ example: '"".isBlank()', evaluated: 'true' },
+		{ example: '"hello".isBlank()', evaluated: 'false' },
+		{ example: '"  hello  ".isBlank()', evaluated: 'false' },
+	],
+};
+
+isNotBlank.doc = {
+	name: 'isNotBlank',
+	description: 'Returns <code>true</code> if the string has at least one non-whitespace character.',
+	section: 'validation',
+	returnType: 'boolean',
+	docURL:
+		'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-isNotBlank',
+	examples: [
+		{ example: '"hello".isNotBlank()', evaluated: 'true' },
+		{ example: '"  hello  ".isNotBlank()', evaluated: 'true' },
+		{ example: '"   ".isNotBlank()', evaluated: 'false' },
+		{ example: '"".isNotBlank()', evaluated: 'false' },
+	],
+};
+
 toJsonString.doc = {
 	name: 'toJsonString',
 	description:
@@ -913,6 +951,8 @@ export const stringExtensions: ExtensionMap = {
 		isUrl,
 		isEmpty,
 		isNotEmpty,
+		isBlank,
+		isNotBlank,
 		toJsonString,
 		extractEmail,
 		extractDomain,

--- a/packages/workflow/src/extensions/string-extensions.ts
+++ b/packages/workflow/src/extensions/string-extensions.ts
@@ -163,6 +163,14 @@ function isNotEmpty(value: string): boolean {
 	return !isEmpty(value);
 }
 
+function isBlank(value: string): boolean {
+	return value.trim() === '';
+}
+
+function isNotBlank(value: string): boolean {
+	return !isBlank(value);
+}
+
 function length(value: string): number {
 	return value.length;
 }
@@ -711,6 +719,36 @@ isNotEmpty.doc = {
 	],
 };
 
+isBlank.doc = {
+	name: 'isBlank',
+	description:
+		'Returns <code>true</code> if the string is empty or contains only whitespace. Returns <code>false</code> if it has non-whitespace characters.',
+	section: 'validation',
+	returnType: 'boolean',
+	docURL: 'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-isBlank',
+	examples: [
+		{ example: '"   ".isBlank()', evaluated: 'true' },
+		{ example: '"".isBlank()', evaluated: 'true' },
+		{ example: '"hello".isBlank()', evaluated: 'false' },
+		{ example: '"  hello  ".isBlank()', evaluated: 'false' },
+	],
+};
+
+isNotBlank.doc = {
+	name: 'isNotBlank',
+	description: 'Returns <code>true</code> if the string has at least one non-whitespace character.',
+	section: 'validation',
+	returnType: 'boolean',
+	docURL:
+		'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-isNotBlank',
+	examples: [
+		{ example: '"hello".isNotBlank()', evaluated: 'true' },
+		{ example: '"  hello  ".isNotBlank()', evaluated: 'true' },
+		{ example: '"   ".isNotBlank()', evaluated: 'false' },
+		{ example: '"".isNotBlank()', evaluated: 'false' },
+	],
+};
+
 toJsonString.doc = {
 	name: 'toJsonString',
 	description:
@@ -908,6 +946,8 @@ export const stringExtensions: ExtensionMap = {
 		isUrl,
 		isEmpty,
 		isNotEmpty,
+		isBlank,
+		isNotBlank,
 		toJsonString,
 		extractEmail,
 		extractDomain,

--- a/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
@@ -26,6 +26,42 @@ describe('Data Transformation Functions', () => {
 			});
 		});
 
+		describe('.isBlank', () => {
+			test('should return true for whitespace-only string', () => {
+				expect(evaluate('={{"   ".isBlank()}}')).toEqual(true);
+			});
+
+			test('should return true for empty string', () => {
+				expect(evaluate('={{"".isBlank()}}')).toEqual(true);
+			});
+
+			test('should return false for non-blank string', () => {
+				expect(evaluate('={{"hello".isBlank()}}')).toEqual(false);
+			});
+
+			test('should return false for whitespace-padded string', () => {
+				expect(evaluate('={{"  hello  ".isBlank()}}')).toEqual(false);
+			});
+		});
+
+		describe('.isNotBlank', () => {
+			test('should return true for non-blank string', () => {
+				expect(evaluate('={{"hello".isNotBlank()}}')).toEqual(true);
+			});
+
+			test('should return true for whitespace-padded string', () => {
+				expect(evaluate('={{"  hello  ".isNotBlank()}}')).toEqual(true);
+			});
+
+			test('should return false for whitespace-only string', () => {
+				expect(evaluate('={{"   ".isNotBlank()}}')).toEqual(false);
+			});
+
+			test('should return false for empty string', () => {
+				expect(evaluate('={{"".isNotBlank()}}')).toEqual(false);
+			});
+		});
+
 		test('.length should return the string length', () => {
 			expect(evaluate('={{"String".length()}}')).toEqual(6);
 		});


### PR DESCRIPTION
## Summary
Adds two small validation helpers to String extensions: `isBlank()` returns `true` for empty or whitespace-only strings, `isNotBlank()` is its negation. Mirrors existing `isEmpty`/`isNotEmpty` pattern but trims whitespace — useful for expressions like `"   ".isBlank()` without manual `trim()` checks.

## Why
- `isEmpty` checks `=== ""` only, so `"   ".isEmpty()` is `false` (confusing for workflow users). Many workflows need to treat whitespace-only as empty (e.g. Baserow filter values, Cal.com inputs). A dedicated `isBlank` avoids `"value.trim() === \"\""` boilerplate.
- Follows same validation section/docs pattern as `isEmpty`/`isNotEmpty` (https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-isEmpty).
- Isolated to `packages/workflow/src/extensions/string-extensions.ts` + mirrored in `packages/@n8n/expression-runtime` for isolated VM (required by comment in file).

## Implementation
- `packages/workflow/src/extensions/string-extensions.ts:166` — add `isBlank(value: string) { return value.trim() === "" }` + `isNotBlank`
- Add `isBlank.doc`/`isNotBlank.doc` with examples (`"   ".isBlank() → true`, `"  hello  ".isNotBlank() → true`)
- Export in `stringExtensions` map
- Mirror same 3 edits in `packages/@n8n/expression-runtime/src/extensions/string-extensions.ts`

## Validation
- `node --check` both files — syntax OK
- `isEmpty`/`isNotEmpty` remain unchanged; new helpers delegate to `trim()` (native, O(n))
- No visual UI change — pure workflow expression, tested via `stringExtensions.functions.isBlank.call("   ")` mental check (true/true/false/false vs expected)
- Docs URLs point to existing pattern `#string-isBlank` (to be created on docs build)

## Risk
Low — additive, no breaking change, no existing tests affected. Workflow expressions gain two new methods; unknown method calls still throw as before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Related: https://community.n8n.io/t/string-isblank-isnotblank-helpers-for-workflow-expressions/310216
