### PR TITLE
test: Shard cli unit tests two ways on 4 vCPU (no-changelog)

### DIFF
--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -38,8 +38,12 @@ env:
 
 jobs:
   unit-test-backend:
-    name: Backend Unit Tests
+    name: Backend Unit Tests (${{ matrix.shard }})
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
@@ -73,11 +77,14 @@ jobs:
       # @n8n/vitest-config/node), peak forks ≈ 2 × 50% ≈ the core count, instead
       # of ~10 concurrent suites each spawning a core-sized pool and pegging CPU.
       - name: Test Unit (backend, except cli and nodes-base)
+        if: matrix.shard == 1
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
+      # EXPERIMENT: split cli across 2 shards. `test-scoped` forwards unknown
+      # flags to vitest, so --shard needs no janitor change.
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
-        run: pnpm turbo test:unit:changed --filter=n8n --summarize
+        run: pnpm turbo test:unit:changed --filter=n8n --summarize -- --shard=${{ matrix.shard }}/2
 
       - name: Send Test Stats
         if: ${{ !cancelled() }}
@@ -93,7 +100,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          name: backend-unit-tests
+          name: backend-unit-tests-${{ matrix.shard }}
 
       - name: Upload coverage to Codecov
         if: env.COVERAGE_ENABLED == 'true'
@@ -101,7 +108,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend-unit
-          name: backend-unit
+          name: backend-unit-${{ matrix.shard }}
           files: ./packages/**/coverage/lcov.info
 
   integration-test-backend:

--- a/packages/@n8n/constants/src/index.ts
+++ b/packages/@n8n/constants/src/index.ts
@@ -151,3 +151,6 @@ export const NANOID_ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl
 
 /** Protected-resource id of the instance MCP server, shared by the mcp and oauth-server modules. */
 export const INSTANCE_MCP_RESOURCE_ID = 'instance-mcp';
+
+// EXPERIMENT MARKER: forces cli into the upstream-affected full-suite path so
+// both shard arms measure the same workload. Throwaway, never merged.


### PR DESCRIPTION
Throwaway experiment arm A — never merged, closed once measured.

Splits `Test Unit (cli, scoped)` across a 2-shard matrix on **4 vCPU** runners.

## Why

cli is now the dominant unit-test cost: 88% of merges push it to the full-suite path (#34986, 2026-07-30), where it runs ~1,150 files in ~660s. Earlier arms established that raising the worker cap and disabling isolation both make it worse, so the remaining levers are sharding and runner size.

Billable minutes are wall-clock x vCPU, so the two arms answer different questions:

| arm | question |
|---|---|
| 4 vCPU (this repo's default) | does sharding buy latency, and what does the duplicated setup cost? |
| 2 vCPU | does halving the runner while halving the work save money? |

Cost parity for the 2 vCPU arm sits at 660s per shard. Anything faster is a saving; the downside is bounded near cost-neutral.

## Implementation notes

- `janitor test-scoped` already forwards unknown flags to vitest and `--shard=` does not collide with its own `--shards=` / `--shard-index=`, so `--shard=N/2` needed no janitor change.
- The bulk backend step is gated to `matrix.shard == 1` so it is not duplicated and cannot confound the cli measurement.
- A marker comment is appended to `@n8n/constants` — a cli runtime dependency — to force the upstream-affected full-suite path deterministically. Both arms carry the identical marker so the workload matches.
- Codecov artifact names are suffixed per shard to avoid collision.

## Prediction

I expect the 2 vCPU arm to fail. At 4 workers on 4 cores the job was ~20% oversubscribed and produced 35 timeouts with 5.6x slower aggregate execution; 2 workers on 2 cores is the same ratio. Recording that up front so the result is not read after the fact.

## Reading the result

Duration is only quoted after parity passes — suites, test count and turbo cache must match across arms, via `blacksmith jobs tests`. Three previous readings in this series were wrong because I compared durations across runs that had silently done different amounts of work.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

