### PR TITLE
refactor(core): Extract execution setup and bootstrap from the main loop (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -61,7 +61,7 @@ import {
 	createRunExecutionData,
 	applyDynamicCredentialsUsage,
 } from 'n8n-workflow';
-import PCancelable from 'p-cancelable';
+import PCancelable, { type OnCancelFunction } from 'p-cancelable';
 
 import { ErrorReporter } from '@/errors/error-reporter';
 import { WorkflowHasIssuesError } from '@/errors/workflow-has-issues.error';
@@ -1575,6 +1575,95 @@ export class WorkflowExecute {
 		}
 	}
 
+	/**
+	 * Connect the PCancelable cancellation callback. On cancellation it aborts the
+	 * running nodes and reports the run so far through the lifecycle hooks.
+	 */
+	private setupCancellation(
+		onCancel: OnCancelFunction,
+		hooks: ExecutionLifecycleHooks,
+		startedAt: Date,
+	): void {
+		// Let as many nodes listen to the abort signal, without getting the MaxListenersExceededWarning
+		setMaxListeners(Infinity, this.abortController.signal);
+
+		onCancel.shouldReject = false;
+		onCancel(() => {
+			this.status = 'canceled';
+			this.updateTaskStatusesToCancelled();
+			this.abortController.abort();
+			const fullRunData = this.getFullRunData(startedAt);
+			void hooks.runHook('workflowExecuteAfter', [fullRunData]);
+		});
+	}
+
+	/**
+	 * Acquire the expression isolate, establish the execution context and run the first
+	 * lifecycle hook. If any of that fails, record the error on the first node of the
+	 * stack so it is saved correctly, then rethrow.
+	 */
+	private async initializeExecution(
+		workflow: Workflow,
+		hooks: ExecutionLifecycleHooks,
+	): Promise<void> {
+		try {
+			await workflow.expression.acquireIsolate();
+
+			// Establish the execution context
+			await establishExecutionContext(
+				workflow,
+				this.runExecutionData,
+				this.additionalData,
+				this.mode,
+			);
+
+			if (!this.additionalData.restartExecutionId) {
+				await hooks.runHook('workflowExecuteBefore', [workflow, this.runExecutionData]);
+			} else {
+				await hooks.runHook('workflowExecuteResume', [workflow, this.runExecutionData]);
+			}
+		} catch (error) {
+			const e = error as unknown as ExecutionBaseError;
+
+			// Set the error that it can be saved correctly
+			const executionError: ExecutionBaseError = {
+				...e,
+				message: e.message,
+				stack: e.stack,
+			};
+
+			// Set the incoming data of the node that it can be saved correctly.
+			// A Chat Trigger-only workflow has an empty stack, so there may be no node to
+			// blame — recording the error alone beats throwing over the top of it.
+			const startItem = this.runExecutionData.executionData!.nodeExecutionStack.at(0);
+
+			if (startItem) {
+				const taskData: ITaskData = {
+					startTime: Date.now(),
+					executionIndex: 0,
+					executionTime: 0,
+					data: {
+						main: startItem.data.main,
+					},
+					source: [],
+					executionStatus: 'error',
+					hints: [],
+				};
+				this.runExecutionData.resultData = {
+					runData: {
+						[startItem.node.name]: [taskData],
+					},
+					lastNodeExecuted: startItem.node.name,
+					error: executionError,
+				};
+			} else {
+				this.runExecutionData.resultData.error = executionError;
+			}
+
+			throw error;
+		}
+	}
+
 	/** True while there are nodes queued for execution. */
 	private isExecutionStackNotEmpty(): boolean {
 		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
@@ -1647,77 +1736,11 @@ export class WorkflowExecute {
 		let closeFunction: Promise<void> | undefined;
 
 		return new PCancelable(async (resolve, _reject, onCancel) => {
-			// Let as many nodes listen to the abort signal, without getting the MaxListenersExceededWarning
-			setMaxListeners(Infinity, this.abortController.signal);
-
-			onCancel.shouldReject = false;
-			onCancel(() => {
-				this.status = 'canceled';
-				this.updateTaskStatusesToCancelled();
-				this.abortController.abort();
-				const fullRunData = this.getFullRunData(startedAt);
-				void hooks.runHook('workflowExecuteAfter', [fullRunData]);
-			});
+			this.setupCancellation(onCancel, hooks, startedAt);
 
 			// eslint-disable-next-line complexity
 			const returnPromise = (async () => {
-				try {
-					await workflow.expression.acquireIsolate();
-
-					// Establish the execution context
-					await establishExecutionContext(
-						workflow,
-						this.runExecutionData,
-						this.additionalData,
-						this.mode,
-					);
-
-					if (!this.additionalData.restartExecutionId) {
-						await hooks.runHook('workflowExecuteBefore', [workflow, this.runExecutionData]);
-					} else {
-						await hooks.runHook('workflowExecuteResume', [workflow, this.runExecutionData]);
-					}
-				} catch (error) {
-					const e = error as unknown as ExecutionBaseError;
-
-					// Set the error that it can be saved correctly
-					executionError = {
-						...e,
-						message: e.message,
-						stack: e.stack,
-					};
-
-					// Set the incoming data of the node that it can be saved correctly.
-					// A Chat Trigger-only workflow has an empty stack, so there may be no node to
-					// blame — recording the error alone beats throwing over the top of it.
-					const startItem = this.runExecutionData.executionData!.nodeExecutionStack.at(0);
-
-					if (startItem) {
-						executionData = startItem;
-						const taskData: ITaskData = {
-							startTime: Date.now(),
-							executionIndex: 0,
-							executionTime: 0,
-							data: {
-								main: executionData.data.main,
-							},
-							source: [],
-							executionStatus: 'error',
-							hints: [],
-						};
-						this.runExecutionData.resultData = {
-							runData: {
-								[executionData.node.name]: [taskData],
-							},
-							lastNodeExecuted: executionData.node.name,
-							error: executionError,
-						};
-					} else {
-						this.runExecutionData.resultData.error = executionError;
-					}
-
-					throw error;
-				}
+				await this.initializeExecution(workflow, hooks);
 
 				executionLoop: while (this.isExecutionStackNotEmpty()) {
 					if (this.shouldStopExecuting()) {


### PR DESCRIPTION
## Summary

Move the two blocks that run before the execution loop into named methods:

- `setupCancellation` wires the `PCancelable` cancel callback.
- `initializeExecution` acquires the expression isolate, establishes the execution context and runs the first lifecycle hook.

The bootstrap catch block no longer assigns the loop-scoped `executionError` and `executionData` variables. It always rethrows, so those assignments were never read again.

---

### The stack

`processRunExecutionData` is 982 lines on `master`. This stack cuts it to 341 lines. Each PR extracts one phase of the loop into named private methods. Review and merge them in order.

1. #37387 — Name the loop control conditions
2. #37382 — Extract setup and bootstrap
3. #37383 — Extract the per-node preamble
4. #37384 — Extract the node run block
5. #37385 — Extract node error reporting
6. #37386 — Extract task data assembly
7. #37388 — Extract node scheduling

The stack splits #28374 by @ivan-kiselev and rebases it onto current `master`. The file moved by +302/−75 since that PR was written, so each extraction was redone against the new code, not replayed.

Two changes in #28374 are **not** carried over. Both look like regressions:

- It moved `assignPairedItems`, the `alwaysOutputData` block and the `nodeSuccessData === null` check out of the retry `try` block. After a node fails, `nodeSuccessData` is `null` and `executionError` is set, so the relocated `if (nodeSuccessData === null && !waitTill) continue executionLoop` skips the error handling. Errors get swallowed.
- It hoisted the pin-data lookup out of the retry loop, which is what forced the change above.

Every PR in the stack passes `pnpm test` (2083 tests), `pnpm typecheck`, ESLint and Biome in `packages/core`.

## How to test

This is a refactor. No behaviour change is intended.

```bash
cd packages/core
pnpm test
pnpm typecheck
```

Read the diff with `git diff --color-moved=zebra` to see the moved blocks.

## Related Linear tickets, Github issues, and Community forum posts

Splits and rebases #28374 by @ivan-kiselev.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
