### PR TITLE
chore: Add lint rule to require system tasks for leader-only timers

### DIFF
--- a/packages/@n8n/eslint-config/src/rules/index.ts
+++ b/packages/@n8n/eslint-config/src/rules/index.ts
@@ -32,6 +32,7 @@ import { RequirePublicApiControllerRule } from './require-public-api-controller.
 import { NoPublicApiGuardrailDisableRule } from './no-public-api-guardrail-disable.js';
 import { NoLegacyCipherMethodsRule } from './no-legacy-cipher-methods.js';
 import { NoUnsealedWorkflowEntityWriteRule } from './no-unsealed-workflow-entity-write.js';
+import { NoOnLeaderTakeoverRule } from './no-on-leader-takeover.js';
 
 export const rules = {
 	'no-uncaught-json-parse': NoUncaughtJsonParseRule,
@@ -67,4 +68,5 @@ export const rules = {
 	'no-public-api-guardrail-disable': NoPublicApiGuardrailDisableRule,
 	'no-legacy-cipher-methods': NoLegacyCipherMethodsRule,
 	'no-unsealed-workflow-entity-write': NoUnsealedWorkflowEntityWriteRule,
+	'no-on-leader-takeover': NoOnLeaderTakeoverRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.test.ts
@@ -1,0 +1,22 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { NoOnLeaderTakeoverRule } from './no-on-leader-takeover.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-on-leader-takeover', NoOnLeaderTakeoverRule, {
+	valid: [
+		{ code: "import { OnShutdown, OnLeaderStepdown } from '@n8n/decorators';" },
+		{ code: "import { SystemTask } from '@n8n/decorators';" },
+		{ code: "import { OnLeaderTakeover } from './my-local-decorators';" },
+	],
+	invalid: [
+		{
+			code: "import { OnLeaderTakeover } from '@n8n/decorators';",
+			errors: [{ messageId: 'useSystemTask' }],
+		},
+		{
+			code: "import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';",
+			errors: [{ messageId: 'useSystemTask' }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.test.ts
@@ -8,6 +8,7 @@ ruleTester.run('no-on-leader-takeover', NoOnLeaderTakeoverRule, {
 		{ code: "import { OnShutdown, OnLeaderStepdown } from '@n8n/decorators';" },
 		{ code: "import { SystemTask } from '@n8n/decorators';" },
 		{ code: "import { OnLeaderTakeover } from './my-local-decorators';" },
+		{ code: "import * as decorators from './my-local-decorators';" },
 	],
 	invalid: [
 		{
@@ -17,6 +18,10 @@ ruleTester.run('no-on-leader-takeover', NoOnLeaderTakeoverRule, {
 		{
 			code: "import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';",
 			errors: [{ messageId: 'useSystemTask' }],
+		},
+		{
+			code: "import * as decorators from '@n8n/decorators';",
+			errors: [{ messageId: 'noNamespaceImport' }],
 		},
 	],
 });

--- a/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.ts
@@ -10,6 +10,8 @@ export const NoOnLeaderTakeoverRule = ESLintUtils.RuleCreator.withoutDocs({
 		messages: {
 			useSystemTask:
 				'Periodic leader-only work belongs on a `@SystemTask()` class (`*.task.ts`); the system task runner owns the leader takeover/stepdown and shutdown lifecycle. Reserve `@OnLeaderTakeover` for services that hold live resources on the leader (webhooks, pollers, sockets) or need a one-shot catch-up on takeover, and add such a file to the allowlist in `eslint.config.mjs`.',
+			noNamespaceImport:
+				'Use named imports from `@n8n/decorators`. A namespace import hides `OnLeaderTakeover` usage from this rule.',
 		},
 		schema: [],
 	},
@@ -20,7 +22,9 @@ export const NoOnLeaderTakeoverRule = ESLintUtils.RuleCreator.withoutDocs({
 				if (node.source.value !== '@n8n/decorators') return;
 
 				for (const specifier of node.specifiers) {
-					if (
+					if (specifier.type === 'ImportNamespaceSpecifier') {
+						context.report({ node: specifier, messageId: 'noNamespaceImport' });
+					} else if (
 						specifier.type === 'ImportSpecifier' &&
 						specifier.imported.type === 'Identifier' &&
 						specifier.imported.name === 'OnLeaderTakeover'

--- a/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-on-leader-takeover.ts
@@ -1,0 +1,34 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+export const NoOnLeaderTakeoverRule = ESLintUtils.RuleCreator.withoutDocs({
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Ensure periodic leader-only work runs as a `@SystemTask()` class instead of hand-rolled `@OnLeaderTakeover` timers.',
+		},
+		messages: {
+			useSystemTask:
+				'Periodic leader-only work belongs on a `@SystemTask()` class (`*.task.ts`); the system task runner owns the leader takeover/stepdown and shutdown lifecycle. Reserve `@OnLeaderTakeover` for services that hold live resources on the leader (webhooks, pollers, sockets) or need a one-shot catch-up on takeover, and add such a file to the allowlist in `eslint.config.mjs`.',
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+	create(context) {
+		return {
+			ImportDeclaration(node) {
+				if (node.source.value !== '@n8n/decorators') return;
+
+				for (const specifier of node.specifiers) {
+					if (
+						specifier.type === 'ImportSpecifier' &&
+						specifier.imported.type === 'Identifier' &&
+						specifier.imported.name === 'OnLeaderTakeover'
+					) {
+						context.report({ node: specifier, messageId: 'useSystemTask' });
+					}
+				}
+			},
+		};
+	},
+});

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -55,6 +55,9 @@ export default defineConfig(
 			// Seal WorkflowEntity node-writes to the token-gated repository methods.
 			// The allowlist below must shrink to empty; a new unsealed write fails CI.
 			'n8n-local-rules/no-unsealed-workflow-entity-write': 'error',
+			// Periodic leader-only work must be a @SystemTask() class; hand-rolled
+			// @OnLeaderTakeover timers are reserved for the allowlisted services below.
+			'n8n-local-rules/no-on-leader-takeover': 'error',
 			// The clearance minter lives on the `policy-internal` subpath, off the public barrel.
 			// Only PolicyEnforcementService may reach it; callers use enforce*/evaluate*.
 			'@typescript-eslint/no-restricted-imports': [
@@ -382,9 +385,51 @@ export default defineConfig(
 		},
 	},
 	{
+		// Sanctioned `@OnLeaderTakeover` users. Permanent, but additions need review:
+		// the system task runner itself, services that hold live resources on the
+		// leader (webhooks, pollers, sockets, queue consumers), and services that
+		// run a documented one-shot catch-up pass on takeover.
+		files: [
+			'./src/scheduling/system-tasks/system-task-runner.ts',
+			'./src/active-workflow-manager.ts',
+			'./src/metrics/prometheus/instance-role-metrics.service.ts',
+			'./src/scaling/scaling.service.ts',
+			'./src/wait-tracker.ts',
+			'./src/workflows/publication/workflow-publication-outbox-consumer.ts',
+			'./src/workflows/publication/workflow-publication-reconciler.service.ts',
+			'./src/modules/agents/agent-task.service.ts',
+			'./src/modules/agents/integrations/agent-channel-reconciler.service.ts',
+			'./src/modules/agents/integrations/leader-channel-relay.service.ts',
+			'./src/modules/agents/integrations/platforms/discord-integration.ts',
+		],
+		rules: { 'n8n-local-rules/no-on-leader-takeover': 'off' },
+	},
+	{
+		// Shrink-only ratchet: periodic leader timers not yet migrated to system
+		// tasks. NEVER add to this list — new periodic leader work must be a
+		// @SystemTask() class. Entries are removed as each migrates on its own ticket.
+		files: [
+			'./src/license.ts',
+			'./src/modules/agents/integrations/n8n-checkpoint-storage.ts',
+			'./src/modules/insights/insights.service.ts',
+			'./src/modules/instance-ai/instance-ai.service.ts',
+			'./src/modules/instance-registry/checks/check.service.ts',
+			'./src/modules/instance-registry/stale-member-cleanup.service.ts',
+			'./src/modules/mcp-registry/registry/mcp-registry.service.ts',
+			'./src/modules/token-exchange/services/jti-cleanup.service.ts',
+			'./src/modules/token-exchange/services/trusted-key.service.ts',
+			'./src/services/pruning/executions-pruning.service.ts',
+			'./src/services/pruning/workflow-history-compaction.service.ts',
+			'./src/services/workflow-statistics-rollup.service.ts',
+			'./src/workflows/publication/workflow-publication-outbox-cleanup.service.ts',
+		],
+		rules: { 'n8n-local-rules/no-on-leader-takeover': 'off' },
+	},
+	{
 		files: ['./test/**/*.ts', './src/**/__tests__/**/*.ts'],
 		rules: {
 			'n8n-local-rules/no-type-unsafe-event-emitter': 'off',
+			'n8n-local-rules/no-on-leader-takeover': 'off',
 		},
 	},
 	{

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -7,7 +7,7 @@ import {
 	ExecutionRepository,
 	SettingsRepository,
 } from '@n8n/db';
-import { Command } from '@n8n/decorators';
+import { Command, SystemTaskMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { McpServer } from '@n8n/n8n-nodes-langchain/mcp/core';
 import { sleep } from '@n8n/utils/sleep';
@@ -38,6 +38,7 @@ import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import { DurableScheduler } from '@/scheduling/durable-scheduler';
 import { PollJobProvider } from '@/scheduling/poll-trigger-node/poll-job-provider';
+import { mainSystemTasks } from '@/scheduling/system-tasks/main-system-tasks';
 import { SystemTaskRunner } from '@/scheduling/system-tasks/system-task-runner';
 import { Server } from '@/server';
 import { JwtService } from '@/services/jwt.service';
@@ -426,6 +427,11 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		Container.get(N8NCheckpointStorage).init();
 		Container.get(SystemTaskRunner).init();
 		Container.get(DurableScheduler).start();
+
+		const systemTaskMetadata = Container.get(SystemTaskMetadata);
+		for (const taskClass of mainSystemTasks()) {
+			systemTaskMetadata.register(taskClass);
+		}
 
 		if (this.globalConfig.executions.mode === 'regular') {
 			const { EnqueuedExecutionRecoveryService } = await import(

--- a/packages/cli/src/scheduling/system-tasks/main-system-tasks.ts
+++ b/packages/cli/src/scheduling/system-tasks/main-system-tasks.ts
@@ -1,0 +1,8 @@
+import type { SystemTaskClass } from '@n8n/decorators';
+
+/**
+ * Return the main command's own system tasks, owned by no backend module.
+ */
+export function mainSystemTasks(): SystemTaskClass[] {
+	return [];
+}


### PR DESCRIPTION
## Summary

This is the base PR for the SystemTask migration. Follow-up PRs will convert each periodic leader-only task to a `@SystemTask()` class, module by module, and will stack on top of this branch.

This PR adds the guard rail and the registration point:
- New ESLint rule `n8n-local-rules/no-on-leader-takeover`
- Add `mainSystemTasks()` as the registration point for system tasks owned by the main command

Behaviour does not change.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4154

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
