### PR TITLE
feat(editor): Add manual agent creation entry point on the agents pages

### DIFF
--- a/packages/@n8n/telemetry/src/events/agents.ts
+++ b/packages/@n8n/telemetry/src/events/agents.ts
@@ -447,6 +447,12 @@ export const AGENTS_TELEMETRY = defineTelemetryEvents({
 		properties: z.object({
 			source: z.enum(['button', 'dropdown', 'card']),
 			agent_id: z.string().describe('Minted at the click; no agent row exists yet'),
+			manual: z
+				.boolean()
+				.optional()
+				.describe(
+					'True when the click came from a "Create agent manually" entry point that skips the Instance AI flow',
+				),
 			session_id: sessionId,
 		}),
 	},

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5858,6 +5858,7 @@
 	"projects.header.create.workflow": "Create workflow",
 	"projects.header.create.credential": "Create credential",
 	"projects.header.create.agent": "Create agent",
+	"projects.header.create.agentManually": "Create agent manually",
 	"projects.header.create.folder": "Create folder",
 	"projects.create": "Create",
 	"projects.create.personal": "Create in personal",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
@@ -65,6 +65,34 @@ describe('NewAgentView', () => {
 		});
 	});
 
+	it('opens the manual builder when manual mode is requested, even with Instance AI ready', async () => {
+		mocks.route.query = { projectId: 'project-1', mode: 'manual' };
+		history.replaceState({ instanceAiPendingAgentId: 'ZyXwVuTsRqPoNmLk' }, '');
+
+		mount(NewAgentView);
+		await flushPromises();
+
+		expect(mocks.syncThread).not.toHaveBeenCalled();
+		expect(mocks.updateThreadMetadata).not.toHaveBeenCalled();
+		expect(mocks.replace).toHaveBeenCalledWith({
+			name: AGENT_BUILDER_VIEW,
+			params: { projectId: 'project-1', agentId: 'ZyXwVuTsRqPoNmLk' },
+			state: { instanceAiPendingAgentId: 'ZyXwVuTsRqPoNmLk' },
+		});
+	});
+
+	it('keeps the Instance AI flow for an unrecognized mode query', async () => {
+		mocks.route.query = { projectId: 'project-1', mode: 'something-else' };
+
+		mount(NewAgentView);
+		await flushPromises();
+
+		expect(mocks.replace).toHaveBeenCalledWith({
+			name: INSTANCE_AI_THREAD_VIEW,
+			params: { threadId: 'thread-1' },
+		});
+	});
+
 	it('opens an unsaved agent artifact when Instance AI is set up', async () => {
 		mount(NewAgentView);
 		await flushPromises();

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentTelemetry.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentTelemetry.ts
@@ -23,10 +23,15 @@ export function useAgentTelemetry() {
 		}
 	}
 
-	function trackClickedNewAgent(source: AgentCreateSource, agentId: string) {
+	function trackClickedNewAgent(
+		source: AgentCreateSource,
+		agentId: string,
+		options?: { manual?: boolean },
+	) {
 		safeTrack(TELEMETRY_EVENT.AGENTS.USER_CLICKED_NEW_AGENT, {
 			source,
 			agent_id: agentId,
+			...(options?.manual ? { manual: true } : {}),
 			...common(),
 		});
 	}

--- a/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
@@ -7,6 +7,8 @@ import { generateNanoId } from '@n8n/utils/generate-nano-id';
 
 import { useToast } from '@n8n/composables/useToast';
 import {
+	INSTANCE_AI_CREATE_AGENT_MODE_MANUAL,
+	INSTANCE_AI_CREATE_AGENT_MODE_QUERY,
 	INSTANCE_AI_PENDING_AGENT_ID_STATE,
 	INSTANCE_AI_PENDING_AGENT_METADATA_KEY,
 	INSTANCE_AI_THREAD_VIEW,
@@ -52,8 +54,12 @@ onMounted(async () => {
 		typeof clickedAgentId === 'string' && MINTED_AGENT_ID.test(clickedAgentId)
 			? clickedAgentId
 			: generateNanoId();
+	// The query flag is a mode switch only, never a data channel: the agent id
+	// above still comes exclusively from history state.
+	const manualRequested =
+		route.query[INSTANCE_AI_CREATE_AGENT_MODE_QUERY] === INSTANCE_AI_CREATE_AGENT_MODE_MANUAL;
 	try {
-		if (!instanceAiReady.value) {
+		if (manualRequested || !instanceAiReady.value) {
 			await router.replace({
 				name: AGENT_BUILDER_VIEW,
 				params: { projectId, agentId },

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/constants.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/constants.ts
@@ -5,6 +5,13 @@ export const INSTANCE_AI_THREAD_VIEW = 'InstanceAiThread';
 export const INSTANCE_AI_SETTINGS_VIEW = 'InstanceAiSettings';
 export const INSTANCE_AI_PROJECT_ID_QUERY = 'projectId';
 /**
+ * Query flag for the new-agent view: `mode=manual` skips the Instance AI flow
+ * and opens the standalone builder directly. A mode switch only — the agent id
+ * still travels exclusively in history state.
+ */
+export const INSTANCE_AI_CREATE_AGENT_MODE_QUERY = 'mode';
+export const INSTANCE_AI_CREATE_AGENT_MODE_MANUAL = 'manual';
+/**
  * History-state key for the agent id minted at the click. Carried to the
  * new-agent view so the "clicked" and "created" events share a join key even
  * though no agent exists yet. Kept out of the URL so a hand-authored query

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/createAgentRoute.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/createAgentRoute.ts
@@ -1,16 +1,29 @@
 import type { RouteLocationRaw } from 'vue-router';
 import { NEW_AGENT_VIEW } from '@/features/agents/constants';
-import { INSTANCE_AI_PENDING_AGENT_ID_STATE, INSTANCE_AI_PROJECT_ID_QUERY } from './constants';
+import {
+	INSTANCE_AI_CREATE_AGENT_MODE_MANUAL,
+	INSTANCE_AI_CREATE_AGENT_MODE_QUERY,
+	INSTANCE_AI_PENDING_AGENT_ID_STATE,
+	INSTANCE_AI_PROJECT_ID_QUERY,
+} from './constants';
 
 /**
  * `agentId` lets a caller that reports the click pin the agent the click will
  * eventually produce. Omit it and the new-agent view mints its own.
+ * `manual` skips the Instance AI flow and opens the standalone builder.
  */
-export function instanceAiCreateAgentRoute(projectId: string, agentId?: string): RouteLocationRaw {
+export function instanceAiCreateAgentRoute(
+	projectId: string,
+	agentId?: string,
+	options?: { manual?: boolean },
+): RouteLocationRaw {
 	return {
 		name: NEW_AGENT_VIEW,
 		query: {
 			[INSTANCE_AI_PROJECT_ID_QUERY]: projectId,
+			...(options?.manual
+				? { [INSTANCE_AI_CREATE_AGENT_MODE_QUERY]: INSTANCE_AI_CREATE_AGENT_MODE_MANUAL }
+				: {}),
 		},
 		...(agentId ? { state: { [INSTANCE_AI_PENDING_AGENT_ID_STATE]: agentId } } : {}),
 	};

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.test.ts
@@ -42,6 +42,20 @@ vi.mock('@/features/agents/composables/useAgentTelemetry', () => ({
 	}),
 }));
 
+const instanceAiMocks = vi.hoisted(() => ({ ready: false }));
+vi.mock('@/features/ai/instanceAi/composables/useInstanceAiAvailability', () => ({
+	useInstanceAiAvailable: () => ({
+		get value() {
+			return instanceAiMocks.ready;
+		},
+	}),
+	useInstanceAiReady: () => ({
+		get value() {
+			return instanceAiMocks.ready;
+		},
+	}),
+}));
+
 vi.mock('@/features/collaboration/projects/composables/useProjectPages', () => ({
 	useProjectPages: vi.fn().mockReturnValue({
 		isOverviewSubPage: false,
@@ -66,8 +80,9 @@ const ProjectCreateResourceStub = {
 			<button data-test-id="action-workflow" @click="$emit('action', 'workflow')">Workflow</button>
 			<button data-test-id="action-dataTable" @click="$emit('action', 'dataTable')">Data Table</button>
 			<button data-test-id="action-agent" @click="$emit('action', 'agent')">Agent</button>
+			<button data-test-id="action-agentManual" @click="$emit('action', 'agentManual')">Agent manually</button>
 			<div data-test-id="add-resource-actions" >
-				<button v-for="action in $props.actions" :key="action.value"></button>
+				<button v-for="action in $props.actions" :key="action.value" :data-test-id="'menu-' + action.value"></button>
 			</div>
 		</div>
 	`,
@@ -99,6 +114,7 @@ describe('ProjectHeader', () => {
 		uiStore = mockedStore(useUIStore);
 		projectPages = useProjectPages();
 
+		instanceAiMocks.ready = false;
 		projectsStore.teamProjectsLimit = -1;
 		settingsStore.settings.folders = { enabled: false };
 		settingsStore.isDataTableFeatureEnabled = true;
@@ -346,6 +362,55 @@ describe('ProjectHeader', () => {
 
 			expect(trackClickedNewAgent).toHaveBeenCalledTimes(1);
 			expect(trackClickedNewAgent).toHaveBeenCalledWith('dropdown', expect.any(String));
+		});
+
+		it('tracks the manual flag when the manual agent action is selected', async () => {
+			instanceAiMocks.ready = true;
+			const { getByTestId } = renderComponent({ props: { mainButton: 'agent' } });
+
+			await userEvent.click(within(getByTestId('add-resource')).getByRole('button'));
+			await waitFor(() => expect(getByTestId('action-agentManual')).toBeVisible());
+			await userEvent.click(getByTestId('action-agentManual'));
+
+			expect(trackClickedNewAgent).toHaveBeenCalledTimes(1);
+			expect(trackClickedNewAgent).toHaveBeenCalledWith('dropdown', expect.any(String), {
+				manual: true,
+			});
+			expect(mockPush).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.objectContaining({ mode: 'manual' }),
+				}),
+			);
+		});
+	});
+
+	describe('manual agent creation menu item', () => {
+		beforeEach(() => {
+			settingsStore.isModuleActive = vi.fn().mockImplementation((mod) => mod === 'agents');
+			const project = createTestProject({ scopes: ['agent:create'] });
+			projectsStore.currentProject = project;
+			projectsStore.myProjects = [project] as unknown as ProjectListItem[];
+		});
+
+		it('is offered on the agents pages while Instance AI is ready', () => {
+			instanceAiMocks.ready = true;
+			const { queryByTestId } = renderComponent({ props: { mainButton: 'agent' } });
+
+			expect(queryByTestId('menu-agentManual')).toBeInTheDocument();
+		});
+
+		it('is not offered while Instance AI is not ready — the main button is already manual', () => {
+			instanceAiMocks.ready = false;
+			const { queryByTestId } = renderComponent({ props: { mainButton: 'agent' } });
+
+			expect(queryByTestId('menu-agentManual')).not.toBeInTheDocument();
+		});
+
+		it('is not offered outside the agents pages', () => {
+			instanceAiMocks.ready = true;
+			const { queryByTestId } = renderComponent();
+
+			expect(queryByTestId('menu-agentManual')).not.toBeInTheDocument();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.vue
@@ -21,6 +21,7 @@ import { type IconOrEmoji, isIconOrEmoji } from '@n8n/design-system';
 import { useUIStore } from '@/app/stores/ui.store';
 import { PROJECT_DATA_TABLES } from '@/features/core/dataTable/constants';
 import { instanceAiCreateAgentRoute } from '@/features/ai/instanceAi/createAgentRoute';
+import { useInstanceAiReady } from '@/features/ai/instanceAi/composables/useInstanceAiAvailability';
 import { generateNanoId } from '@n8n/utils/generate-nano-id';
 import { useAgentPermissions } from '@/features/agents/composables/useAgentPermissions';
 import ReadyToRunButton from '@/features/workflows/readyToRun/components/ReadyToRunButton.vue';
@@ -83,6 +84,7 @@ const headerIcon = computed((): IconOrEmoji => {
 const homeProject = computed(() => projectsStore.currentProject ?? projectsStore.personalProject);
 
 const { canCreate: canCreateAgent } = useAgentPermissions(() => homeProject.value?.id);
+const instanceAiReady = useInstanceAiReady();
 
 const isPersonalProject = computed(() => {
 	return homeProject.value?.type === ProjectTypes.Personal;
@@ -161,6 +163,7 @@ const ACTION_TYPES = {
 	DATA_TABLE: 'dataTable',
 	VARIABLE: 'variable',
 	AGENT: 'agent',
+	AGENT_MANUAL: 'agentManual',
 } as const;
 type ActionTypes = (typeof ACTION_TYPES)[keyof typeof ACTION_TYPES];
 
@@ -297,15 +300,23 @@ const menu = computed(() => {
 		});
 	}
 
-	if (
-		settingsStore.isModuleActive('agents') &&
-		selectedMainButtonType.value !== ACTION_TYPES.AGENT
-	) {
-		items.push({
-			value: ACTION_TYPES.AGENT,
-			label: i18n.baseText('projects.header.create.agent'),
-			disabled: !canCreateAgent.value,
-		});
+	if (settingsStore.isModuleActive('agents')) {
+		if (selectedMainButtonType.value !== ACTION_TYPES.AGENT) {
+			items.push({
+				value: ACTION_TYPES.AGENT,
+				label: i18n.baseText('projects.header.create.agent'),
+				disabled: !canCreateAgent.value,
+			});
+		} else if (instanceAiReady.value) {
+			// Escape hatch on the agents pages for users who want to skip the
+			// Instance AI creation flow. Only offered while Instance AI is ready —
+			// otherwise the main create-agent button already opens the manual builder.
+			items.push({
+				value: ACTION_TYPES.AGENT_MANUAL,
+				label: i18n.baseText('projects.header.create.agentManually'),
+				disabled: !canCreateAgent.value,
+			});
+		}
 	}
 
 	return items;
@@ -390,6 +401,11 @@ const actions: Record<ActionTypes, (projectId: string, source: CreateSource) => 
 		const agentId = generateNanoId();
 		agentTelemetry.trackClickedNewAgent(source, agentId);
 		void router.push(instanceAiCreateAgentRoute(projectId, agentId));
+	},
+	[ACTION_TYPES.AGENT_MANUAL]: (projectId, source) => {
+		const agentId = generateNanoId();
+		agentTelemetry.trackClickedNewAgent(source, agentId, { manual: true });
+		void router.push(instanceAiCreateAgentRoute(projectId, agentId, { manual: true }));
 	},
 } as const;
 


### PR DESCRIPTION
## Summary

Re-adds a way to create an agent manually, without going through the Instance AI assisted creation flow.

- The `/new-agent` dispatcher now accepts a `mode=manual` query flag that forces the existing manual-builder branch (standalone `AgentBuilderView` on an unpersisted draft), instead of minting an Instance AI thread. The flag is a mode switch only — the agent id still travels exclusively in history state.
- The create-dropdown next to the main **Create agent** button on the agents pages gains an understated **Create agent manually** item that uses this flag. It is only offered while Instance AI is ready: when it is not, the main button already opens the manual builder.
- The `User clicked new agent` telemetry event gains an optional `manual` property so manual creations can be distinguished, while keeping the minted `agent_id` join key.

## How to test

1. On an instance with Instance AI set up and ready, open an agents list page (project or overview).
2. Open the dropdown next to the **Create agent** button → **Create agent manually**.
3. The standalone agent builder opens on an unsaved draft (no 404); the agent persists on the first config edit.
4. The main **Create agent** button still opens the Instance AI flow.
5. With Instance AI not set up, the manual item is hidden and the main button still lands in the manual builder (unchanged fallback).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

