### PR TITLE
ci: Retarget bundle branches after sync

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -416,7 +416,7 @@ Push to master/1.x
 
 | Schedule (UTC)            | Workflow                          | Purpose                  |
 |---------------------------|-----------------------------------|--------------------------|
-| Hourly :00                | `sec-sync-public-to-private.yml`  | Mirror public → private  |
+| Hourly :00                | `sec-sync-public-to-private.yml`  | Mirror public → private, reset a published `bundle/*` |
 | Daily 03:00               | `sec-sync-bundle-branches.yml`    | Merge the base into `bundle/*` |
 | Daily 00:00               | `docker-build-push.yml`           | Nightly Docker images    |
 | Daily 00:00               | `test-db.yml`                     | Database compatibility   |
@@ -571,15 +571,17 @@ Scripts in `.github/scripts/`:
 
 ### Branch Replay Scripts
 
-Both keep a long-lived branch that is "base + its own commits" in sync by rebasing those
-commits onto the base and force-pushing, sharing the merge-tree content guard that makes the
-rewrite safe.
+These keep a long-lived branch that is "base + its own commits" in sync with that base, all
+sharing the merge-tree content guard that makes a rewrite safe: whatever route a script takes,
+the tree it pushes must be exactly the tree a merge of the two sides produces.
 
 | Script                     | Purpose                                                              | Called By                          |
 |----------------------------|----------------------------------------------------------------------|------------------------------------|
-| `branch-replay.mjs`        | Shared primitives: merge-tree, tree guard, marker scan               | the two scripts below              |
+| `branch-replay.mjs`        | Shared primitives: merge-tree, tree guard, marker scan, guarded replay | the scripts below                |
 | `sync-master-to-3x.mjs`    | master → `3.x`, rebased; auto-resolves mechanical files, opens a conflict PR | `util-sync-master-to-3x.yml`       |
 | `sync-bundle-branch.mjs`   | base → `bundle/*` in n8n-private, merged; fail-loud, never resolves conflicts | `sec-sync-bundle-branches.yml`   |
+| `reset-bundle-after-cut.mjs` | `bundle/*` → the base, in place, once the cut it carried is published back | `sec-sync-public-to-private.yml` |
+| `restack-bundle-prs.mjs`   | the open fix branches → the reset `bundle/*`; skips stacks, fail-loud  | `sec-restack-bundle-prs.yml`       |
 
 ### Slack Scripts
 
@@ -877,15 +879,70 @@ via [`scripts/sync-bundle-branch.mjs`](scripts/sync-bundle-branch.mjs) and pushe
 forcing. Every push is verified to carry exactly the tree a merge of the two sides would
 produce (`git merge-tree`); a mismatch, or a conflict marker, fails the run instead of pushing.
 
-**`bundle/*` is append-only — never rebase it, never force-push it.** These branches receive
-PRs, and rewriting a branch that receives PRs orphans the copies of its commits that the open
-PR branches already contain: every such PR's merge base regresses to an old base commit, so
-GitHub shows it carrying everyone else's fixes, in the commit list *and* in the diff (which
-can then trip required checks like *PR Size Limit*). It compounds — each refresh between
-rewrites picks up another duplicate generation of the same fixes and starts conflicting with
-itself. To refresh a fix branch, use GitHub's **Update branch** button or
+**`bundle/*` is append-only between cuts — never rebase it, never force-push it.** These
+branches receive PRs, and rewriting a branch that receives PRs orphans the copies of its
+commits that the open PR branches already contain: every such PR's merge base regresses to an
+old base commit, so GitHub shows it carrying everyone else's fixes, in the commit list *and*
+in the diff (which can then trip required checks like *PR Size Limit*). It compounds — each
+refresh between rewrites picks up another duplicate generation of the same fixes and starts
+conflicting with itself. To refresh a fix branch, use GitHub's **Update branch** button or
 `git merge origin/bundle/2.x`; squash-merging a fix *into* the bundle branch leaves every
 sibling PR's merge base untouched, which is why only a rewrite breaks this.
+
+**A `bundle/*` branch must never be deleted.** Deleting it makes GitHub retarget every open PR
+based on it onto the base, and re-creating a branch of the same name never re-points them —
+the pending fixes end up queued against the branch the cut publishes *from*, where merging one
+publishes it on its own, under its own title. A bypass-free ruleset on `refs/heads/bundle/*`
+refuses the deletion, including the auto-delete that follows merging the cut PR. If a branch
+does go missing, `sec-sync-public-to-private.yml` says so in `#alerts-security` and the daily
+sync re-creates it — but the PRs it stranded have to be reclaimed by hand, with
+`sec-restack-bundle-prs.yml` dispatched with `adopt-stranded`.
+
+#### Resetting a bundle branch after a cut
+
+A bundle branch carries the pending fixes as separate commits and the cut squashes them into
+one, so once the batch is published the branch's own commits are redundant — and merging the
+base back in would keep every published fix in its log forever. The branch is therefore
+**reset onto the base in place**: the same end state as deleting and re-creating it, reached
+without the branch ever ceasing to exist. This is the one sanctioned rewrite of a bundle
+branch, and it is safe only because the open fix branches are replayed onto the new tip
+immediately afterwards.
+
+```mermaid
+sequenceDiagram
+    participant B as bundle/2.x
+    participant M as private master
+    participant P as public master
+    B->>M: cut PR squash-merges
+    Note over M: sec-publish-fix records refs/bundle-cut/2.x/pr-N
+    M->>P: public PR opened and merged
+    P->>M: hourly mirror resets master to public master
+    M->>B: reset-bundle-after-cut replays onto the new base
+    B->>B: restack-bundle-prs replays every open fix branch
+```
+
+`sec-publish-fix.yml` records the cut as a ref — `refs/bundle-cut/<2.x|1.x>/pr-<public PR>`,
+pointing at the bundle tip that was squashed. A ref, not a repository variable, so the flow
+needs no permission beyond the push it already makes. `reset-bundle-after-cut.mjs` then runs
+on every hourly mirror and does nothing until that public PR is merged *and* its commit has
+reached the freshly synced base; resetting earlier would drop the whole batch. It replays
+anything that landed on the branch during the window onto the new base, force-pushes with a
+lease, and deletes the marker only after the push lands, so a premature run is a free no-op.
+
+`sec-restack-bundle-prs.yml` then replays each open fix branch from the cut onto the new tip.
+The commits it inherited from the published batch replay empty and drop, leaving the PR
+showing exactly its own work. Three things to know about it:
+
+- It **force-pushes contributors' branches**, so `dismiss_stale_reviews_on_push` costs one
+  round of approvals per cut. Any refresh mechanism pays this; a merge would too.
+- It **skips stacks**. A PR that another open PR is based on cannot be rewritten on its own —
+  the child keeps the old parent commits. Those chains are reported for a human to restack in
+  order, root first.
+- A conflicted branch is left untouched, reported on its own PR, and **fails the run**.
+
+Only a `bundle/*` head may be published: `sec-publish-fix.yml` skips anything else merged into
+private `master`/`1.x` and reports it, because cherry-picking such a merge would open a public
+PR under a title that names the fix.
 
 The costs of merging are deliberate and paid for: a merge commit per run, and fixes that have
 already been published staying in the branch's log (the old rebase dropped them as empty

--- a/.github/scripts/branch-replay.mjs
+++ b/.github/scripts/branch-replay.mjs
@@ -9,8 +9,10 @@
  * merge landed on the content it was supposed to.
  *
  * Callers: `sync-master-to-3x.mjs` (master → 3.x, rebased, with mechanical conflict
- * resolution and a conflict PR) and `sync-bundle-branch.mjs` (base → bundle/*, merged
- * because those branches receive PRs, fail-loud).
+ * resolution and a conflict PR), `sync-bundle-branch.mjs` (base → bundle/*, merged because
+ * those branches receive PRs, fail-loud), `reset-bundle-after-cut.mjs` (bundle/* → the base
+ * once its batch is published) and `restack-bundle-prs.mjs` (the open fix branches → the
+ * reset bundle branch).
  *
  * Requires git 2.38+ (`merge-tree --write-tree`).
  */
@@ -105,4 +107,33 @@ export function assertNoMarkers(git, rev = 'HEAD') {
 		throw new Error(`Refusing to continue: conflict markers present in ${rev}:\n${found.out}`);
 	if (found.out.includes('fatal:'))
 		throw new Error(`Could not scan ${rev} for conflict markers:\n${found.out}`);
+}
+
+/**
+ * Replay `from..branch` onto `onto`, then prove the result is the tree merging the two sides
+ * yields. Commits whose content `onto` already carries replay empty and are dropped — that is
+ * how a branch built on a batch that has since been squashed into `onto` sheds the duplicates
+ * instead of re-proposing them.
+ *
+ * Never leaves a rebase in progress: a stall aborts, so the caller can report and move on to
+ * the next branch. `ok: false` with `conflictedPaths` means the two sides genuinely clash.
+ * `branch` must already exist locally at the revision to replay.
+ */
+export function replayOnto(git, { branch, onto, from }) {
+	const head = git(['rev-parse', branch]);
+	const merged = mergeTree(git, head, onto);
+	if (!merged.ok) return { ok: false, conflictedPaths: merged.conflictedPaths, out: merged.out };
+
+	git(['checkout', '--force', '-B', branch, head]);
+	const replay = attempt(git, ['rebase', '--empty=drop', '--onto', onto, from, branch]);
+	if (!replay.ok) {
+		// A stall the merge tree did not predict (delete/modify leaves no markers, so
+		// merge-tree can call it clean while the replay still stops).
+		attempt(git, ['rebase', '--abort']);
+		return { ok: false, conflictedPaths: [], out: replay.out };
+	}
+
+	assertTreeMatches(git, merged.tree);
+	assertNoMarkers(git);
+	return { ok: true, sha: git(['rev-parse', 'HEAD']) };
 }

--- a/.github/scripts/reset-bundle-after-cut.mjs
+++ b/.github/scripts/reset-bundle-after-cut.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * Resets a bundle integration branch (`bundle/2.x`, `bundle/1.x` in n8n-io/n8n-private) onto
+ * its base once the batch it carried has been published.
+ *
+ * A bundle branch holds the pending fixes as separate commits; the cut squashes them into
+ * private master as one commit, which is then republished into public master and mirrored
+ * back. From that moment the branch's own commits are redundant, and merging the base in
+ * would keep every published fix in its log forever. So the branch is reset to the base
+ * instead — the same end state as deleting and re-creating it, reached WITHOUT the branch
+ * ever ceasing to exist.
+ *
+ * That distinction is the whole point of this script. Deleting the branch makes GitHub
+ * retarget every open PR based on it onto master, and re-creating a branch of the same name
+ * never re-points them: the fixes end up queued against the branch the cut publishes from.
+ * Resetting in place keeps every PR's base intact. It needs the `non_fast_forward` bypass the
+ * n8n-assistant app already holds on the `bundle/*` ruleset.
+ *
+ * This is the ONE sanctioned rewrite of a bundle branch, and it is safe only because
+ * restack-bundle-prs.mjs immediately replays the open fix branches onto the new tip. Between
+ * cuts the branch stays append-only — see sync-bundle-branch.mjs.
+ *
+ * The reset must not fire before the round-trip lands, or it would drop the whole batch. The
+ * cut records itself as a ref — `refs/bundle-cut/<2.x|1.x>/pr-<public PR>` pointing at the
+ * bundle tip that was squashed (see sec-publish-fix.yml). A ref rather than a repository
+ * variable so the flow needs nothing beyond the `contents: write` it already has. This script
+ * waits until that public PR is merged AND its commit is on the freshly synced base, then
+ * replays whatever landed on the branch after the cut onto the new base. It deletes the
+ * marker only after the push succeeds, so a premature run is a no-op that retries next hour.
+ *
+ * FAIL LOUD: a conflict leaves the branch untouched and fails the run. A human replays the
+ * branch locally, resolves, pushes, and deletes the marker.
+ *
+ * Env: BUNDLE_BRANCH (e.g. bundle/2.x), BASE_BRANCH (e.g. master),
+ *      GH_TOKEN (installation token for the private repo, contents:write),
+ *      PUBLIC_GH_TOKEN (optional read-only token for the public repo; GH_TOKEN is used when
+ *      it is unset, which only works if that token can see the public repo),
+ *      GITHUB_REPOSITORY (owner/repo, auto-provided by Actions),
+ *      PUBLIC_REPO (optional, defaults to n8n-io/n8n).
+ * Requires git 2.38+ (`merge-tree --write-tree`) and `gh` on PATH.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { attempt, isAncestor, replayOnto, runGit } from './branch-replay.mjs';
+import { writeGithubOutput } from './github-helpers.mjs';
+
+const BOT_NAME = 'n8n-assistant[bot]';
+const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
+
+export const runGh = (args, opts = {}) =>
+	execFileSync('gh', args, { encoding: 'utf8', ...opts }).trim();
+
+function required(env, name) {
+	const value = env[name];
+	if (!value) throw new Error(`${name} env var is required`);
+	return value;
+}
+
+// A GitHub annotation is one line: fold anything multi-line into the URL-escaped form so the
+// whole message survives in the run's error list.
+export function annotation(title, message) {
+	return `::error title=${title}::${message.replace(/\n/g, '%0A')}`;
+}
+
+/** Where a cut of this bundle branch records itself. */
+export const cutRefPrefix = (bundle) => `refs/bundle-cut/${bundle.replace(/^bundle\//, '')}/pr-`;
+
+/**
+ * The pending cut — `{ cutSha, publicPr, ref }` — or null when there is none. The ref name
+ * carries the public PR number and the ref value the bundle tip that was squashed, so one
+ * atomic push records both and one delete retires them.
+ */
+export function readCutMarker({ git, remote, prefix }) {
+	const listed = attempt(git, ['ls-remote', remote, `${prefix}*`]);
+	if (!listed.ok) throw new Error(`Could not read the cut markers under ${prefix}:\n${listed.out}`);
+	if (!listed.out) return null;
+
+	const rows = listed.out.split('\n').map((line) => line.split('\t'));
+	if (rows.length > 1) {
+		throw new Error(
+			`${rows.length} cuts are recorded under ${prefix}; a previous one was never retired. ` +
+				`Delete the stale ref(s) and re-run:\n${rows.map(([, ref]) => ref).join('\n')}`,
+		);
+	}
+
+	const [cutSha, ref] = rows[0];
+	const publicPr = Number(ref.slice(prefix.length));
+	if (!cutSha || !Number.isInteger(publicPr) || publicPr <= 0) {
+		throw new Error(`${ref} is not a usable cut marker.`);
+	}
+	return { cutSha, publicPr, ref };
+}
+
+/**
+ * The commit the published PR landed as, or null while it is still open.
+ *
+ * Read with its own token: the private repo's token is the one that force-pushes, and it has
+ * no business holding write on the public repo just to answer this question.
+ */
+function publishedCommit({ gh, publicRepo, publicPr, token }) {
+	const view = gh(
+		['pr', 'view', String(publicPr), '--repo', publicRepo, '--json', 'state,mergeCommit'],
+		token ? { env: { ...process.env, GH_TOKEN: token } } : {},
+	);
+	const { state, mergeCommit } = JSON.parse(view);
+	if (state !== 'MERGED') return null;
+	if (!mergeCommit?.oid) {
+		throw new Error(`${publicRepo}#${publicPr} is merged but reports no merge commit.`);
+	}
+	return mergeCommit.oid;
+}
+
+export function resetBundleAfterCut({
+	git = runGit,
+	gh = runGh,
+	env = process.env,
+	log = console.log,
+} = {}) {
+	const bundle = required(env, 'BUNDLE_BRANCH');
+	const base = required(env, 'BASE_BRANCH');
+	const repo = required(env, 'GITHUB_REPOSITORY');
+	const publicRepo = env.PUBLIC_REPO || 'n8n-io/n8n';
+	const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+	if (!token) throw new Error('GH_TOKEN / GITHUB_TOKEN env var is required');
+
+	// Every remote operation goes through this URL: checkout does not persist credentials, and
+	// the repository is private, so `git fetch origin` on its own is unauthenticated.
+	const remote = `https://x-access-token:${token}@github.com/${repo}.git`;
+	const prefix = cutRefPrefix(bundle);
+
+	const marker = readCutMarker({ git, remote, prefix });
+	if (!marker) {
+		log(`No cut recorded under ${prefix}; ${bundle} needs no reset.`);
+		return { status: 'no-cut' };
+	}
+
+	const published = publishedCommit({
+		gh,
+		publicRepo,
+		publicPr: marker.publicPr,
+		token: env.PUBLIC_GH_TOKEN,
+	});
+	if (!published) {
+		log(`${publicRepo}#${marker.publicPr} is not merged yet; leaving ${bundle} alone.`);
+		return { status: 'awaiting-publish' };
+	}
+
+	git(['config', 'user.name', BOT_NAME]);
+	git(['config', 'user.email', BOT_EMAIL]);
+	// A rebase must never sit waiting for an editor.
+	git(['config', 'core.editor', 'true']);
+
+	git(['fetch', remote, base]);
+	const baseSha = git(['rev-parse', 'FETCH_HEAD']);
+
+	// The mirror runs hourly and the publish is immediate, so the base normally lags the
+	// public merge by up to an hour. Resetting onto a base without the batch would drop it.
+	if (!isAncestor(git, published, baseSha)) {
+		log(`${base} does not carry ${published} yet; leaving ${bundle} alone.`);
+		return { status: 'awaiting-sync' };
+	}
+
+	const listed = attempt(git, ['ls-remote', '--heads', remote, `refs/heads/${bundle}`]);
+	if (!listed.ok) {
+		throw new Error(`Could not check whether ${bundle} exists on the remote:\n${listed.out}`);
+	}
+	if (!listed.out) {
+		// The ruleset is supposed to make this impossible; say so loudly rather than papering
+		// over it, because every PR that was based on the branch is now targeting the base.
+		throw new Error(
+			`${bundle} does not exist. It must never be deleted — open PRs get retargeted onto ` +
+				`${base} and re-creating the branch does not bring them back. Re-create it at ` +
+				`${baseSha}, restore those PRs' bases, then delete ${marker.ref}.`,
+		);
+	}
+
+	git(['fetch', remote, bundle]);
+	git(['checkout', '--force', '-B', bundle, 'FETCH_HEAD']);
+	const preHead = git(['rev-parse', 'HEAD']);
+
+	if (preHead === baseSha) {
+		// The reset landed and only retiring the marker failed. Finish that and stop.
+		log(`${bundle} is already at ${base} (${baseSha}); retiring ${marker.ref}.`);
+		git(['push', remote, `:${marker.ref}`]);
+		return { status: 'current', cutSha: marker.cutSha };
+	}
+	// Deliberately no "the branch already contains the base" shortcut: the daily sync may have
+	// merged the base in first, and that merge is exactly what leaves the published fixes
+	// duplicated in the log. Replaying from the cut drops them either way.
+	if (!isAncestor(git, marker.cutSha, preHead)) {
+		throw new Error(
+			`The recorded cut ${marker.cutSha} is not an ancestor of ${bundle} (${preHead}); ` +
+				`the branch was rewritten outside this flow. Resolve by hand and delete ${marker.ref}.`,
+		);
+	}
+
+	// Everything up to the cut is published and replays empty; only fixes that landed during
+	// the window survive onto the new base.
+	const pending = git([
+		'log',
+		'--no-merges',
+		'--reverse',
+		'--format=%h %s',
+		`${marker.cutSha}..${preHead}`,
+	]);
+	log(`Resetting ${bundle} onto ${base} ${baseSha}. Landed since the cut:\n${pending || '(none)'}`);
+
+	const replayed = replayOnto(git, { branch: bundle, onto: baseSha, from: marker.cutSha });
+	if (!replayed.ok) {
+		const paths = replayed.conflictedPaths;
+		log(
+			annotation(
+				`${bundle} cannot be reset onto ${base}`,
+				`${paths.length ? `They conflict on: ${paths.join(', ')}` : 'The replay stalled'}\n` +
+					`${bundle} is untouched and ${marker.ref} is kept. Replay ${bundle} onto ${base} ` +
+					`locally, resolve, push, then delete ${marker.ref} and re-run this workflow.`,
+			),
+		);
+		throw new Error(`Could not reset ${bundle} onto ${base}; leaving ${bundle} untouched.`);
+	}
+
+	const push = attempt(git, [
+		'push',
+		`--force-with-lease=refs/heads/${bundle}:${preHead}`,
+		remote,
+		`HEAD:refs/heads/${bundle}`,
+	]);
+	if (!push.ok) {
+		// The lease failed: a fix landed mid-run. Keep the marker so the next run picks it up.
+		if (push.out) log(push.out);
+		return { status: 'rejected', cutSha: marker.cutSha };
+	}
+
+	// Only now: while the marker is there, a premature run is a harmless no-op.
+	git(['push', remote, `:${marker.ref}`]);
+
+	log(`Reset ${bundle} onto ${base}. Open PRs kept their base and now need restacking.`);
+	return { status: 'reset', sha: replayed.sha, cutSha: marker.cutSha };
+}
+
+// Only run when executed directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		const result = resetBundleAfterCut();
+		writeGithubOutput({
+			status: result.status,
+			bundle_sha: result.sha ?? '',
+			cut_sha: result.cutSha ?? '',
+		});
+	} catch (error) {
+		console.error(`Error: ${error.message}`);
+		process.exit(1);
+	}
+}

--- a/.github/scripts/reset-bundle-after-cut.test.mjs
+++ b/.github/scripts/reset-bundle-after-cut.test.mjs
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resetBundleAfterCut } from './reset-bundle-after-cut.mjs';
+
+// A command stub: routes calls by a matcher, records every invocation.
+function makeStub(routes = []) {
+	const calls = [];
+	const fn = (args) => {
+		calls.push(args);
+		for (const [match, result] of routes) {
+			if (match(args)) return typeof result === 'function' ? result(args) : result;
+		}
+		return '';
+	};
+	fn.calls = calls;
+	return fn;
+}
+
+const fail =
+	(stdout = '') =>
+	() => {
+		const err = new Error('command failed');
+		err.status = 1;
+		err.stdout = stdout;
+		throw err;
+	};
+
+const CUT = 'CUTSHA';
+const PRE_HEAD = 'PREHEAD';
+const BASE = 'BASESHA';
+const PUBLISHED = 'PUBSHA';
+const MERGE_TREE = 'MERGETREEOID';
+
+const CUT_REF = 'refs/bundle-cut/2.x/pr-42';
+
+const env = {
+	BUNDLE_BRANCH: 'bundle/2.x',
+	BASE_BRANCH: 'master',
+	GH_TOKEN: 'tok',
+	GITHUB_REPOSITORY: 'n8n-io/n8n-private',
+};
+
+const isPush = (a) => a[0] === 'push' && !deletesMarker(a);
+const isRebase = (a) => a[0] === 'rebase';
+const isAncestorOf = (a, ancestor, descendant) =>
+	a[0] === 'merge-base' && a[2] === ancestor && a[3] === descendant;
+const isFetch = (a) => a[0] === 'fetch';
+const readsMarker = (a) => a[0] === 'ls-remote' && a.at(-1).startsWith('refs/bundle-cut/');
+const deletesMarker = (a) => a[0] === 'push' && a.at(-1) === `:${CUT_REF}`;
+
+// What `git merge-tree --write-tree --name-only` emits on a conflict: the (marker-carrying)
+// tree OID, the conflicted paths, a blank line, then informational messages.
+const conflictedMergeTree = (...paths) =>
+	fail(`${MERGE_TREE}\n${paths.join('\n')}\n\nCONFLICT (content): Merge conflict in ${paths[0]}`);
+
+// The happy path: a cut is recorded, its public PR is merged, the base carries the published
+// commit, the bundle branch still sits exactly where the cut left it, and the replay is clean.
+const baseGhRoutes = [
+	[
+		(a) => a[0] === 'pr' && a[1] === 'view',
+		JSON.stringify({ state: 'MERGED', mergeCommit: { oid: PUBLISHED } }),
+	],
+];
+
+const baseGitRoutes = [
+	[readsMarker, `${CUT}\t${CUT_REF}`],
+	[(a) => a[0] === 'ls-remote', `${PRE_HEAD}\trefs/heads/bundle/2.x`],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD', BASE],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', MERGE_TREE],
+	[(a) => a[0] === 'rev-parse', PRE_HEAD],
+	[(a) => isAncestorOf(a, PUBLISHED, BASE), ''], // the base carries the batch
+	[(a) => isAncestorOf(a, BASE, PRE_HEAD), fail()], // the bundle does not carry the base
+	[(a) => isAncestorOf(a, CUT, PRE_HEAD), ''], // the cut is where we left it
+	[(a) => a[0] === 'merge-tree', MERGE_TREE],
+	[(a) => a[0] === 'grep', fail()], // no conflict markers
+];
+
+const silent = () => {};
+
+test('a missing branch env var fails before any command runs', () => {
+	const git = makeStub();
+	const gh = makeStub();
+	assert.throws(
+		() => resetBundleAfterCut({ git, gh, env: { ...env, BASE_BRANCH: '' }, log: silent }),
+		{ message: /BASE_BRANCH env var is required/ },
+	);
+	assert.equal(git.calls.length, 0);
+	assert.equal(gh.calls.length, 0);
+});
+
+test('no recorded cut leaves the branch alone', () => {
+	const git = makeStub([[readsMarker, ''], ...baseGitRoutes]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.equal(resetBundleAfterCut({ git, gh, env, log: silent }).status, 'no-cut');
+	assert.equal(git.calls.filter(isFetch).length, 0);
+	assert.equal(gh.calls.length, 0);
+});
+
+test('two recorded cuts fail loud rather than guessing which one is live', () => {
+	const git = makeStub([
+		[readsMarker, `${CUT}\t${CUT_REF}\nOTHERSHA\trefs/bundle-cut/2.x/pr-41`],
+		...baseGitRoutes,
+	]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.throws(() => resetBundleAfterCut({ git, gh, env, log: silent }), {
+		message: /a previous one was never retired/,
+	});
+	assert.equal(git.calls.filter(isFetch).length, 0);
+});
+
+test('an unmerged public PR leaves the branch alone', () => {
+	const git = makeStub(baseGitRoutes);
+	const gh = makeStub([
+		[(a) => a[0] === 'pr', JSON.stringify({ state: 'OPEN', mergeCommit: null })],
+	]);
+
+	assert.equal(resetBundleAfterCut({ git, gh, env, log: silent }).status, 'awaiting-publish');
+	assert.equal(git.calls.filter(isFetch).length, 0);
+});
+
+test('a base that has not received the published commit leaves the branch alone', () => {
+	const git = makeStub([[(a) => isAncestorOf(a, PUBLISHED, BASE), fail()], ...baseGitRoutes]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.equal(resetBundleAfterCut({ git, gh, env, log: silent }).status, 'awaiting-sync');
+	assert.equal(git.calls.filter(isPush).length, 0);
+	assert.equal(git.calls.filter(deletesMarker).length, 0);
+});
+
+test('an untouched bundle branch is reset onto the base and the marker is cleared', () => {
+	const git = makeStub(baseGitRoutes);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.equal(resetBundleAfterCut({ git, gh, env, log: silent }).status, 'reset');
+
+	const rebase = git.calls.find(isRebase);
+	assert.deepEqual(rebase, ['rebase', '--empty=drop', '--onto', BASE, CUT, 'bundle/2.x']);
+	const push = git.calls.find(isPush);
+	assert.equal(push[1], `--force-with-lease=refs/heads/bundle/2.x:${PRE_HEAD}`);
+	assert.equal(git.calls.filter(deletesMarker).length, 1);
+});
+
+test('a branch already sitting at the base only has its marker retired', () => {
+	const git = makeStub([[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', BASE], ...baseGitRoutes]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.equal(resetBundleAfterCut({ git, gh, env, log: silent }).status, 'current');
+	assert.equal(git.calls.filter(isPush).length, 0);
+	assert.equal(git.calls.filter(deletesMarker).length, 1);
+});
+
+test('a base already merged into the branch does not stop the replay', () => {
+	const git = makeStub([[(a) => isAncestorOf(a, BASE, PRE_HEAD), ''], ...baseGitRoutes]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.equal(resetBundleAfterCut({ git, gh, env, log: silent }).status, 'reset');
+	assert.deepEqual(git.calls.find(isRebase), [
+		'rebase',
+		'--empty=drop',
+		'--onto',
+		BASE,
+		CUT,
+		'bundle/2.x',
+	]);
+});
+
+test('a cut that is no longer an ancestor of the branch fails loud', () => {
+	const git = makeStub([[(a) => isAncestorOf(a, CUT, PRE_HEAD), fail()], ...baseGitRoutes]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.throws(() => resetBundleAfterCut({ git, gh, env, log: silent }), {
+		message: /was rewritten outside this flow/,
+	});
+	assert.equal(git.calls.filter(isPush).length, 0);
+});
+
+test('a deleted bundle branch fails loud instead of being re-created', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'ls-remote' && a.at(-1).startsWith('refs/heads/'), ''],
+		...baseGitRoutes,
+	]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.throws(() => resetBundleAfterCut({ git, gh, env, log: silent }), {
+		message: /must never be deleted/,
+	});
+	assert.equal(git.calls.filter(isPush).length, 0);
+	assert.equal(git.calls.filter(deletesMarker).length, 0);
+});
+
+test('a conflict pushes nothing and keeps the marker', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge-tree', conflictedMergeTree('packages/cli/src/x.ts')],
+		...baseGitRoutes,
+	]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.throws(() => resetBundleAfterCut({ git, gh, env, log: silent }), {
+		message: /Could not reset bundle\/2\.x onto master/,
+	});
+	assert.equal(git.calls.filter(isPush).length, 0);
+	assert.equal(git.calls.filter(isRebase).length, 0);
+	assert.equal(git.calls.filter(deletesMarker).length, 0);
+});
+
+test('a replay that stalls without conflict markers aborts the rebase', () => {
+	const git = makeStub([[isRebase, fail('could not apply')], ...baseGitRoutes]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.throws(() => resetBundleAfterCut({ git, gh, env, log: silent }));
+	assert.deepEqual(git.calls.filter(isRebase).at(-1), ['rebase', '--abort']);
+	assert.equal(git.calls.filter(isPush).length, 0);
+});
+
+test('a lost lease keeps the marker so the next run retries', () => {
+	const git = makeStub([[isPush, fail('non-fast-forward')], ...baseGitRoutes]);
+	const gh = makeStub(baseGhRoutes);
+
+	assert.equal(resetBundleAfterCut({ git, gh, env, log: silent }).status, 'rejected');
+	assert.equal(git.calls.filter(deletesMarker).length, 0);
+});

--- a/.github/scripts/restack-bundle-prs.mjs
+++ b/.github/scripts/restack-bundle-prs.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Replays the open fix branches of n8n-io/n8n-private onto a bundle branch that was just
+ * reset onto its base (see reset-bundle-after-cut.mjs).
+ *
+ * After a cut, every open fix PR still carries the batch that was just published in its
+ * ancestry, so GitHub shows it re-proposing everyone else's fixes. Replaying each head from
+ * the cut onto the new tip drops those commits — they replay empty, the content already being
+ * in the base — and leaves the PR showing exactly its own work.
+ *
+ * This is the second half of the reset, not an optional tidy-up: resetting a branch that
+ * receives PRs is only safe because the heads are restacked straight after. It force-pushes
+ * contributors' branches, which the `bundle/*` ruleset's `dismiss_stale_reviews_on_push`
+ * turns into one round of dismissed approvals per cut. A merge would dismiss them too.
+ *
+ * STACKS ARE SKIPPED. A PR whose head another open PR is based on cannot be rewritten on its
+ * own: the child keeps the old parent commits and its diff turns into a merge of both. Those
+ * chains are reported for a human to restack in order.
+ *
+ * A conflicted branch is left untouched and reported on its own PR; the rest still get
+ * restacked, and the run fails at the end so a stalled branch is never hidden by a green run.
+ *
+ * `ADOPT_STRANDED` covers the branches that a previous cut already stranded on the base:
+ * it restacks them from their merge base and then points them back at the bundle branch.
+ *
+ * Env: BUNDLE_BRANCH (e.g. bundle/2.x), BASE_BRANCH (e.g. master),
+ *      CUT_SHA (the bundle tip the cut squashed; omit to replay from each branch's merge
+ *      base with the bundle branch, which is the only option once a cut record is gone),
+ *      GH_TOKEN (installation token with contents + pull-requests write),
+ *      GITHUB_REPOSITORY (owner/repo, auto-provided by Actions),
+ *      DRY_RUN ('true' to report the planned rewrites and push nothing),
+ *      ADOPT_STRANDED ('true' to also reclaim PRs left targeting the base).
+ * Requires git 2.38+ (`merge-tree --write-tree`) and `gh` on PATH.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { attempt, isAncestor, replayOnto, runGit } from './branch-replay.mjs';
+import { writeGithubOutput } from './github-helpers.mjs';
+
+const BOT_NAME = 'n8n-assistant[bot]';
+const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
+
+export const runGh = (args, opts = {}) =>
+	execFileSync('gh', args, { encoding: 'utf8', ...opts }).trim();
+
+function required(env, name) {
+	const value = env[name];
+	if (!value) throw new Error(`${name} env var is required`);
+	return value;
+}
+
+/**
+ * Split the open PRs into the ones this run may rewrite and the ones it must not.
+ *
+ * `stacked` is any PR another open PR is based on: rewriting a link of a chain leaves the rest
+ * pointing at commits that no longer exist on it. The children are never candidates anyway —
+ * their base is a fix branch, not the bundle branch.
+ */
+export function planRestack(pulls, { bundle, base, adoptStranded }) {
+	const basesInUse = new Set(pulls.map((pr) => pr.baseRefName));
+	const stackedHeads = new Set(
+		pulls.filter((pr) => basesInUse.has(pr.headRefName)).map((pr) => pr.headRefName),
+	);
+
+	const targets = [];
+	const stacked = [];
+	for (const pr of pulls) {
+		const onBundle = pr.baseRefName === bundle;
+		const stranded =
+			adoptStranded && pr.baseRefName === base && !pr.headRefName.startsWith('bundle/');
+		if (!onBundle && !stranded) continue;
+
+		// A child of a stack is caught here too: its base is a fix branch, so it is neither
+		// `onBundle` nor `stranded` and never reaches this point — only the roots do.
+		if (stackedHeads.has(pr.headRefName)) stacked.push(pr);
+		else targets.push({ ...pr, retarget: stranded });
+	}
+	return { targets, stacked };
+}
+
+// Reclaiming a PR an earlier cut stranded on the base. Done after the replay, so the PR is
+// never briefly proposing the published batch against the branch it publishes from.
+function retarget({ gh, pr, repo, bundle }) {
+	gh(['pr', 'edit', String(pr.number), '--repo', repo, '--base', bundle]);
+}
+
+function restackOne({ git, gh, log, pr, repo, remote, bundle, ontoSha, cutSha, dryRun }) {
+	git(['fetch', remote, pr.headRefName]);
+	git(['checkout', '--force', '-B', pr.headRefName, 'FETCH_HEAD']);
+	const preHead = git(['rev-parse', 'HEAD']);
+
+	if (isAncestor(git, ontoSha, preHead)) {
+		log(`#${pr.number} already sits on ${bundle}; nothing to replay.`);
+		if (pr.retarget && !dryRun) retarget({ gh, pr, repo, bundle });
+		return 'current';
+	}
+
+	// Without a cut record — a PR stranded by an earlier cut — the merge base is the only
+	// honest starting point: everything from there is either the PR's own work or a published
+	// fix it inherited, and the published ones replay empty.
+	const from =
+		cutSha && isAncestor(git, cutSha, preHead) ? cutSha : git(['merge-base', ontoSha, preHead]);
+
+	const own = git(['log', '--no-merges', '--reverse', '--format=%h %s', `${from}..${preHead}`]);
+	log(`#${pr.number} (${pr.headRefName}) replays from ${from}:\n${own || '(none)'}`);
+
+	if (dryRun) return 'planned';
+
+	const replayed = replayOnto(git, { branch: pr.headRefName, onto: ontoSha, from });
+	if (!replayed.ok) {
+		const paths = replayed.conflictedPaths;
+		attempt(gh, [
+			'pr',
+			'comment',
+			String(pr.number),
+			'--repo',
+			repo,
+			'--body',
+			`This branch could not be replayed onto the reset \`${bundle}\`, so it was left as it is.` +
+				(paths.length
+					? `\n\nIt clashes with the new base on: ${paths.map((p) => `\`${p}\``).join(', ')}`
+					: '') +
+				`\n\nRun \`git rebase --onto origin/${bundle} ${from}\` on it, resolve, and force-push. ` +
+				'Until then this PR shows the fixes the last bundle already published.',
+		]);
+		return 'conflict';
+	}
+
+	const push = attempt(git, [
+		'push',
+		`--force-with-lease=refs/heads/${pr.headRefName}:${preHead}`,
+		remote,
+		`HEAD:refs/heads/${pr.headRefName}`,
+	]);
+	if (!push.ok) {
+		// The lease failed: the author pushed mid-run. Their branch wins; the next run retries.
+		if (push.out) log(push.out);
+		return 'rejected';
+	}
+
+	if (pr.retarget) retarget({ gh, pr, repo, bundle });
+	return 'restacked';
+}
+
+export function restackBundlePrs({
+	git = runGit,
+	gh = runGh,
+	env = process.env,
+	log = console.log,
+} = {}) {
+	const bundle = required(env, 'BUNDLE_BRANCH');
+	const base = required(env, 'BASE_BRANCH');
+	const repo = required(env, 'GITHUB_REPOSITORY');
+	const cutSha = env.CUT_SHA || '';
+	const dryRun = env.DRY_RUN === 'true';
+	const adoptStranded = env.ADOPT_STRANDED === 'true';
+	const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+	if (!token) throw new Error('GH_TOKEN / GITHUB_TOKEN env var is required');
+
+	const pulls = JSON.parse(
+		gh([
+			'pr',
+			'list',
+			'--repo',
+			repo,
+			'--state',
+			'open',
+			'--limit',
+			'200',
+			'--json',
+			'number,headRefName,baseRefName',
+		]),
+	);
+	const { targets, stacked } = planRestack(pulls, { bundle, base, adoptStranded });
+
+	if (stacked.length > 0) {
+		log(
+			`Skipping ${stacked.length} PR(s) that other open PRs are based on: ` +
+				`${stacked.map((pr) => `#${pr.number}`).join(', ')}. Restack each chain by hand, root first.`,
+		);
+	}
+	if (targets.length === 0) {
+		log(`Nothing to restack onto ${bundle}.`);
+		return {
+			restacked: 0,
+			current: 0,
+			planned: 0,
+			rejected: 0,
+			conflicts: [],
+			skipped: stacked.map((pr) => pr.number),
+		};
+	}
+
+	git(['config', 'user.name', BOT_NAME]);
+	git(['config', 'user.email', BOT_EMAIL]);
+	git(['config', 'core.editor', 'true']);
+
+	const remote = `https://x-access-token:${token}@github.com/${repo}.git`;
+	git(['fetch', remote, bundle]);
+	const ontoSha = git(['rev-parse', 'FETCH_HEAD']);
+
+	const counts = { restacked: 0, current: 0, planned: 0, rejected: 0 };
+	const conflicts = [];
+	for (const pr of targets) {
+		const outcome = restackOne({ git, gh, log, pr, repo, remote, bundle, ontoSha, cutSha, dryRun });
+		if (outcome === 'conflict') conflicts.push(pr.number);
+		else counts[outcome] += 1;
+	}
+
+	log(
+		`Onto ${bundle} ${ontoSha}: ${counts.restacked} restacked, ${counts.current} already current, ` +
+			`${counts.planned} planned, ${counts.rejected} raced, ${conflicts.length} conflicted, ` +
+			`${stacked.length} stacked and skipped.`,
+	);
+	return { ...counts, conflicts, skipped: stacked.map((pr) => pr.number) };
+}
+
+// Only run when executed directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		const result = restackBundlePrs();
+		writeGithubOutput({
+			restacked: result.restacked,
+			conflicts: result.conflicts.length,
+			skipped: result.skipped.length,
+		});
+		// A branch left carrying the published batch is not a green outcome.
+		if (result.conflicts.length > 0) process.exit(1);
+	} catch (error) {
+		console.error(`Error: ${error.message}`);
+		process.exit(1);
+	}
+}

--- a/.github/scripts/restack-bundle-prs.test.mjs
+++ b/.github/scripts/restack-bundle-prs.test.mjs
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { planRestack, restackBundlePrs } from './restack-bundle-prs.mjs';
+
+function makeStub(routes = []) {
+	const calls = [];
+	const fn = (args) => {
+		calls.push(args);
+		for (const [match, result] of routes) {
+			if (match(args)) return typeof result === 'function' ? result(args) : result;
+		}
+		return '';
+	};
+	fn.calls = calls;
+	return fn;
+}
+
+const fail =
+	(stdout = '') =>
+	() => {
+		const err = new Error('command failed');
+		err.status = 1;
+		err.stdout = stdout;
+		throw err;
+	};
+
+const CUT = 'CUTSHA';
+const ONTO = 'ONTOSHA';
+const PRE_HEAD = 'PREHEAD';
+const MERGE_TREE = 'MERGETREEOID';
+
+const env = {
+	BUNDLE_BRANCH: 'bundle/2.x',
+	BASE_BRANCH: 'master',
+	CUT_SHA: CUT,
+	GH_TOKEN: 'tok',
+	GITHUB_REPOSITORY: 'n8n-io/n8n-private',
+};
+
+const isPush = (a) => a[0] === 'push';
+const isRebase = (a) => a[0] === 'rebase';
+const isComment = (a) => a[0] === 'pr' && a[1] === 'comment';
+const isEdit = (a) => a[0] === 'pr' && a[1] === 'edit';
+const isAncestorOf = (a, ancestor, descendant) =>
+	a[0] === 'merge-base' && a[2] === ancestor && a[3] === descendant;
+
+const conflictedMergeTree = (...paths) =>
+	fail(`${MERGE_TREE}\n${paths.join('\n')}\n\nCONFLICT (content): Merge conflict in ${paths[0]}`);
+
+const gitRoutes = [
+	[(a) => a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD', ONTO],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', MERGE_TREE],
+	[(a) => a[0] === 'rev-parse', PRE_HEAD],
+	[(a) => isAncestorOf(a, ONTO, PRE_HEAD), fail()], // the branch is not on the new tip yet
+	[(a) => isAncestorOf(a, CUT, PRE_HEAD), ''], // it was branched off the bundle before the cut
+	[(a) => a[0] === 'merge-tree', MERGE_TREE],
+	[(a) => a[0] === 'grep', fail()],
+];
+
+const prList = (pulls) => [(a) => a[0] === 'pr' && a[1] === 'list', JSON.stringify(pulls)];
+
+const silent = () => {};
+
+test('only PRs based on the bundle branch are restacked', () => {
+	const { targets, stacked } = planRestack(
+		[
+			{ number: 1, headRefName: 'security/one', baseRefName: 'bundle/2.x' },
+			{ number: 2, headRefName: 'security/two', baseRefName: 'master' },
+			{ number: 3, headRefName: 'bundle/2.x', baseRefName: 'master' },
+		],
+		{ bundle: 'bundle/2.x', base: 'master', adoptStranded: false },
+	);
+
+	assert.deepEqual(
+		targets.map((pr) => pr.number),
+		[1],
+	);
+	assert.deepEqual(stacked, []);
+});
+
+test('stranded PRs are reclaimed only when asked, and the cut PR never is', () => {
+	const pulls = [
+		{ number: 2, headRefName: 'security/two', baseRefName: 'master' },
+		{ number: 3, headRefName: 'bundle/2.x', baseRefName: 'master' },
+	];
+	const { targets } = planRestack(pulls, {
+		bundle: 'bundle/2.x',
+		base: 'master',
+		adoptStranded: true,
+	});
+
+	assert.deepEqual(
+		targets.map((pr) => pr.number),
+		[2],
+	);
+	assert.equal(targets[0].retarget, true);
+});
+
+test('a PR another open PR is based on is skipped, not half-restacked', () => {
+	const { targets, stacked } = planRestack(
+		[
+			{ number: 1, headRefName: 'security/root', baseRefName: 'bundle/2.x' },
+			{ number: 2, headRefName: 'security/child', baseRefName: 'security/root' },
+			{ number: 3, headRefName: 'security/lone', baseRefName: 'bundle/2.x' },
+		],
+		{ bundle: 'bundle/2.x', base: 'master', adoptStranded: false },
+	);
+
+	assert.deepEqual(
+		stacked.map((pr) => pr.number),
+		[1],
+	);
+	assert.deepEqual(
+		targets.map((pr) => pr.number),
+		[3],
+	);
+});
+
+test('a clean branch is replayed from the cut and force-pushed with a lease', () => {
+	const git = makeStub(gitRoutes);
+	const gh = makeStub([
+		prList([{ number: 7, headRefName: 'security/one', baseRefName: 'bundle/2.x' }]),
+	]);
+
+	const result = restackBundlePrs({ git, gh, env, log: silent });
+
+	assert.equal(result.restacked, 1);
+	assert.deepEqual(git.calls.find(isRebase), [
+		'rebase',
+		'--empty=drop',
+		'--onto',
+		ONTO,
+		CUT,
+		'security/one',
+	]);
+	assert.equal(git.calls.find(isPush)[1], `--force-with-lease=refs/heads/security/one:${PRE_HEAD}`);
+	assert.equal(gh.calls.filter(isEdit).length, 0);
+});
+
+test('a stranded branch is replayed from its merge base when no cut is recorded', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge-base' && a[1] === ONTO, 'MERGEBASE'],
+		...gitRoutes,
+	]);
+	const gh = makeStub([
+		prList([{ number: 8, headRefName: 'security/old', baseRefName: 'master' }]),
+	]);
+
+	const result = restackBundlePrs({
+		git,
+		gh,
+		env: { ...env, CUT_SHA: '', ADOPT_STRANDED: 'true' },
+		log: silent,
+	});
+
+	assert.equal(result.restacked, 1);
+	assert.equal(git.calls.find(isRebase)[4], 'MERGEBASE');
+	assert.deepEqual(gh.calls.find(isEdit), [
+		'pr',
+		'edit',
+		'8',
+		'--repo',
+		'n8n-io/n8n-private',
+		'--base',
+		'bundle/2.x',
+	]);
+});
+
+test('a stranded branch already on the new tip is still pointed back at the bundle', () => {
+	const git = makeStub([[(a) => isAncestorOf(a, ONTO, PRE_HEAD), ''], ...gitRoutes]);
+	const gh = makeStub([
+		prList([{ number: 9, headRefName: 'security/fresh', baseRefName: 'master' }]),
+	]);
+
+	const result = restackBundlePrs({
+		git,
+		gh,
+		env: { ...env, ADOPT_STRANDED: 'true' },
+		log: silent,
+	});
+
+	assert.equal(result.current, 1);
+	assert.equal(git.calls.filter(isPush).length, 0);
+	assert.equal(gh.calls.filter(isEdit).length, 1);
+});
+
+test('a conflicted branch is left untouched, reported on its PR, and does not stop the others', () => {
+	// The first branch conflicts; the second is clean.
+	let seen = 0;
+	const git = makeStub([
+		[
+			(a) => a[0] === 'merge-tree',
+			(args) => (seen++ === 0 ? conflictedMergeTree('packages/cli/src/x.ts')(args) : MERGE_TREE),
+		],
+		...gitRoutes,
+	]);
+	const gh = makeStub([
+		prList([
+			{ number: 10, headRefName: 'security/clash', baseRefName: 'bundle/2.x' },
+			{ number: 11, headRefName: 'security/clean', baseRefName: 'bundle/2.x' },
+		]),
+	]);
+
+	const result = restackBundlePrs({ git, gh, env, log: silent });
+
+	assert.deepEqual(result.conflicts, [10]);
+	assert.equal(result.restacked, 1);
+	assert.equal(gh.calls.filter(isComment).length, 1);
+	assert.match(gh.calls.find(isComment)[6], /packages\/cli\/src\/x\.ts/);
+	assert.equal(git.calls.filter(isPush).length, 1);
+});
+
+test('a dry run reports the planned rewrites and pushes nothing', () => {
+	const git = makeStub(gitRoutes);
+	const gh = makeStub([
+		prList([{ number: 12, headRefName: 'security/one', baseRefName: 'bundle/2.x' }]),
+	]);
+
+	const result = restackBundlePrs({ git, gh, env: { ...env, DRY_RUN: 'true' }, log: silent });
+
+	assert.equal(result.planned, 1);
+	assert.equal(result.restacked, 0);
+	assert.equal(git.calls.filter(isPush).length, 0);
+	assert.equal(git.calls.filter(isRebase).length, 0);
+});
+
+test('nothing to restack touches no branch at all', () => {
+	const git = makeStub(gitRoutes);
+	const gh = makeStub([prList([{ number: 13, headRefName: 'bundle/2.x', baseRefName: 'master' }])]);
+
+	const result = restackBundlePrs({ git, gh, env, log: silent });
+
+	assert.equal(result.restacked, 0);
+	assert.equal(git.calls.length, 0);
+});

--- a/.github/workflows/sec-publish-fix-1x.yml
+++ b/.github/workflows/sec-publish-fix-1x.yml
@@ -5,9 +5,17 @@ on:
     types: [closed]
     branches: ['1.x']
 
+# Least privilege by default; each job opts into exactly what it needs.
+permissions: {}
+
 jobs:
   sync-security-fix:
-    if: github.repository == 'n8n-io/n8n-private' && github.event.pull_request.merged == true
+    # Only a bundle cut is publishable. Anything else merged into 1.x is a mistake — it
+    # would be cherry-picked into a public PR under its own title, which names the fix.
+    if: |
+      github.repository == 'n8n-io/n8n-private' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'bundle/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,22 +48,32 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git cherry-pick "$COMMIT_TO_PUBLISH"
           git push public-repo "$BRANCH_NAME"
-          gh pr create \
+          PUBLIC_PR_URL=$(gh pr create \
             --repo n8n-io/n8n \
             --base 1.x \
             --head "$BRANCH_NAME" \
             --title "$PR_TITLE" \
-            --body "Cherry-picked from n8n-private. Original PR: $PR_URL"
+            --body "Cherry-picked from n8n-private. Original PR: $PR_URL")
+
+          # Record the cut for sec-sync-public-to-private.yml: the ref name carries the public
+          # PR to wait for, its value the bundle tip that was squashed. The branch is reset
+          # onto the base once that PR is merged and mirrored back. A ref rather than a
+          # repository variable, so this needs no permission beyond the push it already does.
+          git push origin "$CUT_SHA:refs/bundle-cut/${HEAD_REF#bundle/}/pr-${PUBLIC_PR_URL##*/}"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CUT_SHA: ${{ github.event.pull_request.head.sha }}
 
   notify-on-failure:
     name: Notify Slack on failure
     needs: [sync-security-fix]
     if: ${{ always() && needs.sync-security-fix.result == 'failure' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the slack scripts
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -69,3 +87,31 @@ jobs:
           node .github/scripts/slack/notify.mjs \
             --channel '#alerts-security' \
             --text 'Security fix PR creation failed (1.x). Run "Security: Sync from Public" workflow, rebase your branch, reopen PR. (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+
+  # Nothing was published, but a fix has reached the branch the mirror pushes to public
+  # outside a batch. The mirror halts on it too (it refuses to sync while 1.x is ahead by
+  # a non-`chore: Bundle` commit); this says so at once. Link only — the PR title names the fix.
+  report-unbatched-merge:
+    name: Report a merge that is not a bundle cut
+    if: |
+      github.repository == 'n8n-io/n8n-private' &&
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'bundle/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the slack scripts
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          sparse-checkout: .github/scripts/slack
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Notify Slack
+        env:
+          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel '#alerts-security' \
+            --text "<${PR_URL}|A PR that is not a bundle cut was merged into 1.x>. It was not published, and the public mirror stays halted until 1.x matches public again."

--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -5,9 +5,17 @@ on:
     types: [closed]
     branches: [master]
 
+# Least privilege by default; each job opts into exactly what it needs.
+permissions: {}
+
 jobs:
   sync-security-fix:
-    if: github.repository == 'n8n-io/n8n-private' && github.event.pull_request.merged == true
+    # Only a bundle cut is publishable. Anything else merged into master is a mistake — it
+    # would be cherry-picked into a public PR under its own title, which names the fix.
+    if: |
+      github.repository == 'n8n-io/n8n-private' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'bundle/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,16 +48,24 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git cherry-pick "$COMMIT_TO_PUBLISH"
           git push public-repo "$BRANCH_NAME"
-          gh pr create \
+          PUBLIC_PR_URL=$(gh pr create \
             --repo n8n-io/n8n \
             --base master \
             --head "$BRANCH_NAME" \
             --title "$PR_TITLE" \
-            --body "Cherry-picked from n8n-private. Original PR: $PR_URL"
+            --body "Cherry-picked from n8n-private. Original PR: $PR_URL")
+
+          # Record the cut for sec-sync-public-to-private.yml: the ref name carries the public
+          # PR to wait for, its value the bundle tip that was squashed. The branch is reset
+          # onto the base once that PR is merged and mirrored back. A ref rather than a
+          # repository variable, so this needs no permission beyond the push it already does.
+          git push origin "$CUT_SHA:refs/bundle-cut/${HEAD_REF#bundle/}/pr-${PUBLIC_PR_URL##*/}"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CUT_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Notify on failure
         if: failure()
@@ -59,3 +75,31 @@ jobs:
           node .github/scripts/slack/notify.mjs \
             --channel '#alerts-security' \
             --text 'Security fix PR creation failed. Run "Security: Sync from Public" workflow, rebase your branch, reopen PR. (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+
+  # Nothing was published, but a fix has reached the branch the mirror pushes to public
+  # outside a batch. The mirror halts on it too (it refuses to sync while master is ahead by
+  # a non-`chore: Bundle` commit); this says so at once. Link only — the PR title names the fix.
+  report-unbatched-merge:
+    name: Report a merge that is not a bundle cut
+    if: |
+      github.repository == 'n8n-io/n8n-private' &&
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'bundle/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the slack scripts
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          sparse-checkout: .github/scripts/slack
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Notify Slack
+        env:
+          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel '#alerts-security' \
+            --text "<${PR_URL}|A PR that is not a bundle cut was merged into master>. It was not published, and the public mirror stays halted until master matches public again."

--- a/.github/workflows/sec-restack-bundle-prs.yml
+++ b/.github/workflows/sec-restack-bundle-prs.yml
@@ -1,0 +1,120 @@
+# Replays the open fix branches of n8n-io/n8n-private onto a bundle branch that was just
+# reset onto its base.
+#
+# This is the second half of the post-cut reset, not a tidy-up. Resetting a branch that
+# receives PRs is only safe when the heads follow it: until they do, every open fix PR carries
+# the batch that was just published in its ancestry and shows itself re-proposing everyone
+# else's fixes. See reset-bundle-after-cut.mjs for the first half, and restack-bundle-prs.mjs
+# for what a replay does and does not touch.
+#
+# Called by sec-sync-public-to-private.yml right after a reset. Dispatch it by hand to
+# rehearse (dry run), to retry after a conflict was resolved, or with adopt-stranded to
+# reclaim PRs that an earlier cut left targeting the base.
+#
+# A conflicted branch is reported on its own PR and FAILS the run: a branch still carrying a
+# published batch must not hide behind a green tick.
+
+name: 'Security: Restack bundle PRs'
+run-name: "Restack ${{ inputs.bundle }} PRs${{ inputs['dry-run'] && ' (dry run)' || '' }}"
+
+on:
+  workflow_call:
+    inputs:
+      bundle:
+        description: Bundle branch the PRs should sit on.
+        required: true
+        type: string
+      cut-sha:
+        description: The bundle tip the cut squashed; empty replays from each merge base.
+        required: false
+        type: string
+        default: ''
+      dry-run:
+        required: false
+        type: boolean
+        default: false
+      adopt-stranded:
+        description: Also reclaim PRs left targeting the base by an earlier cut.
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      bundle:
+        description: Bundle branch the PRs should sit on.
+        required: true
+        type: choice
+        options:
+          - bundle/2.x
+          - bundle/1.x
+      cut-sha:
+        description: The bundle tip the cut squashed; empty replays from each merge base.
+        required: false
+        type: string
+        default: ''
+      dry-run:
+        description: Report the planned rewrites and push nothing.
+        required: false
+        type: boolean
+        default: true
+      adopt-stranded:
+        description: Also reclaim PRs left targeting the base by an earlier cut.
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  restack:
+    name: Restack PRs onto ${{ inputs.bundle }}
+    if: github.repository == 'n8n-io/n8n-private'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency: # never two restacks of the same branch at once
+      group: restack-${{ inputs.bundle }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          permission-contents: write # force-push the replayed fix branches
+          permission-pull-requests: write # comment on a conflict, retarget a stranded PR
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Always run the script from the default branch, never from a bundle or fix branch —
+          # it holds a contents:write token and fetches every ref it needs itself.
+          ref: master
+          fetch-depth: 0
+          persist-credentials: false # we push with an explicit token URL instead
+
+      - name: Restack the open fix branches
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BUNDLE_BRANCH: ${{ inputs.bundle }}
+          BASE_BRANCH: ${{ inputs.bundle == 'bundle/1.x' && '1.x' || 'master' }}
+          CUT_SHA: ${{ inputs['cut-sha'] }}
+          DRY_RUN: ${{ inputs['dry-run'] }}
+          ADOPT_STRANDED: ${{ inputs['adopt-stranded'] }}
+        run: node .github/scripts/restack-bundle-prs.mjs
+
+      # Branch names hint at the vulnerability and Slack reaches a wider audience than the
+      # private repo, so this carries a run link and nothing else. The affected PR already
+      # has the detail, posted on itself.
+      - name: Notify Slack on failure
+        if: failure()
+        continue-on-error: true
+        env:
+          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel '#alerts-security' \
+            --text "<${RUN_URL}|A fix branch could not be replayed onto its bundle branch>. It is untouched and still carries the published batch; the run says which."

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -8,7 +8,11 @@
 #
 # A skipped branch or a hard failure is reported to #alerts-build.
 #
-# The bundle/* integration branches are kept current by sec-sync-bundle-branches.yml.
+# The bundle/* integration branches are kept current by sec-sync-bundle-branches.yml. This
+# workflow only touches them right after a cut has been published: once the batch a bundle
+# branch carried comes back from public, the branch is RESET onto the base in place (never
+# deleted and re-created — that retargets every open fix PR onto master and no re-creation
+# brings them back) and the open fix branches are replayed onto the new tip.
 
 name: 'Security: Sync from Public'
 run-name: "${{ github.event_name == 'workflow_dispatch' && format('Security: Sync from Public (force={0})', inputs.force) || '' }}"
@@ -23,6 +27,8 @@ on:
         type: boolean
         default: true
 
+permissions: {}
+
 jobs:
   sync-from-public:
     if: github.repository == 'n8n-io/n8n-private'
@@ -30,6 +36,11 @@ jobs:
     permissions:
       contents: write
       actions: write
+    outputs:
+      reset_2x: ${{ steps.reset-2x.outputs.status }}
+      cut_sha_2x: ${{ steps.reset-2x.outputs.cut_sha }}
+      reset_1x: ${{ steps.reset-1x.outputs.status }}
+      cut_sha_1x: ${{ steps.reset-1x.outputs.cut_sha }}
 
     steps:
       - name: Generate App Token
@@ -102,7 +113,44 @@ jobs:
           git reset --hard public-1.x
           git push origin 1.x --force-with-lease
 
-      - name: Re-create missing bundle branches
+      # Answering "has the cut come back from public yet?" needs to see a PR in the public
+      # repo, and nothing more. Kept apart from the token above, which force-pushes here.
+      - name: Generate a read-only token for the public repo
+        id: public-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          owner: n8n-io
+          repositories: n8n
+          permission-contents: read
+          permission-pull-requests: read
+
+      # No-ops until the batch this branch carried is merged in public AND mirrored back, so
+      # a run between the cut and the round-trip costs nothing and the next hour retries.
+      - name: Reset bundle/2.x after a published cut
+        id: reset-2x
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PUBLIC_GH_TOKEN: ${{ steps.public-token.outputs.token }}
+          BUNDLE_BRANCH: bundle/2.x
+          BASE_BRANCH: master
+        run: node .github/scripts/reset-bundle-after-cut.mjs
+
+      - name: Reset bundle/1.x after a published cut
+        id: reset-1x
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PUBLIC_GH_TOKEN: ${{ steps.public-token.outputs.token }}
+          BUNDLE_BRANCH: bundle/1.x
+          BASE_BRANCH: '1.x'
+        run: node .github/scripts/reset-bundle-after-cut.mjs
+
+      # A bundle branch must never go missing: the `bundle/*` ruleset forbids deleting one,
+      # because every open PR based on it is retargeted onto the base the moment it does.
+      # Recovery still belongs to the daily sync, which re-creates it at the base.
+      - name: Check the bundle branches exist
+        id: missing-bundles
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -120,8 +168,21 @@ jobs:
             exit 0
           fi
 
-          echo "Missing: ${MISSING[*]} - dispatching Security: Sync Bundle Branches"
+          echo "missing=${MISSING[*]}" >> "$GITHUB_OUTPUT"
+          echo "::warning::Missing: ${MISSING[*]} - dispatching Security: Sync Bundle Branches"
           gh workflow run sec-sync-bundle-branches.yml --ref master
+
+      - name: Notify Slack on a missing bundle branch
+        continue-on-error: true
+        if: ${{ !cancelled() && steps.missing-bundles.outputs.missing }}
+        env:
+          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+          MISSING: ${{ steps.missing-bundles.outputs.missing }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel '#alerts-security' \
+            --text "<${RUN_URL}|A bundle branch is missing>: ${MISSING}. It is being re-created, but every PR that targeted it has been retargeted onto its base and must be reclaimed."
 
       - name: Notify Slack on failure
         if: failure()
@@ -156,3 +217,31 @@ jobs:
           node .github/scripts/slack/notify.mjs \
             --channel '#alerts-build' \
             --text "<${RUN_URL}|Public → private sync skipped>: ${DETAILS} of public. Re-run with force once resolved."
+
+  # Replaying the heads is what makes the reset above safe: until it runs, every open fix PR
+  # still carries the batch that was just published and shows itself re-proposing it.
+  restack-2x:
+    name: Restack bundle/2.x PRs
+    needs: sync-from-public
+    if: needs.sync-from-public.outputs.reset_2x == 'reset'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/sec-restack-bundle-prs.yml
+    with:
+      bundle: bundle/2.x
+      cut-sha: ${{ needs.sync-from-public.outputs.cut_sha_2x }}
+    secrets: inherit
+
+  restack-1x:
+    name: Restack bundle/1.x PRs
+    needs: sync-from-public
+    if: needs.sync-from-public.outputs.reset_1x == 'reset'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/sec-restack-bundle-prs.yml
+    with:
+      bundle: bundle/1.x
+      cut-sha: ${{ needs.sync-from-public.outputs.cut_sha_1x }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

After a bundle branch is merged, we used to delete the branch and this caused all pending PRs targeting it to retarget to master. 

This PR introduces mechanisms for handling the sync more gracefully, by not deleting the previous bundle, by waiting for the next sync to happen and then replaying the new changes from master onto the bundle branches. This should fight against unnecessary churn in pending PRs.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

