### PR TITLE
ci: Drop exports-subpath stubs from image SBOMs (no-changelog)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -706,8 +706,11 @@ jobs:
   notify-on-failure:
     name: Notify Cats on nightly build failure
     runs-on: ubuntu-latest
-    needs: [build-and-push-docker]
-    if: always() && needs.build-and-push-docker.result == 'failure' && github.event_name == 'schedule'
+    needs: [build-and-push-docker, sbom-attestation]
+    if: |
+      always() && github.event_name == 'schedule' &&
+      (needs.build-and-push-docker.result == 'failure' ||
+       needs.sbom-attestation.result == 'failure')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -719,4 +722,4 @@ jobs:
         run: |
           node .github/scripts/slack/notify.mjs \
             --channel '#team-catalysts' \
-            --text 'Nightly Docker build failed - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            --text 'Nightly Docker build failed (build=${{ needs.build-and-push-docker.result }}, sbom=${{ needs.sbom-attestation.result }}) - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/scripts/licenses/enrich-sbom.mjs
+++ b/scripts/licenses/enrich-sbom.mjs
@@ -76,6 +76,16 @@ function srcFileOf(component) {
 }
 
 /**
+ * An npm name is `name` or `@scope/name` — neither part may contain a slash. A
+ * further slash means the scanner named a directory inside a package, i.e. an
+ * `exports` subpath (@google/genai/node, @linear/sdk/webhooks).
+ */
+function isExportsSubpath(component) {
+	const qualified = qualifiedName(component) ?? '';
+	return qualified.replace(/^@[^/]+\//, '').includes('/');
+}
+
+/**
  * A scan of a container image filesystem (unlike the pnpm-lockfile scan of the
  * release closure) deep-walks node_modules and mis-catalogs nested package.json
  * as standalone components: `exports` subpaths (@google/genai/web), sub-builds
@@ -90,6 +100,11 @@ function srcFileOf(component) {
 export function isPhantomNpm(component) {
 	const purl = component.purl ?? '';
 	if (!purl.startsWith('pkg:npm/')) return false;
+
+	// Checked before the path rules: a subpath stub lives at
+	// node_modules/@google/genai/node/package.json, which *does* end with its own
+	// qualified name, so the canonical-path check below would call it real.
+	if (isExportsSubpath(component)) return true;
 
 	const src = srcFileOf(component);
 	// syft writes "UNKNOWN" where cdxgen omits the field. Neither is a real

--- a/scripts/licenses/enrich-sbom.test.mjs
+++ b/scripts/licenses/enrich-sbom.test.mjs
@@ -204,6 +204,42 @@ describe('isPhantomNpm (cdxgen image-scan noise)', () => {
 
 	const syftSrc = (p) => ({ properties: [{ name: 'syft:location:0:path', value: p }] });
 
+	it('flags an exports subpath whose syft path matches its own qualified name', () => {
+		assert.equal(
+			isPhantomNpm({
+				name: 'genai/node',
+				group: '@google',
+				version: 'UNKNOWN',
+				purl: 'pkg:npm/%40google/genai%2Fnode',
+				...syftSrc('/usr/local/lib/node_modules/n8n/node_modules/@google/genai/node/package.json'),
+			}),
+			true,
+		);
+		assert.equal(
+			isPhantomNpm({
+				name: 'sdk/webhooks',
+				group: '@linear',
+				version: 'UNKNOWN',
+				purl: 'pkg:npm/%40linear/sdk%2Fwebhooks',
+				...syftSrc('/usr/local/lib/node_modules/n8n/node_modules/@linear/sdk/webhooks/package.json'),
+			}),
+			true,
+		);
+	});
+
+	it('keeps an unscoped package whose name is a prefix of a subpath', () => {
+		assert.equal(
+			isPhantomNpm({
+				name: 'genai',
+				group: '@google',
+				version: '1.19.0',
+				purl: 'pkg:npm/%40google/genai@1.19.0',
+				...syftSrc('/usr/local/lib/node_modules/n8n/node_modules/@google/genai/package.json'),
+			}),
+			false,
+		);
+	});
+
 	it('keeps an application root outside node_modules (runners ship the task runner there)', () => {
 		assert.equal(
 			isPhantomNpm({

--- a/scripts/licenses/properties.test.mjs
+++ b/scripts/licenses/properties.test.mjs
@@ -238,7 +238,7 @@ describe('isPhantomNpm — properties', () => {
 		}
 	});
 
-	it('CANONICAL-PATH-WITH-VERSION-NEVER-PHANTOM', () => {
+	it('CANONICAL-PATH-WITH-VERSION-NEVER-PHANTOM (for a well-formed npm name)', () => {
 		const node = (group, name) => ({
 			group,
 			name,
@@ -253,6 +253,27 @@ describe('isPhantomNpm — properties', () => {
 		});
 		assert.equal(isPhantomNpm(node('', 'ssh2')), false);
 		assert.equal(isPhantomNpm(node('@n8n', 'db')), false);
+	});
+
+	it('SUBPATH-NAME-ALWAYS-PHANTOM: a slash past the scope is never a real npm name', () => {
+		const atCanonicalPath = (group, name) => ({
+			group,
+			name,
+			version: '1.0.0',
+			purl: `pkg:npm/${group ? group + '/' : ''}${name}@1.0.0`,
+			properties: [
+				{
+					name: 'syft:location:0:path',
+					value: `/x/node_modules/${group ? group + '/' : ''}${name}/package.json`,
+				},
+			],
+		});
+		// Canonical path AND a resolved version — every other signal says "real".
+		assert.equal(isPhantomNpm(atCanonicalPath('@google', 'genai/node')), true);
+		assert.equal(isPhantomNpm(atCanonicalPath('@linear', 'sdk/webhooks')), true);
+		assert.equal(isPhantomNpm(atCanonicalPath('', 'foo/bar')), true);
+		// The scope slash alone must not trip it.
+		assert.equal(isPhantomNpm(atCanonicalPath('@google', 'genai')), false);
 	});
 
 	it('NON-NPM-NEVER-PHANTOM: OS and other ecosystems are out of scope', () => {


### PR DESCRIPTION
## Summary

The release SBOM license gate has been failing on `n8n` and `n8n-pc` with three components that carry no license:

```
@google/genai/node@UNKNOWN    (pkg:npm/%40google/genai%2Fnode)
@google/genai/web@UNKNOWN     (pkg:npm/%40google/genai%2Fweb)
@linear/sdk/webhooks@UNKNOWN  (pkg:npm/%40linear/sdk%2Fwebhooks)
```

None of these are packages. They are `exports`-subpath stubs — a small `package.json` inside a real package that redirects a subpath import, with no version, no license, and a name npm could never accept:

```json
{ "name": "@google/genai/node", "main": "../dist/node/index.js" }
```

`enrich-sbom.mjs` already filters these out. The filter stopped catching them when release image scanning moved from cdxgen to syft, because of *how* it identified them:

| scanner | source path emitted | branch taken |
| --- | --- | --- |
| cdxgen | none | versionless → dropped |
| syft | `…/node_modules/@google/genai/node/package.json` | canonical-path → **kept** |

The canonical-path rule asks whether the path ends with the component's own qualified name. For a subpath stub it does — `qualifiedName` is `@google/genai/node`, and the stub really does live at `.../@google/genai/node/package.json`. So the strongest "this is a real package" signal fires on exactly the thing that is not one.

An npm name is `name` or `@scope/name`; a further slash cannot be a real package. This drops on that, before the path rules run — independent of scanner, path and version.

A scan of the full closure finds 10 such stubs (also `rxjs/*`, `styled-components/native`), so the generic rule should stop this recurring as dependencies change.

### Second commit: nightly alerting

`notify-on-failure` only watched `build-and-push-docker`, so a red `sbom-attestation` was silent. The nightlies on 08-30 and 09-01 both failed on these same three components — the second 6.5 hours before the release run hit it. The notifier now covers both jobs and reports each result.

## How to test

Unit and property coverage is included; the regression test fails without the filter change and passes with it.

```bash
cd scripts/licenses && for f in *.test.mjs; do node --test "$f"; done
```

End-to-end against the exact syft output that failed, using the same flags CI passes:

```bash
node scripts/licenses/enrich-sbom.mjs <sbom>.cdx.json --lenient-config --drop-phantom-npm
node scripts/licenses/check-sbom-licenses.mjs <sbom>.cdx.json \
  --allow-ref=LicenseRef-n8n-sustainable-use \
  --allow-ref=LicenseRef-n8n-enterprise \
  --enforce-prefix=pkg:npm/
```

The three stubs are dropped as phantoms, the real parents (`@google/genai@1.19.0`, `@linear/sdk@76.0.0`) are retained with their licenses, and the gate exits 0.

The nightly notifier path is only exercised by a scheduled run, so it is verified by review and actionlint rather than execution.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #37344, which moved release image scanning to syft.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

