### PR TITLE
ci: Serve the local sandbox runner over TLS (no-changelog)

### DIFF
--- a/packages/testing/containers/services/sandbox.ts
+++ b/packages/testing/containers/services/sandbox.ts
@@ -258,7 +258,7 @@ export const sandbox: Service<SandboxResult> = {
 					SANDBOX_RUNNER_API_KEYS: RUNNER_API_KEY,
 					SANDBOX_RUNNER_REGISTRATION_TOKEN: REGISTRATION_TOKEN,
 					SANDBOX_RUNNER_API_GRPC_ADDR: `${API_HOSTNAME}:${API_GRPC_PORT}`,
-					SANDBOX_RUNNER_HTTP_BASE_URL: `http://${RUNNER_HOSTNAME}:${API_HTTP_PORT}`,
+					SANDBOX_RUNNER_HTTP_BASE_URL: `https://${RUNNER_HOSTNAME}:${API_HTTP_PORT}`,
 					SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR: ':9091',
 					SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR: `${RUNNER_HOSTNAME}:9091`,
 					SANDBOX_RUNNER_ID: 'ci-runner-1',
@@ -274,8 +274,11 @@ export const sandbox: Service<SandboxResult> = {
 				})
 				.withExposedPorts(API_HTTP_PORT)
 				.withWaitStrategy(
+					// `/healthz` is the one route exempt from the client-certificate check.
+					// BusyBox wget cannot be given a CA file, so the probe skips verification:
+					// it answers "is the listener up", and the mTLS path is what the API uses.
 					Wait.forSuccessfulCommand(
-						`wget -q -O /dev/null --header='X-Api-Key: ${RUNNER_API_KEY}' http://localhost:${API_HTTP_PORT}/healthz`,
+						`wget -q -O /dev/null --no-check-certificate https://localhost:${API_HTTP_PORT}/healthz`,
 					).withStartupTimeout(120_000),
 				)
 				.withLogConsumer(runnerConsumer)

--- a/packages/testing/containers/test-containers.ts
+++ b/packages/testing/containers/test-containers.ts
@@ -45,11 +45,9 @@ const DEFAULT_IMAGES = {
 	localstack: 'localstack/localstack:4.13.1',
 	postgresExporter: 'prometheuscommunity/postgres-exporter:v0.17.1',
 	cadvisor: 'gcr.io/cadvisor/cadvisor:v0.49.1',
-	// Pinned: from 1.3.0 the runner rejects a non-https SANDBOX_RUNNER_HTTP_BASE_URL,
-	// which the local stack in services/sandbox.ts still sets.
-	sandboxApi: 'n8nio/n8n-sandbox-service-api:1.2.0',
-	sandboxRunner: 'n8nio/n8n-sandbox-service-runner-dind:1.2.0',
-	sandboxSandbox: 'n8nio/n8n-sandbox-service-sandbox:1.1.0',
+	sandboxApi: 'n8nio/n8n-sandbox-service-api:1.3.0',
+	sandboxRunner: 'n8nio/n8n-sandbox-service-runner-dind:1.3.0',
+	sandboxSandbox: 'n8nio/n8n-sandbox-service-sandbox:1.3.0',
 } as const;
 
 /** Convert camelCase to SCREAMING_SNAKE_CASE for env var names */


### PR DESCRIPTION
## Summary

#37596 pinned the sandbox service test images to 1.2.0 to get CI back. This is the actual fix, and it moves the pins to 1.3.0.

From 1.3.0 ([CP-2674](https://linear.app/n8n/issue/CP-2674), upstream n8n-io/n8n-sandbox-service#135) the runner serves its HTTP listener — the one that carries exec and file traffic — over TLS, and requires a verified client certificate on every route except health and metrics. `SANDBOX_RUNNER_HTTP_BASE_URL` must be `https://`, validated at boot, which is why the runner container was exiting at config load.

The change is small because the upstream design deliberately avoided new PKI: the runner reuses its control gRPC certificate, key and client CA for the listener, and the API presents its existing control client certificate. Our local stack already mounts and configures all of that. So:

- `SANDBOX_RUNNER_HTTP_BASE_URL` gets the `https` scheme.
- The readiness probe moves to https. BusyBox `wget` accepts no CA file (`--ca-certificate` is not a supported option), so the probe skips verification — it establishes that the listener is up, and the mTLS path is the one the API exercises.
- Images move to 1.3.0.

No new environment variables. Confirmed by diffing the 1.3.0 runner binary's `SANDBOX_RUNNER_*` symbols against what `services/sandbox.ts` already sets.

## Verification

Ran the stack locally against 1.3.0 (`pnpm --filter n8n-containers services --services sandbox`). Stack ready in 10.75s, then, through the API:

- `POST /sandboxes` → sandbox created, placed on the runner.
- `POST /sandboxes/{id}/executions` with `echo mtls-round-trip-ok` → `started` / `stdout: mtls-round-trip-ok` / `exit 0, success: true`. This is exec traffic over the listener that now requires mTLS.
- `DELETE /sandboxes/{id}` → 204.

And the listener behaves as CP-2674 specifies, probed from inside the runner with no client certificate:

| Request | Result |
| --- | --- |
| `https://localhost:8080/healthz` | `200 OK` — exempt, as intended |
| `https://localhost:8080/sandboxes` | `401 Unauthorized` — client cert required |
| `http://localhost:8080/healthz` | `400 Bad Request` — listener is TLS-only |

`pnpm --filter n8n-containers lint` and `tsc --noEmit` are clean.

## Notes for the reviewer

The images stay pinned rather than going back to `:latest`. Tracking `:latest` is what turned an upstream release into red CI on the release branches; every other entry in `DEFAULT_IMAGES` carries an explicit version.

CI on this PR does not exercise any of the above: master E2E uses the hosted sandbox service when the secrets are set (#37297), so the local stack it fixes is only reached on fork PRs and during a hosted outage. The local run described above is the evidence.

This does not need a backport. The release branches only need #37596 — 1.2.0 works there.

## Review / Merge checklist

- [x] PR title conforms to the conventions
- [x] Verified locally end to end (see above)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

