### PR TITLE
feat(Zendesk Node): Add support for PKCE and client credentials grant types

### DIFF
--- a/packages/nodes-base/credentials/ZendeskOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ZendeskOAuth2Api.credentials.ts
@@ -24,7 +24,22 @@ export class ZendeskOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Grant Type',
 			name: 'grantType',
-			type: 'hidden',
+			type: 'options',
+			options: [
+				{
+					name: 'Authorization Code',
+					value: 'authorizationCode',
+				},
+				{
+					name: 'Client Credentials',
+					value: 'clientCredentials',
+				},
+				{
+					name: 'PKCE',
+					value: 'pkce',
+				},
+			],
+			// Default stays authorizationCode so already-saved credentials keep working
 			default: 'authorizationCode',
 		},
 		{

--- a/packages/nodes-base/credentials/test/ZendeskOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/ZendeskOAuth2Api.credentials.test.ts
@@ -20,6 +20,18 @@ describe('ZendeskOAuth2Api Credential', () => {
 		);
 	});
 
+	it('should allow selection of the grant type', () => {
+		const grantTypeProperty = credential.properties.find((p) => p.name === 'grantType');
+		expect(grantTypeProperty?.type).toBe('options');
+		expect(grantTypeProperty?.options).toEqual([
+			{ name: 'Authorization Code', value: 'authorizationCode' },
+			{ name: 'Client Credentials', value: 'clientCredentials' },
+			{ name: 'PKCE', value: 'pkce' },
+		]);
+		// authorizationCode stays the default so already-saved credentials keep working
+		expect(grantTypeProperty?.default).toBe('authorizationCode');
+	});
+
 	it('should use body authentication', () => {
 		const authenticationProperty = credential.properties.find((p) => p.name === 'authentication');
 		expect(authenticationProperty?.type).toBe('hidden');


### PR DESCRIPTION
## Summary

The Zendesk OAuth2 credential locks the grant type to a hidden `authorizationCode` value. This change makes the grant type selectable. Users can select Authorization Code, Client Credentials, or PKCE.

Zendesk requires PKCE for OAuth clients that are marked as **Public**. The public client kind disables the client credentials flow for the client. The current credential cannot connect to these clients. Zendesk supports the client credentials grant for OAuth clients that are marked as **Confidential**.

The options match the grant types of the generic OAuth2 API credential. The core OAuth2 flow already supports all three values, so no backend change is needed. The default stays `authorizationCode`, so already-saved credentials keep working.

## How to test

1. Create an OAuth client in Zendesk Admin Center with the redirect URL `<n8n-url>/rest/oauth2-credential/callback`.
2. Create a new Zendesk OAuth2 API credential in n8n. Check that the **Grant Type** dropdown shows Authorization Code, Client Credentials, and PKCE, with Authorization Code selected by default.
3. Mark the Zendesk OAuth client as public. Select **PKCE** in n8n, enter the subdomain, client ID, and client secret, and connect. The OAuth flow must complete and the Zendesk node must run.
4. Mark the Zendesk OAuth client as confidential. Select **Client Credentials** in n8n and connect. The credential must authenticate and the Zendesk node must run.
5. Open a Zendesk OAuth2 credential that was saved before this change. It must still authenticate without edits.

## Related Linear tickets, Github issues, and Community forum posts

Feature request on the community forum: https://community.n8n.io/t/zendesk-oauth2-credential-support-pkce-and-client-credentials-grant-types/310978

Docs PR: https://github.com/n8n-io/n8n-docs/pull/5319

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




