### PR TITLE
feat(Microsoft Teams Node): Add the chat member get many operation

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/__schema__/v2.0.0/chatMember/getAll.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/__schema__/v2.0.0/chatMember/getAll.json
@@ -1,0 +1,33 @@
+{
+	"type": "object",
+	"properties": {
+		"@odata.type": {
+			"type": "string"
+		},
+		"displayName": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"roles": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"tenantId": {
+			"type": "string"
+		},
+		"userId": {
+			"type": "string"
+		},
+		"visibleHistoryStartDateTime": {
+			"type": "string"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.returnAll.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.returnAll.workflow.json
@@ -1,0 +1,105 @@
+{
+	"name": "Teams chatMember getAll returnAll",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "chatMember",
+				"operation": "getAll",
+				"chatId": {
+					"__rl": true,
+					"value": "19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2",
+					"mode": "list",
+					"cachedResultName": "Project team (group)"
+				},
+				"returnAll": true
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==",
+					"roles": ["owner"],
+					"displayName": "Ann Smith",
+					"userId": "e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111",
+					"email": "ann@contoso.com",
+					"tenantId": "23786ca6-7ff2-4672-87d0-5c649ee0a337",
+					"visibleHistoryStartDateTime": "0001-01-01T00:00:00Z"
+				}
+			},
+			{
+				"json": {
+					"id": "MCMjMSMj",
+					"roles": ["owner"],
+					"displayName": "Bob Jones",
+					"userId": "aa11bb22-5c3f-4f1e-9d5e-4d8f0f6ab222",
+					"email": "bob@contoso.com",
+					"tenantId": "23786ca6-7ff2-4672-87d0-5c649ee0a337",
+					"visibleHistoryStartDateTime": null
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "8a1b2c3d-0004-4000-8000-000000000004",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.returnAll.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.returnAll.workflow.json
@@ -46,7 +46,8 @@
 		"No Operation, do nothing": [
 			{
 				"json": {
-					"id": "MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==",
+					"id": "MCMjMCMjMjM3ODZjYTYtN2ZmMi00NjcyLTg3ZDAtNWM2NDllZTBhMzM3IyMxOTplYmVkOWFkNDJjOTA0ZDZjODNhZGYwZGIzNjAwNTNlY0B0aHJlYWQudjIjI2U3NmY0NTZmLTVjM2YtNGYxZS05ZDVlLTRkOGYwZjZhYjExMQ==",
+					"@odata.type": "#microsoft.graph.aadUserConversationMember",
 					"roles": ["owner"],
 					"displayName": "Ann Smith",
 					"userId": "e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111",
@@ -57,7 +58,8 @@
 			},
 			{
 				"json": {
-					"id": "MCMjMSMj",
+					"id": "MCMjMCMjMjM3ODZjYTYtN2ZmMi00NjcyLTg3ZDAtNWM2NDllZTBhMzM3IyMxOTplYmVkOWFkNDJjOTA0ZDZjODNhZGYwZGIzNjAwNTNlY0B0aHJlYWQudjIjI2FhMTFiYjIyLTVjM2YtNGYxZS05ZDVlLTRkOGYwZjZhYjIyMg==",
+					"@odata.type": "#microsoft.graph.aadUserConversationMember",
 					"roles": ["owner"],
 					"displayName": "Bob Jones",
 					"userId": "aa11bb22-5c3f-4f1e-9d5e-4d8f0f6ab222",

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.test.ts
@@ -1,0 +1,50 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+const member1 = {
+	id: 'MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==',
+	roles: ['owner'],
+	displayName: 'Ann Smith',
+	userId: 'e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111',
+	email: 'ann@contoso.com',
+	tenantId: '23786ca6-7ff2-4672-87d0-5c649ee0a337',
+	visibleHistoryStartDateTime: '0001-01-01T00:00:00Z',
+};
+const member2 = {
+	id: 'MCMjMSMj',
+	roles: ['owner'],
+	displayName: 'Bob Jones',
+	userId: 'aa11bb22-5c3f-4f1e-9d5e-4d8f0f6ab222',
+	email: 'bob@contoso.com',
+	tenantId: '23786ca6-7ff2-4672-87d0-5c649ee0a337',
+	visibleHistoryStartDateTime: null,
+};
+
+describe('Test MicrosoftTeamsV2, chatMember => getAll', () => {
+	// Registered WITHOUT `.query(...)`: this endpoint supports no OData parameters, so
+	// the test fails if `$top` is ever added.
+	nock('https://graph.microsoft.com')
+		.get('/v1.0/chats/19:ebed9ad42c904d6c83adf0db360053ec@thread.v2/members')
+		.reply(200, { value: [member1, member2] });
+
+	// Two pages for the returnAll workflow, on its own chat id so the interceptors
+	// cannot be matched in the wrong order. The nextLink must stay same-origin or the
+	// transport refuses it.
+	nock('https://graph.microsoft.com')
+		.get('/v1.0/chats/19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2/members')
+		.reply(200, {
+			value: [member1],
+			'@odata.nextLink':
+				'https://graph.microsoft.com/v1.0/chats/19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2/members?$skiptoken=page2',
+		})
+		.get('/v1.0/chats/19:ff1e2d3c4b5a69788796a5b4c3d2e1f0@thread.v2/members')
+		.query({ $skiptoken: 'page2' })
+		.reply(200, { value: [member2] });
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['getAll.workflow.json', 'getAll.returnAll.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.test.ts
@@ -3,8 +3,11 @@ import nock from 'nock';
 
 import { credentials } from '../../../credentials';
 
+// Membership ids are opaque base64 of `0##0##<tenantId>##<chatId>##<userId>`,
+// derived here from the tenant, chat and user ids below so the fixture is self-consistent.
 const member1 = {
-	id: 'MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==',
+	id: 'MCMjMCMjMjM3ODZjYTYtN2ZmMi00NjcyLTg3ZDAtNWM2NDllZTBhMzM3IyMxOTplYmVkOWFkNDJjOTA0ZDZjODNhZGYwZGIzNjAwNTNlY0B0aHJlYWQudjIjI2U3NmY0NTZmLTVjM2YtNGYxZS05ZDVlLTRkOGYwZjZhYjExMQ==',
+	'@odata.type': '#microsoft.graph.aadUserConversationMember',
 	roles: ['owner'],
 	displayName: 'Ann Smith',
 	userId: 'e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111',
@@ -13,7 +16,8 @@ const member1 = {
 	visibleHistoryStartDateTime: '0001-01-01T00:00:00Z',
 };
 const member2 = {
-	id: 'MCMjMSMj',
+	id: 'MCMjMCMjMjM3ODZjYTYtN2ZmMi00NjcyLTg3ZDAtNWM2NDllZTBhMzM3IyMxOTplYmVkOWFkNDJjOTA0ZDZjODNhZGYwZGIzNjAwNTNlY0B0aHJlYWQudjIjI2FhMTFiYjIyLTVjM2YtNGYxZS05ZDVlLTRkOGYwZjZhYjIyMg==',
+	'@odata.type': '#microsoft.graph.aadUserConversationMember',
 	roles: ['owner'],
 	displayName: 'Bob Jones',
 	userId: 'aa11bb22-5c3f-4f1e-9d5e-4d8f0f6ab222',
@@ -25,6 +29,9 @@ const member2 = {
 describe('Test MicrosoftTeamsV2, chatMember => getAll', () => {
 	// Registered WITHOUT `.query(...)`: this endpoint supports no OData parameters, so
 	// the test fails if `$top` is ever added.
+	// The workflow passes this chat id By ID and percent-encoded, the way the RLC hint
+	// tells users to copy it out of a Teams URL. The decoded form below is what
+	// `validateMicrosoftGraphId` must interpolate into the path.
 	nock('https://graph.microsoft.com')
 		.get('/v1.0/chats/19:ebed9ad42c904d6c83adf0db360053ec@thread.v2/members')
 		.reply(200, { value: [member1, member2] });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.workflow.json
@@ -1,0 +1,94 @@
+{
+	"name": "Teams chatMember getAll",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"resource": "chatMember",
+				"operation": "getAll",
+				"chatId": {
+					"__rl": true,
+					"value": "19:ebed9ad42c904d6c83adf0db360053ec@thread.v2",
+					"mode": "list",
+					"cachedResultName": "Project team (group)"
+				},
+				"limit": 1
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftTeamsOAuth2Api": {
+					"id": "6isd5ytvA0qV78eK",
+					"name": "Microsoft Teams account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==",
+					"roles": ["owner"],
+					"displayName": "Ann Smith",
+					"userId": "e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111",
+					"email": "ann@contoso.com",
+					"tenantId": "23786ca6-7ff2-4672-87d0-5c649ee0a337",
+					"visibleHistoryStartDateTime": "0001-01-01T00:00:00Z"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "8a1b2c3d-0003-4000-8000-000000000003",
+	"id": "i3NYGF0LXV4qDFV9",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMember/getAll.workflow.json
@@ -15,9 +15,8 @@
 				"operation": "getAll",
 				"chatId": {
 					"__rl": true,
-					"value": "19:ebed9ad42c904d6c83adf0db360053ec@thread.v2",
-					"mode": "list",
-					"cachedResultName": "Project team (group)"
+					"value": "19%3Aebed9ad42c904d6c83adf0db360053ec%40thread.v2",
+					"mode": "id"
 				},
 				"limit": 1
 			},
@@ -46,7 +45,8 @@
 		"No Operation, do nothing": [
 			{
 				"json": {
-					"id": "MCMjMCMjZmJlMmJmNDctMTZjOC00N2NmLWI0YTUtNGI5YTE5YzBmZTI4IyMxOTpiOTVhNTc3NGMxYzc0MjJmYjNkMTljMTU2Y2E5N2I5NEB0aHJlYWQudjIjIzg2MTA0MDBhLTUyYzYtNGI2Yy04MTZjLThjNjIzZDNlZmQ5Yg==",
+					"id": "MCMjMCMjMjM3ODZjYTYtN2ZmMi00NjcyLTg3ZDAtNWM2NDllZTBhMzM3IyMxOTplYmVkOWFkNDJjOTA0ZDZjODNhZGYwZGIzNjAwNTNlY0B0aHJlYWQudjIjI2U3NmY0NTZmLTVjM2YtNGYxZS05ZDVlLTRkOGYwZjZhYjExMQ==",
+					"@odata.type": "#microsoft.graph.aadUserConversationMember",
 					"roles": ["owner"],
 					"displayName": "Ann Smith",
 					"userId": "e76f456f-5c3f-4f1e-9d5e-4d8f0f6ab111",

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -72,6 +72,24 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
 	});
 
+	it.each(['getAll'])(
+		'chatMember:%s throws a static error and issues no request under SP',
+		async (operation) => {
+			selectSp({
+				resource: 'chatMember',
+				operation,
+				chatId: 'chatID',
+				returnAll: true,
+			});
+
+			await expect(node.execute.call(ctx)).rejects.toThrow(
+				'Chat members are not available with the Service Principal credential',
+			);
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+			expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
+		},
+	);
+
 	it.each([
 		['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }],
 		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -87,6 +87,8 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 			);
 			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 			expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
+			// the guard reads only the `authentication` parameter, never the credential itself
+			expect(ctx.getCredentials).not.toHaveBeenCalled();
 		},
 	);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -66,6 +66,40 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
+	describe('chatMember - hidden under SP via the slash-prefixed field-level key', () => {
+		it('operation selector carries hide["/authentication"] = [SP]', () => {
+			const op = actionProps.find(
+				(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes('chatMember'),
+			);
+			expect(isSpHidden(op)).toBe(true);
+			// distinct from the un-prefixed credential gate
+			expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
+		});
+
+		it('every chatMember field copy is hidden under SP', () => {
+			const memberFields = actionProps.filter((p) =>
+				p.displayOptions?.show?.resource?.includes('chatMember'),
+			);
+			// every chatMember input field, whichever operation declares it
+			const gatedFields = memberFields.filter((p) => p.type !== 'notice' && p.name !== 'operation');
+			expect(gatedFields.length).toBeGreaterThan(0);
+			for (const field of gatedFields) {
+				expect(isSpHidden(field)).toBe(true);
+			}
+		});
+
+		it('shows an SP notice for the chatMember resource', () => {
+			const notice = actionProps.find(
+				(p) =>
+					p.type === 'notice' &&
+					p.displayOptions?.show?.resource?.includes('chatMember') &&
+					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+			);
+			expect(notice).toBeDefined();
+			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+		});
+	});
+
 	describe('onlineMeeting — hidden under SP via the slash-prefixed field-level key', () => {
 		it('operation selector carries hide["/authentication"] = [SP]', () => {
 			const op = actionProps.find(

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -32,110 +32,40 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
-	describe('chatMessage — hidden under SP via the slash-prefixed field-level key', () => {
-		it('operation selector carries hide["/authentication"] = [SP]', () => {
-			const op = actionProps.find(
-				(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes('chatMessage'),
-			);
-			expect(isSpHidden(op)).toBe(true);
-			// distinct from the un-prefixed credential gate
-			expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
-		});
+	describe.each(['chatMessage', 'chatMember', 'onlineMeeting'])(
+		'%s - hidden under SP via the slash-prefixed field-level key',
+		(resource) => {
+			it('operation selector carries hide["/authentication"] = [SP]', () => {
+				const op = actionProps.find(
+					(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes(resource),
+				);
+				expect(isSpHidden(op)).toBe(true);
+				// distinct from the un-prefixed credential gate
+				expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
+			});
 
-		it('every chatMessage field copy is hidden under SP', () => {
-			const chatFields = actionProps.filter((p) =>
-				p.displayOptions?.show?.resource?.includes('chatMessage'),
-			);
-			// the chatId RLC, message, contentType, options, messageId, send-and-wait props…
-			const gatedFields = chatFields.filter((p) => p.type !== 'notice' && p.name !== 'operation');
-			expect(gatedFields.length).toBeGreaterThan(0);
-			for (const field of gatedFields) {
-				expect(isSpHidden(field)).toBe(true);
-			}
-		});
+			it('every field copy is hidden under SP', () => {
+				const fields = actionProps.filter((p) =>
+					p.displayOptions?.show?.resource?.includes(resource),
+				);
+				const gatedFields = fields.filter((p) => p.type !== 'notice' && p.name !== 'operation');
+				expect(gatedFields.length).toBeGreaterThan(0);
+				for (const field of gatedFields) {
+					expect(isSpHidden(field)).toBe(true);
+				}
+			});
 
-		it('shows an SP notice for the chatMessage resource', () => {
-			const notice = actionProps.find(
-				(p) =>
-					p.type === 'notice' &&
-					p.displayOptions?.show?.resource?.includes('chatMessage') &&
-					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
-			);
-			expect(notice).toBeDefined();
-			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
-		});
-	});
-
-	describe('chatMember - hidden under SP via the slash-prefixed field-level key', () => {
-		it('operation selector carries hide["/authentication"] = [SP]', () => {
-			const op = actionProps.find(
-				(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes('chatMember'),
-			);
-			expect(isSpHidden(op)).toBe(true);
-			// distinct from the un-prefixed credential gate
-			expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
-		});
-
-		it('every chatMember field copy is hidden under SP', () => {
-			const memberFields = actionProps.filter((p) =>
-				p.displayOptions?.show?.resource?.includes('chatMember'),
-			);
-			// every chatMember input field, whichever operation declares it
-			const gatedFields = memberFields.filter((p) => p.type !== 'notice' && p.name !== 'operation');
-			expect(gatedFields.length).toBeGreaterThan(0);
-			for (const field of gatedFields) {
-				expect(isSpHidden(field)).toBe(true);
-			}
-		});
-
-		it('shows an SP notice for the chatMember resource', () => {
-			const notice = actionProps.find(
-				(p) =>
-					p.type === 'notice' &&
-					p.displayOptions?.show?.resource?.includes('chatMember') &&
-					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
-			);
-			expect(notice).toBeDefined();
-			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
-		});
-	});
-
-	describe('onlineMeeting — hidden under SP via the slash-prefixed field-level key', () => {
-		it('operation selector carries hide["/authentication"] = [SP]', () => {
-			const op = actionProps.find(
-				(p) =>
-					p.name === 'operation' && p.displayOptions?.show?.resource?.includes('onlineMeeting'),
-			);
-			expect(isSpHidden(op)).toBe(true);
-			// distinct from the un-prefixed credential gate
-			expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
-		});
-
-		it('every onlineMeeting field copy is hidden under SP', () => {
-			const meetingFields = actionProps.filter((p) =>
-				p.displayOptions?.show?.resource?.includes('onlineMeeting'),
-			);
-			// subject, start/end times, options, meetingId…
-			const gatedFields = meetingFields.filter(
-				(p) => p.type !== 'notice' && p.name !== 'operation',
-			);
-			expect(gatedFields.length).toBeGreaterThan(0);
-			for (const field of gatedFields) {
-				expect(isSpHidden(field)).toBe(true);
-			}
-		});
-
-		it('shows an SP notice for the onlineMeeting resource', () => {
-			const notice = actionProps.find(
-				(p) =>
-					p.type === 'notice' &&
-					p.displayOptions?.show?.resource?.includes('onlineMeeting') &&
-					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
-			);
-			expect(notice).toBeDefined();
-			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
-		});
-	});
+			it('shows an SP notice for the resource', () => {
+				const notice = actionProps.find(
+					(p) =>
+						p.type === 'notice' &&
+						p.displayOptions?.show?.resource?.includes(resource) &&
+						p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+				);
+				expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+			});
+		},
+	);
 
 	describe('channelMessage — only the sending operations are hidden under SP', () => {
 		const fieldsFor = (operation: string) =>

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/getAll.operation.ts
@@ -1,0 +1,42 @@
+import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
+
+import { returnAllOrLimit } from '@utils/descriptions';
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { chatRLC } from '../../descriptions';
+import { buildTeamsPath, microsoftApiRequestAllItems, SP_HIDE } from '../../transport';
+import { throwIfChatMemberUnsupported } from './sharedGuard';
+
+const properties: INodeProperties[] = [chatRLC, ...returnAllOrLimit];
+
+const displayOptions = {
+	show: {
+		resource: ['chatMember'],
+		operation: ['getAll'],
+	},
+	hide: {
+		...SP_HIDE,
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number) {
+	// https://learn.microsoft.com/en-us/graph/api/chat-list-members?view=graph-rest-1.0
+
+	// App-only Graph cannot read chats; fail before any request.
+	throwIfChatMemberUnsupported.call(this, i);
+
+	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
+	const returnAll = this.getNodeParameter('returnAll', i);
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/members']);
+
+	if (returnAll) {
+		return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint);
+	}
+
+	// No `$top`: this endpoint supports no OData query parameters, so the limit is
+	// applied client-side while paging through @odata.nextLink.
+	const limit = this.getNodeParameter('limit', i);
+	return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint, {}, {}, limit);
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/getAll.operation.ts
@@ -24,19 +24,15 @@ export const description = updateDisplayOptions(displayOptions, properties);
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/chat-list-members?view=graph-rest-1.0
 
-	// App-only Graph cannot read chats; fail before any request.
-	throwIfChatMemberUnsupported.call(this, i);
+	// The chat picker cannot list chats app-only; fail before any request.
+	throwIfChatMemberUnsupported.call(this);
 
 	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
-	const returnAll = this.getNodeParameter('returnAll', i);
 	const endpoint = buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/members']);
-
-	if (returnAll) {
-		return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint);
-	}
 
 	// No `$top`: this endpoint supports no OData query parameters, so the limit is
 	// applied client-side while paging through @odata.nextLink.
-	const limit = this.getNodeParameter('limit', i);
+	const returnAll = this.getNodeParameter('returnAll', i);
+	const limit = returnAll ? undefined : this.getNodeParameter('limit', i);
 	return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint, {}, {}, limit);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/index.ts
@@ -1,0 +1,47 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as getAll from './getAll.operation';
+import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
+
+export { getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName:
+			'Chat members are not available with the Service Principal credential. App-only Microsoft Graph has no signed-in user; use an OAuth2 credential for chat actions.',
+		name: 'chatMemberServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['chatMember'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+	},
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['chatMember'],
+			},
+			hide: {
+				...SP_HIDE,
+			},
+		},
+		options: [
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many members of a chat',
+				action: 'Get many chat members',
+			},
+		],
+		default: 'getAll',
+	},
+
+	...getAll.description,
+];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/index.ts
@@ -8,7 +8,7 @@ export { getAll };
 export const description: INodeProperties[] = [
 	{
 		displayName:
-			'Chat members are not available with the Service Principal credential. App-only Microsoft Graph has no signed-in user; use an OAuth2 credential for chat actions.',
+			'Chat members are not available with the Service Principal credential. The chat picker cannot list chats app-only; use an OAuth2 credential for chat actions.',
 		name: 'chatMemberServicePrincipalNotice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
@@ -1,0 +1,26 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { getTeamsCredentialType, SERVICE_PRINCIPAL_AUTH } from '../../transport';
+
+/**
+ * Throws a static `NodeOperationError` when the node is configured with the
+ * app-only (Service Principal) credential. Chat membership has no usable app-only
+ * form (app-only Graph has no signed-in user), so every chatMember operation guards
+ * on this BEFORE any request - covering hand-edited workflows that bypass the
+ * hidden UI. Takes the item index so the error points at the failing item inside
+ * the router's per-item `continueOnFail` loop.
+ */
+export function throwIfChatMemberUnsupported(this: IExecuteFunctions, i: number): void {
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Chat members are not available with the Service Principal credential',
+			{
+				description:
+					'App-only Microsoft Graph has no signed-in user. Use an OAuth2 credential for chat actions.',
+				itemIndex: i,
+			},
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMember/sharedGuard.ts
@@ -5,21 +5,20 @@ import { getTeamsCredentialType, SERVICE_PRINCIPAL_AUTH } from '../../transport'
 
 /**
  * Throws a static `NodeOperationError` when the node is configured with the
- * app-only (Service Principal) credential. Chat membership has no usable app-only
- * form (app-only Graph has no signed-in user), so every chatMember operation guards
- * on this BEFORE any request - covering hand-edited workflows that bypass the
- * hidden UI. Takes the item index so the error points at the failing item inside
- * the router's per-item `continueOnFail` loop.
+ * app-only (Service Principal) credential. The endpoints themselves have
+ * application permissions, but the chat picker does not: `GET /chats` is
+ * delegated-only (app-only must go through `GET /users/{id}/chats`), so every
+ * chatMember operation guards on this BEFORE any request - covering
+ * hand-edited workflows that bypass the hidden UI.
  */
-export function throwIfChatMemberUnsupported(this: IExecuteFunctions, i: number): void {
+export function throwIfChatMemberUnsupported(this: IExecuteFunctions): void {
 	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
 		throw new NodeOperationError(
 			this.getNode(),
 			'Chat members are not available with the Service Principal credential',
 			{
 				description:
-					'App-only Microsoft Graph has no signed-in user. Use an OAuth2 credential for chat actions.',
-				itemIndex: i,
+					'The chat picker cannot list chats app-only. Use an OAuth2 credential for chat actions.',
 			},
 		);
 	}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/node.type.ts
@@ -3,6 +3,7 @@ import type { AllEntities } from 'n8n-workflow';
 type NodeMap = {
 	channel: 'create' | 'deleteChannel' | 'get' | 'getAll' | 'update';
 	channelMessage: 'create' | 'get' | 'getAll' | 'getAllReplies' | 'reply';
+	chatMember: 'getAll';
 	chatMessage: 'create' | 'get' | 'getAll' | 'sendAndWait';
 	onlineMeeting: 'create' | 'get';
 	task: 'create' | 'deleteTask' | 'get' | 'getAll' | 'update';

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
@@ -9,6 +9,7 @@ import {
 
 import * as channel from './channel';
 import * as channelMessage from './channelMessage';
+import * as chatMember from './chatMember';
 import * as chatMessage from './chatMessage';
 import type { MicrosoftTeamsType } from './node.type';
 import * as onlineMeeting from './onlineMeeting';
@@ -63,6 +64,9 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 						nodeVersion,
 						instanceId,
 					);
+					break;
+				case 'chatMember':
+					responseData = await chatMember[microsoftTeamsTypeData.operation].execute.call(this, i);
 					break;
 				case 'chatMessage':
 					responseData = await chatMessage[microsoftTeamsTypeData.operation].execute.call(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
@@ -3,6 +3,7 @@ import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 
 import * as channel from './channel';
 import * as channelMessage from './channelMessage';
+import * as chatMember from './chatMember';
 import * as chatMessage from './chatMessage';
 import * as onlineMeeting from './onlineMeeting';
 import * as task from './task';
@@ -95,6 +96,10 @@ export const versionDescription: INodeTypeDescription = {
 					value: 'channelMessage',
 				},
 				{
+					name: 'Chat Member',
+					value: 'chatMember',
+				},
+				{
 					name: 'Chat Message',
 					value: 'chatMessage',
 				},
@@ -112,6 +117,7 @@ export const versionDescription: INodeTypeDescription = {
 
 		...channel.description,
 		...channelMessage.description,
+		...chatMember.description,
 		...chatMessage.description,
 		...onlineMeeting.description,
 		...task.description,

--- a/packages/nodes-base/utils/microsoft/transport.ts
+++ b/packages/nodes-base/utils/microsoft/transport.ts
@@ -67,7 +67,7 @@ export function validateMicrosoftGraphId(id: string, node: INode): string {
 		throw new NodeOperationError(node, 'A required ID is empty', {
 			// Teams wording; make it injectable (UserTargetMessages pattern in
 			// nodes/Microsoft/GenericFunctions.ts) when the second consumer (SharePoint v2) lands.
-			description: 'Set the team, channel, plan, bucket, task or meeting ID and try again.',
+			description: 'Set the chat, team, channel, plan, bucket, task or meeting ID and try again.',
 		});
 	}
 	let value: string;


### PR DESCRIPTION
## Summary

First of three stacked PRs adding a **Chat Member** resource to the Microsoft Teams node. This one introduces the resource itself plus the read-only operation: **Get Many**, listing the members of an existing chat via `GET /chats/{id}/members`.

Nothing here needs a new Graph permission. Listing chat members is covered by `Chat.ReadWrite`, which the Teams OAuth2 credential already requests, so this can merge as soon as it is reviewed.

Two things worth knowing while reading it:

- **`Chat Member` appears without a `Chat` resource.** That is intentional and consistent with the node today, which already ships `Chat Message` without a `Chat` resource. ENT-323 adds `chat` separately and the two only overlap in three one-line registrations.

**The resource is gated to the OAuth2 credential, matching every other chat surface.** The endpoint itself does have application permissions (`ChatMember.Read.All`), but the chat picker does not: `GET /chats` is delegated-only, and app-only must go through `GET /users/{id}/chats`. Under the Service Principal credential the picker can therefore never list a chat, so the operation and its fields hide and a notice explains why. Each operation also guards on the credential type before it sends any request, so a hand-edited workflow that bypasses the hidden UI still fails cleanly.

### Stack

| | PR | Needs new scope |
|---|---|---|
| 1 | **this PR** - resource shell + Get Many | No |
| 2 | Add (user picker) | No |
| 3 | Remove | Yes - `ChatMember.ReadWrite`, admin consent |

Reviewing bottom-up is easiest. This one is self-contained: it builds, typechecks, lints and passes tests on its own.

## How to test

Needs a delegated Teams OAuth2 credential and any existing chat.

1. Add a Microsoft Teams node, pick **Chat Member** → **Get Many**, select a chat from the dropdown, run it. You should get one row per member.
2. Note that the `id` field is a long base64 string, distinct from `userId`.
3. Toggle **Return All** off and set **Limit** to 1, run again, and confirm you get a single row.
4. Switch the node to the Service Principal credential. **Chat Member** stays in the Resource dropdown - the resource option carries no `displayOptions`. Confirm that the Operation selector and the fields hide, and that the notice shows instead.

[
<img width="1678" height="795" alt="Screenshot 2026-09-03 at 17 13 42" src="https://github.com/user-attachments/assets/8abbfbfc-26bf-4948-a374-9e571c92ec29" />
](url)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-349

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


