### PR TITLE
feat(core): Improve node grouping instructions for AI Assistant and MCP (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/skills/registry.ts
+++ b/packages/@n8n/agents/src/skills/registry.ts
@@ -29,6 +29,11 @@ export class InvalidRuntimeSkillError extends Error {
 
 export interface LoadRuntimeSkillSourceFromDirectoryOptions {
 	exclude?: string[];
+	/**
+	 * Transforms the received instructions, for example replacing placeholders, before
+	 * the skill is registered and served through `load_skill`.
+	 */
+	transformInstructions?: (instructions: string) => string;
 }
 
 export function createRuntimeSkillSource(skills: RuntimeSkill[]): RuntimeSkillSource {
@@ -91,9 +96,17 @@ export function loadRuntimeSkillSourceFromDirectory(
 	options: LoadRuntimeSkillSourceFromDirectoryOptions = {},
 ): RuntimeSkillSource {
 	const excludedSkillIds = new Set(options.exclude ?? []);
-	const skills = loadRuntimeSkillsFromDirectory(rootDir).filter(
-		(skill) => !excludedSkillIds.has(skill.id),
-	);
+	const { transformInstructions = (instructions) => instructions } = options;
+
+	const skills = loadRuntimeSkillsFromDirectory(rootDir)
+		.filter((skill) => !excludedSkillIds.has(skill.id))
+		.map((skill) => {
+			return {
+				...skill,
+				instructions: transformInstructions(skill.instructions),
+			};
+		});
+
 	const source = createRuntimeSkillSource(skills);
 	const skillsById = new Map(skills.map((skill) => [skill.id, skill]));
 

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -612,18 +612,14 @@ import {
 
 ## Node Groups
 
-Organise multi-stage workflows into named node groups — visual frames on the canvas — so the
-result is readable the first time the user sees it. Group each clear stage (ingest → transform
-→ deliver); small workflows don't need groups. Give every group a one-sentence
-`description` — groups are collapsed by default, so name + description is what the user sees
-first.
+{{GROUPING_GUIDANCE_PLACEHOLDER}}
 
-`.group(name, members, { description })` on the workflow builder; members are the node handles.
-Read `knowledge-base/reference/node-groups.md` for the exact rules (trigger nodes excluded,
-one connected section, AI sub-nodes stay with their Agent) before creating groups. Agent save
-tools drop an invalid group from the saved workflow and report a warning, so fix the source
-instead of re-emitting it. When editing an existing workflow, keep existing `.group(...)` calls
-and their descriptions intact unless the change is about grouping.
+Declare a group with `.group(name, members, { description })` on the workflow builder; members
+are the node handles. Before you emit a `.group(...)`, read
+`${N8N_WORKSPACE_DIR}/knowledge-base/reference/node-groups.md` — it carries the rules that make
+a group valid and the contract for editing an existing workflow's groups. Do not restate those
+rules from memory: an invalid group is dropped from the saved workflow with a warning, so the
+source has to be fixed rather than re-emitted.
 
 ## Workflow Rules
 

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -211,6 +211,10 @@ follow its build → publish → assign steps.
    and later `fixtureOverrides` can exercise those scenarios. Do not simulate
    every external read by default; use this when branch coverage or deterministic
    proof depends on controlling the upstream data.
+   Decide grouping now, while writing the source: `.group(...)` lives in the code, so
+   it cannot be added after the build. See [Node Groups](#node-groups) for the
+   criteria, and reach a decision either way — groups declared, or this workflow does
+   not warrant them.
 7. Before the first `build-workflow` (and again after substantive edits), run
    SDK validation on the workspace source file via
    `workspace_execute_command`:
@@ -893,6 +897,9 @@ workflow code or build specs unless the workflow actually needs to send or
 store its own public endpoint.
 
 ## Completion
+
+Do not report a build as done until you have made the grouping decision described in
+[Node Groups](#node-groups).
 
 For a successful build, finish with one concise sentence naming the workflow and
 what changed. Include the workflow ID when it is available. If setup is

--- a/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
@@ -6,6 +6,7 @@ import {
 	type Workspace,
 	type WorkspaceSandbox,
 } from '@n8n/agents';
+import { GROUPING_GUIDANCE } from '@n8n/workflow-sdk/prompts/sdk-reference';
 import { jsonParse } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 
@@ -397,5 +398,47 @@ describe('materializeRuntimeSkillsIntoWorkspace', () => {
 		expect(message).toBe('Runtime skill file exceeds load_skill output limit');
 		expect(meta?.skill).toBe('large-skill');
 		expect(meta?.maxBytes).toBe(runtimeSkillMaxOutputBytes);
+	});
+});
+
+describe('grouping guidance injection', () => {
+	const root = '/home/daytona/workspace';
+	const skillPath = `${root}/${SANDBOX_RUNTIME_SKILLS_DIR}/workflow-builder/SKILL.md`;
+
+	it('injects the shared grouping guidance into the builder skill', async () => {
+		const bundle = await buildRuntimeSkillWorkspaceBundle({
+			source: loadInstanceAiRuntimeSkillSource(),
+			root,
+			logger: mockLogger,
+		});
+
+		expect(bundle?.files.get(skillPath)).toContain(GROUPING_GUIDANCE);
+	});
+
+	it('leaves no unresolved placeholder in any materialized skill', async () => {
+		const bundle = await buildRuntimeSkillWorkspaceBundle({
+			source: loadInstanceAiRuntimeSkillSource(),
+			root,
+			logger: mockLogger,
+		});
+
+		if (!bundle) {
+			throw new Error('Expected runtime skill bundle');
+		}
+
+		for (const [path, content] of bundle.files) {
+			expect(content, path).not.toMatch(/\{\{[A-Z_]+\}\}/);
+		}
+	});
+
+	it('keeps the builder skill source free of its own grouping criteria', async () => {
+		const skill = await loadInstanceAiRuntimeSkillSource().loadSkill('workflow-builder');
+
+		if (!skill) {
+			throw new Error('Expected the workflow-builder skill to load');
+		}
+
+		expect(skill.instructions).toContain('{{GROUPING_GUIDANCE_PLACEHOLDER}}');
+		expect(skill.instructions).not.toMatch(/3 to 5|at most 7 items|one-sentence/i);
 	});
 });

--- a/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
@@ -8,6 +8,8 @@ import {
 } from '@n8n/agents';
 import { GROUPING_GUIDANCE } from '@n8n/workflow-sdk/prompts/sdk-reference';
 import { jsonParse } from 'n8n-workflow';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { Mock } from 'vitest';
 
 import {
@@ -21,7 +23,7 @@ import {
 	createLazyWorkspaceRuntimeSkillSource,
 	materializeRuntimeSkillsIntoWorkspace,
 } from '../materialize-runtime-skills';
-import { loadInstanceAiRuntimeSkillSource } from '../runtime-skills';
+import { INSTANCE_AI_SKILLS_DIR, loadInstanceAiRuntimeSkillSource } from '../runtime-skills';
 
 /** Extract the text body from the content-block form of a load_skill success result. */
 function skillLoadText(output: unknown): string {
@@ -431,14 +433,38 @@ describe('grouping guidance injection', () => {
 		}
 	});
 
-	it('keeps the builder skill source free of its own grouping criteria', async () => {
+	it('serves the guidance through load_skill, not just the materialized file', async () => {
+		// The tool returns `instructions` directly, so substituting only at render time
+		// ships the literal placeholder to the agent.
+		const loadTool = createSkillLoadTool(loadInstanceAiRuntimeSkillSource());
+		const result = await loadTool.handler?.({ skillId: 'workflow-builder' }, {});
+
+		const text = skillLoadText(result);
+
+		expect(text).toContain(GROUPING_GUIDANCE);
+		expect(text).not.toContain('{{GROUPING_GUIDANCE_PLACEHOLDER}}');
+	});
+
+	it('resolves placeholders before the skill is hashed', async () => {
+		// The skill hash covers `instructions`, so substituting later leaves caches keyed
+		// on skillsHash unable to notice a guidance change.
 		const skill = await loadInstanceAiRuntimeSkillSource().loadSkill('workflow-builder');
 
 		if (!skill) {
 			throw new Error('Expected the workflow-builder skill to load');
 		}
 
-		expect(skill.instructions).toContain('{{GROUPING_GUIDANCE_PLACEHOLDER}}');
-		expect(skill.instructions).not.toMatch(/3 to 5|at most 7 items|one-sentence/i);
+		expect(skill.instructions).toContain(GROUPING_GUIDANCE);
+		expect(skill.instructions).not.toContain('{{GROUPING_GUIDANCE_PLACEHOLDER}}');
+	});
+
+	it('keeps the builder skill file free of its own grouping criteria', async () => {
+		// Guards the single source of truth: a hand-written copy drifts from the shared
+		// constant, and this skill is what an agent reads first.
+		const skillFile = join(INSTANCE_AI_SKILLS_DIR, 'workflow-builder', 'SKILL.md');
+		const raw = await readFile(skillFile, 'utf-8');
+
+		expect(raw).toContain('{{GROUPING_GUIDANCE_PLACEHOLDER}}');
+		expect(raw).not.toMatch(/3 to 5|at most 7 items|one-sentence/i);
 	});
 });

--- a/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
@@ -262,14 +262,12 @@ function renderRuntimeSkillMarkdown(
 	addFrontmatterField(lines, 'metadata', skill.metadata);
 	lines.push('---', '');
 
-	// At this point, any {{placeholder}}s in the instructions text are already resolved
 	const instructions = substituteRuntimeSkillVars(
 		skill.instructions,
 		skillDir,
 		workspaceRoot,
 		skillsRoot,
 	);
-
 	const sourceNote =
 		entry.sourceDirectory && entry.sourceDirectory !== entry.name
 			? `<!-- materialized from ${entry.sourceDirectory} -->\n\n`

--- a/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
@@ -12,7 +12,6 @@ import {
 	type Workspace,
 } from '@n8n/agents';
 import { getWorkspaceRoot } from '@n8n/agents/sandbox';
-import { GROUPING_GUIDANCE } from '@n8n/workflow-sdk/prompts/sdk-reference';
 import { join as posixJoin, normalize as posixNormalize } from 'node:path/posix';
 
 import type { Logger } from '../logger';
@@ -30,8 +29,6 @@ export const RUNTIME_SKILL_MANIFEST_SCHEMA_VERSION = 1;
 export const N8N_SKILLS_DIR_ENV = 'N8N_SKILLS_DIR';
 export const N8N_SKILL_DIR_ENV = 'N8N_SKILL_DIR';
 export const N8N_WORKSPACE_DIR_ENV = 'N8N_WORKSPACE_DIR';
-
-type SkillPlaceholder = 'GROUPING_GUIDANCE_PLACEHOLDER';
 
 export interface MaterializedRuntimeSkill {
 	id: string;
@@ -182,14 +179,6 @@ function substituteRuntimeSkillVars(
 		.replaceAll(N8N_WORKSPACE_DIR_TEMPLATE, workspaceRoot);
 }
 
-function substitutePlaceholderWithText(
-	content: string,
-	placeholder: SkillPlaceholder,
-	replacement: string,
-): string {
-	return content.replaceAll(`{{${placeholder}}}`, replacement);
-}
-
 function toFrontmatterInterface(
 	value: RuntimeSkillInterfaceContract | undefined,
 ): Record<string, unknown> | undefined {
@@ -273,12 +262,9 @@ function renderRuntimeSkillMarkdown(
 	addFrontmatterField(lines, 'metadata', skill.metadata);
 	lines.push('---', '');
 
+	// At this point, any {{placeholder}}s in the instructions text are already resolved
 	const instructions = substituteRuntimeSkillVars(
-		substitutePlaceholderWithText(
-			skill.instructions,
-			'GROUPING_GUIDANCE_PLACEHOLDER',
-			GROUPING_GUIDANCE,
-		),
+		skill.instructions,
 		skillDir,
 		workspaceRoot,
 		skillsRoot,

--- a/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
@@ -12,6 +12,7 @@ import {
 	type Workspace,
 } from '@n8n/agents';
 import { getWorkspaceRoot } from '@n8n/agents/sandbox';
+import { GROUPING_GUIDANCE } from '@n8n/workflow-sdk/prompts/sdk-reference';
 import { join as posixJoin, normalize as posixNormalize } from 'node:path/posix';
 
 import type { Logger } from '../logger';
@@ -29,6 +30,8 @@ export const RUNTIME_SKILL_MANIFEST_SCHEMA_VERSION = 1;
 export const N8N_SKILLS_DIR_ENV = 'N8N_SKILLS_DIR';
 export const N8N_SKILL_DIR_ENV = 'N8N_SKILL_DIR';
 export const N8N_WORKSPACE_DIR_ENV = 'N8N_WORKSPACE_DIR';
+
+type SkillPlaceholder = 'GROUPING_GUIDANCE_PLACEHOLDER';
 
 export interface MaterializedRuntimeSkill {
 	id: string;
@@ -179,6 +182,14 @@ function substituteRuntimeSkillVars(
 		.replaceAll(N8N_WORKSPACE_DIR_TEMPLATE, workspaceRoot);
 }
 
+function substitutePlaceholderWithText(
+	content: string,
+	placeholder: SkillPlaceholder,
+	replacement: string,
+): string {
+	return content.replaceAll(`{{${placeholder}}}`, replacement);
+}
+
 function toFrontmatterInterface(
 	value: RuntimeSkillInterfaceContract | undefined,
 ): Record<string, unknown> | undefined {
@@ -263,11 +274,16 @@ function renderRuntimeSkillMarkdown(
 	lines.push('---', '');
 
 	const instructions = substituteRuntimeSkillVars(
-		skill.instructions,
+		substitutePlaceholderWithText(
+			skill.instructions,
+			'GROUPING_GUIDANCE_PLACEHOLDER',
+			GROUPING_GUIDANCE,
+		),
 		skillDir,
 		workspaceRoot,
 		skillsRoot,
 	);
+
 	const sourceNote =
 		entry.sourceDirectory && entry.sourceDirectory !== entry.name
 			? `<!-- materialized from ${entry.sourceDirectory} -->\n\n`

--- a/packages/@n8n/instance-ai/src/skills/runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/runtime-skills.ts
@@ -1,4 +1,5 @@
 import { loadRuntimeSkillSourceFromDirectory, type RuntimeSkillSource } from '@n8n/agents';
+import { GROUPING_GUIDANCE } from '@n8n/workflow-sdk/prompts/sdk-reference';
 import { resolve } from 'node:path';
 
 import { isAgentFeatureEnabled } from '@/utils/agent-feature-enabled';
@@ -8,9 +9,22 @@ const AGENTS_MODULE_RUNTIME_SKILLS = new Set(['agent-builder', 'intent-recogniti
 
 let cachedRuntimeSkillSource: RuntimeSkillSource | undefined;
 
+/** Prompt text a skill can pull in by placeholder rather than keeping its own copy. */
+const SKILL_PLACEHOLDER_TEXT: Record<string, string> = {
+	GROUPING_GUIDANCE_PLACEHOLDER: GROUPING_GUIDANCE,
+};
+
+export function substituteSkillPlaceholders(instructions: string): string {
+	return Object.entries(SKILL_PLACEHOLDER_TEXT).reduce(
+		(content, [placeholder, text]) => content.replaceAll(`{{${placeholder}}}`, text),
+		instructions,
+	);
+}
+
 export function loadInstanceAiRuntimeSkillSource(): RuntimeSkillSource {
 	cachedRuntimeSkillSource ??= loadRuntimeSkillSourceFromDirectory(INSTANCE_AI_SKILLS_DIR, {
 		exclude: isAgentFeatureEnabled() ? [] : [...AGENTS_MODULE_RUNTIME_SKILLS],
+		transformInstructions: substituteSkillPlaceholders,
 	});
 	return cachedRuntimeSkillSource;
 }

--- a/packages/@n8n/instance-ai/src/skills/runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/runtime-skills.ts
@@ -9,7 +9,6 @@ const AGENTS_MODULE_RUNTIME_SKILLS = new Set(['agent-builder', 'intent-recogniti
 
 let cachedRuntimeSkillSource: RuntimeSkillSource | undefined;
 
-/** Prompt text a skill can pull in by placeholder rather than keeping its own copy. */
 const SKILL_PLACEHOLDER_TEXT: Record<string, string> = {
 	GROUPING_GUIDANCE_PLACEHOLDER: GROUPING_GUIDANCE,
 };

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -193,9 +193,20 @@ describe('GROUPING_GUIDANCE', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/deciding against groups/i);
 		});
 
-		it('tells agents to leave small or linear workflows ungrouped', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/small or purely linear/i);
-			expect(GROUPING_GUIDANCE).toMatch(/no groups at all/i);
+		it('decides whether to group by counting, not by shape', () => {
+			// An agent read "purely linear" as a standalone exemption and skipped the
+			// count: 9 top-level items, no groups.
+			expect(GROUPING_GUIDANCE).toMatch(/count the top-level items/i);
+			expect(GROUPING_GUIDANCE).toMatch(/more than 7 means you must group/i);
+			expect(GROUPING_GUIDANCE).toMatch(/one straight line is not an exemption/i);
+		});
+
+		it('leaves a workflow under the ceiling ungrouped', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/7 items or fewer.+leave it ungrouped/is);
+		});
+
+		it('tells agents to widen boundaries instead of emitting one-node groups', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/one or two nodes each, the boundaries are too fine/i);
 		});
 
 		it('breaks ties toward fewer groups', () => {

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -209,8 +209,15 @@ describe('GROUPING_GUIDANCE', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/one or two nodes each, the boundaries are too fine/i);
 		});
 
-		it('breaks ties toward fewer groups', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/in doubt, fewer groups/i);
+		it('breaks ties toward fewer, larger groups', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/in doubt, fewer and larger groups/i);
+		});
+
+		it('does not let the ceiling justify an invalid or absurd split', () => {
+			// A trigger-level fan-out cannot share a group, so some graphs land over the
+			// ceiling and chasing the number would produce groups the save path drops.
+			expect(GROUPING_GUIDANCE).toMatch(/never invent a group that breaks the validity rules/i);
+			expect(GROUPING_GUIDANCE).toMatch(/an item or two over is fine/i);
 		});
 
 		it('gives a group count for a medium workflow', () => {
@@ -259,8 +266,15 @@ describe('GROUPING_GUIDANCE', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/write one for every group/i);
 		});
 
-		it('forbids restating the title', () => {
+		it('forbids restating the title, including as an opening clause', () => {
+			// An agent restated the title and appended a detail, and the collapsed group
+			// clipped the description before the detail was visible.
 			expect(GROUPING_GUIDANCE).toMatch(/add to the title, never restate it/i);
+			expect(GROUPING_GUIDANCE).toMatch(/must not open by repeating it/i);
+		});
+
+		it('tells agents to lead with the detail because collapsed text is clipped', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/collapsed group clips the description/i);
 		});
 
 		it('interpolates the length cap instead of hardcoding it', () => {

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -277,6 +277,13 @@ describe('GROUPING_GUIDANCE', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/collapsed group clips the description/i);
 		});
 
+		it('forbids opening on the nodes the group is built from', () => {
+			// A build spent the visible half of a description on "AI agent with Postgres
+			// chat memory", which the reader can already see on the canvas.
+			expect(GROUPING_GUIDANCE).toMatch(/never on what the group is built from/i);
+			expect(GROUPING_GUIDANCE).toMatch(/opens on the parts list/i);
+		});
+
 		it('interpolates the length cap instead of hardcoding it', () => {
 			// A hardcoded number silently starts lying the day the constant moves.
 			expect(GROUPING_GUIDANCE).toContain(`${GROUP_DESCRIPTION_MAX_LENGTH} characters`);

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -1,6 +1,7 @@
-import { GROUP_DESCRIPTION_MAX_LENGTH } from 'n8n-workflow';
+import { GROUP_DESCRIPTION_MAX_LENGTH, NODE_GROUPING_RULES } from 'n8n-workflow';
 
 import {
+	GROUPING_GUIDANCE,
 	NODE_GROUPS_REFERENCE,
 	SDK_LANGUAGE_REFERENCE,
 	buildSdkLanguageReference,
@@ -105,9 +106,10 @@ describe('NODE_GROUPS_REFERENCE', () => {
 		expect(NODE_GROUPS_REFERENCE).toMatch(/\.group\('[^']+', \[/);
 	});
 
-	it('documents the optional description and its length limit', () => {
+	it('documents the description and its length limit without calling it optional', () => {
 		expect(NODE_GROUPS_REFERENCE).toContain('description:');
 		expect(NODE_GROUPS_REFERENCE).toContain(`${GROUP_DESCRIPTION_MAX_LENGTH} characters`);
+		expect(NODE_GROUPS_REFERENCE).not.toMatch(/`description` is optional/i);
 	});
 
 	it('tells an editing agent to keep existing descriptions', () => {
@@ -171,6 +173,105 @@ describe('NODE_GROUPS_REFERENCE', () => {
 
 		it('states the at-least-one-member rule', () => {
 			expect(NODE_GROUPS_REFERENCE).toMatch(/at least one (node|member)/i);
+		});
+	});
+});
+
+describe('GROUPING_GUIDANCE', () => {
+	it('is served under the heading both consumers key on', () => {
+		// MCP (best-practices tool) and Instance AI (node-groups KB entry) both assert
+		// on this heading to detect that grouping guidance shipped.
+		expect(GROUPING_GUIDANCE).toContain('## Grouping');
+	});
+
+	describe('when and how much to group', () => {
+		it('tells agents to leave small or linear workflows ungrouped', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/small or purely linear/i);
+			expect(GROUPING_GUIDANCE).toMatch(/no groups at all/i);
+		});
+
+		it('breaks ties toward fewer groups', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/in doubt, fewer groups/i);
+		});
+
+		it('gives a group count for a medium workflow', () => {
+			// Without a number, "larger workflows" is unfalsifiable and the model
+			// over-groups — this range is the main fix.
+			expect(GROUPING_GUIDANCE).toMatch(/3 to 5|3-5/);
+		});
+
+		it('caps what is visible at the canvas top level', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/at most 7 items/i);
+			expect(GROUPING_GUIDANCE).toMatch(/counting the trigger/i);
+		});
+
+		it('makes a group a business outcome rather than a technical category', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/business outcome/i);
+			expect(GROUPING_GUIDANCE).toMatch(/never a technical category/i);
+			expect(GROUPING_GUIDANCE).toMatch(/merge two groups/i);
+		});
+
+		it('keeps the groups-vs-sub-workflows distinction', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/sub-workflow/i);
+		});
+	});
+
+	describe('naming', () => {
+		it('caps titles at 2-4 words and demands outcome-first phrasing', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/outcome-first/i);
+			expect(GROUPING_GUIDANCE).toMatch(/2-4 words/);
+		});
+
+		it('bans implementation jargon in titles', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/no node, credential, or API names/i);
+		});
+
+		it('gives the self-explanatory test for a title', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/from the title alone, without expanding/i);
+		});
+
+		it('tells agents to split a group whose purpose will not fit the title', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/doing too much — split it/i);
+		});
+	});
+
+	describe('descriptions', () => {
+		it('requires one on every group', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/write one for every group/i);
+		});
+
+		it('forbids restating the title', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/add to the title, never restate it/i);
+		});
+
+		it('interpolates the length cap instead of hardcoding it', () => {
+			// A hardcoded number silently starts lying the day the constant moves.
+			expect(GROUPING_GUIDANCE).toContain(`${GROUP_DESCRIPTION_MAX_LENGTH} characters`);
+		});
+
+		it('shows worked title-to-description pairs', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/^- "[^"]+" → "[^"]+"$/m);
+		});
+	});
+
+	describe('boundary with NODE_GROUPS_REFERENCE', () => {
+		it.each(Object.values(NODE_GROUPING_RULES))(
+			'does not restate the structural validity rules',
+			(rule) => {
+				// Duplicating a rule lets the two copies contradict each other
+				// and MCP can serve one without the other.
+				expect(GROUPING_GUIDANCE).not.toContain(rule.sdkReference);
+			},
+		);
+
+		it('does not claim invalid groups are rejected on save', () => {
+			// Agent save tools prune the invalid group and warn, so an agent never hits the
+			// server-side rejection — promising one would misdescribe what it will see.
+			expect(GROUPING_GUIDANCE).not.toContain('rejected on save');
+		});
+
+		it('points agents at the reference for the exact rules', () => {
+			expect(GROUPING_GUIDANCE).toMatch(/node groups reference/i);
 		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -185,6 +185,14 @@ describe('GROUPING_GUIDANCE', () => {
 	});
 
 	describe('when and how much to group', () => {
+		it('makes the grouping decision mandatory while leaving "no groups" a valid answer', () => {
+			// The observed failure was omission, not misjudgement: the agent knew the
+			// criteria and never reached the step.
+			expect(GROUPING_GUIDANCE).toMatch(/explicit grouping decision/i);
+			expect(GROUPING_GUIDANCE).toMatch(/skipping the decision is not an option/i);
+			expect(GROUPING_GUIDANCE).toMatch(/deciding against groups/i);
+		});
+
 		it('tells agents to leave small or linear workflows ungrouped', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/small or purely linear/i);
 			expect(GROUPING_GUIDANCE).toMatch(/no groups at all/i);

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -116,9 +116,13 @@ describe('NODE_GROUPS_REFERENCE', () => {
 		expect(NODE_GROUPS_REFERENCE).toMatch(/keep the .+ and their descriptions\s+intact/is);
 	});
 
-	it('tells agents invalid groups are dropped with warnings and source should be fixed', () => {
+	it('tells agents invalid groups are dropped with warnings and the boundary redrawn', () => {
+		// A build took two dropped-group warnings as licence to publish the stage
+		// ungrouped instead of moving the boundary.
 		expect(NODE_GROUPS_REFERENCE).toMatch(/drop an invalid group.+report a warning/is);
-		expect(NODE_GROUPS_REFERENCE).toMatch(/fix the source.+not re-emitted/is);
+		expect(NODE_GROUPS_REFERENCE).toMatch(/not that the stage\s+should stay ungrouped/is);
+		expect(NODE_GROUPS_REFERENCE).toMatch(/redraw it so the group is valid/i);
+		expect(NODE_GROUPS_REFERENCE).toMatch(/never re-emit the\s+same invalid group/is);
 		expect(NODE_GROUPS_REFERENCE).not.toContain('rejected on save');
 	});
 
@@ -189,35 +193,51 @@ describe('GROUPING_GUIDANCE', () => {
 			// The observed failure was omission, not misjudgement: the agent knew the
 			// criteria and never reached the step.
 			expect(GROUPING_GUIDANCE).toMatch(/explicit grouping decision/i);
-			expect(GROUPING_GUIDANCE).toMatch(/skipping the decision is not an option/i);
+			expect(GROUPING_GUIDANCE).toMatch(/skipping the decision is not/i);
 			expect(GROUPING_GUIDANCE).toMatch(/deciding against groups/i);
 		});
 
 		it('decides whether to group by counting, not by shape', () => {
 			// An agent read "purely linear" as a standalone exemption and skipped the
 			// count: 9 top-level items, no groups.
-			expect(GROUPING_GUIDANCE).toMatch(/count the top-level items/i);
-			expect(GROUPING_GUIDANCE).toMatch(/more than 7 means you must group/i);
-			expect(GROUPING_GUIDANCE).toMatch(/one straight line is not an exemption/i);
+			expect(GROUPING_GUIDANCE).toMatch(/count top-level items/i);
+			expect(GROUPING_GUIDANCE).toMatch(/more than 7 → you must group/i);
+			expect(GROUPING_GUIDANCE).toMatch(
+				/linear pipeline is the normal case for grouping, not an exemption/i,
+			);
 		});
 
 		it('leaves a workflow under the ceiling ungrouped', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/7 items or fewer.+leave it ungrouped/is);
+			expect(GROUPING_GUIDANCE).toMatch(/7 or fewer.+leave it ungrouped/is);
 		});
 
 		it('tells agents to widen boundaries instead of emitting one-node groups', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/one or two nodes each, the boundaries are too fine/i);
+			expect(GROUPING_GUIDANCE).toMatch(/one or two nodes mean the boundaries are too fine/i);
+		});
+
+		it('says where to cut when an objective ends in a branch', () => {
+			// A build grouped an IF with its stop branch and lost both groups to
+			// `Output Edge From Non-Leaf Node`: the IF continued inside and exited too.
+			expect(GROUPING_GUIDANCE).toMatch(/end the group before the branch node/i);
+			expect(GROUPING_GUIDANCE).toMatch(/both continues inside it and exits it/i);
 		});
 
 		it('breaks ties toward fewer, larger groups', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/in doubt, fewer and larger groups/i);
+			expect(GROUPING_GUIDANCE).toMatch(/in doubt, fewer and larger/i);
 		});
 
 		it('does not let the ceiling justify an invalid or absurd split', () => {
-			// A trigger-level fan-out cannot share a group, so some graphs land over the
-			// ceiling and chasing the number would produce groups the save path drops.
-			expect(GROUPING_GUIDANCE).toMatch(/never invent a group that breaks the validity rules/i);
-			expect(GROUPING_GUIDANCE).toMatch(/an item or two over is fine/i);
+			// A branchy graph cannot always reach 7, and chasing the number produces
+			// groups the save path drops.
+			expect(GROUPING_GUIDANCE).toMatch(/never break a validity rule/i);
+			expect(GROUPING_GUIDANCE).toMatch(/split one objective to hit the number/i);
+		});
+
+		it('allows exceeding the ceiling only for items that cannot be grouped', () => {
+			// A build left five groupable nodes at the top level and settled at 8.
+			expect(GROUPING_GUIDANCE).toMatch(/staying above 7 is only acceptable/i);
+			expect(GROUPING_GUIDANCE).toMatch(/cannot join one without breaking a validity rule/i);
+			expect(GROUPING_GUIDANCE).toMatch(/check each one before you settle/i);
 		});
 
 		it('gives a group count for a medium workflow', () => {
@@ -227,14 +247,14 @@ describe('GROUPING_GUIDANCE', () => {
 		});
 
 		it('caps what is visible at the canvas top level', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/at most 7 items/i);
-			expect(GROUPING_GUIDANCE).toMatch(/counting the trigger/i);
+			expect(GROUPING_GUIDANCE).toMatch(/at most 7 top-level items/i);
+			expect(GROUPING_GUIDANCE).toMatch(/trigger \+ groups \+ nodes left outside/i);
 		});
 
 		it('makes a group a business outcome rather than a technical category', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/business outcome/i);
 			expect(GROUPING_GUIDANCE).toMatch(/never a technical category/i);
-			expect(GROUPING_GUIDANCE).toMatch(/merge two groups/i);
+			expect(GROUPING_GUIDANCE).toMatch(/merge groups serving the same outcome/i);
 		});
 
 		it('keeps the groups-vs-sub-workflows distinction', () => {
@@ -248,12 +268,22 @@ describe('GROUPING_GUIDANCE', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/2-4 words/);
 		});
 
+		it('prefers one outcome over two verbs, without licensing a split', () => {
+			// Builds produced "Charge & ship" and "Store & alert": the steps, not the
+			// outcome. Coverage still wins — a two-verb title beats fewer groups.
+			expect(GROUPING_GUIDANCE).toMatch(/naming one outcome/i);
+			expect(GROUPING_GUIDANCE).toMatch(/find the outcome they add up to/i);
+			expect(GROUPING_GUIDANCE).toMatch(
+				/two-verb title beats splitting a coherent stage or leaving it ungrouped/i,
+			);
+		});
+
 		it('bans implementation jargon in titles', () => {
 			expect(GROUPING_GUIDANCE).toMatch(/no node, credential, or API names/i);
 		});
 
 		it('gives the self-explanatory test for a title', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/from the title alone, without expanding/i);
+			expect(GROUPING_GUIDANCE).toMatch(/from the title alone/i);
 		});
 
 		it('tells agents to split a group whose purpose will not fit the title', () => {
@@ -263,25 +293,25 @@ describe('GROUPING_GUIDANCE', () => {
 
 	describe('descriptions', () => {
 		it('requires one on every group', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/write one for every group/i);
+			expect(GROUPING_GUIDANCE).toMatch(/one per group/i);
 		});
 
 		it('forbids restating the title, including as an opening clause', () => {
 			// An agent restated the title and appended a detail, and the collapsed group
 			// clipped the description before the detail was visible.
-			expect(GROUPING_GUIDANCE).toMatch(/add to the title, never restate it/i);
-			expect(GROUPING_GUIDANCE).toMatch(/must not open by repeating it/i);
+			expect(GROUPING_GUIDANCE).toMatch(/add to the title — never restate it/i);
+			expect(GROUPING_GUIDANCE).toMatch(/open by repeating it/i);
 		});
 
 		it('tells agents to lead with the detail because collapsed text is clipped', () => {
-			expect(GROUPING_GUIDANCE).toMatch(/collapsed group clips the description/i);
+			expect(GROUPING_GUIDANCE).toMatch(/collapsed groups clip the text/i);
 		});
 
 		it('forbids opening on the nodes the group is built from', () => {
 			// A build spent the visible half of a description on "AI agent with Postgres
 			// chat memory", which the reader can already see on the canvas.
-			expect(GROUPING_GUIDANCE).toMatch(/never on what the group is built from/i);
-			expect(GROUPING_GUIDANCE).toMatch(/opens on the parts list/i);
+			expect(GROUPING_GUIDANCE).toMatch(/never open on the parts list/i);
+			expect(GROUPING_GUIDANCE).toMatch(/says only what the reader can already see/i);
 		});
 
 		it('interpolates the length cap instead of hardcoding it', () => {

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -120,7 +120,7 @@ Node groups are named visual frames drawn on the canvas, so a workflow reads cor
 Every workflow you build needs an explicit grouping decision, taken while you write the code: declare the groups, or conclude this workflow does not warrant any. Skipping the decision is not an option; deciding against groups often is.
 
 - **When to group:** count the top-level items the workflow would have with no groups — the trigger plus every node or existing group. More than 7 means you must group. The workflow being one straight line is not an exemption: stages run in sequence (e.g. ingest → transform → deliver), so a linear pipeline is the normal case for grouping, not the exception. At 7 items or fewer, serving a single objective, leave it ungrouped.
-- **How many:** one group per distinct stage or high-level objective — typically 3 to 5. After grouping, the top level must be at most 7 items, counting the trigger (always ungrouped), every group, and every node left outside one. When in doubt, fewer groups.
+- **How many:** one group per distinct stage or high-level objective — typically 3 to 5. After grouping, aim for at most 7 items at the top level, counting the trigger (always ungrouped), every group, and every node left outside one. Some graphs cannot reach it — branches fanning straight out of the trigger cannot share a group — and landing an item or two over is fine there. Never invent a group that breaks the validity rules, or split a stage that reads as one objective, just to hit the number. When in doubt, fewer and larger groups.
 - **What belongs together:** a group is one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Put the boundary where the objective changes, and merge two groups that serve the same outcome. If the stages you find come out at one or two nodes each, the boundaries are too fine: widen them until each group is a real objective.
 - **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
 
@@ -136,7 +136,8 @@ Groups are created collapsed, so the title is the first and often the only thing
 ### Descriptions
 
 - Write one for every group, at most ${GROUP_DESCRIPTION_MAX_LENGTH} characters.
-- It must add to the title, never restate it. For "Fetch new recordings", "Fetches new recordings from Gong" is wasted space.
+- It must add to the title, never restate it, and it must not open by repeating it. "Validates the shipping address against the Google API and reduces it to a verdict" under the title "Validate via Google" wastes the words the user actually reads.
+- Lead with the detail that earns its place. A collapsed group clips the description, so the first few words are often all the user sees — spend them on the trigger, the destination, or the scope, never on the title again.
 - The detail worth adding is the trigger or input, the destination or output, or the scope boundary.
 - Plain language a non-technical reader follows — no node types or parameter values.
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -115,7 +115,9 @@ ${renderRulesLines()}
  */
 export const GROUPING_GUIDANCE = `## Grouping
 
-Organise larger workflows into named node groups — visual frames drawn on the canvas — so the result is readable the first time the user sees it.
+Node groups are named visual frames drawn on the canvas, so a workflow reads correctly the first time the user sees it.
+
+Every workflow you build needs an explicit grouping decision, taken while you write the code: declare the groups, or conclude this workflow does not warrant any. Skipping the decision is not an option; deciding against groups often is.
 
 - **When to group:** only workflows big enough to split into clear stages (e.g. ingest → transform → deliver). A small or purely linear workflow gets no groups at all — a group there is just visual noise. When in doubt, fewer groups.
 - **How many:** one group per distinct stage or high-level objective — typically 3 to 5 for a medium-sized workflow. Keep the canvas top level to at most 7 items, counting the trigger (always ungrouped), every group, and every node left outside one.

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -66,21 +66,13 @@ const SAFE_METHODS_SENTENCE =
 	'Native array/string methods such as `.join()`, `.map()`, `.filter()`, `.reduce()`, and `.split()` are NOT available.';
 
 /**
- * Node-groups documentation, extracted so consumers can import just this section
- * without the whole builder-language reference. Shared by Instance AI (embedded
- * in `SDK_LANGUAGE_REFERENCE` below) and the MCP `get_sdk_reference` tool.
+ * Node-groups documentation, shared by Instance AI and the MCP `get_sdk_reference` tool.
  *
  * The rules stated here must match what the server enforces on save:
  * - basic rules (unique id/name, non-empty): `validateWorkflowGroups`
  * - structural rules: `validateNodeSelectionForGrouping`
- * The four structural rules (and their save-path rejection messages) are sourced
- * from the shared `NODE_GROUPING_RULES` constant in `n8n-workflow`, so this doc,
+ * Sourced from the `NODE_GROUPING_RULES` constant in `n8n-workflow`, so this doc,
  * the canvas, and the save path share one definition.
- *
- * Grouping DOES enforce a single entry/exit *boundary* (at most one incoming and
- * one outgoing main connection) via the `invalid-subgraph` rule. The stricter
- * per-node single-main-port check (`multiple-input/-output-branches`) is
- * extraction-only (`validateNodeSelectionForExtraction`) and is not stated here.
  */
 export const NODE_GROUPS_REFERENCE = `## Node groups
 
@@ -100,8 +92,9 @@ export default workflow('id', 'My workflow')
   });
 \`\`\`
 
-\`description\` is optional and shown when the group is collapsed. Keep it to one
-sentence — anything past ${GROUP_DESCRIPTION_MAX_LENGTH} characters is cut off.
+\`description\` is what the user sees while the group is collapsed, so always set one.
+Anything past ${GROUP_DESCRIPTION_MAX_LENGTH} characters is cut off. What the description
+should say is covered by the grouping guidance.
 
 When editing an existing workflow, **keep the \`.group(...)\` calls and their descriptions
 intact** unless the change is specifically about grouping.
@@ -124,10 +117,32 @@ export const GROUPING_GUIDANCE = `## Grouping
 
 Organise larger workflows into named node groups — visual frames drawn on the canvas — so the result is readable the first time the user sees it.
 
-- **When to group:** larger workflows that split into clear stages (e.g. ingest → transform → deliver). Give each stage its own group. Small workflows don't need groups — a group there is just noise.
+- **When to group:** only workflows big enough to split into clear stages (e.g. ingest → transform → deliver). A small or purely linear workflow gets no groups at all — a group there is just visual noise. When in doubt, fewer groups.
+- **How many:** one group per distinct stage or high-level objective — typically 3 to 5 for a medium-sized workflow. Keep the canvas top level to at most 7 items, counting the trigger (always ungrouped), every group, and every node left outside one.
+- **What belongs together:** a group is one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Put the boundary where the objective changes, and merge two groups that serve the same outcome.
 - **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
-- **Naming:** short, outcome-first titles ("Fetch new recordings", not "HTTP + Drive").
-- Groups are created collapsed by default, so the name is what the user sees first — make it descriptive.
+
+### Naming
+
+Groups are created collapsed, so the title is the first and often the only thing the user reads.
+
+- Outcome-first and 2-4 words: "Fetch new recordings", not "HTTP + Drive"; "Generate call summary", not "Claude + Edit Fields".
+- No implementation jargon — no node, credential, or API names.
+- Test it: could someone who has never seen this workflow tell what the group does from the title alone, without expanding it? If not, fix the title or the boundary.
+- If the purpose does not fit in 2-4 words, the group is doing too much — split it.
+
+### Descriptions
+
+- Write one for every group, at most ${GROUP_DESCRIPTION_MAX_LENGTH} characters.
+- It must add to the title, never restate it. For "Fetch new recordings", "Fetches new recordings from Gong" is wasted space.
+- The detail worth adding is the trigger or input, the destination or output, or the scope boundary.
+- Plain language a non-technical reader follows — no node types or parameter values.
+
+Examples:
+
+- "Fetch new recordings" → "Polls Gong every 15 min for fresh calls, downloads audio, stores raw files in Google Drive"
+- "Generate call summary" → "Transcribes the audio, then extracts action items, sentiment, and key topics"
+- "Save and notify" → "Writes summary and metadata to Supabase, then alerts the sales team in Slack"
 
 Read the node groups reference for the exact rules before creating groups.`;
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -137,7 +137,7 @@ Groups are created collapsed, so the title is the first and often the only thing
 
 - Write one for every group, at most ${GROUP_DESCRIPTION_MAX_LENGTH} characters.
 - It must add to the title, never restate it, and it must not open by repeating it. "Validates the shipping address against the Google API and reduces it to a verdict" under the title "Validate via Google" wastes the words the user actually reads.
-- Lead with the detail that earns its place. A collapsed group clips the description, so the first few words are often all the user sees — spend them on the trigger, the destination, or the scope, never on the title again.
+- Lead with the detail that earns its place. A collapsed group clips the description, so the first few words are often all the user sees — spend them on the trigger, the destination, or the scope. Never on the title again, and never on what the group is built from: "AI agent with Postgres chat memory drafts a reply" opens on the parts list and says nothing the reader could not already see.
 - The detail worth adding is the trigger or input, the destination or output, or the scope boundary.
 - Plain language a non-technical reader follows — no node types or parameter values.
 
@@ -146,6 +146,7 @@ Examples:
 - "Fetch new recordings" → "Polls Gong every 15 min for fresh calls, downloads audio, stores raw files in Google Drive"
 - "Generate call summary" → "Transcribes the audio, then extracts action items, sentiment, and key topics"
 - "Save and notify" → "Writes summary and metadata to Supabase, then alerts the sales team in Slack"
+- "Draft support reply" → "Turns the email and the customer's plan and open tickets into a draft, citing our docs"
 
 Read the node groups reference for the exact rules before creating groups.`;
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -76,10 +76,10 @@ const SAFE_METHODS_SENTENCE =
  */
 export const NODE_GROUPS_REFERENCE = `## Node groups
 
-A node group is a named, visual grouping of nodes (a frame on the canvas). It is
-purely organisational — nothing about execution depends on it. Declare one with
-\`.group(name, members, options?)\` on the workflow. Members are the node handles (the
-\`const\` from \`node(...)\`) — the same way connections reference nodes:
+A node group is a named visual frame around nodes on the canvas, purely organisational —
+nothing about execution depends on it. Declare one with \`.group(name, members, options?)\`
+on the workflow; members are the node handles (the \`const\` from \`node(...)\`), the same
+way connections reference nodes:
 
 \`\`\`typescript
 const fetch = node({ /* ... name: 'Fetch data' */ });
@@ -92,16 +92,17 @@ export default workflow('id', 'My workflow')
   });
 \`\`\`
 
-\`description\` is what the user sees while the group is collapsed, so always set one.
-Anything past ${GROUP_DESCRIPTION_MAX_LENGTH} characters is cut off. What the description
-should say is covered by the grouping guidance.
+\`description\` is what the user sees while the group is collapsed, so always set one —
+anything past ${GROUP_DESCRIPTION_MAX_LENGTH} characters is cut off. The grouping guidance
+covers what it should say.
 
 When editing an existing workflow, **keep the \`.group(...)\` calls and their descriptions
 intact** unless the change is specifically about grouping.
 
-Agent save tools drop an invalid group from the saved workflow and report a warning.
-Fix the source so the invalid group is not re-emitted. These rules MUST be followed
-when creating or editing groups.
+The rules below MUST be followed. Agent save tools drop an invalid group from the saved
+workflow and report a warning. A warning means the boundary was wrong, not that the stage
+should stay ungrouped: redraw it so the group is valid and build again. Never re-emit the
+same invalid group.
 
 Rules:
 ${renderRulesLines()}
@@ -115,37 +116,25 @@ ${renderRulesLines()}
  */
 export const GROUPING_GUIDANCE = `## Grouping
 
-Node groups are named visual frames drawn on the canvas, so a workflow reads correctly the first time the user sees it.
+Node groups are named visual frames on the canvas.
 
-Every workflow you build needs an explicit grouping decision, taken while you write the code: declare the groups, or conclude this workflow does not warrant any. Skipping the decision is not an option; deciding against groups often is.
+Every workflow needs an explicit grouping decision, taken while you write the code: declare groups, or conclude this one does not warrant any. Deciding against groups is fine; skipping the decision is not.
 
-- **When to group:** count the top-level items the workflow would have with no groups — the trigger plus every node or existing group. More than 7 means you must group. The workflow being one straight line is not an exemption: stages run in sequence (e.g. ingest → transform → deliver), so a linear pipeline is the normal case for grouping, not the exception. At 7 items or fewer, serving a single objective, leave it ungrouped.
-- **How many:** one group per distinct stage or high-level objective — typically 3 to 5. After grouping, aim for at most 7 items at the top level, counting the trigger (always ungrouped), every group, and every node left outside one. Some graphs cannot reach it — branches fanning straight out of the trigger cannot share a group — and landing an item or two over is fine there. Never invent a group that breaks the validity rules, or split a stage that reads as one objective, just to hit the number. When in doubt, fewer and larger groups.
-- **What belongs together:** a group is one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Put the boundary where the objective changes, and merge two groups that serve the same outcome. If the stages you find come out at one or two nodes each, the boundaries are too fine: widen them until each group is a real objective.
-- **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
+- **When:** count top-level items with no groups (trigger + every node or existing group). More than 7 → you must group. A linear pipeline is the normal case for grouping, not an exemption: stages run in sequence (ingest → transform → deliver). 7 or fewer serving one objective → leave it ungrouped.
+- **How many:** one per stage or high-level objective, typically 3-5, aiming for at most 7 top-level items after grouping (trigger + groups + nodes left outside). Staying above 7 is only acceptable when every item still at the top level is either a group already, or a node that cannot join one without breaking a validity rule — check each one before you settle. Never break a validity rule or split one objective to hit the number. When in doubt, fewer and larger.
+- **What belongs together:** one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Cut where the objective changes; merge groups serving the same outcome. Stages of one or two nodes mean the boundaries are too fine — widen them. Where an objective ends in a branch that stops one way and continues the other, end the group before the branch node, or leave that node and its stop path outside: a group cannot hold a node that both continues inside it and exits it.
+- **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is separately executed and reusable. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
 
-### Naming
+Groups are created collapsed, so title + description is all the user sees.
 
-Groups are created collapsed, so the title is the first and often the only thing the user reads.
+**Titles:** outcome-first, 2-4 words, naming one outcome. "Fetch new recordings", not "HTTP + Drive"; "Generate call summary", not "Claude + Edit Fields". No node, credential, or API names. Two verbs joined by "and" or "&" mean you named the steps instead of the outcome — find the outcome they add up to: "Create & invite" is really "Provision new hire". This one is a preference, not a rule: a two-verb title beats splitting a coherent stage or leaving it ungrouped. If someone who has never seen the workflow cannot tell what it does from the title alone, fix the title or the boundary. If the purpose does not fit in 2-4 words, the group is doing too much — split it.
 
-- Outcome-first and 2-4 words: "Fetch new recordings", not "HTTP + Drive"; "Generate call summary", not "Claude + Edit Fields".
-- No implementation jargon — no node, credential, or API names.
-- Test it: could someone who has never seen this workflow tell what the group does from the title alone, without expanding it? If not, fix the title or the boundary.
-- If the purpose does not fit in 2-4 words, the group is doing too much — split it.
-
-### Descriptions
-
-- Write one for every group, at most ${GROUP_DESCRIPTION_MAX_LENGTH} characters.
-- It must add to the title, never restate it, and it must not open by repeating it. "Validates the shipping address against the Google API and reduces it to a verdict" under the title "Validate via Google" wastes the words the user actually reads.
-- Lead with the detail that earns its place. A collapsed group clips the description, so the first few words are often all the user sees — spend them on the trigger, the destination, or the scope. Never on the title again, and never on what the group is built from: "AI agent with Postgres chat memory drafts a reply" opens on the parts list and says nothing the reader could not already see.
-- The detail worth adding is the trigger or input, the destination or output, or the scope boundary.
-- Plain language a non-technical reader follows — no node types or parameter values.
+**Descriptions:** one per group, at most ${GROUP_DESCRIPTION_MAX_LENGTH} characters, plain language a non-technical reader follows, no node types or parameter values. It must add to the title — never restate it or open by repeating it ("Validates the shipping address against the Google API…" under the title "Validate via Google"), and never open on the parts list ("AI agent with Postgres chat memory drafts a reply" says only what the reader can already see). Collapsed groups clip the text, so spend the first words on the trigger/input, the destination/output, or the scope boundary.
 
 Examples:
 
 - "Fetch new recordings" → "Polls Gong every 15 min for fresh calls, downloads audio, stores raw files in Google Drive"
 - "Generate call summary" → "Transcribes the audio, then extracts action items, sentiment, and key topics"
-- "Save and notify" → "Writes summary and metadata to Supabase, then alerts the sales team in Slack"
 - "Draft support reply" → "Turns the email and the customer's plan and open tickets into a draft, citing our docs"
 
 Read the node groups reference for the exact rules before creating groups.`;

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -119,9 +119,9 @@ Node groups are named visual frames drawn on the canvas, so a workflow reads cor
 
 Every workflow you build needs an explicit grouping decision, taken while you write the code: declare the groups, or conclude this workflow does not warrant any. Skipping the decision is not an option; deciding against groups often is.
 
-- **When to group:** only workflows big enough to split into clear stages (e.g. ingest → transform → deliver). A small or purely linear workflow gets no groups at all — a group there is just visual noise. When in doubt, fewer groups.
-- **How many:** one group per distinct stage or high-level objective — typically 3 to 5 for a medium-sized workflow. Keep the canvas top level to at most 7 items, counting the trigger (always ungrouped), every group, and every node left outside one.
-- **What belongs together:** a group is one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Put the boundary where the objective changes, and merge two groups that serve the same outcome.
+- **When to group:** count the top-level items the workflow would have with no groups — the trigger plus every node or existing group. More than 7 means you must group. The workflow being one straight line is not an exemption: stages run in sequence (e.g. ingest → transform → deliver), so a linear pipeline is the normal case for grouping, not the exception. At 7 items or fewer, serving a single objective, leave it ungrouped.
+- **How many:** one group per distinct stage or high-level objective — typically 3 to 5. After grouping, the top level must be at most 7 items, counting the trigger (always ungrouped), every group, and every node left outside one. When in doubt, fewer groups.
+- **What belongs together:** a group is one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Put the boundary where the objective changes, and merge two groups that serve the same outcome. If the stages you find come out at one or two nodes each, the boundaries are too fine: widen them until each group is a real objective.
 - **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
 
 ### Naming


### PR DESCRIPTION
## Summary

The AI Assistant and MCP clients over-group workflows. They draw frames on trivial
workflows, put one or two nodes in a group, and write titles that name the nodes inside
instead of the outcome.

The instructions are two shared strings in
`packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts`. Instance AI and MCP
both import them, so both surfaces serve the new text with no further change.

**The Instance AI builder skill no longer keeps its own copy.** Its `## Node Groups` section
(`packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md`) held a hand-written summary that
had already drifted: no group counts, and a "one-sentence description" instruction this PR
removes. That summary is inline, so it is what an agent acts on, while the updated guidance sat
in a knowledge-base file the agent had to choose to open.

The skill now injects the shared constant at materialization time through a
`{{GROUPING_GUIDANCE_PLACEHOLDER}}` token (`substitutePlaceholderWithText` in
`packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts`). The skill is loaded in
full, so the criteria arrive in context without an extra read, and there is one source of
truth. What stays hand-written is one line of mechanics and a pointer to the node-groups
reference. Tests assert the injected text is present, that no placeholder is left unresolved in
any materialized skill, and that the skill source carries no grouping criteria of its own, so a
hand-written copy cannot come back unnoticed.

`NODE_GROUPS_REFERENCE` is deliberately not injected: it is mechanical, it is only needed while
writing a `.group(...)` call, and it already ships inside the SDK language reference the builder
has to read anyway.

**`GROUPING_GUIDANCE` now carries the judgement.** It had no numbers at all, only "larger
workflows" and "small workflows", which an agent cannot act on. It now states:

- Leave a small or purely linear workflow ungrouped. When in doubt, use fewer groups.
- Use 3 to 5 groups for a medium-sized workflow. Keep the canvas top level to 7 items or
  fewer, counting the trigger, every group, and every ungrouped node.
- Make each group one business outcome, not a technical category. Merge two groups that
  serve the same outcome.
- Write outcome-first titles of 2 to 4 words. Do not use node, credential, or API names.
  Split a group whose purpose does not fit in 2 to 4 words.
- Write a description for every group. The description must add to the title. It must not
  restate the title.

**`NODE_GROUPS_REFERENCE` keeps only the mechanics.** It called the description
`optional` and asked for a single sentence. Both clauses undercut the new guidance, so
they are gone. The field, the length cap, and the collapsed-state behaviour stay.

The structural rules still come from the `NODE_GROUPING_RULES` constant in `n8n-workflow`.
The guidance does not restate them. A test walks that constant and fails if a rule is
duplicated, so the two copies cannot drift apart.

## How to test

Unit tests:

```bash
pnpm --filter @n8n/workflow-sdk test sdk-language
pnpm --filter @n8n/instance-ai test materialize-knowledge-base
pnpm --filter n8n test get-workflow-best-practices
pnpm --filter n8n test get-workflow-sdk-reference
```

Manual check. The canvas-groups feature flag must be on, or no group documentation is
served and every prompt produces zero groups. Build each workflow below on both surfaces,
then read its `nodeGroups` — with `get_workflow_details` on MCP, from the canvas on the AI
Assistant.

Three rules keep runs comparable. Never mention groups in the prompt: unprompted behaviour
is what is under test. Answer clarifying questions with the shortest possible answer and
skip credential setup, or each run builds a different number of nodes. Run each prompt at
least three times, because group output varies between runs.

**1. No groups.** One stage, so a frame can only wrap the whole canvas.

> When a webhook receives a POST, look up the customer in Postgres and reply with their
> subscription tier.

Expect 4 nodes or fewer and zero groups. Any group is a failure.

**2. No groups, the tie-break case.** Not tiny, but one continuous objective.

> Every hour, read new rows from a Google Sheet, clean up the phone numbers, remove
> duplicates, look up each country code, and write the result back to a second sheet.

Zero groups is correct. One group is acceptable. Three groups named "Read data", "Transform
data", "Write data" is the failure to watch for: that is a split by technical category, not by
outcome.

Count the nodes before scoring. At 7 nodes or fewer the workflow is small enough that no reading
of the guidance asks for a group, so zero groups only confirms restraint and the tie-break is
not under test. The case becomes informative at 8 nodes or more, where the chain is long enough
to tempt a split but still serves a single objective.

**3. Three groups.** Three distinct outcomes, each nameable on its own.

> Every 15 minutes, pull new call recordings from Gong. Transcribe the audio, then use
> Claude to extract action items and sentiment. Save the summary to Supabase and post an
> alert in the #sales Slack channel.

Expect 10 to 14 nodes and 3 groups, with the Schedule Trigger outside all of them. Check
the text too: titles are outcome-first and 2 to 4 words ("Fetch new recordings", not
"Gong + Drive"); no node, credential, or API names in a title; every group has a
description; no description restates its title.

**4. Validity survives judgement.**

> Build a support chatbot. On a chat message, run an AI agent with a Postgres chat memory
> and two tools: one that searches our docs in a vector store, and one that creates a
> Linear ticket. Send the answer back to the user and log every conversation to a data
> table.

The group count is not scored here; 0 to 3 groups are all defensible at this size. What
must hold is that the AI Agent and its language model, memory, and tool sub-nodes sit in
the same group. A model, tool, or memory connection that crosses a group boundary makes
the group invalid, so the save path drops it and reports a warning. A dropped-group
warning is a failure even when the grouping intent was right.

**5. The top-level ceiling.**

> Build an order-fulfilment workflow. On a new Shopify order: validate the address, check
> stock in Postgres, charge the card in Stripe, create a shipping label, email the customer
> their tracking number, write the order to our warehouse system, and notify #ops in Slack.

Expect 20 or more nodes and 7 items or fewer at the canvas top level, counting the trigger,
every group, and every ungrouped node. In practice that means 4 to 6 groups. Failures: 8 or
more top-level items, or one group per integration.

Do not add per-node error handling to this prompt. It has two legitimate implementations
with opposite grouping outcomes, so a failure could not be attributed to the grouping
criteria: per-node error outputs leave each failing node as a non-leaf with an edge out of
its group, which invalidates that group, while a separate error workflow adds no edges and
leaves everything groupable.

**6. Preservation on edit.** Start from the result of case 3, then:

> Also save the raw transcript to Google Drive.

Expect the existing groups and their descriptions unchanged. The new node joins the group
whose outcome it serves. Failures: groups missing from the saved workflow; a renamed group
or a rewritten description; the new node left loose when it belongs to an existing stage.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5802

Evals for these instructions are the second acceptance criterion of the ticket. They are a
follow-up, so that the baseline is a real before-and-after measurement.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




