### PR TITLE
fix(core): let expression data shadow Object.prototype members

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -299,7 +299,14 @@ export function createDeepLazyProxy(
 				return arrayLength;
 			}
 
-			// Check cache - if already fetched, return cached value
+			if (Object.prototype.hasOwnProperty.call(targetObj, prop)) {
+				return targetObj[prop];
+			}
+
+			if (!isArray && objectKeys?.includes(prop)) {
+				return fetchAndCacheObjectValue(prop);
+			}
+
 			if (prop in targetObj) {
 				return targetObj[prop];
 			}

--- a/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
@@ -140,12 +140,6 @@ const unsafeObjectProperties = new Set([
 	'__defineSetter__',
 	'__lookupGetter__',
 	'__lookupSetter__',
-	'toString',
-	'valueOf',
-	'toLocaleString',
-	'hasOwnProperty',
-	'isPrototypeOf',
-	'propertyIsEnumerable',
 ]);
 
 export function __sanitize(value: unknown): unknown {


### PR DESCRIPTION
## Summary

Expression data fields named `toString`, `valueOf`, or another Object prototype member resolved to the inherited function instead of the field value.

The lazy proxy now checks own and known data keys before inherited members. Dynamic access is also allowed for these data keys. Prototype methods remain available when the data does not define the key.

## How to test

Run `pnpm test expression-prototype-key-shadowing.test.ts` from the `packages/workflow` package. The test covers dot, bracket, computed, and nested access, plus unchanged prototype behavior.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #36473

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

