### PR TITLE
refactor(core): Extract node scheduling from the execution loop (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1919,6 +1919,215 @@ export class WorkflowExecute {
 		return { ...e, message: e.message, stack: e.stack };
 	}
 
+	/**
+	 * A node with `alwaysOutputData` that returned nothing gets one empty item, so the
+	 * nodes after it still run. The item keeps the lineage of all input items.
+	 */
+	private ensureAlwaysOutputData(
+		nodeSuccessData: INodeExecutionData[][] | null | undefined,
+		executionData: IExecuteData,
+	): INodeExecutionData[][] | null | undefined {
+		if (nodeSuccessData?.[0]?.[0]) return nodeSuccessData;
+		if (executionData.node.alwaysOutputData !== true) return nodeSuccessData;
+
+		// Get pairedItem from all input items
+		const pairedItem: IPairedItemData[] = [];
+		executionData.data.main.forEach((inputData, inputIndex) => {
+			if (!inputData) {
+				return;
+			}
+			inputData.forEach((_item, itemIndex) => {
+				pairedItem.push({ item: itemIndex, input: inputIndex });
+			});
+		});
+
+		nodeSuccessData ??= [];
+		nodeSuccessData[0] = [{ json: {}, pairedItem }];
+		return nodeSuccessData;
+	}
+
+	/** Build the task record for a finished node run. */
+	private createTaskData(
+		taskStartedData: ITaskStartedData,
+		executionData: IExecuteData,
+	): ITaskData {
+		return {
+			...taskStartedData,
+			executionTime: Date.now() - taskStartedData.startTime,
+			metadata: executionData.metadata,
+			executionStatus: this.runExecutionData.waitTill ? 'waiting' : 'success',
+			usedDynamicCredentials: this.additionalData.currentNodeUsedDynamicCredentials || undefined,
+			attemptedDynamicCredentials:
+				this.additionalData.currentNodeAttemptedDynamicCredentials || undefined,
+		};
+	}
+
+	/**
+	 * Record the n8n user a dynamically-resolved private credential belongs to onto the
+	 * execution context, so the redaction layer can grant that user access to their own
+	 * data. The identity is execution-scoped, so this is the same value across nodes.
+	 */
+	private recordDynamicCredentialsUser(): void {
+		if (
+			this.additionalData.currentNodeUsedDynamicCredentials &&
+			this.additionalData.dynamicCredentialsResolvedUserId &&
+			this.runExecutionData.executionData?.runtimeData
+		) {
+			this.runExecutionData.executionData.runtimeData.executedByUserId =
+				this.additionalData.dynamicCredentialsResolvedUserId;
+		}
+	}
+
+	/**
+	 * Record a node error on the task data and decide how the execution goes on.
+	 *
+	 * If the node continues on error, its input data passes through to the next node and
+	 * the loop continues. Otherwise the task data is stored, the node is pushed back onto
+	 * the stack so it can be restarted, and the loop must stop.
+	 */
+	private async handleNodeExecutionError({
+		executionNode,
+		executionData,
+		taskData,
+		executionError,
+		nodeSuccessData,
+		runIndex,
+		hooks,
+	}: {
+		executionNode: INode;
+		executionData: IExecuteData;
+		taskData: ITaskData;
+		executionError: ExecutionBaseError;
+		nodeSuccessData: INodeExecutionData[][] | null | undefined;
+		runIndex: number;
+		hooks: ExecutionLifecycleHooks;
+	}): Promise<{
+		continueExecution: boolean;
+		nodeSuccessData: INodeExecutionData[][] | null | undefined;
+	}> {
+		taskData.error = executionError;
+		taskData.executionStatus = 'error';
+
+		// Send error to the response if necessary
+		await hooks?.runHook('sendChunk', [
+			{
+				type: 'error',
+				content: executionError.description,
+				metadata: {
+					nodeId: executionNode.id,
+					nodeName: executionNode.name,
+					runIndex,
+					itemIndex: 0,
+				},
+			},
+		]);
+
+		// AI tools default to continue-on-fail so the agent receives the
+		// error as a tool response. Explicit `onError: 'stopWorkflow'`
+		// still wins.
+		const isAiToolExecution = executionNode.rewireOutputLogTo === NodeConnectionTypes.AiTool;
+		const aiToolDefaultsToContinue =
+			isAiToolExecution && executionData.node.onError !== 'stopWorkflow';
+
+		if (this.continuesOnError(executionData.node) || aiToolDefaultsToContinue) {
+			// Workflow should continue running even if node errors
+			if (isAiToolExecution) {
+				// Surface the error on the ai_tool channel so the agent receives it
+				nodeSuccessData = [[{ json: { error: executionError.message } }]];
+			} else if (Object.hasOwn(executionData.data, 'main') && executionData.data.main.length > 0) {
+				// Simply get the input data of the node if it has any and pass it through
+				// to the next node
+				if (executionData.data.main[0] !== null) {
+					nodeSuccessData = [executionData.data.main[0]];
+				}
+			}
+
+			return { continueExecution: true, nodeSuccessData };
+		}
+
+		// Node execution did fail so add error and stop execution
+		// TODO: Remove when AI-723 lands.
+		// For AI tool nodes with rewireOutputLogTo, preserve inputOverride and set correct output type
+		if (executionNode.rewireOutputLogTo) {
+			taskData.inputOverride =
+				this.runExecutionData.resultData.runData[executionNode.name][runIndex]?.inputOverride || {};
+			taskData.data = {
+				[executionNode.rewireOutputLogTo]: [[{ json: { error: executionError.message } }]],
+			} as ITaskDataConnections;
+		}
+
+		this.upsertTaskData(executionNode.name, runIndex, taskData);
+
+		// Add the execution data again so that it can get restarted
+		this.pushExecutionStack(executionData);
+		// Only execute the nodeExecuteAfter hook if the node did not get aborted
+		if (!this.isCancelled) {
+			await hooks.runHook('nodeExecuteAfter', [
+				executionNode.name,
+				taskData,
+				this.runExecutionData,
+			]);
+		}
+
+		return { continueExecution: false, nodeSuccessData };
+	}
+
+	/**
+	 * Store the task data for a node run.
+	 *
+	 * TODO: Remove when AI-723 lands. There is no need to merge anymore, because the only
+	 * reason to have this entry already is because of `inputOverride`.
+	 */
+	private upsertTaskData(nodeName: string, runIndex: number, taskData: ITaskData): void {
+		const nodeRunData = this.runExecutionData.resultData.runData[nodeName];
+		if (nodeRunData[runIndex]) {
+			Object.assign(nodeRunData[runIndex], taskData);
+		} else {
+			nodeRunData.push(taskData);
+		}
+	}
+
+	/**
+	 * Move the error a node reported in `$error` onto the standard `error` and `json`
+	 * fields of the item, so all nodes report errors the same way.
+	 */
+	private normalizeNodeErrors(nodeSuccessData: INodeExecutionData[][]): void {
+		for (const execution of nodeSuccessData) {
+			for (const lineResult of execution) {
+				if (
+					lineResult.json !== undefined &&
+					lineResult.json.$error !== undefined &&
+					lineResult.json.$json !== undefined
+				) {
+					lineResult.error = lineResult.json.$error as NodeApiError | NodeOperationError;
+					lineResult.json = { error: lineResult.error.message };
+				} else if (lineResult.error !== undefined) {
+					lineResult.json = { error: lineResult.error.message };
+				}
+			}
+		}
+	}
+
+	/**
+	 * Log the output of an AI tool node on its own connection type instead of `main`.
+	 * TODO: Remove when AI-723 lands.
+	 */
+	private rewireOutputLog(
+		executionNode: INode,
+		taskData: ITaskData,
+		nodeSuccessData: INodeExecutionData[][],
+		runIndex: number,
+	): void {
+		if (!executionNode.rewireOutputLogTo) return;
+
+		// Try to get inputOverride from existing run data
+		taskData.inputOverride =
+			this.runExecutionData.resultData.runData[executionNode.name]?.[runIndex]?.inputOverride || {};
+		taskData.data = {
+			[executionNode.rewireOutputLogTo]: nodeSuccessData,
+		} as ITaskDataConnections;
+	}
+
 	/** True while there are nodes queued for execution. */
 	private isExecutionStackNotEmpty(): boolean {
 		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
@@ -2148,32 +2357,7 @@ export class WorkflowExecute {
 								this.runExecutionData.resultData.lastNodeExecuted = executionData.node.name;
 							}
 
-							if (!nodeSuccessData?.[0]?.[0]) {
-								if (executionData.node.alwaysOutputData === true) {
-									const pairedItem: IPairedItemData[] = [];
-
-									// Get pairedItem from all input items
-									executionData.data.main.forEach((inputData, inputIndex) => {
-										if (!inputData) {
-											return;
-										}
-										inputData.forEach((_item, itemIndex) => {
-											pairedItem.push({
-												item: itemIndex,
-												input: inputIndex,
-											});
-										});
-									});
-
-									nodeSuccessData ??= [];
-									nodeSuccessData[0] = [
-										{
-											json: {},
-											pairedItem,
-										},
-									];
-								}
-							}
+							nodeSuccessData = this.ensureAlwaysOutputData(nodeSuccessData, executionData);
 
 							if (nodeSuccessData === null && !this.runExecutionData.waitTill) {
 								// If null gets returned it means that the node did succeed
@@ -2195,132 +2379,26 @@ export class WorkflowExecute {
 						this.runExecutionData.resultData.runData[executionNode.name] = [];
 					}
 
-					const taskData: ITaskData = {
-						...taskStartedData,
-						executionTime: Date.now() - taskStartedData.startTime,
-						metadata: executionData.metadata,
-						executionStatus: this.runExecutionData.waitTill ? 'waiting' : 'success',
-						usedDynamicCredentials:
-							this.additionalData.currentNodeUsedDynamicCredentials || undefined,
-						attemptedDynamicCredentials:
-							this.additionalData.currentNodeAttemptedDynamicCredentials || undefined,
-					};
-
-					// Record the n8n user a dynamically-resolved private credential
-					// belongs to onto the execution context, so the redaction layer
-					// can grant that user access to their own data. The identity is
-					// execution-scoped, so this is the same value across nodes.
-					if (
-						this.additionalData.currentNodeUsedDynamicCredentials &&
-						this.additionalData.dynamicCredentialsResolvedUserId &&
-						this.runExecutionData.executionData?.runtimeData
-					) {
-						this.runExecutionData.executionData.runtimeData.executedByUserId =
-							this.additionalData.dynamicCredentialsResolvedUserId;
-					}
+					const taskData = this.createTaskData(taskStartedData, executionData);
+					this.recordDynamicCredentialsUser();
 
 					if (executionError !== undefined) {
-						taskData.error = executionError;
-						taskData.executionStatus = 'error';
-
-						// Send error to the response if necessary
-						await hooks?.runHook('sendChunk', [
-							{
-								type: 'error',
-								content: executionError.description,
-								metadata: {
-									nodeId: executionNode.id,
-									nodeName: executionNode.name,
-									runIndex,
-									itemIndex: 0,
-								},
-							},
-						]);
-
-						// AI tools default to continue-on-fail so the agent receives the
-						// error as a tool response. Explicit `onError: 'stopWorkflow'`
-						// still wins.
-						const isAiToolExecution =
-							executionNode.rewireOutputLogTo === NodeConnectionTypes.AiTool;
-						const aiToolDefaultsToContinue =
-							isAiToolExecution && executionData.node.onError !== 'stopWorkflow';
-
-						if (this.continuesOnError(executionData.node) || aiToolDefaultsToContinue) {
-							// Workflow should continue running even if node errors
-							if (isAiToolExecution) {
-								// Surface the error on the ai_tool channel so the agent receives it
-								nodeSuccessData = [[{ json: { error: executionError.message } }]];
-							} else if (
-								Object.hasOwn(executionData.data, 'main') &&
-								executionData.data.main.length > 0
-							) {
-								// Simply get the input data of the node if it has any and pass it through
-								// to the next node
-								if (executionData.data.main[0] !== null) {
-									nodeSuccessData = [executionData.data.main[0]];
-								}
-							}
-						} else {
-							// Node execution did fail so add error and stop execution
-							// TODO: Remove when AI-723 lands.
-							// For AI tool nodes with rewireOutputLogTo, preserve inputOverride and set correct output type
-							if (executionNode.rewireOutputLogTo) {
-								taskData.inputOverride =
-									this.runExecutionData.resultData.runData[executionNode.name][runIndex]
-										?.inputOverride || {};
-								taskData.data = {
-									[executionNode.rewireOutputLogTo]: [
-										[{ json: { error: executionError.message } }],
-									],
-								} as ITaskDataConnections;
-							}
-
-							// TODO: Remove when AI-723 lands.
-							// Check if entry already exists (e.g., from requests-response.ts inputOverride)
-							const errorRunDataExists =
-								!!this.runExecutionData.resultData.runData[executionNode.name][runIndex];
-							if (errorRunDataExists) {
-								const currentTaskData =
-									this.runExecutionData.resultData.runData[executionNode.name][runIndex];
-								Object.assign(currentTaskData, taskData);
-							} else {
-								this.runExecutionData.resultData.runData[executionNode.name].push(taskData);
-							}
-
-							// Add the execution data again so that it can get restarted
-							this.pushExecutionStack(executionData);
-							// Only execute the nodeExecuteAfter hook if the node did not get aborted
-							if (!this.isCancelled) {
-								await hooks.runHook('nodeExecuteAfter', [
-									executionNode.name,
-									taskData,
-									this.runExecutionData,
-								]);
-							}
-
+						const outcome = await this.handleNodeExecutionError({
+							executionNode,
+							executionData,
+							taskData,
+							executionError,
+							nodeSuccessData,
+							runIndex,
+							hooks,
+						});
+						nodeSuccessData = outcome.nodeSuccessData;
+						if (!outcome.continueExecution) {
 							break;
 						}
 					}
 
-					// Merge error information to default output for now
-					// As the new nodes can report the errors in
-					// the `error` property.
-					for (const execution of nodeSuccessData!) {
-						for (const lineResult of execution) {
-							if (
-								lineResult.json !== undefined &&
-								lineResult.json.$error !== undefined &&
-								lineResult.json.$json !== undefined
-							) {
-								lineResult.error = lineResult.json.$error as NodeApiError | NodeOperationError;
-								lineResult.json = {
-									error: (lineResult.json.$error as NodeApiError | NodeOperationError).message,
-								};
-							} else if (lineResult.error !== undefined) {
-								lineResult.json = { error: lineResult.error.message };
-							}
-						}
-					}
+					this.normalizeNodeErrors(nodeSuccessData!);
 
 					// Node executed successfully. So add data and go on.
 					taskData.data = {
@@ -2328,29 +2406,9 @@ export class WorkflowExecute {
 					} as ITaskDataConnections;
 
 					// Rewire output data log to the given connectionType
-					if (executionNode.rewireOutputLogTo) {
-						// TODO: Remove when AI-723 lands.
-						// Try to get inputOverride from existing run data
-						taskData.inputOverride =
-							this.runExecutionData.resultData.runData[executionNode.name]?.[runIndex]
-								?.inputOverride || {};
-						taskData.data = {
-							[executionNode.rewireOutputLogTo]: nodeSuccessData,
-						} as ITaskDataConnections;
-					}
+					this.rewireOutputLog(executionNode, taskData, nodeSuccessData!, runIndex);
 
-					const runDataAlreadyExists =
-						!!this.runExecutionData.resultData.runData[executionNode.name][runIndex];
-					if (runDataAlreadyExists) {
-						// TODO: Remove when AI-723 lands. There is no need to merge
-						// anymore, because the only reason to have this entry already is
-						// because of `inputOverride`.
-						const currentTaskData =
-							this.runExecutionData.resultData.runData[executionNode.name][runIndex];
-						Object.assign(currentTaskData, taskData);
-					} else {
-						this.runExecutionData.resultData.runData[executionNode.name].push(taskData);
-					}
+					this.upsertTaskData(executionNode.name, runIndex, taskData);
 
 					if (this.runExecutionData.waitTill) {
 						await hooks.runHook('nodeExecuteAfter', [

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2128,6 +2128,266 @@ export class WorkflowExecute {
 		} as ITaskDataConnections;
 	}
 
+	/**
+	 * Queue every node connected to an output of the node that just ran. In execution
+	 * order v1 the nodes are sorted first, so the one closest to the top left runs first.
+	 */
+	private scheduleDownstreamNodes(
+		workflow: Workflow,
+		executionNode: INode,
+		nodeSuccessData: INodeExecutionData[][],
+		runIndex: number,
+	): void {
+		// Add the nodes to which the current node has an output connection to that they can
+		// be executed next
+		if (Object.hasOwn(workflow.connectionsBySourceNode, executionNode.name)) {
+			if (Object.hasOwn(workflow.connectionsBySourceNode[executionNode.name], 'main')) {
+				let outputIndex: string;
+				let connectionData: IConnection;
+				// Iterate over all the outputs
+
+				const nodesToAdd: Array<{
+					position: [number, number];
+					connection: IConnection;
+					outputIndex: number;
+				}> = [];
+
+				// Add the nodes to be executed
+				// eslint-disable-next-line @typescript-eslint/no-for-in-array
+				for (outputIndex in workflow.connectionsBySourceNode[executionNode.name].main) {
+					if (
+						!Object.hasOwn(workflow.connectionsBySourceNode[executionNode.name].main, outputIndex)
+					) {
+						continue;
+					}
+
+					// Iterate over all the different connections of this output
+					for (connectionData of workflow.connectionsBySourceNode[executionNode.name].main[
+						outputIndex
+					] ?? []) {
+						if (!Object.hasOwn(workflow.nodes, connectionData.node)) {
+							throw new UnexpectedError('Destination node not found', {
+								extra: {
+									sourceNodeName: executionNode.name,
+									destinationNodeName: connectionData.node,
+								},
+							});
+						}
+
+						if (
+							nodeSuccessData[outputIndex] &&
+							(nodeSuccessData[outputIndex].length !== 0 ||
+								(connectionData.index > 0 && this.isLegacyExecutionOrder(workflow)))
+						) {
+							// Add the node only if it did execute or if connected to second "optional" input
+							if (workflow.settings.executionOrder === 'v1') {
+								const nodeToAdd = workflow.getNode(connectionData.node);
+								nodesToAdd.push({
+									position: nodeToAdd?.position || [0, 0],
+									connection: connectionData,
+									outputIndex: parseInt(outputIndex, 10),
+								});
+							} else {
+								this.addNodeToBeExecuted(
+									workflow,
+									connectionData,
+									parseInt(outputIndex, 10),
+									executionNode.name,
+									nodeSuccessData,
+									runIndex,
+								);
+							}
+						}
+					}
+				}
+
+				if (workflow.settings.executionOrder === 'v1') {
+					// Always execute the node that is more to the top-left first
+					nodesToAdd.sort((a, b) => {
+						if (a.position[1] < b.position[1]) {
+							return 1;
+						}
+						if (a.position[1] > b.position[1]) {
+							return -1;
+						}
+
+						if (a.position[0] > b.position[0]) {
+							return -1;
+						}
+
+						return 0;
+					});
+
+					for (const nodeData of nodesToAdd) {
+						this.addNodeToBeExecuted(
+							workflow,
+							nodeData.connection,
+							nodeData.outputIndex,
+							executionNode.name,
+							nodeSuccessData,
+							runIndex,
+						);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * When nothing is left to execute, look for a node that waits for input on more than
+	 * one connection and already got enough of it. Queue the first such node and drop the
+	 * waiting entries it consumed.
+	 */
+	private promoteWaitingNodesToExecutionStack(workflow: Workflow): void {
+		if (this.runExecutionData.executionData!.nodeExecutionStack.length !== 0) return;
+
+		let waitingNodes = Object.keys(this.runExecutionData.executionData!.waitingExecution);
+		if (waitingNodes.length === 0) return;
+
+		// There are no more nodes in the execution stack. Check if there are
+		// waiting nodes that do not require data on all inputs and execute them,
+		// one by one.
+
+		// TODO: Should this also care about workflow position (top-left first?)
+		for (let i = 0; i < waitingNodes.length; i++) {
+			const nodeName = waitingNodes[i];
+
+			const checkNode = workflow.getNode(nodeName);
+			if (!checkNode) {
+				continue;
+			}
+			const nodeType = workflow.nodeTypes.getByNameAndVersion(
+				checkNode.type,
+				checkNode.typeVersion,
+			);
+
+			// Check if the node is only allowed execute if all inputs received data
+			let requiredInputs =
+				workflow.settings.executionOrder === 'v1' ? nodeType.description.requiredInputs : undefined;
+			if (requiredInputs !== undefined) {
+				if (typeof requiredInputs === 'string') {
+					requiredInputs = workflow.expression.getSimpleParameterValue(
+						checkNode,
+						requiredInputs,
+						this.mode,
+						{ $version: checkNode.typeVersion },
+						undefined,
+						[],
+					) as number[];
+				}
+
+				if (
+					(requiredInputs !== undefined &&
+						Array.isArray(requiredInputs) &&
+						requiredInputs.length === nodeType.description.inputs.length) ||
+					requiredInputs === nodeType.description.inputs.length
+				) {
+					// All inputs are required, but not all have data so do not continue
+					continue;
+				}
+			}
+
+			const parentNodes = workflow.getParentNodes(nodeName);
+
+			// Check if input nodes (of same run) got already executed
+
+			const parentIsWaiting = parentNodes.some((value) => waitingNodes.includes(value));
+			if (parentIsWaiting) {
+				// Execute node later as one of its dependencies is still outstanding
+				continue;
+			}
+
+			const runIndexes = Object.keys(
+				this.runExecutionData.executionData!.waitingExecution[nodeName],
+			).sort();
+
+			// The run-index of the earliest outstanding one
+			const firstRunIndex = parseInt(runIndexes[0]);
+
+			// Find all the inputs which received any kind of data, even if it was an empty
+			// array as this shows that the parent nodes executed but they did not have any
+			// data to pass on.
+			const inputsWithData = this.runExecutionData
+				.executionData!.waitingExecution[nodeName][firstRunIndex].main.map((data, index) =>
+					data === null ? null : index,
+				)
+				.filter((data) => data !== null);
+
+			if (requiredInputs !== undefined) {
+				// Certain inputs are required that the node can execute
+
+				if (Array.isArray(requiredInputs)) {
+					// Specific inputs are required (array of input indexes)
+					let inputDataMissing = false;
+					for (const requiredInput of requiredInputs) {
+						if (!inputsWithData.includes(requiredInput)) {
+							inputDataMissing = true;
+							break;
+						}
+					}
+					if (inputDataMissing) {
+						continue;
+					}
+				} else {
+					// A certain amount of inputs are required (amount of inputs)
+					if (inputsWithData.length < requiredInputs) {
+						continue;
+					}
+				}
+			}
+
+			const taskDataMain = this.runExecutionData.executionData!.waitingExecution[nodeName][
+				firstRunIndex
+			].main.map((data) => {
+				// For the inputs for which never any data got received set it to an empty array
+				return data === null ? [] : data;
+			});
+
+			if (taskDataMain.filter((data) => data.length).length !== 0) {
+				// Add the node to be executed
+
+				// Make sure that each input at least receives an empty array
+				if (taskDataMain.length < nodeType.description.inputs.length) {
+					for (; taskDataMain.length < nodeType.description.inputs.length; ) {
+						taskDataMain.push([]);
+					}
+				}
+
+				this.runExecutionData.executionData!.nodeExecutionStack.push({
+					node: workflow.nodes[nodeName],
+					data: {
+						main: taskDataMain,
+					},
+					source:
+						this.runExecutionData.executionData!.waitingExecutionSource![nodeName][firstRunIndex],
+				});
+			}
+
+			// Remove the node from waiting
+			delete this.runExecutionData.executionData!.waitingExecution[nodeName][firstRunIndex];
+			delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName][firstRunIndex];
+
+			if (
+				Object.keys(this.runExecutionData.executionData!.waitingExecution[nodeName]).length === 0
+			) {
+				// No more data left for the node so also delete that one
+				delete this.runExecutionData.executionData!.waitingExecution[nodeName];
+				delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName];
+			}
+
+			if (taskDataMain.filter((data) => data.length).length !== 0) {
+				// Node to execute got found and added to stop
+				break;
+			} else {
+				// Node to add did not get found, rather an empty one removed so continue with search
+				waitingNodes = Object.keys(this.runExecutionData.executionData!.waitingExecution);
+				// Set counter to start again from the beginning. Set it to -1 as it auto increments
+				// after run. So only like that will we end up again at 0.
+				i = -1;
+			}
+		}
+	}
+
 	/** True while there are nodes queued for execution. */
 	private isExecutionStackNotEmpty(): boolean {
 		return this.runExecutionData.executionData!.nodeExecutionStack.length !== 0;
@@ -2438,100 +2698,7 @@ export class WorkflowExecute {
 
 					// Add the nodes to which the current node has an output connection to that they can
 					// be executed next
-					if (Object.hasOwn(workflow.connectionsBySourceNode, executionNode.name)) {
-						if (Object.hasOwn(workflow.connectionsBySourceNode[executionNode.name], 'main')) {
-							let outputIndex: string;
-							let connectionData: IConnection;
-							// Iterate over all the outputs
-
-							const nodesToAdd: Array<{
-								position: [number, number];
-								connection: IConnection;
-								outputIndex: number;
-							}> = [];
-
-							// Add the nodes to be executed
-							// eslint-disable-next-line @typescript-eslint/no-for-in-array
-							for (outputIndex in workflow.connectionsBySourceNode[executionNode.name].main) {
-								if (
-									!Object.hasOwn(
-										workflow.connectionsBySourceNode[executionNode.name].main,
-										outputIndex,
-									)
-								) {
-									continue;
-								}
-
-								// Iterate over all the different connections of this output
-								for (connectionData of workflow.connectionsBySourceNode[executionNode.name].main[
-									outputIndex
-								] ?? []) {
-									if (!Object.hasOwn(workflow.nodes, connectionData.node)) {
-										throw new UnexpectedError('Destination node not found', {
-											extra: {
-												sourceNodeName: executionNode.name,
-												destinationNodeName: connectionData.node,
-											},
-										});
-									}
-
-									if (
-										nodeSuccessData![outputIndex] &&
-										(nodeSuccessData![outputIndex].length !== 0 ||
-											(connectionData.index > 0 && this.isLegacyExecutionOrder(workflow)))
-									) {
-										// Add the node only if it did execute or if connected to second "optional" input
-										if (workflow.settings.executionOrder === 'v1') {
-											const nodeToAdd = workflow.getNode(connectionData.node);
-											nodesToAdd.push({
-												position: nodeToAdd?.position || [0, 0],
-												connection: connectionData,
-												outputIndex: parseInt(outputIndex, 10),
-											});
-										} else {
-											this.addNodeToBeExecuted(
-												workflow,
-												connectionData,
-												parseInt(outputIndex, 10),
-												executionNode.name,
-												nodeSuccessData!,
-												runIndex,
-											);
-										}
-									}
-								}
-							}
-
-							if (workflow.settings.executionOrder === 'v1') {
-								// Always execute the node that is more to the top-left first
-								nodesToAdd.sort((a, b) => {
-									if (a.position[1] < b.position[1]) {
-										return 1;
-									}
-									if (a.position[1] > b.position[1]) {
-										return -1;
-									}
-
-									if (a.position[0] > b.position[0]) {
-										return -1;
-									}
-
-									return 0;
-								});
-
-								for (const nodeData of nodesToAdd) {
-									this.addNodeToBeExecuted(
-										workflow,
-										nodeData.connection,
-										nodeData.outputIndex,
-										executionNode.name,
-										nodeSuccessData!,
-										runIndex,
-									);
-								}
-							}
-						}
-					}
+					this.scheduleDownstreamNodes(workflow, executionNode, nodeSuccessData!, runIndex);
 
 					// If we got here, it means that we did not stop executing from manual executions / destination.
 					// Execute hooks now to make sure that all hooks are executed properly
@@ -2543,164 +2710,7 @@ export class WorkflowExecute {
 						this.runExecutionData,
 					]);
 
-					let waitingNodes: string[] = Object.keys(
-						this.runExecutionData.executionData!.waitingExecution,
-					);
-
-					if (
-						this.runExecutionData.executionData!.nodeExecutionStack.length === 0 &&
-						waitingNodes.length
-					) {
-						// There are no more nodes in the execution stack. Check if there are
-						// waiting nodes that do not require data on all inputs and execute them,
-						// one by one.
-
-						// TODO: Should this also care about workflow position (top-left first?)
-						for (let i = 0; i < waitingNodes.length; i++) {
-							const nodeName = waitingNodes[i];
-
-							const checkNode = workflow.getNode(nodeName);
-							if (!checkNode) {
-								continue;
-							}
-							const nodeType = workflow.nodeTypes.getByNameAndVersion(
-								checkNode.type,
-								checkNode.typeVersion,
-							);
-
-							// Check if the node is only allowed execute if all inputs received data
-							let requiredInputs =
-								workflow.settings.executionOrder === 'v1'
-									? nodeType.description.requiredInputs
-									: undefined;
-							if (requiredInputs !== undefined) {
-								if (typeof requiredInputs === 'string') {
-									requiredInputs = workflow.expression.getSimpleParameterValue(
-										checkNode,
-										requiredInputs,
-										this.mode,
-										{ $version: checkNode.typeVersion },
-										undefined,
-										[],
-									) as number[];
-								}
-
-								if (
-									(requiredInputs !== undefined &&
-										Array.isArray(requiredInputs) &&
-										requiredInputs.length === nodeType.description.inputs.length) ||
-									requiredInputs === nodeType.description.inputs.length
-								) {
-									// All inputs are required, but not all have data so do not continue
-									continue;
-								}
-							}
-
-							const parentNodes = workflow.getParentNodes(nodeName);
-
-							// Check if input nodes (of same run) got already executed
-
-							const parentIsWaiting = parentNodes.some((value) => waitingNodes.includes(value));
-							if (parentIsWaiting) {
-								// Execute node later as one of its dependencies is still outstanding
-								continue;
-							}
-
-							const runIndexes = Object.keys(
-								this.runExecutionData.executionData!.waitingExecution[nodeName],
-							).sort();
-
-							// The run-index of the earliest outstanding one
-							const firstRunIndex = parseInt(runIndexes[0]);
-
-							// Find all the inputs which received any kind of data, even if it was an empty
-							// array as this shows that the parent nodes executed but they did not have any
-							// data to pass on.
-							const inputsWithData = this.runExecutionData
-								.executionData!.waitingExecution[nodeName][firstRunIndex].main.map((data, index) =>
-									data === null ? null : index,
-								)
-								.filter((data) => data !== null);
-
-							if (requiredInputs !== undefined) {
-								// Certain inputs are required that the node can execute
-
-								if (Array.isArray(requiredInputs)) {
-									// Specific inputs are required (array of input indexes)
-									let inputDataMissing = false;
-									for (const requiredInput of requiredInputs) {
-										if (!inputsWithData.includes(requiredInput)) {
-											inputDataMissing = true;
-											break;
-										}
-									}
-									if (inputDataMissing) {
-										continue;
-									}
-								} else {
-									// A certain amount of inputs are required (amount of inputs)
-									if (inputsWithData.length < requiredInputs) {
-										continue;
-									}
-								}
-							}
-
-							const taskDataMain = this.runExecutionData.executionData!.waitingExecution[nodeName][
-								firstRunIndex
-							].main.map((data) => {
-								// For the inputs for which never any data got received set it to an empty array
-								return data === null ? [] : data;
-							});
-
-							if (taskDataMain.filter((data) => data.length).length !== 0) {
-								// Add the node to be executed
-
-								// Make sure that each input at least receives an empty array
-								if (taskDataMain.length < nodeType.description.inputs.length) {
-									for (; taskDataMain.length < nodeType.description.inputs.length; ) {
-										taskDataMain.push([]);
-									}
-								}
-
-								this.runExecutionData.executionData!.nodeExecutionStack.push({
-									node: workflow.nodes[nodeName],
-									data: {
-										main: taskDataMain,
-									},
-									source:
-										this.runExecutionData.executionData!.waitingExecutionSource![nodeName][
-											firstRunIndex
-										],
-								});
-							}
-
-							// Remove the node from waiting
-							delete this.runExecutionData.executionData!.waitingExecution[nodeName][firstRunIndex];
-							delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName][
-								firstRunIndex
-							];
-
-							if (
-								Object.keys(this.runExecutionData.executionData!.waitingExecution[nodeName])
-									.length === 0
-							) {
-								// No more data left for the node so also delete that one
-								delete this.runExecutionData.executionData!.waitingExecution[nodeName];
-								delete this.runExecutionData.executionData!.waitingExecutionSource![nodeName];
-							}
-
-							if (taskDataMain.filter((data) => data.length).length !== 0) {
-								// Node to execute got found and added to stop
-								break;
-							} else {
-								// Node to add did not get found, rather an empty one removed so continue with search
-								waitingNodes = Object.keys(this.runExecutionData.executionData!.waitingExecution);
-								// Set counter to start again from the beginning. Set it to -1 as it auto increments
-								// after run. So only like that will we end up again at 0.
-								i = -1;
-							}
-						}
-					}
+					this.promoteWaitingNodesToExecutionStack(workflow);
 				}
 
 				return;


### PR DESCRIPTION
## Summary

Move the two blocks at the end of the loop body into named methods:

- `scheduleDownstreamNodes` queues the nodes connected to the outputs of the node that just ran.
- `promoteWaitingNodesToExecutionStack` queues a multi-input node once it got enough data.

Both bodies move unchanged. `promoteWaitingNodesToExecutionStack` returns early instead of nesting its body in the guard condition.

Review this one with `git diff --color-moved=zebra`. The diff is large but the tokens are identical. Only the indentation and the line wrapping changed.

After this PR `processRunExecutionData` is 341 lines, down from 982.

---

### The stack

`processRunExecutionData` is 982 lines on `master`. This stack cuts it to 341 lines. Each PR extracts one phase of the loop into named private methods. Review and merge them in order.

1. #37387 — Name the loop control conditions
2. #37382 — Extract setup and bootstrap
3. #37383 — Extract the per-node preamble
4. #37384 — Extract the node run block
5. #37385 — Extract node error reporting
6. #37386 — Extract task data assembly
7. #37388 — Extract node scheduling

The stack splits #28374 by @ivan-kiselev and rebases it onto current `master`. The file moved by +302/−75 since that PR was written, so each extraction was redone against the new code, not replayed.

Two changes in #28374 are **not** carried over. Both look like regressions:

- It moved `assignPairedItems`, the `alwaysOutputData` block and the `nodeSuccessData === null` check out of the retry `try` block. After a node fails, `nodeSuccessData` is `null` and `executionError` is set, so the relocated `if (nodeSuccessData === null && !waitTill) continue executionLoop` skips the error handling. Errors get swallowed.
- It hoisted the pin-data lookup out of the retry loop, which is what forced the change above.

Every PR in the stack passes `pnpm test` (2083 tests), `pnpm typecheck`, ESLint and Biome in `packages/core`.

## How to test

This is a refactor. No behaviour change is intended.

```bash
cd packages/core
pnpm test
pnpm typecheck
```

Read the diff with `git diff --color-moved=zebra` to see the moved blocks.

## Related Linear tickets, Github issues, and Community forum posts

Splits and rebases #28374 by @ivan-kiselev.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
