### PR TITLE
feat(Microsoft Teams Node): Add get and reply operations for channel messages

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/get.test.ts
@@ -1,0 +1,48 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, channelMessage => get', () => {
+	nock('https://graph.microsoft.com')
+		.get('/beta/teams/1111-2222-3333/channels/42:aaabbbccc.tacv2/messages/1698324478896')
+		.reply(200, {
+			'@odata.context':
+				"https://graph.microsoft.com/beta/$metadata#teams('1111-2222-3333')/channels('threadId')/messages/$entity",
+			id: '1698324478896',
+			replyToId: null,
+			etag: '1698324478896',
+			messageType: 'message',
+			createdDateTime: '2023-10-26T12:47:58.896Z',
+			lastModifiedDateTime: '2023-10-26T12:47:58.896Z',
+			subject: null,
+			importance: 'normal',
+			locale: 'en-us',
+			from: {
+				application: null,
+				device: null,
+				user: {
+					'@odata.type': '#microsoft.graph.teamworkUserIdentity',
+					id: '11111-2222-3333',
+					displayName: 'My Name',
+					userIdentityType: 'aadUser',
+				},
+			},
+			body: {
+				contentType: 'html',
+				content: 'new sale',
+			},
+			channelIdentity: {
+				teamId: '1111-2222-3333',
+				channelId: '42:aaabbbccc.tacv2',
+			},
+			attachments: [],
+			mentions: [],
+			reactions: [],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['get.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/get.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/get.workflow.json
@@ -1,0 +1,124 @@
+{
+	"name": "Teams channelMessage get",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "channelMessage",
+				"operation": "get",
+				"teamId": {
+					"__rl": true,
+					"value": "1111-2222-3333",
+					"mode": "list",
+					"cachedResultName": "U.S. Sales"
+				},
+				"channelId": {
+					"__rl": true,
+					"value": "42:aaabbbccc.tacv2",
+					"mode": "list",
+					"cachedResultName": "Sales West"
+				},
+				"messageId": "1698324478896"
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"@odata.context": "https://graph.microsoft.com/beta/$metadata#teams('1111-2222-3333')/channels('threadId')/messages/$entity",
+					"id": "1698324478896",
+					"replyToId": null,
+					"etag": "1698324478896",
+					"messageType": "message",
+					"createdDateTime": "2023-10-26T12:47:58.896Z",
+					"lastModifiedDateTime": "2023-10-26T12:47:58.896Z",
+					"subject": null,
+					"importance": "normal",
+					"locale": "en-us",
+					"from": {
+						"application": null,
+						"device": null,
+						"user": {
+							"@odata.type": "#microsoft.graph.teamworkUserIdentity",
+							"id": "11111-2222-3333",
+							"displayName": "My Name",
+							"userIdentityType": "aadUser"
+						}
+					},
+					"body": {
+						"contentType": "html",
+						"content": "new sale"
+					},
+					"channelIdentity": {
+						"teamId": "1111-2222-3333",
+						"channelId": "42:aaabbbccc.tacv2"
+					},
+					"attachments": [],
+					"mentions": [],
+					"reactions": []
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "30cec397-a737-41b8-8da2-dff4d293ce70",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.limit.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.limit.workflow.json
@@ -1,0 +1,103 @@
+{
+	"name": "Teams channelMessage getAllReplies (limit)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "channelMessage",
+				"operation": "getAllReplies",
+				"teamId": {
+					"__rl": true,
+					"value": "1111-2222-3333",
+					"mode": "list",
+					"cachedResultName": "U.S. Sales"
+				},
+				"channelId": {
+					"__rl": true,
+					"value": "42:aaabbbccc.tacv2",
+					"mode": "list",
+					"cachedResultName": "Sales West",
+					"cachedResultUrl": "https://teams.microsoft.com/l/channel/threadId/Sales%20West?groupId=1111-2222-3333&tenantId=tenantId-111-222-333&allowXTenantAccess=False"
+				},
+				"returnAll": false,
+				"messageId": "1698324478896",
+				"limit": 1
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "1698324500123",
+					"replyToId": "1698324478896",
+					"messageType": "message",
+					"body": {
+						"contentType": "html",
+						"content": "<div>First reply</div>"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "d89de79a-1819-4d29-b781-a1f3f00b4a2e",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.test.ts
@@ -1,0 +1,48 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, channelMessage => getAllReplies', () => {
+	nock('https://graph.microsoft.com')
+		.get('/beta/teams/1111-2222-3333/channels/42:aaabbbccc.tacv2/messages/1698324478896/replies')
+		.reply(200, {
+			value: [
+				{
+					id: '1698324500123',
+					replyToId: '1698324478896',
+					etag: '1698324500123',
+					messageType: 'message',
+					createdDateTime: '2026-10-26T12:48:20.123Z',
+					importance: 'normal',
+					locale: 'en-us',
+					from: {
+						application: null,
+						device: null,
+						user: {
+							'@odata.type': '#microsoft.graph.teamworkUserIdentity',
+							id: '11111-2222-3333',
+							displayName: 'My Name',
+							userIdentityType: 'aadUser',
+						},
+					},
+					body: {
+						contentType: 'html',
+						content: '<div>on it</div>',
+					},
+					channelIdentity: {
+						teamId: '1111-2222-3333',
+						channelId: '42:aaabbbccc.tacv2',
+					},
+					attachments: [],
+					mentions: [],
+					reactions: [],
+				},
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['getAllReplies.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.test.ts
@@ -41,8 +41,38 @@ describe('Test MicrosoftTeamsV2, channelMessage => getAllReplies', () => {
 			],
 		});
 
+	// Limit branch: `$top` goes to Graph, the page is truncated to `limit`, and the
+	// `@odata.nextLink` is not followed.
+	nock('https://graph.microsoft.com')
+		.get('/beta/teams/1111-2222-3333/channels/42:aaabbbccc.tacv2/messages/1698324478896/replies')
+		.query({ $top: 1 })
+		.reply(200, {
+			'@odata.nextLink':
+				'https://graph.microsoft.com/beta/teams/1111-2222-3333/channels/42:aaabbbccc.tacv2/messages/1698324478896/replies?$skiptoken=abc',
+			value: [
+				{
+					id: '1698324500123',
+					replyToId: '1698324478896',
+					messageType: 'message',
+					body: {
+						contentType: 'html',
+						content: '<div>First reply</div>',
+					},
+				},
+				{
+					id: '1698324500456',
+					replyToId: '1698324478896',
+					messageType: 'message',
+					body: {
+						contentType: 'html',
+						content: '<div>Second reply</div>',
+					},
+				},
+			],
+		});
+
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['getAllReplies.workflow.json'],
+		workflowFiles: ['getAllReplies.workflow.json', 'getAllReplies.limit.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAllReplies.workflow.json
@@ -1,0 +1,123 @@
+{
+	"name": "Teams channelMessage getAllReplies",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "channelMessage",
+				"operation": "getAllReplies",
+				"teamId": {
+					"__rl": true,
+					"value": "1111-2222-3333",
+					"mode": "list",
+					"cachedResultName": "U.S. Sales"
+				},
+				"channelId": {
+					"__rl": true,
+					"value": "42:aaabbbccc.tacv2",
+					"mode": "list",
+					"cachedResultName": "Sales West",
+					"cachedResultUrl": "https://teams.microsoft.com/l/channel/threadId/Sales%20West?groupId=1111-2222-3333&tenantId=tenantId-111-222-333&allowXTenantAccess=False"
+				},
+				"returnAll": true,
+				"messageId": "1698324478896"
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "1698324500123",
+					"replyToId": "1698324478896",
+					"etag": "1698324500123",
+					"messageType": "message",
+					"createdDateTime": "2026-10-26T12:48:20.123Z",
+					"importance": "normal",
+					"locale": "en-us",
+					"from": {
+						"application": null,
+						"device": null,
+						"user": {
+							"@odata.type": "#microsoft.graph.teamworkUserIdentity",
+							"id": "11111-2222-3333",
+							"displayName": "My Name",
+							"userIdentityType": "aadUser"
+						}
+					},
+					"body": {
+						"contentType": "html",
+						"content": "<div>on it</div>"
+					},
+					"channelIdentity": {
+						"teamId": "1111-2222-3333",
+						"channelId": "42:aaabbbccc.tacv2"
+					},
+					"attachments": [],
+					"mentions": [],
+					"reactions": []
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "d89de79a-1819-4d29-b781-a1f3f00b4a2e",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/reply.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/reply.test.ts
@@ -1,0 +1,50 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, channelMessage => reply', () => {
+	nock('https://graph.microsoft.com')
+		.post('/beta/teams/1111-2222-3333/channels/42:aaabbbccc.tacv2/messages/1698324478896/replies', {
+			body: { content: 'on it', contentType: 'html' },
+		})
+		.reply(200, {
+			'@odata.context':
+				"https://graph.microsoft.com/beta/$metadata#teams('1111-2222-3333')/channels('threadId')/messages/$entity",
+			id: '1698324500123',
+			replyToId: '1698324478896',
+			etag: '1698324500123',
+			messageType: 'message',
+			createdDateTime: '2023-10-26T12:48:20.123Z',
+			lastModifiedDateTime: '2023-10-26T12:48:20.123Z',
+			subject: null,
+			importance: 'normal',
+			locale: 'en-us',
+			from: {
+				application: null,
+				device: null,
+				user: {
+					'@odata.type': '#microsoft.graph.teamworkUserIdentity',
+					id: '11111-2222-3333',
+					displayName: 'My Name',
+					userIdentityType: 'aadUser',
+				},
+			},
+			body: {
+				contentType: 'html',
+				content: 'on it',
+			},
+			channelIdentity: {
+				teamId: '1111-2222-3333',
+				channelId: '42:aaabbbccc.tacv2',
+			},
+			attachments: [],
+			mentions: [],
+			reactions: [],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['reply.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/reply.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/reply.workflow.json
@@ -1,0 +1,129 @@
+{
+	"name": "Teams channelMessage reply",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "channelMessage",
+				"operation": "reply",
+				"teamId": {
+					"__rl": true,
+					"value": "1111-2222-3333",
+					"mode": "list",
+					"cachedResultName": "U.S. Sales"
+				},
+				"channelId": {
+					"__rl": true,
+					"value": "42:aaabbbccc.tacv2",
+					"mode": "list",
+					"cachedResultName": "Sales West"
+				},
+				"messageId": "1698324478896",
+				"contentType": "html",
+				"message": "on it",
+				"options": {
+					"includeLinkToWorkflow": false
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"@odata.context": "https://graph.microsoft.com/beta/$metadata#teams('1111-2222-3333')/channels('threadId')/messages/$entity",
+					"id": "1698324500123",
+					"replyToId": "1698324478896",
+					"etag": "1698324500123",
+					"messageType": "message",
+					"createdDateTime": "2023-10-26T12:48:20.123Z",
+					"lastModifiedDateTime": "2023-10-26T12:48:20.123Z",
+					"subject": null,
+					"importance": "normal",
+					"locale": "en-us",
+					"from": {
+						"application": null,
+						"device": null,
+						"user": {
+							"@odata.type": "#microsoft.graph.teamworkUserIdentity",
+							"id": "11111-2222-3333",
+							"displayName": "My Name",
+							"userIdentityType": "aadUser"
+						}
+					},
+					"body": {
+						"contentType": "html",
+						"content": "on it"
+					},
+					"channelIdentity": {
+						"teamId": "1111-2222-3333",
+						"channelId": "42:aaabbbccc.tacv2"
+					},
+					"attachments": [],
+					"mentions": [],
+					"reactions": []
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "30cec397-a737-41b8-8da2-dff4d293ce70",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/reply.workflowLink.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/reply.workflowLink.test.ts
@@ -1,0 +1,85 @@
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+import type { Mock } from 'vitest';
+import type { IExecuteFunctions, INode, NodeParameterValueType } from 'n8n-workflow';
+
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+// The workflow-file harness leaves `getInstanceBaseUrl` an unconfigured mock, so the
+// appended link is unassertable there and every fixture opts out of it. These tests
+// drive `execute` directly to cover the on-by-default branch of `Include Link to
+// Workflow`, and its parity with `channelMessage:create`.
+describe('MicrosoftTeamsV2, channelMessage => reply, workflow link', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = mock<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.getWorkflow.mockReturnValue({ id: 'workflowId', name: 'wf', active: false });
+		ctx.getInstanceBaseUrl.mockReturnValue('https://n8n.example.com/');
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: 'replyId' });
+		ctx.helpers.returnJsonArray = vi.fn((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+		ctx.helpers.constructExecutionMetaData = vi.fn(
+			(data) => data,
+		) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const run = async (options: Record<string, unknown> | undefined) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown): NodeParameterValueType => {
+				const params: Record<string, unknown> = {
+					resource: 'channelMessage',
+					operation: 'reply',
+					teamId: 'teamId',
+					channelId: 'channelId',
+					messageId: 'messageId',
+					contentType: 'text',
+					message: 'on it',
+					...(options === undefined ? {} : { options }),
+				};
+				return (name in params ? params[name] : fallback) as NodeParameterValueType;
+			},
+		);
+		await node.execute.call(ctx);
+		return (transport.microsoftApiRequest as Mock).mock.calls[0][2] as {
+			body: { content: string; contentType: string };
+		};
+	};
+
+	it('appends the workflow link and switches to html when the option is unset', async () => {
+		const body = await run({});
+
+		expect(body.body.contentType).toBe('html');
+		expect(body.body.content).toBe(
+			'on it<br><br><em> Powered by <a href="https://n8n.example.com/workflow/workflowId?utm_source=n8n-internal&utm_medium=powered_by&utm_campaign=n8n-nodes-base.microsoftTeams_instanceId">this n8n workflow</a> </em>',
+		);
+	});
+
+	it('sends the message untouched when the option is off', async () => {
+		const body = await run({ includeLinkToWorkflow: false });
+
+		expect(body.body).toEqual({ contentType: 'text', content: 'on it' });
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -120,6 +120,24 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 	});
 
+	it('channelMessage:reply throws a static error and issues no request under SP', async () => {
+		selectSp({
+			resource: 'channelMessage',
+			operation: 'reply',
+			teamId: 'teamID',
+			channelId: 'channelID',
+			messageId: 'messageID',
+			contentType: 'text',
+			message: 'hi',
+			options: {},
+		});
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Sending channel messages is not available with the Service Principal credential',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
 	it('channelMessage:getAll under SP hits the exact raw /beta path (colon id, not encoded, no /me)', async () => {
 		(transport.microsoftApiRequestAllItems as Mock).mockResolvedValue([{ id: 'm1' }]);
 		ctx.helpers.returnJsonArray = vi.fn((data) =>

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -120,7 +120,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 			}
 		});
 
-		it.each(['get', 'getAll'])('%s fields are shown under SP', (operation) => {
+		it.each(['get', 'getAll', 'getAllReplies'])('%s fields are shown under SP', (operation) => {
 			const fields = fieldsFor(operation);
 			expect(fields.length).toBeGreaterThan(0);
 			for (const field of fields) {
@@ -136,7 +136,9 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
 			);
 			const operations = notices.flatMap((n) => n.displayOptions?.show?.operation ?? []);
-			expect(operations).toEqual(expect.arrayContaining(['create', 'reply', 'get', 'getAll']));
+			expect(operations).toEqual(
+				expect.arrayContaining(['create', 'reply', 'get', 'getAll', 'getAllReplies']),
+			);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -103,32 +103,32 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
-	describe('channelMessage — only create hidden under SP', () => {
-		it('create fields are hidden, getAll fields are shown', () => {
-			const createFields = actionProps.filter(
+	describe('channelMessage — only the sending operations are hidden under SP', () => {
+		const fieldsFor = (operation: string) =>
+			actionProps.filter(
 				(p) =>
 					p.type !== 'notice' &&
 					p.displayOptions?.show?.resource?.includes('channelMessage') &&
-					p.displayOptions?.show?.operation?.includes('create'),
+					p.displayOptions?.show?.operation?.includes(operation),
 			);
-			expect(createFields.length).toBeGreaterThan(0);
-			for (const field of createFields) {
+
+		it.each(['create', 'reply'])('%s fields are hidden under SP', (operation) => {
+			const fields = fieldsFor(operation);
+			expect(fields.length).toBeGreaterThan(0);
+			for (const field of fields) {
 				expect(isSpHidden(field)).toBe(true);
 			}
+		});
 
-			const getAllFields = actionProps.filter(
-				(p) =>
-					p.type !== 'notice' &&
-					p.displayOptions?.show?.resource?.includes('channelMessage') &&
-					p.displayOptions?.show?.operation?.includes('getAll'),
-			);
-			expect(getAllFields.length).toBeGreaterThan(0);
-			for (const field of getAllFields) {
+		it.each(['get', 'getAll'])('%s fields are shown under SP', (operation) => {
+			const fields = fieldsFor(operation);
+			expect(fields.length).toBeGreaterThan(0);
+			for (const field of fields) {
 				expect(isSpHidden(field)).toBe(false);
 			}
 		});
 
-		it('has both the create and the getAll SP notices', () => {
+		it('has an SP notice for every channelMessage operation', () => {
 			const notices = actionProps.filter(
 				(p) =>
 					p.type === 'notice' &&
@@ -136,8 +136,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
 			);
 			const operations = notices.flatMap((n) => n.displayOptions?.show?.operation ?? []);
-			expect(operations).toContain('create');
-			expect(operations).toContain('getAll');
+			expect(operations).toEqual(expect.arrayContaining(['create', 'reply', 'get', 'getAll']));
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/get.operation.ts
@@ -1,0 +1,49 @@
+import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { channelRLC, teamRLC } from '../../descriptions';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
+
+const properties: INodeProperties[] = [
+	teamRLC,
+	channelRLC,
+	{
+		displayName: 'Message ID',
+		name: 'messageId',
+		required: true,
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. 1673355049064',
+		description:
+			'The ID of the message to retrieve. The message ID is the number before "?tenantId" in the message URL.',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['channelMessage'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	//https://learn.microsoft.com/en-us/graph/api/chatmessage-get?view=graph-rest-beta&tabs=http
+
+	const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
+	const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
+	const messageId = this.getNodeParameter('messageId', i) as string;
+
+	const endpoint = buildTeamsPath.call(this, [
+		'/beta/teams/',
+		{ id: teamId },
+		'/channels/',
+		{ id: channelId },
+		'/messages/',
+		{ id: messageId },
+	]);
+
+	return await microsoftApiRequest.call(this, 'GET', endpoint);
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAllReplies.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAllReplies.operation.ts
@@ -1,0 +1,66 @@
+import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
+
+import { returnAllOrLimit } from '@utils/descriptions';
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { channelRLC, teamRLC } from '../../descriptions';
+import { buildTeamsPath, microsoftApiRequestAllItems } from '../../transport';
+
+const properties: INodeProperties[] = [
+	teamRLC,
+	channelRLC,
+	{
+		displayName: 'Message ID',
+		name: 'messageId',
+		required: true,
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. 1673355049064',
+		description:
+			'The ID of the message whose replies to retrieve. The message ID is the number before "?tenantId" in the message URL.',
+	},
+	...returnAllOrLimit,
+];
+
+const displayOptions = {
+	show: {
+		resource: ['channelMessage'],
+		operation: ['getAllReplies'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	//https://learn.microsoft.com/en-us/graph/api/chatmessage-list-replies?view=graph-rest-beta&tabs=http
+
+	const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
+	const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
+	const messageId = this.getNodeParameter('messageId', i) as string;
+	const returnAll = this.getNodeParameter('returnAll', i);
+
+	const endpoint = buildTeamsPath.call(this, [
+		'/beta/teams/',
+		{ id: teamId },
+		'/channels/',
+		{ id: channelId },
+		'/messages/',
+		{ id: messageId },
+		'/replies',
+	]);
+
+	if (returnAll) {
+		return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint);
+	}
+
+	const limit = this.getNodeParameter('limit', i);
+	return await microsoftApiRequestAllItems.call(
+		this,
+		'value',
+		'GET',
+		endpoint,
+		{},
+		{ $top: limit },
+		limit,
+	);
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/index.ts
@@ -3,10 +3,11 @@ import type { INodeProperties } from 'n8n-workflow';
 import * as create from './create.operation';
 import * as get from './get.operation';
 import * as getAll from './getAll.operation';
+import * as getAllReplies from './getAllReplies.operation';
 import * as reply from './reply.operation';
 import { SERVICE_PRINCIPAL_AUTH } from '../../transport';
 
-export { create, get, getAll, reply };
+export { create, get, getAll, getAllReplies, reply };
 
 export const description: INodeProperties[] = [
 	{
@@ -37,6 +38,12 @@ export const description: INodeProperties[] = [
 				value: 'getAll',
 				description: 'Get many messages from a channel',
 				action: 'Get many messages',
+			},
+			{
+				name: 'Get Many Replies',
+				value: 'getAllReplies',
+				description: 'Get many replies to a message in a channel',
+				action: 'Get many replies',
 			},
 			{
 				name: 'Reply',
@@ -70,7 +77,7 @@ export const description: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['channelMessage'],
-				operation: ['get', 'getAll'],
+				operation: ['get', 'getAll', 'getAllReplies'],
 				authentication: [SERVICE_PRINCIPAL_AUTH],
 			},
 		},
@@ -79,5 +86,6 @@ export const description: INodeProperties[] = [
 	...create.description,
 	...get.description,
 	...getAll.description,
+	...getAllReplies.description,
 	...reply.description,
 ];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/index.ts
@@ -1,10 +1,12 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as create from './create.operation';
+import * as get from './get.operation';
 import * as getAll from './getAll.operation';
+import * as reply from './reply.operation';
 import { SERVICE_PRINCIPAL_AUTH } from '../../transport';
 
-export { create, getAll };
+export { create, get, getAll, reply };
 
 export const description: INodeProperties[] = [
 	{
@@ -25,10 +27,22 @@ export const description: INodeProperties[] = [
 				action: 'Create message',
 			},
 			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a message from a channel',
+				action: 'Get message',
+			},
+			{
 				name: 'Get Many',
 				value: 'getAll',
 				description: 'Get many messages from a channel',
 				action: 'Get many messages',
+			},
+			{
+				name: 'Reply',
+				value: 'reply',
+				description: 'Reply to a message in a channel',
+				action: 'Reply to message',
 			},
 		],
 		default: 'create',
@@ -42,7 +56,7 @@ export const description: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['channelMessage'],
-				operation: ['create'],
+				operation: ['create', 'reply'],
 				authentication: [SERVICE_PRINCIPAL_AUTH],
 			},
 		},
@@ -56,12 +70,14 @@ export const description: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['channelMessage'],
-				operation: ['getAll'],
+				operation: ['get', 'getAll'],
 				authentication: [SERVICE_PRINCIPAL_AUTH],
 			},
 		},
 	},
 
 	...create.description,
+	...get.description,
 	...getAll.description,
+	...reply.description,
 ];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/reply.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/reply.operation.ts
@@ -11,6 +11,16 @@ const properties: INodeProperties[] = [
 	teamRLC,
 	channelRLC,
 	{
+		displayName: 'Message ID',
+		name: 'messageId',
+		required: true,
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. 1673355049064',
+		description:
+			'The ID of the message to reply to. The message ID is the number before "?tenantId" in the message URL.',
+	},
+	{
 		displayName: 'Content Type',
 		name: 'contentType',
 		required: true,
@@ -26,7 +36,7 @@ const properties: INodeProperties[] = [
 			},
 		],
 		default: 'text',
-		description: 'Whether the message is plain text or HTML',
+		description: 'Whether the reply is plain text or HTML',
 	},
 	{
 		displayName: 'Message',
@@ -34,7 +44,7 @@ const properties: INodeProperties[] = [
 		required: true,
 		type: 'string',
 		default: '',
-		description: 'The content of the message to be sent',
+		description: 'The content of the reply to be sent',
 		typeOptions: {
 			rows: 2,
 		},
@@ -45,25 +55,14 @@ const properties: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add option',
 		default: {},
-		options: [
-			includeLinkToWorkflowOption,
-			{
-				displayName: 'Reply to ID',
-				name: 'makeReply',
-				type: 'string',
-				default: '',
-				placeholder: 'e.g. 1673348720590',
-				description:
-					'An optional ID of the message you want to reply to. The message ID is the number before "?tenantId" in the message URL. The Reply operation does the same thing and is easier to find.',
-			},
-		],
+		options: [includeLinkToWorkflowOption],
 	},
 ];
 
 const displayOptions = {
 	show: {
 		resource: ['channelMessage'],
-		operation: ['create'],
+		operation: ['reply'],
 	},
 	hide: {
 		...SP_HIDE,
@@ -75,61 +74,39 @@ export const description = updateDisplayOptions(displayOptions, properties);
 export async function execute(
 	this: IExecuteFunctions,
 	i: number,
-	nodeVersion: number,
+	_nodeVersion: number,
 	instanceId: string,
 ) {
-	//https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-beta&tabs=http
-	//https://docs.microsoft.com/en-us/graph/api/channel-post-messagereply?view=graph-rest-beta&tabs=http
+	//https://learn.microsoft.com/en-us/graph/api/chatmessage-post-replies?view=graph-rest-beta&tabs=http
 
 	throwIfChannelMessageSendUnsupported.call(this, i);
 
 	const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
 	const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
+	const messageId = this.getNodeParameter('messageId', i) as string;
 	const contentType = this.getNodeParameter('contentType', i) as string;
 	const message = this.getNodeParameter('message', i) as string;
-	const options = this.getNodeParameter('options', i);
-
-	let includeLinkToWorkflow = options.includeLinkToWorkflow;
-	if (includeLinkToWorkflow === undefined) {
-		includeLinkToWorkflow = nodeVersion >= 1.1;
-	}
+	// Destructuring default matches `create`: only an unset option falls back to
+	// on, any explicit value keeps its own truthiness.
+	const { includeLinkToWorkflow = true } = this.getNodeParameter('options', i);
 
 	const body: IDataObject = prepareMessage.call(
 		this,
 		message,
 		contentType,
-		includeLinkToWorkflow as boolean,
+		Boolean(includeLinkToWorkflow),
 		instanceId,
 	);
 
-	if (options.makeReply) {
-		const replyToId = options.makeReply as string;
-		return await microsoftApiRequest.call(
-			this,
-			'POST',
-			buildTeamsPath.call(this, [
-				'/beta/teams/',
-				{ id: teamId },
-				'/channels/',
-				{ id: channelId },
-				'/messages/',
-				{ id: replyToId },
-				'/replies',
-			]),
-			body,
-		);
-	} else {
-		return await microsoftApiRequest.call(
-			this,
-			'POST',
-			buildTeamsPath.call(this, [
-				'/beta/teams/',
-				{ id: teamId },
-				'/channels/',
-				{ id: channelId },
-				'/messages',
-			]),
-			body,
-		);
-	}
+	const endpoint = buildTeamsPath.call(this, [
+		'/beta/teams/',
+		{ id: teamId },
+		'/channels/',
+		{ id: channelId },
+		'/messages/',
+		{ id: messageId },
+		'/replies',
+	]);
+
+	return await microsoftApiRequest.call(this, 'POST', endpoint, body);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/sharedGuard.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/sharedGuard.ts
@@ -1,0 +1,24 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { getTeamsCredentialType, SERVICE_PRINCIPAL_AUTH } from '../../transport';
+
+/**
+ * Throws a static `NodeOperationError` when the node is configured with the
+ * app-only (Service Principal) credential. App-only Graph exposes channel-message
+ * posting only via migration import, so `create` and `reply` guard on this BEFORE
+ * any request — covering hand-edited workflows that bypass the hidden UI.
+ */
+export function throwIfChannelMessageSendUnsupported(this: IExecuteFunctions, i: number): void {
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Sending channel messages is not available with the Service Principal credential',
+			{
+				itemIndex: i,
+				description:
+					'App-only Microsoft Graph supports only migration import for channel messages. Use an OAuth2 credential to post messages.',
+			},
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -2,7 +2,7 @@ import type { AllEntities } from 'n8n-workflow';
 
 type NodeMap = {
 	channel: 'create' | 'deleteChannel' | 'get' | 'getAll' | 'update';
-	channelMessage: 'create' | 'get' | 'getAll' | 'reply';
+	channelMessage: 'create' | 'get' | 'getAll' | 'getAllReplies' | 'reply';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
 	onlineMeeting: 'create';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -2,7 +2,7 @@ import type { AllEntities } from 'n8n-workflow';
 
 type NodeMap = {
 	channel: 'create' | 'deleteChannel' | 'get' | 'getAll' | 'update';
-	channelMessage: 'create' | 'getAll';
+	channelMessage: 'create' | 'get' | 'getAll' | 'reply';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
 	onlineMeeting: 'create';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/common.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/common.description.ts
@@ -1,26 +1,5 @@
 import type { INodeProperties } from 'n8n-workflow';
 
-export const groupSourceOptions: INodeProperties = {
-	displayName: 'Group Source',
-	name: 'groupSource',
-	required: true,
-	type: 'options',
-	default: 'all',
-	description: 'From where to select groups and teams',
-	options: [
-		{
-			name: 'All Groups',
-			value: 'all',
-			description: 'From all groups',
-		},
-		{
-			name: 'My Groups',
-			value: 'mine',
-			description: 'Only load groups that account is member of',
-		},
-	],
-};
-
 /**
  * Shared by `channelMessage:create` and `channelMessage:reply`. Both read it with
  * the same destructuring default (unset means on), so one definition keeps the

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/common.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/common.description.ts
@@ -20,3 +20,17 @@ export const groupSourceOptions: INodeProperties = {
 		},
 	],
 };
+
+/**
+ * Shared by `channelMessage:create` and `channelMessage:reply`. Both read it with
+ * the same destructuring default (unset means on), so one definition keeps the
+ * two operations from drifting apart on when the link is appended.
+ */
+export const includeLinkToWorkflowOption: INodeProperties = {
+	displayName: 'Include Link to Workflow',
+	name: 'includeLinkToWorkflow',
+	type: 'boolean',
+	default: true,
+	description:
+		'Whether to append a link to this workflow at the end of the message. This is helpful if you have many workflows sending messages.',
+};


### PR DESCRIPTION
## Summary

The Microsoft Teams node could create and list channel messages, but not fetch one, and not work with threads. Replying was only possible through a `Reply to ID` option inside the Create operation. This PR adds three operations to the Channel Message resource:

- **Get**: fetch a single message by ID.
- **Reply**: post into an existing message thread.
- **Get Many Replies**: list the replies to a message, with the node's standard pagination.

Replying is now discoverable. An option inside Create does not show in the nodes panel. It is also not offered to AI agents, because agents read the per-operation action. The action "Reply to message" now exists.

The `Reply to ID` option still works, so saved workflows do not change. Its description points to the new operation.

## How to test

Add a Microsoft Teams node. Select the Channel Message resource. The Operation list must show Create, Get, Get Many, Get Many Replies and Reply.

1. **Get**: select a team and a channel. Enter a message ID. The message ID is the number before `?tenantId` in the message URL. The node returns that message.
2. **Reply**: select the same team and channel. Enter the same message ID and a message body. The node posts a threaded reply. It does not post a new top-level message.
3. **Get Many Replies**: select the same team, channel and message ID. The node returns the replies in that thread. Set **Return All** to test pagination.

Use an OAuth2 credential. No new scopes are needed. Reads use `ChannelMessage.Read.All` and posting a reply is covered by `Group.ReadWrite.All`, both already in `defaultScopes`.

Create and Reply are hidden for the Service Principal credential. App-only Microsoft Graph cannot post channel messages, except through migration import. The three read operations stay available.

### Notes for reviewers

- The node version does not change. The change is additive only. It does not change existing operations, fields, defaults or outputs. Saved workflows run as before.
- The `__schema__` files for the new operations are not included. Generation of these files needs live API responses from a configured tenant.
- ENT-321 asks for a Cloud check with a managed credential before closing. Not done yet.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-321

Docs PR: https://github.com/n8n-io/n8n-docs/pull/5311

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
