### PR TITLE
docs: Fix broken example workflow links in the chat package README

### DIFF
--- a/packages/frontend/@n8n/chat/README.md
+++ b/packages/frontend/@n8n/chat/README.md
@@ -12,10 +12,10 @@ Create a n8n workflow which you want to execute via chat. The workflow has to be
 
 Open the **Chat Trigger** node and add your domain to the **Allowed Origins (CORS)** field. This makes sure that only requests from your domain are accepted.
 
-[See example workflow](https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/chat/resources/workflow.json)
+[See example workflow](https://github.com/n8n-io/n8n/blob/master/packages/frontend/%40n8n/chat/resources/workflow.json)
 
 To use streaming responses, you need to enable the **Streaming response** response mode in the **Chat Trigger** node.
-[See example workflow with streaming](https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/chat/resources/workflow-streaming.json)
+[See example workflow with streaming](https://github.com/n8n-io/n8n/blob/master/packages/frontend/%40n8n/chat/resources/workflow-streaming.json)
 
 > Make sure the workflow is **Active.**
 


### PR DESCRIPTION
## Summary

Two links in `packages/frontend/@n8n/chat/README.md` point to `packages/%40n8n/chat/resources/workflow*.json`, a path from before the packages were moved under `packages/frontend/`. Both return 404. The image URLs in the same file already use the current path, so only these two links were left behind.

## How to test

| Link | Before | After |
| --- | --- | --- |
| `workflow.json` | [404](https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/chat/resources/workflow.json) | [200](https://github.com/n8n-io/n8n/blob/master/packages/frontend/%40n8n/chat/resources/workflow.json) |
| `workflow-streaming.json` | 404 | 200 |

```
curl -o /dev/null -w '%{http_code}\n' <url>
```

## Related Linear tickets, Github issues, and Community forum posts

None — documentation link fix, no behaviour change.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.

---

Prepared with AI assistance; reviewed and verified by the author before submission.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

