### PR TITLE
fix(core): Keep an overridden toString when workflow data crosses the isolate boundary

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/class-instance-marshaling.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/class-instance-marshaling.test.ts
@@ -84,13 +84,25 @@ describe('class instances in workflow data', () => {
 
 	it('treats a throwing toString as absent instead of failing the expression', () => {
 		class Unstringable {
-			readonly x = undefined;
 			toString(): string {
 				throw new Error('boom');
 			}
 		}
 		const data = { $json: { b: new Unstringable() } };
 
-		expect(evaluator.evaluate('{{ $json.b.x }}', data, caller)).toBeUndefined();
+		// Asserting on `toString()` rather than a sibling field is deliberate: a
+		// sibling read yields `undefined` whether or not the host swallows the
+		// throw, so it cannot fail if the guard is removed. Here the two outcomes
+		// differ — with the guard the string form is absent and the proxy falls
+		// back to `Object.prototype.toString`; without it the marshaled value
+		// errors and the expression yields `undefined`.
+		expect(evaluator.evaluate('{{ $json.b.toString() }}', data, caller)).toBe('[object Object]');
+	});
+
+	it('keeps it when the value is a top-level context key', () => {
+		const data = { $json: new ObjectIdLike(HEX) as unknown as Record<string, unknown> };
+
+		expect(evaluator.evaluate('{{ $json.toString() }}', data, caller)).toBe(HEX);
+		expect(evaluator.evaluate('{{ "v=" + $json }}', data, caller)).toBe(`v=${HEX}`);
 	});
 });

--- a/packages/@n8n/expression-runtime/src/__tests__/class-instance-marshaling.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/class-instance-marshaling.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
+
+/**
+ * Only `Object.keys` crosses the isolate boundary, so a class instance in
+ * workflow data used to arrive as a plain shape and lose the `toString` that
+ * carried its meaning. `Date` was already passed through whole for the same
+ * reason; these cover the classes the runtime cannot know by name, such as a
+ * BSON `ObjectId` in a MongoDB node's `_id`.
+ */
+describe('class instances in workflow data', () => {
+	let evaluator: ExpressionEvaluator;
+	const caller = {};
+
+	beforeAll(async () => {
+		evaluator = new ExpressionEvaluator({
+			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			maxCodeCacheSize: 1024,
+		});
+		await evaluator.initialize();
+		await evaluator.acquire(caller);
+	});
+
+	afterAll(async () => {
+		await evaluator.release(caller);
+		await evaluator.dispose();
+	});
+
+	/** Shaped like a BSON ObjectId: the hex lives behind `toString`. */
+	class ObjectIdLike {
+		constructor(private readonly hex: string) {}
+		toString() {
+			return this.hex;
+		}
+	}
+
+	const HEX = '507f1f77bcf86cd799439011';
+
+	it('keeps an overridden toString at the top level', () => {
+		const data = { $json: { _id: new ObjectIdLike(HEX) } };
+
+		expect(evaluator.evaluate('{{ $json._id.toString() }}', data, caller)).toBe(HEX);
+	});
+
+	it('keeps it under string coercion', () => {
+		const data = { $json: { _id: new ObjectIdLike(HEX) } };
+
+		expect(evaluator.evaluate('{{ "id=" + $json._id }}', data, caller)).toBe(`id=${HEX}`);
+	});
+
+	it('keeps it when nested', () => {
+		const data = { $json: { row: { _id: new ObjectIdLike(HEX) } } };
+
+		expect(evaluator.evaluate('{{ $json.row._id.toString() }}', data, caller)).toBe(HEX);
+	});
+
+	it('keeps it inside an array', () => {
+		const data = { $json: { ids: [new ObjectIdLike(HEX)] } };
+
+		expect(evaluator.evaluate('{{ $json.ids[0].toString() }}', data, caller)).toBe(HEX);
+	});
+
+	it('leaves a plain object on native Object.prototype.toString', () => {
+		const data = { $json: { o: { a: 1 } } };
+
+		expect(evaluator.evaluate('{{ $json.o.toString() }}', data, caller)).toBe('[object Object]');
+	});
+
+	it('leaves an array on Array.prototype.toString', () => {
+		const data = { $json: { a: [1, 2, 3] } };
+
+		expect(evaluator.evaluate('{{ $json.a.toString() }}', data, caller)).toBe('1,2,3');
+	});
+
+	it('leaves Date marshaling alone', () => {
+		const data = { $json: { d: new Date('2026-06-30T20:34:04.498Z') } };
+
+		expect(evaluator.evaluate('{{ $json.d.toISOString() }}', data, caller)).toBe(
+			'2026-06-30T20:34:04.498Z',
+		);
+	});
+
+	it('treats a throwing toString as absent instead of failing the expression', () => {
+		class Unstringable {
+			readonly x = undefined;
+			toString(): string {
+				throw new Error('boom');
+			}
+		}
+		const data = { $json: { b: new Unstringable() } };
+
+		expect(evaluator.evaluate('{{ $json.b.x }}', data, caller)).toBeUndefined();
+	});
+});

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -77,6 +77,31 @@ async function readRuntimeBundle(): Promise<string> {
 }
 
 /**
+ * Primitive string form for a value whose identity lives on its prototype.
+ *
+ * Only `Object.keys` crosses the boundary, so a class instance such as a BSON
+ * `ObjectId` arrives in the isolate as a plain shape and loses the `toString`
+ * that gave it meaning — `{{ $json._id.toString() }}` returned the hex before
+ * the isolate runtime and `[object Object]` after. `Date` is already passed
+ * through whole for the same reason; this covers the classes the runtime cannot
+ * know about by name.
+ *
+ * Captured only when `toString` is genuinely overridden, so plain objects keep
+ * native `Object.prototype.toString` behaviour and pay nothing. A `toString`
+ * that throws is treated as absent rather than failing the expression.
+ */
+function overriddenStringForm(value: object): string | undefined {
+	const fn = (value as { toString?: unknown }).toString;
+	if (typeof fn !== 'function' || fn === Object.prototype.toString) return undefined;
+	try {
+		const str = (fn as () => unknown).call(value);
+		return typeof str === 'string' ? str : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * IsolatedVmBridge - Runtime bridge using isolated-vm for secure expression evaluation.
  *
  * This bridge creates a V8 isolate with:
@@ -349,6 +374,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 					return {
 						__isObject: true,
 						__keys: Object.keys(value),
+						__stringForm: overriddenStringForm(value),
 					};
 				}
 
@@ -433,6 +459,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 					return {
 						__isObject: true,
 						__keys: Object.keys(element),
+						__stringForm: overriddenStringForm(element),
 					};
 				}
 

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -375,7 +375,11 @@ export function buildContext(
 			return true;
 		}
 		if (isObjectMetadata(value)) {
-			target[key] = createDeepLazyProxy([key], { kind: 'object', keys: value.__keys }, callbacks);
+			target[key] = createDeepLazyProxy(
+				[key],
+				{ kind: 'object', keys: value.__keys, stringForm: value.__stringForm },
+				callbacks,
+			);
 			return true;
 		}
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -27,6 +27,8 @@ export interface ErrorSentinel {
 interface ObjectMetadata {
 	__isObject: true;
 	__keys: string[];
+	/** Set only when the host value overrides `toString` — see `overriddenStringForm`. */
+	__stringForm?: string;
 }
 
 interface ArrayMetadata {
@@ -86,7 +88,9 @@ export function getProxyPath(obj: object): string[] | undefined {
  * - `array` proxies wrap an array target so `Array.isArray(proxy)` is `true`
  *   and structured clone / `Array.prototype.map` iterate indices correctly.
  */
-export type ProxyMeta = { kind: 'object'; keys?: string[] } | { kind: 'array'; length: number };
+export type ProxyMeta =
+	| { kind: 'object'; keys?: string[]; stringForm?: string }
+	| { kind: 'array'; length: number };
 
 /**
  * Creates a deep lazy-loading proxy for workflow data.
@@ -125,6 +129,7 @@ export function createDeepLazyProxy(
 	const isArray = meta?.kind === 'array';
 	const arrayLength = isArray ? meta.length : 0;
 	const objectKeys = meta?.kind === 'object' ? meta.keys : undefined;
+	const stringForm = meta?.kind === 'object' ? meta.stringForm : undefined;
 
 	// Cache for keys fetched from the bridge (root object proxies without known keys).
 	// Shared between ownKeys and getOwnPropertyDescriptor for consistency.
@@ -160,7 +165,11 @@ export function createDeepLazyProxy(
 		}
 		if (isObjectMetadata(value)) {
 			const path = [...basePath, propOrIdx];
-			return createDeepLazyProxy(path, { kind: 'object', keys: value.__keys }, callbacks);
+			return createDeepLazyProxy(
+				path,
+				{ kind: 'object', keys: value.__keys, stringForm: value.__stringForm },
+				callbacks,
+			);
 		}
 		return value;
 	}
@@ -297,6 +306,22 @@ export function createDeepLazyProxy(
 			// Array length is known at construction — no bridge call needed
 			if (isArray && prop === 'length') {
 				return arrayLength;
+			}
+
+			// Only `Object.keys` crosses the boundary, so a class instance arrives
+			// as a plain shape and loses the `toString` that carried its meaning:
+			// `$json._id.toString()` on a BSON ObjectId returned the hex before the
+			// isolate runtime and `[object Object]` after. The host captured that
+			// string when — and only when — `toString` was genuinely overridden, so
+			// plain objects keep native `Object.prototype.toString`. A cached entry
+			// or a declared data key of the same name still takes precedence.
+			if (
+				stringForm !== undefined &&
+				prop === 'toString' &&
+				!Object.prototype.hasOwnProperty.call(targetObj, prop) &&
+				!objectKeys?.includes(prop)
+			) {
+				return () => stringForm;
 			}
 
 			// Check cache - if already fetched, return cached value

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -129,11 +129,12 @@ export function createDeepLazyProxy(
 	const isArray = meta?.kind === 'array';
 	const arrayLength = isArray ? meta.length : 0;
 	const objectKeys = meta?.kind === 'object' ? meta.keys : undefined;
-	const stringForm = meta?.kind === 'object' ? meta.stringForm : undefined;
+	const metaStringForm = meta?.kind === 'object' ? meta.stringForm : undefined;
 
 	// Cache for keys fetched from the bridge (root object proxies without known keys).
 	// Shared between ownKeys and getOwnPropertyDescriptor for consistency.
 	let fetchedKeys: string[] | undefined;
+	let fetchedStringForm: string | undefined;
 
 	function resolveObjectKeys(): string[] {
 		if (objectKeys) return objectKeys;
@@ -142,9 +143,30 @@ export function createDeepLazyProxy(
 		throwIfErrorSentinel(value);
 		if (isObjectMetadata(value)) {
 			fetchedKeys = value.__keys;
+			fetchedStringForm = value.__stringForm;
 			return fetchedKeys;
 		}
 		return [];
+	}
+
+	/**
+	 * The host's string form for this value, if it had an overridden `toString`.
+	 *
+	 * Deliberately never triggers a bridge call. `toString()` on a proxy is
+	 * required to cost nothing — `lazy-proxy.test.ts` asserts `getValueAtPath` is
+	 * not called for it — so this reads the metadata the proxy was built with, or
+	 * what a previous fetch already cached, and otherwise gives up and lets
+	 * `Object.prototype.toString` answer.
+	 *
+	 * The consequence is that a proxy created with no metadata at all
+	 * (`$item(n)`, `$('Node')`, `$input`) whose value is itself a class instance
+	 * keeps returning `[object Object]`. Those roots are always item or
+	 * collection objects in practice, and paying a host round-trip on every
+	 * `toString()` to cover a case that cannot occur is the wrong trade against
+	 * an invariant the suite pins.
+	 */
+	function resolveStringForm(): string | undefined {
+		return metaStringForm ?? fetchedStringForm;
 	}
 
 	function isInArrayBounds(prop: string): number | undefined {
@@ -316,12 +338,13 @@ export function createDeepLazyProxy(
 			// plain objects keep native `Object.prototype.toString`. A cached entry
 			// or a declared data key of the same name still takes precedence.
 			if (
-				stringForm !== undefined &&
 				prop === 'toString' &&
+				!isArray &&
 				!Object.prototype.hasOwnProperty.call(targetObj, prop) &&
 				!objectKeys?.includes(prop)
 			) {
-				return () => stringForm;
+				const resolved = resolveStringForm();
+				if (resolved !== undefined) return () => resolved;
 			}
 
 			// Check cache - if already fetched, return cached value


### PR DESCRIPTION
## Summary

A value whose meaning lives on its prototype loses it crossing into the expression runtime, so `{{ $json._id.toString() }}` on a MongoDB `_id` returned the hex before the isolate runtime and `[object Object]` after, with nothing raised. Reported on a live 2.36.8 instance by @chung1912, who notes it worked before 2.34.x.

**Root cause.** Only `Object.keys` crosses the boundary. In `isolated-vm-bridge.ts` a non-`Date` object is marshaled as `{ __isObject: true, __keys: Object.keys(value) }`, so the prototype and any `toString` on it are dropped. A driver-returned `ObjectId` has `Object.keys() === ["buffer"]`, so the hex is simply gone and `Object.prototype.toString` answers. `Date` already gets a pass-through at both marshaling sites for the same underlying reason — "Dates have no enumerable own keys" — and there is a "Date marshaling from workflow data" block in the integration tests from an earlier round of this. This is the same problem for the classes the runtime cannot know by name. `Decimal128` is affected identically.

**The change.**

- The host captures `String(value)` as `__stringForm`, but only when `toString` is genuinely overridden (`toString !== Object.prototype.toString`), at both `getValueAtPath` and `getArrayElement`.
- The lazy proxy serves that string for `toString` alone. Nothing else about the value changes.

**Why it is safe.** Deliberately narrow, since this is the isolate data boundary:

- A plain object is untouched — its `toString` *is* `Object.prototype.toString`, so nothing is captured and `[object Object]` still comes back. Arrays are handled before this branch and keep `Array.prototype.toString`.
- No extra host work for ordinary data: the check is one identity comparison.
- A `toString` that throws is treated as absent rather than failing the whole expression.
- A cached entry or a declared data key named `toString` takes precedence over the captured string, so this stays independent of the key-shadowing bug in #36473 / #37358 (the reverse case, where a key *named* `toString` resolves to the prototype method). I verified the independence rather than assuming it: with this fix applied and the key-shadowing fix absent, a key named `toString` still resolves to the prototype method. #37359 is the fix for that one.

This restores `toString` only. It does not try to revive arbitrary class behaviour across the boundary, which structured clone cannot carry anyway. If you would rather solve it another way — passing more types through whole, or handling it in the MongoDB node — say so and I will follow; I went this way because it matches the existing `Date` precedent and leaves plain-object semantics alone.

## How to test

```bash
cd packages/@n8n/expression-runtime
pnpm build:runtime          # the isolate runs a bundled copy of the runtime
pnpm vitest run src/__tests__/class-instance-marshaling.test.ts
```

`pnpm build:runtime` matters: editing `src/runtime/` has no effect until the IIFE bundle is rebuilt.

To watch it fail, revert the two source files and rebuild the bundle:

```bash
git checkout master -- src/bridge/isolated-vm-bridge.ts src/runtime/lazy-proxy.ts
pnpm build:runtime && pnpm vitest run src/__tests__/class-instance-marshaling.test.ts
```

### Committed tests

Eight, and the split is deliberate. Four fail on `master` and pass here:

| test | on `master` |
|---|---|
| overridden `toString` at the top level | **fails** |
| under string coercion (`"id=" + $json._id`) | **fails** |
| nested (`$json.row._id`) | **fails** |
| inside an array (`$json.ids[0]`) | **fails** |
| plain object still `[object Object]` | passes |
| array still `1,2,3` | passes |
| `Date` marshaling unchanged | passes |
| a throwing `toString` does not fail the expression | passes |

The last four pass on `master` too — regression guards for behaviour that must not move, not evidence of the bug. The committed tests use a small stand-in class so the package takes no dependency on `mongodb`.

### Verified against a real MongoDB as well

Because the stand-in could be accused of proving only itself, I also ran the real thing: MongoDB 7 in Docker, real `mongodb` 6.11.0 driver (the version `nodes-base` resolves), document inserted and fetched with `findOne()`, then @chung1912's exact expression against that result.

```
driver returned _id        -> ObjectId 6a9568ffce3ca127e583b1bb
Object.keys(_id)           -> ["buffer"]

master :  {{ $json._id.toString() }} -> "[object Object]"
          {{ "id=" + $json._id }}    -> "id=[object Object]"
          {{ $json.price.toString() }} -> "[object Object]"   (Decimal128)

this PR:  {{ $json._id.toString() }} -> "6a9568ffce3ca127e583b1bb"
          {{ "id=" + $json._id }}    -> "id=6a9568ffce3ca127e583b1bb"
          {{ $json.price.toString() }} -> "12.345"

both   :  {{ $json.name }} -> "invoice"   (sibling fields unaffected)
```

```
pnpm vitest run                    ->  19 files, 374 passed
pnpm typecheck                     ->  clean
prettier --check <changed files>   ->  clean
```

## Related Linear tickets, Github issues, and Community forum posts

Fixes #37420

Related but a separate root cause, and deliberately not fixed by this: #36473 / #37358, where a data key literally named `toString` resolves to the prototype method instead of the data. That is #37359.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
