### PR TITLE
feat: Add in-widget credential status strip to @n8n/chat

### DIFF
--- a/packages/frontend/@n8n/chat/src/__tests__/Chat.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/Chat.spec.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { chatEventBus } from '@n8n/chat/event-buses';
 
 import Chat from '../components/Chat.vue';
+import type { CredentialStatus } from '../types/credentialStatus';
 import type { ChatMessage } from '../types/messages';
 
 // Mock child components
@@ -27,7 +28,7 @@ vi.mock('../components/Input.vue', () => ({
 vi.mock('../components/Layout.vue', () => ({
 	default: {
 		name: 'Layout',
-		template: '<div><slot /><slot name="footer" /></div>',
+		template: '<div><slot /><slot name="statusStrip" /><slot name="footer" /></div>',
 	},
 }));
 
@@ -47,6 +48,7 @@ const mockChatStore = {
 	initialize: vi.fn().mockResolvedValue(undefined),
 	startNewSession: vi.fn(),
 	messages: [] as ChatMessage[],
+	credentialStatus: { value: null as CredentialStatus | null },
 };
 
 const mockOptions = {
@@ -64,6 +66,7 @@ vi.mock('@n8n/chat/composables', () => ({
 		initialize: mockChatStore.initialize,
 		startNewSession: mockChatStore.startNewSession,
 		currentSessionId: { value: 'test-session' },
+		credentialStatus: mockChatStore.credentialStatus,
 	}),
 	useOptions: () => ({ options: mockOptions }),
 }));
@@ -81,6 +84,7 @@ describe('Chat', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockChatStore.messages = [];
+		mockChatStore.credentialStatus.value = null;
 	});
 
 	afterEach(() => {
@@ -294,6 +298,35 @@ describe('Chat', () => {
 			expect(vi.mocked(chatEventBus.emit)).toHaveBeenCalledWith('blurInput');
 			// Should focus after setting value
 			expect(vi.mocked(chatEventBus.emit)).toHaveBeenCalledWith('focusInput');
+		});
+	});
+
+	describe('credential status strip', () => {
+		it('does not render the strip when no host has ever signaled credential status', () => {
+			wrapper = mount(Chat);
+
+			expect(wrapper.find('[data-test-id="chat-credential-status-strip"]').exists()).toBe(false);
+		});
+
+		it('renders the strip while required accounts are still missing', () => {
+			mockChatStore.credentialStatus.value = { ready: false, missingCount: 2, testMode: false };
+			wrapper = mount(Chat);
+
+			expect(wrapper.find('[data-test-id="chat-credential-status-strip"]').exists()).toBe(true);
+		});
+
+		it('hides the strip once the host reports readiness outside test mode', () => {
+			mockChatStore.credentialStatus.value = { ready: true, missingCount: 0, testMode: false };
+			wrapper = mount(Chat);
+
+			expect(wrapper.find('[data-test-id="chat-credential-status-strip"]').exists()).toBe(false);
+		});
+
+		it('keeps the strip visible in test mode even when credentials are ready', () => {
+			mockChatStore.credentialStatus.value = { ready: true, missingCount: 0, testMode: true };
+			wrapper = mount(Chat);
+
+			expect(wrapper.find('[data-test-id="chat-credential-status-strip"]').exists()).toBe(true);
 		});
 	});
 });

--- a/packages/frontend/@n8n/chat/src/__tests__/CredentialStatusStrip.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/CredentialStatusStrip.spec.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils';
+
+import CredentialStatusStrip from '../components/CredentialStatusStrip.vue';
+import type { CredentialStatus } from '../types';
+
+const i18n: Record<string, string> = {
+	credentialStatusMissingAccount: 'Connect 1 account to start chatting',
+	credentialStatusMissingAccounts: 'Connect {count} accounts to start chatting',
+	credentialStatusTestMode: "You're testing with your own connected accounts.",
+};
+
+vi.mock('@n8n/chat/composables', () => ({
+	useI18n: () => ({
+		t: (key: string) => i18n[key] ?? key,
+	}),
+}));
+
+function mountStrip(status: CredentialStatus) {
+	return mount(CredentialStatusStrip, { props: { status } });
+}
+
+describe('CredentialStatusStrip', () => {
+	it('renders the singular message for exactly one missing account', () => {
+		const wrapper = mountStrip({ ready: false, missingCount: 1, testMode: false });
+
+		expect(wrapper.text()).toBe('Connect 1 account to start chatting');
+	});
+
+	it('renders the plural message with the interpolated count for multiple missing accounts', () => {
+		const wrapper = mountStrip({ ready: false, missingCount: 3, testMode: false });
+
+		expect(wrapper.text()).toBe('Connect 3 accounts to start chatting');
+	});
+
+	it('renders the test-mode message regardless of the missing count', () => {
+		const wrapper = mountStrip({ ready: true, missingCount: 0, testMode: true });
+
+		expect(wrapper.text()).toBe("You're testing with your own connected accounts.");
+	});
+});

--- a/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
@@ -1,8 +1,12 @@
 import type { VueWrapper } from '@vue/test-utils';
 import { mount } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ref } from 'vue';
 
 import Input from '../components/Input.vue';
+import type { CredentialStatus } from '../types/credentialStatus';
+
+const mockCredentialStatus: { value: CredentialStatus | null } = { value: null };
 
 vi.mock('@vueuse/core', () => ({
 	useFileDialog: vi.fn(() => ({
@@ -29,8 +33,9 @@ vi.mock('@n8n/chat/composables', () => ({
 		t: (key: string) => key,
 	}),
 	useChat: () => ({
-		waitingForResponse: { value: false },
+		waitingForResponse: ref(false),
 		blockUserInput: { value: false },
+		credentialStatus: mockCredentialStatus,
 		currentSessionId: { value: 'session-123' },
 		messages: { value: [] },
 		sendMessage: vi.fn(),
@@ -79,6 +84,7 @@ describe('ChatInput', () => {
 			wrapper.unmount();
 		}
 		vi.clearAllMocks();
+		mockCredentialStatus.value = null;
 	});
 
 	it('renders the component with default props', () => {
@@ -176,6 +182,35 @@ describe('ChatInput', () => {
 		await submitButton.trigger('click');
 
 		expect(wrapper.vm.isSubmitting).toBe(false);
+	});
+
+	describe('credential status gate', () => {
+		it('disables the textarea and send button while required accounts are missing', async () => {
+			mockCredentialStatus.value = { ready: false, missingCount: 1, testMode: false };
+			wrapper = mount(Input);
+			await wrapper.find('textarea').setValue('Hello');
+
+			expect(wrapper.find('textarea').attributes('disabled')).toBeDefined();
+			expect(wrapper.find('.chat-input-send-button').attributes('disabled')).toBeDefined();
+		});
+
+		it('does not disable the input once the host reports readiness', async () => {
+			mockCredentialStatus.value = { ready: true, missingCount: 0, testMode: false };
+			wrapper = mount(Input);
+			await wrapper.find('textarea').setValue('Hello');
+
+			expect(wrapper.find('textarea').attributes('disabled')).toBeUndefined();
+			expect(wrapper.find('.chat-input-send-button').attributes('disabled')).toBeUndefined();
+		});
+
+		it('does not disable the input in test mode even though missingCount is 0 and ready', async () => {
+			mockCredentialStatus.value = { ready: true, missingCount: 0, testMode: true };
+			wrapper = mount(Input);
+			await wrapper.find('textarea').setValue('Hello');
+
+			expect(wrapper.find('textarea').attributes('disabled')).toBeUndefined();
+			expect(wrapper.find('.chat-input-send-button').attributes('disabled')).toBeUndefined();
+		});
 	});
 
 	describe('WebSocket frame handling (backward compatible)', () => {

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/credentialStatus.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/credentialStatus.spec.ts
@@ -1,0 +1,86 @@
+import {
+	CREDENTIAL_STATUS_MESSAGE_TYPE,
+	listenForCredentialStatus,
+} from '@n8n/chat/utils/credentialStatus';
+
+describe('listenForCredentialStatus', () => {
+	const originalParent = window.parent;
+	let stop: (() => void) | undefined;
+
+	function post(data: unknown, source: MessageEventSource | null) {
+		window.dispatchEvent(new MessageEvent('message', { data, source }));
+	}
+
+	afterEach(() => {
+		stop?.();
+		stop = undefined;
+		Object.defineProperty(window, 'parent', { value: originalParent, configurable: true });
+	});
+
+	it('ignores messages when not embedded in a frame (window.parent === window)', () => {
+		const onStatus = vi.fn();
+		stop = listenForCredentialStatus(onStatus);
+
+		post({ type: CREDENTIAL_STATUS_MESSAGE_TYPE, ready: false, missingCount: 2 }, window);
+
+		expect(onStatus).not.toHaveBeenCalled();
+	});
+
+	it('ignores messages whose source is not window.parent', () => {
+		const fakeParent = {} as MessageEventSource;
+		Object.defineProperty(window, 'parent', { value: fakeParent, configurable: true });
+		const onStatus = vi.fn();
+		stop = listenForCredentialStatus(onStatus);
+
+		post({ type: CREDENTIAL_STATUS_MESSAGE_TYPE, ready: false }, {} as MessageEventSource);
+
+		expect(onStatus).not.toHaveBeenCalled();
+	});
+
+	it('ignores messages with the wrong shape', () => {
+		const fakeParent = {} as MessageEventSource;
+		Object.defineProperty(window, 'parent', { value: fakeParent, configurable: true });
+		const onStatus = vi.fn();
+		stop = listenForCredentialStatus(onStatus);
+
+		post({ type: 'something-else', ready: false }, fakeParent);
+		post({ type: CREDENTIAL_STATUS_MESSAGE_TYPE }, fakeParent);
+		post('not an object', fakeParent);
+
+		expect(onStatus).not.toHaveBeenCalled();
+	});
+
+	it('forwards a valid credential-status message from the parent frame, defaulting optional fields', () => {
+		const fakeParent = {} as MessageEventSource;
+		Object.defineProperty(window, 'parent', { value: fakeParent, configurable: true });
+		const onStatus = vi.fn();
+		stop = listenForCredentialStatus(onStatus);
+
+		post({ type: CREDENTIAL_STATUS_MESSAGE_TYPE, ready: false, missingCount: 3 }, fakeParent);
+
+		expect(onStatus).toHaveBeenCalledWith({ ready: false, missingCount: 3, testMode: false });
+	});
+
+	it('passes through an explicit testMode flag', () => {
+		const fakeParent = {} as MessageEventSource;
+		Object.defineProperty(window, 'parent', { value: fakeParent, configurable: true });
+		const onStatus = vi.fn();
+		stop = listenForCredentialStatus(onStatus);
+
+		post({ type: CREDENTIAL_STATUS_MESSAGE_TYPE, ready: true, testMode: true }, fakeParent);
+
+		expect(onStatus).toHaveBeenCalledWith({ ready: true, missingCount: 0, testMode: true });
+	});
+
+	it('stops forwarding messages once stopped', () => {
+		const fakeParent = {} as MessageEventSource;
+		Object.defineProperty(window, 'parent', { value: fakeParent, configurable: true });
+		const onStatus = vi.fn();
+		stop = listenForCredentialStatus(onStatus);
+		stop();
+
+		post({ type: CREDENTIAL_STATUS_MESSAGE_TYPE, ready: true }, fakeParent);
+
+		expect(onStatus).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/@n8n/chat/src/components/Chat.vue
+++ b/packages/frontend/@n8n/chat/src/components/Chat.vue
@@ -2,6 +2,7 @@
 import Close from 'virtual:icons/mdi/close';
 import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
 
+import CredentialStatusStrip from '@n8n/chat/components/CredentialStatusStrip.vue';
 import GetStarted from '@n8n/chat/components/GetStarted.vue';
 import GetStartedFooter from '@n8n/chat/components/GetStartedFooter.vue';
 import Input from '@n8n/chat/components/Input.vue';
@@ -10,14 +11,22 @@ import Layout from '@n8n/chat/components/Layout.vue';
 import MessagesList from '@n8n/chat/components/MessagesList.vue';
 import { useI18n, useChat, useOptions } from '@n8n/chat/composables';
 import { chatEventBus } from '@n8n/chat/event-buses';
+import type { CredentialStatus } from '@n8n/chat/types';
+import { listenForCredentialStatus } from '@n8n/chat/utils/credentialStatus';
 
 const { t } = useI18n();
 const chatStore = useChat();
 
-const { messages, currentSessionId } = chatStore;
+const { messages, currentSessionId, credentialStatus } = chatStore;
 const { options } = useOptions();
 
 const showCloseButton = computed(() => options.mode === 'window' && options.showWindowCloseButton);
+
+const activeCredentialStatus = computed<CredentialStatus | null>(() => {
+	const status = credentialStatus.value;
+	if (!status) return null;
+	return status.testMode || !status.ready ? status : null;
+});
 
 // Message history navigation
 const messageHistoryIndex = ref(-1);
@@ -102,6 +111,7 @@ function onArrowKeyDown(payload: ArrowKeyDownPayload) {
 }
 
 let clearOnMessageSent: () => void;
+let stopListeningForCredentialStatus: () => void;
 
 onMounted(async () => {
 	if (!messages.value.length && options.messageHistory) {
@@ -117,11 +127,18 @@ onMounted(async () => {
 		messageHistoryIndex.value = -1;
 		currentInputBuffer.value = '';
 	});
+
+	stopListeningForCredentialStatus = listenForCredentialStatus((status) => {
+		credentialStatus.value = status;
+	});
 });
 
 onUnmounted(() => {
 	if (clearOnMessageSent) {
 		clearOnMessageSent();
+	}
+	if (stopListeningForCredentialStatus) {
+		stopListeningForCredentialStatus();
 	}
 });
 </script>
@@ -146,6 +163,9 @@ onUnmounted(() => {
 		</template>
 		<GetStarted v-if="!currentSessionId && options.showWelcomeScreen" @click:button="getStarted" />
 		<MessagesList v-else :messages="messages" />
+		<template v-if="activeCredentialStatus" #statusStrip>
+			<CredentialStatusStrip :status="activeCredentialStatus" />
+		</template>
 		<template #footer>
 			<Input v-if="currentSessionId" @arrow-key-down="onArrowKeyDown" />
 			<GetStartedFooter v-else />

--- a/packages/frontend/@n8n/chat/src/components/Chat.vue
+++ b/packages/frontend/@n8n/chat/src/components/Chat.vue
@@ -114,6 +114,12 @@ let clearOnMessageSent: () => void;
 let stopListeningForCredentialStatus: () => void;
 
 onMounted(async () => {
+	// Register before the initialize() await so a credential-status message
+	// arriving while loadPreviousSession() is pending isn't dropped.
+	stopListeningForCredentialStatus = listenForCredentialStatus((status) => {
+		credentialStatus.value = status;
+	});
+
 	if (!messages.value.length && options.messageHistory) {
 		messages.value = options.messageHistory.map((m) => ({ ...m }));
 	}
@@ -126,10 +132,6 @@ onMounted(async () => {
 	clearOnMessageSent = chatEventBus.on('messageSent', () => {
 		messageHistoryIndex.value = -1;
 		currentInputBuffer.value = '';
-	});
-
-	stopListeningForCredentialStatus = listenForCredentialStatus((status) => {
-		credentialStatus.value = status;
 	});
 });
 

--- a/packages/frontend/@n8n/chat/src/components/CredentialStatusStrip.vue
+++ b/packages/frontend/@n8n/chat/src/components/CredentialStatusStrip.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useI18n } from '@n8n/chat/composables';
+import type { CredentialStatus } from '@n8n/chat/types';
+
+const props = defineProps<{
+	status: CredentialStatus;
+}>();
+
+const { t } = useI18n();
+
+const message = computed(() => {
+	if (props.status.testMode) {
+		return t('credentialStatusTestMode');
+	}
+
+	const template =
+		props.status.missingCount === 1
+			? t('credentialStatusMissingAccount')
+			: t('credentialStatusMissingAccounts');
+
+	return template.replace('{count}', String(props.status.missingCount));
+});
+</script>
+
+<template>
+	<div class="chat-credential-status" data-test-id="chat-credential-status-strip">
+		{{ message }}
+	</div>
+</template>
+
+<style lang="scss">
+.chat-credential-status {
+	padding: var(--chat--credential-status--padding, 0.75em 1em);
+	background: var(--chat--credential-status--background, var(--chat--color-light-shade-50));
+	color: var(--chat--credential-status--color, var(--chat--color-dark));
+	font-size: var(--chat--credential-status--font-size, 0.85em);
+	border-top: var(
+		--chat--credential-status--border-top,
+		1px solid var(--chat--color-light-shade-100)
+	);
+}
+</style>

--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -36,7 +36,7 @@ const emit = defineEmits<{
 
 const { options } = useOptions();
 const chatStore = useChat();
-const { waitingForResponse } = chatStore;
+const { waitingForResponse, credentialStatus } = chatStore;
 
 const files = ref<FileList | null>(null);
 const chatTextArea = ref<HTMLTextAreaElement | null>(null);
@@ -45,13 +45,21 @@ const isSubmitting = ref(false);
 const resizeObserver = ref<ResizeObserver | null>(null);
 const waitingForChatResponse = ref(false);
 
+const isCredentialGateActive = computed(() => {
+	const status = credentialStatus.value;
+	return status !== null && !status.testMode && !status.ready;
+});
+
 const isSubmitDisabled = computed(() => {
 	if (chatStore.blockUserInput.value) return true;
+	if (isCredentialGateActive.value) return true;
 	if (waitingForChatResponse.value) return false;
 	return input.value === '' || unref(waitingForResponse) || options.disabled?.value === true;
 });
 
-const isInputDisabled = computed(() => options.disabled?.value === true);
+const isInputDisabled = computed(
+	() => options.disabled?.value === true || isCredentialGateActive.value,
+);
 const isFileUploadDisabled = computed(
 	() => isFileUploadAllowed.value && unref(waitingForResponse) && !options.disabled?.value,
 );

--- a/packages/frontend/@n8n/chat/src/components/Layout.vue
+++ b/packages/frontend/@n8n/chat/src/components/Layout.vue
@@ -30,6 +30,9 @@ onBeforeUnmount(() => {
 		<div v-if="$slots.default" ref="chatBodyRef" class="chat-body">
 			<slot />
 		</div>
+		<div v-if="$slots.statusStrip" class="chat-status-strip">
+			<slot name="statusStrip" />
+		</div>
 		<div v-if="$slots.footer" class="chat-footer">
 			<slot name="footer" />
 		</div>

--- a/packages/frontend/@n8n/chat/src/constants/defaults.ts
+++ b/packages/frontend/@n8n/chat/src/constants/defaults.ts
@@ -26,6 +26,10 @@ export const defaultOptions: ChatOptions = {
 			closeButtonTooltip: 'Close chat',
 			repostButton: 'Repost message',
 			reuseButton: 'Reuse message',
+			credentialStatusMissingAccount: 'Connect 1 account to start chatting',
+			credentialStatusMissingAccounts: 'Connect {count} accounts to start chatting',
+			credentialStatusTestMode:
+				"You're testing with your own connected accounts. Visitors will need to connect their own.",
 		},
 	},
 	theme: {},

--- a/packages/frontend/@n8n/chat/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/chat/src/css/_tokens.scss
@@ -137,6 +137,13 @@
 	--chat--footer--background: var(--chat--color-light);
 	--chat--footer--color: var(--chat--color-dark);
 	--chat--footer--border-top: 1px solid var(--chat--color-light-shade-100);
+
+	/* Credential Status Strip */
+	--chat--credential-status--padding: 0.75em 1em;
+	--chat--credential-status--background: var(--chat--color-light-shade-50);
+	--chat--credential-status--color: var(--chat--color-dark);
+	--chat--credential-status--font-size: 0.85em;
+	--chat--credential-status--border-top: 1px solid var(--chat--color-light-shade-100);
 }
 
 .n8n-chat {

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -8,6 +8,7 @@ import type {
 	ChatMessage,
 	ChatOptions,
 	ChatMessageText,
+	CredentialStatus,
 	SendMessageResponse,
 } from '@n8n/chat/types';
 import { StreamingMessageManager, createBotMessage } from '@n8n/chat/utils/streaming';
@@ -214,6 +215,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 		const currentSessionId = ref<string | null>(null);
 		const waitingForResponse = ref(false);
 		const blockUserInput = ref(false);
+		const credentialStatus = ref<CredentialStatus | null>(null);
 
 		const initialMessages = computed<ChatMessage[]>(() =>
 			(options.initialMessages ?? []).map((text) => ({
@@ -353,6 +355,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 			currentSessionId,
 			waitingForResponse,
 			blockUserInput,
+			credentialStatus,
 			loadPreviousSession,
 			startNewSession,
 			sendMessage,

--- a/packages/frontend/@n8n/chat/src/types/chat.ts
+++ b/packages/frontend/@n8n/chat/src/types/chat.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue';
 
+import type { CredentialStatus } from '@n8n/chat/types/credentialStatus';
 import type { ChatMessage } from '@n8n/chat/types/messages';
 
 import type { SendMessageResponse } from './webhook';
@@ -10,6 +11,7 @@ export interface Chat {
 	currentSessionId: Ref<string | null>;
 	waitingForResponse: Ref<boolean>;
 	blockUserInput: Ref<boolean>;
+	credentialStatus: Ref<CredentialStatus | null>;
 	loadPreviousSession?: () => Promise<string | undefined>;
 	startNewSession?: () => Promise<void>;
 	sendMessage: (text: string, files?: File[]) => Promise<SendMessageResponse | null>;

--- a/packages/frontend/@n8n/chat/src/types/credentialStatus.ts
+++ b/packages/frontend/@n8n/chat/src/types/credentialStatus.ts
@@ -1,0 +1,17 @@
+/**
+ * Read-only credential-readiness signal for the in-widget status strip.
+ * Populated only when a host page (the hosted chat shell) posts it in via
+ * `postMessage` - see `@n8n/chat/utils/credentialStatus`. The widget never
+ * mutates this itself and holds no credential logic of its own.
+ */
+export interface CredentialStatus {
+	/** Whether all required end-user credentials are connected. */
+	ready: boolean;
+	/** How many required accounts are still not connected. */
+	missingCount: number;
+	/**
+	 * True during a test-mode execution, where identity was established using
+	 * the builder's own already-connected credentials rather than a visitor's.
+	 */
+	testMode: boolean;
+}

--- a/packages/frontend/@n8n/chat/src/types/index.ts
+++ b/packages/frontend/@n8n/chat/src/types/index.ts
@@ -1,4 +1,5 @@
 export type * from './chat';
+export type * from './credentialStatus';
 export type * from './messages';
 export type * from './options';
 export type * from './webhook';

--- a/packages/frontend/@n8n/chat/src/utils/credentialStatus.ts
+++ b/packages/frontend/@n8n/chat/src/utils/credentialStatus.ts
@@ -14,7 +14,16 @@ function isCredentialStatusMessageData(data: unknown): data is CredentialStatusM
 	if (typeof data !== 'object' || data === null) return false;
 
 	const candidate = data as Record<string, unknown>;
-	return candidate.type === CREDENTIAL_STATUS_MESSAGE_TYPE && typeof candidate.ready === 'boolean';
+	return (
+		candidate.type === CREDENTIAL_STATUS_MESSAGE_TYPE &&
+		typeof candidate.ready === 'boolean' &&
+		(candidate.missingCount === undefined ||
+			(typeof candidate.missingCount === 'number' &&
+				Number.isFinite(candidate.missingCount) &&
+				Number.isInteger(candidate.missingCount) &&
+				candidate.missingCount >= 0)) &&
+		(candidate.testMode === undefined || typeof candidate.testMode === 'boolean')
+	);
 }
 
 /**

--- a/packages/frontend/@n8n/chat/src/utils/credentialStatus.ts
+++ b/packages/frontend/@n8n/chat/src/utils/credentialStatus.ts
@@ -1,0 +1,50 @@
+import type { CredentialStatus } from '@n8n/chat/types';
+
+/** Message `type` the hosted chat shell uses to signal credential readiness. */
+export const CREDENTIAL_STATUS_MESSAGE_TYPE = 'n8n-chat:credential-status';
+
+interface CredentialStatusMessageData {
+	type: typeof CREDENTIAL_STATUS_MESSAGE_TYPE;
+	ready: boolean;
+	missingCount?: number;
+	testMode?: boolean;
+}
+
+function isCredentialStatusMessageData(data: unknown): data is CredentialStatusMessageData {
+	if (typeof data !== 'object' || data === null) return false;
+
+	const candidate = data as Record<string, unknown>;
+	return candidate.type === CREDENTIAL_STATUS_MESSAGE_TYPE && typeof candidate.ready === 'boolean';
+}
+
+/**
+ * Listens for the hosted chat page's credential-readiness signal and forwards
+ * parsed updates to `onStatus`. Returns a function that stops listening.
+ *
+ * The widget may run inside a sandboxed, opaque-origin iframe (the hosted
+ * chat shell), so `event.origin` can't be checked against an allowlist -
+ * instead only messages sent by our own parent frame are accepted. This also
+ * makes the listener a no-op when `@n8n/chat` is embedded directly on a
+ * third-party page: with no surrounding frame, `window.parent === window`,
+ * so no message from the page itself is ever mistaken for the host's signal.
+ */
+export function listenForCredentialStatus(
+	onStatus: (status: CredentialStatus) => void,
+): () => void {
+	function handleMessage(event: MessageEvent) {
+		if (window.parent === window || event.source !== window.parent) return;
+		if (!isCredentialStatusMessageData(event.data)) return;
+
+		onStatus({
+			ready: event.data.ready,
+			missingCount: event.data.missingCount ?? 0,
+			testMode: event.data.testMode ?? false,
+		});
+	}
+
+	window.addEventListener('message', handleMessage);
+
+	return () => {
+		window.removeEventListener('message', handleMessage);
+	};
+}


### PR DESCRIPTION
## Summary

Adds a read-only credential-status strip to `@n8n/chat`'s widget layout, rendered between the message list and the input row via a new `statusStrip` slot in `Layout.vue`.

The widget listens for a `postMessage` signal (`n8n-chat:credential-status`) from a host page and, when it reports outstanding accounts, shows a remaining-account count and disables the input/send button. When the host reports readiness, the strip clears and the input re-enables without a reload. A distinct message is shown during test-mode executions ("You're testing with your own connected accounts...") since identity there is established via the builder's own credentials rather than a visitor's.

The widget holds no credential logic itself — it only reacts to the signal. It's additive and backward-compatible: with no host ever sending the signal (e.g. `@n8n/chat` embedded directly on a third-party site), the widget behaves exactly as today.

Note: this only implements the widget's *receiving* side. The sender — the hosted chat shell (IAM-1275) and "Connect your accounts" dialog (IAM-1267) — lands in separate PRs, so this change has no visible effect on its own yet.

## How to test

Covered by unit tests (`Chat.spec.ts`, `Input.spec.ts`, `CredentialStatusStrip.spec.ts`, `utils/credentialStatus.spec.ts`). To see it live before the host-side sender lands, embed the built widget in a page that posts:
```js
iframe.contentWindow.postMessage({ type: 'n8n-chat:credential-status', ready: false, missingCount: 2 }, '*');
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1274

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

