### PR TITLE
feat(core): Seal the chat-hub workflow creates with a clearance token (no-changelog)

### DIFF
--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -222,7 +222,6 @@ export default defineConfig(
 			'./src/modules/source-control.ee/source-control-import.service.ee.ts',
 			'./src/modules/instance-ai/instance-ai.adapter.service.ts',
 			'./src/modules/instance-ai/eval/thread-restore.service.ts',
-			'./src/modules/chat-hub/chat-hub-workflow.service.ts',
 		],
 		rules: { 'n8n-local-rules/no-unsealed-workflow-entity-write': 'off' },
 	},

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub-agent.service.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub-agent.service.test.ts
@@ -499,14 +499,10 @@ describe('ChatHubAgentService', () => {
 				executionData: {} as IRunExecutionData,
 			});
 
-			const mockTransaction = vi.fn(
-				async (cb: (trx: never) => Promise<unknown>) => await cb(mock()),
+			agentRepository.runInTransaction.mockImplementation(
+				async (ctx: unknown, fn: (em: never, ctx: unknown) => Promise<unknown>) =>
+					await fn(mock(), ctx),
 			);
-
-			Object.defineProperty(agentRepository, 'manager', {
-				value: { transaction: mockTransaction },
-				configurable: true,
-			});
 			workflowExecutionService.executeChatWorkflow.mockResolvedValue({
 				executionId: 'exec-1',
 			} as never);

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub-workflow.service.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub-workflow.service.test.ts
@@ -1,3 +1,4 @@
+import type { PolicyCleared } from '@n8n/decorators';
 import type { Logger } from '@n8n/backend-common';
 import type { WorkflowRepository, SharedWorkflowRepository, User } from '@n8n/db';
 import type { EntityManager } from '@n8n/typeorm';
@@ -6,6 +7,7 @@ import { type IBinaryData, type INode, CHAT_TRIGGER_NODE_TYPE } from 'n8n-workfl
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import type { ChatHubAgent } from '../chat-hub-agent.entity';
@@ -35,6 +37,7 @@ describe('ChatHubWorkflowService', () => {
 	const workflowFinderService = mock<WorkflowFinderService>();
 
 	const mockCipher = mock<Cipher>();
+	const policyEnforcementService = mock<PolicyEnforcementService>();
 
 	let chatHubAttachmentService: ChatHubAttachmentService;
 	let service: ChatHubWorkflowService;
@@ -68,6 +71,7 @@ describe('ChatHubWorkflowService', () => {
 			chatHubToolService,
 			workflowFinderService,
 			mockCipher,
+			policyEnforcementService,
 		);
 
 		// Mock repository methods
@@ -78,14 +82,137 @@ describe('ChatHubWorkflowService', () => {
 			}),
 		} as any;
 
-		Object.defineProperty(workflowRepository, 'manager', {
-			value: {
-				transaction: vi.fn((cb) => cb(mockEntityManager)),
-			},
-			writable: true,
-		});
+		workflowRepository.runInTransaction.mockImplementation(
+			async (ctx: unknown, fn: (em: unknown, ctx: unknown) => Promise<unknown>) =>
+				await fn(mockEntityManager, ctx),
+		);
+		workflowRepository.createContent.mockImplementation(
+			async (workflow: unknown) => ({ ...(workflow as object), id: 'workflow-123' }) as never,
+		);
+		policyEnforcementService.enforceWorkflowSave.mockResolvedValue(mock());
 
 		(sharedWorkflowRepository.create as Mock) = vi.fn().mockReturnValue({});
+	});
+
+	describe('content policy', () => {
+		const cleared = mock<PolicyCleared<'workflowSave'>>();
+		const semanticSearchOptions: SemanticSearchOptions = {
+			embeddingModel: { provider: 'openai', credentialId: 'embedding-cred' },
+			vectorStore: {
+				nodeType: 'vectorStore',
+				credentialType: 'pineconeApi',
+				credentialId: 'vs-cred',
+			},
+		};
+
+		beforeEach(() => {
+			policyEnforcementService.enforceWorkflowSave.mockResolvedValue(cleared);
+		});
+
+		// Chat workflows are system-generated but their nodes are real, so a blocked node type
+		// has to stop the run rather than reach the engine.
+		it('enforces the save and threads the clearance to the write', async () => {
+			await service.createChatWorkflow(
+				'user-123',
+				'session-456',
+				'project-789',
+				[],
+				'Hello',
+				[],
+				{},
+				{ provider: 'openai', model: 'gpt-4' },
+				undefined,
+				[],
+				'UTC',
+				null,
+				defaultExecutionMetadata,
+			);
+
+			expect(policyEnforcementService.enforceWorkflowSave).toHaveBeenCalledWith(
+				expect.objectContaining({ storedWorkflow: null, projectId: 'project-789' }),
+			);
+			expect(workflowRepository.createContent).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ policyCleared: cleared }),
+			);
+		});
+
+		it('writes nothing when the policy blocks the save', async () => {
+			policyEnforcementService.enforceWorkflowSave.mockRejectedValue(new Error('blocked'));
+
+			await expect(
+				service.createChatWorkflow(
+					'user-123',
+					'session-456',
+					'project-789',
+					[],
+					'Hello',
+					[],
+					{},
+					{ provider: 'openai', model: 'gpt-4' },
+					undefined,
+					[],
+					'UTC',
+					null,
+					defaultExecutionMetadata,
+				),
+			).rejects.toThrow('blocked');
+
+			expect(workflowRepository.createContent).not.toHaveBeenCalled();
+		});
+
+		it('enforces the save for the title-generation workflow', async () => {
+			await service.createTitleGenerationWorkflow(
+				'user-123',
+				'session-456',
+				'project-789',
+				'Hello',
+				[],
+				{},
+				{ provider: 'openai', model: 'gpt-4' },
+			);
+
+			expect(policyEnforcementService.enforceWorkflowSave).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: 'project-789' }),
+			);
+			expect(workflowRepository.createContent).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ policyCleared: cleared }),
+			);
+		});
+
+		it('enforces the save for the embeddings-insertion workflow', async () => {
+			await service.createEmbeddingsInsertionWorkflow(
+				mock<User>({ id: 'user-1' }),
+				'project-1',
+				[
+					{
+						attachment: {
+							data: 'base64data',
+							mimeType: 'application/pdf',
+							fileName: 'doc.pdf',
+						} as IBinaryData,
+						knowledgeId: 'knowledge-1',
+					},
+				],
+				'agent-1',
+				semanticSearchOptions,
+				{},
+				'workflow-1',
+			);
+
+			// This site supplies its own id, so the clearance binds to that rather than to a hash.
+			expect(policyEnforcementService.enforceWorkflowSave).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workflow: expect.objectContaining({ id: 'workflow-1' }),
+					projectId: 'project-1',
+				}),
+			);
+			expect(workflowRepository.createContent).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ policyCleared: cleared }),
+			);
+		});
 	});
 
 	describe('createChatWorkflow', () => {
@@ -1148,13 +1275,6 @@ describe('ChatHubWorkflowService', () => {
 			},
 		};
 
-		let trx: ReturnType<typeof mock<EntityManager>>;
-
-		beforeEach(() => {
-			trx = mock<EntityManager>();
-			trx.save.mockImplementation(async (entity) => entity as never);
-		});
-
 		const attachment = {
 			attachment: {
 				data: 'base64data',
@@ -1171,7 +1291,7 @@ describe('ChatHubWorkflowService', () => {
 				[attachment],
 				'agent-1',
 				SEMANTIC_SEARCH_OPTIONS,
-				trx,
+				{},
 				'workflow-1',
 			);
 
@@ -1195,7 +1315,7 @@ describe('ChatHubWorkflowService', () => {
 				[attachment],
 				'agent-1',
 				SEMANTIC_SEARCH_OPTIONS,
-				trx,
+				{},
 				'workflow-1',
 			);
 
@@ -1220,6 +1340,7 @@ describe('ChatHubWorkflowService', () => {
 				chatHubToolService,
 				workflowFinderService,
 				mockCipher,
+				policyEnforcementService,
 			);
 
 			const mockTrx = mock<EntityManager>();
@@ -1244,7 +1365,7 @@ describe('ChatHubWorkflowService', () => {
 				[],
 				[],
 				'UTC',
-				mockTrx,
+				{},
 				defaultExecutionMetadata,
 			);
 

--- a/packages/cli/src/modules/chat-hub/chat-hub-agent.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-agent.repository.ts
@@ -1,12 +1,13 @@
+import { BaseRepository, TransactionRunner } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
+import { DataSource, EntityManager } from '@n8n/typeorm';
 
 import { ChatHubAgent, IChatHubAgent } from './chat-hub-agent.entity';
 
 @Service()
-export class ChatHubAgentRepository extends Repository<ChatHubAgent> {
-	constructor(dataSource: DataSource) {
-		super(ChatHubAgent, dataSource.manager);
+export class ChatHubAgentRepository extends BaseRepository<ChatHubAgent> {
+	constructor(dataSource: DataSource, transactionRunner: TransactionRunner) {
+		super(ChatHubAgent, dataSource.manager, transactionRunner);
 	}
 
 	async createAgent(

--- a/packages/cli/src/modules/chat-hub/chat-hub-agent.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-agent.service.ts
@@ -226,8 +226,9 @@ export class ChatHubAgentService {
 		try {
 			const settings = await this.ensureSemanticSearchOptions();
 
-			const { workflowData, executionData } = await this.chatAgentRepository.manager.transaction(
-				async (trx) => {
+			const { workflowData, executionData } = await this.chatAgentRepository.runInTransaction(
+				{},
+				async (trx, ctx) => {
 					const project = await this.chatHubCredentialsService.findPersonalProject(user, trx);
 
 					return await this.chatHubWorkflowService.createEmbeddingsInsertionWorkflow(
@@ -236,7 +237,7 @@ export class ChatHubAgentService {
 						files,
 						agentId,
 						settings,
-						trx,
+						ctx,
 						workflowId,
 					);
 				},

--- a/packages/cli/src/modules/chat-hub/chat-hub-title.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-title.service.ts
@@ -85,7 +85,7 @@ export class ChatHubTitleService {
 		incomingCredentials: INodeCredentials,
 		incomingModel: ChatHubConversationModel,
 	) {
-		return await this.sessionRepository.manager.transaction(async (trx) => {
+		return await this.sessionRepository.runInTransaction({}, async (trx, ctx) => {
 			const { resolvedCredentials, resolvedModel, credentialId, projectId } =
 				await this.resolveCredentialsAndModelForTitle(
 					user,
@@ -115,7 +115,7 @@ export class ChatHubTitleService {
 				attachments,
 				resolvedCredentials,
 				resolvedModel,
-				trx,
+				ctx,
 				providerSettings,
 			);
 		});

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -13,11 +13,11 @@ import {
 	parseMessage,
 	collectChatArtifacts,
 } from '@n8n/chat-hub';
+import type { OperationContext } from '@n8n/db';
 import {
 	SharedWorkflow,
 	SharedWorkflowRepository,
 	User,
-	withTransaction,
 	WorkflowEntity,
 	WorkflowRepository,
 } from '@n8n/db';
@@ -50,6 +50,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { ChatHubAgentRepository } from './chat-hub-agent.repository';
@@ -93,6 +94,7 @@ export class ChatHubWorkflowService {
 		private readonly chatHubToolService: ChatHubToolService,
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly cipher: Cipher,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 	) {
 		this.logger = this.logger.scoped('chat-hub');
 	}
@@ -117,64 +119,81 @@ export class ChatHubWorkflowService {
 		timeZone: string,
 		vectorStoreSearch: { agentId: string; options: SemanticSearchOptions } | null,
 		executionMetadata: ChatHubAuthenticationMetadata,
-		trx?: EntityManager,
+		ctx: OperationContext = {},
 		providerSettings?: ChatProviderSettingsDto,
 	): Promise<{
 		workflowData: IWorkflowBase;
 		executionData: IRunExecutionData;
 		responseMode: ChatTriggerResponseMode;
 	}> {
-		return await withTransaction(this.workflowRepository.manager, trx, async (em) => {
-			this.logger.debug(
-				`Creating chat workflow for user ${userId} and session ${sessionId}, provider ${model.provider}`,
-			);
+		this.logger.debug(
+			`Creating chat workflow for user ${userId} and session ${sessionId}, provider ${model.provider}`,
+		);
 
-			const { nodes, connections, executionData } = await this.buildChatWorkflow({
-				userId,
-				sessionId,
-				history,
-				humanMessage,
-				attachments,
-				credentials,
-				model,
-				systemMessage: systemMessage ?? this.getBaseSystemMessage(history, timeZone),
-				tools,
-				vectorStoreSearch,
-				executionMetadata,
-				providerSettings,
-			});
+		const { nodes, connections, executionData } = await this.buildChatWorkflow({
+			userId,
+			sessionId,
+			history,
+			humanMessage,
+			attachments,
+			credentials,
+			model,
+			systemMessage: systemMessage ?? this.getBaseSystemMessage(history, timeZone),
+			tools,
+			vectorStoreSearch,
+			executionMetadata,
+			providerSettings,
+		});
 
-			const newWorkflow = new WorkflowEntity();
+		const newWorkflow = new WorkflowEntity();
 
-			// Chat workflows are created as archived to hide them
-			// from the user by default while they are being run.
-			newWorkflow.isArchived = true;
+		// Chat workflows are created as archived to hide them
+		// from the user by default while they are being run.
+		newWorkflow.isArchived = true;
 
-			newWorkflow.versionId = uuidv4();
-			newWorkflow.name = `Chat ${sessionId}`;
-			newWorkflow.active = false;
-			newWorkflow.activeVersionId = null;
-			newWorkflow.nodes = nodes;
-			newWorkflow.connections = connections;
-			newWorkflow.settings = {
-				executionOrder: 'v1',
-			};
+		newWorkflow.versionId = uuidv4();
+		newWorkflow.name = `Chat ${sessionId}`;
+		newWorkflow.active = false;
+		newWorkflow.activeVersionId = null;
+		newWorkflow.nodes = nodes;
+		newWorkflow.connections = connections;
+		newWorkflow.settings = {
+			executionOrder: 'v1',
+		};
 
-			const workflow = await em.save<WorkflowEntity>(newWorkflow);
+		const cleared = await this.enforceChatWorkflowSave(newWorkflow, projectId);
 
-			await em.save<SharedWorkflow>(
-				this.sharedWorkflowRepository.create({
-					role: 'workflow:owner',
-					projectId,
-					workflow,
-				}),
-			);
+		return await this.workflowRepository.runInTransaction(
+			{ ...ctx, policyCleared: cleared },
+			async (em, txCtx) => {
+				const workflow = await this.workflowRepository.createContent(newWorkflow, txCtx);
 
-			return {
-				workflowData: workflow,
-				executionData,
-				responseMode: 'streaming',
-			};
+				await em.save<SharedWorkflow>(
+					this.sharedWorkflowRepository.create({
+						role: 'workflow:owner',
+						projectId,
+						workflow,
+					}),
+				);
+
+				return {
+					workflowData: workflow,
+					executionData,
+					responseMode: 'streaming' as const,
+				};
+			},
+		);
+	}
+
+	/**
+	 * Chat workflows are system-generated but policed like any other: the nodes are real, so a
+	 * blocked node type has to block the run rather than reach the engine.
+	 */
+	private async enforceChatWorkflowSave(workflow: WorkflowEntity, projectId: string) {
+		return await this.policyEnforcementService.enforceWorkflowSave({
+			workflow: { id: workflow.id ?? null, name: workflow.name, nodes: workflow.nodes },
+			storedWorkflow: null,
+			projectId,
 		});
 	}
 
@@ -186,58 +205,63 @@ export class ChatHubWorkflowService {
 		attachments: IBinaryData[],
 		credentials: INodeCredentials,
 		model: ChatHubConversationModel,
-		trx?: EntityManager,
+		ctx: OperationContext = {},
 		providerSettings?: ChatProviderSettingsDto,
 	): Promise<{ workflowData: IWorkflowBase; executionData: IRunExecutionData }> {
-		return await withTransaction(this.workflowRepository.manager, trx, async (em) => {
-			this.logger.debug(
-				`Creating title generation workflow for user ${userId} and session ${sessionId}, provider ${model.provider}`,
-			);
+		this.logger.debug(
+			`Creating title generation workflow for user ${userId} and session ${sessionId}, provider ${model.provider}`,
+		);
 
-			const { nodes, connections, executionData } = this.buildTitleGenerationWorkflow(
-				userId,
-				sessionId,
-				credentials,
-				model,
-				humanMessage,
-				attachments,
-				providerSettings,
-			);
+		const { nodes, connections, executionData } = this.buildTitleGenerationWorkflow(
+			userId,
+			sessionId,
+			credentials,
+			model,
+			humanMessage,
+			attachments,
+			providerSettings,
+		);
 
-			const newWorkflow = new WorkflowEntity();
+		const newWorkflow = new WorkflowEntity();
 
-			// Chat workflows are created as archived to hide them
-			// from the user by default while they are being run.
-			newWorkflow.isArchived = true;
+		// Chat workflows are created as archived to hide them
+		// from the user by default while they are being run.
+		newWorkflow.isArchived = true;
 
-			newWorkflow.versionId = uuidv4();
-			newWorkflow.name = `Chat ${sessionId} (Title Generation)`;
-			newWorkflow.active = false;
-			newWorkflow.activeVersionId = null;
-			newWorkflow.nodes = nodes;
-			newWorkflow.connections = connections;
-			newWorkflow.settings = {
-				executionOrder: 'v1',
-				// Ensure chat workflows save data on successful executions regardless of instance settings
-				// This is done to ensure generated title can be read after execution.
-				saveDataSuccessExecution: 'all',
-			};
+		newWorkflow.versionId = uuidv4();
+		newWorkflow.name = `Chat ${sessionId} (Title Generation)`;
+		newWorkflow.active = false;
+		newWorkflow.activeVersionId = null;
+		newWorkflow.nodes = nodes;
+		newWorkflow.connections = connections;
+		newWorkflow.settings = {
+			executionOrder: 'v1',
+			// Ensure chat workflows save data on successful executions regardless of instance settings
+			// This is done to ensure generated title can be read after execution.
+			saveDataSuccessExecution: 'all',
+		};
 
-			const workflow = await em.save<WorkflowEntity>(newWorkflow);
+		const cleared = await this.enforceChatWorkflowSave(newWorkflow, projectId);
 
-			await em.save<SharedWorkflow>(
-				this.sharedWorkflowRepository.create({
-					role: 'workflow:owner',
-					projectId,
-					workflow,
-				}),
-			);
+		return await this.workflowRepository.runInTransaction(
+			{ ...ctx, policyCleared: cleared },
+			async (em, txCtx) => {
+				const workflow = await this.workflowRepository.createContent(newWorkflow, txCtx);
 
-			return {
-				workflowData: workflow,
-				executionData,
-			};
-		});
+				await em.save<SharedWorkflow>(
+					this.sharedWorkflowRepository.create({
+						role: 'workflow:owner',
+						projectId,
+						workflow,
+					}),
+				);
+
+				return {
+					workflowData: workflow,
+					executionData,
+				};
+			},
+		);
 	}
 
 	/**
@@ -1233,7 +1257,7 @@ Respond the title only:`,
 		tools: INode[],
 		attachments: IBinaryData[],
 		timeZone: string,
-		trx: EntityManager,
+		ctx: OperationContext,
 		executionMetadata: ChatHubAuthenticationMetadata,
 		manual?: boolean,
 	): Promise<PreparedChatWorkflow> {
@@ -1244,7 +1268,7 @@ Respond the title only:`,
 				model.workflowId,
 				message,
 				attachments,
-				trx,
+				ctx,
 				executionMetadata,
 				manual,
 			);
@@ -1259,7 +1283,7 @@ Respond the title only:`,
 				message,
 				attachments,
 				timeZone,
-				trx,
+				ctx,
 				executionMetadata,
 			);
 		}
@@ -1276,7 +1300,7 @@ Respond the title only:`,
 			attachments,
 			timeZone,
 			null,
-			trx,
+			ctx,
 			executionMetadata,
 		);
 	}
@@ -1293,34 +1317,38 @@ Respond the title only:`,
 		attachments: IBinaryData[],
 		timeZone: string,
 		vectorStoreSearch: { agentId: string; options: SemanticSearchOptions } | null,
-		trx: EntityManager,
+		ctx: OperationContext,
 		executionMetadata: ChatHubAuthenticationMetadata,
 	) {
-		await this.chatHubSettingsService.ensureModelIsAllowed(model, trx);
-		this.chatHubCredentialsService.findProviderCredential(model.provider, credentials);
-		const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
-		const providerSettings = await this.chatHubSettingsService.getProviderSettings(
-			model.provider,
-			trx,
-		);
+		// Joins the caller's transaction and recovers its manager for the reads below, which
+		// still take an `EntityManager`.
+		return await this.workflowRepository.runInTransaction(ctx, async (trx, txCtx) => {
+			await this.chatHubSettingsService.ensureModelIsAllowed(model, trx);
+			this.chatHubCredentialsService.findProviderCredential(model.provider, credentials);
+			const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
+			const providerSettings = await this.chatHubSettingsService.getProviderSettings(
+				model.provider,
+				trx,
+			);
 
-		return await this.createChatWorkflow(
-			user.id,
-			sessionId,
-			projectId,
-			history,
-			message,
-			attachments,
-			credentials,
-			model,
-			systemMessage,
-			tools,
-			timeZone,
-			vectorStoreSearch,
-			executionMetadata,
-			trx,
-			providerSettings,
-		);
+			return await this.createChatWorkflow(
+				user.id,
+				sessionId,
+				projectId,
+				history,
+				message,
+				attachments,
+				credentials,
+				model,
+				systemMessage,
+				tools,
+				timeZone,
+				vectorStoreSearch,
+				executionMetadata,
+				txCtx,
+				providerSettings,
+			);
+		});
 	}
 
 	private async prepareChatAgentWorkflow(
@@ -1331,7 +1359,35 @@ Respond the title only:`,
 		message: string,
 		attachments: IBinaryData[],
 		timeZone: string,
+		ctx: OperationContext,
+		executionMetadata: ChatHubAuthenticationMetadata,
+	) {
+		return await this.workflowRepository.runInTransaction(ctx, async (trx, txCtx) => {
+			return await this.prepareChatAgentWorkflowInTransaction(
+				agentId,
+				user,
+				sessionId,
+				history,
+				message,
+				attachments,
+				timeZone,
+				trx,
+				txCtx,
+				executionMetadata,
+			);
+		});
+	}
+
+	private async prepareChatAgentWorkflowInTransaction(
+		agentId: string,
+		user: User,
+		sessionId: ChatSessionId,
+		history: ChatHubMessage[],
+		message: string,
+		attachments: IBinaryData[],
+		timeZone: string,
 		trx: EntityManager,
+		ctx: OperationContext,
 		executionMetadata: ChatHubAuthenticationMetadata,
 	) {
 		const agent = await this.chatHubAgentRepository.getOneById(agentId, user.id, trx);
@@ -1388,12 +1444,40 @@ Respond the title only:`,
 			agent.files.length > 0 && semanticSearchOptions
 				? { agentId: agent.id, options: semanticSearchOptions }
 				: null,
-			trx,
+			ctx,
 			executionMetadata,
 		);
 	}
 
 	private async prepareWorkflowAgentWorkflow(
+		user: User,
+		sessionId: ChatSessionId,
+		workflowId: string,
+		message: string,
+		attachments: IBinaryData[],
+		ctx: OperationContext,
+		executionMetadata: ChatHubAuthenticationMetadata,
+		manual?: boolean,
+	) {
+		// This branch runs the user's own workflow rather than creating one, so it needs the
+		// caller's manager but no clearance.
+		return await this.workflowRepository.runInTransaction(
+			ctx,
+			async (trx) =>
+				await this.prepareWorkflowAgentWorkflowInTransaction(
+					user,
+					sessionId,
+					workflowId,
+					message,
+					attachments,
+					trx,
+					executionMetadata,
+					manual,
+				),
+		);
+	}
+
+	private async prepareWorkflowAgentWorkflowInTransaction(
 		user: User,
 		sessionId: ChatSessionId,
 		workflowId: string,
@@ -1644,7 +1728,7 @@ You can update the most recent document using the commands described above, or c
 		attachments: Array<{ attachment: IBinaryData; knowledgeId: string }>,
 		agentId: string,
 		vectorStoreSearch: SemanticSearchOptions,
-		trx: EntityManager,
+		ctx: OperationContext,
 		workflowId: string,
 	): Promise<{
 		workflowData: IWorkflowBase;
@@ -1782,45 +1866,50 @@ You can update the most recent document using the commands described above, or c
 			},
 		];
 
-		return await withTransaction(this.workflowRepository.manager, trx, async (em) => {
-			const newWorkflow = new WorkflowEntity();
+		const newWorkflow = new WorkflowEntity();
 
-			// Chat workflows are created as archived to hide them
-			// from the user by default while they are being run.
-			newWorkflow.isArchived = true;
+		// Chat workflows are created as archived to hide them
+		// from the user by default while they are being run.
+		newWorkflow.isArchived = true;
 
-			newWorkflow.id = workflowId;
-			newWorkflow.versionId = uuidv4();
-			newWorkflow.name = `Chat files insertion ${uuidv4()}`;
-			newWorkflow.active = false;
-			newWorkflow.activeVersionId = null;
-			newWorkflow.nodes = nodes;
-			newWorkflow.connections = connections;
-			newWorkflow.settings = {
-				executionOrder: 'v1',
-			};
+		newWorkflow.id = workflowId;
+		newWorkflow.versionId = uuidv4();
+		newWorkflow.name = `Chat files insertion ${uuidv4()}`;
+		newWorkflow.active = false;
+		newWorkflow.activeVersionId = null;
+		newWorkflow.nodes = nodes;
+		newWorkflow.connections = connections;
+		newWorkflow.settings = {
+			executionOrder: 'v1',
+		};
 
-			const workflow = await em.save<WorkflowEntity>(newWorkflow);
+		const cleared = await this.enforceChatWorkflowSave(newWorkflow, projectId);
 
-			await em.save<SharedWorkflow>(
-				this.sharedWorkflowRepository.create({
-					role: 'workflow:owner',
-					projectId,
-					workflow,
-				}),
-			);
+		return await this.workflowRepository.runInTransaction(
+			{ ...ctx, policyCleared: cleared },
+			async (em, txCtx) => {
+				const workflow = await this.workflowRepository.createContent(newWorkflow, txCtx);
 
-			return {
-				workflowData: workflow,
-				executionData: createRunExecutionData({
-					executionData: {
-						nodeExecutionStack,
-					},
-					manualData: {
-						userId: user.id,
-					},
-				}),
-			};
-		});
+				await em.save<SharedWorkflow>(
+					this.sharedWorkflowRepository.create({
+						role: 'workflow:owner',
+						projectId,
+						workflow,
+					}),
+				);
+
+				return {
+					workflowData: workflow,
+					executionData: createRunExecutionData({
+						executionData: {
+							nodeExecutionStack,
+						},
+						manualData: {
+							userId: user.id,
+						},
+					}),
+				};
+			},
+		);
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -457,7 +457,7 @@ export class ChatHubService {
 		let previousMessage: ChatHubMessage | undefined;
 
 		try {
-			const result = await this.messageRepository.manager.transaction(async (trx) => {
+			const result = await this.messageRepository.runInTransaction({}, async (trx, ctx) => {
 				let session = await this.getChatSession(user, sessionId, trx);
 				const isNewSession = !session;
 				session ??= await this.createChatSession(
@@ -516,7 +516,7 @@ export class ChatHubService {
 					tools,
 					processedAttachments,
 					tz,
-					trx,
+					ctx,
 					executionMetadata,
 				);
 
@@ -612,7 +612,7 @@ export class ChatHubService {
 		let workflow: PreparedChatWorkflow;
 		let previousMessage: ChatHubMessage | undefined;
 		try {
-			const result = await this.messageRepository.manager.transaction(async (trx) => {
+			const result = await this.messageRepository.runInTransaction({}, async (trx, ctx) => {
 				let session = await this.getChatSession(user, sessionId, trx);
 				session ??= await this.createChatSession(
 					user,
@@ -672,7 +672,7 @@ export class ChatHubService {
 					tools,
 					processedAttachments,
 					tz,
-					trx,
+					ctx,
 					executionMetadata,
 					true, // manual
 				);
@@ -757,7 +757,7 @@ export class ChatHubService {
 		let newStoredAttachments: IBinaryData[] = [];
 
 		try {
-			result = await this.messageRepository.manager.transaction(async (trx) => {
+			result = await this.messageRepository.runInTransaction({}, async (trx, ctx) => {
 				const session = await this.getChatSession(user, sessionId, trx);
 				if (!session) {
 					throw new NotFoundError('Chat session not found');
@@ -814,7 +814,7 @@ export class ChatHubService {
 						tools,
 						attachments,
 						tz,
-						trx,
+						ctx,
 						executionMetadata,
 					);
 
@@ -895,7 +895,7 @@ export class ChatHubService {
 		let newStoredAttachments: IBinaryData[] = [];
 
 		try {
-			result = await this.messageRepository.manager.transaction(async (trx) => {
+			result = await this.messageRepository.runInTransaction({}, async (trx, ctx) => {
 				const session = await this.getChatSession(user, sessionId, trx);
 				if (!session) {
 					throw new NotFoundError('Chat session not found');
@@ -968,7 +968,7 @@ export class ChatHubService {
 						tools,
 						attachments,
 						tz,
-						trx,
+						ctx,
 						executionMetadata,
 						true, // manual
 					);
@@ -1039,7 +1039,7 @@ export class ChatHubService {
 		const tz = timeZone ?? this.globalConfig.generic.timezone;
 
 		const { retryOfMessageId, previousMessageId, workflow } =
-			await this.messageRepository.manager.transaction(async (trx) => {
+			await this.messageRepository.runInTransaction({}, async (trx, ctx) => {
 				const session = await this.getChatSession(user, sessionId, trx);
 				if (!session) {
 					throw new NotFoundError('Chat session not found');
@@ -1080,7 +1080,7 @@ export class ChatHubService {
 					tools,
 					attachments,
 					tz,
-					trx,
+					ctx,
 					executionMetadata,
 				);
 
@@ -1124,7 +1124,7 @@ export class ChatHubService {
 		}
 
 		const { retryOfMessageId, previousMessageId, workflow } =
-			await this.messageRepository.manager.transaction(async (trx) => {
+			await this.messageRepository.runInTransaction({}, async (trx, ctx) => {
 				const session = await this.getChatSession(user, sessionId, trx);
 				if (!session) {
 					throw new NotFoundError('Chat session not found');
@@ -1166,7 +1166,7 @@ export class ChatHubService {
 					tools,
 					attachments,
 					tz,
-					trx,
+					ctx,
 					executionMetadata,
 					true, // manual
 				);

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -4,9 +4,9 @@ import type {
 	ChatMessageId,
 	ChatSessionId,
 } from '@n8n/api-types';
-import { User, withTransaction } from '@n8n/db';
+import { BaseRepository, TransactionRunner, User, withTransaction } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
+import { DataSource, EntityManager } from '@n8n/typeorm';
 import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { UnexpectedError, type IBinaryData } from 'n8n-workflow';
 
@@ -15,12 +15,13 @@ import { EditMessagePayload, HumanMessagePayload } from './chat-hub.types';
 import { ChatHubSessionRepository } from './chat-session.repository';
 
 @Service()
-export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
+export class ChatHubMessageRepository extends BaseRepository<ChatHubMessage> {
 	constructor(
 		dataSource: DataSource,
 		private chatSessionRepository: ChatHubSessionRepository,
+		transactionRunner: TransactionRunner,
 	) {
-		super(ChatHubMessage, dataSource.manager);
+		super(ChatHubMessage, dataSource.manager, transactionRunner);
 	}
 
 	async createChatMessage(message: QueryDeepPartialEntity<ChatHubMessage>, trx?: EntityManager) {

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -1,14 +1,15 @@
+import { BaseRepository, TransactionRunner } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
+import { DataSource, EntityManager } from '@n8n/typeorm';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { ChatHubSession, IChatHubSession } from './chat-hub-session.entity';
 
 @Service()
-export class ChatHubSessionRepository extends Repository<ChatHubSession> {
-	constructor(dataSource: DataSource) {
-		super(ChatHubSession, dataSource.manager);
+export class ChatHubSessionRepository extends BaseRepository<ChatHubSession> {
+	constructor(dataSource: DataSource, transactionRunner: TransactionRunner) {
+		super(ChatHubSession, dataSource.manager, transactionRunner);
 	}
 
 	async createChatSession(


### PR DESCRIPTION
## Summary

All three chat-hub creates wrote their workflow row with a raw `em.save<WorkflowEntity>(…)`; they now go through the token-gated `WorkflowRepository.createContent`. Chat workflows are system-generated, but their nodes are real, so a blocked node type stops the run instead of reaching the engine. The structural work is the transaction: these creates join a transaction the *caller* opened with the raw TypeORM API, so the operation context the sealed method needs had nowhere to come from. The chat-hub chain now threads a context instead of an `EntityManager` — each method joins the caller's transaction via `runInTransaction` and recovers the manager for the reads that still take one, so the whole chat path stays in a single transaction exactly as before. The chat-hub message, session and agent repositories extend `BaseRepository`, which is what lets their callers open a context-carrying transaction in the first place.

`getAttachmentPolicy` and the workflow-agent branch deliberately keep taking a manager: they read the user's own workflow rather than creating one, so they need no clearance.

## How to test

The policy layer is opt-in. Enable it with `N8N_ENABLED_MODULES=policy-infrastructure`.

1. Run `pnpm --filter n8n test src/modules/chat-hub`. Four new tests cover all three sites: the clearance is enforced and threaded into `createContent` for the chat, title-generation and embeddings-insertion workflows, and a blocked save writes nothing. The embeddings case supplies its own workflow id, so it also covers the id-bound subject rather than the node hash.
2. To confirm the lint ratchet guards the file, replace any `createContent` call in `chat-hub-workflow.service.ts` with `em.save<WorkflowEntity>(newWorkflow)` and run `npx eslint src/modules/chat-hub/chat-hub-workflow.service.ts` from `packages/cli`. It must fail with `no-unsealed-workflow-entity-write` at each site.
3. With no module enabled, send a chat message, let a session title generate, and attach a file to an agent. All three must work unchanged and stay in one transaction.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/IAM-1304

Part of the staged delivery under https://linear.app/n8n/issue/IAM-1128, alongside #37461, #37481 and #37493. Those three are stacked on each other; this one is not, so it can merge in any order relative to them. Whichever lands last should drop the now-empty allowlist block.

One note for review: `chat-hub-workflow.service.ts` still imports `EntityManager`, so it stays on the separate `misplaced-n8n-typeorm-import` ratchet. Dropping that too means converting `getAttachmentPolicy` and the sibling chat-hub services off `EntityManager`, which is its own change.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
