### PR TITLE
test: Fix intl.DateTimeFormatter bug in mailer tests

### DIFF
--- a/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
+++ b/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
@@ -191,7 +191,7 @@ describe('UserManagementMailer', () => {
 			expect(callBody).toContain('Test 123');
 			expect(callBody).toContain('aaa5');
 			expect(callBody).toContain('Jan Ostrówka');
-			expect(callBody).toMatch(/\d{1,2} [A-Z][a-z]{2} \d{4}/);
+			expect(callBody).toMatch(/\d{1,2} [A-Z][a-z]{2,3} \d{4}/);
 		});
 
 		it('falls back to the revoker email when no name is set', async () => {
@@ -241,7 +241,7 @@ describe('UserManagementMailer', () => {
 			const callBody = nodeMailer.sendMail.mock.calls[0][0].body as string;
 			expect(callBody).toContain('Claude Code');
 			expect(callBody).toContain('Jan Ostrówka');
-			expect(callBody).toMatch(/\d{1,2} [A-Z][a-z]{2} \d{4}/);
+			expect(callBody).toMatch(/\d{1,2} [A-Z][a-z]{2,3} \d{4}/);
 		});
 
 		it('should send project share notifications', async () => {


### PR DESCRIPTION
## Summary

A test case was using Regex to check a datetime string inside our email templates. This crashed as September's timestamp didn't fit the test case.

<img width="738" height="884" alt="image" src="https://github.com/user-attachments/assets/840a608b-c2e6-43db-b06e-cdea17a139ad" />


## How to test

```bash
cd packages/cli
pnpm test src/user-management/email/__tests__/user-management-mailer.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

