### PR TITLE
test: Measure control arm with default worker caps (no-changelog)

### DIFF
--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -39,11 +39,15 @@ export const cjsPinAliases = (deps: string[], from: string = process.cwd()): Ali
  * `--concurrency` near the core count, and adapts to the runner size instead of
  * a hardcoded value. Off outside CI, so a single-package `pnpm test` keeps full
  * parallelism and behaviour is unchanged.
+ *
+ * A step that runs exactly one package gets no benefit from turbo concurrency,
+ * so half the cores stay idle for its whole duration. Such a step raises the
+ * cap with VITEST_MAX_WORKERS.
  */
 export const forkPoolOptions = (): InlineConfig => {
 	if (process.env.CI !== 'true') return {};
 	// Vitest accepts a percentage for `maxWorkers` (half of availableParallelism).
-	return { pool: 'forks', maxWorkers: '50%' };
+	return { pool: 'forks', maxWorkers: process.env.VITEST_MAX_WORKERS ?? '50%' };
 };
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,12 @@
 {
 	"globalEnv": ["CI", "BUILD_WITH_COVERAGE"],
-	"globalPassThroughEnv": ["CODECOV_TOKEN", "COVERAGE_ENABLED", "SENTRY_AUTH_TOKEN"],
+	"globalPassThroughEnv": [
+		"CODECOV_TOKEN",
+		"COVERAGE_ENABLED",
+		"SENTRY_AUTH_TOKEN",
+		// Worker count changes timing, never output, so it must not enter the hash.
+		"VITEST_MAX_WORKERS"
+	],
 	"boundaries": {
 		// `~icons/*` is a vite virtual module injected by unplugin-icons (design-system
 		// icon barrel), not a real package — declare it so boundaries doesn't flag it.


### PR DESCRIPTION
Control arm for #37466 — do not merge, will be closed once measured.

Carries the `vitest-config` and `turbo.json` changes so the affected-package fan-out (and therefore test scope) matches the other arms, but sets **no** `VITEST_MAX_WORKERS` anywhere. Both target steps run at the default 50%.

Added because the first round had only one control sample per step while accumulating four treatment samples — not enough to establish baseline variance. This arm supplies the missing control on the same rebased base as the other three.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

