### PR TITLE
feat(Microsoft Teams Node): Add Online Meeting resource with Create operation

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
@@ -9,6 +9,7 @@ const defaultScopes = [
 	'Group.ReadWrite.All',
 	'Chat.ReadWrite',
 	'ChannelMessage.Read.All',
+	'OnlineMeetings.ReadWrite',
 ];
 
 export class MicrosoftTeamsOAuth2Api implements ICredentialType {

--- a/packages/nodes-base/credentials/test/MicrosoftTeamsOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftTeamsOAuth2Api.credentials.test.ts
@@ -12,6 +12,7 @@ describe('MicrosoftTeamsOAuth2Api Credential', () => {
 		'Group.ReadWrite.All',
 		'Chat.ReadWrite',
 		'ChannelMessage.Read.All',
+		'OnlineMeetings.ReadWrite',
 	];
 
 	// Shared OAuth2 configuration
@@ -70,7 +71,7 @@ describe('MicrosoftTeamsOAuth2Api Credential', () => {
 			(p) => p.name === 'enabledScopes',
 		);
 		expect(enabledScopesProperty?.default).toBe(
-			'openid offline_access User.Read.All Group.ReadWrite.All Chat.ReadWrite ChannelMessage.Read.All',
+			'openid offline_access User.Read.All Group.ReadWrite.All Chat.ReadWrite ChannelMessage.Read.All OnlineMeetings.ReadWrite',
 		);
 	});
 
@@ -87,6 +88,7 @@ describe('MicrosoftTeamsOAuth2Api Credential', () => {
 			expect(authUri).toContain('Group.ReadWrite.All');
 			expect(authUri).toContain('Chat.ReadWrite');
 			expect(authUri).toContain('ChannelMessage.Read.All');
+			expect(authUri).toContain('OnlineMeetings.ReadWrite');
 			expect(authUri).toContain(`client_id=${clientId}`);
 			expect(authUri).toContain('response_type=code');
 		});
@@ -104,6 +106,7 @@ describe('MicrosoftTeamsOAuth2Api Credential', () => {
 			expect(token.data.scope).toContain('Group.ReadWrite.All');
 			expect(token.data.scope).toContain('Chat.ReadWrite');
 			expect(token.data.scope).toContain('ChannelMessage.Read.All');
+			expect(token.data.scope).toContain('OnlineMeetings.ReadWrite');
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.minimal.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.minimal.workflow.json
@@ -1,0 +1,88 @@
+{
+	"name": "onlineMeeting create minimal",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "create",
+				"subject": "Standup",
+				"startDateTime": "2026-09-11T09:00:00Z",
+				"endDateTime": "2026-09-11T09:15:00Z"
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MSpTdGFuZHVwLW1pbmltYWw",
+					"startDateTime": "2026-09-11T09:00:00Z",
+					"endDateTime": "2026-09-11T09:15:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_c3RhbmR1cA%40thread.v2/0",
+					"subject": "Standup"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "ec0b4e3d-2fd7-4fac-90e5-f18ecd620a05",
+	"id": "onlineMeetingCreate02",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.test.ts
@@ -45,8 +45,24 @@ describe('Test MicrosoftTeamsV2, onlineMeeting => create', () => {
 			},
 		});
 
+	// Minimal create: options collection omitted entirely — exact body proves no
+	// option keys leak into the request.
+	nock('https://graph.microsoft.com')
+		.post('/v1.0/me/onlineMeetings', {
+			subject: 'Standup',
+			startDateTime: '2026-09-11T09:00:00Z',
+			endDateTime: '2026-09-11T09:15:00Z',
+		})
+		.reply(201, {
+			id: 'MSpTdGFuZHVwLW1pbmltYWw',
+			startDateTime: '2026-09-11T09:00:00Z',
+			endDateTime: '2026-09-11T09:15:00Z',
+			joinWebUrl: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_c3RhbmR1cA%40thread.v2/0',
+			subject: 'Standup',
+		});
+
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['create.workflow.json'],
+		workflowFiles: ['create.workflow.json', 'create.minimal.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.test.ts
@@ -1,0 +1,52 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, onlineMeeting => create', () => {
+	nock('https://graph.microsoft.com')
+		// Exact body: proves option mapping, including booleans explicitly set to false.
+		.post('/v1.0/me/onlineMeetings', {
+			subject: 'Quarterly Sync',
+			startDateTime: '2026-09-10T10:00:00Z',
+			endDateTime: '2026-09-10T10:30:00Z',
+			allowAttendeeToEnableCamera: false,
+			allowAttendeeToEnableMic: true,
+			allowMeetingChat: 'limited',
+			allowTeamworkReactions: false,
+			allowedPresenters: 'organizer',
+			isEntryExitAnnounced: true,
+			lobbyBypassSettings: { scope: 'organizationAndFederated' },
+			recordAutomatically: false,
+			joinMeetingIdSettings: { isPasscodeRequired: true },
+		})
+		.reply(201, {
+			'@odata.context':
+				"https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+			id: 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+			creationDateTime: '2026-09-01T09:00:00.649Z',
+			startDateTime: '2026-09-10T10:00:00Z',
+			endDateTime: '2026-09-10T10:30:00Z',
+			joinWebUrl:
+				'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d',
+			subject: 'Quarterly Sync',
+			participants: {
+				organizer: {
+					upn: 'alex@contoso.com',
+					identity: {
+						user: { id: '11111111-2222-3333-4444-555555555555', displayName: 'Alex Wilber' },
+					},
+				},
+			},
+			joinMeetingIdSettings: {
+				isPasscodeRequired: true,
+				joinMeetingId: '1234567890',
+				passcode: 'xK7mp2',
+			},
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['create.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.workflow.json
@@ -1,0 +1,117 @@
+{
+	"name": "onlineMeeting create",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "create",
+				"subject": "Quarterly Sync",
+				"startDateTime": "2026-09-10T10:00:00Z",
+				"endDateTime": "2026-09-10T10:30:00Z",
+				"options": {
+					"allowAttendeeToEnableCamera": false,
+					"allowAttendeeToEnableMic": true,
+					"allowMeetingChat": "limited",
+					"allowTeamworkReactions": false,
+					"allowedPresenters": "organizer",
+					"isEntryExitAnnounced": true,
+					"lobbyBypassScope": "organizationAndFederated",
+					"recordAutomatically": false,
+					"passcodeRequired": true
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+					"id": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi",
+					"creationDateTime": "2026-09-01T09:00:00.649Z",
+					"startDateTime": "2026-09-10T10:00:00Z",
+					"endDateTime": "2026-09-10T10:30:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d",
+					"subject": "Quarterly Sync",
+					"participants": {
+						"organizer": {
+							"upn": "alex@contoso.com",
+							"identity": {
+								"user": {
+									"id": "11111111-2222-3333-4444-555555555555",
+									"displayName": "Alex Wilber"
+								}
+							}
+						}
+					},
+					"joinMeetingIdSettings": {
+						"isPasscodeRequired": true,
+						"joinMeetingId": "1234567890",
+						"passcode": "xK7mp2"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "ec0b4e3d-2fd7-4fac-90e5-f18ecd620a01",
+	"id": "onlineMeetingCreate01",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -72,6 +72,19 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
 	});
 
+	it.each([['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }]])(
+		'onlineMeeting:%s throws a static error and issues no request under SP',
+		async (op, params) => {
+			selectSp({ resource: 'onlineMeeting', operation: op, ...params });
+
+			await expect(node.execute.call(ctx)).rejects.toThrow(
+				'Online meetings are not available with the Service Principal credential',
+			);
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+			expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
+		},
+	);
+
 	it('chatMessage:sendAndWait throws under SP and NEVER calls putExecutionToWait', async () => {
 		selectSp({
 			resource: 'chatMessage',

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -66,6 +66,43 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
+	describe('onlineMeeting — hidden under SP via the slash-prefixed field-level key', () => {
+		it('operation selector carries hide["/authentication"] = [SP]', () => {
+			const op = actionProps.find(
+				(p) =>
+					p.name === 'operation' && p.displayOptions?.show?.resource?.includes('onlineMeeting'),
+			);
+			expect(isSpHidden(op)).toBe(true);
+			// distinct from the un-prefixed credential gate
+			expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
+		});
+
+		it('every onlineMeeting field copy is hidden under SP', () => {
+			const meetingFields = actionProps.filter((p) =>
+				p.displayOptions?.show?.resource?.includes('onlineMeeting'),
+			);
+			// subject, start/end times, options, getBy, meetingId, joinWebUrl…
+			const gatedFields = meetingFields.filter(
+				(p) => p.type !== 'notice' && p.name !== 'operation',
+			);
+			expect(gatedFields.length).toBeGreaterThan(0);
+			for (const field of gatedFields) {
+				expect(isSpHidden(field)).toBe(true);
+			}
+		});
+
+		it('shows an SP notice for the onlineMeeting resource', () => {
+			const notice = actionProps.find(
+				(p) =>
+					p.type === 'notice' &&
+					p.displayOptions?.show?.resource?.includes('onlineMeeting') &&
+					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+			);
+			expect(notice).toBeDefined();
+			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+		});
+	});
+
 	describe('channelMessage — only create hidden under SP', () => {
 		it('create fields are hidden, getAll fields are shown', () => {
 			const createFields = actionProps.filter(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -4,6 +4,7 @@ type NodeMap = {
 	channel: 'create' | 'deleteChannel' | 'get' | 'getAll' | 'update';
 	channelMessage: 'create' | 'getAll';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
+	onlineMeeting: 'create';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';
 };
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
@@ -1,0 +1,212 @@
+import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { throwIfOnlineMeetingUnsupported } from './sharedGuard';
+import { microsoftApiRequest, SP_HIDE } from '../../transport';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Subject',
+		name: 'subject',
+		required: true,
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. Quarterly Sync',
+		description: 'The subject of the meeting',
+	},
+	{
+		displayName: 'Start Time',
+		name: 'startDateTime',
+		required: true,
+		type: 'dateTime',
+		default: '',
+		description: 'The date and time when the meeting starts',
+	},
+	{
+		displayName: 'End Time',
+		name: 'endDateTime',
+		required: true,
+		type: 'dateTime',
+		default: '',
+		description: 'The date and time when the meeting ends. Must be later than the start time.',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		options: [
+			{
+				displayName: 'Allow Attendees to Enable Camera',
+				name: 'allowAttendeeToEnableCamera',
+				type: 'boolean',
+				default: true,
+				description: 'Whether attendees can turn on their camera',
+			},
+			{
+				displayName: 'Allow Attendees to Enable Microphone',
+				name: 'allowAttendeeToEnableMic',
+				type: 'boolean',
+				default: true,
+				description: 'Whether attendees can turn on their microphone',
+			},
+			{
+				displayName: 'Allow Meeting Chat',
+				name: 'allowMeetingChat',
+				type: 'options',
+				options: [
+					{
+						name: 'Disabled',
+						value: 'disabled',
+					},
+					{
+						name: 'Enabled',
+						value: 'enabled',
+					},
+					{
+						name: 'Limited',
+						value: 'limited',
+						description: 'Chat is available only during the meeting',
+					},
+				],
+				default: 'enabled',
+				description: 'The mode of the meeting chat',
+			},
+			{
+				displayName: 'Allow Teamwork Reactions',
+				name: 'allowTeamworkReactions',
+				type: 'boolean',
+				default: true,
+				description: 'Whether Teams reactions are enabled for the meeting',
+			},
+			{
+				displayName: 'Allowed Presenters',
+				name: 'allowedPresenters',
+				type: 'options',
+				options: [
+					{
+						name: 'Everyone',
+						value: 'everyone',
+					},
+					{
+						name: 'Organization',
+						value: 'organization',
+					},
+					{
+						name: 'Organizer',
+						value: 'organizer',
+					},
+				],
+				default: 'everyone',
+				description: 'Who can present in the meeting',
+			},
+			{
+				displayName: 'Announce Entry and Exit',
+				name: 'isEntryExitAnnounced',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to announce when callers join or leave the meeting',
+			},
+			{
+				displayName: 'Lobby Bypass Scope',
+				name: 'lobbyBypassScope',
+				type: 'options',
+				options: [
+					{
+						name: 'Everyone',
+						value: 'everyone',
+					},
+					{
+						name: 'Organization',
+						value: 'organization',
+					},
+					{
+						name: 'Organization and Federated',
+						value: 'organizationAndFederated',
+						description: 'People in the organization and guests from trusted organizations',
+					},
+					{
+						name: 'Organizer',
+						value: 'organizer',
+					},
+				],
+				default: 'organization',
+				description: 'Who can join the meeting without waiting in the lobby',
+			},
+			{
+				displayName: 'Record Automatically',
+				name: 'recordAutomatically',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to record the meeting automatically',
+			},
+			{
+				displayName: 'Require Passcode',
+				name: 'passcodeRequired',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether a passcode is required to join the meeting by meeting ID. This setting cannot be changed after the meeting is created.',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['onlineMeeting'],
+		operation: ['create'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/application-post-onlinemeetings?view=graph-rest-1.0&tabs=http
+	throwIfOnlineMeetingUnsupported.call(this);
+
+	const subject = this.getNodeParameter('subject', i) as string;
+	const startDateTime = this.getNodeParameter('startDateTime', i) as string;
+	const endDateTime = this.getNodeParameter('endDateTime', i) as string;
+	const options = this.getNodeParameter('options', i);
+
+	const body: IDataObject = {
+		subject,
+		startDateTime,
+		endDateTime,
+	};
+	if (options.allowAttendeeToEnableCamera !== undefined) {
+		body.allowAttendeeToEnableCamera = options.allowAttendeeToEnableCamera as boolean;
+	}
+	if (options.allowAttendeeToEnableMic !== undefined) {
+		body.allowAttendeeToEnableMic = options.allowAttendeeToEnableMic as boolean;
+	}
+	if (options.allowMeetingChat) {
+		body.allowMeetingChat = options.allowMeetingChat as string;
+	}
+	if (options.allowTeamworkReactions !== undefined) {
+		body.allowTeamworkReactions = options.allowTeamworkReactions as boolean;
+	}
+	if (options.allowedPresenters) {
+		body.allowedPresenters = options.allowedPresenters as string;
+	}
+	if (options.isEntryExitAnnounced !== undefined) {
+		body.isEntryExitAnnounced = options.isEntryExitAnnounced as boolean;
+	}
+	if (options.lobbyBypassScope) {
+		body.lobbyBypassSettings = { scope: options.lobbyBypassScope as string };
+	}
+	if (options.recordAutomatically !== undefined) {
+		body.recordAutomatically = options.recordAutomatically as boolean;
+	}
+	if (options.passcodeRequired !== undefined) {
+		body.joinMeetingIdSettings = { isPasscodeRequired: options.passcodeRequired as boolean };
+	}
+
+	return await microsoftApiRequest.call(this, 'POST', '/v1.0/me/onlineMeetings', body);
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -1,0 +1,47 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
+
+export { create };
+
+export const description: INodeProperties[] = [
+	{
+		displayName:
+			'Online meetings are not available with the Service Principal credential. Online meeting operations run on the signed-in user (/me); use an OAuth2 credential instead.',
+		name: 'onlineMeetingServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['onlineMeeting'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+	},
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['onlineMeeting'],
+			},
+			hide: {
+				...SP_HIDE,
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create an online meeting',
+				action: 'Create online meeting',
+			},
+		],
+		default: 'create',
+	},
+
+	...create.description,
+];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/sharedGuard.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/sharedGuard.ts
@@ -1,0 +1,24 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { getTeamsCredentialType, SERVICE_PRINCIPAL_AUTH } from '../../transport';
+
+/**
+ * Throws a static `NodeOperationError` when the node is configured with the
+ * app-only (Service Principal) credential. Every online-meeting operation runs
+ * on the signed-in user's `/me` path, which does not exist app-only, so each
+ * operation guards on this BEFORE any request — covering hand-edited workflows
+ * that bypass the hidden UI.
+ */
+export function throwIfOnlineMeetingUnsupported(this: IExecuteFunctions): void {
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Online meetings are not available with the Service Principal credential',
+			{
+				description:
+					'Online meeting operations run on the signed-in user (/me). Use an OAuth2 credential instead.',
+			},
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
@@ -11,6 +11,7 @@ import * as channel from './channel';
 import * as channelMessage from './channelMessage';
 import * as chatMessage from './chatMessage';
 import type { MicrosoftTeamsType } from './node.type';
+import * as onlineMeeting from './onlineMeeting';
 import * as task from './task';
 import { configureWaitTillDate } from '../../../../../utils/sendAndWait/configureWaitTillDate.util';
 
@@ -68,6 +69,12 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 						this,
 						i,
 						instanceId,
+					);
+					break;
+				case 'onlineMeeting':
+					responseData = await onlineMeeting[microsoftTeamsTypeData.operation].execute.call(
+						this,
+						i,
 					);
 					break;
 				case 'task':

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
@@ -4,6 +4,7 @@ import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 import * as channel from './channel';
 import * as channelMessage from './channelMessage';
 import * as chatMessage from './chatMessage';
+import * as onlineMeeting from './onlineMeeting';
 import * as task from './task';
 import { sendAndWaitWebhooksDescription } from '../../../../../utils/sendAndWait/descriptions';
 import { SEND_AND_WAIT_WAITING_TOOLTIP } from '../../../../../utils/sendAndWait/utils';
@@ -68,13 +69,13 @@ export const versionDescription: INodeTypeDescription = {
 					name: 'Microsoft OAuth2 (Graph)',
 					value: 'microsoftOAuth2Api',
 					description:
-						'Generic Microsoft Graph credential. Add the Teams Graph scopes (e.g. Chat.ReadWrite, ChannelMessage.Read.All, Group.ReadWrite.All) and grant admin consent on the credential. See the docs for the full scope string.',
+						'Generic Microsoft Graph credential. Add the Teams Graph scopes (e.g. Chat.ReadWrite, ChannelMessage.Read.All, Group.ReadWrite.All, OnlineMeetings.ReadWrite) and grant admin consent on the credential. See the docs for the full scope string.',
 				},
 				{
 					name: 'Service Principal (App-Only)',
 					value: SERVICE_PRINCIPAL_AUTH,
 					description:
-						'App-only access via a Microsoft Entra app registration. App-only Graph cannot act as a signed-in user, so chat actions and chat triggers are unavailable. Grant the relevant application permissions (e.g. Team.ReadBasic.All, Channel.ReadBasic.All, Tasks.ReadWrite.All) and admin consent on the credential.',
+						'App-only access via a Microsoft Entra app registration. App-only Graph cannot act as a signed-in user, so chat actions, chat triggers, and online meetings are unavailable. Grant the relevant application permissions (e.g. Team.ReadBasic.All, Channel.ReadBasic.All, Tasks.ReadWrite.All) and admin consent on the credential.',
 				},
 			],
 			default: 'microsoftTeamsOAuth2Api',
@@ -98,6 +99,10 @@ export const versionDescription: INodeTypeDescription = {
 					value: 'chatMessage',
 				},
 				{
+					name: 'Online Meeting',
+					value: 'onlineMeeting',
+				},
+				{
 					name: 'Task',
 					value: 'task',
 				},
@@ -108,6 +113,7 @@ export const versionDescription: INodeTypeDescription = {
 		...channel.description,
 		...channelMessage.description,
 		...chatMessage.description,
+		...onlineMeeting.description,
 		...task.description,
 	],
 };


### PR DESCRIPTION
## Summary

> **Stacked PR 1/3** for ENT-325. This PR adds the resource and the Create operation. Get follows in the next PR, Delete in the one after.

Add an **Online Meeting** resource to the Microsoft Teams node (v2) with the **Create** operation.

- **Create**: `POST /v1.0/me/onlineMeetings` (delegated `/me` path) with subject, start time, end time, and nine optional meeting settings (presenters, lobby bypass, meeting chat mode, camera/mic/reactions toggles, entry/exit announcement, auto recording, passcode).
- The resource ships hidden for the Service Principal credential, following the chatMessage pattern: `SP_HIDE` on the operation selector and every field, an SP notice, and a runtime guard that throws before any request. App-only Graph has no `/me` path. ENT-352 adds the app-only route and un-gates the resource.
- Adds `OnlineMeetings.ReadWrite` to the Teams OAuth2 credential default scopes, with the lockstep credential test update. Existing credentials keep their old consent until the user reconnects.

Scope decision from the ticket readiness note: **Create does not expose a `participants` field in this version.** The acceptance criteria do not require it, the shared org-wide user picker (ENT-324) has not landed, and update (ENT-351) covers participants editing. `allowedPresenters` therefore omits `roleIsPresenter`, which only takes effect with an attendee list.

Note for release: before ENT-325 closes, the `OnlineMeetings.ReadWrite` scope needs consent on n8n's Cloud Entra app (Cloud check per ENT-335).

## How to test

1. Connect a Microsoft Teams OAuth2 credential. Reconnect an existing credential so it picks up the new `OnlineMeetings.ReadWrite` scope.
2. Add a Microsoft Teams node. Select the Online Meeting resource and the Create operation. Set subject, start time, and end time. Execute. Check that the returned `joinWebUrl` opens a Teams meeting.
3. Switch the node to a Service Principal credential. The Online Meeting operations disappear and a notice explains why.

Automated coverage: a workflow-harness test that asserts the exact create request body for all nine options, the SP displayOptions contract block, and the SP runtime-guard test.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-325

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
