### PR TITLE
ci: Skip the scoped cli integration step when the DB matrix runs

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -211,6 +211,9 @@ jobs:
       collectCoverage: ${{ github.event_name != 'merge_group' }}
       affectedPackages: ${{ needs.install-and-build.outputs.affected_packages }}
       changedFiles: ${{ needs.install-and-build.outputs.changed_files }}
+      # The DB matrix's "SQLite Pooled" leg runs the full cli integration
+      # suite with the same command and environment as the scoped step.
+      skipCliIntegration: ${{ needs.install-and-build.outputs.db == 'true' }}
     secrets: inherit
 
   typecheck:

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -33,6 +33,15 @@ on:
         required: false
         default: ''
         type: string
+      skipCliIntegration:
+        description: |
+          Skip the scoped cli integration step. The PR workflow sets this when
+          the DB matrix runs: its "SQLite Pooled" leg runs the full cli
+          integration suite with the same command and environment, so the
+          scoped run here adds no coverage.
+        required: false
+        default: false
+        type: boolean
 env:
   NODE_OPTIONS: --max-old-space-size=7168
 
@@ -136,7 +145,7 @@ jobs:
         run: pnpm turbo test:integration --continue --concurrency=1 --filter='!./packages/frontend/**' --filter='!./packages/modules/**' --filter='!n8n' --summarize
 
       - name: Test Integration (cli, scoped)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !inputs.skipCliIntegration }}
         run: pnpm turbo test:integration:changed --filter=n8n --summarize
 
       - name: Send Test Stats


### PR DESCRIPTION
## Summary

When the `db` filter trips, cli integration tests on SQLite run twice in the same CI run:

1. The Backend Integration Tests job runs `test:integration:changed` — a change-scoped subset via `janitor test-scoped`.
2. The DB matrix's "SQLite Pooled" leg runs `test:sqlite` — the full suite.

`test:sqlite` and `test:integration` are the same command with the same environment (`DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite vitest run --config vitest.config.integration.ts`). The full run is a superset of the scoped run, so the scoped step adds no coverage on those PRs. It cost 9 to 13 minutes on the runs I sampled.

This PR adds a `skipCliIntegration` input to `test-unit-reusable.yml` and sets it from the `db` filter output. When the DB matrix does not run, the scoped step runs as before. `ci-master.yml` does not pass the input, so master runs are unchanged (default `false`).

Coverage note: on db-tripping PRs, the `backend-integration` Codecov flag no longer includes cli integration coverage from this job. The primary Postgres leg still uploads full cli integration coverage under `backend-integration-postgres`.

## How to test

- Open a PR that trips the `db` filter (for example, change a file under `packages/cli/test/integration/**`). The Backend Integration Tests job must skip "Test Integration (cli, scoped)", and the "SQLite Pooled" leg must run the full suite.
- Open a PR that touches cli source without tripping `db`. The scoped step must run as before.
- `actionlint` passes on both workflows.

## Related Linear tickets, Github issues, and Community forum posts

Related: https://linear.app/n8n/issue/DEVP-188 (CI test scoping umbrella)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

