### PR TITLE
ci: Pin sandbox service API and runner images to 1.2.0 (no-changelog)

### DIFF
--- a/docker/get-n8n-compose.yml
+++ b/docker/get-n8n-compose.yml
@@ -10,7 +10,8 @@ volumes:
 
 services:
   sandbox-certs:
-    image: ghcr.io/n8n-io/n8n-sandbox-service-api:latest
+    # Pinned: 1.3.0 rejects a non-https SANDBOX_RUNNER_HTTP_BASE_URL, which this stack uses.
+    image: ghcr.io/n8n-io/n8n-sandbox-service-api:1.2.0
     user: '0:0'
     entrypoint: ['sh', '-c']
     command:
@@ -24,7 +25,7 @@ services:
       - sandbox-tls:/tls
 
   sandbox-api:
-    image: ghcr.io/n8n-io/n8n-sandbox-service-api:latest
+    image: ghcr.io/n8n-io/n8n-sandbox-service-api:1.2.0
     depends_on:
       sandbox-certs:
         condition: service_completed_successfully
@@ -49,7 +50,7 @@ services:
     # n8n reaches this container by service name, over the default Compose network.
 
   sandbox-runner-1:
-    image: ghcr.io/n8n-io/n8n-sandbox-service-runner-dind:latest
+    image: ghcr.io/n8n-io/n8n-sandbox-service-runner-dind:1.2.0
     privileged: true
     depends_on:
       sandbox-api:

--- a/docker/get-n8n-compose.yml
+++ b/docker/get-n8n-compose.yml
@@ -10,7 +10,6 @@ volumes:
 
 services:
   sandbox-certs:
-    # Pinned: 1.3.0 rejects a non-https SANDBOX_RUNNER_HTTP_BASE_URL, which this stack uses.
     image: ghcr.io/n8n-io/n8n-sandbox-service-api:1.2.0
     user: '0:0'
     entrypoint: ['sh', '-c']


### PR DESCRIPTION
## Summary

The getting-started stack (`docker/get-n8n-compose.yml`, used by `get-n8n.sh`) pins the sandbox service API and runner images to `1.2.0`. It previously used `:latest`.

Version `1.3.0` of the runner rejects a non-https `SANDBOX_RUNNER_HTTP_BASE_URL`. This stack sets a plain `http://` URL for the runner. Pinning to `1.2.0` keeps the getting-started install working.

## How to test

1. Run `docker/get-n8n.sh` in a fresh directory.
2. Check that the sandbox stack starts and reaches a healthy state.
3. Confirm `docker compose config` (or `ps`) shows the `sandbox-api`, `sandbox-certs`, and `sandbox-runner-1` services on the `1.2.0` tag.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

