### PR TITLE
fix(Jira Software Node): Send expand as comma-separated string for Jira Cloud searches

### DIFF
--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -870,10 +870,15 @@ export class Jira implements INodeType {
 						}
 						body.jql = options.jql as string;
 						if (options.expand) {
-							if (typeof options.expand === 'string') {
-								body.expand = options.expand.split(',');
+							const expand = Array.isArray(options.expand)
+								? options.expand.join(',')
+								: String(options.expand);
+							if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+								// The legacy search endpoint expects expand as an array
+								body.expand = expand.split(',');
 							} else {
-								body.expand = options.expand;
+								// The Jira Cloud enhanced search endpoint expects expand as a comma-separated string
+								body.expand = expand;
 							}
 						}
 						if (returnAll) {

--- a/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
@@ -122,6 +122,68 @@ describe('Jira Node', () => {
 			);
 		});
 
+		it('should send expand as a comma-separated string on Jira Cloud', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issue';
+					case 'operation':
+						return 'getAll';
+					case 'jiraVersion':
+						return 'cloud';
+					case 'returnAll':
+						return false;
+					case 'limit':
+						return 10;
+					case 'options':
+						return { expand: ['changelog', 'names'] };
+					default:
+						return null;
+				}
+			});
+
+			await jiraNode.execute.call(executeFunctionsMock);
+
+			expect(jiraSoftwareCloudApiRequestMock).toHaveBeenCalledWith(
+				'/api/2/search/jql',
+				'POST',
+				expect.objectContaining({
+					expand: 'changelog,names',
+				}),
+			);
+		});
+
+		it('should send expand as an array on Jira Server', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issue';
+					case 'operation':
+						return 'getAll';
+					case 'jiraVersion':
+						return 'server';
+					case 'returnAll':
+						return false;
+					case 'limit':
+						return 10;
+					case 'options':
+						return { expand: ['changelog', 'names'] };
+					default:
+						return null;
+				}
+			});
+
+			await jiraNode.execute.call(executeFunctionsMock);
+
+			expect(jiraSoftwareCloudApiRequestMock).toHaveBeenCalledWith(
+				'/api/2/search',
+				'POST',
+				expect.objectContaining({
+					expand: ['changelog', 'names'],
+				}),
+			);
+		});
+
 		it('should use custom JQL filter when provided', async () => {
 			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
 				switch (parameterName) {


### PR DESCRIPTION
## Summary

The Get Many Issues operation sends the search body to two different endpoints. Jira Server and Server (PAT) use the legacy `POST /api/2/search`, which accepts `expand` as an array. Jira Cloud uses the enhanced `POST /api/2/search/jql`, which requires `expand` as a comma-separated string. The code converted `expand` to an array for both versions, so the expand option stopped working on Jira Cloud.

This change keeps the array format for Server and Server (PAT), and sends a comma-separated string for Cloud. The `expand` parameter is a `multiOptions` field, so the value arrives as an array and is normalized first.

## How to test

1. Create a Jira node with Jira Cloud credentials.
2. Select Issue > Get Many.
3. Set a JQL filter and add the Expand option with one or more values (for example Changelog).
4. Run the node. The issues now include the expanded data.

Unit tests cover both formats: `should send expand as a comma-separated string on Jira Cloud` and `should send expand as an array on Jira Server` in `packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts`. All 16 tests in the file pass, and `pnpm typecheck` passes in `packages/nodes-base`.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #37434
Community forum: https://community.n8n.io/t/jira-node-issue-get-many-vs-expand/310504
Linear: https://linear.app/n8n/issue/ENT-402

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


