### PR TITLE
ci: Let lint tasks write to the turbo cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint:styles:fix": "turbo run lint:styles:fix",
     "lint:affected": "turbo run lint --affected",
     "lint:fix": "turbo run lint:fix",
-    "lint:ci": "turbo run lint lint:styles --concurrency=2 --cache=local:r,remote:r && pnpm boundaries:check && pnpm check:workspace-private-deps",
+    "lint:ci": "turbo run lint lint:styles --concurrency=2 && pnpm boundaries:check && pnpm check:workspace-private-deps",
     "boundaries": "turbo boundaries",
     "boundaries:check": "node scripts/check-boundaries.mjs",
     "boundaries:baseline": "node scripts/check-boundaries.mjs --write",


### PR DESCRIPTION
## Summary

`lint:ci` runs turbo with `--cache=local:r,remote:r` — read-only. Every lint entry point in CI (`test-linting-reusable.yml`, used by PR runs, merge-queue runs, and master pushes) uses this script. Nothing ever writes a lint cache entry, so the read side always misses and every run pays a full-repo ESLint + stylelint pass: 9 to 14 minutes per PR push, again per merge-queue group, again per master push.

This PR removes the flag. Turbo then defaults to `local:rw,remote:rw`:

- Master runs seed the shared remote cache (the `rharkor/caching-for-turbo` server in `setup-nodejs`; GitHub Actions cache entries created on `master` are readable from every PR and merge-queue branch).
- A typical PR then re-lints only the packages its change invalidates, plus dependents.

Why this is sound to cache:

- The flag has no recorded rationale. It arrived inside an unrelated dependency-update PR (#36635) with no mention in the PR body, and the follow-up concurrency change (#37227, DEVP-894) kept it without comment.
- The `lint` task declares `dependsOn: ^build` plus `@n8n/eslint-config#build`, and `lint:styles` depends on `@n8n/stylelint-config#build`, so config-package changes invalidate dependents through the task graph.
- Turbo also hashes internal dependency files directly. Verified on this repo with `turbo --dry=json`: a whitespace-only change to `packages/@n8n/typescript-config/tsconfig.common.go.json` (a package with no build task) changes the `@n8n/permissions#lint` hash from `f8100491ea59d4c8` to `3634b136d6731d34`. Type-aware lint inputs are covered.
- ESLint versions and plugins resolve from the lockfile, which turbo hashes per package.
- A lint task has no declared `outputs`, so a cache entry stores logs only — the write cost and the cache-quota cost (see DEVP-912) are small.

The `boundaries:check` and `check:workspace-private-deps` steps in the same script are separate commands and still run in full on every job.

If a poisoned or stale lint pass ever surfaces, the single-flag revert restores the current behavior.

## How to test

- `pnpm lint:ci` still runs the same tasks; only the cache mode changes.
- After merge, compare the Lint job duration on a PR with a small diff against the current 9-to-14-minute baseline. The first master push after merge seeds the cache; PRs after that should mostly replay cache hits.
- Sanity check for correctness: change one package's source so it violates a lint rule, and confirm the Lint job fails for that package (cache miss, real run).

## Related Linear tickets, Github issues, and Community forum posts

- Related: https://linear.app/n8n/issue/DEVP-894 (bounded lint concurrency; kept the flag without comment)
- Related: https://linear.app/n8n/issue/DEVP-912 (CI cache saturation — lint entries are log-only and small)
- Related: https://linear.app/n8n/issue/DEVP-188 (CI test scoping umbrella)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

