### PR TITLE
chore(core): Skip workflow history compaction telemetry for no-op runs

### DIFF
--- a/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
@@ -1,6 +1,6 @@
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { GlobalConfig, WorkflowHistoryCompactionConfig } from '@n8n/config';
-import type { DbConnection } from '@n8n/db';
+import type { DbConnection, WorkflowHistoryRepository } from '@n8n/db';
 import type { InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
@@ -263,6 +263,51 @@ describe('WorkflowHistoryCompactionService', () => {
 		expect(trimLongRunningHistoriesSpy).toHaveBeenCalled();
 
 		vi.useRealTimers();
+	});
+
+	describe('compactHistories', () => {
+		const createService = (workflowHistoryRepository: WorkflowHistoryRepository) => {
+			const eventService = mock<EventService>();
+			const compactingService = new WorkflowHistoryCompactionService(
+				config,
+				globalConfig,
+				mockLogger(),
+				mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
+				dbConnection,
+				workflowHistoryRepository,
+				eventService,
+			);
+			return { compactingService, eventService };
+		};
+
+		it('should not emit telemetry when no workflows are in range', async () => {
+			const workflowHistoryRepository = mock<WorkflowHistoryRepository>();
+			workflowHistoryRepository.getWorkflowIdsInRange.mockResolvedValue([]);
+			const { compactingService, eventService } = createService(workflowHistoryRepository);
+
+			await compactingService['optimizeHistories']();
+
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('should emit telemetry when workflows are in range', async () => {
+			const workflowHistoryRepository = mock<WorkflowHistoryRepository>();
+			workflowHistoryRepository.getWorkflowIdsInRange.mockResolvedValue(['workflow-id']);
+			workflowHistoryRepository.pruneHistory.mockResolvedValue({ seen: 5, deleted: 2 });
+			const { compactingService, eventService } = createService(workflowHistoryRepository);
+
+			await compactingService['optimizeHistories']();
+
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'history-compacted',
+				expect.objectContaining({
+					workflowsProcessed: 1,
+					totalVersionsSeen: 5,
+					totalVersionsDeleted: 2,
+					errorCount: 0,
+				}),
+			);
+		});
 	});
 
 	it('should not trim if triggered outside of 3 AM with trimOnStartUp as false', () => {

--- a/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
+++ b/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
@@ -290,6 +290,8 @@ export class WorkflowHistoryCompactionService {
 			windowEndIso: endIso,
 		} satisfies RelayEventMap['history-compacted'];
 		this.logger.debug('Workflow history compaction complete', payload);
-		this.eventService.emit('history-compacted', payload);
+
+		// Runs are frequent and often find no work; only report runs that did something
+		if (workflowIds.length > 0) this.eventService.emit('history-compacted', payload);
 	}
 }


### PR DESCRIPTION
## Summary

`WorkflowHistoryCompactionService` sends an `Instance compacted workflow history` telemetry event after each run. With the default config, this adds up to ~25 events per instance per day, even when a run finds no workflow versions to compact. This PR skips the telemetry event when a run finds no workflows in the time window. Runs that process workflows still report the same metrics, and the local debug log still records every run.

## How to test

1. Start an instance with no recent workflow edits.
2. Wait for an optimization pass (or restart to trigger the startup pass).
3. Confirm no `Instance compacted workflow history` telemetry event is sent.
4. Edit a workflow, wait for the versions to enter the optimization window, and confirm the event is sent with the run metrics.

Unit tests cover both cases in `packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://linear.app/n8n/issue/ADO-4701

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

