### PR TITLE
feat(core): Gate worker pools behind the worker pools license (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/license-state.ts
+++ b/packages/@n8n/backend-common/src/license-state.ts
@@ -170,6 +170,10 @@ export class LicenseState {
 		return this.isLicensed('feat:workerView');
 	}
 
+	isWorkerPoolsLicensed() {
+		return this.isLicensed('feat:workerPools');
+	}
+
 	isProjectRoleAdminLicensed() {
 		return this.isLicensed('feat:projectRole:admin');
 	}

--- a/packages/@n8n/constants/src/index.ts
+++ b/packages/@n8n/constants/src/index.ts
@@ -56,6 +56,7 @@ export const LICENSE_FEATURES = {
 	DATA_REDACTION: 'feat:dataRedaction',
 	OTEL_CUSTOM_SPAN_ATTRIBUTES: 'feat:otel:customSpanAttributes',
 	WORKFLOW_REVIEWS: 'feat:workflowReviews',
+	WORKER_POOLS: 'feat:workerPools',
 } as const;
 
 export const LICENSE_QUOTAS = {

--- a/packages/cli/src/commands/__tests__/worker.test.ts
+++ b/packages/cli/src/commands/__tests__/worker.test.ts
@@ -153,6 +153,7 @@ describe('Worker', () => {
 				taskRunners: {},
 				outboundProxy: { mode: 'all' },
 				expressionEngine: { engine: 'legacy', poolSize: 1, maxCodeCacheSize: 1024 },
+				queue: { workerPool: { enabled: false, name: '' } },
 			};
 			// Stub the init steps that go beyond `super.init()`, as in start.test.ts
 			worker.setConcurrency = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -1,4 +1,4 @@
-import { inTest } from '@n8n/backend-common';
+import { inTest, LicenseState } from '@n8n/backend-common';
 import { DeploymentKeyRepository } from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
@@ -109,6 +109,17 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		await this.initLicense();
 		this.logger.debug('License init complete');
+
+		if (
+			resolveWorkerPoolName(this.globalConfig.queue.workerPool) !== '' &&
+			!Container.get(LicenseState).isWorkerPoolsLicensed()
+		) {
+			this.logger.error(
+				'A worker pool is configured (`N8N_WORKER_POOL_NAME`), but worker pools are not licensed. Either remove the worker pool configuration, or upgrade to a license that supports this feature.',
+			);
+			process.exit(1);
+		}
+
 		await this.initCommunityPackages();
 		await Container.get(CredentialsOverwrites).init();
 		this.logger.debug('Credentials overwrites init complete');

--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -144,6 +144,7 @@ export class E2EController {
 		[LICENSE_FEATURES.DATA_REDACTION]: false,
 		[LICENSE_FEATURES.WORKFLOW_REVIEWS]: false,
 		[LICENSE_FEATURES.OTEL_CUSTOM_SPAN_ATTRIBUTES]: false,
+		[LICENSE_FEATURES.WORKER_POOLS]: false,
 	};
 
 	private static readonly numericFeaturesDefaults: Record<NumericLicenseFeature, number> = {

--- a/packages/cli/src/controllers/project-pool-settings.controller.ts
+++ b/packages/cli/src/controllers/project-pool-settings.controller.ts
@@ -10,7 +10,7 @@ import { PoolConfigService } from '@/scaling/pool-config.service';
 export class ProjectPoolSettingsController {
 	constructor(private readonly poolConfigService: PoolConfigService) {}
 
-	@Licensed(LICENSE_FEATURES.WORKER_VIEW)
+	@Licensed(LICENSE_FEATURES.WORKER_POOLS)
 	@ProjectScope('project:read')
 	@Get('/')
 	async getPoolSettings(
@@ -21,7 +21,7 @@ export class ProjectPoolSettingsController {
 		return await this.poolConfigService.getProjectPoolSettings(projectId);
 	}
 
-	@Licensed(LICENSE_FEATURES.WORKER_VIEW)
+	@Licensed(LICENSE_FEATURES.WORKER_POOLS)
 	@ProjectScope('project:update')
 	@Patch('/')
 	async updatePoolSettings(

--- a/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
@@ -1,3 +1,4 @@
+import type { LicenseState } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
 import type { ProjectPoolSettingsRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
@@ -11,6 +12,7 @@ describe('PoolConfigService', () => {
 	const cacheService = mock<CacheService>();
 	const workerPoolsService = mock<WorkerPoolsService>();
 	const globalConfig = mock<GlobalConfig>();
+	const licenseState = mock<LicenseState>();
 
 	const setEnabled = (enabled: boolean) => {
 		globalConfig.queue = { workerPool: { enabled } } as GlobalConfig['queue'];
@@ -21,11 +23,13 @@ describe('PoolConfigService', () => {
 		cacheService,
 		workerPoolsService,
 		globalConfig,
+		licenseState,
 	);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		setEnabled(true);
+		licenseState.isWorkerPoolsLicensed.mockReturnValue(true);
 		// Default: cache miss, no workers registered
 		cacheService.get.mockResolvedValue(undefined);
 		workerPoolsService.getAvailablePools.mockResolvedValue([]);
@@ -41,6 +45,17 @@ describe('PoolConfigService', () => {
 			const result = await service.resolvePoolForExecution({ projectId });
 
 			expect(result).toEqual({ queueName: 'jobs-gpu', poolName: 'gpu' });
+		});
+
+		it('falls back to the default queue when worker pools are not licensed', async () => {
+			licenseState.isWorkerPoolsLicensed.mockReturnValue(false);
+			projectPoolSettingsRepository.getDefaultPool.mockResolvedValue('gpu');
+			workerPoolsService.getAvailablePools.mockResolvedValue(['gpu']);
+
+			const result = await service.resolvePoolForExecution({ projectId });
+
+			expect(result).toEqual({ queueName: 'jobs', poolName: undefined });
+			expect(projectPoolSettingsRepository.getDefaultPool).not.toHaveBeenCalled();
 		});
 
 		it('falls back to the default queue when the project has no pool set', async () => {

--- a/packages/cli/src/scaling/pool-config.service.ts
+++ b/packages/cli/src/scaling/pool-config.service.ts
@@ -1,4 +1,5 @@
 import type { ProjectPoolSettingsResponse, UpdateProjectPoolSettingsDto } from '@n8n/api-types';
+import { LicenseState } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { ProjectPoolSettingsRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -24,6 +25,7 @@ export class PoolConfigService {
 		private readonly cacheService: CacheService,
 		private readonly workerPoolsService: WorkerPoolsService,
 		private readonly globalConfig: GlobalConfig,
+		private readonly licenseState: LicenseState,
 	) {}
 
 	/**
@@ -37,6 +39,7 @@ export class PoolConfigService {
 		const systemDefault = { queueName: DEFAULT_QUEUE_NAME, poolName: undefined };
 
 		if (!this.globalConfig.queue.workerPool.enabled) return systemDefault;
+		if (!this.licenseState.isWorkerPoolsLicensed()) return systemDefault;
 		if (!data.projectId) return systemDefault;
 
 		const pool = await this.getProjectDefaultPool(data.projectId);

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -169,6 +169,7 @@ describe('FrontendService', () => {
 		isOidcLicensed: vi.fn().mockReturnValue(false),
 		isMFAEnforcementLicensed: vi.fn().mockReturnValue(false),
 		isOtelCustomSpanAttributesLicensed: vi.fn().mockReturnValue(false),
+		isWorkerPoolsLicensed: vi.fn().mockReturnValue(false),
 		getMaxWorkflowsWithEvaluations: vi.fn().mockReturnValue(0),
 	});
 
@@ -529,6 +530,36 @@ describe('FrontendService', () => {
 			const settings = await service.getSettings();
 
 			expect(settings.enterprise.otelCustomSpanAttributes).toBe(true);
+		});
+
+		it('should enable worker pools when both the config flag and the license are on', async () => {
+			globalConfig.queue = { workerPool: { enabled: true } } as GlobalConfig['queue'];
+			licenseState.isWorkerPoolsLicensed.mockReturnValue(true);
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.workerPools.enabled).toBe(true);
+		});
+
+		it('should keep worker pools disabled when the config flag is on but the feature is not licensed', async () => {
+			globalConfig.queue = { workerPool: { enabled: true } } as GlobalConfig['queue'];
+			licenseState.isWorkerPoolsLicensed.mockReturnValue(false);
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.workerPools.enabled).toBe(false);
+		});
+
+		it('should keep worker pools disabled when licensed but the config flag is off', async () => {
+			globalConfig.queue = { workerPool: { enabled: false } } as GlobalConfig['queue'];
+			licenseState.isWorkerPoolsLicensed.mockReturnValue(true);
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.workerPools.enabled).toBe(false);
 		});
 
 		it('should surface useWorkflowPublicationService from workflows config', async () => {

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -424,7 +424,7 @@ export class FrontendService {
 				enabled: false,
 			},
 			workerPools: {
-				enabled: this.globalConfig.queue.workerPool.enabled,
+				enabled: false,
 			},
 			evaluation: {
 				quota: this.licenseState.getMaxWorkflowsWithEvaluations(),
@@ -546,6 +546,9 @@ export class FrontendService {
 			otelCustomSpanAttributes: this.licenseState.isOtelCustomSpanAttributesLicensed(),
 			workflowReviews: this.licenseState.isWorkflowReviewsLicensed(),
 		});
+
+		this.settings.workerPools.enabled =
+			this.globalConfig.queue.workerPool.enabled && this.licenseState.isWorkerPoolsLicensed();
 
 		if (this.license.isLdapEnabled()) {
 			Object.assign(this.settings.sso.ldap, {


### PR DESCRIPTION
## Summary

Adds a dedicated license feature for worker pools: `feat:workerPools`. The feature is active only when the instance is licensed **and** the operator opted in via `N8N_WORKER_POOLS_ENABLED` (license AND config flag).

Gate points:

- **Execution routing** (`PoolConfigService.resolvePoolForExecution`): unlicensed instances route every execution to the default queue, before any DB or registry read.
- **API** (`ProjectPoolSettingsController`): both routes now require `feat:workerPools` (they previously borrowed `feat:workerView`) — unlicensed returns 403 via the standard `@Licensed` middleware.
- **Frontend** (`frontend.service.ts`): `workerPools.enabled` is now `flag && licensed`, computed in the settings refresh path so it re-evaluates on license activation. No frontend code changes needed — the settings store and project settings UI already key off this value and hide the section.
- **Worker boot** (`worker.ts`): a worker configured with a non-default pool (`N8N_WORKER_POOL_NAME`) on an unlicensed instance logs an error and exits, following the existing S3 binary-data precedent in `base-command.ts`. Rationale: the configuration demands a licensed feature, so it fails loudly instead of idling silently. Like the S3 checks, this exit path has no dedicated test.
- **e2e controller**: license toggle map entry (enforced by the exhaustive `Record<BooleanLicenseFeature, boolean>` type).

Deliberately not gated: worker queue *naming* stays license-independent at runtime (routing is main-side); service-level `get/setProjectPoolSettings` remain guarded at the HTTP layer only, as before.

## How to test

Unit tests cover: routing falls back to the default queue when unlicensed (flag on, pool live); `workerPools.enabled` truth table (flag × license); existing controller and worker suites.

Manually: run queue mode with `N8N_WORKER_POOLS_ENABLED=true` and no license — the project settings UI shows no pool section, `GET /rest/projects/:id/pool-settings` returns 403, executions run on the `jobs` queue, and a worker started with `N8N_WORKER_POOL_NAME=gpu` exits with the license error. Enable `feat:workerPools` on the license — everything above activates.

## Related Linear tickets, Github issues, and Community forum posts

Parent PR: #32975

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

