### PR TITLE
fix(AMQP Trigger Node): Reattach the receiver link when the broker detaches it

### DIFF
--- a/packages/nodes-base/nodes/Amqp/Amqp.node.test.ts
+++ b/packages/nodes-base/nodes/Amqp/Amqp.node.test.ts
@@ -120,6 +120,34 @@ describe('AMQP Node', () => {
 		});
 	});
 
+	it('should pass the reconnect option through to the connection', async () => {
+		executeFunctions.getNodeParameter.calledWith('options', 0).mockReturnValue({
+			reconnect: false,
+		});
+
+		await new Amqp().execute.call(executeFunctions);
+
+		expect(mockContainer.connect).toHaveBeenLastCalledWith(
+			expect.objectContaining({ reconnect: false, reconnect_limit: 50 }),
+		);
+	});
+
+	it('should fail fast when the connection drops and reconnect is disabled', async () => {
+		executeFunctions.getNodeParameter.calledWith('options', 0).mockReturnValue({
+			reconnect: false,
+		});
+		// no 'sendable': the connection drops before anything can be sent
+		mockContainer.once.mockImplementation(() => {});
+		mockContainer.on.mockImplementation((event: string, callback: any) => {
+			if (event === 'connection_open') setImmediate(() => callback({}));
+			if (event === 'disconnected') {
+				setImmediate(() => callback({ error: new Error('Connection lost') }));
+			}
+		});
+
+		await expect(new Amqp().execute.call(executeFunctions)).rejects.toThrow('Connection lost');
+	});
+
 	it('should send data as object when configured', async () => {
 		executeFunctions.getNodeParameter.calledWith('options', 0).mockReturnValue({
 			dataAsObject: true,

--- a/packages/nodes-base/nodes/Amqp/Amqp.node.ts
+++ b/packages/nodes-base/nodes/Amqp/Amqp.node.ts
@@ -175,7 +175,7 @@ export class Amqp implements INodeType {
 				| object;
 			const options = this.getNodeParameter('options', 0, {});
 			const containerId = options.containerId as string;
-			const containerReconnect = (options.reconnect as boolean) || true;
+			const containerReconnect = (options.reconnect as boolean) ?? true;
 			const containerReconnectLimit = (options.reconnectLimit as number) || 50;
 
 			let headerProperties: Dictionary<any>;
@@ -215,7 +215,8 @@ export class Amqp implements INodeType {
 
 				container.on('disconnected', function (context: EventContext) {
 					//handling this manually as container, despite reconnect_limit, does reconnect on disconnect
-					if (limit <= 0) {
+					// with reconnect off there is no retry to wait for, so the first drop is final
+					if (limit <= 0 || !containerReconnect) {
 						connection!.options.reconnect = false;
 						const error = new NodeOperationError(
 							node,

--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.test.ts
@@ -1,7 +1,7 @@
 import { testTriggerNode } from '@test/nodes/TriggerHelpers';
 import { mockDeep } from 'vitest-mock-extended';
 import { NodeOperationError } from 'n8n-workflow';
-import type { IRun, ITriggerFunctions } from 'n8n-workflow';
+import type { IDataObject, IRun, ITriggerFunctions } from 'n8n-workflow';
 
 import { AmqpTrigger } from './AmqpTrigger.node';
 
@@ -15,6 +15,7 @@ const mockConnection = {
 	open_receiver: mockOpenReceiver,
 	close: mockClose,
 };
+const mockConnect = vi.fn(() => mockConnection);
 
 vi.mock('rhea', () => ({
 	create_container: vi.fn(() => ({
@@ -24,9 +25,18 @@ vi.mock('rhea', () => ({
 		removeAllListeners: vi.fn((event: string) => {
 			delete eventHandlers[event];
 		}),
-		connect: vi.fn(() => mockConnection),
+		connect: mockConnect,
 	})),
 }));
+
+const detachForced = {
+	receiver: {
+		error: {
+			condition: 'amqp:link:detach-forced',
+			description: 'Idle timeout: 00:10:00',
+		},
+	},
+};
 
 describe('AMQP Trigger Node', () => {
 	beforeEach(() => {
@@ -472,5 +482,203 @@ describe('AMQP Trigger Node', () => {
 		vi.advanceTimersByTime(10);
 		vi.useRealTimers();
 		expect(addCreditSpy).toHaveBeenCalledWith(1);
+	});
+
+	describe('when the broker detaches the receiver link', () => {
+		// every test here leaves a pending reattach timer behind, which would fire
+		// into the shared mocks of a later test
+		let closeTrigger: (() => Promise<void>) | undefined;
+
+		const startTrigger = async (options: IDataObject = {}) => {
+			const started = await testTriggerNode(AmqpTrigger, {
+				mode: 'trigger',
+				node: { parameters: { sink: 'queue://test', options } },
+				credential: { hostname: 'localhost', port: 5672 },
+			});
+			closeTrigger = started.close;
+			return started;
+		};
+
+		const forceDetach = (context: unknown = detachForced) => {
+			expect(eventHandlers['receiver_close'], 'no receiver_close handler registered').toBeTypeOf(
+				'function',
+			);
+			eventHandlers['receiver_close'](context);
+		};
+
+		afterEach(async () => {
+			await closeTrigger?.();
+			closeTrigger = undefined;
+			vi.useRealTimers();
+		});
+
+		it('should reopen the receiver with the original options', async () => {
+			await startTrigger();
+
+			vi.useFakeTimers();
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(100);
+
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(2);
+			expect(mockOpenReceiver).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					source: expect.objectContaining({ address: 'queue://test' }),
+					credit_window: 0,
+				}),
+			);
+		});
+
+		it('should log the detach with the peer condition and description', async () => {
+			const { logger } = await startTrigger();
+
+			forceDetach();
+
+			expect(logger.info).toHaveBeenCalledWith(
+				expect.stringContaining('detached'),
+				expect.objectContaining({
+					condition: 'amqp:link:detach-forced',
+					description: 'Idle timeout: 00:10:00',
+				}),
+			);
+		});
+
+		it('should reattach after a detach that carries no error', async () => {
+			const { logger } = await startTrigger();
+
+			vi.useFakeTimers();
+			forceDetach({ receiver: {} });
+			await vi.advanceTimersByTimeAsync(100);
+
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(2);
+			expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('detached'), {
+				condition: undefined,
+				description: undefined,
+			});
+		});
+
+		it('should leave a connection-level disconnect to rhea, which reattaches links itself', async () => {
+			await startTrigger();
+
+			vi.useFakeTimers();
+			eventHandlers['disconnected']({ reconnecting: true });
+			await vi.advanceTimersByTimeAsync(60_000);
+
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not grant credit to the detached link while it is down', async () => {
+			const addCreditSpy = vi.fn();
+			await startTrigger({ pullMessagesNumber: 3, sleepTime: 500 });
+
+			const receiver = { add_credit: addCreditSpy };
+			eventHandlers['receiver_open']({ receiver });
+
+			vi.useFakeTimers();
+			await Promise.resolve(
+				eventHandlers['message']({ message: { body: 'a', message_id: 1 }, receiver }),
+			);
+			forceDetach();
+			addCreditSpy.mockClear();
+
+			// the execution finishes while the link is detached
+			await vi.advanceTimersByTimeAsync(500);
+
+			expect(addCreditSpy).not.toHaveBeenCalled();
+		});
+
+		it('should grant credit to the reattached receiver, not the detached one', async () => {
+			const detachedAddCredit = vi.fn();
+			const reattachedAddCredit = vi.fn();
+			await startTrigger({ pullMessagesNumber: 3, sleepTime: 500 });
+
+			const detachedReceiver = { add_credit: detachedAddCredit };
+			eventHandlers['receiver_open']({ receiver: detachedReceiver });
+
+			vi.useFakeTimers();
+			await Promise.resolve(
+				eventHandlers['message']({
+					message: { body: 'a', message_id: 1 },
+					receiver: detachedReceiver,
+				}),
+			);
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(100);
+			detachedAddCredit.mockClear();
+
+			// the reattached link starts with the free slots only, the in-flight message still holds one
+			eventHandlers['receiver_open']({ receiver: { add_credit: reattachedAddCredit } });
+			expect(reattachedAddCredit).toHaveBeenLastCalledWith(2);
+
+			await vi.advanceTimersByTimeAsync(500);
+			expect(reattachedAddCredit).toHaveBeenLastCalledWith(1);
+			expect(detachedAddCredit).not.toHaveBeenCalled();
+		});
+
+		it('should back off between reopen attempts and stop at the reconnect limit', async () => {
+			const { emitError } = await startTrigger({ reconnectLimit: 2 });
+
+			vi.useFakeTimers();
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(100);
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(2);
+
+			// the reopened link is detached again before it ever attaches
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(100);
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(2);
+			await vi.advanceTimersByTimeAsync(100);
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(3);
+
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(3);
+			expect(emitError).toHaveBeenCalledWith(expect.any(NodeOperationError));
+		});
+
+		it('should reset the backoff once the receiver reattaches', async () => {
+			await startTrigger({ reconnectLimit: 1 });
+
+			vi.useFakeTimers();
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(100);
+			eventHandlers['receiver_open']({ receiver: { add_credit: vi.fn() } });
+
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(100);
+
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(3);
+		});
+
+		it('should report an error instead of reopening when reconnect is disabled', async () => {
+			const { emitError } = await startTrigger({ reconnect: false });
+
+			vi.useFakeTimers();
+			forceDetach();
+			await vi.advanceTimersByTimeAsync(60_000);
+
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(1);
+			expect(emitError).toHaveBeenCalledWith(expect.any(NodeOperationError));
+		});
+
+		it('should not reopen the receiver after the trigger was closed', async () => {
+			const { close } = await startTrigger();
+
+			vi.useFakeTimers();
+			forceDetach();
+			await close();
+			await vi.advanceTimersByTimeAsync(60_000);
+
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it('should pass the reconnect option through to the connection', async () => {
+		await testTriggerNode(AmqpTrigger, {
+			mode: 'trigger',
+			node: { parameters: { sink: 'queue://test', options: { reconnect: false } } },
+			credential: { hostname: 'localhost', port: 5672 },
+		});
+
+		expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ reconnect: false }));
 	});
 });

--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.test.ts
@@ -556,6 +556,18 @@ describe('AMQP Trigger Node', () => {
 			});
 		});
 
+		it('should not reopen the receiver when the link reattaches before the timer fires', async () => {
+			await startTrigger();
+
+			vi.useFakeTimers();
+			forceDetach();
+			// a connection-level reconnect can reattach the link while the timer is pending
+			eventHandlers['receiver_open']({ receiver: { add_credit: vi.fn() } });
+			await vi.advanceTimersByTimeAsync(60_000);
+
+			expect(mockOpenReceiver).toHaveBeenCalledTimes(1);
+		});
+
 		it('should leave a connection-level disconnect to rhea, which reattaches links itself', async () => {
 			await startTrigger();
 
@@ -650,7 +662,7 @@ describe('AMQP Trigger Node', () => {
 		});
 
 		it('should report an error instead of reopening when reconnect is disabled', async () => {
-			const { emitError } = await startTrigger({ reconnect: false });
+			const { emitError, logger } = await startTrigger({ reconnect: false });
 
 			vi.useFakeTimers();
 			forceDetach();
@@ -658,6 +670,11 @@ describe('AMQP Trigger Node', () => {
 
 			expect(mockOpenReceiver).toHaveBeenCalledTimes(1);
 			expect(emitError).toHaveBeenCalledWith(expect.any(NodeOperationError));
+			// the peer's reason is most valuable on the detach that is not recoverable
+			expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('detached'), {
+				condition: 'amqp:link:detach-forced',
+				description: 'Idle timeout: 00:10:00',
+			});
 		});
 
 		it('should not reopen the receiver after the trigger was closed', async () => {

--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
@@ -6,11 +6,14 @@ import type {
 	ITriggerResponse,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
-import type { ConnectionOptions, EventContext, ReceiverOptions } from 'rhea';
+import type { ConnectionOptions, EventContext, Receiver, ReceiverOptions } from 'rhea';
 import { create_container } from 'rhea';
 
 import { handleMessage } from './helpers/handleMessage';
 import type { AmqpCredential } from './types';
+
+const INITIAL_REATTACH_DELAY_MS = 100;
+const MAX_REATTACH_DELAY_MS = 60_000;
 
 export class AmqpTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -146,7 +149,7 @@ export class AmqpTrigger implements INodeType {
 		const parallelProcessing = this.getNodeParameter('options.parallelProcessing', true) as boolean;
 		const pullMessagesNumber = (options.pullMessagesNumber as number) || 100;
 		const containerId = options.containerId as string;
-		const containerReconnect = (options.reconnect as boolean) || true;
+		const containerReconnect = (options.reconnect as boolean) ?? true;
 		// Keep reconnecting (exponential backoff) forever unless user sets a limit
 		const containerReconnectLimit = (options.reconnectLimit as number) ?? undefined;
 
@@ -167,13 +170,31 @@ export class AmqpTrigger implements INodeType {
 		// rhea resets link credit when a reconnect attempt starts, so credit added
 		// between disconnect and reattach would double-count with the grant below
 		let receiverReady = true;
+		// a peer-forced detach replaces the link, so credit has to be granted to
+		// whichever receiver is attached now and not to the one that delivered
+		let receiver: Receiver | undefined = undefined;
+		let reattachAttempts = 0;
+		let reattachTimer: NodeJS.Timeout | undefined = undefined;
 
-		container.on('disconnected', () => {
+		container.on('disconnected', (context: EventContext) => {
 			receiverReady = false;
+			// rhea sets reconnecting: false once it has exhausted reconnect_limit, and
+			// leaves it unset when reconnect is off - either way nothing will come back
+			if (!containerReconnect || context.reconnecting === false) {
+				this.emitError(
+					new NodeOperationError(
+						this.getNode(),
+						context.error ?? new Error('AMQP connection lost'),
+						{ description: 'The connection will not be re-established, reactivate the workflow' },
+					),
+				);
+			}
 		});
 
 		container.on('receiver_open', (context: EventContext) => {
+			receiver = context.receiver;
 			receiverReady = true;
+			reattachAttempts = 0;
 			// on reconnect, executions from before the disconnect may still hold slots
 			context.receiver?.add_credit(Math.max(0, pullMessagesNumber - inFlightMessages));
 		});
@@ -196,7 +217,7 @@ export class AmqpTrigger implements INodeType {
 					() => {
 						inFlightMessages--;
 						// while the link is down its freed slot is granted by receiver_open instead
-						if (receiverReady) context.receiver?.add_credit(1);
+						if (receiverReady) (receiver ?? context.receiver)?.add_credit(1);
 					},
 					(options.sleepTime as number) || 10,
 				);
@@ -244,14 +265,68 @@ export class AmqpTrigger implements INodeType {
 		};
 		connection.open_receiver(clientOptions);
 
-		// The "closeFunction" function gets called by n8n whenever
-		// the workflow gets deactivated and can so clean up.
-		async function closeFunction() {
+		const canReattach = () =>
+			containerReconnect &&
+			(containerReconnectLimit === undefined || reattachAttempts < containerReconnectLimit);
+
+		const scheduleReattach = () => {
+			if (reattachTimer) return;
+
+			const delay = Math.min(
+				INITIAL_REATTACH_DELAY_MS * 2 ** reattachAttempts,
+				MAX_REATTACH_DELAY_MS,
+			);
+			reattachAttempts++;
+			reattachTimer = setTimeout(() => {
+				reattachTimer = undefined;
+				connection.open_receiver(clientOptions);
+			}, delay);
+		};
+
+		// Brokers such as Azure Service Bus detach an idle link and keep the
+		// connection open, so nothing at connection level notices the stall
+		container.on('receiver_close', (context: EventContext) => {
+			receiverReady = false;
+			receiver = undefined;
+
+			const error = context.receiver?.error;
+			const detachError = error && 'condition' in error ? error : undefined;
+			const detail = {
+				condition: detachError?.condition,
+				description: detachError?.description,
+			};
+
+			if (!canReattach()) {
+				this.emitError(
+					new NodeOperationError(
+						this.getNode(),
+						'AMQP receiver link was detached and could not be reattached',
+						{ description: detachError?.description ?? detachError?.condition },
+					),
+				);
+				return;
+			}
+
+			const message = 'AMQP receiver link was detached by the peer, reattaching';
+			// a second detach with no attach in between means the link is not just idling out
+			if (reattachAttempts === 0) this.logger.info(message, detail);
+			else this.logger.warn(message, detail);
+
+			scheduleReattach();
+		});
+
+		const teardown = () => {
+			clearTimeout(reattachTimer);
 			container.removeAllListeners('disconnected');
 			container.removeAllListeners('receiver_open');
+			container.removeAllListeners('receiver_close');
 			container.removeAllListeners('message');
 			connection.close();
-		}
+		};
+
+		// The "closeFunction" function gets called by n8n whenever
+		// the workflow gets deactivated and can so clean up.
+		const closeFunction = async () => teardown();
 
 		// The "manualTriggerFunction" function gets called by n8n
 		// when a user is in the workflow editor and starts the
@@ -264,10 +339,7 @@ export class AmqpTrigger implements INodeType {
 				container.removeAllListeners('message');
 
 				const timeoutHandler = setTimeout(() => {
-					container.removeAllListeners('disconnected');
-					container.removeAllListeners('receiver_open');
-					container.removeAllListeners('message');
-					connection.close();
+					teardown();
 
 					reject(
 						new NodeOperationError(

--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
@@ -181,6 +181,9 @@ export class AmqpTrigger implements INodeType {
 			// rhea sets reconnecting: false once it has exhausted reconnect_limit, and
 			// leaves it unset when reconnect is off - either way nothing will come back
 			if (!containerReconnect || context.reconnecting === false) {
+				this.logger.error('AMQP connection was lost and will not be reconnected', {
+					error: context.error?.message,
+				});
 				this.emitError(
 					new NodeOperationError(
 						this.getNode(),
@@ -195,6 +198,9 @@ export class AmqpTrigger implements INodeType {
 			receiver = context.receiver;
 			receiverReady = true;
 			reattachAttempts = 0;
+			// a link is attached, so a still pending reattach would open a second one
+			clearTimeout(reattachTimer);
+			reattachTimer = undefined;
 			// on reconnect, executions from before the disconnect may still hold slots
 			context.receiver?.add_credit(Math.max(0, pullMessagesNumber - inFlightMessages));
 		});
@@ -297,6 +303,7 @@ export class AmqpTrigger implements INodeType {
 			};
 
 			if (!canReattach()) {
+				this.logger.error('AMQP receiver link was detached and will not be reattached', detail);
 				this.emitError(
 					new NodeOperationError(
 						this.getNode(),


### PR DESCRIPTION
## Summary

A broker can detach an idle receiver link and keep the TCP connection open. Azure Service Bus does this after a link idles for ten minutes (`amqp:link:detach-forced`, `Idle timeout: 00:10:00`).

The AMQP Trigger only listened for connection-level events, so it never saw this:

- It registered `disconnected`, `receiver_open` and `message`. It never registered `receiver_close`, and it never called `open_receiver()` a second time.
- `credit_window` is `0`, so rhea does not replenish credit on its own. The only bulk `add_credit` call is in the `receiver_open` handler. No reattach means no credit, ever.
- `receiverReady` was cleared only by the connection-level `disconnected` event, so it stayed `true` through a link detach and the node reported itself healthy.

Result: messages pile up on the queue, the workflow still shows as published, and no execution is created. The backlog only drains when somebody republishes the workflow.

This PR:

- Handles `receiver_close`, clears the link state, and re-opens the receiver with exponential backoff (100 ms, doubling up to a minute), bounded by the existing **Reconnect** and **Reconnect Limit** options.
- Grants freed credit to the link that is attached now. A reattach creates a new receiver object, unlike a connection reconnect, which reuses the old one. Credit released after a reattach used to go to the dead link and was lost.
- Logs the detach with the peer's condition and description. The level rises to `warn` when a reattach did not stick, so a permanent condition is visible.
- Reports an error through `emitError` when the link cannot be recovered, instead of consuming nothing in silence.

It also makes the **Reconnect** option work. Both AMQP nodes read it as `(options.reconnect as boolean) || true`, which is always `true`, so the toggle did nothing. Two notes on that:

- Handling `receiver_close` also removes an uncaught exception. rhea emits `error` on the container when neither `receiver_error` nor `receiver_close` is handled. With no listener, that is an unhandled `'error'` event.
- **Reconnect Limit** now bounds two counters: rhea's connection reconnects and our link reattaches. They cover different failure modes and rhea does not unify them either.

## How to test

You need a broker that force-detaches an idle link. Azure Service Bus does it after ten minutes. The listener below does it after ten seconds.

**1. Start the example listener.** It needs `rhea` and nothing else:

```bash
mkdir /tmp/amqp-listener && cd /tmp/amqp-listener
npm init -y && npm install rhea@3
# save listener.cjs from the section below into this directory
node listener.cjs
```

It prints `listening on amqp://localhost:5673, waiting for a receiver link to attach` and then drives this timeline, anchored to the moment your trigger attaches: message #1 after 2 s, a forced detach after 12 s, then messages #2, #3 and #4.

<details>
<summary>listener.cjs</summary>

```js
// AMQP 1.0 listener that force-detaches an idle receiver link and keeps the
// connection open, the way Azure Service Bus does after ten minutes.
const { create_container } = require('rhea');

const PORT = 5673;
const IDLE_MS = 10_000; // stands in for Azure's ten minutes
const backlog = [];
let sender;
let idleTimer;
let seq = 0;
let started = false;

const log = (...args) => console.log(new Date().toISOString().slice(11, 23), '[listener]', ...args);
const container = create_container();

container.on('connection_open', () => log('connection opened'));

container.on('sender_open', (context) => {
	sender = context.sender;
	log('receiver link ATTACHED');
	if (!started) {
		started = true;
		[2, 16, 22, 28].forEach((s, i) => setTimeout(() => enqueue(`message #${i + 1}`), s * 1000));
	}
	armIdleTimer();
	flush();
});

container.on('sendable', () => flush());

container.on('disconnected', () => {
	sender = undefined;
	clearTimeout(idleTimer);
});

function armIdleTimer() {
	clearTimeout(idleTimer);
	idleTimer = setTimeout(() => {
		if (!sender || sender.is_closed()) return;
		log(`no traffic for ${IDLE_MS / 1000}s -> FORCING DETACH (connection stays open)`);
		sender.close({ condition: 'amqp:link:detach-forced', description: 'Idle timeout: 00:10:00' });
		sender = undefined;
	}, IDLE_MS);
}

function flush() {
	if (!sender || sender.is_closed()) {
		if (backlog.length) log(`no attached link -> ${backlog.length} message(s) STUCK on queue`);
		return;
	}
	while (backlog.length && sender.sendable()) {
		const body = backlog.shift();
		sender.send({ message_id: `msg-${++seq}`, body });
		log(`delivered ${body}`);
		armIdleTimer();
	}
}

function enqueue(body) {
	log(`enqueued ${body}`);
	backlog.push(body);
	flush();
}

container.listen({ port: PORT });
log(`listening on amqp://localhost:${PORT}, waiting for a receiver link to attach`);
```

</details>

**2. Import the example workflow** and open it.

<details>
<summary>Example workflow (copy and paste onto the canvas)</summary>

```json
{
  "nodes": [
    {
      "parameters": {
        "sink": "queue://n8n-test",
        "clientname": "",
        "subscription": "",
        "options": {}
      },
      "type": "n8n-nodes-base.amqpTrigger",
      "typeVersion": 1,
      "position": [
        0,
        0
      ],
      "id": "5f0c2f6a-2f2b-4a1a-9f01-1f6d1b4a5848",
      "name": "AMQP Trigger"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "1",
              "name": "received",
              "value": "={{ $json.body }}",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        220,
        0
      ],
      "id": "5f0c2f6a-2f2b-4a1a-9f01-1f6d1b4a5849",
      "name": "Received"
    }
  ],
  "connections": {
    "AMQP Trigger": {
      "main": [
        [
          {
            "node": "Received",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {}
}```

</details>

**3. Create an AMQP credential** and select it on the trigger: hostname `localhost`, port `5673`, no user, no password, transport `tcp`. The workflow above ships without a credential, so you have to pick yours.

**4. Activate the workflow** and watch the listener output.

On master the listener delivers message #1, force-detaches the link, and then reports every later message as stuck:

```
[listener] receiver link ATTACHED
[listener] delivered message #1
[listener] no traffic for 10s -> FORCING DETACH (connection stays open)
[listener] no attached link -> 1 message(s) STUCK on queue
[listener] no attached link -> 2 message(s) STUCK on queue
```

n8n creates one execution and then nothing. No error appears on the canvas and the workflow stays published.

With this branch the link comes back about 100 ms after the detach and every later message is delivered, one execution each:

```
[listener] delivered message #1
[listener] no traffic for 10s -> FORCING DETACH (connection stays open)
[listener] link closed by client
[listener] receiver link ATTACHED
[listener] delivered message #2
[listener] delivered message #3
```

The n8n log also shows `AMQP receiver link was detached by the peer, reattaching` at info level. The attach and detach cycle then repeats for as long as the link keeps idling out.

**5. Check the Reconnect option.** Set **Reconnect** to `false` on an **AMQP Sender** node, point its credential at a port where nothing listens, and execute it. On master the execution hangs until the workflow times out. On this branch it fails at once with the connection error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5848

Earlier work on this file handled connection-level reconnect only: NODE-2458 (#18980) and #34787. NODE-5107 (#36716, #36801) fixed the same failure class in the Email Trigger (IMAP): a silent stall while the workflow stays active.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
