### PR TITLE
fix(core): Teach the AI Assistant to mark polled items handled after create actions

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -680,15 +680,21 @@ Follow these rules strictly when generating workflows:
    upstream of the data producer, or have B reference `$('Data Node')`
    explicitly.
 8. A polling trigger (Gmail Trigger, Outlook Trigger, or similar) feeding an
-   action that creates or writes records must guarantee each polled item is
-   processed exactly once — poll cursors reset on republish and re-deliver
-   every still-matching item as a duplicate. Either restrict the trigger to
-   unread/unprocessed items AND mark each item handled (mark as read, move to
-   a folder, apply a label) once its record exists, or record handled ids in a
-   Data Table and skip ids already seen. An unread filter alone is not enough:
-   if no step ever marks the item read, it never excludes anything. Wire the
-   mark-as-handled step AFTER the record-creating node, so a mid-run failure
-   cannot consume an item without producing its output.
+   action that creates or writes records must ensure each polled item is
+   processed once — poll cursors are best-effort bookkeeping (they reset when
+   the trigger node is recreated or renamed) and every still-matching item is
+   then re-delivered as a duplicate. Either restrict the trigger to
+   unread/unprocessed items AND mark each item handled once its record exists,
+   in a way the trigger's own filter excludes — mark as read when filtering
+   unread, move out of the watched folder, or apply a label only if the
+   trigger's query also excludes that label (a label does not mark a message
+   read) — or record handled ids in a Data Table: look the id up before
+   creating the record, skip ids already seen, and insert it only after the
+   create succeeds. An unread filter alone is not enough: if no step ever
+   marks the item read, it never excludes anything. Wire the mark-as-handled
+   step AFTER the record-creating node, so a mid-run failure cannot consume an
+   item without producing its output — this trades a rare duplicate (create
+   succeeded, marking failed) for never losing an item; do not invert it.
 
 ## Tool Naming Rules
 

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -679,6 +679,16 @@ Follow these rules strictly when generating workflows:
    branch the inserted node in parallel from the data producer, reorder it
    upstream of the data producer, or have B reference `$('Data Node')`
    explicitly.
+8. A polling trigger (Gmail Trigger, Outlook Trigger, or similar) feeding an
+   action that creates or writes records must guarantee each polled item is
+   processed exactly once — poll cursors reset on republish and re-deliver
+   every still-matching item as a duplicate. Either restrict the trigger to
+   unread/unprocessed items AND mark each item handled (mark as read, move to
+   a folder, apply a label) once its record exists, or record handled ids in a
+   Data Table and skip ids already seen. An unread filter alone is not enough:
+   if no step ever marks the item read, it never excludes anything. Wire the
+   mark-as-handled step AFTER the record-creating node, so a mid-run failure
+   cannot consume an item without producing its output.
 
 ## Tool Naming Rules
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.test.ts
@@ -26,4 +26,12 @@ describe('WORKFLOW_RULES', () => {
 		expect(WORKFLOW_RULES).toContain('A Filter or IF only selects items');
 		expect(WORKFLOW_RULES).toContain('wire the corresponding action node on the matching path');
 	});
+
+	it('requires a mark-as-handled step when a polling trigger feeds a create/write action', () => {
+		expect(WORKFLOW_RULES).toContain('Polling triggers that feed create/write actions');
+		expect(WORKFLOW_RULES).toContain('mark each item handled once its record exists');
+		expect(WORKFLOW_RULES).toContain('Record handled item ids in a Data Table');
+		expect(WORKFLOW_RULES).toContain('An unread filter alone is NOT enough');
+		expect(WORKFLOW_RULES).toContain('must run AFTER the record is created');
+	});
 });

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
@@ -61,4 +61,12 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
      - **Reference explicitly**: have the downstream node read \`$('Data Node').item.json.field\` instead of \`$json\`.
    - Counter-example to AVOID:
      - WRONG: \`code.to(ensureSheet).to(appendRows)\` — appendRows maps the create-sheet response, not the rows from \`code\`.
-     - CORRECT: \`trigger.to(ensureSheet).to(code).to(appendRows)\` — the ensure step runs before the data is produced, and the write still receives the data.`;
+     - CORRECT: \`trigger.to(ensureSheet).to(code).to(appendRows)\` — the ensure step runs before the data is produced, and the write still receives the data.
+
+8. **Polling triggers that feed create/write actions need a mark-as-handled step**
+   - When a polling trigger (Gmail Trigger, Outlook Trigger, or similar) feeds an action that creates or writes records — tasks, rows, tickets, messages — the workflow must guarantee each polled item is processed exactly once. Poll cursors reset when the workflow is updated or republished, and every still-matching item is then re-delivered and re-creates its record as a duplicate.
+   - Use one of these mechanisms:
+     - Restrict the trigger to unread/unprocessed items AND mark each item handled once its record exists — mark as read, move to a folder, or apply a label.
+     - Record handled item ids in a Data Table and skip ids already seen.
+   - An unread filter alone is NOT enough. If no step ever marks the item read, the filter never excludes anything — the workflow looks correct on the canvas while still reprocessing every item.
+   - The mark-as-handled step must run AFTER the record is created — wire it downstream of the create node (a terminal write is fine under rule 7) — so a mid-run failure cannot consume an item without producing its output.`;

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
@@ -64,9 +64,9 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
      - CORRECT: \`trigger.to(ensureSheet).to(code).to(appendRows)\` — the ensure step runs before the data is produced, and the write still receives the data.
 
 8. **Polling triggers that feed create/write actions need a mark-as-handled step**
-   - When a polling trigger (Gmail Trigger, Outlook Trigger, or similar) feeds an action that creates or writes records — tasks, rows, tickets, messages — the workflow must guarantee each polled item is processed exactly once. Poll cursors reset when the workflow is updated or republished, and every still-matching item is then re-delivered and re-creates its record as a duplicate.
+   - When a polling trigger (Gmail Trigger, Outlook Trigger, or similar) feeds an action that creates or writes records — tasks, rows, tickets, messages — the workflow must ensure each polled item is processed once. Poll cursors are best-effort bookkeeping: they reset when the trigger node is recreated or renamed, and every still-matching item is then re-delivered and re-creates its record as a duplicate.
    - Use one of these mechanisms:
-     - Restrict the trigger to unread/unprocessed items AND mark each item handled once its record exists — mark as read, move to a folder, or apply a label.
-     - Record handled item ids in a Data Table and skip ids already seen.
+     - Restrict the trigger to unread/unprocessed items AND mark each item handled once its record exists — in a way the trigger's own filter excludes: mark as read when filtering unread, move out of the watched folder, or apply a label ONLY if the trigger's query also excludes that label (adding a label does not mark a message read, so a label alone changes nothing under an unread filter).
+     - Record handled item ids in a Data Table and skip ids already seen: look the id up BEFORE creating the record, and insert it only AFTER the create succeeds.
    - An unread filter alone is NOT enough. If no step ever marks the item read, the filter never excludes anything — the workflow looks correct on the canvas while still reprocessing every item.
-   - The mark-as-handled step must run AFTER the record is created — wire it downstream of the create node (a terminal write is fine under rule 7) — so a mid-run failure cannot consume an item without producing its output.`;
+   - The mark-as-handled step must run AFTER the record is created — wire it downstream of the create node (a terminal write is fine under rule 7) — so a mid-run failure cannot consume an item without producing its output. This ordering deliberately trades a rare duplicate (create succeeded, marking failed) for never losing an item; do not invert it.`;

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -50,6 +50,30 @@ export class GmailTrigger implements INodeType {
 		defaults: {
 			name: 'Gmail Trigger',
 		},
+		builderHint: {
+			searchHint:
+				'When downstream nodes create records (tasks, rows, tickets) per email, guarantee each email is processed exactly once: filter to unread AND mark each email read/labelled after its record is created, or track handled message ids in a Data Table. Otherwise the same email can be reprocessed into duplicates.',
+			relatedNodes: [
+				{
+					nodeType: 'n8n-nodes-base.gmail',
+					relationHint:
+						'Mark polled emails as handled after processing (message markAsRead or addLabels) so they are not picked up again',
+				},
+				{
+					nodeType: 'n8n-nodes-base.dataTable',
+					relationHint: 'Record handled message ids to skip emails that were already processed',
+				},
+			],
+			extraTypeDefContent: [
+				{
+					content: `<patterns>
+<pattern title="Do not reprocess the same email">
+When this trigger feeds an action that creates records (tasks, rows, tickets, messages), guarantee each email is handled exactly once: keep \`readStatus: 'unread'\` AND add a Gmail \`markAsRead\` (or \`addLabels\`) step, or record handled message ids in a Data Table and skip ids already seen. The unread filter alone changes nothing if no step ever marks the email read. Wire the mark-as-handled step AFTER the record-creating node, so a mid-run failure cannot consume an email without producing its record.
+</pattern>
+</patterns>`,
+				},
+			],
+		},
 		credentials: [
 			{
 				name: 'googleApi',

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -57,7 +57,7 @@ export class GmailTrigger implements INodeType {
 				{
 					nodeType: 'n8n-nodes-base.gmail',
 					relationHint:
-						'Mark polled emails as handled after processing (message markAsRead or addLabels) so they are not picked up again',
+						'Mark polled emails as handled after processing (message markAsRead, or addLabels when the trigger query excludes that label) so they are not picked up again',
 				},
 				{
 					nodeType: 'n8n-nodes-base.dataTable',
@@ -68,7 +68,7 @@ export class GmailTrigger implements INodeType {
 				{
 					content: `<patterns>
 <pattern title="Do not reprocess the same email">
-When this trigger feeds an action that creates records (tasks, rows, tickets, messages), guarantee each email is handled exactly once: keep \`readStatus: 'unread'\` AND add a Gmail \`markAsRead\` (or \`addLabels\`) step, or record handled message ids in a Data Table and skip ids already seen. The unread filter alone changes nothing if no step ever marks the email read. Wire the mark-as-handled step AFTER the record-creating node, so a mid-run failure cannot consume an email without producing its record.
+When this trigger feeds an action that creates records (tasks, rows, tickets, messages), ensure each email is handled once: keep \`readStatus: 'unread'\` AND add a Gmail \`markAsRead\` step (\`addLabels\` works only if this trigger's \`q\` also excludes that label — a label does not mark the email read), or record handled message ids in a Data Table — look the id up before creating the record, skip ids already seen, insert it after the create succeeds. The unread filter alone changes nothing if no step ever marks the email read. Wire the mark-as-handled step AFTER the record-creating node, so a mid-run failure cannot consume an email without producing its record.
 </pattern>
 </patterns>`,
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
@@ -43,7 +43,7 @@ export class MicrosoftOutlookTrigger implements INodeType {
 				{
 					content: `<patterns>
 <pattern title="Do not reprocess the same email">
-When this trigger feeds an action that creates records (tasks, rows, tickets, messages), guarantee each email is handled exactly once: filter to unread emails AND add an Outlook step that marks each email handled — message \`update\` with \`isRead: true\`, or message \`move\` to a processed folder — or record handled message ids in a Data Table and skip ids already seen. The unread filter alone changes nothing if no step ever marks the email read. Wire the mark-as-handled step AFTER the record-creating node, so a mid-run failure cannot consume an email without producing its record.
+When this trigger feeds an action that creates records (tasks, rows, tickets, messages), ensure each email is handled once: filter to unread emails AND add an Outlook step that marks each email handled — message \`update\` with \`isRead: true\`, or message \`move\` to a processed folder — or record handled message ids in a Data Table — look the id up before creating the record, skip ids already seen, insert it after the create succeeds. The unread filter alone changes nothing if no step ever marks the email read. Wire the mark-as-handled step AFTER the record-creating node, so a mid-run failure cannot consume an email without producing its record.
 </pattern>
 </patterns>`,
 				},

--- a/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
@@ -25,6 +25,30 @@ export class MicrosoftOutlookTrigger implements INodeType {
 		defaults: {
 			name: 'Microsoft Outlook Trigger',
 		},
+		builderHint: {
+			searchHint:
+				'When downstream nodes create records (tasks, rows, tickets) per email, guarantee each email is processed exactly once: filter to unread AND mark each email read or move it to a folder after its record is created, or track handled message ids in a Data Table. Otherwise the same email can be reprocessed into duplicates.',
+			relatedNodes: [
+				{
+					nodeType: 'n8n-nodes-base.microsoftOutlook',
+					relationHint:
+						'Mark polled emails as handled after processing (message update with isRead: true, or message move to a folder) so they are not picked up again',
+				},
+				{
+					nodeType: 'n8n-nodes-base.dataTable',
+					relationHint: 'Record handled message ids to skip emails that were already processed',
+				},
+			],
+			extraTypeDefContent: [
+				{
+					content: `<patterns>
+<pattern title="Do not reprocess the same email">
+When this trigger feeds an action that creates records (tasks, rows, tickets, messages), guarantee each email is handled exactly once: filter to unread emails AND add an Outlook step that marks each email handled — message \`update\` with \`isRead: true\`, or message \`move\` to a processed folder — or record handled message ids in a Data Table and skip ids already seen. The unread filter alone changes nothing if no step ever marks the email read. Wire the mark-as-handled step AFTER the record-creating node, so a mid-run failure cannot consume an email without producing its record.
+</pattern>
+</patterns>`,
+				},
+			],
+		},
 		credentials: [
 			{
 				name: 'microsoftOutlookOAuth2Api',


### PR DESCRIPTION
## Summary

When the AI Assistant pairs a polling email trigger with something that creates records (say, a task per voicemail email), it filters the trigger to unread mail — and then never marks anything as read. So the filter never excludes anything, and the same email becomes a duplicate task on every poll. It looks correct on the canvas, which makes it worse. This came from a real user thread where duplicate to-dos piled up every minute, and eval case #630 (`polling-email-task-not-reprocessed`) has been red on this every night.

This PR teaches the builder to close the loop:

- New rule in the shared workflow rules (`workflow-sdk`): a polling trigger feeding a create/write step must either filter to unread **and** mark each item read/moved/labelled once its record exists, or track handled ids in a Data Table. The mark-as-read step goes *after* the create, so a failure mid-run can't eat an email without producing its task.
- Same rule mirrored in the Instance AI workflow-builder skill (that section is a hand-maintained copy, so it needs its own edit).
- Builder hints on the Gmail and Outlook triggers pointing at the matching mark-as-read/move operations and the Data Table node, shown when the builder picks or configures the trigger. IMAP already marks mail as read by default, so it's untouched.


## How to test

1. Ask the AI Assistant to build something like: *"Our phone system emails me a notification whenever someone leaves a voicemail. Transcribe the attached audio and create a to-do task per voicemail with the caller and a short summary."*
2. Check the built workflow: the trigger should filter to unread emails **and** there should be a mark-as-read (or label/move) step wired *after* the task creation — not missing, and not before it.
3. Or run the eval: `pnpm eval:instance-ai --source langtracer --suite baseline --filter polling-email-task-not-reprocessed`. On master it passes 1/3 expectations; with this PR I got 9/9 across 3 fresh local builds (`trigger → transcribe → extract → create task → mark email read` every time).

Unit tests cover the new rule, and the existing Gmail/Outlook trigger tests still pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1264

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

