### PR TITLE
ci: Skip unit-test jobs whose package group is not affected

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -35,7 +35,9 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
       db_test_matrix: ${{ steps.generate-db-test-matrix.outputs.db_test_matrix }}
       skip_tests: ${{ steps.generate-matrix.outputs.skip-tests }}
-      affected_packages: ${{ steps.affected-packages.outputs.list }}
+      unit_backend: ${{ steps.affected-test-groups.outputs.backend }}
+      unit_nodes: ${{ steps.affected-test-groups.outputs.nodes }}
+      unit_frontend: ${{ steps.affected-test-groups.outputs.frontend }}
       changed_files: ${{ steps.ci-filter.outputs.changed-files }}
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
@@ -191,15 +193,42 @@ jobs:
         if: fromJSON(steps.ci-filter.outputs.results).db
         run: echo "db_test_matrix=$(node .github/scripts/db-test-matrix.mjs)" >> "$GITHUB_OUTPUT"
 
-      - name: Compute affected packages
-        id: affected-packages
+      # Maps the affected-package set onto the unit workflow's job groups so
+      # whole jobs skip when their group has no affected package. Runner
+      # boot-up (checkout + install + cached build) costs ~2 minutes per job
+      # even when janitor then skips every package inside it.
+      - name: Compute affected test groups
+        id: affected-test-groups
         if: fromJSON(steps.ci-filter.outputs.results).unit
         env:
           CHANGED_FILES: ${{ steps.ci-filter.outputs.changed-files }}
         run: |
-          PACKAGES=$(node packages/testing/janitor/dist/cli.js affected-packages | tr '\n' ' ' | sed 's/ *$//')
-          echo "Affected packages: $PACKAGES"
-          echo "list=$PACKAGES" >> "$GITHUB_OUTPUT"
+          DIRS=$(node packages/testing/janitor/dist/cli.js affected-packages --paths)
+          printf 'Affected package dirs:\n%s\n' "$DIRS"
+          FRONTEND=false; NODES=false; BACKEND=false
+          # Files outside packages/ (turbo.json, patches, root scripts) can
+          # change test behavior in ways the package graph cannot see, and an
+          # empty dir list means the graph recognized nothing. Both fail open
+          # to running every group.
+          NON_PKG=$(printf '%s\n' "$CHANGED_FILES" | sed '/^[[:space:]]*$/d' | { grep -cv '^packages/' || true; })
+          if [ -z "$CHANGED_FILES" ] || [ -z "$DIRS" ] || [ "$NON_PKG" -gt 0 ]; then
+            FRONTEND=true; NODES=true; BACKEND=true
+            echo 'Fail-open: running every group'
+          else
+            while IFS= read -r dir; do
+              case "$dir" in
+                packages/frontend/*|packages/modules/*) FRONTEND=true ;;
+                packages/nodes-base) NODES=true ;;
+                *) BACKEND=true ;;
+              esac
+            done <<< "$DIRS"
+          fi
+          {
+            echo "frontend=$FRONTEND"
+            echo "nodes=$NODES"
+            echo "backend=$BACKEND"
+          } >> "$GITHUB_OUTPUT"
+          echo "Groups: backend=$BACKEND nodes=$NODES frontend=$FRONTEND"
 
   unit-test:
     name: Unit tests
@@ -209,8 +238,11 @@ jobs:
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
       collectCoverage: ${{ github.event_name != 'merge_group' }}
-      affectedPackages: ${{ needs.install-and-build.outputs.affected_packages }}
       changedFiles: ${{ needs.install-and-build.outputs.changed_files }}
+      # `!= 'false'` fails open when the groups step did not run.
+      runBackendTests: ${{ needs.install-and-build.outputs.unit_backend != 'false' }}
+      runNodesTests: ${{ needs.install-and-build.outputs.unit_nodes != 'false' }}
+      runFrontendTests: ${{ needs.install-and-build.outputs.unit_frontend != 'false' }}
     secrets: inherit
 
   typecheck:

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -17,14 +17,23 @@ on:
         required: false
         default: false
         type: boolean
-      affectedPackages:
+      runBackendTests:
         description: |
-          Space-separated list of workspace packages affected by the PR, as
-          computed by `janitor affected-packages` in install-and-build. Empty
-          string means "no scoping data, run everything".
+          Run the backend unit and integration jobs. The PR workflow turns
+          this off when no backend package is in the affected set.
         required: false
-        default: ''
-        type: string
+        default: true
+        type: boolean
+      runNodesTests:
+        description: Run the nodes-base job. Off when nodes-base is not affected.
+        required: false
+        default: true
+        type: boolean
+      runFrontendTests:
+        description: Run the frontend shard jobs. Off when no frontend or module package is affected.
+        required: false
+        default: true
+        type: boolean
       changedFiles:
         description: |
           Newline-separated list of CHANGED_FILES from ci-filter. Passed to
@@ -39,10 +48,10 @@ env:
 jobs:
   unit-test-backend:
     name: Backend Unit Tests
+    if: inputs.runBackendTests
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
-      AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
@@ -106,10 +115,10 @@ jobs:
 
   integration-test-backend:
     name: Backend Integration Tests
+    if: inputs.runBackendTests
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
-      AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
@@ -166,10 +175,10 @@ jobs:
 
   unit-test-nodes:
     name: Nodes Unit Tests
+    if: inputs.runNodesTests
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
-      AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
@@ -211,6 +220,7 @@ jobs:
 
   unit-test-frontend:
     name: Frontend (${{ matrix.shard }}/2)
+    if: inputs.runFrontendTests
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     strategy:
       fail-fast: false
@@ -218,7 +228,6 @@ jobs:
         shard: [1, 2]
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
-      AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1

--- a/packages/testing/janitor/README.md
+++ b/packages/testing/janitor/README.md
@@ -203,11 +203,12 @@ ci-filter (in install-and-build)
   │
   └─→ CHANGED_FILES (newline-separated)
         │
-        ├─→ janitor affected-packages    (walks pnpm workspace dep graph)
+        ├─→ janitor affected-packages --paths   (walks pnpm workspace dep graph)
         │     │
-        │     └─→ AFFECTED_PACKAGES (space-separated list)
+        │     └─→ job-group flags (backend / nodes / frontend)
         │           │
-        │           └─→ passed to test jobs as workflow input
+        │           └─→ whole unit-test jobs skip when their group has no
+        │               affected package (fail-open for files outside packages/)
         │
         └─→ CHANGED_FILES forwarded to test jobs
               │
@@ -223,6 +224,9 @@ ci-filter (in install-and-build)
 ```bash
 # Walk the workspace dep graph. Output: one package name per line.
 CHANGED_FILES="packages/workflow/src/x.ts" janitor affected-packages
+
+# Same walk, but print repo-root-relative package dirs instead of names.
+CHANGED_FILES="packages/workflow/src/x.ts" janitor affected-packages --paths
 
 # Compute scope for the cwd package. Output: SKIP | RUN_FULL | <files>
 janitor scope

--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -654,6 +654,7 @@ function runAffectedPackages(options: CliOptions): void {
 	const result = affectedPackages({
 		rootDir: findWorkspaceRoot(process.cwd()),
 		changedFiles: readChangedFiles(options),
+		paths: options.paths,
 	});
 	console.log(result.join('\n'));
 }

--- a/packages/testing/janitor/src/cli/arg-parser.ts
+++ b/packages/testing/janitor/src/cli/arg-parser.ts
@@ -57,6 +57,8 @@ export interface CliOptions {
 	// Affected-packages / scope options
 	changedFiles?: string;
 	packageDir?: string;
+	/** affected-packages: print package dirs instead of package names. */
+	paths: boolean;
 	/** Anything after `--` — forwarded to the test runner by `test-scoped`. */
 	passthroughArgs: string[];
 	// filter-shard-specific options
@@ -140,6 +142,9 @@ const FLAG_HANDLERS: Record<string, FlagHandler> = {
 	},
 	'--impact': (opts) => {
 		opts.impact = true;
+	},
+	'--paths': (opts) => {
+		opts.paths = true;
 	},
 };
 
@@ -243,6 +248,7 @@ function createDefaultOptions(): CliOptions {
 		impact: false,
 		changedFiles: undefined,
 		packageDir: undefined,
+		paths: false,
 		passthroughArgs: [],
 		url: undefined,
 	};

--- a/packages/testing/janitor/src/cli/help.ts
+++ b/packages/testing/janitor/src/cli/help.ts
@@ -220,17 +220,18 @@ Walks the pnpm workspace dependency graph: directly-affected packages plus
 everything transitively downstream. Outputs one package name per line.
 
 Usage:
-  janitor affected-packages [--changed-files=<list>]
+  janitor affected-packages [--changed-files=<list>] [--paths]
 
   --changed-files: newline- OR comma-separated repo-root-relative paths.
                    Defaults to $CHANGED_FILES env var.
+  --paths:         print repo-root-relative package dirs instead of names.
 
 When neither --changed-files nor $CHANGED_FILES is set, returns ALL packages
 (safe default for local dev).
 
 Bailout triggers (return ALL packages): pnpm-lock.yaml, root package.json,
-anything under packages/@n8n/db/ (entities and migrations resolved at
-runtime via the DI container by every consuming package's integration tests).
+and the global trigger prefixes in core/global-triggers.ts (packages/@n8n/db,
+packages/workflow, packages/core, packages/@n8n/vitest-config).
 `);
 }
 

--- a/packages/testing/janitor/src/core/affected-packages-analyzer.test.ts
+++ b/packages/testing/janitor/src/core/affected-packages-analyzer.test.ts
@@ -84,6 +84,31 @@ describe('affectedPackages', () => {
 		expect(affectedPackages({ rootDir, changedFiles: ['packages/a/src/index.ts'] })).toEqual(['a']);
 	});
 
+	it('returns package dirs instead of names with paths', () => {
+		const rootDir = makeFixture({
+			patterns: ['packages/*'],
+			packages: {
+				'packages/lib': { name: 'lib' },
+				'packages/app': { name: 'app', deps: ['lib'] },
+				'packages/unrelated': { name: 'unrelated' },
+			},
+		});
+		expect(
+			affectedPackages({ rootDir, changedFiles: ['packages/lib/src/index.ts'], paths: true }),
+		).toEqual(['packages/app', 'packages/lib']);
+	});
+
+	it('returns all package dirs with paths when the signal is missing', () => {
+		const rootDir = makeFixture({
+			patterns: ['packages/*'],
+			packages: { 'packages/a': { name: 'a' }, 'packages/b': { name: 'b' } },
+		});
+		expect(affectedPackages({ rootDir, changedFiles: null, paths: true })).toEqual([
+			'packages/a',
+			'packages/b',
+		]);
+	});
+
 	it('includes transitive downstream packages', () => {
 		// Uses non-global-trigger package names so this exercises the dep-graph
 		// walk, not the workspace-wide bailout (workflow/core ARE global triggers).

--- a/packages/testing/janitor/src/core/affected-packages-analyzer.ts
+++ b/packages/testing/janitor/src/core/affected-packages-analyzer.ts
@@ -103,6 +103,8 @@ export interface AnalyzeOptions {
 	rootDir?: string;
 	/** Repo-root-relative, forward slashes. `null` = no signal → all packages. */
 	changedFiles: string[] | null;
+	/** Return repo-root-relative package dirs instead of package names. */
+	paths?: boolean;
 }
 
 function loadWorkspacePackages(rootDir: string): WorkspacePackage[] {
@@ -185,12 +187,15 @@ function loadTurboExtraInputs(rootDir: string, packages: WorkspacePackage[]): Tu
 export function affectedPackages(options: AnalyzeOptions): string[] {
 	const rootDir = options.rootDir ?? findWorkspaceRoot(process.cwd());
 	const packages = loadWorkspacePackages(rootDir);
+	const dirByName = new Map(packages.map((p) => [p.name, p.dir]));
+	const toOutput = (names: string[]): string[] =>
+		options.paths ? names.map((name) => dirByName.get(name) ?? name).sort() : names;
 	const allNames = packages.map((p) => p.name).sort();
 
 	// No signal (local dev, missing env) → safest default: everything.
-	if (options.changedFiles === null) return allNames;
+	if (options.changedFiles === null) return toOutput(allNames);
 
-	if (options.changedFiles.some(matchesGlobalTrigger)) return allNames;
+	if (options.changedFiles.some(matchesGlobalTrigger)) return toOutput(allNames);
 
 	const direct = new Set<string>();
 	for (const file of options.changedFiles) {
@@ -221,5 +226,5 @@ export function affectedPackages(options: AnalyzeOptions): string[] {
 		affected.add(name);
 		queue.push(...(dependents.get(name) ?? []));
 	}
-	return [...affected].sort();
+	return toOutput([...affected].sort());
 }


### PR DESCRIPTION
## Summary

`install-and-build` computes `janitor affected-packages` and passes the result into `test-unit-reusable.yml` as the `affectedPackages` input. Nothing reads it: no `process.env.AFFECTED_PACKAGES` exists in the repo, and `janitor test-scoped` recomputes the affected set itself from `CHANGED_FILES`. Meanwhile, every unit-test job boots a runner (checkout + install + cached build, about 2 minutes) even when janitor then skips every package in it. On a backend-only PR, that is two frontend shards plus the nodes job of pure setup; the same repeats in the merge queue.

This PR makes the computed affected set do real work:

- `janitor affected-packages --paths` (new flag) prints repo-root-relative package dirs instead of names. Covered by new analyzer tests.
- `install-and-build` maps the dirs onto three job groups: `backend` (everything outside `packages/frontend` and `packages/modules`), `nodes` (`packages/nodes-base`), and `frontend` (`packages/frontend`, `packages/modules`).
- `test-unit-reusable.yml` gains `runBackendTests` / `runNodesTests` / `runFrontendTests` boolean inputs (default `true`) and skips whole jobs from them. `ci-master.yml` passes none, so master runs are unchanged.
- The dead `affectedPackages` input and `AFFECTED_PACKAGES` job envs are removed.

The gate reuses the same dependency walk `janitor test-scoped` already applies per package, so a skipped job is one where every scoped step would print `SKIP`. It fails open (all groups run) when:

- any changed file lives outside `packages/` (turbo.json, patches, root scripts — invisible to the package graph),
- the affected set resolves to no known package,
- `CHANGED_FILES` is empty (no signal, or the >1000-file blowout guard).

Verified against the real dependency graph:

| Change | backend | nodes | frontend |
|---|---|---|---|
| `packages/cli/src/webhooks/foo.ts` | run | skip | skip |
| `packages/nodes-base/nodes/Slack/...` | run | run | skip |
| `packages/frontend/editor-ui/src/x.ts` | run¹ | skip | run |
| `packages/@n8n/api-types/src/t.ts` | run | run | run |
| `turbo.json` | run | run | run |

¹ `packages/cli` declares `n8n-editor-ui` as a dependency (it serves the built editor), so frontend changes keep the backend group on. This matches what janitor already decides today: the cli scoped step goes `RUN_FULL` on editor-ui changes.

The `unit-test` aggregator job and the `required-checks` validator both treat skipped jobs as passing, so branch protection is unaffected.

Relation to DEVP-171 (canceled): that ticket proposed affected-only turbo execution inside the jobs on merge-queue runs. This PR is narrower. It changes which jobs boot, not which tests a booted job runs, and its decisions are identical to the per-package skips already in production.

## How to test

- `pnpm --filter @n8n/playwright-janitor test` — 400 tests pass, including the new `--paths` cases.
- `CHANGED_FILES="packages/cli/src/x.ts" node packages/testing/janitor/dist/cli.js affected-packages --paths` — prints dirs.
- Open a PR that touches only cli source. The Frontend shards and Nodes Unit Tests jobs must skip; Backend jobs must run.
- Open a PR that touches `turbo.json`. Every unit job must run.
- `actionlint` passes on both workflows.

## Related Linear tickets, Github issues, and Community forum posts

- Related: https://linear.app/n8n/issue/DEVP-188 (CI test scoping umbrella)
- Related: https://linear.app/n8n/issue/DEVP-171 (canceled affected-only proposal; see comparison above)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

