### PR TITLE
feat(Microsoft Teams Node): Add Online Meeting Get operation

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.joinUrl.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.joinUrl.workflow.json
@@ -1,0 +1,107 @@
+{
+	"name": "onlineMeeting get by join URL",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "get",
+				"meetingId": {
+					"__rl": true,
+					"mode": "url",
+					"value": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi",
+					"creationDateTime": "2026-09-01T09:00:00.649Z",
+					"startDateTime": "2026-09-10T10:00:00Z",
+					"endDateTime": "2026-09-10T10:30:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d",
+					"subject": "Quarterly Sync",
+					"participants": {
+						"organizer": {
+							"upn": "alex@contoso.com",
+							"identity": {
+								"user": {
+									"id": "11111111-2222-3333-4444-555555555555",
+									"displayName": "Alex Wilber"
+								}
+							}
+						}
+					},
+					"joinMeetingIdSettings": {
+						"isPasscodeRequired": false,
+						"joinMeetingId": "1234567890",
+						"passcode": null
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "ec0b4e3d-2fd7-4fac-90e5-f18ecd620a03",
+	"id": "onlineMeetingGetUrl1",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.test.ts
@@ -1,0 +1,44 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+const meeting = {
+	id: 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+	creationDateTime: '2026-09-01T09:00:00.649Z',
+	startDateTime: '2026-09-10T10:00:00Z',
+	endDateTime: '2026-09-10T10:30:00Z',
+	joinWebUrl:
+		'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d',
+	subject: 'Quarterly Sync',
+	participants: {
+		organizer: {
+			upn: 'alex@contoso.com',
+			identity: {
+				user: { id: '11111111-2222-3333-4444-555555555555', displayName: 'Alex Wilber' },
+			},
+		},
+	},
+	joinMeetingIdSettings: {
+		isPasscodeRequired: false,
+		joinMeetingId: '1234567890',
+		passcode: null,
+	},
+};
+
+describe('Test MicrosoftTeamsV2, onlineMeeting => get', () => {
+	nock('https://graph.microsoft.com')
+		.get('/v1.0/me/onlineMeetings/MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi')
+		.reply(200, meeting)
+		// Get by join URL returns a collection envelope; the operation unwraps value[0].
+		.get('/v1.0/me/onlineMeetings')
+		.query({
+			$filter: `JoinWebUrl eq '${meeting.joinWebUrl}'`,
+		})
+		.reply(200, { value: [meeting] });
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['get.workflow.json', 'get.joinUrl.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.validation.test.ts
@@ -1,0 +1,243 @@
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+import type {
+	IExecuteFunctions,
+	INode,
+	INodePropertyRegexValidation,
+	NodeParameterValueType,
+} from 'n8n-workflow';
+
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { meetingRLC } from '../../../../v2/descriptions';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+// Real transport except the network helper, so buildTeamsPath/validateTeamsId
+// run for real; only microsoftApiRequest is stubbed.
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const byId = (value: string) => ({ __rl: true, mode: 'id', value });
+const byUrl = (value: string) => ({ __rl: true, mode: 'url', value });
+
+describe('Microsoft Teams V2 — onlineMeeting:get lookup handling', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = mock<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.helpers.returnJsonArray = vi.fn((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+		ctx.helpers.constructExecutionMetaData = vi.fn(
+			(data) => data,
+		) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown): NodeParameterValueType =>
+				(name in params ? params[name] : fallback) as NodeParameterValueType,
+		);
+	};
+
+	const joinWebUrl =
+		'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d';
+
+	it.each([
+		['with the __rl marker', byUrl(joinWebUrl)],
+		['without the __rl marker', { mode: 'url', value: joinWebUrl }],
+	])(
+		'queries Graph with the documented JoinWebUrl OData filter and unwraps value[0] (%s)',
+		async (_label, meetingId) => {
+			(transport.microsoftApiRequest as Mock).mockResolvedValue({ value: [{ id: 'meeting-1' }] });
+			setParams({ resource: 'onlineMeeting', operation: 'get', meetingId });
+
+			const result = await node.execute.call(ctx);
+
+			expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/v1.0/me/onlineMeetings',
+				{},
+				{ $filter: `JoinWebUrl eq '${joinWebUrl}'` },
+			);
+			expect(result).toEqual([[{ json: { id: 'meeting-1' } }]]);
+		},
+	);
+
+	it('doubles single quotes in the join URL to keep the OData literal intact', async () => {
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ value: [{ id: 'meeting-1' }] });
+		setParams({
+			resource: 'onlineMeeting',
+			operation: 'get',
+			meetingId: byUrl("https://teams.microsoft.com/l/meetup-join/o'brien"),
+		});
+
+		await node.execute.call(ctx);
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'GET',
+			'/v1.0/me/onlineMeetings',
+			{},
+			{ $filter: "JoinWebUrl eq 'https://teams.microsoft.com/l/meetup-join/o''brien'" },
+		);
+	});
+
+	it('throws a clear error when no meeting matches the join URL', async () => {
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ value: [] });
+		setParams({
+			resource: 'onlineMeeting',
+			operation: 'get',
+			meetingId: byUrl('https://teams.microsoft.com/l/meetup-join/unknown'),
+		});
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'No meeting was found for the provided join URL',
+		);
+	});
+
+	it('throws on a blank join URL before any request', async () => {
+		setParams({ resource: 'onlineMeeting', operation: 'get', meetingId: byUrl(' ') });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow('The meeting join URL is empty');
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['url', null, 'The meeting join URL is empty'],
+		['url', { nested: true }, 'The meeting join URL is empty'],
+		['id', null, 'A required ID is empty'],
+		['id', ['x'], 'A required ID is empty'],
+	])('fails before any request when the %s value resolves to %j', async (mode, value, message) => {
+		setParams({
+			resource: 'onlineMeeting',
+			operation: 'get',
+			meetingId: { __rl: true, mode, value },
+		});
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(message);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('treats a plain string meetingId as an ID', async () => {
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: 'meeting-1' });
+		setParams({
+			resource: 'onlineMeeting',
+			operation: 'get',
+			meetingId: 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+		});
+
+		await node.execute.call(ctx);
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'GET',
+			'/v1.0/me/onlineMeetings/MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+		);
+	});
+
+	it.each(['get'])(
+		'onlineMeeting:%s rejects a separator-bearing meetingId before any request',
+		async (op) => {
+			setParams({
+				resource: 'onlineMeeting',
+				operation: op,
+				meetingId: byId('x/../../users/evil'),
+			});
+
+			// The path (and its validation) is built outside the op's try/catch, so the
+			// validator's specific message surfaces instead of the generic "doesn't exist" one.
+			await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([['get', "The meeting you are trying to get doesn't exist"]])(
+		'replaces a Graph 404 on %s by ID with the friendly not-found message',
+		async (op, message) => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				Object.assign(new Error('Not Found'), { httpCode: '404' }),
+			);
+			setParams({
+				resource: 'onlineMeeting',
+				operation: op,
+				meetingId: byId('MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi'),
+			});
+
+			await expect(node.execute.call(ctx)).rejects.toThrow(message);
+		},
+	);
+
+	it.each(['get'])(
+		'rethrows a non-404 Graph error on %s unchanged (e.g. missing-scope 403)',
+		async (op) => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				Object.assign(new Error('Insufficient privileges to complete the operation'), {
+					httpCode: '403',
+				}),
+			);
+			setParams({
+				resource: 'onlineMeeting',
+				operation: op,
+				meetingId: byId('MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi'),
+			});
+
+			await expect(node.execute.call(ctx)).rejects.toThrow(
+				'Insufficient privileges to complete the operation',
+			);
+		},
+	);
+});
+
+describe('Microsoft Teams V2 — meeting resource locator', () => {
+	const modePattern = (name: string) => {
+		const mode = meetingRLC.modes?.find((candidate) => candidate.name === name);
+		const validation = mode?.validation?.[0] as INodePropertyRegexValidation;
+		return new RegExp(`^${validation.properties.regex}$`);
+	};
+	const joinUrlPattern = modePattern('url');
+	const idPattern = modePattern('id');
+
+	it.each([
+		'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d',
+		'https://gov.teams.microsoft.us/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0',
+		' https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0 ',
+		'',
+	])('url mode accepts %j', (url) => {
+		expect(joinUrlPattern.test(url)).toBe(true);
+	});
+
+	it.each([
+		'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+		'https://teams.microsoft.com/meet/2345678901234?p=abc',
+	])('url mode rejects %s, which the JoinWebUrl filter can never match', (value) => {
+		expect(joinUrlPattern.test(value)).toBe(false);
+	});
+
+	it.each(['MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi', 'MSpk+YzE3=', ''])('id mode accepts %j', (id) => {
+		expect(idPattern.test(id)).toBe(true);
+	});
+
+	it.each([
+		'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0',
+		'x/../../users/evil',
+		'MSpk%2F',
+	])('id mode rejects %s, which buildTeamsPath would refuse at run time', (id) => {
+		expect(idPattern.test(id)).toBe(false);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.workflow.json
@@ -1,0 +1,107 @@
+{
+	"name": "onlineMeeting get by ID",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "get",
+				"meetingId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi",
+					"creationDateTime": "2026-09-01T09:00:00.649Z",
+					"startDateTime": "2026-09-10T10:00:00Z",
+					"endDateTime": "2026-09-10T10:30:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d",
+					"subject": "Quarterly Sync",
+					"participants": {
+						"organizer": {
+							"upn": "alex@contoso.com",
+							"identity": {
+								"user": {
+									"id": "11111111-2222-3333-4444-555555555555",
+									"displayName": "Alex Wilber"
+								}
+							}
+						}
+					},
+					"joinMeetingIdSettings": {
+						"isPasscodeRequired": false,
+						"joinMeetingId": "1234567890",
+						"passcode": null
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "ec0b4e3d-2fd7-4fac-90e5-f18ecd620a02",
+	"id": "onlineMeetingGet0001",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -72,7 +72,10 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
 	});
 
-	it.each([['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }]])(
+	it.each([
+		['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }],
+		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
+	])(
 		'onlineMeeting:%s throws a static error and issues no request under SP',
 		async (op, params) => {
 			selectSp({ resource: 'onlineMeeting', operation: op, ...params });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -81,7 +81,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 			const meetingFields = actionProps.filter((p) =>
 				p.displayOptions?.show?.resource?.includes('onlineMeeting'),
 			);
-			// subject, start/end times, options, getBy, meetingId, joinWebUrl…
+			// subject, start/end times, options, meetingId…
 			const gatedFields = meetingFields.filter(
 				(p) => p.type !== 'notice' && p.name !== 'operation',
 			);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -4,7 +4,7 @@ type NodeMap = {
 	channel: 'create' | 'deleteChannel' | 'get' | 'getAll' | 'update';
 	channelMessage: 'create' | 'getAll';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
-	onlineMeeting: 'create';
+	onlineMeeting: 'create' | 'get';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';
 };
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/get.operation.ts
@@ -1,0 +1,51 @@
+import { type INodeProperties, type IExecuteFunctions, NodeOperationError } from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { fetchMeetingByJoinUrl, readMeetingLocator } from './meetingLocator';
+import { throwIfOnlineMeetingUnsupported } from './sharedGuard';
+import { meetingRLC } from '../../descriptions';
+import { buildTeamsPath, microsoftApiRequest, SP_HIDE } from '../../transport';
+
+const properties: INodeProperties[] = [meetingRLC];
+
+const displayOptions = {
+	show: {
+		resource: ['onlineMeeting'],
+		operation: ['get'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get?view=graph-rest-1.0&tabs=http
+	throwIfOnlineMeetingUnsupported.call(this);
+
+	const { mode, value } = readMeetingLocator.call(this, i);
+	if (mode === 'url') {
+		return await fetchMeetingByJoinUrl.call(this, value);
+	}
+
+	// Built outside the try so an invalid id surfaces as its own validation
+	// error instead of being replaced by the not-found message below
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: value }]);
+
+	try {
+		return await microsoftApiRequest.call(this, 'GET', endpoint);
+	} catch (error) {
+		// Only a 404 means the meeting is gone; other statuses (403 from a missing
+		// OnlineMeetings.ReadWrite consent, 429, 5xx) must surface as the real error.
+		if (error?.httpCode !== '404') throw error;
+		throw new NodeOperationError(
+			this.getNode(),
+			"The meeting you are trying to get doesn't exist",
+			{
+				description: "Check that the 'Meeting' parameter is correctly set",
+			},
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -1,9 +1,10 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as create from './create.operation';
+import * as get from './get.operation';
 import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
 
-export { create };
+export { create, get };
 
 export const description: INodeProperties[] = [
 	{
@@ -39,9 +40,16 @@ export const description: INodeProperties[] = [
 				description: 'Create an online meeting',
 				action: 'Create online meeting',
 			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get an online meeting by ID or join URL',
+				action: 'Get online meeting',
+			},
 		],
 		default: 'create',
 	},
 
 	...create.description,
+	...get.description,
 ];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
@@ -1,0 +1,43 @@
+import { type IDataObject, type IExecuteFunctions, NodeOperationError } from 'n8n-workflow';
+
+import { microsoftApiRequest } from '../../transport';
+
+const isLocator = (value: unknown): value is { mode: unknown; value: unknown } =>
+	typeof value === 'object' && value !== null && 'mode' in value && 'value' in value;
+
+const asText = (value: unknown) =>
+	typeof value === 'string' || typeof value === 'number' ? String(value).trim() : '';
+
+export function readMeetingLocator(
+	this: IExecuteFunctions,
+	i: number,
+): { mode: string; value: string } {
+	const raw = this.getNodeParameter('meetingId', i);
+	const locator = isLocator(raw) ? raw : { mode: 'id', value: raw };
+	return { mode: String(locator.mode), value: asText(locator.value) };
+}
+
+export async function fetchMeetingByJoinUrl(
+	this: IExecuteFunctions,
+	joinWebUrl: string,
+): Promise<IDataObject> {
+	if (!joinWebUrl) {
+		throw new NodeOperationError(this.getNode(), 'The meeting join URL is empty', {
+			description: "Enter the join URL in the 'Meeting' parameter and try again",
+		});
+	}
+	const response = await microsoftApiRequest.call(
+		this,
+		'GET',
+		'/v1.0/me/onlineMeetings',
+		{},
+		{ $filter: `JoinWebUrl eq '${joinWebUrl.replace(/'/g, "''")}'` },
+	);
+	const meeting = response?.value?.[0];
+	if (!meeting) {
+		throw new NodeOperationError(this.getNode(), 'No meeting was found for the provided join URL', {
+			description: "Check that the 'Meeting' parameter is correctly set",
+		});
+	}
+	return meeting;
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/rlc.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/rlc.description.ts
@@ -267,3 +267,46 @@ export const memberRLC: INodeProperties = {
 		},
 	],
 };
+
+export const meetingRLC: INodeProperties = {
+	displayName: 'Meeting',
+	name: 'meetingId',
+	type: 'resourceLocator',
+	default: { mode: 'id', value: '' },
+	required: true,
+	description: 'The online meeting, by its ID or by its join URL',
+	modes: [
+		{
+			displayName: 'By ID',
+			name: 'id',
+			type: 'string',
+			placeholder: 'e.g. MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi...',
+			hint: 'The ID returned when the meeting was created, not the numeric meeting ID from the invite',
+			validation: [
+				{
+					type: 'regex',
+					properties: {
+						regex: '[^\\/\\\\?#%]*',
+						errorMessage: "Not a valid meeting ID. To use a join URL, switch to 'By URL'",
+					},
+				},
+			],
+		},
+		{
+			displayName: 'By URL',
+			name: 'url',
+			type: 'string',
+			placeholder: 'e.g. https://teams.microsoft.com/l/meetup-join/19%3ameeting...',
+			validation: [
+				{
+					type: 'regex',
+					properties: {
+						regex: '(\\s*https:\\/\\/.+\\/l\\/meetup-join\\/.+\\s*)?',
+						errorMessage:
+							"Use the meeting link that contains '/l/meetup-join/', such as the joinWebUrl returned when the meeting was created",
+					},
+				},
+			],
+		},
+	],
+};

--- a/packages/nodes-base/utils/microsoft/transport.ts
+++ b/packages/nodes-base/utils/microsoft/transport.ts
@@ -67,7 +67,7 @@ export function validateMicrosoftGraphId(id: string, node: INode): string {
 		throw new NodeOperationError(node, 'A required ID is empty', {
 			// Teams wording; make it injectable (UserTargetMessages pattern in
 			// nodes/Microsoft/GenericFunctions.ts) when the second consumer (SharePoint v2) lands.
-			description: 'Set the team, channel, plan, bucket or task ID and try again.',
+			description: 'Set the team, channel, plan, bucket, task or meeting ID and try again.',
 		});
 	}
 	let value: string;


### PR DESCRIPTION
## Summary

> **Stacked PR 2/3** for ENT-325. The Create PR (#37500) has merged, so this PR now targets master directly. Delete follows in the next PR.

Add the **Get** operation to the Teams Online Meeting resource.

- **Meeting resource locator**: one `Meeting` parameter (`meetingRLC`, shared in `rlc.description.ts`) with the standard `By ID` and `By URL` modes, replacing the earlier `Get By` selector plus two string fields. There is no `From list` mode because Graph rejects an unfiltered `GET /me/onlineMeetings`, so nothing can be listed. The `By ID` mode carries a hint that the ID is the one returned on creation, not the numeric meeting ID from the invite, and flags path characters (a pasted URL) with a pointer to `By URL`. The `By URL` mode validates the shape `https://<host>/l/meetup-join/...` and tells the user which link to paste when it does not match; the host is not pinned because the credential can target a sovereign Graph cloud.
- **By ID**: `GET /v1.0/me/onlineMeetings/{id}`. The ID goes through `buildTeamsPath` validation. Only a Graph 404 is rewritten to the friendly "meeting doesn't exist" message; other statuses (403 from a stale credential consent, 429, 5xx) surface unchanged.
- **By URL**: `GET /v1.0/me/onlineMeetings?$filter=JoinWebUrl eq '...'` per the Graph docs. The lookup lives in `meetingLocator.ts` so Delete and Update can reuse it. It escapes single quotes in the OData literal, unwraps the single-item `value` envelope, and reports a clear error when no meeting matches or the URL is blank. A plain-string `meetingId` (hand-edited workflow JSON) is treated as an ID, and a locator object without the `__rl` marker is accepted like n8n core does.
- Extends the shared Microsoft transport's empty-ID error description to mention meeting IDs.

## How to test

1. Create a meeting with the Create operation (previous PR in the stack).
2. Get the meeting `By ID`, then `By URL` with the returned join URL. Both must return the same meeting.
3. Get with a wrong but well-formed ID. The node reports the not-found error.
4. In `By URL` mode, paste a non-join link (for example a `/meet/` short link). The parameter shows a validation issue before you run.

Automated coverage: harness tests for both modes, unit tests for the filter shape, quote escaping, empty results, blank and null values in both modes, plain-string and no-`__rl` fallbacks, path-injection rejection, 404 vs non-404 error handling, both mode validation regexes (commercial and sovereign hosts accepted, bare IDs and short links rejected for URL; URLs and path characters rejected for ID), plus the SP runtime-guard row for get.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-325

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
