### PR TITLE
fix(core): Fall back to the instance key when the key store is unavailable (no-changelog)

### DIFF
--- a/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
@@ -1,8 +1,10 @@
+import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { DeploymentKey } from '@n8n/db';
 import { DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { Cipher } from 'n8n-core';
+import { Cipher, InstanceSettings } from 'n8n-core';
+import { mock } from 'vitest-mock-extended';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { KeyManagerService } from '@/modules/encryption-key-manager/key-manager.service';
@@ -22,6 +24,8 @@ const makeKey = (overrides: Partial<DeploymentKey> = {}): DeploymentKey =>
 describe('KeyManagerService', () => {
 	const repository = mockInstance(DeploymentKeyRepository);
 	const cipher = mockInstance(Cipher);
+	mockInstance(InstanceSettings, { encryptionKey: 'test_key' });
+	mockInstance(Logger);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -73,7 +77,7 @@ describe('KeyManagerService', () => {
 	});
 
 	describe('getLegacyKey()', () => {
-		it('returns KeyInfo for the aes-256-cbc key', async () => {
+		it('returns the stored KeyInfo for the aes-256-cbc key when the store serves it', async () => {
 			const key = makeKey({ algorithm: 'aes-256-cbc' });
 			repository.findOne.mockResolvedValue(key);
 
@@ -83,12 +87,55 @@ describe('KeyManagerService', () => {
 			expect(repository.findOne).toHaveBeenCalledWith({
 				where: { type: 'data_encryption', algorithm: 'aes-256-cbc' },
 			});
+			expect(cipher.encryptDEKWithInstanceKey).not.toHaveBeenCalled();
 		});
 
-		it('throws NotFoundError when no CBC key exists', async () => {
+		it('falls back to the instance key when the legacy key is not seeded', async () => {
 			repository.findOne.mockResolvedValue(null);
+			cipher.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
 
-			await expect(Container.get(KeyManagerService).getLegacyKey()).rejects.toThrow(NotFoundError);
+			const result = await Container.get(KeyManagerService).getLegacyKey();
+
+			expect(result.value).toBe('wrapped-instance-key');
+			expect(result.algorithm).toBe('aes-256-cbc');
+		});
+
+		it('falls back to the instance key when the store lookup fails', async () => {
+			repository.findOne.mockRejectedValue(new Error('connection refused'));
+			cipher.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
+
+			const result = await Container.get(KeyManagerService).getLegacyKey();
+
+			expect(result.value).toBe('wrapped-instance-key');
+			expect(result.algorithm).toBe('aes-256-cbc');
+		});
+
+		// Uses a freshly constructed service so the memoized fallback starts cold,
+		// independent of test order. The seeded legacy key IS the instance key, so
+		// the fallback wraps the instance key exactly as bootstrap would.
+		it('wraps the instance key only once and reuses the result', async () => {
+			const repo = mock<DeploymentKeyRepository>();
+			repo.findOne.mockResolvedValue(null);
+			const cipherMock = mock<Cipher>();
+			cipherMock.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
+			const service = new KeyManagerService(
+				repo,
+				cipherMock,
+				mock<InstanceSettings>({ encryptionKey: 'test_key' }),
+				mock<Logger>(),
+			);
+
+			const first = await service.getLegacyKey();
+			const second = await service.getLegacyKey();
+
+			expect(cipherMock.encryptDEKWithInstanceKey).toHaveBeenCalledTimes(1);
+			expect(cipherMock.encryptDEKWithInstanceKey).toHaveBeenCalledWith('test_key');
+			expect(first).toEqual({
+				id: 'instance-key',
+				value: 'wrapped-instance-key',
+				algorithm: 'aes-256-cbc',
+			});
+			expect(second).toBe(first);
 		});
 	});
 

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
@@ -21,6 +21,20 @@ const makeKey = (overrides: Partial<DeploymentKey> = {}): DeploymentKey =>
 		...overrides,
 	}) as DeploymentKey;
 
+// Builds a service with its own mocks so the memoized legacy-key cache starts
+// cold, independent of the shared DI singleton and test order.
+const makeFreshService = () => {
+	const repo = mock<DeploymentKeyRepository>();
+	const cipherMock = mock<Cipher>();
+	const service = new KeyManagerService(
+		repo,
+		cipherMock,
+		mock<InstanceSettings>({ encryptionKey: 'test_key' }),
+		mock<Logger>(),
+	);
+	return { service, repo, cipherMock };
+};
+
 describe('KeyManagerService', () => {
 	const repository = mockInstance(DeploymentKeyRepository);
 	const cipher = mockInstance(Cipher);
@@ -91,39 +105,35 @@ describe('KeyManagerService', () => {
 		});
 
 		it('falls back to the instance key when the legacy key is not seeded', async () => {
-			repository.findOne.mockResolvedValue(null);
-			cipher.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
+			const { service, repo, cipherMock } = makeFreshService();
+			repo.findOne.mockResolvedValue(null);
+			cipherMock.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
 
-			const result = await Container.get(KeyManagerService).getLegacyKey();
+			const result = await service.getLegacyKey();
 
 			expect(result.value).toBe('wrapped-instance-key');
 			expect(result.algorithm).toBe('aes-256-cbc');
+			expect(cipherMock.encryptDEKWithInstanceKey).toHaveBeenCalledWith('test_key');
 		});
 
 		it('falls back to the instance key when the store lookup fails', async () => {
-			repository.findOne.mockRejectedValue(new Error('connection refused'));
-			cipher.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
+			const { service, repo, cipherMock } = makeFreshService();
+			repo.findOne.mockRejectedValue(new Error('connection refused'));
+			cipherMock.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
 
-			const result = await Container.get(KeyManagerService).getLegacyKey();
+			const result = await service.getLegacyKey();
 
 			expect(result.value).toBe('wrapped-instance-key');
 			expect(result.algorithm).toBe('aes-256-cbc');
+			expect(cipherMock.encryptDEKWithInstanceKey).toHaveBeenCalledWith('test_key');
 		});
 
-		// Uses a freshly constructed service so the memoized fallback starts cold,
-		// independent of test order. The seeded legacy key IS the instance key, so
-		// the fallback wraps the instance key exactly as bootstrap would.
+		// The seeded legacy key IS the instance key, so the fallback wraps the
+		// instance key exactly as bootstrap would.
 		it('wraps the instance key only once and reuses the result', async () => {
-			const repo = mock<DeploymentKeyRepository>();
+			const { service, repo, cipherMock } = makeFreshService();
 			repo.findOne.mockResolvedValue(null);
-			const cipherMock = mock<Cipher>();
 			cipherMock.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
-			const service = new KeyManagerService(
-				repo,
-				cipherMock,
-				mock<InstanceSettings>({ encryptionKey: 'test_key' }),
-				mock<Logger>(),
-			);
 
 			const first = await service.getLegacyKey();
 			const second = await service.getLegacyKey();

--- a/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
@@ -64,7 +64,11 @@ export class KeyManagerService {
 			if (key) {
 				return { id: key.id, value: key.value, algorithm: key.algorithm! };
 			}
-			this.logger.warn('Legacy aes-256-cbc encryption key not found; falling back to instance key');
+			if (!this.cachedInstanceKeyInfo) {
+				this.logger.warn(
+					'Legacy aes-256-cbc encryption key not found; falling back to instance key',
+				);
+			}
 		} catch (error) {
 			this.logger.warn(
 				'Key store unavailable while reading legacy key; using the instance key directly',

--- a/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
@@ -1,4 +1,5 @@
 import type { ListEncryptionKeysQueryDto } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
 import {
 	DeploymentKeyRepository,
 	type DeploymentKey,
@@ -6,7 +7,7 @@ import {
 	type DeploymentKeySortField,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { Cipher, type CipherAlgorithm } from 'n8n-core';
+import { Cipher, InstanceSettings, type CipherAlgorithm } from 'n8n-core';
 import { randomBytes } from 'node:crypto';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -15,9 +16,13 @@ type KeyInfo = { id: string; value: string; algorithm: string };
 
 @Service()
 export class KeyManagerService {
+	private cachedInstanceKeyInfo?: KeyInfo;
+
 	constructor(
 		private readonly deploymentKeyRepository: DeploymentKeyRepository,
 		private readonly cipher: Cipher,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly logger: Logger,
 	) {}
 
 	/** Returns the current active encryption key. Throws if none exists or if multiple are found. */
@@ -42,15 +47,31 @@ export class KeyManagerService {
 		return { id: key.id, value: key.value, algorithm: key.algorithm! };
 	}
 
-	/** Returns the legacy CBC key (used to decrypt rows with NULL encryptionKeyId). */
+	/**
+	 * Returns the legacy CBC key used to decrypt old rows (no keyId prefix).
+	 *
+	 * Prefers the stored key so the real read path stays exercised. If the store
+	 * cannot serve it — the key is not seeded, or the store is unreachable — falls
+	 * back to the instance key directly. Old data is plain CBC under the instance
+	 * key, and the seeded legacy key IS the instance key, so both paths yield the
+	 * same result. This keeps reads of old data working while the store is degraded.
+	 */
 	async getLegacyKey(): Promise<KeyInfo> {
-		const key = await this.deploymentKeyRepository.findOne({
-			where: { type: 'data_encryption', algorithm: 'aes-256-cbc' },
-		});
-		if (!key) {
-			throw new NotFoundError('No legacy aes-256-cbc encryption key found');
+		try {
+			const key = await this.deploymentKeyRepository.findOne({
+				where: { type: 'data_encryption', algorithm: 'aes-256-cbc' },
+			});
+			if (key) {
+				return { id: key.id, value: key.value, algorithm: key.algorithm! };
+			}
+			this.logger.warn('Legacy aes-256-cbc encryption key not found; falling back to instance key');
+		} catch (error) {
+			this.logger.warn(
+				'Key store unavailable while reading legacy key; using the instance key directly',
+				{ error },
+			);
 		}
-		return { id: key.id, value: key.value, algorithm: key.algorithm! };
+		return this.instanceKeyLegacyInfo();
 	}
 
 	/**
@@ -71,6 +92,21 @@ export class KeyManagerService {
 			status: 'inactive',
 		});
 		await this.deploymentKeyRepository.save(entity);
+	}
+
+	/**
+	 * Builds the legacy KeyInfo from the instance key, the fallback when the store
+	 * cannot serve the legacy key. Wraps the instance key exactly as bootstrap
+	 * does, so `Cipher` unwraps it and decrypts old CBC data unchanged. Memoized
+	 * because the instance key does not change at runtime.
+	 */
+	private instanceKeyLegacyInfo(): KeyInfo {
+		this.cachedInstanceKeyInfo ??= {
+			id: 'instance-key',
+			value: this.cipher.encryptDEKWithInstanceKey(this.instanceSettings.encryptionKey),
+			algorithm: 'aes-256-cbc',
+		};
+		return this.cachedInstanceKeyInfo;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Reading old (pre-rotation) data through the key-rotation feature routes every decryption of a legacy row through the key store. This change lets that read fall back to the instance key directly when the store cannot serve the legacy key — the key is not seeded, or the store is unreachable.

Old data is plain AES-256-CBC encrypted with the instance key, and the seeded legacy key is the instance key, so the fallback yields the same result the store path would. Reads of old data keep working while the store is degraded, so the read-support step does not add a new way to break reading old data.

This is part of the Encryption Key Rotation V2 rollout (Release A — Read-support). It is gated by `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION` and produces no user-facing change on its own.

### How to test manually

Prerequisites: a running instance with a database you can edit.

1. Start n8n with `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION` unset, then create a credential. This writes old-format data (AES-256-CBC under the instance key, no keyId prefix).
2. Set `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=true` and restart. The module loads and seeds the legacy key. Open the credential and confirm it still decrypts (this exercises the store path).
3. Delete the legacy key row: `DELETE FROM deployment_key WHERE type = 'data_encryption' AND algorithm = 'aes-256-cbc';`
4. Open the credential again. It still decrypts — the read falls back to the instance key. A `warn` log records the fallback.
5. Edge case — store outage: make the lookup fail (for example, stop the database mid-read). Reading old data still returns the plaintext through the same fallback.

Automated coverage: `pnpm --filter n8n test key-manager.service.test.ts` covers the store-serves path, the unseeded fallback, the lookup-failure fallback, and that the instance-key fallback is built once and reused.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-1289

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

