### PR TITLE
feat(ai-builder): Make AI Assistant capability-aware for agent changes

### DIFF
--- a/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
@@ -30,18 +30,20 @@ on the Agent.
 
 ## Supported channels & unsupported requests
 
-`list_agent_capabilities` returns every chat channel n8n Agents support, each
+`list-agent-capabilities` returns every chat channel n8n Agents support, each
 with `capabilities`, `useIntegrationWhen`, and `useNodeToolWhen`. It is the
 authoritative source the orchestrator can read before building; a channel
 absent from its result is unsupported for agents.
 
 When the user asks for a channel that is not supported (e.g. WhatsApp,
 Microsoft Teams), do not forward it to the builder as a channel to configure
-and do not improvise a workflow substitute. Explain the channel is unsupported
-for agents, offer the supported alternatives, and ask which to use — or whether
-the user wants a workflow path after the limitation is stated. Only forward a
-channel to `build-agent` once it is a supported type or the user has chosen an
-alternative.
+and do not fake it by adding the platform as an agent tool. Explain the channel
+is unsupported for agents, offer the supported alternatives, and ask which to
+use — or whether the user explicitly wants that unsupported platform as the
+conversation surface, in which case offer the `agent-entrypoint` workflow
+bridge described in Prerequisites (it connects the platform trigger to Message
+an Agent; it is not a channel config). Only forward a channel to `build-agent`
+once it is a supported type or the user has chosen an alternative.
 
 ## Faithful handoff
 

--- a/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
@@ -22,6 +22,27 @@ when the conversation already targets an Agent and the user is continuing that
 build. Do not rerun intent recognition for routine Agent edits or extensions.
 Use `build-agent` only for Agent artifacts.
 
+When the conversation opens from an existing Agent in the editor and the user
+asks to change its configuration or capabilities, that is an agent-anchored
+request — target that Agent and call `build-agent`. Do not reroute to
+`workflow-builder`, and do not spawn a workflow to satisfy a capability change
+on the Agent.
+
+## Supported channels & unsupported requests
+
+`list_agent_capabilities` returns every chat channel n8n Agents support, each
+with `capabilities`, `useIntegrationWhen`, and `useNodeToolWhen`. It is the
+authoritative source the orchestrator can read before building; a channel
+absent from its result is unsupported for agents.
+
+When the user asks for a channel that is not supported (e.g. WhatsApp,
+Microsoft Teams), do not forward it to the builder as a channel to configure
+and do not improvise a workflow substitute. Explain the channel is unsupported
+for agents, offer the supported alternatives, and ask which to use — or whether
+the user wants a workflow path after the limitation is stated. Only forward a
+channel to `build-agent` once it is a supported type or the user has chosen an
+alternative.
+
 ## Faithful handoff
 
 Treat `message` as a faithful handoff of the user's request, not an Agent build

--- a/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
@@ -260,7 +260,7 @@ continuity for that primitive.
 
 **Unsupported capabilities**: when the user names a specific channel or
 capability for an agent (e.g. "WhatsApp", "Teams"), call
-`list_agent_capabilities` before classifying. If the named channel is
+`list-agent-capabilities` before classifying. If the named channel is
 absent, it is unsupported for agents — do not classify the request as a
 workflow substitute, do not improvise workflow nodes to fake the channel,
 and do not claim it can be configured. Explain that it is unavailable for
@@ -365,7 +365,7 @@ instead.
   rules exist or this needs judgment-based triage.
 - "Build me an agent my team can @mention on WhatsApp to triage customer
   messages." -> **agent-anchored** (explicit agent artifact + chat
-  interaction), but call `list_agent_capabilities` first: WhatsApp is absent,
+  interaction), but call `list-agent-capabilities` first: WhatsApp is absent,
   so do not build. Explain WhatsApp is unsupported for agents, offer the
   supported chat channels the tool returned, with their
   `capabilities`, and ask which to use — or whether the user wants a
@@ -404,7 +404,7 @@ instead.
   workflow-anchored pipeline. A Chat Trigger workflow is correct only when
   chat is merely the manual trigger for a fixed graph.
 - Never improvise a workflow substitute for an unsupported agent channel or
-  capability. When the user names a channel not in `list_agent_capabilities`,
+  capability. When the user names a channel not in `list-agent-capabilities`,
   explain the limitation and offer supported alternatives — do not add
   workflow nodes that fake the channel or silently translate the request
   into a workflow change.

--- a/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
@@ -38,6 +38,10 @@ directly for out-of-scope.
 - The user's request or scenario prompt.
 - Whether the user is mid-build on an existing workflow or agent in this
   conversation — incremental requests default to extending that primitive.
+- Whether the editor/canvas context the conversation opened from shows an
+  existing **agent** or an existing **workflow** (or both). An existing agent
+  in context that the user asks to change is an agent-anchored request — see
+  Context continuity and Existing-agent modification.
 - Any explicit constraints about determinism, auditability, latency, cost,
   compliance, reusability, or allowed tools.
 - If the request is underspecified on an anchor-deciding axis, ask for the
@@ -236,6 +240,35 @@ Only cross into the other primitive when the
 incremental request itself carries its own anchor signal — and even then,
 prefer asking before switching paradigm if it isn't clearly load-bearing.
 
+**Existing-agent modification**: context continuity extends to an agent the
+user did not build in this conversation but opened in the editor. When the
+editor/canvas context shows an existing agent and the user asks to change,
+add, or remove its configuration or capabilities (instructions, model,
+tools, skills, tasks, channels, memory, sub-agents), classify
+**agent-anchored** and route to `build-agent` targeting that agent. Do not
+route to `workflow-builder`, and do not treat the request as a workflow
+change even when a workflow is also in context, unless the user explicitly
+names the workflow as the target. A capability the agent cannot have is
+still an agent-anchored request — handle it per Unsupported capabilities
+below, do not reclassify it as a workflow.
+
+**Mixed agent + workflow context**: when both an agent and a workflow are in
+context and the request is ambiguous about which one the user wants to
+change, classify **needs-clarification** and ask which target — do not
+assume the workflow. Once the user names the target, follow context
+continuity for that primitive.
+
+**Unsupported capabilities**: when the user names a specific channel or
+capability for an agent (e.g. "WhatsApp", "Teams"), call
+`list_agent_capabilities` before classifying. If the named channel is
+absent, it is unsupported for agents — do not classify the request as a
+workflow substitute, do not improvise workflow nodes to fake the channel,
+and do not claim it can be configured. Explain that it is unavailable for
+agents, offer the supported alternatives the tool returned (with their
+`capabilities`), and only build a workflow if the user explicitly chooses
+that path after the limitation is stated. This is an agent-anchored request
+that the agent cannot fully satisfy, not a workflow-anchored one.
+
 **Clarify triggers**: rule-based vs judgment-based (what defines "important"
 or "urgent"?), scope/autonomy (act on its own vs draft for review),
 interaction mode (one-shot vs chat). Do not clarify when the criterion could
@@ -330,6 +363,23 @@ instead.
 - "Tell me when something important happens with our shipments." ->
   **needs-clarification**: "important" is undefined; ask whether concrete
   rules exist or this needs judgment-based triage.
+- "Build me an agent my team can @mention on WhatsApp to triage customer
+  messages." -> **agent-anchored** (explicit agent artifact + chat
+  interaction), but call `list_agent_capabilities` first: WhatsApp is absent,
+  so do not build. Explain WhatsApp is unsupported for agents, offer the
+  supported chat channels (Slack, Telegram, Discord, Linear) with their
+  `capabilities`, and ask which to use — or whether the user wants a
+  workflow path instead. Do not improvise a workflow with a WhatsApp node
+  and do not claim the channel is configured.
+- (An existing agent is open in the editor.) "Make it also file a Linear
+  ticket when it can't resolve an issue." -> **agent-anchored**: the open
+  agent is the target; route to `build-agent` targeting that agent to add the
+  capability. Do not start a workflow build, even though a workflow could
+  also file a ticket — the user asked to change the agent.
+- (Both an agent and a workflow are open.) "Add a daily summary of new
+  signups to the data warehouse." -> **needs-clarification**: ask whether
+  the summary belongs to the agent (a scheduled task on it) or the workflow
+  (a new branch in the graph); do not assume the workflow.
 
 ## Gotchas
 
@@ -353,6 +403,11 @@ instead.
   *node* exists only for `embeds_other: true` steps inside a genuinely
   workflow-anchored pipeline. A Chat Trigger workflow is correct only when
   chat is merely the manual trigger for a fixed graph.
+- Never improvise a workflow substitute for an unsupported agent channel or
+  capability. When the user names a channel not in `list_agent_capabilities`,
+  explain the limitation and offer supported alternatives — do not add
+  workflow nodes that fake the channel or silently translate the request
+  into a workflow change.
 - Do not demote an explicitly requested agent to an embedded AI Agent step
   inside a workflow — workflow-anchored with `embeds_other: true` is for
   agent steps inside a pipeline the user described as a pipeline.

--- a/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
@@ -367,7 +367,7 @@ instead.
   messages." -> **agent-anchored** (explicit agent artifact + chat
   interaction), but call `list_agent_capabilities` first: WhatsApp is absent,
   so do not build. Explain WhatsApp is unsupported for agents, offer the
-  supported chat channels (Slack, Telegram, Discord, Linear) with their
+  supported chat channels the tool returned, with their
   `capabilities`, and ask which to use — or whether the user wants a
   workflow path instead. Do not improvise a workflow with a WhatsApp node
   and do not claim the channel is configured.

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -698,6 +698,7 @@ export type {
 	FolderSummary,
 	ServiceProxyConfig,
 	InstanceAiBuilderDelegate,
+	AgentCapabilitiesSummary,
 	BuilderDelegateSession,
 	BuilderTurnStream,
 	BuilderOpenSuspension,

--- a/packages/@n8n/instance-ai/src/tools/__tests__/index.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/index.test.ts
@@ -45,6 +45,10 @@ vi.mock('../orchestration/build-agent.tool', () => ({
 	createBuildAgentTool: vi.fn(() => ({ id: 'build-agent' })),
 }));
 
+vi.mock('../orchestration/list-agent-capabilities.tool', () => ({
+	createListAgentCapabilitiesTool: vi.fn(() => ({ id: 'list-agent-capabilities' })),
+}));
+
 vi.mock('../orchestration/complete-checkpoint.tool', () => ({
 	createCompleteCheckpointTool: vi.fn(() => ({ id: 'complete-checkpoint' })),
 }));
@@ -228,6 +232,15 @@ describe('domain tool construction', () => {
 		expect(ALWAYS_LOADED_TOOL_NAMES.has('mcp-servers')).toBe(true);
 	});
 
+	it('pairs list-agent-capabilities with build-agent in the always-loaded set', () => {
+		// Both are gated on the agents feature flag at module load time, so they
+		// must always be in or out together — the orchestrator needs to check
+		// support during intent recognition on the same footing as build-agent.
+		expect(ALWAYS_LOADED_TOOL_NAMES.has('list-agent-capabilities')).toBe(
+			ALWAYS_LOADED_TOOL_NAMES.has('build-agent'),
+		);
+	});
+
 	it('registers create-tasks but not the removed plan orchestration tool', () => {
 		const context = makeContext({
 			workflowTaskService: {},
@@ -246,6 +259,7 @@ describe('domain tool construction', () => {
 			makeContext({ domainContext: {} } as Partial<InstanceAiContext>) as never,
 		);
 		expect(withoutDelegate.has('build-agent')).toBe(false);
+		expect(withoutDelegate.has('list-agent-capabilities')).toBe(false);
 
 		const withDelegate = createOrchestrationTools(
 			makeContext({
@@ -254,6 +268,7 @@ describe('domain tool construction', () => {
 		);
 		expect(Object.fromEntries(withDelegate)).toMatchObject({
 			'build-agent': { id: 'build-agent' },
+			'list-agent-capabilities': { id: 'list-agent-capabilities' },
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/tools/index.ts
+++ b/packages/@n8n/instance-ai/src/tools/index.ts
@@ -41,6 +41,10 @@ const loadBuildAgentTool = lazyMod(
 	() =>
 		require('./orchestration/build-agent.tool') as typeof import('./orchestration/build-agent.tool'),
 );
+const loadListAgentCapabilitiesTool = lazyMod(
+	() =>
+		require('./orchestration/list-agent-capabilities.tool') as typeof import('./orchestration/list-agent-capabilities.tool'),
+);
 const loadGetSessionTool = lazyMod(
 	() =>
 		require('./orchestration/get-session.tool') as typeof import('./orchestration/get-session.tool'),
@@ -205,6 +209,10 @@ export function createOrchestrationTools(context: OrchestrationContext): Instanc
 		tools.push([
 			ORCHESTRATION_TOOL_IDS.BUILD_AGENT,
 			loadBuildAgentTool().createBuildAgentTool(context),
+		]);
+		tools.push([
+			ORCHESTRATION_TOOL_IDS.LIST_AGENT_CAPABILITIES,
+			loadListAgentCapabilitiesTool().createListAgentCapabilitiesTool(context),
 		]);
 		tools.push([DOMAIN_TOOL_IDS.AGENTS, loadAgentsTool().createAgentsTool(context)]);
 	}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
@@ -291,6 +291,8 @@ function createBuilderDelegate(
 
 		listAgents: async () => await Promise.resolve([]),
 
+		listAgentCapabilities: async () => await Promise.resolve([]),
+
 		resolveAgentName: async () => await Promise.resolve(undefined),
 	};
 }

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
@@ -291,7 +291,8 @@ function createBuilderDelegate(
 
 		listAgents: async () => await Promise.resolve([]),
 
-		listAgentCapabilities: async () => await Promise.resolve([]),
+		listAgentCapabilities: async () =>
+			await Promise.resolve({ channels: [], agentCapabilities: [], limitations: [] }),
 
 		resolveAgentName: async () => await Promise.resolve(undefined),
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/list-agent-capabilities.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/list-agent-capabilities.tool.test.ts
@@ -1,0 +1,72 @@
+import type { ChatIntegrationDescriptor } from '@n8n/api-types';
+import { mock } from 'vitest-mock-extended';
+
+import { executeTool } from '../../../__tests__/tool-test-utils';
+import type { InstanceAiBuilderDelegate, OrchestrationContext } from '../../../types';
+import { createListAgentCapabilitiesTool } from '../list-agent-capabilities.tool';
+
+function makeContext(delegate: InstanceAiBuilderDelegate | undefined): OrchestrationContext {
+	return {
+		domainContext: delegate ? { builderDelegate: delegate } : {},
+	} as unknown as OrchestrationContext;
+}
+
+const sampleChannels: ChatIntegrationDescriptor[] = [
+	{
+		type: 'slack',
+		label: 'Slack',
+		icon: 'slack',
+		credentialTypes: ['slackApi'],
+		capabilities: ['send messages'],
+		useIntegrationWhen: ['the agent should reply in Slack'],
+		useNodeToolWhen: ['only operating on Slack data'],
+	},
+	{
+		type: 'telegram',
+		label: 'Telegram',
+		icon: 'telegram',
+		credentialTypes: ['telegramApi'],
+	},
+];
+
+describe('list-agent-capabilities tool', () => {
+	it('returns the delegate channel list verbatim plus the agent-level limitations', async () => {
+		const delegate = mock<InstanceAiBuilderDelegate>();
+		delegate.listAgentCapabilities.mockResolvedValue(sampleChannels);
+
+		const tool = createListAgentCapabilitiesTool(makeContext(delegate));
+		const output = await executeTool<{
+			channels: ChatIntegrationDescriptor[];
+			limitations: string[];
+		}>(tool, {});
+
+		expect(delegate.listAgentCapabilities).toHaveBeenCalledWith();
+		expect(output.channels).toEqual(sampleChannels);
+		expect(output.limitations).toEqual([
+			'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
+			'Chat channels must come from this list — any other channel is unsupported.',
+		]);
+	});
+
+	it('throws when no builder delegate is wired (agents module inactive)', async () => {
+		const tool = createListAgentCapabilitiesTool(makeContext(undefined));
+		await expect(executeTool(tool, {})).rejects.toThrow(
+			'Agent capabilities are not available on this instance.',
+		);
+	});
+
+	it('returns an empty channel list when the registry has no public integrations', async () => {
+		const delegate = mock<InstanceAiBuilderDelegate>();
+		delegate.listAgentCapabilities.mockResolvedValue([]);
+
+		const tool = createListAgentCapabilitiesTool(makeContext(delegate));
+		const output = await executeTool<{
+			channels: ChatIntegrationDescriptor[];
+			limitations: string[];
+		}>(tool, {});
+
+		expect(output.channels).toEqual([]);
+		// Limitations are static guidance, present regardless of channel count.
+		expect(output.limitations).toHaveLength(2);
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/list-agent-capabilities.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/list-agent-capabilities.tool.test.ts
@@ -30,18 +30,22 @@ const sampleChannels: ChatIntegrationDescriptor[] = [
 ];
 
 describe('list-agent-capabilities tool', () => {
-	it('returns the delegate channel list verbatim plus the agent-level limitations', async () => {
+	it('returns the delegate channel list verbatim plus agent capabilities and limitations', async () => {
 		const delegate = mock<InstanceAiBuilderDelegate>();
 		delegate.listAgentCapabilities.mockResolvedValue(sampleChannels);
 
 		const tool = createListAgentCapabilitiesTool(makeContext(delegate));
 		const output = await executeTool<{
 			channels: ChatIntegrationDescriptor[];
+			agentCapabilities: string[];
 			limitations: string[];
 		}>(tool, {});
 
 		expect(delegate.listAgentCapabilities).toHaveBeenCalledWith();
 		expect(output.channels).toEqual(sampleChannels);
+		expect(output.agentCapabilities.length).toBeGreaterThan(0);
+		expect(output.agentCapabilities.some((c) => c.includes('MCP'))).toBe(true);
+		expect(output.agentCapabilities.some((c) => c.includes('scheduled tasks'))).toBe(true);
 		expect(output.limitations).toEqual([
 			'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
 			'Chat channels must come from this list — any other channel is unsupported.',
@@ -55,18 +59,20 @@ describe('list-agent-capabilities tool', () => {
 		);
 	});
 
-	it('returns an empty channel list when the registry has no public integrations', async () => {
+	it('returns an empty channel list but still surfaces agent capabilities when the registry has no public integrations', async () => {
 		const delegate = mock<InstanceAiBuilderDelegate>();
 		delegate.listAgentCapabilities.mockResolvedValue([]);
 
 		const tool = createListAgentCapabilitiesTool(makeContext(delegate));
 		const output = await executeTool<{
 			channels: ChatIntegrationDescriptor[];
+			agentCapabilities: string[];
 			limitations: string[];
 		}>(tool, {});
 
 		expect(output.channels).toEqual([]);
-		// Limitations are static guidance, present regardless of channel count.
+		// Agent capabilities and limitations are static guidance, present regardless of channel count.
+		expect(output.agentCapabilities.length).toBeGreaterThan(0);
 		expect(output.limitations).toHaveLength(2);
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/list-agent-capabilities.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/list-agent-capabilities.tool.test.ts
@@ -2,7 +2,11 @@ import type { ChatIntegrationDescriptor } from '@n8n/api-types';
 import { mock } from 'vitest-mock-extended';
 
 import { executeTool } from '../../../__tests__/tool-test-utils';
-import type { InstanceAiBuilderDelegate, OrchestrationContext } from '../../../types';
+import type {
+	AgentCapabilitiesSummary,
+	InstanceAiBuilderDelegate,
+	OrchestrationContext,
+} from '../../../types';
 import { createListAgentCapabilitiesTool } from '../list-agent-capabilities.tool';
 
 function makeContext(delegate: InstanceAiBuilderDelegate | undefined): OrchestrationContext {
@@ -29,27 +33,34 @@ const sampleChannels: ChatIntegrationDescriptor[] = [
 	},
 ];
 
+const sampleSummary: AgentCapabilitiesSummary = {
+	channels: sampleChannels,
+	agentCapabilities: [
+		'Call tools to take actions and query services.',
+		'Connect to MCP servers to expose external tool catalogs.',
+		'Run scheduled tasks without a chat trigger.',
+	],
+	limitations: [
+		'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
+		'Chat channels must come from this list — any other channel is unsupported.',
+	],
+};
+
 describe('list-agent-capabilities tool', () => {
-	it('returns the delegate channel list verbatim plus agent capabilities and limitations', async () => {
+	it('returns the delegate summary verbatim (channels, agentCapabilities, limitations)', async () => {
 		const delegate = mock<InstanceAiBuilderDelegate>();
-		delegate.listAgentCapabilities.mockResolvedValue(sampleChannels);
+		delegate.listAgentCapabilities.mockResolvedValue(sampleSummary);
 
 		const tool = createListAgentCapabilitiesTool(makeContext(delegate));
-		const output = await executeTool<{
-			channels: ChatIntegrationDescriptor[];
-			agentCapabilities: string[];
-			limitations: string[];
-		}>(tool, {});
+		const output = await executeTool<AgentCapabilitiesSummary>(tool, {});
 
 		expect(delegate.listAgentCapabilities).toHaveBeenCalledWith();
+		// The tool passes the delegate's summary through unchanged — it never
+		// hardcodes capability info, so the agents module stays the source of truth.
+		expect(output).toEqual(sampleSummary);
 		expect(output.channels).toEqual(sampleChannels);
-		expect(output.agentCapabilities.length).toBeGreaterThan(0);
-		expect(output.agentCapabilities.some((c) => c.includes('MCP'))).toBe(true);
-		expect(output.agentCapabilities.some((c) => c.includes('scheduled tasks'))).toBe(true);
-		expect(output.limitations).toEqual([
-			'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
-			'Chat channels must come from this list — any other channel is unsupported.',
-		]);
+		expect(output.agentCapabilities).toBe(sampleSummary.agentCapabilities);
+		expect(output.limitations).toBe(sampleSummary.limitations);
 	});
 
 	it('throws when no builder delegate is wired (agents module inactive)', async () => {
@@ -59,20 +70,21 @@ describe('list-agent-capabilities tool', () => {
 		);
 	});
 
-	it('returns an empty channel list but still surfaces agent capabilities when the registry has no public integrations', async () => {
+	it('passes an empty channel list through unchanged when the registry has no public integrations', async () => {
 		const delegate = mock<InstanceAiBuilderDelegate>();
-		delegate.listAgentCapabilities.mockResolvedValue([]);
+		const emptySummary: AgentCapabilitiesSummary = {
+			channels: [],
+			agentCapabilities: ['Call tools to take actions.'],
+			limitations: ['Chat channels must come from this list.'],
+		};
+		delegate.listAgentCapabilities.mockResolvedValue(emptySummary);
 
 		const tool = createListAgentCapabilitiesTool(makeContext(delegate));
-		const output = await executeTool<{
-			channels: ChatIntegrationDescriptor[];
-			agentCapabilities: string[];
-			limitations: string[];
-		}>(tool, {});
+		const output = await executeTool<AgentCapabilitiesSummary>(tool, {});
 
+		// The tool surfaces whatever the delegate returned, including an empty
+		// channel list, without substituting hardcoded capabilities.
+		expect(output).toEqual(emptySummary);
 		expect(output.channels).toEqual([]);
-		// Agent capabilities and limitations are static guidance, present regardless of channel count.
-		expect(output.agentCapabilities.length).toBeGreaterThan(0);
-		expect(output.limitations).toHaveLength(2);
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
@@ -1,5 +1,5 @@
 /**
- * list_agent_capabilities — read-only orchestration tool that exposes the
+ * list-agent-capabilities — read-only orchestration tool that exposes the
  * agents module's authoritative supported integrations (and
  * their builder guidance) to the Instance AI orchestrator because
  * the orchestrator cannot see the subagent builder's toolset.
@@ -40,16 +40,14 @@ export function createListAgentCapabilitiesTool(context: OrchestrationContext) {
 			'List what n8n Agents can do and the chat-channel integrations they support. ' +
 				"Returns each supported channel's `type`, `label`, supported credential types, " +
 				'and builder guidance (`capabilities`, `useIntegrationWhen`, `useNodeToolWhen`), ' +
-				'plus a brief `agentCapabilities` list of what an agent can do beyond chat ' +
-				'(call tools, attach workflows, connect to MCP servers, use skills, run ' +
-				'scheduled tasks, delegate to sub-agents, use memory and vector stores). ' +
+				'plus `agentCapabilities` (what an agent can do beyond chat) and `limitations` ' +
+				'(agent-level constraints to respect when planning a build). ' +
 				'Call this before building or modifying an agent whenever the user names a ' +
 				'specific channel or capability (e.g. WhatsApp, Teams): if the named channel ' +
-				'is absent, it is unsupported for agents — explain the limitation and offer the ' +
-				'listed alternatives instead of improvising a workflow substitute or claiming ' +
-				'it is configured. Also returns agent-level limitations (cannot create ' +
-				'workflows or data tables; channels must come from this list). Read-only; ' +
-				'channels and capabilities are configured via `build-agent`.',
+				'is absent from `channels`, it is unsupported for agents — explain the ' +
+				'limitation and offer the listed alternatives instead of improvising a ' +
+				'workflow substitute or claiming it is configured. Read-only; channels and ' +
+				'capabilities are configured via `build-agent`.',
 		)
 		.input(z.object({}))
 		.output(listAgentCapabilitiesOutputSchema)

--- a/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
@@ -1,0 +1,75 @@
+/**
+ * list_agent_capabilities — read-only orchestration tool that exposes the
+ * agents module's authoritative supported chat-channel integrations (and
+ * their builder guidance) to the Instance AI orchestrator.
+ *
+ * The orchestrator cannot see the agents-module builder's toolset, so it has
+ * no way to check whether a channel the user named (e.g. WhatsApp) is
+ * supported before committing to a build path. Without this tool the model
+ * either improvises a workflow substitute for an unsupported agent channel or
+ * delegates to `build-agent` and learns the limitation only after the builder
+ * rejects it. This tool projects the same `ChatIntegrationRegistry` list the
+ * builder's `list_integration_types` uses, so the registry stays the single
+ * source of truth and the orchestrator can explain unsupported channels and
+ * offer valid alternatives at intent time.
+ *
+ * Returns each supported channel's `type`, `label`, `credentialTypes`, and
+ * builder guidance (`capabilities`, `useIntegrationWhen`, `useNodeToolWhen`),
+ * plus a concise agent-level limitations note. Read-only; channels are
+ * configured via the builder (`build-agent`).
+ */
+import { Tool } from '@n8n/agents';
+import { z } from 'zod';
+
+import type { OrchestrationContext } from '../../types';
+import { ORCHESTRATION_TOOL_IDS } from '../tool-ids';
+
+const chatIntegrationDescriptorSchema = z.object({
+	type: z.string(),
+	label: z.string(),
+	icon: z.string(),
+	credentialTypes: z.array(z.string()),
+	capabilities: z.array(z.string()).optional(),
+	useIntegrationWhen: z.array(z.string()).optional(),
+	useNodeToolWhen: z.array(z.string()).optional(),
+});
+
+const listAgentCapabilitiesOutputSchema = z.object({
+	/** Supported chat-channel integrations; absence from this list means unsupported. */
+	channels: z.array(chatIntegrationDescriptorSchema),
+	/** Agent-level limitations the orchestrator must respect when planning an agent build. */
+	limitations: z.array(z.string()),
+});
+
+export function createListAgentCapabilitiesTool(context: OrchestrationContext) {
+	return new Tool(ORCHESTRATION_TOOL_IDS.LIST_AGENT_CAPABILITIES)
+		.description(
+			'List the chat-channel integrations n8n Agents currently support, with each ' +
+				"channel's `type`, `label`, supported credential types, and builder guidance " +
+				'(`capabilities`, `useIntegrationWhen`, `useNodeToolWhen`). Call this before ' +
+				'building or modifying an agent whenever the user names a specific channel or ' +
+				'capability (e.g. WhatsApp, Teams): if the named channel is absent, it is ' +
+				'unsupported for agents — explain the limitation and offer the listed ' +
+				'alternatives instead of improvising a workflow substitute or claiming it is ' +
+				'configured. Also returns agent-level limitations (cannot create workflows or ' +
+				'data tables; channels must come from this list). Read-only; channels are ' +
+				'configured via `build-agent`.',
+		)
+		.input(z.object({}))
+		.output(listAgentCapabilitiesOutputSchema)
+		.handler(async () => {
+			const delegate = context.domainContext?.builderDelegate;
+			if (!delegate) {
+				throw new Error('Agent capabilities are not available on this instance.');
+			}
+			const channels = await delegate.listAgentCapabilities();
+			return {
+				channels,
+				limitations: [
+					'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
+					'Chat channels must come from this list — any other channel is unsupported.',
+				],
+			};
+		})
+		.build();
+}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
@@ -1,17 +1,8 @@
 /**
  * list_agent_capabilities — read-only orchestration tool that exposes the
- * agents module's authoritative supported chat-channel integrations (and
- * their builder guidance) to the Instance AI orchestrator.
- *
- * The orchestrator cannot see the agents-module builder's toolset, so it has
- * no way to check whether a channel the user named (e.g. WhatsApp) is
- * supported before committing to a build path. Without this tool the model
- * either improvises a workflow substitute for an unsupported agent channel or
- * delegates to `build-agent` and learns the limitation only after the builder
- * rejects it. This tool projects the same `ChatIntegrationRegistry` list the
- * builder's `list_integration_types` uses, so the registry stays the single
- * source of truth and the orchestrator can explain unsupported channels and
- * offer valid alternatives at intent time.
+ * agents module's authoritative supported integrations (and
+ * their builder guidance) to the Instance AI orchestrator because
+ * the orchestrator cannot see the subagent builder's toolset.
  *
  * Returns each supported channel's `type`, `label`, `credentialTypes`, and
  * builder guidance (`capabilities`, `useIntegrationWhen`, `useNodeToolWhen`),
@@ -37,6 +28,8 @@ const chatIntegrationDescriptorSchema = z.object({
 const listAgentCapabilitiesOutputSchema = z.object({
 	/** Supported chat-channel integrations; absence from this list means unsupported. */
 	channels: z.array(chatIntegrationDescriptorSchema),
+	/** What an n8n Agent can do beyond chat channels — brief, for planning. */
+	agentCapabilities: z.array(z.string()),
 	/** Agent-level limitations the orchestrator must respect when planning an agent build. */
 	limitations: z.array(z.string()),
 });
@@ -44,16 +37,19 @@ const listAgentCapabilitiesOutputSchema = z.object({
 export function createListAgentCapabilitiesTool(context: OrchestrationContext) {
 	return new Tool(ORCHESTRATION_TOOL_IDS.LIST_AGENT_CAPABILITIES)
 		.description(
-			'List the chat-channel integrations n8n Agents currently support, with each ' +
-				"channel's `type`, `label`, supported credential types, and builder guidance " +
-				'(`capabilities`, `useIntegrationWhen`, `useNodeToolWhen`). Call this before ' +
-				'building or modifying an agent whenever the user names a specific channel or ' +
-				'capability (e.g. WhatsApp, Teams): if the named channel is absent, it is ' +
-				'unsupported for agents — explain the limitation and offer the listed ' +
-				'alternatives instead of improvising a workflow substitute or claiming it is ' +
-				'configured. Also returns agent-level limitations (cannot create workflows or ' +
-				'data tables; channels must come from this list). Read-only; channels are ' +
-				'configured via `build-agent`.',
+			'List what n8n Agents can do and the chat-channel integrations they support. ' +
+				"Returns each supported channel's `type`, `label`, supported credential types, " +
+				'and builder guidance (`capabilities`, `useIntegrationWhen`, `useNodeToolWhen`), ' +
+				'plus a brief `agentCapabilities` list of what an agent can do beyond chat ' +
+				'(call tools, attach workflows, connect to MCP servers, use skills, run ' +
+				'scheduled tasks, delegate to sub-agents, use memory and vector stores). ' +
+				'Call this before building or modifying an agent whenever the user names a ' +
+				'specific channel or capability (e.g. WhatsApp, Teams): if the named channel ' +
+				'is absent, it is unsupported for agents — explain the limitation and offer the ' +
+				'listed alternatives instead of improvising a workflow substitute or claiming ' +
+				'it is configured. Also returns agent-level limitations (cannot create ' +
+				'workflows or data tables; channels must come from this list). Read-only; ' +
+				'channels and capabilities are configured via `build-agent`.',
 		)
 		.input(z.object({}))
 		.output(listAgentCapabilitiesOutputSchema)
@@ -65,6 +61,15 @@ export function createListAgentCapabilitiesTool(context: OrchestrationContext) {
 			const channels = await delegate.listAgentCapabilities();
 			return {
 				channels,
+				agentCapabilities: [
+					'Call tools — n8n nodes, attached workflows, or custom code tools — to take actions and query services.',
+					'Connect to MCP servers to expose external tool catalogs.',
+					'Use skills — reusable instruction bundles — to extend its behavior.',
+					'Run scheduled tasks (e.g. a daily summary) without a chat trigger.',
+					'Delegate to published sub-agents for specialized work.',
+					'Use memory and vector stores to recall context and search documents.',
+					'Be triggered from a supported chat channel (see `channels`) or Preview.',
+				],
 				limitations: [
 					'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
 					'Chat channels must come from this list — any other channel is unsupported.',

--- a/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/list-agent-capabilities.tool.ts
@@ -58,23 +58,10 @@ export function createListAgentCapabilitiesTool(context: OrchestrationContext) {
 			if (!delegate) {
 				throw new Error('Agent capabilities are not available on this instance.');
 			}
-			const channels = await delegate.listAgentCapabilities();
-			return {
-				channels,
-				agentCapabilities: [
-					'Call tools — n8n nodes, attached workflows, or custom code tools — to take actions and query services.',
-					'Connect to MCP servers to expose external tool catalogs.',
-					'Use skills — reusable instruction bundles — to extend its behavior.',
-					'Run scheduled tasks (e.g. a daily summary) without a chat trigger.',
-					'Delegate to published sub-agents for specialized work.',
-					'Use memory and vector stores to recall context and search documents.',
-					'Be triggered from a supported chat channel (see `channels`) or Preview.',
-				],
-				limitations: [
-					'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
-					'Chat channels must come from this list — any other channel is unsupported.',
-				],
-			};
+			// Channels, agent-level capabilities, and limitations all come from the
+			// agents module via the delegate, so the orchestrator never hardcodes
+			// capability info and stays aligned as the module evolves.
+			return await delegate.listAgentCapabilities();
 		})
 		.build();
 }

--- a/packages/@n8n/instance-ai/src/tools/tool-ids.ts
+++ b/packages/@n8n/instance-ai/src/tools/tool-ids.ts
@@ -38,6 +38,7 @@ export const ORCHESTRATION_TOOL_IDS = {
 	REPORT_VERIFICATION_VERDICT: 'report-verification-verdict',
 	APPLY_WORKFLOW_CREDENTIALS: 'apply-workflow-credentials',
 	BUILD_AGENT: 'build-agent',
+	LIST_AGENT_CAPABILITIES: 'list-agent-capabilities',
 	GET_SESSION: 'get-session',
 } as const;
 
@@ -80,6 +81,12 @@ export const ALWAYS_LOADED_TOOL_NAMES = new Set<string>([
 	// costs 2 LLM rounds (search_tools + load_tool) and a prompt-cache rewrite
 	// on every agent build.
 	...(isAgentFeatureEnabled() ? [ORCHESTRATION_TOOL_IDS.BUILD_AGENT] : []),
+	// Paired with build-agent: the model must be able to check supported agent
+	// channels/capabilities during intent recognition — before committing to a
+	// path — so an unsupported channel (e.g. WhatsApp) is explained rather than
+	// improvised as a workflow. Deferring it costs a search_tools + load_tool
+	// round-trip and lets the model fall back to workflow assumptions first.
+	...(isAgentFeatureEnabled() ? [ORCHESTRATION_TOOL_IDS.LIST_AGENT_CAPABILITIES] : []),
 ]);
 
 export const CHECKPOINT_FOLLOW_UP_TOOL_NAMES = new Set<string>([

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -16,6 +16,7 @@ import type { AiGatewayNodeMeta } from '@n8n/ai-utilities/node-catalog';
 import type {
 	AgentJsonConfig,
 	AgentSkill,
+	ChatIntegrationDescriptor,
 	EvaluationMetric,
 	TaskList,
 	InstanceAiFileAttachment,
@@ -1062,6 +1063,11 @@ export interface InstanceAiBuilderDelegate {
 	listAgents(): Promise<
 		Array<{ agentId: string; name: string; published: boolean; updatedAt: string }>
 	>;
+	/** Supported chat-channel integrations with builder guidance, projected from the
+	 *  agents module's `ChatIntegrationRegistry` (the same source the builder's
+	 *  `list_integration_types` uses). Lets the orchestrator check support for a
+	 *  named channel before committing to a build path. */
+	listAgentCapabilities(): Promise<ChatIntegrationDescriptor[]>;
 	/** Current display name of the agent, or undefined when not found. */
 	resolveAgentName(agentId: string): Promise<string | undefined>;
 	/** Config + skills for the `agent-snapshot` trace event; `null` when the agent

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -1038,6 +1038,20 @@ export interface BuilderOpenSuspension {
  * suspend, which the caller cascades through its own suspend/resume so the
  * builder's questions survive a process restart.
  */
+
+/** Capabilities and limitations the orchestrator surfaces to plan an agent
+ *  build, sourced from the agents module via `InstanceAiBuilderDelegate.listAgentCapabilities`
+ *  so they stay aligned with the agent config schema and business rules as
+ * they evolve — the orchestrator never hardcodes these. */
+export interface AgentCapabilitiesSummary {
+	/** Supported chat-channel integrations; absence from this list means unsupported. */
+	channels: ChatIntegrationDescriptor[];
+	/** What an n8n Agent can do beyond chat channels — brief, for planning. */
+	agentCapabilities: string[];
+	/** Agent-level limitations the orchestrator must respect when planning a build. */
+	limitations: string[];
+}
+
 export interface InstanceAiBuilderDelegate {
 	/** `id` creates the agent under an id the frontend already minted for its
 	 *  unsaved artifact, so the chat and the editor converge on one agent. */
@@ -1063,11 +1077,11 @@ export interface InstanceAiBuilderDelegate {
 	listAgents(): Promise<
 		Array<{ agentId: string; name: string; published: boolean; updatedAt: string }>
 	>;
-	/** Supported chat-channel integrations with builder guidance, projected from the
-	 *  agents module's `ChatIntegrationRegistry` (the same source the builder's
-	 *  `list_integration_types` uses). Lets the orchestrator check support for a
-	 *  named channel before committing to a build path. */
-	listAgentCapabilities(): Promise<ChatIntegrationDescriptor[]>;
+	/** Capabilities and limitations the orchestrator surfaces to plan an agent
+	 *  build, sourced from the agents module via `listAgentCapabilities` so they
+	 *  stay aligned with the agent config schema and business rules as they
+	 *  evolve — the orchestrator never hardcodes these. */
+	listAgentCapabilities(): Promise<AgentCapabilitiesSummary>;
 	/** Current display name of the agent, or undefined when not found. */
 	resolveAgentName(agentId: string): Promise<string | undefined>;
 	/** Config + skills for the `agent-snapshot` trace event; `null` when the agent

--- a/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
@@ -25,6 +25,7 @@ import {
 	InstanceAiBuilderDelegateAdapterService,
 } from '../instance-ai-builder-delegate.adapter';
 import type { AgentConfigService } from '../agent-config.service';
+import { AGENT_CAPABILITIES, AGENT_LIMITATIONS } from '../agent-capabilities';
 import type { AgentIntegrationPersistenceService } from '../agent-integration-persistence.service';
 import { getAgentConfigHash } from '../utils/agent-config-hash';
 import type { AgentSkillsService } from '../agent-skills.service';
@@ -531,7 +532,7 @@ describe('InstanceAiBuilderDelegateAdapterService', () => {
 	});
 
 	describe('listAgentCapabilities', () => {
-		it('projects the agent-integration persistence service list verbatim', async () => {
+		it('returns channels from the registry plus the module agent capabilities and limitations', async () => {
 			const { delegate, agentIntegrationPersistenceService } = setup();
 			vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
 			const channels = [
@@ -547,7 +548,11 @@ describe('InstanceAiBuilderDelegateAdapterService', () => {
 			];
 			agentIntegrationPersistenceService.listChatIntegrations.mockReturnValue(channels);
 
-			await expect(delegate.listAgentCapabilities()).resolves.toEqual(channels);
+			await expect(delegate.listAgentCapabilities()).resolves.toEqual({
+				channels,
+				agentCapabilities: [...AGENT_CAPABILITIES],
+				limitations: [...AGENT_LIMITATIONS],
+			});
 			expect(agentIntegrationPersistenceService.listChatIntegrations).toHaveBeenCalledWith();
 		});
 

--- a/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
@@ -25,6 +25,7 @@ import {
 	InstanceAiBuilderDelegateAdapterService,
 } from '../instance-ai-builder-delegate.adapter';
 import type { AgentConfigService } from '../agent-config.service';
+import type { AgentIntegrationPersistenceService } from '../agent-integration-persistence.service';
 import { getAgentConfigHash } from '../utils/agent-config-hash';
 import type { AgentSkillsService } from '../agent-skills.service';
 import type { N8nMemory, N8nMemoryImpl } from '../integrations/n8n-memory';
@@ -38,6 +39,7 @@ function setup() {
 	const agentConfig = mock<AgentConfigService>();
 	const agentSkills = mock<AgentSkillsService>();
 	const credentialService = mock<InstanceAiCredentialService>();
+	const agentIntegrationPersistenceService = mock<AgentIntegrationPersistenceService>();
 
 	const service = new InstanceAiBuilderDelegateAdapterService(
 		agentsService,
@@ -46,6 +48,7 @@ function setup() {
 		agentThreadRepository,
 		agentConfig,
 		agentSkills,
+		agentIntegrationPersistenceService,
 	);
 
 	const user = mock<User>({ id: 'user-1' });
@@ -62,6 +65,7 @@ function setup() {
 		agentThreadRepository,
 		agentConfig,
 		agentSkills,
+		agentIntegrationPersistenceService,
 		credentialProvider,
 		credentialService,
 	};
@@ -520,6 +524,39 @@ describe('InstanceAiBuilderDelegateAdapterService', () => {
 
 			await expect(delegate.listAgents()).rejects.toThrow(ForbiddenError);
 			expect(agentsService.findByProjectId).not.toHaveBeenCalled();
+			expect(checkAccess.userHasScopes).toHaveBeenCalledWith(user, ['agent:read'], false, {
+				projectId: 'project-1',
+			});
+		});
+	});
+
+	describe('listAgentCapabilities', () => {
+		it('projects the agent-integration persistence service list verbatim', async () => {
+			const { delegate, agentIntegrationPersistenceService } = setup();
+			vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
+			const channels = [
+				{
+					type: 'slack',
+					label: 'Slack',
+					icon: 'slack',
+					credentialTypes: ['slackApi'],
+					capabilities: ['send messages'],
+					useIntegrationWhen: ['the agent should reply in Slack'],
+					useNodeToolWhen: ['only operating on Slack data'],
+				},
+			];
+			agentIntegrationPersistenceService.listChatIntegrations.mockReturnValue(channels);
+
+			await expect(delegate.listAgentCapabilities()).resolves.toEqual(channels);
+			expect(agentIntegrationPersistenceService.listChatIntegrations).toHaveBeenCalledWith();
+		});
+
+		it('rejects when the user lacks agent:read scope', async () => {
+			const { delegate, agentIntegrationPersistenceService, user } = setup();
+			vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
+
+			await expect(delegate.listAgentCapabilities()).rejects.toThrow(ForbiddenError);
+			expect(agentIntegrationPersistenceService.listChatIntegrations).not.toHaveBeenCalled();
 			expect(checkAccess.userHasScopes).toHaveBeenCalledWith(user, ['agent:read'], false, {
 				projectId: 'project-1',
 			});

--- a/packages/cli/src/modules/agents/agent-capabilities.ts
+++ b/packages/cli/src/modules/agents/agent-capabilities.ts
@@ -21,5 +21,5 @@ export const AGENT_CAPABILITIES = [
 /** Agent-level limitations the orchestrator must respect when planning a build. */
 export const AGENT_LIMITATIONS = [
 	'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
-	'Chat channels must come from this list — any other channel is unsupported.',
+	'Chat channels must come from the channels field of this result — any other channel is unsupported.',
 ] as const;

--- a/packages/cli/src/modules/agents/agent-capabilities.ts
+++ b/packages/cli/src/modules/agents/agent-capabilities.ts
@@ -1,0 +1,25 @@
+/**
+ * Agent-level capabilities and limitations the Instance AI orchestrator surfaces
+ * to plan agent builds. Lives in the agents module — the source of truth — so
+ * it stays aligned with the agent config schema and business rules as they
+ * evolve. The orchestrator reads these through the builder delegate
+ * (`listAgentCapabilities`), never hardcoding them, so a capability added or
+ * removed here flows to the orchestrator without a cross-package change.
+ */
+
+/** What an n8n Agent can do beyond chat channels — brief, for planning. */
+export const AGENT_CAPABILITIES = [
+	'Call tools — n8n nodes, attached workflows, or custom code tools — to take actions and query services.',
+	'Connect to MCP servers to expose external tool catalogs.',
+	'Use skills — reusable instruction bundles — to extend its behavior.',
+	'Run scheduled tasks (e.g. a daily summary) without a chat trigger.',
+	'Delegate to published sub-agents for specialized work.',
+	'Use memory and vector stores to recall context and search documents.',
+	'Be triggered from a supported chat channel (see `channels`) or Preview.',
+] as const;
+
+/** Agent-level limitations the orchestrator must respect when planning a build. */
+export const AGENT_LIMITATIONS = [
+	'Agents cannot create n8n workflows or data tables; attach existing workflows only.',
+	'Chat channels must come from this list — any other channel is unsupported.',
+] as const;

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -49,22 +49,6 @@ Teams):
 When the user asks to change the target agent's channels, prefer a supported
 one from the list; never invent a type.`;
 
-export const MODIFYING_EXISTING_AGENT_SECTION = `\
-## Modifying an existing agent
-
-When the user opens an existing agent and asks to change its configuration or
-capabilities — instructions, model, tools, skills, tasks, channels, memory, or
-sub-agents — target that agent through the agent-builder path. Use the bound
-\`agentRef\`/\`agentId\` (or adopt it via \`agentId\` when it was not built in this
-conversation) and call \`build-agent\` with a faithful handoff of the requested
-change.
-
-Do not spawn a workflow to satisfy a capability change on an existing agent,
-and do not treat a modification request as a workflow change even when a
-workflow is also in context. If the requested capability is an unsupported
-channel, apply "Supported channels & unsupported requests" instead of routing
-around it with a workflow.`;
-
 export function getConversationModeSection(agentPreviewPath: string): string {
 	return `\
 ## When To Build vs When To Converse
@@ -363,7 +347,6 @@ export function buildBuilderPrompt(ctx: BuilderPromptContext): string {
 		TARGET_AGENT_SECTION,
 		PREREQUISITES_SECTION,
 		SUPPORTED_CHANNELS_SECTION,
-		MODIFYING_EXISTING_AGENT_SECTION,
 		getConversationModeSection(agentPreviewPath),
 		getConfigMutationPrompt(),
 		getLlmSelectionPrompt(modelRecommendationsSection),

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -21,7 +21,49 @@ export const PREREQUISITES_SECTION = `\
 
 You cannot create n8n workflows or data tables. Attach existing workflows only via \`list_workflows\` and \`{ "type": "workflow", "workflowId": "<id>", "workflow": "<name>" }\`.
 
-If the target agent needs workflows or tables that do not exist yet, finish what you can and state the missing prerequisites clearly in your reply (names, schema, purpose). Do not ask the user to create them in this chat.`;
+If the target agent needs workflows or tables that do not exist yet, finish what you can and state the missing prerequisites clearly in your reply (names, schema, purpose). Do not ask the user to create them in this chat.
+
+\`list_integration_types\` is the authoritative source of supported chat channels — any channel it does not return is unsupported for agents. See "Supported channels & unsupported requests" below.`;
+
+export const SUPPORTED_CHANNELS_SECTION = `\
+## Supported channels & unsupported requests
+
+\`list_integration_types\` returns every chat channel n8n Agents support, each with
+\`capabilities\`, \`useIntegrationWhen\`, and \`useNodeToolWhen\`. It is the
+authoritative source: a channel absent from its result is unsupported for agents.
+
+When the user asks for a channel that is not supported (e.g. WhatsApp, Microsoft
+Teams):
+
+- Do not add it to \`integrations\`, do not draft it, and do not call
+  \`configure_channel\` or \`finish_setup\` with it. Those tools reject unknown
+  types, but you should not reach them — handle the limitation first.
+- Do not improvise a workflow substitute (e.g. a WhatsApp/Twilio node in a
+  workflow) and do not add unrelated workflow nodes to fake the channel.
+- Do not claim the channel is configured or available.
+- Explain that the channel is not supported for agents, list the supported
+  alternatives returned by \`list_integration_types\` with their \`capabilities\`,
+  and ask which one to use instead — or whether the user wants a workflow path
+  after the limitation is stated.
+
+When the user asks to change the target agent's channels, prefer a supported
+one from the list; never invent a type.`;
+
+export const MODIFYING_EXISTING_AGENT_SECTION = `\
+## Modifying an existing agent
+
+When the user opens an existing agent and asks to change its configuration or
+capabilities — instructions, model, tools, skills, tasks, channels, memory, or
+sub-agents — target that agent through the agent-builder path. Use the bound
+\`agentRef\`/\`agentId\` (or adopt it via \`agentId\` when it was not built in this
+conversation) and call \`build-agent\` with a faithful handoff of the requested
+change.
+
+Do not spawn a workflow to satisfy a capability change on an existing agent,
+and do not treat a modification request as a workflow change even when a
+workflow is also in context. If the requested capability is an unsupported
+channel, apply "Supported channels & unsupported requests" instead of routing
+around it with a workflow.`;
 
 export function getConversationModeSection(agentPreviewPath: string): string {
 	return `\
@@ -320,6 +362,8 @@ export function buildBuilderPrompt(ctx: BuilderPromptContext): string {
 		'You are an expert agent builder. You help users create and configure AI agents by writing raw JSON configuration and building custom tools.',
 		TARGET_AGENT_SECTION,
 		PREREQUISITES_SECTION,
+		SUPPORTED_CHANNELS_SECTION,
+		MODIFYING_EXISTING_AGENT_SECTION,
 		getConversationModeSection(agentPreviewPath),
 		getConfigMutationPrompt(),
 		getLlmSelectionPrompt(modelRecommendationsSection),

--- a/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/external-services.skill.ts
@@ -159,7 +159,13 @@ The \`integrations\` array controls how the target agent is triggered.
 
 ### Gotchas
 
-- Chat integration types must come from \`list_integration_types\`.
+- Chat integration types must come from \`list_integration_types\`. A channel
+  absent from its result is unsupported for agents — never invent a type, never
+  draft or configure it, and never substitute a workflow node (e.g. a
+  WhatsApp/Twilio node) to fake an unsupported chat channel. Instead, explain
+  the channel is unsupported, offer the supported alternatives the tool
+  returned with their \`capabilities\`, and ask which to use (or whether the
+  user wants a workflow path after the limitation is stated).
 - Do not add a chat integration just because the agent needs CRUD or notifications
   for that product. Resolve the callable capability through \`resolve_integration\`
   unless the product itself is the chat/trigger context.

--- a/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
+++ b/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
@@ -17,6 +17,7 @@ import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
 import { AgentConfigService } from './agent-config.service';
+import { AgentIntegrationPersistenceService } from './agent-integration-persistence.service';
 import { AgentSkillsService } from './agent-skills.service';
 import { AgentsService } from './agents.service';
 import { AgentsBuilderService } from './builder/agents-builder.service';
@@ -96,6 +97,7 @@ export class InstanceAiBuilderDelegateAdapterService {
 		private readonly agentThreadRepository: AgentThreadRepository,
 		private readonly agentConfig: AgentConfigService,
 		private readonly agentSkills: AgentSkillsService,
+		private readonly agentIntegrationPersistenceService: AgentIntegrationPersistenceService,
 	) {}
 
 	/** Builder session options for the sub-agent surface: appends the sub-agent prompt rules. */
@@ -205,6 +207,13 @@ export class InstanceAiBuilderDelegateAdapterService {
 					published: agent.activeVersionId !== null,
 					updatedAt: agent.updatedAt.toISOString(),
 				}));
+			},
+
+			listAgentCapabilities: async () => {
+				await assertProjectScope('agent:read');
+				// Same source the builder's `list_integration_types` projects, so the
+				// registry stays the single source of truth as channels are added.
+				return this.agentIntegrationPersistenceService.listChatIntegrations();
 			},
 
 			resolveAgentName: async (agentId) => {

--- a/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
+++ b/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
@@ -17,6 +17,7 @@ import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
 import { AgentConfigService } from './agent-config.service';
+import { AGENT_CAPABILITIES, AGENT_LIMITATIONS } from './agent-capabilities';
 import { AgentIntegrationPersistenceService } from './agent-integration-persistence.service';
 import { AgentSkillsService } from './agent-skills.service';
 import { AgentsService } from './agents.service';
@@ -211,9 +212,17 @@ export class InstanceAiBuilderDelegateAdapterService {
 
 			listAgentCapabilities: async () => {
 				await assertProjectScope('agent:read');
-				// Same source the builder's `list_integration_types` projects, so the
-				// registry stays the single source of truth as channels are added.
-				return this.agentIntegrationPersistenceService.listChatIntegrations();
+				// Channels come from the registry (same source the builder's
+				// `list_integration_types` projects); agent-level capabilities and
+				// limitations come from this module's constants, so the registry
+				// and the agent config schema stay the single sources of truth as
+				// channels, tools, or limits are added or removed.
+				const channels = this.agentIntegrationPersistenceService.listChatIntegrations();
+				return {
+					channels,
+					agentCapabilities: [...AGENT_CAPABILITIES],
+					limitations: [...AGENT_LIMITATIONS],
+				};
 			},
 
 			resolveAgentName: async (agentId) => {


### PR DESCRIPTION
## Summary
Makes the AI Assistant capability-aware for agent changes so it stops defaulting to workflow-first assumptions when the intent is to create or modify an agent, and handles unsupported agent channels (e.g. WhatsApp, Teams) at intent time instead of after delegating to the builder.
Two parts:
- **Expose the agents module's authoritative capabilities to Instance AI.** Adds a new  read-only orchestration tool `list_agent_capabilities` that surfaces the supported  chat-channel integrations (type, label, credential types, and builder guidance) plus a  brief list of what an agent can do beyond chat (call tools, attach workflows, connect to  MCP servers, use skills, run scheduled tasks, delegate to sub-agents, use memory and  vector stores) and the agent-level limitations (cannot create workflows or data tables;  channels must come from the list). It's always-loaded alongside `build-agent` (gated on  the agents module) so the orchestrator can check a named channel before building instead  of improvising a workflow substitute or claiming an unsupported channel is configured.  
- **Harden the intent-recognition and agent-builder guidance** so the LLM routes  correctly: existing-agent modification requests go to the agent-builder path (not a new  workflow), mixed agent+workflow contexts get clarified, and unsupported channels are   explained with the listed alternatives rather than worked around. 

Also adds t**hree Instance AI intent-resolution eval cases** pushed to the LangTracer `agents`  suite (ids 640–642).

## How to test
  1. Open the AI Assistant.
  2. Ask it to build an agent on an **unsupported** channel, e.g. "Create an agent that     replies to WhatsApp messages." Expect: the assistant calls `list_agent_capabilities`,     explains WhatsApp isn't supported, and offers the listed alternatives (Slack,     Telegram, Linear, Discord) instead of building a workflow substitute.
  3. Open an existing agent and ask to modify it, e.g. "Add a daily summary task."     Expect: the change is routed to the agent-builder path against the existing agent,     not a new workflow.
  4. In a fresh thread with no canvas context, ask something that could be either, e.g.     "Summarize new bugs and post them." Expect: the assistant clarifies whether you want     an agent (chat-triggered / scheduled) or a workflow rather than silently picking one.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AGENT-698

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that 
needs to be backported)


