### PR TITLE
feat(core): Add chat-specific branding to the shared OAuth consent screen

### DIFF
--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/chat-trigger-resource.base.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/chat-trigger-resource.base.ts
@@ -12,6 +12,7 @@ import type { WorkflowFinderService } from '@/workflows/workflow-finder.service'
 
 import { triggerResourceGate } from '../resource-gate';
 import {
+	CHAT_TRIGGER_CONSENT_HINTS,
 	CHAT_TRIGGER_SCOPES,
 	isOAuthProtectedChatTrigger,
 	resourceUrlToWebhookPath,
@@ -113,7 +114,7 @@ export abstract class ChatTriggerResourceResolverBase implements ProtectedResour
 			getAllowedRedirectUris: async () => [resourceUrl],
 			scopes: CHAT_TRIGGER_SCOPES,
 			displayName: workflowName,
-			// `uiHints` is IAM-1266's.
+			uiHints: CHAT_TRIGGER_CONSENT_HINTS,
 			...triggerResourceGate(this.workflowFinderService, {
 				audiences,
 				executeAccessWorkflowId: requireExecute ? workflowId : undefined,

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/utils.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/utils.ts
@@ -24,6 +24,12 @@ export const WEBHOOK_TRIGGER_SCOPES: string[] = [];
 /** Scopes advertised for per-workflow Chat trigger resources. Empty, like the other triggers. */
 export const CHAT_TRIGGER_SCOPES: string[] = [];
 
+/** Consent-screen presentation hints for per-workflow Chat trigger resources. */
+export const CHAT_TRIGGER_CONSENT_HINTS: ConsentUiHints = {
+	icon: 'node:chat-trigger',
+	consentType: 'chat',
+};
+
 /**
  * A chat trigger is an OAuth protected resource only in the shape the hosted page can actually
  * serve: enabled, published publicly, on the n8n-hosted page rather than the embedded widget, and

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2632,6 +2632,7 @@
 	"oauth.consentView.firstParty.heading": "\"{resourceName}\" wants to run using your n8n login",
 	"oauth.consentView.firstParty.description": "Running this {resourceType} executes its workflow using your account and any connected credentials. Only continue if you trust the creator of this {resourceType}.",
 	"oauth.consentView.firstParty.type.form": "form",
+	"oauth.consentView.firstParty.type.chat": "chatbot",
 	"oauth.consentView.firstParty.type.default": "resource",
 	"oauth.consentView.allowDisabled.trust": "First confirm you recognize and trust the URL above",
 	"oauth.consentView.allowDisabled.noScopes": "Select at least one scope to grant",


### PR DESCRIPTION
## Summary

- Adds `CHAT_TRIGGER_CONSENT_HINTS` (icon `node:chat-trigger`, `consentType: 'chat'`) alongside the existing `FORM_TRIGGER_CONSENT_HINTS`.
- Wires it into `ChatTriggerResourceResolverBase.resolveByPath`, so both the production and test-webhook chat resolvers set `uiHints` on the protected-resource descriptor they return.
- Adds the `oauth.consentView.firstParty.type.chat` i18n string ("chatbot") so the shared `/oauth/consent` screen renders chat-appropriate copy ("...trust the creator of this chatbot") instead of falling back to generic "resource" wording.

No changes to the consent screen component itself (`OAuthConsentView.vue`) — it already renders whatever `uiHints` the backend sends, the same way it does for Form triggers.

## How to test

1. Enable chat OAuth2 (`N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2`), publish a workflow with a Chat Trigger set to `authentication: n8nUserAuth`, public, hosted-chat mode.
2. Open the hosted chat link as a visitor without an existing session.
3. On the consent step, confirm the screen shows the chat trigger's icon and "chatbot" wording (not the generic "resource" copy), and that no separate custom consent page/route exists.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1266

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. (none needed — Form's own `uiHints` constant has no dedicated resolver-level test either; existing `oauth-consent.service.test.ts` coverage of the generic forwarding path still passes)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (n/a)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

