### PR TITLE
 fix(Microsoft SQL Node): Add TLS server name option to credentials

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
@@ -54,6 +54,19 @@ export class MicrosoftSql implements ICredentialType {
 			default: true,
 		},
 		{
+			displayName: 'TLS Server Name',
+			name: 'serverName',
+			type: 'string',
+			default: '',
+			displayOptions: {
+				show: {
+					tls: [true],
+				},
+			},
+			description:
+				'The TLS Server Name (SNI) to send during handshake. Useful when connecting via IP address with TLS enabled, even if certificate verification is skipped.',
+		},
+		{
 			displayName: 'Ignore SSL Issues (Insecure)',
 			name: 'allowUnauthorizedCerts',
 			type: 'boolean',

--- a/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
@@ -95,6 +95,7 @@ export function formatColumns(columns: string) {
 }
 
 export function configurePool(credentials: IDataObject) {
+	const serverName = (credentials.serverName as string)?.trim();
 	const config = {
 		server: credentials.server as string,
 		port: credentials.port as number,
@@ -109,6 +110,7 @@ export function configurePool(credentials: IDataObject) {
 			enableArithAbort: false,
 			tdsVersion: credentials.tdsVersion as string,
 			trustServerCertificate: credentials.allowUnauthorizedCerts as boolean,
+			...(serverName ? { serverName } : {}),
 		},
 	};
 

--- a/packages/nodes-base/nodes/Microsoft/Sql/test/MicrosoftSql.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/test/MicrosoftSql.node.test.ts
@@ -5,6 +5,7 @@ import { constructExecutionMetaData, returnJsonArray } from 'n8n-core';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
 import { MicrosoftSql } from '../MicrosoftSql.node';
+import { configurePool } from '../GenericFunctions';
 import type { MockedClass } from 'vitest';
 
 vi.mock('mssql');
@@ -224,6 +225,93 @@ describe('MicrosoftSql Node', () => {
 			}
 
 			expect(Object.getOwnPropertyNames(Object.prototype)).toEqual(protoKeysBefore);
+		});
+	});
+
+	describe('configurePool', () => {
+		beforeEach(() => {
+			mockedConnectionPool.mockClear();
+		});
+
+		it('should pass serverName to pool options when provided in credentials', () => {
+			const credentials = {
+				server: '10.0.0.5',
+				database: 'testdb',
+				user: 'testuser',
+				password: 'testpass',
+				port: 1433,
+				tls: true,
+				serverName: 'db.example.com',
+				allowUnauthorizedCerts: false,
+				tdsVersion: '7_4',
+				connectTimeout: 15000,
+				requestTimeout: 15000,
+			};
+
+			configurePool(credentials);
+
+			expect(mockedConnectionPool).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					server: '10.0.0.5',
+					options: expect.objectContaining({
+						encrypt: true,
+						serverName: 'db.example.com',
+					}),
+				}),
+			);
+		});
+
+		it('should not include serverName in options when not provided', () => {
+			const credentials = {
+				server: 'localhost',
+				database: 'testdb',
+				user: 'testuser',
+				password: 'testpass',
+				port: 1433,
+				tls: true,
+				allowUnauthorizedCerts: false,
+				tdsVersion: '7_4',
+				connectTimeout: 15000,
+				requestTimeout: 15000,
+			};
+
+			configurePool(credentials);
+
+			expect(mockedConnectionPool).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					server: 'localhost',
+					options: expect.not.objectContaining({
+						serverName: expect.anything(),
+					}),
+				}),
+			);
+		});
+
+		it('should not include serverName in options when empty string (UI default) or whitespace', () => {
+			const credentials = {
+				server: 'localhost',
+				database: 'testdb',
+				user: 'testuser',
+				password: 'testpass',
+				port: 1433,
+				tls: true,
+				serverName: '',
+				allowUnauthorizedCerts: false,
+				tdsVersion: '7_4',
+				connectTimeout: 15000,
+				requestTimeout: 15000,
+			};
+
+			configurePool(credentials);
+
+			expect(mockedConnectionPool).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					server: 'localhost',
+					options: expect.not.objectContaining({
+						serverName: expect.anything(),
+					}),
+				}),
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

When connecting to a Microsoft SQL Server instance using an IP address with TLS enabled, Node.js throws:
`Failed to connect to [DB IP]:1433 - The property 'options.servername' Setting the TLS ServerName to an IP address is not permitted.. Received '[DB IP]'`

RFC 6066 does not permit literal IP addresses in the TLS Server Name Indication (SNI). Previously, `MicrosoftSql.credentials.ts` did not provide a way to specify the expected TLS server name / certificate hostname, causing the underlying `tedious` driver to fall back to the IP address.

This PR adds:
- `serverName` (`TLS Server Name`) field to `MicrosoftSql.credentials.ts`, conditionally displayed when `tls` is enabled.
- Passes `serverName` to connection pool options in `GenericFunctions.ts`.
- Unit tests in `MicrosoftSql.node.test.ts` verifying that `serverName` is correctly included when provided in credentials and omitted when absent.

## How to test

1. Set up a Microsoft SQL Server with TLS enabled.
2. In n8n Credentials, create a new Microsoft SQL credential.
3. Enter an IP address in the `Server` field and enable `TLS`.
4. Enter the certificate hostname in the new `TLS Server Name` field (e.g. `db.example.com`).
5. Click **Save** / Test Step — the connection now establishes without the Node.js `options.servername` error.
6. Run automated unit tests:
   ```bash
   pnpm --filter n8n-nodes-base test packages/nodes-base/nodes/Microsoft/Sql/test/MicrosoftSql.node.test.ts
   ```

## Related Linear tickets, Github issues, and Community forum posts

Related: https://community.n8n.io/u/vimaln2005/activity/pending
Fixes #37675

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
