### PR TITLE
ci: Gate the Docker smoke build on native pins instead of re-verifying pushed images (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -555,6 +555,8 @@ Scripts in `.github/scripts/`:
 | `docker/docker-config.mjs`| Build context   | `docker-build-push.yml`|
 | `docker/docker-tags.mjs`  | Image tags      | `docker-build-push.yml`|
 | `docker/kafka-native-smoke-check.mjs`| Verify librdkafka binary loads in built image | `docker-build-push.yml`|
+| `docker/assert-manifest-format.mjs`| Assert a merged manifest is an OCI image index with the expected platforms | `docker-build-push.yml`|
+| `docker/should-smoke-build.mjs`| Narrow the `pnpm-workspace.yaml` smoke trigger to native dependency pins | `docker-build-smoke.yml`|
 
 ### Validation Scripts
 

--- a/.github/scripts/docker/should-smoke-build.mjs
+++ b/.github/scripts/docker/should-smoke-build.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Decides whether a PR needs the no-cache Docker smoke build.
+ *
+ * pnpm-workspace.yaml is a trigger path because it pins the native deps the
+ * smoke build compiles, but it changes ~daily while those pins change a few
+ * times a year. The trigger stays coarse and is narrowed here by content.
+ *
+ * Usage: node should-smoke-build.mjs --base <ref> --changed-files <file>
+ */
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const WORKSPACE_FILE = 'pnpm-workspace.yaml';
+
+const BUMP_ONLY = [/^pnpm-workspace\.yaml$/, /^pnpm-lock\.yaml$/, /(^|\/)package\.json$/];
+
+export function isBumpOnly(files) {
+	return files.length > 0 && files.every((f) => BUMP_ONLY.some((re) => re.test(f)));
+}
+
+// Packages pnpm may run build scripts for — read from the file so a newly
+// added native dep is watched without editing this script.
+export function buildableDeps(text) {
+	const deps = new Set();
+	let inSection = false;
+	for (const line of text.split('\n')) {
+		if (/^allowBuilds:/.test(line)) {
+			inSection = true;
+			continue;
+		}
+		if (inSection && /^\S/.test(line)) break;
+		if (!inSection) continue;
+		const match = line.match(/^\s+'?([^'":]+)'?:\s*true\s*$/);
+		if (match) deps.add(match[1]);
+	}
+	return deps;
+}
+
+// Catalog pins, `catalogs:` entries and `patchedDependencies` are all keyed by
+// package name, so one pass over the file covers every place a pin can move.
+function pinsFor(text, deps) {
+	const pins = [];
+	for (const line of text.split('\n')) {
+		const match = line.match(/^\s+'?([^'":]+?)'?(@[^'":]+)?'?:\s*(.+?)\s*$/);
+		if (match && deps.has(match[1])) pins.push(line.trim());
+	}
+	return pins.sort();
+}
+
+export function nativePinsChanged(baseText, headText) {
+	const baseDeps = buildableDeps(baseText);
+	const headDeps = buildableDeps(headText);
+	const union = new Set([...baseDeps, ...headDeps]);
+
+	if (
+		baseDeps.size !== headDeps.size ||
+		[...union].some((d) => baseDeps.has(d) !== headDeps.has(d))
+	) {
+		return { changed: true, reason: 'the set of buildable dependencies changed' };
+	}
+
+	if (pinsFor(baseText, union).join('\n') !== pinsFor(headText, union).join('\n')) {
+		return { changed: true, reason: 'a buildable dependency pin changed' };
+	}
+
+	return { changed: false, reason: 'no buildable dependency pin changed' };
+}
+
+function fileAt(ref, path) {
+	try {
+		return execFileSync('git', ['show', `${ref}:${path}`], { encoding: 'utf8' });
+	} catch {
+		return null;
+	}
+}
+
+function main(argv) {
+	const base = argv[argv.indexOf('--base') + 1];
+	const files = readFileSync(argv[argv.indexOf('--changed-files') + 1], 'utf8')
+		.split('\n')
+		.map((f) => f.trim())
+		.filter(Boolean);
+
+	let build = true;
+	let reason = 'a Docker-chain file changed';
+
+	if (isBumpOnly(files)) {
+		const baseText = fileAt(base, WORKSPACE_FILE);
+		const headText = fileAt('HEAD', WORKSPACE_FILE);
+		if (baseText === null || headText === null) {
+			reason = `could not read ${WORKSPACE_FILE} on both sides of the diff`;
+		} else {
+			({ changed: build, reason } = nativePinsChanged(baseText, headText));
+		}
+	}
+
+	console.log(`${build ? 'building' : 'skipping'}: ${reason}`);
+	if (process.env.GITHUB_OUTPUT) {
+		appendFileSync(process.env.GITHUB_OUTPUT, `build=${build}\n`);
+	}
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main(process.argv.slice(2));
+}

--- a/.github/scripts/docker/should-smoke-build.test.mjs
+++ b/.github/scripts/docker/should-smoke-build.test.mjs
@@ -1,0 +1,88 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { buildableDeps, isBumpOnly, nativePinsChanged } from './should-smoke-build.mjs';
+
+const workspace = ({ kafka = '1.9.1', vm = '^7.0.0', sentry = '10.70.0', allowVm = true } = {}) => `
+catalog:
+  '@confluentinc/kafka-javascript': ${kafka}
+  '@sentry/core': ${sentry}
+  isolated-vm: ${vm}
+
+patchedDependencies:
+  '@confluentinc/kafka-javascript@${kafka}': patches/@confluentinc__kafka-javascript@${kafka}.patch
+
+allowBuilds:
+  '@confluentinc/kafka-javascript': true
+  esbuild: false
+  isolated-vm: ${allowVm}
+  sqlite3: true
+
+onlyBuiltDependencies:
+  - nothing
+`;
+
+describe('isBumpOnly', () => {
+	it('accepts a catalog bump', () => {
+		assert.equal(isBumpOnly(['pnpm-workspace.yaml', 'pnpm-lock.yaml']), true);
+	});
+
+	it('accepts a package.json at any depth', () => {
+		assert.equal(isBumpOnly(['pnpm-workspace.yaml', 'packages/cli/package.json']), true);
+	});
+
+	it('rejects a Dockerfile change', () => {
+		assert.equal(isBumpOnly(['pnpm-workspace.yaml', 'docker/images/n8n/Dockerfile']), false);
+	});
+
+	it('rejects an empty list so an unknown diff still builds', () => {
+		assert.equal(isBumpOnly([]), false);
+	});
+});
+
+describe('buildableDeps', () => {
+	it('collects only the true entries under allowBuilds', () => {
+		assert.deepEqual([...buildableDeps(workspace())].sort(), [
+			'@confluentinc/kafka-javascript',
+			'isolated-vm',
+			'sqlite3',
+		]);
+	});
+
+	it('stops at the next top-level key', () => {
+		assert.equal(buildableDeps(workspace()).has('nothing'), false);
+	});
+
+	it('parses the real workspace file', () => {
+		const text = readFileSync(new URL('../../../pnpm-workspace.yaml', import.meta.url), 'utf8');
+		assert.ok(buildableDeps(text).has('isolated-vm'));
+	});
+});
+
+describe('nativePinsChanged', () => {
+	it('ignores a non-native catalog bump', () => {
+		const { changed } = nativePinsChanged(workspace(), workspace({ sentry: '10.71.0' }));
+		assert.equal(changed, false);
+	});
+
+	it('catches a native version bump', () => {
+		const { changed } = nativePinsChanged(workspace(), workspace({ vm: '^8.0.0' }));
+		assert.equal(changed, true);
+	});
+
+	it('catches a patch re-pin alongside the version', () => {
+		const { changed, reason } = nativePinsChanged(workspace(), workspace({ kafka: '1.10.0' }));
+		assert.equal(changed, true);
+		assert.match(reason, /pin changed/);
+	});
+
+	it('catches a dep becoming non-buildable', () => {
+		const { changed, reason } = nativePinsChanged(workspace(), workspace({ allowVm: false }));
+		assert.equal(changed, true);
+		assert.match(reason, /set of buildable dependencies/);
+	});
+
+	it('reports no change for an identical file', () => {
+		assert.equal(nativePinsChanged(workspace(), workspace()).changed, false);
+	});
+});

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -314,8 +314,8 @@ jobs:
       # manifest list and every pull failed on older containerd (#31997). The
       # exporter flags that keep this an OCI index live in the build job, but
       # the merge happens here, so this is the only place the published shape
-      # can be asserted.
-      - name: Assert merged manifests are OCI image indexes
+      # can be asserted. Docker Hub merges separately below and is asserted there.
+      - name: Assert merged GHCR manifests are OCI image indexes
         env:
           RELEASE_TYPE: ${{ needs.determine-build-context.outputs.release_type }}
           N8N_TAG: ${{ needs.build-and-push-docker.outputs.primary_ghcr_manifest_tag }}
@@ -364,6 +364,12 @@ jobs:
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-amd64" \
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-arm64"
 
+            # Self-hosted pulls come from here, and this merge is independent of
+            # the GHCR one above, so it needs its own assertion. Always both
+            # arches: push_to_docker is never set for amd64-only branch builds.
+            node .github/scripts/docker/assert-manifest-format.mjs \
+              "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}" --expect-platforms 2
+
             # Create SHA-tagged manifest (immutable reference)
             # For distroless, insert SHA between version and -distroless suffix
             # to match docker-tags.mjs format: nightly-abc1234-distroless (not nightly-distroless-abc1234)
@@ -406,43 +412,6 @@ jobs:
           RUNNERS_TAG: ${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}
           DISTROLESS_TAG: ${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}
         run: node .github/scripts/docker/get-manifest-digests.mjs
-
-  # Execs the artifact that actually shipped. docker-build-smoke.yml runs the
-  # same checks, but against its own no-cache build of the branch tip - a
-  # different image, and its PR trigger deliberately skips pnpm-workspace.yaml,
-  # which is where the native deps are pinned. So a catalog bump of
-  # @confluentinc/kafka-javascript or isolated-vm reaches a published tag
-  # unexercised unless something pulls the pushed image back and runs it.
-  verify-pushed-images:
-    name: Verify Pushed Images
-    needs: [determine-build-context, create_multi_arch_manifest]
-    runs-on: ubuntu-latest
-    if: needs.create_multi_arch_manifest.result == 'success'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      # Installs only, no build: the script needs zx and yaml, not a compiled
-      # workspace. The image under test is pulled from the registry.
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
-        with:
-          node-version: '26.7.0'
-          build-command: ''
-
-      - name: Login to GHCR
-        uses: ./.github/actions/docker-registry-login
-        with:
-          login-ghcr: true
-
-      - name: Exec native bindings and runner interpreters
-        env:
-          SMOKE_IMAGE: ${{ needs.create_multi_arch_manifest.outputs.n8n_image }}@${{ needs.create_multi_arch_manifest.outputs.n8n_digest }}
-          SMOKE_RUNNERS_IMAGES: ${{ needs.create_multi_arch_manifest.outputs.runners_image }}@${{ needs.create_multi_arch_manifest.outputs.runners_digest }},${{ needs.create_multi_arch_manifest.outputs.runners_distroless_image }}@${{ needs.create_multi_arch_manifest.outputs.runners_distroless_digest }}
-          # The cloud-chart invocations need a token this job does not carry;
-          # the binding and interpreter execs are what guard the release.
-          SMOKE_SKIP_CLOUD: 'true'
-        run: node scripts/smoke-n8n-image.mjs
 
   call-success-url:
     name: Call Success URL

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -32,16 +32,16 @@ on:
       - 'scripts/dockerize-n8n.mjs'
       - 'scripts/smoke-n8n-image.mjs'
       - '.github/scripts/docker/kafka-native-smoke-check.mjs'
+      - '.github/scripts/docker/should-smoke-build.mjs'
       # These drive the build and the image distribution, so a change here can
       # break the chain without touching a Dockerfile.
       - '.github/actions/build-n8n-docker/action.yml'
       - '.github/actions/load-n8n-docker/action.yml'
       - '.github/workflows/docker-build-push.yml'
-      # Patched native dependencies change here. pnpm-workspace.yaml is
-      # excluded: it changes too often for a two-arch no-cache build. A native
-      # catalog bump that slips past this is still caught before it ships, by
-      # verify-pushed-images in docker-build-push.yml.
       - 'patches/**'
+      # Pins the native deps this build compiles, but changes far more often
+      # than they do — the gate job narrows it to the pins that matter.
+      - 'pnpm-workspace.yaml'
   workflow_dispatch:
 
 concurrency:
@@ -49,6 +49,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  gate:
+    name: 'Check for relevant changes'
+    runs-on: ubuntu-slim
+    outputs:
+      build: ${{ steps.gate.outputs.build }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # HEAD is the PR merge commit, so HEAD^1 is the base tip.
+          fetch-depth: 2
+
+      - id: gate
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT" != 'pull_request' ]]; then
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --name-only HEAD^1 HEAD > "$RUNNER_TEMP/changed-files"
+          node .github/scripts/docker/should-smoke-build.mjs \
+            --base HEAD^1 --changed-files "$RUNNER_TEMP/changed-files"
+
   docker-smoke-test:
     name: 'Docker Build (no cache, ${{ matrix.platform }})'
     # Both architectures build natively: the runtime images assemble binaries
@@ -64,7 +88,8 @@ jobs:
           - platform: arm64
             runner: blacksmith-8vcpu-ubuntu-2204-arm
     runs-on: ${{ matrix.runner }}
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    needs: gate
+    if: ${{ !github.event.pull_request.head.repo.fork && needs.gate.outputs.build == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/scripts/smoke-n8n-image.mjs
+++ b/scripts/smoke-n8n-image.mjs
@@ -14,7 +14,7 @@ process.env.FORCE_COLOR = '1';
 const IMAGE = process.env.SMOKE_IMAGE || 'n8nio/n8n:local';
 // Runners images to exec-check. Tracks DOCKER_BUILD_DISTROLESS so the same
 // flag drives both build and check. SMOKE_RUNNERS_IMAGES (comma-separated)
-// overrides both, so the release job can point this at the pushed tags.
+// overrides both.
 const RUNNERS_IMAGES = process.env.SMOKE_RUNNERS_IMAGES
 	? process.env.SMOKE_RUNNERS_IMAGES.split(',')
 			.map((s) => s.trim())


### PR DESCRIPTION
## Summary

Removes the `Verify Pushed Images` job added in #37356 and closes the gap it was justified by at PR time instead.

That job pulled the published GHCR manifest back and re-ran the exec checks `docker-build-smoke.yml` already runs. Two problems with it:

- **It can't prevent anything.** It runs after the images are pushed, and nothing `needs:` it — so a failure turns the run red without blocking the push, the provenance, the attestations or `Call Success URL`.
- **It failed on its first run on master** ([33380001242](https://github.com/n8n-io/n8n/actions/runs/33380001242)), because `TIMEOUT = '45s'` in `scripts/smoke-n8n-image.mjs` was sized for a locally-loaded image and the job pointed it at registry digests, so the budget had to cover an implicit multi-arch `docker pull` with five pulls contending. Removing the job removes that failure mode.

Its stated justification was that the smoke PR trigger skips `pnpm-workspace.yaml`, where the native deps are pinned. That gap is real, so this closes it where it's useful — before merge.

## What changed

**`pnpm-workspace.yaml` becomes a smoke trigger path, narrowed by content.** A file-level filter is ~30x too coarse: the file changed 92 times in the last 90 days, while the pins the smoke build actually protects changed 6 times in 180 days. A new `gate` job runs `should-smoke-build.mjs`, which builds when either

- a changed file is outside the set a dependency bump touches (`pnpm-workspace.yaml`, `pnpm-lock.yaml`, `**/package.json`) — i.e. a real Docker-chain change, or
- a package pnpm may run build scripts for had a pin change.

The watched set is read from `allowBuilds:` rather than hardcoded, so a newly added native dep is covered without editing the script.

**The manifest-format assertion now covers Docker Hub.** It stays in the manifest job — the merge happens there — but the Hub merge is independent of the GHCR one and was unasserted, and self-hosted users pull from Hub.

## Verification

- `should-smoke-build.test.mjs`: 12 cases; full `.github/scripts` suite green (532 tests).
- Replayed the gate over all 139 `pnpm-workspace.yaml` commits in the last 180 days.
- Exercised the CLI end to end against real commits:

  | scenario | result |
  |---|---|
  | irrelevant catalog bump (+ lockfile) | skip |
  | `isolated-vm` bump | build |
  | `@confluentinc/kafka-javascript` bump | build |
  | `allowBuilds` flip | build |
  | Dockerfile change | build |
  | workspace + Dockerfile | build |

- `docker-smoke-test` is not in the master ruleset's required checks, so gating it can't block merges.

## Review notes

- **Coverage this gives up:** exec of the published artifact. The nightly smoke at 03:00 already no-cache builds master tip on both arches and runs the same script, so what's lost is specifically post-push exec between a merge and the next nightly. Given the job couldn't block a bad push anyway, that reads as an acceptable trade — but it is a reduction, so worth a second opinion.
- The gate uses `HEAD^1` as the base, which relies on the PR merge-commit checkout (`fetch-depth: 2`).
- `docker-build-smoke.yml` has no top-level `permissions:` block. Pre-existing, left alone to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


