### PR TITLE
fix(Chat Trigger Node): Respect private chat setting in tests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -845,8 +845,8 @@ export class ChatTrigger extends Node {
 
 		const mode = ctx.getMode() === 'manual' ? 'test' : 'production';
 
-		// Allow execution in manual mode (test) even when not public
-		if (!isPublic && mode !== 'test') {
+		// Only the editor's session-scoped canvas test route may execute a non-public chat
+		if (!isPublic && (mode !== 'test' || !ctx.isChatSessionTest())) {
 			res.status(404).end();
 			return {
 				noWebhookResponse: true,

--- a/packages/cli/test/integration/chat-trigger-test-webhook-auth.api.test.ts
+++ b/packages/cli/test/integration/chat-trigger-test-webhook-auth.api.test.ts
@@ -1,12 +1,10 @@
 /**
- * Authentication on Chat Trigger test webhooks (`/webhook-test/...`).
+ * Access controls on Chat Trigger test webhooks (`/webhook-test/...`).
  *
- * A Chat Trigger's configured authentication applies to its test webhook the same way
- * it does in production. The one exemption is the editor's canvas chat: its registration
- * is rewritten to the session-scoped `{workflowId}/{chatSessionId}` route and flagged as
- * such by the backend, and only that flagged registration runs without webhook
- * credentials. A rejected request responds before any execution starts and leaves the
- * one-shot registration in place for a later authorized request.
+ * Sessionless test webhooks enforce the trigger's public visibility and configured
+ * authentication. The editor's canvas chat is the one exemption: its registration is
+ * rewritten to the session-scoped `{workflowId}/{chatSessionId}` route and flagged by
+ * the backend, so only that route may run a private, protected chat.
  */
 
 import {
@@ -204,6 +202,31 @@ describe('chat trigger test webhooks', () => {
 			.expect(404);
 	});
 
+	test('does not expose a private chat through a sessionless test route', async () => {
+		const trigger = chatTriggerNode({
+			public: false,
+			mode: 'webhook',
+			authentication: 'none',
+		});
+		const workflow = await createChatWorkflow(trigger);
+
+		const listening = await startListening(workflow.id);
+		expect(listening.body.data).toEqual({ waitingForWebhook: true });
+
+		await webhookAgent
+			.post(`/${webhookTestEndpoint}/${trigger.webhookId}/chat`)
+			.send(chatMessage())
+			.expect(404);
+
+		const executionCount = await Container.get(ExecutionRepository).count({
+			where: { workflowId: workflow.id },
+		});
+		expect(executionCount).toBe(0);
+
+		// Disarm the pending registration's timeout so the suite exits cleanly.
+		await Container.get(TestWebhooks).cancelWebhook(workflow.id);
+	});
+
 	test('requires an n8n session for user-authenticated test webhooks', async () => {
 		const trigger = chatTriggerNode({ authentication: 'n8nUserAuth' });
 		const workflow = await createChatWorkflow(trigger);
@@ -225,10 +248,10 @@ describe('chat trigger test webhooks', () => {
 		await Container.get(TestWebhooks).cancelWebhook(workflow.id);
 	});
 
-	test('allows the editor chat session route without webhook credentials', async () => {
+	test('allows a private protected chat through the editor session route', async () => {
 		const credential = await createBasicAuthCredential();
 		const trigger = chatTriggerNode(
-			{ authentication: 'basicAuth' },
+			{ public: false, authentication: 'basicAuth' },
 			{ id: credential.id, name: credential.name },
 		);
 		const workflow = await createChatWorkflow(trigger);


### PR DESCRIPTION
## Summary

- Apply the private chat setting to standard test routes.
- Keep the editor canvas session route available for workflow testing.
- Add real HTTP coverage for private and protected test route behavior.

## How to test

1. Create a workflow with a Chat Trigger.
2. Turn off **Make Chat Publicly Available** and configure Basic Auth.
3. Send a message through the editor canvas chat. Confirm that the workflow runs.
4. Confirm that non-editor test routes return 404 for the private chat.

Automated checks:

- `pnpm build`
- Changed-file ESLint checks
- Package typechecks for `@n8n/nodes-langchain` and `n8n`
- `pnpm test:integration test/integration/chat-trigger-test-webhook-auth.api.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-10985

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

