### PR TITLE
build(editor): Delete frontend source maps after the Sentry upload

### DIFF
--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -38,7 +38,7 @@ const singleInstanceDedupe = ['zod'];
 
 const alias = editorUiAliases(__dirname, packagesDir);
 
-const { RELEASE: release } = process.env;
+const { RELEASE: release, SENTRY_AUTH_TOKEN: sentryAuthToken } = process.env;
 
 const plugins: UserConfig['plugins'] = [
 	devServerPlugin(process.env),
@@ -139,15 +139,19 @@ const plugins: UserConfig['plugins'] = [
 				sentryVitePlugin({
 					org: 'n8nio',
 					project: 'instance-frontend',
-					authToken: process.env.SENTRY_AUTH_TOKEN,
+					authToken: sentryAuthToken,
+					// Stop the deletion hook if the Sentry upload fails.
+					errorHandler: (error) => {
+						throw error;
+					},
 					telemetry: false,
 					release: {
 						name: `n8n@${release}`,
 					},
 					sourcemaps: {
 						// Sentry keeps these maps, so the image does not need them (156MB).
-						// The plugin deletes them only after the upload succeeds.
-						filesToDeleteAfterUpload: ['./dist/**/*.map'],
+						// Keep the maps if upload credentials are not available.
+						filesToDeleteAfterUpload: sentryAuthToken ? ['./dist/**/*.map'] : undefined,
 					},
 				}),
 			]

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -144,6 +144,11 @@ const plugins: UserConfig['plugins'] = [
 					release: {
 						name: `n8n@${release}`,
 					},
+					sourcemaps: {
+						// Sentry keeps these maps, so the image does not need them (156MB).
+						// The plugin deletes them only after the upload succeeds.
+						filesToDeleteAfterUpload: ['./dist/**/*.map'],
+					},
 				}),
 			]
 		: []),
@@ -194,7 +199,9 @@ export default defineConfig({
 		minify: !!release,
 		// Coverage builds emit INLINE maps so browser V8 coverage carries the
 		// map in the script source and monocart resolves offsets back to src.
-		sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : !!release,
+		// 'hidden' writes the maps but omits the sourceMappingURL comment.
+		// Deleted maps then cause no 404 in devtools.
+		sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : release ? 'hidden' : false,
 		target,
 	},
 	optimizeDeps: {


### PR DESCRIPTION
## Summary

The editor source maps are **155.8 MB of the shipped image**, across 1,215 files. They are 2.4x the size of the assets they map. This change deletes them after the Sentry upload.

Sentry already holds these maps. The Sentry Vite plugin uploads them at build time, and the uploaded maps embed `sourcesContent`. Sentry therefore resolves a minified frame to source without any map file in the image.

Verified against a live `n8n@2.38.1` event. The browser reported a minified frame:

```
W_/<@https://.../assets/workflows.store-EIeAOnum.js:27:112909
```

Sentry resolved it to source, with context lines:

```
../../src/features/ndv/shared/ndv.store.ts:504:14 (W_/<)
  503 │ 		if (!documentStore) {
→ 504 │ 			throw new Error(
```

### The change

- **`sourcemaps.filesToDeleteAfterUpload`** — the plugin removes the maps, but only after the upload succeeds. Do not replace this with a separate delete step. The plugin only warns if `SENTRY_AUTH_TOKEN` is absent, so a separate step can delete maps that never reached Sentry.
- **`sourcemap: 'hidden'`** for release builds — 1,215 of 1,285 JavaScript files carry a `sourceMappingURL` comment. `'hidden'` omits that comment, so the deleted maps cause no 404 in devtools.

### Effect on image size

| Metric | Now | After |
| --- | --- | --- |
| compressed | 313.5 MB | ~283 MB |
| uncompressed | 1,239.6 MB | ~1,084 MB |

Measured with `dive` and `gzip -6` on `ghcr.io/n8n-io/n8n:2.38.1` (arm64). ~283 MB is below 2.0.0 (291.1 MB).

### Backend maps are untouched

Backend maps carry no `sourcesContent`, so `source-map-support` reads them from disk for Sentry stack traces. This change only affects `editor-ui/dist`.

## How to test

**A local build cannot verify this.** `sourcemap` is gated on `RELEASE`, so a snapshot build never writes these maps. A local image looks the same before and after.

Config resolution, which you can check locally:

```bash
RELEASE=9.9.9 pnpm --filter n8n-editor-ui exec node --input-type=module -e "
import { loadConfigFromFile } from 'vite';
const r = await loadConfigFromFile({ command: 'build', mode: 'production' });
console.log(r.config.build?.sourcemap);
"
```

| Environment | Expected |
| --- | --- |
| `RELEASE` set | `hidden` |
| no `RELEASE` | `false` |
| `BUILD_WITH_COVERAGE=true` | `inline` |
| `RELEASE` + coverage | `inline` |

On the first release build, check both halves:

1. The image carries no editor maps:
   ```bash
   docker run --rm --entrypoint sh <image> -c \
     'find /usr/local/lib/node_modules/n8n -path "*editor-ui/dist*" -name "*.map" | wc -l'
   ```
   Expect `0`. Confirm the compressed image size dropped by about 30 MB.
2. Symbolication still works. Trigger a frontend error, then confirm the Sentry event resolves to `.vue` or `.ts` source and not to bundled output.

If the image size does not move, the glob matched nothing. Check it before you assume the upload failed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-914

Tier A of that ticket. Tier B (third-party maps) and the platform-binary strip shipped in 2.38.1. Tier C (backend maps) stays out of scope, because it needs backend maps uploaded to Sentry first.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. `build` does not appear in the changelog.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. Not needed. No user-facing behaviour changes.
- [ ] Tests included. No test added. The behaviour only appears in a release build, and no harness covers that path. DEVP-286 is the durable guard.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

