### PR TITLE
feat(core): Suspend in-flight production executions at worker shutdown

### DIFF
--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -151,4 +151,13 @@ export class ScalingModeConfig {
 
 	@Nested
 	bull: BullConfig;
+
+	/**
+	 * Whether a worker that receives a shutdown signal suspends in-flight
+	 * production executions at the next node boundary. Suspended executions are
+	 * persisted as 'waiting' and resumed on another worker, instead of running
+	 * to completion (or force-kill) on the exiting worker.
+	 */
+	@Env('N8N_WORKER_SUSPEND_EXECUTIONS_ON_SHUTDOWN')
+	suspendExecutionsOnShutdown: boolean = false;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -408,6 +408,7 @@ describe('GlobalConfig', () => {
 					stalledInterval: 30_000,
 				},
 			},
+			suspendExecutionsOnShutdown: false,
 		},
 		taskRunners: {
 			mode: 'internal',

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -263,6 +263,7 @@ describe('JobProcessor', () => {
 	describe('suspension', () => {
 		beforeEach(() => {
 			workflowExecuteSuspendMock.mockClear();
+			logger.info.mockClear();
 		});
 
 		const createJobProcessor = (executionPersistence: ExecutionPersistence) =>
@@ -311,6 +312,10 @@ describe('JobProcessor', () => {
 
 			jobProcessor.suspendRunningJobs();
 			expect(workflowExecuteSuspendMock).toHaveBeenCalledTimes(1);
+			expect(logger.info).toHaveBeenCalledWith(
+				expect.stringContaining('Requested suspension of 1 execution(s)'),
+			);
+			expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('exec-1'));
 
 			resolveRun(successRun());
 			await processPromise;
@@ -348,6 +353,7 @@ describe('JobProcessor', () => {
 
 			jobProcessor.suspendRunningJobs();
 			expect(workflowExecuteSuspendMock).not.toHaveBeenCalled();
+			expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('Requested suspension'));
 
 			resolveRun(successRun());
 			await processPromise;

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -64,6 +64,7 @@ mockInstance(OwnershipService, {
 });
 
 const processRunExecutionDataMock = vi.fn();
+const workflowExecuteSuspendMock = vi.fn();
 vi.mock('n8n-core', async () => {
 	const original = await vi.importActual<typeof import('n8n-core')>('n8n-core');
 
@@ -71,7 +72,10 @@ vi.mock('n8n-core', async () => {
 	return {
 		...original,
 		WorkflowExecute: vi.fn(function () {
-			return { processRunExecutionData: processRunExecutionDataMock };
+			return {
+				processRunExecutionData: processRunExecutionDataMock,
+				suspend: workflowExecuteSuspendMock,
+			};
 		}),
 	};
 });
@@ -254,6 +258,148 @@ describe('JobProcessor', () => {
 		await expect(jobProcessor.processJob(job)).rejects.toThrow('workflow run rejected');
 
 		expect(jobProcessor.getRunningJobIds()).toEqual([]);
+	});
+
+	describe('suspension', () => {
+		beforeEach(() => {
+			workflowExecuteSuspendMock.mockClear();
+		});
+
+		const createJobProcessor = (executionPersistence: ExecutionPersistence) =>
+			new JobProcessor(
+				logger,
+				mock<ExecutionRepository>(),
+				executionPersistence,
+				mock(),
+				mock(),
+				mock(),
+				createManualExecutionServiceMock(),
+				executionsConfig,
+				mock(),
+				mock(),
+			);
+
+		it('should wire a suspend handle to the engine for a suspendable job', async () => {
+			const executionPersistence = mock<ExecutionPersistence>();
+			executionPersistence.findSingleExecution.mockResolvedValue(
+				mock<IExecutionResponse>({
+					mode: 'webhook',
+					workflowData: { nodes: [], staticData: {} },
+					data: mock<IRunExecutionData>(),
+				}),
+			);
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
+				mock<IWorkflowExecuteAdditionalData>(),
+			);
+			const jobProcessor = createJobProcessor(executionPersistence);
+
+			let resolveRun!: (run: IRun) => void;
+			processRunExecutionDataMock.mockReturnValue(new Promise<IRun>((r) => (resolveRun = r)));
+
+			const job = mock<Job>({
+				id: 'job-1',
+				data: {
+					executionId: 'exec-1',
+					loadStaticData: false,
+					streamingEnabled: false,
+					isMcpExecution: false,
+				},
+			});
+
+			const processPromise = jobProcessor.processJob(job);
+			await vi.waitFor(() => expect(jobProcessor.getRunningJobIds()).toEqual(['job-1']));
+
+			jobProcessor.suspendRunningJobs();
+			expect(workflowExecuteSuspendMock).toHaveBeenCalledTimes(1);
+
+			resolveRun(successRun());
+			await processPromise;
+		});
+
+		it('should not attach a suspend handle to a non-suspendable job', async () => {
+			const executionPersistence = mock<ExecutionPersistence>();
+			executionPersistence.findSingleExecution.mockResolvedValue(
+				mock<IExecutionResponse>({
+					mode: 'webhook',
+					workflowData: { nodes: [], staticData: {} },
+					data: mock<IRunExecutionData>(),
+				}),
+			);
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
+				mock<IWorkflowExecuteAdditionalData>(),
+			);
+			const jobProcessor = createJobProcessor(executionPersistence);
+
+			let resolveRun!: (run: IRun) => void;
+			processRunExecutionDataMock.mockReturnValue(new Promise<IRun>((r) => (resolveRun = r)));
+
+			const job = mock<Job>({
+				id: 'job-1',
+				data: {
+					executionId: 'exec-1',
+					loadStaticData: false,
+					streamingEnabled: true,
+					isMcpExecution: false,
+				},
+			});
+
+			const processPromise = jobProcessor.processJob(job);
+			await vi.waitFor(() => expect(jobProcessor.getRunningJobIds()).toEqual(['job-1']));
+
+			jobProcessor.suspendRunningJobs();
+			expect(workflowExecuteSuspendMock).not.toHaveBeenCalled();
+
+			resolveRun(successRun());
+			await processPromise;
+		});
+
+		describe('isJobSuspendable', () => {
+			const jobProcessor = createJobProcessor(mock<ExecutionPersistence>());
+			const cleanJob = mock<Job>({
+				data: { streamingEnabled: false, isMcpExecution: false },
+			});
+			const cleanExecution = mock<IExecutionResponse>({
+				mode: 'webhook',
+				data: mock<IRunExecutionData>(),
+			});
+			// @ts-expect-error private method
+			const isJobSuspendable = jobProcessor.isJobSuspendable.bind(jobProcessor) as (
+				job: Job,
+				execution: IExecutionResponse,
+			) => boolean;
+
+			it.each(['webhook', 'trigger', 'retry'] as const)(
+				'should allow a clean %s execution',
+				(mode) => {
+					expect(isJobSuspendable(cleanJob, { ...cleanExecution, mode })).toBe(true);
+				},
+			);
+
+			it.each(['manual', 'evaluation', 'integrated', 'error'] as const)(
+				'should refuse a %s execution',
+				(mode) => {
+					expect(isJobSuspendable(cleanJob, { ...cleanExecution, mode })).toBe(false);
+				},
+			);
+
+			it('should refuse a streaming execution', () => {
+				const job = mock<Job>({ data: { streamingEnabled: true, isMcpExecution: false } });
+				expect(isJobSuspendable(job, cleanExecution)).toBe(false);
+			});
+
+			it('should refuse an MCP execution', () => {
+				const job = mock<Job>({ data: { streamingEnabled: false, isMcpExecution: true } });
+				expect(isJobSuspendable(job, cleanExecution)).toBe(false);
+			});
+
+			it('should refuse an execution without run state', () => {
+				const execution = {
+					...cleanExecution,
+					data: mock<IRunExecutionData>({ executionData: undefined }),
+				};
+				expect(isJobSuspendable(cleanJob, execution)).toBe(false);
+			});
+		});
 	});
 
 	it('should send job-finished with success=false when execution has errors', async () => {

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -259,6 +259,34 @@ describe('ScalingService', () => {
 				expect(stopQueueRecoverySpy).not.toHaveBeenCalled();
 			});
 
+			afterEach(() => {
+				globalConfig.queue.suspendExecutionsOnShutdown = false;
+			});
+
+			it('should suspend running jobs when suspension is enabled', async () => {
+				// @ts-expect-error readonly property
+				instanceSettings.instanceType = 'worker';
+				await scalingService.setupQueue();
+				globalConfig.queue.suspendExecutionsOnShutdown = true;
+				jobProcessor.getRunningJobIds.mockReturnValue([]);
+
+				await scalingService.stop();
+
+				expect(jobProcessor.suspendRunningJobs).toHaveBeenCalledTimes(1);
+			});
+
+			it('should not suspend running jobs when suspension is disabled', async () => {
+				// @ts-expect-error readonly property
+				instanceSettings.instanceType = 'worker';
+				await scalingService.setupQueue();
+				globalConfig.queue.suspendExecutionsOnShutdown = false;
+				jobProcessor.getRunningJobIds.mockReturnValue([]);
+
+				await scalingService.stop();
+
+				expect(jobProcessor.suspendRunningJobs).not.toHaveBeenCalled();
+			});
+
 			it('should log the execution IDs it is waiting for while draining', async () => {
 				// @ts-expect-error readonly property
 				instanceSettings.instanceType = 'worker';

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -532,8 +532,18 @@ export class JobProcessor {
 
 	/** Ask every suspendable running job to stop at its next node boundary. */
 	suspendRunningJobs() {
+		const executionIds: string[] = [];
+
 		for (const runningJob of Object.values(this.runningJobs)) {
-			runningJob.suspend?.();
+			if (!runningJob.suspend) continue;
+			runningJob.suspend();
+			executionIds.push(runningJob.executionId);
+		}
+
+		if (executionIds.length > 0) {
+			this.logger.info(
+				`Requested suspension of ${executionIds.length} execution(s) at the next node boundary (execution IDs: ${executionIds.join(', ')})`,
+			);
 		}
 	}
 

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -2,6 +2,7 @@ import type { Tool } from '@langchain/core/tools';
 import type { RunningJobSummary } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig } from '@n8n/config';
+import type { IExecutionResponse } from '@n8n/db';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import {
@@ -265,7 +266,7 @@ export class JobProcessor {
 			);
 		};
 
-		let workflowExecute: WorkflowExecute;
+		let workflowExecute: WorkflowExecute | undefined;
 		let workflowRun: PCancelable<IRun>;
 
 		const { startData, resultData, manualData } = execution.data;
@@ -326,6 +327,11 @@ export class JobProcessor {
 			retryOf: execution.retryOf ?? undefined,
 			status: execution.status,
 		};
+
+		if (workflowExecute && this.isJobSuspendable(job, execution)) {
+			const suspendable = workflowExecute;
+			runningJob.suspend = () => suspendable.suspend();
+		}
 
 		this.runningJobs[job.id] = runningJob;
 
@@ -505,6 +511,30 @@ export class JobProcessor {
 
 		runningJob.run.cancel();
 		delete this.runningJobs[jobId];
+	}
+
+	/**
+	 * Whether a job may be suspended at worker shutdown. Only production
+	 * executions qualify: manual and evaluation runs are tied to a session,
+	 * streaming responses cannot migrate mid-stream, and MCP executions are
+	 * pinned to their session.
+	 */
+	private isJobSuspendable(job: Job, execution: IExecutionResponse): boolean {
+		const isProductionMode = ['webhook', 'trigger', 'retry'].includes(execution.mode);
+
+		return (
+			isProductionMode &&
+			!job.data.streamingEnabled &&
+			!job.data.isMcpExecution &&
+			execution.data.executionData !== undefined
+		);
+	}
+
+	/** Ask every suspendable running job to stop at its next node boundary. */
+	suspendRunningJobs() {
+		for (const runningJob of Object.values(this.runningJobs)) {
+			runningJob.suspend?.();
+		}
 	}
 
 	getRunningJobIds(): JobId[] {

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -182,6 +182,10 @@ export class ScalingService {
 	private async stopWorker() {
 		await this.pauseQueue();
 
+		if (this.globalConfig.queue.suspendExecutionsOnShutdown) {
+			this.jobProcessor.suspendRunningJobs();
+		}
+
 		let count = 0;
 
 		while (this.getRunningJobsCount() !== 0) {

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -145,6 +145,8 @@ export type AbortJobMessage = {
 
 export type RunningJob = RunningJobSummary & {
 	run: PCancelable<IRun>;
+	/** Present only when the job may be suspended at worker shutdown. */
+	suspend?: () => void;
 };
 
 export type QueueRecoveryContext = {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-suspend.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-suspend.test.ts
@@ -25,7 +25,8 @@ describe('WorkflowExecute suspension', () => {
 	/** Runs the workflow, requesting suspension right after `suspendAfterNode` executes. */
 	const runAndSuspend = async (suspendAfterNode: string) => {
 		const workflow = createWorkflow();
-		const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+		const workflowExecuteAfter = createDeferredPromise<IRun>();
+		const additionalData = Helpers.WorkflowExecuteAdditionalData(workflowExecuteAfter);
 		const setExecutionStatus = vi.fn();
 		additionalData.setExecutionStatus = setExecutionStatus;
 		const workflowExecute = new WorkflowExecute(additionalData, executionMode);
@@ -35,14 +36,19 @@ describe('WorkflowExecute suspension', () => {
 		});
 
 		const run = await workflowExecute.run({ workflow, startNode: trigger });
-		return { run, workflow, setExecutionStatus };
+		return { run, workflow, setExecutionStatus, workflowExecuteAfter };
 	};
 
 	test('suspend mid-run parks the execution as waiting with an intact stack', async () => {
-		const { run, setExecutionStatus } = await runAndSuspend('node1');
+		const { run, setExecutionStatus, workflowExecuteAfter } = await runAndSuspend('node1');
 
 		expect(run.status).toBe('waiting');
 		expect(setExecutionStatus).toHaveBeenCalledWith('waiting');
+
+		// The save hooks persist off this event: it must fire with the waiting run.
+		const hookRun = await workflowExecuteAfter.promise;
+		expect(hookRun.status).toBe('waiting');
+		expect(hookRun.waitTill).toBeInstanceOf(Date);
 		expect(run.waitTill).toBeInstanceOf(Date);
 		expect(run.finished).not.toBe(true);
 		expect(run.data.resumeInstruction).toBe('run-stack-head');

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-suspend.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-suspend.test.ts
@@ -26,6 +26,8 @@ describe('WorkflowExecute suspension', () => {
 	const runAndSuspend = async (suspendAfterNode: string) => {
 		const workflow = createWorkflow();
 		const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+		const setExecutionStatus = vi.fn();
+		additionalData.setExecutionStatus = setExecutionStatus;
 		const workflowExecute = new WorkflowExecute(additionalData, executionMode);
 
 		additionalData.hooks!.addHandler('nodeExecuteAfter', function (nodeName) {
@@ -33,13 +35,14 @@ describe('WorkflowExecute suspension', () => {
 		});
 
 		const run = await workflowExecute.run({ workflow, startNode: trigger });
-		return { run, workflow };
+		return { run, workflow, setExecutionStatus };
 	};
 
 	test('suspend mid-run parks the execution as waiting with an intact stack', async () => {
-		const { run } = await runAndSuspend('node1');
+		const { run, setExecutionStatus } = await runAndSuspend('node1');
 
 		expect(run.status).toBe('waiting');
+		expect(setExecutionStatus).toHaveBeenCalledWith('waiting');
 		expect(run.waitTill).toBeInstanceOf(Date);
 		expect(run.finished).not.toBe(true);
 		expect(run.data.resumeInstruction).toBe('run-stack-head');
@@ -80,20 +83,20 @@ describe('WorkflowExecute suspension', () => {
 		const workflow = createWorkflow();
 		// A Wait-node-style parked state: the executed node pushed back onto the
 		// stack head, its run recorded, waitTill set, no resume instruction.
+		const stackHead = { node: { ...node1 }, data: { main: [[{ json: {} }]] }, source: null };
+		const preParkRun = toITaskData([{ data: {} }]);
 		const parked: IRunExecutionData = createRunExecutionData({
 			startData: {},
 			resultData: {
 				runData: {
 					trigger: [toITaskData([{ data: {} }])],
-					node1: [toITaskData([{ data: {} }])],
+					node1: [preParkRun],
 				},
 				lastNodeExecuted: 'node1',
 			},
 			executionData: {
 				contextData: {},
-				nodeExecutionStack: [
-					{ node: { ...node1 }, data: { main: [[{ json: {} }]] }, source: null },
-				],
+				nodeExecutionStack: [stackHead],
 				metadata: {},
 				waitingExecution: {},
 				waitingExecutionSource: {},
@@ -108,7 +111,8 @@ describe('WorkflowExecute suspension', () => {
 		expect(resumed.status).toBe('success');
 		// Skip-head: the pushed-back node was disabled to pass its input through,
 		// and its pre-park run entry was popped.
-		expect(parked.executionData!.nodeExecutionStack[0]?.node.disabled ?? true).toBe(true);
+		expect(stackHead.node.disabled).toBe(true);
+		expect(resumed.data.resultData.runData.node1).not.toContain(preParkRun);
 		expect(resumed.data.resultData.runData.node2).toHaveLength(1);
 	});
 

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-suspend.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-suspend.test.ts
@@ -1,0 +1,163 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import type { IRun, IRunExecutionData } from 'n8n-workflow';
+import { createRunExecutionData, WorkflowOperationError } from 'n8n-workflow';
+
+import * as Helpers from '@test/helpers';
+
+import { DirectedGraph } from '../partial-execution-utils';
+import { createNodeData, toITaskData } from '../partial-execution-utils/__tests__/helpers';
+import { WorkflowExecute } from '../workflow-execute';
+
+describe('WorkflowExecute suspension', () => {
+	const executionMode = 'trigger';
+	const nodeTypes = Helpers.NodeTypes();
+
+	const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+	const node1 = createNodeData({ name: 'node1' });
+	const node2 = createNodeData({ name: 'node2' });
+
+	const createWorkflow = () =>
+		new DirectedGraph()
+			.addNodes(trigger, node1, node2)
+			.addConnections({ from: trigger, to: node1 }, { from: node1, to: node2 })
+			.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+	/** Runs the workflow, requesting suspension right after `suspendAfterNode` executes. */
+	const runAndSuspend = async (suspendAfterNode: string) => {
+		const workflow = createWorkflow();
+		const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+		const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+
+		additionalData.hooks!.addHandler('nodeExecuteAfter', function (nodeName) {
+			if (nodeName === suspendAfterNode) workflowExecute.suspend();
+		});
+
+		const run = await workflowExecute.run({ workflow, startNode: trigger });
+		return { run, workflow };
+	};
+
+	test('suspend mid-run parks the execution as waiting with an intact stack', async () => {
+		const { run } = await runAndSuspend('node1');
+
+		expect(run.status).toBe('waiting');
+		expect(run.waitTill).toBeInstanceOf(Date);
+		expect(run.finished).not.toBe(true);
+		expect(run.data.resumeInstruction).toBe('run-stack-head');
+
+		// The next, not-yet-executed node is the stack head, untouched.
+		const stack = run.data.executionData!.nodeExecutionStack;
+		expect(stack).toHaveLength(1);
+		expect(stack[0].node.name).toBe('node2');
+		expect(stack[0].node.disabled).toBe(false);
+
+		// Executed nodes keep their run data; the unexecuted node has none.
+		expect(run.data.resultData.runData.node1).toHaveLength(1);
+		expect(run.data.resultData.runData.node2).toBeUndefined();
+	});
+
+	test('resume executes the stack head normally and clears the instruction', async () => {
+		const { run, workflow } = await runAndSuspend('node1');
+
+		const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+		const resumed = await new WorkflowExecute(
+			additionalData,
+			executionMode,
+			run.data,
+		).processRunExecutionData(workflow);
+
+		expect(resumed.status).toBe('success');
+		expect(resumed.finished).toBe(true);
+		expect(resumed.data.resumeInstruction).toBeUndefined();
+
+		// node2 ran normally: not disabled, exactly one run recorded.
+		expect(node2.disabled).toBe(false);
+		expect(resumed.data.resultData.runData.node2).toHaveLength(1);
+		// The legacy path would have popped node1's run data; it must survive.
+		expect(resumed.data.resultData.runData.node1).toHaveLength(1);
+	});
+
+	test('legacy waiting state (no resume instruction) keeps the skip-head behavior', async () => {
+		const workflow = createWorkflow();
+		// A Wait-node-style parked state: the executed node pushed back onto the
+		// stack head, its run recorded, waitTill set, no resume instruction.
+		const parked: IRunExecutionData = createRunExecutionData({
+			startData: {},
+			resultData: {
+				runData: {
+					trigger: [toITaskData([{ data: {} }])],
+					node1: [toITaskData([{ data: {} }])],
+				},
+				lastNodeExecuted: 'node1',
+			},
+			executionData: {
+				contextData: {},
+				nodeExecutionStack: [
+					{ node: { ...node1 }, data: { main: [[{ json: {} }]] }, source: null },
+				],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: {},
+			},
+			waitTill: new Date(),
+		});
+
+		const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+		const workflowExecute = new WorkflowExecute(additionalData, executionMode, parked);
+		const resumed = await workflowExecute.processRunExecutionData(workflow);
+
+		expect(resumed.status).toBe('success');
+		// Skip-head: the pushed-back node was disabled to pass its input through,
+		// and its pre-park run entry was popped.
+		expect(parked.executionData!.nodeExecutionStack[0]?.node.disabled ?? true).toBe(true);
+		expect(resumed.data.resultData.runData.node2).toHaveLength(1);
+	});
+
+	test('suspend after the last node yields a normal success', async () => {
+		const { run } = await runAndSuspend('node2');
+
+		expect(run.status).toBe('success');
+		expect(run.finished).toBe(true);
+		expect(run.waitTill).toBeUndefined();
+		expect(run.data.resumeInstruction).toBeUndefined();
+	});
+
+	test('suspend before the run starts is a no-op', async () => {
+		const workflow = createWorkflow();
+		const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+		const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+
+		workflowExecute.suspend(); // status is 'new', must not arm suspension
+
+		const run = await workflowExecute.run({ workflow, startNode: trigger });
+
+		expect(run.status).toBe('success');
+		expect(run.data.resumeInstruction).toBeUndefined();
+	});
+
+	test('an error after suspension clears the resume markers', async () => {
+		const workflow = createWorkflow();
+		const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+		const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+
+		// Simulate the race: suspension stamped the run data, then a cancel error
+		// reaches processSuccessExecution before the waiting state is persisted.
+		// @ts-expect-error private property
+		workflowExecute.status = 'running';
+		workflowExecute.suspend();
+		// @ts-expect-error private property
+		const runExecutionData: IRunExecutionData = workflowExecute.runExecutionData;
+		runExecutionData.waitTill = new Date();
+		runExecutionData.resumeInstruction = 'run-stack-head';
+
+		const run = await workflowExecute.processSuccessExecution(
+			new Date(),
+			workflow,
+			new WorkflowOperationError('Workflow execution canceled'),
+		);
+
+		expect(run.status).toBe('canceled');
+		expect(run.waitTill).toBeUndefined();
+		expect(run.data.waitTill).toBeUndefined();
+		expect(run.data.resumeInstruction).toBeUndefined();
+	});
+});

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2237,6 +2237,7 @@ export class WorkflowExecute {
 					if (this.suspensionRequested) {
 						this.runExecutionData.waitTill = new Date();
 						this.runExecutionData.resumeInstruction = 'run-stack-head';
+						this.additionalData.setExecutionStatus?.('waiting');
 						return;
 					}
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -120,6 +120,19 @@ export class WorkflowExecute {
 	private readonly abortController = new AbortController();
 	timedOut: boolean = false;
 
+	private suspensionRequested = false;
+
+	/**
+	 * Ask the engine to stop at the next node boundary and park the execution as
+	 * 'waiting', so another process can resume it from the persisted state. The
+	 * node currently executing runs to completion. Safe to call at any time;
+	 * no-ops if the run finishes, waits, or is canceled first.
+	 */
+	suspend(): void {
+		if (this.status !== 'running') return;
+		this.suspensionRequested = true;
+	}
+
 	constructor(
 		private readonly additionalData: IWorkflowExecuteAdditionalData,
 		private readonly mode: WorkflowExecuteMode,
@@ -1468,6 +1481,13 @@ export class WorkflowExecute {
 				this.mode,
 			);
 
+			if (this.runExecutionData.resumeInstruction === 'run-stack-head') {
+				// The engine was suspended at a node boundary, so the stack head has
+				// not executed yet: run it normally instead of passing it through.
+				this.runExecutionData.resumeInstruction = undefined;
+				return;
+			}
+
 			const executionStackEntry = this.runExecutionData.executionData.nodeExecutionStack[0];
 			// Error reporting itself does not depend on this: `runNode` checks
 			// `metadata.resumeError` before `node.disabled`, so the entry carrying the
@@ -2211,6 +2231,15 @@ export class WorkflowExecute {
 						return;
 					}
 
+					// Suspension exits before popping, so the stack head is the next
+					// not-yet-executed node and the persisted state resumes by running it.
+					// The cancel check above must win over suspension.
+					if (this.suspensionRequested) {
+						this.runExecutionData.waitTill = new Date();
+						this.runExecutionData.resumeInstruction = 'run-stack-head';
+						return;
+					}
+
 					subNodeExecutionResults = makeEngineResponse();
 
 					let nodeSuccessData: INodeExecutionData[][] | null | undefined = null;
@@ -2848,6 +2877,13 @@ export class WorkflowExecute {
 	): Promise<IRun> {
 		// Set status before creating fullRunData
 		if (executionError !== undefined) {
+			// A cancel or error can land after a suspension already stamped the run
+			// data; clear the markers so the persisted state is not treated as
+			// resumable. A genuine Wait-node waitTill is never cleared here.
+			if (this.suspensionRequested) {
+				this.runExecutionData.waitTill = undefined;
+				this.runExecutionData.resumeInstruction = undefined;
+			}
 			Logger.debug('Workflow execution finished with error', {
 				error: executionError,
 				workflowId: workflow.id,

--- a/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
@@ -64,6 +64,14 @@ export interface IRunExecutionDataV1 {
 	 */
 	resumeToken?: string;
 	waitTill?: Date;
+	/**
+	 * How to treat the head of `nodeExecutionStack` when resuming a waiting
+	 * execution. Absent (legacy): the head already executed and was pushed back
+	 * (Wait node), so resume disables it to pass input through and pops its
+	 * duplicate runData entry. 'run-stack-head': the engine was suspended at a
+	 * node boundary, so the head has not executed yet and must run normally.
+	 */
+	resumeInstruction?: 'run-stack-head';
 	pushRef?: string;
 
 	/** Data needed for a worker to run a manual execution. */


### PR DESCRIPTION
## PR stack

1. #37649 — engine suspension primitive
2. 👉 #37650 — worker shutdown wiring (flag, suspendability predicate, `stopWorker`) (this PR)
3. _planned_ — queue-mode e2e, telemetry, docs

## Summary

Stacked on #37649.

When a queue-mode worker receives a shutdown signal, in-flight production executions currently run until they finish or the force-kill timer ends the process. An execution killed mid-run loses its Bull lock and fails permanently, because `maxStalledCount` is `0`.

With this PR, behind a new opt-in flag, the worker asks every suspendable running execution to stop at its next node boundary (`WorkflowExecute.suspend()` from #37649). Each suspended execution persists as `waiting` with `waitTill = now`, its Bull job completes normally, and the WaitTracker on the leader main re-enqueues it within its normal poll interval (up to ~60s). Another worker resumes it from the persisted state. The resume path reuses the Wait-node machinery end to end, including the atomic claim that prevents double-resume.

Changes:

- `N8N_WORKER_SUSPEND_EXECUTIONS_ON_SHUTDOWN` (default `false`) in `ScalingModeConfig`.
- `JobProcessor.isJobSuspendable()`: only production executions (`webhook`, `trigger`, `retry`) with run state qualify; streaming and MCP executions are excluded. Manual and evaluation runs never qualify (they go through `runManually` and stay session-bound).
- Suspendable jobs carry a `suspend` handle on their `RunningJob` entry; `suspendRunningJobs()` invokes all of them.
- `stopWorker()` calls `suspendRunningJobs()` after pausing the queue, gated by the flag at this single call site.

Scope notes:

- Suspension is boundary-granular and opportunistic. A node that runs longer than the graceful shutdown window still hits the force-kill; an execution stuck inside a node (for example on an unresponsive task runner) cannot be suspended. That failure mode is tracked separately on CAT-4336.
- Sub-executions run in-process on the worker; a parent suspends only after its Execute Workflow node returns.

PR 3 will add queue-mode e2e coverage, a telemetry event, and docs (including the ECS note that a task-runner sidecar needs container dependency ordering to outlive the worker drain).

## How to test

Unit tests:

```
cd packages/cli
pnpm test src/scaling/__tests__/job-processor.service.test.ts src/scaling/__tests__/scaling.service.test.ts
cd ../@n8n/config && pnpm test
```

Manual, in a queue-mode setup with two workers and `N8N_WORKER_SUSPEND_EXECUTIONS_ON_SHUTDOWN=true` on both:

1. Start a production (webhook/schedule) execution of a multi-node workflow with a slow middle node on worker A.
2. Send SIGTERM to worker A while the slow node runs.
3. The current node finishes, worker A logs the drain reaching zero and exits cleanly inside the graceful window.
4. The execution row shows status `waiting`; within ~60s the WaitTracker re-enqueues it and worker B completes it. Every node ran exactly once.
5. Repeat with the flag unset: the execution behaves as today (runs to completion on worker A or dies at force-kill).

## Related Linear tickets, Github issues, and Community forum posts

Related: https://linear.app/n8n/issue/CAT-4336

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


