### PR TITLE
fix(Call n8n Workflow Tool Node): Return empty tool output as an empty array

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.test.ts
@@ -288,6 +288,26 @@ describe('ToolWorkflowV1', () => {
 		);
 	});
 
+	it('should return an empty array when the sub-workflow returns no items', async () => {
+		const { ctx, logAiEvent } = createContext();
+		const mockExecuteWorkflowResponse: ExecuteWorkflowData = {
+			data: [],
+			executionId: 'test-execution',
+		};
+		vi.spyOn(ctx, 'executeWorkflow').mockResolvedValueOnce(mockExecuteWorkflowResponse);
+
+		const toolWorkflowNode = new ToolWorkflow();
+		const node = toolWorkflowNode.nodeVersions[1.3] as ToolWorkflowV1;
+		const supplyDataResult = await node.supplyData.call(ctx, 0);
+		const tool = supplyDataResult.response as DynamicTool;
+
+		await expect(tool.func('hello')).resolves.toBe('[]');
+		expect(logAiEvent).toHaveBeenCalledWith(
+			'ai-tool-called',
+			JSON.stringify({ query: 'hello', response: '[]' }),
+		);
+	});
+
 	it('should emit ai-tool-called when the sub-workflow fails', async () => {
 		const { ctx, logAiEvent } = createContext();
 		vi.spyOn(ctx, 'executeWorkflow').mockRejectedValueOnce(new Error('Workflow execution failed'));

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/ToolWorkflowV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/ToolWorkflowV1.node.ts
@@ -138,10 +138,7 @@ export class ToolWorkflowV1 implements INodeType {
 				| string
 				| undefined;
 			if (response === undefined) {
-				throw new NodeOperationError(
-					this.getNode(),
-					'There was an error: "The workflow did not return a response"',
-				);
+				return '[]';
 			}
 
 			return response;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -392,16 +392,28 @@ describe('WorkflowTool::WorkflowToolService', () => {
 			);
 		});
 
-		it('should throw error when workflow returns no response', async () => {
-			const mockResponse: ExecuteWorkflowData = {
-				data: [],
-				executionId: 'test-execution',
-			};
+		it.each([{ data: [] }, { data: [[]] }])(
+			'should return an empty array when workflow data is $data',
+			async ({ data }) => {
+				const mockResponse: ExecuteWorkflowData = {
+					data,
+					executionId: 'test-execution',
+				};
+				const workflowProxyMock = {
+					$execution: { id: 'exec-id' },
+					$workflow: { id: 'workflow-id' },
+				} as unknown as IWorkflowDataProxyData;
 
-			vi.spyOn(context, 'executeWorkflow').mockResolvedValueOnce(mockResponse);
+				vi.spyOn(context, 'executeWorkflow').mockResolvedValueOnce(mockResponse);
 
-			await expect(service['executeSubWorkflow'](context, {}, [], {} as never)).rejects.toThrow();
-		});
+				await expect(
+					service['executeSubWorkflow'](context, {}, [], workflowProxyMock),
+				).resolves.toEqual({
+					response: [],
+					subExecutionId: 'test-execution',
+				});
+			},
+		);
 	});
 
 	describe('getSubWorkflowInfo', () => {

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -294,18 +294,8 @@ export class WorkflowToolService {
 			throw new NodeOperationError(context.getNode(), error as Error);
 		}
 
-		let response: IDataObject | INodeExecutionData[] | undefined;
-		if (this.returnAllItems) {
-			response = receivedData?.data?.[0]?.length ? receivedData.data[0] : undefined;
-		} else {
-			response = receivedData?.data?.[0]?.[0]?.json;
-		}
-		if (response === undefined) {
-			throw new NodeOperationError(
-				context.getNode(),
-				'There was an error: "The workflow did not return a response"',
-			);
-		}
+		const outputItems = receivedData.data?.[0] ?? [];
+		const response = this.returnAllItems ? outputItems : (outputItems[0]?.json ?? []);
 
 		return { response, subExecutionId: receivedData.executionId };
 	}

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -601,6 +601,45 @@ describe('makeHandleToolInvocation', () => {
 		]);
 	});
 
+	it.each([{ mockResult: [] }, { mockResult: [[]] }])(
+		'should return an empty array when execution returns $mockResult',
+		async ({ mockResult }) => {
+			const mockContext = mock<IExecuteFunctions>();
+			contextFactory.mockReturnValue(mockContext);
+			execute.mockResolvedValueOnce(mockResult);
+
+			const handleToolInvocation = makeHandleToolInvocation(
+				contextFactory,
+				connectedNode,
+				connectedNodeType,
+				runExecutionData,
+			);
+
+			await expect(handleToolInvocation(toolArgs)).resolves.toBe('[]');
+			expect(mockContext.addOutputData).toHaveBeenCalledWith(NodeConnectionTypes.AiTool, 0, [
+				[{ json: { response: [] } }],
+			]);
+		},
+	);
+
+	it('should preserve an undefined execution result', async () => {
+		const mockContext = mock<IExecuteFunctions>();
+		contextFactory.mockReturnValue(mockContext);
+		execute.mockResolvedValueOnce(undefined);
+
+		const handleToolInvocation = makeHandleToolInvocation(
+			contextFactory,
+			connectedNode,
+			connectedNodeType,
+			runExecutionData,
+		);
+
+		await expect(handleToolInvocation(toolArgs)).resolves.toBeUndefined();
+		expect(mockContext.addOutputData).toHaveBeenCalledWith(NodeConnectionTypes.AiTool, 0, [
+			[{ json: { response: undefined } }],
+		]);
+	});
+
 	it('should handle binary data and return a warning message', async () => {
 		const mockContext = mock<IExecuteFunctions>();
 		contextFactory.mockReturnValue(mockContext);

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -195,7 +195,7 @@ function mapResult(result?: NodeOutput) {
 	let nodeHasMixedJsonAndBinaryData = false;
 	let sendMessage: ChatNodeMessageWithButtons | string | undefined = undefined;
 
-	if (result === undefined) {
+	if (result === undefined || result === null) {
 		response = undefined;
 	} else if (isEngineRequest(result)) {
 		// Tools running inside `makeHandleToolInvocation` cannot relay an
@@ -218,7 +218,7 @@ function mapResult(result?: NodeOutput) {
 		if (containsBinaryData(result)) {
 			nodeHasMixedJsonAndBinaryData = true;
 		}
-		response = result?.[0]?.flatMap((item) => item.json);
+		response = (result[0] ?? []).flatMap((item) => item.json);
 
 		// Chat node always returns single item with sendMessage property
 		// alongside json, this is used to send a bot message to the chat


### PR DESCRIPTION
## Summary

Treat empty tool output as success. Call n8n Workflow Tool returns `[]` instead of throwing. Node-as-tool maps `[]` and `[[]]` to `"[]"`. Tools that never return still hang.

## How to test

1. Connect Call n8n Workflow Tool to an AI Agent.
2. Point it at a sub-workflow whose last node returns no items (`[]` or `[[]]`).
3. Run the agent so it calls the tool.
4. Confirm the tool succeeds and the agent gets `[]`.
5. Repeat with a node used as a tool that returns `[]` or `[[]]`. Confirm the observation is `"[]"`.
6. Confirm a tool that never returns still hangs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-463

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

