### PR TITLE
feat(Microsoft Teams Node): Add Online Meeting Delete operation

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/byId.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/byId.validation.test.ts
@@ -17,7 +17,10 @@ vi.mock('../../../../v2/transport', async () => {
 	};
 });
 
-const operations: Array<[string, Record<string, unknown>, string]> = [['get', {}, 'get']];
+const operations: Array<[string, Record<string, unknown>, string]> = [
+	['get', {}, 'get'],
+	['deleteMeeting', {}, 'delete'],
+];
 
 describe('Microsoft Teams V2 — onlineMeeting by-ID operations', () => {
 	let node: MicrosoftTeamsV2;

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/deleteMeeting.joinUrl.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/deleteMeeting.joinUrl.workflow.json
@@ -1,0 +1,86 @@
+{
+	"name": "onlineMeeting delete by join URL",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "deleteMeeting",
+				"meetingId": {
+					"__rl": true,
+					"mode": "url",
+					"value": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "ec0b4e3d-2fd7-4fac-90e5-f18ecd620a09",
+	"id": "onlineMeetingDelUrl1",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/deleteMeeting.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/deleteMeeting.test.ts
@@ -1,0 +1,24 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+const meetingId = 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi';
+const joinWebUrl =
+	'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d';
+
+describe('Test MicrosoftTeamsV2, onlineMeeting => deleteMeeting', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.get('/v1.0/me/onlineMeetings')
+		.query({ $filter: `JoinWebUrl eq '${joinWebUrl}'` })
+		.reply(200, { value: [{ id: meetingId, joinWebUrl }] })
+		.delete(`/v1.0/me/onlineMeetings/${meetingId}`)
+		.times(2)
+		.reply(204);
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['deleteMeeting.workflow.json', 'deleteMeeting.joinUrl.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/deleteMeeting.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/deleteMeeting.workflow.json
@@ -1,0 +1,86 @@
+{
+	"name": "onlineMeeting delete",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "deleteMeeting",
+				"meetingId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "ec0b4e3d-2fd7-4fac-90e5-f18ecd620a04",
+	"id": "onlineMeetingDel0001",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -75,6 +75,7 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 	it.each([
 		['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }],
 		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
+		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 	])(
 		'onlineMeeting:%s throws a static error and issues no request under SP',
 		async (op, params) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -4,7 +4,7 @@ type NodeMap = {
 	channel: 'create' | 'deleteChannel' | 'get' | 'getAll' | 'update';
 	channelMessage: 'create' | 'get' | 'getAll' | 'getAllReplies' | 'reply';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
-	onlineMeeting: 'create' | 'get';
+	onlineMeeting: 'create' | 'deleteMeeting' | 'get';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';
 };
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
@@ -1,0 +1,42 @@
+import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { resolveMeetingId } from './meetingLocator';
+import { MEETING_HINT, meetingRequest, throwIfOnlineMeetingUnsupported } from './shared';
+import { meetingRLC } from '../../descriptions';
+import { buildTeamsPath, rewriteNotFound, SP_HIDE } from '../../transport';
+
+const properties: INodeProperties[] = [meetingRLC];
+
+const displayOptions = {
+	show: {
+		resource: ['onlineMeeting'],
+		operation: ['deleteMeeting'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-delete?view=graph-rest-1.0&tabs=http
+	throwIfOnlineMeetingUnsupported.call(this);
+
+	const meetingId = await resolveMeetingId.call(this, i);
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: meetingId }]);
+
+	try {
+		await meetingRequest.call(this, 'DELETE', endpoint);
+		return { success: true };
+	} catch (error) {
+		rewriteNotFound.call(
+			this,
+			error,
+			"The meeting you are trying to delete doesn't exist",
+			MEETING_HINT,
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
@@ -32,7 +32,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		await meetingRequest.call(this, 'DELETE', endpoint);
 		return { success: true };
 	} catch (error) {
-		rewriteNotFound.call(
+		throw rewriteNotFound.call(
 			this,
 			error,
 			"The meeting you are trying to delete doesn't exist",

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -1,11 +1,12 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as create from './create.operation';
+import * as deleteMeeting from './deleteMeeting.operation';
 import * as get from './get.operation';
 import { SERVICE_PRINCIPAL_UNSUPPORTED } from './shared';
 import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
 
-export { create, get };
+export { create, deleteMeeting, get };
 
 export const description: INodeProperties[] = [
 	{
@@ -41,6 +42,12 @@ export const description: INodeProperties[] = [
 				action: 'Create online meeting',
 			},
 			{
+				name: 'Delete',
+				value: 'deleteMeeting',
+				description: 'Delete an online meeting',
+				action: 'Delete online meeting',
+			},
+			{
 				name: 'Get',
 				value: 'get',
 				description: 'Get an online meeting by ID or join URL',
@@ -51,5 +58,6 @@ export const description: INodeProperties[] = [
 	},
 
 	...create.description,
+	...deleteMeeting.description,
 	...get.description,
 ];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
@@ -45,3 +45,10 @@ export async function fetchMeetingByJoinUrl(
 	}
 	return meeting;
 }
+
+export async function resolveMeetingId(this: IExecuteFunctions, i: number): Promise<string> {
+	const { mode, value } = readMeetingLocator.call(this, i);
+	if (mode !== 'url') return value;
+	const meeting = await fetchMeetingByJoinUrl.call(this, value);
+	return asText(meeting.id);
+}


### PR DESCRIPTION
## Summary

> **Stacked PR 3/3** for ENT-325. The Create (#37500), Get (#37501) and review-fixes (#37723) PRs are merged, so this PR now sits directly on master. Merging this completes the ticket scope (create, get by ID/join URL, delete).

Add the **Delete** operation to the Teams Online Meeting resource.

- **Meeting resource locator**: reuses the `Meeting` locator from the Get PR (`By ID` / `By URL`). The new `resolveMeetingId` helper in `meetingLocator.ts` returns the ID directly in `By ID` mode and, in `By URL` mode, looks the meeting up by its join URL first and uses the returned ID.
- **Delete**: `DELETE /v1.0/me/onlineMeetings/{id}`, returns `{ "success": true }`. The meeting ID goes through `buildTeamsPath` validation. A Graph 404 is rewritten to the friendly "meeting doesn't exist" message by the shared `rewriteNotFound` in the transport layer (from #37723, now on master); other statuses surface unchanged.

## How to test

1. Create a meeting with the Create operation (first PR in the stack).
2. Delete the meeting `By ID`. The node returns `{ "success": true }`. Create another one and delete it `By URL` with its join URL.
3. Get the meeting by that ID. The node reports the not-found error.

Automated coverage: harness tests for the 204 happy path in both locator modes (the URL mode asserts the lookup request followed by the delete), a `deleteMeeting` row in the shared by-ID table (empty ID, separator-bearing ID, 404 rewrite, non-404 passthrough), plus the SP runtime-guard row for deleteMeeting.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-325

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
