### PR TITLE
chore: Add a lint rule for escaping values in third-party query strings (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-config/src/rules/index.ts
+++ b/packages/@n8n/eslint-config/src/rules/index.ts
@@ -32,6 +32,7 @@ import { RequirePublicApiControllerRule } from './require-public-api-controller.
 import { NoPublicApiGuardrailDisableRule } from './no-public-api-guardrail-disable.js';
 import { NoLegacyCipherMethodsRule } from './no-legacy-cipher-methods.js';
 import { NoUnsealedWorkflowEntityWriteRule } from './no-unsealed-workflow-entity-write.js';
+import { RequireEscapedQueryValuesRule } from './require-escaped-query-values.js';
 import { NoOnLeaderTakeoverRule } from './no-on-leader-takeover.js';
 
 export const rules = {
@@ -68,5 +69,6 @@ export const rules = {
 	'no-public-api-guardrail-disable': NoPublicApiGuardrailDisableRule,
 	'no-legacy-cipher-methods': NoLegacyCipherMethodsRule,
 	'no-unsealed-workflow-entity-write': NoUnsealedWorkflowEntityWriteRule,
+	'require-escaped-query-values': RequireEscapedQueryValuesRule,
 	'no-on-leader-takeover': NoOnLeaderTakeoverRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.test.ts
@@ -46,6 +46,9 @@ query.push(\`mimeType = '\${FOLDER_MIME}'\`);`,
 		{ code: withImport("qs.$filter = `eq '${escapeODataValue(x) as string}'`;") },
 		{ code: withImport("qs.$filter = `eq '${escapeODataValue(x)!}'`;") },
 
+		// A literal with no quote of its own cannot end the literal it sits in.
+		{ code: 'qs.$filter = `eq \'${"ab"}\'`;' },
+
 		// A quote of the other kind inside a literal is data, not a delimiter.
 		{ code: withImport("qs.q = `name = \"it's\" and owner = '${escapeODataValue(ownerId)}'`;") },
 		// `satisfies` is transparent, like `as` and `!`.
@@ -158,6 +161,17 @@ qs.$filter = \`displayName eq '\${filterValue}'\`;`),
 		// The sink is still found through a `satisfies` wrapper.
 		{
 			code: "qs.$filter = `eq '${filter}'` satisfies string;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// A literal carrying the active quote would end the literal it sits in.
+		{
+			code: "qs.$filter = `eq '${\"a'b\"}'`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// Same through a const, which is the shape that actually occurs.
+		{
+			code: `const DEFAULT_NAME = "it's";
+qs.$filter = \`eq '\${DEFAULT_NAME}'\`;`,
 			errors: [{ messageId: 'escapeQueryValue' }],
 		},
 		// An approved name reached through a member access proves nothing.

--- a/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.test.ts
@@ -1,0 +1,191 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { RequireEscapedQueryValuesRule } from './require-escaped-query-values.js';
+
+const ruleTester = new RuleTester();
+
+const IMPORT =
+	"import { escapeBackslashQuotedValue, escapeODataSearchValue, escapeODataValue } from '@utils/query-escaping';\n";
+
+/** Prefixes the escaper import the rule requires before trusting a call. */
+const withImport = (code: string) => IMPORT + code;
+
+ruleTester.run('require-escaped-query-values', RequireEscapedQueryValuesRule, {
+	valid: [
+		{ code: withImport("qs.$filter = `displayName eq '${escapeODataValue(filter)}'`;") },
+		{
+			code: withImport(
+				"const qs = { q: `name contains '${escapeBackslashQuotedValue(filter)}'` };",
+			),
+		},
+		{ code: withImport("query.push(`name contains '${escapeBackslashQuotedValue(filter)}'`);") },
+		{ code: withImport("qs.$filter += ` AND contains(subject, '${escapeODataValue(value)}')`;") },
+		{ code: withImport("const query = `email LIKE '${escapeBackslashQuotedValue(email)}'`;") },
+
+		// Escaped one hop back, through a `const`.
+		{
+			code: withImport(`const filterValue = escapeODataValue(encodeURI(filter));
+qs.$filter = \`contains(displayName, '\${filterValue}')\`;`),
+		},
+		// Escaped in both arms of a conditional.
+		{
+			code: withImport("const q = `name contains '${filter ? escapeODataValue(filter) : ''}'`;"),
+		},
+
+		// A module constant is fixed at build time.
+		{
+			code: `import { DRIVE } from './interfaces';
+query.push(\`mimeType = '\${DRIVE.FOLDER}'\`);`,
+		},
+		{
+			code: `import { FOLDER_MIME } from './interfaces';
+query.push(\`mimeType = '\${FOLDER_MIME}'\`);`,
+		},
+
+		// Escaped through the constructs isNeutralised looks past.
+		{ code: withImport("qs.$filter = `eq '${escapeODataValue(a) || escapeODataValue(b)}'`;") },
+		{ code: withImport("qs.$filter = `eq '${escapeODataValue(x) as string}'`;") },
+		{ code: withImport("qs.$filter = `eq '${escapeODataValue(x)!}'`;") },
+
+		// A quote of the other kind inside a literal is data, not a delimiter.
+		{ code: withImport("qs.q = `name = \"it's\" and owner = '${escapeODataValue(ownerId)}'`;") },
+		// `satisfies` is transparent, like `as` and `!`.
+		{ code: withImport("qs.$filter = `eq '${escapeODataValue(x)}'` satisfies string;") },
+
+		{ code: "qs.q = `owner = ${ownerId} and name = 'x'`;" },
+
+		// Double-quoted literals count too, e.g. an OData `$search` phrase.
+		{ code: withImport('qs.$search = `"displayName:${escapeODataSearchValue(filter)}"`;') },
+
+		// Outside a quoted literal the value cannot close one, so the language's
+		// own syntax applies and escaping is not what protects it.
+		{ code: "qs.$filter = `contains(${nameProperty}, 'literal')`;" },
+		{ code: 'qs.sysparm_query = `table_name=${tableName}`;' },
+
+		// Not a query sink.
+		{ code: "throw new Error(`The resource '${resource}' is unknown`);" },
+		{ code: "const message = `Column '${key}' does not exist`;" },
+		{ code: "items.push(`field '${name}' is missing`);" },
+		{ code: "const body = { subject: `Re: '${subject}'` };" },
+
+		// A quote already closed by the time the value is interpolated.
+		{ code: "const q = `name = 'literal' and owner = ${ownerId}`;" },
+
+		// Escaped quotes in the template do not open a literal.
+		{ code: "const q = `label = \\'x\\' and owner = ${ownerId}`;" },
+	],
+
+	invalid: [
+		{
+			code: "qs.$filter = `displayName eq '${filter}'`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "Object.assign(body, { query: `email LIKE '${email}' ` });",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "query.push(`name contains '${filter}'`);",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "const q = filter ? `name contains '${filter}'` : undefined;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "qs['$filter'] = `fields/Title eq '${filter}'`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// Both interpolations sit inside a literal, so both are reported.
+		{
+			code: "qs.$filter = `startsWith(displayName, '${filter}') OR startsWith(mail, '${filter}')`;",
+			errors: [{ messageId: 'escapeQueryValue' }, { messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "const query = `name contains '${prefix}${suffix}'`;",
+			errors: [{ messageId: 'escapeQueryValue' }, { messageId: 'escapeQueryValue' }],
+		},
+		// A `let` may be reassigned, so following it back proves nothing.
+		{
+			code: withImport(`let filterValue = escapeODataValue(filter);
+qs.$filter = \`displayName eq '\${filterValue}'\`;`),
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// Only one arm of the conditional is escaped.
+		{
+			code: withImport(
+				"const q = `name contains '${filter ? filter : escapeODataValue(fallback)}'`;",
+			),
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// encodeURI leaves single quotes untouched, so it is not an escape.
+		{
+			code: "qs.$filter = `contains(subject, '${encodeURI(filter)}')`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "qs.$filter = `contains(subject, '${encodeURIComponent(filter)}')`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: 'qs.$search = `"displayName:${filter}"`;',
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// The sink is still found when reached through a choosing expression or a cast.
+		{
+			code: "const q = fallback || `name contains '${filter}'`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "qs.$filter = `eq '${filter}'` as string;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// Only one arm of the logical expression is escaped.
+		{
+			code: withImport("qs.$filter = `eq '${a || escapeODataValue(b)}'`;"),
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// The single quote inside the double-quoted literal must not be mistaken for
+		// a delimiter — the interpolation below it really is inside a literal.
+		{
+			code: "qs.q = `name = \"it's\" and owner = '${ownerId}'`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// An escaper for a different dialect does not make this value safe.
+		{
+			code: "query.push(`name contains '${escapeSqlIdentifier(filter)}'`);",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// The sink is still found through a `satisfies` wrapper.
+		{
+			code: "qs.$filter = `eq '${filter}'` satisfies string;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// An approved name reached through a member access proves nothing.
+		{
+			code: `const evil = { escapeODataValue: (v: string) => v };
+qs.$filter = \`eq '\${evil.escapeODataValue(filter)}'\`;`,
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		{
+			code: "qs.$filter = `eq '${this.escapeODataValue(filter)}'`;",
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// A local function with an approved name is not the approved escaper.
+		{
+			code: `const escapeODataValue = (v: string) => v;
+qs.$filter = \`eq '\${escapeODataValue(filter)}'\`;`,
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// A property of a bound parameter is not a module constant.
+		{
+			code: `const options = this.getNodeParameter('options', i);
+query.push(\`mimeType = '\${options.fileType}'\`);`,
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+		// `String.replace` with a string pattern replaces only the first match.
+		{
+			code: `query.push(\`name contains '\${filter.replace("'", "\\\\'")}'\`);`,
+			errors: [{ messageId: 'escapeQueryValue' }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.ts
+++ b/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.ts
@@ -54,7 +54,8 @@ function calleeName(callee: TSESTree.Expression): string | undefined {
 	return undefined;
 }
 
-type OpenLiteral = "'" | '"' | null;
+type OpenQuote = "'" | '"';
+type OpenLiteral = OpenQuote | null;
 
 /**
  * Counting each quote character independently would be wrong: query languages
@@ -83,6 +84,7 @@ function scanLiteral(text: string, open: OpenLiteral): OpenLiteral {
 
 function isNeutralised(
 	node: TSESTree.Node,
+	open: OpenQuote,
 	getScope: (
 		node: TSESTree.Node,
 	) => ReturnType<RuleContext<MessageIds, Options>['sourceCode']['getScope']>,
@@ -93,9 +95,10 @@ function isNeutralised(
 	if (depth >= MAX_BINDING_DEPTH) return false;
 
 	switch (node.type) {
-		// A literal written in source contributes no runtime value.
+		// A literal contributes no runtime value, but it can still carry the quote
+		// that would end the literal it sits in.
 		case 'Literal':
-			return true;
+			return !String(node.value).includes(open);
 
 		case 'CallExpression': {
 			const name = calleeName(node.callee as TSESTree.Expression);
@@ -114,7 +117,7 @@ function isNeutralised(
 		// an import initialised from a runtime call is accepted here — same
 		// assumption as no-dynamic-regexp.
 		case 'MemberExpression':
-			return !node.computed && isNeutralised(node.object, getScope, depth + 1);
+			return !node.computed && isNeutralised(node.object, open, getScope, depth + 1);
 
 		case 'Identifier': {
 			const variable = ASTUtils.findVariable(getScope(node), node.name);
@@ -125,26 +128,26 @@ function isNeutralised(
 			if (definition.type !== 'Variable' || definition.parent.kind !== 'const') return false;
 
 			const init = definition.node.type === 'VariableDeclarator' ? definition.node.init : null;
-			return init !== null && isNeutralised(init, getScope, depth + 1);
+			return init !== null && isNeutralised(init, open, getScope, depth + 1);
 		}
 
 		case 'ConditionalExpression':
 			return (
-				isNeutralised(node.consequent, getScope, depth + 1) &&
-				isNeutralised(node.alternate, getScope, depth + 1)
+				isNeutralised(node.consequent, open, getScope, depth + 1) &&
+				isNeutralised(node.alternate, open, getScope, depth + 1)
 			);
 
 		case 'LogicalExpression':
 			return (
-				isNeutralised(node.left, getScope, depth + 1) &&
-				isNeutralised(node.right, getScope, depth + 1)
+				isNeutralised(node.left, open, getScope, depth + 1) &&
+				isNeutralised(node.right, open, getScope, depth + 1)
 			);
 
 		// TypeScript-only wrappers that do not change the runtime value.
 		case 'TSAsExpression':
 		case 'TSNonNullExpression':
 		case 'TSSatisfiesExpression':
-			return isNeutralised(node.expression, getScope, depth + 1);
+			return isNeutralised(node.expression, open, getScope, depth + 1);
 
 		default:
 			return false;
@@ -240,6 +243,13 @@ export const RequireEscapedQueryValuesRule = ESLintUtils.RuleCreator.withoutDocs
 			// as `.map()` fragments joined later, or assigned to a `let`. Nor does it
 			// know about a guard on an earlier statement, such as
 			// `assertNoQueryDelimiters`. Those need a test, not this rule.
+			//
+			// It also checks only that a value went through an approved escaper, not
+			// that the escaper matches the sink's dialect. A sink name does not carry
+			// one: `filterString` is used by an OData `$filter` builder, which doubles
+			// a quote, and by the Cognito `ListUsers` filter, which backslash-escapes
+			// it; `q` by both the Google Drive query language and SOQL. Picking the
+			// dialect stays a review judgement.
 			description:
 				"Require values interpolated into a quoted literal of a third-party query language to go through that language's escape helper.",
 		},
@@ -266,7 +276,7 @@ export const RequireEscapedQueryValuesRule = ESLintUtils.RuleCreator.withoutDocs
 					// Only an interpolation inside a quoted literal can close it.
 					if (!expression || open === null) return;
 
-					if (isNeutralised(expression, (n) => sourceCode.getScope(n))) return;
+					if (isNeutralised(expression, open, (n) => sourceCode.getScope(n))) return;
 
 					context.report({ node: expression, messageId: 'escapeQueryValue' });
 				});

--- a/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.ts
+++ b/packages/@n8n/eslint-config/src/rules/require-escaped-query-values.ts
@@ -1,0 +1,276 @@
+import { ASTUtils, ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
+
+type MessageIds = 'escapeQueryValue';
+type Options = [];
+
+/** A template literal reaching one of these is treated as a query being assembled. */
+const QUERY_SINKS = new Set([
+	'$filter',
+	'$search',
+	'filter',
+	'jql',
+	'q',
+	'query',
+	'sql',
+	'sysparm_query',
+	'where',
+]);
+
+/** Names of arrays whose entries are joined into a query. */
+const QUERY_PART_SINKS = new Set(['conditions', 'filterString', 'filters', 'query']);
+
+/**
+ * The sanctioned escapers, by name. A prefix pattern such as `/^escape/` would
+ * accept any similarly named function, including one for a different query
+ * language or one that escapes identifiers rather than values — so a new dialect
+ * helper has to be added here deliberately.
+ *
+ * `encodeURI`/`encodeURIComponent` are absent on purpose: neither encodes a
+ * quote, so neither keeps a value inside its literal.
+ */
+const ESCAPERS = new Set([
+	'escapeBackslashQuotedValue',
+	'escapeCognitoFilterValue',
+	'escapeSgqlLikeValue',
+	'escapeFilterValue',
+	'escapeODataSearchValue',
+	'escapeODataValue',
+	'escapeSoqlString',
+	'escapeSqlString',
+]);
+
+// Deliberately absent: `escapeSqlIdentifier`, which escapes a backtick. That
+// makes a value safe as an identifier, not inside a quoted string literal.
+
+/** How far to follow `const` bindings back to their initialiser. */
+const MAX_BINDING_DEPTH = 5;
+
+function calleeName(callee: TSESTree.Expression): string | undefined {
+	if (callee.type === 'Identifier') return callee.name;
+	if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier') {
+		return callee.property.name;
+	}
+	return undefined;
+}
+
+type OpenLiteral = "'" | '"' | null;
+
+/**
+ * Counting each quote character independently would be wrong: query languages
+ * use both (OData `$filter` quotes with `'`, `$search` with `"`), and a `'`
+ * inside a `"…"` literal is data, not a delimiter.
+ *
+ * Reads the cooked text, because that is what the query language receives — a
+ * `\'` written in the template source is a plain quote by then, and a backslash
+ * the query language itself should treat as an escape is written `\\'`.
+ */
+function scanLiteral(text: string, open: OpenLiteral): OpenLiteral {
+	for (let i = 0; i < text.length; i++) {
+		const char = text[i];
+
+		if (open !== null && char === '\\') {
+			i++; // an escaped character cannot close the literal
+		} else if (open === null) {
+			if (char === "'" || char === '"') open = char;
+		} else if (char === open) {
+			open = null;
+		}
+	}
+
+	return open;
+}
+
+function isNeutralised(
+	node: TSESTree.Node,
+	getScope: (
+		node: TSESTree.Node,
+	) => ReturnType<RuleContext<MessageIds, Options>['sourceCode']['getScope']>,
+	depth = 0,
+): boolean {
+	// Report rather than pass when the chain gets too long to follow: an unread
+	// value is not a safe one.
+	if (depth >= MAX_BINDING_DEPTH) return false;
+
+	switch (node.type) {
+		// A literal written in source contributes no runtime value.
+		case 'Literal':
+			return true;
+
+		case 'CallExpression': {
+			const name = calleeName(node.callee as TSESTree.Expression);
+			if (name === undefined || !ESCAPERS.has(name)) return false;
+
+			// Only a bare call to the imported helper counts. A member access such as
+			// `helpers.escapeODataValue(x)` carries an approved name but proves nothing
+			// about what it calls, so it is not accepted.
+			if (node.callee.type !== 'Identifier') return false;
+
+			const variable = ASTUtils.findVariable(getScope(node.callee), node.callee.name);
+			return variable?.defs.some((definition) => definition.type === 'ImportBinding') ?? false;
+		}
+
+		// Assumed fixed at build time. Proving it would need cross-file analysis, so
+		// an import initialised from a runtime call is accepted here — same
+		// assumption as no-dynamic-regexp.
+		case 'MemberExpression':
+			return !node.computed && isNeutralised(node.object, getScope, depth + 1);
+
+		case 'Identifier': {
+			const variable = ASTUtils.findVariable(getScope(node), node.name);
+			if (!variable || variable.defs.length !== 1) return false;
+
+			const [definition] = variable.defs;
+			if (definition.type === 'ImportBinding') return true;
+			if (definition.type !== 'Variable' || definition.parent.kind !== 'const') return false;
+
+			const init = definition.node.type === 'VariableDeclarator' ? definition.node.init : null;
+			return init !== null && isNeutralised(init, getScope, depth + 1);
+		}
+
+		case 'ConditionalExpression':
+			return (
+				isNeutralised(node.consequent, getScope, depth + 1) &&
+				isNeutralised(node.alternate, getScope, depth + 1)
+			);
+
+		case 'LogicalExpression':
+			return (
+				isNeutralised(node.left, getScope, depth + 1) &&
+				isNeutralised(node.right, getScope, depth + 1)
+			);
+
+		// TypeScript-only wrappers that do not change the runtime value.
+		case 'TSAsExpression':
+		case 'TSNonNullExpression':
+		case 'TSSatisfiesExpression':
+			return isNeutralised(node.expression, getScope, depth + 1);
+
+		default:
+			return false;
+	}
+}
+
+function propertyName(node: TSESTree.MemberExpression): string | undefined {
+	if (!node.computed && node.property.type === 'Identifier') return node.property.name;
+	if (
+		node.computed &&
+		node.property.type === 'Literal' &&
+		typeof node.property.value === 'string'
+	) {
+		return node.property.value;
+	}
+	return undefined;
+}
+
+/**
+ * Climbs past expressions that only choose between values, so a query reached
+ * through one — `q: filter ? \`...\` : undefined` — is still recognised.
+ */
+function effectiveParent(node: TSESTree.Node): TSESTree.Node | undefined {
+	let parent: TSESTree.Node | undefined = node.parent;
+
+	while (
+		parent?.type === 'ConditionalExpression' ||
+		parent?.type === 'LogicalExpression' ||
+		parent?.type === 'TSAsExpression' ||
+		parent?.type === 'TSNonNullExpression' ||
+		parent?.type === 'TSSatisfiesExpression'
+	) {
+		parent = parent.parent;
+	}
+
+	return parent;
+}
+
+function isQuerySink(node: TSESTree.TemplateLiteral): boolean {
+	const parent = effectiveParent(node);
+	if (!parent) return false;
+
+	switch (parent.type) {
+		// `{ query: `...` }`
+		case 'Property':
+			return (
+				(parent.key.type === 'Identifier' && QUERY_SINKS.has(parent.key.name)) ||
+				(parent.key.type === 'Literal' &&
+					typeof parent.key.value === 'string' &&
+					QUERY_SINKS.has(parent.key.value))
+			);
+
+		// `qs.$filter = `...`` / `qs.$filter += `...``
+		case 'AssignmentExpression': {
+			if (parent.left.type !== 'MemberExpression') return false;
+			const name = propertyName(parent.left);
+			return name !== undefined && QUERY_SINKS.has(name);
+		}
+
+		// `const q = `...``
+		case 'VariableDeclarator':
+			return (
+				parent.id.type === 'Identifier' &&
+				(QUERY_SINKS.has(parent.id.name) || QUERY_PART_SINKS.has(parent.id.name))
+			);
+
+		// `query.push(`...`)`
+		case 'CallExpression':
+			return (
+				parent.callee.type === 'MemberExpression' &&
+				propertyName(parent.callee) === 'push' &&
+				parent.callee.object.type === 'Identifier' &&
+				QUERY_PART_SINKS.has(parent.callee.object.name)
+			);
+
+		default:
+			return false;
+	}
+}
+
+export const RequireEscapedQueryValuesRule = ESLintUtils.RuleCreator.withoutDocs<
+	Options,
+	MessageIds
+>({
+	meta: {
+		type: 'problem',
+		docs: {
+			// Coverage boundary, so this is not mistaken for a complete gate: the rule
+			// only inspects a template literal that lands directly in a recognised
+			// sink, and only proves safety from the interpolated expression itself. It
+			// does not see a template passed as a call argument (a query inside a URL
+			// path), returned from a helper, built by string concatenation, assembled
+			// as `.map()` fragments joined later, or assigned to a `let`. Nor does it
+			// know about a guard on an earlier statement, such as
+			// `assertNoQueryDelimiters`. Those need a test, not this rule.
+			description:
+				"Require values interpolated into a quoted literal of a third-party query language to go through that language's escape helper.",
+		},
+		schema: [],
+		messages: {
+			escapeQueryValue:
+				'A value interpolated into a quoted query literal must go through the escape helper for that query language (@utils/query-escaping). Disable this rule on the line if the value provably cannot contain a quote.',
+		},
+	},
+	defaultOptions: [],
+	create(context) {
+		const sourceCode = context.sourceCode;
+
+		return {
+			TemplateLiteral(node) {
+				if (!isQuerySink(node)) return;
+
+				let open: OpenLiteral = null;
+
+				node.quasis.forEach((quasi, index) => {
+					open = scanLiteral(quasi.value.cooked ?? quasi.value.raw, open);
+
+					const expression = node.expressions[index];
+					// Only an interpolation inside a quoted literal can close it.
+					if (!expression || open === null) return;
+
+					if (isNeutralised(expression, (n) => sourceCode.getScope(n))) return;
+
+					context.report({ node: expression, messageId: 'escapeQueryValue' });
+				});
+			},
+		};
+	},
+});

--- a/packages/nodes-base/eslint.config.mjs
+++ b/packages/nodes-base/eslint.config.mjs
@@ -27,7 +27,7 @@ export default defineConfig(
 			'@n8n/community-nodes/node-class-description-icon-missing': 'warn',
 			'@n8n/community-nodes/cred-class-field-icon-missing': 'warn',
 			'n8n-local-rules/no-dynamic-regexp': 'error',
-			'n8n-local-rules/require-escaped-query-values': 'warn',
+			'n8n-local-rules/require-escaped-query-values': 'error',
 
 			// TODO: remove all the following rules
 			eqeqeq: 'warn',

--- a/packages/nodes-base/eslint.config.mjs
+++ b/packages/nodes-base/eslint.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig(
 			'@n8n/community-nodes/node-class-description-icon-missing': 'warn',
 			'@n8n/community-nodes/cred-class-field-icon-missing': 'warn',
 			'n8n-local-rules/no-dynamic-regexp': 'error',
+			'n8n-local-rules/require-escaped-query-values': 'warn',
 
 			// TODO: remove all the following rules
 			eqeqeq: 'warn',
@@ -198,6 +199,7 @@ export default defineConfig(
 			'import-x/no-extraneous-dependencies': 'off',
 			'n8n-nodes-base/node-filename-against-convention': 'off',
 			'n8n-local-rules/no-dynamic-regexp': 'off',
+			'n8n-local-rules/require-escaped-query-values': 'off',
 		},
 	},
 	...databricksUserAgentRestriction,


### PR DESCRIPTION
## Summary

Nodes build a query or filter string for an upstream API by interpolating node parameters into it. A node parameter is bindable, so its value can come from anywhere in the workflow's data, and it has to go through the escape helper for that query language before it lands inside a quoted literal.

This adds `n8n-local-rules/require-escaped-query-values`. It reports a quoted interpolation that reaches a recognised query sink unless the value went through one of the sanctioned escapers.

**Enabled as a `warn` for `nodes-base`**, so it surfaces in the editor while the existing call sites are brought through the helpers. It reports **31 findings across 15 files** today. `packages/nodes-base` lints with `--quiet`, so warnings are not printed in CI and this does not gate the build — verified: `eslint nodes credentials utils test --quiet` exits 0.

Turning it up to an `error` is a follow-up, once those call sites are routed through the escape helpers.

### How it decides

- **Sink** — a template literal that lands in a property, assignment, declarator or `.push()` whose name is a known query holder (`$filter`, `$search`, `q`, `query`, `sysparm_query`, `filterString`, …). It climbs past a conditional, a logical expression, `as` and `satisfies` to find that.
- **Inside a literal** — it tracks *which* quote character has an open literal at each point, rather than counting quotes. Query languages use both: OData `$filter` quotes with `'`, `$search` with `"`, so a `'` inside a `"…"` literal is data, not a delimiter. It reads the cooked template text, because that is what the query language receives — a `\'` in the source is a plain quote by then.
- **Neutralised** — the interpolated expression is a source literal, a module constant, or a call to a sanctioned escaper. It follows a single-definition `const` back to its initialiser, and both arms of a conditional must qualify.

The escaper list is an explicit allowlist of names rather than a prefix pattern, and a name must resolve to an import, so neither a same-named local nor a member access on an arbitrary object counts. `escapeSqlIdentifier` is excluded on purpose: escaping a backtick makes a value safe as an identifier, not inside a quoted string. `encodeURI`/`encodeURIComponent` are absent too — neither encodes a quote.

### Coverage boundary

Recorded in the rule's docblock so it is not read as a complete gate. The rule inspects a template literal that lands directly in a sink, and proves safety from the interpolated expression alone. It does **not** follow a template passed as a call argument, returned from a helper, built by string concatenation, assembled as `.map()` fragments joined later, or assigned to a `let`; nor does it know about a guard on an earlier statement. Those need a test rather than this rule.

## How to test

```bash
pnpm --filter @n8n/eslint-config build
cd packages/nodes-base
# the rule is a warning, so drop --quiet to see it
NODE_OPTIONS=--max-old-space-size=8192 npx eslint nodes utils --format=stylish 2>&1 | grep require-escaped-query-values
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5846

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


