### PR TITLE
ci: Run DB migration tests only when a migration-relevant path changes

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -27,6 +27,7 @@ jobs:
       workflows: ${{ fromJSON(steps.ci-filter.outputs.results).workflows == true }}
       workflow_scripts: ${{ fromJSON(steps.ci-filter.outputs.results)['workflow-scripts'] == true }}
       db: ${{ fromJSON(steps.ci-filter.outputs.results).db == true }}
+      db_migrations: ${{ fromJSON(steps.ci-filter.outputs.results)['db-migrations'] == true }}
       e2e_performance: ${{ fromJSON(steps.ci-filter.outputs.results)['e2e-performance'] == true }}
       instance_ai_workflow_eval: ${{ fromJSON(steps.ci-filter.outputs.results)['instance-ai-workflow-eval'] == true }}
       commit_sha: ${{ steps.commit-sha.outputs.sha }}
@@ -163,6 +164,23 @@ jobs:
               docs/generated/**
               .tbls.sqlite.yml
               .tbls.postgres.yml
+            # Sub-filter of db. Lists the paths that can change a migration
+            # test result. Gates the migration step inside each DB matrix leg.
+            db-migrations:
+              packages/@n8n/db/**
+              packages/@n8n/backend-test-utils/**
+              packages/cli/test/migration/**
+              packages/cli/test/shared/db/**
+              packages/cli/test/setup-testcontainers.js
+              packages/cli/test/teardown-testcontainers.js
+              packages/cli/vitest.config.base.ts
+              packages/cli/vitest.config.migration.ts
+              packages/cli/vitest.config.migration.testcontainers.ts
+              packages/testing/containers/services/postgres.ts
+              packages/testing/containers/postgres-versions.json
+              packages/testing/containers/test-containers.ts
+              .github/workflows/test-db-reusable.yml
+              .github/scripts/db-test-matrix.mjs
 
       - name: Setup and Build
         if: fromJSON(steps.ci-filter.outputs.results).ci || fromJSON(steps.ci-filter.outputs.results).e2e
@@ -327,6 +345,7 @@ jobs:
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
       matrix: ${{ needs.install-and-build.outputs.db_test_matrix }}
+      run-migrations: ${{ needs.install-and-build.outputs.db_migrations == 'true' }}
 
   e2e-performance:
     name: E2E Performance

--- a/.github/workflows/test-db-reusable.yml
+++ b/.github/workflows/test-db-reusable.yml
@@ -11,6 +11,11 @@ on:
         description: 'Job matrix JSON, from .github/scripts/db-test-matrix.mjs.'
         required: true
         type: string
+      run-migrations:
+        description: 'Run the migration test step in each leg. The caller turns this off when no migration-relevant path changed.'
+        required: false
+        type: boolean
+        default: true
 
 env:
   NODE_OPTIONS: '--max-old-space-size=6144'
@@ -43,7 +48,7 @@ jobs:
         run: ${{ matrix.test-cmd }}
 
       - name: Run Migration Tests
-        if: matrix.migration-cmd != ''
+        if: matrix.migration-cmd != '' && inputs.run-migrations
         working-directory: packages/cli
         run: ${{ matrix.migration-cmd }}
 


### PR DESCRIPTION
## Summary

Each DB matrix leg runs a migration test step. The step takes about 7.5 minutes per leg, about 30 machine-minutes across the 4 legs. It runs on every PR that trips the `db` filter, even when the change cannot alter a migration result. Example: a change to `packages/cli/test/integration/**` runs migrations on all 4 legs today.

This PR gates the migration step on a new `db-migrations` sub-filter. The sub-filter lists every path that feeds the migration suites:

- `packages/@n8n/db/**` — schema migrations, entities, and `DbConnection`
- `packages/cli/test/migration/**` — the migration tests
- the migration vitest configs and the shared base config
- the shared DB test helpers and testcontainers plumbing
- the DB workflow and matrix script themselves

The `run-migrations` input on `test-db-reusable.yml` defaults to `true`, so any other caller keeps the current behavior. The integration tests and the schema-docs check in each leg are not affected.

Note: `packages/cli/src/modules/*/database/` dirs hold entities and repositories only. DB schema migrations live in `packages/@n8n/db/src/migrations`, which the sub-filter covers. The `migrations/` dir under `breaking-changes` holds workflow-node migrations, which the DB legs do not run.

## How to test

- Open a PR that changes only `packages/cli/test/integration/**`. The DB legs must run their integration tests and skip "Run Migration Tests".
- Open a PR that changes a file under `packages/@n8n/db/src/migrations/**` or `packages/cli/test/migration/**`. The migration step must run on every leg.
- `actionlint` passes on both workflows.

## Related Linear tickets, Github issues, and Community forum posts

Related: https://linear.app/n8n/issue/DEVP-188 (CI test scoping umbrella)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

