### PR TITLE
fix(core): List the valid techniques when get_workflow_best_practices rejects input

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts
@@ -48,6 +48,37 @@ describe('get-workflow-best-practices MCP tool', () => {
 		expect(tool.config.inputSchema?.technique).toBeDefined();
 	});
 
+	describe('technique input schema', () => {
+		const techniqueSchema = () => createTool().config.inputSchema!.technique;
+
+		test('accepts every technique key and the list sentinel', () => {
+			const schema = techniqueSchema();
+
+			for (const value of ['list', ...Object.values(WorkflowTechnique)]) {
+				expect(schema.safeParse(value).success).toBe(true);
+			}
+		});
+
+		test('names the accepted values when the technique is unknown', () => {
+			const result = techniqueSchema().safeParse('webhook');
+
+			expect(result.success).toBe(false);
+			const message = result.error?.issues[0]?.message ?? '';
+			expect(message).not.toBe('Invalid input');
+			expect(message).toContain('list');
+			expect(message).toContain(WorkflowTechnique.CHATBOT);
+			expect(message).toContain(WorkflowTechnique.WEB_APP);
+		});
+
+		test('lists the accepted values in the parameter description', () => {
+			const description = techniqueSchema().description ?? '';
+
+			for (const value of ['list', ...Object.values(WorkflowTechnique)]) {
+				expect(description).toContain(value);
+			}
+		});
+	});
+
 	test('returns the full technique catalog when technique="list"', async () => {
 		const tool = createTool();
 		const result = await tool.handler({ technique: 'list' }, {} as never);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
@@ -16,9 +16,6 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.ty
 
 const LIST_SENTINEL = 'list';
 
-// One flat enum instead of a union of enum + literal: a failed union reports only
-// "Invalid input", but a failed enum reports the accepted values, so a caller that
-// passes a wrong technique can correct itself.
 const TECHNIQUE_CHOICES = [LIST_SENTINEL, ...Object.values(WorkflowTechnique)] as const;
 
 const inputSchema = {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
@@ -16,11 +16,16 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.ty
 
 const LIST_SENTINEL = 'list';
 
+// One flat enum instead of a union of enum + literal: a failed union reports only
+// "Invalid input", but a failed enum reports the accepted values, so a caller that
+// passes a wrong technique can correct itself.
+const TECHNIQUE_CHOICES = [LIST_SENTINEL, ...Object.values(WorkflowTechnique)] as const;
+
 const inputSchema = {
 	technique: z
-		.union([z.nativeEnum(WorkflowTechnique), z.literal(LIST_SENTINEL)])
+		.enum(TECHNIQUE_CHOICES)
 		.describe(
-			`Workflow technique key (e.g. "chatbot", "scheduling", "triage") to fetch best-practices guidance for. Pass "${LIST_SENTINEL}" to discover all available techniques.`,
+			`Workflow technique key to fetch best-practices guidance for. Pass "${LIST_SENTINEL}" to discover all available techniques. One of: ${TECHNIQUE_CHOICES.join(', ')}.`,
 		),
 } satisfies z.ZodRawShape;
 


### PR DESCRIPTION
## Summary

The `technique` parameter of the `get_workflow_best_practices` MCP tool was a union of the technique enum and the `"list"` literal. When a union fails, Zod reports only `Invalid input`. An agent that passed a wrong key, for example `technique: "webhook"`, got no list of accepted values and could not correct itself.

This PR replaces the union with one flat enum that contains the 17 techniques and `"list"`. A failed enum names the accepted values:

```
Invalid enum value. Expected 'list' | 'scheduling' | 'chatbot' | ... , received 'webhook'
```

The published input JSON Schema also becomes a flat `{"type": "string", "enum": [...]}` instead of an `anyOf`, so clients can validate and autocomplete the parameter. The parameter description now lists every accepted value, because it named only three before.

## How to test

The MCP server needs the `mcp` module. Start n8n with `N8N_ENABLED_MODULES=mcp`, enable MCP access in **Settings > MCP Access**, then connect an MCP client to `/mcp-server/http`.

1. Call `get_workflow_best_practices` with `technique: "webhook"`. The error must name the accepted values instead of `Invalid input`.
2. Call it with `technique: "list"`. The full technique catalog must come back.
3. Call it with `technique: "chatbot"`. The chatbot guide must come back.
4. Read the tool schema. The `technique` property must be a flat `enum`, not an `anyOf`.

Unit tests:

```bash
cd packages/cli
pnpm test src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5855

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

