### PR TITLE
feat(Microsoft Teams Node): Add chat member operations (add, list, remove)

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
@@ -8,6 +8,8 @@ const defaultScopes = [
 	'User.Read.All',
 	'Group.ReadWrite.All',
 	'Chat.ReadWrite',
+	// Removing a chat member has no higher-privileged alternative, so this scope is mandatory
+	'ChatMember.ReadWrite',
 	'ChannelMessage.Read.All',
 	'OnlineMeetings.ReadWrite',
 ];

--- a/packages/nodes-base/credentials/test/MicrosoftTeamsOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftTeamsOAuth2Api.credentials.test.ts
@@ -11,6 +11,7 @@ describe('MicrosoftTeamsOAuth2Api Credential', () => {
 		'User.Read.All',
 		'Group.ReadWrite.All',
 		'Chat.ReadWrite',
+		'ChatMember.ReadWrite',
 		'ChannelMessage.Read.All',
 		'OnlineMeetings.ReadWrite',
 	];
@@ -71,7 +72,7 @@ describe('MicrosoftTeamsOAuth2Api Credential', () => {
 			(p) => p.name === 'enabledScopes',
 		);
 		expect(enabledScopesProperty?.default).toBe(
-			'openid offline_access User.Read.All Group.ReadWrite.All Chat.ReadWrite ChannelMessage.Read.All OnlineMeetings.ReadWrite',
+			'openid offline_access User.Read.All Group.ReadWrite.All Chat.ReadWrite ChatMember.ReadWrite ChannelMessage.Read.All OnlineMeetings.ReadWrite',
 		);
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
@@ -1,4 +1,8 @@
-import type { INodeCredentialDescription, INodeProperties } from 'n8n-workflow';
+import type {
+	INodeCredentialDescription,
+	INodeProperties,
+	INodePropertyOptions,
+} from 'n8n-workflow';
 
 import { MicrosoftTeamsTrigger } from '../MicrosoftTeamsTrigger.node';
 import { versionDescription } from '../v2/actions/versionDescription';
@@ -81,5 +85,23 @@ describe.each(cases)('$name authentication selector', ({ properties, credentials
 		);
 
 		expect(credentialGatedByDefault?.name).toBe('microsoftTeamsOAuth2Api');
+	});
+});
+
+// Outside the describe.each above: the trigger carries its own separately-worded
+// description, which this contract does not cover.
+describe('Microsoft Teams action (v2) generic credential scope hint', () => {
+	it('names ChatMember.ReadWrite and User.Read.All in the microsoftOAuth2Api option', () => {
+		const authProperty = versionDescription.properties.find(
+			(property) => property.name === 'authentication',
+		);
+		const genericOption = (authProperty?.options ?? []).find(
+			(option) => 'value' in option && option.value === 'microsoftOAuth2Api',
+		);
+
+		expect(genericOption).toBeDefined();
+		const description = (genericOption as INodePropertyOptions).description ?? '';
+		expect(description).toContain('ChatMember.ReadWrite');
+		expect(description).toContain('User.Read.All');
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.body.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.body.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../../../v2/transport', async () => {
 	};
 });
 
-describe('Microsoft Teams V2 — chatMember:add request body', () => {
+describe('Microsoft Teams V2 - chatMember:add request body', () => {
 	let node: MicrosoftTeamsV2;
 	let ctx: MockProxy<IExecuteFunctions>;
 	const apiRequest = transport.microsoftApiRequest as Mock;
@@ -109,7 +109,7 @@ describe('Microsoft Teams V2 — chatMember:add request body', () => {
 	});
 
 	// Every Entra B2B guest principal name carries `#EXT#`, which the Graph id
-	// validator rejects — guests have to be given by object ID.
+	// validator rejects - guests have to be given by object ID.
 	it('rejects a guest UPN containing #EXT# before any request', async () => {
 		setParams(addParams({ userId: 'alias_contoso.com#EXT#@tenant.onmicrosoft.com', options: {} }));
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.body.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.body.test.ts
@@ -1,0 +1,132 @@
+import type { IExecuteFunctions, INode, NodeParameterValueType } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+// Real transport except the network helper, so buildTeamsPath/validateTeamsId and
+// getGraphBaseUrl run for real; only microsoftApiRequest is stubbed.
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+describe('Microsoft Teams V2 — chatMember:add request body', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+	const userId = 'e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111';
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown): NodeParameterValueType =>
+				(name in params ? params[name] : fallback) as NodeParameterValueType,
+		);
+	};
+
+	const addParams = (params: Record<string, unknown>) => ({
+		authentication: 'microsoftTeamsOAuth2Api',
+		resource: 'chatMember',
+		operation: 'add',
+		chatId: '19:abc@thread.v2',
+		userId,
+		...params,
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = mock<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		// `getGraphBaseUrl` is the real implementation here, so the credential must
+		// resolve or every case would fail on an unrelated TypeError instead.
+		ctx.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+		ctx.helpers.returnJsonArray = vi.fn((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+		ctx.helpers.constructExecutionMetaData = vi.fn(
+			(data) => data,
+		) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+	});
+
+	it('sends the 0001-01-01T00:00:00Z sentinel for All history', async () => {
+		setParams(addParams({ options: { shareHistory: 'all' } }));
+
+		await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledWith('POST', '/v1.0/chats/19:abc@thread.v2/members', {
+			'@odata.type': '#microsoft.graph.aadUserConversationMember',
+			'user@odata.bind': `https://graph.microsoft.com/v1.0/users/${userId}`,
+			roles: ['owner'],
+			visibleHistoryStartDateTime: '0001-01-01T00:00:00Z',
+		});
+	});
+
+	it('sends the selected date for From Date', async () => {
+		setParams(
+			addParams({
+				options: { shareHistory: 'fromDate', historyStartDate: '2026-08-01T00:00:00Z' },
+			}),
+		);
+
+		await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledWith('POST', '/v1.0/chats/19:abc@thread.v2/members', {
+			'@odata.type': '#microsoft.graph.aadUserConversationMember',
+			'user@odata.bind': `https://graph.microsoft.com/v1.0/users/${userId}`,
+			roles: ['owner'],
+			visibleHistoryStartDateTime: '2026-08-01T00:00:00Z',
+		});
+	});
+
+	it('throws when From Date is selected without a date, and issues no request', async () => {
+		setParams(addParams({ options: { shareHistory: 'fromDate', historyStartDate: '' } }));
+
+		await expect(node.execute.call(ctx)).rejects.toThrow('No history start date was given');
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('sends roles: ["guest"] when the Guest role is selected', async () => {
+		setParams(addParams({ options: { role: 'guest' } }));
+
+		await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledWith('POST', '/v1.0/chats/19:abc@thread.v2/members', {
+			'@odata.type': '#microsoft.graph.aadUserConversationMember',
+			'user@odata.bind': `https://graph.microsoft.com/v1.0/users/${userId}`,
+			roles: ['guest'],
+		});
+	});
+
+	// Every Entra B2B guest principal name carries `#EXT#`, which the Graph id
+	// validator rejects — guests have to be given by object ID.
+	it('rejects a guest UPN containing #EXT# before any request', async () => {
+		setParams(addParams({ userId: 'alias_contoso.com#EXT#@tenant.onmicrosoft.com', options: {} }));
+
+		await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('uses the credential graphApiBaseUrl in user@odata.bind (sovereign cloud)', async () => {
+		ctx.getCredentials.mockResolvedValue({ graphApiBaseUrl: 'https://graph.microsoft.us' });
+		setParams(addParams({ options: {} }));
+
+		await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledWith('POST', '/v1.0/chats/19:abc@thread.v2/members', {
+			'@odata.type': '#microsoft.graph.aadUserConversationMember',
+			'user@odata.bind': `https://graph.microsoft.us/v1.0/users/${userId}`,
+			roles: ['owner'],
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.test.ts
@@ -1,0 +1,22 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, chatMember => add', () => {
+	// The body spec is deep-equal, so this also pins that omitting the History option
+	// sends NO visibleHistoryStartDateTime at all.
+	nock('https://graph.microsoft.com')
+		.post('/v1.0/chats/19:ebed9ad42c904d6c83adf0db360053ec@thread.v2/members', {
+			'@odata.type': '#microsoft.graph.aadUserConversationMember',
+			'user@odata.bind':
+				'https://graph.microsoft.com/v1.0/users/e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111',
+			roles: ['owner'],
+		})
+		.reply(201);
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['add.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.upn.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.upn.test.ts
@@ -1,0 +1,28 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+/**
+ * A user principal name given in By-ID mode must reach Graph verbatim, so this runs
+ * through the harness rather than calling `execute` directly: only the harness puts
+ * core's extract-value step in the loop, which is what a GUID-only `extractValue` on
+ * `userRLC` would break.
+ */
+describe('Test MicrosoftTeamsV2, chatMember => add with a user principal name', () => {
+	const scope = nock('https://graph.microsoft.com')
+		.post('/v1.0/chats/19:ebed9ad42c904d6c83adf0db360053ec@thread.v2/members', {
+			'@odata.type': '#microsoft.graph.aadUserConversationMember',
+			'user@odata.bind': 'https://graph.microsoft.com/v1.0/users/jacob@contoso.com',
+			roles: ['owner'],
+		})
+		.reply(201);
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['add.upn.workflow.json'],
+		// The interceptor is single-use and net connect is disabled, so a second
+		// outgoing request would fail the run: this pins exactly one.
+		customAssertions: () => expect(scope.isDone()).toBe(true),
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.upn.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.upn.workflow.json
@@ -1,0 +1,93 @@
+{
+	"name": "Teams chatMember add by UPN",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "chatMember",
+				"operation": "add",
+				"chatId": {
+					"__rl": true,
+					"value": "19:ebed9ad42c904d6c83adf0db360053ec@thread.v2",
+					"mode": "list",
+					"cachedResultName": "Project team (group)"
+				},
+				"userId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "jacob@contoso.com"
+				},
+				"options": {}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "8a1b2c3d-0002-4000-8000-000000000002",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/add.workflow.json
@@ -1,0 +1,94 @@
+{
+	"name": "Teams chatMember add",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "chatMember",
+				"operation": "add",
+				"chatId": {
+					"__rl": true,
+					"value": "19:ebed9ad42c904d6c83adf0db360053ec@thread.v2",
+					"mode": "list",
+					"cachedResultName": "Project team (group)"
+				},
+				"userId": {
+					"__rl": true,
+					"value": "e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111",
+					"mode": "list",
+					"cachedResultName": "Ann Smith (ann@contoso.com)"
+				},
+				"options": {}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "8a1b2c3d-0001-4000-8000-000000000001",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.returnAll.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.returnAll.workflow.json
@@ -1,0 +1,105 @@
+{
+	"name": "Teams chatMember getAll returnAll",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "chatMember",
+				"operation": "getAll",
+				"chatId": {
+					"__rl": true,
+					"value": "19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2",
+					"mode": "list",
+					"cachedResultName": "Project team (group)"
+				},
+				"returnAll": true
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==",
+					"roles": ["owner"],
+					"displayName": "Ann Smith",
+					"userId": "e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111",
+					"email": "ann@contoso.com",
+					"tenantId": "23786ca6-7ff2-4672-87d0-5c649ee0a337",
+					"visibleHistoryStartDateTime": "0001-01-01T00:00:00Z"
+				}
+			},
+			{
+				"json": {
+					"id": "MCMjMSMj",
+					"roles": ["owner"],
+					"displayName": "Bob Jones",
+					"userId": "aa11bb22-5c3f-4f1e-9d5e-4d8f0f6ab222",
+					"email": "bob@contoso.com",
+					"tenantId": "23786ca6-7ff2-4672-87d0-5c649ee0a337",
+					"visibleHistoryStartDateTime": null
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "8a1b2c3d-0004-4000-8000-000000000004",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.test.ts
@@ -1,0 +1,50 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+const member1 = {
+	id: 'MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==',
+	roles: ['owner'],
+	displayName: 'Ann Smith',
+	userId: 'e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111',
+	email: 'ann@contoso.com',
+	tenantId: '23786ca6-7ff2-4672-87d0-5c649ee0a337',
+	visibleHistoryStartDateTime: '0001-01-01T00:00:00Z',
+};
+const member2 = {
+	id: 'MCMjMSMj',
+	roles: ['owner'],
+	displayName: 'Bob Jones',
+	userId: 'aa11bb22-5c3f-4f1e-9d5e-4d8f0f6ab222',
+	email: 'bob@contoso.com',
+	tenantId: '23786ca6-7ff2-4672-87d0-5c649ee0a337',
+	visibleHistoryStartDateTime: null,
+};
+
+describe('Test MicrosoftTeamsV2, chatMember => getAll', () => {
+	// Registered WITHOUT `.query(...)`: this endpoint supports no OData parameters, so
+	// the test fails if `$top` is ever added.
+	nock('https://graph.microsoft.com')
+		.get('/v1.0/chats/19:ebed9ad42c904d6c83adf0db360053ec@thread.v2/members')
+		.reply(200, { value: [member1, member2] });
+
+	// Two pages for the returnAll workflow, on its own chat id so the interceptors
+	// cannot be matched in the wrong order. The nextLink must stay same-origin or the
+	// transport refuses it.
+	nock('https://graph.microsoft.com')
+		.get('/v1.0/chats/19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2/members')
+		.reply(200, {
+			value: [member1],
+			'@odata.nextLink':
+				'https://graph.microsoft.com/v1.0/chats/19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2/members?$skiptoken=page2',
+		})
+		.get('/v1.0/chats/19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2/members')
+		.query({ $skiptoken: 'page2' })
+		.reply(200, { value: [member2] });
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['getAll.workflow.json', 'getAll.returnAll.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.workflow.json
@@ -1,0 +1,94 @@
+{
+	"name": "Teams chatMember getAll",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "chatMember",
+				"operation": "getAll",
+				"chatId": {
+					"__rl": true,
+					"value": "19:ebed9ad42c904d6c83adf0db360053ec@thread.v2",
+					"mode": "list",
+					"cachedResultName": "Project team (group)"
+				},
+				"limit": 1
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==",
+					"roles": ["owner"],
+					"displayName": "Ann Smith",
+					"userId": "e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111",
+					"email": "ann@contoso.com",
+					"tenantId": "23786ca6-7ff2-4672-87d0-5c649ee0a337",
+					"visibleHistoryStartDateTime": "0001-01-01T00:00:00Z"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "8a1b2c3d-0003-4000-8000-000000000003",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.error.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.error.test.ts
@@ -17,7 +17,7 @@ import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
  * real transport builds, so the rejection is injected at the request-library layer
  * to prove the whole chain, not just that the code branches on a hand-set property.
  */
-describe('Microsoft Teams V2 — chatMember:remove error surfacing', () => {
+describe('Microsoft Teams V2 - chatMember:remove error surfacing', () => {
 	let node: MicrosoftTeamsV2;
 	let ctx: MockProxy<IExecuteFunctions>;
 	let requestOAuth2: Mock;

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.error.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.error.test.ts
@@ -28,6 +28,15 @@ describe('Microsoft Teams V2 — chatMember:remove error surfacing', () => {
 			error: { error: { code, message } },
 		});
 
+	const executeAndCatch = async () => {
+		try {
+			await node.execute.call(ctx);
+		} catch (error) {
+			return error as NodeApiError | NodeOperationError;
+		}
+		throw new Error('execute was expected to throw');
+	};
+
 	const setParams = (params: Record<string, unknown>) => {
 		ctx.getNodeParameter.mockImplementation(
 			(name: string, _itemIndex?: number, fallback?: unknown): NodeParameterValueType =>
@@ -66,15 +75,14 @@ describe('Microsoft Teams V2 — chatMember:remove error surfacing', () => {
 			),
 		);
 
-		const error = await node.execute.call(ctx).catch((e: Error) => e);
+		const error = await executeAndCatch();
 
 		expect(error).toBeInstanceOf(NodeOperationError);
 		// Graph's own text stays the message: a 403 here is not necessarily a scope problem.
 		expect(error.message).toContain('Insufficient privileges to complete the operation.');
-		const { description } = error as NodeOperationError;
-		expect(description).toContain('ChatMember.ReadWrite');
-		expect(description).toContain('reconnect');
-		expect(description).toContain('Enabled Scopes');
+		expect(error.description).toContain('ChatMember.ReadWrite');
+		expect(error.description).toContain('reconnect');
+		expect(error.description).toContain('Enabled Scopes');
 		expect(requestOAuth2).toHaveBeenCalledTimes(1);
 	});
 
@@ -83,7 +91,7 @@ describe('Microsoft Teams V2 — chatMember:remove error surfacing', () => {
 			graphError(404, 'itemNotFound', 'The requested item was not found.'),
 		);
 
-		const error = await node.execute.call(ctx).catch((e: Error) => e);
+		const error = await executeAndCatch();
 
 		expect(error).toBeInstanceOf(NodeApiError);
 		expect((error as NodeApiError).httpCode).toBe('404');

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.error.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.error.test.ts
@@ -1,0 +1,93 @@
+import {
+	NodeApiError,
+	NodeOperationError,
+	type IExecuteFunctions,
+	type INode,
+	type NodeParameterValueType,
+} from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+
+/**
+ * The transport is NOT mocked here: the 403 rewrite keys off the `NodeApiError` the
+ * real transport builds, so the rejection is injected at the request-library layer
+ * to prove the whole chain, not just that the code branches on a hand-set property.
+ */
+describe('Microsoft Teams V2 — chatMember:remove error surfacing', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+	let requestOAuth2: Mock;
+
+	const graphError = (statusCode: number, code: string, message: string) =>
+		Object.assign(new Error(`${statusCode}`), {
+			statusCode,
+			error: { error: { code, message } },
+		});
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown): NodeParameterValueType =>
+				(name in params ? params[name] : fallback) as NodeParameterValueType,
+		);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = mock<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		// Without this the real transport throws a TypeError before reaching
+		// requestOAuth2, and a bare rejects.toThrow() would pass on that instead.
+		ctx.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+		requestOAuth2 = vi.fn();
+		ctx.helpers.requestOAuth2 = requestOAuth2;
+		setParams({
+			authentication: 'microsoftTeamsOAuth2Api',
+			resource: 'chatMember',
+			operation: 'remove',
+			chatId: '19:abc@thread.v2',
+			membershipId: 'MCMjMiMj',
+		});
+	});
+
+	it('a 403 is rewritten with a description naming ChatMember.ReadWrite and the reconnect', async () => {
+		requestOAuth2.mockRejectedValue(
+			graphError(
+				403,
+				'Authorization_RequestDenied',
+				'Insufficient privileges to complete the operation.',
+			),
+		);
+
+		const error = await node.execute.call(ctx).catch((e: Error) => e);
+
+		expect(error).toBeInstanceOf(NodeOperationError);
+		// Graph's own text stays the message: a 403 here is not necessarily a scope problem.
+		expect(error.message).toContain('Insufficient privileges to complete the operation.');
+		const { description } = error as NodeOperationError;
+		expect(description).toContain('ChatMember.ReadWrite');
+		expect(description).toContain('reconnect');
+		expect(description).toContain('Enabled Scopes');
+		expect(requestOAuth2).toHaveBeenCalledTimes(1);
+	});
+
+	it('a 404 passes through unchanged', async () => {
+		requestOAuth2.mockRejectedValue(
+			graphError(404, 'itemNotFound', 'The requested item was not found.'),
+		);
+
+		const error = await node.execute.call(ctx).catch((e: Error) => e);
+
+		expect(error).toBeInstanceOf(NodeApiError);
+		expect((error as NodeApiError).httpCode).toBe('404');
+		expect(error.message).toContain('The requested item was not found.');
+		expect(requestOAuth2).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.test.ts
@@ -1,0 +1,19 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftTeamsV2, chatMember => remove', () => {
+	// The base64 membership id has to be the last path segment - a `userId` here would
+	// not match.
+	nock('https://graph.microsoft.com')
+		.delete(
+			'/v1.0/chats/19:ebed9ad42c904d6c83adf0db360053ec@thread.v2/members/MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==',
+		)
+		.reply(204);
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['remove.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/remove.workflow.json
@@ -1,0 +1,93 @@
+{
+	"name": "Teams chatMember remove",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "chatMember",
+				"operation": "remove",
+				"chatId": {
+					"__rl": true,
+					"value": "19:ebed9ad42c904d6c83adf0db360053ec@thread.v2",
+					"mode": "list",
+					"cachedResultName": "Project team (group)"
+				},
+				"membershipId": {
+					"__rl": true,
+					"value": "MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==",
+					"mode": "list",
+					"cachedResultName": "Ann Smith (ann@contoso.com)"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "8a1b2c3d-0005-4000-8000-000000000005",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -72,6 +72,27 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
 	});
 
+	it.each(['add', 'getAll', 'remove'])(
+		'chatMember:%s throws a static error and issues no request under SP',
+		async (operation) => {
+			selectSp({
+				resource: 'chatMember',
+				operation,
+				chatId: 'chatID',
+				userId: 'e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111',
+				membershipId: 'MCMjMiMj',
+				returnAll: true,
+				options: {},
+			});
+
+			await expect(node.execute.call(ctx)).rejects.toThrow(
+				'Chat members are not available with the Service Principal credential',
+			);
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+			expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
+		},
+	);
+
 	it.each([['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }]])(
 		'onlineMeeting:%s throws a static error and issues no request under SP',
 		async (op, params) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -66,6 +66,40 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
+	describe('chatMember — hidden under SP via the slash-prefixed field-level key', () => {
+		it('operation selector carries hide["/authentication"] = [SP]', () => {
+			const op = actionProps.find(
+				(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes('chatMember'),
+			);
+			expect(isSpHidden(op)).toBe(true);
+			// distinct from the un-prefixed credential gate
+			expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
+		});
+
+		it('every chatMember field copy is hidden under SP', () => {
+			const memberFields = actionProps.filter((p) =>
+				p.displayOptions?.show?.resource?.includes('chatMember'),
+			);
+			// the chatId RLC, the user RLC, the membership RLC, options, returnAll, limit…
+			const gatedFields = memberFields.filter((p) => p.type !== 'notice' && p.name !== 'operation');
+			expect(gatedFields.length).toBeGreaterThan(0);
+			for (const field of gatedFields) {
+				expect(isSpHidden(field)).toBe(true);
+			}
+		});
+
+		it('shows an SP notice for the chatMember resource', () => {
+			const notice = actionProps.find(
+				(p) =>
+					p.type === 'notice' &&
+					p.displayOptions?.show?.resource?.includes('chatMember') &&
+					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+			);
+			expect(notice).toBeDefined();
+			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+		});
+	});
+
 	describe('onlineMeeting — hidden under SP via the slash-prefixed field-level key', () => {
 		it('operation selector carries hide["/authentication"] = [SP]', () => {
 			const op = actionProps.find(

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -66,7 +66,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
-	describe('chatMember — hidden under SP via the slash-prefixed field-level key', () => {
+	describe('chatMember - hidden under SP via the slash-prefixed field-level key', () => {
 		it('operation selector carries hide["/authentication"] = [SP]', () => {
 			const op = actionProps.find(
 				(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes('chatMember'),

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/add.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/add.operation.ts
@@ -1,0 +1,143 @@
+import {
+	type INodeProperties,
+	type IExecuteFunctions,
+	type IDataObject,
+	NodeOperationError,
+} from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { chatRLC, userRLC } from '../../descriptions';
+import {
+	buildTeamsPath,
+	getGraphBaseUrl,
+	microsoftApiRequest,
+	SP_HIDE,
+	validateTeamsId,
+} from '../../transport';
+import { throwIfChatMemberUnsupported } from './sharedGuard';
+
+const properties: INodeProperties[] = [
+	chatRLC,
+	userRLC,
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		default: {},
+		description: 'Other options to set',
+		placeholder: 'Add option',
+		options: [
+			{
+				displayName: 'History Start Date',
+				name: 'historyStartDate',
+				type: 'dateTime',
+				default: '',
+				description: 'Point in time from which the chat history is shared',
+				displayOptions: {
+					show: {
+						shareHistory: ['fromDate'],
+					},
+				},
+			},
+			{
+				displayName: 'Role',
+				name: 'role',
+				type: 'options',
+				default: 'owner',
+				description:
+					'Select Guest for a B2B guest user, since adding a guest as an owner fails. A guest must be identified by object ID, not by user principal name.',
+				options: [
+					{
+						name: 'Guest',
+						value: 'guest',
+					},
+					{
+						name: 'Owner',
+						value: 'owner',
+					},
+				],
+			},
+			{
+				displayName: 'Share History',
+				name: 'shareHistory',
+				type: 'options',
+				default: 'none',
+				description: 'How much of the existing chat history the new member can read',
+				options: [
+					{
+						name: 'All',
+						value: 'all',
+					},
+					{
+						name: 'From Date',
+						value: 'fromDate',
+					},
+					{
+						name: 'None',
+						value: 'none',
+					},
+				],
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['chatMember'],
+		operation: ['add'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/chat-post-members?view=graph-rest-1.0
+
+	// App-only Graph cannot change chat membership; fail before any request.
+	throwIfChatMemberUnsupported.call(this, i);
+
+	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
+	// Direct validator call rather than buildTeamsPath: this id is interpolated into
+	// the body, and RLC `validation` is UI-only, so an expression can still supply
+	// anything. The returned value (trimmed, decoded) is what must be interpolated.
+	const userId = validateTeamsId(
+		this.getNodeParameter('userId', i, '', { extractValue: true }) as string,
+		this.getNode(),
+	);
+	const options = this.getNodeParameter('options', i, {});
+
+	const body: IDataObject = {
+		'@odata.type': '#microsoft.graph.aadUserConversationMember',
+		'user@odata.bind': `${await getGraphBaseUrl.call(this)}/v1.0/users/${userId}`,
+		roles: [options.role ?? 'owner'],
+	};
+
+	// Not inverted: omitting the field shares NO history, and the 0001-01-01 sentinel
+	// shares the WHOLE history.
+	if (options.shareHistory === 'all') {
+		body.visibleHistoryStartDateTime = '0001-01-01T00:00:00Z';
+	} else if (options.shareHistory === 'fromDate') {
+		if (!options.historyStartDate) {
+			throw new NodeOperationError(this.getNode(), 'No history start date was given', {
+				description: 'Set "History Start Date", or change "Share History" to "All" or "None".',
+				itemIndex: i,
+			});
+		}
+		body.visibleHistoryStartDateTime = options.historyStartDate;
+	}
+
+	await microsoftApiRequest.call(
+		this,
+		'POST',
+		buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/members']),
+		body,
+	);
+
+	// Graph answers 201 with a Location header and no body.
+	return { success: true };
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/getAll.operation.ts
@@ -1,0 +1,42 @@
+import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
+
+import { returnAllOrLimit } from '@utils/descriptions';
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { chatRLC } from '../../descriptions';
+import { buildTeamsPath, microsoftApiRequestAllItems, SP_HIDE } from '../../transport';
+import { throwIfChatMemberUnsupported } from './sharedGuard';
+
+const properties: INodeProperties[] = [chatRLC, ...returnAllOrLimit];
+
+const displayOptions = {
+	show: {
+		resource: ['chatMember'],
+		operation: ['getAll'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/chat-list-members?view=graph-rest-1.0
+
+	// App-only Graph cannot read chats; fail before any request.
+	throwIfChatMemberUnsupported.call(this, i);
+
+	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
+	const returnAll = this.getNodeParameter('returnAll', i);
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/members']);
+
+	if (returnAll) {
+		return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint);
+	}
+
+	// No `$top`: this endpoint supports no OData query parameters, so the limit is
+	// applied client-side while paging through @odata.nextLink.
+	const limit = this.getNodeParameter('limit', i);
+	return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint, {}, {}, limit);
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/index.ts
@@ -1,0 +1,63 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as add from './add.operation';
+import * as getAll from './getAll.operation';
+import * as remove from './remove.operation';
+import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
+
+export { add, getAll, remove };
+
+export const description: INodeProperties[] = [
+	{
+		displayName:
+			'Chat members are not available with the Service Principal credential. App-only Microsoft Graph has no signed-in user; use an OAuth2 credential for chat actions.',
+		name: 'chatMemberServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['chatMember'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+	},
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['chatMember'],
+			},
+			hide: {
+				...SP_HIDE,
+			},
+		},
+		options: [
+			{
+				name: 'Add',
+				value: 'add',
+				description: 'Add a member to a chat',
+				action: 'Add chat member',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many members of a chat',
+				action: 'Get many chat members',
+			},
+			{
+				name: 'Remove',
+				value: 'remove',
+				description: 'Remove a member from a chat',
+				action: 'Remove chat member',
+			},
+		],
+		default: 'add',
+	},
+
+	...add.description,
+	...getAll.description,
+	...remove.description,
+];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/remove.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/remove.operation.ts
@@ -50,7 +50,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		// here can equally be a legitimate refusal. Inline because there is a single
 		// call site - see the per-operation 403 hint note in utils/microsoft/transport.ts.
 		if (error instanceof NodeApiError && error.httpCode === '403') {
-			throw new NodeOperationError(this.getNode(), error as Error, {
+			throw new NodeOperationError(this.getNode(), error, {
 				itemIndex: i,
 				description:
 					'Removing a member needs the ChatMember.ReadWrite permission, which has no higher-privileged alternative: reconnect the credential to grant it (a tenant admin may have to consent again), and if Custom Scopes is enabled add it to Enabled Scopes by hand. Microsoft also refuses this call on a one-on-one chat, when removing the last owner, and when removing yourself.',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/remove.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/remove.operation.ts
@@ -1,0 +1,61 @@
+import {
+	type INodeProperties,
+	type IExecuteFunctions,
+	NodeApiError,
+	NodeOperationError,
+} from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { chatMemberRLC, chatRLC } from '../../descriptions';
+import { buildTeamsPath, microsoftApiRequest, SP_HIDE } from '../../transport';
+import { throwIfChatMemberUnsupported } from './sharedGuard';
+
+const properties: INodeProperties[] = [chatRLC, chatMemberRLC];
+
+const displayOptions = {
+	show: {
+		resource: ['chatMember'],
+		operation: ['remove'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/chat-delete-members?view=graph-rest-1.0
+
+	// App-only Graph cannot change chat membership; fail before any request.
+	throwIfChatMemberUnsupported.call(this, i);
+
+	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
+	const membershipId = this.getNodeParameter('membershipId', i, '', {
+		extractValue: true,
+	}) as string;
+	const endpoint = buildTeamsPath.call(this, [
+		'/v1.0/chats/',
+		{ id: chatId },
+		'/members/',
+		{ id: membershipId },
+	]);
+
+	try {
+		await microsoftApiRequest.call(this, 'DELETE', endpoint);
+		return { success: true };
+	} catch (error) {
+		// 403 only, never a catch-all, and Graph's own message stays the message: a 403
+		// here can equally be a legitimate refusal. Inline because there is a single
+		// call site — see the per-operation 403 hint note in utils/microsoft/transport.ts.
+		if (error instanceof NodeApiError && error.httpCode === '403') {
+			throw new NodeOperationError(this.getNode(), error as Error, {
+				itemIndex: i,
+				description:
+					'Removing a member needs the ChatMember.ReadWrite permission, which has no higher-privileged alternative: reconnect the credential to grant it (a tenant admin may have to consent again), and if Custom Scopes is enabled add it to Enabled Scopes by hand. Microsoft also refuses this call on a one-on-one chat, when removing the last owner, and when removing yourself.',
+			});
+		}
+		throw error;
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/remove.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/remove.operation.ts
@@ -48,7 +48,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	} catch (error) {
 		// 403 only, never a catch-all, and Graph's own message stays the message: a 403
 		// here can equally be a legitimate refusal. Inline because there is a single
-		// call site — see the per-operation 403 hint note in utils/microsoft/transport.ts.
+		// call site - see the per-operation 403 hint note in utils/microsoft/transport.ts.
 		if (error instanceof NodeApiError && error.httpCode === '403') {
 			throw new NodeOperationError(this.getNode(), error as Error, {
 				itemIndex: i,

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
@@ -1,0 +1,26 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { getTeamsCredentialType, SERVICE_PRINCIPAL_AUTH } from '../../transport';
+
+/**
+ * Throws a static `NodeOperationError` when the node is configured with the
+ * app-only (Service Principal) credential. Chat membership has no usable app-only
+ * form (app-only Graph has no signed-in user), so every chatMember operation guards
+ * on this BEFORE any request — covering hand-edited workflows that bypass the
+ * hidden UI. Takes the item index so the error points at the failing item inside
+ * the router's per-item `continueOnFail` loop.
+ */
+export function throwIfChatMemberUnsupported(this: IExecuteFunctions, i: number): void {
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Chat members are not available with the Service Principal credential',
+			{
+				description:
+					'App-only Microsoft Graph has no signed-in user. Use an OAuth2 credential for chat actions.',
+				itemIndex: i,
+			},
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
@@ -7,7 +7,7 @@ import { getTeamsCredentialType, SERVICE_PRINCIPAL_AUTH } from '../../transport'
  * Throws a static `NodeOperationError` when the node is configured with the
  * app-only (Service Principal) credential. Chat membership has no usable app-only
  * form (app-only Graph has no signed-in user), so every chatMember operation guards
- * on this BEFORE any request — covering hand-edited workflows that bypass the
+ * on this BEFORE any request - covering hand-edited workflows that bypass the
  * hidden UI. Takes the item index so the error points at the failing item inside
  * the router's per-item `continueOnFail` loop.
  */

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -3,6 +3,7 @@ import type { AllEntities } from 'n8n-workflow';
 type NodeMap = {
 	channel: 'create' | 'deleteChannel' | 'get' | 'getAll' | 'update';
 	channelMessage: 'create' | 'get' | 'getAll' | 'getAllReplies' | 'reply';
+	chatMember: 'add' | 'getAll' | 'remove';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
 	onlineMeeting: 'create';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
@@ -9,6 +9,7 @@ import {
 
 import * as channel from './channel';
 import * as channelMessage from './channelMessage';
+import * as chatMember from './chatMember';
 import * as chatMessage from './chatMessage';
 import type { MicrosoftTeamsType } from './node.type';
 import * as onlineMeeting from './onlineMeeting';
@@ -63,6 +64,9 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 						nodeVersion,
 						instanceId,
 					);
+					break;
+				case 'chatMember':
+					responseData = await chatMember[microsoftTeamsTypeData.operation].execute.call(this, i);
 					break;
 				case 'chatMessage':
 					responseData = await chatMessage[microsoftTeamsTypeData.operation].execute.call(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
@@ -3,6 +3,7 @@ import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 
 import * as channel from './channel';
 import * as channelMessage from './channelMessage';
+import * as chatMember from './chatMember';
 import * as chatMessage from './chatMessage';
 import * as onlineMeeting from './onlineMeeting';
 import * as task from './task';
@@ -69,7 +70,7 @@ export const versionDescription: INodeTypeDescription = {
 					name: 'Microsoft OAuth2 (Graph)',
 					value: 'microsoftOAuth2Api',
 					description:
-						'Generic Microsoft Graph credential. Add the Teams Graph scopes (e.g. Chat.ReadWrite, ChannelMessage.Read.All, Group.ReadWrite.All, OnlineMeetings.ReadWrite) and grant admin consent on the credential. See the docs for the full scope string.',
+						'Generic Microsoft Graph credential. Add the Teams Graph scopes (e.g. Chat.ReadWrite, ChatMember.ReadWrite, ChannelMessage.Read.All, Group.ReadWrite.All, OnlineMeetings.ReadWrite, User.Read.All) and grant admin consent on the credential. See the docs for the full scope string.',
 				},
 				{
 					name: 'Service Principal (App-Only)',
@@ -95,6 +96,10 @@ export const versionDescription: INodeTypeDescription = {
 					value: 'channelMessage',
 				},
 				{
+					name: 'Chat Member',
+					value: 'chatMember',
+				},
+				{
 					name: 'Chat Message',
 					value: 'chatMessage',
 				},
@@ -112,6 +117,7 @@ export const versionDescription: INodeTypeDescription = {
 
 		...channel.description,
 		...channelMessage.description,
+		...chatMember.description,
 		...chatMessage.description,
 		...onlineMeeting.description,
 		...task.description,

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/rlc.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/rlc.description.ts
@@ -267,3 +267,77 @@ export const memberRLC: INodeProperties = {
 		},
 	],
 };
+
+export const userRLC: INodeProperties = {
+	displayName: 'User',
+	name: 'userId',
+	type: 'resourceLocator',
+	default: { mode: 'list', value: '' },
+	required: true,
+	description:
+		'Select the user from the list or by ID. Guest users must be given by their object ID, not by their user principal name.',
+	modes: [
+		{
+			displayName: 'From List',
+			name: 'list',
+			type: 'list',
+			placeholder: 'Select a User...',
+			typeOptions: {
+				searchListMethod: 'getUsers',
+				searchable: true,
+			},
+		},
+		{
+			displayName: 'By ID',
+			name: 'id',
+			type: 'string',
+			placeholder: 'e.g. jacob@contoso.com',
+			// `validation` only, never an `extractValue`: a GUID-only extractor makes core
+			// reject any expression that resolves to a user principal name before the node
+			// runs, and Graph binds a principal name directly.
+			validation: [
+				{
+					type: 'regex',
+					properties: {
+						regex:
+							'^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[^\\s@]+@[^\\s@]+)[ \t]*$',
+						errorMessage: 'Not a valid user ID or user principal name',
+					},
+				},
+			],
+		},
+	],
+};
+
+export const chatMemberRLC: INodeProperties = {
+	displayName: 'Member',
+	name: 'membershipId',
+	type: 'resourceLocator',
+	default: { mode: 'list', value: '' },
+	required: true,
+	description:
+		'Select the member from the list, or give the membership ID returned by Chat Member → Get Many (the "id" field, not "userId")',
+	typeOptions: {
+		loadOptionsDependsOn: ['chatId.value'],
+	},
+	modes: [
+		{
+			displayName: 'From List',
+			name: 'list',
+			type: 'list',
+			placeholder: 'Select a Member...',
+			typeOptions: {
+				searchListMethod: 'getChatMembers',
+				searchable: true,
+			},
+		},
+		{
+			displayName: 'By ID',
+			name: 'id',
+			type: 'string',
+			placeholder:
+				'e.g. MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==',
+			// validation missing because Microsoft documents no shape for membership ids.
+		},
+	],
+};

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/rlc.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/descriptions/rlc.description.ts
@@ -316,7 +316,7 @@ export const chatMemberRLC: INodeProperties = {
 	default: { mode: 'list', value: '' },
 	required: true,
 	description:
-		'Select the member from the list, or give the membership ID returned by Chat Member → Get Many (the "id" field, not "userId")',
+		'Select the member from the list, or give the membership ID returned by Chat Member → Get Many (the ID field, not the "userId" field)',
 	typeOptions: {
 		loadOptionsDependsOn: ['chatId.value'],
 	},

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
@@ -36,9 +36,22 @@ export async function getChats(
 	}
 
 	const returnData: INodeListSearchItems[] = [];
+	// ponytail: one page of 50 (the endpoint maximum), not full pagination - a user with >50 chats
+	// that are mostly 1:1 may still not see every group chat. Upgrade path if that is ever reported:
+	// server-side `$filter` on `chatType` if Graph supports it on this endpoint (unverified), else
+	// `microsoftApiRequestAllItems`. By-ID mode is the escape hatch meanwhile.
 	const qs: IDataObject = {
 		$expand: 'members',
+		$top: 50,
 	};
+
+	// `0` is the FALLBACK value in load-options contexts, not an itemIndex: the Teams
+	// trigger shares this picker and has neither parameter, so dropping the fallback
+	// makes `getNodeParameter` throw there instead of listing chats.
+	const operation = this.getNodeParameter('operation', 0) as string;
+	const resource = this.getNodeParameter('resource', 0) as string;
+	// Only Add and Remove are impossible on a 1:1 chat; listing its members is legal.
+	const excludeOneOnOne = resource === 'chatMember' && ['add', 'remove'].includes(operation);
 
 	// `/v1.0/chats` occasionally 5xxs transiently; retry up to `maxAttempts` times,
 	// sleeping 1s between attempts (not after the last one), and surface the final
@@ -72,6 +85,7 @@ export async function getChats(
 				.map((member: IDataObject) => member.displayName)
 				.join(', ');
 		}
+		if (excludeOneOnOne && chat.chatType === 'oneOnOne') continue;
 		const chatName = `${chat.topic || '(no title) - ' + chat.id} (${chat.chatType})`;
 		const chatId = chat.id;
 		const url = chat.webUrl as string;
@@ -100,6 +114,85 @@ export async function getChats(
 		});
 
 	return { results };
+}
+
+export async function getChatMembers(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const chatId = this.getCurrentNodeParameter('chatId', { extractValue: true }) as string;
+	// The picker can be opened before a chat is selected; show an empty list instead
+	// of failing on an empty id.
+	if (!chatId) return { results: [] };
+
+	// `GET /chats/{id}/members` supports no OData query parameters, so there is no
+	// server-side search to pass the filter to - it pages via @odata.nextLink only.
+	const value = (await microsoftApiRequestAllItems.call(
+		this,
+		'value',
+		'GET',
+		buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/members']),
+	)) as IDataObject[];
+
+	const returnData: INodeListSearchItems[] = value.map((member) => ({
+		name: member.email ? `${member.displayName} (${member.email})` : (member.displayName as string),
+		// `id` is the base64 membership id the DELETE path needs, NOT `userId`.
+		value: member.id as string,
+	}));
+
+	const results = filterSortSearchListItems(returnData, filter);
+	return { results };
+}
+
+export async function getUsers(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+	paginationToken?: string,
+): Promise<INodeListSearchResult> {
+	// ConsistencyLevel is sent on every call: directory paging drops custom headers on
+	// nextLink requests, so the token branch needs it too or Graph rejects the $search.
+	const headers: IDataObject = { ConsistencyLevel: 'eventual' };
+	let response: IDataObject;
+	if (paginationToken) {
+		response = (await microsoftApiRequest.call(
+			this,
+			'GET',
+			'',
+			{},
+			{},
+			paginationToken,
+			headers,
+		)) as IDataObject;
+	} else {
+		const qs: IDataObject = { $select: 'id,displayName,userPrincipalName' };
+		if (filter) {
+			// `$search` escaping is NOT `$filter`'s quote-doubling: backslash-escape `\`
+			// first, then `"`, and the OR operator is uppercase and outside the quotes.
+			const escaped = filter.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+			qs.$search = `"displayName:${escaped}" OR "userPrincipalName:${escaped}"`;
+		}
+		response = (await microsoftApiRequest.call(
+			this,
+			'GET',
+			'/v1.0/users',
+			{},
+			qs,
+			undefined,
+			headers,
+		)) as IDataObject;
+	}
+
+	const returnData: INodeListSearchItems[] = (response.value as IDataObject[]).map((user) => ({
+		name: `${user.displayName} (${user.userPrincipalName})`,
+		value: user.id as string,
+	}));
+
+	// No filter argument: `$search` already filtered server-side across the whole
+	// collection, so this only applies the sort every sibling picker uses.
+	return {
+		results: filterSortSearchListItems(returnData),
+		paginationToken: response['@odata.nextLink'] as string | undefined,
+	};
 }
 
 export async function getTeams(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
@@ -79,13 +79,13 @@ export async function getChats(
 	}
 
 	for (const chat of value) {
+		if (excludeOneOnOne && chat.chatType === 'oneOnOne') continue;
 		if (!chat.topic) {
 			chat.topic = (chat.members as IDataObject[])
 				.filter((member: IDataObject) => member.displayName)
 				.map((member: IDataObject) => member.displayName)
 				.join(', ');
 		}
-		if (excludeOneOnOne && chat.chatType === 'oneOnOne') continue;
 		const chatName = `${chat.topic || '(no title) - ' + chat.id} (${chat.chatType})`;
 		const chatId = chat.id;
 		const url = chat.webUrl as string;

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
@@ -1,19 +1,20 @@
-import type { ILoadOptionsFunctions, INode } from 'n8n-workflow';
+import { UserError, type ILoadOptionsFunctions, type INode } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
 import type { Mock } from 'vitest';
 import type { DeepMockProxy } from 'vitest-mock-extended';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
-import { getChats } from '../../methods/listSearch';
+import { getChatMembers, getChats, getUsers } from '../../methods/listSearch';
 import * as transport from '../../transport';
 import type * as _importType0 from '../../transport';
 
-// Real transport module except the network helper
+// Real transport module except the network helpers
 vi.mock('../../transport', async () => {
 	const originalModule = await vi.importActual<typeof _importType0>('../../transport');
 	return {
 		...originalModule,
 		microsoftApiRequest: vi.fn(),
+		microsoftApiRequestAllItems: vi.fn(),
 	};
 });
 
@@ -31,11 +32,16 @@ describe('Microsoft Teams v2 — getChats', () => {
 	const apiRequest = transport.microsoftApiRequest as Mock;
 	const sleepMock = sleep as unknown as Mock;
 
+	// Faithful to the load-options signature: the SECOND argument is the fallback
+	// value (there is no itemIndex), and a read with no fallback and no stored value
+	// throws — which is what lets the "no resource or operation" case below fail if
+	// the fallback form is ever dropped from `getChats`.
 	const setParams = (params: Record<string, unknown>) => {
-		ctx.getNodeParameter.mockImplementation(
-			(name: string, _itemIndex?: number, fallback?: unknown) =>
-				(name in params ? params[name] : fallback) as never,
-		);
+		ctx.getNodeParameter.mockImplementation((name: string, fallback?: unknown) => {
+			const value = name in params ? params[name] : fallback;
+			if (value === undefined) throw new UserError(`Could not get parameter "${name}"`);
+			return value as never;
+		});
 	};
 
 	beforeEach(() => {
@@ -85,6 +91,17 @@ describe('Microsoft Teams v2 — getChats', () => {
 
 		expect(apiRequest).toHaveBeenCalledTimes(1);
 		expect(sleepMock).not.toHaveBeenCalled();
+		// `$top: 50` (the endpoint maximum) keeps the Add/Remove picker from rendering
+		// empty once 1:1 chats are filtered out of a default-sized page.
+		expect(apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'/v1.0/chats',
+			{},
+			{
+				$expand: 'members',
+				$top: 50,
+			},
+		);
 	});
 
 	it('returns an empty result for a genuinely empty tenant without throwing', async () => {
@@ -112,5 +129,234 @@ describe('Microsoft Teams v2 — getChats', () => {
 		expect(result.results).toEqual([
 			{ name: 'Alice, Bob (oneOnOne)', value: 'c2', url: 'https://teams/chat/c2' },
 		]);
+	});
+
+	describe('one-on-one chats are hidden only for the member operations that cannot use them', () => {
+		const mixedChats = {
+			value: [
+				{ id: 'c1', topic: 'Standup', chatType: 'group', webUrl: 'https://teams/chat/c1' },
+				{ id: 'c2', topic: 'Alice', chatType: 'oneOnOne', webUrl: 'https://teams/chat/c2' },
+				{ id: 'c3', topic: 'Review', chatType: 'meeting', webUrl: 'https://teams/chat/c3' },
+			],
+		};
+
+		beforeEach(() => {
+			apiRequest.mockResolvedValue(mixedChats);
+		});
+
+		it.each(['add', 'remove'])('hides oneOnOne chats for chatMember:%s', async (operation) => {
+			setParams({
+				authentication: 'microsoftOAuth2Api',
+				resource: 'chatMember',
+				operation,
+			});
+
+			const result = await getChats.call(ctx);
+
+			expect(result.results.map((r) => r.value)).toEqual(['c3', 'c1']);
+		});
+
+		it('keeps group and meeting chats for chatMember:add', async () => {
+			setParams({
+				authentication: 'microsoftOAuth2Api',
+				resource: 'chatMember',
+				operation: 'add',
+			});
+
+			const result = await getChats.call(ctx);
+
+			expect(result.results.map((r) => r.name)).toEqual(['Review (meeting)', 'Standup (group)']);
+		});
+
+		it('keeps oneOnOne chats for chatMember:getAll', async () => {
+			setParams({
+				authentication: 'microsoftOAuth2Api',
+				resource: 'chatMember',
+				operation: 'getAll',
+			});
+
+			const result = await getChats.call(ctx);
+
+			expect(result.results.map((r) => r.value)).toEqual(['c2', 'c3', 'c1']);
+		});
+
+		it('keeps oneOnOne chats for chatMessage', async () => {
+			setParams({
+				authentication: 'microsoftOAuth2Api',
+				resource: 'chatMessage',
+				operation: 'create',
+			});
+
+			const result = await getChats.call(ctx);
+
+			expect(result.results.map((r) => r.value)).toEqual(['c2', 'c3', 'c1']);
+		});
+
+		// Regression guard for the Teams trigger, which shares `getChats` but has
+		// neither a `resource` nor an `operation` parameter: both reads must keep the
+		// fallback form or the picker throws instead of listing chats.
+		it('keeps oneOnOne chats when the node has no resource or operation parameter', async () => {
+			setParams({ authentication: 'microsoftOAuth2Api' });
+
+			const result = await getChats.call(ctx);
+
+			expect(result.results.map((r) => r.value)).toEqual(['c2', 'c3', 'c1']);
+		});
+	});
+});
+
+describe('Microsoft Teams v2 — getUsers', () => {
+	let ctx: DeepMockProxy<ILoadOptionsFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ctx = mockDeep<ILoadOptionsFunctions>();
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+		apiRequest.mockResolvedValue({ value: [] });
+	});
+
+	it('requests only $select when no filter is given, with ConsistencyLevel: eventual', async () => {
+		await getUsers.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'/v1.0/users',
+			{},
+			{ $select: 'id,displayName,userPrincipalName' },
+			undefined,
+			{ ConsistencyLevel: 'eventual' },
+		);
+	});
+
+	it('builds the $search string exactly', async () => {
+		apiRequest.mockResolvedValue({
+			value: [],
+			'@odata.nextLink': 'https://graph.microsoft.com/v1.0/users?$skiptoken=abc',
+		});
+
+		const result = await getUsers.call(ctx, 'ann');
+
+		expect(apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'/v1.0/users',
+			{},
+			{
+				$select: 'id,displayName,userPrincipalName',
+				$search: '"displayName:ann" OR "userPrincipalName:ann"',
+			},
+			undefined,
+			{ ConsistencyLevel: 'eventual' },
+		);
+		expect(result.paginationToken).toBe('https://graph.microsoft.com/v1.0/users?$skiptoken=abc');
+	});
+
+	it('backslash-escapes double quotes and backslashes in the search term', async () => {
+		await getUsers.call(ctx, 'a"b\\c');
+
+		expect(apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'/v1.0/users',
+			{},
+			{
+				$select: 'id,displayName,userPrincipalName',
+				$search: '"displayName:a\\"b\\\\c" OR "userPrincipalName:a\\"b\\\\c"',
+			},
+			undefined,
+			{ ConsistencyLevel: 'eventual' },
+		);
+	});
+
+	it('follows a paginationToken URL verbatim (no endpoint, no query) and still sends ConsistencyLevel', async () => {
+		await getUsers.call(ctx, undefined, 'https://graph.microsoft.com/v1.0/users?$skiptoken=abc');
+
+		expect(apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'',
+			{},
+			{},
+			'https://graph.microsoft.com/v1.0/users?$skiptoken=abc',
+			{ ConsistencyLevel: 'eventual' },
+		);
+	});
+
+	it('labels entries "Display Name (upn)", uses the user id as value, and sorts by display name', async () => {
+		apiRequest.mockResolvedValue({
+			value: [
+				{ id: 'u2', displayName: 'Zoe Brown', userPrincipalName: 'zoe@contoso.com' },
+				{ id: 'u1', displayName: 'Ann Smith', userPrincipalName: 'ann@contoso.com' },
+			],
+		});
+
+		const result = await getUsers.call(ctx);
+
+		expect(result.results).toEqual([
+			{ name: 'Ann Smith (ann@contoso.com)', value: 'u1' },
+			{ name: 'Zoe Brown (zoe@contoso.com)', value: 'u2' },
+		]);
+	});
+});
+
+describe('Microsoft Teams v2 — getChatMembers', () => {
+	let ctx: DeepMockProxy<ILoadOptionsFunctions>;
+	const apiRequestAllItems = transport.microsoftApiRequestAllItems as Mock;
+
+	// `id` (base64 membership id) and `userId` are deliberately different values, so a
+	// mapping that returned `userId` cannot pass.
+	const membershipId =
+		'MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==';
+	const members = [
+		{
+			id: membershipId,
+			userId: 'e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111',
+			displayName: 'Ann Smith',
+			email: 'ann@contoso.com',
+		},
+		{
+			id: 'MCMjMiMj',
+			userId: 'aa11bb22-5c3f-4f1e-9d5e-4d8f0f6ab222',
+			displayName: 'Bob Jones',
+			email: null,
+		},
+	];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ctx = mockDeep<ILoadOptionsFunctions>();
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+		ctx.getCurrentNodeParameter.mockReturnValue('19:abc@thread.v2');
+		apiRequestAllItems.mockResolvedValue(members);
+	});
+
+	it('maps value to the base64 membership id, not userId', async () => {
+		const result = await getChatMembers.call(ctx);
+
+		expect(result.results[0]).toEqual({ name: 'Ann Smith (ann@contoso.com)', value: membershipId });
+		expect(apiRequestAllItems).toHaveBeenCalledWith(
+			'value',
+			'GET',
+			'/v1.0/chats/19:abc@thread.v2/members',
+		);
+	});
+
+	it('labels entries with display name and email, falling back to display name when email is missing', async () => {
+		const result = await getChatMembers.call(ctx);
+
+		expect(result.results.map((r) => r.name)).toEqual(['Ann Smith (ann@contoso.com)', 'Bob Jones']);
+	});
+
+	it('filters client-side on the typed filter', async () => {
+		const result = await getChatMembers.call(ctx, 'bob');
+
+		expect(result.results).toEqual([{ name: 'Bob Jones', value: 'MCMjMiMj' }]);
+	});
+
+	it('returns an empty list and issues no request when no chat is selected', async () => {
+		ctx.getCurrentNodeParameter.mockReturnValue('');
+
+		const result = await getChatMembers.call(ctx);
+
+		expect(result).toEqual({ results: [] });
+		expect(apiRequestAllItems).not.toHaveBeenCalled();
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
@@ -34,7 +34,7 @@ describe('Microsoft Teams v2 — getChats', () => {
 
 	// Faithful to the load-options signature: the SECOND argument is the fallback
 	// value (there is no itemIndex), and a read with no fallback and no stored value
-	// throws — which is what lets the "no resource or operation" case below fail if
+	// throws - which is what lets the "no resource or operation" case below fail if
 	// the fallback form is ever dropped from `getChats`.
 	const setParams = (params: Record<string, unknown>) => {
 		ctx.getNodeParameter.mockImplementation((name: string, fallback?: unknown) => {
@@ -205,7 +205,7 @@ describe('Microsoft Teams v2 — getChats', () => {
 	});
 });
 
-describe('Microsoft Teams v2 — getUsers', () => {
+describe('Microsoft Teams v2 - getUsers', () => {
 	let ctx: DeepMockProxy<ILoadOptionsFunctions>;
 	const apiRequest = transport.microsoftApiRequest as Mock;
 
@@ -297,7 +297,7 @@ describe('Microsoft Teams v2 — getUsers', () => {
 	});
 });
 
-describe('Microsoft Teams v2 — getChatMembers', () => {
+describe('Microsoft Teams v2 - getChatMembers', () => {
 	let ctx: DeepMockProxy<ILoadOptionsFunctions>;
 	const apiRequestAllItems = transport.microsoftApiRequestAllItems as Mock;
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -6,6 +6,7 @@ import { MicrosoftTeamsTrigger } from '../../../MicrosoftTeamsTrigger.node';
 import {
 	getBuckets,
 	getChannels,
+	getChatMembers,
 	getChats,
 	getGroups,
 	getMembers,
@@ -249,6 +250,13 @@ describe('Microsoft Teams Transport', () => {
 				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(malformedId);
 
 				await expect(getMembers.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
+				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+			});
+
+			it('getChatMembers rejects a malformed chatId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(malformedId);
+
+				await expect(getChatMembers.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
 				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
 			});
 		});

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -23,11 +23,17 @@ export type TeamsCredentialType = MicrosoftGraphCredentialType<'microsoftTeamsOA
 
 const {
 	getCredentialType: getTeamsCredentialType,
+	getGraphBaseUrl,
 	microsoftApiRequest,
 	microsoftApiRequestAllItems,
 } = createMicrosoftGraphTransport({ defaultCredentialType: 'microsoftTeamsOAuth2Api' });
 
-export { getTeamsCredentialType, microsoftApiRequest, microsoftApiRequestAllItems };
+export {
+	getTeamsCredentialType,
+	getGraphBaseUrl,
+	microsoftApiRequest,
+	microsoftApiRequestAllItems,
+};
 
 /**
  * App-only Microsoft Graph has no `/me`, so the joined-teams listing is fetched

--- a/packages/nodes-base/utils/microsoft/test/transport.test.ts
+++ b/packages/nodes-base/utils/microsoft/test/transport.test.ts
@@ -470,6 +470,13 @@ describe('Microsoft Graph transport kernel', () => {
 			expect(() =>
 				validateMicrosoftGraphId('rl1HYb0cUEiHPc7zgB_KWWUAA7Of', mockNode),
 			).not.toThrow();
+			// base64 chat-membership id: the trailing `=` padding must not be rejected
+			expect(() =>
+				validateMicrosoftGraphId(
+					'MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==',
+					mockNode,
+				),
+			).not.toThrow();
 		});
 
 		it('accepts a real colon-bearing channel id (`:` and `@` are allowed)', () => {

--- a/packages/nodes-base/utils/microsoft/transport.ts
+++ b/packages/nodes-base/utils/microsoft/transport.ts
@@ -67,7 +67,7 @@ export function validateMicrosoftGraphId(id: string, node: INode): string {
 		throw new NodeOperationError(node, 'A required ID is empty', {
 			// Teams wording; make it injectable (UserTargetMessages pattern in
 			// nodes/Microsoft/GenericFunctions.ts) when the second consumer (SharePoint v2) lands.
-			description: 'Set the team, channel, plan, bucket or task ID and try again.',
+			description: 'Set the team, channel, plan, bucket, task, user or member ID and try again.',
 		});
 	}
 	let value: string;
@@ -197,6 +197,24 @@ export function createMicrosoftGraphTransport<TDefault extends string>(config: {
 			: defaultCredentialType;
 	}
 
+	/**
+	 * Resolves the Graph host the node's credential is bound to (sovereign clouds
+	 * included), trailing slashes stripped. `microsoftApiRequest` must compute its
+	 * `baseUrl` ONLY through this: the same value feeds the same-origin guard below,
+	 * so a second copy of this logic would let an operation that builds an absolute
+	 * Graph URL (e.g. `user@odata.bind`) drift from the host the request goes to.
+	 */
+	async function getGraphBaseUrl(
+		this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+	): Promise<string> {
+		const credentials = await this.getCredentials(getCredentialType.call(this));
+		return (
+			typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
+				? credentials.graphApiBaseUrl
+				: 'https://graph.microsoft.com'
+		).replace(/\/+$/, '');
+	}
+
 	async function microsoftApiRequest(
 		this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
 		method: IHttpRequestMethods,
@@ -208,12 +226,7 @@ export function createMicrosoftGraphTransport<TDefault extends string>(config: {
 	): Promise<any> {
 		const credentialType = getCredentialType.call(this);
 		const isServicePrincipal = credentialType === SERVICE_PRINCIPAL_AUTH;
-		const credentials = await this.getCredentials(credentialType);
-		const baseUrl = (
-			typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
-				? credentials.graphApiBaseUrl
-				: 'https://graph.microsoft.com'
-		).replace(/\/+$/, '');
+		const baseUrl = await getGraphBaseUrl.call(this);
 		// An explicit `uri` (e.g. a next-page link from Graph) is used verbatim,
 		// but it must stay on the credential's Graph host: the bearer token must
 		// never travel to an unexpected origin. Graph's own @odata.nextLink is
@@ -347,5 +360,5 @@ export function createMicrosoftGraphTransport<TDefault extends string>(config: {
 		return returnData;
 	}
 
-	return { getCredentialType, microsoftApiRequest, microsoftApiRequestAllItems };
+	return { getCredentialType, getGraphBaseUrl, microsoftApiRequest, microsoftApiRequestAllItems };
 }


### PR DESCRIPTION
## Summary

Adds a **Chat Member** resource to the Microsoft Teams node with three operations - Add, Get Many and Remove - so a workflow can manage the membership of an existing chat. Everything runs against the delegated Graph endpoints (`GET`/`POST`/`DELETE /chats/{id}/members`) and stays hidden under the Service Principal credential, matching the rest of the chat surfaces.

Three details are worth a reviewer's attention, because each one is the opposite of what it looks like:

- **Remove takes the membership ID, not the user ID.** `GET /chats/{id}/members` returns a long base64 `id` alongside `userId`, and only the former works for a delete. A picker on the Remove operation resolves it, so nobody has to know that.
- **Sharing chat history is inverted from what you would guess.** Omitting `visibleHistoryStartDateTime` shares *no* history; the `0001-01-01T00:00:00Z` sentinel shares *all* of it. Both branches are pinned by tests so the semantics cannot quietly flip back.
- **The user picker takes a UPN as well as an object ID**, and deliberately has no `extractValue` regex on its By-ID mode. A GUID-only regex would make the core engine reject a UPN-valued expression before the node ever runs.

The user picker (`getUsers`) is new and shared: ENT-324 and ENT-326 are expected to reuse it as-is.

### Please do not merge this yet

`ChatMember.ReadWrite` is added to the Teams OAuth2 credential's default scopes. Remove genuinely cannot work without it - Microsoft lists the delegated higher-privileged alternative as "Not available." - but it needs admin consent, so it has to be consented on n8n's Cloud Entra app **before** this merges, or new Teams credential connections will fail consent for tenants that have not re-consented. That affects people who never touch chat members, so it is the one blocking item.

Two follow-on notes for the same reason:

- **Existing credentials keep working.** Token refresh never re-sends the scope list, so connected credentials are unaffected until someone reconnects. Add and Get Many need no new scope either - only Remove does. Anyone hitting a 403 on Remove gets a message naming the scope and what to do about it.
- **Self-hosted users with their own Entra app registration** have to add the scope themselves. The generic Microsoft OAuth2 (Graph) credential's scope hint has been updated to list it, along with `User.Read.All` which the new user picker needs and which was previously missing from that hint.

### One side effect outside this feature

`getChats` now sends `$top: 50`. It previously fetched a single default-size page and filtered client-side, so hiding one-on-one chats from the Chat Member picker could have left the dropdown empty and unsearchable. The same picker is shared by the Chat Message resource and by the Teams **trigger**, so a user with 21-50 chats will now see chats in those two dropdowns that were previously invisible. That is an improvement, but it is a visible change in places this PR is otherwise not about, so please do not be surprised by it in QA.

## How to test

Needs a delegated Teams OAuth2 credential whose consent includes `ChatMember.ReadWrite`, plus an existing **group** chat (one-on-one chats are deliberately not offered for Add and Remove, since Graph refuses membership changes on them).

1. **Get Many** - select the chat, run. You get one row per member. Note the base64 `id` field is distinct from `userId`.
2. **Add** - select the same chat and pick a user from the User dropdown. Try searching by **surname**, which only works because the picker uses Graph's `$search` rather than a prefix filter. Leave Options empty, run, then re-run Get Many to see the new member.
3. **Add with history** - add another user with Options → Share History → All, and confirm in the Teams client that they can see the earlier messages. With Share History left at None they should not.
4. **Remove** - select the chat, pick the member you just added from the Chat Member dropdown, run. Re-run Get Many to confirm they are gone. Reopen the node between operations, since the chat picker caches its list.
5. **Service Principal** - switch the node to the Service Principal credential and confirm the Chat Member resource disappears from the Resource dropdown.

Automated coverage: 304 tests pass across the Teams node, the shared Microsoft transport, and the credential. The workflow-JSON tests run through the real router and transport with nock, so they cover URL and body composition rather than just the operation functions.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-349

Split out of ENT-323 (Chat resource: create, get, get many), which owns the `chat` resource itself and can land in either order - the overlap is three one-line registrations.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

