### PR TITLE
feat(editor): Add Contact Support link to Help menu for Cloud instances

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts
@@ -163,6 +163,7 @@ import IconLucideLanguages from '~icons/lucide/languages';
 import IconLucideLaptop from '~icons/lucide/laptop';
 import IconLucideLayers from '~icons/lucide/layers';
 import IconLucideLayoutTemplate from '~icons/lucide/layout-template';
+import IconLucideLifeBuoy from '~icons/lucide/life-buoy';
 import IconLucideLightbulb from '~icons/lucide/lightbulb';
 import IconLucideLink from '~icons/lucide/link';
 import IconLucideList from '~icons/lucide/list';
@@ -669,6 +670,7 @@ export const updatedIconSet = {
 	laptop: IconLucideLaptop,
 	layers: IconLucideLayers,
 	'layout-template': IconLucideLayoutTemplate,
+	'life-buoy': IconLucideLifeBuoy,
 	lightbulb: IconLucideLightbulb,
 	link: IconLucideLink,
 	list: IconLucideList,

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1892,6 +1892,7 @@
 	"mainSidebar.credentials": "Credentials",
 	"mainSidebar.variables": "Variables",
 	"mainSidebar.help": "Help",
+	"mainSidebar.helpMenuItems.contactSupport": "Contact Support",
 	"mainSidebar.helpMenuItems.course": "Course",
 	"mainSidebar.helpMenuItems.documentation": "Documentation",
 	"mainSidebar.helpMenuItems.forum": "Forum",

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.test.ts
@@ -167,6 +167,26 @@ describe('MainSidebar', () => {
 
 			expect(getByTestId('main-sidebar-settings')).toBeInTheDocument();
 		});
+
+		it('should show contact support item in help menu when on cloud deployment', async () => {
+			settingsStore.isCloudDeployment = true;
+
+			const { getByText, findByText } = renderComponent();
+
+			getByText('Help').click();
+
+			expect(await findByText('Contact Support')).toBeInTheDocument();
+		});
+
+		it('should not show contact support item in help menu when not on cloud deployment', async () => {
+			settingsStore.isCloudDeployment = false;
+
+			const { getByText, queryByText } = renderComponent();
+
+			getByText('Help').click();
+
+			expect(queryByText('Contact Support')).not.toBeInTheDocument();
+		});
 	});
 
 	describe('handleSelect', () => {

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.test.ts
@@ -181,9 +181,11 @@ describe('MainSidebar', () => {
 		it('should not show contact support item in help menu when not on cloud deployment', async () => {
 			settingsStore.isCloudDeployment = false;
 
-			const { getByText, queryByText } = renderComponent();
+			const { getByText, findByRole, queryByText } = renderComponent();
 
 			getByText('Help').click();
+			// Wait for the popover to mount before checking
+			await findByRole('dialog');
 
 			expect(queryByText('Contact Support')).not.toBeInTheDocument();
 		});

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
@@ -187,6 +187,19 @@ const mainMenuItems = computed<IMenuItem[]>(() => [
 					target: '_blank',
 				},
 			},
+			...(settingsStore.isCloudDeployment
+				? [
+						{
+							id: 'contact-support',
+							icon: 'life-buoy',
+							label: i18n.baseText('mainSidebar.helpMenuItems.contactSupport'),
+							link: {
+								href: EXTERNAL_LINKS.SUPPORT,
+								target: '_blank',
+							},
+						},
+					]
+				: []),
 			{
 				id: 'report-bug',
 				icon: 'bug',
@@ -301,6 +314,7 @@ const handleSelect = (key: string) => {
 			void handleSettingsItemSelect(key);
 			break;
 		}
+		case 'contact-support':
 		case 'quickstart':
 		case 'docs':
 		case 'forum':

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
@@ -187,19 +187,16 @@ const mainMenuItems = computed<IMenuItem[]>(() => [
 					target: '_blank',
 				},
 			},
-			...(settingsStore.isCloudDeployment
-				? [
-						{
-							id: 'contact-support',
-							icon: 'life-buoy',
-							label: i18n.baseText('mainSidebar.helpMenuItems.contactSupport'),
-							link: {
-								href: EXTERNAL_LINKS.SUPPORT,
-								target: '_blank',
-							},
-						},
-					]
-				: []),
+			{
+				id: 'contact-support',
+				icon: 'life-buoy',
+				label: i18n.baseText('mainSidebar.helpMenuItems.contactSupport'),
+				available: settingsStore.isCloudDeployment,
+				link: {
+					href: EXTERNAL_LINKS.SUPPORT,
+					target: '_blank',
+				},
+			},
 			{
 				id: 'report-bug',
 				icon: 'bug',
@@ -227,7 +224,12 @@ const mainMenuItems = computed<IMenuItem[]>(() => [
 ]);
 
 const visibleMenuItems = computed<IMenuItem[]>(() =>
-	mainMenuItems.value.filter((item) => item.available !== false),
+	mainMenuItems.value
+		.filter((item) => item.available !== false)
+		.map((item) => ({
+			...item,
+			children: item.children?.filter((child) => child.available !== false),
+		})),
 );
 
 const checkOverflow = () => {

--- a/packages/frontend/editor-ui/src/app/constants/externalLinks.ts
+++ b/packages/frontend/editor-ui/src/app/constants/externalLinks.ts
@@ -3,4 +3,5 @@ export const EXTERNAL_LINKS = {
 	DOCUMENTATION: 'https://docs.n8n.io?utm_source=n8n_app&utm_medium=app_sidebar',
 	FORUM: 'https://community.n8n.io?utm_source=n8n_app&utm_medium=app_sidebar',
 	COURSES: 'https://docs.n8n.io/courses/',
+	SUPPORT: 'https://support.n8n.io',
 } as const;


### PR DESCRIPTION
## Summary

Add a "Contact Support" item under the editor's Help menu to give n8n Cloud instance users access to the support portal at [support.n8n.io](https://support.n8n.io/).

<img width="394" height="386" alt="contact-support" src="https://github.com/user-attachments/assets/93029285-6d66-40e3-ad9a-72bf944579eb" />

## How to test
1. Run n8n with `N8N_DEPLOYMENT_TYPE=cloud` set
2. Open the editor, open the Help menu from the sidebar
3. Confirm "Contact Support" appears between "Course" and "Report a bug".
4. On a self-hosted instance, confirm it does not appear.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CX-225/ 

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

