### PR TITLE
docs: Document the scheduled job owner contract and pin the job lifecycle (no-changelog)

### DIFF
--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -321,18 +321,20 @@ sight:
 ```mermaid
 stateDiagram-v2
     [*] --> Running: rule provisioned
-    Running --> Quarantined: owner reported gone<br/>(disabled, queued runs withdrawn)
-    Quarantined --> Running: owner reported alive again<br/>(re-enabled, clock recomputed)
+    Running --> Quarantined: owner reported gone<br/>(clock stopped, queued runs withdrawn)
+    Quarantined --> Running: owner reported alive again<br/>(clock recomputed)
     Quarantined --> [*]: still gone past the grace period<br/>(deleted)
     Running --> Running: owner reported alive
 ```
 
-- A job whose owner is reported gone is **disabled and stamped**, and its already-queued
-  runs are withdrawn, so it stops firing immediately.
+- A job whose owner is reported gone has its **clock stopped and is stamped**, and its
+  already-queued runs are withdrawn, so it stops firing immediately. Its `enabled` flag is
+  left as it was: the sweep never turns a job on or off.
 - It is **deleted only once that stamp is older than the quarantine grace** (a day by
   default), and only while its owner is still reported gone.
-- A stamped job whose owner turns out to exist after all is **re-enabled** with a freshly
-  computed clock, so a resolver bug corrected inside the grace window destroys nothing.
+- A stamped job whose owner turns out to exist after all is **revived** with a freshly
+  computed clock, so a resolver bug corrected inside the grace window destroys nothing. A
+  job that was disabled before the quarantine comes back disabled, with no clock.
 
 A resolver answers whether an owner exists, not what it currently wants, so a revival
 restores the job exactly as it was stored. A job the owner would no longer provision

--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -14,13 +14,13 @@ restarts, the timers are gone. If you run several copies of the server for high
 availability, every copy fires the same timer and the work runs many times.
 
 This package takes a different approach: **write the work down before running it.**
-Every upcoming run is recorded in the database first, then picked up and fired from
-there. Because the source of truth lives in storage and not in one process's memory:
+Every upcoming run is recorded in shared, durable storage first, then picked up and
+fired from there. Because the source of truth lives in storage and not in one process's memory:
 
 - a restart or crash loses nothing (the run is still recorded and gets picked up
   again),
 - any server in the cluster can pick up any run, and
-- coordination in the database drives each run toward firing on **exactly one**
+- coordination through the shared store drives each run toward firing on **exactly one**
   server, with safety mechanisms (claims, leases, recovery) to fall back on when a
   server crashes mid-run.
 
@@ -44,10 +44,9 @@ From then on it:
 - recovers runs that were stranded by a crashed server,
 - cleans up finished runs after a retention window.
 
-**How it is built.** The package is **pure logic**. It talks to no database and
-uses no dependency injection directly. Instead the host (in n8n, the `cli`
-package) hands it a small set of storage functions and configuration, and the
-scheduler composes its algorithms over them. This keeps every algorithm easy to
+**How it is built.** The package is **pure logic**. It owns no storage and uses no
+dependency injection directly. Instead the host hands it a small set of storage
+functions and configuration, and the scheduler composes its algorithms over them. This keeps every algorithm easy to
 test in isolation with a fake store. The work is split into a few focused
 submodules, described below.
 
@@ -216,18 +215,143 @@ Schedule and poll triggers both use `skip`: it matches what n8n did before the
 durable scheduler, where a missed run was never replayed. Running late is opt-in
 per job, which is where `coalesce` and `coalesce_owner` come in.
 
+## Owning scheduled jobs
+
+Every scheduled job belongs to something: a published workflow, an instance-level
+maintenance task, an agent. That something is its **owner**, and it is plain data on
+the job row — three fields, none of which this package interprets:
+
+| Field | Meaning |
+|---|---|
+| `ownerType` | what kind of thing owns the job (`workflow`, `system-task`, …) |
+| `ownerId` | which one (a workflow id, a task name, an agent id) |
+| `ownerMemberId` | optionally, which part of it (the trigger node, for a workflow) |
+
+Because ownership is data rather than a schema relationship, any part of the product
+can own scheduled jobs without the scheduler learning what its owners are, and
+without a migration. A job with nothing else to own it is **self-owned**: its
+`ownerId` is its own name. There is no such thing as an ownerless job, so there is
+no second code path for one.
+
+### The two obligations of a new owner type
+
+Ownership is a contract, not just a label. A module that owns scheduled jobs takes on
+**both** of the following. Neither substitutes for the other, and shipping an owner
+type without them leaves schedules running for things that no longer exist.
+
+**1. Deprovision inside your own delete transaction.**
+
+There is no storage-level cascade behind these rows. When your owner goes away,
+*you* delete its jobs, in the same transaction as the write that removes the owner:
+
+```ts
+// Inside the transaction that stops the owner from existing.
+await myOwnerRepository.remove(trx, ownerId);
+await jobProvisioner.deprovisionOwnerInTransaction(trx, { ownerType: 'my-thing', ownerId });
+```
+
+Committing the two together is what makes the guarantee: a crash can never leave a job
+firing for an owner that is already gone. Deprovisioning is idempotent, so a retried
+teardown is safe, and a path that no longer knows which of an owner's parts
+provisioned what can delete the whole owner at once.
+
+Where the teardown genuinely cannot share one transaction, **deprovision first** and
+remove the owner second. A crash between the two then leaves an owner with no
+schedules, which the next attempt fixes, rather than schedules with no owner, which
+only the sweep below would ever find.
+
+n8n's own `workflow` owner type is the worked example of both shapes: a deactivation
+deprovisions inside the transaction that writes `active = false` (`WorkflowService`),
+while an unpublish deprovisions the workflow's jobs immediately before removing the
+`workflow_published_version` mapping that made it an owner
+(`WorkflowPublicationApplier`).
+
+**2. Register a liveness resolver.**
+
+The scheduler cannot tell whether one of your owners still exists, so you answer that
+question for it: register a resolver for your owner type that, given owner ids, says
+which of them are still there.
+
+```ts
+registry.register('my-thing', {
+  async findExisting(ownerIds) {
+    return await myOwners.findExistingIds(ownerIds); // a Set of the ids that remain
+  },
+});
+```
+
+Build the registry in one place, a single manifest the host owns: declare every
+owner module there, and let both readers (the provisioner and the scheduler's
+reconciliation pass) build theirs from it, so neither can see an owner the other
+does not.
+
+Two rules make the answer safe to act on:
+
+- **Absence means gone.** An id you leave out of the result is read as a positive
+  statement that the owner no longer exists. Never omit an id your lookup simply did
+  not cover.
+- **Throw when you cannot tell.** If the lookup fails (a data source is unreachable, a
+  dependency is not ready), throw. "Could not tell" is never treated as "gone", and
+  the sweep leaves every job of your owner type exactly as it was.
+
+Provisioning **refuses** an owner type with no registered resolver, so a new kind of
+owner cannot ship without a cleanup story. The refusal is built into
+`createJobProvisioner` itself: the registry is one of its required dependencies.
+
+### The reconciliation sweep
+
+The resolvers feed a periodic sweep, the safety net behind obligation 1. It exists for
+what synchronous deprovisioning cannot cover: a process killed between two writes, a
+teardown path written before it knew about scheduled jobs, an owner deleted straight
+from storage.
+
+Because it acts on an answer from code it does not own, it never deletes on first
+sight:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running: rule provisioned
+    Running --> Quarantined: owner reported gone<br/>(disabled, queued runs withdrawn)
+    Quarantined --> Running: owner reported alive again<br/>(re-enabled, clock recomputed)
+    Quarantined --> [*]: still gone past the grace period<br/>(deleted)
+    Running --> Running: owner reported alive
+```
+
+- A job whose owner is reported gone is **disabled and stamped**, and its already-queued
+  runs are withdrawn, so it stops firing immediately.
+- It is **deleted only once that stamp is older than the quarantine grace** (a day by
+  default), and only while its owner is still reported gone.
+- A stamped job whose owner turns out to exist after all is **re-enabled** with a freshly
+  computed clock, so a resolver bug corrected inside the grace window destroys nothing.
+
+A resolver answers whether an owner exists, not what it currently wants, so a revival
+restores the job exactly as it was stored. A job the owner would no longer provision
+(a part of it dropped while its jobs were quarantined) comes back too, and its runs
+fail until the owner provisions again. Provisioning is what reconciles an owner's set
+of jobs; the sweep only decides whether they may run at all.
+
+Two more guardrails: an owner type whose resolver throws, or that nothing claimed, is
+left entirely alone; and jobs younger than a short settle period are skipped, so an
+owner written just after its jobs is never mistaken for one that never existed.
+
+The third layer, behind both of these, is the handler itself: a task whose subject has
+disappeared should no-op and report "not dispatched" rather than fail. n8n's trigger
+handlers do that for a node they can no longer resolve and for an occurrence already
+executed, but not yet for a workflow whose published version is gone: that one fails the
+occurrence, so it retries and dead-letters until the sweep retires the job.
+
 ## Durable and distributed
 
 Two properties describe the whole design, and everything else follows from them.
 
 **Durable** means nothing important lives only in memory. The rules, every upcoming
-run, and each run's current state all live in the database. A process can restart
+run, and each run's current state all live in the shared store. A process can restart
 or crash at any moment and the scheduler simply picks up where the stored state left
 off. Compare an in-memory scheduler, where a restart forgets every pending timer.
 
 **Distributed and leaderless** means there is no elected "scheduler node" that the
 others depend on. Every server runs the same passes over the same shared state, and
-they coordinate purely through the database. There is no leader to elect, fail over,
+they coordinate purely through the shared store. There is no leader to elect, fail over,
 or lose. Adding or removing a server changes throughput, not correctness: any server
 can plan any rule and run any due task.
 
@@ -240,9 +364,9 @@ over never repeating it.** In rare recovery situations that can mean a run execu
 more than once, so handlers should tolerate being called again for the same run.
 The design leans on a few ideas working together.
 
-- **Claim.** A run is only ever picked up through an atomic database claim: a
-  single statement that flips exactly one waiting row to "running" and stamps it
-  with the server that claimed it. Because the database resolves the race, only one
+- **Claim.** A run is only ever picked up through an atomic claim in the shared
+  store: a single statement that flips exactly one waiting row to "running" and stamps it
+  with the server that claimed it. Because the store resolves the race, only one
   server can win a given run, no matter how many try at once.
 - **Lease.** A claim comes with an expiry (a *lease*). While the lease is valid the
   run belongs to that server. If the server dies, the lease lapses and the recovery
@@ -328,8 +452,8 @@ stateDiagram-v2
 ## What this package is (and is not)
 
 It is a **library of scheduling logic**, not a running service on its own. It owns
-the algorithms and the schedule math; it does not own a database connection, a DI
-container, or a configuration source. A **host** provides those and drives it.
+the algorithms and the schedule math; it does not own storage, a DI container, or
+a configuration source. A **host** provides those and drives it.
 
 The public surface is small:
 
@@ -345,7 +469,7 @@ The public surface is small:
 - A few pure helpers are exported too: schedule validation, next-run computation,
   and the provisioning entry points.
 
-In n8n, that host is the `cli` package's durable-scheduler module, which wires up
+In n8n, that host is the server's durable-scheduler module, which wires up
 DI, configuration and instance identity, and routes the scheduler's events to the
 logger. While `N8N_SCHEDULER_ENABLED` is off, the previous in-memory engine stays
 in place; turning the flag off again is the rollback.
@@ -354,7 +478,7 @@ The boundary this section describes is enforced, not just documented.
 `src/__tests__/dependency-purity.test.ts` fails if the package ever gains a
 forbidden dependency, whether a new `package.json` entry outside the allowlist or
 an `import` of something effectful (`@n8n/db`, TypeORM, `n8n-core`, the DI
-container, the `cli` package, or a Node I/O built-in). Its opening doc comment is
+container, the host server package, or a Node I/O built-in). Its opening doc comment is
 the living explanation of the approach: why scheduling is split from execution and
 storage, why each excluded dependency is excluded, and how far the idea could be
 taken. Read it first if you want the reasoning behind the split above.
@@ -394,7 +518,7 @@ A few things that are not obvious from the code but save a lot of confusion.
   event sink at `warn` level, so they land in the host's logs:
   - a **clock-skew warning** at start-up. Due-ness and leases are judged on the
     clock the scheduler coordinates on (the host supplies it via `now`, e.g. the
-    database clock), but fire timers are armed on this instance's own clock. When
+    shared store's clock), but fire timers are armed on this instance's own clock. When
     `start` samples the two and they differ by more than the threshold (default
     `1s`, `CLOCK_SKEW_WARN_THRESHOLD_MS`), it warns: tasks may fire early or late,
     and the instance clock should be synchronised (e.g. via NTP). The sample runs
@@ -420,10 +544,10 @@ A few things that are not obvious from the code but save a lot of confusion.
 
 - **A dedicated host module.** Today the wiring that turns this pure library into a
   running scheduler (DI, configuration, instance identity, event routing) lives
-  inside the large `cli` package. Extracting it into its own module, for example
-  `@n8n/scheduler-cli` or `@n8n/scheduler-features`, would keep the integration
-  concerns together and out of `cli`, and mirror the clean split this package
-  already draws between algorithm and host.
+  inside n8n's large server package. Extracting it into its own module, for example
+  `@n8n/scheduler-features`, would keep the integration concerns together on their
+  own, and mirror the clean split this package already draws between algorithm and
+  host.
 - **Lease renewal for long handlers.** A claim's lease is fixed for now, so a
   handler that runs longer than its lease risks being recovered and re-run. A
   heartbeat that extends the lease while a handler is genuinely still working would
@@ -433,14 +557,14 @@ A few things that are not obvious from the code but save a lot of confusion.
 
 Pushed all the way, that host module becomes its own deployable worker. On a due
 task it does not run the workflow, it creates an execution and enqueues a job (Bull
-and Redis) for the regular workers, so the real work is decomposing `cli`. The
-result is far leaner than `cli`, which bundles every node's dependencies (1Password,
-S3, and more). The worker only needs:
+and Redis) for the regular workers, so the real work is decomposing the server
+package. The result is far leaner than that package, which bundles every node's
+dependencies (1Password, S3, and more). The worker only needs:
 
 | Needs | Package | Pulls in |
 | --- | --- | --- |
 | Core logic | `@n8n/scheduler` | luxon, cron-parser |
-| Task store + transactions | `@n8n/db` | `@n8n/typeorm` + a database driver |
+| Task store + transactions | `@n8n/db` | `@n8n/typeorm` + its driver |
 | Enqueue executions (a new, extracted publisher) | `@n8n/…-publisher` | Bull + ioredis, execution writes, trigger-context |
 | Logging + lifecycle | `@n8n/backend-common` | winston |
 | Wiring + types | `@n8n/config`, `@n8n/di`, `@n8n/decorators`, `n8n-workflow` | reflect-metadata |

--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -57,8 +57,10 @@ path during rollout.
 ## The moving parts
 
 The scheduler runs four small background routines, each on its own repeating
-timer. Each one is a separate submodule with a single responsibility. Their code
-names are in parentheses; the rest of this document uses the plain names.
+timer, plus an optional fifth when owner reconciliation is configured (see
+[The reconciliation sweep](#the-reconciliation-sweep)). Each one is a separate
+submodule with a single responsibility. Their code names are in parentheses; the
+rest of this document uses the plain names.
 
 ```mermaid
 flowchart TD
@@ -74,6 +76,8 @@ flowchart TD
     RE["Recovery<br/><i>(reaper)</i>"] -.->|"rescues runs stranded<br/>by a crashed server"| T
     T -.->|"finished runs,<br/>past their window"| C["Cleanup<br/><i>(retention)</i>"]
     C -.->|deletes| T
+
+    RC["Reconciliation<br/><i>(owner sweep, optional)</i>"] -.->|"quarantines rules<br/>whose owner is gone"| J
 
     classDef store fill:#2d3748,stroke:#4a5568,color:#fff;
     class J,T store;
@@ -124,9 +128,9 @@ Successful and failed runs can be kept for different lengths of time.
   is the next run? It handles cron expressions, intervals, one-offs, and the
   "every N periods" variant described below, including timezone and daylight-saving
   behaviour.
-- **Lifecycle** is the set of repeating loops that drive the four passes above,
-  each on its own interval with a little randomness ("jitter") so multiple servers
-  don't all fire their passes in lockstep.
+- **Lifecycle** is the set of repeating loops that drive the four passes above
+  (five with reconciliation), each on its own interval with a little randomness
+  ("jitter") so multiple servers don't all fire their passes in lockstep.
 
 ## Schedule kinds
 
@@ -304,6 +308,12 @@ The resolvers feed a periodic sweep, the safety net behind obligation 1. It exis
 what synchronous deprovisioning cannot cover: a process killed between two writes, a
 teardown path written before it knew about scheduled jobs, an owner deleted straight
 from storage.
+
+It runs as a fifth lifecycle loop, composed only when the host passes `reconciliation`
+to `createScheduler`, so a deployment without it pays nothing. It follows the same
+jittered cadence as the other passes, every fifteen minutes by default with a five
+minute timeout, and pages through live jobs in bounded batches so one pass never scans
+the whole table.
 
 Because it acts on an answer from code it does not own, it never deletes on first
 sight:
@@ -536,7 +546,7 @@ A few things that are not obvious from the code but save a lot of confusion.
   to stop already-queued runs, unless the rule-writing path withdraws them (which
   provisioning does).
 
-- **Each background pass runs on its own timer, with jitter.** The four passes are
+- **Each background pass runs on its own timer, with jitter.** The passes are
   independent and slightly randomised, so several servers do not all run their
   passes in lockstep, and one slow pass does not stall the others.
 

--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -336,9 +336,10 @@ stateDiagram-v2
 
 A resolver answers whether an owner exists, not what it currently wants, so a revival
 restores the job exactly as it was stored. A job the owner would no longer provision
-(a part of it dropped while its jobs were quarantined) comes back too, and its runs
-fail until the owner provisions again. Provisioning is what reconciles an owner's set
-of jobs; the sweep only decides whether they may run at all.
+(a part of it dropped while its jobs were quarantined) comes back too, and stays
+runnable until the owner provisions or deprovisions again and removes it. Provisioning
+is what reconciles an owner's set of jobs; the sweep only decides whether they may run
+at all.
 
 Two more guardrails: an owner type whose resolver throws, or that nothing claimed, is
 left entirely alone; and jobs younger than a short settle period are skipped, so an

--- a/packages/cli/test/integration/scheduling/scheduled-job-lifecycle.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduled-job-lifecycle.test.ts
@@ -1,0 +1,293 @@
+import {
+	createWorkflowWithHistory,
+	mockInstance,
+	setActiveVersion,
+	testDb,
+} from '@n8n/backend-test-utils';
+import { SchedulerConfig, WorkflowsConfig } from '@n8n/config';
+import type { WorkflowEntity } from '@n8n/db';
+import {
+	ScheduledJobRepository,
+	WorkflowPublicationOutboxRepository,
+	WorkflowPublishedVersionRepository,
+	WorkflowRepository,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+import { ActiveWorkflowTriggers, ExternalSecretsProxy, InstanceSettings } from 'n8n-core';
+import { ScheduleTrigger } from 'n8n-nodes-base/nodes/Schedule/ScheduleTrigger.node';
+import type { INode, INodeTypeData } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
+
+import { ActiveExecutions } from '@/active-executions';
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { ExecutionService } from '@/executions/execution.service';
+import { ExternalHooks } from '@/external-hooks';
+import { Push } from '@/push';
+import { WorkflowScheduledJobOwner } from '@/scheduling/workflow-scheduled-job-owner';
+import { OwnershipService } from '@/services/ownership.service';
+import { Telemetry } from '@/telemetry';
+import { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
+import { WorkflowService } from '@/workflows/workflow.service';
+
+import { createOwner } from '../shared/db/users';
+import { createWorkflowHistoryItem } from '../shared/db/workflow-history';
+import * as utils from '../shared/utils/';
+
+import { workflowOwned } from './shared/job-factory';
+
+/**
+ * What a workflow's `scheduled_job` rows do across its whole publication
+ * lifecycle, now that no foreign key ties them to `workflow_published_version`.
+ *
+ * Driven through the real publication consumer rather than the provisioner, so
+ * each step exercises the ordering the applier owns (deactivate, advance the
+ * published version, activate) instead of a hand-rolled stand-in for it.
+ */
+mockInstance(ActiveExecutions);
+mockInstance(Push);
+mockInstance(ExternalSecretsProxy);
+mockInstance(ExecutionService);
+mockInstance(WorkflowService);
+mockInstance(OwnershipService);
+mockInstance(ExternalHooks);
+mockInstance(Telemetry);
+
+const abortSignal = new AbortController().signal;
+
+let consumer: WorkflowPublicationOutboxConsumer;
+let activeWorkflowManager: ActiveWorkflowManager;
+let activeWorkflowTriggers: ActiveWorkflowTriggers;
+let outboxRepository: WorkflowPublicationOutboxRepository;
+let publishedVersions: WorkflowPublishedVersionRepository;
+let workflowRepository: WorkflowRepository;
+let jobRepo: ScheduledJobRepository;
+let owner: WorkflowScheduledJobOwner;
+let originalUseWorkflowPublicationService: boolean;
+let originalSchedulerEnabled: boolean;
+
+/** A Schedule Trigger firing on a fixed cadence, so it maps to one interval job. */
+const scheduleNode = (suffix: string, id = `node-${suffix}`): INode => ({
+	id,
+	name: `Schedule ${suffix}`,
+	type: 'n8n-nodes-base.scheduleTrigger',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters: { rule: { interval: [{ field: 'minutes', minutesInterval: 5 }] } },
+});
+
+/** Run the one pending publication record, as the leader's consumer would. */
+const applyNextRecord = async () => {
+	const record = await outboxRepository.claimNextPendingRecord();
+	expect(record).not.toBeNull();
+	await consumer.processRecord(record!, abortSignal);
+};
+
+/** Publish `workflow`'s current version for the first time. */
+const publish = async (workflow: WorkflowEntity) => {
+	await setActiveVersion(workflow.id, workflow.versionId);
+	await outboxRepository.enqueue(workflow.id, workflow.versionId, 'publish');
+	await applyNextRecord();
+};
+
+/** Publish a new version carrying `nodes`, and return its version id. */
+const republish = async (workflow: WorkflowEntity, nodes: INode[]) => {
+	const versionId = uuid();
+	await createWorkflowHistoryItem(workflow.id, { versionId, nodes, connections: {} });
+	await setActiveVersion(workflow.id, versionId);
+	await outboxRepository.enqueue(workflow.id, versionId, 'publish');
+	await applyNextRecord();
+	return versionId;
+};
+
+/** Unpublish: the workflow keeps no active version, which is what the applier reads. */
+const unpublish = async (workflow: WorkflowEntity, publishedVersionId: string) => {
+	await workflowRepository.update(workflow.id, { active: false, activeVersionId: null });
+	await outboxRepository.enqueue(workflow.id, publishedVersionId, 'publish');
+	await applyNextRecord();
+};
+
+const jobsOf = async (workflowId: string) =>
+	await jobRepo.find({
+		where: { ownerType: 'workflow', ownerId: workflowId },
+		order: { id: 'ASC' },
+	});
+
+beforeAll(async () => {
+	const workflowsConfig = Container.get(WorkflowsConfig);
+	const schedulerConfig = Container.get(SchedulerConfig);
+	originalUseWorkflowPublicationService = workflowsConfig.useWorkflowPublicationService;
+	originalSchedulerEnabled = schedulerConfig.enabled;
+	// Both must be on before the registrar is constructed: it caches whether it
+	// intercepts schedule triggers at construction time.
+	workflowsConfig.useWorkflowPublicationService = true;
+	schedulerConfig.enabled = true;
+
+	await testDb.init();
+
+	const nodes: INodeTypeData = {
+		'n8n-nodes-base.scheduleTrigger': { type: new ScheduleTrigger(), sourcePath: '' },
+	};
+	await utils.initNodeTypes(nodes);
+
+	Container.get(InstanceSettings).markAsLeader();
+
+	consumer = Container.get(WorkflowPublicationOutboxConsumer);
+	activeWorkflowManager = Container.get(ActiveWorkflowManager);
+	activeWorkflowTriggers = Container.get(ActiveWorkflowTriggers);
+	outboxRepository = Container.get(WorkflowPublicationOutboxRepository);
+	publishedVersions = Container.get(WorkflowPublishedVersionRepository);
+	workflowRepository = Container.get(WorkflowRepository);
+	jobRepo = Container.get(ScheduledJobRepository);
+	owner = Container.get(WorkflowScheduledJobOwner);
+});
+
+afterEach(async () => {
+	await activeWorkflowManager.removeAll();
+	await testDb.truncate([
+		'ScheduledTask',
+		'ScheduledJob',
+		'WorkflowPublishedVersion',
+		'WorkflowPublicationOutbox',
+		'WorkflowPublishHistory',
+		'WorkflowEntity',
+		'WorkflowHistory',
+	]);
+});
+
+afterAll(async () => {
+	Container.get(WorkflowsConfig).useWorkflowPublicationService =
+		originalUseWorkflowPublicationService;
+	Container.get(SchedulerConfig).enabled = originalSchedulerEnabled;
+	await testDb.terminate();
+});
+
+describe('scheduled job lifecycle across publish, unpublish and republish', () => {
+	let projectOwner: Awaited<ReturnType<typeof createOwner>>;
+
+	beforeAll(async () => {
+		projectOwner = await createOwner();
+	});
+
+	const createWorkflow = async (nodes: INode[]) =>
+		await createWorkflowWithHistory({ nodes }, projectOwner);
+
+	it('publishing provisions one live row per rule, owned by the workflow and its node', async () => {
+		const trigger = scheduleNode('a');
+		const workflow = await createWorkflow([trigger]);
+
+		await publish(workflow);
+
+		const jobs = await jobsOf(workflow.id);
+		expect(jobs).toHaveLength(1);
+		expect(jobs[0]).toMatchObject({
+			ownerType: 'workflow',
+			ownerId: workflow.id,
+			ownerMemberId: trigger.id,
+			enabled: true,
+			orphanedAt: null,
+		});
+		expect(jobs[0].nextRunAt).not.toBeNull();
+		expect(jobs[0].name.startsWith(`${workflow.id}:${trigger.id}:`)).toBe(true);
+	});
+
+	it('unpublishing deletes every row the workflow owned, with no cascade behind it', async () => {
+		const workflow = await createWorkflow([scheduleNode('a')]);
+		await publish(workflow);
+		expect(await jobsOf(workflow.id)).toHaveLength(1);
+
+		await unpublish(workflow, workflow.versionId);
+
+		expect(await jobsOf(workflow.id)).toEqual([]);
+		expect(await publishedVersions.findOneBy({ workflowId: workflow.id })).toBeNull();
+	});
+
+	it('republishing after an unpublish provisions the rules again under a fresh row', async () => {
+		const trigger = scheduleNode('a');
+		const workflow = await createWorkflow([trigger]);
+		await publish(workflow);
+		const [first] = await jobsOf(workflow.id);
+		await unpublish(workflow, workflow.versionId);
+
+		await republish(workflow, [trigger]);
+
+		// One row, under the same name: an unchanged rule converges on one identity
+		// however many times the workflow goes round the cycle.
+		const jobs = await jobsOf(workflow.id);
+		expect(jobs).toHaveLength(1);
+		expect(jobs[0].name).toBe(first.name);
+		expect(jobs[0]).toMatchObject({ enabled: true, orphanedAt: null });
+		expect(jobs[0].nextRunAt).not.toBeNull();
+	});
+
+	it('republishing an unchanged trigger keeps its row, and therefore its queued runs', async () => {
+		const trigger = scheduleNode('a');
+		const workflow = await createWorkflow([trigger]);
+		await publish(workflow);
+		const [first] = await jobsOf(workflow.id);
+
+		await republish(workflow, [trigger, scheduleNode('b')]);
+
+		const jobs = await jobsOf(workflow.id);
+		expect(jobs).toHaveLength(2);
+		expect(jobs.find((job) => job.ownerMemberId === trigger.id)?.id).toBe(first.id);
+	});
+
+	it('republishing without a trigger node deletes that node’s rows', async () => {
+		const kept = scheduleNode('kept');
+		const dropped = scheduleNode('dropped');
+		const workflow = await createWorkflow([kept, dropped]);
+		await publish(workflow);
+		expect(await jobsOf(workflow.id)).toHaveLength(2);
+
+		await republish(workflow, [kept]);
+
+		const jobs = await jobsOf(workflow.id);
+		expect(jobs).toHaveLength(1);
+		expect(jobs[0].ownerMemberId).toBe(kept.id);
+		expect(activeWorkflowTriggers.get(workflow.id)?.has(dropped.id)).toBe(false);
+	});
+
+	it('changing a trigger node’s id retires the old rows and provisions new ones', async () => {
+		const before = scheduleNode('a', uuid());
+		const workflow = await createWorkflow([before]);
+		await publish(workflow);
+		const [original] = await jobsOf(workflow.id);
+
+		const after = { ...before, id: uuid() };
+		await republish(workflow, [after]);
+
+		// The name carries the node id, so the rule cannot be matched to the old
+		// row: it is a fresh job, and its clock and dedup identity restart with it.
+		const jobs = await jobsOf(workflow.id);
+		expect(jobs).toHaveLength(1);
+		expect(jobs[0].ownerMemberId).toBe(after.id);
+		expect(jobs[0].name).not.toBe(original.name);
+	});
+
+	it('leaves behind the rows of a member the workflow no longer provisions', async () => {
+		// The documented gap: the sweep reconciles owners, not their members. A row
+		// no teardown path reached stays put while the workflow is published, since
+		// its owner is alive by the only question the resolver answers.
+		const trigger = scheduleNode('a');
+		const workflow = await createWorkflow([trigger]);
+		await publish(workflow);
+		const ghost = await jobRepo.save(
+			jobRepo.create({
+				name: `${workflow.id}:ghost:0`,
+				...workflowOwned(workflow.id, 'ghost-node'),
+				taskType: 'workflow:schedule-trigger',
+				payload: { workflowId: workflow.id, nodeId: 'ghost-node' },
+				kind: 'interval',
+				intervalSeconds: 3600,
+				enabled: true,
+				nextRunAt: new Date(),
+				maxAttempts: 3,
+			}),
+		);
+
+		await republish(workflow, [trigger]);
+
+		expect(await jobRepo.findOneBy({ id: ghost.id })).not.toBeNull();
+		expect(await owner.findExisting([workflow.id])).toEqual(new Set([workflow.id]));
+	});
+});

--- a/packages/cli/test/integration/scheduling/scheduled-job-owner-teardown.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduled-job-owner-teardown.test.ts
@@ -203,6 +203,49 @@ describe('scheduled job owner teardown', () => {
 		expect(revived.nextRunAt).not.toBeNull();
 	});
 
+	it('lifts a quarantine on a rule that must never fire, which no redefine would reach', async () => {
+		// A rule with no clock is stored exactly as a quarantined one looks (no
+		// `nextRunAt`), so the provisioning diff finds it unchanged and rewrites
+		// nothing. Lifting the quarantine before the diff is the only thing that
+		// brings this job back.
+		const workflow = await publishWorkflow();
+		const nodeId = uuid();
+		const desired = [
+			{
+				name: `${workflow.id}:${nodeId}:0`,
+				schedule: { kind: 'interval', intervalSeconds: 3600 } as const,
+				firstRunAt: null,
+			},
+		];
+		const provisionOnce = async () =>
+			await provisioner.provision({
+				owner: owner.member(workflow.id, nodeId),
+				taskType: SCHEDULE_TRIGGER_TASK_TYPE,
+				payload: { workflowId: workflow.id, nodeId },
+				desired,
+				misfirePolicy: ScheduledJobMisfirePolicy.Skip,
+			});
+
+		const { inserted } = await provisionOnce();
+		const jobId = inserted[0].id;
+		await jobRepo.quarantineByOwnerIds(
+			'workflow',
+			[workflow.id],
+			new Date(),
+			new Date(Date.now() + 60_000),
+		);
+
+		const summary = await provisionOnce();
+
+		expect(summary.redefined).toEqual([]);
+		expect(summary.unchanged).toHaveLength(1);
+		expect(await jobRepo.findOneByOrFail({ id: jobId })).toMatchObject({
+			enabled: true,
+			orphanedAt: null,
+			nextRunAt: null,
+		});
+	});
+
 	it('provisions a workflow owner, whose type the workflow owner module claims', async () => {
 		const workflow = await publishWorkflow();
 		const nodeId = uuid();

--- a/packages/cli/test/integration/scheduling/scheduled-job-owner-teardown.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduled-job-owner-teardown.test.ts
@@ -234,6 +234,8 @@ describe('scheduled job owner teardown', () => {
 			new Date(),
 			new Date(Date.now() + 60_000),
 		);
+		const quarantined = await jobRepo.findOneByOrFail({ id: jobId });
+		expect(quarantined.orphanedAt).not.toBeNull();
 
 		const summary = await provisionOnce();
 


### PR DESCRIPTION
## Stack (merged bottom-up)

1. #37132 owner as data
2. #37133 reconciliation sweep
3. #37134 schema + host switch
4. #37135 explicit teardown
5. contract docs + lifecycle tests **← this PR**

Replaces #37136. GitHub closed that PR when the stack branches it targeted were deleted after the merge.

<img width="834" height="405" alt="image" src="https://github.com/user-attachments/assets/f8890a26-7abb-4a21-8ed5-53b8158c8037" />


## Summary

Last layer of the CAT-4226 stack, in two parts.

**Docs.** The "Owning scheduled jobs" section of the `@n8n/scheduler` README documents the owner contract.

**Lifecycle tests.** An integration suite drives the real publication outbox consumer. It pins what a workflow's `scheduled_job` rows do across the whole publication lifecycle now that no foreign key ties them to `workflow_published_version`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4226

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

