### PR TITLE
refactor(core): Extract the per-node preamble of the execution loop (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1664,6 +1664,117 @@ export class WorkflowExecute {
 		}
 	}
 
+	/**
+	 * Prepare the dynamic-credential bookkeeping for the node that is about to run.
+	 *
+	 * A sub-execution that finished while this execution was waiting reported its
+	 * private-credential usage on the resumed stack entry (the node re-runs disabled,
+	 * so `executeWorkflow` never reports again). Restore it so the new task and
+	 * `runtimeData.executedByUserId` still inherit the flags. The stash is
+	 * transport-only, so consume it to keep it out of the persisted task metadata.
+	 */
+	private resetDynamicCredentialsUsage(executionData: IExecuteData): void {
+		this.additionalData.currentNodeUsedDynamicCredentials = false;
+		this.additionalData.currentNodeAttemptedDynamicCredentials = false;
+
+		const reportedUsage = executionData.metadata?.dynamicCredentialsUsage;
+		if (reportedUsage) {
+			applyDynamicCredentialsUsage(this.additionalData, reportedUsage);
+			delete executionData.metadata?.dynamicCredentialsUsage;
+		}
+	}
+
+	/** Create the task metadata that is known before the node runs. */
+	private createTaskStartedData(executionData: IExecuteData): ITaskStartedData {
+		return {
+			startTime: Date.now(),
+			executionIndex: this.additionalData.currentNodeExecutionIndex++,
+			source: !executionData.source ? [] : executionData.source.main,
+			hints: [],
+		};
+	}
+
+	/**
+	 * Stamp every input item with its `pairedItem` lineage, so an item can be traced back
+	 * to the item it came from.
+	 */
+	private addPairedItemLineage(executionData: IExecuteData): ITaskDataConnections {
+		const newTaskDataConnections: ITaskDataConnections = {};
+		for (const connectionType of Object.keys(executionData.data)) {
+			newTaskDataConnections[connectionType] = executionData.data[connectionType].map(
+				(input, inputIndex) => {
+					if (input === null) {
+						return input;
+					}
+
+					return input.map((item, itemIndex) => {
+						// Preserve any existing sourceOverwrite from the pairedItem
+						// for tool executions. Tool calls don't have a main
+						// connection to the agent's input, so the data proxy needs
+						// the sourceOverwrite information to know where to look up
+						// paired items. This is necessary because the workflow data
+						// proxy works on input data which normally scrubs paired
+						// item information before executing the node.
+						const sourceOverwrite = resolveSourceOverwrite(item, executionData);
+						if (sourceOverwrite) {
+							return {
+								...item,
+								pairedItem: {
+									item: itemIndex,
+									input: inputIndex || undefined,
+									sourceOverwrite,
+								},
+							};
+						}
+
+						return {
+							...item,
+							pairedItem: {
+								item: itemIndex,
+								input: inputIndex || undefined,
+							},
+						};
+					});
+				},
+			);
+		}
+		return newTaskDataConnections;
+	}
+
+	/**
+	 * The run index of this node execution. Engine requests set it explicitly. Otherwise
+	 * it is the number of times the node already ran.
+	 */
+	private computeRunIndex(executionData: IExecuteData): number {
+		if (executionData.runIndex !== undefined) {
+			return executionData.runIndex;
+		}
+
+		const { runData } = this.runExecutionData.resultData;
+		const nodeName = executionData.node.name;
+		return Object.hasOwn(runData, nodeName) ? runData[nodeName].length : 0;
+	}
+
+	/**
+	 * The retry budget for a node, as `[maxTries, waitBetweenTries]`.
+	 *
+	 * A node resuming with a sub-workflow error has already failed in the sub-workflow;
+	 * there is nothing to re-run, so don't apply retryOnFail (it would just re-throw the
+	 * same error after pointless waits without re-executing anything).
+	 */
+	private getRetryParams(executionData: IExecuteData): [number, number] {
+		const isResumedError = executionData.metadata?.resumeError !== undefined;
+		if (executionData.node.retryOnFail !== true || isResumedError) {
+			return [1, 0];
+		}
+
+		// TODO: Remove the hardcoded default-values here and also in NodeSettings.vue
+		return [
+			Math.min(5, Math.max(2, executionData.node.maxTries || 3)),
+			Math.min(5000, Math.max(0, executionData.node.waitBetweenTries || 1000)),
+		];
+	}
+
 	/** True while there are nodes queued for execution. */
 	private isExecutionStackNotEmpty(): boolean {
 		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
@@ -1754,77 +1865,14 @@ export class WorkflowExecute {
 					executionData = this.popExecutionStack();
 					executionNode = executionData.node;
 
-					// Reset per-node dynamic credential flags before each node execution
-					this.additionalData.currentNodeUsedDynamicCredentials = false;
-					this.additionalData.currentNodeAttemptedDynamicCredentials = false;
+					this.resetDynamicCredentialsUsage(executionData);
 
-					// A sub-execution that finished while this execution was waiting reported its
-					// private-credential usage on the resumed stack entry (the node re-runs disabled,
-					// so `executeWorkflow` never reports again) — restore it so the new task and
-					// `runtimeData.executedByUserId` still inherit the flags. The stash is
-					// transport-only, so consume it to keep it out of the persisted task metadata.
-					const reportedUsage = executionData.metadata?.dynamicCredentialsUsage;
-					if (reportedUsage) {
-						applyDynamicCredentialsUsage(this.additionalData, reportedUsage);
-						delete executionData.metadata?.dynamicCredentialsUsage;
-					}
-
-					const taskStartedData: ITaskStartedData = {
-						startTime: Date.now(),
-						executionIndex: this.additionalData.currentNodeExecutionIndex++,
-						source: !executionData.source ? [] : executionData.source.main,
-						hints: [],
-					};
+					const taskStartedData = this.createTaskStartedData(executionData);
 
 					// Update the pairedItem information on items
-					const newTaskDataConnections: ITaskDataConnections = {};
-					for (const connectionType of Object.keys(executionData.data)) {
-						newTaskDataConnections[connectionType] = executionData.data[connectionType].map(
-							(input, inputIndex) => {
-								if (input === null) {
-									return input;
-								}
+					executionData.data = this.addPairedItemLineage(executionData);
 
-								return input.map((item, itemIndex) => {
-									// Preserve any existing sourceOverwrite from the pairedItem
-									// for tool executions. Tool calls don't have a main
-									// connection to the agent's input, so the data proxy needs
-									// the sourceOverwrite information to know where to look up
-									// paired items. This is necessary because the workflow data
-									// proxy works on input data which normally scrubs paired
-									// item information before executing the node.
-									const sourceOverwrite = resolveSourceOverwrite(item, executionData);
-									if (sourceOverwrite) {
-										return {
-											...item,
-											pairedItem: {
-												item: itemIndex,
-												input: inputIndex || undefined,
-												sourceOverwrite,
-											},
-										};
-									}
-
-									return {
-										...item,
-										pairedItem: {
-											item: itemIndex,
-											input: inputIndex || undefined,
-										},
-									};
-								});
-							},
-						);
-					}
-					executionData.data = newTaskDataConnections;
-
-					// Get the index of the current run
-					runIndex = 0;
-					if (executionData.runIndex !== undefined) {
-						runIndex = executionData.runIndex;
-					} else if (Object.hasOwn(this.runExecutionData.resultData.runData, executionNode.name)) {
-						runIndex = this.runExecutionData.resultData.runData[executionNode.name].length;
-					}
+					runIndex = this.computeRunIndex(executionData);
 
 					currentExecutionTry = `${executionNode.name}:${runIndex}`;
 					if (currentExecutionTry === lastExecutionTry) {
@@ -1855,27 +1903,10 @@ export class WorkflowExecute {
 					if (!executionData.metadata?.nodeWasResumed) {
 						await hooks.runHook('nodeExecuteBefore', [executionNode.name, taskStartedData]);
 					}
-					let maxTries = 1;
 					const isErrorValue = (v: unknown) => v !== undefined && v !== null && v !== false;
 					const checkFailure = (data: IRunNodeResponse | EngineRequest) =>
 						!isEngineRequest(data) && isErrorValue(data.data?.[0]?.[0]?.json?.error);
-					// A node resuming with a sub-workflow error has already failed in the sub-workflow;
-					// there is nothing to re-run, so don't apply retryOnFail (it would just re-throw the
-					// same error after pointless waits without re-executing anything).
-					const isResumedError = executionData.metadata?.resumeError !== undefined;
-					if (executionData.node.retryOnFail === true && !isResumedError) {
-						// TODO: Remove the hardcoded default-values here and also in NodeSettings.vue
-						maxTries = Math.min(5, Math.max(2, executionData.node.maxTries || 3));
-					}
-
-					let waitBetweenTries = 0;
-					if (executionData.node.retryOnFail === true && !isResumedError) {
-						// TODO: Remove the hardcoded default-values here and also in NodeSettings.vue
-						waitBetweenTries = Math.min(
-							5000,
-							Math.max(0, executionData.node.waitBetweenTries || 1000),
-						);
-					}
+					const [maxTries, waitBetweenTries] = this.getRetryParams(executionData);
 
 					for (let tryIndex = 0; tryIndex < maxTries; tryIndex++) {
 						try {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -61,7 +61,7 @@ import {
 	createRunExecutionData,
 	applyDynamicCredentialsUsage,
 } from 'n8n-workflow';
-import PCancelable from 'p-cancelable';
+import PCancelable, { type OnCancelFunction } from 'p-cancelable';
 
 import { ErrorReporter } from '@/errors/error-reporter';
 import { WorkflowHasIssuesError } from '@/errors/workflow-has-issues.error';
@@ -1575,6 +1575,95 @@ export class WorkflowExecute {
 		}
 	}
 
+	/**
+	 * Connect the PCancelable cancellation callback. On cancellation it aborts the
+	 * running nodes and reports the run so far through the lifecycle hooks.
+	 */
+	private setupCancellation(
+		onCancel: OnCancelFunction,
+		hooks: ExecutionLifecycleHooks,
+		startedAt: Date,
+	): void {
+		// Let as many nodes listen to the abort signal, without getting the MaxListenersExceededWarning
+		setMaxListeners(Infinity, this.abortController.signal);
+
+		onCancel.shouldReject = false;
+		onCancel(() => {
+			this.status = 'canceled';
+			this.updateTaskStatusesToCancelled();
+			this.abortController.abort();
+			const fullRunData = this.getFullRunData(startedAt);
+			void hooks.runHook('workflowExecuteAfter', [fullRunData]);
+		});
+	}
+
+	/**
+	 * Acquire the expression isolate, establish the execution context and run the first
+	 * lifecycle hook. If any of that fails, record the error on the first node of the
+	 * stack so it is saved correctly, then rethrow.
+	 */
+	private async initializeExecution(
+		workflow: Workflow,
+		hooks: ExecutionLifecycleHooks,
+	): Promise<void> {
+		try {
+			await workflow.expression.acquireIsolate();
+
+			// Establish the execution context
+			await establishExecutionContext(
+				workflow,
+				this.runExecutionData,
+				this.additionalData,
+				this.mode,
+			);
+
+			if (!this.additionalData.restartExecutionId) {
+				await hooks.runHook('workflowExecuteBefore', [workflow, this.runExecutionData]);
+			} else {
+				await hooks.runHook('workflowExecuteResume', [workflow, this.runExecutionData]);
+			}
+		} catch (error) {
+			const e = error as unknown as ExecutionBaseError;
+
+			// Set the error that it can be saved correctly
+			const executionError: ExecutionBaseError = {
+				...e,
+				message: e.message,
+				stack: e.stack,
+			};
+
+			// Set the incoming data of the node that it can be saved correctly.
+			// A Chat Trigger-only workflow has an empty stack, so there may be no node to
+			// blame — recording the error alone beats throwing over the top of it.
+			const startItem = this.runExecutionData.executionData!.nodeExecutionStack.at(0);
+
+			if (startItem) {
+				const taskData: ITaskData = {
+					startTime: Date.now(),
+					executionIndex: 0,
+					executionTime: 0,
+					data: {
+						main: startItem.data.main,
+					},
+					source: [],
+					executionStatus: 'error',
+					hints: [],
+				};
+				this.runExecutionData.resultData = {
+					runData: {
+						[startItem.node.name]: [taskData],
+					},
+					lastNodeExecuted: startItem.node.name,
+					error: executionError,
+				};
+			} else {
+				this.runExecutionData.resultData.error = executionError;
+			}
+
+			throw error;
+		}
+	}
+
 	/** True while there are nodes queued for execution. */
 	private isExecutionStackNotEmpty(): boolean {
 		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
@@ -1647,77 +1736,11 @@ export class WorkflowExecute {
 		let closeFunction: Promise<void> | undefined;
 
 		return new PCancelable(async (resolve, _reject, onCancel) => {
-			// Let as many nodes listen to the abort signal, without getting the MaxListenersExceededWarning
-			setMaxListeners(Infinity, this.abortController.signal);
-
-			onCancel.shouldReject = false;
-			onCancel(() => {
-				this.status = 'canceled';
-				this.updateTaskStatusesToCancelled();
-				this.abortController.abort();
-				const fullRunData = this.getFullRunData(startedAt);
-				void hooks.runHook('workflowExecuteAfter', [fullRunData]);
-			});
+			this.setupCancellation(onCancel, hooks, startedAt);
 
 			// eslint-disable-next-line complexity
 			const returnPromise = (async () => {
-				try {
-					await workflow.expression.acquireIsolate();
-
-					// Establish the execution context
-					await establishExecutionContext(
-						workflow,
-						this.runExecutionData,
-						this.additionalData,
-						this.mode,
-					);
-
-					if (!this.additionalData.restartExecutionId) {
-						await hooks.runHook('workflowExecuteBefore', [workflow, this.runExecutionData]);
-					} else {
-						await hooks.runHook('workflowExecuteResume', [workflow, this.runExecutionData]);
-					}
-				} catch (error) {
-					const e = error as unknown as ExecutionBaseError;
-
-					// Set the error that it can be saved correctly
-					executionError = {
-						...e,
-						message: e.message,
-						stack: e.stack,
-					};
-
-					// Set the incoming data of the node that it can be saved correctly.
-					// A Chat Trigger-only workflow has an empty stack, so there may be no node to
-					// blame — recording the error alone beats throwing over the top of it.
-					const startItem = this.runExecutionData.executionData!.nodeExecutionStack.at(0);
-
-					if (startItem) {
-						executionData = startItem;
-						const taskData: ITaskData = {
-							startTime: Date.now(),
-							executionIndex: 0,
-							executionTime: 0,
-							data: {
-								main: executionData.data.main,
-							},
-							source: [],
-							executionStatus: 'error',
-							hints: [],
-						};
-						this.runExecutionData.resultData = {
-							runData: {
-								[executionData.node.name]: [taskData],
-							},
-							lastNodeExecuted: executionData.node.name,
-							error: executionError,
-						};
-					} else {
-						this.runExecutionData.resultData.error = executionError;
-					}
-
-					throw error;
-				}
+				await this.initializeExecution(workflow, hooks);
 
 				executionLoop: while (this.isExecutionStackNotEmpty()) {
 					if (this.shouldStopExecuting()) {


### PR DESCRIPTION
## Summary

Move the work the loop does before it runs a node into named methods:

- `resetDynamicCredentialsUsage`
- `createTaskStartedData`
- `addPairedItemLineage`
- `computeRunIndex`
- `getRetryParams`

`getRetryParams` returns both retry values from one branch. The old code tested `retryOnFail` and `isResumedError` twice, once for each value.

---

### The stack

`processRunExecutionData` is 982 lines on `master`. This stack cuts it to 341 lines. Each PR extracts one phase of the loop into named private methods. Review and merge them in order.

1. #37387 — Name the loop control conditions
2. #37382 — Extract setup and bootstrap
3. #37383 — Extract the per-node preamble
4. #37384 — Extract the node run block
5. #37385 — Extract node error reporting
6. #37386 — Extract task data assembly
7. #37388 — Extract node scheduling

The stack splits #28374 by @ivan-kiselev and rebases it onto current `master`. The file moved by +302/−75 since that PR was written, so each extraction was redone against the new code, not replayed.

Two changes in #28374 are **not** carried over. Both look like regressions:

- It moved `assignPairedItems`, the `alwaysOutputData` block and the `nodeSuccessData === null` check out of the retry `try` block. After a node fails, `nodeSuccessData` is `null` and `executionError` is set, so the relocated `if (nodeSuccessData === null && !waitTill) continue executionLoop` skips the error handling. Errors get swallowed.
- It hoisted the pin-data lookup out of the retry loop, which is what forced the change above.

Every PR in the stack passes `pnpm test` (2083 tests), `pnpm typecheck`, ESLint and Biome in `packages/core`.

## How to test

This is a refactor. No behaviour change is intended.

```bash
cd packages/core
pnpm test
pnpm typecheck
```

Read the diff with `git diff --color-moved=zebra` to see the moved blocks.

## Related Linear tickets, Github issues, and Community forum posts

Splits and rebases #28374 by @ivan-kiselev.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
