### PR TITLE
feat(core): Make OTel traces identifiable while an execution is running

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
@@ -879,4 +879,107 @@ describe('ExecutionLevelTracer', () => {
 			expect(tracer.getActiveContext('non-existent', 'SomeNode')).toBeUndefined();
 		});
 	});
+	describe('workflow identity on node spans', () => {
+		const startExecution = (executionId: string, project?: { id: string }) =>
+			tracer.startWorkflow({ executionId, workflow: defaultWorkflow, project });
+
+		const runNode = (executionId: string) => {
+			const node = {
+				id: 'node-1',
+				name: 'HTTP Request',
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 4.2,
+			};
+			tracer.startNode({ executionId, node });
+			tracer.endNode({ executionId, node, inputItemCount: 1, outputItemCount: 1 });
+		};
+
+		it('should stamp workflow, execution and project identity onto node spans', () => {
+			startExecution('exec-identity', { id: 'project-1' });
+			runNode('exec-identity');
+
+			const nodeSpan = otel.getFinishedSpans().find((span) => span.name === 'node.execute')!;
+			expect(nodeSpan.attributes['n8n.workflow.id']).toBe('wf-1');
+			expect(nodeSpan.attributes['n8n.workflow.name']).toBe('Test');
+			expect(nodeSpan.attributes['n8n.execution.id']).toBe('exec-identity');
+			expect(nodeSpan.attributes['n8n.project.id']).toBe('project-1');
+			// Node-level attributes are still present alongside the inherited identity.
+			expect(nodeSpan.attributes['n8n.node.name']).toBe('HTTP Request');
+		});
+
+		it('should omit the project id when the execution has no project', () => {
+			startExecution('exec-no-project');
+			runNode('exec-no-project');
+
+			const nodeSpan = otel.getFinishedSpans().find((span) => span.name === 'node.execute')!;
+			expect(nodeSpan.attributes['n8n.workflow.id']).toBe('wf-1');
+			expect(nodeSpan.attributes['n8n.project.id']).toBeUndefined();
+		});
+
+		it('should not copy workflow-level-only attributes onto node spans', () => {
+			tracer.startWorkflow({
+				executionId: 'exec-root-only',
+				workflow: {
+					...defaultWorkflow,
+					customAttributes: { env: 'production' },
+				},
+				project: { id: 'project-1', customAttributes: { team: 'platform' } },
+			});
+			runNode('exec-root-only');
+
+			const nodeSpan = otel.getFinishedSpans().find((span) => span.name === 'node.execute')!;
+			// version_id / node_count are workflow-shaped, and custom attributes are
+			// license-gated - none of them belong on a per-node span.
+			expect(nodeSpan.attributes['n8n.workflow.version_id']).toBeUndefined();
+			expect(nodeSpan.attributes['n8n.workflow.node_count']).toBeUndefined();
+			expect(
+				Object.keys(nodeSpan.attributes).filter((key) => key.includes('.custom.')),
+			).toHaveLength(0);
+		});
+	});
+
+	describe('mid-execution export state', () => {
+		// A span is only exported once it ends, so `getFinishedSpans()` before `endWorkflow`
+		// models exactly what a collector holds while the execution is still running.
+		it('should export identifiable node spans before the workflow span ends', () => {
+			const nodeA = {
+				id: 'a',
+				name: 'Slow A',
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 4.2,
+			};
+			const nodeB = {
+				id: 'b',
+				name: 'Slow B',
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 4.2,
+			};
+
+			tracer.startWorkflow({
+				executionId: 'exec-live',
+				workflow: defaultWorkflow,
+				project: { id: 'project-1' },
+			});
+			tracer.startNode({ executionId: 'exec-live', node: nodeA });
+			tracer.endNode({
+				executionId: 'exec-live',
+				node: nodeA,
+				inputItemCount: 1,
+				outputItemCount: 1,
+			});
+			tracer.startNode({ executionId: 'exec-live', node: nodeB }); // still running
+
+			const exported = otel.getFinishedSpans();
+
+			// The root span has not ended, so monitoring cannot rely on it yet.
+			expect(exported.some((span) => span.name === 'workflow.execute')).toBe(false);
+
+			// ...but the finished node span already identifies its execution on its own.
+			const nodeSpan = exported.find((span) => span.name === 'node.execute')!;
+			expect(nodeSpan.attributes['n8n.node.name']).toBe('Slow A');
+			expect(nodeSpan.attributes['n8n.workflow.id']).toBe('wf-1');
+			expect(nodeSpan.attributes['n8n.execution.id']).toBe('exec-live');
+			expect(nodeSpan.attributes['n8n.project.id']).toBe('project-1');
+		});
+	});
 });

--- a/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
@@ -38,6 +38,14 @@ describe('ExecutionLevelTracer', () => {
 
 	const defaultWorkflow = { id: 'wf-1', name: 'Test', versionId: 'v1', nodeCount: 2 };
 
+	/**
+	 * Spans excluding the `workflow.execute.started` marker, which is emitted once per
+	 * `startWorkflow` and asserted on in its own describe below. Existing expectations stay
+	 * about the workflow/node spans under test rather than tracking the marker's presence.
+	 */
+	const visibleSpans = () =>
+		otel.getFinishedSpans().filter((span) => span.name !== 'workflow.execute.started');
+
 	describe('startWorkflow / endWorkflow', () => {
 		it('should create a workflow span with correct attributes', () => {
 			tracer.startWorkflow({
@@ -53,7 +61,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const spans = otel.getFinishedSpans();
+			const spans = visibleSpans();
 			expect(spans).toHaveLength(1);
 
 			const span = spans[0];
@@ -83,7 +91,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const span = otel.getFinishedSpans()[0];
+			const span = visibleSpans()[0];
 			expect(span.attributes['n8n.project.custom.env']).toBe('production');
 			expect(span.attributes['n8n.project.custom.team']).toBe('platform');
 		});
@@ -112,7 +120,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const spans = otel.getFinishedSpans();
+			const spans = visibleSpans();
 			const nodeSpan = spans.find((s) => s.name === 'node.execute')!;
 			// No project custom attributes should appear on the node span
 			const projectCustomKeys = Object.keys(nodeSpan.attributes).filter((k) =>
@@ -134,7 +142,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			expect(otel.getFinishedSpans()[0].attributes['n8n.project.id']).toBeUndefined();
+			expect(visibleSpans()[0].attributes['n8n.project.id']).toBeUndefined();
 		});
 
 		it('should set error status on failed executions', () => {
@@ -153,7 +161,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const spans = otel.getFinishedSpans();
+			const spans = visibleSpans();
 			expect(spans).toHaveLength(1);
 			expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
 			expect(spans[0].attributes['n8n.execution.error_type']).toBe('Error');
@@ -179,7 +187,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const span = otel.getFinishedSpans()[0];
+			const span = visibleSpans()[0];
 			expect(span.attributes['n8n.execution.error_type']).toBe('ReferenceError');
 			expect(span.events[0].attributes?.['exception.type']).toBe('ReferenceError');
 		});
@@ -198,7 +206,7 @@ describe('ExecutionLevelTracer', () => {
 				retryOf: 'exec-original',
 			});
 
-			const span = otel.getFinishedSpans()[0];
+			const span = visibleSpans()[0];
 			expect(span.attributes['n8n.execution.is_retry']).toBe(true);
 			expect(span.attributes['n8n.execution.retry_of']).toBe('exec-original');
 		});
@@ -223,7 +231,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const span = otel.getFinishedSpans()[0];
+			const span = visibleSpans()[0];
 			expect(span.attributes['n8n.workflow.custom.environment']).toBe('production');
 			expect(span.attributes['n8n.workflow.custom.retryCount']).toBe('3');
 			expect(span.attributes['n8n.workflow.custom.isCritical']).toBe('true');
@@ -242,7 +250,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const span = otel.getFinishedSpans()[0];
+			const span = visibleSpans()[0];
 			// The span inherits the traceId from the inbound traceparent
 			expect(span.spanContext().traceId).toBe('0af7651916cd43dd8448eb211c80319c');
 		});
@@ -314,7 +322,7 @@ describe('ExecutionLevelTracer', () => {
 				}),
 			).not.toThrow();
 
-			expect(otel.getFinishedSpans()).toHaveLength(0);
+			expect(visibleSpans()).toHaveLength(0);
 		});
 	});
 
@@ -348,7 +356,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const spans = otel.getFinishedSpans();
+			const spans = visibleSpans();
 			expect(spans).toHaveLength(2);
 
 			const nodeSpan = spans.find((s) => s.name === 'node.execute')!;
@@ -389,7 +397,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan.status.code).toBe(SpanStatusCode.ERROR);
 			expect(nodeSpan.events).toHaveLength(1);
 			expect(nodeSpan.events[0].name).toBe('exception');
@@ -429,7 +437,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan.events[0].attributes?.['exception.message']).toBe(
 				'unknown is not defined [line 1]',
 			);
@@ -467,7 +475,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan.events[0].attributes?.['exception.message']).toBe('Intentional error');
 			expect(nodeSpan.events[0].attributes?.['exception.type']).toBe('UnknownError');
 		});
@@ -481,7 +489,7 @@ describe('ExecutionLevelTracer', () => {
 			expect(logger.warn).toHaveBeenCalledWith(
 				expect.stringContaining('without a pre-existing parent workflow trace'),
 			);
-			expect(otel.getFinishedSpans()).toHaveLength(0);
+			expect(visibleSpans()).toHaveLength(0);
 		});
 
 		it('should no-op when endNode is called for a node that was never started', () => {
@@ -508,7 +516,7 @@ describe('ExecutionLevelTracer', () => {
 			});
 
 			// Only the workflow span should be finished.
-			const spans = otel.getFinishedSpans();
+			const spans = visibleSpans();
 			expect(spans).toHaveLength(1);
 			expect(spans[0].name).toBe('workflow.execute');
 		});
@@ -538,7 +546,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan.attributes['n8n.node.custom.llm.model']).toBe('gpt-4o');
 			expect(nodeSpan.attributes['n8n.node.custom.llm.tokens']).toBe('500');
 		});
@@ -570,7 +578,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan.attributes['n8n.workflow.custom.env']).toBeUndefined();
 			expect(nodeSpan.attributes['n8n.workflow.custom.retryCount']).toBeUndefined();
 			expect(nodeSpan.attributes['n8n.workflow.custom.isCritical']).toBeUndefined();
@@ -604,7 +612,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan.attributes['n8n.workflow.custom.env']).toBeUndefined();
 			expect(nodeSpan.attributes['n8n.node.custom.env']).toBe('node');
 		});
@@ -643,7 +651,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan.status.code).toBe(SpanStatusCode.ERROR);
 			expect(nodeSpan.attributes['n8n.node.custom.ai.agent.version']).toBe('v3');
 			expect(nodeSpan.attributes['n8n.node.custom.ai.agent.failure.type']).toBe(
@@ -671,7 +679,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpan).toBeDefined();
 			expect(nodeSpan.status.code).toBe(SpanStatusCode.ERROR);
 			expect(nodeSpan.attributes['n8n.node.termination_reason']).toBe('workflow_cancelled');
@@ -847,7 +855,7 @@ describe('ExecutionLevelTracer', () => {
 				isRetry: false,
 			});
 
-			const finishedNodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			const finishedNodeSpan = visibleSpans().find((s) => s.name === 'node.execute')!;
 			expect(nodeSpanId).toBe(finishedNodeSpan.spanContext().spanId);
 		});
 
@@ -898,7 +906,7 @@ describe('ExecutionLevelTracer', () => {
 			startExecution('exec-identity', { id: 'project-1' });
 			runNode('exec-identity');
 
-			const nodeSpan = otel.getFinishedSpans().find((span) => span.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((span) => span.name === 'node.execute')!;
 			expect(nodeSpan.attributes['n8n.workflow.id']).toBe('wf-1');
 			expect(nodeSpan.attributes['n8n.workflow.name']).toBe('Test');
 			expect(nodeSpan.attributes['n8n.execution.id']).toBe('exec-identity');
@@ -911,7 +919,7 @@ describe('ExecutionLevelTracer', () => {
 			startExecution('exec-no-project');
 			runNode('exec-no-project');
 
-			const nodeSpan = otel.getFinishedSpans().find((span) => span.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((span) => span.name === 'node.execute')!;
 			expect(nodeSpan.attributes['n8n.workflow.id']).toBe('wf-1');
 			expect(nodeSpan.attributes['n8n.project.id']).toBeUndefined();
 		});
@@ -927,7 +935,7 @@ describe('ExecutionLevelTracer', () => {
 			});
 			runNode('exec-root-only');
 
-			const nodeSpan = otel.getFinishedSpans().find((span) => span.name === 'node.execute')!;
+			const nodeSpan = visibleSpans().find((span) => span.name === 'node.execute')!;
 			// version_id / node_count are workflow-shaped, and custom attributes are
 			// license-gated - none of them belong on a per-node span.
 			expect(nodeSpan.attributes['n8n.workflow.version_id']).toBeUndefined();
@@ -980,6 +988,58 @@ describe('ExecutionLevelTracer', () => {
 			expect(nodeSpan.attributes['n8n.workflow.id']).toBe('wf-1');
 			expect(nodeSpan.attributes['n8n.execution.id']).toBe('exec-live');
 			expect(nodeSpan.attributes['n8n.project.id']).toBe('project-1');
+		});
+	});
+
+	describe('workflow start marker', () => {
+		it('should export an identified marker span at execution start', () => {
+			tracer.startWorkflow({
+				executionId: 'exec-marker',
+				workflow: defaultWorkflow,
+				project: { id: 'project-1' },
+			});
+
+			// Nothing else has ended yet, so this is the only span the collector has.
+			const exported = otel.getFinishedSpans();
+			expect(exported).toHaveLength(1);
+
+			const marker = exported[0];
+			expect(marker.name).toBe('workflow.execute.started');
+			expect(marker.attributes['n8n.workflow.id']).toBe('wf-1');
+			expect(marker.attributes['n8n.workflow.name']).toBe('Test');
+			expect(marker.attributes['n8n.execution.id']).toBe('exec-marker');
+			expect(marker.attributes['n8n.project.id']).toBe('project-1');
+		});
+
+		it('should parent the marker to the workflow span so they share a trace', () => {
+			tracer.startWorkflow({ executionId: 'exec-marker-parent', workflow: defaultWorkflow });
+			const marker = otel.getFinishedSpans()[0];
+
+			tracer.endWorkflow({
+				executionId: 'exec-marker-parent',
+				status: 'success',
+				mode: 'manual',
+				isRetry: false,
+			});
+			const workflowSpan = otel
+				.getFinishedSpans()
+				.find((span) => span.name === 'workflow.execute')!;
+
+			expect(marker.spanContext().traceId).toBe(workflowSpan.spanContext().traceId);
+			expect(marker.parentSpanContext?.spanId).toBe(workflowSpan.spanContext().spanId);
+		});
+
+		it('should keep license-gated custom attributes off the marker', () => {
+			tracer.startWorkflow({
+				executionId: 'exec-marker-custom',
+				workflow: { ...defaultWorkflow, customAttributes: { env: 'production' } },
+				project: { id: 'project-1', customAttributes: { team: 'platform' } },
+			});
+
+			const marker = otel.getFinishedSpans()[0];
+			expect(Object.keys(marker.attributes).filter((key) => key.includes('.custom.'))).toHaveLength(
+				0,
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
@@ -86,6 +86,35 @@ describe('OTEL Workflow Tracing Integration', () => {
 		expect(workflowSpan.attributes['n8n.project.id']).toBe(personalProject.id);
 	});
 
+	it('should stamp workflow, execution and project identity onto every node span', async () => {
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id);
+		await waitForExecution(executionRepository, executionId);
+
+		const nodeSpans = otel.getFinishedSpans().filter((s) => s.name === 'node.execute');
+		expect(nodeSpans).toHaveLength(workflow.nodes.length);
+		for (const nodeSpan of nodeSpans) {
+			expect(nodeSpan.attributes['n8n.execution.id']).toBe(executionId);
+			expect(nodeSpan.attributes['n8n.workflow.id']).toBe(workflow.id);
+			expect(nodeSpan.attributes['n8n.project.id']).toBe(project.id);
+		}
+	});
+
+	it('should stamp a personal project id onto node spans', async () => {
+		const owner = await createUser();
+		const personalProject = await getPersonalProject(owner);
+		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), personalProject);
+		const executionId = await executeWorkflow(workflowRunner, workflow, personalProject.id);
+		await waitForExecution(executionRepository, executionId);
+
+		const nodeSpans = otel.getFinishedSpans().filter((s) => s.name === 'node.execute');
+		expect(nodeSpans.length).toBeGreaterThan(0);
+		for (const nodeSpan of nodeSpans) {
+			expect(nodeSpan.attributes['n8n.project.id']).toBe(personalProject.id);
+		}
+	});
+
 	it('should persist tracingContext to the execution entity after root span creation', async () => {
 		const project = await createTeamProject();
 		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), project);

--- a/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
@@ -115,6 +115,29 @@ describe('OTEL Workflow Tracing Integration', () => {
 		}
 	});
 
+	it('should export an identified start marker ahead of the workflow span', async () => {
+		const toNanos = ([seconds, nanos]: [number, number]) => seconds * 1e9 + nanos;
+
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id);
+		await waitForExecution(executionRepository, executionId);
+
+		const spans = otel.getFinishedSpans();
+		const marker = spans.find((s) => s.name === 'workflow.execute.started');
+		const workflowSpan = spans.find((s) => s.name === 'workflow.execute')!;
+
+		expect(marker).toBeDefined();
+		expect(marker!.attributes['n8n.execution.id']).toBe(executionId);
+		expect(marker!.attributes['n8n.workflow.id']).toBe(workflow.id);
+		expect(marker!.attributes['n8n.project.id']).toBe(project.id);
+
+		// Same trace as the root, but it leaves the process first - which is the whole point:
+		// monitoring can identify the execution before it finishes.
+		expect(marker!.spanContext().traceId).toBe(workflowSpan.spanContext().traceId);
+		expect(toNanos(marker!.endTime)).toBeLessThan(toNanos(workflowSpan.endTime));
+	});
+
 	it('should persist tracingContext to the execution entity after root span creation', async () => {
 		const project = await createTeamProject();
 		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), project);

--- a/packages/cli/src/modules/otel/execution-level-tracer.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import type { Context, Exception, Span } from '@opentelemetry/api';
+import type { Attributes, Context, Exception, Span } from '@opentelemetry/api';
 import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api';
 import type { ExecutionStatus } from 'n8n-workflow';
 
@@ -25,9 +25,15 @@ function isError(status: ExecutionStatus): boolean {
 
 type TrackedSpan = { span: Span };
 
+/**
+ * The workflow's root span plus the identity attributes copied onto each of its node
+ * spans, so a node span can be tied back to its workflow/execution/project on its own.
+ */
+type TrackedWorkflowSpan = TrackedSpan & { identity: Attributes };
+
 @Service()
 export class ExecutionLevelTracer {
-	private readonly activeWorkflowSpans = new Map<string, TrackedSpan>();
+	private readonly activeWorkflowSpans = new Map<string, TrackedWorkflowSpan>();
 	private readonly activeNodeSpansByExecutionId = new Map<string, Map<string, TrackedSpan>>();
 	private tracer = trace.getTracer(TRACER_NAME);
 
@@ -50,16 +56,22 @@ export class ExecutionLevelTracer {
 			const parentCtx = this.parseTraceParentHeaders(params.tracingContext);
 			const links = this.buildContinuationLinks(params.linkTo);
 
+			// Kept deliberately small: only what identifies the execution, so it stays cheap to
+			// repeat on every node span. Custom (license-gated) attributes stay root-only.
+			const identity: Attributes = {
+				[ATTR.WORKFLOW_ID]: params.workflow.id,
+				[ATTR.WORKFLOW_NAME]: params.workflow.name,
+				[ATTR.EXECUTION_ID]: params.executionId,
+				...(params.project?.id && { [ATTR.PROJECT_ID]: params.project.id }),
+			};
+
 			const span = this.tracer.startSpan(
 				'workflow.execute',
 				{
 					attributes: {
-						[ATTR.WORKFLOW_ID]: params.workflow.id,
-						[ATTR.WORKFLOW_NAME]: params.workflow.name,
+						...identity,
 						[ATTR.WORKFLOW_VERSION_ID]: params.workflow.versionId ?? '',
 						[ATTR.WORKFLOW_NODE_COUNT]: params.workflow.nodeCount,
-						[ATTR.EXECUTION_ID]: params.executionId,
-						...(params.project?.id && { [ATTR.PROJECT_ID]: params.project.id }),
 						...buildCustomAttributes(
 							ATTR.WORKFLOW_CUSTOM_PREFIX,
 							params.workflow?.customAttributes,
@@ -71,9 +83,8 @@ export class ExecutionLevelTracer {
 				parentCtx,
 			);
 
-			this.activeWorkflowSpans.set(params.executionId, {
-				span,
-			});
+			this.activeWorkflowSpans.set(params.executionId, { span, identity });
+
 			return toTracingParentContext(span);
 		} catch (error) {
 			this.logger.warn('Failed to start workflow span', {
@@ -122,20 +133,24 @@ export class ExecutionLevelTracer {
 
 	startNode(params: StartNodeParams): void {
 		try {
-			//	We should always have the node running in a workflow so parentCtx should never be null
-			const parentCtx = this.findWorkflowSpanContext(params.executionId);
+			//	We should always have the node running in a workflow so this should never be missing
+			const trackedWorkflow = this.activeWorkflowSpans.get(params.executionId);
 
-			if (!parentCtx) {
+			if (!trackedWorkflow) {
 				this.logger.warn(
 					'Trying to start a node without a pre-existing parent workflow trace - ignoring',
 				);
 				return;
 			}
 
+			const parentCtx = trace.setSpan(context.active(), trackedWorkflow.span);
+
 			const span = this.tracer.startSpan(
 				'node.execute',
 				{
 					attributes: {
+						// Repeated from the root span, which is not exported until the workflow ends.
+						...trackedWorkflow.identity,
 						[ATTR.NODE_ID]: params.node.id,
 						[ATTR.NODE_NAME]: params.node.name,
 						[ATTR.NODE_TYPE]: params.node.type,
@@ -247,11 +262,6 @@ export class ExecutionLevelTracer {
 				attributes: { [ATTR.CONTINUATION_REASON]: 'resume' },
 			},
 		];
-	}
-
-	private findWorkflowSpanContext(executionId: string) {
-		const tracked = this.activeWorkflowSpans.get(executionId);
-		return tracked ? trace.setSpan(context.active(), tracked.span) : undefined;
 	}
 
 	private findMostSpecificSpan(executionId: string, nodeName?: string): Span | undefined {

--- a/packages/cli/src/modules/otel/execution-level-tracer.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.ts
@@ -19,6 +19,13 @@ const TRACER_NAME = 'n8n-workflow';
 const UNKNOWN_ERROR_TYPE = 'UnknownError';
 const OBJECT_ERROR_TYPE = 'Object';
 
+/**
+ * Marker span emitted (and ended) at execution start. A span is only exported once it
+ * ends, so without this nothing identifiable reaches the collector until the first node
+ * or the workflow itself finishes.
+ */
+const WORKFLOW_START_SPAN_NAME = 'workflow.execute.started';
+
 function isError(status: ExecutionStatus): boolean {
 	return status === 'error' || status === 'crashed';
 }
@@ -84,6 +91,7 @@ export class ExecutionLevelTracer {
 			);
 
 			this.activeWorkflowSpans.set(params.executionId, { span, identity });
+			this.emitStartMarker(span, identity);
 
 			return toTracingParentContext(span);
 		} catch (error) {
@@ -262,6 +270,21 @@ export class ExecutionLevelTracer {
 				attributes: { [ATTR.CONTINUATION_REASON]: 'resume' },
 			},
 		];
+	}
+
+	/**
+	 * Starts and immediately ends a child of the workflow span, so one identified span is
+	 * exported at execution start rather than at execution end. Being a child keeps it in
+	 * the same trace and inherits the root's sampling decision; it does not affect the
+	 * traceparent handed back to callers, which still points at the root span.
+	 */
+	private emitStartMarker(workflowSpan: Span, identity: Attributes): void {
+		const marker = this.tracer.startSpan(
+			WORKFLOW_START_SPAN_NAME,
+			{ attributes: identity },
+			trace.setSpan(context.active(), workflowSpan),
+		);
+		marker.end();
 	}
 
 	private findMostSpecificSpan(executionId: string, nodeName?: string): Span | undefined {


### PR DESCRIPTION
## Summary

OpenTelemetry exports a span only when that span ends. The `workflow.execute` root span stays open for the whole run, so it reached the collector only after the execution finished.

Node spans already ended per node, so they did arrive during the run. But they carried only node-level attributes — `n8n.node.id`, `n8n.node.name`, `n8n.node.type`, `n8n.node.type_version`. Every attribute that identifies the run lived on the root span alone. A node span was therefore unusable on arrival: a query for `n8n.workflow.id` returned no results until the run was over.

This is visible on any workflow made of long synchronous nodes. Monitoring cannot answer "what is this workflow doing right now", because nothing identifiable has been exported yet.

Two commits:

1. **`fix(core)`** — Cache the identifying attributes next to the root span and stamp them onto each node span. The attributes are cached rather than passed in from the lifecycle handler because `startNode` is synchronous, and project identity is only reachable through an awaited lookup; passing it in would put an awaited call on the per-node path.
2. **`feat(core)`** — Add `workflow.execute.started`, a zero-duration child of the root span that carries the same attributes. This covers the two cases the node attributes cannot: node spans turned off (`N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false`), where no node span exists to carry identity, and executions resumed after a wait, where no trigger node runs again.

Measured on a webhook execution with three sequential 20-second HTTP nodes, querying Jaeger by `n8n.workflow.id`:

| | Before | After |
|---|---|---|
| Found at t=5s | No | Yes |
| Found during the run | No — 0 results for 60s | Yes, continuously |
| First time it can be found | t=65s, after completion | t=5s, one batch interval |

The root span's attributes do not change. No new attribute keys are added, so existing dashboard queries keep working. The license-gated custom attributes stay on the root span only. Cost is one extra span per execution — not per node, and not per loop iteration.

Out of scope, on purpose: the exporter still batches, so the floor stays at one `BatchSpanProcessor` interval (~5s by default). This PR does not change batching or add a flush.

## How to test

OpenTelemetry is off by default. Start an OTLP collector, then run n8n against it.

1. Start Jaeger:

```bash
docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:latest
```

2. Start n8n. `N8N_OTEL_TRACES_PRODUCTION_ONLY` defaults to `true`, so set it to `false` if you want to test with manual executions:

```bash
cd packages/cli
N8N_OTEL_ENABLED=true \
N8N_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
N8N_OTEL_TRACES_PRODUCTION_ONLY=false \
pnpm run dev
```

3. Build a workflow with a Webhook trigger followed by two or three HTTP Request nodes that each take about 20 seconds. Any slow endpoint works. To keep it local:

```bash
python3 -c "
import time
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
class H(BaseHTTPRequestHandler):
    protocol_version='HTTP/1.1'
    def do_GET(self):
        time.sleep(20); b=b'{\"ok\":true}'
        self.send_response(200); self.send_header('Content-Length',str(len(b))); self.end_headers(); self.wfile.write(b)
ThreadingHTTPServer(('127.0.0.1',8099),H).serve_forever()"
```

Point each HTTP Request node at `http://127.0.0.1:8099/`.

4. Activate the workflow and call its production webhook URL.
5. While it runs, open http://localhost:16686. Select the service, add tag `n8n.workflow.id=<your workflow id>`, and click **Find Traces**.

Expected: the execution is found within about 5 seconds, and each finished node span carries `n8n.workflow.id`, `n8n.execution.id` and `n8n.project.id`. The trace shows `workflow.execute.started` immediately. Before this change the same search returned nothing until the run ended.

To check the second commit on its own, restart with `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false` and repeat. Nothing was exported before the run ended; now the marker span appears at the start.

Automated coverage: `pnpm test src/modules/otel/__tests__/execution-level-tracer.test.ts` (40 tests) and `pnpm test:integration src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts` (12 tests), both from `packages/cli`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-1086

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

### Notes for reviewers

- In scaling mode the marker span is emitted once on the main process and once on the worker. `workflowExecuteBefore` already fires on both, and two `workflow.execute` spans are already produced today. The marker inherits that existing behaviour; it does not introduce it.
- The existing unit tests select spans through a `visibleSpans()` helper that filters the marker out. This keeps those assertions about the spans under test, and it means the second commit can be dropped without touching them.
- Parentless-span rendering was verified on Jaeger v2 only. Other backends may treat a trace whose root has not yet arrived differently.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

