### PR TITLE
refactor(core): Extract the node run block of the execution loop (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1775,6 +1775,77 @@ export class WorkflowExecute {
 		];
 	}
 
+	/** The pinned output of a node, or undefined if the node has none. */
+	private getPinnedOutput(node: INode): INodeExecutionData[][] | undefined {
+		const { pinData } = this.runExecutionData.resultData;
+		if (!pinData || node.disabled || pinData[node.name] === undefined) {
+			return undefined;
+		}
+
+		return [pinData[node.name]]; // always zeroth runIndex
+	}
+
+	/**
+	 * Collect the results of the sub-nodes an AI agent asked for, so the agent can
+	 * resume with them. Does nothing if the node is not resuming from a tool call.
+	 */
+	private collectSubNodeResults(
+		executionData: IExecuteData,
+		subNodeExecutionResults: EngineResponse,
+	): void {
+		const { subNodeExecutionData } = executionData.metadata ?? {};
+		if (!subNodeExecutionData) return;
+
+		subNodeExecutionResults.metadata = subNodeExecutionData.metadata;
+		for (const subNode of subNodeExecutionData.actions) {
+			const nodeRunData = this.runExecutionData.resultData.runData[subNode.nodeName];
+			if (nodeRunData?.[subNode.runIndex]) {
+				subNodeExecutionResults.actionResponses.push({
+					data: nodeRunData[subNode.runIndex],
+					action: subNode.action,
+				});
+			}
+		}
+	}
+
+	/**
+	 * Post-process the raw output of a node: move binary data to the configured storage,
+	 * collect the hints it reported and route items to the error output if it is enabled.
+	 * Returns the output data and the close function the node asked to run at the end.
+	 */
+	private async processNodeOutput(
+		runNodeData: IRunNodeResponse,
+		workflow: Workflow,
+		executionData: IExecuteData,
+		taskStartedData: ITaskStartedData,
+		runIndex: number,
+	): Promise<{
+		nodeSuccessData: INodeExecutionData[][] | null | undefined;
+		closeFunction: Promise<void> | undefined;
+	}> {
+		const converted = await convertBinaryData(
+			workflow.id,
+			this.additionalData.executionId,
+			runNodeData,
+			workflow.settings.binaryMode,
+		);
+
+		const nodeSuccessData = converted.data;
+
+		if (converted.hints?.length) {
+			taskStartedData.hints!.push(...converted.hints);
+		}
+
+		if (nodeSuccessData && executionData.node.onError === 'continueErrorOutput') {
+			this.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, runIndex);
+		}
+
+		// Explanation why we do this can be found in n8n-workflow/Workflow.ts -> runNode
+		const closeFunction = converted.closeFunction?.();
+
+		return { nodeSuccessData, closeFunction };
+	}
+
 	/** True while there are nodes queued for execution. */
 	private isExecutionStackNotEmpty(): boolean {
 		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
@@ -1925,27 +1996,12 @@ export class WorkflowExecute {
 								}
 							}
 
-							const { pinData } = this.runExecutionData.resultData;
+							const pinnedOutput = this.getPinnedOutput(executionNode);
 
-							if (pinData && !executionNode.disabled && pinData[executionNode.name] !== undefined) {
-								const nodePinData = pinData[executionNode.name];
-
-								nodeSuccessData = [nodePinData]; // always zeroth runIndex
+							if (pinnedOutput) {
+								nodeSuccessData = pinnedOutput;
 							} else {
-								if (executionData.metadata?.subNodeExecutionData) {
-									subNodeExecutionResults.metadata =
-										executionData.metadata.subNodeExecutionData.metadata;
-									for (const subNode of executionData.metadata.subNodeExecutionData.actions) {
-										const nodeRunData = this.runExecutionData.resultData.runData[subNode.nodeName];
-										if (nodeRunData && nodeRunData[subNode.runIndex]) {
-											const data = nodeRunData[subNode.runIndex];
-											subNodeExecutionResults.actionResponses.push({
-												data,
-												action: subNode.action,
-											});
-										}
-									}
-								}
+								this.collectSubNodeResults(executionData, subNodeExecutionResults);
 
 								Logger.debug(`Running node "${executionNode.name}" started`, {
 									node: executionNode.name,
@@ -1996,28 +2052,16 @@ export class WorkflowExecute {
 									continue executionLoop;
 								}
 
-								runNodeData = await convertBinaryData(
-									workflow.id,
-									this.additionalData.executionId,
+								const nodeOutput = await this.processNodeOutput(
 									runNodeData,
-									workflow.settings.binaryMode,
+									workflow,
+									executionData,
+									taskStartedData,
+									runIndex,
 								);
-
-								nodeSuccessData = runNodeData.data;
-
-								if (runNodeData.hints?.length) {
-									taskStartedData.hints!.push.apply(taskStartedData.hints!, runNodeData.hints);
-								}
-
-								if (nodeSuccessData && executionData.node.onError === 'continueErrorOutput') {
-									this.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, runIndex);
-								}
-
-								if (runNodeData.closeFunction) {
-									// Explanation why we do this can be found in n8n-workflow/Workflow.ts -> runNode
-
-									closeFunction = runNodeData.closeFunction();
-								}
+								nodeSuccessData = nodeOutput.nodeSuccessData;
+								// Keep the close function of an earlier node if this one registered none
+								closeFunction = nodeOutput.closeFunction ?? closeFunction;
 							}
 
 							Logger.debug(`Running node "${executionNode.name}" finished successfully`, {


### PR DESCRIPTION
## Summary

Move the work around a single node run into named methods:

- `getPinnedOutput` replaces the inline pin-data lookup and flattens the pinned / not-pinned branch.
- `collectSubNodeResults` gathers the sub-node results an AI agent resumes with.
- `processNodeOutput` converts binary data, collects hints and routes items to the error output.

**One point for the reviewer.** The old code assigned `closeFunction` only when the node registered one, so a close function survived the nodes that came after it. The obvious extraction overwrites it with `undefined`. This PR keeps the old behaviour with `?? closeFunction` and a comment. It reads like a latent bug, but a refactor is the wrong place to change it.

---

### The stack

`processRunExecutionData` is 982 lines on `master`. This stack cuts it to 341 lines. Each PR extracts one phase of the loop into named private methods. Review and merge them in order.

1. #37387 — Name the loop control conditions
2. #37382 — Extract setup and bootstrap
3. #37383 — Extract the per-node preamble
4. #37384 — Extract the node run block
5. #37385 — Extract node error reporting
6. #37386 — Extract task data assembly
7. #37388 — Extract node scheduling

The stack splits #28374 by @ivan-kiselev and rebases it onto current `master`. The file moved by +302/−75 since that PR was written, so each extraction was redone against the new code, not replayed.

Two changes in #28374 are **not** carried over. Both look like regressions:

- It moved `assignPairedItems`, the `alwaysOutputData` block and the `nodeSuccessData === null` check out of the retry `try` block. After a node fails, `nodeSuccessData` is `null` and `executionError` is set, so the relocated `if (nodeSuccessData === null && !waitTill) continue executionLoop` skips the error handling. Errors get swallowed.
- It hoisted the pin-data lookup out of the retry loop, which is what forced the change above.

Every PR in the stack passes `pnpm test` (2083 tests), `pnpm typecheck`, ESLint and Biome in `packages/core`.

## How to test

This is a refactor. No behaviour change is intended.

```bash
cd packages/core
pnpm test
pnpm typecheck
```

Read the diff with `git diff --color-moved=zebra` to see the moved blocks.

## Related Linear tickets, Github issues, and Community forum posts

Splits and rebases #28374 by @ivan-kiselev.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
