### PR TITLE
fix(ai-builder): UI tweak to prevent overflowing text on err callout when on Agent Preview

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nAiActivityStep/AiActivityStep.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAiActivityStep/AiActivityStep.vue
@@ -164,6 +164,8 @@ const errorTooltip = computed(() =>
 .errorCallout {
 	margin-top: var(--spacing--xs);
 	max-width: 90%;
+	overflow-wrap: anywhere;
+	word-break: break-word;
 }
 .activityErrorIcon {
 	transform: translateY(1px);


### PR DESCRIPTION
## Summary

When an agent run surfaces a provider error in the chat, the raw error payload is rendered as one long unbroken string inside the red error callout. The string does not wrap, so the text expands horizontally past the right edge of the box and is clipped.
This PR tweaks the error callout component to wrap the text instead of overflowing.

## How to test

1. Run an agent so that a step fails with a long unbroken error string (any long token without spaces reproduces it; here it was a Cloudflare 502 JSON error payload from the model provider).
2. Open the agent chat and look at the red error callout.
3. The error text no longer overflows the box horizontally and wraps instead.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AGENT-748/bug-agent-chat-error-text-overflows-the-error-callout-box


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

