### PR TITLE
test: Measure cli worker cap at 75 percent (no-changelog)

### DIFF
--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -75,12 +75,11 @@ jobs:
       - name: Test Unit (backend, except cli and nodes-base)
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
-      # Single package, so turbo's --concurrency has nothing to overlap and the
-      # default 50% cap leaves half the runner idle for the whole step.
+      # Left at the default 50%. Measured at 100%: CPU rose from 59% to 92% but
+      # the step got SLOWER (435s to 500s) and a timing-sensitive test timed
+      # out, so the extra forks buy contention, not throughput.
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
-        env:
-          VITEST_MAX_WORKERS: '100%'
         run: pnpm turbo test:unit:changed --filter=n8n --summarize
 
       - name: Send Test Stats
@@ -185,7 +184,8 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
-      # Single package — see the note on "Test Unit (cli, scoped)".
+      # Single package, so turbo's --concurrency has nothing to overlap and the
+      # default 50% cap leaves half the runner idle. Measured: 376s to 302s.
       - name: Test Nodes
         env:
           VITEST_MAX_WORKERS: '100%'

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -75,11 +75,11 @@ jobs:
       - name: Test Unit (backend, except cli and nodes-base)
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
-      # Left at the default 50%. Measured at 100%: CPU rose from 59% to 92% but
-      # the step got SLOWER (435s to 500s) and a timing-sensitive test timed
-      # out, so the extra forks buy contention, not throughput.
+      # EXPERIMENT ARM: cli at 75%.
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
+        env:
+          VITEST_MAX_WORKERS: '75%'
         run: pnpm turbo test:unit:changed --filter=n8n --summarize
 
       - name: Send Test Stats

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -75,8 +75,12 @@ jobs:
       - name: Test Unit (backend, except cli and nodes-base)
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
+      # Single package, so turbo's --concurrency has nothing to overlap and the
+      # default 50% cap leaves half the runner idle for the whole step.
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
+        env:
+          VITEST_MAX_WORKERS: '100%'
         run: pnpm turbo test:unit:changed --filter=n8n --summarize
 
       - name: Send Test Stats
@@ -181,7 +185,10 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      # Single package — see the note on "Test Unit (cli, scoped)".
       - name: Test Nodes
+        env:
+          VITEST_MAX_WORKERS: '100%'
         run: pnpm turbo test:changed --filter=n8n-nodes-base --summarize
 
       - name: Send Test Stats

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -39,11 +39,15 @@ export const cjsPinAliases = (deps: string[], from: string = process.cwd()): Ali
  * `--concurrency` near the core count, and adapts to the runner size instead of
  * a hardcoded value. Off outside CI, so a single-package `pnpm test` keeps full
  * parallelism and behaviour is unchanged.
+ *
+ * A step that runs exactly one package gets no benefit from turbo concurrency,
+ * so half the cores stay idle for its whole duration. Such a step raises the
+ * cap with VITEST_MAX_WORKERS.
  */
 export const forkPoolOptions = (): InlineConfig => {
 	if (process.env.CI !== 'true') return {};
 	// Vitest accepts a percentage for `maxWorkers` (half of availableParallelism).
-	return { pool: 'forks', maxWorkers: '50%' };
+	return { pool: 'forks', maxWorkers: process.env.VITEST_MAX_WORKERS ?? '50%' };
 };
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,12 @@
 {
 	"globalEnv": ["CI", "BUILD_WITH_COVERAGE"],
-	"globalPassThroughEnv": ["CODECOV_TOKEN", "COVERAGE_ENABLED", "SENTRY_AUTH_TOKEN"],
+	"globalPassThroughEnv": [
+		"CODECOV_TOKEN",
+		"COVERAGE_ENABLED",
+		"SENTRY_AUTH_TOKEN",
+		// Worker count changes timing, never output, so it must not enter the hash.
+		"VITEST_MAX_WORKERS"
+	],
 	"boundaries": {
 		// `~icons/*` is a vite virtual module injected by unplugin-icons (design-system
 		// icon barrel), not a real package — declare it so boundaries doesn't flag it.


### PR DESCRIPTION
Experiment arm for #37466 — do not merge, will be closed once measured.

Identical to #37466 except `Test Unit (cli, scoped)` runs at `VITEST_MAX_WORKERS: '75%'`. Carries the same `vitest-config` change so the affected-package fan-out, and therefore the cli test scope, matches the other arms.

Separate PR because CI uses `concurrency: cancel-in-progress` keyed on PR number — arms on the same PR would cancel each other, arms on different PRs run in parallel.

Measuring `Test Unit (cli, scoped)` duration plus CPU mean/p95 windowed to that step.

| arm | control | 100% (run 1) |
|---|---|---|
| cli step | 435s, cpu 59% | 500s, cpu 92%, 1 timeout |


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

