### PR TITLE
fix(core): Preserve provider tool results in agent memory

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime-conversion.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime-conversion.test.ts
@@ -770,6 +770,52 @@ describe('toAiMessages + fromAiMessages — round-trip', () => {
 			{ type: 'text', text: 'Here is what I found.' },
 		]);
 	});
+	it('keeps provider result metadata only on provider-executed tool results', () => {
+		const providerOptions = { anthropic: { cacheControl: { type: 'ephemeral' } } };
+		const aiMessages: ModelMessage[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'srvtoolu_1',
+						toolName: 'web_search',
+						input: { query: 'n8n' },
+						providerExecuted: true,
+					},
+					{
+						type: 'tool-result',
+						toolCallId: 'srvtoolu_1',
+						toolName: 'web_search',
+						output: { type: 'json', value: [] },
+						providerOptions,
+					},
+					{ type: 'tool-call', toolCallId: 'call_1', toolName: 'local', input: {} },
+				],
+			},
+			{
+				role: 'tool',
+				content: [
+					{
+						type: 'tool-result',
+						toolCallId: 'call_1',
+						toolName: 'local',
+						output: { type: 'json', value: 'ok' },
+						providerOptions,
+					},
+				],
+			},
+		];
+
+		const replayed = toAiMessages(fromAiMessages(aiMessages) as Message[]);
+
+		expect(replayed[0].content).toMatchObject([
+			{ type: 'tool-call', toolCallId: 'srvtoolu_1' },
+			{ type: 'tool-result', toolCallId: 'srvtoolu_1', providerOptions },
+			{ type: 'tool-call', toolCallId: 'call_1' },
+		]);
+		expect(replayed[1].content[0]).not.toHaveProperty('providerOptions');
+	});
 
 	it('round-trip is structurally equivalent for a resolved tool-call', () => {
 		const original: Message[] = [

--- a/packages/@n8n/agents/src/runtime/__tests__/strip-orphaned-tool-messages.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/strip-orphaned-tool-messages.test.ts
@@ -244,6 +244,31 @@ describe('settleOrphanedToolMessages', () => {
 		expect(settledBlock(result, 1, 0).state).toBe('rejected');
 	});
 
+	it('drops a pending provider-executed tool call without fabricating a result', () => {
+		const messages: AgentMessage[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'srvtoolu-1',
+						toolName: 'anthropic.web_search_20250305',
+						input: { query: 'n8n' },
+						providerExecuted: true,
+						state: 'pending',
+					},
+					{ type: 'text', text: 'I found n8n.' },
+				],
+			},
+		];
+
+		const result = settleOrphanedToolMessages(messages);
+
+		expect(result).toEqual([
+			{ role: 'assistant', content: [{ type: 'text', text: 'I found n8n.' }] },
+		]);
+	});
+
 	it('settles only pending blocks in a mixed message', () => {
 		const messages: AgentMessage[] = [
 			{

--- a/packages/@n8n/agents/src/runtime/memory/strip-orphaned-tool-messages.ts
+++ b/packages/@n8n/agents/src/runtime/memory/strip-orphaned-tool-messages.ts
@@ -2,8 +2,9 @@ import { isLlmMessage } from '../../sdk/message';
 import type { AgentMessage, ContentToolCall, MessageContent } from '../../types/sdk/message';
 
 /**
- * Settle pending tool-call blocks in loaded thread history by rejecting them
- * with an explanation that the call never completed.
+ * Settle pending local tool-call blocks in loaded thread history by rejecting
+ * them with an explanation that the call never completed. Remove pending
+ * provider-executed calls because a local result is invalid for their protocol.
  *
  * A pending block in *history* means a previous turn suspended on the call
  * (usually awaiting a user confirmation) and was never resumed — the user
@@ -19,14 +20,23 @@ import type { AgentMessage, ContentToolCall, MessageContent } from '../../types/
  * live suspension, which receives its real result on resume.
  */
 export function settleOrphanedToolMessages<T extends AgentMessage>(messages: T[]): T[] {
-	return messages.map((msg) => {
-		if (!isLlmMessage(msg)) return msg;
+	const result: T[] = [];
+
+	for (const msg of messages) {
+		if (!isLlmMessage(msg)) {
+			result.push(msg);
+			continue;
+		}
 		if (!msg.content.some((block) => block.type === 'tool-call' && block.state === 'pending')) {
-			return msg;
+			result.push(msg);
+			continue;
 		}
 
-		const content = msg.content.map((block: MessageContent) => {
+		const content = msg.content.flatMap((block: MessageContent) => {
 			if (block.type !== 'tool-call' || block.state !== 'pending') return block;
+			// Provider tools execute inside the model response. A synthetic local
+			// result is not valid for their server tool-call protocol.
+			if (block.providerExecuted) return [];
 			const { suspension, ...rest } = block;
 			return {
 				...rest,
@@ -34,8 +44,10 @@ export function settleOrphanedToolMessages<T extends AgentMessage>(messages: T[]
 				error: buildAbandonedSuspensionError(block),
 			};
 		});
-		return { ...msg, content };
-	});
+		if (content.length > 0) result.push({ ...msg, content });
+	}
+
+	return result;
 }
 
 function buildAbandonedSuspensionError(

--- a/packages/@n8n/agents/src/runtime/model/messages.ts
+++ b/packages/@n8n/agents/src/runtime/model/messages.ts
@@ -268,6 +268,12 @@ function toAiContent(block: MessageContent): AiContentPart | undefined {
 function toolCallToResultPart(
 	block: ContentToolCall & { state: 'resolved' | 'rejected' },
 ): ToolResultPart {
+	// Providers replay their own result metadata; local results carry none.
+	const replay =
+		block.providerExecuted && block.providerOptions
+			? { providerOptions: block.providerOptions }
+			: {};
+
 	if (block.state === 'resolved') {
 		return {
 			type: 'tool-result',
@@ -276,6 +282,7 @@ function toolCallToResultPart(
 			output: isContentToolResultOutput(block.output)
 				? block.output
 				: { type: 'json', value: block.output },
+			...replay,
 		};
 	}
 	// rejected
@@ -290,6 +297,7 @@ function toolCallToResultPart(
 			output: block.providerExecuted
 				? { type: 'error-json', value: errorValue }
 				: { type: 'error-text', value: errorValue },
+			...replay,
 		};
 	}
 	return {
@@ -297,6 +305,7 @@ function toolCallToResultPart(
 		toolCallId: block.toolCallId,
 		toolName: block.toolName,
 		output: { type: 'error-json', value: errorValue as JSONValue },
+		...replay,
 	};
 }
 
@@ -539,6 +548,8 @@ export function fromAiMessages(messages: ModelMessage[]): AgentMessage[] {
 				mutableBlock.state = 'rejected';
 				mutableBlock.error = JSON.stringify(output);
 			}
+			if (block.providerExecuted && part.providerOptions)
+				block.providerOptions = part.providerOptions;
 		}
 	};
 


### PR DESCRIPTION
## Summary

Provider-executed tools (for example Anthropic web search) run inside the model response. Two parts of that protocol did not survive a round trip through agent memory:

- The strip step rejected pending provider-executed tool calls with a synthetic local error. The provider does not accept a local result for its own tool call. The strip step now removes the pending call. It removes the message when no content remains.
- Provider tool results lost their `providerOptions` on replay. The conversion now stores the result metadata on the tool-call block and replays it on the tool-result part. Local tool results do not carry this metadata.

## How to test

1. Run the unit tests:
   ```
   pnpm --filter @n8n/agents test src/runtime/__tests__/agent-runtime-conversion.test.ts src/runtime/__tests__/strip-orphaned-tool-messages.test.ts
   ```
2. Start an agent with native web search. Interrupt a run while a search is pending. Send a new message. The next model call must succeed.

## Related Linear tickets, Github issues, and Community forum posts

Split out of #37617.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

