### PR TITLE
feat(core): Add backend chat-trigger message-send gate for end-user credentials (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -11,6 +11,7 @@ import {
 	getHighlightedInputKey,
 	HIGHLIGHTED_SESSION_KEY,
 	CHAT_TRIGGER_PATH_SUFFIX,
+	buildCredentialConnectionsRequiredResponse,
 } from 'n8n-workflow';
 import type {
 	IDataObject,
@@ -21,6 +22,7 @@ import type {
 	INodeExecutionData,
 	IBinaryData,
 	INodeProperties,
+	CredentialCheckResult,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
 import { ChatTriggerConfig } from '@n8n/config';
@@ -1017,6 +1019,20 @@ export class ChatTrigger extends Node {
 				return {
 					webhookResponse: { data: [] },
 				};
+			}
+		} else {
+			let readiness: CredentialCheckResult | undefined;
+			try {
+				readiness = await ctx.checkTriggerCredentialStatus();
+			} catch (error) {
+				ctx.logger.error('Chat trigger credential readiness check failed', { error });
+				res.status(503).json({ status: 'credential_readiness_check_failed' });
+				return { noWebhookResponse: true };
+			}
+
+			if (readiness && !readiness.readyToExecute) {
+				res.status(428).json(buildCredentialConnectionsRequiredResponse(readiness));
+				return { noWebhookResponse: true };
 			}
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -1,7 +1,7 @@
 import { ChatTriggerConfig } from '@n8n/config/src';
 import { Container } from '@n8n/di';
 import type { Request, Response } from 'express';
-import type { INode, IWebhookFunctions } from 'n8n-workflow';
+import type { CredentialCheckResult, INode, IWebhookFunctions } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { ChatTrigger } from '../ChatTrigger.node';
@@ -39,9 +39,20 @@ describe('ChatTrigger Node', () => {
 
 		mockResponse.status.mockReturnValue(mockResponse);
 		mockResponse.send.mockReturnValue(mockResponse);
+		mockResponse.json.mockReturnValue(mockResponse);
 		mockResponse.end.mockReturnValue(mockResponse);
 		mockResponse.writeHead.mockReturnValue(mockResponse);
 		mockResponse.flushHeaders.mockImplementation(() => mockResponse);
+
+		// No identity established / dynamic credentials disabled by default - the gate
+		// is a no-op unless a test opts in with a readiness result.
+		mockContext.checkTriggerCredentialStatus.mockResolvedValue(undefined);
+		mockContext.logger = {
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+			info: vi.fn(),
+		} as unknown as IWebhookFunctions['logger'];
 
 		// Provide socket methods required by the streaming keepalive configuration
 		mockRequest.socket = {
@@ -415,6 +426,99 @@ describe('ChatTrigger Node', () => {
 				'www-authenticate': 'Basic realm="Webhook"',
 			});
 			expect(result).toEqual({ noWebhookResponse: true });
+		});
+	});
+
+	describe('message-send credential readiness gate', () => {
+		const notReady: CredentialCheckResult = {
+			readyToExecute: false,
+			credentials: [
+				{
+					credentialId: 'cred-missing',
+					credentialName: 'My Gmail',
+					credentialType: 'gmailOAuth2',
+					resolverId: 'resolver-1',
+					status: 'missing',
+					authorizationUrl: 'https://example.com/authorize',
+					revokeUrl: 'https://example.com/revoke',
+				},
+			],
+		};
+
+		it('rejects the message and creates no execution when a required credential is missing', async () => {
+			mockContext.checkTriggerCredentialStatus.mockResolvedValue(notReady);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(428);
+			expect(mockResponse.json).toHaveBeenCalledWith({
+				status: 'credential_connections_required',
+				readyToExecute: false,
+				credentials: [
+					{
+						credentialId: 'cred-missing',
+						credentialName: 'My Gmail',
+						credentialType: 'gmailOAuth2',
+						credentialStatus: 'missing',
+					},
+				],
+			});
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('enqueues the execution when the check reports ready', async () => {
+			mockContext.checkTriggerCredentialStatus.mockResolvedValue({
+				readyToExecute: true,
+				credentials: [],
+			});
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(mockResponse.status).not.toHaveBeenCalledWith(428);
+			expect(result).toMatchObject({
+				webhookResponse: { status: 200 },
+				workflowData: expect.any(Array),
+			});
+		});
+
+		it('enqueues the execution when no check applies (no identity established)', async () => {
+			mockContext.checkTriggerCredentialStatus.mockResolvedValue(undefined);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(mockResponse.status).not.toHaveBeenCalled();
+			expect(result).toMatchObject({
+				webhookResponse: { status: 200 },
+				workflowData: expect.any(Array),
+			});
+		});
+
+		it('fails closed with 503 when the check throws', async () => {
+			const error = new Error('could not decrypt credential context');
+			mockContext.checkTriggerCredentialStatus.mockRejectedValue(error);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(mockResponse.status).toHaveBeenCalledWith(503);
+			expect(mockResponse.json).toHaveBeenCalledWith({
+				status: 'credential_readiness_check_failed',
+			});
+			expect(mockContext.logger.error).toHaveBeenCalledWith(
+				'Chat trigger credential readiness check failed',
+				{ error },
+			);
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('excludes loadPreviousSession requests from the gate', async () => {
+			mockContext.getBodyData.mockReturnValue({ action: 'loadPreviousSession' });
+			mockContext.checkTriggerCredentialStatus.mockResolvedValue(notReady);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(mockContext.checkTriggerCredentialStatus).not.toHaveBeenCalled();
+			expect(mockResponse.status).not.toHaveBeenCalledWith(428);
+			expect(result).toEqual({ webhookResponse: { data: [] } });
 		});
 	});
 

--- a/packages/cli/test/integration/dynamic-credentials.ee/chat-trigger-test-run.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/chat-trigger-test-run.api.test.ts
@@ -24,7 +24,6 @@ import {
 } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { Project, User, WorkflowEntity } from '@n8n/db';
-import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { DirectoryLoader } from 'n8n-core';
 import { Cipher, UnrecognizedNodeTypeError } from 'n8n-core';
@@ -236,13 +235,6 @@ const sendChatMessage = async (workflow: WorkflowEntity, chatSessionId: string) 
 		.post(`/${webhookTestEndpoint}/${workflow.id}/${chatSessionId}`)
 		.send({ action: 'sendMessage', chatInput: 'hello', sessionId: chatSessionId });
 
-const lastExecutionFor = async (workflowId: string) =>
-	await Container.get(ExecutionRepository).findOne({
-		where: { workflowId },
-		order: { createdAt: 'DESC' },
-		relations: ['executionData'],
-	});
-
 beforeAll(async () => {
 	await initNodeTypes(loadNodesFromDist([HTTP_REQUEST]));
 	registerChatTrigger();
@@ -320,13 +312,17 @@ describe('chat trigger test run with end-user credentials', () => {
 		const vendorScope = mockVendorCall();
 
 		await startListening(workflow, chatSessionId);
-		await sendChatMessage(workflow, chatSessionId);
+		const response = await sendChatMessage(workflow, chatSessionId);
 
-		const execution = await lastExecutionFor(workflow.id);
-		const runError = JSON.stringify(execution?.executionData?.data ?? '');
-
-		expect(runError).toContain('is not connected for you');
-		expect(runError).not.toContain('Unable to sign without access token');
+		// The message-send gate now rejects before the run ever reaches the HTTP Request
+		// node, so the builder gets a structured "not connected" response instead of a run
+		// that dies signing the request with no token.
+		expect(response.statusCode).toBe(428);
+		expect(response.body).toMatchObject({
+			status: 'credential_connections_required',
+			readyToExecute: false,
+			credentials: [expect.objectContaining({ credentialId, credentialStatus: 'missing' })],
+		});
 		expect(vendorScope.isDone()).toBe(false);
 	});
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1555,8 +1555,9 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	 * for this workflow, using the execution context established by
 	 * `establishTriggerIdentity`. Returns connection URLs for any missing credential, or
 	 * `undefined` when no check applies (dynamic-credentials disabled or no identity
-	 * established). Used by the MCP trigger to gate a tool call, and by the Form trigger
-	 * to gate a submission, before an execution is enqueued.
+	 * established). Used by the MCP trigger to gate a tool call, by the Form trigger to
+	 * gate a submission, and by the Chat trigger to gate a message send, before an
+	 * execution is enqueued.
 	 */
 	checkTriggerCredentialStatus(): Promise<CredentialCheckResult | undefined>;
 	getInputConnectionData(


### PR DESCRIPTION
## Summary

Re-checks end-user credential readiness server-side at chat message-send time, after identity establishment and before the execution is enqueued. Mirrors the Form trigger's existing submit-time gate (#35539), reusing the same shared `checkTriggerCredentialStatus()` / `buildCredentialConnectionsRequiredResponse()` helpers from `n8n-workflow`.

- `ChatTrigger.node.ts`: after `validateAuth` establishes the sending user's identity, calls `ctx.checkTriggerCredentialStatus()` before enqueuing the execution.
  - Not ready → responds `428` with the missing-credential list, no execution created.
  - Check throws → fails closed with `503` (a thrown error would otherwise be swallowed by the webhook layer, which enqueues anyway).
  - Ready, or no check applies (no identity established / dynamic-credentials disabled) → proceeds normally.
  - `loadPreviousSession` requests are excluded — they never send a message.
- `interfaces.ts`: extends the `checkTriggerCredentialStatus` doc comment to mention the Chat trigger alongside MCP and Form.

## How to test

1. Enable dynamic credentials + `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2`.
2. Publish a workflow with a Chat Trigger (`n8nUserAuth`, hosted chat) feeding a node with a resolvable end-user credential.
3. Open the hosted chat page, don't connect the credential, send a message → expect `428` and no execution.
4. Connect the credential, send a message → expect normal execution.
5. Disconnect the credential mid-conversation, send another message → expect `428` again.

Unit tests added in `ChatTrigger.node.test.ts` cover: reject when not ready, allow when ready, allow when no check applies, fail-closed on throw, and exclusion of `loadPreviousSession`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1264

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

