### PR TITLE
test: Raise the vitest worker cap on single-package CI steps (no-changelog)

### DIFF
--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -75,12 +75,11 @@ jobs:
       - name: Test Unit (backend, except cli and nodes-base)
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
-      # Single package, so turbo's --concurrency has nothing to overlap and the
-      # default 50% cap leaves half the runner idle for the whole step.
+      # Left at the default 50%. Measured at 100%: CPU rose from 59% to 92% but
+      # the step got SLOWER (435s to 500s) and a timing-sensitive test timed
+      # out, so the extra forks buy contention, not throughput.
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
-        env:
-          VITEST_MAX_WORKERS: '100%'
         run: pnpm turbo test:unit:changed --filter=n8n --summarize
 
       - name: Send Test Stats
@@ -185,7 +184,8 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
-      # Single package — see the note on "Test Unit (cli, scoped)".
+      # Single package, so turbo's --concurrency has nothing to overlap and the
+      # default 50% cap leaves half the runner idle. Measured: 376s to 302s.
       - name: Test Nodes
         env:
           VITEST_MAX_WORKERS: '100%'

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -75,8 +75,12 @@ jobs:
       - name: Test Unit (backend, except cli and nodes-base)
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
+      # Single package, so turbo's --concurrency has nothing to overlap and the
+      # default 50% cap leaves half the runner idle for the whole step.
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
+        env:
+          VITEST_MAX_WORKERS: '100%'
         run: pnpm turbo test:unit:changed --filter=n8n --summarize
 
       - name: Send Test Stats
@@ -181,7 +185,10 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      # Single package — see the note on "Test Unit (cli, scoped)".
       - name: Test Nodes
+        env:
+          VITEST_MAX_WORKERS: '100%'
         run: pnpm turbo test:changed --filter=n8n-nodes-base --summarize
 
       - name: Send Test Stats

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -39,11 +39,15 @@ export const cjsPinAliases = (deps: string[], from: string = process.cwd()): Ali
  * `--concurrency` near the core count, and adapts to the runner size instead of
  * a hardcoded value. Off outside CI, so a single-package `pnpm test` keeps full
  * parallelism and behaviour is unchanged.
+ *
+ * A step that runs exactly one package gets no benefit from turbo concurrency,
+ * so half the cores stay idle for its whole duration. Such a step raises the
+ * cap with VITEST_MAX_WORKERS.
  */
 export const forkPoolOptions = (): InlineConfig => {
 	if (process.env.CI !== 'true') return {};
 	// Vitest accepts a percentage for `maxWorkers` (half of availableParallelism).
-	return { pool: 'forks', maxWorkers: '50%' };
+	return { pool: 'forks', maxWorkers: process.env.VITEST_MAX_WORKERS ?? '50%' };
 };
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,12 @@
 {
 	"globalEnv": ["CI", "BUILD_WITH_COVERAGE"],
-	"globalPassThroughEnv": ["CODECOV_TOKEN", "COVERAGE_ENABLED", "SENTRY_AUTH_TOKEN"],
+	"globalPassThroughEnv": [
+		"CODECOV_TOKEN",
+		"COVERAGE_ENABLED",
+		"SENTRY_AUTH_TOKEN",
+		// Worker count changes timing, never output, so it must not enter the hash.
+		"VITEST_MAX_WORKERS"
+	],
 	"boundaries": {
 		// `~icons/*` is a vite virtual module injected by unplugin-icons (design-system
 		// icon barrel), not a real package — declare it so boundaries doesn't flag it.


### PR DESCRIPTION
## Summary

**This is a measurement PR, not a proposal.** It exists to get CI data; the decision to keep, tune, or revert comes after the numbers.

`forkPoolOptions()` in `packages/@n8n/vitest-config/node.ts` caps every CI suite at `maxWorkers: '50%'`. That cap is right for the bulk turbo steps — `--concurrency=2` overlaps two suites, so 2 x 50% lands near the core count, exactly as the existing comment reasons.

It is wrong for a step that filters to a single package. Nothing overlaps, so the step runs on 2 of 4 cores for its whole duration.

Three steps run one package. Two are unit steps, and they are the largest in their jobs:

| step | filter | median step time |
|---|---|---|
| `Test Unit (cli, scoped)` | `--filter=n8n` | **522s** |
| `Test Nodes` | `--filter=n8n-nodes-base` | **342s** |

## Evidence that there is headroom

Blacksmith, 14 days, `blacksmith-4vcpu-ubuntu-2204`:

| job | cpu p50 | cpu p95 | frac >80% | mem p50 | mem p95 | OOM |
|---|---|---|---|---|---|---|
| Backend Unit Tests | **54%** | 65% | **0.06** | 23% | 26% | 0 |
| Nodes Unit Tests | **44%** | 57% | 0.03 | 12% | 15% | 0 |

Backend unit sits above 80% CPU for 6% of samples and never exceeds a quarter of memory. Nothing is starved — it is deliberately throttled.

## Change

Add a `VITEST_MAX_WORKERS` override, default unchanged at `50%`, and set it to `100%` on those two steps only. Every other suite keeps today's behaviour.

`Test Integration (cli, scoped)` is **deliberately excluded**. The workflow records that backend integration suites share DB sockets, ports and fixtures, which is why its bulk step runs at `--concurrency=1`. Raising its parallelism is a separate question with its own failure mode. One variable at a time.

## What to look for

Baseline is the 14d p50 above. Success is CPU rising toward saturation and wall time falling, with memory and stability unaffected.

| signal | baseline | expected | fails the experiment if |
|---|---|---|---|
| `Test Unit (cli, scoped)` step | 522s | materially lower | unchanged, meaning it is not CPU-bound |
| `Test Nodes` step | 342s | materially lower | unchanged |
| Backend Unit CPU p50 | 54% | 80-95% | still around 54% |
| Backend Unit memory peak | 23% | around 45% | above 75% |
| OOM events | 0 | 0 | any |
| test outcome | green | green | new failures or flakes |

Memory is the one to watch: doubling forks roughly doubles peak. From 23% that should land near 45%, but this run is what confirms it. For context, Lint already peaks at 94% memory with 9 OOM events in 14 days — untouched here, but it shows these runners do have a ceiling worth respecting.

## How the result gets read

```bash
blacksmith jobs steps <job_id>   # per-step timings
blacksmith jobs stats <job_id>   # CPU / memory / OOM
```

Compared against the 14d `blacksmith jobs aggregate` baseline. Several re-runs are needed before concluding — one sample per job is not enough when this job's own spread is 9.3m at p50 against 15.1m at p95.

## Two things this does NOT do

**It does not save money.** Billable minutes are wall-clock x vCPU regardless of utilisation, so 100% CPU for half the time costs the same as 50% for the full time. This is a latency change only.

**It does not move the PR feedback median on its own.** Unit tests finish around 13.8 min into a run whose critical path is E2E at 21.8 min. The value is making unit tests fast enough that they do not become the gate once the E2E and Docker paths are shortened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

