### PR TITLE
ci: Refresh E2E shard metrics and add a per-shard minimum test time (no-changelog)

### DIFF
--- a/.github/test-metrics/playwright.json
+++ b/.github/test-metrics/playwright.json
@@ -1,851 +1,1031 @@
 {
-  "updatedAt": "2026-05-30T21:09:56.531Z",
+  "updatedAt": "2026-08-31T14:52:43.296Z",
   "source": "currents",
   "projectId": "nHHLA5",
   "specs": {
-    "tests/e2e/workflows/editor/canvas/actions.spec.ts": {
-      "avgDuration": 147589,
-      "testCount": 20,
-      "flakyRate": 0.0725
+    "tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts": {
+      "avgDuration": 228188,
+      "testCount": 1,
+      "flakyRate": 0.064
     },
-    "tests/e2e/projects/projects.spec.ts": {
-      "avgDuration": 140795,
-      "testCount": 7,
-      "flakyRate": 0.0074
+    "tests/e2e/workflows/editor/canvas/node-groups.spec.ts": {
+      "avgDuration": 214656,
+      "testCount": 28,
+      "flakyRate": 0.0039
+    },
+    "tests/e2e/workflows/editor/canvas/actions.spec.ts": {
+      "avgDuration": 211223,
+      "testCount": 20,
+      "flakyRate": 0.0319
     },
     "tests/e2e/credentials/crud.spec.ts": {
-      "avgDuration": 135501,
+      "avgDuration": 197441,
       "testCount": 14,
-      "flakyRate": 0
+      "flakyRate": 0.0085
+    },
+    "tests/e2e/projects/projects.spec.ts": {
+      "avgDuration": 191530,
+      "testCount": 7,
+      "flakyRate": 0.0077
+    },
+    "tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts": {
+      "avgDuration": 183185,
+      "testCount": 5,
+      "flakyRate": 0.0566
     },
     "tests/e2e/workflows/list/workflows.spec.ts": {
-      "avgDuration": 123645,
+      "avgDuration": 179027,
       "testCount": 10,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/workflows/editor/canvas/undo-redo.spec.ts": {
-      "avgDuration": 113108,
-      "testCount": 14,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/code/code-node.spec.ts": {
-      "avgDuration": 106521,
-      "testCount": 12,
-      "flakyRate": 0.0206
-    },
-    "tests/e2e/ai/langchain-agents.spec.ts": {
-      "avgDuration": 102809,
-      "testCount": 7,
-      "flakyRate": 0.0045
-    },
-    "tests/e2e/settings/personal/two-factor-authentication.spec.ts": {
-      "avgDuration": 102682,
-      "testCount": 7,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts": {
-      "avgDuration": 101807,
-      "testCount": 13,
-      "flakyRate": 0.0193
-    },
-    "tests/e2e/data-tables/tables.spec.ts": {
-      "avgDuration": 98164,
-      "testCount": 7,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/ndv/ndv-core.spec.ts": {
-      "avgDuration": 97676,
-      "testCount": 14,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/workflows/editor/code/editors.spec.ts": {
-      "avgDuration": 97261,
-      "testCount": 11,
-      "flakyRate": 0
+      "flakyRate": 0.0099
     },
     "tests/e2e/workflows/editor/execution/logs.spec.ts": {
-      "avgDuration": 97008,
-      "testCount": 8,
-      "flakyRate": 0.0672
+      "avgDuration": 170700,
+      "testCount": 10,
+      "flakyRate": 0.0104
     },
-    "tests/e2e/ai/assistant-basic.spec.ts": {
-      "avgDuration": 94686,
-      "testCount": 11,
-      "flakyRate": 0.003
+    "tests/e2e/settings/personal/two-factor-authentication.spec.ts": {
+      "avgDuration": 162971,
+      "testCount": 7,
+      "flakyRate": 0.0068
     },
-    "tests/e2e/ai/builder-setup-wizard.spec.ts": {
-      "avgDuration": 94290,
-      "testCount": 9,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts": {
-      "avgDuration": 90153,
-      "testCount": 8,
-      "flakyRate": 0.0447
+    "tests/e2e/redaction-enforcement/redaction-enforcement.spec.ts": {
+      "avgDuration": 156214,
+      "testCount": 19,
+      "flakyRate": 0.0111
     },
     "tests/e2e/workflows/editor/ndv/ndv-data-display.spec.ts": {
-      "avgDuration": 86872,
+      "avgDuration": 156145,
       "testCount": 11,
-      "flakyRate": 0.003
+      "flakyRate": 0.0353
     },
-    "tests/e2e/data-tables/details.spec.ts": {
-      "avgDuration": 85776,
+    "tests/e2e/data-tables/tables.spec.ts": {
+      "avgDuration": 154938,
+      "testCount": 7,
+      "flakyRate": 0.0041
+    },
+    "tests/e2e/workflows/editor/ndv/ndv-core.spec.ts": {
+      "avgDuration": 154157,
+      "testCount": 14,
+      "flakyRate": 0
+    },
+    "tests/e2e/ai/langchain-agents.spec.ts": {
+      "avgDuration": 153950,
+      "testCount": 7,
+      "flakyRate": 0.0247
+    },
+    "tests/e2e/workflows/editor/code/code-node.spec.ts": {
+      "avgDuration": 149685,
+      "testCount": 12,
+      "flakyRate": 0.066
+    },
+    "tests/e2e/workflows/editor/canvas/undo-redo.spec.ts": {
+      "avgDuration": 148285,
+      "testCount": 14,
+      "flakyRate": 0.0076
+    },
+    "tests/e2e/workflows/editor/code/editors.spec.ts": {
+      "avgDuration": 136383,
       "testCount": 11,
+      "flakyRate": 0.0154
+    },
+    "tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts": {
+      "avgDuration": 133781,
+      "testCount": 13,
       "flakyRate": 0
     },
     "tests/e2e/projects/folders-operations.spec.ts": {
-      "avgDuration": 84269,
+      "avgDuration": 131773,
       "testCount": 14,
-      "flakyRate": 0.0044
+      "flakyRate": 0.0034
     },
-    "tests/e2e/nodes/webhook.spec.ts": {
-      "avgDuration": 83651,
-      "testCount": 9,
-      "flakyRate": 0.0075
-    },
-    "tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts": {
-      "avgDuration": 81370,
-      "testCount": 9,
-      "flakyRate": 0.0651
-    },
-    "tests/e2e/workflows/editor/canvas/node-groups.spec.ts": {
-      "avgDuration": 80965,
-      "testCount": 13,
-      "flakyRate": 0.0064
-    },
-    "tests/e2e/workflows/executions/list.spec.ts": {
-      "avgDuration": 78344,
-      "testCount": 11,
-      "flakyRate": 0.0711
-    },
-    "tests/e2e/sharing/credential-visibility.spec.ts": {
-      "avgDuration": 77671,
-      "testCount": 5,
-      "flakyRate": 0.0045
-    },
-    "tests/e2e/workflows/templates/credentials-setup.spec.ts": {
-      "avgDuration": 76596,
+    "tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts": {
+      "avgDuration": 129169,
       "testCount": 8,
-      "flakyRate": 0.0045
+      "flakyRate": 0.0069
     },
-    "tests/e2e/projects/project-settings.spec.ts": {
-      "avgDuration": 74890,
-      "testCount": 10,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/instance-ai/instance-ai-sidebar.spec.ts": {
-      "avgDuration": 69144,
-      "testCount": 4,
-      "flakyRate": 0.1581
-    },
-    "tests/e2e/ai/langchain-chains.spec.ts": {
-      "avgDuration": 68598,
+    "tests/e2e/instance-ai/instance-ai-workflow-preview.spec.ts": {
+      "avgDuration": 128222,
       "testCount": 4,
       "flakyRate": 0
     },
-    "tests/e2e/ai/ai-2505-pdf-embed.spec.ts": {
-      "avgDuration": 65301,
-      "testCount": 1,
+    "tests/e2e/data-tables/details.spec.ts": {
+      "avgDuration": 127653,
+      "testCount": 11,
       "flakyRate": 0.007
     },
-    "tests/e2e/workflows/editor/ndv/pinning.spec.ts": {
-      "avgDuration": 64729,
+    "tests/e2e/projects/project-settings.spec.ts": {
+      "avgDuration": 120887,
       "testCount": 10,
-      "flakyRate": 0.0015
+      "flakyRate": 0.0068
     },
-    "tests/e2e/ai/hitl-for-tools.spec.ts": {
-      "avgDuration": 63651,
-      "testCount": 2,
-      "flakyRate": 0.3423
-    },
-    "tests/e2e/building-blocks/canvas-actions.spec.ts": {
-      "avgDuration": 63214,
+    "tests/e2e/nodes/webhook.spec.ts": {
+      "avgDuration": 119964,
       "testCount": 9,
-      "flakyRate": 0.0015
+      "flakyRate": 0.0065
     },
-    "tests/e2e/workflows/editor/viewer-permissions.spec.ts": {
-      "avgDuration": 62889,
-      "testCount": 3,
-      "flakyRate": 0.0178
+    "tests/e2e/sharing/credential-visibility.spec.ts": {
+      "avgDuration": 118389,
+      "testCount": 5,
+      "flakyRate": 0.0055
     },
-    "tests/e2e/workflows/editor/expressions/mapping.spec.ts": {
-      "avgDuration": 62666,
-      "testCount": 10,
-      "flakyRate": 0
+    "tests/e2e/ai/assistant-basic.spec.ts": {
+      "avgDuration": 116839,
+      "testCount": 11,
+      "flakyRate": 0.0068
     },
-    "tests/e2e/workflows/editor/execution/execution.spec.ts": {
-      "avgDuration": 61908,
-      "testCount": 14,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": {
-      "avgDuration": 57840,
-      "testCount": 9,
-      "flakyRate": 0.0119
-    },
-    "tests/e2e/ai/langchain-vectorstores.spec.ts": {
-      "avgDuration": 57456,
+    "tests/e2e/instance-ai/instance-ai-artifacts.spec.ts": {
+      "avgDuration": 109768,
       "testCount": 2,
-      "flakyRate": 0.0045
-    },
-    "tests/e2e/workflows/editor/expressions/modal.spec.ts": {
-      "avgDuration": 56975,
-      "testCount": 6,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/workflows/editor/ndv/paired-item.spec.ts": {
-      "avgDuration": 56960,
-      "testCount": 6,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/auth/oidc.spec.ts": {
-      "avgDuration": 55757,
-      "testCount": 1,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/ai/workflow-builder.spec.ts": {
-      "avgDuration": 55728,
-      "testCount": 5,
-      "flakyRate": 0.0469
-    },
-    "tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts": {
-      "avgDuration": 55629,
-      "testCount": 5,
-      "flakyRate": 0.129
-    },
-    "tests/e2e/workflows/editor/ndv/resource-locator.spec.ts": {
-      "avgDuration": 55531,
-      "testCount": 7,
-      "flakyRate": 0.1257
-    },
-    "tests/e2e/workflows/editor/routing.spec.ts": {
-      "avgDuration": 54730,
-      "testCount": 6,
       "flakyRate": 0
     },
-    "tests/e2e/ai/assistant-credential-help.spec.ts": {
-      "avgDuration": 53463,
+    "tests/e2e/ai/builder-setup-wizard.spec.ts": {
+      "avgDuration": 106790,
+      "testCount": 9,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/templates/credentials-setup.spec.ts": {
+      "avgDuration": 104870,
+      "testCount": 8,
+      "flakyRate": 0.005
+    },
+    "tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts": {
+      "avgDuration": 102540,
+      "testCount": 9,
+      "flakyRate": 0.0306
+    },
+    "tests/e2e/instance-ai/instance-ai-sidebar.spec.ts": {
+      "avgDuration": 102510,
       "testCount": 4,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/checklist/production-checklist.spec.ts": {
-      "avgDuration": 53437,
+    "tests/e2e/instance-ai/instance-ai-onboarding.spec.ts": {
+      "avgDuration": 100625,
+      "testCount": 2,
+      "flakyRate": 0.1165
+    },
+    "tests/e2e/workflows/editor/ndv/pinning.spec.ts": {
+      "avgDuration": 99976,
+      "testCount": 10,
+      "flakyRate": 0.0063
+    },
+    "tests/e2e/instance-ai/instance-ai-chat-basics.spec.ts": {
+      "avgDuration": 97853,
+      "testCount": 4,
+      "flakyRate": 0.0801
+    },
+    "tests/e2e/workflows/executions/list.spec.ts": {
+      "avgDuration": 95622,
+      "testCount": 12,
+      "flakyRate": 0.0031
+    },
+    "tests/e2e/workflows/editor/tags.spec.ts": {
+      "avgDuration": 91542,
       "testCount": 7,
+      "flakyRate": 0.0486
+    },
+    "tests/e2e/workflows/editor/execution/execution.spec.ts": {
+      "avgDuration": 90218,
+      "testCount": 14,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/environments/source-control.spec.ts": {
+      "avgDuration": 88754,
+      "testCount": 4,
       "flakyRate": 0
     },
     "tests/e2e/workflows/editor/expressions/inline.spec.ts": {
-      "avgDuration": 53365,
+      "avgDuration": 86306,
       "testCount": 7,
-      "flakyRate": 0.0404
+      "flakyRate": 0.1045
     },
-    "tests/e2e/chat-hub/chat-hub-basic.spec.ts": {
-      "avgDuration": 52778,
+    "tests/e2e/workflows/editor/viewer-permissions.spec.ts": {
+      "avgDuration": 86106,
       "testCount": 3,
-      "flakyRate": 0.0179
-    },
-    "tests/e2e/instance-ai/instance-ai-chat-basics.spec.ts": {
-      "avgDuration": 50961,
-      "testCount": 4,
-      "flakyRate": 0.0254
-    },
-    "tests/e2e/building-blocks/node-details-configuration.spec.ts": {
-      "avgDuration": 50330,
-      "testCount": 7,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/editor/expressions/transformation.spec.ts": {
-      "avgDuration": 50264,
-      "testCount": 6,
-      "flakyRate": 0
-    },
-    "tests/e2e/nodes/form-trigger-node.spec.ts": {
-      "avgDuration": 49969,
+    "tests/e2e/ai/workflow-builder.spec.ts": {
+      "avgDuration": 86079,
       "testCount": 5,
-      "flakyRate": 0.0118
+      "flakyRate": 0.2615
     },
-    "tests/e2e/projects/projects-move-resources.spec.ts": {
-      "avgDuration": 49198,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/credentials/global.spec.ts": {
-      "avgDuration": 48731,
-      "testCount": 5,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/publish.spec.ts": {
-      "avgDuration": 47925,
-      "testCount": 8,
-      "flakyRate": 0.003
-    },
-    "tests/e2e/projects/folders-basic.spec.ts": {
-      "avgDuration": 47621,
+    "tests/e2e/workflows/editor/expressions/mapping.spec.ts": {
+      "avgDuration": 83929,
       "testCount": 10,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/editor/tags.spec.ts": {
-      "avgDuration": 46815,
-      "testCount": 7,
-      "flakyRate": 0.0029
-    },
-    "tests/e2e/workflows/editor/execution/executions-list-infinite-scroll.spec.ts": {
-      "avgDuration": 46590,
-      "testCount": 2,
-      "flakyRate": 0.0088
-    },
-    "tests/e2e/ai/assistant-support-chat.spec.ts": {
-      "avgDuration": 46479,
-      "testCount": 3,
-      "flakyRate": 0.0342
-    },
-    "tests/e2e/workflows/editor/execution/debug.spec.ts": {
-      "avgDuration": 46230,
-      "testCount": 4,
-      "flakyRate": 0.0238
-    },
-    "tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": {
-      "avgDuration": 45917,
-      "testCount": 5,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/ai/assistant-code-help.spec.ts": {
-      "avgDuration": 45830,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/dynamic-credentials/execution-status.spec.ts": {
-      "avgDuration": 45346,
-      "testCount": 2,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/chat-hub/chat-hub-workflow-agent.spec.ts": {
-      "avgDuration": 45232,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/building-blocks/credentials.spec.ts": {
-      "avgDuration": 43620,
-      "testCount": 6,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/executions/filter.spec.ts": {
-      "avgDuration": 43069,
-      "testCount": 2,
-      "flakyRate": 0.1456
-    },
-    "tests/e2e/capabilities/proxy-server.spec.ts": {
-      "avgDuration": 42728,
-      "testCount": 4,
-      "flakyRate": 0
-    },
-    "tests/e2e/settings/log-streaming/log-streaming-observability.spec.ts": {
-      "avgDuration": 42703,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/templates/templates.spec.ts": {
-      "avgDuration": 42366,
+    "tests/e2e/building-blocks/canvas-actions.spec.ts": {
+      "avgDuration": 82586,
       "testCount": 9,
-      "flakyRate": 0.149
+      "flakyRate": 0.01
     },
-    "tests/e2e/instance-ai/instance-ai-confirmations.spec.ts": {
-      "avgDuration": 41968,
+    "tests/e2e/nodes/form-trigger-node.spec.ts": {
+      "avgDuration": 81311,
       "testCount": 5,
-      "flakyRate": 0.0433
+      "flakyRate": 0.0528
     },
-    "tests/e2e/projects/folders-advanced.spec.ts": {
-      "avgDuration": 41959,
+    "tests/e2e/building-blocks/node-details-configuration.spec.ts": {
+      "avgDuration": 79978,
+      "testCount": 7,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/projects/folders-basic.spec.ts": {
+      "avgDuration": 78940,
+      "testCount": 10,
+      "flakyRate": 0.0034
+    },
+    "tests/e2e/workflows/editor/expressions/modal.spec.ts": {
+      "avgDuration": 78771,
       "testCount": 6,
       "flakyRate": 0
-    },
-    "tests/e2e/ai/rag-callout.spec.ts": {
-      "avgDuration": 41455,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/chat-hub/chat-hub-attachment.spec.ts": {
-      "avgDuration": 41438,
-      "testCount": 3,
-      "flakyRate": 0.0249
-    },
-    "tests/e2e/chat-hub/chat-hub-tools.spec.ts": {
-      "avgDuration": 40986,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/instance-ai/instance-ai-artifacts.spec.ts": {
-      "avgDuration": 40886,
-      "testCount": 2,
-      "flakyRate": 0.0089
-    },
-    "tests/e2e/nodes/kafka-nodes.spec.ts": {
-      "avgDuration": 39672,
-      "testCount": 2,
-      "flakyRate": 0.003
-    },
-    "tests/e2e/workflows/editor/ndv/ndv-floating-nodes.spec.ts": {
-      "avgDuration": 39320,
-      "testCount": 4,
-      "flakyRate": 0
-    },
-    "tests/e2e/cloud/cloud.spec.ts": {
-      "avgDuration": 39318,
-      "testCount": 3,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/instance-ai/instance-ai-workflow-preview.spec.ts": {
-      "avgDuration": 38388,
-      "testCount": 4,
-      "flakyRate": 0.0673
-    },
-    "tests/e2e/workflows/editor/subworkflows/extraction.spec.ts": {
-      "avgDuration": 36213,
-      "testCount": 3,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/workflows/editor/ndv/resource-mapper.spec.ts": {
-      "avgDuration": 35393,
-      "testCount": 5,
-      "flakyRate": 0.0075
-    },
-    "tests/e2e/regression/ADO-4462-template-setup-experiment.spec.ts": {
-      "avgDuration": 34370,
-      "testCount": 2,
-      "flakyRate": 0.0597
-    },
-    "tests/e2e/building-blocks/credential-mismatch.spec.ts": {
-      "avgDuration": 32894,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/app-config/demo.spec.ts": {
-      "avgDuration": 32764,
-      "testCount": 4,
-      "flakyRate": 0.003
-    },
-    "tests/e2e/building-blocks/workflow-entry-points.spec.ts": {
-      "avgDuration": 31263,
-      "testCount": 5,
-      "flakyRate": 0.0007
-    },
-    "tests/e2e/api/binary-data-xss.spec.ts": {
-      "avgDuration": 30320,
-      "testCount": 1,
-      "flakyRate": 0.003
     },
     "tests/e2e/nodes/send-and-wait.spec.ts": {
-      "avgDuration": 29701,
+      "avgDuration": 77281,
       "testCount": 5,
+      "flakyRate": 0.0422
+    },
+    "tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": {
+      "avgDuration": 76368,
+      "testCount": 9,
+      "flakyRate": 0.0036
+    },
+    "tests/e2e/auth/oidc.spec.ts": {
+      "avgDuration": 75449,
+      "testCount": 1,
+      "flakyRate": 0.0098
+    },
+    "tests/e2e/projects/folders-advanced.spec.ts": {
+      "avgDuration": 74178,
+      "testCount": 6,
       "flakyRate": 0
     },
-    "tests/e2e/node-creator/navigation.spec.ts": {
-      "avgDuration": 29411,
+    "tests/e2e/projects/projects-move-resources.spec.ts": {
+      "avgDuration": 73964,
+      "testCount": 2,
+      "flakyRate": 0.1102
+    },
+    "tests/e2e/chat-hub/chat-hub-tools.spec.ts": {
+      "avgDuration": 73000,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/dynamic-credentials/form-trigger-end-user-credential-shell.spec.ts": {
+      "avgDuration": 72327,
+      "testCount": 2,
+      "flakyRate": 0.0435
+    },
+    "tests/e2e/workflows/editor/routing.spec.ts": {
+      "avgDuration": 71721,
+      "testCount": 6,
+      "flakyRate": 0.0034
+    },
+    "tests/e2e/ai/langchain-vectorstores.spec.ts": {
+      "avgDuration": 71614,
+      "testCount": 2,
+      "flakyRate": 0.0064
+    },
+    "tests/e2e/workflows/editor/ndv/resource-locator.spec.ts": {
+      "avgDuration": 70996,
+      "testCount": 7,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/ndv/paired-item.spec.ts": {
+      "avgDuration": 70922,
+      "testCount": 6,
+      "flakyRate": 0.0068
+    },
+    "tests/e2e/workflows/editor/expressions/transformation.spec.ts": {
+      "avgDuration": 70679,
+      "testCount": 6,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/publish.spec.ts": {
+      "avgDuration": 69585,
+      "testCount": 8,
+      "flakyRate": 0.0098
+    },
+    "tests/e2e/building-blocks/credentials.spec.ts": {
+      "avgDuration": 66234,
+      "testCount": 6,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/execution/executions-list-infinite-scroll.spec.ts": {
+      "avgDuration": 65971,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/instance-ai/instance-ai-oversized-attachments.spec.ts": {
+      "avgDuration": 65381,
+      "testCount": 5,
+      "flakyRate": 0.0805
+    },
+    "tests/e2e/workflows/editor/ndv/ndv-floating-nodes.spec.ts": {
+      "avgDuration": 64602,
       "testCount": 4,
       "flakyRate": 0
     },
-    "tests/e2e/nodes/mcp-trigger.spec.ts": {
-      "avgDuration": 29273,
-      "testCount": 23,
-      "flakyRate": 0.0163
-    },
-    "tests/e2e/app-config/security-notifications.spec.ts": {
-      "avgDuration": 29144,
+    "tests/e2e/credentials/global.spec.ts": {
+      "avgDuration": 63848,
       "testCount": 5,
-      "flakyRate": 0.0015
+      "flakyRate": 0.0046
     },
-    "tests/e2e/workflows/list/import.spec.ts": {
-      "avgDuration": 29107,
-      "testCount": 5,
+    "tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts": {
+      "avgDuration": 59840,
+      "testCount": 2,
       "flakyRate": 0
     },
-    "tests/e2e/sentry/sentry-baseline.spec.ts": {
-      "avgDuration": 27861,
-      "testCount": 3,
-      "flakyRate": 0.009
+    "tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": {
+      "avgDuration": 59163,
+      "testCount": 5,
+      "flakyRate": 0.0035
     },
-    "tests/e2e/nodes/community-nodes.spec.ts": {
-      "avgDuration": 27799,
-      "testCount": 3,
-      "flakyRate": 0
+    "tests/e2e/capabilities/proxy-server.spec.ts": {
+      "avgDuration": 59043,
+      "testCount": 4,
+      "flakyRate": 0.0252
     },
-    "tests/e2e/workflows/demo-diff.spec.ts": {
-      "avgDuration": 27383,
+    "tests/e2e/chat-hub/chat-hub-basic.spec.ts": {
+      "avgDuration": 58764,
+      "testCount": 3,
+      "flakyRate": 0.0181
+    },
+    "tests/e2e/workflows/checklist/production-checklist.spec.ts": {
+      "avgDuration": 58339,
+      "testCount": 6,
+      "flakyRate": 0.0033
+    },
+    "tests/e2e/chat-hub/chat-hub-attachment.spec.ts": {
+      "avgDuration": 58090,
+      "testCount": 3,
+      "flakyRate": 0.0023
+    },
+    "tests/e2e/workflows/templates/templates.spec.ts": {
+      "avgDuration": 57530,
       "testCount": 9,
       "flakyRate": 0
     },
-    "tests/e2e/instance-ai/instance-ai-attachments.spec.ts": {
-      "avgDuration": 27310,
+    "tests/e2e/ai/assistant-support-chat.spec.ts": {
+      "avgDuration": 55431,
+      "testCount": 3,
+      "flakyRate": 0.0345
+    },
+    "tests/e2e/dynamic-credentials/execution-status.spec.ts": {
+      "avgDuration": 53819,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/ndv/resource-mapper.spec.ts": {
+      "avgDuration": 53796,
+      "testCount": 5,
+      "flakyRate": 0
+    },
+    "tests/e2e/chat-hub/chat-hub-workflow-agent.spec.ts": {
+      "avgDuration": 53249,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/ai/assistant-credential-help.spec.ts": {
+      "avgDuration": 52935,
+      "testCount": 4,
+      "flakyRate": 0.0134
+    },
+    "tests/e2e/workflows/editor/execution/debug.spec.ts": {
+      "avgDuration": 52061,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflow-reviews/review-round-trip.spec.ts": {
+      "avgDuration": 51959,
       "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/ai/assistant-code-help.spec.ts": {
+      "avgDuration": 51568,
+      "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/building-blocks/user-service.spec.ts": {
-      "avgDuration": 26659,
+      "avgDuration": 51389,
       "testCount": 8,
-      "flakyRate": 0
+      "flakyRate": 0.0036
     },
-    "tests/e2e/workflows/editor/subworkflows/debugging.spec.ts": {
-      "avgDuration": 26524,
+    "tests/e2e/settings/log-streaming/log-streaming.spec.ts": {
+      "avgDuration": 50536,
+      "testCount": 6,
+      "flakyRate": 0.004
+    },
+    "tests/e2e/scheduling/schedule-trigger-durable.spec.ts": {
+      "avgDuration": 50242,
       "testCount": 4,
       "flakyRate": 0
     },
-    "tests/e2e/settings/external-secrets/aws-secrets-manager.spec.ts": {
-      "avgDuration": 26395,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/node-creator/special-nodes.spec.ts": {
-      "avgDuration": 26202,
+    "tests/e2e/workflows/editor/subworkflows/extraction.spec.ts": {
+      "avgDuration": 49510,
       "testCount": 3,
       "flakyRate": 0
     },
-    "tests/e2e/api/waiting-endpoint-security.spec.ts": {
-      "avgDuration": 26169,
+    "tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts": {
+      "avgDuration": 49329,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/instance-ai/instance-ai-multimain.spec.ts": {
+      "avgDuration": 49227,
+      "testCount": 1,
+      "flakyRate": 0.0069
+    },
+    "tests/e2e/dynamic-credentials/form-trigger-submit-gate-client.spec.ts": {
+      "avgDuration": 48968,
+      "testCount": 2,
+      "flakyRate": 0.0756
+    },
+    "tests/e2e/cloud/cloud.spec.ts": {
+      "avgDuration": 48584,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/ADO-4462-template-setup-experiment.spec.ts": {
+      "avgDuration": 48083,
+      "testCount": 2,
+      "flakyRate": 0.0033
+    },
+    "tests/e2e/agents/agent-sessions.spec.ts": {
+      "avgDuration": 47698,
+      "testCount": 2,
+      "flakyRate": 0.0047
+    },
+    "tests/e2e/app-config/security-notifications.spec.ts": {
+      "avgDuration": 47033,
+      "testCount": 5,
+      "flakyRate": 0.0069
+    },
+    "tests/e2e/nodes/kafka-nodes.spec.ts": {
+      "avgDuration": 46723,
       "testCount": 2,
       "flakyRate": 0
     },
-    "tests/e2e/nodes/http-request-node.spec.ts": {
-      "avgDuration": 25946,
+    "tests/e2e/workflows/demo-diff.spec.ts": {
+      "avgDuration": 45902,
+      "testCount": 9,
+      "flakyRate": 0.0085
+    },
+    "tests/e2e/settings/log-streaming/log-streaming-observability.spec.ts": {
+      "avgDuration": 45143,
       "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/chat-hub/chat-hub-personal-agent.spec.ts": {
+      "avgDuration": 43980,
+      "testCount": 2,
+      "flakyRate": 0.0231
+    },
+    "tests/e2e/ai/rag-callout.spec.ts": {
+      "avgDuration": 43891,
+      "testCount": 2,
+      "flakyRate": 0.0045
+    },
+    "tests/e2e/instance-ai/instance-ai-attachments.spec.ts": {
+      "avgDuration": 43646,
+      "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/settings/environments/variables.spec.ts": {
-      "avgDuration": 25793,
+      "avgDuration": 43102,
       "testCount": 7,
-      "flakyRate": 0
+      "flakyRate": 0.0042
     },
-    "tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts": {
-      "avgDuration": 25779,
-      "testCount": 2,
-      "flakyRate": 0.0193
-    },
-    "tests/e2e/chat-hub/chat-hub-chat-user.spec.ts": {
-      "avgDuration": 25157,
-      "testCount": 1,
-      "flakyRate": 0.006
-    },
-    "tests/e2e/mcp-registry/mcp-registry.spec.ts": {
-      "avgDuration": 25147,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/node-creator/actions.spec.ts": {
-      "avgDuration": 24552,
+    "tests/e2e/ai/langchain-chains.spec.ts": {
+      "avgDuration": 42326,
       "testCount": 4,
-      "flakyRate": 0.0015
+      "flakyRate": 0.0037
     },
-    "tests/e2e/api/webhook-isolation.spec.ts": {
-      "avgDuration": 24448,
-      "testCount": 14,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/settings/personal/personal.spec.ts": {
-      "avgDuration": 24246,
-      "testCount": 2,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/sharing/access-control.spec.ts": {
-      "avgDuration": 24246,
+    "tests/e2e/building-blocks/workflow-entry-points.spec.ts": {
+      "avgDuration": 41662,
       "testCount": 5,
       "flakyRate": 0.0015
     },
-    "tests/e2e/api/form-endpoint-isolation.spec.ts": {
-      "avgDuration": 24118,
-      "testCount": 2,
-      "flakyRate": 0.0075
-    },
-    "tests/e2e/chat-hub/chat-hub-personal-agent.spec.ts": {
-      "avgDuration": 24008,
-      "testCount": 2,
-      "flakyRate": 0.0117
-    },
-    "tests/e2e/settings/log-streaming/log-streaming.spec.ts": {
-      "avgDuration": 23366,
-      "testCount": 5,
+    "tests/e2e/ai/ai-2505-pdf-embed.spec.ts": {
+      "avgDuration": 41537,
+      "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/auth/password-reset.spec.ts": {
-      "avgDuration": 23160,
+    "tests/e2e/instance-ai/instance-ai-background-lifecycle.spec.ts": {
+      "avgDuration": 41490,
       "testCount": 1,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/node-creator/vector-stores.spec.ts": {
-      "avgDuration": 22336,
-      "testCount": 3,
       "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/editor-after-route-changes.spec.ts": {
-      "avgDuration": 22281,
-      "testCount": 1,
-      "flakyRate": 0.0821
     },
     "tests/e2e/auth/authenticated.spec.ts": {
-      "avgDuration": 21885,
-      "testCount": 5,
-      "flakyRate": 0
+      "avgDuration": 41043,
+      "testCount": 6,
+      "flakyRate": 0.0033
     },
-    "tests/e2e/auth/token-exchange.spec.ts": {
-      "avgDuration": 21394,
-      "testCount": 9,
-      "flakyRate": 0.0118
+    "tests/e2e/node-creator/actions.spec.ts": {
+      "avgDuration": 41036,
+      "testCount": 4,
+      "flakyRate": 0.0065
     },
-    "tests/e2e/capabilities/task-runner.spec.ts": {
-      "avgDuration": 21067,
+    "tests/e2e/scheduling/schedule-trigger-multimain.spec.ts": {
+      "avgDuration": 40807,
       "testCount": 2,
       "flakyRate": 0
     },
-    "tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts": {
-      "avgDuration": 19867,
+    "tests/e2e/building-blocks/credential-mismatch.spec.ts": {
+      "avgDuration": 40299,
+      "testCount": 2,
+      "flakyRate": 0.0094
+    },
+    "tests/e2e/sentry/sentry-baseline.spec.ts": {
+      "avgDuration": 40245,
+      "testCount": 3,
+      "flakyRate": 0.0036
+    },
+    "tests/e2e/workflows/editor/subworkflows/debugging.spec.ts": {
+      "avgDuration": 39603,
+      "testCount": 4,
+      "flakyRate": 0.0035
+    },
+    "tests/e2e/node-creator/navigation.spec.ts": {
+      "avgDuration": 39506,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/mcp/mcp-oauth.spec.ts": {
+      "avgDuration": 39301,
+      "testCount": 15,
+      "flakyRate": 0.0048
+    },
+    "tests/e2e/instance-ai/thread-launcher.spec.ts": {
+      "avgDuration": 38801,
+      "testCount": 2,
+      "flakyRate": 0.0675
+    },
+    "tests/e2e/workflows/editor/editor-after-route-changes.spec.ts": {
+      "avgDuration": 38517,
       "testCount": 1,
-      "flakyRate": 0
+      "flakyRate": 0.0664
     },
-    "tests/e2e/settings/users/users.spec.ts": {
-      "avgDuration": 19292,
-      "testCount": 5,
-      "flakyRate": 0
-    },
-    "tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts": {
-      "avgDuration": 18833,
+    "tests/e2e/nodes/community-nodes.spec.ts": {
+      "avgDuration": 38333,
       "testCount": 3,
       "flakyRate": 0
     },
-    "tests/e2e/api/webhook-external.spec.ts": {
-      "avgDuration": 18502,
+    "tests/e2e/scheduling/poll-trigger-cursor-migrated.spec.ts": {
+      "avgDuration": 38306,
+      "testCount": 3,
+      "flakyRate": 0.0095
+    },
+    "tests/e2e/capabilities/task-runner.spec.ts": {
+      "avgDuration": 38287,
       "testCount": 2,
-      "flakyRate": 0.0029
+      "flakyRate": 0.0085
     },
-    "tests/e2e/sharing/workflow-sharing.spec.ts": {
-      "avgDuration": 18327,
-      "testCount": 4,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/node-creator/workflows.spec.ts": {
-      "avgDuration": 18311,
-      "testCount": 2,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/workflows/editor/execution/inject-previous.spec.ts": {
-      "avgDuration": 18026,
+    "tests/e2e/ai/eval-collections-compare.spec.ts": {
+      "avgDuration": 37157,
       "testCount": 2,
       "flakyRate": 0.003
     },
-    "tests/e2e/workflows/editor/ndv/io-filter.spec.ts": {
-      "avgDuration": 17435,
+    "tests/e2e/settings/personal/personal.spec.ts": {
+      "avgDuration": 36741,
       "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/list/import.spec.ts": {
+      "avgDuration": 36693,
+      "testCount": 5,
       "flakyRate": 0
     },
     "tests/e2e/api/wait-form-resume.spec.ts": {
-      "avgDuration": 17145,
-      "testCount": 2,
-      "flakyRate": 0.0015
+      "avgDuration": 36286,
+      "testCount": 3,
+      "flakyRate": 0.0434
+    },
+    "tests/e2e/settings/users/users.spec.ts": {
+      "avgDuration": 35203,
+      "testCount": 5,
+      "flakyRate": 0
     },
     "tests/e2e/chat-hub/chat-hub-settings.spec.ts": {
-      "avgDuration": 15994,
+      "avgDuration": 35102,
       "testCount": 2,
-      "flakyRate": 0.006
+      "flakyRate": 0.0035
     },
-    "tests/e2e/nodes/if-node.spec.ts": {
-      "avgDuration": 15212,
+    "tests/e2e/mcp-registry/mcp-registry.spec.ts": {
+      "avgDuration": 34813,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/push/sse-push-backend.spec.ts": {
+      "avgDuration": 34699,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/scheduling/poll-trigger-misfire-skip.spec.ts": {
+      "avgDuration": 34622,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/waiting-endpoint-security.spec.ts": {
+      "avgDuration": 34566,
+      "testCount": 2,
+      "flakyRate": 0.0466
+    },
+    "tests/e2e/scheduling/schedule-trigger-misfire-coalesce.spec.ts": {
+      "avgDuration": 34344,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/sharing/access-control.spec.ts": {
+      "avgDuration": 33440,
+      "testCount": 5,
+      "flakyRate": 0.0031
+    },
+    "tests/e2e/app-config/demo.spec.ts": {
+      "avgDuration": 33117,
+      "testCount": 4,
+      "flakyRate": 0.0079
+    },
+    "tests/e2e/ai/chat-session.spec.ts": {
+      "avgDuration": 32752,
+      "testCount": 1,
+      "flakyRate": 0.1011
+    },
+    "tests/e2e/scheduling/poll-trigger-durable.spec.ts": {
+      "avgDuration": 32611,
+      "testCount": 4,
+      "flakyRate": 0.0032
+    },
+    "tests/e2e/chat-hub/chat-hub-chat-user.spec.ts": {
+      "avgDuration": 32092,
+      "testCount": 1,
+      "flakyRate": 0.0045
+    },
+    "tests/e2e/instance-ai/instance-ai-confirmations.spec.ts": {
+      "avgDuration": 31920,
+      "testCount": 5,
+      "flakyRate": 0
+    },
+    "tests/e2e/app-config/demo-reimport.spec.ts": {
+      "avgDuration": 31736,
+      "testCount": 3,
+      "flakyRate": 0.0182
+    },
+    "tests/e2e/credentials/oauth.spec.ts": {
+      "avgDuration": 31378,
       "testCount": 2,
       "flakyRate": 0
     },
-    "tests/e2e/sharing/credential-sharing.spec.ts": {
-      "avgDuration": 15083,
+    "tests/e2e/sharing/workflow-sharing.spec.ts": {
+      "avgDuration": 31348,
+      "testCount": 4,
+      "flakyRate": 0.0217
+    },
+    "tests/e2e/scheduling/poll-trigger-cursor-unmigrated.spec.ts": {
+      "avgDuration": 30925,
+      "testCount": 2,
+      "flakyRate": 0.0032
+    },
+    "tests/e2e/api/webhook-isolation.spec.ts": {
+      "avgDuration": 30684,
+      "testCount": 14,
+      "flakyRate": 0
+    },
+    "tests/e2e/scheduling/poll-trigger-backoff.spec.ts": {
+      "avgDuration": 30400,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/log-streaming/log-streaming-delivery.spec.ts": {
+      "avgDuration": 30177,
+      "testCount": 5,
+      "flakyRate": 0.0025
+    },
+    "tests/e2e/workflows/editor/execution/inject-previous.spec.ts": {
+      "avgDuration": 30127,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/external-secrets/aws-secrets-manager.spec.ts": {
+      "avgDuration": 29822,
+      "testCount": 1,
+      "flakyRate": 0.0161
+    },
+    "tests/e2e/instance-ai/instance-ai-out-of-credits.spec.ts": {
+      "avgDuration": 29620,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/form-endpoint-isolation.spec.ts": {
+      "avgDuration": 29345,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/node-creator/special-nodes.spec.ts": {
+      "avgDuration": 29256,
       "testCount": 3,
       "flakyRate": 0
     },
+    "tests/e2e/nodes/email-send-node.spec.ts": {
+      "avgDuration": 28715,
+      "testCount": 1,
+      "flakyRate": 0.0023
+    },
+    "tests/e2e/nodes/mcp-trigger.spec.ts": {
+      "avgDuration": 28662,
+      "testCount": 23,
+      "flakyRate": 0
+    },
+    "tests/e2e/auth/token-exchange.spec.ts": {
+      "avgDuration": 28148,
+      "testCount": 9,
+      "flakyRate": 0.0282
+    },
+    "tests/e2e/auth/password-reset.spec.ts": {
+      "avgDuration": 28087,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/nodes/if-node.spec.ts": {
+      "avgDuration": 27660,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/workflow-publication-service.spec.ts": {
+      "avgDuration": 27323,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts": {
+      "avgDuration": 27000,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/node-creator/vector-stores.spec.ts": {
+      "avgDuration": 26801,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/scheduling/schedule-trigger-timezone.spec.ts": {
+      "avgDuration": 26032,
+      "testCount": 1,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/scheduling/poll-trigger-legacy.spec.ts": {
+      "avgDuration": 25020,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/sharing/credential-sharing.spec.ts": {
+      "avgDuration": 24621,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/scheduling/schedule-trigger-restart.spec.ts": {
+      "avgDuration": 24409,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/discovery.spec.ts": {
+      "avgDuration": 23936,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/executions/preview-isolation.spec.ts": {
+      "avgDuration": 23725,
+      "testCount": 2,
+      "flakyRate": 0.0175
+    },
+    "tests/e2e/workflows/executions/filter.spec.ts": {
+      "avgDuration": 23232,
+      "testCount": 2,
+      "flakyRate": 0
+    },
     "tests/e2e/workflows/editor/execution/partial.spec.ts": {
-      "avgDuration": 14503,
+      "avgDuration": 23148,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/nodes/http-request-node.spec.ts": {
+      "avgDuration": 22512,
+      "testCount": 2,
+      "flakyRate": 0.0035
+    },
+    "tests/e2e/regression/AI-812-partial-execs-broken-when-using-chat-trigger.spec.ts": {
+      "avgDuration": 22497,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/ndv/io-filter.spec.ts": {
+      "avgDuration": 22010,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/app-config/env-feature-flags.spec.ts": {
+      "avgDuration": 21715,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/webhook-isolate-skip.spec.ts": {
+      "avgDuration": 21111,
+      "testCount": 7,
+      "flakyRate": 0.0498
+    },
+    "tests/e2e/settings/workers/workers.spec.ts": {
+      "avgDuration": 20940,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/webhook-external.spec.ts": {
+      "avgDuration": 20487,
       "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/auth/admin-smoke.spec.ts": {
-      "avgDuration": 13957,
+      "avgDuration": 19525,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/regression/AI-812-partial-execs-broken-when-using-chat-trigger.spec.ts": {
-      "avgDuration": 13400,
+    "tests/e2e/node-creator/workflows.spec.ts": {
+      "avgDuration": 18443,
       "testCount": 2,
-      "flakyRate": 0.0045
-    },
-    "tests/e2e/app-config/demo-reimport.spec.ts": {
-      "avgDuration": 12143,
-      "testCount": 3,
-      "flakyRate": 0.0104
+      "flakyRate": 0.0039
     },
     "tests/e2e/regression/ADO-2372-prevent-clipping-params.spec.ts": {
-      "avgDuration": 12133,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/settings/workers/workers.spec.ts": {
-      "avgDuration": 11351,
-      "testCount": 4,
-      "flakyRate": 0
-    },
-    "tests/e2e/instance-ai/instance-ai-timeline.spec.ts": {
-      "avgDuration": 10375,
-      "testCount": 1,
-      "flakyRate": 0.0134
-    },
-    "tests/e2e/nodes/pdf-node.spec.ts": {
-      "avgDuration": 9150,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/regression/ADO-1338-ndv-missing-input-panel.spec.ts": {
-      "avgDuration": 9059,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/ai/chat-session.spec.ts": {
-      "avgDuration": 8746,
-      "testCount": 1,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/api/discovery.spec.ts": {
-      "avgDuration": 8274,
-      "testCount": 4,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/ndv/schema-preview.spec.ts": {
-      "avgDuration": 8106,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/regression/CAT-726-canvas-node-connectors-not-rendered-when-nodes-inserted.spec.ts": {
-      "avgDuration": 8098,
-      "testCount": 1,
-      "flakyRate": 0.0133
-    },
-    "tests/e2e/app-config/env-feature-flags.spec.ts": {
-      "avgDuration": 7862,
+      "avgDuration": 18027,
       "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/auth/signin.spec.ts": {
-      "avgDuration": 7781,
+      "avgDuration": 17579,
       "testCount": 1,
-      "flakyRate": 0.0015
+      "flakyRate": 0.0039
     },
-    "tests/e2e/regression/SUG-121-fields-reset-after-closing-ndv.spec.ts": {
-      "avgDuration": 7424,
+    "tests/e2e/settings/log-streaming/log-streaming-ui-e2e.spec.ts": {
+      "avgDuration": 17563,
       "testCount": 1,
-      "flakyRate": 0.0089
+      "flakyRate": 0.0113
     },
-    "tests/e2e/settings/community-nodes/community-nodes.spec.ts": {
-      "avgDuration": 7299,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/regression/AI-1401-sub-nodes-input-panel.spec.ts": {
-      "avgDuration": 7297,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/regression/SUG-38-inline-expression-preview.spec.ts": {
-      "avgDuration": 7142,
-      "testCount": 1,
+    "tests/e2e/mcp/mcp-service.spec.ts": {
+      "avgDuration": 15957,
+      "testCount": 26,
       "flakyRate": 0
     },
     "tests/e2e/regression/AI-716-correctly-set-up-agent-model-shows-error.spec.ts": {
-      "avgDuration": 6869,
+      "avgDuration": 15759,
       "testCount": 1,
+      "flakyRate": 0.0281
+    },
+    "tests/e2e/app-config/versions.spec.ts": {
+      "avgDuration": 14993,
+      "testCount": 1,
+      "flakyRate": 0.0038
+    },
+    "tests/e2e/instance-ai/instance-ai-workflow-setup.spec.ts": {
+      "avgDuration": 14822,
+      "testCount": 10,
+      "flakyRate": 0
+    },
+    "tests/e2e/dynamic-credentials/mcp-trigger-credential-gate.spec.ts": {
+      "avgDuration": 14817,
+      "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/journeys/admin-views-executions-list.spec.ts": {
-      "avgDuration": 6694,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/regression/ADO-2230-ndv-reset-data-pagination.spec.ts": {
-      "avgDuration": 6460,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/credentials/oauth.spec.ts": {
-      "avgDuration": 6454,
-      "testCount": 1,
-      "flakyRate": 0.0045
-    },
-    "tests/e2e/nodes/email-send-node.spec.ts": {
-      "avgDuration": 6317,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/nodes/schedule-trigger-node.spec.ts": {
-      "avgDuration": 5942,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/credentials/api-operations.spec.ts": {
-      "avgDuration": 5920,
-      "testCount": 5,
-      "flakyRate": 0.0015
-    },
-    "tests/e2e/app-config/versions.spec.ts": {
-      "avgDuration": 5749,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/canvas/focus-panel.spec.ts": {
-      "avgDuration": 5366,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/regression/ADO-2929-can-load-old-switch-node-workflows.spec.ts": {
-      "avgDuration": 5249,
+      "avgDuration": 14436,
       "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/workflows/editor/canvas/stickies.spec.ts": {
-      "avgDuration": 5179,
+      "avgDuration": 14093,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/dynamic-credentials/external-user-trigger.spec.ts": {
+      "avgDuration": 13865,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/settings/log-streaming/log-streaming-ui-e2e.spec.ts": {
-      "avgDuration": 4850,
+    "tests/e2e/regression/CAT-726-canvas-node-connectors-not-rendered-when-nodes-inserted.spec.ts": {
+      "avgDuration": 13492,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/nodes/pdf-node.spec.ts": {
+      "avgDuration": 13404,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/community-nodes/community-nodes.spec.ts": {
+      "avgDuration": 13232,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/AI-1401-sub-nodes-input-panel.spec.ts": {
+      "avgDuration": 13108,
+      "testCount": 1,
+      "flakyRate": 0.0028
+    },
+    "tests/e2e/regression/ADO-5808-stale-node-execution-data.spec.ts": {
+      "avgDuration": 13054,
+      "testCount": 1,
+      "flakyRate": 0.0103
+    },
+    "tests/e2e/workflows/editor/ndv/schema-preview.spec.ts": {
+      "avgDuration": 12921,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/ADO-1338-ndv-missing-input-panel.spec.ts": {
+      "avgDuration": 12037,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/nodes/schedule-trigger-node.spec.ts": {
+      "avgDuration": 11536,
+      "testCount": 1,
+      "flakyRate": 0.0031
+    },
+    "tests/e2e/regression/SUG-121-fields-reset-after-closing-ndv.spec.ts": {
+      "avgDuration": 11533,
+      "testCount": 1,
+      "flakyRate": 0.023
+    },
+    "tests/e2e/regression/SUG-38-inline-expression-preview.spec.ts": {
+      "avgDuration": 10318,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/ADO-2230-ndv-reset-data-pagination.spec.ts": {
+      "avgDuration": 10250,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/binary-data-xss.spec.ts": {
+      "avgDuration": 9975,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/sharing/credential-picker-scope.spec.ts": {
+      "avgDuration": 9218,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/CAT-2395-node-spacing.spec.ts": {
+      "avgDuration": 9013,
       "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/workflows/demo-executable-chat-trigger.spec.ts": {
-      "avgDuration": 4424,
+      "avgDuration": 8816,
       "testCount": 1,
-      "flakyRate": 0.0044
+      "flakyRate": 0.0034
     },
-    "tests/e2e/mcp/mcp-service.spec.ts": {
-      "avgDuration": 4375,
-      "testCount": 26,
+    "tests/e2e/workflows/editor/canvas/focus-panel.spec.ts": {
+      "avgDuration": 7610,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/ADO-2929-can-load-old-switch-node-workflows.spec.ts": {
+      "avgDuration": 7506,
+      "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/workflows/editor/subworkflows/wait.spec.ts": {
-      "avgDuration": 4232,
-      "testCount": 4,
-      "flakyRate": 0.0103
+      "avgDuration": 7178,
+      "testCount": 5,
+      "flakyRate": 0.005
     },
-    "tests/e2e/workflows/editor/subworkflows/subworkflow-version-resolution.spec.ts": {
-      "avgDuration": 2352,
-      "testCount": 4,
-      "flakyRate": 0.0015
+    "tests/e2e/webhooks/webhook-trigger-oauth2.spec.ts": {
+      "avgDuration": 5575,
+      "testCount": 3,
+      "flakyRate": 0
     },
-    "tests/e2e/dynamic-credentials/external-user-trigger.spec.ts": {
-      "avgDuration": 1179,
+    "tests/e2e/workflows/editor/execution/subworkflow-stop.spec.ts": {
+      "avgDuration": 4954,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/instance-ai/instance-ai-workflow-setup.spec.ts": {
-      "avgDuration": 1105,
-      "testCount": 10,
-      "flakyRate": 0.0015
+    "tests/e2e/credentials/api-operations.spec.ts": {
+      "avgDuration": 4384,
+      "testCount": 5,
+      "flakyRate": 0
     },
-    "tests/e2e/dynamic-credentials/resolver-deletion.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 3,
-      "flakyRate": 0.0015
+    "tests/e2e/workflows/editor/subworkflows/subworkflow-version-resolution.spec.ts": {
+      "avgDuration": 3691,
+      "testCount": 4,
+      "flakyRate": 0
     },
     "tests/e2e/nodes/n8n-trigger.spec.ts": {
-      "avgDuration": 60000,
+      "avgDuration": 3086,
       "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/scheduling/schedule-trigger-legacy.spec.ts": {
+      "avgDuration": 2238,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/dynamic-credentials/resolver-deletion.spec.ts": {
+      "avgDuration": 1181,
+      "testCount": 3,
       "flakyRate": 0
     },
     "tests/e2e/nodes/code-node-api.spec.ts": {
@@ -858,74 +1038,74 @@
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/instance-ai/instance-ai-timeouts.spec.ts": {
+    "tests/e2e/ai/evaluations.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 1,
+      "testCount": 0,
       "flakyRate": 0
     },
-    "tests/e2e/source-control/push.spec.ts": {
+    "tests/e2e/ai/hitl-for-tools.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 4,
-      "flakyRate": 0
-    },
-    "tests/e2e/settings/environments/source-control.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 4,
+      "testCount": 0,
       "flakyRate": 0
     },
     "tests/e2e/ai/langchain-memory.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/duplicate.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/copy-paste.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 3,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/settings.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 3,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/run.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 4,
+      "testCount": 0,
       "flakyRate": 0
     },
     "tests/e2e/ai/langchain-tools.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/source-control/pull.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 2,
+      "testCount": 0,
       "flakyRate": 0
     },
     "tests/e2e/app-config/nps-survey.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 1,
+      "testCount": 0,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/editor/execution/previous-nodes.spec.ts": {
+    "tests/e2e/instance-ai/instance-ai-timeouts.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/ai/evaluations.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 1,
+      "testCount": 0,
       "flakyRate": 0
     },
     "tests/e2e/node-creator/categories.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 1,
+      "testCount": 0,
+      "flakyRate": 0
+    },
+    "tests/e2e/source-control/pull.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 0,
+      "flakyRate": 0
+    },
+    "tests/e2e/source-control/push.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 0,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/execution/previous-nodes.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 0,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/copy-paste.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 0,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/duplicate.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 0,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/run.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 0,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/settings.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 0,
       "flakyRate": 0
     }
   }

--- a/packages/testing/janitor/src/config.ts
+++ b/packages/testing/janitor/src/config.ts
@@ -101,8 +101,8 @@ export interface JanitorConfig {
 		defaultDuration: number;
 		/** Max group duration before splitting into sub-groups (ms) @default 300_000 */
 		maxGroupDuration: number;
-		/** Minimum test time per shard. Limits the shard count on small selections (ms) @default 300_000 */
-		minShardDuration: number;
+		/** Test time to aim for per shard. Limits the shard count on small selections (ms) @default 300_000 */
+		targetShardDuration: number;
 		/** Minimum specs per shard. Limits the shard count. Set to 1 to disable. @default 1 */
 		minShardSpecs: number;
 		/** Only include specs with paths starting with this prefix @default undefined (all specs) */
@@ -194,7 +194,7 @@ export const defaultConfig: Omit<JanitorConfig, 'rootDir'> = {
 	orchestration: {
 		defaultDuration: 60_000,
 		maxGroupDuration: 5 * 60 * 1000,
-		minShardDuration: 5 * 60 * 1000,
+		targetShardDuration: 5 * 60 * 1000,
 		minShardSpecs: 1,
 	},
 

--- a/packages/testing/janitor/src/config.ts
+++ b/packages/testing/janitor/src/config.ts
@@ -101,6 +101,10 @@ export interface JanitorConfig {
 		defaultDuration: number;
 		/** Max group duration before splitting into sub-groups (ms) @default 300_000 */
 		maxGroupDuration: number;
+		/** Minimum test time per shard. Limits the shard count on small selections (ms) @default 300_000 */
+		minShardDuration: number;
+		/** Minimum specs per shard. Limits the shard count. Set to 1 to disable. @default 1 */
+		minShardSpecs: number;
 		/** Only include specs with paths starting with this prefix @default undefined (all specs) */
 		specFilter?: string;
 	};
@@ -190,6 +194,8 @@ export const defaultConfig: Omit<JanitorConfig, 'rootDir'> = {
 	orchestration: {
 		defaultDuration: 60_000,
 		maxGroupDuration: 5 * 60 * 1000,
+		minShardDuration: 5 * 60 * 1000,
+		minShardSpecs: 1,
 	},
 
 	tcr: {

--- a/packages/testing/playwright/docs/ORCHESTRATION.md
+++ b/packages/testing/playwright/docs/ORCHESTRATION.md
@@ -7,18 +7,41 @@ Capability-aware test distribution across CI shards.
 | Step | What Happens |
 |------|--------------|
 | 1. Discovery | `pnpm janitor discover` (AST-based, detects `test.fixme()`/`test.skip()` automatically) |
-| 2. Metrics | Get `avgDuration` per spec from Currents (last 30 days) |
+| 2. Metrics | Get `avgDuration` per spec from Currents (last 7 days) |
 | 3. Default | Missing specs get **60s** default (accounts for container startup) |
 | 4. Group | Group specs by `@capability:xxx` tag for worker reuse |
 | 5. Effective Duration | Calculate actual time accounting for container reuse within groups |
 | 6. Split | If a group exceeds **5 min**, split into sub-groups |
-| 7. Bin Pack | Greedy assign groups + standard specs to lightest shard |
+| 7. Limit | Keep at least **5 min** of tests on each shard |
+| 8. Bin Pack | Greedy assign groups + standard specs to lightest shard |
 
 ### Why Group by Capability?
 
 Tests requiring containers (proxy, email, etc.) include ~20s startup overhead. When grouped on the same shard, only the first test pays this cost - the rest reuse the worker.
 
 **Example:** 15 proxy tests across 8 shards = 8 container starts (160s). Grouped on 2 shards = 2 starts (40s). **Saves 120s.**
+
+### Why the Shard Count Has a Minimum
+
+Each shard pays about 3.4 minutes of fixed setup: checkout, Setup Environment,
+browser install, and image load. This cost does not change with the size of the
+workload. An impact-scoped PR selects only a few specs. Without a limit, the
+packer distributes those few minutes of tests over many runners, and each runner
+pays the full setup cost.
+
+`minShardDuration` (5 minutes) limits the bucket count to
+`ceil(totalTestTime / minShardDuration)`. The packer creates only the shards it
+can fill. `minShardSpecs` applies a second limit to the same count. Set it to
+`1` to disable it.
+
+The packer applies both limits before it fills the buckets. Bin-packing still
+balances the shards. This is not a merge step after the packer runs.
+
+Full-suite selections do not change: about 196 minutes of test time still fills
+all 16 shards. Over 7 days of PR CI, the 5-minute minimum removed about 9% of
+the E2E shard jobs, and the average wall-clock time did not increase.
+
+Configure both values under `orchestration` in `janitor.config.mjs`.
 
 ### Self-Balancing
 
@@ -133,12 +156,22 @@ echo "$MATRIX_SPECS" | janitor filter-shard
 CURRENTS_API_KEY=<key> node packages/testing/playwright/scripts/fetch-currents-metrics.mjs --project=nHHLA5
 ```
 
-This fetches the last 30 days of test durations from Currents, aggregates by spec, and writes to `.github/test-metrics/playwright.json`. The PR-CI project is `nHHLA5` (n8n-ci); the legacy `LRxcNt` project still backs the nightly e2e workflows.
+This fetches the last 7 days of test durations from Currents, aggregates by spec, and writes to `.github/test-metrics/playwright.json`. The PR-CI project is `nHHLA5` (n8n-ci); the legacy `LRxcNt` project still backs the nightly e2e workflows.
 
 **When to refresh:**
 - Weekly (recommended)
 - After significant test changes
 - When adding new specs (optional - they get 60s default)
+
+Stale metrics do not cause an obvious failure. The packer still reports balanced
+shards, because it balances against the durations in the file. The real spread is
+what changes. A 3-month-stale file predicted a uniform 9.7 minutes for each
+shard. Against refreshed durations, the same shards took 8.6 to 18.5 minutes.
+
+**How to read the reported numbers:** Currents `avgDuration` is about 1.5 times
+the test time that a shard uses in CI. Use `Total test time` and
+`Expected wall-clock` to compare the shards with each other. Do not use them as
+absolute predictions. `minShardDuration` uses these same units.
 
 ## Architecture
 

--- a/packages/testing/playwright/docs/ORCHESTRATION.md
+++ b/packages/testing/playwright/docs/ORCHESTRATION.md
@@ -12,7 +12,7 @@ Capability-aware test distribution across CI shards.
 | 4. Group | Group specs by `@capability:xxx` tag for worker reuse |
 | 5. Effective Duration | Calculate actual time accounting for container reuse within groups |
 | 6. Split | If a group exceeds **5 min**, split into sub-groups |
-| 7. Limit | Keep at least **5 min** of tests on each shard |
+| 7. Limit | Aim for **5 min** of tests on each shard, one shard per capability |
 | 8. Bin Pack | Greedy assign groups + standard specs to lightest shard |
 
 ### Why Group by Capability?
@@ -21,7 +21,7 @@ Tests requiring containers (proxy, email, etc.) include ~20s startup overhead. W
 
 **Example:** 15 proxy tests across 8 shards = 8 container starts (160s). Grouped on 2 shards = 2 starts (40s). **Saves 120s.**
 
-### Why the Shard Count Has a Minimum
+### Why the Shard Count Has a Limit
 
 Each shard pays about 3.4 minutes of fixed setup: checkout, Setup Environment,
 browser install, and image load. This cost does not change with the size of the
@@ -29,17 +29,26 @@ workload. An impact-scoped PR selects only a few specs. Without a limit, the
 packer distributes those few minutes of tests over many runners, and each runner
 pays the full setup cost.
 
-`minShardDuration` (5 minutes) limits the bucket count to
-`ceil(totalTestTime / minShardDuration)`. The packer creates only the shards it
-can fill. `minShardSpecs` applies a second limit to the same count. Set it to
+`targetShardDuration` (5 minutes) limits the bucket count to
+`ceil(totalTestTime / targetShardDuration)`. The packer creates only the shards
+it can fill. `minShardSpecs` applies a second limit to the same count. Set it to
 `1` to disable it.
 
-The packer applies both limits before it fills the buckets. Bin-packing still
+The name says target, not minimum, because `ceil` divides the work evenly over
+the shards that remain. A 12-minute selection gets 3 shards of 4 minutes, not 2
+shards of 6 minutes. `floor` would enforce a true minimum, but it would also add
+about 2 minutes of wall-clock time to keep one more runner idle.
+
+The shard count never drops below the number of capability groups. One runner
+that starts every image set pays back in container startup what it saved in
+setup. Capability groups therefore stay on separate shards.
+
+The packer applies the limits before it fills the buckets. Bin-packing still
 balances the shards. This is not a merge step after the packer runs.
 
 Full-suite selections do not change: about 196 minutes of test time still fills
-all 16 shards. Over 7 days of PR CI, the 5-minute minimum removed about 9% of
-the E2E shard jobs, and the average wall-clock time did not increase.
+all 16 shards. Over 7 days of PR CI, the limit removed about 9% of the E2E shard
+jobs, and the average wall-clock time did not increase.
 
 Configure both values under `orchestration` in `janitor.config.mjs`.
 
@@ -171,7 +180,7 @@ shard. Against refreshed durations, the same shards took 8.6 to 18.5 minutes.
 **How to read the reported numbers:** Currents `avgDuration` is about 1.5 times
 the test time that a shard uses in CI. Use `Total test time` and
 `Expected wall-clock` to compare the shards with each other. Do not use them as
-absolute predictions. `minShardDuration` uses these same units.
+absolute predictions. `targetShardDuration` uses these same units.
 
 ## Architecture
 

--- a/packages/testing/test-impact/src/shard-distributor.test.ts
+++ b/packages/testing/test-impact/src/shard-distributor.test.ts
@@ -164,4 +164,95 @@ describe('distributeShards', () => {
 
 		expect(result.totalTestTime).toBe(100_000 + 200_000 + 60_000);
 	});
+	describe('shard-count limits', () => {
+		const MIN = 5 * 60_000;
+		const withLimit = { ...DEFAULT_CONFIG, minShardDuration: MIN };
+		const evenSpecs = (n: number, each: number) => ({
+			specs: Array.from({ length: n }, (_, i) => spec(`s${i}.spec.ts`)),
+			metrics: Object.fromEntries(Array.from({ length: n }, (_, i) => [`s${i}.spec.ts`, each])),
+		});
+
+		it('leaves the shard count unchanged when no limit is configured', () => {
+			const { specs, metrics } = evenSpecs(6, 30_000);
+			const result = distributeShards(specs, 6, metrics, DEFAULT_CONFIG);
+
+			expect(result.shards).toHaveLength(6);
+		});
+
+		it('collapses a single-spec selection to one shard', () => {
+			const result = distributeShards([spec('a.spec.ts')], 16, { 'a.spec.ts': 30_000 }, withLimit);
+
+			expect(result.shards).toHaveLength(1);
+		});
+
+		it('gives a 12-minute selection 3 shards at a 5-minute limit', () => {
+			const { specs, metrics } = evenSpecs(12, 60_000);
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			expect(result.shards).toHaveLength(3);
+		});
+
+		it('still uses every shard for a full-suite selection', () => {
+			const { specs, metrics } = evenSpecs(108, 60_000);
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			expect(result.shards).toHaveLength(16);
+		});
+
+		it('never returns zero shards when the total test time is below the limit', () => {
+			const { specs, metrics } = evenSpecs(2, 1_000);
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			expect(result.shards).toHaveLength(1);
+			expect(result.shards[0].specs).toHaveLength(2);
+		});
+
+		it('returns no shards for an empty selection even with a limit', () => {
+			expect(distributeShards([], 16, {}, withLimit).shards).toHaveLength(0);
+		});
+
+		it('limits the shard count by minShardSpecs', () => {
+			const { specs, metrics } = evenSpecs(6, 10 * 60_000);
+			const result = distributeShards(specs, 16, metrics, {
+				...DEFAULT_CONFIG,
+				minShardSpecs: 3,
+			});
+
+			expect(result.shards).toHaveLength(2);
+		});
+
+		it('treats minShardSpecs of 1 as disabled', () => {
+			const { specs, metrics } = evenSpecs(4, 10 * 60_000);
+			const result = distributeShards(specs, 4, metrics, {
+				...DEFAULT_CONFIG,
+				minShardSpecs: 1,
+			});
+
+			expect(result.shards).toHaveLength(4);
+		});
+
+		it('applies the lower of the two limits', () => {
+			const { specs, metrics } = evenSpecs(9, 5 * 60_000);
+			const config = { ...DEFAULT_CONFIG, minShardDuration: MIN, minShardSpecs: 3 };
+
+			// by time: ceil(45/5) = 9 shards. by specs: floor(9/3) = 3 shards
+			expect(distributeShards(specs, 16, metrics, config).shards).toHaveLength(3);
+		});
+
+		it('keeps bin-packing balanced within the limited shard count', () => {
+			const metrics = {
+				'a.spec.ts': 5 * 60_000,
+				'b.spec.ts': 3 * 60_000,
+				'c.spec.ts': 2 * 60_000,
+			};
+			const specs = [spec('a.spec.ts'), spec('b.spec.ts'), spec('c.spec.ts')];
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			expect(result.shards).toHaveLength(2);
+			expect(result.shards.map((s) => s.testTime).sort((x, y) => x - y)).toEqual([
+				5 * 60_000,
+				5 * 60_000,
+			]);
+		});
+	});
 });

--- a/packages/testing/test-impact/src/shard-distributor.test.ts
+++ b/packages/testing/test-impact/src/shard-distributor.test.ts
@@ -166,7 +166,7 @@ describe('distributeShards', () => {
 	});
 	describe('shard-count limits', () => {
 		const MIN = 5 * 60_000;
-		const withLimit = { ...DEFAULT_CONFIG, minShardDuration: MIN };
+		const withLimit = { ...DEFAULT_CONFIG, targetShardDuration: MIN };
 		const evenSpecs = (n: number, each: number) => ({
 			specs: Array.from({ length: n }, (_, i) => spec(`s${i}.spec.ts`)),
 			metrics: Object.fromEntries(Array.from({ length: n }, (_, i) => [`s${i}.spec.ts`, each])),
@@ -183,13 +183,6 @@ describe('distributeShards', () => {
 			const result = distributeShards([spec('a.spec.ts')], 16, { 'a.spec.ts': 30_000 }, withLimit);
 
 			expect(result.shards).toHaveLength(1);
-		});
-
-		it('gives a 12-minute selection 3 shards at a 5-minute limit', () => {
-			const { specs, metrics } = evenSpecs(12, 60_000);
-			const result = distributeShards(specs, 16, metrics, withLimit);
-
-			expect(result.shards).toHaveLength(3);
 		});
 
 		it('still uses every shard for a full-suite selection', () => {
@@ -233,7 +226,7 @@ describe('distributeShards', () => {
 
 		it('applies the lower of the two limits', () => {
 			const { specs, metrics } = evenSpecs(9, 5 * 60_000);
-			const config = { ...DEFAULT_CONFIG, minShardDuration: MIN, minShardSpecs: 3 };
+			const config = { ...DEFAULT_CONFIG, targetShardDuration: MIN, minShardSpecs: 3 };
 
 			// by time: ceil(45/5) = 9 shards. by specs: floor(9/3) = 3 shards
 			expect(distributeShards(specs, 16, metrics, config).shards).toHaveLength(3);
@@ -253,6 +246,47 @@ describe('distributeShards', () => {
 				5 * 60_000,
 				5 * 60_000,
 			]);
+		});
+		it('never merges capability groups onto one shard', () => {
+			const specs = [
+				spec('proxy.spec.ts', ['proxy']),
+				spec('email.spec.ts', ['email']),
+				spec('oidc.spec.ts', ['oidc']),
+				spec('kafka.spec.ts', ['kafka']),
+			];
+			const metrics = Object.fromEntries(specs.map((s) => [s.path, 45_000]));
+
+			// 3 min total is far below the limit, but 4 capability groups need 4 shards
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			expect(result.shards).toHaveLength(4);
+			expect(result.shards.every((s) => s.fixtureCount === 1)).toBe(true);
+		});
+
+		it('still collapses specs that share one capability group', () => {
+			const specs = Array.from({ length: 4 }, (_, i) => spec(`p${i}.spec.ts`, ['proxy']));
+			const metrics = Object.fromEntries(specs.map((s) => [s.path, 45_000]));
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			expect(result.shards).toHaveLength(1);
+		});
+
+		it('never exceeds numShards when capability groups outnumber the shards', () => {
+			const specs = Array.from({ length: 6 }, (_, i) => spec(`c${i}.spec.ts`, [`cap${i}`]));
+			const metrics = Object.fromEntries(specs.map((s) => [s.path, 10_000]));
+			const result = distributeShards(specs, 2, metrics, withLimit);
+
+			expect(result.shards).toHaveLength(2);
+		});
+
+		it('treats the duration limit as a target, not a hard minimum', () => {
+			const { specs, metrics } = evenSpecs(12, 60_000);
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			// ceil(12/5) = 3 shards of 4 min each — below MIN, and deliberately so:
+			// floor() would give 2 shards of 6 min and add 2 min of wall-clock.
+			expect(result.shards).toHaveLength(3);
+			expect(Math.min(...result.shards.map((s) => s.testTime))).toBeLessThan(MIN);
 		});
 	});
 });

--- a/packages/testing/test-impact/src/shard-distributor.test.ts
+++ b/packages/testing/test-impact/src/shard-distributor.test.ts
@@ -263,6 +263,21 @@ describe('distributeShards', () => {
 			expect(result.shards.every((s) => s.fixtureCount === 1)).toBe(true);
 		});
 
+		it('never merges capability groups when a large group is split', () => {
+			// 'proxy' totals 12 min and splits into 3 items, so the 5 capability items
+			// need 5 shards even though there are only 3 distinct capabilities.
+			const specs = [
+				...Array.from({ length: 12 }, (_, i) => spec(`proxy${i}.spec.ts`, ['proxy'])),
+				spec('email.spec.ts', ['email']),
+				spec('oidc.spec.ts', ['oidc']),
+			];
+			const metrics = Object.fromEntries(specs.map((s) => [s.path, 60_000]));
+
+			const result = distributeShards(specs, 16, metrics, withLimit);
+
+			expect(result.shards.every((s) => s.fixtureCount === 1)).toBe(true);
+		});
+
 		it('still collapses specs that share one capability group', () => {
 			const specs = Array.from({ length: 4 }, (_, i) => spec(`p${i}.spec.ts`, ['proxy']));
 			const metrics = Object.fromEntries(specs.map((s) => [s.path, 45_000]));

--- a/packages/testing/test-impact/src/shard-distributor.ts
+++ b/packages/testing/test-impact/src/shard-distributor.ts
@@ -3,7 +3,8 @@
  * 1. Enrich specs with duration from metrics
  * 2. Group by capability (specs sharing a capability stay together)
  * 3. Split large groups exceeding maxGroupDuration
- * 4. Greedy bin-packing: assign heaviest items to lightest shard
+ * 4. Limit the bucket count so each shard keeps at least minShardDuration
+ * 5. Greedy bin-packing: assign heaviest items to lightest shard
  */
 
 import type { DiscoveredSpec } from './types.js';
@@ -24,6 +25,8 @@ export interface ShardDistribution {
 interface DistributeConfig {
 	defaultDuration: number;
 	maxGroupDuration: number;
+	minShardDuration?: number;
+	minShardSpecs?: number;
 }
 
 interface SpecWithDuration {
@@ -124,6 +127,27 @@ function splitLargeGroups(
 	return items;
 }
 
+/**
+ * Each shard pays the same fixed setup cost, so a small selection on many shards
+ * spends more time in setup than in tests. The limit applies before bin-packing,
+ * so the packer still balances the shards it gets.
+ */
+function boundShardCount(
+	numShards: number,
+	totalTestTime: number,
+	specCount: number,
+	config: DistributeConfig,
+): number {
+	const limits = [numShards];
+	if (config.minShardDuration && config.minShardDuration > 0) {
+		limits.push(Math.ceil(totalTestTime / config.minShardDuration));
+	}
+	if (config.minShardSpecs && config.minShardSpecs > 1) {
+		limits.push(Math.floor(specCount / config.minShardSpecs));
+	}
+	return Math.max(1, Math.min(...limits));
+}
+
 function assignToShards(items: PackingItem[], numShards: number): Bucket[] {
 	const allItems = items.sort((a, b) => b.duration - a.duration);
 
@@ -166,8 +190,9 @@ export function distributeShards(
 		duration: spec.duration,
 	}));
 
-	const buckets = assignToShards([...capabilityItems, ...standardItems], numShards);
 	const totalTestTime = enriched.reduce((sum, s) => sum + s.duration, 0);
+	const targetShards = boundShardCount(numShards, totalTestTime, enriched.length, config);
+	const buckets = assignToShards([...capabilityItems, ...standardItems], targetShards);
 
 	return {
 		shards: buckets

--- a/packages/testing/test-impact/src/shard-distributor.ts
+++ b/packages/testing/test-impact/src/shard-distributor.ts
@@ -132,14 +132,17 @@ function splitLargeGroups(
  * spends more time in setup than in tests. The limit applies before bin-packing,
  * so the packer still balances the shards it gets.
  *
- * The count never drops below the number of capability groups. One runner that
- * starts every image set pays back in container startup what it saved in setup.
+ * The count never drops below the number of capability packing items. A group
+ * split by maxGroupDuration needs one shard per piece, so counting distinct
+ * capabilities instead would leave the packer too few shards and merge the
+ * remaining capabilities' fixtures onto one runner. One runner that starts every
+ * image set pays back in container startup what it saved in setup.
  */
 function boundShardCount(
 	numShards: number,
 	totalTestTime: number,
 	specCount: number,
-	capabilityGroups: number,
+	capabilityItemCount: number,
 	config: DistributeConfig,
 ): number {
 	const limits = [numShards];
@@ -149,7 +152,7 @@ function boundShardCount(
 	if (config.minShardSpecs && config.minShardSpecs > 1) {
 		limits.push(Math.floor(specCount / config.minShardSpecs));
 	}
-	return Math.min(numShards, Math.max(1, capabilityGroups, Math.min(...limits)));
+	return Math.min(numShards, Math.max(1, capabilityItemCount, Math.min(...limits)));
 }
 
 function assignToShards(items: PackingItem[], numShards: number): Bucket[] {
@@ -199,7 +202,7 @@ export function distributeShards(
 		numShards,
 		totalTestTime,
 		enriched.length,
-		groups.size,
+		capabilityItems.length,
 		config,
 	);
 	const buckets = assignToShards([...capabilityItems, ...standardItems], targetShards);

--- a/packages/testing/test-impact/src/shard-distributor.ts
+++ b/packages/testing/test-impact/src/shard-distributor.ts
@@ -3,7 +3,7 @@
  * 1. Enrich specs with duration from metrics
  * 2. Group by capability (specs sharing a capability stay together)
  * 3. Split large groups exceeding maxGroupDuration
- * 4. Limit the bucket count so each shard keeps at least minShardDuration
+ * 4. Limit the bucket count to keep each shard near targetShardDuration
  * 5. Greedy bin-packing: assign heaviest items to lightest shard
  */
 
@@ -25,7 +25,7 @@ export interface ShardDistribution {
 interface DistributeConfig {
 	defaultDuration: number;
 	maxGroupDuration: number;
-	minShardDuration?: number;
+	targetShardDuration?: number;
 	minShardSpecs?: number;
 }
 
@@ -131,21 +131,25 @@ function splitLargeGroups(
  * Each shard pays the same fixed setup cost, so a small selection on many shards
  * spends more time in setup than in tests. The limit applies before bin-packing,
  * so the packer still balances the shards it gets.
+ *
+ * The count never drops below the number of capability groups. One runner that
+ * starts every image set pays back in container startup what it saved in setup.
  */
 function boundShardCount(
 	numShards: number,
 	totalTestTime: number,
 	specCount: number,
+	capabilityGroups: number,
 	config: DistributeConfig,
 ): number {
 	const limits = [numShards];
-	if (config.minShardDuration && config.minShardDuration > 0) {
-		limits.push(Math.ceil(totalTestTime / config.minShardDuration));
+	if (config.targetShardDuration && config.targetShardDuration > 0) {
+		limits.push(Math.ceil(totalTestTime / config.targetShardDuration));
 	}
 	if (config.minShardSpecs && config.minShardSpecs > 1) {
 		limits.push(Math.floor(specCount / config.minShardSpecs));
 	}
-	return Math.max(1, Math.min(...limits));
+	return Math.min(numShards, Math.max(1, capabilityGroups, Math.min(...limits)));
 }
 
 function assignToShards(items: PackingItem[], numShards: number): Bucket[] {
@@ -191,7 +195,13 @@ export function distributeShards(
 	}));
 
 	const totalTestTime = enriched.reduce((sum, s) => sum + s.duration, 0);
-	const targetShards = boundShardCount(numShards, totalTestTime, enriched.length, config);
+	const targetShards = boundShardCount(
+		numShards,
+		totalTestTime,
+		enriched.length,
+		groups.size,
+		config,
+	);
 	const buckets = assignToShards([...capabilityItems, ...standardItems], targetShards);
 
 	return {


### PR DESCRIPTION
## Summary

Two related changes to E2E shard distribution.

**1. Refresh the shard metrics.** `.github/test-metrics/playwright.json` was last refreshed on 2026-05-30 — 185 specs then, 221 now.

Stale metrics do not fail loudly. The packer still reports every shard as balanced, because it balances against the weights it was given. What drifts is the real spread. Scored against refreshed durations, the current assignment is badly skewed:

| | shortest shard | p50 | longest shard | spread |
|---|---|---|---|---|
| Stale metrics (what CI runs today) | 8.6 min | 12.4 | **18.5 min** | 9.9 min |
| Refreshed | 11.3 min | 12.3 | **12.3 min** | 1.0 min |

Blacksmith confirms it independently. Over 30d, 303 PR-CI E2E runs, 194 of them full 16-shard fan-outs:

- per-shard wall-clock **p50 11.5 min**, longest shard **p50 16.1 min** — the same 40% gap
- longest shard **p90 22.8 min, max 31.4 min** against a **30 min job timeout**
- step breakdown on p50 full-run shards: **3.43 min setup** (Setup Environment is 114s of it) + **9.83 min Run Tests**

Refreshing should pull longest-shard wall-clock from ~16.1 to ~11.5-12 min. Roughly **4 min off the E2E critical path per full run**, at no extra spend.

**2. Add a minimum test time per shard** (DEVP-913). Every shard pays the same ~3.4 min of fixed setup regardless of how little it runs, so a scoped selection should not fan out across runners it cannot fill.

`boundShardCount()` caps the bucket count at `min(numShards, ceil(totalTestTime / targetShardDuration), floor(specCount / minShardSpecs))`, and never reduces it below the number of capability groups. It is applied **inside** the packer rather than as a merge afterwards, so bin-packing still balances whatever buckets remain. Defaults: `targetShardDuration` 5 min (active), `minShardSpecs` 1 (disabled).

The name says *target*, not minimum: `ceil` divides work evenly over the shards that remain, so a 12 min selection gets 3 shards of 4 min. `floor` would enforce a true minimum but add ~2 min of wall-clock to idle one more runner. `minShardSpecs` uses `floor` and is a genuine minimum.

I left the spec-count limit off by default. The time limit already subsumes the single-spec-shard case, and a hard spec floor can double scoped wall-clock when the few selected specs are individually long. It is there as a lever.

Simulated against 7 days of real `Shard Distribution` log lines (**1,245 runs / 16,405 shard-jobs**), rescaled into post-refresh metric units:

Rate and spend are read from `blacksmith usage`, not assumed: **$0.002 per billing minute**, n8n repo **$8,287/month**, E2E shard jobs **49,681/month costing $2,158** (26% of repo spend). Of that, ~**$682/month is per-shard setup** — that is the addressable pool.

Simulated over 7 days of `Shard Distribution` log lines, joined to the runs that actually produced E2E jobs (877 of 1,223 planned matrices) and rescaled into post-refresh metric units:

| target | shards planned → packed | cut | shard-jobs saved /mo | saving |
|---|---|---|---|---|
| 3 min | | ~4% | ~1,900 | ~$26/mo |
| **5 min** | **11,306 → 10,241** | **9.4%** | **~4,564** | **~$63/mo** |
| 6.3 min | | ~14% | ~6,800 | ~$93/mo |
| 8 min | | ~20% | ~9,700 | ~$133/mo |

5 min is the only value where average wall-clock improves rather than degrades, and it matches the figure in the ticket.

Cross-check: 11,306 planned shards on executed runs vs 11,430 actually billed in the same window — within 1%.

Keeping capability groups on separate shards costs nothing: 1,498 shard-jobs saved with the rule against 1,500 without it. Real scoped runs rarely span more than two capabilities (217 have one, 37 have two, 80 have none).

**The metrics refresh saves no money** — the same test work is packed into the same 16 shards, so total billed minutes are unchanged. Its value is latency: ~4 min off the longest shard on every full run. E2E shards are the top PR-gating job class by p95 (22.1 min), so that is time a developer waits. There is no timeout waste to recover either: 0 `timed_out` conclusions in 7 days.

Per-selection shape:

| specs selected | today | 5 min target |
|---|---|---|
| 3 | 3 shards / 4.1 min | 1 shard / 4.2 min |
| 20 | 16 shards / 5.3 min | 4 shards / 7.5 min |
| 50 | 16 shards / 6.9 min | 11 shards / 7.3 min |
| 207 (full) | 16 shards / 12.6 min | 16 shards / 12.6 min |

Worst case is 7.5 min against the 12.6 min that full runs already pay, so this is latency-neutral at the PR level.

**Docs.** `ORCHESTRATION.md` gains a "Why the Shard Count Has a Minimum" section, and records two non-obvious properties: stale metrics still report as balanced, and Currents `avgDuration` runs ~1.5x the test time a shard actually spends in CI — so `Total test time` and `Expected wall-clock` are comparative, not absolute. Also fixes a doc drift: the metrics window is 7 days, not the 30 days documented.

## How to test

Full-suite selections must be unchanged; scoped selections must collapse.

```bash
pnpm turbo run build --filter=@n8n/test-impact --filter=@n8n/playwright-janitor

# full suite: still 16 shards, ~196 min total
node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate 2>&1 >/dev/null | tail -4

# scoped: 3 specs collapse from 3 shards to 2
printf 'tests/e2e/credentials/crud.spec.ts\ntests/e2e/projects/projects.spec.ts\ntests/e2e/data-tables/tables.spec.ts\n' > /tmp/scoped3.txt
cd packages/testing/playwright && node ../janitor/dist/cli.js distribute --shards=16 --include-specs-file=/tmp/scoped3.txt | jq '.shards | length'
```

Unit tests (10 new cases covering the ticket's acceptance criteria):

```bash
cd packages/testing/test-impact && pnpm vitest run src/shard-distributor.test.ts
```

Verified locally: 234/234 test-impact, 398/398 janitor, lint + typecheck + format clean on both packages.

To reproduce the measurement after merge:

```bash
blacksmith logs search --query 'repo:n8n-io/n8n AND step_name:"Generate shard matrix" AND "min test"' --since 7d
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-913

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




