### PR TITLE
refactor(core): Extract node error reporting from the execution loop (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1846,6 +1846,79 @@ export class WorkflowExecute {
 		return { nodeSuccessData, closeFunction };
 	}
 
+	/**
+	 * The error to send to the error reporter, or undefined if this error must not be
+	 * reported. Errors of our own classes report their cause. Other errors report only
+	 * their class and call frames, because their message can hold user data.
+	 */
+	private buildErrorReport(error: unknown): Error | undefined {
+		if (error instanceof ApplicationError) {
+			// Report any unhandled errors that were wrapped in by one of our error classes
+			return error.cause instanceof Error ? error.cause : undefined;
+		}
+
+		if (error instanceof BaseError) {
+			// BaseError subclasses specify shouldReport and level
+			// so always report and let beforeSend decide
+			return error;
+		}
+
+		if (!(error instanceof Error) || isAxiosError(error)) {
+			// Axios errors are suppressed in ErrorReporter's beforeSend via the
+			// `isAxiosError` brand, which sanitizing below would strip - so skip them here
+			return undefined;
+		}
+
+		// Non-BaseError errors only report their class and call frames
+		// The full error is still stored in the execution resultData
+		// Stack frames are in the format `<name>: <message>\n<call frames>`
+		// they can span multiple lines, so we drop everything except call frame lines
+		const errorClass = error.name || 'Error';
+		const sanitized = new Error(errorClass);
+		sanitized.name = errorClass;
+		const frames = (error.stack ?? '').split('\n').filter((line) => /^\s+at\s/.test(line));
+		sanitized.stack = [errorClass, ...frames].join('\n');
+		return sanitized;
+	}
+
+	/**
+	 * Handle an error a node threw: mark the node as the last one executed, report the
+	 * error and return it in the serializable shape the run data stores.
+	 */
+	private reportNodeExecutionError(
+		error: unknown,
+		executionNode: INode,
+		workflow: Workflow,
+	): ExecutionBaseError {
+		this.runExecutionData.resultData.lastNodeExecuted = executionNode.name;
+
+		const toReport = this.buildErrorReport(error);
+		if (toReport) {
+			const { executionId, instanceBaseUrl } = this.additionalData;
+			Container.get(ErrorReporter).error(toReport, {
+				extra: {
+					nodeName: executionNode.name,
+					nodeType: executionNode.type,
+					nodeVersion: executionNode.typeVersion,
+					workflowId: workflow.id,
+					executionId,
+					executionUrl:
+						instanceBaseUrl && executionId
+							? `${instanceBaseUrl}workflow/${workflow.id}/executions/${executionId}`
+							: undefined,
+				},
+			});
+		}
+
+		Logger.debug(`Running node "${executionNode.name}" finished with error`, {
+			node: executionNode.name,
+			workflowId: workflow.id,
+		});
+
+		const e = normalizeUnhandledAxiosError(error, executionNode);
+		return { ...e, message: e.message, stack: e.stack };
+	}
+
 	/** True while there are nodes queued for execution. */
 	private isExecutionStackNotEmpty(): boolean {
 		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
@@ -2111,57 +2184,7 @@ export class WorkflowExecute {
 
 							break;
 						} catch (error) {
-							this.runExecutionData.resultData.lastNodeExecuted = executionData.node.name;
-
-							let toReport: Error | undefined;
-							if (error instanceof ApplicationError) {
-								// Report any unhandled errors that were wrapped in by one of our error classes
-								if (error.cause instanceof Error) toReport = error.cause;
-							} else if (error instanceof BaseError) {
-								// BaseError subclasses specify shouldReport and level
-								// so always report and let beforeSend decide
-								toReport = error;
-							} else if (error instanceof Error && !isAxiosError(error)) {
-								// Axios errors are suppressed in ErrorReporter's beforeSend via the
-								// `isAxiosError` brand, which sanitizing below would strip - so skip them here
-								// Non-BaseError errors only report their class and call frames
-								// The full error is still stored in the execution resultData
-								// Stack frames are in the format `<name>: <message>\n<call frames>`
-								// they can span multiple lines, so we drop everything except call frame lines
-								const errorClass = error.name || 'Error';
-								const sanitized = new Error(errorClass);
-								sanitized.name = errorClass;
-								const frames = (error.stack ?? '')
-									.split('\n')
-									.filter((line) => /^\s+at\s/.test(line));
-								sanitized.stack = [errorClass, ...frames].join('\n');
-								toReport = sanitized;
-							}
-							if (toReport) {
-								const { executionId, instanceBaseUrl } = this.additionalData;
-								Container.get(ErrorReporter).error(toReport, {
-									extra: {
-										nodeName: executionNode.name,
-										nodeType: executionNode.type,
-										nodeVersion: executionNode.typeVersion,
-										workflowId: workflow.id,
-										executionId,
-										executionUrl:
-											instanceBaseUrl && executionId
-												? `${instanceBaseUrl}workflow/${workflow.id}/executions/${executionId}`
-												: undefined,
-									},
-								});
-							}
-
-							const e = normalizeUnhandledAxiosError(error, executionNode);
-
-							executionError = { ...e, message: e.message, stack: e.stack };
-
-							Logger.debug(`Running node "${executionNode.name}" finished with error`, {
-								node: executionNode.name,
-								workflowId: workflow.id,
-							});
+							executionError = this.reportNodeExecutionError(error, executionNode, workflow);
 						}
 					}
 


### PR DESCRIPTION
## Summary

Move the catch block of the node retry loop into two named methods:

- `buildErrorReport` decides what to send to the error reporter. The chain of `if`/`else if` became early returns.
- `reportNodeExecutionError` records the failing node, reports the error and returns it in the serializable shape the run data stores.

---

### The stack

`processRunExecutionData` is 982 lines on `master`. This stack cuts it to 341 lines. Each PR extracts one phase of the loop into named private methods. Review and merge them in order.

1. #37387 — Name the loop control conditions
2. #37382 — Extract setup and bootstrap
3. #37383 — Extract the per-node preamble
4. #37384 — Extract the node run block
5. #37385 — Extract node error reporting
6. #37386 — Extract task data assembly
7. #37388 — Extract node scheduling

The stack splits #28374 by @ivan-kiselev and rebases it onto current `master`. The file moved by +302/−75 since that PR was written, so each extraction was redone against the new code, not replayed.

Two changes in #28374 are **not** carried over. Both look like regressions:

- It moved `assignPairedItems`, the `alwaysOutputData` block and the `nodeSuccessData === null` check out of the retry `try` block. After a node fails, `nodeSuccessData` is `null` and `executionError` is set, so the relocated `if (nodeSuccessData === null && !waitTill) continue executionLoop` skips the error handling. Errors get swallowed.
- It hoisted the pin-data lookup out of the retry loop, which is what forced the change above.

Every PR in the stack passes `pnpm test` (2083 tests), `pnpm typecheck`, ESLint and Biome in `packages/core`.

## How to test

This is a refactor. No behaviour change is intended.

```bash
cd packages/core
pnpm test
pnpm typecheck
```

Read the diff with `git diff --color-moved=zebra` to see the moved blocks.

## Related Linear tickets, Github issues, and Community forum posts

Splits and rebases #28374 by @ivan-kiselev.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
