### PR TITLE
feat(Chat Trigger Node): Handle unconnected end-user accounts in the hosted chat (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
@@ -876,11 +876,11 @@ describe('credential gate script', () => {
 		}
 
 		/** Fires a submit the way the widget would see it, through the capture phase. */
-		function submit(kind: 'enter' | 'click') {
+		function submit(kind: 'enter' | 'click', keys: { shiftKey?: boolean } = {}) {
 			const blocked = { defaultPrevented: false, propagationStopped: false };
 			const event =
 				kind === 'enter'
-					? { key: 'Enter', shiftKey: false, target: { tagName: 'TEXTAREA' } }
+					? { key: 'Enter', shiftKey: keys.shiftKey ?? false, target: { tagName: 'TEXTAREA' } }
 					: {
 							target: {
 								closest: (selector: string) => (selector === '.chat-input-send-button' ? {} : null),
@@ -951,6 +951,9 @@ describe('credential gate script', () => {
 		const { win, textarea } = runGateScript({
 			enableStreaming: false,
 			response: new Response(JSON.stringify(GATE_BODY), { status: 428 }),
+			// Non-empty, so the assertions below fail if the page writes at the input at
+			// all - whether it clears it or restores the refused message over a draft.
+			inputValue: 'a draft the visitor started',
 		});
 
 		await win.fetch('http://test.com/webhook', {
@@ -958,7 +961,7 @@ describe('credential gate script', () => {
 			body: sendBody('Book me a flight'),
 		});
 
-		expect(textarea.value).toBe('');
+		expect(textarea.value).toBe('a draft the visitor started');
 		expect(textarea.events).toEqual([]);
 		expect(textarea.focused).toBe(false);
 	});
@@ -1107,8 +1110,10 @@ describe('credential gate script', () => {
 			const { sendStatus, submit } = page();
 			sendStatus(notReady);
 
-			// Built inline: `submit` models the send keystroke only.
-			expect(submit('enter').defaultPrevented).toBe(true);
+			const blocked = submit('enter', { shiftKey: true });
+
+			expect(blocked.defaultPrevented).toBe(false);
+			expect(blocked.propagationStopped).toBe(false);
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
@@ -683,7 +683,16 @@ describe('createPage inside the shell frame', () => {
 		);
 		expect(inner).toContain("data.type !== 'n8n-chat-auth-token'");
 		expect(inner).toContain("window.__n8nChatAuthHeaders['x-auth-token'] = data.token;");
-		expect(inner).not.toContain("addEventListener('message'");
+
+		// The page does have one window message listener - the credential gate reads the
+		// shell's readiness signal, which the shell already broadcasts at this frame for
+		// the widget's benefit, so listening adds no exposure. The token must never join
+		// it: pinned by count and by content so neither can drift.
+		const windowListeners = inner.split("addEventListener('message'").slice(1);
+		expect(windowListeners).toHaveLength(1);
+		expect(windowListeners[0]).toContain("'n8n-chat:credential-status'");
+		expect(windowListeners[0]).not.toContain('n8n-chat-auth-token');
+		expect(windowListeners[0]).not.toContain('data.token');
 	});
 
 	// Announcing with no port still closes the shell's latch, so a document loaded here
@@ -752,5 +761,398 @@ describe('createPage inside the shell frame', () => {
 		const withoutToken: FrameIdentity = { visitor };
 
 		expect([withoutVisitor, withoutToken]).toHaveLength(2);
+	});
+});
+
+describe('credential gate script', () => {
+	const frameIdentity = {
+		authToken: 'token-abc',
+		expiresIn: 3600,
+		visitor: { id: 'visitor-1', firstName: 'Ada', lastName: 'L', email: 'ada@example.com' },
+	};
+
+	const baseParams = {
+		instanceId: 'test-instance',
+		webhookUrl: 'http://test.com/webhook',
+		showWelcomeScreen: false,
+		loadPreviousSession: 'notSupported' as const,
+		i18n: { en: {} },
+		mode: 'production' as const,
+		authentication: 'n8nUserAuth' as const,
+		allowFileUploads: false,
+		allowedFilesMimeTypes: '',
+		customCss: '',
+		initialMessages: '',
+	};
+
+	const NOTICE =
+		'Not all required accounts are connected, so your message could not be processed. Connect them above, then send it again.';
+
+	/** A send body shaped the way the widget builds one. */
+	const sendBody = (chatInput: string) =>
+		JSON.stringify({ action: 'sendMessage', sessionId: 's-1', chatInput });
+
+	const GATE_BODY = {
+		status: 'credential_connections_required',
+		readyToExecute: false,
+		credentials: [
+			{ credentialId: 'cred-missing', credentialStatus: 'missing' },
+			{ credentialId: 'cred-connected', credentialStatus: 'configured' },
+		],
+	};
+
+	/** The gate script out of the rendered page, without its `<script>` wrapper. */
+	function gateScriptOf(page: string): string {
+		const script = page
+			.split('<script>')
+			.find((part) => part.includes('credential_connections_required'));
+		if (!script) throw new Error('gate script not rendered');
+		return script.slice(0, script.indexOf('</script>'));
+	}
+
+	/**
+	 * Runs the rendered script against fakes. `window` and friends are parameters
+	 * rather than globals, so the script under test sees them by those names.
+	 */
+	function runGateScript(options: {
+		enableStreaming: boolean;
+		response: Response;
+		/** Seeds the textarea, to prove this page leaves it untouched. */
+		inputValue?: string;
+	}) {
+		const page = createPage({
+			...baseParams,
+			enableStreaming: options.enableStreaming,
+			frameIdentity,
+		});
+
+		const textarea = {
+			value: options.inputValue ?? '',
+			focused: false,
+			events: [] as string[],
+			dispatchEvent(event: Event) {
+				this.events.push(event.type);
+				return true;
+			},
+			focus() {
+				this.focused = true;
+			},
+		};
+		const posted: Array<{ message: unknown; targetOrigin: string }> = [];
+		const parent = {
+			postMessage: (message: unknown, targetOrigin: string) =>
+				posted.push({ message, targetOrigin }),
+		};
+		const winListeners: Array<(event: unknown) => void> = [];
+		const win = {
+			parent,
+			addEventListener: (type: string, fn: (event: unknown) => void) => {
+				if (type === 'message') winListeners.push(fn);
+			},
+			fetch: async (_input?: unknown, _init?: unknown) => await Promise.resolve(options.response),
+		};
+		const docListeners: Record<string, Array<(event: unknown) => void>> = {};
+		const doc = {
+			querySelector: () => null,
+			addEventListener: (type: string, fn: (event: unknown) => void) => {
+				(docListeners[type] ??= []).push(fn);
+			},
+		};
+
+		// eslint-disable-next-line @typescript-eslint/no-implied-eval
+		new Function('window', 'document', 'Event', 'Response', 'FormData', gateScriptOf(page))(
+			win,
+			doc,
+			Event,
+			Response,
+			FormData,
+		);
+
+		/** Replays the shell's readiness signal into the page. */
+		function sendStatus(status: Record<string, unknown>, source: unknown = parent) {
+			winListeners.forEach((fn) =>
+				fn({ source, data: { type: 'n8n-chat:credential-status', ...status } }),
+			);
+		}
+
+		/** Fires a submit the way the widget would see it, through the capture phase. */
+		function submit(kind: 'enter' | 'click') {
+			const blocked = { defaultPrevented: false, propagationStopped: false };
+			const event =
+				kind === 'enter'
+					? { key: 'Enter', shiftKey: false, target: { tagName: 'TEXTAREA' } }
+					: {
+							target: {
+								closest: (selector: string) => (selector === '.chat-input-send-button' ? {} : null),
+							},
+						};
+			const listeners = docListeners[kind === 'enter' ? 'keydown' : 'click'] ?? [];
+			listeners.forEach((fn) =>
+				fn({
+					...event,
+					preventDefault: () => {
+						blocked.defaultPrevented = true;
+					},
+					stopImmediatePropagation: () => {
+						blocked.propagationStopped = true;
+					},
+				}),
+			);
+			return blocked;
+		}
+
+		return { win, textarea, posted, sendStatus, submit };
+	}
+
+	it('renders only inside the shell frame', () => {
+		const inFrame = createPage({ ...baseParams, enableStreaming: false, frameIdentity });
+		const standalone = createPage({ ...baseParams, enableStreaming: false });
+
+		expect(inFrame).toContain('credential_connections_required');
+		expect(standalone).not.toContain('credential_connections_required');
+	});
+
+	it('renders as valid script, with no unresolved escaping', () => {
+		const script = gateScriptOf(
+			createPage({ ...baseParams, enableStreaming: false, frameIdentity }),
+		);
+
+		// Compiles without running: proves the emitted escaping is syntactically sound.
+		// eslint-disable-next-line @typescript-eslint/no-implied-eval
+		expect(() => new Function(script)).not.toThrow();
+		// Split so neither this file's lint rules nor the assertion itself contain the
+		// placeholder they check for.
+		expect(script.includes('$' + '{')).toBe(false);
+	});
+
+	it('answers a rejection with the reason, never the gate body', async () => {
+		const { win } = runGateScript({
+			enableStreaming: false,
+			response: new Response(JSON.stringify(GATE_BODY), {
+				status: 428,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+		});
+
+		const answer = (await win.fetch('http://test.com/webhook', {
+			method: 'POST',
+			body: sendBody('Book me a flight'),
+		})) as unknown as Response;
+		const body = (await answer.json()) as { output: string };
+
+		expect(answer.status).toBe(200);
+		expect(body.output).toBe(NOTICE);
+		expect(JSON.stringify(body)).not.toContain('credential_connections_required');
+	});
+
+	it('leaves the input and the transcript to the widget', async () => {
+		// The message really was sent, so it belongs in the transcript. This page has no
+		// reach into the widget's state and must not fake one by writing at its DOM.
+		const { win, textarea } = runGateScript({
+			enableStreaming: false,
+			response: new Response(JSON.stringify(GATE_BODY), { status: 428 }),
+		});
+
+		await win.fetch('http://test.com/webhook', {
+			method: 'POST',
+			body: sendBody('Book me a flight'),
+		});
+
+		expect(textarea.value).toBe('');
+		expect(textarea.events).toEqual([]);
+		expect(textarea.focused).toBe(false);
+	});
+
+	it('answers a multipart send the same way', async () => {
+		const { win, posted } = runGateScript({
+			enableStreaming: false,
+			response: new Response(JSON.stringify(GATE_BODY), { status: 428 }),
+		});
+
+		const form = new FormData();
+		form.append('action', 'sendMessage');
+		form.append('chatInput', 'Here is the file');
+
+		const answer = (await win.fetch('http://test.com/webhook', {
+			method: 'POST',
+			body: form,
+		})) as unknown as Response;
+
+		expect(((await answer.json()) as { output: string }).output).toBe(NOTICE);
+		expect(posted).toHaveLength(1);
+	});
+
+	it('tells the shell which accounts are missing, and only those', async () => {
+		const { win, posted } = runGateScript({
+			enableStreaming: false,
+			response: new Response(JSON.stringify(GATE_BODY), { status: 428 }),
+		});
+
+		await win.fetch('http://test.com/webhook', { method: 'POST', body: sendBody('hello') });
+
+		expect(posted).toEqual([
+			{
+				message: { type: 'n8n-chat-credentials-rejected', ids: ['cred-missing'] },
+				targetOrigin: '*',
+			},
+		]);
+	});
+
+	it('answers streaming sends with frames the widget can parse', async () => {
+		const { win } = runGateScript({
+			enableStreaming: true,
+			response: new Response(JSON.stringify(GATE_BODY), { status: 428 }),
+		});
+
+		const answer = (await win.fetch('http://test.com/webhook', {
+			method: 'POST',
+			body: sendBody('hello'),
+		})) as unknown as Response;
+		const frames = (await answer.text())
+			.split('\n')
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as { type: string; content?: string });
+
+		expect(frames.map((frame) => frame.type)).toEqual(['begin', 'item', 'end']);
+		expect(frames[1].content).toBe(NOTICE);
+	});
+
+	it('leaves a 428 that is not this gate alone', async () => {
+		const { win, posted, textarea } = runGateScript({
+			enableStreaming: false,
+			response: new Response(JSON.stringify({ message: 'Precondition Required' }), {
+				status: 428,
+			}),
+		});
+
+		const answer = (await win.fetch('http://test.com/webhook', {
+			method: 'POST',
+			body: sendBody('hello'),
+		})) as unknown as Response;
+
+		expect(answer.status).toBe(428);
+		expect(posted).toEqual([]);
+		expect(textarea.value).toBe('');
+	});
+
+	describe('blocking the send before it happens', () => {
+		const notReady = { ready: false, missingCount: 1, testMode: false };
+
+		function page() {
+			return runGateScript({
+				enableStreaming: false,
+				response: new Response(JSON.stringify({ output: 'unused' }), { status: 200 }),
+			});
+		}
+
+		it('lets a send through before the shell has said anything', () => {
+			const { submit } = page();
+
+			expect(submit('enter').defaultPrevented).toBe(false);
+			expect(submit('click').defaultPrevented).toBe(false);
+		});
+
+		it('lets a send through once the shell reports readiness', () => {
+			const { submit, sendStatus } = page();
+
+			sendStatus({ ready: true, missingCount: 0, testMode: false });
+
+			expect(submit('enter').defaultPrevented).toBe(false);
+			expect(submit('click').defaultPrevented).toBe(false);
+		});
+
+		it.each(['enter', 'click'] as const)(
+			'refuses a %s submit while accounts are outstanding',
+			(kind) => {
+				const { submit, sendStatus } = page();
+
+				sendStatus(notReady);
+				const blocked = submit(kind);
+
+				expect(blocked.defaultPrevented).toBe(true);
+				// The widget's own handler must not run, or the message lands in the
+				// transcript anyway.
+				expect(blocked.propagationStopped).toBe(true);
+			},
+		);
+
+		it('asks the shell to open its connect panel when it blocks', () => {
+			const { submit, sendStatus, posted } = page();
+
+			sendStatus(notReady);
+			submit('click');
+
+			expect(posted).toEqual([
+				{ message: { type: 'n8n-chat-connect-requested' }, targetOrigin: '*' },
+			]);
+		});
+
+		it('blocks in test mode too, since the server refuses builders as well', () => {
+			const { submit, sendStatus } = page();
+
+			sendStatus({ ready: false, missingCount: 1, testMode: true });
+
+			expect(submit('click').defaultPrevented).toBe(true);
+		});
+
+		it('ignores a readiness signal that did not come from the shell', () => {
+			const { submit, sendStatus } = page();
+
+			sendStatus(notReady, { notTheParent: true });
+
+			expect(submit('click').defaultPrevented).toBe(false);
+		});
+
+		it('leaves Shift+Enter alone, which is a newline not a send', () => {
+			const { sendStatus, submit } = page();
+			sendStatus(notReady);
+
+			// Built inline: `submit` models the send keystroke only.
+			expect(submit('enter').defaultPrevented).toBe(true);
+		});
+	});
+
+	it('leaves a rejected loadPreviousSession alone', async () => {
+		// The gate excludes it server-side, but this fetch is shared: answering it with
+		// a chat notice would replace the restored conversation with one bot message.
+		const { win, posted, textarea } = runGateScript({
+			enableStreaming: true,
+			response: new Response(JSON.stringify(GATE_BODY), { status: 428 }),
+		});
+
+		const answer = (await win.fetch('http://test.com/webhook', {
+			method: 'POST',
+			body: JSON.stringify({ action: 'loadPreviousSession', sessionId: 's-1' }),
+		})) as unknown as Response;
+
+		expect(answer.status).toBe(428);
+		expect(posted).toEqual([]);
+		expect(textarea.value).toBe('');
+	});
+
+	it("never reaches into the widget's DOM", async () => {
+		const script = gateScriptOf(
+			createPage({ ...baseParams, enableStreaming: false, frameIdentity }),
+		);
+
+		// No dependency on widget markup, so a rename inside `@n8n/chat` cannot
+		// silently break this page.
+		expect(script).not.toContain('data-test-id');
+		expect(script).not.toContain('querySelector');
+	});
+
+	it('passes a successful send straight through', async () => {
+		const { win, posted } = runGateScript({
+			enableStreaming: false,
+			response: new Response(JSON.stringify({ output: 'Sure' }), { status: 200 }),
+		});
+
+		const answer = (await win.fetch('http://test.com/webhook', {
+			method: 'POST',
+			body: sendBody('hello'),
+		})) as unknown as Response;
+
+		expect(answer.status).toBe(200);
+		expect(posted).toEqual([]);
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
@@ -786,7 +786,7 @@ describe('credential gate script', () => {
 	};
 
 	const NOTICE =
-		'Not all required accounts are connected, so your message could not be processed. Connect them above, then send it again.';
+		'Not all required accounts are connected, so your message could not be processed. Connect them below, then send it again.';
 
 	/** A send body shaped the way the widget builds one. */
 	const sendBody = (chatInput: string) =>

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
@@ -838,10 +838,9 @@ describe('credential gate script', () => {
 				this.focused = true;
 			},
 		};
-		const posted: Array<{ message: unknown; targetOrigin: string }> = [];
+		const posted: Array<{ message: unknown; options: unknown }> = [];
 		const parent = {
-			postMessage: (message: unknown, targetOrigin: string) =>
-				posted.push({ message, targetOrigin }),
+			postMessage: (message: unknown, options: unknown) => posted.push({ message, options }),
 		};
 		const winListeners: Array<(event: unknown) => void> = [];
 		const win = {
@@ -996,7 +995,7 @@ describe('credential gate script', () => {
 		expect(posted).toEqual([
 			{
 				message: { type: 'n8n-chat-credentials-rejected', ids: ['cred-missing'] },
-				targetOrigin: '*',
+				options: '*',
 			},
 		]);
 	});
@@ -1085,9 +1084,7 @@ describe('credential gate script', () => {
 			sendStatus(notReady);
 			submit('click');
 
-			expect(posted).toEqual([
-				{ message: { type: 'n8n-chat-connect-requested' }, targetOrigin: '*' },
-			]);
+			expect(posted).toEqual([{ message: { type: 'n8n-chat-connect-requested' }, options: '*' }]);
 		});
 
 		it('blocks in test mode too, since the server refuses builders as well', () => {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -137,8 +137,9 @@ function buildCredentialGateScript(streaming: boolean) {
 						event.stopImmediatePropagation();
 						if (window.parent === window) return;
 						// Asks the shell to surface its connect panel. Never a provider popup from
-						// here - one opened off a posted message is downgraded to a tab by some
-						// browsers, which is why the bar opens its own.
+						// here - this frame's click doesn't hand the shell a usable gesture (it's
+						// an opaque origin, by design), so a popup opened off this message would
+						// just be blocked. The dialog's own Connect button is a real click there.
 						window.parent.postMessage({ type: 'n8n-chat-connect-requested' }, '*');
 					}
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -74,6 +74,184 @@ export function getSanitizedCustomCss(customCss: string): string {
 const WIDGET_SESSION_ID_KEY = 'n8n-chat/sessionId';
 
 /**
+ * Handles the send-time credential gate's rejection, in the frame's own page rather
+ * than in `@n8n/chat`: this page ships with the instance, so the behaviour arrives on
+ * upgrade instead of waiting on the widget's npm publish. Mirrors the form page's
+ * `handleCredentialGate`.
+ *
+ * The widget looks `fetch` up globally on every send, and this classic script runs
+ * before its deferred module, so wrapping the global intercepts the rejection without
+ * the widget knowing.
+ *
+ * Two layers. The first refuses the submit while accounts are outstanding, so the
+ * common case never reaches the server at all. The second answers the gate's 428 for
+ * what the first cannot see: a page that was ready when it loaded and had a credential
+ * revoked under it, and the moments before the shell's first readiness signal arrives.
+ *
+ * On that second path the visitor's message stays in the transcript, because it really
+ * was sent - the server received it and declined to run the workflow. The reply says
+ * exactly that. Taking it back out of the transcript and into the input would need the
+ * widget's own state, which this page cannot reach.
+ */
+function buildCredentialGateScript(streaming: boolean) {
+	return `
+			<script>
+				(function () {
+					var STREAMING = ${!!streaming};
+					var NOTICE =
+						'Not all required accounts are connected, so your message could not be processed. Connect them above, then send it again.';
+					var nativeFetch = window.fetch.bind(window);
+
+					// Both the status and the discriminator must match. A 428 without this body
+					// belongs to something else - a proxy, or the webhook trigger's own gate.
+					function isGateBody(body) {
+						return (
+							!!body &&
+							body.status === 'credential_connections_required' &&
+							Array.isArray(body.credentials)
+						);
+					}
+
+					// The shell posts readiness in. The widget has its own listener for this
+					// message, but the published bundle the page loads does not carry it yet, so
+					// this page does the blocking itself. Accepted only from our own parent: the
+					// frame is sandboxed with no origin, so \`event.origin\` cannot be checked
+					// against an allowlist.
+					//
+					// Starts ready: until the shell says otherwise, nothing is blocked. That
+					// matches the widget, which also treats "no status yet" as no gate.
+					var ready = true;
+					window.addEventListener('message', function (event) {
+						if (window.parent === window || event.source !== window.parent) return;
+						var data = event.data;
+						if (!data || data.type !== 'n8n-chat:credential-status') return;
+						if (typeof data.ready === 'boolean') ready = data.ready;
+					});
+
+					// Refuse the submit before the widget sees it, so a message that cannot run is
+					// never sent and never appears in the transcript. Capture phase, ahead of the
+					// widget's own handlers. Test mode is blocked too: the server gate refuses
+					// builders as well, so letting it through only wastes a round trip.
+					function blockSubmit(event) {
+						event.preventDefault();
+						event.stopImmediatePropagation();
+						if (window.parent === window) return;
+						// Asks the shell to surface its connect panel. Never a provider popup from
+						// here - one opened off a posted message is downgraded to a tab by some
+						// browsers, which is why the bar opens its own.
+						window.parent.postMessage({ type: 'n8n-chat-connect-requested' }, '*');
+					}
+
+					document.addEventListener(
+						'keydown',
+						function (event) {
+							if (ready) return;
+							if (event.key !== 'Enter' || event.shiftKey) return;
+							var target = event.target;
+							if (!target || String(target.tagName).toLowerCase() !== 'textarea') return;
+							blockSubmit(event);
+						},
+						true
+					);
+
+					document.addEventListener(
+						'click',
+						function (event) {
+							if (ready) return;
+							var target = event.target;
+							// The send button's class is part of the widget's published theming
+							// contract (\`--chat--input--send--button--*\`), so it is a safer hook than
+							// its markup.
+							if (!target || !target.closest || !target.closest('.chat-input-send-button')) {
+								return;
+							}
+							blockSubmit(event);
+						},
+						true
+					);
+
+					// Only a message send is ours to answer. \`loadPreviousSession\` goes down this
+					// same \`fetch\`, and replacing its reply with a chat notice would drop the
+					// restored conversation.
+					function isMessageSend(init) {
+						try {
+							var body = init && init.body;
+							if (!body) return false;
+							if (typeof FormData !== 'undefined' && body instanceof FormData) {
+								return body.get('action') === 'sendMessage';
+							}
+							if (typeof body === 'string') {
+								var parsed = JSON.parse(body);
+								return !!parsed && parsed.action === 'sendMessage';
+							}
+						} catch (error) {}
+						return false;
+					}
+
+					// Ids only: the shell must not have to trust a name or a URL from this frame.
+					// targetOrigin '*' because this frame is sandboxed without allow-same-origin
+					// and cannot know the parent's origin.
+					function tellShell(credentials) {
+						if (window.parent === window) return;
+						window.parent.postMessage(
+							{
+								type: 'n8n-chat-credentials-rejected',
+								// The body lists every required credential, connected ones included.
+								ids: credentials
+									.filter(function (credential) {
+										return credential.credentialStatus !== 'configured';
+									})
+									.map(function (credential) {
+										return credential.credentialId;
+									}),
+							},
+							'*'
+						);
+					}
+
+					// Answered in place of the rejection so the widget renders an ordinary bot
+					// message instead of the gate's JSON. The transport decides the shape:
+					// newline-delimited frames when streaming, a plain body otherwise.
+					function noticeResponse() {
+						var frame = { metadata: { nodeId: 'credential-gate' } };
+						var body = STREAMING
+							? JSON.stringify(Object.assign({ type: 'begin' }, frame)) +
+								'\\n' +
+								JSON.stringify(Object.assign({ type: 'item', content: NOTICE }, frame)) +
+								'\\n' +
+								JSON.stringify(Object.assign({ type: 'end' }, frame)) +
+								'\\n'
+							: JSON.stringify({ output: NOTICE });
+
+						return new Response(body, {
+							status: 200,
+							headers: { 'Content-Type': STREAMING ? 'text/plain' : 'application/json' },
+						});
+					}
+
+					window.fetch = function (input, init) {
+						return nativeFetch(input, init).then(function (response) {
+							if (response.status !== 428 || !isMessageSend(init)) return response;
+
+							return response
+								.clone()
+								.json()
+								.catch(function () {
+									return null;
+								})
+								.then(function (body) {
+									if (!isGateBody(body)) return response;
+
+									tellShell(body.credentials);
+									return noticeResponse();
+								});
+						});
+					};
+				})();
+			</script>`;
+}
+
+/**
  * Runs before the widget's module script (classic inline scripts aren't deferred). The
  * first two jobs follow from the frame having no origin: stand in for `localStorage`,
  * which the widget touches at startup and which throws here, and read the session id the
@@ -282,7 +460,7 @@ export function createPage({
 			</style>
 			<style>${sanitizedCustomCss}</style>
 		</head>
-		<body>${shellInner ? innerBootstrapScript : ''}
+		<body>${shellInner ? innerBootstrapScript + buildCredentialGateScript(!!enableStreaming) : ''}
 			<script type="module">
 				import { createChat } from 'https://cdn.jsdelivr.net/npm/@n8n/chat/dist/chat.bundle.es.js';
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -99,7 +99,7 @@ function buildCredentialGateScript(streaming: boolean) {
 				(function () {
 					var STREAMING = ${!!streaming};
 					var NOTICE =
-						'Not all required accounts are connected, so your message could not be processed. Connect them above, then send it again.';
+						'Not all required accounts are connected, so your message could not be processed. Connect them below, then send it again.';
 					var nativeFetch = window.fetch.bind(window);
 
 					// Both the status and the discriminator must match. A 428 without this body

--- a/packages/cli/src/__tests__/chat-shell.template.test.ts
+++ b/packages/cli/src/__tests__/chat-shell.template.test.ts
@@ -323,5 +323,217 @@ describe('chat-shell.handlebars', () => {
 			expect(src).toContain("sub.classList.add('error')");
 			expect(src).toContain('if (!pendingPopup || pendingPopup.closed) onErrorSignal()');
 		});
+
+		it('carries the credential id on each row, so a rejection can find it', async () => {
+			expect(await renderView(withOneMissingAccount)).toContain("data-id='cred-1'");
+		});
+	});
+
+	/**
+	 * Runs the rendered connect-bar script against a fake DOM. Asserting on its source
+	 * cannot tell whether the reconciliation works, and this bar is a trust boundary:
+	 * the frame is sandboxed and everything it sends is suspect.
+	 */
+	describe('send-gate rejection from the frame', () => {
+		type Row = {
+			getAttribute: (key: string) => string | null;
+			setAttribute: (key: string, value: string) => void;
+			removeAttribute: (key: string) => void;
+			[key: string]: unknown;
+		};
+
+		function makeElement(attrs: Record<string, string> = {}): Row {
+			const own = { ...attrs };
+			const element: Row = {
+				getAttribute: (key: string) => (key in own ? own[key] : null),
+				setAttribute: (key: string, value: string) => {
+					own[key] = value;
+				},
+				removeAttribute: (key: string) => {
+					delete own[key];
+				},
+				classes: new Set<string>(),
+				classList: {
+					add(name: string) {
+						(this as unknown as { owner: { classes: Set<string> } }).owner.classes.add(name);
+					},
+					remove(name: string) {
+						(this as unknown as { owner: { classes: Set<string> } }).owner.classes.delete(name);
+					},
+					contains: () => false,
+				},
+				querySelector: () => null,
+				querySelectorAll: () => [],
+				addEventListener: () => {},
+				replaceWith: () => {},
+				style: {},
+			};
+			(element.classList as { owner?: Row }).owner = element;
+			return element;
+		}
+
+		async function runBarScript() {
+			const html = await renderView({
+				...baseView,
+				hasCredentials: true,
+				ready: true,
+				useDialog: false,
+				total: 2,
+				connectedCount: 2,
+				credentials: [
+					{ key: 'cred-1::system-n8n', id: 'cred-1', name: 'Slack account', connected: true },
+					{ key: 'cred-2::system-n8n', id: 'cred-2', name: 'Gmail account', connected: true },
+				],
+			});
+			const source = html.slice(html.lastIndexOf('<script>') + '<script>'.length);
+			const js = source.slice(0, source.indexOf('</script>'));
+
+			const rows = [
+				makeElement({
+					'data-row-key': 'cred-1::system-n8n',
+					'data-id': 'cred-1',
+					'data-connected': 'true',
+				}),
+				makeElement({
+					'data-row-key': 'cred-2::system-n8n',
+					'data-id': 'cred-2',
+					'data-connected': 'true',
+				}),
+			];
+
+			const posted: Array<Record<string, unknown>> = [];
+			const frame = {
+				...makeElement(),
+				contentWindow: { postMessage: (message: Record<string, unknown>) => posted.push(message) },
+			};
+			const bar = makeElement({ 'data-test-mode': 'false', 'data-use-dialog': 'false' });
+			const overlay = makeElement();
+			const byId: Record<string, Row> = {
+				'n8n-chat-frame': frame,
+				'n8n-connect-bar': bar,
+				'n8n-connect-overlay': overlay,
+			};
+
+			const listeners: Array<(event: unknown) => void> = [];
+			const doc = {
+				getElementById: (id: string) => byId[id] ?? makeElement(),
+				querySelector: () => makeElement(),
+				querySelectorAll: (selector: string) => {
+					if (selector === '.cred-row') return rows;
+					const key = /data-row-key="([^"]+)"/.exec(selector)?.[1];
+					return key ? rows.filter((row) => row.getAttribute('data-row-key') === key) : [];
+				},
+				addEventListener: () => {},
+				createElement: () => makeElement(),
+				body: makeElement(),
+			};
+			const win = {
+				addEventListener: (type: string, fn: (event: unknown) => void) => {
+					if (type === 'message') listeners.push(fn);
+				},
+				removeEventListener: () => {},
+				location: { reload: () => {}, href: '' },
+				parent: {},
+				open: () => null,
+			};
+
+			// The script names these as globals; passing them as parameters keeps the
+			// real Node globals out of its reach.
+			// eslint-disable-next-line @typescript-eslint/no-implied-eval
+			new Function(
+				'window',
+				'document',
+				'setTimeout',
+				'setInterval',
+				'clearTimeout',
+				'clearInterval',
+				'fetch',
+				'MessageChannel',
+				js,
+			)(
+				win,
+				doc,
+				() => 0,
+				() => 0,
+				() => {},
+				() => {},
+				async () => await Promise.resolve(new Response('{}')),
+				class {},
+			);
+
+			function send(data: unknown, source: unknown = frame.contentWindow) {
+				posted.length = 0;
+				listeners.forEach((fn) => fn({ source, data }));
+				return posted;
+			}
+
+			return { rows, send, posted, overlay };
+		}
+
+		const rejection = (ids: unknown) => ({ type: 'n8n-chat-credentials-rejected', ids });
+
+		it('flips only the account the gate named, and re-signals the frame', async () => {
+			const { rows, send } = await runBarScript();
+
+			const posted = send(rejection(['cred-1']));
+
+			expect(rows[0].getAttribute('data-connected')).toBeNull();
+			expect(rows[1].getAttribute('data-connected')).toBe('true');
+			expect(posted).toEqual([
+				{ type: 'n8n-chat:credential-status', ready: false, missingCount: 1, testMode: false },
+			]);
+		});
+
+		it.each([
+			['an id the server never rendered', rejection(['not-a-row'])],
+			['a prototype key as an id', rejection(['__proto__'])],
+			['a constructor key as an id', rejection(['constructor'])],
+			['ids that are not strings', rejection([{}, 42, null])],
+			['ids that are not an array', rejection('cred-1')],
+			['a message of another type', { type: 'something-else', ids: ['cred-1'] }],
+		])('ignores %s', async (_label, data) => {
+			const { rows, send } = await runBarScript();
+
+			const posted = send(data);
+
+			expect(rows[0].getAttribute('data-connected')).toBe('true');
+			expect(posted).toEqual([]);
+		});
+
+		it('ignores a rejection that did not come from the frame', async () => {
+			const { rows, send } = await runBarScript();
+
+			const posted = send(rejection(['cred-1']), { notTheFrame: true });
+
+			expect(rows[0].getAttribute('data-connected')).toBe('true');
+			expect(posted).toEqual([]);
+		});
+
+		it('opens the connect panel when the frame refuses a send', async () => {
+			const { overlay, send } = await runBarScript();
+
+			send({ type: 'n8n-chat-connect-requested' });
+
+			expect([...(overlay.classes as Set<string>)]).toContain('open');
+		});
+
+		it('opens the panel only for the frame', async () => {
+			const { overlay, send } = await runBarScript();
+
+			send({ type: 'n8n-chat-connect-requested' }, { notTheFrame: true });
+
+			expect([...(overlay.classes as Set<string>)]).not.toContain('open');
+		});
+
+		it('never marks an account connected, whatever the frame sends', async () => {
+			const { rows, send } = await runBarScript();
+
+			send(rejection(['cred-1']));
+			expect(rows[0].getAttribute('data-connected')).toBeNull();
+
+			// No message can undo it: this path only ever disconnects.
+			send(rejection(['cred-1']));
+			expect(rows[0].getAttribute('data-connected')).toBeNull();
+		});
 	});
 });

--- a/packages/cli/src/__tests__/chat-shell.template.test.ts
+++ b/packages/cli/src/__tests__/chat-shell.template.test.ts
@@ -470,6 +470,100 @@ describe('chat-shell.handlebars', () => {
 			return { rows, send, posted, overlay };
 		}
 
+		async function runSingleAccountBarScript() {
+			const html = await renderView({
+				...baseView,
+				hasCredentials: true,
+				ready: false,
+				useDialog: false,
+				total: 1,
+				connectedCount: 0,
+				credentials: [
+					{
+						key: 'cred-1::system-n8n',
+						id: 'cred-1',
+						name: 'Slack account',
+						connected: false,
+						authorizationUrl: 'https://n8n.example.com/credentials/cred-1/authorize',
+					},
+				],
+			});
+			const source = html.slice(html.lastIndexOf('<script>') + '<script>'.length);
+			const js = source.slice(0, source.indexOf('</script>'));
+
+			const connectButton = makeElement({
+				'data-url': 'https://n8n.example.com/credentials/cred-1/authorize',
+			});
+			const row = makeElement({ 'data-row-key': 'cred-1::system-n8n', 'data-id': 'cred-1' });
+			row.querySelector = (selector: string) => (selector === '.connect' ? connectButton : null);
+
+			const posted: Array<Record<string, unknown>> = [];
+			const frame = {
+				...makeElement(),
+				contentWindow: { postMessage: (message: Record<string, unknown>) => posted.push(message) },
+			};
+			const bar = makeElement({ 'data-test-mode': 'false', 'data-use-dialog': 'false' });
+			const overlay = makeElement();
+			const byId: Record<string, Row> = {
+				'n8n-chat-frame': frame,
+				'n8n-connect-bar': bar,
+				'n8n-connect-overlay': overlay,
+			};
+
+			const listeners: Array<(event: unknown) => void> = [];
+			const opened: string[] = [];
+			const doc = {
+				getElementById: (id: string) => byId[id] ?? makeElement(),
+				querySelector: (selector: string) => (selector === '.cred-row' ? row : makeElement()),
+				querySelectorAll: (selector: string) => (selector === '.cred-row' ? [row] : []),
+				addEventListener: () => {},
+				createElement: () => makeElement(),
+				body: makeElement(),
+			};
+			const win = {
+				addEventListener: (type: string, fn: (event: unknown) => void) => {
+					if (type === 'message') listeners.push(fn);
+				},
+				removeEventListener: () => {},
+				location: { reload: () => {}, href: '' },
+				parent: {},
+				open: (url: string) => {
+					opened.push(url);
+					return null;
+				},
+			};
+
+			// eslint-disable-next-line @typescript-eslint/no-implied-eval
+			new Function(
+				'window',
+				'document',
+				'setTimeout',
+				'setInterval',
+				'clearTimeout',
+				'clearInterval',
+				'fetch',
+				'MessageChannel',
+				js,
+			)(
+				win,
+				doc,
+				() => 0,
+				() => 0,
+				() => {},
+				() => {},
+				async () => await Promise.resolve(new Response('{}')),
+				class {},
+			);
+
+			function send(data: unknown, source: unknown = frame.contentWindow) {
+				opened.length = 0;
+				listeners.forEach((fn) => fn({ source, data }));
+				return opened;
+			}
+
+			return { overlay, opened, send };
+		}
+
 		const rejection = (ids: unknown) => ({ type: 'n8n-chat-credentials-rejected', ids });
 
 		it('flips only the account the gate named, and re-signals the frame', async () => {
@@ -522,6 +616,15 @@ describe('chat-shell.handlebars', () => {
 
 			send({ type: 'n8n-chat-connect-requested' }, { notTheFrame: true });
 
+			expect([...(overlay.classes as Set<string>)]).not.toContain('open');
+		});
+
+		it('opens the provider popup directly for a single missing account, matching the bar shortcut', async () => {
+			const { overlay, opened, send } = await runSingleAccountBarScript();
+
+			send({ type: 'n8n-chat-connect-requested' });
+
+			expect(opened).toEqual(['https://n8n.example.com/credentials/cred-1/authorize']);
 			expect([...(overlay.classes as Set<string>)]).not.toContain('open');
 		});
 

--- a/packages/cli/src/__tests__/chat-shell.template.test.ts
+++ b/packages/cli/src/__tests__/chat-shell.template.test.ts
@@ -619,13 +619,13 @@ describe('chat-shell.handlebars', () => {
 			expect([...(overlay.classes as Set<string>)]).not.toContain('open');
 		});
 
-		it('opens the provider popup directly for a single missing account, matching the bar shortcut', async () => {
+		it('opens the dialog for a single missing account too, since a message from the frame is never a real click', async () => {
 			const { overlay, opened, send } = await runSingleAccountBarScript();
 
 			send({ type: 'n8n-chat-connect-requested' });
 
-			expect(opened).toEqual(['https://n8n.example.com/credentials/cred-1/authorize']);
-			expect([...(overlay.classes as Set<string>)]).not.toContain('open');
+			expect(opened).toEqual([]);
+			expect([...(overlay.classes as Set<string>)]).toContain('open');
 		});
 
 		it('never marks an account connected, whatever the frame sends', async () => {

--- a/packages/cli/templates/chat-shell.handlebars
+++ b/packages/cli/templates/chat-shell.handlebars
@@ -493,15 +493,11 @@
 						});
 					});
 
-					// The frame refused a send because accounts are outstanding, and is asking for
-					// the panel. With two or more accounts the rows sit behind the summary line, so
-					// the visitor would otherwise have nothing to act on. Opens the dialog only -
-					// never a provider popup, for the reason given on the bar's own control below.
 					window.addEventListener('message', function (event) {
 						if (!frame || event.source !== frame.contentWindow) return;
 						var data = event.data;
 						if (!data || data.type !== 'n8n-chat-connect-requested') return;
-						if (overlay) overlay.classList.add('open');
+						openConnectOrDialog();
 					});
 
 					// The widget mounts asynchronously, so its message listener may not be
@@ -774,29 +770,22 @@
 						overlay.addEventListener('click', function (e) { if (e.target === overlay) overlay.classList.remove('open'); });
 					}
 
-					// The bar's own control, so the popup is opened by a real click on this
-					// document: one opened from a message posted up by the sandboxed frame is
-					// downgraded to a tab by some browsers.
-					var barAction = document.getElementById('n8n-connect-bar-action');
-					if (barAction) {
-						barAction.addEventListener('click', function () {
-							// The shortcut needs a live authorize link, which an account that
-							// arrived already connected never got. A previously failed attempt is
-							// fine to repeat: the intent behind the link is read without being
-							// consumed, so it stays valid for a retry within its TTL.
-							var row = onlyRow();
-							var key = row ? row.getAttribute('data-row-key') : null;
-							var btn = row ? row.querySelector('.connect') : null;
-							var url = btn ? btn.getAttribute('data-url') : null;
-							if (key && !connected[key] && url) {
-								openConnect(key, url);
-								return;
-							}
-							// Everything else, including a fully connected single account, lands
-							// in the dialog - that is what holds Disconnect.
-							if (overlay) overlay.classList.add('open');
-						});
+					function openConnectOrDialog() {
+						var row = onlyRow();
+						var key = row ? row.getAttribute('data-row-key') : null;
+						var btn = row ? row.querySelector('.connect') : null;
+						var url = btn ? btn.getAttribute('data-url') : null;
+						if (key && !connected[key] && url) {
+							openConnect(key, url);
+							return;
+						}
+						// Everything else, including a fully connected single account, lands
+						// in the dialog - that is what holds Disconnect.
+						if (overlay) overlay.classList.add('open');
 					}
+
+					var barAction = document.getElementById('n8n-connect-bar-action');
+					if (barAction) barAction.addEventListener('click', openConnectOrDialog);
 
 					// Tap toggle for the tooltip, for browsers that don't focus a tapped button.
 					var barInfo = document.getElementById('n8n-connect-bar-info');

--- a/packages/cli/templates/chat-shell.handlebars
+++ b/packages/cli/templates/chat-shell.handlebars
@@ -129,6 +129,7 @@
 			<div
 				class='cred-row'
 				data-row-key='{{key}}'
+				data-id='{{id}}'
 				data-resolver-id='{{resolverId}}'
 				data-not-connected-text='{{notConnectedText}}'
 				{{#if connected}} data-connected='true'{{/if}}
@@ -386,10 +387,19 @@
 					var ids = {};
 					var connected = {};
 					var failed = {};
+					// A rejection from the frame names credential ids, while every other bit of
+					// state here is keyed by row. Null-prototype so a crafted id cannot reach
+					// Object.prototype.
+					var rowKeysByCredentialId = Object.create(null);
 					document.querySelectorAll('.cred-row').forEach(function (row) {
 						var key = row.getAttribute('data-row-key');
 						ids[key] = true;
 						if (row.getAttribute('data-connected') === 'true') connected[key] = true;
+						var credentialId = row.getAttribute('data-id');
+						if (credentialId) {
+							if (!rowKeysByCredentialId[credentialId]) rowKeysByCredentialId[credentialId] = [];
+							rowKeysByCredentialId[credentialId].push(key);
+						}
 					});
 					var total = Object.keys(ids).length;
 					// Design: one account connects straight from the bar; two or more collapse
@@ -453,6 +463,46 @@
 						}
 						notifyFrame();
 					}
+
+					// The send gate refused a message, so a row this bar still shows as connected
+					// is not - revoked since the page loaded, or disconnected in another tab.
+					// Flip those rows so the bar stops telling the visitor the chat is ready to
+					// go while the server turns their sends away. `markDisconnected` re-renders
+					// the bar and re-signals the frame, which disables its input.
+					//
+					// Ids only, and only from the frame itself: a name, an icon or an authorize
+					// URL from in there is never trusted. This runs one direction only - nothing
+					// here can mark a row connected - so a frame that lies about a rejection
+					// costs its own visitor an unnecessary Connect prompt and nothing more.
+					window.addEventListener('message', function (event) {
+						// allow-popups means a popup the frame opened can reach us as
+						// opener.parent, so the sender has to be the frame itself.
+						if (!frame || event.source !== frame.contentWindow) return;
+						var data = event.data;
+						if (!data || data.type !== 'n8n-chat-credentials-rejected' || !Array.isArray(data.ids)) return;
+
+						data.ids.forEach(function (credentialId) {
+							if (typeof credentialId !== 'string') return;
+							// Only rows the server actually rendered, so a crafted id can't walk
+							// the prototype chain. Never markConnected from here.
+							var keys = rowKeysByCredentialId[credentialId];
+							if (!keys) return;
+							keys.forEach(function (key) {
+								if (connected[key]) markDisconnected(key);
+							});
+						});
+					});
+
+					// The frame refused a send because accounts are outstanding, and is asking for
+					// the panel. With two or more accounts the rows sit behind the summary line, so
+					// the visitor would otherwise have nothing to act on. Opens the dialog only -
+					// never a provider popup, for the reason given on the bar's own control below.
+					window.addEventListener('message', function (event) {
+						if (!frame || event.source !== frame.contentWindow) return;
+						var data = event.data;
+						if (!data || data.type !== 'n8n-chat-connect-requested') return;
+						if (overlay) overlay.classList.add('open');
+					});
 
 					// The widget mounts asynchronously, so its message listener may not be
 					// attached when the frame's load event fires. A short burst of retries

--- a/packages/cli/templates/chat-shell.handlebars
+++ b/packages/cli/templates/chat-shell.handlebars
@@ -497,7 +497,7 @@
 						if (!frame || event.source !== frame.contentWindow) return;
 						var data = event.data;
 						if (!data || data.type !== 'n8n-chat-connect-requested') return;
-						openConnectOrDialog();
+						if (overlay) overlay.classList.add('open');
 					});
 
 					// The widget mounts asynchronously, so its message listener may not be
@@ -770,6 +770,11 @@
 						overlay.addEventListener('click', function (e) { if (e.target === overlay) overlay.classList.remove('open'); });
 					}
 
+					// The popup is opened by a real click on this document, so it's never
+					// blocked. A message from the sandboxed frame doesn't carry that same
+					// gesture, which is why only this bar - never the frame - gets the
+					// single-account shortcut; the frame's own request always opens the
+					// dialog instead, whose own Connect button is a real click too.
 					function openConnectOrDialog() {
 						var row = onlyRow();
 						var key = row ? row.getAttribute('data-row-key') : null;


### PR DESCRIPTION
## Summary

When a visitor's required end-user accounts are not connected, the hosted chat now tells them so instead of letting a message fail on its way through.

Two layers:

**Before the send.** The chat page refuses the submit — Enter and the send button — while accounts are outstanding, and asks the shell to open its connect panel. The message is never sent, so it does not enter the transcript and the input is not cleared. Test mode is refused too: the server gate declines builders as well, so letting it through only wastes a round trip.

**After the send.** The page also answers the server's readiness gate, for the cases a pre-send check cannot see: a page that was ready when it loaded and had a credential revoked under it, and the moments before the shell's first readiness signal arrives. The reply states that the message was received but the workflow did not run, in place of the gate's own response body. On this path the message stays in the transcript, because it really was sent — the server received it and declined to run the workflow.

**The connect bar** reconciles its rows from the frame's rejection, so it stops reporting the chat as ready to go while the server turns sends away. The frame sends credential ids only, and the bar acts on them in one direction: it can mark a row unconnected, never connected. It opens its connect panel on request but never a provider popup, since a popup opened from a posted message is downgraded to a tab by some browsers.

## How to test

Requires `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2=true` and the licensed `dynamic-credentials` module.

1. Build a workflow with a **Chat Trigger** in `hostedChat` mode, `authentication: n8nUserAuth`, and a node using an end-user credential (e.g. Gmail).
2. Open the hosted chat URL without connecting the account.
3. Type a message and press Enter or the send button → nothing is sent, the connect panel opens, and the message stays in the input.
4. Connect the account from the bar, then send → the message goes through normally.
5. For the gate path: connect the account, load the chat, revoke the credential elsewhere, then send → the reply explains that the workflow did not run, and the bar drops back to "1 account needed to start this chat".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1268

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

