### PR TITLE
feat(editor): Add a new option to output the user details with a chat message trigger (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -952,7 +952,7 @@ export class ChatTrigger extends Node {
 				// Auth is skipped here, but the editor user who started the run is known, so
 				// report them under the same conditions production would.
 				if (authentication === 'n8nUserAuth') {
-					authedUser = await ctx.getTestWebhookUser();
+					authedUser = await ctx.getTestWebhookUser?.();
 				}
 			} else {
 				authedUser = await validateAuth(ctx);

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -949,31 +949,33 @@ export class ChatTrigger extends Node {
 
 		const authentication = ctx.getNodeParameter('authentication', 'none');
 		let authedUser: IUser | undefined;
-		try {
-			// The editor's canvas chat can't supply webhook credentials, so its session-scoped
-			// test route (flagged by the backend at registration) is exempt from auth. Every
-			// other request — production or sessionless test — enforces the configured auth.
-			if (mode === 'test' && ctx.isChatSessionTest()) {
-				// Auth is skipped here, but the editor user who started the run is known, so
-				// report them under the same conditions production would.
-				if (authentication === 'n8nUserAuth') {
-					authedUser = await ctx.getTestWebhookUser?.();
-				}
-			} else {
+		// The editor's canvas chat can't supply webhook credentials, so its session-scoped
+		// test route (flagged by the backend at registration) is exempt from auth. Every
+		// other request — production or sessionless test — enforces the configured auth.
+		if (mode === 'test' && ctx.isChatSessionTest()) {
+			// Auth is skipped here, but the editor user who started the run is known, so
+			// report them under the same conditions production would. This lookup is identity,
+			// not authorization: it stays outside the `catch` below, which reads its error as
+			// an auth challenge and would answer with an undefined status code.
+			if (authentication === 'n8nUserAuth') {
+				authedUser = await ctx.getTestWebhookUser?.();
+			}
+		} else {
+			try {
 				authedUser = await validateAuth(ctx);
+			} catch (error) {
+				if (error) {
+					// Realm is scoped per webhook so browsers don't reuse cached credentials across chats sharing an origin
+					const webhookId = ctx.getNode().webhookId;
+					const realm = webhookId ? `Webhook ${webhookId}` : 'Webhook';
+					res.writeHead((error as IDataObject).responseCode as number, {
+						'www-authenticate': `Basic realm="${realm}"`,
+					});
+					res.end((error as IDataObject).message as string);
+					return { noWebhookResponse: true };
+				}
+				throw error;
 			}
-		} catch (error) {
-			if (error) {
-				// Realm is scoped per webhook so browsers don't reuse cached credentials across chats sharing an origin
-				const webhookId = ctx.getNode().webhookId;
-				const realm = webhookId ? `Webhook ${webhookId}` : 'Webhook';
-				res.writeHead((error as IDataObject).responseCode as number, {
-					'www-authenticate': `Basic realm="${realm}"`,
-				});
-				res.end((error as IDataObject).message as string);
-				return { noWebhookResponse: true };
-			}
-			throw error;
 		}
 		if (nodeMode === 'hostedChat') {
 			// Show the chat on GET request

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -23,6 +23,7 @@ import type {
 	IBinaryData,
 	INodeProperties,
 	CredentialCheckResult,
+	IUser,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
 import { ChatTriggerConfig } from '@n8n/config';
@@ -48,6 +49,32 @@ import { createPage } from './templates';
 import { assertValidLoadPreviousSessionOption, type ChatFrameIdentity } from './types';
 
 const isPublicChatTriggerDisabled = () => Container.get(ChatTriggerConfig).disablePublicChat;
+
+/**
+ * The emitted item's `json` starts as the caller's own request body, so a caller can
+ * put a `user` key in it and have it land in the output. Drop any claimed `user`
+ * unconditionally and re-add only the identity the server itself resolved, so
+ * `json.user` is either absent or trustworthy — never whatever the request claimed.
+ *
+ * An array body is returned as is: it can carry no `user` key, and object rest would
+ * silently turn it into `{ 0: …, 1: … }`.
+ */
+function withAuthenticatedUser(json: IDataObject, user: IUser | undefined): IDataObject {
+	if (Array.isArray(json)) return json;
+	const { user: claimedUser, ...rest } = json;
+	if (!user) return rest;
+	// Field by field, so a future `IUser` field cannot leak into workflow data.
+	return {
+		...rest,
+		user: {
+			id: user.id,
+			email: user.email,
+			firstName: user.firstName,
+			lastName: user.lastName,
+		},
+	};
+}
+
 const allowFileUploadsOption: INodeProperties = {
 	displayName: 'Allow File Uploads',
 	name: 'allowFileUploads',
@@ -248,8 +275,8 @@ export class ChatTrigger extends Node {
 		icon: 'node:chat-trigger',
 		iconColor: 'black',
 		group: ['trigger'],
-		version: [1, 1.1, 1.2, 1.3, 1.4],
-		defaultVersion: 1.4,
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
+		defaultVersion: 1.5,
 		description: 'Runs the workflow when an n8n generated webchat is submitted',
 		defaults: {
 			name: 'When chat message received',
@@ -458,6 +485,23 @@ export class ChatTrigger extends Node {
 				},
 				description:
 					'Whether the triggering user must also have permission to execute the workflow in the project it belongs to',
+			},
+			{
+				displayName: 'Include User in Output',
+				name: 'includeUserInOutput',
+				type: 'boolean',
+				default: true,
+				displayOptions: {
+					show: {
+						authentication: ['n8nUserAuth'],
+						public: [true],
+						'@version': [{ _cnd: { gte: 1.5 } }],
+					},
+				},
+				// No `mode` gate, unlike its neighbour: `n8nUserAuth` also works in `webhook`
+				// mode through the cookie check, and that path emits an item too.
+				description:
+					"Whether to include the logged-in user's ID, email and name in the trigger output",
 			},
 			{
 				displayName: 'Initial Message(s)',
@@ -890,12 +934,20 @@ export class ChatTrigger extends Node {
 		const webhookName = ctx.getWebhookName();
 		const bodyData = ctx.getBodyData() ?? {};
 
+		const authentication = ctx.getNodeParameter('authentication', 'none');
+		let authedUser: IUser | undefined;
 		try {
 			// The editor's canvas chat can't supply webhook credentials, so its session-scoped
 			// test route (flagged by the backend at registration) is exempt from auth. Every
 			// other request — production or sessionless test — enforces the configured auth.
-			if (mode !== 'test' || !ctx.isChatSessionTest()) {
-				await validateAuth(ctx);
+			if (mode === 'test' && ctx.isChatSessionTest()) {
+				// Auth is skipped here, but the editor user who started the run is known, so
+				// report them under the same conditions production would.
+				if (authentication === 'n8nUserAuth') {
+					authedUser = await ctx.getTestWebhookUser();
+				}
+			} else {
+				authedUser = await validateAuth(ctx);
 			}
 		} catch (error) {
 			if (error) {
@@ -1085,7 +1137,6 @@ export class ChatTrigger extends Node {
 			}
 		}
 
-		let returnData: INodeExecutionData[];
 		const webhookResponse: IDataObject = { status: 200 };
 
 		// Handle streaming responses
@@ -1109,27 +1160,35 @@ export class ChatTrigger extends Node {
 
 			// Flush headers immediately
 			res.flushHeaders();
+		}
 
-			if (req.contentType === 'multipart/form-data') {
-				returnData = [await this.handleFormData(ctx)];
-			} else {
-				returnData = [{ json: bodyData }];
-			}
+		const isMultipart = req.contentType === 'multipart/form-data';
+		const item = isMultipart ? await this.handleFormData(ctx) : { json: bodyData };
 
+		// The single merge point for all three emission paths — see `withAuthenticatedUser`.
+		// Spread so the multipart path keeps its `binary` attachments.
+		const returnItem: INodeExecutionData = {
+			...item,
+			json: withAuthenticatedUser(
+				item.json,
+				ctx.getNodeParameter('includeUserInOutput', true) !== false ? authedUser : undefined,
+			),
+		};
+
+		const returnData: INodeExecutionData[] = [returnItem];
+
+		if (enableStreaming) {
 			return {
 				workflowData: [ctx.helpers.returnJsonArray(returnData)],
 				noWebhookResponse: true,
 			};
 		}
 
-		if (req.contentType === 'multipart/form-data') {
-			returnData = [await this.handleFormData(ctx)];
+		if (isMultipart) {
 			return {
 				webhookResponse,
 				workflowData: [returnData],
 			};
-		} else {
-			returnData = [{ json: bodyData }];
 		}
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -60,15 +60,20 @@ const isPublicChatTriggerDisabled = () => Container.get(ChatTriggerConfig).disab
  * modes no server identity exists, `user` is ordinary body data, and the body passes
  * through untouched.
  *
- * An array body is returned as is: it can carry no `user` key, and object rest would
- * silently turn it into `{ 0: …, 1: … }`.
+ * Only a plain object body is merged into. A string (`text/plain`), a scalar or an array
+ * body can carry no `user` key, and object rest would silently shred it into
+ * `{ 0: …, 1: … }`, so those pass through as they are.
  */
+function isPlainObject(value: unknown): value is IDataObject {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function withAuthenticatedUser(
 	json: IDataObject,
 	user: IUser | undefined,
 	serverOwnsUserKey: boolean,
 ): IDataObject {
-	if (!serverOwnsUserKey || Array.isArray(json)) return json;
+	if (!serverOwnsUserKey || !isPlainObject(json)) return json;
 	const { user: claimedUser, ...rest } = json;
 	if (!user) return rest;
 	// Field by field, so a future `IUser` field cannot leak into workflow data.

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -95,6 +95,19 @@ const allowFileUploadsOption: INodeProperties = {
 	default: false,
 	description: 'Whether to allow file uploads in the chat',
 };
+const includeUserInOutputOption: INodeProperties = {
+	displayName: 'Include User in Output',
+	name: 'includeUserInOutput',
+	type: 'boolean',
+	default: true,
+	// Hidden until the chat OAuth2 rollout reaches GA. Display only — `webhook()`
+	// checks the same flag itself.
+	envFeatureFlag: 'CHAT_TRIGGER_OAUTH2',
+	// No `mode` gate, unlike its neighbour: `n8nUserAuth` also works in `webhook`
+	// mode through the cookie check, and that path emits an item too.
+	description: "Whether to include the logged-in user's ID, email and name in the trigger output",
+};
+
 const allowedFileMimeTypeOption: INodeProperties = {
 	displayName: 'Allowed File Mime Types',
 	name: 'allowedFilesMimeTypes',
@@ -500,10 +513,7 @@ export class ChatTrigger extends Node {
 					'Whether the triggering user must also have permission to execute the workflow in the project it belongs to',
 			},
 			{
-				displayName: 'Include User in Output',
-				name: 'includeUserInOutput',
-				type: 'boolean',
-				default: true,
+				...includeUserInOutputOption,
 				displayOptions: {
 					show: {
 						authentication: ['n8nUserAuth'],
@@ -511,10 +521,20 @@ export class ChatTrigger extends Node {
 						'@version': [{ _cnd: { gte: 1.5 } }],
 					},
 				},
-				// No `mode` gate, unlike its neighbour: `n8nUserAuth` also works in `webhook`
-				// mode through the cookie check, and that path emits an item too.
-				description:
-					"Whether to include the logged-in user's ID, email and name in the trigger output",
+			},
+			{
+				...includeUserInOutputOption,
+				// Off below 1.5: `n8nUserAuth` has been selectable since the node shipped, so chats
+				// built long before this feature must keep their output shape. Still visible, so they
+				// can opt in without being rebuilt — which would change their public chat URL.
+				default: false,
+				displayOptions: {
+					show: {
+						authentication: ['n8nUserAuth'],
+						public: [true],
+						'@version': [{ _cnd: { lt: 1.5 } }],
+					},
+				},
 			},
 			{
 				displayName: 'Initial Message(s)',
@@ -957,7 +977,7 @@ export class ChatTrigger extends Node {
 			// report them under the same conditions production would. This lookup is identity,
 			// not authorization: it stays outside the `catch` below, which reads its error as
 			// an auth challenge and would answer with an undefined status code.
-			if (authentication === 'n8nUserAuth') {
+			if (isChatOAuth2Enabled() && authentication === 'n8nUserAuth') {
 				authedUser = await ctx.getTestWebhookUser?.();
 			}
 		} else {
@@ -1180,14 +1200,22 @@ export class ChatTrigger extends Node {
 		const isMultipart = req.contentType === 'multipart/form-data';
 		const item = isMultipart ? await this.handleFormData(ctx) : { json: bodyData };
 
+		// Gated until GA: with the flag off this node behaves exactly as it did before the feature.
+		const userOutputEnabled = isChatOAuth2Enabled() && authentication === 'n8nUserAuth';
+		// The declared `default` only drives the editor. An absent parameter resolves to this
+		// fallback, so it is what decides for a node that never had the key saved.
+		const includeUser =
+			userOutputEnabled &&
+			ctx.getNodeParameter('includeUserInOutput', ctx.getNode().typeVersion >= 1.5) !== false;
+
 		// The single merge point for all three emission paths — see `withAuthenticatedUser`.
 		// Spread so the multipart path keeps its `binary` attachments.
 		const returnItem: INodeExecutionData = {
 			...item,
 			json: withAuthenticatedUser(
 				item.json,
-				ctx.getNodeParameter('includeUserInOutput', true) !== false ? authedUser : undefined,
-				authentication === 'n8nUserAuth',
+				includeUser ? authedUser : undefined,
+				userOutputEnabled,
 			),
 		};
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -56,9 +56,10 @@ const isPublicChatTriggerDisabled = () => Container.get(ChatTriggerConfig).disab
  * Under `n8nUserAuth` the `user` key belongs to the server. The item's `json` starts as
  * the caller's own request body, so any `user` the caller sent is dropped — whether or
  * not a verified one replaces it, since a workflow reading `json.user` must never get an
- * attacker-controlled value in the slot the trusted one occupies. Under the other auth
- * modes no server identity exists, `user` is ordinary body data, and the body passes
- * through untouched.
+ * attacker-controlled value in the slot the trusted one occupies. That holds even when
+ * the rollout flag is off and no verified value is written: the flag can change under a
+ * workflow that already trusts the key. Under the other auth modes no server identity
+ * exists, `user` is ordinary body data, and the body passes through untouched.
  *
  * Only a plain object body is merged into. A string (`text/plain`), a scalar or an array
  * body can carry no `user` key, and object rest would silently shred it into
@@ -1200,12 +1201,17 @@ export class ChatTrigger extends Node {
 		const isMultipart = req.contentType === 'multipart/form-data';
 		const item = isMultipart ? await this.handleFormData(ctx) : { json: bodyData };
 
-		// Gated until GA: with the flag off this node behaves exactly as it did before the feature.
-		const userOutputEnabled = isChatOAuth2Enabled() && authentication === 'n8nUserAuth';
-		// The declared `default` only drives the editor. An absent parameter resolves to this
-		// fallback, so it is what decides for a node that never had the key saved.
+		// Ownership of the `user` key follows the auth mode alone, never the rollout flag. A
+		// workflow built while the flag was on keeps trusting `json.user`, and it travels
+		// between instances — export/import, a rollback, drifted env on one main — while the
+		// env var does not. So a claimed `user` is dropped on every `n8nUserAuth` chat.
+		const serverOwnsUserKey = authentication === 'n8nUserAuth';
+		// Only writing the verified identity is gated until GA. The declared `default` drives
+		// the editor alone; an absent parameter resolves to this fallback, so it is what
+		// decides for a node that never had the key saved.
 		const includeUser =
-			userOutputEnabled &&
+			serverOwnsUserKey &&
+			isChatOAuth2Enabled() &&
 			ctx.getNodeParameter('includeUserInOutput', ctx.getNode().typeVersion >= 1.5) !== false;
 
 		// The single merge point for all three emission paths — see `withAuthenticatedUser`.
@@ -1215,7 +1221,7 @@ export class ChatTrigger extends Node {
 			json: withAuthenticatedUser(
 				item.json,
 				includeUser ? authedUser : undefined,
-				userOutputEnabled,
+				serverOwnsUserKey,
 			),
 		};
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -51,16 +51,24 @@ import { assertValidLoadPreviousSessionOption, type ChatFrameIdentity } from './
 const isPublicChatTriggerDisabled = () => Container.get(ChatTriggerConfig).disablePublicChat;
 
 /**
- * The emitted item's `json` starts as the caller's own request body, so a caller can
- * put a `user` key in it and have it land in the output. Drop any claimed `user`
- * unconditionally and re-add only the identity the server itself resolved, so
- * `json.user` is either absent or trustworthy — never whatever the request claimed.
+ * Merges the server-verified identity into the emitted item's `json`.
+ *
+ * Under `n8nUserAuth` the `user` key belongs to the server. The item's `json` starts as
+ * the caller's own request body, so any `user` the caller sent is dropped — whether or
+ * not a verified one replaces it, since a workflow reading `json.user` must never get an
+ * attacker-controlled value in the slot the trusted one occupies. Under the other auth
+ * modes no server identity exists, `user` is ordinary body data, and the body passes
+ * through untouched.
  *
  * An array body is returned as is: it can carry no `user` key, and object rest would
  * silently turn it into `{ 0: …, 1: … }`.
  */
-function withAuthenticatedUser(json: IDataObject, user: IUser | undefined): IDataObject {
-	if (Array.isArray(json)) return json;
+function withAuthenticatedUser(
+	json: IDataObject,
+	user: IUser | undefined,
+	serverOwnsUserKey: boolean,
+): IDataObject {
+	if (!serverOwnsUserKey || Array.isArray(json)) return json;
 	const { user: claimedUser, ...rest } = json;
 	if (!user) return rest;
 	// Field by field, so a future `IUser` field cannot leak into workflow data.
@@ -1172,6 +1180,7 @@ export class ChatTrigger extends Node {
 			json: withAuthenticatedUser(
 				item.json,
 				ctx.getNodeParameter('includeUserInOutput', true) !== false ? authedUser : undefined,
+				authentication === 'n8nUserAuth',
 			),
 		};
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/GenericFunctions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/GenericFunctions.ts
@@ -1,6 +1,6 @@
 import basicAuth from 'basic-auth';
 import { UnexpectedError } from 'n8n-workflow';
-import type { ICredentialDataDecryptedObject, IWebhookFunctions } from 'n8n-workflow';
+import type { ICredentialDataDecryptedObject, IUser, IWebhookFunctions } from 'n8n-workflow';
 
 import { ChatTriggerAuthorizationError } from './error';
 import {
@@ -27,7 +27,13 @@ function secondsUntil(expiresAt: number): number {
 	return Math.max(0, (expiresAt - Date.now()) / 1000);
 }
 
-export async function validateAuth(context: IWebhookFunctions) {
+/**
+ * Verifies the caller against the node's configured authentication. Throws a
+ * `ChatTriggerAuthorizationError` when the caller fails the check, so the return value
+ * only ever answers *who*: the authenticated n8n user under `n8nUserAuth`, or
+ * `undefined` for the modes that identify nobody (`none`, `basicAuth`, `setup`).
+ */
+export async function validateAuth(context: IWebhookFunctions): Promise<IUser | undefined> {
 	const authentication = context.getNodeParameter(
 		'authentication',
 		'none',
@@ -87,7 +93,7 @@ export async function validateAuth(context: IWebhookFunctions) {
 						const validation = await context.validateN8nOAuth2Token(chatToken, resourceUrl);
 						if (validation.valid) {
 							await context.establishTriggerIdentity(chatToken, resourceUrl, validation.user.id);
-							return;
+							return validation.user;
 						}
 					}
 					throw new ChatTriggerAuthorizationError(401, 'Invalid authentication token');
@@ -100,7 +106,8 @@ export async function validateAuth(context: IWebhookFunctions) {
 			}
 
 			try {
-				await context.validateCookieAuth(authCookie);
+				// Kept inside the `try` so a rejection still becomes a 401.
+				return await context.validateCookieAuth(authCookie);
 			} catch {
 				throw new ChatTriggerAuthorizationError(401, 'Invalid authentication token');
 			}

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -84,7 +84,9 @@ describe('ChatTrigger Node', () => {
 		mockContext.getNode.mockReturnValue({
 			name: 'Chat Trigger',
 			type: 'n8n-nodes-langchain.chatTrigger',
-			typeVersion: 1,
+			// At or above 1.5, so `includeUserInOutput` defaults on where a test does not
+			// override the version.
+			typeVersion: 1.5,
 		} as INode);
 		mockContext.getMode.mockReturnValue('webhook');
 		mockContext.getWebhookName.mockReturnValue('default');
@@ -573,22 +575,40 @@ describe('ChatTrigger Node', () => {
 			(result.workflowData as INodeExecutionData[][])[0][0].json;
 
 		beforeEach(() => {
+			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 			vi.mocked(validateAuth).mockResolvedValue(authedUser);
 		});
 
-		it('exposes the toggle, on by default and scoped to n8nUserAuth public chats', () => {
-			const includeUserParam = chatTrigger.description.properties.find(
+		it('exposes one toggle per version band, scoped to n8nUserAuth public chats', () => {
+			const includeUserParams = chatTrigger.description.properties.filter(
 				(property) => property.name === 'includeUserInOutput',
 			);
 
-			expect(includeUserParam).toMatchObject({
+			expect(includeUserParams).toHaveLength(2);
+			// The `gte` variant comes first: some consumers resolve a name with `.find()`,
+			// and 1.5 is `defaultVersion`, so first-match must be the current shape.
+			expect(includeUserParams[0]).toMatchObject({
 				type: 'boolean',
 				default: true,
+				envFeatureFlag: 'CHAT_TRIGGER_OAUTH2',
 				displayOptions: {
 					show: {
 						authentication: ['n8nUserAuth'],
 						public: [true],
 						'@version': [{ _cnd: { gte: 1.5 } }],
+					},
+				},
+			});
+			// Off below 1.5, but still shown, so an existing chat can opt in.
+			expect(includeUserParams[1]).toMatchObject({
+				type: 'boolean',
+				default: false,
+				envFeatureFlag: 'CHAT_TRIGGER_OAUTH2',
+				displayOptions: {
+					show: {
+						authentication: ['n8nUserAuth'],
+						public: [true],
+						'@version': [{ _cnd: { lt: 1.5 } }],
 					},
 				},
 			});
@@ -671,6 +691,49 @@ describe('ChatTrigger Node', () => {
 
 			expect(emittedJson(result)).toEqual({ message: 'Hello' });
 		});
+
+		// `n8nUserAuth` has been selectable since the node shipped, so a chat built before
+		// this feature must keep its output shape until its owner opts in.
+		it('omits the user below 1.5 when the toggle was never saved', async () => {
+			mockContext.getNode.mockReturnValue({
+				name: 'Chat Trigger',
+				type: 'n8n-nodes-langchain.chatTrigger',
+				typeVersion: 1.4,
+			} as INode);
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
+		});
+
+		it('adds the user below 1.5 once the toggle is turned on', async () => {
+			mockContext.getNode.mockReturnValue({
+				name: 'Chat Trigger',
+				type: 'n8n-nodes-langchain.chatTrigger',
+				typeVersion: 1.4,
+			} as INode);
+			setParams({ includeUserInOutput: true });
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello', user: authedUser });
+		});
+
+		// With the flag off the node must behave exactly as it did before the feature: no
+		// verified user added, and no caller-supplied `user` stripped.
+		it('emits no user and strips nothing when the feature flag is off', async () => {
+			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
+			mockContext.getBodyData.mockReturnValue({
+				message: 'Hello',
+				user: { email: 'ceo@acme.com' },
+			});
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello', user: { email: 'ceo@acme.com' } });
+		});
 	});
 
 	// The editor's canvas chat can't supply webhook credentials, so its session-scoped
@@ -704,6 +767,7 @@ describe('ChatTrigger Node', () => {
 			(result.workflowData as INodeExecutionData[][])[0][0].json;
 
 		beforeEach(() => {
+			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 			mockContext.getMode.mockReturnValue('manual');
 			mockContext.isChatSessionTest.mockReturnValue(true);
 			getTestWebhookUser.mockResolvedValue(editorUser);
@@ -790,6 +854,7 @@ describe('ChatTrigger Node', () => {
 			(result.workflowData as INodeExecutionData[][])[0][0].json;
 
 		beforeEach(() => {
+			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 			mockContext.getBodyData.mockReturnValue({ chatInput: 'hi', user: forgedUser });
 			vi.mocked(validateAuth).mockResolvedValue(authedUser);
 		});

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -720,9 +720,10 @@ describe('ChatTrigger Node', () => {
 			expect(emittedJson(result)).toEqual({ message: 'Hello', user: authedUser });
 		});
 
-		// With the flag off the node must behave exactly as it did before the feature: no
-		// verified user added, and no caller-supplied `user` stripped.
-		it('emits no user and strips nothing when the feature flag is off', async () => {
+		// The flag gates writing the verified user, not ownership of the key. A claimed
+		// `user` is still dropped, so a workflow built while the flag was on cannot be
+		// spoofed if the flag is later turned off.
+		it('emits no user but still strips a claimed one when the feature flag is off', async () => {
 			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
 			mockContext.getBodyData.mockReturnValue({
 				message: 'Hello',
@@ -732,7 +733,7 @@ describe('ChatTrigger Node', () => {
 
 			const result = await chatTrigger.webhook(mockContext);
 
-			expect(emittedJson(result)).toEqual({ message: 'Hello', user: { email: 'ceo@acme.com' } });
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
 		});
 	});
 
@@ -887,6 +888,17 @@ describe('ChatTrigger Node', () => {
 
 		it('strips a caller-supplied user when the toggle is off', async () => {
 			setParams({ includeUserInOutput: false });
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi' });
+		});
+
+		// The key's owner is the auth mode, not the rollout flag. An instance that turns the
+		// flag off must not start trusting a claimed `user` in a workflow built while it was on.
+		it('strips a caller-supplied user with the feature flag off', async () => {
+			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
+			setParams();
 
 			const result = await chatTrigger.webhook(mockContext);
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -731,7 +731,9 @@ describe('ChatTrigger Node', () => {
 	});
 
 	// `json` starts life as the caller's own request body, so a caller can put a `user`
-	// key in it. It must never survive into the output and look authoritative.
+	// key in it. Under `n8nUserAuth` that key is the server's, so a claimed one must never
+	// survive into the output and look authoritative. Under the other auth modes there is
+	// no server identity to shadow, so the body is left exactly as it arrived.
 	describe('user spoofing', () => {
 		const authedUser = {
 			id: 'user-1',
@@ -774,13 +776,22 @@ describe('ChatTrigger Node', () => {
 			expect(emittedJson(result)).toEqual({ chatInput: 'hi', user: authedUser });
 		});
 
-		it('strips a caller-supplied user when the chat is unauthenticated', async () => {
+		it('leaves a caller-supplied user alone when the chat is unauthenticated', async () => {
 			setParams({ authentication: 'none' });
 			vi.mocked(validateAuth).mockResolvedValue(undefined);
 
 			const result = await chatTrigger.webhook(mockContext);
 
-			expect(emittedJson(result)).toEqual({ chatInput: 'hi' });
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi', user: forgedUser });
+		});
+
+		it('leaves a caller-supplied user alone under basicAuth', async () => {
+			setParams({ authentication: 'basicAuth' });
+			vi.mocked(validateAuth).mockResolvedValue(undefined);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi', user: forgedUser });
 		});
 
 		it('strips a caller-supplied user when the toggle is off', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -744,6 +744,16 @@ describe('ChatTrigger Node', () => {
 
 			expect(emittedJson(result)).toEqual({ message: 'Hello' });
 		});
+
+		// The lookup is identity, not authorization. Handling its failure as an auth
+		// challenge would write a response with an undefined status code.
+		it('surfaces a failed lookup as an error rather than an auth challenge', async () => {
+			setParams();
+			getTestWebhookUser.mockRejectedValue(new Error('lookup failed'));
+
+			await expect(chatTrigger.webhook(mockContext)).rejects.toThrow('lookup failed');
+			expect(mockResponse.writeHead).not.toHaveBeenCalled();
+		});
 	});
 
 	// `json` starts life as the caller's own request body, so a caller can put a `user`

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -635,6 +635,17 @@ describe('ChatTrigger Node', () => {
 			expect(json).toEqual(arrayBody);
 		});
 
+		// A `text/plain` request body reaches the node as a string. Object rest would shred
+		// it into `{ 0: 'H', 1: 'e', … }`, so it must pass through untouched.
+		it('passes a string body through unchanged', async () => {
+			mockContext.getBodyData.mockReturnValue('Hello' as unknown as IDataObject);
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toBe('Hello');
+		});
+
 		it('omits the user when the toggle is off', async () => {
 			setParams({ includeUserInOutput: false });
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -1,7 +1,14 @@
 import { ChatTriggerConfig } from '@n8n/config/src';
 import { Container } from '@n8n/di';
 import type { Request, Response } from 'express';
-import type { CredentialCheckResult, INode, IWebhookFunctions } from 'n8n-workflow';
+import type {
+	CredentialCheckResult,
+	IDataObject,
+	INode,
+	INodeExecutionData,
+	IWebhookFunctions,
+	IWebhookResponseData,
+} from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { ChatTrigger } from '../ChatTrigger.node';
@@ -64,6 +71,9 @@ describe('ChatTrigger Node', () => {
 			setKeepAlive: vi.fn(),
 		} as unknown as Request['socket'];
 
+		mockRequest.contentType = undefined;
+		mockContext.customData = mock<IWebhookFunctions['customData']>();
+
 		mockContext.getRequestObject.mockReturnValue(mockRequest);
 		mockContext.getResponseObject.mockReturnValue(mockResponse);
 		mockContext.getNode.mockReturnValue({
@@ -75,7 +85,8 @@ describe('ChatTrigger Node', () => {
 		mockContext.getWebhookName.mockReturnValue('default');
 		mockContext.getBodyData.mockReturnValue({ message: 'Hello' });
 		mockContext.helpers = {
-			returnJsonArray: vi.fn().mockReturnValue([]),
+			// Pass through, so tests can assert on the item the node actually emits.
+			returnJsonArray: vi.fn((data) => (Array.isArray(data) ? data : [data])),
 		} as unknown as IWebhookFunctions['helpers'];
 		mockContext.getNodeParameter.mockImplementation(
 			(
@@ -524,6 +535,281 @@ describe('ChatTrigger Node', () => {
 			expect(mockContext.checkTriggerCredentialStatus).not.toHaveBeenCalled();
 			expect(mockResponse.status).not.toHaveBeenCalledWith(428);
 			expect(result).toEqual({ webhookResponse: { data: [] } });
+		});
+	});
+
+	describe('includeUserInOutput', () => {
+		const authedUser = {
+			id: 'user-1',
+			email: 'user@example.com',
+			firstName: 'Test',
+			lastName: 'User',
+		};
+
+		/** The default parameter set for a public `n8nUserAuth` chat, with overrides. */
+		const setParams = (overrides: Record<string, boolean | string | object> = {}) => {
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName in overrides) return overrides[paramName];
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return {};
+					if (paramName === 'availableInChat') return false;
+					if (paramName === 'authentication') return 'n8nUserAuth';
+					return defaultValue;
+				},
+			);
+		};
+
+		const emittedJson = (result: IWebhookResponseData) =>
+			(result.workflowData as INodeExecutionData[][])[0][0].json;
+
+		beforeEach(() => {
+			vi.mocked(validateAuth).mockResolvedValue(authedUser);
+		});
+
+		it('exposes the toggle, on by default and scoped to n8nUserAuth public chats', () => {
+			const includeUserParam = chatTrigger.description.properties.find(
+				(property) => property.name === 'includeUserInOutput',
+			);
+
+			expect(includeUserParam).toMatchObject({
+				type: 'boolean',
+				default: true,
+				displayOptions: {
+					show: {
+						authentication: ['n8nUserAuth'],
+						public: [true],
+						'@version': [{ _cnd: { gte: 1.5 } }],
+					},
+				},
+			});
+		});
+
+		it('adds the authenticated user to a JSON message', async () => {
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello', user: authedUser });
+		});
+
+		it('adds the authenticated user to a streamed message', async () => {
+			setParams({ availableInChat: true });
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(result).toMatchObject({ noWebhookResponse: true });
+			expect(emittedJson(result)).toEqual({ message: 'Hello', user: authedUser });
+		});
+
+		it('adds the authenticated user to a multipart message', async () => {
+			mockRequest.contentType = 'multipart/form-data';
+			mockRequest.body = { data: { message: 'Hello' }, files: {} };
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello', user: authedUser });
+		});
+
+		// An array body has no `user` key to merge, and must survive as an array —
+		// object rest/spread would rewrite it to `{ 0: …, 1: … }`.
+		it('passes an array body through unchanged', async () => {
+			const arrayBody = [{ a: 1 }, { b: 2 }];
+			mockContext.getBodyData.mockReturnValue(arrayBody as unknown as IDataObject);
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+			const json = emittedJson(result);
+
+			expect(Array.isArray(json)).toBe(true);
+			expect(json).toEqual(arrayBody);
+		});
+
+		it('omits the user when the toggle is off', async () => {
+			setParams({ includeUserInOutput: false });
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
+		});
+
+		it('omits the user for basicAuth, which identifies nobody', async () => {
+			setParams({ authentication: 'basicAuth' });
+			vi.mocked(validateAuth).mockResolvedValue(undefined);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
+		});
+
+		it('omits the user for unauthenticated chats', async () => {
+			setParams({ authentication: 'none' });
+			vi.mocked(validateAuth).mockResolvedValue(undefined);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
+		});
+	});
+
+	// The editor's canvas chat can't supply webhook credentials, so its session-scoped
+	// route skips auth. The editor user who started the run is known instead, so test
+	// output keeps the same shape as production.
+	describe('canvas test route', () => {
+		const editorUser = {
+			id: 'editor-1',
+			email: 'editor@example.com',
+			firstName: 'Ed',
+			lastName: 'Itor',
+		};
+
+		const setParams = (authentication = 'n8nUserAuth') => {
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return {};
+					if (paramName === 'availableInChat') return false;
+					if (paramName === 'authentication') return authentication;
+					return defaultValue;
+				},
+			);
+		};
+
+		const emittedJson = (result: IWebhookResponseData) =>
+			(result.workflowData as INodeExecutionData[][])[0][0].json;
+
+		beforeEach(() => {
+			mockContext.getMode.mockReturnValue('manual');
+			mockContext.isChatSessionTest.mockReturnValue(true);
+			mockContext.getTestWebhookUser.mockResolvedValue(editorUser);
+		});
+
+		it('reports the editor user without running webhook auth', async () => {
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(validateAuth).not.toHaveBeenCalled();
+			expect(emittedJson(result)).toEqual({ message: 'Hello', user: editorUser });
+		});
+
+		it('does not consult the editor user when auth is none', async () => {
+			setParams('none');
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(mockContext.getTestWebhookUser).not.toHaveBeenCalled();
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
+		});
+
+		it('does not consult the editor user when auth is basicAuth', async () => {
+			setParams('basicAuth');
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(mockContext.getTestWebhookUser).not.toHaveBeenCalled();
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
+		});
+
+		it('emits no user, and does not throw, when the editor user cannot be resolved', async () => {
+			setParams();
+			mockContext.getTestWebhookUser.mockResolvedValue(undefined);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ message: 'Hello' });
+		});
+	});
+
+	// `json` starts life as the caller's own request body, so a caller can put a `user`
+	// key in it. It must never survive into the output and look authoritative.
+	describe('user spoofing', () => {
+		const authedUser = {
+			id: 'user-1',
+			email: 'user@example.com',
+			firstName: 'Test',
+			lastName: 'User',
+		};
+		const forgedUser = { email: 'ceo@acme.com' };
+
+		const setParams = (overrides: Record<string, boolean | string | object> = {}) => {
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName in overrides) return overrides[paramName];
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return {};
+					if (paramName === 'availableInChat') return false;
+					if (paramName === 'authentication') return 'n8nUserAuth';
+					return defaultValue;
+				},
+			);
+		};
+
+		const emittedJson = (result: IWebhookResponseData) =>
+			(result.workflowData as INodeExecutionData[][])[0][0].json;
+
+		beforeEach(() => {
+			mockContext.getBodyData.mockReturnValue({ chatInput: 'hi', user: forgedUser });
+			vi.mocked(validateAuth).mockResolvedValue(authedUser);
+		});
+
+		it('overwrites a caller-supplied user with the authenticated one', async () => {
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi', user: authedUser });
+		});
+
+		it('strips a caller-supplied user when the chat is unauthenticated', async () => {
+			setParams({ authentication: 'none' });
+			vi.mocked(validateAuth).mockResolvedValue(undefined);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi' });
+		});
+
+		it('strips a caller-supplied user when the toggle is off', async () => {
+			setParams({ includeUserInOutput: false });
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi' });
+		});
+
+		it('strips a caller-supplied user on the canvas test route with no resolvable user', async () => {
+			setParams();
+			mockContext.getMode.mockReturnValue('manual');
+			mockContext.isChatSessionTest.mockReturnValue(true);
+			mockContext.getTestWebhookUser.mockResolvedValue(undefined);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi' });
+		});
+
+		it('strips a caller-supplied user from multipart form data', async () => {
+			mockRequest.contentType = 'multipart/form-data';
+			mockRequest.body = { data: { chatInput: 'hi', user: forgedUser }, files: {} };
+			setParams();
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(emittedJson(result)).toEqual({ chatInput: 'hi', user: authedUser });
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -6,6 +6,7 @@ import type {
 	IDataObject,
 	INode,
 	INodeExecutionData,
+	IUser,
 	IWebhookFunctions,
 	IWebhookResponseData,
 } from 'n8n-workflow';
@@ -37,6 +38,9 @@ describe('ChatTrigger Node', () => {
 	const mockResponse = mock<Response>();
 	let chatTrigger: ChatTrigger;
 	let chatTriggerConfig: ChatTriggerConfig;
+	// Optional on `IWebhookFunctions`, so `mock<T>()` leaves it a plain function rather
+	// than a mock. Keep a typed handle and assign it onto the context each run.
+	const getTestWebhookUser = vi.fn<() => Promise<IUser | undefined>>();
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -73,6 +77,7 @@ describe('ChatTrigger Node', () => {
 
 		mockRequest.contentType = undefined;
 		mockContext.customData = mock<IWebhookFunctions['customData']>();
+		mockContext.getTestWebhookUser = getTestWebhookUser;
 
 		mockContext.getRequestObject.mockReturnValue(mockRequest);
 		mockContext.getResponseObject.mockReturnValue(mockResponse);
@@ -690,7 +695,7 @@ describe('ChatTrigger Node', () => {
 		beforeEach(() => {
 			mockContext.getMode.mockReturnValue('manual');
 			mockContext.isChatSessionTest.mockReturnValue(true);
-			mockContext.getTestWebhookUser.mockResolvedValue(editorUser);
+			getTestWebhookUser.mockResolvedValue(editorUser);
 		});
 
 		it('reports the editor user without running webhook auth', async () => {
@@ -707,7 +712,7 @@ describe('ChatTrigger Node', () => {
 
 			const result = await chatTrigger.webhook(mockContext);
 
-			expect(mockContext.getTestWebhookUser).not.toHaveBeenCalled();
+			expect(getTestWebhookUser).not.toHaveBeenCalled();
 			expect(emittedJson(result)).toEqual({ message: 'Hello' });
 		});
 
@@ -716,13 +721,13 @@ describe('ChatTrigger Node', () => {
 
 			const result = await chatTrigger.webhook(mockContext);
 
-			expect(mockContext.getTestWebhookUser).not.toHaveBeenCalled();
+			expect(getTestWebhookUser).not.toHaveBeenCalled();
 			expect(emittedJson(result)).toEqual({ message: 'Hello' });
 		});
 
 		it('emits no user, and does not throw, when the editor user cannot be resolved', async () => {
 			setParams();
-			mockContext.getTestWebhookUser.mockResolvedValue(undefined);
+			getTestWebhookUser.mockResolvedValue(undefined);
 
 			const result = await chatTrigger.webhook(mockContext);
 
@@ -806,7 +811,7 @@ describe('ChatTrigger Node', () => {
 			setParams();
 			mockContext.getMode.mockReturnValue('manual');
 			mockContext.isChatSessionTest.mockReturnValue(true);
-			mockContext.getTestWebhookUser.mockResolvedValue(undefined);
+			getTestWebhookUser.mockResolvedValue(undefined);
 
 			const result = await chatTrigger.webhook(mockContext);
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/GenericFunctions.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/GenericFunctions.test.ts
@@ -11,13 +11,20 @@ import {
 
 describe('validateAuth', () => {
 	const mockContext = mock<IWebhookFunctions>();
+	/** The n8n user every successful `n8nUserAuth` leg below resolves to. */
+	const authedUser = {
+		id: 'user-1',
+		email: 'user@example.com',
+		firstName: 'Test',
+		lastName: 'User',
+	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
 	describe('authentication = none', () => {
-		it('should pass without error', async () => {
+		it('should pass without error, and identify nobody', async () => {
 			mockContext.getNodeParameter.calledWith('authentication').mockReturnValue('none');
 
 			await expect(validateAuth(mockContext)).resolves.toBeUndefined();
@@ -70,7 +77,7 @@ describe('validateAuth', () => {
 			});
 		});
 
-		it('should pass with correct credentials', async () => {
+		it('should pass with correct credentials, and identify nobody', async () => {
 			mockContext.getCredentials.mockResolvedValue({
 				user: 'admin',
 				password: 'secret',
@@ -90,7 +97,7 @@ describe('validateAuth', () => {
 			mockContext.getNodeParameter.calledWith('authentication').mockReturnValue('n8nUserAuth');
 		});
 
-		it('should skip validation for setup webhook', async () => {
+		it('should skip validation for the setup webhook, and identify nobody', async () => {
 			mockContext.getWebhookName.mockReturnValue('setup');
 			mockContext.getHeaderData.mockReturnValue({});
 
@@ -141,14 +148,9 @@ describe('validateAuth', () => {
 			mockContext.getHeaderData.mockReturnValue({
 				cookie: 'n8n-auth=valid.jwt.token',
 			});
-			mockContext.validateCookieAuth.mockResolvedValue({
-				id: 'user-1',
-				email: 'user@example.com',
-				firstName: 'Test',
-				lastName: 'User',
-			});
+			mockContext.validateCookieAuth.mockResolvedValue(authedUser);
 
-			await expect(validateAuth(mockContext)).resolves.toBeUndefined();
+			await expect(validateAuth(mockContext)).resolves.toEqual(authedUser);
 			expect(mockContext.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
 		});
 
@@ -157,14 +159,9 @@ describe('validateAuth', () => {
 			mockContext.getHeaderData.mockReturnValue({
 				cookie: 'other=value; n8n-auth=valid.jwt.token; another=thing',
 			});
-			mockContext.validateCookieAuth.mockResolvedValue({
-				id: 'user-1',
-				email: 'user@example.com',
-				firstName: 'Test',
-				lastName: 'User',
-			});
+			mockContext.validateCookieAuth.mockResolvedValue(authedUser);
 
-			await expect(validateAuth(mockContext)).resolves.toBeUndefined();
+			await expect(validateAuth(mockContext)).resolves.toEqual(authedUser);
 			expect(mockContext.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
 		});
 
@@ -174,12 +171,6 @@ describe('validateAuth', () => {
 		// identity — through the shared trigger-identity pipeline.
 		describe('x-auth-token from the sandboxed frame', () => {
 			const resourceUrl = 'http://localhost:5678/webhook/abc/chat';
-			const user = {
-				id: 'user-1',
-				email: 'user@example.com',
-				firstName: 'Test',
-				lastName: 'User',
-			};
 
 			beforeEach(() => {
 				mockContext.getWebhookName.mockReturnValue('default');
@@ -194,15 +185,15 @@ describe('validateAuth', () => {
 
 			it('establishes the trigger identity and passes for a valid token', async () => {
 				mockContext.getHeaderData.mockReturnValue({ 'x-auth-token': 'as-token' });
-				mockContext.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user });
+				mockContext.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user: authedUser });
 
-				await expect(validateAuth(mockContext)).resolves.toBeUndefined();
+				await expect(validateAuth(mockContext)).resolves.toEqual(authedUser);
 
 				expect(mockContext.validateN8nOAuth2Token).toHaveBeenCalledWith('as-token', resourceUrl);
 				expect(mockContext.establishTriggerIdentity).toHaveBeenCalledWith(
 					'as-token',
 					resourceUrl,
-					user.id,
+					authedUser.id,
 				);
 				expect(mockContext.validateCookieAuth).not.toHaveBeenCalled();
 			});
@@ -268,14 +259,9 @@ describe('validateAuth', () => {
 					'x-auth-token': 'as-token',
 					cookie: 'n8n-auth=valid.jwt.token',
 				});
-				mockContext.validateCookieAuth.mockResolvedValue({
-					id: 'user-1',
-					email: 'user@example.com',
-					firstName: 'Test',
-					lastName: 'User',
-				});
+				mockContext.validateCookieAuth.mockResolvedValue(authedUser);
 
-				await expect(validateAuth(mockContext)).resolves.toBeUndefined();
+				await expect(validateAuth(mockContext)).resolves.toEqual(authedUser);
 				expect(mockContext.validateCookieAuth).toHaveBeenCalledWith('valid.jwt.token');
 			});
 		});

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -1574,6 +1574,10 @@ describe('executeWebhook getUserById', () => {
 				email: 'user@example.com',
 				firstName: 'Test',
 				lastName: 'User',
+				// Extra entity fields, so the assertion below fails if the projection is dropped.
+				password: 'hashed',
+				mfaSecret: 'totp-secret',
+				disabled: false,
 			}),
 		);
 

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -59,7 +59,8 @@ import {
 } from '../webhook-helpers';
 import { EXECUTION_ENDED_WITHOUT_RESPONSE } from '../constants';
 import type { IWebhookResponseCallbackData, WebhookRequest } from '../webhook.types';
-import type { Project } from '@n8n/db';
+import type { Project, User } from '@n8n/db';
+import { UserRepository } from '@n8n/db';
 import { ActiveExecutions } from '@/active-executions';
 import { AuthService } from '@/auth/auth.service';
 import { EventService } from '@/events/event.service';
@@ -1114,6 +1115,7 @@ const workflowRunner = mockInstance(WorkflowRunner);
 const activeExecutions = mockInstance(ActiveExecutions);
 const resourceRegistry = mockInstance(ProtectedResourceRegistry);
 const executionContextService = mockInstance(ExecutionContextService);
+const userRepository = mockInstance(UserRepository);
 mockInstance(AuthService);
 mockInstance(EventService);
 mockInstance(WorkflowStatisticsService);
@@ -1488,6 +1490,110 @@ describe('executeWebhook establishTriggerIdentity', () => {
 		expect(executionContextService.buildTriggerIdentityCredentials).not.toHaveBeenCalled();
 		expect(additionalData.encryptedRunnerIdentity).toBe('registration-context');
 		expect(runData.encryptedRunnerIdentity).toBe('registration-context');
+	});
+});
+
+describe('executeWebhook getUserById', () => {
+	/**
+	 * Drives `executeWebhook` far enough for the node's `webhook()` to be called, and
+	 * hands back the lookup the webhook layer wired onto `additionalData`.
+	 */
+	const resolveGetUserById = async () => {
+		resourceRegistry.getByResourceUrl.mockResolvedValue(undefined);
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-1', name: 'Project 1' }),
+		);
+		workflowRunner.run.mockResolvedValue(EXECUTION_ID);
+		activeExecutions.getPostExecutePromise.mockReturnValue(new Promise(() => {}));
+		executionContextService.maybeBindExecutionId.mockImplementation(async (context) => context);
+		executionContextService.augmentExecutionContextWithHooks.mockImplementation(
+			async (_workflow, _startItem, context) => ({ context, triggerItems: null }),
+		);
+
+		const additionalData = {
+			webhookWaitingBaseUrl: 'https://n8n.test/webhook-waiting',
+			formWaitingBaseUrl: 'https://n8n.test/form-waiting',
+		} as unknown as IWorkflowExecuteAdditionalData;
+		vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
+
+		webhookService.runWebhook.mockResolvedValue({ workflowData: [[{ json: {} }]] });
+
+		const workflowStartNode = mock<INode>({
+			name: 'Chat Trigger',
+			type: CHAT_TRIGGER_NODE_TYPE,
+			typeVersion: 1.5,
+			parameters: { authentication: 'n8nUserAuth' },
+		});
+
+		const workflow = mock<Workflow>({
+			id: WORKFLOW_ID,
+			name: 'Test Workflow',
+			nodeTypes: {
+				getByNameAndVersion: vi
+					.fn()
+					.mockReturnValue(mock<INodeType>({ description: { name: 'chatTrigger' } })),
+			},
+			expression: {
+				getSimpleParameterValue: vi.fn().mockReturnValue('onReceived'),
+				getComplexParameterValue: vi.fn().mockReturnValue('firstEntryJson'),
+			},
+		});
+
+		await executeWebhook(
+			workflow,
+			{
+				webhookDescription: { name: 'default' },
+				workflowId: WORKFLOW_ID,
+			} as unknown as IWebhookData,
+			mock<IWorkflowBase>({ id: WORKFLOW_ID, name: 'Test Workflow' }),
+			workflowStartNode,
+			'manual',
+			undefined,
+			undefined,
+			undefined,
+			mock<WebhookRequest>({ method: 'POST', contentType: undefined }),
+			mock<express.Response>({ headersSent: false }),
+			vi.fn(),
+			undefined,
+			{},
+		);
+
+		expect(additionalData.getUserById).toBeDefined();
+		return additionalData.getUserById!;
+	};
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.clearAllMocks();
+	});
+
+	it('projects the looked-up user down to the four public fields', async () => {
+		userRepository.findByIdWithRole.mockResolvedValue(
+			mock<User>({
+				id: 'user-1',
+				email: 'user@example.com',
+				firstName: 'Test',
+				lastName: 'User',
+			}),
+		);
+
+		const getUserById = await resolveGetUserById();
+
+		await expect(getUserById('user-1')).resolves.toEqual({
+			id: 'user-1',
+			email: 'user@example.com',
+			firstName: 'Test',
+			lastName: 'User',
+		});
+		expect(userRepository.findByIdWithRole).toHaveBeenCalledWith('user-1');
+	});
+
+	it('resolves undefined for an id that no longer maps to a user', async () => {
+		userRepository.findByIdWithRole.mockResolvedValue(null);
+
+		const getUserById = await resolveGetUserById();
+
+		await expect(getUserById('gone')).resolves.toBeUndefined();
 	});
 });
 

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -7,6 +7,7 @@
 import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
 import type { Project } from '@n8n/db';
+import { UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { createDeferredPromise, type IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type express from 'express';
@@ -591,6 +592,17 @@ export async function executeWebhook(
 	const authService = Container.get(AuthService);
 	additionalData.validateCookieAuth = async (token: string) => {
 		const user = await authService.validateCookieToken(token);
+		return {
+			id: user.id,
+			email: user.email,
+			firstName: user.firstName,
+			lastName: user.lastName,
+		};
+	};
+
+	additionalData.getUserById = async (id: string) => {
+		const user = await Container.get(UserRepository).findByIdWithRole(id);
+		if (!user) return undefined;
 		return {
 			id: user.id,
 			email: user.email,

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
@@ -209,6 +209,58 @@ describe('WebhookContext', () => {
 		});
 	});
 
+	describe('getTestWebhookUser', () => {
+		const user = {
+			id: 'user-1',
+			email: 'user@example.com',
+			firstName: 'Test',
+			lastName: 'User',
+		};
+
+		const contextWith = (
+			webhookOverrides: Partial<IWebhookData>,
+			getUserById?: IWorkflowExecuteAdditionalData['getUserById'],
+		) =>
+			new WebhookContext(
+				workflow,
+				node,
+				{ ...additionalData, getUserById } as IWorkflowExecuteAdditionalData,
+				mode,
+				mock<IWebhookData>({ webhookDescription: { name: 'default' }, ...webhookOverrides }),
+				[],
+				null,
+			);
+
+		it('should return the user recorded on the test-webhook registration', async () => {
+			const getUserById = vi.fn().mockResolvedValue(user);
+			const context = contextWith({ userId: 'user-1' }, getUserById);
+
+			await expect(context.getTestWebhookUser()).resolves.toEqual(user);
+			expect(getUserById).toHaveBeenCalledWith('user-1');
+		});
+
+		// Production webhooks never carry a user id, so they must resolve to nobody.
+		it('should return undefined when the webhook carries no user id', async () => {
+			const getUserById = vi.fn();
+			const context = contextWith({ userId: undefined }, getUserById);
+
+			await expect(context.getTestWebhookUser()).resolves.toBeUndefined();
+			expect(getUserById).not.toHaveBeenCalled();
+		});
+
+		it('should return undefined when no user lookup is wired up', async () => {
+			const context = contextWith({ userId: 'user-1' }, undefined);
+
+			await expect(context.getTestWebhookUser()).resolves.toBeUndefined();
+		});
+
+		it('should return undefined when the user no longer exists', async () => {
+			const context = contextWith({ userId: 'user-1' }, vi.fn().mockResolvedValue(undefined));
+
+			await expect(context.getTestWebhookUser()).resolves.toBeUndefined();
+		});
+	});
+
 	describe('webhook URLs', () => {
 		const WEBHOOK_KINDS = [
 			['a generic webhook', undefined],

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -184,6 +184,14 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		});
 	}
 
+	async getTestWebhookUser(): Promise<IUser | undefined> {
+		// Only test-webhook registrations record the user who started the run, so this is
+		// `undefined` on a production webhook by construction.
+		const userId = this.webhookData.userId;
+		if (!userId) return undefined;
+		return await this.additionalData.getUserById?.(userId);
+	}
+
 	async validateCookieAuth(cookieValue: string): Promise<IUser> {
 		if (!this.additionalData.validateCookieAuth) {
 			throw new UnexpectedError('Cookie auth validation is not available');

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1620,8 +1620,11 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	/**
 	 * The n8n user who started this test run, recorded on the webhook registration.
 	 * Only test webhooks carry it, so this resolves to `undefined` in production.
+	 *
+	 * Optional so hosts that implement this interface themselves are not forced to
+	 * supply it; call it as `getTestWebhookUser?.()`.
 	 */
-	getTestWebhookUser(): Promise<IUser | undefined>;
+	getTestWebhookUser?(): Promise<IUser | undefined>;
 	/** Emits telemetry for an advanced HITL response actioned via this webhook. */
 	logHitlResponse(payload: { approved: boolean; authorized: boolean }): void;
 	nodeHelpers: NodeHelperFunctions;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1617,6 +1617,11 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	/** Whether this request arrived on the editor's session-scoped canvas chat test route. */
 	isChatSessionTest(): boolean;
 	validateCookieAuth(cookieValue: string): Promise<IUser>;
+	/**
+	 * The n8n user who started this test run, recorded on the webhook registration.
+	 * Only test webhooks carry it, so this resolves to `undefined` in production.
+	 */
+	getTestWebhookUser(): Promise<IUser | undefined>;
 	/** Emits telemetry for an advanced HITL response actioned via this webhook. */
 	logHitlResponse(payload: { approved: boolean; authorized: boolean }): void;
 	nodeHelpers: NodeHelperFunctions;
@@ -3852,6 +3857,7 @@ export interface IWorkflowExecuteAdditionalData {
 	): Promise<Result<T, E>>;
 	getRunnerStatus?(taskType: string): { available: true } | { available: false; reason?: string };
 	validateCookieAuth?: (cookieValue: string) => Promise<IUser>;
+	getUserById?: (id: string) => Promise<IUser | undefined>;
 	/**
 	 * Mutable flag set to true during a node's execution if any credential was resolved
 	 * dynamically. Reset to false by the execution engine before each node runs.


### PR DESCRIPTION
## Summary
Adds a new 'Include User in Output' option (ENABLED by default) to the Chat trigger node that is visible when a Chat trigger has its authentication set to 'n8n user auth'. When the option is enabled, along with its standard output, the even from the Chat trigger will also include the triggering users information - first name, last name, email and ID. This matches what both the MCP trigger and Form trigger nodes do in their similar states. This option will appear for all Chat trigger node versions, but there is also a bump to version 1.5; this is to allow us to control the _default_ value - gte 1.5 === `true`, lt 1.5 === `false` - this is for backwards compatibility reasons.

Adding the user to the output will allow the workflow to tailor their response on a per-user basis, or to attach actions to specific users, etc.

This will also work in 'test' mode from within the editor and will attach the identity of the user currently logged into n8n.

For any nodes that were somehow passing a custom `user` property, this will now be stripped if 'n8n user auth' is used, but is let untouched for other options.

<img width="899" height="769" alt="Screenshot 2026-09-02 at 15 25 30" src="https://github.com/user-attachments/assets/89adb5b3-6a12-4376-9d9f-24183c80a5bd" />

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
1. Create a workflow with a chat trigger.
2. Enable the `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2` feature flag, set the Chat trigger's authentication to be 'n8n user auth'
3. Note that the 'Include User in Output' option appears _and_ is already enabled.
4. Publish the workflow and browse to the public URL of that that (alternatively, 'open chat' within the workflow editor - this is 'test' mode)
5. Enter a chat message and observe that the user information is included in the output.
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-1325/chat-trigger-include-the-authenticated-user-in-the-message-output
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

