### PR TITLE
fix(core): Complete a scheduled occurrence as not dispatched when its workflow is unpublished

### DIFF
--- a/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
@@ -124,7 +124,7 @@ describe('PollTriggerTaskHandler', () => {
 		pollFunctions = mock<IPollFunctions>() as PollFunctionsMock;
 		pollFunctions.__runPoll.mockImplementation(async (poll) => await poll());
 
-		triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(workflowData);
+		triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(workflowData);
 		triggerExecutionContextFactory.createPollExecutionContext.mockResolvedValue({
 			workflow,
 			pollFunctions,
@@ -149,7 +149,7 @@ describe('PollTriggerTaskHandler', () => {
 		// fire before the healer's corrected version replaces the jobs; resolving a
 		// duplicated id would poll the wrong node and write shared cursor state.
 		test('skips the occurrence when the published version has duplicate node ids', async () => {
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(
 				buildWorkflowData({
 					nodes: [triggerNode, { ...triggerNode, name: 'Other Poll Trigger' }],
 				}),
@@ -162,7 +162,7 @@ describe('PollTriggerTaskHandler', () => {
 		});
 
 		test('skips the occurrence when the published version has a node without an id', async () => {
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(
 				buildWorkflowData({
 					nodes: [triggerNode, { ...triggerNode, id: '', name: 'Other Poll Trigger' }],
 				}),
@@ -218,7 +218,7 @@ describe('PollTriggerTaskHandler', () => {
 		test('reads workflow data fresh (non-cached) so the poll cursor is never stale', async () => {
 			await handler.execute(buildTask(), report);
 
-			expect(triggerExecutionContextFactory.loadPublishedWorkflowData).toHaveBeenCalledWith(
+			expect(triggerExecutionContextFactory.findPublishedWorkflowData).toHaveBeenCalledWith(
 				'wf-1',
 				{
 					bypassCache: true,
@@ -503,23 +503,31 @@ describe('PollTriggerTaskHandler', () => {
 			await expect(handler.execute(task, report)).rejects.toThrow(
 				'Poll-trigger task payload is missing workflowId or nodeId',
 			);
-			expect(triggerExecutionContextFactory.loadPublishedWorkflowData).not.toHaveBeenCalled();
+			expect(triggerExecutionContextFactory.findPublishedWorkflowData).not.toHaveBeenCalled();
 			expect(triggersAndPollers.runPollFunction).not.toHaveBeenCalled();
 		});
 
-		test('propagates a missing published workflow so the executor records the failure', async () => {
-			const error = new UnexpectedError('Published version not found for workflow');
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockRejectedValue(error);
+		test('reports no dispatch when the published workflow is gone', async () => {
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(null);
 
-			await expect(handler.execute(buildTask(), report)).rejects.toThrow(error);
+			const decision = await handler.execute(buildTask(), report);
+
+			// The workflow was unpublished after the claim: the occurrence completes as a
+			// no-op instead of retrying to dead-letter while the owner retires the job.
+			expect(decision).toBe(report.notDispatched());
 			expect(triggersAndPollers.runPollFunction).not.toHaveBeenCalled();
+			expect(onDispatch).not.toHaveBeenCalled();
+			expect(scopedLogger.debug).toHaveBeenCalledWith(
+				expect.stringContaining('no published version'),
+				expect.objectContaining({ taskId: 'task-1', workflowId: 'wf-1', nodeId: 'node-1' }),
+			);
 		});
 
 		test.each([
 			['gone from', [] as INode[]],
 			['disabled in', [{ ...triggerNode, disabled: true }]],
 		])('rejects a task whose trigger node is %s the published workflow', async (_case, nodes) => {
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(
 				buildWorkflowData({ nodes }),
 			);
 
@@ -570,7 +578,7 @@ describe('PollTriggerTaskHandler', () => {
 			const decision = await handler.execute(buildTask(), report);
 
 			expect(decision).toBe(report.notDispatched());
-			expect(triggerExecutionContextFactory.loadPublishedWorkflowData).not.toHaveBeenCalled();
+			expect(triggerExecutionContextFactory.findPublishedWorkflowData).not.toHaveBeenCalled();
 			expect(triggersAndPollers.runPollFunction).not.toHaveBeenCalled();
 			expect(onDispatch).not.toHaveBeenCalled();
 			expect(pollBackoffService.isBackingOff).toHaveBeenCalledWith(state, fixedNow);
@@ -702,11 +710,11 @@ describe('PollTriggerTaskHandler', () => {
 		});
 
 		test('does not touch the failure counters when the published workflow is missing', async () => {
-			const error = new UnexpectedError('Published version not found for workflow');
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockRejectedValue(error);
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(null);
 
-			await expect(handler.execute(buildTask(), report)).rejects.toThrow(error);
+			const decision = await handler.execute(buildTask(), report);
 
+			expect(decision).toBe(report.notDispatched());
 			expect(pollBackoffService.recordFailure).not.toHaveBeenCalled();
 			expect(pollBackoffService.recordSuccess).not.toHaveBeenCalled();
 		});

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -89,11 +89,20 @@ export class PollTriggerTaskHandler implements TaskHandler {
 			return report.notDispatched();
 		}
 
-		// bypassCache: the poll cursor in staticData must be read live, not from the publish-time cache.
-		const workflowData = await this.triggerExecutionContextFactory.loadPublishedWorkflowData(
+		const workflowData = await this.triggerExecutionContextFactory.findPublishedWorkflowData(
 			workflowId,
-			{ bypassCache: true },
+			{ bypassCache: true }, // the poll cursor in staticData must be read live, not from the publish-time cache.
 		);
+
+		if (workflowData === null) {
+			this.logger.debug('Workflow has no published version. Skipping the occurrence.', {
+				taskId: task.id,
+				jobId: task.jobId,
+				workflowId,
+				nodeId,
+			});
+			return report.notDispatched();
+		}
 
 		// A due task persisted for a version with duplicate or missing node ids can
 		// fire before the healed version's outbox record replaces the jobs.

--- a/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
@@ -84,7 +84,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
-		triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(buildWorkflowData());
+		triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(buildWorkflowData());
 		workflowExecutionService.runWorkflow.mockResolvedValue('exec-1');
 		ownershipService.getWorkflowProjectCached.mockResolvedValue(
 			mock<Project>({ id: 'project-1', name: 'My Project' }),
@@ -101,7 +101,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 		test('creates a trigger execution with the occurrence-derived dedup key', async () => {
 			await handler.execute(buildTask(), report);
 
-			expect(triggerExecutionContextFactory.loadPublishedWorkflowData).toHaveBeenCalledWith('wf-1');
+			expect(triggerExecutionContextFactory.findPublishedWorkflowData).toHaveBeenCalledWith('wf-1');
 			expect(workflowExecutionService.runWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ id: 'wf-1' }),
 				triggerNode,
@@ -125,7 +125,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 		});
 
 		test('falls back to the instance timezone when the workflow sets none', async () => {
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(
 				buildWorkflowData({ settings: {} }),
 			);
 
@@ -139,7 +139,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 		});
 
 		test("resolves the 'DEFAULT' timezone sentinel to the instance timezone", async () => {
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(
 				buildWorkflowData({ settings: { timezone: 'DEFAULT' } }),
 			);
 
@@ -232,16 +232,24 @@ describe('ScheduleTriggerTaskHandler', () => {
 			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
 		});
 
-		test('propagates a missing published workflow so the executor records the failure', async () => {
-			const error = new UnexpectedError('Published version not found for workflow');
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockRejectedValue(error);
+		test('reports no dispatch when the published workflow is gone', async () => {
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(null);
 
-			await expect(handler.execute(buildTask(), report)).rejects.toThrow(error);
+			const decision = await handler.execute(buildTask(), report);
+
+			// The workflow was unpublished after the claim: the occurrence completes as a
+			// no-op instead of retrying to dead-letter while the owner retires the job.
+			expect(decision).toBe(report.notDispatched());
 			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+			expect(onDispatch).not.toHaveBeenCalled();
+			expect(scopedLogger.debug).toHaveBeenCalledWith(
+				expect.stringContaining('no published version'),
+				expect.objectContaining({ taskId: 'task-1', jobId: 7, workflowId: 'wf-1' }),
+			);
 		});
 
 		test('rejects a task whose trigger node is gone from the published workflow', async () => {
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(
 				buildWorkflowData({ nodes: [] }),
 			);
 
@@ -252,7 +260,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 		});
 
 		test('rejects a task whose trigger node is disabled', async () => {
-			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+			triggerExecutionContextFactory.findPublishedWorkflowData.mockResolvedValue(
 				buildWorkflowData({ nodes: [mock<INode>({ id: 'node-1', disabled: true })] }),
 			);
 

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
@@ -49,7 +49,17 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 	async execute(task: ClaimedTask, report: DispatchReporter): Promise<DispatchDecision> {
 		const { workflowId, nodeId } = this.parsePayload(task);
 		const workflowData =
-			await this.triggerExecutionContextFactory.loadPublishedWorkflowData(workflowId);
+			await this.triggerExecutionContextFactory.findPublishedWorkflowData(workflowId);
+
+		if (workflowData === null) {
+			this.logger.debug('Workflow has no published version. Skipping the occurrence', {
+				taskId: task.id,
+				jobId: task.jobId,
+				workflowId,
+				nodeId,
+			});
+			return report.notDispatched();
+		}
 		const node = this.resolveTriggerNode(workflowData, nodeId, task);
 
 		const deduplicationKey = scheduleTriggerDeduplicationKey(task);

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1632,4 +1632,39 @@ describe('TriggerExecutionContextFactory', () => {
 			},
 		);
 	});
+
+	describe('findPublishedWorkflowData', () => {
+		it.each([
+			{
+				description: 'default (cached) path',
+				options: undefined,
+				calledMethod: 'getCachedPublishedWorkflowDataForExecution' as const,
+				skippedMethod: 'getPublishedWorkflowDataForExecution' as const,
+			},
+			{
+				description: 'bypassCache path',
+				options: { bypassCache: true },
+				calledMethod: 'getPublishedWorkflowDataForExecution' as const,
+				skippedMethod: 'getCachedPublishedWorkflowDataForExecution' as const,
+			},
+		])(
+			'returns null instead of throwing when the service returns null ($description)',
+			async ({ options, calledMethod, skippedMethod }) => {
+				workflowPublishedDataService[calledMethod].mockResolvedValue(null);
+
+				await expect(factory.findPublishedWorkflowData('wf-1', options)).resolves.toBeNull();
+				expect(workflowPublishedDataService[calledMethod]).toHaveBeenCalledWith('wf-1');
+				expect(workflowPublishedDataService[skippedMethod]).not.toHaveBeenCalled();
+			},
+		);
+
+		test('returns the published workflow data when it exists', async () => {
+			const workflowData = buildPublishedWorkflowData();
+			workflowPublishedDataService.getCachedPublishedWorkflowDataForExecution.mockResolvedValue(
+				workflowData,
+			);
+
+			await expect(factory.findPublishedWorkflowData('wf-1')).resolves.toBe(workflowData);
+		});
+	});
 });

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -501,7 +501,8 @@ export class TriggerExecutionContextFactory {
 
 	/**
 	 * Builds the {@link IWorkflowBase} to execute for an active trigger from the
-	 * published data. `pinData` and `meta` are deliberately left out: they are
+	 * published data, or returns `null` when the workflow has no published
+	 * version. `pinData` and `meta` are deliberately left out: they are
 	 * irrelevant to a production trigger execution.
 	 *
 	 * Pass `bypassCache` on the poll path: the poll cursor lives in `poller_state`,
@@ -509,15 +510,28 @@ export class TriggerExecutionContextFactory {
 	 *
 	 * TODO: Add error handling / fallback strategy for transient DB failures.
 	 */
-	async loadPublishedWorkflowData(
+	async findPublishedWorkflowData(
 		workflowId: string,
 		{ bypassCache = false }: { bypassCache?: boolean } = {},
-	): Promise<IWorkflowBase> {
-		const publishedData = bypassCache
+	): Promise<IWorkflowBase | null> {
+		return bypassCache
 			? await this.workflowPublishedDataService.getPublishedWorkflowDataForExecution(workflowId)
 			: await this.workflowPublishedDataService.getCachedPublishedWorkflowDataForExecution(
 					workflowId,
 				);
+	}
+
+	/**
+	 * Same as {@link findPublishedWorkflowData}, for callers that require a
+	 * published version to exist.
+	 *
+	 * @throws {UnexpectedError} when the workflow has no published version
+	 */
+	async loadPublishedWorkflowData(
+		workflowId: string,
+		options: { bypassCache?: boolean } = {},
+	): Promise<IWorkflowBase> {
+		const publishedData = await this.findPublishedWorkflowData(workflowId, options);
 
 		if (!publishedData) {
 			throw new UnexpectedError('Published version not found for workflow', {

--- a/packages/cli/test/integration/scheduling/scheduler-trigger-handler.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduler-trigger-handler.test.ts
@@ -73,7 +73,7 @@ describe('schedule-trigger occurrence to a real execution', () => {
 	});
 
 	// A published workflow whose Schedule Trigger the handler fires. The published
-	// version mapping is what `loadPublishedWorkflowData` reads, so all three parts
+	// version mapping is what `findPublishedWorkflowData` reads, so all three parts
 	// (workflow, history, mapping) must exist.
 	const createPublishedScheduleWorkflow = async () => {
 		const triggerNodeId = uuid();


### PR DESCRIPTION
## Summary

A schedule or poll occurrence claimed just before its workflow is unpublished might fail.
The handler asked `TriggerExecutionContextFactory.loadPublishedWorkflowData()` for the published version, that call threw, and the executor retried the occurrence up to `N8N_SCHEDULER_MAX_ATTEMPTS` and then dead-lettered it. The owner teardown was already retiring the job, so the retries had no purpose.

This PR closes the gap.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4350

Review thread that raised the gap: https://github.com/n8n-io/n8n/pull/37685#discussion_r3918623975

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

