### PR TITLE
feat(core): Seal the AI-builder workflow create with a clearance token (no-changelog)

### DIFF
--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -217,10 +217,7 @@ export default defineConfig(
 	{
 		// Shrink-only ratchet: node-write sites not yet migrated to the sealed repository path.
 		// NEVER add a new write here — it must fail CI. Remove each entry as its site migrates.
-		files: [
-			'./src/modules/source-control.ee/source-control-import.service.ee.ts',
-			'./src/modules/instance-ai/instance-ai.adapter.service.ts',
-		],
+		files: ['./src/modules/source-control.ee/source-control-import.service.ee.ts'],
 		rules: { 'n8n-local-rules/no-unsealed-workflow-entity-write': 'off' },
 	},
 	{

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
@@ -65,6 +65,7 @@ import type { DataTableRepository } from '@/modules/data-table/data-table.reposi
 import type { DataTableService } from '@/modules/data-table/data-table.service';
 import type { InstanceWriteAccessService } from '@/services/instance-write-access.service';
 import type { NodeTypes } from '@/node-types';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { RoleService } from '@/services/role.service';
 import type { OutboundHttp } from '@n8n/backend-network';
 import type { AiGatewayService } from '@/services/ai-gateway.service';
@@ -131,6 +132,9 @@ const nodeResourceExplorerService = new NodeResourceExplorerService(
 	nodeTypes,
 );
 
+const policyEnforcementService = mock<PolicyEnforcementService>();
+policyEnforcementService.enforceWorkflowSave.mockResolvedValue(mock());
+
 const service = new InstanceAiAdapterService(
 	logger,
 	globalConfig,
@@ -167,6 +171,7 @@ const service = new InstanceAiAdapterService(
 	mock<AiGatewayService>(),
 	mock<WorkflowTemplatesService>(),
 	mock<CollaborationService>(),
+	policyEnforcementService,
 );
 
 const user = mock<User>({

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -44,6 +44,7 @@ vi.mock('@n8n/ai-utilities', () => ({
 	searxngSearch: vi.fn(),
 }));
 
+import type { PolicyCleared } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { generateWorkflowCode } from '@n8n/workflow-sdk';
 import { mock } from 'vitest-mock-extended';
@@ -102,6 +103,11 @@ function globalConfigStub(
 		ai: { allowSendingParameterValues: overrides.allowSendingParameterValues ?? false },
 		executions: { mode: overrides.queueMode ? 'queue' : 'regular' },
 	} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[1];
+}
+
+/** Clears every save: the adapter's own tests are not exercising policy decisions. */
+function createMockPolicyEnforcementService() {
+	return { enforceWorkflowSave: vi.fn().mockResolvedValue(mock()) };
 }
 
 function createMockCollaborationService() {
@@ -1358,6 +1364,9 @@ function createNodeAdapterServiceForTests(
 		createMockCollaborationService() as unknown as ConstructorParameters<
 			typeof InstanceAiAdapterService
 		>[34],
+		createMockPolicyEnforcementService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 		nodeCatalogService,
 	);
 
@@ -1721,6 +1730,9 @@ function createDataTableAdapterForTests(overrides?: {
 		createMockCollaborationService() as unknown as ConstructorParameters<
 			typeof InstanceAiAdapterService
 		>[34],
+		createMockPolicyEnforcementService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const adapter = service.createContext(mockUser, {
@@ -1939,15 +1951,13 @@ function createWorkflowAdapterForTests(overrides?: {
 		create: vi.fn().mockImplementation((data: Record<string, unknown>) => data),
 		save: vi.fn().mockResolvedValue(savedWorkflow),
 		update: vi.fn().mockResolvedValue(undefined),
-		manager: {
-			transaction: vi.fn(
-				async (fn: (transactionManager: { save: Mock }) => Promise<unknown>): Promise<unknown> => {
-					return await fn({
-						save: vi.fn().mockResolvedValue(savedWorkflow),
-					});
-				},
-			),
-		},
+		createContent: vi.fn().mockResolvedValue(savedWorkflow),
+		runInTransaction: vi.fn(
+			async (
+				ctx: unknown,
+				fn: (transactionManager: { save: Mock }, ctx: unknown) => Promise<unknown>,
+			): Promise<unknown> => await fn({ save: vi.fn().mockResolvedValue(savedWorkflow) }, ctx),
+		),
 	};
 
 	const mockWorkflowFinderService = {
@@ -1988,6 +1998,7 @@ function createWorkflowAdapterForTests(overrides?: {
 	};
 	mockLogger.scoped.mockReturnValue(mockLogger);
 	const mockCollaborationService = createMockCollaborationService();
+	const mockPolicyEnforcementService = createMockPolicyEnforcementService();
 
 	const mockUser = { id: 'user-1', role: { slug: 'global:member' } } as unknown as User;
 
@@ -2049,6 +2060,9 @@ function createWorkflowAdapterForTests(overrides?: {
 		mockCollaborationService as unknown as ConstructorParameters<
 			typeof InstanceAiAdapterService
 		>[34],
+		mockPolicyEnforcementService as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const boundProjectId =
@@ -2072,6 +2086,7 @@ function createWorkflowAdapterForTests(overrides?: {
 		mockWorkflowHistoryService,
 		mockEnterpriseWorkflowService,
 		mockCollaborationService,
+		mockPolicyEnforcementService,
 		mockTelemetry,
 		mockLogger,
 		mockUser,
@@ -2367,6 +2382,41 @@ describe('createWorkflowAdapter', () => {
 		);
 	});
 
+	// The shell carries no nodes; the generated content is policed by the sealed `update()`
+	// below. Enforced here anyway, because no `WorkflowEntity` write may skip the funnel.
+	it('enforces the save for the shell and threads the clearance to the write', async () => {
+		const { adapter, mockWorkflowRepository, mockPolicyEnforcementService } =
+			createWorkflowAdapterForTests();
+		const cleared = mock<PolicyCleared<'workflowSave'>>();
+		mockPolicyEnforcementService.enforceWorkflowSave.mockResolvedValue(cleared);
+
+		await adapter.createFromWorkflowJSON(minimalWorkflowJSON);
+
+		expect(mockPolicyEnforcementService.enforceWorkflowSave).toHaveBeenCalledWith({
+			workflow: { id: null, name: minimalWorkflowJSON.name, nodes: [] },
+			storedWorkflow: null,
+			projectId: 'team-project-id',
+		});
+		expect(mockWorkflowRepository.runInTransaction).toHaveBeenCalledWith(
+			{ policyCleared: cleared },
+			expect.any(Function),
+		);
+		expect(mockWorkflowRepository.createContent).toHaveBeenCalledWith(
+			expect.objectContaining({ nodes: [] }),
+			expect.objectContaining({ policyCleared: cleared }),
+		);
+	});
+
+	it('does not write the shell when the policy blocks the save', async () => {
+		const { adapter, mockWorkflowRepository, mockPolicyEnforcementService } =
+			createWorkflowAdapterForTests();
+		mockPolicyEnforcementService.enforceWorkflowSave.mockRejectedValue(new Error('blocked'));
+
+		await expect(adapter.createFromWorkflowJSON(minimalWorkflowJSON)).rejects.toThrow('blocked');
+
+		expect(mockWorkflowRepository.createContent).not.toHaveBeenCalled();
+	});
+
 	it('throws when the run has no bound project', async () => {
 		const { adapter } = createWorkflowAdapterForTests({ projectId: null });
 
@@ -2412,7 +2462,7 @@ describe('createWorkflowAdapter', () => {
 		expect(mockWorkflowRepository.create).toHaveBeenCalledWith(
 			expect.not.objectContaining({ meta: expect.anything() }),
 		);
-		expect(mockWorkflowRepository.manager.transaction).toHaveBeenCalled();
+		expect(mockWorkflowRepository.runInTransaction).toHaveBeenCalled();
 		expect(mockSharedWorkflowRepository.makeOwner).toHaveBeenCalledWith(
 			['wf-new'],
 			'team-project-id',
@@ -3178,6 +3228,9 @@ function createExecutionAdapterForTests(overrides?: { sharingEnabled?: boolean }
 		createMockCollaborationService() as unknown as ConstructorParameters<
 			typeof InstanceAiAdapterService
 		>[34],
+		createMockPolicyEnforcementService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const adapter = service.createContext(mockUser).executionService;
@@ -3445,6 +3498,9 @@ function createRunAdapterForTests(
 		createMockCollaborationService() as unknown as ConstructorParameters<
 			typeof InstanceAiAdapterService
 		>[34],
+		createMockPolicyEnforcementService() as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 	);
 
 	const adapter = service.createContext(mockUser, { threadId: options?.threadId }).executionService;

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -142,6 +142,7 @@ import { McpRegistryService } from '@/modules/mcp-registry/registry/mcp-registry
 import { NodeCatalogService } from '@/node-catalog';
 import { NodeTypes } from '@/node-types';
 import { userHasScopes } from '@/permissions.ee/check-access';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { PostHogClient } from '@/posthog';
 import { AiGatewayService } from '@/services/ai-gateway.service';
 import { FolderService } from '@/services/folder.service';
@@ -330,6 +331,7 @@ export class InstanceAiAdapterService {
 		private readonly aiGatewayService: AiGatewayService,
 		private readonly workflowTemplatesService: WorkflowTemplatesService,
 		private readonly collaborationService: CollaborationService,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 		private readonly nodeCatalogService?: NodeCatalogService,
 		// Optional: absent only in package/test contexts constructed without DI.
 		// DI (by type, not position) always provides it in a running instance.
@@ -662,6 +664,7 @@ export class InstanceAiAdapterService {
 			allowSendingParameterValues,
 			telemetry,
 			collaborationService,
+			policyEnforcementService,
 		} = this;
 		const logger = this.logger;
 		const assertNotReadOnly = () => this.assertInstanceNotReadOnly('workflows');
@@ -954,23 +957,34 @@ export class InstanceAiAdapterService {
 					versionId: randomUUID(),
 				} as Partial<WorkflowEntity>);
 
-				const saved = await workflowRepository.manager.transaction(async (transactionManager) => {
-					const workflow = await transactionManager.save(WorkflowEntity, newWorkflow);
-					await sharedWorkflowRepository.makeOwner([workflow.id], projectId, transactionManager);
-					if (options?.markAsAiTemporary) {
-						if (!threadId) {
-							throw new UnexpectedError(
-								'Cannot mark AI-builder temporary workflow without a thread ID',
+				// The shell has no nodes, so the real content check is the `update()` below.
+				// This call is still needed: `createContent` refuses to write without a clearance.
+				const cleared = await policyEnforcementService.enforceWorkflowSave({
+					workflow: { id: null, name: newWorkflow.name, nodes: newWorkflow.nodes },
+					storedWorkflow: null,
+					projectId,
+				});
+
+				const saved = await workflowRepository.runInTransaction(
+					{ policyCleared: cleared },
+					async (transactionManager, ctx) => {
+						const workflow = await workflowRepository.createContent(newWorkflow, ctx);
+						await sharedWorkflowRepository.makeOwner([workflow.id], projectId, transactionManager);
+						if (options?.markAsAiTemporary) {
+							if (!threadId) {
+								throw new UnexpectedError(
+									'Cannot mark AI-builder temporary workflow without a thread ID',
+								);
+							}
+							await aiBuilderTemporaryWorkflowRepository.mark(
+								workflow.id,
+								threadId,
+								transactionManager,
 							);
 						}
-						await aiBuilderTemporaryWorkflowRepository.mark(
-							workflow.id,
-							threadId,
-							transactionManager,
-						);
-					}
-					return workflow;
-				});
+						return workflow;
+					},
+				);
 
 				// Now update with actual nodes — this creates the WorkflowHistory entry
 				// needed for activation and publishing.


### PR DESCRIPTION
## Summary

The AI builder wrote its workflow row with a raw `transactionManager.save(WorkflowEntity, …)`. This routes it through the token-gated `WorkflowRepository.createContent`, and moves the create transaction to `runInTransaction` so the owner row and the temporary-workflow marker keep the manager they take today. System-generated workflows are policed like any other, per the parent ticket.

Worth knowing for review: the builder creates the workflow **shell without nodes** and the generated content arrives via a `workflowService.update()` that already goes through the sealed editor-save path — so the clearance minted here clears trivially and the real content check is the one that already exists. It is enforced anyway, because the value of the seal is that no `WorkflowEntity` write can skip the funnel, and the lint rule now holds this file to it.

## How to test

The policy layer is opt-in. Enable it with `N8N_ENABLED_MODULES=policy-infrastructure`.

1. Run `pnpm --filter n8n test src/modules/instance-ai`. Two new tests cover it: the clearance is minted for the empty-nodes shell against the bound project and threaded into `createContent`, and a blocked save writes nothing.
2. To confirm the lint ratchet guards the file, replace the `createContent` call in `instance-ai.adapter.service.ts` with `transactionManager.save(WorkflowEntity, newWorkflow)` and run `npx eslint src/modules/instance-ai/instance-ai.adapter.service.ts` from `packages/cli`. It must fail with `no-unsealed-workflow-entity-write`.
3. With no module enabled, build a workflow with the AI assistant. It must save and activate unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1303

Staged under https://linear.app/n8n/issue/IAM-1128. Sequenced after https://linear.app/n8n/issue/IAM-1302 (#37481) in the ticket plan, but independent of it in code.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


