### PR TITLE
ci: Repin rharkor/caching-for-turbo from v2.4.2 to v2.5.1 (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -284,7 +284,7 @@ runs:
     # build job stays green; Linux/Blacksmith jobs keep remote caching.
     - name: Configure Turborepo Cache
       if: steps.turbo-server.outputs.running != 'true' && runner.os != 'Windows'
-      uses: rharkor/caching-for-turbo@5d14fba18e450c09393333cfd4242e8b3cb455a6 # v2.4.2
+      uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       with:
         server-port: 0
 


### PR DESCRIPTION
## Summary

CI is red repo-wide. The `caching-for-turbo` commit we pin in `.github/actions/setup-nodejs/action.yml` can no longer be downloaded — `codeload.github.com` returns a deterministic **400** for its `tar.gz`, which is the only format the runner fetches:

```
Failed to download archive 'https://codeload.github.com/rharkor/caching-for-turbo/tar.gz/5d14fba18e450c09393333cfd4242e8b3cb455a6' after 3 attempts.
```

Actions are downloaded in *Prepare all required actions*, before the step's `if:` is evaluated, so every `Install & Build` job fails — including on runners where the step would be skipped. `Required Checks` fails with it, so the merge queue is dropping PRs, and backports to the release-candidate branches and `3.x` are affected too.

This repins to v2.5.1.

### This is a GitHub-side archive-cache fault, not a change in the action

The commit and its content are intact — only one `(repo, sha, format)` tuple is broken:

| Request | Result |
| --- | --- |
| `tar.gz/5d14fba…` (our pin, v2.4.2) | **400** |
| `zip/5d14fba…` — same commit | 200 |
| `tar.gz/v2.4.2` — same commit, by tag | 200 |
| `tar.gz/2f61e9be…` (v2.4.1) | 200 |
| `tar.gz/75f8ebf4…` (v2.5.0) | 200 |
| `tar.gz/2238fae6…` (v2.5.1) | 200 |

A deleted or rewritten ref would give 404, and would not leave the same commit's `zip` and tag archive serving fine. Also ruled out the known codeload HTTP/2 connection-reuse 400: still 400 on `--http1.1`, on `Connection: close`, and both authenticated and anonymous. `githubstatus.com` reports all systems operational.

Repinning is the only fix in our control — the runner chooses `tar.gz`, and zizmor requires a SHA pin, so a tag ref is not an option.

### Diligence on v2.5.1

Diffed the shipped bundles rather than trusting the changelog:

- 52 of 63 `dist/` files are byte-identical to v2.4.2.
- Sourcemap source-list diff: **zero first-party files added or removed** — same 14-file `src/` set. All 46 added sources are `node_modules` from AWS SDK / smithy / `fast-xml-parser` bumps.
- Outbound hostname scan of `dist/setup/index.js` and `dist/post/index.js`: only `github.com`, `api.github.com`, Azure blob (`@actions/cache`), S3 and `localhost`; the rest are spec/doc URLs in vendored comments.
- Upstream has `check-dist.yml` (rebuilds and compares committed `dist/`) plus CodeQL, both passing on the release merge commit.

The two behavioural changes since v2.4.2 are `useRelativeCachePath` (new opt-in input, we don't set it) and a retry on 429 during cache restore, which is a straight improvement for us.

## How to test

CI on this PR exercises it: `Install & Build` reaching *Setup and Build* and completing means the action resolves again. Worth confirming the Windows build job stays green, since it deliberately skips this step.

## Related Linear tickets, Github issues, and Community forum posts

None — unplanned CI breakage.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — n/a, internal CI action pin
- [ ] Tests included. — n/a, CI itself is the test
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
