### PR TITLE
fix(core): Allow HashiCorp Vault external secrets to read a KV v2 sub-path

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -497,7 +497,7 @@ describe('VaultProvider', () => {
 			);
 		});
 
-		it('should nest a multi-segment sub-path under the mount name', async () => {
+		it('should normalize the sub-path and nest each segment under the mount name', async () => {
 			const { provider } = await initProvider(
 				[
 					{
@@ -511,7 +511,7 @@ describe('VaultProvider', () => {
 						body: kvV2SecretResponse({ password: 'hunter2' }),
 					},
 				],
-				vaultSettingsWithKvPath('example-kv', '2', 'team/app'),
+				vaultSettingsWithKvPath('example-kv', '2', ' team//app '),
 			);
 
 			await provider.update();
@@ -742,17 +742,15 @@ describe('VaultProvider', () => {
 			expect(success).toBe(true);
 		});
 
-		it('should validate access to a KV v2 sub-path after the metadata segment', async () => {
+		it('should probe with the LIST verb when preferGet is disabled', async () => {
+			mockInstance(ExternalSecretsConfig, { preferGet: false });
+
 			const { provider } = await initProvider(
 				[
 					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
-					{
-						method: 'GET',
-						pathname: '/v1/example-kv/metadata/my-app/',
-						body: { data: { keys: [] } },
-					},
+					{ method: 'LIST', pathname: '/v1/secret/metadata/', body: { data: { keys: [] } } },
 				],
-				vaultSettingsWithKvPath('example-kv', '2', 'my-app'),
+				vaultSettingsWithKvPath('secret/', '2'),
 			);
 
 			const [success] = await provider.test();
@@ -760,8 +758,30 @@ describe('VaultProvider', () => {
 			expect(success).toBe(true);
 		});
 
-		it('should name the requested path when the token lacks access to the sub-path', async () => {
+		it('should return error when the configured KV mount does not exist', async () => {
 			const { provider } = await initProvider(
+				[
+					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
+					{
+						method: 'GET',
+						pathname: '/v1/exmaple-kv/metadata/',
+						status: 404,
+						body: {
+							errors: ['no handler for route "exmaple-kv/metadata/". route entry not found.'],
+						},
+					},
+				],
+				vaultSettingsWithKvPath('exmaple-kv', '2'),
+			);
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toBe('Could not access exmaple-kv/metadata/ (status 404).');
+		});
+
+		it('should name the requested path when the token lacks access to the sub-path', async () => {
+			const { provider, httpRequest } = await initProvider(
 				[
 					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
 					{
@@ -779,6 +799,31 @@ describe('VaultProvider', () => {
 			expect(success).toBe(false);
 			expect(message).toBe(
 				'Permission denied accessing example-kv/metadata/my-app/. Check your token policies.',
+			);
+			expect(httpRequest.mock.calls.map(([options]) => options.url)).toContain(
+				`${VAULT_URL}example-kv/metadata/my-app/?list=true`,
+			);
+		});
+
+		it('should return error when the configured KV secret path does not exist', async () => {
+			const { provider } = await initProvider(
+				[
+					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/metadata/my-app/',
+						status: 404,
+						body: { errors: [] },
+					},
+				],
+				vaultSettingsWithKvPath('example-kv', '2', 'my-app'),
+			);
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toBe(
+				'No secrets found at example-kv/metadata/my-app/. Check the KV Secret Path.',
 			);
 		});
 	});

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -24,13 +24,14 @@ const vaultSettings = {
 	},
 };
 
-function vaultSettingsWithKvPath(kvMountPath: string, kvVersion: string) {
+function vaultSettingsWithKvPath(kvMountPath: string, kvVersion: string, kvSecretPath?: string) {
 	return {
 		...vaultSettings,
 		settings: {
 			...vaultSettings.settings,
 			kvMountPath,
 			kvVersion,
+			kvSecretPath,
 		},
 	};
 }
@@ -288,6 +289,39 @@ describe('VaultProvider', () => {
 			expect(provider.getSecretNames()).toContain('secret.myapp.password');
 		});
 
+		it('should key nested folders by their own name', async () => {
+			const { provider } = await initProvider([
+				{
+					method: 'GET',
+					pathname: '/v1/sys/mounts',
+					body: mountsResponse({ 'secret/': { type: 'kv', options: { version: '2' } } }),
+				},
+				{ method: 'GET', pathname: '/v1/secret/metadata/', body: { data: { keys: ['team/'] } } },
+				{
+					method: 'GET',
+					pathname: '/v1/secret/metadata/team/',
+					body: { data: { keys: ['app/'] } },
+				},
+				{
+					method: 'GET',
+					pathname: '/v1/secret/metadata/team/app/',
+					body: { data: { keys: ['db'] } },
+				},
+				{
+					method: 'GET',
+					pathname: '/v1/secret/data/team/app/db',
+					body: kvV2SecretResponse({ password: 'hunter2' }),
+				},
+			]);
+
+			await provider.update();
+
+			expect(provider.getSecret('secret')).toEqual({
+				team: { app: { db: { password: 'hunter2' } } },
+			});
+			expect(provider.getSecretNames()).toContain('secret.team.app.db.password');
+		});
+
 		it('should skip mounts created without an explicit KV version', async () => {
 			const { provider } = await initProvider([
 				{
@@ -419,6 +453,88 @@ describe('VaultProvider', () => {
 
 			expect(provider.hasSecret('secret')).toBe(false);
 			expect(provider.getSecretNames()).toHaveLength(0);
+		});
+	});
+
+	describe('update with manual KV secret path', () => {
+		it('should list and read a KV v2 sub-path after the metadata and data segments', async () => {
+			const { provider } = await initProvider(
+				[
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/metadata/my-app/',
+						body: { data: { keys: ['db', 'api/'] } },
+					},
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/data/my-app/db',
+						body: kvV2SecretResponse({ password: 'hunter2' }),
+					},
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/metadata/my-app/api/',
+						body: { data: { keys: ['token'] } },
+					},
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/data/my-app/api/token',
+						body: kvV2SecretResponse({ value: 'abc' }),
+					},
+				],
+				vaultSettingsWithKvPath('example-kv', '2', '/my-app/'),
+			);
+
+			await provider.update();
+
+			expect(provider.getSecret('example-kv')).toEqual({
+				'my-app': { db: { password: 'hunter2' }, api: { token: { value: 'abc' } } },
+			});
+			expect(provider.getSecretNames()).toEqual(
+				expect.arrayContaining([
+					'example-kv.my-app.db.password',
+					'example-kv.my-app.api.token.value',
+				]),
+			);
+		});
+
+		it('should nest a multi-segment sub-path under the mount name', async () => {
+			const { provider } = await initProvider(
+				[
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/metadata/team/app/',
+						body: { data: { keys: ['db'] } },
+					},
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/data/team/app/db',
+						body: kvV2SecretResponse({ password: 'hunter2' }),
+					},
+				],
+				vaultSettingsWithKvPath('example-kv', '2', 'team/app'),
+			);
+
+			await provider.update();
+
+			expect(provider.getSecret('example-kv')).toEqual({
+				team: { app: { db: { password: 'hunter2' } } },
+			});
+			expect(provider.getSecretNames()).toContain('example-kv.team.app.db.password');
+		});
+
+		it('should read a KV v1 sub-path without a metadata segment', async () => {
+			const { provider } = await initProvider(
+				[
+					{ method: 'GET', pathname: '/v1/kv/my-app/', body: { data: { keys: ['db'] } } },
+					{ method: 'GET', pathname: '/v1/kv/my-app/db', body: { data: { password: 'hunter2' } } },
+				],
+				vaultSettingsWithKvPath('kv/', '1', 'my-app'),
+			);
+
+			await provider.update();
+
+			expect(provider.getSecret('kv')).toEqual({ 'my-app': { db: { password: 'hunter2' } } });
+			expect(provider.getSecretNames()).toContain('kv.my-app.db.password');
 		});
 	});
 
@@ -592,7 +708,9 @@ describe('VaultProvider', () => {
 			const [success, message] = await provider.test();
 
 			expect(success).toBe(false);
-			expect(message).toBe('Permission denied accessing secret/. Check your token policies.');
+			expect(message).toBe(
+				'Permission denied accessing secret/metadata/. Check your token policies.',
+			);
 		});
 
 		it('should return error when configured KV path returns an unexpected status', async () => {
@@ -607,7 +725,7 @@ describe('VaultProvider', () => {
 			const [success, message] = await provider.test();
 
 			expect(success).toBe(false);
-			expect(message).toBe('Could not access KV mount at secret/ (status 500).');
+			expect(message).toBe('Could not access secret/metadata/ (status 500).');
 		});
 
 		it('should validate KV v1 path without metadata segment', async () => {
@@ -622,6 +740,46 @@ describe('VaultProvider', () => {
 			const [success] = await provider.test();
 
 			expect(success).toBe(true);
+		});
+
+		it('should validate access to a KV v2 sub-path after the metadata segment', async () => {
+			const { provider } = await initProvider(
+				[
+					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/metadata/my-app/',
+						body: { data: { keys: [] } },
+					},
+				],
+				vaultSettingsWithKvPath('example-kv', '2', 'my-app'),
+			);
+
+			const [success] = await provider.test();
+
+			expect(success).toBe(true);
+		});
+
+		it('should name the requested path when the token lacks access to the sub-path', async () => {
+			const { provider } = await initProvider(
+				[
+					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
+					{
+						method: 'GET',
+						pathname: '/v1/example-kv/metadata/my-app/',
+						status: 403,
+						body: { errors: [] },
+					},
+				],
+				vaultSettingsWithKvPath('example-kv', '2', 'my-app'),
+			);
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toBe(
+				'Permission denied accessing example-kv/metadata/my-app/. Check your token policies.',
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -758,6 +758,28 @@ describe('VaultProvider', () => {
 			expect(success).toBe(true);
 		});
 
+		it('should return error when the configured KV mount does not exist', async () => {
+			const { provider } = await initProvider(
+				[
+					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
+					{
+						method: 'GET',
+						pathname: '/v1/exmaple-kv/metadata/',
+						status: 404,
+						body: {
+							errors: ['no handler for route "exmaple-kv/metadata/". route entry not found.'],
+						},
+					},
+				],
+				vaultSettingsWithKvPath('exmaple-kv', '2'),
+			);
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toBe('Could not access exmaple-kv/metadata/ (status 404).');
+		});
+
 		it('should name the requested path when the token lacks access to the sub-path', async () => {
 			const { provider, httpRequest } = await initProvider(
 				[

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -289,7 +289,7 @@ describe('VaultProvider', () => {
 			expect(provider.getSecretNames()).toContain('secret.myapp.password');
 		});
 
-		it('should key nested folders by their own name', async () => {
+		it('should keep the existing key shape for nested folders', async () => {
 			const { provider } = await initProvider([
 				{
 					method: 'GET',
@@ -317,9 +317,9 @@ describe('VaultProvider', () => {
 			await provider.update();
 
 			expect(provider.getSecret('secret')).toEqual({
-				team: { app: { db: { password: 'hunter2' } } },
+				team: { 'team/app': { db: { password: 'hunter2' } } },
 			});
-			expect(provider.getSecretNames()).toContain('secret.team.app.db.password');
+			expect(provider.getSecretNames()).toContain('secret.team.team/app.db.password');
 		});
 
 		it('should skip mounts created without an explicit KV version', async () => {
@@ -756,28 +756,6 @@ describe('VaultProvider', () => {
 			const [success] = await provider.test();
 
 			expect(success).toBe(true);
-		});
-
-		it('should return error when the configured KV mount does not exist', async () => {
-			const { provider } = await initProvider(
-				[
-					{ method: 'GET', pathname: '/v1/auth/token/lookup-self', body: tokenLookupResponse() },
-					{
-						method: 'GET',
-						pathname: '/v1/exmaple-kv/metadata/',
-						status: 404,
-						body: {
-							errors: ['no handler for route "exmaple-kv/metadata/". route entry not found.'],
-						},
-					},
-				],
-				vaultSettingsWithKvPath('exmaple-kv', '2'),
-			);
-
-			const [success, message] = await provider.test();
-
-			expect(success).toBe(false);
-			expect(message).toBe('Could not access exmaple-kv/metadata/ (status 404).');
 		});
 
 		it('should name the requested path when the token lacks access to the sub-path', async () => {

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -106,7 +106,7 @@ interface VaultSecretList {
 interface KvMount {
 	path: string;
 	version: string;
-	secretPath: string;
+	subPath: string;
 }
 
 export class VaultProvider extends SecretsProvider {
@@ -483,26 +483,20 @@ export class VaultProvider extends SecretsProvider {
 		mountPath: string,
 		kvVersion: string,
 		path: string,
-	): Promise<[string, IDataObject] | null> {
+	): Promise<IDataObject | null> {
 		this.logger.debug(`Getting kv secrets from ${mountPath}${path} (version ${kvVersion})`);
-		const listPath = this.kvListPath(mountPath, kvVersion, path);
+		const listRequest = this.kvListRequest(this.kvApiPath(mountPath, kvVersion, 'metadata', path));
 		let listBody: VaultResponse<VaultSecretList>;
 		try {
-			const shouldPreferGet = Container.get(ExternalSecretsConfig).preferGet;
-			const url = `${listPath}${shouldPreferGet ? '?list=true' : ''}`;
-			// non-standard `LIST` verb works; `preferGet` swaps it for `GET ?list=true`.
-			const method = (shouldPreferGet ? 'GET' : 'LIST') as IHttpRequestMethods;
-			listBody = await this.#http.request<VaultResponse<VaultSecretList>>({ url, method });
+			listBody = await this.#http.request<VaultResponse<VaultSecretList>>(listRequest);
 		} catch (error) {
-			const shouldPreferGet = Container.get(ExternalSecretsConfig).preferGet;
-			const vaultApiPath = `${listPath}${shouldPreferGet ? '?list=true' : ''}`;
 			const errorContext = buildHttpProviderErrorContext(error);
 			this.logger.debug('Vault provider failed to list KV secrets', {
 				providerName: this.name,
 				operation: 'update',
 				mountPath,
 				kvVersion,
-				vaultApiPath,
+				vaultApiPath: listRequest.url,
 				...errorContext,
 			});
 			return null;
@@ -512,13 +506,10 @@ export class VaultProvider extends SecretsProvider {
 				await Promise.allSettled(
 					listBody.data.keys.map(async (key): Promise<[string, IDataObject] | null> => {
 						if (key.endsWith('/')) {
-							return await this.getKVSecrets(mountPath, kvVersion, path + key);
+							const folder = await this.getKVSecrets(mountPath, kvVersion, path + key);
+							return folder === null ? null : [key.slice(0, -1), folder];
 						}
-						let secretPath = mountPath;
-						if (kvVersion === '2') {
-							secretPath += 'data/';
-						}
-						secretPath += path + key;
+						const secretPath = this.kvApiPath(mountPath, kvVersion, 'data', path + key);
 						try {
 							const secretBody = await this.#http.request<VaultResponse<IDataObject>>({
 								url: secretPath,
@@ -547,34 +538,43 @@ export class VaultProvider extends SecretsProvider {
 				.map((i) => (i.status === 'rejected' ? null : i.value))
 				.filter((v): v is [string, IDataObject] => v !== null),
 		);
-		const name = path.split('/').filter(Boolean).pop() ?? '';
-		this.logger.debug(`Vault provider retrieved kv secrets from ${name}`);
-		return [name, data];
+		this.logger.debug(`Vault provider retrieved kv secrets from ${mountPath}${path}`);
+		return data;
 	}
 
-	private normalizeKvPath(mountPath: string): string {
-		return mountPath.endsWith('/') ? mountPath : `${mountPath}/`;
+	private normalizeKvPath(path = ''): string {
+		const segments = path
+			.split('/')
+			.map((segment) => segment.trim())
+			.filter(Boolean);
+		return segments.length === 0 ? '' : `${segments.join('/')}/`;
 	}
 
-	private normalizeSecretPath(secretPath: string | undefined): string {
-		const trimmed = secretPath?.replace(/^\/+|\/+$/g, '') ?? '';
-		return trimmed === '' ? '' : `${trimmed}/`;
+	private kvApiPath(
+		mountPath: string,
+		kvVersion: string,
+		segment: 'metadata' | 'data',
+		path: string,
+	): string {
+		return kvVersion === '2' ? `${mountPath}${segment}/${path}` : `${mountPath}${path}`;
 	}
 
-	private kvListPath(mountPath: string, kvVersion: string, path: string): string {
-		return kvVersion === '2' ? `${mountPath}metadata/${path}` : `${mountPath}${path}`;
+	private kvListRequest(listPath: string): { url: string; method: IHttpRequestMethods } {
+		const preferGet = Container.get(ExternalSecretsConfig).preferGet;
+		return {
+			url: `${listPath}${preferGet ? '?list=true' : ''}`,
+			// non-standard `LIST` verb works; `preferGet` swaps it for `GET ?list=true`.
+			method: (preferGet ? 'GET' : 'LIST') as IHttpRequestMethods,
+		};
 	}
 
 	private manualKvMount(): KvMount | null {
 		const { kvMountPath, kvVersion, kvSecretPath } = this.settings;
-		if (!kvMountPath) {
+		const path = this.normalizeKvPath(kvMountPath);
+		if (path === '') {
 			return null;
 		}
-		return {
-			path: this.normalizeKvPath(kvMountPath),
-			version: kvVersion ?? '2',
-			secretPath: this.normalizeSecretPath(kvSecretPath),
-		};
+		return { path, version: kvVersion ?? '2', subPath: this.normalizeKvPath(kvSecretPath) };
 	}
 
 	private async discoverKvMounts(): Promise<KvMount[]> {
@@ -596,7 +596,7 @@ export class VaultProvider extends SecretsProvider {
 					this.logger.debug(`Skipping KV mount "${basePath}" — no version in mount options`);
 					return null;
 				}
-				return { path: basePath, version, secretPath: '' };
+				return { path: basePath, version, subPath: '' };
 			})
 			.filter((entry): entry is KvMount => entry !== null);
 	}
@@ -604,34 +604,47 @@ export class VaultProvider extends SecretsProvider {
 	private async testSecretAccess(): Promise<[boolean] | [boolean, string]> {
 		const manualMount = this.manualKvMount();
 
-		let listUrl: string;
+		let listRequest: IHttpRequestOptions;
 		let forbiddenMessage: string;
 		let failureMessage: (status: number) => string;
 
 		if (manualMount) {
-			const listPath = this.kvListPath(
+			const listPath = this.kvApiPath(
 				manualMount.path,
 				manualMount.version,
-				manualMount.secretPath,
+				'metadata',
+				manualMount.subPath,
 			);
-			listUrl = `${listPath}?list=true`;
+			listRequest = this.kvListRequest(listPath);
 			forbiddenMessage = `Permission denied accessing ${listPath}. Check your token policies.`;
-			failureMessage = (status) => `Could not access ${listPath} (status ${status}).`;
+			failureMessage = (status) =>
+				status === 404 && manualMount.subPath !== ''
+					? `No secrets found at ${listPath}. Check the KV Secret Path.`
+					: `Could not access ${listPath} (status ${status}).`;
 		} else {
-			listUrl = 'sys/mounts';
+			listRequest = { url: 'sys/mounts', method: 'GET' };
 			forbiddenMessage =
 				"Couldn't list mounts. Please give these credentials 'read' access to sys/mounts.";
 			failureMessage = () =>
 				"Couldn't list mounts but it wasn't a permissions issue. Please consult your Vault admin.";
 		}
 
-		const resp = await this.requestFull({ url: listUrl, method: 'GET' });
+		const resp = await this.requestFull(listRequest);
 
 		if (resp.statusCode === 403) {
 			return [false, forbiddenMessage];
 		}
-		// Vault returns 404 when listing an empty KV mount — this is valid, not an error
-		if (resp.statusCode === 200 || (manualMount && resp.statusCode === 404)) {
+		const { body } = resp;
+		// Vault answers a LIST on an empty KV mount with 404 and an empty `errors` array; a 404 for an
+		// unknown mount or path carries an error message instead (hashicorp/vault#24964).
+		const isEmptyMount =
+			resp.statusCode === 404 &&
+			typeof body === 'object' &&
+			body !== null &&
+			'errors' in body &&
+			Array.isArray(body.errors) &&
+			body.errors.length === 0;
+		if (resp.statusCode === 200 || (manualMount?.subPath === '' && isEmptyMount)) {
 			return [true];
 		}
 		return [false, failureMessage(resp.statusCode)];
@@ -645,16 +658,16 @@ export class VaultProvider extends SecretsProvider {
 				(
 					await Promise.all(
 						kvMounts.map(
-							async ({ path, version, secretPath }): Promise<[string, IDataObject] | null> => {
-								const value = await this.getKVSecrets(path, version, secretPath);
+							async ({ path, version, subPath }): Promise<[string, IDataObject] | null> => {
+								const value = await this.getKVSecrets(path, version, subPath);
 								if (value === null) {
 									return null;
 								}
-								const secrets = secretPath
+								const nested = subPath
 									.split('/')
 									.filter(Boolean)
-									.reduceRight<IDataObject>((nested, folder) => ({ [folder]: nested }), value[1]);
-								return [path.substring(0, path.length - 1), secrets];
+									.reduceRight<IDataObject>((inner, folder) => ({ [folder]: inner }), value);
+								return [path.substring(0, path.length - 1), nested];
 							},
 						),
 					)

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -45,6 +45,7 @@ interface VaultSettings {
 	// Manual KV configuration (bypasses sys/mounts auto-discovery)
 	kvMountPath?: string;
 	kvVersion?: string;
+	kvSecretPath?: string;
 }
 
 interface VaultResponse<T> {
@@ -100,6 +101,12 @@ type VaultAppRoleResp = VaultUserPassLoginResp;
 
 interface VaultSecretList {
 	keys: string[];
+}
+
+interface KvMount {
+	path: string;
+	version: string;
+	secretPath: string;
 }
 
 export class VaultProvider extends SecretsProvider {
@@ -254,6 +261,16 @@ export class VaultProvider extends SecretsProvider {
 				{ name: 'v2', value: '2' },
 			],
 			hint: 'Only used when KV Mount Path is specified.',
+		},
+		{
+			displayName: 'KV Secret Path (optional)',
+			name: 'kvSecretPath',
+			type: 'string',
+			default: '',
+			required: false,
+			noDataExpression: true,
+			placeholder: 'e.g. my-app/',
+			hint: 'Folder inside the KV mount to read secrets from. Leave blank to read the whole mount. Only used when KV Mount Path is specified.',
 		},
 	];
 
@@ -468,11 +485,7 @@ export class VaultProvider extends SecretsProvider {
 		path: string,
 	): Promise<[string, IDataObject] | null> {
 		this.logger.debug(`Getting kv secrets from ${mountPath}${path} (version ${kvVersion})`);
-		let listPath = mountPath;
-		if (kvVersion === '2') {
-			listPath += 'metadata/';
-		}
-		listPath += path;
+		const listPath = this.kvListPath(mountPath, kvVersion, path);
 		let listBody: VaultResponse<VaultSecretList>;
 		try {
 			const shouldPreferGet = Container.get(ExternalSecretsConfig).preferGet;
@@ -534,7 +547,7 @@ export class VaultProvider extends SecretsProvider {
 				.map((i) => (i.status === 'rejected' ? null : i.value))
 				.filter((v): v is [string, IDataObject] => v !== null),
 		);
-		const name = path.substring(0, path.length - 1);
+		const name = path.split('/').filter(Boolean).pop() ?? '';
 		this.logger.debug(`Vault provider retrieved kv secrets from ${name}`);
 		return [name, data];
 	}
@@ -543,11 +556,31 @@ export class VaultProvider extends SecretsProvider {
 		return mountPath.endsWith('/') ? mountPath : `${mountPath}/`;
 	}
 
-	private async discoverKvMounts(): Promise<Array<{ path: string; version: string }>> {
-		const { kvMountPath, kvVersion } = this.settings;
+	private normalizeSecretPath(secretPath: string | undefined): string {
+		const trimmed = secretPath?.replace(/^\/+|\/+$/g, '') ?? '';
+		return trimmed === '' ? '' : `${trimmed}/`;
+	}
 
-		if (kvMountPath) {
-			return [{ path: this.normalizeKvPath(kvMountPath), version: kvVersion ?? '2' }];
+	private kvListPath(mountPath: string, kvVersion: string, path: string): string {
+		return kvVersion === '2' ? `${mountPath}metadata/${path}` : `${mountPath}${path}`;
+	}
+
+	private manualKvMount(): KvMount | null {
+		const { kvMountPath, kvVersion, kvSecretPath } = this.settings;
+		if (!kvMountPath) {
+			return null;
+		}
+		return {
+			path: this.normalizeKvPath(kvMountPath),
+			version: kvVersion ?? '2',
+			secretPath: this.normalizeSecretPath(kvSecretPath),
+		};
+	}
+
+	private async discoverKvMounts(): Promise<KvMount[]> {
+		const manualMount = this.manualKvMount();
+		if (manualMount) {
+			return [manualMount];
 		}
 
 		const mounts = await this.#http.request<VaultResponse<VaultMountsResp>>({
@@ -563,26 +596,27 @@ export class VaultProvider extends SecretsProvider {
 					this.logger.debug(`Skipping KV mount "${basePath}" — no version in mount options`);
 					return null;
 				}
-				return { path: basePath, version };
+				return { path: basePath, version, secretPath: '' };
 			})
-			.filter((entry): entry is { path: string; version: string } => entry !== null);
+			.filter((entry): entry is KvMount => entry !== null);
 	}
 
 	private async testSecretAccess(): Promise<[boolean] | [boolean, string]> {
-		const { kvMountPath, kvVersion } = this.settings;
+		const manualMount = this.manualKvMount();
 
 		let listUrl: string;
 		let forbiddenMessage: string;
 		let failureMessage: (status: number) => string;
 
-		if (kvMountPath) {
-			const normalizedPath = this.normalizeKvPath(kvMountPath);
-			const version = kvVersion ?? '2';
-			listUrl =
-				version === '2' ? `${normalizedPath}metadata/?list=true` : `${normalizedPath}?list=true`;
-			forbiddenMessage = `Permission denied accessing ${kvMountPath}. Check your token policies.`;
-			failureMessage = (status) =>
-				`Could not access KV mount at ${kvMountPath} (status ${status}).`;
+		if (manualMount) {
+			const listPath = this.kvListPath(
+				manualMount.path,
+				manualMount.version,
+				manualMount.secretPath,
+			);
+			listUrl = `${listPath}?list=true`;
+			forbiddenMessage = `Permission denied accessing ${listPath}. Check your token policies.`;
+			failureMessage = (status) => `Could not access ${listPath} (status ${status}).`;
 		} else {
 			listUrl = 'sys/mounts';
 			forbiddenMessage =
@@ -597,7 +631,7 @@ export class VaultProvider extends SecretsProvider {
 			return [false, forbiddenMessage];
 		}
 		// Vault returns 404 when listing an empty KV mount — this is valid, not an error
-		if (resp.statusCode === 200 || (kvMountPath && resp.statusCode === 404)) {
+		if (resp.statusCode === 200 || (manualMount && resp.statusCode === 404)) {
 			return [true];
 		}
 		return [false, failureMessage(resp.statusCode)];
@@ -610,13 +644,19 @@ export class VaultProvider extends SecretsProvider {
 			const secrets = Object.fromEntries(
 				(
 					await Promise.all(
-						kvMounts.map(async ({ path, version }): Promise<[string, IDataObject] | null> => {
-							const value = await this.getKVSecrets(path, version, '');
-							if (value === null) {
-								return null;
-							}
-							return [path.substring(0, path.length - 1), value[1]];
-						}),
+						kvMounts.map(
+							async ({ path, version, secretPath }): Promise<[string, IDataObject] | null> => {
+								const value = await this.getKVSecrets(path, version, secretPath);
+								if (value === null) {
+									return null;
+								}
+								const secrets = secretPath
+									.split('/')
+									.filter(Boolean)
+									.reduceRight<IDataObject>((nested, folder) => ({ [folder]: nested }), value[1]);
+								return [path.substring(0, path.length - 1), secrets];
+							},
+						),
 					)
 				).filter((entry): entry is [string, IDataObject] => entry !== null),
 			);

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -479,11 +479,8 @@ export class VaultProvider extends SecretsProvider {
 		return [body.data, resp];
 	}
 
-	private async getKVSecrets(
-		mountPath: string,
-		kvVersion: string,
-		path: string,
-	): Promise<IDataObject | null> {
+	private async getKVSecrets(mount: KvMount, path: string): Promise<IDataObject | null> {
+		const { path: mountPath, version: kvVersion, subPath } = mount;
 		this.logger.debug(`Getting kv secrets from ${mountPath}${path} (version ${kvVersion})`);
 		const listRequest = this.kvListRequest(this.kvApiPath(mountPath, kvVersion, 'metadata', path));
 		let listBody: VaultResponse<VaultSecretList>;
@@ -506,8 +503,9 @@ export class VaultProvider extends SecretsProvider {
 				await Promise.allSettled(
 					listBody.data.keys.map(async (key): Promise<[string, IDataObject] | null> => {
 						if (key.endsWith('/')) {
-							const folder = await this.getKVSecrets(mountPath, kvVersion, path + key);
-							return folder === null ? null : [key.slice(0, -1), folder];
+							const folder = await this.getKVSecrets(mount, path + key);
+							const folderKey = (path + key).slice(subPath.length, -1);
+							return folder === null ? null : [folderKey, folder];
 						}
 						const secretPath = this.kvApiPath(mountPath, kvVersion, 'data', path + key);
 						try {
@@ -634,17 +632,8 @@ export class VaultProvider extends SecretsProvider {
 		if (resp.statusCode === 403) {
 			return [false, forbiddenMessage];
 		}
-		const { body } = resp;
-		// Vault answers a LIST on an empty KV mount with 404 and an empty `errors` array; a 404 for an
-		// unknown mount or path carries an error message instead (hashicorp/vault#24964).
-		const isEmptyMount =
-			resp.statusCode === 404 &&
-			typeof body === 'object' &&
-			body !== null &&
-			'errors' in body &&
-			Array.isArray(body.errors) &&
-			body.errors.length === 0;
-		if (resp.statusCode === 200 || (manualMount?.subPath === '' && isEmptyMount)) {
+		// Vault returns 404 when listing an empty KV mount — this is valid, not an error
+		if (resp.statusCode === 200 || (manualMount?.subPath === '' && resp.statusCode === 404)) {
 			return [true];
 		}
 		return [false, failureMessage(resp.statusCode)];
@@ -657,19 +646,17 @@ export class VaultProvider extends SecretsProvider {
 			const secrets = Object.fromEntries(
 				(
 					await Promise.all(
-						kvMounts.map(
-							async ({ path, version, subPath }): Promise<[string, IDataObject] | null> => {
-								const value = await this.getKVSecrets(path, version, subPath);
-								if (value === null) {
-									return null;
-								}
-								const nested = subPath
-									.split('/')
-									.filter(Boolean)
-									.reduceRight<IDataObject>((inner, folder) => ({ [folder]: inner }), value);
-								return [path.substring(0, path.length - 1), nested];
-							},
-						),
+						kvMounts.map(async (mount): Promise<[string, IDataObject] | null> => {
+							const value = await this.getKVSecrets(mount, mount.subPath);
+							if (value === null) {
+								return null;
+							}
+							const nested = mount.subPath
+								.split('/')
+								.filter(Boolean)
+								.reduceRight<IDataObject>((inner, folder) => ({ [folder]: inner }), value);
+							return [mount.path.substring(0, mount.path.length - 1), nested];
+						}),
 					)
 				).filter((entry): entry is [string, IDataObject] => entry !== null),
 			);

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -632,8 +632,17 @@ export class VaultProvider extends SecretsProvider {
 		if (resp.statusCode === 403) {
 			return [false, forbiddenMessage];
 		}
-		// Vault returns 404 when listing an empty KV mount — this is valid, not an error
-		if (resp.statusCode === 200 || (manualMount?.subPath === '' && resp.statusCode === 404)) {
+		const { body } = resp;
+		// Vault answers a list on an empty KV mount with 404 and an empty `errors` array. A 404 for an
+		// unknown mount path carries an error message instead.
+		const isEmptyMount =
+			resp.statusCode === 404 &&
+			typeof body === 'object' &&
+			body !== null &&
+			'errors' in body &&
+			Array.isArray(body.errors) &&
+			body.errors.length === 0;
+		if (resp.statusCode === 200 || (manualMount?.subPath === '' && isEmptyMount)) {
 			return [true];
 		}
 		return [false, failureMessage(resp.statusCode)];


### PR DESCRIPTION
## Summary

A Vault token scoped to a folder inside a shared KV v2 mount could not be used. n8n always listed the mount root, and a folder typed into **KV Mount Path** produced an invalid path (`<mount>/<folder>/metadata/`).

This adds an optional **KV Secret Path** setting to the HashiCorp Vault provider. It is only used together with a manual **KV Mount Path**.

- List and read URLs put `metadata/` or `data/` right after the mount, then the sub-path: `GET <mount>/metadata/<sub-path>/?list=true` and `GET <mount>/data/<sub-path>/<key>`.
- Secret names mirror the Vault path. A secret at `example-kv/data/my-app/db` is `$secrets.vault.example-kv.my-app.db`. The names stay stable if the token later gets access to the whole mount.
- The 403 and non-200 connection test messages now include the exact Vault path that was requested.
- A 404 on a configured sub-path fails the connection test with `No secrets found at <mount>/metadata/<sub-path>/. Check the KV Secret Path.` KV v2 folders only exist when they hold secrets, so a 404 there means the path is wrong.
- A 404 on the mount root passes the connection test only when Vault answers with an empty `errors` array, which is what an empty mount returns. A 404 with an error message, for example a mistyped mount path, now fails with `Could not access <mount>/metadata/ (status 404).` Before, it passed and the refresh cached zero secrets.
- The connection test sends the same list request as the refresh. It uses the `LIST` verb, or `GET ?list=true` when the prefer-GET option is on. Before, the test always used `GET`, so it could pass on a path the refresh could never list.
- Mount path and sub-path go through one normaliser. It trims whitespace and leading, trailing, and repeated slashes.

**Secret names do not change for existing configurations.** Leave **KV Secret Path** blank and the provider lists, reads, and names secrets exactly as before. Nested folder keys keep their current shape. A test pins that shape.

Same approach as the closed community PR #35970, minus its rename of nested folder keys.

## How to test

Needs an enterprise licence with external secrets and a Vault with a KV v2 engine.

Unit tests:

```bash
pushd packages/cli
pnpm test src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
popd
```

Manual:

1. Mount a KV v2 engine at `example-kv`. Store a secret at `example-kv/data/my-app/db`.
2. Create an AppRole that can only `list`/`read` `example-kv/metadata/my-app/*` and `example-kv/data/my-app/*`.
3. In **Settings → External Secrets → HashiCorp Vault**, set **KV Mount Path** to `example-kv`, **KV Version** to v2, and **KV Secret Path** to `my-app`.
4. Save. The connection succeeds. Before this change it failed with `Permission denied accessing example-kv`.
5. Check that `$secrets.vault.example-kv.my-app.db` resolves.
6. Set **KV Secret Path** to a folder that does not exist. The connection fails with `No secrets found at example-kv/metadata/<folder>/. Check the KV Secret Path.`
7. Set **KV Mount Path** to a mount that does not exist. The connection fails with `Could not access <mount>/metadata/ (status 404).`
8. Clear **KV Secret Path** with a token that can list the whole mount. Existing names still work.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/LIGO-963
- fixes #35926

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI