### PR TITLE
feat(engine): Route active trigger runs to the engine 2.0 data plane

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -889,6 +889,7 @@ describe('ActiveWorkflowManager', () => {
 				mock(), // nodeTypes
 				pollCursorService,
 				mock<GlobalConfig>({ scheduler: { pollTimeoutSeconds: 45, leaseDurationSeconds: 60 } }),
+				mock(), // engineV2ActiveTriggers
 			);
 
 			activeWorkflowManager = new ActiveWorkflowManager(

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
@@ -83,6 +83,9 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 		});
 
 		try {
+			// TODO(CAT-4078): an engine 2.0 run writes no execution row, so the unique
+			// index that turns a redelivered occurrence into a `DuplicateExecutionError`
+			// never applies and the redelivery starts a second run.
 			const executionId = await this.workflowExecutionService.runWorkflow(
 				workflowData,
 				node,

--- a/packages/cli/src/services/__tests__/engine-v2-dispatcher.service.test.ts
+++ b/packages/cli/src/services/__tests__/engine-v2-dispatcher.service.test.ts
@@ -31,6 +31,7 @@ const node = (id: string, name: string, type: string): INode => ({
 
 const MANUAL_TRIGGER = node('trigger-id', 'When clicking Execute', 'n8n-nodes-base.manualTrigger');
 const WEBHOOK_TRIGGER = node('webhook-id', 'Webhook', 'n8n-nodes-base.webhook');
+const SCHEDULE_TRIGGER = node('schedule-id', 'Schedule Trigger', 'n8n-nodes-base.scheduleTrigger');
 const SET_NODE = node('set-id', 'Edit Fields', 'n8n-nodes-base.set');
 
 function workflow(overrides: Partial<IWorkflowBase> = {}): IWorkflowBase {
@@ -96,6 +97,30 @@ function webhookRunData(
 	};
 }
 
+/** What `WorkflowExecutionService.runWorkflow` hands the dispatcher for an active trigger. */
+function triggerRunData(
+	main: Array<INodeExecutionData[] | null> = [[{ json: { at: '2026-09-03T07:00:00.000Z' } }]],
+	overrides: Partial<IWorkflowExecutionDataProcess> = {},
+): IWorkflowExecutionDataProcess {
+	return {
+		executionMode: 'trigger',
+		workflowData: workflow({
+			nodes: [SCHEDULE_TRIGGER, SET_NODE],
+			connections: {
+				[SCHEDULE_TRIGGER.name]: {
+					main: [[{ node: SET_NODE.name, type: NodeConnectionTypes.Main, index: 0 }]],
+				},
+			},
+		}),
+		executionData: createRunExecutionData({
+			executionData: {
+				nodeExecutionStack: [{ node: SCHEDULE_TRIGGER, data: { main }, source: null }],
+			},
+		}),
+		...overrides,
+	};
+}
+
 describe('EngineV2Dispatcher', () => {
 	const proxy = mock<EngineDataPlaneProxyService>();
 	const credentialsPermissionChecker = mock<CredentialsPermissionChecker>();
@@ -128,7 +153,11 @@ describe('EngineV2Dispatcher', () => {
 			expect(dispatcher.routesToEngineV2(webhookRunData())).toBe(true);
 		});
 
-		it.each<WorkflowExecuteMode>(['trigger', 'retry', 'chat', 'evaluation'])(
+		it('routes an active trigger run of a workflow that opted into engine 2.0', () => {
+			expect(dispatcher.routesToEngineV2(triggerRunData())).toBe(true);
+		});
+
+		it.each<WorkflowExecuteMode>(['retry', 'chat', 'evaluation'])(
 			'does not route a %s run',
 			(executionMode) => {
 				expect(dispatcher.routesToEngineV2(runData({ executionMode }))).toBe(false);
@@ -138,7 +167,14 @@ describe('EngineV2Dispatcher', () => {
 		it('answers the same question for a workflow and a mode alone', () => {
 			expect(dispatcher.handlesWorkflow(workflow(), 'webhook')).toBe(true);
 			expect(dispatcher.handlesWorkflow(workflow({ settings: {} }), 'webhook')).toBe(false);
-			expect(dispatcher.handlesWorkflow(workflow(), 'trigger')).toBe(false);
+			expect(dispatcher.handlesWorkflow(workflow(), 'trigger')).toBe(true);
+			expect(dispatcher.handlesWorkflow(workflow({ settings: {} }), 'trigger')).toBe(false);
+		});
+
+		it('does not route a polled run, which hands `run` its own execution row', () => {
+			const existingExecution = mock<ResumableExecution>({ executionId: '42' });
+
+			expect(dispatcher.routesToEngineV2(triggerRunData(), existingExecution)).toBe(false);
 		});
 
 		it('does not route a resumed execution', () => {
@@ -338,6 +374,44 @@ describe('EngineV2Dispatcher', () => {
 				});
 
 				await expect(dispatcher.start(data)).resolves.toMatch(UUID_V7_PATTERN);
+			});
+		});
+
+		describe('an active trigger run', () => {
+			it('starts a production run on the engine', async () => {
+				const executionId = await dispatcher.start(triggerRunData());
+
+				expect(proxy.startExecution).toHaveBeenCalledWith(
+					expect.objectContaining({ executionId, workflowId: 'wf-1', mode: 'production' }),
+				);
+			});
+
+			it('roots the graph at the trigger node and makes it the trigger step', async () => {
+				await dispatcher.start(triggerRunData());
+
+				const { graph } = proxy.startExecution.mock.calls[0][0];
+				expect(graph.nodes).toEqual([
+					expect.objectContaining({
+						id: SCHEDULE_TRIGGER.id,
+						name: SCHEDULE_TRIGGER.name,
+						type: 'trigger',
+					}),
+					expect.objectContaining({ id: SET_NODE.id, type: 'v1-node' }),
+				]);
+			});
+
+			it('takes the payload from the trigger node output', async () => {
+				await dispatcher.start(triggerRunData([[{ json: { at: 'now' } }]]));
+
+				expect(proxy.startExecution.mock.calls[0][0].triggerOutputs).toEqual([
+					[{ json: { at: 'now' } }],
+				]);
+			});
+
+			it('registers no push session, because a production trigger run has no watcher', async () => {
+				await dispatcher.start(triggerRunData());
+
+				expect(pushRegistry.register).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/cli/src/services/__tests__/engine-v2-payload-guard.service.test.ts
+++ b/packages/cli/src/services/__tests__/engine-v2-payload-guard.service.test.ts
@@ -1,0 +1,111 @@
+import type { Logger } from '@n8n/backend-common';
+import type { BinaryDataService } from 'n8n-core';
+import type { IBinaryData, INodeExecutionData } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { EngineV2PayloadGuard } from '@/services/engine-v2-payload-guard.service';
+
+const REASON = 'Engine 2.0 cannot receive files from a trigger yet.';
+
+/** A file the control plane wrote to storage, so it has an id to delete. */
+const stored = (id: string): IBinaryData => mock<IBinaryData>({ id, mimeType: 'text/plain' });
+
+/** A file that rides on the item, so there is nothing to delete. */
+const inMemory = (): IBinaryData =>
+	mock<IBinaryData>({ id: undefined, data: 'aGk=', mimeType: 'text/plain' });
+
+describe('EngineV2PayloadGuard', () => {
+	const binaryDataService = mock<BinaryDataService>();
+	const logger = mock<Logger>();
+
+	let guard: EngineV2PayloadGuard;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		binaryDataService.deleteManyByBinaryDataId.mockResolvedValue(undefined);
+		guard = new EngineV2PayloadGuard(binaryDataService, logger);
+	});
+
+	describe('assertNoFiles', () => {
+		it.each([
+			{ name: 'no slots', slots: [] },
+			{ name: 'an empty slot', slots: [[]] },
+			{ name: 'a null slot', slots: [null] },
+			{ name: 'items with no binary key', slots: [[{ json: {} }]] },
+			{ name: 'an empty binary map', slots: [[{ json: {}, binary: {} }]] },
+		])('allows a payload with $name', async ({ slots }) => {
+			await expect(guard.assertNoFiles(slots, REASON)).resolves.toBeUndefined();
+			expect(binaryDataService.deleteManyByBinaryDataId).not.toHaveBeenCalled();
+		});
+
+		it('refuses a stored file and deletes it, because no execution will own it', async () => {
+			const slots = [[{ json: {}, binary: { attachment: stored('filesystem:abc') } }]];
+
+			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(REASON);
+			expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
+				'filesystem:abc',
+			]);
+		});
+
+		it('deletes every stored file across slots and items', async () => {
+			const slots: Array<INodeExecutionData[] | null> = [
+				[
+					{ json: {}, binary: { a: stored('filesystem:1') } },
+					{ json: {}, binary: { b: stored('filesystem:2'), c: inMemory() } },
+				],
+				null,
+				[{ json: {}, binary: { d: stored('filesystem:3') } }],
+			];
+
+			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(UserError);
+			expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
+				'filesystem:1',
+				'filesystem:2',
+				'filesystem:3',
+			]);
+		});
+
+		it('refuses an in-memory file without a delete, as it has no id', async () => {
+			const slots = [[{ json: {}, binary: { attachment: inMemory() } }]];
+
+			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(REASON);
+			expect(binaryDataService.deleteManyByBinaryDataId).not.toHaveBeenCalled();
+		});
+
+		it('keeps the reason when the delete fails, and logs the leak', async () => {
+			binaryDataService.deleteManyByBinaryDataId.mockRejectedValue(new Error('store is down'));
+			const slots = [[{ json: {}, binary: { attachment: stored('s3:abc') } }]];
+
+			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(REASON);
+			expect(logger.error).toHaveBeenCalledWith(
+				'Failed to delete the files of a rejected engine 2.0 payload',
+				expect.objectContaining({ error: expect.any(Error) }),
+			);
+		});
+	});
+
+	describe('discardFiles', () => {
+		it('deletes the stored files without refusing', async () => {
+			const slots = [[{ json: {}, binary: { attachment: stored('filesystem:abc') } }]];
+
+			await expect(guard.discardFiles(slots)).resolves.toBeUndefined();
+			expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
+				'filesystem:abc',
+			]);
+		});
+
+		it('does nothing for a payload with no files', async () => {
+			await expect(guard.discardFiles([[{ json: {} }]])).resolves.toBeUndefined();
+			expect(binaryDataService.deleteManyByBinaryDataId).not.toHaveBeenCalled();
+		});
+
+		it('never throws when the delete fails, so the caller keeps its own answer', async () => {
+			binaryDataService.deleteManyByBinaryDataId.mockRejectedValue(new Error('store is down'));
+			const slots = [[{ json: {}, binary: { attachment: stored('s3:abc') } }]];
+
+			await expect(guard.discardFiles(slots)).resolves.toBeUndefined();
+			expect(logger.error).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/services/engine-v2-dispatcher.service.ts
+++ b/packages/cli/src/services/engine-v2-dispatcher.service.ts
@@ -25,7 +25,7 @@ type FiredTrigger = {
 };
 
 /** Execution modes the v2 path serves today. */
-const ROUTED_MODES = new Set<WorkflowExecuteMode>(['manual', 'webhook']);
+const ROUTED_MODES = new Set<WorkflowExecuteMode>(['manual', 'webhook', 'trigger']);
 
 /** v1's payload for a manual run with no trigger data: one slot, one empty item. */
 const DEFAULT_MAIN_OUTPUT: INodeExecutionData[][] = [[{ json: {} }]];
@@ -59,9 +59,8 @@ export class EngineV2Dispatcher {
 	) {}
 
 	/**
-	 * Manual and webhook runs for now; the trigger entry path (CAT-2921) reuses
-	 * this seam later. A resume must not start a fresh data-plane execution,
-	 * hence the `existingExecution` check.
+	 * Manual, webhook and active trigger runs. A resume must not start a fresh
+	 * data-plane execution, hence the `existingExecution` check.
 	 */
 	routesToEngineV2(
 		data: IWorkflowExecutionDataProcess,
@@ -108,7 +107,8 @@ export class EngineV2Dispatcher {
 				workflowId: workflowData.id,
 				graph,
 				triggerOutputs: this.toTriggerOutputs(trigger.outputs, toStepOutputs),
-				// Only manual and webhook route here, so anything else is a production run.
+				// Only manual, webhook and trigger route here, so anything that is not a
+				// manual run is a production run.
 				mode: data.executionMode === 'manual' ? 'manual' : 'production',
 			});
 		} catch (error) {

--- a/packages/cli/src/services/engine-v2-payload-guard.service.ts
+++ b/packages/cli/src/services/engine-v2-payload-guard.service.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import { BinaryDataService } from 'n8n-core';
+import type { IBinaryData, INodeExecutionData } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+
+/** Output slots as a trigger produces them; v1 uses `null` for a slot it has no data for. */
+type PayloadSlots = Array<INodeExecutionData[] | null | undefined>;
+
+/**
+ * Guards the files a trigger payload carries on the engine 2.0 path.
+ *
+ * The engine takes its payload as JSON, so an item's binary data cannot travel
+ * with it. Worse, the control plane may already have written the file to
+ * storage by the time the refusal happens, and a v2 run keeps no control-plane
+ * execution row — so no execution ever owns the file and no pruning ever
+ * reclaims it. Every refusal that discards such a payload deletes its files
+ * here instead.
+ *
+ * Shared by every v2 entry path whose trigger can produce files: the webhook
+ * surface and the active-trigger surface.
+ */
+@Service()
+export class EngineV2PayloadGuard {
+	constructor(
+		private readonly binaryDataService: BinaryDataService,
+		private readonly logger: Logger,
+	) {}
+
+	/**
+	 * Rejects a payload that carries files, deleting any already stored.
+	 *
+	 * `reason` names the surface, so the user hears which trigger could not be
+	 * served rather than a generic message.
+	 */
+	async assertNoFiles(slots: PayloadSlots, reason: string): Promise<void> {
+		const files = this.filesIn(slots);
+		if (files.length === 0) return;
+
+		await this.deleteStoredFiles(files);
+
+		throw new UserError(reason);
+	}
+
+	/**
+	 * Deletes the files of a payload that is being discarded for some other
+	 * reason. Never throws: the caller's own refusal is the answer.
+	 */
+	async discardFiles(slots: PayloadSlots): Promise<void> {
+		const files = this.filesIn(slots);
+		if (files.length === 0) return;
+
+		await this.deleteStoredFiles(files);
+	}
+
+	/** An empty `binary` map carries no file, so it does not count. */
+	private filesIn(slots: PayloadSlots): IBinaryData[] {
+		return slots.flatMap((slot) => slot ?? []).flatMap((item) => Object.values(item.binary ?? {}));
+	}
+
+	/**
+	 * Only stored modes give a file an id; in memory the data rides on the item and
+	 * there is nothing to delete. A failed delete leaks a file, which must not
+	 * replace the caller's reason with a storage error.
+	 */
+	private async deleteStoredFiles(files: IBinaryData[]): Promise<void> {
+		const storedIds = files.map((file) => file.id).filter((id) => id !== undefined);
+		if (storedIds.length === 0) return;
+
+		try {
+			await this.binaryDataService.deleteManyByBinaryDataId(storedIds);
+		} catch (error) {
+			this.logger.error('Failed to delete the files of a rejected engine 2.0 payload', { error });
+		}
+	}
+}

--- a/packages/cli/src/webhooks/engine-v2-webhooks.ts
+++ b/packages/cli/src/webhooks/engine-v2-webhooks.ts
@@ -1,6 +1,4 @@
-import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import { BinaryDataService } from 'n8n-core';
 import type {
 	INode,
 	IWebhookResponseData,
@@ -20,6 +18,7 @@ import {
 
 import { MCP_TRIGGER_NODE_TYPE } from '@/constants';
 import { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
+import { EngineV2PayloadGuard } from '@/services/engine-v2-payload-guard.service';
 
 /**
  * Trigger types the v2 path cannot serve. Each carries machinery the engine
@@ -54,8 +53,7 @@ export type EngineV2WebhookRequest = {
 export class EngineV2Webhooks {
 	constructor(
 		private readonly dispatcher: EngineV2Dispatcher,
-		private readonly binaryDataService: BinaryDataService,
-		private readonly logger: Logger,
+		private readonly payloadGuard: EngineV2PayloadGuard,
 	) {}
 
 	/** Whether this webhook run starts on the engine 2.0 data plane. */
@@ -113,35 +111,12 @@ export class EngineV2Webhooks {
 	 * Rejects a payload the engine cannot carry.
 	 *
 	 * Only the webhook node's own output says whether the request brought a file,
-	 * so this runs after the node, unlike {@link assertSupported}. In stored binary
-	 * modes the file is already written by then, and no execution will ever own it,
-	 * so it is deleted here rather than left for an execution pruning that never
-	 * comes.
+	 * so this runs after the node, unlike {@link assertSupported}.
 	 */
 	async assertPayloadSupported(webhookResultData: IWebhookResponseData): Promise<void> {
-		const items = (webhookResultData.workflowData ?? []).flatMap((slot) => slot ?? []);
-		// An empty `binary` map carries no file, so it does not count.
-		const files = items.flatMap((item) => Object.values(item.binary ?? {}));
-		if (files.length === 0) return;
-
-		await this.deleteStoredFiles(files.map((file) => file.id));
-
-		throw new UserError('Engine 2.0 cannot receive files from a webhook yet.');
-	}
-
-	/**
-	 * Only stored modes give a file an id; in memory the data rides on the item and
-	 * there is nothing to delete. A failed delete leaks a file, which must not
-	 * replace the caller's reason with a storage error.
-	 */
-	private async deleteStoredFiles(ids: Array<string | undefined>): Promise<void> {
-		const storedIds = ids.filter((id) => id !== undefined);
-		if (storedIds.length === 0) return;
-
-		try {
-			await this.binaryDataService.deleteManyByBinaryDataId(storedIds);
-		} catch (error) {
-			this.logger.error('Failed to delete the files of a rejected engine 2.0 webhook', { error });
-		}
+		await this.payloadGuard.assertNoFiles(
+			webhookResultData.workflowData ?? [],
+			'Engine 2.0 cannot receive files from a webhook yet.',
+		);
 	}
 }

--- a/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
@@ -1,0 +1,66 @@
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import type { IExecuteResponsePromiseData, IRun, IWorkflowBase } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
+import { EngineV2ActiveTriggers } from '@/workflows/triggers/engine-v2-active-triggers';
+
+describe('EngineV2ActiveTriggers', () => {
+	const dispatcher = mock<EngineV2Dispatcher>();
+	const workflowData = mock<IWorkflowBase>();
+
+	let engineV2ActiveTriggers: EngineV2ActiveTriggers;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		engineV2ActiveTriggers = new EngineV2ActiveTriggers(dispatcher);
+	});
+
+	describe('handles', () => {
+		it.each([true, false])('answers what the dispatcher answers: %s', (routes) => {
+			dispatcher.handlesWorkflow.mockReturnValue(routes);
+
+			expect(engineV2ActiveTriggers.handles(workflowData, 'trigger')).toBe(routes);
+			expect(dispatcher.handlesWorkflow).toHaveBeenCalledWith(workflowData, 'trigger');
+		});
+	});
+
+	describe('assertSupported', () => {
+		it('allows an emit that does not wait for its run', () => {
+			expect(() => engineV2ActiveTriggers.assertSupported({})).not.toThrow();
+		});
+
+		it.each([
+			{
+				name: 'a response promise',
+				emit: { responsePromise: mock<IDeferredPromise<IExecuteResponsePromiseData>>() },
+			},
+			{
+				name: 'a done promise',
+				emit: { donePromise: mock<IDeferredPromise<IRun | undefined>>() },
+			},
+			{
+				name: 'both promises',
+				emit: {
+					responsePromise: mock<IDeferredPromise<IExecuteResponsePromiseData>>(),
+					donePromise: mock<IDeferredPromise<IRun | undefined>>(),
+				},
+			},
+		])('refuses an emit that carries $name', ({ emit }) => {
+			expect(() => engineV2ActiveTriggers.assertSupported(emit)).toThrow(UserError);
+			expect(() => engineV2ActiveTriggers.assertSupported(emit)).toThrow(
+				'Engine 2.0 cannot run a trigger that waits for its execution to finish yet. Set the node to hand off without waiting.',
+			);
+		});
+	});
+
+	describe('assertPollSupported', () => {
+		it('always refuses', () => {
+			expect(() => engineV2ActiveTriggers.assertPollSupported()).toThrow(UserError);
+			expect(() => engineV2ActiveTriggers.assertPollSupported()).toThrow(
+				'Engine 2.0 cannot run polling triggers yet.',
+			);
+		});
+	});
+});

--- a/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
@@ -1,20 +1,24 @@
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
-import type { IExecuteResponsePromiseData, IRun, IWorkflowBase } from 'n8n-workflow';
+import type { IBinaryData, IExecuteResponsePromiseData, IRun, IWorkflowBase } from 'n8n-workflow';
 import { UserError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
+import type { EngineV2PayloadGuard } from '@/services/engine-v2-payload-guard.service';
 import { EngineV2ActiveTriggers } from '@/workflows/triggers/engine-v2-active-triggers';
 
 describe('EngineV2ActiveTriggers', () => {
 	const dispatcher = mock<EngineV2Dispatcher>();
+	const payloadGuard = mock<EngineV2PayloadGuard>();
 	const workflowData = mock<IWorkflowBase>();
 
 	let engineV2ActiveTriggers: EngineV2ActiveTriggers;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		engineV2ActiveTriggers = new EngineV2ActiveTriggers(dispatcher);
+		payloadGuard.assertNoFiles.mockResolvedValue(undefined);
+		payloadGuard.discardFiles.mockResolvedValue(undefined);
+		engineV2ActiveTriggers = new EngineV2ActiveTriggers(dispatcher, payloadGuard);
 	});
 
 	describe('handles', () => {
@@ -52,6 +56,35 @@ describe('EngineV2ActiveTriggers', () => {
 			expect(() => engineV2ActiveTriggers.assertSupported(emit)).toThrow(
 				'Engine 2.0 cannot run a trigger that waits for its execution to finish yet. Set the node to hand off without waiting.',
 			);
+		});
+	});
+
+	describe('assertPayloadSupported', () => {
+		it('asks the guard to refuse files, naming the trigger surface', async () => {
+			const slots = [[{ json: {}, binary: { data: mock<IBinaryData>() } }]];
+
+			await engineV2ActiveTriggers.assertPayloadSupported(slots);
+
+			expect(payloadGuard.assertNoFiles).toHaveBeenCalledWith(
+				slots,
+				'Engine 2.0 cannot receive files from a trigger yet.',
+			);
+		});
+
+		it('surfaces the refusal the guard raises', async () => {
+			payloadGuard.assertNoFiles.mockRejectedValue(new UserError('nope'));
+
+			await expect(engineV2ActiveTriggers.assertPayloadSupported([[]])).rejects.toThrow('nope');
+		});
+	});
+
+	describe('discardFiles', () => {
+		it('hands the payload to the guard', async () => {
+			const slots = [[{ json: {} }]];
+
+			await engineV2ActiveTriggers.discardFiles(slots);
+
+			expect(payloadGuard.discardFiles).toHaveBeenCalledWith(slots);
 		});
 	});
 

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -6,7 +6,7 @@ import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { sleep } from '@n8n/utils/sleep';
 import type { ErrorReporter, IGetExecutePollFunctions, StorageConfig } from 'n8n-core';
-import { UnexpectedError, Workflow } from 'n8n-workflow';
+import { UnexpectedError, UserError, Workflow } from 'n8n-workflow';
 import type {
 	Cron,
 	CronExpression,
@@ -40,6 +40,8 @@ import type {
 	PublishedWorkflowDataForExecution,
 	WorkflowPublishedDataService,
 } from '@/workflows/workflow-published-data.service';
+import type { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
+import { EngineV2ActiveTriggers } from '@/workflows/triggers/engine-v2-active-triggers';
 import type { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
 import { createNodeTypes } from './trigger-test-utils';
@@ -63,6 +65,10 @@ describe('TriggerExecutionContextFactory', () => {
 	const scheduleCollectionSession = mock<ScheduleTriggerCollectionSession>();
 	const ownershipService = mock<OwnershipService>();
 	const nodeTypes = createNodeTypes();
+	// The real service over a mocked dispatcher: `engineV2Dispatcher.handlesWorkflow`
+	// is the only input, and the refusals under test stay the production ones.
+	const engineV2Dispatcher = mock<EngineV2Dispatcher>();
+	const engineV2ActiveTriggers = new EngineV2ActiveTriggers(engineV2Dispatcher);
 
 	let factory: TriggerExecutionContextFactory;
 	let errorReporter: ErrorReporter;
@@ -80,6 +86,7 @@ describe('TriggerExecutionContextFactory', () => {
 		);
 
 		scheduleTriggerJobRegistrar.interceptsNode.mockReturnValue(false);
+		engineV2Dispatcher.handlesWorkflow.mockReturnValue(false);
 		scopedLogger = mock<Logger>();
 		const rootLogger = mock<Logger>({ scoped: vi.fn().mockReturnValue(scopedLogger) });
 		errorReporter = mock<ErrorReporter>();
@@ -99,6 +106,7 @@ describe('TriggerExecutionContextFactory', () => {
 			nodeTypes,
 			pollCursorService,
 			mock<GlobalConfig>({ scheduler: { pollTimeoutSeconds: 45, leaseDurationSeconds: 60 } }),
+			engineV2ActiveTriggers,
 		);
 	});
 
@@ -1025,6 +1033,7 @@ describe('TriggerExecutionContextFactory', () => {
 					nodeTypes,
 					pollCursorService,
 					globalConfig,
+					engineV2ActiveTriggers,
 				);
 				const getPollFunctions = budgetFactory.getExecutePollFunctions(
 					mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
@@ -1665,6 +1674,128 @@ describe('TriggerExecutionContextFactory', () => {
 			);
 
 			await expect(factory.findPublishedWorkflowData('wf-1')).resolves.toBe(workflowData);
+		});
+	});
+
+	describe('on engine 2.0', () => {
+		const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+		const additionalData = mock<IWorkflowExecuteAdditionalData>();
+		const mode: WorkflowExecuteMode = 'trigger';
+		const activation: WorkflowActivateMode = 'activate';
+		const workflow = mock<Workflow>({ id: 'wf-1', name: 'Test Workflow' });
+
+		const triggerContext = () => {
+			const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+				workflowData,
+				additionalData,
+				mode,
+				activation,
+				async () => workflowData,
+				mock<TriggerFailureHandler>(),
+				scheduleCollectionSession,
+			);
+			return getTriggerFunctions(
+				workflow,
+				mock<INode>({ name: 'Trigger Node' }),
+				additionalData,
+				mode,
+				activation,
+			);
+		};
+
+		const pollContext = () => {
+			const getPollFunctions = factory.getExecutePollFunctions(
+				workflowData,
+				additionalData,
+				mode,
+				activation,
+				async () => workflowData,
+			);
+			return getPollFunctions(
+				workflow,
+				mock<INode>({ name: 'Poll Node' }),
+				additionalData,
+				mode,
+				activation,
+			);
+		};
+
+		describe('an active trigger', () => {
+			beforeEach(() => {
+				engineV2Dispatcher.handlesWorkflow.mockReturnValue(true);
+			});
+
+			test('hands a plain emit to the runner, which dispatches it', async () => {
+				triggerContext().emit([[{ json: {} }]]);
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalled();
+			});
+
+			test('refuses an emit that waits for its run, and starts nothing', async () => {
+				const donePromise = createDeferredPromise<IRun>();
+
+				triggerContext().emit([[{ json: {} }]], undefined, donePromise);
+				// Attached before the flush, as the nodes do: they await the promise on the
+				// line after `emit`, so the rejection is never unhandled.
+				const refused = expect(donePromise.promise).rejects.toThrow(
+					'Engine 2.0 cannot run a trigger that waits for its execution to finish yet',
+				);
+
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+				await refused;
+			});
+
+			test('rejects the response promise too, so the node does not wait forever', async () => {
+				const responsePromise = createDeferredPromise<IExecuteResponsePromiseData>();
+				const donePromise = createDeferredPromise<IRun>();
+
+				triggerContext().emit([[{ json: {} }]], responsePromise, donePromise);
+				const refused = Promise.all([
+					expect(responsePromise.promise).rejects.toThrow(
+						'Engine 2.0 cannot run a trigger that waits for its execution to finish yet',
+					),
+					expect(donePromise.promise).rejects.toThrow(UserError),
+				]);
+
+				await sleep(0);
+				await refused;
+			});
+		});
+
+		describe('a poll trigger', () => {
+			test('refuses the emit and commits no cursor', () => {
+				engineV2Dispatcher.handlesWorkflow.mockReturnValue(true);
+
+				expect(() => pollContext().__emit([[{ json: {} }]])).toThrow(
+					'Engine 2.0 cannot run polling triggers yet.',
+				);
+				expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+				expect(workflowExecutionService.runPolledWorkflow).not.toHaveBeenCalled();
+				expect(pollCursorService.commitWithExecution).not.toHaveBeenCalled();
+				expect(pollCursorService.commitCursorOnly).not.toHaveBeenCalled();
+				expect(workflowStaticDataService.saveStaticData).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('a workflow that did not opt in', () => {
+			test('runs an emit that waits for its run, as it does today', async () => {
+				const donePromise = createDeferredPromise<IRun>();
+
+				triggerContext().emit([[{ json: {} }]], undefined, donePromise);
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalled();
+			});
+
+			test('runs a polled emit, as it does today', async () => {
+				pollContext().__emit([[{ json: {} }]]);
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalled();
+			});
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -5,12 +5,18 @@ import type { Project, WorkflowEntity } from '@n8n/db';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { sleep } from '@n8n/utils/sleep';
-import type { ErrorReporter, IGetExecutePollFunctions, StorageConfig } from 'n8n-core';
+import type {
+	BinaryDataService,
+	ErrorReporter,
+	IGetExecutePollFunctions,
+	StorageConfig,
+} from 'n8n-core';
 import { UnexpectedError, UserError, Workflow } from 'n8n-workflow';
 import type {
 	Cron,
 	CronExpression,
 	ExecutionError,
+	IBinaryData,
 	IConnections,
 	IExecuteResponsePromiseData,
 	INode,
@@ -41,6 +47,7 @@ import type {
 	WorkflowPublishedDataService,
 } from '@/workflows/workflow-published-data.service';
 import type { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
+import { EngineV2PayloadGuard } from '@/services/engine-v2-payload-guard.service';
 import { EngineV2ActiveTriggers } from '@/workflows/triggers/engine-v2-active-triggers';
 import type { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
@@ -68,7 +75,11 @@ describe('TriggerExecutionContextFactory', () => {
 	// The real service over a mocked dispatcher: `engineV2Dispatcher.handlesWorkflow`
 	// is the only input, and the refusals under test stay the production ones.
 	const engineV2Dispatcher = mock<EngineV2Dispatcher>();
-	const engineV2ActiveTriggers = new EngineV2ActiveTriggers(engineV2Dispatcher);
+	const binaryDataService = mock<BinaryDataService>();
+	const engineV2ActiveTriggers = new EngineV2ActiveTriggers(
+		engineV2Dispatcher,
+		new EngineV2PayloadGuard(binaryDataService, mock<Logger>()),
+	);
 
 	let factory: TriggerExecutionContextFactory;
 	let errorReporter: ErrorReporter;
@@ -1678,6 +1689,9 @@ describe('TriggerExecutionContextFactory', () => {
 	});
 
 	describe('on engine 2.0', () => {
+		/** An attachment already written to storage, so it has an id to delete. */
+		const storedFile = mock<IBinaryData>({ id: 'filesystem:abc', mimeType: 'text/plain' });
+
 		const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
 		const additionalData = mock<IWorkflowExecuteAdditionalData>();
 		const mode: WorkflowExecuteMode = 'trigger';
@@ -1748,6 +1762,34 @@ describe('TriggerExecutionContextFactory', () => {
 				await refused;
 			});
 
+			test('refuses an emit carrying a file, and deletes what it stored', async () => {
+				const data: INodeExecutionData[][] = [[{ json: {}, binary: { attachment: storedFile } }]];
+
+				triggerContext().emit(data);
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+				// No execution will ever own the file, so nothing else would reclaim it.
+				expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
+					'filesystem:abc',
+				]);
+			});
+
+			test('deletes the files even when the emit is refused for waiting on its run', async () => {
+				const data: INodeExecutionData[][] = [[{ json: {}, binary: { attachment: storedFile } }]];
+				const donePromise = createDeferredPromise<IRun>();
+
+				triggerContext().emit(data, undefined, donePromise);
+				const refused = expect(donePromise.promise).rejects.toThrow(UserError);
+
+				await sleep(0);
+
+				expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
+					'filesystem:abc',
+				]);
+				await refused;
+			});
+
 			test('rejects the response promise too, so the node does not wait forever', async () => {
 				const responsePromise = createDeferredPromise<IExecuteResponsePromiseData>();
 				const donePromise = createDeferredPromise<IRun>();
@@ -1766,9 +1808,22 @@ describe('TriggerExecutionContextFactory', () => {
 		});
 
 		describe('a poll trigger', () => {
-			test('refuses the emit and commits no cursor', () => {
+			beforeEach(() => {
 				engineV2Dispatcher.handlesWorkflow.mockReturnValue(true);
+			});
 
+			test('deletes the attachments the refused poll stored', async () => {
+				const data: INodeExecutionData[][] = [[{ json: {}, binary: { attachment: storedFile } }]];
+
+				expect(() => pollContext().__emit(data)).toThrow(UserError);
+				await sleep(0);
+
+				expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
+					'filesystem:abc',
+				]);
+			});
+
+			test('refuses the emit and commits no cursor', () => {
 				expect(() => pollContext().__emit([[{ json: {} }]])).toThrow(
 					'Engine 2.0 cannot run polling triggers yet.',
 				);

--- a/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
+++ b/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
@@ -1,0 +1,69 @@
+import { Service } from '@n8n/di';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import type {
+	IExecuteResponsePromiseData,
+	IRun,
+	IWorkflowBase,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+
+import { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
+
+/** What an active trigger asks for when it hands items over. */
+export type EngineV2ActiveTriggerEmit = {
+	/** Set when the node wants the response a node inside the run produced. */
+	responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>;
+	/** Set when the node wants the finished run. */
+	donePromise?: IDeferredPromise<IRun | undefined>;
+};
+
+/**
+ * The active-trigger surface's seam to engine 2.0.
+ *
+ * The trigger node itself still runs control-plane-side, so only the start call
+ * changes for a v2 workflow. This decides whether a run takes that path, and
+ * rejects the parts of the surface the path does not serve yet.
+ *
+ * A workflow that opted into engine 2.0 never falls back to v1, so each case
+ * fails with the reason instead. These checks live here rather than in
+ * {@link EngineV2Dispatcher} because they need the emit's promises, which never
+ * reach the dispatcher.
+ */
+@Service()
+export class EngineV2ActiveTriggers {
+	constructor(private readonly dispatcher: EngineV2Dispatcher) {}
+
+	/** Whether this trigger run starts on the engine 2.0 data plane. */
+	handles(workflowData: IWorkflowBase, mode: WorkflowExecuteMode): boolean {
+		return this.dispatcher.handlesWorkflow(workflowData, mode);
+	}
+
+	/**
+	 * Rejects an emit that waits for its own run.
+	 *
+	 * A node passes either promise when it settles its source only once the run
+	 * finishes — a broker ack, a consumer offset. A v2 run keeps no control-plane
+	 * execution row, so `getPostExecutePromise` has nothing to await and neither
+	 * promise can carry a result. Starting the run anyway would leave the node
+	 * waiting, and its source would redeliver the same message forever.
+	 */
+	assertSupported({ responsePromise, donePromise }: EngineV2ActiveTriggerEmit): void {
+		if (responsePromise === undefined && donePromise === undefined) return;
+
+		throw new UserError(
+			'Engine 2.0 cannot run a trigger that waits for its execution to finish yet. Set the node to hand off without waiting.',
+		);
+	}
+
+	/**
+	 * Rejects a polled emit.
+	 *
+	 * A migrated poll node commits its cursor in the same transaction as the
+	 * execution row, which a v2 run does not create.
+	 * TODO(CAT-4078): commit the cursor against a data-plane execution instead.
+	 */
+	assertPollSupported(): never {
+		throw new UserError('Engine 2.0 cannot run polling triggers yet.');
+	}
+}

--- a/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
+++ b/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
@@ -2,6 +2,7 @@ import { Service } from '@n8n/di';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	IExecuteResponsePromiseData,
+	INodeExecutionData,
 	IRun,
 	IWorkflowBase,
 	WorkflowExecuteMode,
@@ -9,6 +10,7 @@ import type {
 import { UserError } from 'n8n-workflow';
 
 import { EngineV2Dispatcher } from '@/services/engine-v2-dispatcher.service';
+import { EngineV2PayloadGuard } from '@/services/engine-v2-payload-guard.service';
 
 /** What an active trigger asks for when it hands items over. */
 export type EngineV2ActiveTriggerEmit = {
@@ -32,7 +34,10 @@ export type EngineV2ActiveTriggerEmit = {
  */
 @Service()
 export class EngineV2ActiveTriggers {
-	constructor(private readonly dispatcher: EngineV2Dispatcher) {}
+	constructor(
+		private readonly dispatcher: EngineV2Dispatcher,
+		private readonly payloadGuard: EngineV2PayloadGuard,
+	) {}
 
 	/** Whether this trigger run starts on the engine 2.0 data plane. */
 	handles(workflowData: IWorkflowBase, mode: WorkflowExecuteMode): boolean {
@@ -54,6 +59,29 @@ export class EngineV2ActiveTriggers {
 		throw new UserError(
 			'Engine 2.0 cannot run a trigger that waits for its execution to finish yet. Set the node to hand off without waiting.',
 		);
+	}
+
+	/**
+	 * Rejects an emit that carries files, deleting any the trigger already stored.
+	 *
+	 * The engine takes its payload as JSON, so a file cannot travel with it. Only
+	 * the node's own output says whether it produced one, so this runs on the emit
+	 * rather than at activation. Email Read IMAP is the case that matters today:
+	 * it downloads attachments and passes no promise, so nothing else refuses it.
+	 */
+	async assertPayloadSupported(slots: Array<INodeExecutionData[] | null>): Promise<void> {
+		await this.payloadGuard.assertNoFiles(
+			slots,
+			'Engine 2.0 cannot receive files from a trigger yet.',
+		);
+	}
+
+	/**
+	 * Deletes the files of an emit refused for another reason, so a payload the
+	 * poll path turns away does not leave them behind. Never throws.
+	 */
+	async discardFiles(slots: Array<INodeExecutionData[] | null>): Promise<void> {
+		await this.payloadGuard.discardFiles(slots);
 	}
 
 	/**

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -41,6 +41,8 @@ import type { ScheduleTriggerCollectionSession } from '@/scheduling/schedule-tri
 import { ScheduleTriggerJobRegistrar } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
 import { OwnershipService } from '@/services/ownership.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import type { EngineV2ActiveTriggerEmit } from '@/workflows/triggers/engine-v2-active-triggers';
+import { EngineV2ActiveTriggers } from '@/workflows/triggers/engine-v2-active-triggers';
 import { PollCursorService } from '@/workflows/triggers/poll-cursor.service';
 import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
@@ -82,6 +84,7 @@ export class TriggerExecutionContextFactory {
 		private readonly nodeTypes: NodeTypes,
 		private readonly pollCursorService: PollCursorService,
 		private readonly globalConfig: GlobalConfig,
+		private readonly engineV2ActiveTriggers: EngineV2ActiveTriggers,
 	) {
 		this.logger = this.logger.scoped(['workflow-activation']);
 	}
@@ -104,6 +107,22 @@ export class TriggerExecutionContextFactory {
 					: await this.activeExecutions.getPostExecutePromise(executionId),
 			)
 			.then(donePromise.resolve, (error: unknown) => donePromise.reject(ensureError(error)));
+	}
+
+	/**
+	 * Refuses an emit the engine 2.0 path cannot carry, settling the response
+	 * promise on the way out. `runWorkflow` never receives that promise when the
+	 * emit is refused, and an unsettled deferred promise leaves the node waiting.
+	 * The done promise needs no help here: {@link settleDonePromise} rejects it
+	 * from the returned promise chain.
+	 */
+	private assertEngineV2Supported(emit: EngineV2ActiveTriggerEmit): void {
+		try {
+			this.engineV2ActiveTriggers.assertSupported(emit);
+		} catch (error) {
+			emit.responsePromise?.reject(ensureError(error));
+			throw error;
+		}
 	}
 
 	/**
@@ -179,18 +198,23 @@ export class TriggerExecutionContextFactory {
 				// can feature-flag between in-memory data and the published data
 				// service. Once the flag is removed, we'll call the service directly.
 				const executePromise = resolveWorkflowData()
-					.then(
-						async (freshWorkflowData) =>
-							await this.workflowExecutionService.runWorkflow(
-								freshWorkflowData,
-								node,
-								data,
-								additionalData,
-								mode,
-								responsePromise,
-								deduplicationKey,
-							),
-					)
+					.then(async (freshWorkflowData) => {
+						// Checked against the fresh data, so this agrees with the dispatcher,
+						// which decides on the same copy.
+						if (this.engineV2ActiveTriggers.handles(freshWorkflowData, mode)) {
+							this.assertEngineV2Supported({ responsePromise, donePromise });
+						}
+
+						return await this.workflowExecutionService.runWorkflow(
+							freshWorkflowData,
+							node,
+							data,
+							additionalData,
+							mode,
+							responsePromise,
+							deduplicationKey,
+						);
+					})
 					.catch((error: unknown) => {
 						if (error instanceof DuplicateExecutionError) {
 							const context = {
@@ -336,6 +360,13 @@ export class TriggerExecutionContextFactory {
 				donePromise?: IDeferredPromise<IRun | undefined>,
 			) => {
 				this.logger.debug(`Received event to trigger execution for workflow "${workflow.name}"`);
+
+				// Ahead of the cursor take, so a refused poll leaves its window to be
+				// retried. Reads the registration's copy of the workflow rather than the
+				// fresh one for the same reason: the fresh read comes too late.
+				if (this.engineV2ActiveTriggers.handles(workflowData, mode)) {
+					this.engineV2ActiveTriggers.assertPollSupported();
+				}
 
 				const cursor = takeStagedCursor();
 

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -116,8 +116,15 @@ export class TriggerExecutionContextFactory {
 	 * The done promise needs no help here: {@link settleDonePromise} rejects it
 	 * from the returned promise chain.
 	 */
-	private assertEngineV2Supported(emit: EngineV2ActiveTriggerEmit): void {
+	private async assertEngineV2Supported(
+		data: INodeExecutionData[][],
+		emit: EngineV2ActiveTriggerEmit,
+	): Promise<void> {
 		try {
+			// Files first, because this check deletes what it refuses: a refusal for
+			// any other reason would otherwise leave the stored files behind, owned by
+			// no execution.
+			await this.engineV2ActiveTriggers.assertPayloadSupported(data);
 			this.engineV2ActiveTriggers.assertSupported(emit);
 		} catch (error) {
 			emit.responsePromise?.reject(ensureError(error));
@@ -202,7 +209,7 @@ export class TriggerExecutionContextFactory {
 						// Checked against the fresh data, so this agrees with the dispatcher,
 						// which decides on the same copy.
 						if (this.engineV2ActiveTriggers.handles(freshWorkflowData, mode)) {
-							this.assertEngineV2Supported({ responsePromise, donePromise });
+							await this.assertEngineV2Supported(data, { responsePromise, donePromise });
 						}
 
 						return await this.workflowExecutionService.runWorkflow(
@@ -365,6 +372,11 @@ export class TriggerExecutionContextFactory {
 				// retried. Reads the registration's copy of the workflow rather than the
 				// fresh one for the same reason: the fresh read comes too late.
 				if (this.engineV2ActiveTriggers.handles(workflowData, mode)) {
+					// Detached because `__emit` is synchronous. The poll may have stored
+					// attachments, and no execution will ever own them.
+					void this.engineV2ActiveTriggers
+						.discardFiles(data)
+						.catch((error: unknown) => this.logTriggerExecutionFailure(error, workflowData, node));
 					this.engineV2ActiveTriggers.assertPollSupported();
 				}
 

--- a/packages/cli/test/integration/engine-v2-active-triggers.test.ts
+++ b/packages/cli/test/integration/engine-v2-active-triggers.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Active trigger runs of an `engineType=v2` workflow (CAT-2921).
+ *
+ * The trigger node still runs control-plane-side; only the start call changes.
+ * Every active trigger — the durable schedule handler and the in-memory emit
+ * closures alike — hands off through `WorkflowExecutionService.runWorkflow`, so
+ * these tests drive that funnel and assert what reaches the data plane.
+ */
+
+import { createWorkflow, mockInstance, testDb } from '@n8n/backend-test-utils';
+import { UUID_V7_PATTERN } from '@n8n/constants';
+import type { User, WorkflowEntity } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { INode, INodeExecutionData } from 'n8n-workflow';
+import { NodeConnectionTypes, SCHEDULE_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
+
+import { EngineDataPlaneProxyService } from '@/services/engine-data-plane-proxy.service';
+import { Telemetry } from '@/telemetry';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+
+import { getAllExecutions } from './shared/db/executions';
+import { createOwner } from './shared/db/users';
+import { initNodeTypes, setupTestServer } from './shared/utils';
+
+mockInstance(Telemetry);
+
+setupTestServer({ endpointGroups: ['workflows'] });
+
+const TRIGGER_NAME = 'Schedule Trigger';
+const SET_NAME = 'Edit Fields';
+
+const startExecution = vi.fn();
+const getExecution = vi.fn();
+
+let builder: User;
+
+const triggerNode = (): INode => ({
+	id: randomUUID(),
+	name: TRIGGER_NAME,
+	type: SCHEDULE_TRIGGER_NODE_TYPE,
+	typeVersion: 1.2,
+	position: [0, 0],
+	parameters: { rule: { interval: [{ field: 'minutes' }] } },
+});
+
+const setNode = (): INode => ({
+	id: randomUUID(),
+	name: SET_NAME,
+	type: 'n8n-nodes-base.set',
+	typeVersion: 3.4,
+	position: [220, 0],
+	parameters: { options: {} },
+});
+
+const createV2Workflow = async () =>
+	await createWorkflow(
+		{
+			active: false,
+			nodes: [triggerNode(), setNode()],
+			connections: {
+				[TRIGGER_NAME]: {
+					main: [[{ node: SET_NAME, type: NodeConnectionTypes.Main, index: 0 }]],
+				},
+			},
+			settings: { engineType: 'v2' },
+		},
+		builder,
+	);
+
+/** The hand-off every active trigger makes when it emits items. */
+const handOff = async (workflow: WorkflowEntity, items: INodeExecutionData[][]) => {
+	const additionalData = await WorkflowExecuteAdditionalData.getBase({
+		workflowId: workflow.id,
+		workflowSettings: workflow.settings,
+	});
+
+	return await Container.get(WorkflowExecutionService).runWorkflow(
+		workflow,
+		workflow.nodes[0],
+		items,
+		additionalData,
+		'trigger',
+	);
+};
+
+beforeAll(async () => {
+	await initNodeTypes();
+	Container.get(EngineDataPlaneProxyService).registerProvider({ startExecution, getExecution });
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['ExecutionEntity', 'SharedWorkflow', 'WorkflowEntity']);
+	vi.clearAllMocks();
+
+	// Deliberately not the id the control plane minted, so a caller echoing the
+	// data plane back would fail the assertion below.
+	startExecution.mockResolvedValue({ executionId: 'a3c1e0f2-0000-4000-8000-000000000001' });
+
+	builder = await createOwner();
+});
+
+describe('active trigger runs on engine 2.0', () => {
+	test('hands the trigger payload to the data plane and persists no execution', async () => {
+		const workflow = await createV2Workflow();
+		const item = { json: { 'Readable date': 'September 3, 2026' } };
+
+		const executionId = await handOff(workflow, [[item]]);
+
+		expect(executionId).toMatch(UUID_V7_PATTERN);
+
+		expect(startExecution).toHaveBeenCalledTimes(1);
+		const request = startExecution.mock.calls[0][0];
+		expect(request.executionId).toBe(executionId);
+		expect(request.workflowId).toBe(workflow.id);
+		// An active trigger run is never a manual run.
+		expect(request.mode).toBe('production');
+		// The trigger node's own output, not a placeholder.
+		expect(request.triggerOutputs[0][0].json).toMatchObject(item.json);
+		// The graph is rooted at the trigger node, which becomes the trigger step.
+		expect(request.graph.nodes).toEqual([
+			expect.objectContaining({ name: TRIGGER_NAME, type: 'trigger' }),
+			expect.objectContaining({ name: SET_NAME, type: 'v1-node' }),
+		]);
+
+		// The data plane is the only store for a v2 run.
+		const executions = await getAllExecutions();
+		expect(executions.filter((e) => e.workflowId === workflow.id)).toHaveLength(0);
+	});
+
+	test('keeps a workflow that did not opt in on the control plane', async () => {
+		const workflow = await createV2Workflow();
+		workflow.settings = {};
+
+		await handOff(workflow, [[{ json: {} }]]);
+
+		expect(startExecution).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Route active trigger runs to the engine 2.0. CAT-2922 did this for manual runs, CAT-2920 for webhooks, this
adds the third path.

Refused explicitly:
- An emit that waits for its run (RabbitMQ, Kafka, MQTT, AMQP in waiting
  mode) — nothing can settle the promise, so the source redelivers forever.
- A polled emit — the cursor commit needs an execution row. CAT-4078.
- An emit with files — the engine only takes JSON. Any stored files are
  deleted, since no execution will own them.

**Known gap:** schedule dedup needs an execution row too. A redelivered
occurrence can start a duplicate run until CAT-4078. Marked with a `TODO`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2921

Stacked on https://github.com/n8n-io/n8n/pull/37657

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
