### PR TITLE
fix(core): Ensure running job cleanup when a workflow run rejects

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -217,6 +217,45 @@ describe('JobProcessor', () => {
 		},
 	);
 
+	it('should remove the running job entry when the workflow run rejects', async () => {
+		const executionPersistence = mock<ExecutionPersistence>();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({
+				mode: 'manual',
+				workflowData: { nodes: [], staticData: {} },
+				data: mock<IRunExecutionData>({
+					executionData: undefined,
+				}),
+			}),
+		);
+
+		const manualExecutionService = mock<ManualExecutionService>();
+		manualExecutionService.runManually.mockReturnValue(
+			Promise.reject(new Error('workflow run rejected')) as ReturnType<
+				ManualExecutionService['runManually']
+			>,
+		);
+
+		const jobProcessor = new JobProcessor(
+			logger,
+			mock<ExecutionRepository>(),
+			executionPersistence,
+			mock(),
+			mock(),
+			mock(),
+			manualExecutionService,
+			executionsConfig,
+			mock(),
+			mock(),
+		);
+
+		const job = mock<Job>({ id: 'job-1' });
+
+		await expect(jobProcessor.processJob(job)).rejects.toThrow('workflow run rejected');
+
+		expect(jobProcessor.getRunningJobIds()).toEqual([]);
+	});
+
 	it('should send job-finished with success=false when execution has errors', async () => {
 		const executionRepository = mock<ExecutionRepository>();
 		const executionPersistence = mock<ExecutionPersistence>();

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -258,6 +258,22 @@ describe('ScalingService', () => {
 				expect(queue.pause).toHaveBeenCalled();
 				expect(stopQueueRecoverySpy).not.toHaveBeenCalled();
 			});
+
+			it('should log the execution IDs it is waiting for while draining', async () => {
+				// @ts-expect-error readonly property
+				instanceSettings.instanceType = 'worker';
+				await scalingService.setupQueue();
+				jobProcessor.getRunningJobIds.mockReturnValueOnce(['1']).mockReturnValue([]);
+				jobProcessor.getRunningJobsSummary.mockReturnValue([mock({ executionId: 'exec-1' })]);
+
+				await scalingService.stop();
+
+				// @ts-expect-error private property
+				expect(scalingService.logger.info).toHaveBeenCalledWith(
+					'Waiting for 1 active executions to finish... (execution IDs: exec-1)',
+					{ executionIds: ['exec-1'] },
+				);
+			});
 		});
 	});
 

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -329,9 +329,14 @@ export class JobProcessor {
 
 		this.runningJobs[job.id] = runningJob;
 
-		const run = await workflowRun;
-
-		delete this.runningJobs[job.id];
+		let run: IRun;
+		try {
+			run = await workflowRun;
+		} finally {
+			// An entry left behind on rejection keeps the count of running jobs
+			// above zero forever, which prevents shutdown from ever completing.
+			delete this.runningJobs[job.id];
+		}
 
 		if (run?.status === 'canceled') {
 			throw new ManualExecutionCancelledError(executionId);

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -186,8 +186,11 @@ export class ScalingService {
 
 		while (this.getRunningJobsCount() !== 0) {
 			if (count++ % 4 === 0) {
+				const summaries = this.jobProcessor.getRunningJobsSummary();
+				const executionIds = summaries.map((summary) => summary.executionId);
 				this.logger.info(
-					`Waiting for ${this.getRunningJobsCount()} active executions to finish...`,
+					`Waiting for ${executionIds.length} active executions to finish... (execution IDs: ${executionIds.join(', ')})`,
+					{ executionIds },
 				);
 			}
 


### PR DESCRIPTION
## Summary

On a queue-mode worker, `processJob` adds an entry to `runningJobs`, awaits the workflow run, then deletes the entry. When the run promise rejects, the delete does not run. The entry stays in the map forever and `getRunningJobsCount()` never returns to zero.

The shutdown drain loop in `stopWorker()` waits for that count to reach zero. A leaked entry makes every drain run until the force-shutdown timer kills the process. Every execution still in flight at that moment loses its Bull lock and fails permanently as `MaxStalledCountError`, because `maxStalledCount` is `0`.

This PR makes two changes:

1. Wrap the await in `try`/`finally` so the `runningJobs` entry is always removed, also when the run rejects.
2. Log the execution IDs the drain loop waits on, in the message and as structured metadata. A future stuck drain then names the blocking execution in the worker logs.

Field evidence (from the linked ticket): fleet-wide over 24h, no draining worker ever reached `N=0`, and the stuck count was present before SIGTERM arrived. This matches an entry leaked during normal operation rather than slow executions.

## How to test

1. Run the new unit tests:
   - `packages/cli/src/scaling/__tests__/job-processor.service.test.ts` - a rejected workflow run must leave `getRunningJobIds()` empty. This test fails without the `try`/`finally` fix.
   - `packages/cli/src/scaling/__tests__/scaling.service.test.ts` - the drain log line must include the execution IDs.
2. Manual check: start n8n in queue mode, run a long execution on a worker, send SIGTERM to the worker. The drain log now reads `Waiting for 1 active executions to finish... (execution IDs: <id>)`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4336

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

