### PR TITLE
ci: Run the backport workflow on a runner with a fixed git version (no-changelog)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,7 +24,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.action == 'closed' && github.event.pull_request.merged == true) ||
       (github.event.action == 'labeled' && github.event.pull_request.merged == true && startsWith(github.event.label.name, 'Backport to'))
-    runs-on: ubuntu-slim
+    # ubuntu-slim still ships git 2.54.0, whose shallow-fetch regression makes
+    # the backport action's `git fetch --depth=1` die on a target branch that
+    # exists. ubuntu-latest is on 2.55.0, which has the fix.
+    runs-on: ubuntu-latest
     outputs:
       created_pull_numbers: ${{ steps.backport.outputs.created_pull_numbers }}
     steps:


### PR DESCRIPTION
## Summary

`ubuntu-slim` ships git 2.54.0, whose shallow-fetch regression makes the backport action's `git fetch --depth=1` die on a target branch that exists — and since the action maps every git exit code 128 to `GitRefNotFoundError`, it reports the real error as `couldn't find remote ref`, comments that on the source PR, and lets the workflow finish green.

Moving the job to `ubuntu-latest` puts it on git 2.55.0, which contains the upstream fix.

## How to test

PR #37586 reproduces it. Its backport to `release-candidate/2.38.x` was dropped twice — once on merge ([run 33594046777](https://github.com/n8n-io/n8n/actions/runs/33594046777)) and once on a manual re-dispatch ([run 33594451687](https://github.com/n8n-io/n8n/actions/runs/33594451687)) — while `release-candidate/2.37.x` went through both times. Both runs are green. The `Backport` step log shows the real cause:

```
[command]/usr/bin/git fetch --depth=1 origin release-candidate/2.38.x
fatal: shallow file has changed since we read it
Backport failed for `release-candidate/2.38.x`: couldn't find remote ref `release-candidate/2.38.x`.
```

After this merges, dispatch `Util: Backport pull request changes` with `pull-request-id: 37586` to recover the missing 2.38.x backport. `workflow_dispatch` runs the default-branch copy of the workflow, so it has to land first.

Git version for each runner label, sampled from recent run logs:

| `runs-on` | git |
| --- | --- |
| `ubuntu-latest` | 2.55.0 |
| `ubuntu-slim` | 2.54.0 |
| `blacksmith-*-ubuntu-2204` | 2.52.0 |

Note that `fetch-depth: 0` is not an alternative fix here: a `--depth=1` fetch re-shallows a complete clone, so the action re-enters the same code path regardless of how the repo was checked out.

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket. There is no article about this regression — the primary sources are:

- [python/cpython#151365](https://github.com/python/cpython/issues/151365) — the same failure in CPython's CI, with the full arc: diagnosis, a temporary git downgrade, then a revert once the runner images shipped 2.55.0
- [Original report on the git mailing list](https://www.spinics.net/lists/git/msg524711.html)
- [git commit 2431f5e](https://github.com/git/git/commit/2431f5e0e5cd415a3ab1bddb435b692536cc95e8) — `shallow: fix relative deepen on non-shallow repositories`, the only shallow-related commit between `v2.54.0` and `v2.55.0`

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

