### PR TITLE
refactor(core): Name the execution loop control conditions (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -363,7 +363,7 @@ export class WorkflowExecute {
 						taskData.metadata = { ...taskData.metadata, ...metaRunData };
 					} else {
 						Container.get(ErrorReporter).error(
-							new UnexpectedError('Taskdata missing at the end of an execution'),
+							new UnexpectedError('Task data missing at the end of an execution'),
 							{ extra: { nodeName, index } },
 						);
 					}
@@ -1575,6 +1575,53 @@ export class WorkflowExecute {
 		}
 	}
 
+	/** True while there are nodes queued for execution. */
+	private isExecutionStackNotEmpty(): boolean {
+		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
+	}
+
+	/** Dequeue the next node to execute from the front of the execution stack. */
+	private popExecutionStack(): IExecuteData {
+		return this.runExecutionData.executionData!.nodeExecutionStack.shift() as IExecuteData;
+	}
+
+	/** Push a node back to the front of the execution stack, so it runs again next. */
+	private pushExecutionStack(executionData: IExecuteData): void {
+		this.runExecutionData.executionData!.nodeExecutionStack.unshift(executionData);
+	}
+
+	/** True if the execution has passed its configured timeout. */
+	private hasExecutionTimedOut(): boolean {
+		return (
+			this.additionalData.executionTimeoutTimestamp !== undefined &&
+			Date.now() >= this.additionalData.executionTimeoutTimestamp
+		);
+	}
+
+	/**
+	 * True if the loop must stop now. Marks the execution as timed-out first if its
+	 * timeout has passed, so a timeout is reported as a cancellation.
+	 */
+	private shouldStopExecuting(): boolean {
+		if (this.hasExecutionTimedOut()) {
+			this.status = 'canceled';
+			this.timedOut = true;
+		}
+
+		return this.status === 'canceled';
+	}
+
+	/**
+	 * True if a node filter is set and this node is not in it. The filter holds only the
+	 * nodes on the path to the destination node. Skipping the others avoids execution of
+	 * leaves that are parallel to the destination node. Normally they would execute,
+	 * because they have the same parent and all child nodes of a parent execute.
+	 */
+	private isNodeFilteredOut(nodeName: string): boolean {
+		const { runNodeFilter } = this.runExecutionData.startData!;
+		return runNodeFilter !== undefined && !runNodeFilter.includes(nodeName);
+	}
+
 	/**
 	 * Runs the given execution data.
 	 *
@@ -1672,18 +1719,8 @@ export class WorkflowExecute {
 					throw error;
 				}
 
-				executionLoop: while (
-					this.runExecutionData.executionData!.nodeExecutionStack.length !== 0
-				) {
-					if (
-						this.additionalData.executionTimeoutTimestamp !== undefined &&
-						Date.now() >= this.additionalData.executionTimeoutTimestamp
-					) {
-						this.status = 'canceled';
-						this.timedOut = true;
-					}
-
-					if (this.status === 'canceled') {
+				executionLoop: while (this.isExecutionStackNotEmpty()) {
+					if (this.shouldStopExecuting()) {
 						return;
 					}
 
@@ -1691,8 +1728,7 @@ export class WorkflowExecute {
 
 					let nodeSuccessData: INodeExecutionData[][] | null | undefined = null;
 					executionError = undefined;
-					executionData =
-						this.runExecutionData.executionData!.nodeExecutionStack.shift() as IExecuteData;
+					executionData = this.popExecutionStack();
 					executionNode = executionData.node;
 
 					// Reset per-node dynamic credential flags before each node execution
@@ -1772,13 +1808,7 @@ export class WorkflowExecute {
 						throw new UserError('Stopped execution because it seems to be in an endless loop');
 					}
 
-					if (
-						this.runExecutionData.startData!.runNodeFilter !== undefined &&
-						this.runExecutionData.startData!.runNodeFilter.indexOf(executionNode.name) === -1
-					) {
-						// If filter is set and node is not on filter skip it, that avoids the problem that it executes
-						// leaves that are parallel to a selected destinationNode. Normally it would execute them because
-						// they have the same parent and it executes all child nodes.
+					if (this.isNodeFilteredOut(executionNode.name)) {
 						continue;
 					}
 
@@ -2137,7 +2167,7 @@ export class WorkflowExecute {
 							}
 
 							// Add the execution data again so that it can get restarted
-							this.runExecutionData.executionData!.nodeExecutionStack.unshift(executionData);
+							this.pushExecutionStack(executionData);
 							// Only execute the nodeExecuteAfter hook if the node did not get aborted
 							if (!this.isCancelled) {
 								await hooks.runHook('nodeExecuteAfter', [
@@ -2209,7 +2239,7 @@ export class WorkflowExecute {
 						]);
 
 						// Add the node back to the stack that the workflow can start to execute again from that node
-						this.runExecutionData.executionData!.nodeExecutionStack.unshift(executionData);
+						this.pushExecutionStack(executionData);
 
 						break;
 					}


### PR DESCRIPTION
## Summary

`processRunExecutionData` holds the main execution loop. It is 982 lines long. This stack of 7 PRs cuts it to 341 lines. Each PR extracts one phase of the loop into named private methods.

This PR names the conditions that control the loop. It is a pure rename of inline expressions:

- `isExecutionStackNotEmpty` / `popExecutionStack` / `pushExecutionStack`
- `hasExecutionTimedOut` / `shouldStopExecuting`
- `isNodeFilteredOut`

It also corrects a typo in an error message: `Taskdata` becomes `Task data`.

---

### The stack

`processRunExecutionData` is 982 lines on `master`. This stack cuts it to 341 lines. Each PR extracts one phase of the loop into named private methods. Review and merge them in order.

1. #37387 — Name the loop control conditions
2. #37382 — Extract setup and bootstrap
3. #37383 — Extract the per-node preamble
4. #37384 — Extract the node run block
5. #37385 — Extract node error reporting
6. #37386 — Extract task data assembly
7. #37388 — Extract node scheduling

The stack splits #28374 by @ivan-kiselev and rebases it onto current `master`. The file moved by +302/−75 since that PR was written, so each extraction was redone against the new code, not replayed.

Two changes in #28374 are **not** carried over. Both look like regressions:

- It moved `assignPairedItems`, the `alwaysOutputData` block and the `nodeSuccessData === null` check out of the retry `try` block. After a node fails, `nodeSuccessData` is `null` and `executionError` is set, so the relocated `if (nodeSuccessData === null && !waitTill) continue executionLoop` skips the error handling. Errors get swallowed.
- It hoisted the pin-data lookup out of the retry loop, which is what forced the change above.

Every PR in the stack passes `pnpm test` (2083 tests), `pnpm typecheck`, ESLint and Biome in `packages/core`.

## How to test

This is a refactor. No behaviour change is intended.

```bash
cd packages/core
pnpm test
pnpm typecheck
```

Read the diff with `git diff --color-moved=zebra` to see the moved blocks.

## Related Linear tickets, Github issues, and Community forum posts

Splits and rebases #28374 by @ivan-kiselev.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
