### PR TITLE
fix(core): Report a model id in Instance AI traces and run metrics (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -187,6 +187,8 @@ const loadValidateAttachments = lazyModule(
 
 export { MAX_STEPS } from './constants/max-steps';
 export { parseModelHeadersJson } from './utils/parse-model-headers';
+export { modelConfigId } from './utils/model-config-id';
+export { isEndpointModelConfig } from './utils/modal-session';
 export { resolveCustomModelExperimentDefaultsFromEnv } from './utils/custom-model-defaults';
 export { WorkflowSaveConflictError } from './errors/workflow-save-conflict.error';
 export { WorkflowNotFoundError } from './errors/workflow-not-found.error';

--- a/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
@@ -1734,6 +1734,56 @@ describe('createInstanceAiTraceContext', () => {
 		expect(JSON.stringify(tracing?.orchestratorRun.metadata)).not.toContain('sk-ant-secret');
 	});
 
+	it('records a model id for a pre-built AI SDK model instead of dumping the instance', async () => {
+		// What the proxy routes hand over: `modelId` + `config.provider`, no `id`.
+		// `provider` is a prototype getter on the real SDK model, hence the class.
+		class FakeChatLanguageModel {
+			readonly specificationVersion = 'v4';
+
+			readonly modelId = 'kimi-k3';
+
+			readonly config = {
+				provider: 'moonshotai.chat',
+				url: () => 'https://proxy.example.com/kimi/v1',
+				headers: function getHeaders() {
+					return {};
+				},
+				includeUsage: true,
+			};
+
+			readonly chunkSchema = { '~standard': { vendor: 'zod', version: 1 } };
+
+			get provider() {
+				return this.config.provider;
+			}
+		}
+
+		const tracing = await createInstanceAiTraceContext({
+			threadId: 'thread-1',
+			messageId: 'message-1',
+			runId: 'run-1',
+			userId: 'user-1',
+			modelId: new FakeChatLanguageModel(),
+			input: { message: 'What workflows do I have?' },
+		});
+
+		expect(tracing?.messageRun.metadata).toEqual(
+			expect.objectContaining({ model_id: 'moonshotai/kimi-k3' }),
+		);
+
+		await tracing?.finishRun(tracing.orchestratorRun, {
+			outputs: { result: 'done' },
+			metadata: { model_id: new FakeChatLanguageModel() },
+		});
+
+		expect(tracing?.orchestratorRun.metadata).toEqual(
+			expect.objectContaining({ model_id: 'moonshotai/kimi-k3' }),
+		);
+		const serialized = JSON.stringify(tracing?.orchestratorRun.metadata);
+		expect(serialized).not.toContain('chunkSchema');
+		expect(serialized).not.toContain('[function');
+	});
+
 	it('traces suspendable tools and HITL suspension spans', async () => {
 		const tracing = await createInstanceAiTraceContext({
 			threadId: 'thread-1',

--- a/packages/@n8n/instance-ai/src/tracing/trace-payloads.ts
+++ b/packages/@n8n/instance-ai/src/tracing/trace-payloads.ts
@@ -16,6 +16,7 @@ import {
 } from '../tools/tool-ids';
 import type { InstanceAiToolRegistry } from '../types';
 import { formatAgentRoleLabel, formatTraceLabel } from './trace-labels';
+import { modelConfigId } from '../utils/model-config-id';
 
 const MAX_TRACE_DEPTH = 4;
 const MAX_PROMPT_SCHEMA_TRACE_DEPTH = 12;
@@ -1342,12 +1343,12 @@ export function rawTracePayload(value: unknown): Record<string, unknown> {
 }
 
 export function serializeModelIdForTrace(modelId: unknown): unknown {
-	if (typeof modelId === 'string' && modelId.length > 0) {
-		return truncateString(modelId);
-	}
-
-	if (isRecord(modelId) && typeof modelId.id === 'string') {
-		return truncateString(modelId.id);
+	// Falling through to `sanitizeTraceValue` dumps the whole model instance —
+	// config, zod chunk schema, bound functions — into the span attribute, so
+	// every recognizable variant has to be handled by `modelConfigId`.
+	const id = modelConfigId(modelId);
+	if (id !== undefined) {
+		return truncateString(id);
 	}
 
 	return sanitizeTraceValue(modelId);

--- a/packages/@n8n/instance-ai/src/utils/__tests__/model-config-id.test.ts
+++ b/packages/@n8n/instance-ai/src/utils/__tests__/model-config-id.test.ts
@@ -1,0 +1,66 @@
+import { modelConfigId } from '../model-config-id';
+
+describe('modelConfigId', () => {
+	it('returns plain-string model ids as-is', () => {
+		expect(modelConfigId('anthropic/claude-sonnet-4-6')).toBe('anthropic/claude-sonnet-4-6');
+	});
+
+	it('reads the id off endpoint and Vertex configs', () => {
+		expect(
+			modelConfigId({
+				id: 'anthropic/claude-sonnet-4-6',
+				url: 'https://api.anthropic.com/v1/messages',
+				apiKey: 'sk-ant-secret',
+			}),
+		).toBe('anthropic/claude-sonnet-4-6');
+		expect(
+			modelConfigId({
+				id: 'google-vertex-anthropic/claude-opus-4-8',
+				project: 'p',
+				location: 'europe-west1',
+			}),
+		).toBe('google-vertex-anthropic/claude-opus-4-8');
+	});
+
+	it('reads `modelId` off a pre-built AI SDK model and drops the transport suffix', () => {
+		// Shape of what `createProxyLanguageModel` returns: `modelId` + `config.provider`,
+		// no `id`. `provider` is a prototype getter, so only `config` is an own property.
+		expect(
+			modelConfigId({
+				specificationVersion: 'v4',
+				modelId: 'kimi-k3',
+				config: { provider: 'moonshotai.chat', includeUsage: true },
+			}),
+		).toBe('moonshotai/kimi-k3');
+		expect(
+			modelConfigId({
+				specificationVersion: 'v4',
+				modelId: 'claude-opus-4-8',
+				config: { provider: 'anthropic.messages' },
+			}),
+		).toBe('anthropic/claude-opus-4-8');
+	});
+
+	it('prefers a top-level provider over the config one', () => {
+		expect(
+			modelConfigId({
+				modelId: 'claude-opus-4-8',
+				provider: 'anthropic.messages',
+				config: { provider: 'ignored.chat' },
+			}),
+		).toBe('anthropic/claude-opus-4-8');
+	});
+
+	it('falls back to the bare model name when no provider is readable', () => {
+		expect(modelConfigId({ modelId: 'kimi-k3' })).toBe('kimi-k3');
+		expect(modelConfigId({ modelId: 'kimi-k3', config: { provider: 42 } })).toBe('kimi-k3');
+	});
+
+	it('returns undefined when no id can be read', () => {
+		expect(modelConfigId(undefined)).toBeUndefined();
+		expect(modelConfigId('')).toBeUndefined();
+		expect(modelConfigId({})).toBeUndefined();
+		expect(modelConfigId({ modelId: '' })).toBeUndefined();
+		expect(modelConfigId({ modelId: 7 })).toBeUndefined();
+	});
+});

--- a/packages/@n8n/instance-ai/src/utils/model-config-id.ts
+++ b/packages/@n8n/instance-ai/src/utils/model-config-id.ts
@@ -1,0 +1,41 @@
+import { isRecord } from '@n8n/utils/is-record';
+
+/** Normalize the provider half of a `provider/model` id. The AI SDK reports the
+ *  transport too (`anthropic.messages`, `moonshotai.chat`), which we drop so
+ *  proxy-built models group with the plain-string model ids. */
+function normalizeProvider(provider: unknown): string | undefined {
+	if (typeof provider !== 'string') return undefined;
+	return provider.split('.', 1)[0] || undefined;
+}
+
+/**
+ * Best-effort `provider/model` id for any `ModelConfig` variant — for telemetry,
+ * tracing, and logs.
+ *
+ * Takes `unknown` so callers holding an unnarrowed value can use it too. Returns
+ * `undefined` when no id can be read, so callers pick their own fallback.
+ *
+ * The pre-built AI SDK `LanguageModel` variant (proxy routes) is the reason this
+ * exists: it carries `modelId` plus a `provider` and no `id`, so an `id`-only
+ * lookup silently misses every proxy-backed run.
+ */
+export function modelConfigId(config: unknown): string | undefined {
+	if (typeof config === 'string') {
+		return config.length > 0 ? config : undefined;
+	}
+
+	if (!isRecord(config)) return undefined;
+
+	if (typeof config.id === 'string') return config.id;
+
+	if (typeof config.modelId === 'string' && config.modelId.length > 0) {
+		// `provider` is a prototype getter on AI SDK model instances; `config.provider`
+		// is the own property the openai-compatible and Anthropic providers set.
+		const provider = normalizeProvider(
+			config.provider ?? (isRecord(config.config) ? config.config.provider : undefined),
+		);
+		return provider ? `${provider}/${config.modelId}` : config.modelId;
+	}
+
+	return undefined;
+}

--- a/packages/cli/src/events/maps/instance-ai.event-map.ts
+++ b/packages/cli/src/events/maps/instance-ai.event-map.ts
@@ -40,7 +40,9 @@ export type InstanceAiEventMap = {
 		status: 'completed' | 'cancelled' | 'error' | 'suspended';
 		/** Wall-clock duration of the run, or undefined when the start time is unknown. */
 		durationMs?: number;
-		/** Model identifier for built-in providers; 'custom' for OpenAI-compatible/native instances. */
+		/** Model identifier for managed models (built-in providers and proxy-built
+		 *  instances); 'custom' for user-configured OpenAI-compatible endpoints,
+		 *  whose free-form ids would inflate the metric label's cardinality. */
 		model: string;
 		toolCalls: number;
 		toolErrors: number;

--- a/packages/cli/src/modules/instance-ai/__tests__/observability.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/observability.test.ts
@@ -1,6 +1,6 @@
-import type { InstanceAiTraceContext } from '@n8n/instance-ai';
+import type { InstanceAiTraceContext, ModelConfig } from '@n8n/instance-ai';
 
-import { buildInstanceAiObservabilityContext } from '../observability';
+import { buildInstanceAiObservabilityContext, runMetricsModelLabel } from '../observability';
 
 describe('Instance AI observability', () => {
 	it('builds a flat correlation context from run and trace details', () => {
@@ -47,5 +47,32 @@ describe('Instance AI observability', () => {
 			userId: 'user-1',
 			projectId: 'project-1',
 		});
+	});
+});
+
+describe('runMetricsModelLabel', () => {
+	it('reports managed model ids as-is', () => {
+		expect(runMetricsModelLabel('anthropic/claude-sonnet-4-6')).toBe('anthropic/claude-sonnet-4-6');
+	});
+
+	it('reports the model id of a proxy-built AI SDK instance', () => {
+		const proxyModel = {
+			specificationVersion: 'v4',
+			modelId: 'kimi-k3',
+			config: { provider: 'moonshotai.chat' },
+		} as unknown as ModelConfig;
+
+		expect(runMetricsModelLabel(proxyModel)).toBe('moonshotai/kimi-k3');
+	});
+
+	it("collapses user-configured endpoints and unknown configs to 'custom'", () => {
+		expect(
+			runMetricsModelLabel({
+				id: 'custom/some-self-hosted-model',
+				url: 'https://llm.example.com/v1',
+			}),
+		).toBe('custom');
+		expect(runMetricsModelLabel(undefined)).toBe('custom');
+		expect(runMetricsModelLabel({} as unknown as ModelConfig)).toBe('custom');
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -173,6 +173,7 @@ import { INSTANCE_AI_RUN_TIMEOUT_REASON, InstanceAiLivenessService } from './liv
 import { InstanceAiMcpRegistryService } from './mcp';
 import {
 	buildInstanceAiObservabilityContext,
+	runMetricsModelLabel,
 	type InstanceAiObservabilityContext,
 } from './observability';
 import {
@@ -6742,7 +6743,7 @@ export class InstanceAiService {
 			// Duration is reported once, by the run's terminal event.
 			durationMs:
 				status !== 'suspended' && startedAt !== undefined ? Date.now() - startedAt : undefined,
-			model: typeof options?.modelId === 'string' ? options.modelId : 'custom',
+			model: runMetricsModelLabel(options?.modelId),
 			toolCalls: options?.workSummary?.totalToolCalls ?? 0,
 			toolErrors: options?.workSummary?.totalToolErrors ?? 0,
 			...(options?.usage ? { usage: options.usage } : {}),

--- a/packages/cli/src/modules/instance-ai/observability.ts
+++ b/packages/cli/src/modules/instance-ai/observability.ts
@@ -1,4 +1,5 @@
-import type { InstanceAiTraceContext } from '@n8n/instance-ai';
+import { isEndpointModelConfig, modelConfigId } from '@n8n/instance-ai';
+import type { InstanceAiTraceContext, ModelConfig } from '@n8n/instance-ai';
 
 export type InstanceAiObservabilityContext = {
 	threadId: string;
@@ -34,4 +35,15 @@ export function buildInstanceAiObservabilityContext(
 		...(context.taskId ? { taskId: context.taskId } : {}),
 		...(context.role ? { role: context.role } : {}),
 	};
+}
+
+/**
+ * `model` is a Prometheus label on the Instance AI run metrics, so it has to stay
+ * low-cardinality. Managed models (built-in ids and the pre-built AI SDK
+ * instances the proxy hands over) come from a fixed set and are reported as-is;
+ * a user-configured endpoint's model id is free-form, so it collapses to 'custom'.
+ */
+export function runMetricsModelLabel(modelId: ModelConfig | undefined): string {
+	if (modelId === undefined || isEndpointModelConfig(modelId)) return 'custom';
+	return modelConfigId(modelId) ?? 'custom';
 }


### PR DESCRIPTION
## Summary

`serializeModelIdForTrace` read a model name from a `string` or from a record with an `.id`. `ModelConfig` has a fourth variant — a pre-built AI SDK `LanguageModel`, which is what `createProxyLanguageModel` hands over on every proxy (Gateway credits) run. It carries `modelId` + `provider` and has no `.id`, so it fell through to `sanitizeTraceValue`, which walked the object graph and wrote the whole model instance into the `model_id` span attribute.

Since every cloud run takes the proxy path, `model_id` was unusable for grouping or filtering there: in a 12h window on EU LangSmith `instance-ai`, **zero** runs had a plain-string `model_id`.

I checked langtracer's implementation and this should be fine to do. I'll also let data know when this changes in case they care.

### What the data looked like → what it looks like now

Kimi (`kimi-k3` via `@ai-sdk/openai-compatible`) — the `chunkSchema` is a zod union, ~1.8 KB per span:

```diff
- "model_id": "{\"specificationVersion\":\"v4\",\"modelId\":\"kimi-k3\",\"config\":{\"provider\":\"moonshotai.chat\",\"url\":\"[function url]\",\"headers\":\"[function getHeaders]\",\"fetch\":\"[function fetch]\",\"includeUsage\":true,\"supportsStructuredOutputs\":true},\"chunkSchema\":{\"~standard\":{\"validate\":\"[function validate]\",\"vendor\":\"zod\",\"version\":1},\"def\":{\"type\":\"union\",\"options\":[\"[object 43 keys]\",\"[object 43 keys]\"]},\"check\":\"[function anonymous]\",\"clone\":\"[function anonymous]\",\"brand\":\"[function anonymous]\",\"register\":\"[function anonymous]\",\"parse\":\"[function anonymous]\", … ,\"__truncatedKeys\":1},\"failedResponseHandler\":\"[function anonymous]\",\"supportsStructuredOutputs\":true}"
+ "model_id": "moonshotai/kimi-k3"
```

Anthropic (`@ai-sdk/anthropic` through the proxy) — same shape, ~350 chars:

```diff
- "model_id": "{\"specificationVersion\":\"v4\",\"modelId\":\"claude-opus-4-8\",\"config\":{\"provider\":\"anthropic.messages\",\"baseURL\":\"https://ai-assistant.n8n.io/v1/api-proxy/anthropic/v1\",\"headers\":\"[function getHeaders]\",\"fetch\":\"[function fetch]\",\"generateId\":\"[function generator]\",\"supportedUrls\":\"[function supportedUrls]\"},\"generateId\":\"[function generator]\"}"
+ "model_id": "anthropic/claude-opus-4-8"
```

The other three `ModelConfig` variants are unchanged:

| Variant | Before | After |
| --- | --- | --- |
| plain string | `anthropic/claude-sonnet-4-6` | `anthropic/claude-sonnet-4-6` |
| endpoint `{ id, url, apiKey }` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-sonnet-4-6` |
| Vertex Anthropic | `google-vertex-anthropic/claude-opus-4-8` | `google-vertex-anthropic/claude-opus-4-8` |
| **pre-built AI SDK model** | **serialized model instance** | **`moonshotai/kimi-k3`** |

The AI SDK reports the transport in `provider` (`anthropic.messages`, `moonshotai.chat`); that suffix is dropped so proxy runs group with the plain-string ids — `moonshotai/kimi-k3` matches `MOONSHOTAI_KIMI_K3_MODEL_ID` exactly. This follows the convention already used by `modelProviderOf` in `instance-ai-verification.service.ts`.

### Downstream effects

Two consumers were silently degrading off the same root cause:

- `runtime-telemetry.ts` sets `gen_ai.request.model` only `if (typeof modelId === 'string')`, so the OTel semantic attribute was dropped on every cloud run. It now populates.
- `instance-ai-run-finished` reported `model: 'custom'` for the same reason. Managed models now report their real id:
  ```diff
  - { status: 'completed', model: 'custom', … }
  + { status: 'completed', model: 'anthropic/claude-opus-4-8', … }
  ```
  `model` is a Prometheus label, so a **user-configured** OpenAI-compatible endpoint still collapses to `'custom'` — those ids are free-form and would inflate label cardinality. Managed models come from a fixed set.

No credential exposure before or after: functions serialized as `"[function …]"` placeholders and the proxy apiKey is the literal `proxy-managed`. The payload was bounded by `truncateString` / `MAX_TRACE_OBJECT_KEYS`, so this was trace noise plus lost model attribution, not a leak.

The shared lookup now lives in one place, `modelConfigId`, which also fixes the `model` field in `buildAgentTraceInputs` (same helper).

## How to test

Automated:

```bash
cd packages/@n8n/instance-ai && pnpm vitest run src/utils/__tests__/model-config-id.test.ts src/tracing/__tests__/langsmith-tracing.test.ts
cd packages/cli && pnpm vitest run src/modules/instance-ai/__tests__/observability.test.ts
```

The new `langsmith-tracing` case asserts a proxy-shaped model instance yields `moonshotai/kimi-k3` and that neither `chunkSchema` nor any `[function …]` placeholder reaches the metadata. The existing test only covered the string and `.id` shapes, which is why this slipped through.

Manually, against a proxy-backed instance: send any Instance AI message, then open the `agent: orchestrator` span in LangSmith and read `metadata.model_id` — it is a model id rather than a serialized instance. Locally reproducible without cloud by pointing `resolveProxyModel` at any proxy base URL, since the shape comes from the AI SDK provider, not from the proxy itself.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1299

Found while reading trace `f8cb9a81-f7b3-4073-9ba3-39caf3afcc13` on EU LangSmith (n8n 2.37.4).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- internal observability only, no user-facing surface -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

