### PR TITLE
feat(Microsoft Teams Node): Add Online Meeting Update operation

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/byId.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/byId.validation.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../../../v2/transport', async () => {
 const operations: Array<[string, Record<string, unknown>, string]> = [
 	['get', {}, 'get'],
 	['deleteMeeting', {}, 'delete'],
+	['update', { updateFields: { subject: 'Renamed' } }, 'update'],
 ];
 
 describe('Microsoft Teams V2 — onlineMeeting by-ID operations', () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/meetingSettings.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/meetingSettings.test.ts
@@ -1,0 +1,43 @@
+import type { IDataObject } from 'n8n-workflow';
+
+import {
+	applyMeetingSettings,
+	meetingSettingsProperties,
+	withMeetingSettings,
+} from '../../../../v2/actions/onlineMeeting/meetingSettings';
+
+describe('Microsoft Teams V2 — onlineMeeting meeting settings', () => {
+	it.each<[IDataObject, IDataObject]>([
+		[{ allowAttendeeToEnableCamera: false }, { allowAttendeeToEnableCamera: false }],
+		[{ allowAttendeeToEnableMic: false }, { allowAttendeeToEnableMic: false }],
+		[{ allowMeetingChat: 'limited' }, { allowMeetingChat: 'limited' }],
+		[{ allowTeamworkReactions: false }, { allowTeamworkReactions: false }],
+		[{ allowedPresenters: 'organizer' }, { allowedPresenters: 'organizer' }],
+		[{ isEntryExitAnnounced: true }, { isEntryExitAnnounced: true }],
+		[{ lobbyBypassScope: 'invited' }, { lobbyBypassSettings: { scope: 'invited' } }],
+		[{ recordAutomatically: false }, { recordAutomatically: false }],
+		[{}, {}],
+		[{ passcodeRequired: true }, {}],
+	])('maps %j to %j', (settings, expected) => {
+		const body: IDataObject = {};
+
+		applyMeetingSettings(body, settings);
+
+		expect(body).toEqual(expected);
+	});
+
+	it('sorts the shared settings together with the extra fields', () => {
+		const names = withMeetingSettings([
+			{ displayName: 'Subject', name: 'subject', type: 'string', default: '' },
+			{ displayName: 'Allow Everything', name: 'allowEverything', type: 'boolean', default: true },
+		]).map((property) => property.displayName);
+
+		expect(names).toEqual(
+			[
+				...meetingSettingsProperties.map((property) => property.displayName),
+				'Subject',
+				'Allow Everything',
+			].sort((a, b) => a.localeCompare(b)),
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/meetingSettings.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/meetingSettings.test.ts
@@ -2,9 +2,9 @@ import type { IDataObject } from 'n8n-workflow';
 
 import {
 	applyMeetingSettings,
-	meetingSettingsProperties,
 	withMeetingSettings,
 } from '../../../../v2/actions/onlineMeeting/meetingSettings';
+import { versionDescription } from '../../../../v2/actions/versionDescription';
 
 describe('Microsoft Teams V2 — onlineMeeting meeting settings', () => {
 	it.each<[IDataObject, IDataObject]>([
@@ -16,6 +16,15 @@ describe('Microsoft Teams V2 — onlineMeeting meeting settings', () => {
 		[{ isEntryExitAnnounced: true }, { isEntryExitAnnounced: true }],
 		[{ lobbyBypassScope: 'invited' }, { lobbyBypassSettings: { scope: 'invited' } }],
 		[{ recordAutomatically: false }, { recordAutomatically: false }],
+		[
+			{ allowAttendeeToEnableCamera: false, lobbyBypassScope: 'everyone' },
+			{ allowAttendeeToEnableCamera: false, lobbyBypassSettings: { scope: 'everyone' } },
+		],
+		[{ allowMeetingChat: '' }, {}],
+		[{ allowMeetingChat: null }, {}],
+		[{ allowAttendeeToEnableCamera: '' }, {}],
+		[{ allowAttendeeToEnableCamera: null }, {}],
+		[{ lobbyBypassScope: '' }, {}],
 		[{}, {}],
 		[{ passcodeRequired: true }, {}],
 	])('maps %j to %j', (settings, expected) => {
@@ -23,21 +32,48 @@ describe('Microsoft Teams V2 — onlineMeeting meeting settings', () => {
 
 		applyMeetingSettings(body, settings);
 
-		expect(body).toEqual(expected);
+		expect(body).toStrictEqual(expected);
 	});
 
-	it('sorts the shared settings together with the extra fields', () => {
+	it('interleaves the extra fields with the shared settings in display order', () => {
 		const names = withMeetingSettings([
 			{ displayName: 'Subject', name: 'subject', type: 'string', default: '' },
-			{ displayName: 'Allow Everything', name: 'allowEverything', type: 'boolean', default: true },
+			{ displayName: 'End Time', name: 'endDateTime', type: 'dateTime', default: '' },
 		]).map((property) => property.displayName);
 
-		expect(names).toEqual(
-			[
-				...meetingSettingsProperties.map((property) => property.displayName),
-				'Subject',
-				'Allow Everything',
-			].sort((a, b) => a.localeCompare(b)),
+		expect(names).toEqual([
+			'Allow Attendees to Enable Camera',
+			'Allow Attendees to Enable Microphone',
+			'Allow Meeting Chat',
+			'Allow Teamwork Reactions',
+			'Allowed Presenters',
+			'Announce Entry and Exit',
+			'End Time',
+			'Lobby Bypass Scope',
+			'Record Automatically',
+			'Subject',
+		]);
+	});
+
+	it('offers the shared settings and Require Passcode on Create in display order', () => {
+		const options = versionDescription.properties.find(
+			(property) =>
+				property.name === 'options' &&
+				property.displayOptions?.show?.resource?.includes('onlineMeeting') &&
+				property.displayOptions?.show?.operation?.includes('create'),
 		);
+		const names = (options?.options ?? []).map((option) => option.name);
+
+		expect(names).toEqual([
+			'allowAttendeeToEnableCamera',
+			'allowAttendeeToEnableMic',
+			'allowMeetingChat',
+			'allowTeamworkReactions',
+			'allowedPresenters',
+			'isEntryExitAnnounced',
+			'lobbyBypassScope',
+			'recordAutomatically',
+			'passcodeRequired',
+		]);
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.joinUrl.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.joinUrl.workflow.json
@@ -1,0 +1,101 @@
+{
+	"name": "onlineMeeting update by join URL",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "update",
+				"meetingId": {
+					"__rl": true,
+					"mode": "url",
+					"value": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d"
+				},
+				"updateFields": {
+					"subject": "Quarterly Sync (renamed)"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+					"id": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi",
+					"creationDateTime": "2026-09-01T09:00:00.649Z",
+					"startDateTime": "2026-09-12T10:00:00Z",
+					"endDateTime": "2026-09-12T10:45:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d",
+					"subject": "Quarterly Sync (renamed)",
+					"allowMeetingChat": "disabled",
+					"allowTeamworkReactions": false,
+					"lobbyBypassSettings": {
+						"scope": "organizer",
+						"isDialInBypassEnabled": false
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "a7d3e9c1-5b2f-4e8a-9c6d-1f0b3e5a7c92",
+	"id": "onlineMeetingUpdUrl1",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.test.ts
@@ -3,10 +3,27 @@ import nock from 'nock';
 
 import { credentials } from '../../../credentials';
 
+const meetingId = 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi';
+const joinWebUrl =
+	'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d';
+const meeting = {
+	'@odata.context':
+		"https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+	id: meetingId,
+	creationDateTime: '2026-09-01T09:00:00.649Z',
+	startDateTime: '2026-09-12T10:00:00Z',
+	endDateTime: '2026-09-12T10:45:00Z',
+	joinWebUrl,
+	subject: 'Quarterly Sync (moved)',
+	allowMeetingChat: 'disabled',
+	allowTeamworkReactions: false,
+	lobbyBypassSettings: { scope: 'organizer', isDialInBypassEnabled: false },
+};
+
 describe('Test MicrosoftTeamsV2, onlineMeeting => update', () => {
 	nock('https://graph.microsoft.com')
 		.matchHeader('Prefer', 'include-unknown-enum-members')
-		.patch('/v1.0/me/onlineMeetings/MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi', {
+		.patch(`/v1.0/me/onlineMeetings/${meetingId}`, {
 			subject: 'Quarterly Sync (moved)',
 			startDateTime: '2026-09-12T10:00:00Z',
 			endDateTime: '2026-09-12T10:45:00Z',
@@ -14,23 +31,15 @@ describe('Test MicrosoftTeamsV2, onlineMeeting => update', () => {
 			allowTeamworkReactions: false,
 			lobbyBypassSettings: { scope: 'organizer' },
 		})
-		.reply(200, {
-			'@odata.context':
-				"https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
-			id: 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
-			creationDateTime: '2026-09-01T09:00:00.649Z',
-			startDateTime: '2026-09-12T10:00:00Z',
-			endDateTime: '2026-09-12T10:45:00Z',
-			joinWebUrl:
-				'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d',
-			subject: 'Quarterly Sync (moved)',
-			allowMeetingChat: 'disabled',
-			allowTeamworkReactions: false,
-			lobbyBypassSettings: { scope: 'organizer', isDialInBypassEnabled: false },
-		});
+		.reply(200, meeting)
+		.get('/v1.0/me/onlineMeetings')
+		.query({ $filter: `JoinWebUrl eq '${joinWebUrl}'` })
+		.reply(200, { value: [{ id: meetingId, joinWebUrl }] })
+		.patch(`/v1.0/me/onlineMeetings/${meetingId}`, { subject: 'Quarterly Sync (renamed)' })
+		.reply(200, { ...meeting, subject: 'Quarterly Sync (renamed)' });
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['update.workflow.json'],
+		workflowFiles: ['update.workflow.json', 'update.joinUrl.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.test.ts
@@ -1,0 +1,36 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, onlineMeeting => update', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.patch('/v1.0/me/onlineMeetings/MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi', {
+			subject: 'Quarterly Sync (moved)',
+			startDateTime: '2026-09-12T10:00:00Z',
+			endDateTime: '2026-09-12T10:45:00Z',
+			allowMeetingChat: 'disabled',
+			allowTeamworkReactions: false,
+			lobbyBypassSettings: { scope: 'organizer' },
+		})
+		.reply(200, {
+			'@odata.context':
+				"https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+			id: 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+			creationDateTime: '2026-09-01T09:00:00.649Z',
+			startDateTime: '2026-09-12T10:00:00Z',
+			endDateTime: '2026-09-12T10:45:00Z',
+			joinWebUrl:
+				'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d',
+			subject: 'Quarterly Sync (moved)',
+			allowMeetingChat: 'disabled',
+			allowTeamworkReactions: false,
+			lobbyBypassSettings: { scope: 'organizer', isDialInBypassEnabled: false },
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['update.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.validation.test.ts
@@ -19,6 +19,9 @@ vi.mock('../../../../v2/transport', async () => {
 describe('Microsoft Teams V2 — onlineMeeting:update', () => {
 	const meetingId = 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi';
 	const endpoint = `/v1.0/me/onlineMeetings/${meetingId}`;
+	const joinWebUrl =
+		'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0';
+	const byUrl = { __rl: true, mode: 'url', value: joinWebUrl };
 	let node: MicrosoftTeamsV2;
 	let ctx: MockProxy<IExecuteFunctions>;
 
@@ -37,20 +40,40 @@ describe('Microsoft Teams V2 — onlineMeeting:update', () => {
 		return await node.execute.call(ctx);
 	};
 
-	it('sends only the chosen fields', async () => {
-		await run({ subject: 'Renamed', allowAttendeeToEnableCamera: false });
+	it.each<[string, Record<string, unknown>]>([
+		['a subject and a false setting', { subject: 'Renamed', allowAttendeeToEnableCamera: false }],
+		['only a false setting', { recordAutomatically: false }],
+	])('sends only the chosen fields when %s is set', async (_label, updateFields) => {
+		await run(updateFields);
 
 		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
 			'PATCH',
 			endpoint,
-			{
-				subject: 'Renamed',
-				allowAttendeeToEnableCamera: false,
-			},
+			updateFields,
 			{},
 			undefined,
 			meetingHeaders,
 		);
+	});
+
+	it('sends the trimmed subject', async () => {
+		await run({ subject: '  Renamed  ' });
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'PATCH',
+			endpoint,
+			{ subject: 'Renamed' },
+			{},
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it('throws before any request when the subject is an object', async () => {
+		await expect(run({ subject: { title: 'Renamed' } })).rejects.toThrow(
+			'The Subject must be text',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 	});
 
 	it('sends both times in UTC', async () => {
@@ -72,13 +95,11 @@ describe('Microsoft Teams V2 — onlineMeeting:update', () => {
 	});
 
 	it('looks the meeting up by join URL and patches the returned ID', async () => {
-		const joinWebUrl =
-			'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0';
 		(transport.microsoftApiRequest as Mock)
 			.mockResolvedValueOnce({ value: [{ id: meetingId }] })
 			.mockResolvedValueOnce({ id: meetingId, subject: 'Renamed' });
 
-		await run({ subject: 'Renamed' }, { __rl: true, mode: 'url', value: joinWebUrl });
+		await run({ subject: 'Renamed' }, byUrl);
 
 		expect(transport.microsoftApiRequest).toHaveBeenNthCalledWith(
 			1,
@@ -102,37 +123,39 @@ describe('Microsoft Teams V2 — onlineMeeting:update', () => {
 		);
 	});
 
-	it.each([
-		['no field is set', {}],
-		['only a blank subject is set', { subject: '' }],
-	])('throws before any request when %s', async (_label, updateFields) => {
-		await expect(run(updateFields)).rejects.toThrow('Add at least one field to update');
+	it.each<[string, Record<string, unknown>, unknown]>([
+		['no field is set', {}, meetingId],
+		['only a blank subject is set', { subject: '' }, meetingId],
+		['only a whitespace subject is set', { subject: '   ' }, meetingId],
+		['only a blank setting is set', { allowMeetingChat: '' }, meetingId],
+		['only a null setting is set', { lobbyBypassScope: null }, meetingId],
+		['no field is set and the meeting is chosen by URL', {}, byUrl],
+	])('throws before any request when %s', async (_label, updateFields, id) => {
+		await expect(run(updateFields, id)).rejects.toThrow('No fields are set to update');
 		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 	});
 
-	it.each([
-		['start', { startDateTime: '2026-09-12T10:00:00Z', endDateTime: '' }],
-		['end', { startDateTime: '', endDateTime: '2026-09-12T10:45:00Z' }],
-	])('throws before any request when only the %s time is set', async (_label, updateFields) => {
-		await expect(run(updateFields)).rejects.toThrow(
+	it.each<[string, Record<string, unknown>, unknown]>([
+		[
+			'only the start time is set',
+			{ startDateTime: '2026-09-12T10:00:00Z', endDateTime: '' },
+			meetingId,
+		],
+		[
+			'only the end time is set',
+			{ startDateTime: '', endDateTime: '2026-09-12T10:45:00Z' },
+			meetingId,
+		],
+		[
+			'only the start time is set and the meeting is chosen by URL',
+			{ startDateTime: '2026-09-12T10:00:00Z', endDateTime: '' },
+			byUrl,
+		],
+	])('throws before any request when %s', async (_label, updateFields, id) => {
+		await expect(run(updateFields, id)).rejects.toThrow(
 			'Start Time and End Time must be updated together',
 		);
 		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
-	});
-
-	it('drops a setting that is not offered on Update', async () => {
-		await run({ subject: 'Renamed', passcodeRequired: true });
-
-		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
-			'PATCH',
-			endpoint,
-			{
-				subject: 'Renamed',
-			},
-			{},
-			undefined,
-			meetingHeaders,
-		);
 	});
 
 	it('offers only the properties Graph allows to change after creation', () => {
@@ -144,20 +167,18 @@ describe('Microsoft Teams V2 — onlineMeeting:update', () => {
 		);
 		const names = (updateFields?.options ?? []).map((option) => option.name);
 
-		expect(new Set(names)).toEqual(
-			new Set([
-				'allowAttendeeToEnableCamera',
-				'allowAttendeeToEnableMic',
-				'allowMeetingChat',
-				'allowTeamworkReactions',
-				'allowedPresenters',
-				'endDateTime',
-				'isEntryExitAnnounced',
-				'lobbyBypassScope',
-				'recordAutomatically',
-				'startDateTime',
-				'subject',
-			]),
-		);
+		expect(names).toEqual([
+			'allowAttendeeToEnableCamera',
+			'allowAttendeeToEnableMic',
+			'allowMeetingChat',
+			'allowTeamworkReactions',
+			'allowedPresenters',
+			'isEntryExitAnnounced',
+			'endDateTime',
+			'lobbyBypassScope',
+			'recordAutomatically',
+			'startDateTime',
+			'subject',
+		]);
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.validation.test.ts
@@ -1,0 +1,163 @@
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { createExecuteContext, meetingHeaders, setParams } from '../helpers';
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+describe('Microsoft Teams V2 — onlineMeeting:update', () => {
+	const meetingId = 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi';
+	const endpoint = `/v1.0/me/onlineMeetings/${meetingId}`;
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = createExecuteContext();
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: meetingId });
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const run = async (updateFields: Record<string, unknown>, id: unknown = meetingId) => {
+		setParams(ctx, { resource: 'onlineMeeting', operation: 'update', meetingId: id, updateFields });
+		return await node.execute.call(ctx);
+	};
+
+	it('sends only the chosen fields', async () => {
+		await run({ subject: 'Renamed', allowAttendeeToEnableCamera: false });
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'PATCH',
+			endpoint,
+			{
+				subject: 'Renamed',
+				allowAttendeeToEnableCamera: false,
+			},
+			{},
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it('sends both times in UTC', async () => {
+		ctx.getTimezone.mockReturnValue('Europe/Berlin');
+
+		await run({ startDateTime: '2026-09-12T10:00:00', endDateTime: '2026-09-12T10:45:00' });
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'PATCH',
+			endpoint,
+			{
+				startDateTime: '2026-09-12T08:00:00Z',
+				endDateTime: '2026-09-12T08:45:00Z',
+			},
+			{},
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it('looks the meeting up by join URL and patches the returned ID', async () => {
+		const joinWebUrl =
+			'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0';
+		(transport.microsoftApiRequest as Mock)
+			.mockResolvedValueOnce({ value: [{ id: meetingId }] })
+			.mockResolvedValueOnce({ id: meetingId, subject: 'Renamed' });
+
+		await run({ subject: 'Renamed' }, { __rl: true, mode: 'url', value: joinWebUrl });
+
+		expect(transport.microsoftApiRequest).toHaveBeenNthCalledWith(
+			1,
+			'GET',
+			'/v1.0/me/onlineMeetings',
+			{},
+			{ $filter: `JoinWebUrl eq '${joinWebUrl}'` },
+			undefined,
+			meetingHeaders,
+		);
+		expect(transport.microsoftApiRequest).toHaveBeenNthCalledWith(
+			2,
+			'PATCH',
+			endpoint,
+			{
+				subject: 'Renamed',
+			},
+			{},
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it.each([
+		['no field is set', {}],
+		['only a blank subject is set', { subject: '' }],
+	])('throws before any request when %s', async (_label, updateFields) => {
+		await expect(run(updateFields)).rejects.toThrow('Add at least one field to update');
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['start', { startDateTime: '2026-09-12T10:00:00Z', endDateTime: '' }],
+		['end', { startDateTime: '', endDateTime: '2026-09-12T10:45:00Z' }],
+	])('throws before any request when only the %s time is set', async (_label, updateFields) => {
+		await expect(run(updateFields)).rejects.toThrow(
+			'Start Time and End Time must be updated together',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('drops a setting that is not offered on Update', async () => {
+		await run({ subject: 'Renamed', passcodeRequired: true });
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'PATCH',
+			endpoint,
+			{
+				subject: 'Renamed',
+			},
+			{},
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it('offers only the properties Graph allows to change after creation', () => {
+		const updateFields = versionDescription.properties.find(
+			(property) =>
+				property.name === 'updateFields' &&
+				property.displayOptions?.show?.resource?.includes('onlineMeeting') &&
+				property.displayOptions?.show?.operation?.includes('update'),
+		);
+		const names = (updateFields?.options ?? []).map((option) => option.name);
+
+		expect(new Set(names)).toEqual(
+			new Set([
+				'allowAttendeeToEnableCamera',
+				'allowAttendeeToEnableMic',
+				'allowMeetingChat',
+				'allowTeamworkReactions',
+				'allowedPresenters',
+				'endDateTime',
+				'isEntryExitAnnounced',
+				'lobbyBypassScope',
+				'recordAutomatically',
+				'startDateTime',
+				'subject',
+			]),
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/update.workflow.json
@@ -1,0 +1,106 @@
+{
+	"name": "onlineMeeting update",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "update",
+				"meetingId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi"
+				},
+				"updateFields": {
+					"subject": "Quarterly Sync (moved)",
+					"startDateTime": "2026-09-12T10:00:00Z",
+					"endDateTime": "2026-09-12T10:45:00Z",
+					"allowMeetingChat": "disabled",
+					"allowTeamworkReactions": false,
+					"lobbyBypassScope": "organizer"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+					"id": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi",
+					"creationDateTime": "2026-09-01T09:00:00.649Z",
+					"startDateTime": "2026-09-12T10:00:00Z",
+					"endDateTime": "2026-09-12T10:45:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d",
+					"subject": "Quarterly Sync (moved)",
+					"allowMeetingChat": "disabled",
+					"allowTeamworkReactions": false,
+					"lobbyBypassSettings": {
+						"scope": "organizer",
+						"isDialInBypassEnabled": false
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "5c1c7a0e-2d51-4f0e-9c1e-7b0d2f3a4e01",
+	"id": "onlineMeetingUpdate01",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -96,6 +96,13 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }],
 		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
+		[
+			'update',
+			{
+				meetingId: { __rl: true, mode: 'id', value: 'meeting-id' },
+				updateFields: { subject: 'Renamed' },
+			},
+		],
 	])(
 		'onlineMeeting:%s throws a static error and issues no request under SP',
 		async (op, params) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -5,7 +5,7 @@ type NodeMap = {
 	channelMessage: 'create' | 'get' | 'getAll' | 'getAllReplies' | 'reply';
 	chatMember: 'getAll';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
-	onlineMeeting: 'create' | 'deleteMeeting' | 'get';
+	onlineMeeting: 'create' | 'deleteMeeting' | 'get' | 'update';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';
 };
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
@@ -2,6 +2,7 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { applyMeetingSettings, withMeetingSettings } from './meetingSettings';
 import {
 	meetingRequest,
 	requiredText,
@@ -42,111 +43,7 @@ const properties: INodeProperties[] = [
 		type: 'collection',
 		default: {},
 		placeholder: 'Add option',
-		options: [
-			{
-				displayName: 'Allow Attendees to Enable Camera',
-				name: 'allowAttendeeToEnableCamera',
-				type: 'boolean',
-				default: true,
-				description: 'Whether attendees can turn on their camera',
-			},
-			{
-				displayName: 'Allow Attendees to Enable Microphone',
-				name: 'allowAttendeeToEnableMic',
-				type: 'boolean',
-				default: true,
-				description: 'Whether attendees can turn on their microphone',
-			},
-			{
-				displayName: 'Allow Meeting Chat',
-				name: 'allowMeetingChat',
-				type: 'options',
-				options: [
-					{
-						name: 'Disabled',
-						value: 'disabled',
-					},
-					{
-						name: 'Enabled',
-						value: 'enabled',
-					},
-					{
-						name: 'Limited',
-						value: 'limited',
-						description: 'Chat is available only during the meeting',
-					},
-				],
-				default: 'enabled',
-				description: 'The mode of the meeting chat',
-			},
-			{
-				displayName: 'Allow Teamwork Reactions',
-				name: 'allowTeamworkReactions',
-				type: 'boolean',
-				default: true,
-				description: 'Whether Teams reactions are enabled for the meeting',
-			},
-			{
-				displayName: 'Allowed Presenters',
-				name: 'allowedPresenters',
-				type: 'options',
-				options: [
-					{
-						name: 'Everyone',
-						value: 'everyone',
-					},
-					{
-						name: 'Organization',
-						value: 'organization',
-					},
-					{
-						name: 'Organizer',
-						value: 'organizer',
-					},
-				],
-				default: 'everyone',
-				description: 'Who can present in the meeting',
-			},
-			{
-				displayName: 'Announce Entry and Exit',
-				name: 'isEntryExitAnnounced',
-				type: 'boolean',
-				default: false,
-				description: 'Whether to announce when callers join or leave the meeting',
-			},
-			{
-				displayName: 'Lobby Bypass Scope',
-				name: 'lobbyBypassScope',
-				type: 'options',
-				options: [
-					{
-						name: 'Everyone',
-						value: 'everyone',
-					},
-					{
-						name: 'Organization',
-						value: 'organization',
-					},
-					{
-						name: 'Organization and Federated',
-						value: 'organizationAndFederated',
-						description: 'People in the organization and guests from trusted organizations',
-					},
-					{
-						name: 'Organizer',
-						value: 'organizer',
-					},
-				],
-				default: 'organization',
-				description: 'Who can join the meeting without waiting in the lobby',
-			},
-			{
-				displayName: 'Record Automatically',
-				name: 'recordAutomatically',
-				type: 'boolean',
-				default: false,
-				description: 'Whether to record the meeting automatically',
-			},
+		options: withMeetingSettings([
 			{
 				displayName: 'Require Passcode',
 				name: 'passcodeRequired',
@@ -155,7 +52,7 @@ const properties: INodeProperties[] = [
 				description:
 					'Whether a passcode is required to join the meeting by meeting ID. This setting cannot be changed after the meeting is created.',
 			},
-		],
+		]),
 	},
 ];
 
@@ -181,30 +78,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		startDateTime: toGraphUtc.call(this, this.getNodeParameter('startDateTime', i), 'Start Time'),
 		endDateTime: toGraphUtc.call(this, this.getNodeParameter('endDateTime', i), 'End Time'),
 	};
-	if (options.allowAttendeeToEnableCamera !== undefined) {
-		body.allowAttendeeToEnableCamera = options.allowAttendeeToEnableCamera as boolean;
-	}
-	if (options.allowAttendeeToEnableMic !== undefined) {
-		body.allowAttendeeToEnableMic = options.allowAttendeeToEnableMic as boolean;
-	}
-	if (options.allowMeetingChat) {
-		body.allowMeetingChat = options.allowMeetingChat as string;
-	}
-	if (options.allowTeamworkReactions !== undefined) {
-		body.allowTeamworkReactions = options.allowTeamworkReactions as boolean;
-	}
-	if (options.allowedPresenters) {
-		body.allowedPresenters = options.allowedPresenters as string;
-	}
-	if (options.isEntryExitAnnounced !== undefined) {
-		body.isEntryExitAnnounced = options.isEntryExitAnnounced as boolean;
-	}
-	if (options.lobbyBypassScope) {
-		body.lobbyBypassSettings = { scope: options.lobbyBypassScope as string };
-	}
-	if (options.recordAutomatically !== undefined) {
-		body.recordAutomatically = options.recordAutomatically as boolean;
-	}
+	applyMeetingSettings(body, options);
 	if (options.passcodeRequired !== undefined) {
 		body.joinMeetingIdSettings = { isPasscodeRequired: options.passcodeRequired };
 	}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -4,9 +4,10 @@ import * as create from './create.operation';
 import * as deleteMeeting from './deleteMeeting.operation';
 import * as get from './get.operation';
 import { SERVICE_PRINCIPAL_UNSUPPORTED } from './shared';
+import * as update from './update.operation';
 import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
 
-export { create, deleteMeeting, get };
+export { create, deleteMeeting, get, update };
 
 export const description: INodeProperties[] = [
 	{
@@ -53,6 +54,12 @@ export const description: INodeProperties[] = [
 				description: 'Get an online meeting by ID or join URL',
 				action: 'Get online meeting',
 			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update an online meeting',
+				action: 'Update online meeting',
+			},
 		],
 		default: 'create',
 	},
@@ -60,4 +67,5 @@ export const description: INodeProperties[] = [
 	...create.description,
 	...deleteMeeting.description,
 	...get.description,
+	...update.description,
 ];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingSettings.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingSettings.ts
@@ -1,0 +1,139 @@
+import type { IDataObject, INodeProperties } from 'n8n-workflow';
+
+export const meetingSettingsProperties: INodeProperties[] = [
+	{
+		displayName: 'Allow Attendees to Enable Camera',
+		name: 'allowAttendeeToEnableCamera',
+		type: 'boolean',
+		default: true,
+		description: 'Whether attendees can turn on their camera',
+	},
+	{
+		displayName: 'Allow Attendees to Enable Microphone',
+		name: 'allowAttendeeToEnableMic',
+		type: 'boolean',
+		default: true,
+		description: 'Whether attendees can turn on their microphone',
+	},
+	{
+		displayName: 'Allow Meeting Chat',
+		name: 'allowMeetingChat',
+		type: 'options',
+		options: [
+			{
+				name: 'Disabled',
+				value: 'disabled',
+			},
+			{
+				name: 'Enabled',
+				value: 'enabled',
+			},
+			{
+				name: 'Limited',
+				value: 'limited',
+				description: 'Chat is available only during the meeting',
+			},
+		],
+		default: 'enabled',
+		description: 'The mode of the meeting chat',
+	},
+	{
+		displayName: 'Allow Teamwork Reactions',
+		name: 'allowTeamworkReactions',
+		type: 'boolean',
+		default: true,
+		description: 'Whether Teams reactions are enabled for the meeting',
+	},
+	{
+		displayName: 'Allowed Presenters',
+		name: 'allowedPresenters',
+		type: 'options',
+		options: [
+			{
+				name: 'Everyone',
+				value: 'everyone',
+			},
+			{
+				name: 'Organization',
+				value: 'organization',
+			},
+			{
+				name: 'Organizer',
+				value: 'organizer',
+			},
+		],
+		default: 'everyone',
+		description: 'Who can present in the meeting',
+	},
+	{
+		displayName: 'Announce Entry and Exit',
+		name: 'isEntryExitAnnounced',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to announce when callers join or leave the meeting',
+	},
+	{
+		displayName: 'Lobby Bypass Scope',
+		name: 'lobbyBypassScope',
+		type: 'options',
+		options: [
+			{
+				name: 'Everyone',
+				value: 'everyone',
+			},
+			{
+				name: 'Invited',
+				value: 'invited',
+				description: 'Only people the organizer invited',
+			},
+			{
+				name: 'Organization',
+				value: 'organization',
+				description: 'People in the organization and guests',
+			},
+			{
+				name: 'Organization and Federated',
+				value: 'organizationAndFederated',
+				description: 'People in the organization and guests from trusted organizations',
+			},
+			{
+				name: 'Organization Excluding Guests',
+				value: 'organizationExcludingGuests',
+				description: 'People in the organization, without guests',
+			},
+			{
+				name: 'Organizer',
+				value: 'organizer',
+			},
+		],
+		default: 'organization',
+		description: 'Who can join the meeting without waiting in the lobby',
+	},
+	{
+		displayName: 'Record Automatically',
+		name: 'recordAutomatically',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to record the meeting automatically',
+	},
+];
+
+const flatSettingNames = meetingSettingsProperties
+	.map((property) => property.name)
+	.filter((name) => name !== 'lobbyBypassScope');
+
+export function applyMeetingSettings(body: IDataObject, settings: IDataObject): void {
+	for (const name of flatSettingNames) {
+		if (settings[name] !== undefined) {
+			body[name] = settings[name];
+		}
+	}
+	if (settings.lobbyBypassScope !== undefined) {
+		body.lobbyBypassSettings = { scope: settings.lobbyBypassScope };
+	}
+}
+
+export const withMeetingSettings = (extra: INodeProperties[]): INodeProperties[] =>
+	[...meetingSettingsProperties, ...extra].sort((a, b) =>
+		a.displayName.localeCompare(b.displayName),
+	);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingSettings.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingSettings.ts
@@ -1,6 +1,44 @@
 import type { IDataObject, INodeProperties } from 'n8n-workflow';
 
-export const meetingSettingsProperties: INodeProperties[] = [
+const lobbyBypassScope: INodeProperties = {
+	displayName: 'Lobby Bypass Scope',
+	name: 'lobbyBypassScope',
+	type: 'options',
+	options: [
+		{
+			name: 'Everyone',
+			value: 'everyone',
+		},
+		{
+			name: 'Invited',
+			value: 'invited',
+			description: 'Only people the organizer invited',
+		},
+		{
+			name: 'Organization',
+			value: 'organization',
+			description: 'People in the organization and guests',
+		},
+		{
+			name: 'Organization and Federated',
+			value: 'organizationAndFederated',
+			description: 'People in the organization and guests from trusted organizations',
+		},
+		{
+			name: 'Organization Excluding Guests',
+			value: 'organizationExcludingGuests',
+			description: 'People in the organization, without guests',
+		},
+		{
+			name: 'Organizer',
+			value: 'organizer',
+		},
+	],
+	default: 'organization',
+	description: 'Who can join the meeting without waiting in the lobby',
+};
+
+const meetingSettingsProperties: readonly INodeProperties[] = [
 	{
 		displayName: 'Allow Attendees to Enable Camera',
 		name: 'allowAttendeeToEnableCamera',
@@ -72,43 +110,7 @@ export const meetingSettingsProperties: INodeProperties[] = [
 		default: false,
 		description: 'Whether to announce when callers join or leave the meeting',
 	},
-	{
-		displayName: 'Lobby Bypass Scope',
-		name: 'lobbyBypassScope',
-		type: 'options',
-		options: [
-			{
-				name: 'Everyone',
-				value: 'everyone',
-			},
-			{
-				name: 'Invited',
-				value: 'invited',
-				description: 'Only people the organizer invited',
-			},
-			{
-				name: 'Organization',
-				value: 'organization',
-				description: 'People in the organization and guests',
-			},
-			{
-				name: 'Organization and Federated',
-				value: 'organizationAndFederated',
-				description: 'People in the organization and guests from trusted organizations',
-			},
-			{
-				name: 'Organization Excluding Guests',
-				value: 'organizationExcludingGuests',
-				description: 'People in the organization, without guests',
-			},
-			{
-				name: 'Organizer',
-				value: 'organizer',
-			},
-		],
-		default: 'organization',
-		description: 'Who can join the meeting without waiting in the lobby',
-	},
+	lobbyBypassScope,
 	{
 		displayName: 'Record Automatically',
 		name: 'recordAutomatically',
@@ -118,22 +120,21 @@ export const meetingSettingsProperties: INodeProperties[] = [
 	},
 ];
 
-const flatSettingNames = meetingSettingsProperties
-	.map((property) => property.name)
-	.filter((name) => name !== 'lobbyBypassScope');
+const isSet = (value: unknown) => value !== undefined && value !== null && value !== '';
 
 export function applyMeetingSettings(body: IDataObject, settings: IDataObject): void {
-	for (const name of flatSettingNames) {
-		if (settings[name] !== undefined) {
-			body[name] = settings[name];
+	for (const { name } of meetingSettingsProperties) {
+		const value = settings[name];
+		if (!isSet(value)) continue;
+		if (name === lobbyBypassScope.name) {
+			body.lobbyBypassSettings = { scope: value };
+		} else {
+			body[name] = value;
 		}
-	}
-	if (settings.lobbyBypassScope !== undefined) {
-		body.lobbyBypassSettings = { scope: settings.lobbyBypassScope };
 	}
 }
 
-export const withMeetingSettings = (extra: INodeProperties[]): INodeProperties[] =>
+export const withMeetingSettings = (extra: readonly INodeProperties[]): INodeProperties[] =>
 	[...meetingSettingsProperties, ...extra].sort((a, b) =>
-		a.displayName.localeCompare(b.displayName),
+		a.displayName.localeCompare(b.displayName, 'en'),
 	);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
@@ -12,6 +12,7 @@ import { applyMeetingSettings, withMeetingSettings } from './meetingSettings';
 import {
 	MEETING_HINT,
 	meetingRequest,
+	optionalText,
 	throwIfOnlineMeetingUnsupported,
 	toGraphUtc,
 } from './shared';
@@ -33,14 +34,14 @@ const properties: INodeProperties[] = [
 				type: 'dateTime',
 				default: '',
 				description:
-					'The date and time when the meeting ends. Must be later than the start time. Set together with the start time.',
+					'The date and time when the meeting ends. Must be later than Start Time. Set together with Start Time.',
 			},
 			{
 				displayName: 'Start Time',
 				name: 'startDateTime',
 				type: 'dateTime',
 				default: '',
-				description: 'The date and time when the meeting starts. Set together with the end time.',
+				description: 'The date and time when the meeting starts. Set together with End Time.',
 			},
 			{
 				displayName: 'Subject',
@@ -70,8 +71,6 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-update?view=graph-rest-1.0&tabs=http
 	throwIfOnlineMeetingUnsupported.call(this);
 
-	const meetingId = await resolveMeetingId.call(this, i);
-	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: meetingId }]);
 	const updateFields = this.getNodeParameter('updateFields', i);
 
 	const hasStart = Boolean(updateFields.startDateTime);
@@ -87,8 +86,9 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	}
 
 	const body: IDataObject = {};
-	if (updateFields.subject) {
-		body.subject = updateFields.subject;
+	const subject = optionalText.call(this, updateFields.subject, 'Subject');
+	if (subject) {
+		body.subject = subject;
 	}
 	if (hasStart) {
 		body.startDateTime = toGraphUtc.call(this, updateFields.startDateTime, 'Start Time');
@@ -97,10 +97,13 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	applyMeetingSettings(body, updateFields);
 
 	if (Object.keys(body).length === 0) {
-		throw new NodeOperationError(this.getNode(), 'Add at least one field to update', {
-			description: "Choose the fields to change under 'Update Fields'",
+		throw new NodeOperationError(this.getNode(), 'No fields are set to update', {
+			description: "Add at least one field under 'Update Fields' and try again",
 		});
 	}
+
+	const meetingId = await resolveMeetingId.call(this, i);
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: meetingId }]);
 
 	try {
 		return await meetingRequest.call(this, 'PATCH', endpoint, body);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
@@ -1,0 +1,115 @@
+import {
+	type IDataObject,
+	type INodeProperties,
+	type IExecuteFunctions,
+	NodeOperationError,
+} from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { resolveMeetingId } from './meetingLocator';
+import { applyMeetingSettings, withMeetingSettings } from './meetingSettings';
+import {
+	MEETING_HINT,
+	meetingRequest,
+	throwIfOnlineMeetingUnsupported,
+	toGraphUtc,
+} from './shared';
+import { meetingRLC } from '../../descriptions';
+import { buildTeamsPath, rewriteNotFound, SP_HIDE } from '../../transport';
+
+const properties: INodeProperties[] = [
+	meetingRLC,
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add Field',
+		options: withMeetingSettings([
+			{
+				displayName: 'End Time',
+				name: 'endDateTime',
+				type: 'dateTime',
+				default: '',
+				description:
+					'The date and time when the meeting ends. Must be later than the start time. Set together with the start time.',
+			},
+			{
+				displayName: 'Start Time',
+				name: 'startDateTime',
+				type: 'dateTime',
+				default: '',
+				description: 'The date and time when the meeting starts. Set together with the end time.',
+			},
+			{
+				displayName: 'Subject',
+				name: 'subject',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g. Quarterly Sync',
+				description: 'The subject of the meeting',
+			},
+		]),
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['onlineMeeting'],
+		operation: ['update'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-update?view=graph-rest-1.0&tabs=http
+	throwIfOnlineMeetingUnsupported.call(this);
+
+	const meetingId = await resolveMeetingId.call(this, i);
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: meetingId }]);
+	const updateFields = this.getNodeParameter('updateFields', i);
+
+	const hasStart = Boolean(updateFields.startDateTime);
+	const hasEnd = Boolean(updateFields.endDateTime);
+	if (hasStart !== hasEnd) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Start Time and End Time must be updated together',
+			{
+				description: 'Microsoft Graph requires both times whenever either one changes',
+			},
+		);
+	}
+
+	const body: IDataObject = {};
+	if (updateFields.subject) {
+		body.subject = updateFields.subject;
+	}
+	if (hasStart) {
+		body.startDateTime = toGraphUtc.call(this, updateFields.startDateTime, 'Start Time');
+		body.endDateTime = toGraphUtc.call(this, updateFields.endDateTime, 'End Time');
+	}
+	applyMeetingSettings(body, updateFields);
+
+	if (Object.keys(body).length === 0) {
+		throw new NodeOperationError(this.getNode(), 'Add at least one field to update', {
+			description: "Choose the fields to change under 'Update Fields'",
+		});
+	}
+
+	try {
+		return await meetingRequest.call(this, 'PATCH', endpoint, body);
+	} catch (error) {
+		rewriteNotFound.call(
+			this,
+			error,
+			"The meeting you are trying to update doesn't exist",
+			MEETING_HINT,
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
@@ -108,7 +108,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	try {
 		return await meetingRequest.call(this, 'PATCH', endpoint, body);
 	} catch (error) {
-		rewriteNotFound.call(
+		throw rewriteNotFound.call(
 			this,
 			error,
 			"The meeting you are trying to update doesn't exist",


### PR DESCRIPTION
## Summary

> **Stacked PR 1/2** for ENT-351. The ENT-325 Delete PR (#37502) is merged, so this PR now sits directly on master. Create or Get follows in #37708.

Add the **Update** operation to the Teams Online Meeting resource.

- `PATCH /v1.0/me/onlineMeetings/{id}` with only the fields the user picks under **Update Fields**: subject, start and end time, and the same meeting settings Create offers (camera, microphone, chat mode, reactions, presenters, entry announcement, lobby bypass, auto-recording).
- Graph requires both times whenever either one changes, so the node rejects a lone start or end time before any request, in both `By ID` and `By URL` mode. A Subject or setting that is added but left blank or whitespace-only counts as not set, and an **Update Fields** block with nothing set is rejected the same way, before the join URL lookup. Times are converted to UTC with the shared `toGraphUtc` from #37723, and the Start Time and End Time descriptions name the fields in Title Case to match the error text.
- **Require Passcode** is not offered on Update. Graph does not allow `joinMeetingIdSettings` to change after creation, so the field simply does not exist here rather than failing at Graph.
- The meeting is chosen with the shared `Meeting` locator (`By ID` / `By URL`); in `By URL` mode the node looks the meeting up by its join URL first. The resolved ID goes through `buildTeamsPath` validation. A Graph 404 is rewritten by the shared `rewriteNotFound`; other statuses surface unchanged.
- The meeting settings that Create and Update share now live in one module (`meetingSettings.ts`): the body mapping is derived from the property list, `withMeetingSettings` composes both option lists, and **Lobby Bypass Scope** gains the documented `Invited` and `Organization Excluding Guests` values, which read back with their real names because every meeting request sends `Prefer: include-unknown-enum-members` through the shared `meetingRequest` (#37723). Create's mapping for every existing value is unchanged and still pinned by its fixtures; `meetingSettings.test.ts` covers the mapping directly, including blank and `null` values.
- Hidden under the Service Principal credential with the same guard as the other Online Meeting operations.

Attendee editing is split out to [ENT-407](https://linear.app/n8n/issue/ENT-407), which depends on the org-wide user picker from #37624.

## Changes to the existing Create operation

Create (#37500) is on master but not in a release tag yet, so these ship in the same release as Create itself.

- **Lobby Bypass Scope** gains `Invited` and `Organization Excluding Guests`, and `Organization` gets a description. The four existing values map as before.
- A boolean setting that an expression resolves to an empty string or `null` is dropped instead of sent. The options-typed settings already dropped blank values on master.
- The option list is sorted with English collation, so the order is the same on every server locale.
- A **Subject** expression that resolves to an object or array fails with "The Subject must be text" instead of reaching Graph (from #37723). Luxon and `Date` values are still sent as text.

## How to test

Use a delegated Microsoft Teams OAuth2 credential with `OnlineMeetings.ReadWrite`.

1. Create a meeting with **Online Meeting > Create**, and copy its `id` from the output.
2. Add a node with **Online Meeting > Update**, paste the ID (or switch **Meeting** to `By URL` and paste the join URL), add **Subject** and **Allow Meeting Chat = Disabled**. Execute. The output is the updated meeting and Teams shows the new subject.
3. Add only **Start Time** and execute. The node fails with "Start Time and End Time must be updated together" and sends no request. Add **End Time** as well and it succeeds.
4. Remove all update fields and execute. The node fails with "No fields are set to update".
5. Switch the credential to a Service Principal. The Online Meeting operations are hidden, and a hand-edited workflow fails with the existing static error.

Automated coverage: two workflow-harness fixtures pin the exact PATCH body (including a `false` boolean and the nested lobby bypass object) in `By ID` and `By URL` mode, and unit tests cover the empty-fields and single-time guards in both modes, blank and `null` settings, a body whose only field is `false`, the trimmed subject, the option list and its order, meeting ID validation, the 404 rewrite, non-404 passthrough, and the Service Principal guard.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-351

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. Docs follow with the Online Meeting docs PR once the stack merges; it lists all six Lobby Bypass Scope values under Create and Update.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


