### PR TITLE
feat(core): Seal the eval thread-restore workflow write (no-changelog)

### DIFF
--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -221,7 +221,6 @@ export default defineConfig(
 			'./src/services/import.service.ts',
 			'./src/modules/source-control.ee/source-control-import.service.ee.ts',
 			'./src/modules/instance-ai/instance-ai.adapter.service.ts',
-			'./src/modules/instance-ai/eval/thread-restore.service.ts',
 		],
 		rules: { 'n8n-local-rules/no-unsealed-workflow-entity-write': 'off' },
 	},

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/thread-restore.service.integration.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/thread-restore.service.integration.test.ts
@@ -1,11 +1,14 @@
 import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
 import type { Project } from '@n8n/db';
 import { SharedWorkflowRepository, WorkflowRepository } from '@n8n/db';
+import type { PolicyViolation } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
 import { mockDataTableSizeValidator } from '@/modules/data-table/__tests__/test-helpers';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
 
 import { EvalThreadRestoreService } from '../thread-restore.service';
 
@@ -37,6 +40,7 @@ describe('EvalThreadRestoreService.restoreDataTables (seed rows)', () => {
 			Container.get(WorkflowRepository),
 			Container.get(SharedWorkflowRepository),
 			dataTableService,
+			Container.get(PolicyEnforcementService),
 		);
 	});
 
@@ -115,6 +119,7 @@ describe('EvalThreadRestoreService.reseedDataTableRows', () => {
 			Container.get(WorkflowRepository),
 			Container.get(SharedWorkflowRepository),
 			dataTableService,
+			Container.get(PolicyEnforcementService),
 		);
 	});
 
@@ -157,5 +162,85 @@ describe('EvalThreadRestoreService.reseedDataTableRows', () => {
 
 		const { count } = await dataTableService.getManyRowsAndCount(tableId, project.id, {});
 		expect(count).toBe(0);
+	});
+});
+
+describe('EvalThreadRestoreService.restoreWorkflows (policy seal)', () => {
+	const DENIAL: PolicyViolation = {
+		kind: 'test-denial',
+		checkId: 'integration-test-thread-restore',
+		message: 'Denied by the test policy check',
+		subject: 'n8n-nodes-base.manualTrigger',
+		subjectType: 'nodeType',
+	};
+	/** Only the seed with this name is refused; `null` allows everything. */
+	let denyWorkflowNamed: string | null = null;
+
+	let service: EvalThreadRestoreService;
+	let workflowRepository: WorkflowRepository;
+	let project: Project;
+
+	const seed = (id: string, name: string) => ({
+		id,
+		name,
+		nodes: [
+			{
+				id: `${id}-trigger`,
+				name: 'Manual Trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [240, 300],
+				parameters: {},
+			},
+		],
+		connections: {},
+	});
+
+	beforeAll(() => {
+		workflowRepository = Container.get(WorkflowRepository);
+		// Registration is single-shot per process, so one fake backend serves every case.
+		Container.get(PolicyEnforcementService).setImplementation({
+			enforce: async (_point, context) => ({
+				violations:
+					'workflow' in context && context.workflow.name === denyWorkflowNamed ? [DENIAL] : [],
+			}),
+			evaluate: async () => ({ violations: [] }),
+			hasChecksFor: () => true,
+		});
+		service = new EvalThreadRestoreService(
+			workflowRepository,
+			Container.get(SharedWorkflowRepository),
+			Container.get(DataTableService),
+			Container.get(PolicyEnforcementService),
+		);
+	});
+
+	beforeEach(async () => {
+		denyWorkflowNamed = null;
+		await testDb.truncate(['SharedWorkflow', 'WorkflowEntity']);
+		project = await createTeamProject();
+	});
+
+	it('persists the seed workflow at its id and makes the project its owner', async () => {
+		const created = await service.restoreWorkflows([seed('wf-seeded-1', 'Allowed')], project.id);
+
+		expect(created).toEqual(['wf-seeded-1']);
+		const stored = await workflowRepository.findById('wf-seeded-1');
+		expect(stored?.nodes).toHaveLength(1);
+		expect(stored?.shared.map((s) => s.projectId)).toEqual([project.id]);
+	});
+
+	it('a refused seed fails the restore, names the workflow and leaves nothing behind', async () => {
+		denyWorkflowNamed = 'Blocked';
+
+		const restore = service.restoreWorkflows(
+			[seed('wf-seeded-ok', 'Allowed'), seed('wf-seeded-blocked', 'Blocked')],
+			project.id,
+		);
+
+		await expect(restore).rejects.toThrow(PolicyViolationError);
+		await expect(restore).rejects.toThrow('Seed workflow wf-seeded-blocked ("Blocked")');
+		await expect(restore).rejects.toMatchObject({ violations: [DENIAL] });
+		expect(await workflowRepository.findByIds(['wf-seeded-ok', 'wf-seeded-blocked'])).toEqual([]);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/thread-restore.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/thread-restore.service.test.ts
@@ -1,12 +1,16 @@
 import { ModuleRegistry } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { Project, SharedWorkflowRepository, WorkflowRepository } from '@n8n/db';
+import type { PolicyCleared, PolicyViolation } from '@n8n/decorators';
+import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { AgentsService } from '@/modules/agents/agents.service';
 import type { DataTable } from '@/modules/data-table/data-table.entity';
 import type { DataTableService } from '@/modules/data-table/data-table.service';
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
 
 import { EvalThreadRestoreService } from '../thread-restore.service';
 
@@ -26,11 +30,24 @@ describe('EvalThreadRestoreService', () => {
 	const workflowRepo = mock<WorkflowRepository>();
 	const sharedWorkflowRepo = mock<SharedWorkflowRepository>();
 	const dataTableService = mock<DataTableService>();
-	const service = new EvalThreadRestoreService(workflowRepo, sharedWorkflowRepo, dataTableService);
+	const policyEnforcementService = mock<PolicyEnforcementService>();
+	const service = new EvalThreadRestoreService(
+		workflowRepo,
+		sharedWorkflowRepo,
+		dataTableService,
+		policyEnforcementService,
+	);
+	const transactionManager = mock<EntityManager>();
+	const cleared = mock<PolicyCleared<'workflowSave'>>();
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		workflowRepo.create.mockImplementation((entity) => entity as never);
+		workflowRepo.runInTransaction.mockImplementation(
+			async (ctx, fn) => await fn(transactionManager, ctx),
+		);
+		workflowRepo.findByIds.mockResolvedValue([]);
+		policyEnforcementService.enforceWorkflowSave.mockResolvedValue(cleared);
 		sharedWorkflowRepo.getWorkflowOwningProject.mockResolvedValue(undefined);
 	});
 
@@ -40,7 +57,7 @@ describe('EvalThreadRestoreService', () => {
 			'project-1',
 		);
 
-		expect(workflowRepo.save).toHaveBeenCalledTimes(1);
+		expect(workflowRepo.createContent).toHaveBeenCalledTimes(1);
 		const saved = workflowRepo.create.mock.calls[0][0];
 		expect(saved).toMatchObject({
 			id: 'wf-original',
@@ -48,7 +65,34 @@ describe('EvalThreadRestoreService', () => {
 			active: false,
 		});
 		expect(saved.versionId).toEqual(expect.any(String));
-		expect(sharedWorkflowRepo.makeOwner).toHaveBeenCalledWith(['wf-original'], 'project-1');
+		expect(sharedWorkflowRepo.makeOwner).toHaveBeenCalledWith(
+			['wf-original'],
+			'project-1',
+			transactionManager,
+		);
+	});
+
+	it('checks the seed content against the thread project and threads the clearance into the sealed write', async () => {
+		await service.restoreWorkflows(
+			[{ id: 'wf-1', name: 'Daily digest', nodes: [makeNode()], connections: {} }],
+			'project-1',
+		);
+
+		const saved = workflowRepo.create.mock.calls[0][0];
+		expect(policyEnforcementService.enforceWorkflowSave).toHaveBeenCalledExactlyOnceWith({
+			workflow: { id: null, name: 'Daily digest', nodes: saved.nodes },
+			storedWorkflow: null,
+			projectId: 'project-1',
+		});
+		expect(workflowRepo.runInTransaction).toHaveBeenCalledExactlyOnceWith(
+			{ policyCleared: cleared },
+			expect.any(Function),
+		);
+		expect(workflowRepo.createContent).toHaveBeenCalledExactlyOnceWith(
+			saved,
+			expect.objectContaining({ policyCleared: cleared }),
+		);
+		expect(workflowRepo.save).not.toHaveBeenCalled();
 	});
 
 	it('strips pre-attached node credentials so they cannot bypass the credential pin', async () => {
@@ -69,13 +113,30 @@ describe('EvalThreadRestoreService', () => {
 
 	it('does not re-grant ownership when the workflow already exists in this project', async () => {
 		sharedWorkflowRepo.getWorkflowOwningProject.mockResolvedValue({ id: 'project-1' } as Project);
+		const storedNodes = [makeNode({ id: 'old-node', name: 'Old' })];
+		workflowRepo.findByIds.mockResolvedValue([
+			{ id: 'wf-1', name: 'Old name', nodes: storedNodes },
+		] as never);
 
 		const created = await service.restoreWorkflows(
 			[{ id: 'wf-1', name: 'wf', nodes: [makeNode()], connections: {} }],
 			'project-1',
 		);
 
-		expect(workflowRepo.save).toHaveBeenCalledTimes(1);
+		expect(workflowRepo.findByIds).toHaveBeenCalledWith(['wf-1'], {
+			fields: ['id', 'name', 'nodes'],
+		});
+		expect(policyEnforcementService.enforceWorkflowSave).toHaveBeenCalledExactlyOnceWith({
+			workflow: { id: 'wf-1', name: 'wf', nodes: expect.any(Array) },
+			storedWorkflow: { id: 'wf-1', name: 'Old name', nodes: storedNodes },
+			projectId: 'project-1',
+		});
+		expect(workflowRepo.updateContent).toHaveBeenCalledExactlyOnceWith(
+			'wf-1',
+			expect.objectContaining({ name: 'wf', active: false, versionId: expect.any(String) }),
+			expect.objectContaining({ policyCleared: cleared }),
+		);
+		expect(workflowRepo.createContent).not.toHaveBeenCalled();
 		expect(sharedWorkflowRepo.makeOwner).not.toHaveBeenCalled();
 		expect(created).toEqual([]); // not newly created
 	});
@@ -91,7 +152,8 @@ describe('EvalThreadRestoreService', () => {
 				'project-1',
 			),
 		).rejects.toThrow(BadRequestError);
-		expect(workflowRepo.save).not.toHaveBeenCalled();
+		expect(policyEnforcementService.enforceWorkflowSave).not.toHaveBeenCalled();
+		expect(workflowRepo.createContent).not.toHaveBeenCalled();
 	});
 
 	it('rejects a structurally invalid node without writing anything', async () => {
@@ -101,7 +163,56 @@ describe('EvalThreadRestoreService', () => {
 				'project-1',
 			),
 		).rejects.toThrow(BadRequestError);
-		expect(workflowRepo.save).not.toHaveBeenCalled();
+		expect(policyEnforcementService.enforceWorkflowSave).not.toHaveBeenCalled();
+		expect(workflowRepo.createContent).not.toHaveBeenCalled();
+	});
+
+	describe('policy refusal', () => {
+		const violation: PolicyViolation = {
+			kind: 'test-denial',
+			checkId: 'test-check',
+			message: 'Denied by the test policy check',
+			subject: 'n8n-nodes-base.slack',
+			subjectType: 'nodeType',
+		};
+
+		it('fails the restore, names the refused seed and rolls back the workflows already created', async () => {
+			policyEnforcementService.enforceWorkflowSave
+				.mockResolvedValueOnce(cleared)
+				.mockRejectedValueOnce(new PolicyViolationError([violation]));
+
+			const restore = service.restoreWorkflows(
+				[
+					{ id: 'wf-ok', name: 'Allowed', nodes: [makeNode()], connections: {} },
+					{ id: 'wf-blocked', name: 'Blocked', nodes: [makeNode()], connections: {} },
+				],
+				'project-1',
+			);
+
+			await expect(restore).rejects.toThrow(PolicyViolationError);
+			await expect(restore).rejects.toThrow(
+				'Seed workflow wf-blocked ("Blocked") was refused by policy: Denied by the test policy check',
+			);
+			await expect(restore).rejects.toMatchObject({
+				httpStatusCode: 403,
+				violations: [violation],
+			});
+			expect(workflowRepo.createContent).toHaveBeenCalledTimes(1);
+			expect(workflowRepo.delete).toHaveBeenCalledExactlyOnceWith({ id: 'wf-ok' });
+		});
+
+		it('passes a check that breaks through unchanged', async () => {
+			const failure = new Error('check crashed');
+			policyEnforcementService.enforceWorkflowSave.mockRejectedValue(failure);
+
+			await expect(
+				service.restoreWorkflows(
+					[{ id: 'wf-1', name: 'wf', nodes: [makeNode()], connections: {} }],
+					'project-1',
+				),
+			).rejects.toBe(failure);
+			expect(workflowRepo.createContent).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('data tables', () => {

--- a/packages/cli/src/modules/instance-ai/eval/thread-restore.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/thread-restore.service.ts
@@ -5,7 +5,8 @@ import {
 	type InstanceAiEvalSeedWorkflow,
 } from '@n8n/api-types';
 import { ModuleRegistry } from '@n8n/backend-common';
-import { SharedWorkflowRepository, WorkflowRepository } from '@n8n/db';
+import { SharedWorkflowRepository, WorkflowRepository, type WorkflowEntity } from '@n8n/db';
+import type { PolicedWorkflow, PolicyCleared } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import { jsonParse, type IConnections, type INode } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
@@ -13,6 +14,8 @@ import { randomUUID } from 'node:crypto';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { AgentsService } from '@/modules/agents/agents.service';
 import { DataTableService } from '@/modules/data-table/data-table.service';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { hasViolations, PolicyViolationError } from '@/policy/policy-violation.error';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -61,6 +64,7 @@ export class EvalThreadRestoreService {
 		private readonly workflowRepo: WorkflowRepository,
 		private readonly sharedWorkflowRepo: SharedWorkflowRepository,
 		private readonly dataTableService: DataTableService,
+		private readonly policyEnforcementService: PolicyEnforcementService,
 	) {}
 
 	/**
@@ -297,20 +301,67 @@ export class EvalThreadRestoreService {
 			);
 		}
 
-		await this.workflowRepo.save(
-			this.workflowRepo.create({
-				id: workflow.id,
-				name: workflow.name,
-				nodes,
-				connections,
-				active: false,
-				versionId: randomUUID(),
-			}),
-		);
-		if (!owningProject) {
-			await this.sharedWorkflowRepo.makeOwner([workflow.id], projectId);
-			return true;
+		// A seed re-applied to its own project updates that row, so the check must
+		// see the stored content and the write must go through the id-bound seal.
+		const stored = owningProject ? await this.findStoredWorkflow(workflow.id) : null;
+
+		const entity = this.workflowRepo.create({
+			id: workflow.id,
+			name: workflow.name,
+			nodes,
+			connections,
+			active: false,
+			versionId: randomUUID(),
+		});
+		const cleared = await this.enforceSeedWorkflowSave(workflow, entity, stored, projectId);
+
+		await this.workflowRepo.runInTransaction({ policyCleared: cleared }, async (em, ctx) => {
+			if (stored) {
+				const { name, nodes, connections, active, versionId } = entity;
+				await this.workflowRepo.updateContent(
+					workflow.id,
+					{ name, nodes, connections, active, versionId },
+					ctx,
+				);
+				return;
+			}
+			await this.workflowRepo.createContent(entity, ctx);
+			await this.sharedWorkflowRepo.makeOwner([workflow.id], projectId, em);
+		});
+		return stored === null;
+	}
+
+	private async findStoredWorkflow(id: string): Promise<PolicedWorkflow | null> {
+		const [stored] = await this.workflowRepo.findByIds([id], { fields: ['id', 'name', 'nodes'] });
+		return stored ? { id: stored.id, name: stored.name, nodes: stored.nodes } : null;
+	}
+
+	/**
+	 * The caller holds `instanceAi:eval`, but the nodes come from an exported
+	 * conversation, so they are policed like any authored save into the thread's
+	 * project. A refusal is rethrown naming the seed, so a multi-workflow restore
+	 * says which one policy blocked.
+	 */
+	private async enforceSeedWorkflowSave(
+		seed: InstanceAiEvalSeedWorkflow,
+		entity: WorkflowEntity,
+		stored: PolicedWorkflow | null,
+		projectId: string,
+	): Promise<PolicyCleared<'workflowSave'>> {
+		try {
+			return await this.policyEnforcementService.enforceWorkflowSave({
+				workflow: { id: stored?.id ?? null, name: entity.name, nodes: entity.nodes },
+				storedWorkflow: stored,
+				projectId,
+			});
+		} catch (error) {
+			if (error instanceof PolicyViolationError && hasViolations(error.violations)) {
+				throw new PolicyViolationError(
+					error.violations,
+					`Seed workflow ${seed.id} ("${seed.name}") was refused by policy: ${error.message}`,
+				);
+			}
+			throw error;
 		}
-		return false;
 	}
 }


### PR DESCRIPTION
## Summary

`EvalThreadRestoreService.createWorkflowPinnedToId` wrote seed workflow nodes with a raw `workflowRepo.save`, outside the `workflowSave` seal. The nodes come from the request body of `POST /rest/instance-ai/eval/restore-thread`, so this is a node-content write that policy must govern.

This PR routes the write through the token-gated repository methods:

- Mint a `workflowSave` clearance for each seed workflow against the thread's project. The caller holds `instanceAi:eval`, but the content comes from an exported conversation, so it is policed like any authored save.
- Write the workflow row and its owner row in one `runInTransaction`. A new id goes through `createContent` with a content-bound clearance. A seed re-applied to its own project is an update, so it carries the stored workflow and goes through `updateContent`.
- Rethrow a policy refusal as a `PolicyViolationError` that names the seed. The 403 status and the violations survive, and the refusal happens before any write, so the existing rollback in `restoreWorkflows` and the controller removes the workflows, agents and data tables already created.
- Remove the file from the `no-unsealed-workflow-entity-write` allowlist in `packages/cli/eslint.config.mjs`.

Tests: the unit suite covers the clearance threading, the same-project update path, the named refusal with rollback, and a check that breaks. A new integration case registers a fake policy backend and proves on a real database that a refused seed leaves no workflow behind.

## How to test

1. Run `pnpm vitest run src/modules/instance-ai/eval/__tests__/thread-restore.service.test.ts` in `packages/cli`.
2. Run `pnpm vitest run --config vitest.config.integration.ts src/modules/instance-ai/eval/__tests__/thread-restore.service.integration.test.ts` in `packages/cli`.
3. Run `pnpm exec eslint src/modules/instance-ai/eval/thread-restore.service.ts` in `packages/cli`. Replace `createContent(entity, ctx)` with `save(entity)` and run it again. The ratchet must report the write.
4. Live: enable instance AI and the `policy-infrastructure` module, register a check that denies a node type, and call `POST /rest/instance-ai/eval/restore-thread` with a seed workflow that uses it. The response is a 403 whose message names the seed workflow, and no workflow row remains.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1330

Found by Ruben Castro in review of #37442.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

