### PR TITLE
feat(core): Register system tasks through the module contract (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -1,4 +1,4 @@
-import type { ModuleInterface, ModuleMetadata } from '@n8n/decorators';
+import type { ModuleInterface, ModuleMetadata, SystemTaskMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import path from 'path';
 import { mock } from 'vitest-mock-extended';
@@ -135,7 +135,7 @@ describe('loadModules', () => {
 		});
 
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		await moduleRegistry.loadModules([]);
 
@@ -149,7 +149,7 @@ describe('loadModules', () => {
 		});
 
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		await moduleRegistry.loadModules([]);
 
@@ -167,11 +167,37 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		await moduleRegistry.initModules('main');
 
 		expect(ModuleClass.init).toHaveBeenCalled();
+	});
+
+	it('should register the system tasks returned by a module', async () => {
+		const TaskClass = class TestTask {};
+		const ModuleClass = { init: vi.fn(), systemTasks: vi.fn().mockReturnValue([TaskClass]) };
+		const moduleMetadata = mock<ModuleMetadata>({
+			getEntries: vi
+				.fn()
+				.mockReturnValue([['test-module', { licenseFlag: undefined, class: ModuleClass }]]),
+		});
+		const systemTaskMetadata = mock<SystemTaskMetadata>();
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
+
+		const moduleRegistry = new ModuleRegistry(
+			moduleMetadata,
+			mock(),
+			mock(),
+			mock(),
+			systemTaskMetadata,
+		);
+
+		await moduleRegistry.initModules('main');
+
+		expect(ModuleClass.systemTasks).toHaveBeenCalled();
+		expect(systemTaskMetadata.register).toHaveBeenCalledTimes(1);
+		expect(systemTaskMetadata.register).toHaveBeenCalledWith(TaskClass);
 	});
 
 	it('should init module if it is licensed', async () => {
@@ -186,7 +212,7 @@ describe('initModules', () => {
 		const licenseState = mock<LicenseState>({ isLicensed: vi.fn().mockReturnValue(true) });
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, licenseState, mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, licenseState, mock(), mock(), mock());
 
 		await moduleRegistry.initModules('main');
 
@@ -205,7 +231,7 @@ describe('initModules', () => {
 		const licenseState = mock<LicenseState>({ isLicensed: vi.fn().mockReturnValue(false) });
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, licenseState, mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, licenseState, mock(), mock(), mock());
 
 		await moduleRegistry.initModules('main');
 
@@ -222,7 +248,7 @@ describe('initModules', () => {
 
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		await moduleRegistry.initModules('main');
 
@@ -242,7 +268,7 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		// ACT
 		await moduleRegistry.initModules('main');
@@ -266,7 +292,7 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		// ACT
 		await moduleRegistry.initModules('main');
@@ -288,7 +314,7 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		// ACT
 		await moduleRegistry.initModules('main');
@@ -312,7 +338,7 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		// ACT
 		await moduleRegistry.initModules('main');
@@ -332,7 +358,7 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		// ACT
 		await moduleRegistry.initModules('main');
@@ -352,7 +378,7 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		await moduleRegistry.initModules('main');
 
@@ -368,7 +394,7 @@ describe('initModules', () => {
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		await moduleRegistry.initModules('main');
 
@@ -387,7 +413,7 @@ describe('nodeLoaders', () => {
 			getClasses: vi.fn().mockReturnValue([ModuleClass]),
 		});
 		Container.get = vi.fn().mockReturnValue(ModuleClass);
-		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
+		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
 
 		await moduleRegistry.loadModules([]); // empty to skip dynamic imports
 

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -1,5 +1,5 @@
 import type { InstanceType } from '@n8n/constants';
-import { ModuleMetadata } from '@n8n/decorators';
+import { ModuleMetadata, SystemTaskMetadata } from '@n8n/decorators';
 import type { EntityClass, ModuleContext, ModuleSettings } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import { existsSync } from 'fs';
@@ -38,6 +38,7 @@ export class ModuleRegistry {
 		private readonly licenseState: LicenseState,
 		private readonly logger: Logger,
 		private readonly modulesConfig: ModulesConfig,
+		private readonly systemTaskMetadata: SystemTaskMetadata,
 	) {}
 
 	private readonly defaultModules: ModuleName[] = [
@@ -172,6 +173,12 @@ export class ModuleRegistry {
 			}
 
 			await Container.get(ModuleClass).init?.();
+
+			const systemTasks = await Container.get(ModuleClass).systemTasks?.();
+
+			for (const taskClass of systemTasks ?? []) {
+				this.systemTaskMetadata.register(taskClass);
+			}
 
 			const moduleSettings = await Container.get(ModuleClass).settings?.();
 

--- a/packages/@n8n/decorators/src/module/module.ts
+++ b/packages/@n8n/decorators/src/module/module.ts
@@ -3,6 +3,7 @@ import { Container, Service, type Constructable } from '@n8n/di';
 import type { NodeLoader } from 'n8n-workflow';
 
 import { ModuleMetadata } from './module-metadata';
+import type { SystemTaskClass } from '../system-task/system-task';
 
 /**
  * Structurally similar (not identical) interface to typeorm's `BaseEntity`
@@ -81,6 +82,16 @@ export interface ModuleInterface {
 	 * ```
 	 */
 	context?(): Promise<ModuleContext>;
+
+	/**
+	 * Return the system task classes this module contributes. Each returned
+	 * class is registered with the system task registry after the module's
+	 * `init()`. Return an empty array when a config or environment gate keeps
+	 * the module's tasks off.
+	 *
+	 * @example [ InsightsCompactionTask, InsightsPruningTask ]
+	 */
+	systemTasks?(): Promise<SystemTaskClass[]>;
 
 	/**
 	 * Return zero or more node loaders contributed by this module.

--- a/packages/@n8n/decorators/src/system-task/__tests__/system-task.test.ts
+++ b/packages/@n8n/decorators/src/system-task/__tests__/system-task.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 	Container.set(SystemTaskMetadata, metadata);
 });
 
-it('should register classes decorated with @SystemTask', () => {
+it('should make a decorated class injectable without registering it', () => {
 	vi.spyOn(metadata, 'register');
 
 	@SystemTask()
@@ -30,11 +30,11 @@ it('should register classes decorated with @SystemTask', () => {
 		async run() {}
 	}
 
-	expect(metadata.register).toHaveBeenCalledTimes(1);
-	expect(metadata.register).toHaveBeenCalledWith(TestTask);
+	expect(metadata.register).not.toHaveBeenCalled();
+	expect(Container.get(TestTask)).toBeInstanceOf(TestTask);
 });
 
-it('should notify a subscribed listener when a task class is decorated later', () => {
+it('should notify a subscribed listener when a task class is registered later', () => {
 	const seen: SystemTaskClass[] = [];
 	metadata.subscribe((taskClass) => seen.push(taskClass));
 
@@ -55,10 +55,12 @@ it('should notify a subscribed listener when a task class is decorated later', (
 		async run() {}
 	}
 
+	metadata.register(LateTask);
+
 	expect(seen).toEqual([LateTask]);
 });
 
-it('should make the class injectable before notifying a subscribed listener', () => {
+it('should let a subscribed listener resolve the class it is notified of', () => {
 	const resolved: SystemTask[] = [];
 	metadata.subscribe((taskClass) => resolved.push(Container.get(taskClass)));
 
@@ -74,6 +76,8 @@ it('should make the class injectable before notifying a subscribed listener', ()
 
 		async run() {}
 	}
+
+	metadata.register(ResolvableTask);
 
 	expect(resolved).toHaveLength(1);
 	expect(resolved[0]).toBeInstanceOf(ResolvableTask);

--- a/packages/@n8n/decorators/src/system-task/system-task.ts
+++ b/packages/@n8n/decorators/src/system-task/system-task.ts
@@ -4,10 +4,8 @@ import {
 	type OneOffDefinition,
 	type ScheduleDefinition,
 } from '@n8n/constants';
-import { Container, Service, type Constructable } from '@n8n/di';
+import { Service, type Constructable } from '@n8n/di';
 import { UnexpectedError } from 'n8n-workflow';
-
-import { SystemTaskMetadata } from './system-task-metadata';
 
 /** Whether a run is safe to repeat. */
 export type SystemTaskEffects = 'idempotent' | 'non-idempotent';
@@ -153,8 +151,9 @@ function assertInRange(taskName: string, field: string, value: number, min: numb
 export type SystemTaskClass = Constructable<SystemTask>;
 
 /**
- * Class decorator that registers a system task in {@link SystemTaskMetadata}
- * and makes the class injectable.
+ * Class decorator that makes a system task class injectable. Registration is
+ * explicit: a backend module returns the class from its `systemTasks()` hook,
+ * and anything else hands it to `SystemTaskMetadata` directly.
  *
  * @example
  *
@@ -168,10 +167,7 @@ export type SystemTaskClass = Constructable<SystemTask>;
 export const SystemTask =
 	() =>
 	<T extends SystemTaskClass>(target: T): T => {
-		// Injectable first: a subscribed listener resolves the class while this
-		// decorator is still running.
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		Service()(target);
-		Container.get(SystemTaskMetadata).register(target);
 		return target;
 	};

--- a/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
+++ b/packages/cli/src/scheduling/system-tasks/system-task-runner.ts
@@ -147,15 +147,16 @@ export class SystemTaskRunner {
 
 	/**
 	 * Resolve a registered class and give its task a mode. Resolving eagerly is
-	 * safe: `@SystemTask()` makes the class injectable before it registers, and
-	 * the name and schedule the routing needs live on the instance.
+	 * safe: `@SystemTask()` makes the class injectable at declaration, before
+	 * anything can register it, and the name and schedule the routing needs live
+	 * on the instance.
 	 *
-	 * @throws {UnexpectedError} When a name is registered more than once, whether by
-	 * two tasks claiming it or by one task's module being loaded twice. It surfaces
-	 * out of {@link init} for a task registered before it, and out of the task's own
-	 * `@SystemTask()` decorator for one registered after. Either way the runner is
-	 * left half-routed and startup fails, which is the point: a duplicate name is a
-	 * coding mistake.
+	 * @throws {UnexpectedError} When a name is registered more than once, whether
+	 * by two tasks claiming it or by one task being registered twice. It surfaces
+	 * out of {@link init} for a task registered before it, and out of the
+	 * `SystemTaskMetadata.register` call for one registered after. Either way the
+	 * runner is left half-routed and startup fails, which is the point: a
+	 * duplicate name is a coding mistake.
 	 *
 	 * @throws {UnexpectedError} When a task declares a `retryDelaySeconds` that is
 	 * not an integer between 1 and {@link MAX_RETRY_DELAY_SECONDS}. A timeout would


### PR DESCRIPTION
## Summary

Registering a system task becomes an explicit, typed act instead of an import side effect.

- `ModuleInterface` gains an optional `systemTasks(): Promise<SystemTaskClass[]>` hook, next to `entities()` and `nodeLoaders()`.
- `ModuleRegistry.initModules` calls the hook after each module's `init()` and registers every returned class with `SystemTaskMetadata`.
- `@SystemTask()` no longer self-registers. The decorator only makes the class injectable.

No behavior change: no module implements the hook yet. Adoption of the hook happens in A3.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4314

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

