### PR TITLE
test: Measure cli with environment reuse across test files (no-changelog)

### DIFF
--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -75,8 +75,11 @@ jobs:
       - name: Test Unit (backend, except cli and nodes-base)
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
+      # EXPERIMENT ARM: default 2 workers, environment reused across files.
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
+        env:
+          VITEST_ISOLATE: 'false'
         run: pnpm turbo test:unit:changed --filter=n8n --summarize
 
       - name: Send Test Stats

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -39,11 +39,15 @@ export const cjsPinAliases = (deps: string[], from: string = process.cwd()): Ali
  * `--concurrency` near the core count, and adapts to the runner size instead of
  * a hardcoded value. Off outside CI, so a single-package `pnpm test` keeps full
  * parallelism and behaviour is unchanged.
+ *
+ * A step that runs exactly one package gets no benefit from turbo concurrency,
+ * so half the cores stay idle for its whole duration. Such a step raises the
+ * cap with VITEST_MAX_WORKERS.
  */
 export const forkPoolOptions = (): InlineConfig => {
 	if (process.env.CI !== 'true') return {};
 	// Vitest accepts a percentage for `maxWorkers` (half of availableParallelism).
-	return { pool: 'forks', maxWorkers: '50%' };
+	return { pool: 'forks', maxWorkers: process.env.VITEST_MAX_WORKERS ?? '50%' };
 };
 
 /**

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -47,7 +47,13 @@ export const cjsPinAliases = (deps: string[], from: string = process.cwd()): Ali
 export const forkPoolOptions = (): InlineConfig => {
 	if (process.env.CI !== 'true') return {};
 	// Vitest accepts a percentage for `maxWorkers` (half of availableParallelism).
-	return { pool: 'forks', maxWorkers: process.env.VITEST_MAX_WORKERS ?? '50%' };
+	return {
+		pool: 'forks',
+		maxWorkers: process.env.VITEST_MAX_WORKERS ?? '50%',
+		// A suite whose files do not rely on cross-file side effects can reuse the
+		// environment instead of rebuilding it per file.
+		...(process.env.VITEST_ISOLATE === 'false' ? { isolate: false } : {}),
+	};
 };
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,8 @@
 		"COVERAGE_ENABLED",
 		"SENTRY_AUTH_TOKEN",
 		// Worker count changes timing, never output, so it must not enter the hash.
-		"VITEST_MAX_WORKERS"
+		"VITEST_MAX_WORKERS",
+		"VITEST_ISOLATE"
 	],
 	"boundaries": {
 		// `~icons/*` is a vite virtual module injected by unplugin-icons (design-system

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,12 @@
 {
 	"globalEnv": ["CI", "BUILD_WITH_COVERAGE"],
-	"globalPassThroughEnv": ["CODECOV_TOKEN", "COVERAGE_ENABLED", "SENTRY_AUTH_TOKEN"],
+	"globalPassThroughEnv": [
+		"CODECOV_TOKEN",
+		"COVERAGE_ENABLED",
+		"SENTRY_AUTH_TOKEN",
+		// Worker count changes timing, never output, so it must not enter the hash.
+		"VITEST_MAX_WORKERS"
+	],
 	"boundaries": {
 		// `~icons/*` is a vite virtual module injected by unplugin-icons (design-system
 		// icon barrel), not a real package — declare it so boundaries doesn't flag it.


### PR DESCRIPTION
Experiment arm for #37466 — do not merge, will be closed once measured.

## Why this arm

Parsing the per-file timings out of a 2-worker cli run reframed the problem:

```
test files                     814
tests                       18,119
summed file execution time      67s
step wall-clock                661s
perfect 2-worker parallelism    34s
```

**About 90% of the step is not test execution.** Per-file median is 12ms and 85% of files finish under 50ms, which works out to roughly 770ms of harness overhead per file against ~80ms of median work.

That explains why the worker-cap ladder produced only noise plus timeouts — 2/3/4 workers was optimising the 10%.

## Change

Sets `isolate: false` for the cli unit step only, at the **default 2 workers** — one variable, no oversubscription. Vitest's own docs on the option: *"Disabling this option improves performance if your code doesn't rely on side effects."*

Branched from the control arm (#37487) so `isolate` is the only difference. Adds `VITEST_ISOLATE` to `globalPassThroughEnv` for the same reason `VITEST_MAX_WORKERS` needed it — turbo sanitises the environment and silently drops anything not listed.

## What would make this shippable, and what would not

A green run is **not** sufficient. Reusing the environment means module-level state persists across files, and n8n leans on `@n8n/di` `Container` singletons — leakage shows up as order-dependent flakes, not clean failures. Before anyone ships this it needs several repeat runs plus a shuffled-order run.

If it fails with cross-file errors, that is a useful answer too: the suite depends on isolation and cli should be left alone.

## Comparison set

| arm | cli config | step |
|---|---|---|
| control #37487 | 2 workers, isolated | pending |
| #37466 | 2 workers, isolated | 661s green |
| #37482 | 3 workers, isolated | 606s, 2 timeouts |
| #37483 | 4 workers, isolated | 700s, 6 timeouts |
| **this** | **2 workers, reused env** | **pending** |


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

