### PR TITLE
fix(editor): Update release notes URL to the new changelog page (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/constants/urls.ts
+++ b/packages/frontend/editor-ui/src/app/constants/urls.ts
@@ -17,7 +17,7 @@ export const EXECUTION_DATA_REDACTION_DOCS_URL = `https://${DOCS_DOMAIN}/workflo
 export const EXECUTION_DATA_REDACTION_ENFORCEMENT_DOCS_URL = `${EXECUTION_DATA_REDACTION_DOCS_URL}#instance-level-enforcement`;
 export const TIME_SAVED_DOCS_URL = `https://${DOCS_DOMAIN}/insights/#setting-the-time-saved-by-a-workflow`;
 export const BASE_NODE_SURVEY_URL = 'https://n8n-community.typeform.com/to/BvmzxqYv#nodename=';
-export const RELEASE_NOTES_URL = 'https://docs.n8n.io/release-notes/';
+export const RELEASE_NOTES_URL = 'https://docs.n8n.io/changelog/release-notes';
 export const CHANGELOG_URL = 'https://docs.n8n.io/changelog';
 export const CREATOR_HUB_URL = 'https://creators.n8n.io/hub';
 


### PR DESCRIPTION
## Summary

The "What's new" updates panel linked to release notes via `RELEASE_NOTES_URL`, which pointed at `docs.n8n.io/release-notes/`. That URL now redirects to the archived, frozen 2.x release notes page, which no longer receives new versions. This PR points the constant at the new living release notes page at `docs.n8n.io/changelog/release-notes` so the panel links to current content.

## How to test

Open the "What's new" modal (left sidebar bottom menu, or the "What's new" command in the command bar). When a significant update is available, the warning callout shows a "release notes" link. Confirm the link opens `https://docs.n8n.io/changelog/release-notes`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CP-3113

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use \`(no-changelog)\` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

