### PR TITLE
fix(Code Node): Keep identity and reporting fields when wrapping task runner errors

### DIFF
--- a/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
+++ b/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
@@ -3,16 +3,16 @@ import { UserError } from 'n8n-workflow';
 export type WrappableError = Record<string, unknown>;
 
 /**
- * Errors received from the task runner are not instances of Error.
- * This class wraps them in an Error instance and makes all their
- * properties available.
- */
-/**
  * Properties that control error identity and reporting. The payload comes
  * from JSON, so these must not overwrite the values this class sets.
  */
 const PROTECTED_PROPERTIES = new Set(['name', 'message', 'level', 'shouldReport', 'stack']);
 
+/**
+ * Errors received from the task runner are not instances of Error.
+ * This class wraps them in an Error instance and makes all their
+ * properties available.
+ */
 export class WrappedExecutionError extends UserError {
 	[key: string]: unknown;
 

--- a/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
+++ b/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
@@ -7,6 +7,12 @@ export type WrappableError = Record<string, unknown>;
  * This class wraps them in an Error instance and makes all their
  * properties available.
  */
+/**
+ * Properties that control error identity and reporting. The payload comes
+ * from JSON, so these must not overwrite the values this class sets.
+ */
+const PROTECTED_PROPERTIES = new Set(['name', 'message', 'level', 'shouldReport', 'stack']);
+
 export class WrappedExecutionError extends UserError {
 	[key: string]: unknown;
 
@@ -15,12 +21,14 @@ export class WrappedExecutionError extends UserError {
 		super(message, {
 			cause: error,
 		});
+		this.name = 'WrappedExecutionError';
 
 		this.copyErrorProperties(error);
 	}
 
 	private copyErrorProperties(error: WrappableError) {
 		for (const key of Object.getOwnPropertyNames(error)) {
+			if (PROTECTED_PROPERTIES.has(key)) continue;
 			this[key] = error[key];
 		}
 	}

--- a/packages/nodes-base/nodes/Code/test/WrappedExecutionError.test.ts
+++ b/packages/nodes-base/nodes/Code/test/WrappedExecutionError.test.ts
@@ -1,0 +1,34 @@
+import { WrappedExecutionError } from '../errors/WrappedExecutionError';
+
+describe('WrappedExecutionError', () => {
+	it('copies custom properties from a JSON-serialized runner error', () => {
+		const payload = { message: 'boom', description: 'line 3', lineNumber: 3 };
+		const error = new WrappedExecutionError(payload);
+
+		expect(error.message).toBe('boom');
+		expect(error.description).toBe('line 3');
+		expect(error.lineNumber).toBe(3);
+		expect(error.cause).toBe(payload);
+	});
+
+	it('does not let the payload override identity and reporting properties', () => {
+		const error = new WrappedExecutionError({
+			message: 'boom',
+			name: 'SomeRunnerError',
+			level: 'error',
+			shouldReport: true,
+			stack: 'runner stack',
+		});
+
+		expect(error.name).toBe('WrappedExecutionError');
+		expect(error.level).toBe('info');
+		expect(error.shouldReport).toBe(false);
+		expect(error.stack).not.toBe('runner stack');
+	});
+
+	it('falls back to a generic message when the payload has none', () => {
+		const error = new WrappedExecutionError({ code: 1 });
+
+		expect(error.message).toBe('Unknown error');
+	});
+});


### PR DESCRIPTION
## Summary

The task runner sends failed job errors over the WebSocket as JSON. The Code node wraps these plain objects in `WrappedExecutionError`. The wrapper copied every property of the payload onto the error. The serialized `level` and `shouldReport` values overrode the `UserError` defaults. The error also kept the generic `Error` name. As a result, all these user-code failures reported to Sentry at `level: error` and grouped under one opaque `Error: Error` signature (1,373 events, 625 users).

This PR makes `WrappedExecutionError`:
- Skip the `name`, `message`, `level`, `shouldReport`, and `stack` properties when it copies the payload.
- Set `name` to `WrappedExecutionError`.

The wrapper keeps the `UserError` defaults (`level: 'info'`, `shouldReport: false`), so these failures no longer report to Sentry. All other payload properties (description, line number, etc.) still copy through for the UI.

## How to test

1. Run an instance with task runners enabled.
2. Add a Code node in `Run Once for All Items` mode with JavaScript that throws a non-Error value.
3. Run the workflow.
4. The execution fails with the same user-facing error as before. The wrapped error now has `name: 'WrappedExecutionError'`, `level: 'info'`, and `shouldReport: false`, so the error reporter drops it.

Unit tests: `pnpm --filter=n8n-nodes-base test nodes/Code/test/WrappedExecutionError.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4269

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

