### PR TITLE
refactor(core): Run MCP registry refresh as a system task (no-changelog)

### DIFF
--- a/packages/@n8n/decorators/src/system-task/system-task.ts
+++ b/packages/@n8n/decorators/src/system-task/system-task.ts
@@ -38,8 +38,9 @@ export interface SystemTask {
 	readonly durable: boolean;
 
 	/**
-	 * Runs one occurrence as soon as this instance becomes the leader, on top
-	 * of the scheduled occurrences. In-memory timers only: ignored for a
+	 * Runs one occurrence as soon as this instance becomes the leader,
+	 * including at startup for an instance that is already the leader, on
+	 * top of the scheduled occurrences. In-memory timers only: ignored for a
 	 * durable run.
 	 */
 	readonly runOnTakeover?: boolean;

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -402,7 +402,6 @@ export default defineConfig(
 			'./src/modules/instance-ai/instance-ai.service.ts',
 			'./src/modules/instance-registry/checks/check.service.ts',
 			'./src/modules/instance-registry/stale-member-cleanup.service.ts',
-			'./src/modules/mcp-registry/registry/mcp-registry.service.ts',
 			'./src/modules/token-exchange/services/jti-cleanup.service.ts',
 			'./src/modules/token-exchange/services/trusted-key.service.ts',
 			'./src/services/pruning/executions-pruning.service.ts',

--- a/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-refresh.task.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-refresh.task.test.ts
@@ -1,0 +1,37 @@
+import type { SystemTask } from '@n8n/decorators';
+import { mock } from 'vitest-mock-extended';
+
+import { McpRegistryRefreshTask } from '../mcp-registry-refresh.task';
+import type { McpRegistryService } from '../registry/mcp-registry.service';
+
+describe('McpRegistryRefreshTask', () => {
+	const mcpRegistryService = mock<McpRegistryService>();
+	const task: SystemTask = new McpRegistryRefreshTask(mcpRegistryService);
+
+	beforeEach(() => {
+		mcpRegistryService.refreshFromApi.mockReset();
+	});
+
+	it('should refresh every 8 hours on the leader and once on takeover, without an early retry', () => {
+		expect(task.name).toBe('mcp-registry-refresh');
+		expect(task.schedule).toEqual({ kind: 'interval', intervalSeconds: 8 * 3600 });
+		expect(task.effects).toBe('idempotent');
+		expect(task.durable).toBe(false);
+		expect(task.runOnTakeover).toBe(true);
+		expect(task.retryDelaySeconds).toBeUndefined();
+	});
+
+	it('should refresh the registry on run and hand it the abort signal', async () => {
+		const { signal } = new AbortController();
+
+		await task.run(signal);
+
+		expect(mcpRegistryService.refreshFromApi).toHaveBeenCalledExactlyOnceWith(signal);
+	});
+
+	it('should let a failed refresh propagate to the runner', async () => {
+		mcpRegistryService.refreshFromApi.mockRejectedValue(new Error('api down'));
+
+		await expect(task.run(new AbortController().signal)).rejects.toThrow('api down');
+	});
+});

--- a/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry.module.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry.module.test.ts
@@ -1,0 +1,31 @@
+import { McpRegistryRefreshTask } from '../mcp-registry-refresh.task';
+import { McpRegistryModule } from '../mcp-registry.module';
+
+const flags = vi.hoisted(() => ({ inE2ETests: false }));
+
+vi.mock('@/constants', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@/constants')>()),
+	get inE2ETests() {
+		return flags.inE2ETests;
+	},
+}));
+
+describe('McpRegistryModule', () => {
+	const module = new McpRegistryModule();
+
+	afterEach(() => {
+		flags.inE2ETests = false;
+	});
+
+	describe('systemTasks()', () => {
+		it('should register the refresh task', async () => {
+			await expect(module.systemTasks()).resolves.toEqual([McpRegistryRefreshTask]);
+		});
+
+		it('should register no task in E2E tests, where the registry is seeded', async () => {
+			flags.inE2ETests = true;
+
+			await expect(module.systemTasks()).resolves.toEqual([]);
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp-registry/mcp-registry-refresh.task.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry-refresh.task.ts
@@ -23,8 +23,8 @@ export class McpRegistryRefreshTask implements SystemTask {
 
 	readonly durable = false;
 
-	// Also covers startup: the runner starts the timers as soon as the
-	// instance is the leader, and the registry may have drifted meanwhile.
+	// Only the leader polls the remote registry, so a new leader may be
+	// running on outdated data until this runs.
 	readonly runOnTakeover = true;
 
 	constructor(private readonly mcpRegistryService: McpRegistryService) {}

--- a/packages/cli/src/modules/mcp-registry/mcp-registry-refresh.task.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry-refresh.task.ts
@@ -1,0 +1,35 @@
+import { Time } from '@n8n/constants';
+import { SystemTask } from '@n8n/decorators';
+import type { SystemTaskEffects, SystemTaskSchedule } from '@n8n/decorators';
+
+import { McpRegistryService } from './registry/mcp-registry.service';
+
+const REFRESH_INTERVAL_HOURS = 8;
+
+/**
+ * Refreshes the MCP server registry from the remote API, so newly published
+ * or deprecated servers reach this instance without a restart.
+ */
+@SystemTask()
+export class McpRegistryRefreshTask implements SystemTask {
+	readonly name = 'mcp-registry-refresh';
+
+	readonly schedule: SystemTaskSchedule = {
+		kind: 'interval',
+		intervalSeconds: REFRESH_INTERVAL_HOURS * Time.hours.toSeconds,
+	};
+
+	readonly effects: SystemTaskEffects = 'idempotent';
+
+	readonly durable = false;
+
+	// Also covers startup: the runner starts the timers as soon as the
+	// instance is the leader, and the registry may have drifted meanwhile.
+	readonly runOnTakeover = true;
+
+	constructor(private readonly mcpRegistryService: McpRegistryService) {}
+
+	async run(signal: AbortSignal): Promise<void> {
+		await this.mcpRegistryService.refreshFromApi(signal);
+	}
+}

--- a/packages/cli/src/modules/mcp-registry/mcp-registry.module.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry.module.ts
@@ -18,6 +18,16 @@ export class McpRegistryModule implements ModuleInterface {
 		}
 	}
 
+	async systemTasks() {
+		const { inE2ETests } = await import('@/constants.js');
+		if (inE2ETests) {
+			return [];
+		}
+
+		const { McpRegistryRefreshTask } = await import('./mcp-registry-refresh.task.js');
+		return [McpRegistryRefreshTask];
+	}
+
 	async entities() {
 		const { McpRegistryServerEntity } = await import('./registry/mcp-registry-server.entity.js');
 		return [McpRegistryServerEntity];

--- a/packages/cli/src/modules/mcp-registry/mcp-registry.module.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry.module.ts
@@ -3,6 +3,7 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
+import { inE2ETests } from '@/constants';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 @BackendModule({ name: 'mcp-registry' })
@@ -13,13 +14,12 @@ export class McpRegistryModule implements ModuleInterface {
 
 		await import('./mcp-registry.controller.js');
 
-		if (process.env.E2E_TESTS === 'true') {
+		if (inE2ETests) {
 			await import('./mcp-registry-test.controller.js');
 		}
 	}
 
 	async systemTasks() {
-		const { inE2ETests } = await import('@/constants.js');
 		if (inE2ETests) {
 			return [];
 		}

--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-api.client.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-api.client.test.ts
@@ -217,6 +217,18 @@ describe('McpRegistryApiClient', () => {
 
 			expect(result).toEqual([]);
 		});
+
+		it('should forward the abort signal to paginatedRequest', async () => {
+			const { signal } = new AbortController();
+			mockPaginatedRequest.mockResolvedValue([]);
+
+			await client.fetchAllServers(signal);
+
+			expect(mockPaginatedRequest).toHaveBeenCalledWith(PRODUCTION_URL, expect.anything(), {
+				throwOnError: true,
+				abortSignal: signal,
+			});
+		});
 	});
 
 	describe('fetchServersMetadata', () => {
@@ -246,6 +258,18 @@ describe('McpRegistryApiClient', () => {
 			const result = await client.fetchServersMetadata();
 
 			expect(result).toEqual(mockMetadata);
+		});
+
+		it('should forward the abort signal to paginatedRequest', async () => {
+			const { signal } = new AbortController();
+			mockPaginatedRequest.mockResolvedValue([]);
+
+			await client.fetchServersMetadata(signal);
+
+			expect(mockPaginatedRequest).toHaveBeenCalledWith(PRODUCTION_URL, expect.anything(), {
+				throwOnError: true,
+				abortSignal: signal,
+			});
 		});
 	});
 
@@ -284,6 +308,18 @@ describe('McpRegistryApiClient', () => {
 
 			expect(result).toEqual([]);
 			expect(mockPaginatedRequest).not.toHaveBeenCalled();
+		});
+
+		it('should forward the abort signal to paginatedRequest', async () => {
+			const { signal } = new AbortController();
+			mockPaginatedRequest.mockResolvedValue([]);
+
+			await client.fetchServersBySlugs(['server-a'], signal);
+
+			expect(mockPaginatedRequest).toHaveBeenCalledWith(PRODUCTION_URL, expect.anything(), {
+				throwOnError: true,
+				abortSignal: signal,
+			});
 		});
 
 		it('should batch slugs in chunks of 100', async () => {

--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry.service.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry.service.test.ts
@@ -294,6 +294,20 @@ describe('McpRegistryService', () => {
 			expect(repository.upsert).toHaveBeenCalledTimes(1);
 		});
 
+		it('refreshFromApi stops before the write when the signal aborts during the fetch', async () => {
+			const { service, apiClient, repository, push } = createService({ storedServers: null });
+			const controller = new AbortController();
+			apiClient.fetchAllServers.mockImplementation(async () => {
+				controller.abort();
+				return [notionMockServer];
+			});
+
+			await expect(service.refreshFromApi(controller.signal)).rejects.toThrow();
+
+			expect(repository.upsert).not.toHaveBeenCalled();
+			expect(push.broadcast).not.toHaveBeenCalled();
+		});
+
 		it('refreshFromApi rethrows an API failure and writes nothing', async () => {
 			const { service, apiClient, repository, push } = createService();
 			apiClient.fetchServersMetadata.mockRejectedValue(new Error('api down'));

--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry.service.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry.service.test.ts
@@ -24,7 +24,6 @@ function toMockEntity(server: McpRegistryServer): McpRegistryServerEntity {
 
 type CreateServiceOptions = {
 	storedServers?: McpRegistryServer[] | null;
-	isLeader?: boolean;
 	instanceType?: 'main' | 'worker';
 };
 
@@ -33,7 +32,6 @@ function createService(options: CreateServiceOptions = {}) {
 	const repository = mock<McpRegistryServerRepository>();
 	const apiClient = mock<McpRegistryApiClient>();
 	const instanceSettings = mock<InstanceSettings>({
-		isLeader: options.isLeader ?? false,
 		instanceType: options.instanceType ?? 'main',
 	});
 	const loadNodesAndCredentials = mock<LoadNodesAndCredentials>({ loaders: {} });
@@ -92,7 +90,6 @@ function createService(options: CreateServiceOptions = {}) {
 
 describe('McpRegistryService', () => {
 	afterEach(() => {
-		vi.useRealTimers();
 		vi.restoreAllMocks();
 	});
 
@@ -187,34 +184,16 @@ describe('McpRegistryService', () => {
 	});
 
 	describe('refresh flow', () => {
-		it('init does not start periodic refresh on followers', async () => {
-			vi.useFakeTimers();
-			const setIntervalSpy = vi.spyOn(global, 'setInterval');
-			const { service, apiClient } = createService({ isLeader: false });
+		it('init loads the persisted registry without calling the API', async () => {
+			const { service, apiClient } = createService();
 
 			await service.init();
 
-			expect(setIntervalSpy).not.toHaveBeenCalled();
 			expect(apiClient.fetchServersMetadata).not.toHaveBeenCalled();
+			expect(apiClient.fetchAllServers).not.toHaveBeenCalled();
 		});
 
-		it('init starts periodic refresh and kicks off startup refresh on leaders', async () => {
-			vi.useFakeTimers();
-			const setIntervalSpy = vi.spyOn(global, 'setInterval');
-			const { service, apiClient } = createService({ isLeader: true });
-
-			await service.init();
-			await Promise.resolve();
-
-			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
-			expect(apiClient.fetchServersMetadata).toHaveBeenCalledTimes(1);
-
-			service.shutdown();
-		});
-
-		it('onLeaderTakeover skips write + notifications when metadata is unchanged', async () => {
-			vi.useFakeTimers();
-			const setIntervalSpy = vi.spyOn(global, 'setInterval');
+		it('refreshFromApi skips write + notifications when metadata is unchanged', async () => {
 			const metadata: McpRegistryServerMetadata[] = [
 				{
 					slug: notionMockServer.slug,
@@ -230,18 +209,15 @@ describe('McpRegistryService', () => {
 			const { service, apiClient, repository, push, publisher } = createService();
 			apiClient.fetchServersMetadata.mockResolvedValue(metadata);
 
-			await service.onLeaderTakeover();
+			await service.refreshFromApi();
 
 			expect(apiClient.fetchServersBySlugs).not.toHaveBeenCalled();
 			expect(repository.upsert).not.toHaveBeenCalled();
 			expect(push.broadcast).not.toHaveBeenCalled();
 			expect(publisher.publishCommand).not.toHaveBeenCalled();
-			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
-
-			service.shutdown();
 		});
 
-		it('onLeaderTakeover deprecates servers missing from metadata', async () => {
+		it('refreshFromApi deprecates servers missing from metadata', async () => {
 			const metadata: McpRegistryServerMetadata[] = [
 				{
 					slug: notionMockServer.slug,
@@ -254,7 +230,7 @@ describe('McpRegistryService', () => {
 			});
 			apiClient.fetchServersMetadata.mockResolvedValue(metadata);
 
-			await service.onLeaderTakeover();
+			await service.refreshFromApi();
 
 			expect(apiClient.fetchServersBySlugs).not.toHaveBeenCalled();
 			expect(repository.upsert).toHaveBeenCalledTimes(1);
@@ -271,11 +247,9 @@ describe('McpRegistryService', () => {
 			expect(repository.upsert.mock.calls[0][1]).toEqual(['slug']);
 			expect(push.broadcast).toHaveBeenCalledWith({ type: 'nodeDescriptionUpdated', data: {} });
 			expect(publisher.publishCommand).toHaveBeenCalledWith({ command: 'reload-mcp-registry' });
-
-			service.shutdown();
 		});
 
-		it('onLeaderTakeover fetches only changed servers and publishes reload', async () => {
+		it('refreshFromApi fetches only changed servers and publishes reload', async () => {
 			const staleNotion: McpRegistryServer = {
 				...notionMockServer,
 				version: '1.1.0',
@@ -299,7 +273,7 @@ describe('McpRegistryService', () => {
 			apiClient.fetchServersMetadata.mockResolvedValue(metadata);
 			apiClient.fetchServersBySlugs.mockResolvedValue([notionMockServer]);
 
-			await service.onLeaderTakeover();
+			await service.refreshFromApi();
 
 			expect(apiClient.fetchAllServers).not.toHaveBeenCalled();
 			expect(apiClient.fetchServersBySlugs).toHaveBeenCalledWith([notionMockServer.slug]);
@@ -308,20 +282,26 @@ describe('McpRegistryService', () => {
 			expect(upsertEntities).toEqual([notionMockServer].map(toEntity));
 			expect(push.broadcast).toHaveBeenCalledWith({ type: 'nodeDescriptionUpdated', data: {} });
 			expect(publisher.publishCommand).toHaveBeenCalledWith({ command: 'reload-mcp-registry' });
-
-			service.shutdown();
 		});
 
-		it('onLeaderTakeover fetches all servers when no data is persisted', async () => {
+		it('refreshFromApi fetches all servers when no data is persisted', async () => {
 			const { service, apiClient, repository } = createService({ storedServers: null });
 
-			await service.onLeaderTakeover();
+			await service.refreshFromApi();
 
 			expect(apiClient.fetchAllServers).toHaveBeenCalledTimes(1);
 			expect(apiClient.fetchServersMetadata).not.toHaveBeenCalled();
 			expect(repository.upsert).toHaveBeenCalledTimes(1);
+		});
 
-			service.shutdown();
+		it('refreshFromApi rethrows an API failure and writes nothing', async () => {
+			const { service, apiClient, repository, push } = createService();
+			apiClient.fetchServersMetadata.mockRejectedValue(new Error('api down'));
+
+			await expect(service.refreshFromApi()).rejects.toThrow('api down');
+
+			expect(repository.upsert).not.toHaveBeenCalled();
+			expect(push.broadcast).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry.service.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry.service.test.ts
@@ -276,7 +276,10 @@ describe('McpRegistryService', () => {
 			await service.refreshFromApi();
 
 			expect(apiClient.fetchAllServers).not.toHaveBeenCalled();
-			expect(apiClient.fetchServersBySlugs).toHaveBeenCalledWith([notionMockServer.slug]);
+			expect(apiClient.fetchServersBySlugs).toHaveBeenCalledWith(
+				[notionMockServer.slug],
+				undefined,
+			);
 			expect(repository.upsert).toHaveBeenCalledTimes(1);
 			const upsertEntities = repository.upsert.mock.calls[0][0];
 			expect(upsertEntities).toEqual([notionMockServer].map(toEntity));
@@ -304,6 +307,7 @@ describe('McpRegistryService', () => {
 
 			await expect(service.refreshFromApi(controller.signal)).rejects.toThrow();
 
+			expect(apiClient.fetchAllServers).toHaveBeenCalledWith(controller.signal);
 			expect(repository.upsert).not.toHaveBeenCalled();
 			expect(push.broadcast).not.toHaveBeenCalled();
 		});

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry-api.client.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry-api.client.ts
@@ -27,7 +27,7 @@ export class McpRegistryApiClient {
 		private readonly credentialTypes: CredentialTypes,
 	) {}
 
-	async fetchAllServers(): Promise<McpRegistryServer[]> {
+	async fetchAllServers(signal?: AbortSignal): Promise<McpRegistryServer[]> {
 		const servers = await paginatedRequest<unknown>(
 			this.getUrl(),
 			{
@@ -36,12 +36,13 @@ export class McpRegistryApiClient {
 			},
 			{
 				throwOnError: true,
+				abortSignal: signal,
 			},
 		);
 		return this.parseServers(servers);
 	}
 
-	async fetchServersMetadata(): Promise<McpRegistryServerMetadata[]> {
+	async fetchServersMetadata(signal?: AbortSignal): Promise<McpRegistryServerMetadata[]> {
 		return await paginatedRequest<McpRegistryServerMetadata>(
 			this.getUrl(),
 			{
@@ -51,11 +52,12 @@ export class McpRegistryApiClient {
 			},
 			{
 				throwOnError: true,
+				abortSignal: signal,
 			},
 		);
 	}
 
-	async fetchServersBySlugs(slugs: string[]): Promise<McpRegistryServer[]> {
+	async fetchServersBySlugs(slugs: string[], signal?: AbortSignal): Promise<McpRegistryServer[]> {
 		const data: McpRegistryServer[] = [];
 		for (let i = 0; i < slugs.length; i += STRAPI_ARRAY_LIMIT) {
 			const batch = slugs.slice(i, i + STRAPI_ARRAY_LIMIT);
@@ -72,6 +74,7 @@ export class McpRegistryApiClient {
 				},
 				{
 					throwOnError: true,
+					abortSignal: signal,
 				},
 			);
 			data.push(...this.parseServers(batchData));

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry.service.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry.service.ts
@@ -1,11 +1,9 @@
 import { Logger } from '@n8n/backend-common';
-import { Time } from '@n8n/constants';
-import { OnLeaderStepdown, OnLeaderTakeover, OnPubSubEvent, OnShutdown } from '@n8n/decorators';
+import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 import type { McpRegistryConnection } from 'n8n-workflow';
 
-import { inE2ETests } from '@/constants';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { Push } from '@/push';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
@@ -23,20 +21,8 @@ import type { McpRegistryServer } from './mcp-registry.types';
 import { toEntity, fromEntity } from './mcp-registry.types';
 import { MCP_REGISTRY_PACKAGE_NAME } from '../node-description-transform';
 
-type RefreshReason = 'startup' | 'leader-takeover' | 'interval';
-
-const REFRESH_INTERVAL_HOURS = 8;
-
-const REFRESH_INTERVAL_MS = REFRESH_INTERVAL_HOURS * Time.hours.toMilliseconds;
-
 @Service()
 export class McpRegistryService {
-	private refreshInterval: NodeJS.Timeout | undefined;
-
-	private refreshPromise: Promise<void> | undefined;
-
-	private isShuttingDown = false;
-
 	constructor(
 		private readonly logger: Logger,
 		private readonly repository: McpRegistryServerRepository,
@@ -51,32 +37,6 @@ export class McpRegistryService {
 
 	async init(): Promise<void> {
 		await this.refreshRegistryNodeTypes(false);
-		// In E2E the registry is populated deterministically via the test seed
-		// endpoint; skip the remote refresh so tests never reach api.n8n.io and
-		// the background refresh can't race the seed.
-		if (this.instanceSettings.isLeader && !inE2ETests) {
-			// don't want to wait for API calls to block on init
-			void this.refreshFromApi('startup');
-			this.startPeriodicRefresh();
-		}
-	}
-
-	@OnLeaderTakeover()
-	async onLeaderTakeover(): Promise<void> {
-		if (inE2ETests) return;
-		await this.refreshFromApi('leader-takeover');
-		this.startPeriodicRefresh();
-	}
-
-	@OnLeaderStepdown()
-	onLeaderStepdown(): void {
-		this.stopPeriodicRefresh();
-	}
-
-	@OnShutdown()
-	shutdown(): void {
-		this.isShuttingDown = true;
-		this.stopPeriodicRefresh();
 	}
 
 	@OnPubSubEvent('reload-mcp-registry')
@@ -134,67 +94,33 @@ export class McpRegistryService {
 		return loader.getConnection(nodeTypeName);
 	}
 
-	private startPeriodicRefresh(): void {
-		if (this.isShuttingDown || this.refreshInterval) {
-			return;
-		}
-
-		this.refreshInterval = setInterval(() => {
-			void this.refreshFromApi('interval');
-		}, REFRESH_INTERVAL_MS);
-
-		this.logger.debug('Scheduled MCP registry refresh', {
-			intervalHours: REFRESH_INTERVAL_HOURS,
-		});
-	}
-
-	private stopPeriodicRefresh(): void {
-		clearInterval(this.refreshInterval);
-		this.refreshInterval = undefined;
-	}
-
-	private async refreshFromApi(reason: RefreshReason): Promise<void> {
-		if (this.refreshPromise) {
-			await this.refreshPromise;
-			return;
-		}
-
-		this.refreshPromise = this.refreshFromApiInternal(reason);
-		try {
-			await this.refreshPromise;
-		} finally {
-			this.refreshPromise = undefined;
-		}
-	}
-
-	private async refreshFromApiInternal(reason: RefreshReason): Promise<void> {
-		try {
-			const existingServers = await this.getAll({ includeDeprecated: true });
-			let updatedServers: McpRegistryServer[];
-			if (existingServers.length === 0) {
-				updatedServers = await this.apiClient.fetchAllServers();
-			} else {
-				const result = await this.refreshUpdatedServers(existingServers);
-				if (result === null) {
-					this.logger.debug('MCP registry is up to date', { reason });
-					return;
-				}
-
-				updatedServers = result;
+	/**
+	 * Refreshes the registry from the remote API and reloads the generated node
+	 * types. Skips the write and the reload when nothing changed.
+	 * Not safe to run concurrently with itself.
+	 * @throws when the remote API or the database write fails.
+	 */
+	async refreshFromApi(): Promise<void> {
+		const existingServers = await this.getAll({ includeDeprecated: true });
+		let updatedServers: McpRegistryServer[];
+		if (existingServers.length === 0) {
+			updatedServers = await this.apiClient.fetchAllServers();
+		} else {
+			const result = await this.refreshUpdatedServers(existingServers);
+			if (result === null) {
+				this.logger.debug('MCP registry is up to date');
+				return;
 			}
 
-			await this.saveServers(updatedServers);
-			await this.refreshRegistryNodeTypes(true);
-			this.notifyNodeDescriptionsUpdated();
-			await this.publishReloadCommand();
-
-			this.logger.debug('MCP registry refreshed', {
-				reason,
-				serverCount: updatedServers.length,
-			});
-		} catch (error) {
-			this.logger.error('Failed to refresh MCP registry', { error, reason });
+			updatedServers = result;
 		}
+
+		await this.saveServers(updatedServers);
+		await this.refreshRegistryNodeTypes(true);
+		this.notifyNodeDescriptionsUpdated();
+		await this.publishReloadCommand();
+
+		this.logger.debug('MCP registry refreshed', { serverCount: updatedServers.length });
 	}
 
 	private async refreshUpdatedServers(

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry.service.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry.service.ts
@@ -97,10 +97,11 @@ export class McpRegistryService {
 	/**
 	 * Refreshes the registry from the remote API and reloads the generated node
 	 * types. Skips the write and the reload when nothing changed.
-	 * Not safe to run concurrently with itself.
-	 * @throws when the remote API or the database write fails.
+	 * Callers must serialize runs.
+	 * @throws when the remote API or the database write fails, or when the
+	 * signal aborts before the write starts.
 	 */
-	async refreshFromApi(): Promise<void> {
+	async refreshFromApi(signal?: AbortSignal): Promise<void> {
 		const existingServers = await this.getAll({ includeDeprecated: true });
 		let updatedServers: McpRegistryServer[];
 		if (existingServers.length === 0) {
@@ -115,6 +116,7 @@ export class McpRegistryService {
 			updatedServers = result;
 		}
 
+		signal?.throwIfAborted();
 		await this.saveServers(updatedServers);
 		await this.refreshRegistryNodeTypes(true);
 		this.notifyNodeDescriptionsUpdated();

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry.service.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry.service.ts
@@ -99,15 +99,15 @@ export class McpRegistryService {
 	 * types. Skips the write and the reload when nothing changed.
 	 * Callers must serialize runs.
 	 * @throws when the remote API or the database write fails, or when the
-	 * signal aborts before the write starts.
+	 * signal aborts before the write starts. The signal cancels the API requests.
 	 */
 	async refreshFromApi(signal?: AbortSignal): Promise<void> {
 		const existingServers = await this.getAll({ includeDeprecated: true });
 		let updatedServers: McpRegistryServer[];
 		if (existingServers.length === 0) {
-			updatedServers = await this.apiClient.fetchAllServers();
+			updatedServers = await this.apiClient.fetchAllServers(signal);
 		} else {
-			const result = await this.refreshUpdatedServers(existingServers);
+			const result = await this.refreshUpdatedServers(existingServers, signal);
 			if (result === null) {
 				this.logger.debug('MCP registry is up to date');
 				return;
@@ -127,9 +127,10 @@ export class McpRegistryService {
 
 	private async refreshUpdatedServers(
 		existingServers: McpRegistryServer[],
+		signal?: AbortSignal,
 	): Promise<McpRegistryServer[] | null> {
 		const now = new Date().toISOString();
-		const metadata = await this.apiClient.fetchServersMetadata();
+		const metadata = await this.apiClient.fetchServersMetadata(signal);
 		const existingBySlug = new Map(existingServers.map((server) => [server.slug, server]));
 		const metadataSlugs = new Set(metadata.map(({ slug }) => slug));
 		const slugsToFetch = metadata
@@ -147,7 +148,7 @@ export class McpRegistryService {
 			return serversToDeprecate;
 		}
 
-		const updatedServers = await this.apiClient.fetchServersBySlugs(slugsToFetch);
+		const updatedServers = await this.apiClient.fetchServersBySlugs(slugsToFetch, signal);
 		return [...updatedServers, ...serversToDeprecate];
 	}
 

--- a/packages/cli/src/utils/__tests__/strapi-utils.test.ts
+++ b/packages/cli/src/utils/__tests__/strapi-utils.test.ts
@@ -1,5 +1,7 @@
+import { Logger } from '@n8n/backend-common';
 import { OutboundHttp, type HttpRequestClient } from '@n8n/backend-network';
 import { mockInstance } from '@n8n/backend-test-utils';
+import { ErrorReporter } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
 import { paginatedRequest, buildStrapiUpdateQuery } from '../strapi-utils';
@@ -23,6 +25,8 @@ describe('Strapi utils', () => {
 	const request = vi.fn();
 	const requests = vi.fn().mockReturnValue(mock<HttpRequestClient>({ request }));
 	mockInstance(OutboundHttp, { requests });
+	const logger = mockInstance(Logger);
+	const errorReporter = mockInstance(ErrorReporter);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -92,6 +96,36 @@ describe('Strapi utils', () => {
 					{ throwOnError: true },
 				),
 			).rejects.toThrow('Request failed');
+		});
+
+		it('should forward the abort signal to the request', async () => {
+			const { signal } = new AbortController();
+			request.mockResolvedValueOnce(page([], { page: 1, pageCount: 0 }));
+
+			await paginatedRequest(
+				baseUrl,
+				{ pagination: { page: 1, pageSize: 25 } },
+				{ abortSignal: signal },
+			);
+
+			expect(request).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: signal }));
+		});
+
+		it('should not report or log a request that failed after the signal aborted', async () => {
+			const controller = new AbortController();
+			controller.abort();
+			request.mockRejectedValueOnce(new Error('canceled'));
+
+			await expect(
+				paginatedRequest(
+					baseUrl,
+					{ pagination: { page: 1, pageSize: 25 } },
+					{ throwOnError: true, abortSignal: controller.signal },
+				),
+			).rejects.toThrow('canceled');
+
+			expect(errorReporter.error).not.toHaveBeenCalled();
+			expect(logger.error).not.toHaveBeenCalled();
 		});
 
 		it('should issue a GET with SSRF disabled, JSON, and the 6000ms timeout', async () => {

--- a/packages/cli/src/utils/strapi-utils.ts
+++ b/packages/cli/src/utils/strapi-utils.ts
@@ -35,6 +35,7 @@ interface Pagination {
 
 export interface PaginationRequestOptions {
 	throwOnError?: boolean;
+	abortSignal?: AbortSignal;
 }
 
 export type StrapiFilters = { [key: string]: { ['$eq']?: string; ['$in']?: string[] } };
@@ -96,14 +97,17 @@ export async function paginatedRequest<T>(
 					headers: { 'Content-Type': 'application/json' },
 					qs: params,
 					json: true,
+					abortSignal: options?.abortSignal,
 				});
 		} catch (error) {
-			Container.get(ErrorReporter).error(error, {
-				tags: { source: 'strapiPaginatedRequest' },
-			});
-			Container.get(Logger).error(
-				`Error fetching from Strapi API (${url}): ${(error as Error).message}`,
-			);
+			if (!options?.abortSignal?.aborted) {
+				Container.get(ErrorReporter).error(error, {
+					tags: { source: 'strapiPaginatedRequest' },
+				});
+				Container.get(Logger).error(
+					`Error fetching from Strapi API (${url}): ${(error as Error).message}`,
+				);
+			}
 			if (options?.throwOnError) throw error;
 
 			break;


### PR DESCRIPTION
## Summary

Move the periodic MCP registry refresh out of `McpRegistryService` and into a `@SystemTask()` class, `McpRegistryRefreshTask`.

`McpRegistryService` no longer owns a timer. It drops the `@OnLeaderTakeover`, `@OnLeaderStepdown` and `@OnShutdown` hooks

Behavior is unchanged for operators. 
Part of the migration started in #37540.

## How to test

The `mcp-registry` module is enabled by default and the task is not durable, so no extra env var or license is needed.

1. Start n8n with `N8N_LOG_LEVEL=debug`.
2. On the leader, the log shows the system task runner starting `mcp-registry-refresh`, then `MCP registry refreshed` or `MCP registry is up to date` shortly after boot.
3. Open the node creator. The MCP registry servers are listed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4154

Preceding PR: #37540

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
