### PR TITLE
fix(editor): Expand AI question text input automatically

### DIFF
--- a/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
+++ b/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
@@ -1,7 +1,6 @@
 import { i18n, i18nInstance, setLanguage, updateLocaleMessages } from '@n8n/i18n';
+import type { LocaleMessages } from '@n8n/i18n';
 import { locale as designLocale } from '@n8n/design-system';
-
-type LocaleMessages = Parameters<typeof updateLocaleMessages>[1];
 
 const hot = import.meta.hot;
 const DEFAULT_LOCALE = 'en';

--- a/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
+++ b/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
@@ -1,6 +1,7 @@
 import { i18n, i18nInstance, setLanguage, updateLocaleMessages } from '@n8n/i18n';
-import type { LocaleMessages } from '@n8n/i18n/types';
 import { locale as designLocale } from '@n8n/design-system';
+
+type LocaleMessages = Parameters<typeof updateLocaleMessages>[1];
 
 const hot = import.meta.hot;
 const DEFAULT_LOCALE = 'en';

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
@@ -52,7 +52,7 @@ describe('InstanceAiQuestions', () => {
 			return styles;
 		});
 		vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockImplementation(
-			function getScrollHeight() {
+			function getScrollHeight(this: HTMLTextAreaElement) {
 				return Math.max(this.value.split('\n').length, 1) * 20;
 			},
 		);
@@ -68,7 +68,7 @@ describe('InstanceAiQuestions', () => {
 		await fireEvent.update(textarea, longText);
 
 		await waitFor(() => {
-		expect(textarea).toHaveStyle({ height: '160px', overflowY: 'auto' });
+			expect(textarea).toHaveStyle({ height: '160px', overflowY: 'auto' });
 		});
 
 		const editedText = longText.replace('Line 5', 'Edited line 5');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent } from '@testing-library/vue';
+import { fireEvent, waitFor } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import InstanceAiQuestions, { type QuestionItem } from '../components/InstanceAiQuestions.vue';
 
@@ -36,6 +36,46 @@ function render(questions: QuestionItem[]) {
 describe('InstanceAiQuestions', () => {
 	afterEach(() => {
 		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('keeps the text input between three and eight rows while editing', async () => {
+		const originalGetComputedStyle = window.getComputedStyle;
+		vi.spyOn(window, 'getComputedStyle').mockImplementation(function getComputedStyle(element) {
+			const styles = originalGetComputedStyle(element);
+			const originalGetPropertyValue = styles.getPropertyValue.bind(styles);
+			vi.spyOn(styles, 'getPropertyValue').mockImplementation(function getPropertyValue(property) {
+				if (property === 'box-sizing') return 'content-box';
+				if (property.startsWith('padding-') || property.startsWith('border-')) return '0px';
+				return originalGetPropertyValue(property);
+			});
+			return styles;
+		});
+		vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockImplementation(
+			function getScrollHeight() {
+				return Math.max(this.value.split('\n').length, 1) * 20;
+			},
+		);
+
+		const { getByRole } = render([textQuestion]);
+		const textarea = getByRole('textbox');
+
+		await waitFor(() => {
+			expect(textarea).toHaveStyle({ height: '60px', minHeight: '60px' });
+		});
+
+		const longText = Array.from({ length: 10 }, (_, index) => `Line ${index + 1}`).join('\n');
+		await fireEvent.update(textarea, longText);
+
+		await waitFor(() => {
+			expect(textarea).toHaveStyle({ height: '160px', overflow: 'auto' });
+		});
+
+		const editedText = longText.replace('Line 5', 'Edited line 5');
+		await fireEvent.update(textarea, editedText);
+
+		expect(textarea).toHaveValue(editedText);
+		expect(textarea).toHaveStyle({ height: '160px', overflow: 'auto' });
 	});
 
 	it('submits the final empty text question as skipped', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
@@ -68,7 +68,7 @@ describe('InstanceAiQuestions', () => {
 		await fireEvent.update(textarea, longText);
 
 		await waitFor(() => {
-			expect(textarea).toHaveStyle({ height: '160px', overflow: 'auto' });
+		expect(textarea).toHaveStyle({ height: '160px', overflowY: 'auto' });
 		});
 
 		const editedText = longText.replace('Line 5', 'Edited line 5');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
@@ -156,10 +156,7 @@ function onSingleSelect(option: string) {
 	answer.skipped = false;
 }
 
-function onSingleSelectAndAdvance(
-	option: string,
-	_inputMethod: 'click' | 'keyboard_number' | 'keyboard_enter' = 'click',
-) {
+function onSingleSelectAndAdvance(option: string) {
 	onSingleSelect(option);
 	const idx = filteredOptions.value.indexOf(option);
 	selectedIndex.value = idx >= 0 ? idx : null;
@@ -273,7 +270,7 @@ function submitAnswers() {
 
 // Keyboard navigation
 
-function handleInputEnter(event: KeyboardEvent, _type: string) {
+function handleInputEnter(event: KeyboardEvent) {
 	if (event.key !== 'Enter' || event.shiftKey) return false;
 	event.preventDefault();
 	if (hasCustomText.value || isNextEnabled.value) {
@@ -315,7 +312,7 @@ function handleEnterKey(event: KeyboardEvent, type: string, optionCount: number)
 
 	if (type === 'single') {
 		if (highlightedIndex.value >= 0 && highlightedIndex.value < optionCount) {
-			onSingleSelectAndAdvance(filteredOptions.value[highlightedIndex.value], 'keyboard_enter');
+			onSingleSelectAndAdvance(filteredOptions.value[highlightedIndex.value]);
 		}
 	} else if (type === 'multi') {
 		if (highlightedIndex.value >= 0 && highlightedIndex.value < optionCount) {
@@ -338,7 +335,7 @@ function handleNumberShortcut(event: KeyboardEvent, type: string, optionCount: n
 	const num = parseInt(event.key, 10);
 	if (num >= 1 && num <= optionCount) {
 		event.preventDefault();
-		onSingleSelectAndAdvance(filteredOptions.value[num - 1], 'keyboard_number');
+		onSingleSelectAndAdvance(filteredOptions.value[num - 1]);
 		return true;
 	}
 	return false;
@@ -352,7 +349,7 @@ function onKeydown(event: KeyboardEvent) {
 	const isInputFocused = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA';
 
 	if (isInputFocused) {
-		handleInputEnter(event, q.type) || handleInputArrow(event);
+		handleInputEnter(event) || handleInputArrow(event);
 		return;
 	}
 
@@ -503,7 +500,7 @@ function onOptionMouseEnter(idx: number) {
 						:class="$style.textareaInput"
 						:model-value="currentAnswer.customText"
 						type="textarea"
-						:rows="3"
+						:autosize="{ minRows: 3, maxRows: 8 }"
 						:disabled="disabled"
 						:placeholder="
 							i18n.baseText('aiAssistant.builder.planMode.questions.clarifyPlaceholder')
@@ -732,14 +729,6 @@ function onOptionMouseEnter(idx: number) {
 	display: flex;
 	gap: var(--spacing--2xs);
 	min-height: 28px;
-}
-
-.textareaInput {
-	textarea {
-		height: 5lh;
-		resize: none;
-		overflow-y: auto;
-	}
 }
 
 /* Question fade transition */


### PR DESCRIPTION
## Summary

- Expand the AI question text area as the user enters text.
- Keep the text area between three and eight rows.
- Remove unused keyboard input parameters.

https://github.com/user-attachments/assets/7069eeaf-d0f1-4cbb-b4c7-632a27b64a06

## How to test

1. Build an AI Agent that uses the Ask a question tool.
2. Open the agent preview.
3. Trigger a text question.
4. Paste a large block of text into the response field.
5. Confirm that the field expands from three rows to a maximum of eight rows.
6. Confirm that you can scroll through and edit text after the field reaches its maximum size.
7. Confirm that Enter submits the answer and Shift+Enter adds a new line.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-711

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI