### PR TITLE
fix(core): Route items to the error output when the paired item lookup fails

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1923,6 +1923,28 @@ describe('WorkflowExecute', () => {
 				{ json: {}, error: { message: 'Test error' } as NodeApiError },
 			]);
 		});
+
+		test('should route the error item when the paired item cannot be resolved', () => {
+			// The recorded source data points at an item the previous node never
+			// emitted, so `$getPairedItem` throws instead of returning `null`
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: { error: 'Test error' },
+						pairedItem: { item: 99, input: 0 },
+					},
+				],
+			];
+
+			expect(() => {
+				workflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+			}).not.toThrow();
+
+			expect(nodeSuccessData[0]).toEqual([]);
+			expect(nodeSuccessData[1]).toEqual([
+				{ json: { error: 'Test error' }, pairedItem: { item: 99, input: 0 } },
+			]);
+		});
 	});
 
 	describe('AI tool continue-on-fail default', () => {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -3003,11 +3003,19 @@ export class WorkflowExecute {
 
 						const sourceData = executionData.source[NodeConnectionTypes.Main][pairedItemInputIndex];
 
-						const constPairedItem = dataProxy.$getPairedItem(
-							sourceData!.previousNode,
-							sourceData,
-							pairedItemData,
-						);
+						// Resolving the input item only enriches the error item. If the lookup
+						// fails, still route the item to the error output instead of letting the
+						// error escape and leave the item on the success output.
+						let constPairedItem: INodeExecutionData | null = null;
+						try {
+							constPairedItem = dataProxy.$getPairedItem(
+								sourceData!.previousNode,
+								sourceData,
+								pairedItemData,
+							);
+						} catch {
+							constPairedItem = null;
+						}
 
 						if (constPairedItem === null) {
 							errorItems.push(item);


### PR DESCRIPTION
## Summary

Fixes #37407.

When a node with `onError: continueErrorOutput` fails, `WorkflowExecute.handleNodeErrorOutput()` resolves the node's *input* item through `dataProxy.$getPairedItem(...)` purely to merge its JSON into the error item. That call does not return `null` when the lookup fails — it **throws** (`createMissingPairedItemError` in `workflow-data-proxy.ts`). The surrounding code only handled the `null` return, so the error escaped `handleNodeErrorOutput` entirely and three things went wrong at once:

1. the node's error output never fired, so error branches (e.g. a fallback path) did not run;
2. the node's input item stayed on main output 0 and was consumed downstream as if it were the node's result;
3. `runData` recorded `executionStatus: "error"` while the execution as a whole finished `success`, so nothing surfaced the failure.

The decoration is cosmetic — the code a few lines above already has the correct fallback (`errorItems.push(item)`) for the case where the input item cannot be identified. This change routes the item to the error output through that same fallback when the lookup throws, instead of letting the error propagate.

The lookup throws when the recorded `source` data does not line up with the item the previous node actually emitted (in the reported case a Switch whose `previousNodeOutput` was `0` while the data was emitted on output `2`, so the traceback found no item). Whether that mis-recorded `previousNodeOutput` is a separate bug is out of scope here — `handleNodeErrorOutput` should survive it either way.

## How to test

Regression test added in `packages/core/src/execution-engine/__tests__/workflow-execute.test.ts` (`should route the error item when the paired item cannot be resolved`). It gives the error item a `pairedItem` index the previous node never emitted, which is exactly what makes `$getPairedItem` throw.

```
cd packages/core
pnpm test src/execution-engine/__tests__/workflow-execute.test.ts -t "paired item cannot be resolved"
```

Against `master` without the change, it fails with the error from the issue:

```
AssertionError: expected [Function] to not throw an error but 'ExpressionError: Paired item data for…' was thrown
+ Received:
"ExpressionError: Paired item data for $getPairedItem from node 'previousNode' is unavailable. Ensure 'previousNode' is providing the required output."
```

With the change it passes, the item lands on the error output (index 1) and the success output (index 0) is empty.

Also run: full `workflow-execute.test.ts` suite, `pnpm lint` and `pnpm typecheck` in `packages/core` — all clean.

## Related Linear tickets, Github issues, and Community forum posts

Closes #37407 (GHC-9380)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. — not needed, no user-facing behaviour is documented differently
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

