### PR TITLE
fix(core): Inline reused schema instances in MCP tool schemas (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/tool-schema.util.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/tool-schema.util.test.ts
@@ -88,4 +88,37 @@ describe('shapeToStandardSchema', () => {
 			value: { executionId: null, status: 'error', error: 'workflow failed' },
 		});
 	});
+
+	// A Zod instance reused across two properties must be inlined at both use
+	// sites. The generator's default strategy dedupes the second occurrence into
+	// a `$ref` to a `#/properties/...` path, which strict clients (e.g. Zod v4's
+	// `fromJSONSchema`) refuse to resolve — they only follow refs into `$defs` —
+	// leaving the tool's arguments unvalidated client-side.
+	it('inlines a schema instance that is reused across the shape instead of emitting a $ref', () => {
+		const sharedPosition = z.array(z.number()).length(2).describe('Canvas [x, y].');
+		const reusing = shapeToStandardSchema({
+			node: z.object({ position: sharedPosition.optional() }).optional(),
+			position: sharedPosition.optional().describe('For setNodePosition.'),
+		});
+
+		const json = reusing['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
+
+		expect(JSON.stringify(json)).not.toContain('$ref');
+		expect(json.properties).toMatchObject({
+			node: {
+				type: 'object',
+				properties: {
+					position: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+				},
+			},
+			// The second occurrence keeps its own description override.
+			position: {
+				type: 'array',
+				items: { type: 'number' },
+				minItems: 2,
+				maxItems: 2,
+				description: 'For setNodePosition.',
+			},
+		});
+	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -25,6 +25,7 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
+import { shapeToStandardSchema } from '../tool-schema.util';
 import { createUpdateWorkflowTool } from '../tools/workflow-builder/update-workflow.tool';
 import { NON_FATAL_OPERATION_TYPES } from '../tools/workflow-builder/workflow-operations';
 
@@ -249,6 +250,23 @@ describe('update-workflow MCP tool', () => {
 			);
 			expect(typeof tool.handler).toBe('function');
 		});
+
+		// Regression for GH #36780: a Zod instance shared between the `node.position`
+		// and operation-level `position` properties was deduped into a
+		// `$ref: "#/properties/..."` pointer, which strict MCP clients cannot
+		// resolve — they only follow refs into `$defs` — leaving this tool's
+		// arguments unvalidated client-side.
+		test.each([{ canvasGroupsEnabled: false }, { canvasGroupsEnabled: true }])(
+			'served input schema is self-contained — no JSON pointer refs (canvasGroupsEnabled: $canvasGroupsEnabled)',
+			({ canvasGroupsEnabled }) => {
+				const tool = createTool({ canvasGroupsEnabled });
+				const served = shapeToStandardSchema(tool.config.inputSchema!)[
+					'~standard'
+				].jsonSchema.input({ target: 'draft-2020-12' });
+
+				expect(JSON.stringify(served)).not.toContain('$ref');
+			},
+		);
 	});
 
 	describe('docs mention the non-fatal group exception only when canvasGroupsEnabled', () => {

--- a/packages/cli/src/modules/mcp/tool-schema.util.ts
+++ b/packages/cli/src/modules/mcp/tool-schema.util.ts
@@ -16,7 +16,13 @@ export function shapeToStandardSchema<Shape extends z.ZodRawShape>(
 	z.objectOutputType<Shape, z.ZodTypeAny>
 > {
 	const schema = z.object(shape);
-	const jsonSchema = zodToDraft202012(schema);
+	// `$refStrategy: 'none'` inlines schema instances that are reused across the
+	// shape. The default strategy dedupes a reused instance into a `$ref` to an
+	// arbitrary `#/properties/...` path, which common client-side validators
+	// (e.g. Zod v4's `fromJSONSchema`) refuse to resolve — they only follow refs
+	// into `$defs`/`definitions`. Inlining also matches Zod v4's `toJSONSchema`
+	// default (`reused: 'inline'`), the migration target for this bridge.
+	const jsonSchema = zodToDraft202012(schema, { $refStrategy: 'none' });
 
 	return {
 		'~standard': {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -92,7 +92,11 @@ const buildOperationTypeSchema = (canvasGroupsEnabled: boolean) =>
 	canvasGroupsEnabled
 		? z.enum([...baseOperationTypes, ...gatedGroupOperationTypes])
 		: z.enum(baseOperationTypes);
-const positionInputSchema = z.array(z.number()).length(2).describe('Canvas [x, y].');
+// A factory, not a shared instance: reusing one Zod instance across two
+// properties makes the JSON Schema generator dedupe the second occurrence into
+// a `$ref` to a `#/properties/...` path, which strict MCP clients cannot
+// resolve. Mirrors `positionSchema` in workflow-operations.ts.
+const positionInputSchema = () => z.array(z.number()).length(2).describe('Canvas [x, y].');
 const credentialsInputSchema = z.record(
 	z.string(),
 	z.object({ id: z.string().optional(), name: z.string() }),
@@ -102,7 +106,7 @@ const nodeInputSchema = z.object({
 	type: z.string().describe('Node type, e.g. "n8n-nodes-base.set".'),
 	typeVersion: z.number(),
 	parameters: z.record(z.string(), z.unknown()).optional(),
-	position: positionInputSchema.optional(),
+	position: positionInputSchema().optional(),
 	credentials: credentialsInputSchema.optional(),
 	disabled: z.boolean().optional(),
 	notes: z.string().optional(),
@@ -168,7 +172,7 @@ const buildOperationInputSchema = (canvasGroupsEnabled: boolean) =>
 			credentialKey: z.string().optional().describe('For setNodeCredential.'),
 			credentialId: z.string().optional().describe('For setNodeCredential.'),
 			credentialName: z.string().optional().describe('For setNodeCredential.'),
-			position: positionInputSchema.optional().describe('For setNodePosition.'),
+			position: positionInputSchema().optional().describe('For setNodePosition.'),
 			disabled: z.boolean().optional().describe('For setNodeDisabled.'),
 			settings: combinedSettingsInputSchema
 				.optional()


### PR DESCRIPTION
## Summary

The instance-level MCP server served an `update_workflow` input schema that contained a `$ref` pointing at a `#/properties/...` path. The JSON Schema generator dedupes a Zod instance that is reused across two properties into a positional pointer. Strict MCP clients (for example Zod v4's `fromJSONSchema`) resolve `$ref` only into `$defs`/`definitions`, so they failed to rehydrate the schema and passed tool arguments through unvalidated.

This PR makes every served tool schema self-contained:

- `tool-schema.util.ts` now passes `$refStrategy: 'none'`, so reused schema instances are inlined for all MCP tools. This matches Zod v4's `toJSONSchema` default (`reused: 'inline'`), the migration target for this bridge.
- `positionInputSchema` in `update-workflow.tool.ts` is now a factory, which mirrors `positionSchema` in `workflow-operations.ts`.
- Regression tests: the bridge inlines reused instances, and the real `update_workflow` input schema contains no `$ref` in both `canvasGroupsEnabled` variants.

## How to test

1. Run the unit tests: `pnpm test tool-schema.util update-workflow.tool` in
   `packages/cli`.
2. Optional live check: enable Instance-level MCP in Settings, call
   `tools/list` on `<instance>/mcp-server/http`, and confirm the response
   contains no `"$ref"`.


## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5819

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

