### PR TITLE
refactor(core): Make scheduled job ownerKey non-nullable (no-changelog)

### DIFF
--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -357,7 +357,7 @@ describe('createScheduler materialize', () => {
 			maxAttempts: 3,
 			misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 			misfireGraceSeconds: 60,
-			ownerKey: null,
+			ownerKey: 'owner-1',
 		};
 		const tx = mock<MaterializerTransaction>();
 		tx.retireSuperseded.mockResolvedValue(0);
@@ -403,7 +403,7 @@ describe('createScheduler materialize', () => {
 			maxAttempts: 3,
 			misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 			misfireGraceSeconds: 60,
-			ownerKey: null,
+			ownerKey: 'owner-1',
 		};
 		const tx = mock<MaterializerTransaction>();
 		tx.retireSuperseded.mockResolvedValue(0);
@@ -1267,7 +1267,7 @@ describe('createScheduler tracing', () => {
 			maxAttempts: 3,
 			misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 			misfireGraceSeconds: 60,
-			ownerKey: null,
+			ownerKey: 'owner-1',
 		};
 		const tx = mock<MaterializerTransaction>();
 		tx.retireSuperseded.mockResolvedValue(0);
@@ -1320,7 +1320,7 @@ describe('createScheduler tracing', () => {
 			maxAttempts: 3,
 			misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 			misfireGraceSeconds: 60,
-			ownerKey: null,
+			ownerKey: 'owner-1',
 		};
 		const tx = mock<MaterializerTransaction>();
 		tx.retireSuperseded.mockResolvedValue(0);
@@ -1616,7 +1616,7 @@ describe('createScheduler metrics', () => {
 			maxAttempts: 3,
 			misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 			misfireGraceSeconds: 60,
-			ownerKey: null,
+			ownerKey: 'owner-1',
 		};
 		const tx = mock<MaterializerTransaction>();
 		tx.retireSuperseded.mockResolvedValue(0);

--- a/packages/@n8n/scheduler/src/core/materializer/__tests__/coalesce-group.test.ts
+++ b/packages/@n8n/scheduler/src/core/materializer/__tests__/coalesce-group.test.ts
@@ -137,18 +137,6 @@ describe('applyCoalesceOwnerPolicy', () => {
 		expect(result[0].plan.retireBefore).toEqual(missedAt);
 	});
 
-	it('leaves ownerless members untouched even when they share a task type', () => {
-		const planned = [
-			makeMember({ id: 1, ownerKey: null }, secondsBefore(NOW, 30)),
-			makeMember({ id: 2, ownerKey: null }, secondsBefore(NOW, 20)),
-			makeMember({ id: 3, ownerKey: null }, secondsBefore(NOW, 10)),
-		];
-
-		const result = applyCoalesceOwnerPolicy(planned);
-
-		expect(result.filter(({ plan }) => plan.catchUpAt !== null)).toHaveLength(3);
-	});
-
 	it('leaves members on the per-job coalesce policy untouched despite a shared owner', () => {
 		const perJob = (id: number, missedAt: Date) =>
 			makeMember({ id, misfirePolicy: ScheduledJobMisfirePolicy.Coalesce }, missedAt);

--- a/packages/@n8n/scheduler/src/core/materializer/__tests__/materialize.test.ts
+++ b/packages/@n8n/scheduler/src/core/materializer/__tests__/materialize.test.ts
@@ -24,7 +24,7 @@ const makeJob = (id: number): ScheduledJob => ({
 	maxAttempts: 1,
 	misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 	misfireGraceSeconds: 60,
-	ownerKey: null,
+	ownerKey: 'owner-1',
 });
 
 const makeSkipJob = (id: number): ScheduledJob => ({

--- a/packages/@n8n/scheduler/src/core/materializer/__tests__/plan.property.test.ts
+++ b/packages/@n8n/scheduler/src/core/materializer/__tests__/plan.property.test.ts
@@ -23,7 +23,7 @@ const makeIntervalJob = (intervalSeconds: number): ScheduledJob => ({
 	maxAttempts: 1,
 	misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 	misfireGraceSeconds: 60,
-	ownerKey: null,
+	ownerKey: 'owner-1',
 });
 
 const makeCronJob = (cronExpression: string, timezone: string): ScheduledJob => ({
@@ -42,7 +42,7 @@ const makeCronJob = (cronExpression: string, timezone: string): ScheduledJob => 
 	maxAttempts: 1,
 	misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 	misfireGraceSeconds: 60,
-	ownerKey: null,
+	ownerKey: 'owner-1',
 });
 
 const makeOneOffJob = (fireAt: Date): ScheduledJob => ({
@@ -63,7 +63,7 @@ const makeOneOffJob = (fireAt: Date): ScheduledJob => ({
 	maxAttempts: 1,
 	misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 	misfireGraceSeconds: 60,
-	ownerKey: null,
+	ownerKey: 'owner-1',
 });
 
 /**

--- a/packages/@n8n/scheduler/src/core/materializer/__tests__/plan.test.ts
+++ b/packages/@n8n/scheduler/src/core/materializer/__tests__/plan.test.ts
@@ -25,7 +25,7 @@ const makeJob = (overrides: Partial<ScheduledJob> = {}): ScheduledJob => ({
 	maxAttempts: 1,
 	misfirePolicy: ScheduledJobMisfirePolicy.Coalesce,
 	misfireGraceSeconds: 60,
-	ownerKey: null,
+	ownerKey: 'owner-1',
 	...overrides,
 });
 

--- a/packages/@n8n/scheduler/src/core/materializer/coalesce-group.ts
+++ b/packages/@n8n/scheduler/src/core/materializer/coalesce-group.ts
@@ -10,8 +10,7 @@ interface GroupMember {
 /**
  * Applies `coalesce_owner` across one planning pass: per owner, only the job
  * with the latest missed occurrence keeps its late run; the other jobs drop
- * theirs. Jobs on another policy, without an owner, or with nothing missed
- * are left untouched.
+ * theirs. Jobs on another policy or with nothing missed are left untouched.
  */
 export function applyCoalesceOwnerPolicy(planned: PlannedJob[]): PlannedJob[] {
 	const losers = new Set(
@@ -43,14 +42,10 @@ function groupByOwner(planned: PlannedJob[]): Map<string, GroupMember[]> {
 		);
 }
 
-/** Empty when the policy does not touch the job: no owner, another policy, or nothing missed. */
+/** Empty when the policy does not touch the job: another policy, or nothing missed. */
 function toOwnedMember(entry: PlannedJob): Array<{ key: string; member: GroupMember }> {
 	const { job, plan } = entry;
-	if (
-		job.ownerKey === null ||
-		plan.catchUpAt === null ||
-		job.misfirePolicy !== ScheduledJobMisfirePolicy.CoalesceOwner
-	) {
+	if (plan.catchUpAt === null || job.misfirePolicy !== ScheduledJobMisfirePolicy.CoalesceOwner) {
 		return [];
 	}
 	return [{ key: job.ownerKey, member: { entry, latestMissedAt: plan.catchUpAt.getTime() } }];

--- a/packages/@n8n/scheduler/src/core/recurrence/__tests__/resolve.test.ts
+++ b/packages/@n8n/scheduler/src/core/recurrence/__tests__/resolve.test.ts
@@ -24,7 +24,7 @@ function makeJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
 		maxAttempts: 1,
 		misfirePolicy: 'coalesce',
 		misfireGraceSeconds: 60,
-		ownerKey: null,
+		ownerKey: 'owner-1',
 		...overrides,
 	};
 }

--- a/packages/@n8n/scheduler/src/core/types/schedule.ts
+++ b/packages/@n8n/scheduler/src/core/types/schedule.ts
@@ -109,8 +109,8 @@ export interface ScheduledJob {
 	misfireGraceSeconds: number;
 	/**
 	 * Groups jobs for `coalesce_owner`: same value, same group. The scheduler
-	 * only compares values, it never reads them. `null` means the job stands
-	 * alone. Required so an adapter that forgets to map it fails to compile.
+	 * only compares values, it never reads them. Required so an adapter that
+	 * forgets to map it fails to compile.
 	 */
-	ownerKey: string | null;
+	ownerKey: string;
 }


### PR DESCRIPTION
## Summary

Every scheduled job now has an owner, so `ownerKey` can no longer be `null`.
This PR removes the leftover nullable type and its guards in `@n8n/scheduler`

No behaviour changes. Follows up on the review thread: https://github.com/n8n-io/n8n/pull/37132#discussion_r3912882195

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4350

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

