### PR TITLE
ci: Pin sandbox service test images (no-changelog)

### DIFF
--- a/packages/testing/containers/test-containers.ts
+++ b/packages/testing/containers/test-containers.ts
@@ -45,9 +45,11 @@ const DEFAULT_IMAGES = {
 	localstack: 'localstack/localstack:4.13.1',
 	postgresExporter: 'prometheuscommunity/postgres-exporter:v0.17.1',
 	cadvisor: 'gcr.io/cadvisor/cadvisor:v0.49.1',
-	sandboxApi: 'n8nio/n8n-sandbox-service-api:latest',
-	sandboxRunner: 'n8nio/n8n-sandbox-service-runner-dind:latest',
-	sandboxSandbox: 'n8nio/n8n-sandbox-service-sandbox:latest',
+	// Pinned: from 1.3.0 the runner rejects a non-https SANDBOX_RUNNER_HTTP_BASE_URL,
+	// which the local stack in services/sandbox.ts still sets.
+	sandboxApi: 'n8nio/n8n-sandbox-service-api:1.2.0',
+	sandboxRunner: 'n8nio/n8n-sandbox-service-runner-dind:1.2.0',
+	sandboxSandbox: 'n8nio/n8n-sandbox-service-sandbox:1.1.0',
 } as const;
 
 /** Convert camelCase to SCREAMING_SNAKE_CASE for env var names */


### PR DESCRIPTION
## Summary

The three sandbox service images used by the local test stack tracked `:latest`. Version 1.3.0 of those images was pushed on 2026-09-01 and made the runner require an https `SANDBOX_RUNNER_HTTP_BASE_URL`. `packages/testing/containers/services/sandbox.ts` still sets `http://sandbox-runner-1:8080`, so the runner exits at config load:

```
level=ERROR msg="failed to load config"
error="SANDBOX_RUNNER_HTTP_BASE_URL must be an https:// URL with a host, got \"http://sandbox-runner-1:8080\""
```

The service then never starts:

```
Error: Service "Sandbox service (API + runner)" (sandbox) failed to start:
  (HTTP code 409) container ... is not running
```

This PR pins the three images to the last set that works with the local stack (api 1.2.0, runner 1.2.0, sandbox 1.1.0 — the 2026-08-10 batch). Every other image in `DEFAULT_IMAGES` is already pinned to an explicit version.

## Impact

On `master` the local stack is only a fallback: #37297 made CI use the hosted sandbox service when the secrets are set, so the breakage is invisible here but hits fork PRs and any hosted outage.

On `release-candidate/2.38.x`, which does not have #37297, the local stack is the only path. It turns every `tests/e2e/instance-ai/**` `@capability:proxy` spec red and fails the Instance AI Workflow Evals job. The repeated failed stack starts also leak Docker networks until the daemon reports `all predefined address pools have been fully subnetted`, which takes unrelated specs in the same shard down with them. See #37593.

This needs a backport to `release-candidate/2.38.x`.

## Follow-up

The pin is deliberate, not a version freeze to forget about. Making the local stack work with 1.3.0 means giving the runner HTTP listener a certificate and an https base URL — the mTLS work in https://linear.app/n8n/issue/CP-2674. That is a larger change than a release branch should take right now.

## Review / Merge checklist

- [x] PR title conforms to the conventions
- [ ] Tests included (CI itself is the test here)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

