### PR TITLE
fix(Execute Workflow Node): Return items the sub-workflow put on a branch other than the first

### DIFF
--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -2017,6 +2017,61 @@ describe('WorkflowExecuteAdditionalData', () => {
 				),
 			).toEqual([null]);
 		});
+
+		describe('multi-output terminal node', () => {
+			// An `If` that sends every item out its false branch, with that branch
+			// left unconnected, so the `If` is the last node the sub-workflow ran.
+			const itemsOnTheFalseBranchOnly: Record<string, ITaskData[]> = {
+				[LAST_NODE_EXECUTED]: [
+					{
+						data: {
+							main: [[], [{ json: { itemId: 0 } }, { json: { itemId: 1 } }]],
+						},
+					},
+				] as unknown as ITaskData[],
+			};
+			const expectedItemsOnTheSingleOutput = [[{ json: { itemId: 0 } }, { json: { itemId: 1 } }]];
+
+			it('merges the branches on the merged-runs path', () => {
+				const output = buildSubWorkflowOutput(
+					buildRun({ mode: 'trigger', runData: itemsOnTheFalseBranchOnly }),
+					[trigger(1.2)],
+					false,
+				);
+
+				expect(output).toEqual(expectedItemsOnTheSingleOutput);
+			});
+
+			it('merges the branches on the `lastRunOnly` path', () => {
+				const output = buildSubWorkflowOutput(
+					buildRun({ mode: 'trigger', runData: itemsOnTheFalseBranchOnly }),
+					[trigger(1.1)],
+					false,
+				);
+
+				expect(output).toEqual(expectedItemsOnTheSingleOutput);
+			});
+
+			it('keeps the items of every branch, in branch order', () => {
+				const itemsOnBothBranches: Record<string, ITaskData[]> = {
+					[LAST_NODE_EXECUTED]: [
+						{
+							data: {
+								main: [[{ json: { itemId: 0 } }], [{ json: { itemId: 1 } }]],
+							},
+						},
+					] as unknown as ITaskData[],
+				};
+
+				const output = buildSubWorkflowOutput(
+					buildRun({ mode: 'trigger', runData: itemsOnBothBranches }),
+					[trigger(1.2)],
+					false,
+				);
+
+				expect(output).toEqual([[{ json: { itemId: 0 } }, { json: { itemId: 1 } }]]);
+			});
+		});
 	});
 
 	describe('triggerReturnsLastRunOnly', () => {

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -43,6 +43,7 @@ import {
 	UnexpectedError,
 	Workflow,
 	createRunExecutionData,
+	mergeBranchesIntoSingleOutput,
 	mergeRunsPerBranch,
 	attachDynamicCredentialsUsage,
 	summarizeDynamicCredentialsUsage,
@@ -506,6 +507,8 @@ export function triggerReturnsLastRunOnly(nodes: INode[]): boolean {
  * The caller can additionally force the legacy single-run output via `returnLastRunOnly`
  * (used by LangChain tool/retriever callers that need a single-answer output).
  * Pinned data on the last node always wins in manual mode.
+ * A last node with more than one output (an `If` or a `Switch`) has its branches
+ * merged, because the caller has a single main output to put them on.
  * See n8n-io/n8n#9989.
  */
 export function buildSubWorkflowOutput(
@@ -521,10 +524,12 @@ export function buildSubWorkflowOutput(
 		lastNodeExecuted !== undefined &&
 		pinData[lastNodeExecuted] !== undefined;
 
-	if (!lastRunOnly && runs.length > 0 && !manualPinDataOverride) {
-		return mergeRunsPerBranch(runs);
-	}
-	return WorkflowHelpers.getLastExecutedNodeData(data)?.data?.main ?? [null];
+	const branches =
+		!lastRunOnly && runs.length > 0 && !manualPinDataOverride
+			? mergeRunsPerBranch(runs)
+			: (WorkflowHelpers.getLastExecutedNodeData(data)?.data?.main ?? [null]);
+
+	return mergeBranchesIntoSingleOutput(branches);
 }
 
 async function startExecution(

--- a/packages/workflow/src/sub-workflow-output.ts
+++ b/packages/workflow/src/sub-workflow-output.ts
@@ -9,3 +9,15 @@ export function mergeRunsPerBranch(runs: ITaskData[]): Array<INodeExecutionData[
 		runs.flatMap((run) => run.data?.main?.[branch] ?? []),
 	);
 }
+
+/**
+ * The calling `Execute Sub-workflow` node has a single main output, so items the
+ * sub-workflow's last node put on any other branch have nowhere to go and are
+ * dropped. Concatenate every branch into one, in branch order.
+ */
+export function mergeBranchesIntoSingleOutput(
+	branches: Array<INodeExecutionData[] | null>,
+): Array<INodeExecutionData[] | null> {
+	if (branches.length <= 1) return branches;
+	return [branches.flatMap((branch) => branch ?? [])];
+}

--- a/packages/workflow/test/sub-workflow-output.test.ts
+++ b/packages/workflow/test/sub-workflow-output.test.ts
@@ -1,5 +1,5 @@
 import type { ITaskData } from '../src/interfaces';
-import { mergeRunsPerBranch } from '../src/sub-workflow-output';
+import { mergeBranchesIntoSingleOutput, mergeRunsPerBranch } from '../src/sub-workflow-output';
 
 function buildRun(outputBranches: { json: object }[][]): ITaskData {
 	return {
@@ -60,6 +60,44 @@ describe('mergeRunsPerBranch', () => {
 		expect(mergeRunsPerBranch([runWithPrimaryBranchOnly, runWithBothBranches])).toEqual([
 			mergedPrimaryBranch,
 			secondaryBranchFromTheOnlyRunThatProducedIt,
+		]);
+	});
+});
+
+describe('mergeBranchesIntoSingleOutput', () => {
+	it('returns an empty array unchanged', () => {
+		expect(mergeBranchesIntoSingleOutput([])).toEqual([]);
+	});
+
+	it('returns a single branch unchanged, including the no-data sentinel', () => {
+		const singleBranch = [[{ json: { id: 1 } }]];
+
+		expect(mergeBranchesIntoSingleOutput(singleBranch)).toBe(singleBranch);
+		expect(mergeBranchesIntoSingleOutput([null])).toEqual([null]);
+	});
+
+	it('concatenates the branches of an If in branch order', () => {
+		const trueBranch = [{ json: { id: 55 } }];
+		const falseBranch = [{ json: { id: 56 } }, { json: { id: 57 } }];
+
+		expect(mergeBranchesIntoSingleOutput([trueBranch, falseBranch])).toEqual([
+			[{ json: { id: 55 } }, { json: { id: 56 } }, { json: { id: 57 } }],
+		]);
+	});
+
+	it('keeps items that only the second branch produced', () => {
+		const onlyTheSecondBranchHasItems = [[], [{ json: { id: 56 } }]];
+
+		expect(mergeBranchesIntoSingleOutput(onlyTheSecondBranchHasItems)).toEqual([
+			[{ json: { id: 56 } }],
+		]);
+	});
+
+	it('treats null branches as empty', () => {
+		const switchWithUnusedBranches = [null, [{ json: { id: 1 } }], null];
+
+		expect(mergeBranchesIntoSingleOutput(switchWithUnusedBranches)).toEqual([
+			[{ json: { id: 1 } }],
 		]);
 	});
 });


### PR DESCRIPTION
## Summary

A sub-workflow handed its output to the caller with the per-branch shape of its last node. When an `If` or a `Switch` ends the sub-workflow, items leave on branch 1 or higher, so the output looks like `[[], [items]]`.

The `Execute Sub-workflow` node has one main output. The engine only forwards a branch that has a connection, so every branch after the first had nowhere to go and the items were dropped. The node showed an empty output and the parent workflow stopped.

The same data loss hit two more callers, because both read `data[0]`:

- The Workflow Tool reports `The workflow did not return a response`.
- The Workflow Retriever returns no documents.

With `onError: continueErrorOutput` on the caller, output index 1 is the error output, so those items came out of the error branch instead.

This PR adds `mergeBranchesIntoSingleOutput` and applies it in `buildSubWorkflowOutput`, which is the one place that builds the sub-workflow output. Output that already has one branch is returned unchanged, so the common case does not change. Only the cases that lose data today behave differently.

Two notes for the reviewer:

1. The fix is not gated on a node version. The new behaviour can only surface items that the caller already dropped, so there is no working setup to keep compatible. Tell me if you want it behind a trigger `typeVersion` like #30716 did.
2. A `Switch` in "send to all matching outputs" mode can put the same item on more than one branch. The caller now receives that item once for each branch. Today it receives only the copy on branch 0, so this is an improvement, but it is a visible change for that configuration.

This is not a regression from #30716. The earlier `lastRunOnly` path returned `data.main` too, so both paths carried the branch shape.

## How to test

Create these two workflows.

Sub-workflow, `test subflow`:

```json
{
  "nodes": [
    {
      "parameters": { "workflowInputs": { "values": [{ "name": "id", "type": "number" }] } },
      "type": "n8n-nodes-base.executeWorkflowTrigger",
      "typeVersion": 1.2,
      "position": [0, 0],
      "id": "cb97e884-0e3e-4a72-9bae-42014a24098c",
      "name": "When Executed by Another Workflow"
    },
    {
      "parameters": {
        "conditions": {
          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict", "version": 3 },
          "conditions": [
            {
              "id": "9999bc45-3f1e-46ce-9ad8-cc9a6aa8713d",
              "leftValue": 1,
              "rightValue": 2,
              "operator": { "type": "number", "operation": "equals" }
            }
          ],
          "combinator": "and"
        },
        "options": {}
      },
      "type": "n8n-nodes-base.if",
      "typeVersion": 2.3,
      "position": [220, 0],
      "id": "732ab93b-3bb1-4d94-9db5-19c9758e783a",
      "name": "If"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [440, -120],
      "id": "15a47e0a-beb5-4df3-9c01-07bb85fa7453",
      "name": "only on true"
    }
  ],
  "connections": {
    "When Executed by Another Workflow": {
      "main": [[{ "node": "If", "type": "main", "index": 0 }]]
    },
    "If": {
      "main": [[{ "node": "only on true", "type": "main", "index": 0 }], []]
    }
  },
  "pinData": {}
}
```

The condition `1 == 2` is always false, so every item leaves on the second output of the `If`. That output has no connection, so the `If` is the last node the sub-workflow runs.

Parent workflow. Set `workflowId` to the id of the sub-workflow:

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [0, 0],
      "id": "fe9d9564-3565-4f78-829e-2b4c2b479ac3",
      "name": "When clicking 'Execute workflow'"
    },
    {
      "parameters": {
        "jsCode": "return [{ json: { id: 55 } }, { json: { id: 56 } }, { json: { id: 57 } }];"
      },
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [220, 0],
      "id": "d036380f-1aa9-4b04-8a17-eb31f67e2f05",
      "name": "Generating some items"
    },
    {
      "parameters": {
        "workflowId": { "__rl": true, "value": "PUT_SUB_WORKFLOW_ID_HERE", "mode": "list", "cachedResultName": "test subflow" },
        "workflowInputs": {
          "mappingMode": "defineBelow",
          "value": { "id": "={{ $json.id }}" },
          "matchingColumns": [],
          "schema": [
            {
              "id": "id",
              "displayName": "id",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "canBeUsedToMatch": true,
              "type": "number",
              "removed": false
            }
          ],
          "attemptToConvertTypes": false,
          "convertFieldsToString": true
        },
        "options": {}
      },
      "type": "n8n-nodes-base.executeWorkflow",
      "typeVersion": 1.3,
      "position": [440, 0],
      "id": "230a9160-41f9-4508-b40b-2836a0590a00",
      "name": "Call 'test subflow'"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [660, 0],
      "id": "47795f64-7ebd-4815-b1e6-b0bee6310f26",
      "name": "After sub-workflow"
    }
  ],
  "connections": {
    "When clicking 'Execute workflow'": {
      "main": [[{ "node": "Generating some items", "type": "main", "index": 0 }]]
    },
    "Generating some items": {
      "main": [[{ "node": "Call 'test subflow'", "type": "main", "index": 0 }]]
    },
    "Call 'test subflow'": {
      "main": [[{ "node": "After sub-workflow", "type": "main", "index": 0 }]]
    }
  },
  "pinData": {}
}
```

Run the parent workflow.

- Before the fix: `Call 'test subflow'` shows no output and `After sub-workflow` does not run.
- After the fix: `Call 'test subflow'` returns 3 items and `After sub-workflow` runs.

To check the Workflow Tool, point an AI Agent tool at the same sub-workflow. Before the fix the tool reports `The workflow did not return a response`.

No feature flag, module, or licence is needed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5857

closes #36378

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

