### PR TITLE
fix(core): Recover Instance AI runs from a stale sandbox toolbox URL

### DIFF
--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -9,6 +9,7 @@ interface MockSandbox {
 	memory: number;
 	target: string;
 	state: string;
+	toolboxProxyUrl: string;
 	process: { executeCommand: Mock };
 	fs: Record<string, Mock>;
 	start: Mock;
@@ -50,13 +51,18 @@ const {
 	const queuedGetResults: MockSandbox[] = [];
 	const queuedCreateResults: Array<MockSandbox | Error> = [];
 
-	function makeMockSandbox(id: string, state = 'started'): MockSandbox {
+	function makeMockSandbox(
+		id: string,
+		state = 'started',
+		toolboxProxyUrl = 'https://proxy.example.test/v1/sandbox-proxy/toolbox/',
+	): MockSandbox {
 		return {
 			id,
 			cpu: 2,
 			memory: 4,
 			target: 'us',
 			state,
+			toolboxProxyUrl,
 			process: {
 				executeCommand: vi.fn().mockResolvedValue({
 					exitCode: 0,
@@ -1209,5 +1215,72 @@ describe('DaytonaSandbox (remote sandbox gone during refetch)', () => {
 
 		await filesystem.appendFile('/workspace/log.txt', 'entry');
 		expect(handle.fs.uploadFile).toHaveBeenCalled();
+	});
+});
+
+describe('DaytonaSandbox (stale toolbox URL recovery)', () => {
+	const PROXY_URL = 'https://proxy.example.test/v1/sandbox-proxy/toolbox/';
+	const PROVIDER_URL = 'https://proxy.app-eu.provider.test/toolbox';
+
+	function unauthorized() {
+		return new DaytonaError('unauthorized: authentication failed', 401);
+	}
+
+	// A resumed sandbox can arrive holding the provider's own toolbox URL. The SDK binds its
+	// toolbox client to that URL and keeps it, so every later call is rejected until the handle
+	// is replaced.
+	it('adopts the refetched sandbox and replays the command once', async () => {
+		const stale = makeMockSandbox('remote-stale', 'started', PROVIDER_URL);
+		stale.process.executeCommand
+			.mockRejectedValueOnce(unauthorized())
+			.mockResolvedValue({ exitCode: 0, artifacts: { stdout: 'ok' }, result: 'ok' });
+		queuedGetResults.push(stale, makeMockSandbox('remote-fresh', 'started', PROXY_URL));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			createRetryBackoffBaseMs: 1,
+		});
+		await sandbox.start();
+
+		const result = await sandbox.executeCommand('echo hi');
+
+		expect(result.exitCode).toBe(0);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-fresh');
+	});
+
+	it('propagates the failure when the refetched toolbox URL is unchanged', async () => {
+		const handle = makeMockSandbox('remote-only', 'started', PROXY_URL);
+		handle.process.executeCommand.mockRejectedValue(unauthorized());
+		queuedGetResults.push(handle, makeMockSandbox('remote-probe', 'started', PROXY_URL));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			createRetryBackoffBaseMs: 1,
+		});
+		await sandbox.start();
+
+		await expect(sandbox.executeCommand('echo hi')).rejects.toThrow('unauthorized');
+		expect(handle.process.executeCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not replace the handle for a non-auth failure', async () => {
+		const handle = makeMockSandbox('remote-only', 'started', PROVIDER_URL);
+		handle.process.executeCommand.mockRejectedValue(new DaytonaError('Bad Request', 400));
+		queuedGetResults.push(handle, makeMockSandbox('remote-probe', 'started', PROXY_URL));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			createRetryBackoffBaseMs: 1,
+		});
+		await sandbox.start();
+
+		await expect(sandbox.executeCommand('echo hi')).rejects.toThrow('Bad Request');
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-only');
 	});
 });

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -118,6 +118,15 @@ type ExistingSandboxLookup =
 
 type ConflictLookupResult = ExistingSandboxLookup | { status: 'timeout' };
 
+/**
+ * How a failed sandbox operation can be recovered.
+ * - `resume`: the remote is gone or not running — resume or recreate it, then replay.
+ * - `refresh-handle`: the remote is fine, but the cached handle was stale — adopt the refetched
+ *   one, then replay.
+ * - `none`: propagate the original error.
+ */
+type RecoveryPlan = 'resume' | 'refresh-handle' | 'none';
+
 export interface DaytonaSandboxOptions {
 	id?: string;
 	/** Static Daytona API key (direct mode). Mutually exclusive with `getAuthToken`. */
@@ -173,6 +182,12 @@ function toShellCommand(command: string, args: string[]): string {
 function isSandboxGone(error: unknown): boolean {
 	const { DaytonaNotFoundError } = loadDaytona();
 	return error instanceof DaytonaNotFoundError;
+}
+
+/** Whether the remote rejected our credentials (401/403), rather than failing the operation. */
+function isSandboxAuthError(error: unknown): boolean {
+	const { DaytonaError } = loadDaytona();
+	return error instanceof DaytonaError && (error.statusCode === 401 || error.statusCode === 403);
 }
 
 function isSandboxNameConflictError(error: unknown): boolean {
@@ -269,6 +284,7 @@ export class DaytonaSandbox extends BaseSandbox {
 		} catch (error) {
 			throw this.toAcquisitionError(error);
 		}
+		this.logToolboxTarget();
 		await this.detectWorkingDirectory();
 	}
 
@@ -461,6 +477,35 @@ export class DaytonaSandbox extends BaseSandbox {
 		await this.getDaytona();
 	}
 
+	/**
+	 * Record where toolbox calls will go. In proxy mode they must target the configured
+	 * `apiUrl`. A different origin means the URL escaped the proxy's rewrite, and the failure
+	 * that follows reads as a credential problem rather than a routing one.
+	 */
+	private logToolboxTarget(): void {
+		const toolboxUrl = this.sandbox?.toolboxProxyUrl;
+		const configuredUrl = this.options.apiUrl;
+		if (!toolboxUrl || !configuredUrl) return;
+
+		const originOf = (url: string): string | undefined => {
+			try {
+				return new URL(url).origin;
+			} catch {
+				return undefined;
+			}
+		};
+		const toolboxOrigin = originOf(toolboxUrl);
+		const configuredOrigin = originOf(configuredUrl);
+		if (!toolboxOrigin || !configuredOrigin) return;
+
+		this.options.logger?.debug('Daytona toolbox target resolved', {
+			sandboxName: this.sandboxName,
+			toolboxOrigin,
+			configuredOrigin,
+			matchesConfiguredOrigin: toolboxOrigin === configuredOrigin,
+		});
+	}
+
 	getInfo(): SandboxInfo {
 		return {
 			id: this.id,
@@ -506,6 +551,7 @@ export class DaytonaSandbox extends BaseSandbox {
 		const generation = this.auth.getGeneration();
 		if (this.sandbox && generation !== this.lastClientGeneration) {
 			this.sandbox = await client.get(this.sandboxName);
+			this.logToolboxTarget();
 		}
 		this.lastClientGeneration = generation;
 		return client;
@@ -535,19 +581,49 @@ export class DaytonaSandbox extends BaseSandbox {
 	 * (running, a transient transition, or a failed build) propagates the original error so we
 	 * neither mask real failures nor recreate a sandbox off an unrelated error.
 	 *
-	 * A genuine auth failure is handled implicitly: the probe's own `get()` fails too (it
-	 * uses the same credentials), so we fall through to `false` and never recreate.
+	 * A credential failure against the management API is handled implicitly: the probe's own
+	 * `get()` fails too, so we fall through to `none` and never recreate.
+	 *
+	 * The probe refetches the sandbox, and that response carries the toolbox URL. A running
+	 * remote that rejected our credentials, plus a refetch that returns a different toolbox URL,
+	 * means the cached handle pointed somewhere stale — `refresh-handle` adopts the fresh one.
 	 */
-	private async isRecoverable(error: unknown): Promise<boolean> {
-		if (isSandboxGone(error)) return true;
+	private async planRecovery(error: unknown): Promise<RecoveryPlan> {
+		if (isSandboxGone(error)) return 'resume';
 		try {
 			const client = await this.auth.getClient();
 			const remote = await client.get(this.sandboxName);
-			return remote.state !== undefined && RECOVERABLE_SANDBOX_STATES.has(remote.state);
+			if (remote.state !== undefined && RECOVERABLE_SANDBOX_STATES.has(remote.state)) {
+				return 'resume';
+			}
+			return this.adoptFreshHandle(error, remote) ? 'refresh-handle' : 'none';
 		} catch (probeError) {
 			// Gone entirely → recreate; anything else (incl. auth) → don't mask the original.
-			return isSandboxGone(probeError);
+			return isSandboxGone(probeError) ? 'resume' : 'none';
 		}
+	}
+
+	/**
+	 * Replace the cached handle when it holds a stale toolbox URL.
+	 *
+	 * The SDK binds its toolbox client to the URL in whichever sandbox DTO it saw last, and
+	 * never revisits it. A DTO that reaches us holding the provider's own URL therefore points
+	 * every later toolbox call at the provider, which rejects our credentials — for the life of
+	 * the handle, not just for one call.
+	 */
+	private adoptFreshHandle(error: unknown, remote: Sandbox): boolean {
+		if (!isSandboxAuthError(error)) return false;
+		const staleUrl = this.sandbox?.toolboxProxyUrl;
+		if (!remote.toolboxProxyUrl || remote.toolboxProxyUrl === staleUrl) return false;
+
+		this.options.logger?.warn('Daytona toolbox URL was stale; adopting the refetched sandbox', {
+			sandboxName: this.sandboxName,
+			staleToolboxUrl: staleUrl,
+			freshToolboxUrl: remote.toolboxProxyUrl,
+		});
+		this.sandbox = remote;
+		this.lastClientGeneration = this.auth.getGeneration();
+		return true;
 	}
 
 	/**
@@ -555,19 +631,20 @@ export class DaytonaSandbox extends BaseSandbox {
 	 * deleted out from under us. On a recoverable failure the sandbox is resumed (or recreated if
 	 * gone) and the operation is retried exactly once; a second failure propagates.
 	 *
-	 * Replaying the operation is safe because recovery only triggers when the probe confirms
-	 * the remote was NOT running (stopped/paused/archived/gone — see {@link isRecoverable}). In those
-	 * states the toolbox/exec request never reached a live container, so it could not have
-	 * partially executed. Operations on a running sandbox are never retried — their error
-	 * propagates untouched.
+	 * Replaying the operation is safe under both plans, because neither reached a live container:
+	 * `resume` only triggers when the probe confirms the remote was NOT running
+	 * (stopped/paused/archived/gone — see {@link planRecovery}), and `refresh-handle` only
+	 * triggers on a credential rejection, which the remote refuses before it runs anything.
+	 * Any other failure on a running sandbox propagates untouched.
 	 */
 	private async recoverAndRetry<T>(op: () => Promise<T>): Promise<T> {
 		try {
 			return await op();
 		} catch (error) {
 			if (isAbortError(error)) throw error;
-			if (!(await this.isRecoverable(error))) throw error;
-			await this.recover();
+			const plan = await this.planRecovery(error);
+			if (plan === 'none') throw error;
+			if (plan === 'resume') await this.recover();
 			return await op();
 		}
 	}

--- a/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
@@ -262,6 +262,46 @@ describe('materializeRuntimeSkillsIntoWorkspace', () => {
 		expect(executeCommand).toHaveBeenCalledTimes(1);
 	});
 
+	// A sandbox failure must not fail the whole run. Skill instructions are served from this
+	// process, so an unmaterialized source still answers load_skill.
+	it('serves skills in-process when the workspace is unreachable', async () => {
+		const source = loadInstanceAiRuntimeSkillSource();
+		const { workspace, executeCommand } = createMockWorkspace();
+		executeCommand.mockRejectedValue(new Error('unauthorized: Bearer token is invalid'));
+		const runtimeSource = createLazyWorkspaceRuntimeSkillSource({
+			logger: mockLogger,
+			source,
+			workspace,
+		});
+
+		await expect(runtimeSource.prepare?.()).resolves.toBeUndefined();
+
+		const loadTool = createSkillLoadTool(runtimeSource);
+		const result = await loadTool.handler?.({ skillId: 'data-table-manager' }, {});
+
+		expect(skillLoadText(result)).toContain('[Skill: "data-table-manager"]');
+	});
+
+	it('materializes on a later load once the workspace recovers', async () => {
+		const source = loadInstanceAiRuntimeSkillSource();
+		const { workspace, writes, executeCommand } = createMockWorkspace();
+		executeCommand.mockRejectedValueOnce(new Error('unauthorized: Bearer token is invalid'));
+		const runtimeSource = createLazyWorkspaceRuntimeSkillSource({
+			logger: mockLogger,
+			source,
+			workspace,
+		});
+
+		await runtimeSource.prepare?.();
+		expect(writes.size).toBe(0);
+
+		const loadTool = createSkillLoadTool(runtimeSource);
+		await loadTool.handler?.({ skillId: 'data-table-manager' }, {});
+
+		const skillPath = `/home/daytona/workspace/${SANDBOX_RUNTIME_SKILLS_DIR}/data-table-manager/SKILL.md`;
+		expect(writes.get(skillPath)).toContain('data-tables');
+	});
+
 	it('uses prebaked runtime skills when the manifest matches the source hash', async () => {
 		const source = loadInstanceAiRuntimeSkillSource();
 		const { workspace, writes, executeCommand, writeFile } = createMockWorkspace();

--- a/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
@@ -563,8 +563,13 @@ export function createLazyWorkspaceRuntimeSkillSource({
 
 	const workspaceSource: RuntimeSkillSource = {
 		registry: source.registry,
+		// `Agent.build()` awaits this before the model runs. Materialization needs the sandbox,
+		// so a sandbox failure here would fail the whole run — including runs that never touch
+		// the workspace. Skill instructions come from this process, so an unmaterialized source
+		// still serves every skill; only the files behind `${N8N_SKILL_DIR}` are missing.
+		// Degrade instead, and let the file read fail later if a skill actually needs one.
 		prepare: async () => {
-			await ensureMaterialized();
+			await ensureMaterializedOrDegrade();
 		},
 		loadSkill: async (skillId: string) => await (await ensureSource()).loadSkill(skillId),
 		...(source.loadFile
@@ -599,8 +604,24 @@ export function createLazyWorkspaceRuntimeSkillSource({
 		return await materializePromise;
 	}
 
+	/**
+	 * Materialize, or fall back to the unmaterialized source. Each call retries, because
+	 * `ensureMaterialized` clears its cached promise on failure — a sandbox that recovers
+	 * mid-run materializes on the next skill load.
+	 */
+	async function ensureMaterializedOrDegrade(): Promise<MaterializedRuntimeSkills | undefined> {
+		try {
+			return await ensureMaterialized();
+		} catch (error) {
+			logger.warn('Could not materialize runtime skills into the workspace; serving in-process', {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+
 	async function ensureSource(): Promise<RuntimeSkillSource> {
-		return (await ensureMaterialized())?.source ?? source;
+		return (await ensureMaterializedOrDegrade())?.source ?? source;
 	}
 
 	return workspaceSource;


### PR DESCRIPTION
## Summary

Two independent hardening fixes for the AI Assistant failure in INS-1327, where a conversation became permanently unusable with:

```
DaytonaAuthenticationError: unauthorized: authentication failed: Bearer token is invalid
```

The root cause sits in the sandbox proxy and is fixed separately in [ai-assistant-service#590](https://github.com/n8n-io/ai-assistant-service/pull/590): a resume response was not rewritten, so n8n received the sandbox provider's own toolbox URL. This PR makes n8n survive that class of problem on its own.

**`fix(core): Recover an Instance AI sandbox from a stale toolbox URL`**

The Daytona SDK binds its toolbox client to the URL in whichever sandbox DTO it saw last, and never revisits it. A DTO holding the provider's URL therefore sent every later toolbox call to the provider, which rejects our credentials — and the handle kept that URL, so every message on the thread failed the same way until the sandbox entry expired, the token rotated, or n8n restarted. That is what turned one bad resume into a conversation that could not resume.

The recovery probe already refetched the sandbox and read only its state. It now also compares the toolbox URL: when the remote is running, the operation failed on credentials, and the refetch carries a different URL, n8n adopts the refetched handle and replays the operation once. A replay is safe here — the remote rejects the credentials before it runs anything.

`logToolboxTarget()` also records the resolved toolbox origin at debug level, so a URL that escapes the proxy rewrite reads as a routing problem rather than an authentication one. That distinction is what located this bug, after two wrong hypotheses.

**`fix(core): Keep an Instance AI run alive when the workspace is unreachable`**

`Agent.build()` awaits the runtime skill source's `prepare()` before the model runs, and materialization needs the sandbox. So any sandbox failure killed the whole run — including runs that never touch the workspace, and including unrelated causes such as a provider quota limit.

Skill instructions are served from this process, so an unmaterialized source still answers every `load_skill` call. Only the files behind `${N8N_SKILL_DIR}` are missing, and a skill that needs one now fails on that single read. Materialization still retries on each later skill load, so a sandbox that recovers mid-run materializes then.

## How to test

Verified against live Daytona with the **unfixed** proxy (`ai-assistant-service` on `main`), which confirms this PR resolves the symptom on its own:

1. Run n8n in proxy mode with `N8N_INSTANCE_AI_SANDBOX_PROVIDER=daytona` and `N8N_INSTANCE_AI_SANDBOX_AUTO_STOP_MINUTES=1`.
2. Send a message in a new thread. The sandbox is created.
3. Wait about two minutes, so Daytona auto-stops the idle sandbox.
4. Restart n8n, then send a second message in the same thread.

Before, that second message failed and the thread never recovered. Now:

```
debug  Daytona toolbox target resolved   matchesConfiguredOrigin: false
warn   Daytona toolbox URL was stale; adopting the refetched sandbox
         stale: https://proxy.app-eu.daytona.io/toolbox
         fresh: http://localhost:3000/v1/sandbox-proxy/toolbox/
debug  Using prebaked runtime skills from workspace
       … run completes, model responds
```

Cost of the recovery is one rejected request and a probe, roughly 1.2s, once per stale handle. With ai-assistant-service#590 deployed the stale URL never appears, and this path stays quiet.

Automated: `@n8n/agents` 61 tests and `@n8n/instance-ai` skills 31 tests pass. Five new tests cover adopt-and-replay, no retry when the refetched URL is unchanged, no adoption for a non-auth failure, degrading when the workspace is unreachable, and materializing on a later load once it recovers. I confirmed each new test fails with its fix reverted.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1327

Root cause fix: https://github.com/n8n-io/ai-assistant-service/pull/590

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

