### PR TITLE
fix(editor): Clear node selection for canvas context menu

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -1507,6 +1507,25 @@ describe('Canvas', () => {
 			useContextMenu().close();
 		});
 
+		it('clears the node selection when opening the pane context menu', async () => {
+			const node = createCanvasNodeElement({ id: 'node-1', label: 'Node 1' });
+			workflowDocumentStore.setNodes([createTestNode({ id: node.id, name: 'Node 1' })]);
+
+			const { container } = renderComponent({
+				props: { nodes: [node] },
+			});
+			await waitFor(() => expect(container.querySelectorAll('.vue-flow__node')).toHaveLength(1));
+
+			const { addSelectedNodes, findNode, getSelectedNodes } = useVueFlow(canvasId);
+			addSelectedNodes([findNode(node.id)!]);
+			await waitFor(() => expect(getSelectedNodes.value).toHaveLength(1));
+
+			await fireEvent.contextMenu(container.querySelector('.vue-flow__pane')!);
+
+			await waitFor(() => expect(getSelectedNodes.value).toHaveLength(0));
+			expect(useContextMenu().targetNodeIds.value).toEqual([]);
+		});
+
 		async function renderWithGroup(
 			props: { readOnly?: boolean; suppressInteraction?: boolean } = {},
 			{

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -1407,6 +1407,15 @@ function onOpenContextMenu(
 	});
 }
 
+function onOpenPaneContextMenu(event: MouseEvent) {
+	clearSelectedNodes();
+	contextMenu.open(event, {
+		source: 'canvas',
+		nodeIds: [],
+		readOnly: isContextMenuReadOnly.value,
+	});
+}
+
 function onOpenSelectionContextMenu({ event }: { event: MouseEvent }) {
 	onOpenContextMenu(event);
 }
@@ -1797,7 +1806,7 @@ defineExpose({
 		@connect="onConnect"
 		@connect-end="onConnectEnd"
 		@pane-click="onClickPane"
-		@pane-context-menu="onOpenContextMenu"
+		@pane-context-menu="onOpenPaneContextMenu"
 		@move="onPaneMove"
 		@move-end="onPaneMoveEnd"
 		@node-drag-start="onNodeDragStart"


### PR DESCRIPTION
## Summary

Clear the current node selection when the user opens the canvas context menu.

Keep the selected nodes when the user opens a selection context menu.

## How to test

1. Open a workflow with one node.
2. Select the node.
3. Right-click an empty area of the canvas.
4. Confirm that the node is no longer selected.
5. Confirm that the canvas context menu shows the add-node actions.

Automated checks:

- `pnpm test src/features/workflows/canvas/components/Canvas.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-632

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI