### PR TITLE
feat(core): Remove the worker-pool routing fallbacks (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -516,6 +516,34 @@ describe('enqueueExecution', () => {
 		expect(setupQueue).toHaveBeenCalledTimes(1);
 	});
 
+	it('should finalize the execution when pool resolution fails', async () => {
+		const activeExecutions = Container.get(ActiveExecutions);
+		vi.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValue();
+		const processError = vi.spyOn(runner, 'processError').mockResolvedValueOnce();
+		const data = mock<IWorkflowExecutionDataProcess>({
+			workflowData: { nodes: [], staticData: {} },
+			executionData: undefined,
+		});
+		const error = new Error('pool resolution failed');
+		const { PoolConfigService } = await import('@/scaling/pool-config.service.js');
+		vi.spyOn(
+			Container.get(PoolConfigService),
+			'resolvePoolForExecution',
+		).mockRejectedValueOnce(error);
+
+		// @ts-expect-error Private method
+		await expect(runner.enqueueExecution('1', 'workflow-xyz', data)).rejects.toThrowError(error);
+
+		expect(processError).toHaveBeenCalledWith(
+			error,
+			expect.any(Date),
+			data.executionMode,
+			'1',
+			expect.anything(),
+		);
+		expect(addJob).not.toHaveBeenCalled();
+	});
+
 	it('should include restartExecutionId in job data when provided', async () => {
 		const activeExecutions = Container.get(ActiveExecutions);
 		vi.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValue();

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -526,10 +526,9 @@ describe('enqueueExecution', () => {
 		});
 		const error = new Error('pool resolution failed');
 		const { PoolConfigService } = await import('@/scaling/pool-config.service.js');
-		vi.spyOn(
-			Container.get(PoolConfigService),
-			'resolvePoolForExecution',
-		).mockRejectedValueOnce(error);
+		vi.spyOn(Container.get(PoolConfigService), 'resolvePoolForExecution').mockRejectedValueOnce(
+			error,
+		);
 
 		// @ts-expect-error Private method
 		await expect(runner.enqueueExecution('1', 'workflow-xyz', data)).rejects.toThrowError(error);

--- a/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
@@ -38,13 +38,15 @@ describe('PoolConfigService', () => {
 	describe('resolvePoolForExecution', () => {
 		const projectId = 'project-123';
 
-		it("resolves to the project's default pool when it is live", async () => {
+		it("resolves to the project's default pool without checking worker registration", async () => {
 			projectPoolSettingsRepository.getDefaultPool.mockResolvedValue('gpu');
-			workerPoolsService.getAvailablePools.mockResolvedValue(['gpu', 'cpu']);
 
 			const result = await service.resolvePoolForExecution({ projectId });
 
+			// The pool queue is used even when no worker has registered the pool: executions
+			// wait on the queue, matching plain queue mode with no workers deployed.
 			expect(result).toEqual({ queueName: 'jobs-gpu', poolName: 'gpu' });
+			expect(workerPoolsService.getAvailablePools).not.toHaveBeenCalled();
 		});
 
 		it('falls back to the default queue when worker pools are not licensed', async () => {
@@ -60,15 +62,6 @@ describe('PoolConfigService', () => {
 
 		it('falls back to the default queue when the project has no pool set', async () => {
 			projectPoolSettingsRepository.getDefaultPool.mockResolvedValue(null);
-
-			const result = await service.resolvePoolForExecution({ projectId });
-
-			expect(result).toEqual({ queueName: 'jobs', poolName: undefined });
-		});
-
-		it('falls back to the default queue when the configured pool is not registered by any worker', async () => {
-			projectPoolSettingsRepository.getDefaultPool.mockResolvedValue('gpu');
-			workerPoolsService.getAvailablePools.mockResolvedValue(['cpu']);
 
 			const result = await service.resolvePoolForExecution({ projectId });
 

--- a/packages/cli/src/scaling/pool-config.service.ts
+++ b/packages/cli/src/scaling/pool-config.service.ts
@@ -30,8 +30,9 @@ export class PoolConfigService {
 
 	/**
 	 * Resolve the queue an execution should run on. Returns the project's default pool when worker
-	 * pools are enabled and the pool is live; otherwise the system default queue. Never routes to a
-	 * pool that isn't registered by a worker.
+	 * pools are enabled and licensed; otherwise the system default queue. The pool queue is used
+	 * even when no worker has registered the pool: executions then wait on the queue, matching
+	 * plain queue mode with no workers deployed.
 	 */
 	async resolvePoolForExecution(
 		data: Pick<IWorkflowExecutionDataProcess, 'projectId'>,
@@ -44,9 +45,6 @@ export class PoolConfigService {
 
 		const pool = await this.getProjectDefaultPool(data.projectId);
 		if (!pool) return systemDefault;
-
-		const availablePools = await this.workerPoolsService.getAvailablePools();
-		if (!availablePools.includes(pool)) return systemDefault;
 
 		return { queueName: poolQueueName(pool), poolName: pool };
 	}

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -4,7 +4,6 @@ import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig } from '@n8n/config';
 import { ExecutionRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
-import { ensureError } from '@n8n/utils/errors/ensure-error';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
 import {
@@ -52,7 +51,6 @@ import type { ResumableExecution } from '@/interfaces';
 import { ManualExecutionService } from '@/manual-execution.service';
 import { NodeTypes } from '@/node-types';
 import type { PoolConfigService } from '@/scaling/pool-config.service';
-import { DEFAULT_QUEUE_NAME } from '@/scaling/queue-name';
 import type { ScalingService } from '@/scaling/scaling.service';
 import type { Job, JobData } from '@/scaling/scaling.types';
 import { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
@@ -544,18 +542,7 @@ export class WorkflowRunner {
 			this.poolConfigService = Container.get(PoolConfigService);
 		}
 
-		// A pool-resolution failure must not abort the execution: fall back to the default queue.
-		let queueName: string;
-		let poolName: string | undefined;
-		try {
-			({ queueName, poolName } = await this.poolConfigService.resolvePoolForExecution(data));
-		} catch (error) {
-			this.logger.warn(
-				`Failed to resolve worker pool for execution ${executionId}, falling back to default queue: ${ensureError(error).message}`,
-			);
-			queueName = DEFAULT_QUEUE_NAME;
-			poolName = undefined;
-		}
+		const { queueName, poolName } = await this.poolConfigService.resolvePoolForExecution(data);
 
 		const jobData: JobData = {
 			workflowId,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -300,17 +300,29 @@ export class WorkflowRunner {
 				? this.executionsConfig.mode === 'queue'
 				: this.executionsConfig.mode === 'queue' && data.executionMode !== 'manual';
 
-		if (shouldEnqueue) {
-			await this.enqueueExecution(
-				executionId,
-				workflowId,
-				data,
-				loadStaticData,
-				realtime,
-				existingExecution?.executionId,
-			);
-		} else {
-			await this.runMainProcess(executionId, data, loadStaticData, existingExecution?.executionId);
+		try {
+			if (shouldEnqueue) {
+				await this.enqueueExecution(
+					executionId,
+					workflowId,
+					data,
+					loadStaticData,
+					realtime,
+					existingExecution?.executionId,
+				);
+			} else {
+				await this.runMainProcess(
+					executionId,
+					data,
+					loadStaticData,
+					existingExecution?.executionId,
+				);
+			}
+		} catch (error) {
+			// A failed start means the post-execute promise that normally clears the
+			// heartbeat never settles, so clear it here.
+			if (heartbeatInterval) clearInterval(heartbeatInterval);
+			throw error;
 		}
 
 		// only run these when not in queue mode or when the execution is manual,
@@ -542,34 +554,34 @@ export class WorkflowRunner {
 			this.poolConfigService = Container.get(PoolConfigService);
 		}
 
-		const { queueName, poolName } = await this.poolConfigService.resolvePoolForExecution(data);
-
-		const jobData: JobData = {
-			workflowId,
-			executionId,
-			loadStaticData: !!loadStaticData,
-			pushRef: data.pushRef,
-			streamingEnabled: data.streamingEnabled,
-			restartExecutionId,
-			projectId: data.projectId,
-			projectName: data.projectName,
-			// Carry the manual-execution identity for private credential resolution on the worker.
-			encryptedRunnerIdentity: data.encryptedRunnerIdentity,
-			poolName,
-			// MCP-specific fields for queue mode support
-			isMcpExecution: data.isMcpExecution,
-			mcpType: data.mcpType,
-			mcpSessionId: data.mcpSessionId,
-			mcpMessageId: data.mcpMessageId,
-			mcpToolCall: data.mcpToolCall,
-			mcpToolInput: data.mcpToolInput,
-		};
-
 		// TODO: For realtime jobs should probably also not do retry or not retry if they are older than x seconds.
 		//       Check if they get retried by default and how often.
 		let job: Job;
 		let lifecycleHooks: ExecutionLifecycleHooks;
 		try {
+			const { queueName, poolName } = await this.poolConfigService.resolvePoolForExecution(data);
+
+			const jobData: JobData = {
+				workflowId,
+				executionId,
+				loadStaticData: !!loadStaticData,
+				pushRef: data.pushRef,
+				streamingEnabled: data.streamingEnabled,
+				restartExecutionId,
+				projectId: data.projectId,
+				projectName: data.projectName,
+				// Carry the manual-execution identity for private credential resolution on the worker.
+				encryptedRunnerIdentity: data.encryptedRunnerIdentity,
+				poolName,
+				// MCP-specific fields for queue mode support
+				isMcpExecution: data.isMcpExecution,
+				mcpType: data.mcpType,
+				mcpSessionId: data.mcpSessionId,
+				mcpMessageId: data.mcpMessageId,
+				mcpToolCall: data.mcpToolCall,
+				mcpToolInput: data.mcpToolInput,
+			};
+
 			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100, queueName });
 
 			lifecycleHooks = getLifecycleHooksForScalingMain(data, executionId);


### PR DESCRIPTION
## Summary

Removes both fallback mechanisms from worker-pool execution routing, per the team decision: a project's configured pool is honored unconditionally, and if nothing is listening, executions wait on the queue — the same semantics as plain queue mode with no workers deployed. Observability/monitoring for this may come later.

1. **Liveness guard** (`PoolConfigService.resolvePoolForExecution`): previously, a pool not registered by any live worker was silently replaced with the default queue. Now the pool queue is used regardless of worker registration; `getAvailablePools()` is no longer consulted during routing (it still backs the pool dropdown in the settings endpoints).
2. **Error fallback** (`WorkflowRunner.enqueueExecution`): previously, a pool-resolution failure (e.g. a DB error) logged a warning and routed the execution to the default queue. Now the failure propagates and the enqueue fails visibly — a pool-assigned workflow is never silently run outside its pool.

Stacked on #37715 (license gating) — both PRs edit the same lines in `resolvePoolForExecution` and its tests.

## How to test

Unit tests updated: routing resolves to the pool queue without checking worker registration (and asserts the registry is not consulted); the not-registered fallback test is removed. Manually: point a project at a pool with no workers and run a workflow — the execution stays queued on `jobs-<pool>` until a matching worker starts.

## Related Linear tickets, Github issues, and Community forum posts

Parent PR: #32975. Stacked on #37715.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

