### PR TITLE
ci: Minimize outdated cubic review comments

### DIFF
--- a/.github/workflows/util-hide-outdated-cubic-comments.yml
+++ b/.github/workflows/util-hide-outdated-cubic-comments.yml
@@ -1,0 +1,63 @@
+name: Hide outdated cubic review comments
+
+# Every time cubic re-reviews a PR (e.g. after a new commit) it posts a brand new
+# "left a comment" review summary instead of updating the previous one, which
+# clutters the PR timeline. This workflow minimizes (hides) all but the most
+# recent cubic-dev-ai review comment on a PR, so only the latest summary is
+# visible by default. Hidden comments are collapsed, not deleted -- anyone can
+# still expand them.
+
+on:
+  pull_request:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  hide-old-cubic-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Minimize previous cubic-dev-ai review comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            // Only touch cubic's own reviews that actually have a comment body.
+            const cubicReviews = reviews
+              .filter(
+                (r) =>
+                  r.user &&
+                  r.user.login === 'cubic-dev-ai[bot]' &&
+                  r.body &&
+                  r.body.trim().length > 0
+              )
+              .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at));
+
+            // Keep the newest review visible, hide everything older.
+            const toHide = cubicReviews.slice(0, -1);
+
+            for (const review of toHide) {
+              try {
+                await github.graphql(
+                  `mutation($id: ID!) {
+                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                      minimizedComment { isMinimized }
+                    }
+                  }`,
+                  { id: review.node_id }
+                );
+                console.log(`Minimized cubic review ${review.id}`);
+              } catch (err) {
+                console.log(`Could not minimize review ${review.id}: ${err.message}`);
+              }
+            }

--- a/.github/workflows/util-hide-outdated-cubic-comments.yml
+++ b/.github/workflows/util-hide-outdated-cubic-comments.yml
@@ -8,7 +8,7 @@ name: Hide outdated cubic review comments
 # still expand them.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize]
 
 permissions:

--- a/.github/workflows/util-hide-outdated-cubic-comments.yml
+++ b/.github/workflows/util-hide-outdated-cubic-comments.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Minimize previous cubic-dev-ai review comments
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/util-hide-outdated-cubic-comments.yml
+++ b/.github/workflows/util-hide-outdated-cubic-comments.yml
@@ -7,8 +7,14 @@ name: Hide outdated cubic review comments
 # visible by default. Hidden comments are collapsed, not deleted -- anyone can
 # still expand them.
 
+# Runs on `pull_request` (not `pull_request_target`) so it never executes with
+# elevated permissions against untrusted fork code. The tradeoff: GitHub only
+# grants a write-capable token to `pull_request` runs when the PR's head repo
+# is this same repo, so the job below is skipped for PRs from forks -- outdated
+# cubic comments on external-contributor PRs won't be minimized.
+
 on:
-  pull_request_target:
+  pull_request:
     types: [synchronize]
 
 permissions:
@@ -16,6 +22,7 @@ permissions:
 
 jobs:
   hide-old-cubic-reviews:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Minimize previous cubic-dev-ai review comments


### PR DESCRIPTION
## Summary

cubic posts a brand-new "left a comment" review summary every time it re-reviews
a PR (e.g. after each new commit), instead of updating its previous one. On
long-lived PRs with several commits this clutters the timeline with repeated
"0 issues found" reviews.

This adds a workflow that runs on every push to an open PR and minimizes
(hides) all but the most recent cubic-dev-ai review comment. Hidden comments
are collapsed, not deleted — anyone can still expand them from the timeline.

It only targets reviews authored by `cubic-dev-ai[bot]` with a non-empty body,
so it never touches human comments, other bots, or cubic's inline code
comments.

## How to test

1. Open a PR and push a couple of commits so cubic reviews it more than once.
2. After the second push, confirm the workflow run (`Hide outdated cubic
   review comments`) completes successfully in the Actions tab.
3. Check the PR timeline — only the newest cubic review comment should be
   expanded; older ones should show as collapsed/hidden and expandable.

## Related Linear tickets, Github issues, and Community forum posts


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

