### PR TITLE
feat(core): Grade the agent's captured context state in Instance AI evals (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -268,6 +268,65 @@ Operational details:
 - The judge retries on failure, has a per-attempt timeout, and falls back to an all-fail verdict — a judge failure can't break a run.
 - Absent both fields, it's a complete no-op.
 
+### Context assertions (per test case)
+
+`processExpectations` and `outcomeExpectations` grade what the agent **did**.
+`contextAssertions` grade what it **had** — whether an exact value was in the context the
+model was actually sent.
+
+```jsonc
+"contextAssertions": [
+  { "text": "#ops-alerts", "note": "the channel agreed three turns ago" },
+  { "text": "email_address", "mustAppear": false, "note": "renamed column, should have been dropped" },
+  { "text": "Daily Sync", "anchor": "turn-end" }
+]
+```
+
+- **Deterministic.** Case-insensitive substring search over the captured run debug — no
+  judge, so no rubric, no cost, and nothing to hallucinate. Counted as units in the pass
+  rate like any other expectation.
+- **Three tiers are searched** and the verdict names which one hit: the compressed
+  observation block, the message window, and the system prompt.
+- **Assert atomic values** (`#ops-alerts`, `triggerAtHour`, `2026-03-01`), not formatted
+  phrases (`triggerAtHour: 6`). The same value is serialised with different spacing
+  depending on which tier carries it.
+- **Needs run debug**, so these are skipped in prebuilt/MCP runs. A dropped capture is
+  reported as `incomplete` ("not checked") rather than as the value being absent.
+
+#### `anchor` — which moment the claim is about
+
+This is what makes an A/B attributable rather than just a pass rate.
+
+| Anchor | State it reads | Use for |
+| --- | --- | --- |
+| `probe` (default) | what the model held when the request arrived | **retention** — "a fact from earlier survived to here" |
+| `turn-end` | the state once the turn is over | **retrieval** — "the agent went and fetched it" |
+
+Grade retention at the `probe`, because the agent restates facts as it works and the end
+state would let the claim manufacture its own evidence. Grade retrieval at `turn-end`,
+because tools are called *after* the request arrives — a fetch claim graded at the probe
+can never pass.
+
+A probe-anchored claim that misses is checked again at turn end, so the verdict can
+separate "never had it" from "re-derived it while answering".
+
+When the graded turn captured no usable probe state, probe claims report `incomplete`
+rather than falling back to the end-of-turn state. Borrowing that state would count what
+the agent produced *while answering* as evidence that it remembered.
+
+#### Context outcome (context × build)
+
+Crossing the context verdict with the build verdict names one of four situations, because
+a single pass rate collapses cases whose fixes are opposite:
+
+| | build correct | build wrong |
+| --- | --- | --- |
+| **context had it** | `working` | `context-ignored` — a prompting problem |
+| **context lacked it** | `unattributed-success` — the feature contributed nothing | `retrieval-gap` — a retrieval problem |
+
+Both axes take the strictest reading: every graded claim on that axis must pass. A case
+without a graded claim on both axes is `unclassified` rather than `working`.
+
 ### Artifact types (workflow / agent / config-eval)
 
 A test case's build can produce more than a workflow — a builder can also create a standalone **agent** or attach a **config-eval** (an evaluation config on a workflow, graded against its referenced dataset). These are graded through the **same `outcomeExpectations`** as everything else — there are no artifact-specific case fields.
@@ -710,7 +769,7 @@ The corpus lives in **LangTracer** — suite `baseline` is what CI runs. Author 
 }
 ```
 
-`conversation` (≥1 turn, first must be `user`), plus `complexity` and `tags`, are required. `executionScenarios`, `description`, `triggerType`, `messageBudget`, `processExpectations`, `outcomeExpectations`, `credentials`, and `datasets` (default `["full"]`) are optional — but **a case must declare at least one `executionScenario`, or one process/outcome expectation** (a case that asserts nothing is rejected at load). A _build-only_ case omits `executionScenarios` and is graded by its `processExpectations`/`outcomeExpectations` plus the always-on workflow checks: the workflow is still built, only the mock-execution `successCriteria` pass is skipped. A turn’s `text` may be a string or an array of strings joined with newlines — handy for long stage directions.
+`conversation` (≥1 turn, first must be `user`), plus `complexity` and `tags`, are required. `executionScenarios`, `description`, `triggerType`, `messageBudget`, `processExpectations`, `outcomeExpectations`, `contextAssertions`, `credentials`, and `datasets` (default `["full"]`) are optional — but **a case must declare at least one `executionScenario`, or one process/outcome expectation, or one context assertion** (a case that asserts nothing is rejected at load). A _build-only_ case omits `executionScenarios` and is graded by its `processExpectations`/`outcomeExpectations` plus the always-on workflow checks: the workflow is still built, only the mock-execution `successCriteria` pass is skipped. A turn’s `text` may be a string or an array of strings joined with newlines — handy for long stage directions.
 
 **One case = one LangSmith split**, named from the case slug (the LangTracer case name; for disk-loaded files, the filename without `.json`). Pick a slug you're happy to also use as a `--filter` target.
 

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -283,15 +283,13 @@ model was actually sent.
 ```
 
 - **Deterministic.** Case-insensitive substring search over the captured run debug — no
-  judge, so no rubric, no cost, and nothing to hallucinate. Counted as units in the pass
-  rate like any other expectation.
+  judge, so no rubric, no cost, nothing to hallucinate. Counted as units in the pass rate.
 - **Three tiers are searched** and the verdict names which one hit: the compressed
   observation block, the message window, and the system prompt.
-- **Assert atomic values** (`#ops-alerts`, `triggerAtHour`, `2026-03-01`), not formatted
-  phrases (`triggerAtHour: 6`). The same value is serialised with different spacing
-  depending on which tier carries it.
-- **Needs run debug**, so these are skipped in prebuilt/MCP runs. A dropped capture is
-  reported as `incomplete` ("not checked") rather than as the value being absent.
+- **Assert atomic values** (`#ops-alerts`, `2026-03-01`), not formatted phrases
+  (`triggerAtHour: 6`) — spacing varies by which tier carries the value.
+- **Needs run debug**, so prebuilt/MCP runs report `incomplete` ("not checked") rather
+  than treating the value as absent.
 
 #### `anchor` — which moment the claim is about
 
@@ -299,33 +297,30 @@ This is what makes an A/B attributable rather than just a pass rate.
 
 | Anchor | State it reads | Use for |
 | --- | --- | --- |
-| `probe` (default) | what the model held when the request arrived | **retention** — "a fact from earlier survived to here" |
-| `turn-end` | the state once the turn is over | **retrieval** — "the agent went and fetched it" |
+| `probe` (default) | what the model held when the request arrived | **retention** |
+| `turn-end` | the state once the turn is over | **retrieval** |
 
-Grade retention at the `probe`, because the agent restates facts as it works and the end
-state would let the claim manufacture its own evidence. Grade retrieval at `turn-end`,
-because tools are called *after* the request arrives — a fetch claim graded at the probe
-can never pass.
+Grade retention at the `probe`: the agent restates facts as it works, so the end state
+would let a claim manufacture its own evidence. Grade retrieval at `turn-end`: tools are
+called *after* the request arrives, so a fetch claim graded at the probe can never pass.
 
-A probe-anchored claim that misses is checked again at turn end, so the verdict can
-separate "never had it" from "re-derived it while answering".
-
-When the graded turn captured no usable probe state, probe claims report `incomplete`
-rather than falling back to the end-of-turn state. Borrowing that state would count what
-the agent produced *while answering* as evidence that it remembered.
+Both anchors read the same run — the graded turn. A probe claim that misses is re-checked
+at turn end, separating "never had it" from "re-derived it while answering". If the graded
+turn captured no usable state, claims report `incomplete` rather than falling back to
+another moment or another turn.
 
 #### Context outcome (context × build)
 
-Crossing the context verdict with the build verdict names one of four situations, because
-a single pass rate collapses cases whose fixes are opposite:
+Crossing the two verdicts names one of four situations, because a single pass rate
+collapses cases whose fixes are opposite:
 
 | | build correct | build wrong |
 | --- | --- | --- |
 | **context had it** | `working` | `context-ignored` — a prompting problem |
 | **context lacked it** | `unattributed-success` — the feature contributed nothing | `retrieval-gap` — a retrieval problem |
 
-Both axes take the strictest reading: every graded claim on that axis must pass. A case
-without a graded claim on both axes is `unclassified` rather than `working`.
+Both axes take the strictest reading: every graded claim on that axis must pass. Without a
+graded claim on both axes a case is `unclassified`, not `working`.
 
 ### Artifact types (workflow / agent / config-eval)
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/context-assertions.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/context-assertions.test.ts
@@ -143,8 +143,8 @@ describe('checkContextAssertions', () => {
 		expect(verdict.reason).toContain('no run debug was captured');
 	});
 
-	// A probe claim graded against borrowed end-of-turn state fails toward PASS, which
-	// is the direction that manufactures a finding. It must report "not checked".
+	// A probe claim graded against the end-of-turn state fails toward PASS, which is the
+	// direction that manufactures a finding. It must report "not checked" instead.
 	it('declines to grade a probe claim when the graded turn captured no probe state', () => {
 		const runDebug: InstanceAiRunDebugResponse[] = [
 			{
@@ -152,18 +152,17 @@ describe('checkContextAssertions', () => {
 				runId: 'r1',
 				startedAt: 1,
 				steps: [
+					// First step unparseable, so there is no probe snapshot...
+					{ stepNumber: 1, input: {} },
+					// ...but the agent went and fetched the value later in the same turn.
 					{
-						stepNumber: 1,
-						input: { system: 'sys', messages: [{ role: 'user', content: 'use #ops-alerts' }] },
+						stepNumber: 2,
+						input: {
+							system: 'sys',
+							messages: [{ role: 'assistant', content: 'looked it up: #ops-alerts' }],
+						},
 					},
 				],
-				workflowCode: [],
-			},
-			{
-				threadId: 't1',
-				runId: 'r2',
-				startedAt: 2,
-				steps: [{ stepNumber: 1, input: {} }],
 				workflowCode: [],
 			},
 		];
@@ -173,7 +172,7 @@ describe('checkContextAssertions', () => {
 		expect(probe.reason).toContain('not checked');
 		expect(probe.reason).not.toContain('retained');
 
-		// The end-of-turn state is unaffected, so a turn-end claim is still gradable.
+		// Turn end is a different question, and it is still answerable.
 		const [atEnd] = checkContextAssertions([{ text: '#ops-alerts', anchor: 'turn-end' }], runDebug);
 		expect(atEnd.incomplete).toBeUndefined();
 		expect(atEnd.pass).toBe(true);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/context-assertions.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/context-assertions.test.ts
@@ -1,0 +1,197 @@
+import type { InstanceAiRunDebugResponse } from '@n8n/api-types';
+
+import { checkContextAssertions } from '../harness/context-assertions';
+
+/** Real capture shape: a system prompt plus SDK message parts. Both tiers are present
+ *  because that is what a real step produces — a step missing either is a failed
+ *  capture, which several tests below exercise deliberately. */
+function debug(system: string, messages: unknown[] = [{ role: 'user', content: 'go on' }]) {
+	return [
+		{
+			threadId: 't1',
+			runId: 'r1',
+			startedAt: 1,
+			steps: [{ stepNumber: 1, input: { system, messages } }],
+			workflowCode: [],
+		},
+	] satisfies InstanceAiRunDebugResponse[];
+}
+
+describe('checkContextAssertions', () => {
+	it('returns nothing when a case declares none', () => {
+		expect(checkContextAssertions(undefined, debug('sys'))).toEqual([]);
+		expect(checkContextAssertions([], debug('sys'))).toEqual([]);
+	});
+
+	it('passes when the value is present, naming the tier it was found in', () => {
+		const [verdict] = checkContextAssertions(
+			[{ text: '#ops-alerts' }],
+			debug('sys', [{ role: 'user', content: 'send failures to #ops-alerts' }]),
+		);
+		expect(verdict.pass).toBe(true);
+		expect(verdict.kind).toBe('context');
+		expect(verdict.reason).toContain('retained');
+		expect(verdict.reason).toContain('message window');
+	});
+
+	it('matches case-insensitively', () => {
+		// Casing drifts as content is re-rendered through tool payloads, and a casing
+		// difference is never the finding.
+		const [verdict] = checkContextAssertions(
+			[{ text: '#OPS-Alerts' }],
+			debug('sys', [{ role: 'user', content: 'use #ops-alerts' }]),
+		);
+		expect(verdict.pass).toBe(true);
+	});
+
+	it('searches the system prompt and the observation block, not just messages', () => {
+		const sys = 'You build things.\n<observations>channel is #ops-alerts</observations>';
+		const [inObs] = checkContextAssertions([{ text: '#ops-alerts' }], debug(sys));
+		expect(inObs.pass).toBe(true);
+		expect(inObs.reason).toContain('observation block');
+
+		const [inSys] = checkContextAssertions([{ text: 'You build things' }], debug(sys));
+		expect(inSys.pass).toBe(true);
+		expect(inSys.reason).toContain('system prompt');
+	});
+
+	it('separates "never had it" from "re-derived it while answering"', () => {
+		// The distinction that makes a retention claim worth measuring: the memory
+		// subsystem did not carry this, the agent reproduced it during the turn.
+		const runDebug: InstanceAiRunDebugResponse[] = [
+			{
+				threadId: 't1',
+				runId: 'r1',
+				startedAt: 1,
+				steps: [
+					{
+						stepNumber: 1,
+						input: { system: 'sys', messages: [{ role: 'user', content: 'fix it' }] },
+					},
+					{
+						stepNumber: 2,
+						input: {
+							system: 'sys',
+							messages: [{ role: 'assistant', content: 'looked it up: #ops-alerts' }],
+						},
+					},
+				],
+				workflowCode: [],
+			},
+		];
+		const [verdict] = checkContextAssertions([{ text: '#ops-alerts' }], runDebug);
+		expect(verdict.pass).toBe(false);
+		expect(verdict.reason).toContain('NOT retained');
+		expect(verdict.reason).toContain('re-derived');
+	});
+
+	it('reports a plain miss when the value is nowhere in the turn', () => {
+		const [verdict] = checkContextAssertions([{ text: 'maxTries' }], debug('sys'));
+		expect(verdict.pass).toBe(false);
+		expect(verdict.reason).toContain('not present at the probe');
+		expect(verdict.reason).not.toContain('re-derived');
+	});
+
+	it('supports must-NOT-appear for stale values that should have been dropped', () => {
+		const stale = debug('sys', [{ role: 'user', content: 'the old column was email_address' }]);
+		const [present] = checkContextAssertions([{ text: 'email_address', mustAppear: false }], stale);
+		expect(present.pass).toBe(false);
+		expect(present.reason).toContain('still present');
+
+		const [absent] = checkContextAssertions(
+			[{ text: 'email_address', mustAppear: false }],
+			debug('sys'),
+		);
+		expect(absent.pass).toBe(true);
+		expect(absent.reason).toContain('correctly absent');
+	});
+
+	it('grades a turn-end claim against the end of the turn', () => {
+		// Retrieval happens AFTER the request arrives, so this claim can only be
+		// answered at turn end — grading it at the probe could never pass.
+		const runDebug: InstanceAiRunDebugResponse[] = [
+			{
+				threadId: 't1',
+				runId: 'r1',
+				startedAt: 1,
+				steps: [
+					{
+						stepNumber: 1,
+						input: { system: 'sys', messages: [{ role: 'user', content: 'fix it' }] },
+					},
+					{
+						stepNumber: 2,
+						input: {
+							system: 'sys',
+							messages: [{ role: 'assistant', content: 'fetched Daily Sync' }],
+						},
+					},
+				],
+				workflowCode: [],
+			},
+		];
+		const [atEnd] = checkContextAssertions([{ text: 'Daily Sync', anchor: 'turn-end' }], runDebug);
+		expect(atEnd.pass).toBe(true);
+		expect(atEnd.reason).toContain('carried in or fetched');
+		expect(atEnd.reason).not.toContain('retained');
+	});
+
+	it('declines to grade rather than inventing a verdict when nothing was captured', () => {
+		const [verdict] = checkContextAssertions([{ text: '#ops-alerts' }], undefined);
+		expect(verdict.incomplete).toBe(true);
+		expect(verdict.pass).toBe(false);
+		expect(verdict.reason).toContain('no run debug was captured');
+	});
+
+	// A probe claim graded against borrowed end-of-turn state fails toward PASS, which
+	// is the direction that manufactures a finding. It must report "not checked".
+	it('declines to grade a probe claim when the graded turn captured no probe state', () => {
+		const runDebug: InstanceAiRunDebugResponse[] = [
+			{
+				threadId: 't1',
+				runId: 'r1',
+				startedAt: 1,
+				steps: [
+					{
+						stepNumber: 1,
+						input: { system: 'sys', messages: [{ role: 'user', content: 'use #ops-alerts' }] },
+					},
+				],
+				workflowCode: [],
+			},
+			{
+				threadId: 't1',
+				runId: 'r2',
+				startedAt: 2,
+				steps: [{ stepNumber: 1, input: {} }],
+				workflowCode: [],
+			},
+		];
+
+		const [probe] = checkContextAssertions([{ text: '#ops-alerts' }], runDebug);
+		expect(probe.incomplete).toBe(true);
+		expect(probe.reason).toContain('not checked');
+		expect(probe.reason).not.toContain('retained');
+
+		// The end-of-turn state is unaffected, so a turn-end claim is still gradable.
+		const [atEnd] = checkContextAssertions([{ text: '#ops-alerts', anchor: 'turn-end' }], runDebug);
+		expect(atEnd.incomplete).toBeUndefined();
+		expect(atEnd.pass).toBe(true);
+	});
+
+	it('describes the claim so the report is readable without the case file', () => {
+		const [withNote] = checkContextAssertions(
+			[{ text: '#ops-alerts', note: 'the agreed alert channel', anchor: 'turn-end' }],
+			debug('sys'),
+		);
+		expect(withNote.expectation).toBe(
+			'context contains "#ops-alerts" [by turn end] (the agreed alert channel)',
+		);
+
+		const [excludes] = checkContextAssertions(
+			[{ text: 'email_address', mustAppear: false }],
+			debug('sys'),
+		);
+		expect(excludes.expectation).toBe('context excludes "email_address"');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/context-capture.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/context-capture.test.ts
@@ -66,14 +66,41 @@ describe('captureContext', () => {
 	// must not silently borrow the end-of-turn state. Grading a retention claim against
 	// borrowed content counts what the agent produced WHILE ANSWERING as evidence that
 	// it remembered, and it fails toward PASS.
-	it('reports no probe at all when the graded turn captured nothing usable', () => {
+	it("reports no probe when the graded turn's FIRST step captured nothing", () => {
 		const captured = captureContext([
-			run('r1', 1, [step('real prompt', 1, msg('real content'))]),
-			run('r2', 2, [{ stepNumber: 1, input: {} }]),
+			run('r1', 1, [
+				{ stepNumber: 1, input: {} },
+				step('a prompt', 2, msg('what the agent produced while answering')),
+			]),
 		]);
 		expect(captured?.probe).toBeUndefined();
-		// The end-of-turn state is still reported — it is a different question.
-		expect(captured?.turnEnd.messageWindow).toContain('real content');
+		// Turn end is a different question and is still answerable.
+		expect(captured?.turnEnd.messageWindow).toContain('while answering');
+	});
+
+	it('returns undefined when the graded turn captured nothing usable at all', () => {
+		// Neither anchor can answer. An empty turn-end snapshot would fail every claim
+		// with "not present", inventing a finding out of a capture failure.
+		expect(
+			captureContext([
+				run('r1', 1, [step('real prompt', 1, msg('real content'))]),
+				run('r2', 2, [{ stepNumber: 1, input: {} }]),
+			]),
+		).toBeUndefined();
+	});
+
+	it("does not carry an earlier turn's state into this turn's end state", () => {
+		// Both anchors are scoped to the graded run. A value left over from a previous
+		// turn must not surface as one the agent fetched during this one.
+		const captured = captureContext([
+			run('r1', 1, [
+				step('sys\n<observations>alerts go to #ops</observations>', 1, msg('earlier turn')),
+			]),
+			run('r2', 2, [step('sys', 1, msg('this turn'))]),
+		]);
+		expect(captured?.turnEnd.observations).toBeNull();
+		expect(captured?.turnEnd.messageWindow).toContain('this turn');
+		expect(captured?.turnEnd.messageWindow).not.toContain('earlier turn');
 	});
 
 	it('needs BOTH a prompt and a window before it will call a snapshot gradable', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/context-capture.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/context-capture.test.ts
@@ -1,0 +1,140 @@
+import type { InstanceAiRunDebugResponse, InstanceAiRunDebugStep } from '@n8n/api-types';
+
+import { captureContext, snapshotFor, tiersOf } from '../harness/context-capture';
+
+/**
+ * These exercise the REAL `parseSystemPromptForDisplay` / `parseMessageBlocks` from
+ * `@n8n/api-types`. The observation block is extracted by that parser, so mocking it
+ * would make these pass against a shape the product never emits — fixtures therefore
+ * embed observations the way the agent actually does, as an `<observations>` element
+ * inside the system prompt.
+ */
+function step(system: string, stepNumber = 1, messages?: unknown[]): InstanceAiRunDebugStep {
+	return { stepNumber, input: messages ? { system, messages } : { system } };
+}
+
+function run(
+	runId: string,
+	startedAt: number,
+	steps: InstanceAiRunDebugStep[],
+): InstanceAiRunDebugResponse {
+	return { threadId: 'thread-1', runId, startedAt, steps, workflowCode: [] };
+}
+
+const msg = (text: string) => [{ role: 'user', content: text }];
+
+describe('captureContext', () => {
+	it('returns undefined when nothing was captured', () => {
+		expect(captureContext(undefined)).toBeUndefined();
+		expect(captureContext([])).toBeUndefined();
+		expect(captureContext([run('r1', 1, [])])).toBeUndefined();
+	});
+
+	it('extracts the observation block out of the system prompt', () => {
+		const captured = captureContext([
+			run('r1', 1, [
+				step('You build things.\n<observations>alerts go to #ops</observations>', 1, msg('hi')),
+			]),
+		]);
+		expect(captured?.turnEnd.observations).toBe('alerts go to #ops');
+		// Rendered as its own tier, so it must not leak back into the prompt text.
+		expect(captured?.turnEnd.systemPrompt).not.toContain('alerts go to #ops');
+	});
+
+	it('anchors the probe to the first step of the LAST run', () => {
+		const captured = captureContext([
+			run('r1', 1, [step('sys', 1, msg('an earlier session turn'))]),
+			run('r2', 2, [
+				step('sys', 1, msg('state as the request arrived')),
+				step('sys', 2, msg('what the agent produced while answering')),
+			]),
+		]);
+		expect(captured?.probe?.messageWindow).toContain('state as the request arrived');
+		expect(captured?.probe?.messageWindow).not.toContain('while answering');
+		// Turn end keeps the newest state, which is the point of having two anchors.
+		expect(captured?.turnEnd.messageWindow).toContain('while answering');
+	});
+
+	it('orders steps by stepNumber, not array position', () => {
+		const captured = captureContext([
+			run('r1', 1, [step('sys', 2, msg('later step')), step('sys', 1, msg('probe step'))]),
+		]);
+		expect(captured?.probe?.messageWindow).toContain('probe step');
+	});
+
+	// The bug this design exists to make impossible: a probe step that captured nothing
+	// must not silently borrow the end-of-turn state. Grading a retention claim against
+	// borrowed content counts what the agent produced WHILE ANSWERING as evidence that
+	// it remembered, and it fails toward PASS.
+	it('reports no probe at all when the graded turn captured nothing usable', () => {
+		const captured = captureContext([
+			run('r1', 1, [step('real prompt', 1, msg('real content'))]),
+			run('r2', 2, [{ stepNumber: 1, input: {} }]),
+		]);
+		expect(captured?.probe).toBeUndefined();
+		// The end-of-turn state is still reported — it is a different question.
+		expect(captured?.turnEnd.messageWindow).toContain('real content');
+	});
+
+	it('needs BOTH a prompt and a window before it will call a snapshot gradable', () => {
+		const promptOnly = captureContext([run('r1', 1, [step('a prompt with no window')])]);
+		expect(promptOnly?.probe).toBeUndefined();
+
+		const both = captureContext([run('r1', 1, [step('a prompt', 1, msg('and a window'))])]);
+		expect(both?.probe).toBeDefined();
+	});
+
+	it('keeps the newest non-empty value per tier at turn end', () => {
+		// A trailing step whose prompt failed to parse must not blank out the state we
+		// would otherwise report.
+		const captured = captureContext([
+			run('r1', 1, [step('good prompt', 1, msg('good window')), { stepNumber: 2, input: {} }]),
+		]);
+		expect(captured?.turnEnd.systemPrompt).toContain('good prompt');
+		expect(captured?.turnEnd.messageWindow).toContain('good window');
+	});
+
+	it('searches tool payloads, untruncated', () => {
+		// A value can arrive deep inside a tool result. This text is searched, never
+		// shown to a model, so there is no attention budget to protect.
+		const captured = captureContext([
+			run('r1', 1, [
+				step('sys', 1, [
+					{
+						role: 'assistant',
+						content: [
+							{
+								type: 'tool-result',
+								toolName: 'get_workflow',
+								output: { nodes: [{ name: 'Daily 06:00' }] },
+							},
+						],
+					},
+				]),
+			]),
+		]);
+		expect(captured?.turnEnd.messageWindow).toContain('Daily 06:00');
+	});
+});
+
+describe('snapshotFor', () => {
+	it('selects the snapshot the anchor names', () => {
+		const captured = captureContext([
+			run('r1', 1, [step('sys', 1, msg('probe')), step('sys', 2, msg('end'))]),
+		]);
+		expect(captured).toBeDefined();
+		expect(snapshotFor(captured!, 'probe')?.messageWindow).toContain('probe');
+		expect(snapshotFor(captured!, 'turn-end')?.messageWindow).toContain('end');
+	});
+});
+
+describe('tiersOf', () => {
+	it('names all three tiers even when the observation block is absent', () => {
+		const tiers = tiersOf({ observations: null, systemPrompt: 'p', messageWindow: 'w' });
+		expect(tiers.map(([name]) => name)).toEqual([
+			'observation block',
+			'message window',
+			'system prompt',
+		]);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/context-outcome.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/context-outcome.test.ts
@@ -1,0 +1,72 @@
+import { classifyContextOutcome } from '../run/context-outcome';
+import type { BuildExpectationResult } from '../types';
+
+const context = (pass: boolean, incomplete = false): BuildExpectationResult => ({
+	expectation: 'context contains "#ops-alerts"',
+	pass,
+	reason: 'r',
+	kind: 'context',
+	...(incomplete ? { incomplete: true } : {}),
+});
+
+const build = (pass: boolean, incomplete = false): BuildExpectationResult => ({
+	expectation: 'the workflow posts to the agreed channel',
+	pass,
+	reason: 'r',
+	...(incomplete ? { incomplete: true } : {}),
+});
+
+describe('classifyContextOutcome', () => {
+	it('names all four cells of the cross', () => {
+		expect(classifyContextOutcome([context(true), build(true)]).outcome).toBe('working');
+		expect(classifyContextOutcome([context(true), build(false)]).outcome).toBe('context-ignored');
+		expect(classifyContextOutcome([context(false), build(true)]).outcome).toBe(
+			'unattributed-success',
+		);
+		expect(classifyContextOutcome([context(false), build(false)]).outcome).toBe('retrieval-gap');
+	});
+
+	it('is unclassified without a graded claim on both axes', () => {
+		// Returning `working` for a case with no context claim would let it read as
+		// evidence that the context layer did something.
+		expect(classifyContextOutcome([build(true)]).outcome).toBe('unclassified');
+		expect(classifyContextOutcome([context(true)]).outcome).toBe('unclassified');
+		expect(classifyContextOutcome([]).outcome).toBe('unclassified');
+		expect(classifyContextOutcome(undefined).outcome).toBe('unclassified');
+	});
+
+	it('excludes incomplete verdicts from both axes', () => {
+		// "Not graded" counted either way would invent a finding out of a missing
+		// capture — here the only context claim is ungraded, so there is no cross.
+		const summary = classifyContextOutcome([context(false, true), build(true)]);
+		expect(summary.outcome).toBe('unclassified');
+		expect(summary.contextGraded).toBe(0);
+		expect(summary.buildGraded).toBe(1);
+	});
+
+	it('takes the strictest reading on each axis', () => {
+		// One failed context claim among several means the context was not present:
+		// averaging would turn the interesting cells into a shrug.
+		expect(classifyContextOutcome([context(true), context(false), build(true)]).outcome).toBe(
+			'unattributed-success',
+		);
+		expect(classifyContextOutcome([context(true), build(true), build(false)]).outcome).toBe(
+			'context-ignored',
+		);
+	});
+
+	it('reports the counts behind the verdict', () => {
+		const summary = classifyContextOutcome([
+			context(true),
+			context(false),
+			build(true),
+			build(true),
+		]);
+		expect(summary).toMatchObject({
+			contextPassed: 1,
+			contextGraded: 2,
+			buildPassed: 2,
+			buildGraded: 2,
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/write-eval-results.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/write-eval-results.test.ts
@@ -117,3 +117,59 @@ describe('writeEvalResults — notVerified serialization', () => {
 		);
 	});
 });
+
+// The context/build cross is only worth computing if it survives into the file the
+// dispatcher and the cost report read. Exercised through the real writer, so removing
+// the persist wiring fails here rather than leaving a classifier nothing calls.
+describe('writeEvalResults — contextOutcomePerRun serialization', () => {
+	function caseWithVerdicts(
+		verdicts: WorkflowTestCaseResult['buildExpectationResults'],
+	): WorkflowTestCaseResult {
+		return { ...runResult(scenarioCase(), { success: true }), buildExpectationResults: verdicts };
+	}
+
+	function writeCases(runs: WorkflowTestCaseResult[]): Array<Record<string, unknown>> {
+		const evaluation = aggregateResults([runs], 1);
+		const dir = mkdtempSync(join(tmpdir(), 'eval-results-context-'));
+		const { jsonPath } = writeEvalResults(
+			evaluation,
+			1234,
+			dir,
+			'exp-context',
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+		);
+		return jsonParse<{ testCases: Array<Record<string, unknown>> }>(readFileSync(jsonPath, 'utf8'))
+			.testCases;
+	}
+
+	it('emits the cross when a case graded both a context and a build claim', () => {
+		const [testCase] = writeCases([
+			caseWithVerdicts([
+				{ expectation: 'context contains "#ops"', pass: true, reason: 'r', kind: 'context' },
+				{ expectation: 'the workflow posts there', pass: false, reason: 'r' },
+			]),
+		]);
+
+		expect(testCase.contextOutcomePerRun).toEqual([
+			{
+				outcome: 'context-ignored',
+				contextPassed: 1,
+				contextGraded: 1,
+				buildPassed: 0,
+				buildGraded: 1,
+			},
+		]);
+	});
+
+	it('omits the key entirely for a case with no context claims', () => {
+		const [testCase] = writeCases([
+			caseWithVerdicts([{ expectation: 'the workflow posts there', pass: true, reason: 'r' }]),
+		]);
+
+		expect(testCase).not.toHaveProperty('contextOutcomePerRun');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -185,6 +185,10 @@ export const MCP_BUILD_KEY_SUPPORT: Record<
 	// transcript-less MCP builds there); declaring them needs no build-side setup.
 	processExpectations: 'supported',
 	outcomeExpectations: 'supported',
+	// Graded from the in-product run debug, which an MCP build never produces —
+	// `claude` drives the build, so there is no thread whose context state could be
+	// captured. A case declaring these would score them as ungraded every time.
+	contextAssertions: 'orchestrator-only',
 	// Forbidden legacy key — the schema rejects it at load, so it can never
 	// reach this check; classified only to keep the map schema-complete.
 	buildExpectations: 'supported',

--- a/packages/@n8n/instance-ai/evaluations/harness/context-assertions.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/context-assertions.ts
@@ -1,0 +1,101 @@
+import type { InstanceAiRunDebugResponse } from '@n8n/api-types';
+
+import { captureContext, snapshotFor, tiersOf } from './context-capture';
+import type { BuildExpectationResult, ContextAssertion } from '../types';
+
+/** No run debug at all — the thread produced nothing to search, so every claim is
+ *  unanswerable rather than false. */
+const NO_CAPTURE_REASON =
+	'not checked — no run debug was captured for this thread, so there was no context state to search';
+
+/** The graded turn's first step captured no prompt or window, so there is no probe
+ *  state. Grading against the end of the turn instead would count what the agent
+ *  produced while answering as evidence that it remembered. */
+const NO_PROBE_REASON =
+	'not checked — the graded turn captured no usable state at the probe, so a retention claim cannot be answered';
+
+function describe(assertion: ContextAssertion): string {
+	const verb = assertion.mustAppear === false ? 'excludes' : 'contains';
+	const when = assertion.anchor === 'turn-end' ? ' [by turn end]' : '';
+	const note = assertion.note ? ` (${assertion.note})` : '';
+	return `context ${verb} "${assertion.text}"${when}${note}`;
+}
+
+function ungraded(assertion: ContextAssertion, reason: string): BuildExpectationResult {
+	return {
+		expectation: describe(assertion),
+		pass: false,
+		reason,
+		incomplete: true,
+		kind: 'context',
+	};
+}
+
+/**
+ * Check whether exact values reached the agent's context, deterministically.
+ *
+ * Deliberately not LLM-graded. For a concrete value — a channel, a column name, a
+ * date, a parameter key — "was this string in what the model was sent" is a substring
+ * search over data already captured. It cannot hallucinate, costs nothing, and needs
+ * no rubric, which keeps the judge off the load-bearing path for the claims the A/B
+ * actually turns on.
+ *
+ * Matching is case-insensitive: casing drifts as content is re-rendered through tool
+ * payloads, and a casing difference is never the finding. Assert **atomic** values
+ * (`#ops-alerts`, `triggerAtHour`, `2026-03-01`) rather than formatted phrases
+ * (`triggerAtHour: 6`) — spacing and quoting vary by which tier carries the value.
+ */
+export function checkContextAssertions(
+	assertions: ContextAssertion[] | undefined,
+	runDebug: InstanceAiRunDebugResponse[] | undefined,
+): BuildExpectationResult[] {
+	if (!assertions || assertions.length === 0) return [];
+
+	const captured = captureContext(runDebug);
+	if (!captured) return assertions.map((a) => ungraded(a, NO_CAPTURE_REASON));
+
+	const hits = (anchor: 'probe' | 'turn-end', needle: string): string[] => {
+		const snapshot = snapshotFor(captured, anchor);
+		if (!snapshot) return [];
+		return tiersOf(snapshot)
+			.filter(([, text]) => text.toLowerCase().includes(needle))
+			.map(([tier]) => tier);
+	};
+
+	return assertions.map((assertion) => {
+		const anchor = assertion.anchor ?? 'probe';
+		if (!snapshotFor(captured, anchor)) return ungraded(assertion, NO_PROBE_REASON);
+
+		const needle = assertion.text.toLowerCase();
+		const found = hits(anchor, needle);
+		const mustAppear = assertion.mustAppear !== false;
+		const pass = mustAppear ? found.length > 0 : found.length === 0;
+		const at = anchor === 'turn-end' ? 'at the end of the turn' : 'at the probe';
+
+		// Only asked for a probe claim that missed: it separates "the agent never had
+		// this" from "the agent re-derived it while answering", which are different
+		// findings with different fixes. A turn-end claim is already reading that state.
+		const later = !pass && mustAppear && anchor === 'probe' ? hits('turn-end', needle) : [];
+
+		let reason: string;
+		if (!mustAppear) {
+			reason =
+				found.length === 0
+					? `correctly absent from every context tier ${at}`
+					: `still present ${at} in: ${found.join(', ')}`;
+		} else if (found.length > 0) {
+			// "Retained" is claimed only at the probe. A turn-end hit may be a fetch,
+			// which is a different and equally valid thing.
+			reason =
+				anchor === 'turn-end'
+					? `present by the end of the turn in: ${found.join(', ')} — carried in or fetched during it`
+					: `retained — present at the probe in: ${found.join(', ')}`;
+		} else if (later.length > 0) {
+			reason = `NOT retained — absent at the probe, but present by the end of the turn in: ${later.join(', ')}. The agent re-derived it rather than carrying it forward.`;
+		} else {
+			reason = 'not present at the probe, nor anywhere by the end of the turn';
+		}
+
+		return { expectation: describe(assertion), pass, reason, kind: 'context' };
+	});
+}

--- a/packages/@n8n/instance-ai/evaluations/harness/context-assertions.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/context-assertions.ts
@@ -1,7 +1,7 @@
 import type { InstanceAiRunDebugResponse } from '@n8n/api-types';
 
 import { captureContext, snapshotFor, tiersOf } from './context-capture';
-import type { BuildExpectationResult, ContextAssertion } from '../types';
+import type { BuildExpectationResult, ContextAnchor, ContextAssertion } from '../types';
 
 /** No run debug at all — the thread produced nothing to search, so every claim is
  *  unanswerable rather than false. */
@@ -54,13 +54,26 @@ export function checkContextAssertions(
 	const captured = captureContext(runDebug);
 	if (!captured) return assertions.map((a) => ungraded(a, NO_CAPTURE_REASON));
 
-	const hits = (anchor: 'probe' | 'turn-end', needle: string): string[] => {
+	// Lower-cased once per anchor, not once per assertion. The tiers are immutable for
+	// the life of this call and deliberately untruncated — they carry every tool payload
+	// — so re-casing them inside the loop would copy the whole context up to six times
+	// per assertion.
+	const prepared = new Map<ContextAnchor, Array<[string, string]>>();
+	const tiersLowered = (anchor: ContextAnchor): Array<[string, string]> => {
+		const cached = prepared.get(anchor);
+		if (cached) return cached;
 		const snapshot = snapshotFor(captured, anchor);
-		if (!snapshot) return [];
-		return tiersOf(snapshot)
-			.filter(([, text]) => text.toLowerCase().includes(needle))
-			.map(([tier]) => tier);
+		const lowered: Array<[string, string]> = snapshot
+			? tiersOf(snapshot).map(([tier, text]) => [tier, text.toLowerCase()])
+			: [];
+		prepared.set(anchor, lowered);
+		return lowered;
 	};
+
+	const hits = (anchor: ContextAnchor, needle: string): string[] =>
+		tiersLowered(anchor)
+			.filter(([, text]) => text.includes(needle))
+			.map(([tier]) => tier);
 
 	return assertions.map((assertion) => {
 		const anchor = assertion.anchor ?? 'probe';

--- a/packages/@n8n/instance-ai/evaluations/harness/context-capture.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/context-capture.ts
@@ -8,13 +8,9 @@ import { parseMessageBlocks, parseSystemPromptForDisplay } from '@n8n/api-types'
 
 import type { ContextAnchor } from '../types';
 
-/**
- * The three places a fact can be sitting when the model reads its context.
- *
- * Kept apart rather than concatenated so a verdict can say *where* a value was
- * found: surviving in the compressed observation block is a different claim about
- * the memory subsystem than still being visible in the raw message window.
- */
+/** The three places a fact can sit when the model reads its context. Kept apart, not
+ *  concatenated, so a verdict can say *where* a value was found: surviving compression
+ *  is a different claim than still being visible in the raw message window. */
 export interface ContextSnapshot {
 	/** The compressed observation block. `null` when compression never ran, which is
 	 *  itself a finding rather than a missing capture. */
@@ -24,13 +20,12 @@ export interface ContextSnapshot {
 }
 
 /**
- * One thread's context state at the two moments worth grading.
+ * The graded turn's context state at the two moments worth grading.
  *
- * `probe` is deliberately optional. A step whose prompt and window both failed to
- * parse cannot answer a retention question, and substituting the end-of-turn state
- * would report content the agent produced *while answering* as evidence that it
- * remembered — a pass-biased lie. Making the absence a type rather than a flag means
- * a caller has to decide what to do about it.
+ * `probe` is optional by design. A step whose prompt and window both failed to parse
+ * cannot answer a retention question, and substituting the end-of-turn state would count
+ * what the agent produced *while answering* as evidence that it remembered. Encoding the
+ * absence as a type rather than a flag forces the caller to decide.
  */
 export interface CapturedContext {
 	/** Absent when the graded turn's first step captured nothing gradable. */
@@ -64,9 +59,9 @@ function segmentText(segment: ReadableSegment): string {
 	}
 }
 
-/** Segments are the parsed form of `content`, so prefer them and fall back only when
- *  they render to nothing. Payloads are included untruncated: this text is searched,
- *  never shown to a model, so it has no attention budget to protect. */
+/** Segments are the parsed form of `content`, so prefer them and fall back when they
+ *  render to nothing. Payloads stay untruncated: this text is searched, never shown to a
+ *  model, so there is no attention budget to protect. */
 function blockText(block: ReadableContentBlock): string {
 	const fromSegments = (block.segments ?? [])
 		.map(segmentText)
@@ -95,39 +90,42 @@ function isGradable(snapshot: ContextSnapshot): boolean {
 }
 
 /**
- * Reduce a thread's captured run debug to the two anchored snapshots.
+ * Reduce a thread's captured run debug to the two anchored snapshots of its graded turn.
  *
- * The probe is anchored structurally — the first step of the last run — rather than
- * by matching the probe text. A follow-up turn is paraphrased by the user proxy, so
- * the message actually sent need not match the one the case authored.
+ * The turn is anchored structurally — the last run carrying steps — rather than by
+ * matching the probe text. A follow-up turn is paraphrased by the user proxy, so the
+ * message actually sent need not match the one the case authored.
  */
 export function captureContext(
 	runDebug: InstanceAiRunDebugResponse[] | undefined,
 ): CapturedContext | undefined {
 	if (!runDebug || runDebug.length === 0) return undefined;
 
+	// Both anchors read the SAME run — the last one carrying steps. Spanning the whole
+	// thread would mix tiers across turns, and a value left over from an earlier turn
+	// would surface as one the agent fetched during this one.
 	const runs = [...runDebug].sort((a, b) => a.startedAt - b.startedAt);
-	const turnEnd: ContextSnapshot = { observations: null, systemPrompt: '', messageWindow: '' };
-	let sawStep = false;
-
-	for (const run of runs) {
-		for (const step of run.steps ?? []) {
-			sawStep = true;
-			const snapshot = snapshotOf(step);
-			// Keep the newest non-empty value per tier: a trailing step whose prompt
-			// failed to parse must not blank out the state we would otherwise report.
-			if (snapshot.observations !== null) turnEnd.observations = snapshot.observations;
-			if (snapshot.systemPrompt.trim().length > 0) turnEnd.systemPrompt = snapshot.systemPrompt;
-			if (snapshot.messageWindow.trim().length > 0) turnEnd.messageWindow = snapshot.messageWindow;
-		}
-	}
-	if (!sawStep) return undefined;
-
 	const gradedRun = [...runs].reverse().find((run) => (run.steps ?? []).length > 0);
-	const firstStep = [...(gradedRun?.steps ?? [])].sort((a, b) => a.stepNumber - b.stepNumber)[0];
-	const probe = firstStep ? snapshotOf(firstStep) : undefined;
+	if (!gradedRun) return undefined;
 
-	return { probe: probe && isGradable(probe) ? probe : undefined, turnEnd };
+	const steps = [...(gradedRun.steps ?? [])].sort((a, b) => a.stepNumber - b.stepNumber);
+	const turnEnd: ContextSnapshot = { observations: null, systemPrompt: '', messageWindow: '' };
+	for (const step of steps) {
+		const snapshot = snapshotOf(step);
+		// Newest non-empty value per tier: a trailing step whose prompt failed to parse
+		// must not blank out the state we would otherwise report.
+		if (snapshot.observations !== null) turnEnd.observations = snapshot.observations;
+		if (snapshot.systemPrompt.trim().length > 0) turnEnd.systemPrompt = snapshot.systemPrompt;
+		if (snapshot.messageWindow.trim().length > 0) turnEnd.messageWindow = snapshot.messageWindow;
+	}
+
+	// Nothing usable in the graded turn means neither anchor can answer. An empty
+	// turn-end snapshot is gradable, so it would fail every claim with "not present" —
+	// a finding invented out of a capture failure.
+	if (!isGradable(turnEnd)) return undefined;
+
+	const probe = snapshotOf(steps[0]);
+	return { probe: isGradable(probe) ? probe : undefined, turnEnd };
 }
 
 export function snapshotFor(

--- a/packages/@n8n/instance-ai/evaluations/harness/context-capture.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/context-capture.ts
@@ -1,0 +1,147 @@
+import type {
+	InstanceAiRunDebugResponse,
+	InstanceAiRunDebugStep,
+	ReadableContentBlock,
+	ReadableSegment,
+} from '@n8n/api-types';
+import { parseMessageBlocks, parseSystemPromptForDisplay } from '@n8n/api-types';
+
+import type { ContextAnchor } from '../types';
+
+/**
+ * The three places a fact can be sitting when the model reads its context.
+ *
+ * Kept apart rather than concatenated so a verdict can say *where* a value was
+ * found: surviving in the compressed observation block is a different claim about
+ * the memory subsystem than still being visible in the raw message window.
+ */
+export interface ContextSnapshot {
+	/** The compressed observation block. `null` when compression never ran, which is
+	 *  itself a finding rather than a missing capture. */
+	observations: string | null;
+	systemPrompt: string;
+	messageWindow: string;
+}
+
+/**
+ * One thread's context state at the two moments worth grading.
+ *
+ * `probe` is deliberately optional. A step whose prompt and window both failed to
+ * parse cannot answer a retention question, and substituting the end-of-turn state
+ * would report content the agent produced *while answering* as evidence that it
+ * remembered — a pass-biased lie. Making the absence a type rather than a flag means
+ * a caller has to decide what to do about it.
+ */
+export interface CapturedContext {
+	/** Absent when the graded turn's first step captured nothing gradable. */
+	probe?: ContextSnapshot;
+	turnEnd: ContextSnapshot;
+}
+
+function stringify(payload: unknown): string {
+	if (payload === undefined) return '';
+	try {
+		return JSON.stringify(payload) ?? '';
+	} catch {
+		// Circular or otherwise unserialisable. Losing one payload beats losing the run.
+		return '';
+	}
+}
+
+/** Exhaustive over `ReadableSegment`, so a new segment kind is a type error here
+ *  rather than a value that silently stops being searchable. */
+function segmentText(segment: ReadableSegment): string {
+	switch (segment.type) {
+		case 'text':
+		case 'reasoning':
+			return segment.text;
+		case 'tool-call':
+			return `${segment.name} ${stringify(segment.payload)}`;
+		case 'tool-result':
+			return `${segment.name ?? ''} ${stringify(segment.payload)}`;
+		case 'json':
+			return `${segment.label ?? ''} ${stringify(segment.payload)}`;
+	}
+}
+
+/** Segments are the parsed form of `content`, so prefer them and fall back only when
+ *  they render to nothing. Payloads are included untruncated: this text is searched,
+ *  never shown to a model, so it has no attention budget to protect. */
+function blockText(block: ReadableContentBlock): string {
+	const fromSegments = (block.segments ?? [])
+		.map(segmentText)
+		.filter((text) => text.trim().length > 0)
+		.join('\n');
+	return fromSegments.length > 0 ? fromSegments : block.content;
+}
+
+function snapshotOf(step: InstanceAiRunDebugStep): ContextSnapshot {
+	const parsed = parseSystemPromptForDisplay(step.input?.system);
+	const join = (blocks: string[]) => blocks.filter((text) => text.trim().length > 0).join('\n\n');
+	return {
+		observations: parsed.observations,
+		systemPrompt: join(parsed.systemBlocks.map(blockText)),
+		messageWindow: join(
+			parseMessageBlocks(step.input?.messages).map((block) => `${block.role}\n${blockText(block)}`),
+		),
+	};
+}
+
+/** A snapshot can answer a question only if the model demonstrably had both a prompt
+ *  and a window. Observations are excluded: `null` there means compression did not
+ *  run, not that the capture failed. */
+function isGradable(snapshot: ContextSnapshot): boolean {
+	return snapshot.systemPrompt.trim().length > 0 && snapshot.messageWindow.trim().length > 0;
+}
+
+/**
+ * Reduce a thread's captured run debug to the two anchored snapshots.
+ *
+ * The probe is anchored structurally — the first step of the last run — rather than
+ * by matching the probe text. A follow-up turn is paraphrased by the user proxy, so
+ * the message actually sent need not match the one the case authored.
+ */
+export function captureContext(
+	runDebug: InstanceAiRunDebugResponse[] | undefined,
+): CapturedContext | undefined {
+	if (!runDebug || runDebug.length === 0) return undefined;
+
+	const runs = [...runDebug].sort((a, b) => a.startedAt - b.startedAt);
+	const turnEnd: ContextSnapshot = { observations: null, systemPrompt: '', messageWindow: '' };
+	let sawStep = false;
+
+	for (const run of runs) {
+		for (const step of run.steps ?? []) {
+			sawStep = true;
+			const snapshot = snapshotOf(step);
+			// Keep the newest non-empty value per tier: a trailing step whose prompt
+			// failed to parse must not blank out the state we would otherwise report.
+			if (snapshot.observations !== null) turnEnd.observations = snapshot.observations;
+			if (snapshot.systemPrompt.trim().length > 0) turnEnd.systemPrompt = snapshot.systemPrompt;
+			if (snapshot.messageWindow.trim().length > 0) turnEnd.messageWindow = snapshot.messageWindow;
+		}
+	}
+	if (!sawStep) return undefined;
+
+	const gradedRun = [...runs].reverse().find((run) => (run.steps ?? []).length > 0);
+	const firstStep = [...(gradedRun?.steps ?? [])].sort((a, b) => a.stepNumber - b.stepNumber)[0];
+	const probe = firstStep ? snapshotOf(firstStep) : undefined;
+
+	return { probe: probe && isGradable(probe) ? probe : undefined, turnEnd };
+}
+
+export function snapshotFor(
+	captured: CapturedContext,
+	anchor: ContextAnchor,
+): ContextSnapshot | undefined {
+	return anchor === 'turn-end' ? captured.turnEnd : captured.probe;
+}
+
+/** Tier name → text, in the order a verdict should name them. */
+export function tiersOf(snapshot: ContextSnapshot): Array<[string, string]> {
+	return [
+		['observation block', snapshot.observations ?? ''],
+		['message window', snapshot.messageWindow],
+		['system prompt', snapshot.systemPrompt],
+	];
+}

--- a/packages/@n8n/instance-ai/evaluations/harness/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/schema.ts
@@ -148,6 +148,30 @@ const evalTestCaseObjectSchema = z
 		 *  and from the rendered agent/config-eval context when the build produced one, so they also
 		 *  cover artifact existence/absence/content. Also run in prebuilt/MCP runs. Counted as units. */
 		outcomeExpectations: z.array(z.string().min(1)).optional(),
+		/** Exact values that must (or must not) be in the agent's captured context at a named
+		 *  moment. Checked by deterministic substring search with no LLM in the path, so these
+		 *  cannot hallucinate and need no rubric. Use them for concrete values (a channel, a
+		 *  column name, a date, a parameter key). Assert ATOMIC values, not formatted phrases:
+		 *  the same value is serialised with different spacing depending on which tier carries
+		 *  it. Needs run debug, so skipped in prebuilt/MCP runs. Counted as units. */
+		contextAssertions: z
+			.array(
+				z
+					.object({
+						text: z.string().min(1),
+						/** Omit or true → must appear. False → must NOT appear (a stale value that
+						 *  should have been dropped). */
+						mustAppear: z.boolean().optional(),
+						/** Shown in the verdict when the raw string is not self-explanatory. */
+						note: z.string().min(1).optional(),
+						/** `probe` (default) for retention claims; `turn-end` for a value the agent
+						 *  fetched during this turn. Retrieval happens after the probe, so a fetch
+						 *  claim graded at the probe can never pass. */
+						anchor: z.enum(['probe', 'turn-end']).optional(),
+					})
+					.strict(),
+			)
+			.optional(),
 		/**
 		 * Removed in favour of the process/outcome split. Declared as a forbidden key (rather
 		 * than dropped from the shape) so a legacy fixture fails loudly with a migration hint,
@@ -296,16 +320,18 @@ export const EvalTestCaseSchema = evalTestCaseObjectSchema
 		//
 		// A case needs at least one gradable unit. Execution scenarios grade the built workflow;
 		// process/outcome expectations grade the conversation, the workflow, and any non-workflow
-		// artifact (agent, config-eval) rendered into the judge context.
+		// artifact (agent, config-eval) rendered into the judge context; context assertions grade
+		// the captured context state.
 		if (
 			(c.executionScenarios?.length ?? 0) === 0 &&
 			(c.processExpectations?.length ?? 0) === 0 &&
-			(c.outcomeExpectations?.length ?? 0) === 0
+			(c.outcomeExpectations?.length ?? 0) === 0 &&
+			(c.contextAssertions?.length ?? 0) === 0
 		) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				message:
-					'a case needs at least one executionScenario, or a process/outcome expectation to grade it',
+					'a case needs at least one executionScenario, or a process/outcome expectation or context assertion to grade it',
 			});
 		}
 	});

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -41,6 +41,7 @@ import {
 } from '../harness/build-workflow';
 import { captureThreadRunDebug } from '../harness/capture-run-debug';
 import { effectiveTimeoutMs, runWorkflowChecks } from '../harness/cleanup';
+import { checkContextAssertions } from '../harness/context-assertions';
 import {
 	credentialSetupExpectationTexts,
 	runCredentialSetupChecks,
@@ -429,8 +430,10 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 		// Deterministic credential-setup verdicts, started EAGERLY: per-build
 		// cleanup deletes artifacts later, and a credential read that lost that
 		// race would report "not created" for a run that did create one.
-		const injected = build.credentialSetup
-			? runCredentialSetupChecks({
+		const deterministic: Array<Promise<BuildExpectationResult[]>> = [];
+		if (build.credentialSetup) {
+			deterministic.push(
+				runCredentialSetupChecks({
 					client,
 					facts: build.credentialSetup,
 					searchableRunText,
@@ -444,8 +447,26 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						credentialSetupExpectationTexts(build.credentialSetup?.credentialType),
 						`Credential-setup checks could not run: ${reason}`,
 					);
-				})
-			: undefined;
+				}),
+			);
+		}
+		// Context assertions read the run debug this build already stashes, so they wait
+		// on that promise rather than re-fetching. `stashRunDebug` swallows its own
+		// failures into `[]`, which the checker reports as ungraded — a dropped capture
+		// must not read as the asserted value being absent.
+		if (testCase.contextAssertions?.length) {
+			const assertions = testCase.contextAssertions;
+			const runDebug = build.threadId ? runDebugByThreadId.get(build.threadId) : undefined;
+			deterministic.push(
+				(runDebug ?? Promise.resolve(undefined)).then((debug) =>
+					checkContextAssertions(assertions, debug),
+				),
+			);
+		}
+		const injected =
+			deterministic.length > 0
+				? Promise.all(deterministic).then((lists) => lists.flat())
+				: undefined;
 		const { expectations, transcript, unjudged } = selectAuthorExpectations({
 			testCase,
 			transcript: build.transcript,

--- a/packages/@n8n/instance-ai/evaluations/run/context-outcome.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/context-outcome.ts
@@ -1,0 +1,71 @@
+import type { BuildExpectationResult } from '../types';
+
+/**
+ * Which of four situations a case landed in, from crossing the context verdict with
+ * the build verdict.
+ *
+ * A single pass rate collapses these into one number, and two of them have opposite
+ * fixes: `context-ignored` is a prompting problem, `retrieval-gap` is a retrieval
+ * problem. Building a retrieval system to fix the former would be wasted work, and
+ * the collapsed number cannot tell you which one you have.
+ */
+export type ContextOutcome =
+	/** The context carried what was needed and the build used it. */
+	| 'working'
+	/** The context lacked it and the build was right anyway — re-derived from live
+	 *  state, or the task did not really need it. A context feature contributed
+	 *  nothing here, so this is the cell that flatters a useless one. */
+	| 'unattributed-success'
+	/** The context carried it and the build still got it wrong. Not a retrieval problem. */
+	| 'context-ignored'
+	/** The context never carried it and the build was wrong. The retrieval problem. */
+	| 'retrieval-gap'
+	/** One of the two axes had nothing gradable, so the cross is undefined. */
+	| 'unclassified';
+
+export interface ContextOutcomeSummary {
+	outcome: ContextOutcome;
+	contextPassed: number;
+	contextGraded: number;
+	buildPassed: number;
+	buildGraded: number;
+}
+
+/**
+ * Classify one iteration's verdicts.
+ *
+ * Strictest reading on both axes: context counts as present only if *every* graded
+ * context claim passed, and the build counts as correct only if *every* graded build
+ * claim passed. A case usually carries several of each, and averaging them would turn
+ * the interesting cells into a shrug — "some context arrived and some of the build was
+ * right" names nothing actionable. Per-claim pairing would be better, and needs
+ * case-authoring support that does not exist yet.
+ *
+ * `incomplete` verdicts are excluded from both axes. They mean "not graded", so
+ * counting them either way would invent a finding out of a missing capture.
+ */
+export function classifyContextOutcome(
+	verdicts: BuildExpectationResult[] | undefined,
+): ContextOutcomeSummary {
+	const graded = (verdicts ?? []).filter((verdict) => !verdict.incomplete);
+	const context = graded.filter((verdict) => verdict.kind === 'context');
+	const build = graded.filter((verdict) => verdict.kind !== 'context');
+
+	const summary = {
+		contextPassed: context.filter((verdict) => verdict.pass).length,
+		contextGraded: context.length,
+		buildPassed: build.filter((verdict) => verdict.pass).length,
+		buildGraded: build.length,
+	};
+
+	// Without a graded claim on both axes there is no cross to report. Returning
+	// `working` here would let a case with no context claim at all read as evidence
+	// that the context layer did something.
+	if (context.length === 0 || build.length === 0) return { outcome: 'unclassified', ...summary };
+
+	const contextPresent = summary.contextPassed === context.length;
+	const buildCorrect = summary.buildPassed === build.length;
+
+	if (contextPresent) return { outcome: buildCorrect ? 'working' : 'context-ignored', ...summary };
+	return { outcome: buildCorrect ? 'unattributed-success' : 'retrieval-gap', ...summary };
+}

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -10,6 +10,7 @@ import { join } from 'path';
 
 import { aggregateResults } from './aggregator';
 import type { McpBuildSpend } from './build-orchestrator';
+import { classifyContextOutcome } from './context-outcome';
 import { parseTargetOutput, reshapeLangSmithRuns, type ReshapeRunRow } from './reshape';
 import { roundRobinCaseRows } from './rows';
 import { aggregateWorkflowChecks, statusMap } from '../binaryChecks/aggregate';
@@ -46,6 +47,22 @@ export function summarizeMcpBuildSpend(
 		totalCostUsd: Math.round(totalCost * 100) / 100,
 		avgTurns: Math.round((totalTurns / spend.length) * 10) / 10,
 	};
+}
+
+/**
+ * Per-iteration context/build cross, or `{}` when no iteration carried a gradable
+ * claim on both axes — a case with no context assertions then adds no key.
+ *
+ * Pure arithmetic over verdicts already in this file, so an existing run can be
+ * reclassified without re-running it.
+ */
+function contextOutcomeFields(runs: WorkflowTestCaseResult[]): {
+	contextOutcomePerRun?: Array<ReturnType<typeof classifyContextOutcome>>;
+} {
+	const classified = runs.map((run) => classifyContextOutcome(run.buildExpectationResults));
+	return classified.some((outcome) => outcome.outcome !== 'unclassified')
+		? { contextOutcomePerRun: classified }
+		: {};
 }
 
 interface AggregateMetrics {
@@ -421,6 +438,9 @@ export function writeEvalResults(
 				run.workflowChecks ? statusMap(run.workflowChecks) : null,
 			),
 			buildExpectationResultsPerRun: tc.runs.map((run) => run.buildExpectationResults ?? null),
+			// Which of the four context situations each iteration landed in, crossed from the
+			// verdicts above. Emitted only when at least one iteration could be classified.
+			...contextOutcomeFields(tc.runs),
 			buildExpectations: tc.buildExpectations.map((ea) => ({
 				expectation: ea.expectation,
 				passCount: ea.passCount,

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -259,6 +259,11 @@ export interface WorkflowTestCase {
 	 *  absence and content ("an agent was created and no workflow", "the agent instructions mention
 	 *  escalating refunds"). Also run in prebuilt/MCP runs. Counted toward the pass rate. */
 	outcomeExpectations?: string[];
+	/** Exact values that must (or must not) be in the agent's captured context at a
+	 *  named moment. Checked deterministically by substring search — no judge, so no
+	 *  rubric and no hallucination. Needs run debug, so skipped in prebuilt/MCP runs.
+	 *  Counted toward the pass rate. */
+	contextAssertions?: ContextAssertion[];
 	/**
 	 * Credentials visible to this case's build. Created for real before the build
 	 * and pinned as the thread's entire credential view — cases without this
@@ -311,6 +316,34 @@ export interface ExecutionScenarioResult {
 	incomplete?: boolean;
 }
 
+/**
+ * Which moment in the graded turn a context claim is judged against.
+ *
+ * `probe` — the state the model held when the request arrived, before it produced
+ * anything. Correct for RETENTION claims ("a fact from earlier survived to here"),
+ * because the agent restates facts as it works, so the end state would let a claim
+ * manufacture its own evidence.
+ *
+ * `turn-end` — the state once the turn is over. Correct for WITHIN-TURN RETRIEVAL
+ * claims ("the agent went and fetched the sibling workflow"). The request arrives and
+ * *then* tools are called, so a retrieval claim graded at the probe can never pass:
+ * the anchor excludes the very thing the claim is about.
+ */
+export type ContextAnchor = 'probe' | 'turn-end';
+
+/** One deterministic claim about the agent's captured context, checked by substring
+ *  search rather than by a judge. See `harness/context-assertions.ts`. */
+export interface ContextAssertion {
+	text: string;
+	/** Omit or true → must appear. False → must NOT appear (a stale value that should
+	 *  have been dropped). */
+	mustAppear?: boolean;
+	/** Shown in the verdict when the raw string is not self-explanatory. */
+	note?: string;
+	/** Defaults to `probe`. */
+	anchor?: ContextAnchor;
+}
+
 /** Verdict for one author-written build expectation. Scored as a unit in the
  *  pass rate alongside execution scenarios. */
 export interface BuildExpectationResult {
@@ -319,6 +352,12 @@ export interface BuildExpectationResult {
 	reason: string;
 	/** Judge returned no verdict (flaky/partial). Rendered neutrally, kept out of the count. */
 	incomplete?: boolean;
+	/** Set on verdicts graded against the agent's CONTEXT STATE rather than against the
+	 *  conversation or the built workflow. Present so a context miss is identifiable in
+	 *  the report and in `eval-results.json` without matching expectation strings back
+	 *  to the case file. Conversation-judged verdicts stay untagged, so absence means
+	 *  "process or outcome". */
+	kind?: 'context';
 	/** Who owns a failed expectation. Stamped where the verdicts are attached to
 	 *  a row (the only place that also knows whether the build died on infra). */
 	attribution?: EvalAttribution;


### PR DESCRIPTION
## Summary

Eval-harness infrastructure. No product code changes, no user-facing behaviour.

`processExpectations` and `outcomeExpectations` grade what the agent **did**. Neither can say what it **had**. A context change therefore shows up only as a pass rate: both arms can reach the same fact by different routes and score identically, so a difference cannot be attributed to the feature under test.

This PR adds the missing axis.

**`contextAssertions`** — exact values that must (or must not) be in the context the model was actually sent:

```jsonc
"contextAssertions": [
  { "text": "#ops-alerts", "note": "the channel agreed three turns ago" },
  { "text": "email_address", "mustAppear": false, "note": "renamed column, should have been dropped" },
  { "text": "Daily Sync", "anchor": "turn-end" }
]
```

Checked by case-insensitive substring search over the run debug the harness already captures. No judge in the path, so no rubric, no token cost, and nothing to hallucinate. Three tiers are searched and the verdict names which one hit: the compressed observation block, the message window, and the system prompt.

**`anchor`** is the feature that makes an A/B attributable:

| Anchor | State it reads | Answers |
| -- | -- | -- |
| `probe` (default) | what the model held when the request arrived | retention |
| `turn-end` | the state once the turn is over | retrieval |

The two are not interchangeable. The agent restates facts as it works, so grading retention at turn end lets a claim manufacture its own evidence. Tools are called *after* the request arrives, so grading retrieval at the probe can never pass. A probe claim that misses is re-checked at turn end, which separates "never had it" from "re-derived it while answering".

**`classifyContextOutcome`** crosses the context verdict with the build verdict:

| | build correct | build wrong |
| -- | -- | -- |
| **context had it** | `working` | `context-ignored` — a prompting problem |
| **context lacked it** | `unattributed-success` — the feature contributed nothing | `retrieval-gap` — a retrieval problem |

A single pass rate collapses all four. Two of them have opposite fixes, so the collapsed number cannot tell you which problem you have.

### Design notes

**A missing probe snapshot is a type, not a flag.** `CapturedContext.probe` is optional. A turn whose first step captured no prompt or window has no probe state, so assertions report "not checked" rather than grading against the end of the turn. Substituting that state would count what the agent produced *while answering* as evidence that it remembered — and it fails toward PASS, which is the direction that manufactures findings. A test verifies this by reintroducing the substitution.

**Reuses what the harness already has.** Run debug is captured by `harness/capture-run-debug.ts`. Verdicts ride the existing `injected` channel in `build-orchestrator.ts` used by the credential-setup checks — both are measurements rather than judgements, so neither goes through attribution. Wiring is 25 lines.

**No casts, no `any`.** `segmentText` is an exhaustive switch over the `ReadableSegment` union, so a new segment kind is a compile error rather than content that silently stops being searchable.

**Not supported for MCP builds.** An exhaustive key map in `cli/mcp-builder.ts` forces the decision: an MCP build produces no thread whose context could be captured, so `contextAssertions` is classified `orchestrator-only`.

### Scope

This is **part of** CONTEXT-102, not all of it. The ticket scopes five schema features plus the classifier and the two-arm cost report; this PR delivers `contextAssertions`, `anchor`, and the classifier.

Deferred to their own tickets:

| Deferred | Why not here |
| -- | -- |
| `seed.sessionBoundary`, `seed.priorRuns` | fixture setup, not grading — different axis, different files |
| two-arm cost report | reporting, not instrumentation; depends on the `contextOutcomePerRun` key this PR adds |
| `memoryExpectations` (LLM-judged) | the deterministic check is the better instrument for the claims these cases make; may not be needed at all |
| the eval cases that consume this | CONTEXT-103 |

**CONTEXT-102 has not yet been re-scoped in Linear** — it still describes all five features. That needs doing before this is treated as closing the ticket.

Supersedes #37440, which was a wholesale 7,653-line port of the prototype branch — 7.6x over the repo's 1,000-line size limit. This was rebuilt from master.

## How to test

The harness is inert until a case declares `contextAssertions`.

```bash
pnpm --filter @n8n/instance-ai... build
pnpm --filter @n8n/instance-ai typecheck
cd packages/@n8n/instance-ai && pnpm lint
pnpm vitest run evaluations/
```

Expected: build, typecheck and lint exit 0. Vitest reports 123 files and 1590 tests passed.

The three new test files cover the behaviour directly:

- `__tests__/context-capture.test.ts` — probe anchoring, tier extraction, the absent-probe rule
- `__tests__/context-assertions.test.ts` — verdicts, `mustAppear: false`, retained vs re-derived, declining to grade
- `__tests__/context-outcome.test.ts` — all four cells, strictness, `incomplete` handling

To confirm the tests are load-bearing rather than decorative, reintroduce the defect in `harness/context-capture.ts` and re-run — three tests fail:

```diff
- return { probe: probe && isGradable(probe) ? probe : undefined, turnEnd };
+ return { probe: probe && isGradable(probe) ? probe : turnEnd, turnEnd };
```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CONTEXT-102
- Parent: https://linear.app/n8n/issue/CONTEXT-84
- Partially unblocks https://linear.app/n8n/issue/CONTEXT-103 — it supplies `anchor`, but those cases also need `seed.sessionBoundary` and `seed.priorRuns`, so CONTEXT-103 stays blocked until the deferred ticket above lands

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


