### PR TITLE
feat(core): Make the encryption write path pluggable and move the rotation decision into the module

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -330,6 +330,14 @@ export type FrontendModuleSettings = {
 	};
 
 	/**
+	 * Client settings for the encryption-key-manager module.
+	 */
+	'encryption-key-manager'?: {
+		/** Whether encryption-key rotation (and its management UI) is enabled. */
+		rotationEnabled: boolean;
+	};
+
+	/**
 	 * Client settings for Chat module.
 	 */
 	'chat-hub'?: {

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-bootstrap.service.integration.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-bootstrap.service.integration.test.ts
@@ -90,4 +90,38 @@ describe('EncryptionBootstrapService (integration)', () => {
 		});
 		expect(rows).toHaveLength(1);
 	});
+
+	describe('end-to-end write path (real key store, real cipher)', () => {
+		beforeEach(() => {
+			delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+		});
+
+		it('writes the legacy no-prefix format while rotation is off', async () => {
+			await Container.get(EncryptionBootstrapService).run();
+			const cipher = Container.get(Cipher);
+
+			const encrypted = await cipher.encryptV2('e2e-off');
+
+			expect(encrypted.includes(':')).toBe(false);
+			expect(cipher.decryptWithInstanceKey(encrypted)).toBe('e2e-off');
+			expect(await cipher.decryptV2(encrypted)).toBe('e2e-off');
+		});
+
+		it('writes the keyId-prefixed GCM format while rotation is on, round-tripping through the seeded key', async () => {
+			await Container.get(EncryptionBootstrapService).run();
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
+			try {
+				const cipher = Container.get(Cipher);
+
+				const encrypted = await cipher.encryptV2('e2e-on');
+
+				const active =
+					await Container.get(DeploymentKeyRepository).findActiveByType('data_encryption');
+				expect(encrypted.startsWith(`${active!.id}:`)).toBe(true);
+				expect(await cipher.decryptV2(encrypted)).toBe('e2e-on');
+			} finally {
+				delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+			}
+		});
+	});
 });

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key-manager.module.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key-manager.module.test.ts
@@ -1,0 +1,41 @@
+import type { FrontendModuleSettings } from '@n8n/api-types';
+import { ModuleMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+import { EncryptionKeyManagerModule } from '@/modules/encryption-key-manager/encryption-key-manager.module';
+
+// Compile-time pin: the settings this module returns are read by the frontend
+// under this exact key, so the decorator name must stay a member of
+// `FrontendModuleSettings`.
+const MODULE_NAME = 'encryption-key-manager' satisfies keyof FrontendModuleSettings;
+
+describe('EncryptionKeyManagerModule', () => {
+	beforeEach(() => {
+		// Must not depend on the ambient environment of the developer machine.
+		delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+	});
+
+	afterEach(() => {
+		delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+	});
+
+	describe('settings()', () => {
+		it('reports rotation as disabled by default', async () => {
+			const settings = await new EncryptionKeyManagerModule().settings();
+
+			expect(settings).toEqual({ rotationEnabled: false });
+		});
+
+		it('reports rotation as enabled when the flag is set', async () => {
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
+
+			const settings = await new EncryptionKeyManagerModule().settings();
+
+			expect(settings).toEqual({ rotationEnabled: true });
+		});
+	});
+
+	it('is registered under the module-settings key the frontend reads', () => {
+		expect(Container.get(ModuleMetadata).get(MODULE_NAME)?.class).toBe(EncryptionKeyManagerModule);
+	});
+});

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/key-manager.service.test.ts
@@ -38,21 +38,36 @@ const makeFreshService = () => {
 describe('KeyManagerService', () => {
 	const repository = mockInstance(DeploymentKeyRepository);
 	const cipher = mockInstance(Cipher);
-	mockInstance(InstanceSettings, { encryptionKey: 'test_key' });
+	const instanceSettings = mockInstance(InstanceSettings, {
+		encryptionKey: 'test-instance-key',
+	});
 	mockInstance(Logger);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	describe('getActiveKey()', () => {
-		it('returns KeyInfo when one active key exists', async () => {
+	describe('getActiveKey() with rotation enabled', () => {
+		beforeEach(() => {
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
+		});
+
+		afterEach(() => {
+			delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+		});
+
+		it('returns the active key as a prefixed descriptor', async () => {
 			const key = makeKey();
 			repository.find.mockResolvedValue([key]);
 
 			const result = await Container.get(KeyManagerService).getActiveKey();
 
-			expect(result).toEqual({ id: key.id, value: key.value, algorithm: key.algorithm });
+			expect(result).toEqual({
+				id: key.id,
+				value: key.value,
+				algorithm: key.algorithm,
+				format: 'prefixed',
+			});
 		});
 
 		it('throws NotFoundError when no active key exists', async () => {
@@ -70,6 +85,43 @@ describe('KeyManagerService', () => {
 		});
 	});
 
+	describe('getActiveKey() with rotation disabled', () => {
+		beforeEach(() => {
+			// The disabled path must not depend on the ambient environment.
+			delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+		});
+
+		// Fresh instances: the legacy descriptor is memoized per service instance.
+		const createService = () =>
+			new KeyManagerService(repository, cipher, instanceSettings, mock<Logger>());
+
+		it('returns the legacy no-prefix descriptor without touching the database', async () => {
+			cipher.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
+
+			const result = await createService().getActiveKey();
+
+			expect(result).toEqual({
+				id: 'instance-key',
+				value: 'wrapped-instance-key',
+				algorithm: 'aes-256-cbc',
+				format: 'no-prefix',
+			});
+			expect(cipher.encryptDEKWithInstanceKey).toHaveBeenCalledWith('test-instance-key');
+			expect(repository.find).not.toHaveBeenCalled();
+		});
+
+		it('memoizes the legacy descriptor', async () => {
+			cipher.encryptDEKWithInstanceKey.mockReturnValue('wrapped-instance-key');
+			const service = createService();
+
+			const first = await service.getActiveKey();
+			const second = await service.getActiveKey();
+
+			expect(second).toBe(first);
+			expect(cipher.encryptDEKWithInstanceKey).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	describe('getKeyById()', () => {
 		it('returns KeyInfo when key exists', async () => {
 			const key = makeKey();
@@ -77,7 +129,12 @@ describe('KeyManagerService', () => {
 
 			const result = await Container.get(KeyManagerService).getKeyById('key-1');
 
-			expect(result).toEqual({ id: key.id, value: key.value, algorithm: key.algorithm });
+			expect(result).toEqual({
+				id: key.id,
+				value: key.value,
+				algorithm: key.algorithm,
+				format: 'prefixed',
+			});
 			expect(repository.findOne).toHaveBeenCalledWith({ where: { id: 'key-1' } });
 		});
 
@@ -97,7 +154,12 @@ describe('KeyManagerService', () => {
 
 			const result = await Container.get(KeyManagerService).getLegacyKey();
 
-			expect(result).toEqual({ id: key.id, value: key.value, algorithm: 'aes-256-cbc' });
+			expect(result).toEqual({
+				id: key.id,
+				value: key.value,
+				algorithm: 'aes-256-cbc',
+				format: 'no-prefix',
+			});
 			expect(repository.findOne).toHaveBeenCalledWith({
 				where: { type: 'data_encryption', algorithm: 'aes-256-cbc' },
 			});
@@ -144,6 +206,7 @@ describe('KeyManagerService', () => {
 				id: 'instance-key',
 				value: 'wrapped-instance-key',
 				algorithm: 'aes-256-cbc',
+				format: 'no-prefix',
 			});
 			expect(second).toBe(first);
 		});

--- a/packages/cli/src/modules/encryption-key-manager/encryption-bootstrap.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-bootstrap.service.ts
@@ -19,8 +19,10 @@ export class EncryptionBootstrapService {
 
 	async run(): Promise<void> {
 		// Seeding is deployment-wide state: only a main that is allowed to seed
-		// creates it. One-off CLI commands (`canSeedDeploymentState` false) and
-		// workers/webhooks skip seeding but still get the read-path provider.
+		// creates it. Workers and webhooks skip seeding but still get the
+		// read-path provider. One-off CLI commands never run module init, so
+		// they get neither — keyId-prefixed data is not readable there until
+		// the provider is wired for commands too.
 		if (this.instanceSettings.instanceType === 'main' && this.canSeed) {
 			try {
 				await this.keyManager.bootstrapLegacyCbcKey(this.instanceSettings.encryptionKey);

--- a/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
@@ -21,4 +21,10 @@ export class EncryptionKeyManagerModule implements ModuleInterface {
 		const { EncryptionBootstrapService } = await import('./encryption-bootstrap.service.js');
 		await Container.get(EncryptionBootstrapService).run();
 	}
+
+	/** Settings exposed to the frontend under `/rest/module-settings`. */
+	async settings() {
+		const { isKeyRotationEnabled } = await import('./key-rotation-flag.js');
+		return { rotationEnabled: isKeyRotationEnabled() };
+	}
 }

--- a/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/key-manager.service.ts
@@ -7,15 +7,28 @@ import {
 	type DeploymentKeySortField,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { Cipher, InstanceSettings, type CipherAlgorithm } from 'n8n-core';
+import {
+	Cipher,
+	InstanceSettings,
+	type CipherAlgorithm,
+	type IEncryptionKeyProvider,
+	type KeyInfo,
+} from 'n8n-core';
 import { randomBytes } from 'node:crypto';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
-type KeyInfo = { id: string; value: string; algorithm: string };
+import { isKeyRotationEnabled } from './key-rotation-flag';
 
 @Service()
-export class KeyManagerService {
+export class KeyManagerService implements IEncryptionKeyProvider {
+	/**
+	 * Memoized legacy instance-key descriptor: no `keyId:` prefix, AES-256-CBC,
+	 * and a key that unwraps to the instance key itself. Serves two roles: the
+	 * write descriptor while rotation is off, and the read fallback when the
+	 * key store cannot serve the seeded legacy key. It never changes for the
+	 * lifetime of the process, and building it costs a GCM wrap.
+	 */
 	private cachedInstanceKeyInfo?: KeyInfo;
 
 	constructor(
@@ -25,8 +38,17 @@ export class KeyManagerService {
 		private readonly logger: Logger,
 	) {}
 
-	/** Returns the current active encryption key. Throws if none exists or if multiple are found. */
+	/**
+	 * Returns the descriptor the cipher must encrypt with. The rotation on/off
+	 * decision lives here, in the module: while rotation is off, this is the
+	 * legacy instance-key descriptor (old output format, fully reversible);
+	 * with rotation on, it is the active data-encryption key from the store.
+	 */
 	async getActiveKey(): Promise<KeyInfo> {
+		if (!isKeyRotationEnabled()) {
+			return this.instanceKeyLegacyInfo();
+		}
+
 		const activeKeys = await this.deploymentKeyRepository.find({
 			where: { type: 'data_encryption', status: 'active' },
 		});
@@ -37,14 +59,14 @@ export class KeyManagerService {
 			throw new Error('Encryption key invariant violated: multiple active keys found');
 		}
 		const key = activeKeys[0];
-		return { id: key.id, value: key.value, algorithm: key.algorithm! };
+		return { id: key.id, value: key.value, algorithm: key.algorithm!, format: 'prefixed' };
 	}
 
 	/** Returns a key by id, or null if not found. */
 	async getKeyById(id: string): Promise<KeyInfo | null> {
 		const key = await this.deploymentKeyRepository.findOne({ where: { id } });
 		if (!key) return null;
-		return { id: key.id, value: key.value, algorithm: key.algorithm! };
+		return { id: key.id, value: key.value, algorithm: key.algorithm!, format: 'prefixed' };
 	}
 
 	/**
@@ -62,7 +84,7 @@ export class KeyManagerService {
 				where: { type: 'data_encryption', algorithm: 'aes-256-cbc' },
 			});
 			if (key) {
-				return { id: key.id, value: key.value, algorithm: key.algorithm! };
+				return { id: key.id, value: key.value, algorithm: key.algorithm!, format: 'no-prefix' };
 			}
 			if (!this.cachedInstanceKeyInfo) {
 				this.logger.warn(
@@ -106,6 +128,7 @@ export class KeyManagerService {
 			id: 'instance-key',
 			value: this.cipher.encryptDEKWithInstanceKey(this.instanceSettings.encryptionKey),
 			algorithm: 'aes-256-cbc',
+			format: 'no-prefix',
 		};
 		return this.cachedInstanceKeyInfo;
 	}

--- a/packages/cli/src/modules/encryption-key-manager/key-rotation-flag.ts
+++ b/packages/cli/src/modules/encryption-key-manager/key-rotation-flag.ts
@@ -1,11 +1,12 @@
 /**
- * Whether the encryption-key-rotation paths and management API are enabled.
- * It also decides whether a failed key seed is fatal on startup (see
- * `EncryptionBootstrapService`). Module load, key seeding, and the provider
- * wiring are unconditional (see `EncryptionKeyManagerModule`) so the keys
- * exist fleet-wide, but the cipher still checks this flag per instance before
- * using them to encrypt or decrypt — moving that decision out of the cipher
- * is a separate step.
+ * Whether encryption-key rotation is enabled: with it on, `getActiveKey()`
+ * hands the cipher the active data-encryption key (prefixed output) instead
+ * of the legacy instance-key descriptor, and the management API is
+ * registered. It also decides whether a failed key seed is fatal on startup
+ * (see `EncryptionBootstrapService`). Core no longer reads this flag — the
+ * module folds it into the write descriptor and into its module settings.
+ * Module load, key seeding, and the provider wiring stay unconditional (see
+ * `EncryptionKeyManagerModule`).
  */
 export function isKeyRotationEnabled(): boolean {
 	return process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true';

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -198,8 +198,8 @@ describe('Cipher', () => {
 		});
 	});
 
-	describe('encryptV2 / decryptV2 (proxy-aware)', () => {
-		const instanceKeyForProxy = 'test_key';
+	describe('encryptV2 / decryptV2 (descriptor-driven)', () => {
+		const instanceKey = 'test_key';
 		const plaintextDataKey = '11'.repeat(32);
 		const encryptionKeyProxy = Container.get(EncryptionKeyProxy);
 
@@ -212,7 +212,7 @@ describe('Cipher', () => {
 			encryptionKeyProxy.setProvider(undefined);
 		});
 
-		it('should use active key and embed keyId prefix when proxy is registered and feature flag is on', async () => {
+		it('should encrypt with the active key and embed the keyId prefix when the descriptor is prefixed', async () => {
 			const keyId = 'test-uuid-1234';
 			const encryptedDataKey = cipher.encryptDEKWithInstanceKey(plaintextDataKey);
 
@@ -221,118 +221,116 @@ describe('Cipher', () => {
 					id: keyId,
 					value: encryptedDataKey,
 					algorithm: 'aes-256-gcm',
+					format: 'prefixed',
 				}),
 				getKeyById: async () => null,
-				getLegacyKey: async () => ({
-					id: 'legacy',
-					value: encryptedDataKey,
-					algorithm: 'aes-256-cbc',
-				}),
 			});
 
-			const originalFlag = process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
-			try {
-				const encrypted = await cipher.encryptV2('hello');
-				expect(encrypted.startsWith(`${keyId}:`)).toBe(true);
+			const encrypted = await cipher.encryptV2('hello');
+			expect(encrypted.startsWith(`${keyId}:`)).toBe(true);
 
-				const ciphertext = encrypted.slice(keyId.length + 1);
-				const decrypted = cipher.decryptWithKey(ciphertext, plaintextDataKey, 'aes-256-gcm');
-				expect(decrypted).toEqual('hello');
-			} finally {
-				process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = originalFlag;
-			}
+			const ciphertext = encrypted.slice(keyId.length + 1);
+			const decrypted = cipher.decryptWithKey(ciphertext, plaintextDataKey, 'aes-256-gcm');
+			expect(decrypted).toEqual('hello');
 		});
 
-		it('should decrypt using keyId from prefix when proxy is registered', async () => {
+		it('should write the byte-compatible legacy format when the descriptor is no-prefix', async () => {
+			withProvider({
+				getActiveKey: async () => ({
+					id: 'legacy',
+					value: cipher.encryptDEKWithInstanceKey(instanceKey),
+					algorithm: 'aes-256-cbc',
+					format: 'no-prefix',
+				}),
+				getKeyById: async () => null,
+			});
+
+			const encrypted = await cipher.encryptV2('legacy-write');
+			expect(encrypted.includes(':')).toBe(false);
+			// Byte-compatible with the pre-rotation output: readable both via the
+			// plain instance-key path and by an instance without a provider.
+			expect(cipher.decryptWithInstanceKey(encrypted)).toEqual('legacy-write');
+			expect(await cipher.decryptV2(encrypted)).toEqual('legacy-write');
+		});
+
+		it('should reject a no-prefix descriptor that does not resolve to the instance key', async () => {
+			withProvider({
+				getActiveKey: async () => ({
+					id: 'legacy',
+					value: cipher.encryptDEKWithInstanceKey('some-other-key'),
+					algorithm: 'aes-256-cbc',
+					format: 'no-prefix',
+				}),
+				getKeyById: async () => null,
+			});
+
+			await expect(cipher.encryptV2('data')).rejects.toThrow('must resolve to the instance key');
+		});
+
+		it('should decrypt using the keyId from the prefix when the provider is registered', async () => {
 			const keyId = 'test-uuid-5678';
 			const encryptedDataKey = cipher.encryptDEKWithInstanceKey(plaintextDataKey);
 			const ciphertext = cipher.encryptWithKey('world', plaintextDataKey, 'aes-256-gcm');
 			const prefixed = `${keyId}:${ciphertext}`;
 
 			withProvider({
-				getActiveKey: async () => ({
-					id: keyId,
-					value: encryptedDataKey,
-					algorithm: 'aes-256-gcm',
-				}),
 				getKeyById: async (id: string) =>
-					id === keyId ? { id, value: encryptedDataKey, algorithm: 'aes-256-gcm' } : null,
-				getLegacyKey: async () => ({
-					id: 'legacy',
-					value: encryptedDataKey,
-					algorithm: 'aes-256-cbc',
-				}),
+					id === keyId
+						? { id, value: encryptedDataKey, algorithm: 'aes-256-gcm', format: 'prefixed' }
+						: null,
 			});
 
-			const originalFlag = process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
-			try {
-				const decrypted = await cipher.decryptV2(prefixed);
-				expect(decrypted).toEqual('world');
-			} finally {
-				process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = originalFlag;
-			}
+			const decrypted = await cipher.decryptV2(prefixed);
+			expect(decrypted).toEqual('world');
 		});
 
-		it('should use legacy CBC key for unprefixed data when proxy is registered', async () => {
-			const encryptedDataKey = cipher.encryptDEKWithInstanceKey(instanceKeyForProxy);
-			const legacyCiphertext = cipher.encryptWithKey(
-				'legacy-data',
-				instanceKeyForProxy,
-				'aes-256-cbc',
-			);
+		it('should throw when the prefixed keyId is unknown', async () => {
+			withProvider({ getKeyById: async () => null });
 
-			withProvider({
-				getActiveKey: async () => ({
-					id: 'active',
-					value: encryptedDataKey,
-					algorithm: 'aes-256-cbc',
-				}),
-				getKeyById: async () => null,
-				getLegacyKey: async () => ({
-					id: 'legacy',
-					value: encryptedDataKey,
-					algorithm: 'aes-256-cbc',
-				}),
-			});
-
-			const originalFlag = process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
-			try {
-				const decrypted = await cipher.decryptV2(legacyCiphertext);
-				expect(decrypted).toEqual('legacy-data');
-			} finally {
-				process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = originalFlag;
-			}
+			await expect(cipher.decryptV2('unknown-id:abc')).rejects.toThrow('Encryption key not found');
 		});
 
-		it('should bypass proxy when customEncryptionKey is provided', async () => {
-			const encryptedDataKey = cipher.encryptDEKWithInstanceKey(plaintextDataKey);
-			withProvider({
-				getActiveKey: async () => ({
-					id: 'should-not-be-called',
-					value: encryptedDataKey,
-					algorithm: 'aes-256-gcm',
-				}),
-				getKeyById: async () => null,
-				getLegacyKey: async () => ({
-					id: 'should-not-be-called',
-					value: encryptedDataKey,
-					algorithm: 'aes-256-gcm',
-				}),
-			});
+		it('should treat a colon prefix that cannot be a key id as ciphertext content', async () => {
+			const getKeyById = vi.fn();
+			withProvider({ getKeyById });
 
-			const originalFlag = process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
-			try {
-				const encrypted = await cipher.encryptV2('bypass-test', 'custom-key');
-				expect(encrypted.includes(':')).toBe(false);
-				const decrypted = await cipher.decryptV2(encrypted, 'custom-key');
-				expect(decrypted).toEqual('bypass-test');
-			} finally {
-				process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = originalFlag;
-			}
+			// Junk input: the prefix contains characters no key id can have, so it
+			// goes down the legacy instance-key path (which yields garbage or
+			// throws, same as before rotation) without consulting the key store.
+			const result = await cipher.decryptV2('not+a/key=id:payload').catch(() => '__threw__');
+			expect(result).not.toEqual('payload');
+			expect(getKeyById).not.toHaveBeenCalled();
+		});
+
+		it('should decrypt unprefixed data with the instance key without consulting the provider', async () => {
+			const getKeyById = vi.fn();
+			const getLegacyKey = vi.fn();
+			withProvider({ getKeyById, getLegacyKey });
+
+			const legacyCiphertext = cipher.encryptWithKey('legacy-data', instanceKey, 'aes-256-cbc');
+
+			const decrypted = await cipher.decryptV2(legacyCiphertext);
+			expect(decrypted).toEqual('legacy-data');
+			expect(getKeyById).not.toHaveBeenCalled();
+			expect(getLegacyKey).not.toHaveBeenCalled();
+		});
+
+		it('should bypass the provider when customEncryptionKey is provided', async () => {
+			const getActiveKey = vi.fn();
+			withProvider({ getActiveKey });
+
+			const encrypted = await cipher.encryptV2('bypass-test', 'custom-key');
+			expect(encrypted.includes(':')).toBe(false);
+			const decrypted = await cipher.decryptV2(encrypted, 'custom-key');
+			expect(decrypted).toEqual('bypass-test');
+			expect(getActiveKey).not.toHaveBeenCalled();
+		});
+
+		it('should fall back to the instance key when no provider is configured', async () => {
+			const encrypted = await cipher.encryptV2('no-provider');
+			expect(encrypted.includes(':')).toBe(false);
+			expect(await cipher.decryptV2(encrypted)).toEqual('no-provider');
+			expect(cipher.decryptWithInstanceKey(encrypted)).toEqual('no-provider');
 		});
 	});
 });

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -1,5 +1,6 @@
 import { Service } from '@n8n/di';
 import { createHash } from 'crypto';
+import { UnexpectedError } from 'n8n-workflow';
 
 import { InstanceSettings } from '@/instance-settings';
 import { assertUnreachable } from '@/utils/assertions';
@@ -9,8 +10,23 @@ import { CipherAes256GCM } from './aes-256-gcm';
 import { EncryptionKeyProxy } from './encryption-key-proxy';
 import { CipherAlgorithm } from './interface';
 
+/**
+ * Matches the id shape of stored deployment keys (nanoid charset). A colon
+ * prefix that cannot be a key id is treated as ciphertext content, so junk
+ * or foreign input never reaches the key store and never lands in an error
+ * message unvalidated.
+ */
+const KEY_ID_PATTERN = /^[A-Za-z0-9_-]{1,36}$/;
+
 @Service()
 export class Cipher {
+	/**
+	 * No-prefix descriptors whose key material was already verified to unwrap
+	 * to the instance key. The module memoizes its descriptor, so verifying
+	 * once per object spares a DEK unwrap on every legacy-format write.
+	 */
+	private readonly verifiedLegacyDescriptors = new WeakSet<object>();
+
 	constructor(
 		private readonly instanceSettings: InstanceSettings,
 		private readonly cipherAES256GCM: CipherAes256GCM,
@@ -31,15 +47,40 @@ export class Cipher {
 		return this.decryptWithKey(data, key, 'aes-256-cbc');
 	}
 
+	/**
+	 * Encrypts with whatever active key the provider's descriptor names. The
+	 * descriptor carries the key, the algorithm, and the output format — the
+	 * rotation on/off decision lives in the key-manager module, not here.
+	 * An explicit `customEncryptionKey` stays a short-circuit: raw key, no
+	 * unwrap, no prefix.
+	 */
 	async encryptV2(data: string | object, customEncryptionKey?: string): Promise<string> {
 		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
 
-		if (
-			!customEncryptionKey &&
-			this.encryptionKeyProxy.isConfigured() &&
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true'
-		) {
+		if (customEncryptionKey !== undefined) {
+			return this.encryptWithKey(plaintext, customEncryptionKey, 'aes-256-cbc');
+		}
+
+		if (this.encryptionKeyProxy.isConfigured()) {
 			const keyInfo = await this.encryptionKeyProxy.getActiveKey();
+
+			if (keyInfo.format === 'no-prefix') {
+				// No-prefix output must stay byte-compatible with the pre-rotation
+				// format, which readers decrypt with the instance key directly.
+				if (!this.verifiedLegacyDescriptors.has(keyInfo)) {
+					if (
+						this.decryptDEKWithInstanceKey(keyInfo.value) !== this.instanceSettings.encryptionKey ||
+						keyInfo.algorithm !== 'aes-256-cbc'
+					) {
+						throw new UnexpectedError(
+							'A no-prefix encryption descriptor must resolve to the instance key',
+						);
+					}
+					this.verifiedLegacyDescriptors.add(keyInfo);
+				}
+				return this.encryptWithKey(plaintext, this.instanceSettings.encryptionKey, 'aes-256-cbc');
+			}
+
 			const plaintextKey = this.decryptDEKWithInstanceKey(keyInfo.value);
 			const ciphertext = this.encryptWithKey(
 				plaintext,
@@ -49,32 +90,38 @@ export class Cipher {
 			return `${keyInfo.id}:${ciphertext}`;
 		}
 
-		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
-		return this.encryptWithKey(plaintext, key, 'aes-256-cbc');
+		return this.encryptWithKey(plaintext, this.instanceSettings.encryptionKey, 'aes-256-cbc');
 	}
 
+	/**
+	 * Decrypts data of either format: `keyId:ciphertext` resolves the key by id
+	 * through the provider; ciphertext without a key-id prefix is legacy-format
+	 * data and always decrypts with the instance key.
+	 */
 	async decryptV2(data: string, customEncryptionKey?: string): Promise<string> {
-		if (
-			!customEncryptionKey &&
-			this.encryptionKeyProxy.isConfigured() &&
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true'
-		) {
+		if (customEncryptionKey !== undefined) {
+			return this.decryptWithKey(data, customEncryptionKey, 'aes-256-cbc');
+		}
+
+		if (this.encryptionKeyProxy.isConfigured()) {
 			const colonIdx = data.indexOf(':');
 			if (colonIdx !== -1) {
 				const keyId = data.slice(0, colonIdx);
-				const ciphertext = data.slice(colonIdx + 1);
-				const keyInfo = await this.encryptionKeyProxy.getKeyById(keyId);
-				if (!keyInfo) throw new Error(`Encryption key not found: ${keyId}`);
-				const plaintextKey = this.decryptDEKWithInstanceKey(keyInfo.value);
-				return this.decryptWithKey(ciphertext, plaintextKey, keyInfo.algorithm as CipherAlgorithm);
+				if (KEY_ID_PATTERN.test(keyId)) {
+					const ciphertext = data.slice(colonIdx + 1);
+					const keyInfo = await this.encryptionKeyProxy.getKeyById(keyId);
+					if (!keyInfo) throw new UnexpectedError(`Encryption key not found: ${keyId}`);
+					const plaintextKey = this.decryptDEKWithInstanceKey(keyInfo.value);
+					return this.decryptWithKey(
+						ciphertext,
+						plaintextKey,
+						keyInfo.algorithm as CipherAlgorithm,
+					);
+				}
 			}
-			const keyInfo = await this.encryptionKeyProxy.getLegacyKey();
-			const plaintextKey = this.decryptDEKWithInstanceKey(keyInfo.value);
-			return this.decryptWithKey(data, plaintextKey, keyInfo.algorithm as CipherAlgorithm);
 		}
 
-		const key = customEncryptionKey ?? this.instanceSettings.encryptionKey;
-		return this.decryptWithKey(data, key, 'aes-256-cbc');
+		return this.decryptWithKey(data, this.instanceSettings.encryptionKey, 'aes-256-cbc');
 	}
 
 	/**

--- a/packages/core/src/encryption/encryption-key-proxy.ts
+++ b/packages/core/src/encryption/encryption-key-proxy.ts
@@ -1,11 +1,19 @@
 import { Service } from '@n8n/di';
 import { UnexpectedError } from 'n8n-workflow';
 
-export type KeyInfo = { id: string; value: string; algorithm: string };
+/** Whether ciphertext produced with this key carries a `keyId:` prefix. */
+export type KeyFormat = 'prefixed' | 'no-prefix';
+
+export type KeyInfo = { id: string; value: string; algorithm: string; format: KeyFormat };
 
 export interface IEncryptionKeyProvider {
 	getActiveKey(): Promise<KeyInfo>;
 	getKeyById(id: string): Promise<KeyInfo | null>;
+	/**
+	 * The seeded legacy CBC row. Not on the decrypt path — no-prefix data
+	 * decrypts with the instance key directly — but kept for later
+	 * re-encryption tooling that must enumerate what the legacy key was.
+	 */
 	getLegacyKey(): Promise<KeyInfo>;
 }
 

--- a/packages/core/src/encryption/index.ts
+++ b/packages/core/src/encryption/index.ts
@@ -3,4 +3,4 @@ export { CipherAes256GCM } from './aes-256-gcm';
 export { CipherAes256CBC } from './aes-256-cbc';
 export type { CipherAlgorithm } from './interface';
 export { EncryptionKeyProxy } from './encryption-key-proxy';
-export type { KeyInfo, IEncryptionKeyProvider } from './encryption-key-proxy';
+export type { KeyInfo, KeyFormat, IEncryptionKeyProvider } from './encryption-key-proxy';

--- a/packages/frontend/editor-ui/src/app/composables/useSettingsItems.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSettingsItems.test.ts
@@ -6,6 +6,7 @@ import { VIEWS } from '../constants';
 const isAiGatewayCloudUbbEnabled = ref(false);
 const isAiGatewayEnabled = ref(true);
 const balance = ref<number>();
+const moduleSettings = ref<Record<string, unknown>>({});
 const openTopUpMock = vi.hoisted(() => vi.fn());
 
 vi.mock('vue-router', () => ({ useRouter: vi.fn(() => ({})) }));
@@ -32,12 +33,12 @@ vi.mock('@n8n/stores/settings.store', () => ({
 		isPublicApiEnabled: false,
 		isQueueModeEnabled: false,
 		isModuleActive: vi.fn(() => false),
+		get moduleSettings() {
+			return moduleSettings.value;
+		},
 	})),
 }));
 vi.mock('../utils/rbac/permissions', () => ({ hasPermission: vi.fn(() => false) }));
-vi.mock('@/features/shared/envFeatureFlag/useEnvFeatureFlag', () => ({
-	useEnvFeatureFlag: vi.fn(() => ({ check: computed(() => () => false) })),
-}));
 
 describe('useSettingsItems', () => {
 	beforeEach(() => {
@@ -45,6 +46,25 @@ describe('useSettingsItems', () => {
 		isAiGatewayEnabled.value = true;
 		isAiGatewayCloudUbbEnabled.value = false;
 		balance.value = undefined;
+		moduleSettings.value = {};
+	});
+
+	it('hides the encryption keys item while rotation is disabled', () => {
+		const item = useSettingsItems().settingsItems.value.find(
+			({ id }) => id === 'settings-encryption-keys',
+		);
+
+		expect(item).toBeUndefined();
+	});
+
+	it('shows the encryption keys item when the module reports rotation as enabled', () => {
+		moduleSettings.value = { 'encryption-key-manager': { rotationEnabled: true } };
+
+		const item = useSettingsItems().settingsItems.value.find(
+			({ id }) => id === 'settings-encryption-keys',
+		);
+
+		expect(item?.available).toBe(true);
 	});
 
 	it('links to the n8n Connect settings page for the legacy cohort', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
@@ -10,7 +10,6 @@ import { useUIStore } from '../stores/ui.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { hasPermission } from '../utils/rbac/permissions';
 import { MIGRATION_REPORT_TARGET_VERSION } from '@n8n/api-types';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 
 export function useSettingsItems() {
 	const router = useRouter();
@@ -20,7 +19,6 @@ export function useSettingsItems() {
 	const { canUserAccessRouteByName } = useUserHelpers(router);
 	const { balance } = useAiGateway();
 	const { openTopUp } = useAiGatewayTopUp();
-	const { check: envFeatureFlagCheck } = useEnvFeatureFlag();
 
 	const settingsItems = computed<IMenuItem[]>(() => {
 		const menuItems: IMenuItem[] = [
@@ -141,7 +139,7 @@ export function useSettingsItems() {
 				label: i18n.baseText('settings.encryptionKeys'),
 				position: 'top',
 				available:
-					envFeatureFlagCheck.value('ENCRYPTION_KEY_ROTATION') &&
+					settingsStore.moduleSettings['encryption-key-manager']?.rotationEnabled === true &&
 					canUserAccessRouteByName(VIEWS.ENCRYPTION_KEYS_SETTINGS),
 				route: { to: { name: VIEWS.ENCRYPTION_KEYS_SETTINGS } },
 			},

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -27,7 +27,6 @@ import { usePostHog } from '@/app/stores/posthog.store';
 import { RESOURCE_CENTER_EXPERIMENT, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants/experiments';
 import { useDynamicCredentials } from '@/features/resolvers/composables/useDynamicCredentials';
 import { usePromotionsEnabled } from '@/features/shared/promotions/usePromotionsEnabled';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { INSTANCE_AI_VIEW } from '@/features/ai/instanceAi/constants';
 import {
 	canManageInstanceAi,
@@ -1077,8 +1076,10 @@ export const routes: RouteRecordRaw[] = [
 							scope: 'encryptionKey:manage',
 						},
 						custom: () => {
-							const { check } = useEnvFeatureFlag();
-							return check.value('ENCRYPTION_KEY_ROTATION');
+							const settingsStore = useSettingsStore();
+							return (
+								settingsStore.moduleSettings['encryption-key-manager']?.rotationEnabled === true
+							);
 						},
 					},
 					telemetry: {


### PR DESCRIPTION
## Summary

> Was stacked on #37416 (IAM-1290) — now merged; this PR is rebased onto master and also integrates the instance-key fallback from #37439 (the fallback descriptor doubles as the rotation-off write descriptor).

The core cipher no longer reads `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION`. The rotation on/off decision lives in the `encryption-key-manager` module, so later rollout steps become a setting change with no core change.

- `encryptV2` asks the provider for the active-key **descriptor** — key, algorithm, and output `format` (`prefixed` / `no-prefix`) — and encrypts with whatever it names. A no-prefix descriptor must resolve to the instance key (asserted once per descriptor), which keeps legacy output byte-compatible.
- `decryptV2` reads both formats without the flag: `keyId:`-prefixed data resolves the key by id (the key id is shape-validated first, so junk input never reaches the key store); unprefixed data always decrypts with the instance key directly. `customEncryptionKey` stays a raw-key short-circuit on both paths.
- The module folds the env flag into `getActiveKey()`: legacy instance-key descriptor while rotation is off (memoized, shared with the #37439 read fallback), the active GCM key with a prefix while on. Instances that set the flag today keep their behaviour.
- The module exposes `{ rotationEnabled }` via `ModuleInterface.settings()`; the two frontend gates (settings sidebar item and the `settings/encryption-keys` route) now read `moduleSettings['encryption-key-manager']` instead of the env-feature-flag scan.

Known pre-existing gap, acknowledged but out of scope here: one-off CLI commands never run module init, so the provider is not wired there and `keyId:`-prefixed data is not readable by e.g. `n8n export:credentials --decrypted` once rotation is on (irrelevant while the flag defaults to off). Note the failure surfaces today as a misleading "different encryptionKey was used" error, because `decryptV2` falls back to instance-key CBC over the whole prefixed string — the wiring fix should also fix the message.

## How to test

### Automated (all green on this branch)

```
pushd packages/core && pnpm test src/encryption && popd
pushd packages/cli && pnpm test src/modules/encryption-key-manager/ && pnpm test:integration src/modules/encryption-key-manager/__tests__/encryption-bootstrap.service.integration.test.ts && popd
pushd packages/frontend/editor-ui && pnpm test useSettingsItems && popd
```

The integration suite includes an end-to-end write test: env flag → real seeded key store → real cipher → `keyId:` output → round-trip.

### Runtime verification report (executable specs)

Five black-box scenarios were run against a built checkout of this branch (`2f51d9d615`) through the real REST API and sqlite. Each is a re-runnable script; happy to share the spec suite.

| Scenario | Result | Hard evidence |
|---|---|---|
| Flag OFF: write format unchanged | ✅ | raw `credentials_entity.data` = `U2FsdGVkX1/…`, no `:`; decrypted **offline with plain `openssl enc -d -aes-256-cbc`** using the instance key — byte-compatible with pre-rotation n8n; API round-trip OK |
| Flag ON: prefixed writes | ✅ | stored value `y9UjRAAQ7z26qlVS:Af1haj…` where the prefix equals the id of the single active `aes-256-gcm` row in `deployment_key`; API round-trip OK |
| Flip reversibility (on → off → on) | ✅ | credential written with a prefix stays readable after turning the flag off; new writes revert to the legacy format; mixed-format DB reads fine in both modes; reads never rewrite stored values |
| Module-settings surface | ✅ | `GET /rest/module-settings` → `{"encryption-key-manager":{"rotationEnabled":false/true}}` per flag; `GET /rest/encryption/keys` → 404 without the flag, 200 with it |
| Known one-off CLI gap (documented, pre-existing) | ✅ observed | with rotation on, `n8n export:credentials --all --decrypted` exits 1 ("Credentials could not be decrypted…") — see the gap note above |

### Where to look in the database

```
sqlite3 <N8N_USER_FOLDER>/.n8n/database.sqlite \
  "select id, substr(data,1,50) from credentials_entity;"          -- stored ciphertext (prefix visible here)
sqlite3 <N8N_USER_FOLDER>/.n8n/database.sqlite \
  "select id, algorithm, status from deployment_key where type='data_encryption';"  -- keys: gcm/active = write key when rotation is on
```

### Manual quick pass

1. Without the flag: save a credential → `credentials_entity.data` has no `keyId:` prefix; credential opens fine. Module settings report `rotationEnabled: false`; the Encryption Keys settings page is hidden.
2. With `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=true`: a saved credential value is `<keyId>:<ciphertext>` and decrypts fine; the settings page appears.
3. Flip the flag back off: the prefixed value from step 2 still decrypts.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1286

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)