### PR TITLE
feat(core): Add cursor pagination type for declarative nodes

### DIFF
--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -1,13 +1,15 @@
 import get from 'lodash/get';
-import { Workflow, createEmptyRunExecutionData } from 'n8n-workflow';
+import { Workflow, createEmptyRunExecutionData, deepCopy } from 'n8n-workflow';
 import type {
 	DeclarativeRestApiSettings,
 	ICredentialDataDecryptedObject,
+	IDataObject,
 	IExecuteData,
 	IExecuteSingleFunctions,
 	IHttpRequestOptions,
 	IN8nHttpFullResponse,
 	IN8nHttpResponse,
+	IN8nRequestOperationPaginationCursor,
 	IN8nRequestOperations,
 	INode,
 	INodeCredentialDescription,
@@ -2707,6 +2709,224 @@ describe('RoutingNode', () => {
 			const requestOptions = (result?.[0]?.[0]?.json as { requestOptions: IHttpRequestOptions })
 				.requestOptions;
 			expect(requestOptions.allowedDomains).toBeUndefined();
+		});
+	});
+
+	describe('cursor pagination', () => {
+		const mode = 'internal';
+		const runIndex = 0;
+		const itemIndex = 0;
+		const connectionInputData: INodeExecutionData[] = [];
+		const runExecutionData: IRunExecutionData = createEmptyRunExecutionData();
+
+		const baseNode: INode = {
+			parameters: { returnAll: true },
+			name: 'test',
+			type: 'test.set',
+			typeVersion: 1,
+			id: 'uuid-1234',
+			position: [0, 0],
+		};
+
+		type Page = {
+			items?: Array<{ id: number; key?: string }>;
+			next_cursor?: string | null;
+			has_more?: boolean;
+		};
+
+		// Key of the page the first request returns, since that request carries no cursor
+		const FIRST_PAGE = 'start';
+
+		const cursorPagination = (
+			overrides: Partial<IN8nRequestOperationPaginationCursor['properties']> = {},
+		): IN8nRequestOperationPaginationCursor => ({
+			type: 'cursor',
+			properties: {
+				cursorParameter: 'cursor',
+				nextCursor: '={{ $response.body.next_cursor }}',
+				rootProperty: 'items',
+				type: 'query',
+				...overrides,
+			},
+		});
+
+		/**
+		 * Runs a node whose only parameter paginates over `pages`. Pages are keyed
+		 * by the cursor the request carries, the first request has no cursor.
+		 */
+		const runWithPages = async (
+			pages: Record<string, Page>,
+			pagination: IN8nRequestOperationPaginationCursor,
+			options: { maxResults?: number; qs?: IDataObject; body?: IDataObject } = {},
+		) => {
+			const routingNodeType = nodeTypes.getByNameAndVersion(baseNode.type);
+			routingNodeType.description = {
+				requestDefaults: { baseURL: 'https://api.example.com' },
+				properties: [
+					{
+						displayName: 'Return All',
+						name: 'returnAll',
+						type: 'boolean',
+						default: true,
+						routing: {
+							request: { url: '/items', qs: options.qs, body: options.body },
+							send: { paginate: true },
+							operations: { pagination },
+							output: { maxResults: options.maxResults },
+						},
+					},
+				],
+			} as unknown as INodeTypeDescription;
+
+			const workflow = new Workflow({
+				nodes: [baseNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const executeFunctions = mock<executionContexts.ExecuteContext>();
+			Object.assign(executeFunctions, {
+				executeData: { data: {}, node: baseNode, source: null } as IExecuteData,
+				inputData: { main: [[{ json: {} }]] } as ITaskDataConnections,
+				runIndex,
+				additionalData,
+				workflow,
+				node: baseNode,
+				mode,
+				connectionInputData,
+				runExecutionData,
+			});
+			executeFunctions.getNodeParameter.mockImplementation(() => ({}));
+
+			const executeSingleFunctions = getExecuteSingleFunctions(
+				workflow,
+				runExecutionData,
+				runIndex,
+				baseNode,
+				itemIndex,
+			);
+			const originalGetNodeParameter = executeSingleFunctions.getNodeParameter;
+			// @ts-expect-error overwriting a method
+			executeSingleFunctions.getNodeParameter = (parameterName: string) =>
+				originalGetNodeParameter(parameterName) ?? {};
+
+			const requests: IHttpRequestOptions[] = [];
+			executeSingleFunctions.helpers.httpRequest = async (requestOptions: IHttpRequestOptions) => {
+				// The routing node mutates the options in place, so keep a copy per request
+				requests.push(deepCopy(requestOptions));
+				const body = requestOptions.body as IDataObject | undefined;
+				const cursor = requestOptions.qs?.cursor ?? body?.cursor ?? FIRST_PAGE;
+				const response: IN8nHttpFullResponse = {
+					statusCode: 200,
+					headers: {},
+					body: pages[String(cursor)],
+				};
+				return response;
+			};
+
+			vi.spyOn(executionContexts, 'ExecuteSingleContext').mockImplementation(function (
+				this: executionContexts.ExecuteSingleContext,
+			) {
+				return executeSingleFunctions as never;
+			} as never);
+
+			const routingNode = new RoutingNode(executeFunctions, routingNodeType);
+			const result = await routingNode.runNode();
+			const ids = (result?.[0] ?? []).map((item) => item.json.id);
+			return { ids, requests };
+		};
+
+		const threePages: Record<string, Page> = {
+			[FIRST_PAGE]: { items: [{ id: 1 }, { id: 2 }], next_cursor: 'c2' },
+			c2: { items: [{ id: 3 }, { id: 4 }], next_cursor: 'c3' },
+			c3: { items: [{ id: 5 }], next_cursor: null },
+		};
+
+		test('follows the cursor until none is returned and keeps the other query parameters', async () => {
+			const { ids, requests } = await runWithPages(threePages, cursorPagination(), {
+				qs: { limit: 2 },
+			});
+
+			expect(ids).toEqual([1, 2, 3, 4, 5]);
+			expect(requests.map((request) => request.qs)).toEqual([
+				{ limit: 2 },
+				{ limit: 2, cursor: 'c2' },
+				{ limit: 2, cursor: 'c3' },
+			]);
+		});
+
+		test('stops requesting pages once maxResults is reached', async () => {
+			const { ids, requests } = await runWithPages(threePages, cursorPagination(), {
+				maxResults: 3,
+			});
+
+			expect(requests).toHaveLength(2);
+			expect(ids).toEqual([1, 2, 3]);
+		});
+
+		test('sends the cursor in the body when type is body', async () => {
+			const { ids, requests } = await runWithPages(threePages, cursorPagination({ type: 'body' }), {
+				body: { filter: 'active' },
+			});
+
+			expect(ids).toEqual([1, 2, 3, 4, 5]);
+			expect(requests[1].body).toEqual({ filter: 'active', cursor: 'c2' });
+			expect(requests[1].qs).toEqual({});
+		});
+
+		test('uses the continue expression when the API has no explicit next cursor', async () => {
+			const pages: Record<string, Page> = {
+				[FIRST_PAGE]: {
+					items: [
+						{ id: 1, key: 'a' },
+						{ id: 2, key: 'b' },
+					],
+					has_more: true,
+				},
+				b: { items: [{ id: 3, key: 'c' }], has_more: false },
+			};
+			const { ids, requests } = await runWithPages(
+				pages,
+				cursorPagination({
+					nextCursor: '={{ $response.body.items[$response.body.items.length - 1].key }}',
+					continue: '={{ $response.body.has_more }}',
+				}),
+			);
+
+			expect(ids).toEqual([1, 2, 3]);
+			expect(requests.map((request) => request.qs?.cursor)).toEqual([undefined, 'b']);
+		});
+
+		test('stops when the API repeats the same cursor', async () => {
+			const pages: Record<string, Page> = {
+				[FIRST_PAGE]: { items: [{ id: 1 }], next_cursor: 'c2' },
+				c2: { items: [{ id: 2 }], next_cursor: 'c2' },
+			};
+			const { ids, requests } = await runWithPages(pages, cursorPagination());
+
+			expect(ids).toEqual([1, 2]);
+			expect(requests).toHaveLength(2);
+		});
+
+		test('returns whole pages when no rootProperty is set', async () => {
+			const pages: Record<string, Page> = {
+				[FIRST_PAGE]: { items: [{ id: 1 }], next_cursor: 'c2' },
+				c2: { items: [{ id: 2 }], next_cursor: null },
+			};
+			const { requests } = await runWithPages(pages, cursorPagination({ rootProperty: undefined }));
+
+			expect(requests).toHaveLength(2);
+		});
+
+		test('throws when the rootProperty is missing from a page', async () => {
+			const pages: Record<string, Page> = {
+				[FIRST_PAGE]: { next_cursor: null },
+			};
+
+			await expect(runWithPages(pages, cursorPagination())).rejects.toThrow(
+				'The rootProperty "items" could not be found on item.',
+			);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -19,6 +19,7 @@ import type {
 	ICredentialsDecrypted,
 	IHttpRequestOptions,
 	IN8nHttpFullResponse,
+	IN8nRequestOperationPaginationCursor,
 	INodeExecutionData,
 	INodeParameters,
 	INodePropertyOptions,
@@ -722,26 +723,26 @@ export class RoutingNode {
 							] as number) + properties.pageSize;
 
 						if (properties.rootProperty) {
-							const tempResponseValue = get(tempResponseData[0].json, properties.rootProperty) as
-								| IDataObject[]
-								| undefined;
-							if (tempResponseValue === undefined) {
-								throw new NodeOperationError(
-									node,
-									`The rootProperty "${properties.rootProperty}" could not be found on item.`,
-									{ runIndex, itemIndex },
-								);
-							}
-
-							tempResponseData = tempResponseValue.map((item) => {
-								return {
-									json: item,
-								};
-							});
+							tempResponseData = this.getRootPropertyItems(
+								tempResponseData,
+								properties.rootProperty,
+								runIndex,
+								itemIndex,
+							);
 						}
 
 						responseData.push(...tempResponseData);
 					} while (tempResponseData.length && tempResponseData.length === properties.pageSize);
+				} else if (requestOperations.pagination.type === 'cursor') {
+					responseData = await this.paginateByCursor(
+						requestData,
+						executeSingleFunctions,
+						itemIndex,
+						runIndex,
+						requestOperations.pagination.properties,
+						credentialType,
+						credentialsDecrypted,
+					);
 				}
 			}
 		} else {
@@ -763,6 +764,110 @@ export class RoutingNode {
 			);
 		}
 		return responseData;
+	}
+
+	/**
+	 * Requests pages until the API stops returning a cursor. The cursor is set on
+	 * the existing query string or body, so the other request parameters stay.
+	 */
+	private async paginateByCursor(
+		requestData: DeclarativeRestApiSettings.ResultOptions,
+		executeSingleFunctions: IExecuteSingleFunctions,
+		itemIndex: number,
+		runIndex: number,
+		properties: IN8nRequestOperationPaginationCursor['properties'],
+		credentialType?: string,
+		credentialsDecrypted?: ICredentialsDecrypted,
+	): Promise<INodeExecutionData[]> {
+		const responseData: INodeExecutionData[] = [];
+
+		const optionsType = properties.type === 'body' ? 'body' : 'qs';
+
+		const additionalKeys = {
+			$request: requestData.options,
+			$response: {} as IN8nHttpFullResponse,
+			$version: this.context.node.typeVersion,
+		};
+		const resolve = (value: NodeParameterValueType) =>
+			this.getParameterValue(
+				value,
+				itemIndex,
+				runIndex,
+				executeSingleFunctions.getExecuteData(),
+				additionalKeys,
+				false,
+			);
+
+		let cursor: string | number | undefined;
+		let makeAdditionalRequest: boolean;
+		do {
+			if (requestData.maxResults && responseData.length >= Number(requestData.maxResults)) {
+				// Enough results collected, the remaining pages are not needed
+				break;
+			}
+
+			const response = await this.rawRoutingRequest(
+				executeSingleFunctions,
+				requestData,
+				credentialType,
+				credentialsDecrypted,
+			);
+			additionalKeys.$response = response;
+
+			let items = await this.postProcessResponseData(
+				executeSingleFunctions,
+				response,
+				requestData,
+				itemIndex,
+				runIndex,
+			);
+			if (properties.rootProperty) {
+				items = this.getRootPropertyItems(items, properties.rootProperty, runIndex, itemIndex);
+			}
+			responseData.push(...items);
+
+			const nextCursorValue = resolve(properties.nextCursor);
+			const nextCursor =
+				typeof nextCursorValue === 'string' || typeof nextCursorValue === 'number'
+					? nextCursorValue
+					: undefined;
+
+			makeAdditionalRequest =
+				properties.continue === undefined
+					? nextCursor !== undefined && nextCursor !== ''
+					: Boolean(resolve(properties.continue));
+
+			if (nextCursor === undefined || nextCursor === '' || nextCursor === cursor) {
+				// A missing or repeated cursor would request the same page again and again
+				makeAdditionalRequest = false;
+			}
+
+			if (makeAdditionalRequest) {
+				cursor = nextCursor;
+				set(requestData.options, [optionsType, properties.cursorParameter], nextCursor);
+			}
+		} while (makeAdditionalRequest);
+
+		return responseData;
+	}
+
+	/** Replaces the items of a page with the array found at `rootProperty` on the first item. */
+	private getRootPropertyItems(
+		items: INodeExecutionData[],
+		rootProperty: string,
+		runIndex: number,
+		itemIndex: number,
+	): INodeExecutionData[] {
+		const value: unknown = get(items[0]?.json, rootProperty);
+		if (!Array.isArray(value)) {
+			throw new NodeOperationError(
+				this.context.node,
+				`The rootProperty "${rootProperty}" could not be found on item.`,
+				{ runIndex, itemIndex },
+			);
+		}
+
+		return value.map((item: IDataObject) => ({ json: item }));
 	}
 
 	private getParameterValue(

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -668,6 +668,7 @@ export interface IN8nHttpFullResponse {
 
 export interface IN8nRequestOperations {
 	pagination?:
+		| IN8nRequestOperationPaginationCursor
 		| IN8nRequestOperationPaginationGeneric
 		| IN8nRequestOperationPaginationOffset
 		| ((
@@ -698,6 +699,26 @@ export interface IN8nRequestOperationPaginationOffset extends IN8nRequestOperati
 		offsetParameter: string;
 		pageSize: number;
 		rootProperty?: string; // Optional Path to option array
+		type: 'body' | 'query';
+	};
+}
+
+/**
+ * Pagination for APIs that return a cursor for the next page.
+ * The cursor is written into the existing query string or body, so the other
+ * parameters of the request stay as they are.
+ */
+export interface IN8nRequestOperationPaginationCursor extends IN8nRequestOperationPaginationBase {
+	type: 'cursor';
+	properties: {
+		/** Name of the query or body parameter that carries the cursor on follow-up requests */
+		cursorParameter: string;
+		/** Expression that resolves to the next cursor, for example `={{ $response.body.next_cursor }}`. Must resolve to a string or number. */
+		nextCursor: string;
+		/** Optional expression that decides whether to request another page. Defaults to `nextCursor` resolving to a value. */
+		continue?: boolean | string;
+		/** Optional path to the array of items in each page */
+		rootProperty?: string;
 		type: 'body' | 'query';
 	};
 }

--- a/packages/workflow/src/schemas.ts
+++ b/packages/workflow/src/schemas.ts
@@ -24,6 +24,7 @@ import type {
 	DisplayCondition,
 	INode,
 	IN8nRequestOperations,
+	IN8nRequestOperationPaginationCursor,
 	IN8nRequestOperationPaginationGeneric,
 	IDataObject,
 	IN8nRequestOperationPaginationOffset,
@@ -152,9 +153,22 @@ export const IN8nRequestOperationPaginationOffsetSchema: z.ZodType<IN8nRequestOp
 		}),
 	});
 
+export const IN8nRequestOperationPaginationCursorSchema: z.ZodType<IN8nRequestOperationPaginationCursor> =
+	IN8nRequestOperationPaginationBaseSchema.extend({
+		type: z.literal('cursor'),
+		properties: z.object({
+			cursorParameter: z.string(),
+			nextCursor: z.string(),
+			continue: z.union([z.boolean(), z.string()]).optional(),
+			rootProperty: z.string().optional(),
+			type: z.enum(['body', 'query']),
+		}),
+	});
+
 export const IN8nRequestOperationsSchema: z.ZodType<IN8nRequestOperations> = z.object({
 	pagination: z
 		.union([
+			IN8nRequestOperationPaginationCursorSchema,
 			IN8nRequestOperationPaginationGenericSchema,
 			IN8nRequestOperationPaginationOffsetSchema,
 			// TODO: Validating the function shape is skipped at runtime, any function is accepted


### PR DESCRIPTION
## Summary

Declarative nodes can paginate with `type: 'generic'` or `type: 'offset'`. Neither fits APIs that hand back a cursor for the next page, which is the common shape today (Slack, Stripe, Notion, Luma and others).

With `generic`, the `request` object of the pagination block replaces the query string or body of the follow-up request instead of merging into it. Node authors have to repeat every filter parameter through `$request.qs`. Microsoft Entra and SharePoint do this by hand, and it is easy to drop a parameter without noticing. `generic` also fetches every page before `maxResults` trims the result.

This PR adds `type: 'cursor'`:

```ts
pagination: {
  type: 'cursor',
  properties: {
    cursorParameter: 'pagination_cursor',
    nextCursor: '={{ $response.body.next_cursor }}',
    // continue: '={{ $response.body.has_more }}',  optional, defaults to "a cursor was returned"
    rootProperty: 'entries',
    type: 'query',
  },
}
```

The loop writes the cursor into the existing `qs` or `body`, so all other request parameters stay as they are. It stops when no cursor comes back, when the optional `continue` expression is false, when the API repeats the same cursor, or as soon as `maxResults` items were collected. `rootProperty` behaves like it does for `offset`; the extraction moved into a shared helper that both types use.

The `generic` and `offset` types are unchanged.

## How to test

1. In a declarative node, set the `Return All` parameter's `routing.operations.pagination` to the block above, matching the API's cursor field names.
2. Run the node with `Return All` enabled against an API that returns several pages. Every page is fetched and the filter parameters of the operation are present on every request.
3. Run it with a `Limit` that maps to `output.maxResults`. Requests stop once enough items were collected.
4. Unit tests: `cd packages/core && pnpm test routing-node`.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. The declarative pagination page in n8n-docs needs a section for the new type.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
