### PR TITLE
feat(Microsoft Teams Node): Add Online Meeting Create or Get operation

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.existing.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.existing.workflow.json
@@ -1,0 +1,89 @@
+{
+	"name": "onlineMeeting createOrGet existing",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "createOrGet",
+				"externalId": "order-4711-kickoff"
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+					"id": "MSpjcmVhdGVPckdldC1uZXc",
+					"creationDateTime": "2026-09-02T14:00:00.123Z",
+					"startDateTime": "2026-09-15T09:00:00Z",
+					"endDateTime": "2026-09-15T09:30:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_a2lja29mZg%40thread.v2/0",
+					"subject": "Order 4711 kickoff",
+					"externalId": "order-4711-kickoff"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0f7c2b1a-8e3d-4c5f-9a1b-2d3e4f5a6b02",
+	"id": "onlineMeetingCreateOrGet02",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.test.ts
@@ -3,6 +3,18 @@ import nock from 'nock';
 
 import { credentials } from '../../../credentials';
 
+const meeting = {
+	'@odata.context':
+		"https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+	id: 'MSpjcmVhdGVPckdldC1uZXc',
+	creationDateTime: '2026-09-02T14:00:00.123Z',
+	startDateTime: '2026-09-15T09:00:00Z',
+	endDateTime: '2026-09-15T09:30:00Z',
+	joinWebUrl: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_a2lja29mZg%40thread.v2/0',
+	subject: 'Order 4711 kickoff',
+	externalId: 'order-4711-kickoff',
+};
+
 describe('Test MicrosoftTeamsV2, onlineMeeting => createOrGet', () => {
 	nock('https://graph.microsoft.com')
 		.matchHeader('Prefer', 'include-unknown-enum-members')
@@ -12,20 +24,12 @@ describe('Test MicrosoftTeamsV2, onlineMeeting => createOrGet', () => {
 			startDateTime: '2026-09-15T09:00:00Z',
 			endDateTime: '2026-09-15T09:30:00Z',
 		})
-		.reply(201, {
-			'@odata.context':
-				"https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
-			id: 'MSpjcmVhdGVPckdldC1uZXc',
-			creationDateTime: '2026-09-02T14:00:00.123Z',
-			startDateTime: '2026-09-15T09:00:00Z',
-			endDateTime: '2026-09-15T09:30:00Z',
-			joinWebUrl: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_a2lja29mZg%40thread.v2/0',
-			subject: 'Order 4711 kickoff',
-			externalId: 'order-4711-kickoff',
-		});
+		.reply(201, meeting)
+		.post('/v1.0/me/onlineMeetings/createOrGet', { externalId: 'order-4711-kickoff' })
+		.reply(200, meeting);
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['createOrGet.workflow.json'],
+		workflowFiles: ['createOrGet.workflow.json', 'createOrGet.existing.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.test.ts
@@ -1,0 +1,31 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, onlineMeeting => createOrGet', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.post('/v1.0/me/onlineMeetings/createOrGet', {
+			externalId: 'order-4711-kickoff',
+			subject: 'Order 4711 kickoff',
+			startDateTime: '2026-09-15T09:00:00Z',
+			endDateTime: '2026-09-15T09:30:00Z',
+		})
+		.reply(201, {
+			'@odata.context':
+				"https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+			id: 'MSpjcmVhdGVPckdldC1uZXc',
+			creationDateTime: '2026-09-02T14:00:00.123Z',
+			startDateTime: '2026-09-15T09:00:00Z',
+			endDateTime: '2026-09-15T09:30:00Z',
+			joinWebUrl: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_a2lja29mZg%40thread.v2/0',
+			subject: 'Order 4711 kickoff',
+			externalId: 'order-4711-kickoff',
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['createOrGet.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.validation.test.ts
@@ -52,33 +52,97 @@ describe('Microsoft Teams V2 — onlineMeeting:createOrGet', () => {
 		expect(result).toEqual([[{ json: { id: 'meeting-1' }, pairedItem: { item: 0 } }]]);
 	});
 
-	it('sends a start time in UTC without an end time', async () => {
+	it.each<[string, Record<string, unknown>, Record<string, unknown>]>([
+		[
+			'a start time without an end time',
+			{ startDateTime: '2026-09-15T09:00:00' },
+			{ startDateTime: '2026-09-15T07:00:00Z' },
+		],
+		[
+			'both times',
+			{ startDateTime: '2026-09-15T09:00:00', endDateTime: '2026-09-15T09:30:00' },
+			{ startDateTime: '2026-09-15T07:00:00Z', endDateTime: '2026-09-15T07:30:00Z' },
+		],
+	])('sends %s in UTC', async (_label, options, times) => {
 		ctx.getTimezone.mockReturnValue('Europe/Berlin');
 
-		await run('order-4711', { startDateTime: '2026-09-15T09:00:00' });
+		await run('order-4711', options);
 
 		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
 			'POST',
 			endpoint,
-			{
-				externalId: 'order-4711',
-				startDateTime: '2026-09-15T07:00:00Z',
-			},
+			{ externalId: 'order-4711', ...times },
 			{},
 			undefined,
 			meetingHeaders,
 		);
 	});
 
-	it('throws before any request when the external ID is blank', async () => {
-		await expect(run('   ')).rejects.toThrow('The External ID must not be empty');
+	it.each<[string, unknown, Record<string, unknown>, string]>([
+		['the external ID is blank', '   ', {}, 'The External ID must not be empty'],
+		['the external ID is an object', { id: 4711 }, {}, 'The External ID must be text'],
+		[
+			'the subject is an object',
+			'order-4711',
+			{ subject: { title: 'Kickoff' } },
+			'The Subject must be text',
+		],
+		[
+			'an end time is set without a start time',
+			'order-4711',
+			{ endDateTime: '2026-09-15T09:30:00Z' },
+			'End Time requires a Start Time',
+		],
+		[
+			'an end time is set with a blank start time',
+			'order-4711',
+			{ startDateTime: '', endDateTime: '2026-09-15T09:30:00Z' },
+			'End Time requires a Start Time',
+		],
+	])('throws before any request when %s', async (_label, externalId, options, message) => {
+		await expect(run(externalId, options)).rejects.toThrow(message);
 		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 	});
 
-	it('throws before any request when an end time is set without a start time', async () => {
-		await expect(run('order-4711', { endDateTime: '2026-09-15T09:30:00Z' })).rejects.toThrow(
-			'End Time requires a Start Time',
-		);
+	it.each<[string, Record<string, unknown>]>([
+		['Start Time', { startDateTime: 'tomorrow' }],
+		['End Time', { startDateTime: '2026-09-15T09:00:00Z', endDateTime: 'tomorrow' }],
+	])('throws before any request when the %s is not a date', async (label, options) => {
+		await expect(run('order-4711', options)).rejects.toThrow(`The ${label} is not a valid date`);
 		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it.each<[string, Record<string, unknown>, Record<string, unknown>]>([
+		[
+			'a blank end time',
+			{ startDateTime: '2026-09-15T09:00:00Z', endDateTime: '' },
+			{ startDateTime: '2026-09-15T09:00:00Z' },
+		],
+		['blank times and a blank subject', { subject: '', startDateTime: '', endDateTime: '' }, {}],
+		['a whitespace subject', { subject: '   ' }, {}],
+		['the padding around the subject', { subject: '  Kickoff  ' }, { subject: 'Kickoff' }],
+	])('drops %s from the body', async (_label, options, sent) => {
+		await run('order-4711', options);
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'POST',
+			endpoint,
+			{ externalId: 'order-4711', ...sent },
+			{},
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it('offers only the subject and the two times as options', () => {
+		const options = versionDescription.properties.find(
+			(property) =>
+				property.name === 'options' &&
+				property.displayOptions?.show?.resource?.includes('onlineMeeting') &&
+				property.displayOptions?.show?.operation?.includes('createOrGet'),
+		);
+		const names = (options?.options ?? []).map((option) => option.name);
+
+		expect(names).toEqual(['endDateTime', 'startDateTime', 'subject']);
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.validation.test.ts
@@ -1,0 +1,84 @@
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { createExecuteContext, meetingHeaders, setParams } from '../helpers';
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+describe('Microsoft Teams V2 — onlineMeeting:createOrGet', () => {
+	const endpoint = '/v1.0/me/onlineMeetings/createOrGet';
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = createExecuteContext();
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: 'meeting-1' });
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const run = async (externalId: unknown, options: Record<string, unknown> = {}) => {
+		setParams(ctx, { resource: 'onlineMeeting', operation: 'createOrGet', externalId, options });
+		return await node.execute.call(ctx);
+	};
+
+	it('sends only the trimmed external ID when no option is set', async () => {
+		const result = await run(' order-4711 ');
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'POST',
+			endpoint,
+			{
+				externalId: 'order-4711',
+			},
+			{},
+			undefined,
+			meetingHeaders,
+		);
+		expect(result).toEqual([[{ json: { id: 'meeting-1' }, pairedItem: { item: 0 } }]]);
+	});
+
+	it('sends a start time in UTC without an end time', async () => {
+		ctx.getTimezone.mockReturnValue('Europe/Berlin');
+
+		await run('order-4711', { startDateTime: '2026-09-15T09:00:00' });
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'POST',
+			endpoint,
+			{
+				externalId: 'order-4711',
+				startDateTime: '2026-09-15T07:00:00Z',
+			},
+			{},
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it('throws before any request when the external ID is blank', async () => {
+		await expect(run('   ')).rejects.toThrow('The External ID must not be empty');
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('throws before any request when an end time is set without a start time', async () => {
+		await expect(run('order-4711', { endDateTime: '2026-09-15T09:30:00Z' })).rejects.toThrow(
+			'End Time requires a Start Time',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/createOrGet.workflow.json
@@ -1,0 +1,94 @@
+{
+	"name": "onlineMeeting createOrGet",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "onlineMeeting",
+				"operation": "createOrGet",
+				"externalId": "order-4711-kickoff",
+				"options": {
+					"subject": "Order 4711 kickoff",
+					"startDateTime": "2026-09-15T09:00:00Z",
+					"endDateTime": "2026-09-15T09:30:00Z"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('11111111-2222-3333-4444-555555555555')/onlineMeetings/$entity",
+					"id": "MSpjcmVhdGVPckdldC1uZXc",
+					"creationDateTime": "2026-09-02T14:00:00.123Z",
+					"startDateTime": "2026-09-15T09:00:00Z",
+					"endDateTime": "2026-09-15T09:30:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_a2lja29mZg%40thread.v2/0",
+					"subject": "Order 4711 kickoff",
+					"externalId": "order-4711-kickoff"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0f7c2b1a-8e3d-4c5f-9a1b-2d3e4f5a6b01",
+	"id": "onlineMeetingCreateOrGet01",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -95,6 +95,7 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 	it.each([
 		['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }],
 		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
+		['createOrGet', { externalId: 'order-4711', options: {} }],
 		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 		[
 			'update',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -5,7 +5,7 @@ type NodeMap = {
 	channelMessage: 'create' | 'get' | 'getAll' | 'getAllReplies' | 'reply';
 	chatMember: 'getAll';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
-	onlineMeeting: 'create' | 'deleteMeeting' | 'get' | 'update';
+	onlineMeeting: 'create' | 'createOrGet' | 'deleteMeeting' | 'get' | 'update';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';
 };
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
@@ -9,6 +9,7 @@ import { updateDisplayOptions } from '@utils/utilities';
 
 import {
 	meetingRequest,
+	optionalText,
 	requiredText,
 	throwIfOnlineMeetingUnsupported,
 	toGraphUtc,
@@ -39,7 +40,7 @@ const properties: INodeProperties[] = [
 				type: 'dateTime',
 				default: '',
 				description:
-					'The date and time when the meeting ends. Requires a start time and must be later than it. Defaults to one hour after the start time.',
+					'The date and time when the meeting ends. Must be later than Start Time, which must also be set. If left out, the meeting lasts one hour.',
 			},
 			{
 				displayName: 'Start Time',
@@ -80,13 +81,15 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	const options = this.getNodeParameter('options', i);
 	if (options.endDateTime && !options.startDateTime) {
 		throw new NodeOperationError(this.getNode(), 'End Time requires a Start Time', {
-			description: "Set 'Start Time' as well, or remove 'End Time' to use the default length",
+			description:
+				"Microsoft Graph rejects an End Time without a Start Time. Set 'Start Time' as well, or remove 'End Time' to use the default length",
 		});
 	}
 
 	const body: IDataObject = { externalId };
-	if (options.subject) {
-		body.subject = options.subject;
+	const subject = optionalText.call(this, options.subject, 'Subject');
+	if (subject) {
+		body.subject = subject;
 	}
 	if (options.startDateTime) {
 		body.startDateTime = toGraphUtc.call(this, options.startDateTime, 'Start Time');

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
@@ -1,0 +1,99 @@
+import {
+	type IDataObject,
+	type INodeProperties,
+	type IExecuteFunctions,
+	NodeOperationError,
+} from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import {
+	meetingRequest,
+	requiredText,
+	throwIfOnlineMeetingUnsupported,
+	toGraphUtc,
+} from './shared';
+import { SP_HIDE } from '../../transport';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'External ID',
+		name: 'externalId',
+		required: true,
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. order-4711-kickoff',
+		description:
+			'Your own ID for the meeting. Running the node again with the same ID returns the existing meeting instead of creating another one.',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		placeholder: 'Add option',
+		options: [
+			{
+				displayName: 'End Time',
+				name: 'endDateTime',
+				type: 'dateTime',
+				default: '',
+				description:
+					'The date and time when the meeting ends. Requires a start time and must be later than it. Defaults to one hour after the start time.',
+			},
+			{
+				displayName: 'Start Time',
+				name: 'startDateTime',
+				type: 'dateTime',
+				default: '',
+				description: 'The date and time when the meeting starts. Defaults to now.',
+			},
+			{
+				displayName: 'Subject',
+				name: 'subject',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g. Quarterly Sync',
+				description: 'The subject of the meeting',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['onlineMeeting'],
+		operation: ['createOrGet'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-createorget?view=graph-rest-1.0&tabs=http
+	throwIfOnlineMeetingUnsupported.call(this);
+
+	const externalId = requiredText.call(this, 'externalId', i, 'External ID');
+	const options = this.getNodeParameter('options', i);
+	if (options.endDateTime && !options.startDateTime) {
+		throw new NodeOperationError(this.getNode(), 'End Time requires a Start Time', {
+			description: "Set 'Start Time' as well, or remove 'End Time' to use the default length",
+		});
+	}
+
+	const body: IDataObject = { externalId };
+	if (options.subject) {
+		body.subject = options.subject;
+	}
+	if (options.startDateTime) {
+		body.startDateTime = toGraphUtc.call(this, options.startDateTime, 'Start Time');
+	}
+	if (options.endDateTime) {
+		body.endDateTime = toGraphUtc.call(this, options.endDateTime, 'End Time');
+	}
+
+	return await meetingRequest.call(this, 'POST', '/v1.0/me/onlineMeetings/createOrGet', body);
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -1,13 +1,14 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as create from './create.operation';
+import * as createOrGet from './createOrGet.operation';
 import * as deleteMeeting from './deleteMeeting.operation';
 import * as get from './get.operation';
 import { SERVICE_PRINCIPAL_UNSUPPORTED } from './shared';
 import * as update from './update.operation';
 import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
 
-export { create, deleteMeeting, get, update };
+export { create, createOrGet, deleteMeeting, get, update };
 
 export const description: INodeProperties[] = [
 	{
@@ -43,6 +44,13 @@ export const description: INodeProperties[] = [
 				action: 'Create online meeting',
 			},
 			{
+				name: 'Create or Get',
+				value: 'createOrGet',
+				description:
+					'Create an online meeting with your own external ID, or get the existing meeting with that ID',
+				action: 'Create or get online meeting',
+			},
+			{
 				name: 'Delete',
 				value: 'deleteMeeting',
 				description: 'Delete an online meeting',
@@ -65,6 +73,7 @@ export const description: INodeProperties[] = [
 	},
 
 	...create.description,
+	...createOrGet.description,
 	...deleteMeeting.description,
 	...get.description,
 	...update.description,


### PR DESCRIPTION
## Summary

> **Stacked PR 2/2** for ENT-351. The Update PR (#37707) is merged, so this PR now sits directly on master. Merging this completes the ticket scope.

Add the **Create or Get** operation to the Teams Online Meeting resource.

- `POST /v1.0/me/onlineMeetings/createOrGet` with the user's own **External ID**. Graph creates the meeting on the first call and returns the existing meeting on every later call with the same ID, so a workflow that re-runs does not spawn duplicate meetings.
- **Subject**, **Start Time** and **End Time** are optional. Graph defaults the start to now and the end to one hour after the start. An end time without a start time is rejected by the node before any request, since Graph refuses that combination. Times are converted to UTC with the shared `toGraphUtc`.
- A blank External ID is rejected before any request by the shared `requiredText` helper, and an External ID or Subject expression that resolves to an object or array fails with a node error instead of reaching Graph as `[object Object]`. The request goes through the shared `meetingRequest`, so the response carries real names for newer enum values.
- Hidden under the Service Principal credential with the same guard as the other Online Meeting operations.

## Docs follow-up

- Create or Get takes no meeting settings, so who can bypass the lobby follows the organizer's Teams meeting policy. To change settings, add an **Online Meeting > Update** node after this one.
- The output is the same whether Graph created the meeting or returned the existing one; `creationDateTime` shows when it was first created.
- Attendees for Create, Create or Get and Update are tracked in [ENT-407](https://linear.app/n8n/issue/ENT-407).

## How to test

Use a delegated Microsoft Teams OAuth2 credential with `OnlineMeetings.ReadWrite`.

1. Add **Online Meeting > Create or Get** with External ID `order-4711-kickoff` and a Subject. Execute. The output is a new meeting carrying that `externalId`.
2. Execute the same node again. The output is the same meeting, same `id` and `joinWebUrl`. No second meeting appears in Teams.
3. Add only **End Time** and execute. The node fails with "End Time requires a Start Time" and sends no request.
4. Clear the External ID and execute. The node fails with "The External ID must not be empty".

Automated coverage: two workflow-harness fixtures pin the exact POST body for a created meeting (201) and for an existing one (200, external ID only), and unit tests cover the blank-ID, object-valued and end-without-start guards, UTC conversion of both times, blank options, the trimmed body, the option list, and the Service Principal guard.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-351

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. Docs follow with the Online Meeting docs PR once the stack merges.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)



