### PR TITLE
fix(core): Keep an agent chat run alive when its connection drops

### DIFF
--- a/packages/@n8n/api-types/src/agents/__tests__/agent-chat-resume.dto.test.ts
+++ b/packages/@n8n/api-types/src/agents/__tests__/agent-chat-resume.dto.test.ts
@@ -2,7 +2,15 @@ import { credentialResumeSchema, questionsResumeSchema } from '../agent-interact
 import { AgentChatResumeDto } from '../dto';
 
 describe('AgentChatResumeDto', () => {
-	const base = { runId: 'run-1', toolCallId: 'tc-1' };
+	const base = { runId: 'run-1', toolCallId: 'tc-1', sessionId: 'thread-1' };
+
+	it('requires the thread the resumed turn belongs to', () => {
+		// The controller indexes the run for Stop before it loads the checkpoint,
+		// so the id has to arrive on the request.
+		const { sessionId, ...withoutSession } = base;
+		expect(AgentChatResumeDto.safeParse(withoutSession).success).toBe(false);
+		expect(AgentChatResumeDto.safeParse({ ...base, sessionId: '' }).success).toBe(false);
+	});
 
 	it('does not strip answers from a questions-card resume', () => {
 		const resumeData = {

--- a/packages/@n8n/api-types/src/agents/dto.ts
+++ b/packages/@n8n/api-types/src/agents/dto.ts
@@ -249,6 +249,12 @@ export class AgentChatMessageDto extends Z.class(agentChatMessageShape) {
 export class AgentChatResumeDto extends Z.class({
 	runId: z.string().min(1),
 	toolCallId: z.string().min(1),
+	/**
+	 * Thread the resumed turn belongs to. Carried on the request because the
+	 * controller has to index the run for Stop before it loads the checkpoint,
+	 * which is the first place the thread id would otherwise appear.
+	 */
+	sessionId: z.string().min(1),
 	// Deliberately untyped at this boundary: the possible resume shapes overlap
 	// (e.g. credential's `{approved}` matches questions' `{approved, answers}`
 	// and a non-discriminated union would parse against whichever member

--- a/packages/cli/src/modules/agents/__tests__/agent-active-chat-run.registry.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-active-chat-run.registry.test.ts
@@ -1,0 +1,59 @@
+import { AgentActiveChatRunRegistry } from '../agent-active-chat-run.registry';
+
+describe('AgentActiveChatRunRegistry', () => {
+	it('aborts every run a user has on one agent', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const first = new AbortController();
+		const second = new AbortController();
+		registry.register('agent-1', 'user-1', first);
+		registry.register('agent-1', 'user-1', second);
+
+		expect(registry.cancel('agent-1', 'user-1')).toBe(true);
+		expect(first.signal.aborted).toBe(true);
+		expect(second.signal.aborted).toBe(true);
+	});
+
+	it('scopes runs to the agent and the user', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const controller = new AbortController();
+		registry.register('agent-1', 'user-1', controller);
+
+		expect(registry.cancel('agent-2', 'user-1')).toBe(false);
+		expect(registry.cancel('agent-1', 'user-2')).toBe(false);
+		expect(controller.signal.aborted).toBe(false);
+	});
+
+	it('forgets a run once its disposer runs', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const controller = new AbortController();
+		const dispose = registry.register('agent-1', 'user-1', controller);
+
+		dispose();
+
+		expect(registry.cancel('agent-1', 'user-1')).toBe(false);
+		expect(controller.signal.aborted).toBe(false);
+	});
+
+	it('keeps the other runs when one disposer runs', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const finished = new AbortController();
+		const running = new AbortController();
+		const disposeFinished = registry.register('agent-1', 'user-1', finished);
+		registry.register('agent-1', 'user-1', running);
+
+		disposeFinished();
+
+		expect(registry.cancel('agent-1', 'user-1')).toBe(true);
+		expect(finished.signal.aborted).toBe(false);
+		expect(running.signal.aborted).toBe(true);
+	});
+
+	it('tolerates a disposer running twice', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const dispose = registry.register('agent-1', 'user-1', new AbortController());
+
+		dispose();
+
+		expect(() => dispose()).not.toThrow();
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/agent-active-chat-run.registry.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-active-chat-run.registry.test.ts
@@ -1,36 +1,59 @@
-import { AgentActiveChatRunRegistry } from '../agent-active-chat-run.registry';
+import {
+	AgentActiveChatRunRegistry,
+	CHAT_RUN_INTERRUPTED_BY_SHUTDOWN,
+} from '../agent-active-chat-run.registry';
+
+const key = (overrides: { agentId?: string; userId?: string; threadId?: string } = {}) => ({
+	agentId: 'agent-1',
+	userId: 'user-1',
+	threadId: 'thread-1',
+	...overrides,
+});
 
 describe('AgentActiveChatRunRegistry', () => {
-	it('aborts every run a user has on one agent', () => {
+	it('aborts every run on the thread', () => {
 		const registry = new AgentActiveChatRunRegistry();
-		const first = new AbortController();
-		const second = new AbortController();
-		registry.register('agent-1', 'user-1', first);
-		registry.register('agent-1', 'user-1', second);
+		const turn = new AbortController();
+		const resumedTurn = new AbortController();
+		registry.register(key(), turn);
+		registry.register(key(), resumedTurn);
 
-		expect(registry.cancel('agent-1', 'user-1')).toBe(true);
-		expect(first.signal.aborted).toBe(true);
-		expect(second.signal.aborted).toBe(true);
+		expect(registry.cancel(key())).toBe(true);
+		expect(turn.signal.aborted).toBe(true);
+		expect(resumedTurn.signal.aborted).toBe(true);
 	});
 
-	it('scopes runs to the agent and the user', () => {
+	it('leaves the same user’s other threads on the agent running', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const stopped = new AbortController();
+		const other = new AbortController();
+		registry.register(key({ threadId: 'thread-stopped' }), stopped);
+		registry.register(key({ threadId: 'thread-other' }), other);
+
+		expect(registry.cancel(key({ threadId: 'thread-stopped' }))).toBe(true);
+		expect(stopped.signal.aborted).toBe(true);
+		expect(other.signal.aborted).toBe(false);
+	});
+
+	it('scopes runs to the agent, the user and the thread', () => {
 		const registry = new AgentActiveChatRunRegistry();
 		const controller = new AbortController();
-		registry.register('agent-1', 'user-1', controller);
+		registry.register(key(), controller);
 
-		expect(registry.cancel('agent-2', 'user-1')).toBe(false);
-		expect(registry.cancel('agent-1', 'user-2')).toBe(false);
+		expect(registry.cancel(key({ agentId: 'agent-2' }))).toBe(false);
+		expect(registry.cancel(key({ userId: 'user-2' }))).toBe(false);
+		expect(registry.cancel(key({ threadId: 'thread-2' }))).toBe(false);
 		expect(controller.signal.aborted).toBe(false);
 	});
 
 	it('forgets a run once its disposer runs', () => {
 		const registry = new AgentActiveChatRunRegistry();
 		const controller = new AbortController();
-		const dispose = registry.register('agent-1', 'user-1', controller);
+		const dispose = registry.register(key(), controller);
 
 		dispose();
 
-		expect(registry.cancel('agent-1', 'user-1')).toBe(false);
+		expect(registry.cancel(key())).toBe(false);
 		expect(controller.signal.aborted).toBe(false);
 	});
 
@@ -38,19 +61,47 @@ describe('AgentActiveChatRunRegistry', () => {
 		const registry = new AgentActiveChatRunRegistry();
 		const finished = new AbortController();
 		const running = new AbortController();
-		const disposeFinished = registry.register('agent-1', 'user-1', finished);
-		registry.register('agent-1', 'user-1', running);
+		const disposeFinished = registry.register(key(), finished);
+		registry.register(key(), running);
 
 		disposeFinished();
 
-		expect(registry.cancel('agent-1', 'user-1')).toBe(true);
+		expect(registry.cancel(key())).toBe(true);
 		expect(finished.signal.aborted).toBe(false);
 		expect(running.signal.aborted).toBe(true);
 	});
 
+	it('aborts every registered run on shutdown, across threads and users', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const mine = new AbortController();
+		const otherThread = new AbortController();
+		const otherUser = new AbortController();
+		registry.register(key(), mine);
+		registry.register(key({ threadId: 'thread-2' }), otherThread);
+		registry.register(key({ userId: 'user-2' }), otherUser);
+
+		registry.abortAll();
+
+		for (const controller of [mine, otherThread, otherUser]) {
+			expect(controller.signal.aborted).toBe(true);
+			// The reason is what stops the run being recorded as a user cancel.
+			expect(controller.signal.reason).toBe(CHAT_RUN_INTERRUPTED_BY_SHUTDOWN);
+		}
+	});
+
+	it('marks a user stop differently from a shutdown', () => {
+		const registry = new AgentActiveChatRunRegistry();
+		const controller = new AbortController();
+		registry.register(key(), controller);
+
+		registry.cancel(key());
+
+		expect(controller.signal.reason).not.toBe(CHAT_RUN_INTERRUPTED_BY_SHUTDOWN);
+	});
+
 	it('tolerates a disposer running twice', () => {
 		const registry = new AgentActiveChatRunRegistry();
-		const dispose = registry.register('agent-1', 'user-1', new AbortController());
+		const dispose = registry.register(key(), new AbortController());
 
 		dispose();
 

--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -1,12 +1,13 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import { FileNotFoundError } from 'n8n-core';
 import { EventEmitter } from 'node:events';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import { FileNotFoundError } from 'n8n-core';
-
 import type { CredentialsService } from '@/credentials/credentials.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
+import { AgentActiveChatRunRegistry } from '../agent-active-chat-run.registry';
 import type { AgentChatAttachmentService } from '../agent-chat-attachment.service';
 import { AgentChatController } from '../agent-chat.controller';
 import type { AgentExecutionOrchestratorService } from '../agent-execution-orchestrator.service';
@@ -41,6 +42,7 @@ function makeController() {
 		}),
 	);
 
+	const activeChatRunRegistry = new AgentActiveChatRunRegistry();
 	const controller = new AgentChatController(
 		agentExecutionOrchestratorService,
 		agentTestRunService,
@@ -49,6 +51,7 @@ function makeController() {
 		mock<CredentialsService>(),
 		agentsService as unknown as AgentsService,
 		agentChatAttachmentService,
+		activeChatRunRegistry,
 	);
 
 	return {
@@ -56,6 +59,7 @@ function makeController() {
 		agentExecutionOrchestratorService,
 		agentTestRunService,
 		agentChatAttachmentService,
+		activeChatRunRegistry,
 		agentsService: {
 			findById: agentsService.findById,
 			getConversationHistory: agentExecutionOrchestratorService.getConversationHistory,
@@ -99,6 +103,7 @@ describe('AgentChatController route access scopes', () => {
 	it.each([
 		['chat', 'agent:execute'],
 		['chatResume', 'agent:execute'],
+		['cancelActiveChatRun', 'agent:execute'],
 		['cancelChatRun', 'agent:execute'],
 		['getChatMessages', 'agent:read'],
 		['getTestChatMessages', 'agent:read'],
@@ -165,7 +170,7 @@ describe('AgentChatController chat message history', () => {
 });
 
 describe('AgentChatController SSE done payload', () => {
-	it('does not start a chat after the response closes during preparation', async () => {
+	it('still starts a chat when the response closes during preparation', async () => {
 		const { controller, agentTestRunService } = makeController();
 		let resolvePreparation = (_value: { status: 'ready'; sessionId: string }) => {};
 		agentTestRunService.prepareDraftRun.mockReturnValue(
@@ -187,7 +192,72 @@ describe('AgentChatController SSE done payload', () => {
 		resolvePreparation({ status: 'ready', sessionId: 'thread-1' });
 		await request;
 
-		expect(agentTestRunService.streamDraftRun).not.toHaveBeenCalled();
+		// The turn outlives the connection so it is recorded and a reload shows it.
+		expect(agentTestRunService.streamDraftRun).toHaveBeenCalled();
+	});
+
+	it('stops a chat that is still being prepared', async () => {
+		// Stop is live from the moment the client posts, so the run must be
+		// registered before preparation awaits — otherwise it starts anyway.
+		const { controller, agentTestRunService, agentsService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		const preparing = createDeferredPromise<{ status: 'ready'; sessionId: string }>();
+		agentTestRunService.prepareDraftRun.mockReturnValue(preparing.promise);
+
+		const request = controller.chat(
+			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+			makeSseResponse([]),
+			'agent-1',
+			{ message: 'hi' } as never,
+		);
+		await vi.waitFor(() => expect(agentTestRunService.prepareDraftRun).toHaveBeenCalled());
+
+		await expect(
+			controller.cancelActiveChatRun(
+				{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+				{} as never,
+				'agent-1',
+			),
+		).resolves.toEqual({ cancelled: true });
+
+		preparing.resolve({ status: 'ready', sessionId: 'thread-1' });
+		await request;
+
+		expect(agentTestRunService.streamDraftRun.mock.calls[0][0].abortSignal?.aborted).toBe(true);
+	});
+
+	it('stops writing SSE events once the response is gone', async () => {
+		const { controller, agentExecutionOrchestratorService } = makeController();
+		const runStarted = createDeferredPromise();
+		const runBlocked = createDeferredPromise();
+		agentExecutionOrchestratorService.executeForChat.mockImplementation(async function* () {
+			yield { type: 'text-delta', id: 'text-1', delta: 'before' } as never;
+			runStarted.resolve();
+			await runBlocked.promise;
+			yield { type: 'text-delta', id: 'text-1', delta: 'after' } as never;
+		});
+
+		const writes: string[] = [];
+		const res = makeSseResponse(writes);
+		const request = controller.chat(
+			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+			res,
+			'agent-1',
+			{ message: 'hi', sessionId: 'thread-1' } as never,
+		);
+		await runStarted.promise;
+
+		Object.assign(res, { destroyed: true });
+		(res as unknown as EventEmitter).emit('close');
+		runBlocked.resolve();
+		await request;
+
+		const deltas = writes
+			.filter((line) => line.startsWith('data: '))
+			.map((line) => JSON.parse(line.slice(6).trim()) as { delta?: string })
+			.map((event) => event.delta);
+		expect(deltas).toContain('before');
+		expect(deltas).not.toContain('after');
 	});
 
 	it('includes executionId on done when recorded', async () => {
@@ -268,33 +338,141 @@ describe('AgentChatController SSE done payload', () => {
 				),
 			method: 'resumeForChat' as const,
 		},
-	])('aborts the $name when its SSE response closes early', async ({ start, method }) => {
+	])('lets the $name outlive an SSE response that closes early', async ({ start, method }) => {
 		const { controller, agentExecutionOrchestratorService } = makeController();
 
 		let receivedSignal: AbortSignal | undefined;
-		let releaseRun = () => {};
-		let markStarted = () => {};
-		const runStarted = new Promise<void>((resolve) => {
-			markStarted = resolve;
-		});
-		const runBlocked = new Promise<void>((resolve) => {
-			releaseRun = resolve;
-		});
+		const runStarted = createDeferredPromise();
+		const runBlocked = createDeferredPromise();
 		agentExecutionOrchestratorService[method].mockImplementation(async function* (config) {
 			receivedSignal = (config as { abortSignal?: AbortSignal }).abortSignal;
-			markStarted();
-			await runBlocked;
+			runStarted.resolve();
+			await runBlocked.promise;
 			yield* [];
 		});
 
 		const res = makeSseResponse([]);
 		const request = start(controller, res);
-		await runStarted;
+		await runStarted.promise;
 		(res as unknown as EventEmitter).emit('close');
-		releaseRun();
-		await request;
 
+		// The run keeps going: it is recorded, and a reload shows the result.
+		expect(receivedSignal?.aborted).toBe(false);
+
+		runBlocked.resolve();
+		await request;
+	});
+
+	it.each([
+		{
+			name: 'new chat',
+			start: async (controller: AgentChatController, res: FlushableResponse) =>
+				await controller.chat(
+					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+					res,
+					'agent-1',
+					{ message: 'hi' } as never,
+				),
+			method: 'executeForChat' as const,
+		},
+		{
+			name: 'resumed chat',
+			start: async (controller: AgentChatController, res: FlushableResponse) =>
+				await controller.chatResume(
+					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+					res,
+					'agent-1',
+					{ runId: 'run-1', toolCallId: 'tc-1', resumeData: { approved: true } } as never,
+				),
+			method: 'resumeForChat' as const,
+		},
+	])('aborts the $name on an explicit stop', async ({ start, method }) => {
+		const { controller, agentExecutionOrchestratorService, agentsService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+
+		let receivedSignal: AbortSignal | undefined;
+		const runStarted = createDeferredPromise();
+		const runBlocked = createDeferredPromise();
+		agentExecutionOrchestratorService[method].mockImplementation(async function* (config) {
+			receivedSignal = (config as { abortSignal?: AbortSignal }).abortSignal;
+			runStarted.resolve();
+			await runBlocked.promise;
+			yield* [];
+		});
+
+		const res = makeSseResponse([]);
+		const request = start(controller, res);
+		await runStarted.promise;
+
+		await expect(
+			controller.cancelActiveChatRun(
+				{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+				{} as never,
+				'agent-1',
+			),
+		).resolves.toEqual({ cancelled: true });
 		expect(receivedSignal?.aborted).toBe(true);
+
+		runBlocked.resolve();
+		await request;
+	});
+
+	it('reports no active run to stop once the turn has ended', async () => {
+		const { controller, agentExecutionOrchestratorService, agentsService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		agentExecutionOrchestratorService.executeForChat.mockImplementation(async function* () {
+			yield* [];
+		});
+
+		await controller.chat(
+			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+			makeSseResponse([]),
+			'agent-1',
+			{ message: 'hi', sessionId: 'thread-1' } as never,
+		);
+
+		await expect(
+			controller.cancelActiveChatRun(
+				{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+				{} as never,
+				'agent-1',
+			),
+		).resolves.toEqual({ cancelled: false });
+	});
+
+	it('does not stop another user’s run on the same agent', async () => {
+		const { controller, agentExecutionOrchestratorService, agentsService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+
+		let receivedSignal: AbortSignal | undefined;
+		const runStarted = createDeferredPromise();
+		const runBlocked = createDeferredPromise();
+		agentExecutionOrchestratorService.executeForChat.mockImplementation(async function* (config) {
+			receivedSignal = config.abortSignal;
+			runStarted.resolve();
+			await runBlocked.promise;
+			yield* [];
+		});
+
+		const request = controller.chat(
+			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+			makeSseResponse([]),
+			'agent-1',
+			{ message: 'hi' } as never,
+		);
+		await runStarted.promise;
+
+		await expect(
+			controller.cancelActiveChatRun(
+				{ params: { projectId: 'project-1' }, user: { id: 'user-2' } } as never,
+				{} as never,
+				'agent-1',
+			),
+		).resolves.toEqual({ cancelled: false });
+		expect(receivedSignal?.aborted).toBe(false);
+
+		runBlocked.resolve();
+		await request;
 	});
 });
 

--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -1,4 +1,5 @@
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import { jsonParse } from 'n8n-workflow';
 import { FileNotFoundError } from 'n8n-core';
 import { EventEmitter } from 'node:events';
 import type { Mocked } from 'vitest';
@@ -95,6 +96,13 @@ function makeSseResponse(writes: string[]): FlushableResponse {
 	return res as unknown as FlushableResponse;
 }
 
+/** Parse the `data:` frames a handler wrote to its SSE response. */
+function sseEvents(writes: string[]): Array<Record<string, unknown>> {
+	return writes
+		.filter((line) => line.startsWith('data: '))
+		.map((line) => jsonParse<Record<string, unknown>>(line.slice(6).trim()));
+}
+
 describe('AgentChatController route access scopes', () => {
 	expectProjectScopedAgentRoutes(AgentChatController);
 
@@ -170,16 +178,17 @@ describe('AgentChatController chat message history', () => {
 });
 
 describe('AgentChatController SSE done payload', () => {
-	it('still starts a chat when the response closes during preparation', async () => {
-		const { controller, agentTestRunService } = makeController();
-		let resolvePreparation = (_value: { status: 'ready'; sessionId: string }) => {};
-		agentTestRunService.prepareDraftRun.mockReturnValue(
-			new Promise((resolve) => {
-				resolvePreparation = resolve;
-			}),
-		);
+	it('runs a chat to completion when the response closes during preparation', async () => {
+		const { controller, agentTestRunService, agentExecutionOrchestratorService } = makeController();
+		const preparing = createDeferredPromise<{ status: 'ready'; sessionId: string }>();
+		agentTestRunService.prepareDraftRun.mockReturnValue(preparing.promise);
+		agentExecutionOrchestratorService.executeForChat.mockImplementation(async function* (config) {
+			yield { type: 'text-delta', id: 'text-1', delta: 'answer' } as never;
+			config.onExecutionRecorded?.('exec-after-close');
+		});
 
-		const res = makeSseResponse([]);
+		const writes: string[] = [];
+		const res = makeSseResponse(writes);
 		const request = controller.chat(
 			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 			res,
@@ -189,11 +198,17 @@ describe('AgentChatController SSE done payload', () => {
 		await vi.waitFor(() => expect(agentTestRunService.prepareDraftRun).toHaveBeenCalled());
 
 		(res as unknown as EventEmitter).emit('close');
-		resolvePreparation({ status: 'ready', sessionId: 'thread-1' });
+		preparing.resolve({ status: 'ready', sessionId: 'thread-1' });
 		await request;
 
-		// The turn outlives the connection so it is recorded and a reload shows it.
+		// The turn outlives the connection: it streams to the end and is recorded,
+		// so a reload shows the finished answer.
 		expect(agentTestRunService.streamDraftRun).toHaveBeenCalled();
+		expect(sseEvents(writes)).toContainEqual({
+			type: 'done',
+			sessionId: 'thread-1',
+			executionId: 'exec-after-close',
+		});
 	});
 
 	it('stops a chat that is still being prepared', async () => {
@@ -252,10 +267,7 @@ describe('AgentChatController SSE done payload', () => {
 		runBlocked.resolve();
 		await request;
 
-		const deltas = writes
-			.filter((line) => line.startsWith('data: '))
-			.map((line) => JSON.parse(line.slice(6).trim()) as { delta?: string })
-			.map((event) => event.delta);
+		const deltas = sseEvents(writes).map((event) => event.delta);
 		expect(deltas).toContain('before');
 		expect(deltas).not.toContain('after');
 	});
@@ -277,9 +289,7 @@ describe('AgentChatController SSE done payload', () => {
 			{ message: 'hi', sessionId: 'thread-1' } as never,
 		);
 
-		const events = writes
-			.filter((line) => line.startsWith('data: '))
-			.map((line) => JSON.parse(line.slice(6).trim()) as { type: string });
+		const events = sseEvents(writes);
 
 		expect(events).toContainEqual({
 			type: 'done',
@@ -305,9 +315,7 @@ describe('AgentChatController SSE done payload', () => {
 			{ runId: 'run-1', toolCallId: 'tc-1', resumeData: { approved: true } } as never,
 		);
 
-		const events = writes
-			.filter((line) => line.startsWith('data: '))
-			.map((line) => JSON.parse(line.slice(6).trim()) as { type: string });
+		const events = sseEvents(writes);
 
 		expect(events).toContainEqual({
 			type: 'done',

--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -193,7 +193,7 @@ describe('AgentChatController SSE done payload', () => {
 			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 			res,
 			'agent-1',
-			{ message: 'hi' } as never,
+			{ message: 'hi', sessionId: 'thread-1' } as never,
 		);
 		await vi.waitFor(() => expect(agentTestRunService.prepareDraftRun).toHaveBeenCalled());
 
@@ -223,7 +223,7 @@ describe('AgentChatController SSE done payload', () => {
 			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 			makeSseResponse([]),
 			'agent-1',
-			{ message: 'hi' } as never,
+			{ message: 'hi', sessionId: 'thread-1' } as never,
 		);
 		await vi.waitFor(() => expect(agentTestRunService.prepareDraftRun).toHaveBeenCalled());
 
@@ -232,6 +232,7 @@ describe('AgentChatController SSE done payload', () => {
 				{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 				{} as never,
 				'agent-1',
+				'thread-1',
 			),
 		).resolves.toEqual({ cancelled: true });
 
@@ -312,7 +313,12 @@ describe('AgentChatController SSE done payload', () => {
 			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 			res,
 			'agent-1',
-			{ runId: 'run-1', toolCallId: 'tc-1', resumeData: { approved: true } } as never,
+			{
+				runId: 'run-1',
+				toolCallId: 'tc-1',
+				sessionId: 'thread-1',
+				resumeData: { approved: true },
+			} as never,
 		);
 
 		const events = sseEvents(writes);
@@ -331,7 +337,7 @@ describe('AgentChatController SSE done payload', () => {
 					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 					res,
 					'agent-1',
-					{ message: 'hi' } as never,
+					{ message: 'hi', sessionId: 'thread-1' } as never,
 				),
 			method: 'executeForChat' as const,
 		},
@@ -342,7 +348,12 @@ describe('AgentChatController SSE done payload', () => {
 					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 					res,
 					'agent-1',
-					{ runId: 'run-1', toolCallId: 'tc-1', resumeData: { approved: true } } as never,
+					{
+						runId: 'run-1',
+						toolCallId: 'tc-1',
+						sessionId: 'thread-1',
+						resumeData: { approved: true },
+					} as never,
 				),
 			method: 'resumeForChat' as const,
 		},
@@ -379,7 +390,7 @@ describe('AgentChatController SSE done payload', () => {
 					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 					res,
 					'agent-1',
-					{ message: 'hi' } as never,
+					{ message: 'hi', sessionId: 'thread-1' } as never,
 				),
 			method: 'executeForChat' as const,
 		},
@@ -390,7 +401,12 @@ describe('AgentChatController SSE done payload', () => {
 					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 					res,
 					'agent-1',
-					{ runId: 'run-1', toolCallId: 'tc-1', resumeData: { approved: true } } as never,
+					{
+						runId: 'run-1',
+						toolCallId: 'tc-1',
+						sessionId: 'thread-1',
+						resumeData: { approved: true },
+					} as never,
 				),
 			method: 'resumeForChat' as const,
 		},
@@ -417,6 +433,7 @@ describe('AgentChatController SSE done payload', () => {
 				{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 				{} as never,
 				'agent-1',
+				'thread-1',
 			),
 		).resolves.toEqual({ cancelled: true });
 		expect(receivedSignal?.aborted).toBe(true);
@@ -444,6 +461,7 @@ describe('AgentChatController SSE done payload', () => {
 				{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 				{} as never,
 				'agent-1',
+				'thread-1',
 			),
 		).resolves.toEqual({ cancelled: false });
 	});
@@ -466,7 +484,7 @@ describe('AgentChatController SSE done payload', () => {
 			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
 			makeSseResponse([]),
 			'agent-1',
-			{ message: 'hi' } as never,
+			{ message: 'hi', sessionId: 'thread-1' } as never,
 		);
 		await runStarted.promise;
 
@@ -475,6 +493,7 @@ describe('AgentChatController SSE done payload', () => {
 				{ params: { projectId: 'project-1' }, user: { id: 'user-2' } } as never,
 				{} as never,
 				'agent-1',
+				'thread-1',
 			),
 		).resolves.toEqual({ cancelled: false });
 		expect(receivedSignal?.aborted).toBe(false);
@@ -507,6 +526,41 @@ describe('AgentChatController HITL cancellation', () => {
 			runId: 'run-1',
 			resourceId: 'draft-chat:user-1',
 		});
+	});
+
+	it.each([
+		{
+			name: 'the active run',
+			stop: async (controller: AgentChatController) =>
+				await controller.cancelActiveChatRun(
+					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+					{} as never,
+					'agent-1',
+					'thread-1',
+				),
+		},
+		{
+			name: 'a suspended run',
+			stop: async (controller: AgentChatController) =>
+				await controller.cancelChatRun(
+					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+					{} as never,
+					'agent-1',
+					'run-1',
+				),
+		},
+	])('refuses to stop $name on an agent the project does not have', async ({ stop }) => {
+		const { controller, agentsService, activeChatRunRegistry } = makeController();
+		agentsService.findById.mockResolvedValue(null as never);
+		const controllerForOtherProject = new AbortController();
+		activeChatRunRegistry.register(
+			{ agentId: 'agent-1', userId: 'user-1', threadId: 'thread-1' },
+			controllerForOtherProject,
+		);
+
+		await expect(stop(controller)).rejects.toThrow(NotFoundError);
+		// The 404 has to come before the abort, or the check buys nothing.
+		expect(controllerForOtherProject.signal.aborted).toBe(false);
 	});
 });
 

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -14,6 +14,7 @@ import { mock } from 'vitest-mock-extended';
 import type { ExternalHooks } from '@/external-hooks';
 import type { Telemetry } from '@/telemetry';
 
+import { CHAT_RUN_INTERRUPTED_BY_SHUTDOWN } from '../agent-active-chat-run.registry';
 import { AgentExecutionOrchestratorService } from '../agent-execution-orchestrator.service';
 import type { AgentExecutionService } from '../agent-execution.service';
 import type { AgentRunTracingService } from '../agent-run-tracing.service';
@@ -731,6 +732,47 @@ describe('AgentExecutionOrchestratorService', () => {
 					finishReason: 'cancelled',
 					error: null,
 					timeline: [expect.objectContaining({ type: 'text', content: 'partial answer' })],
+				}),
+			}),
+		);
+	});
+
+	it('keeps the error when a shutdown aborted the chat stream', async () => {
+		// Nobody asked for this one, so recording it as a clean cancel would erase
+		// the only explanation the user gets for the truncated turn.
+		const { service, executionService } = makeService();
+		const abortController = new AbortController();
+		const runtime = makeRuntime([
+			{ type: 'text-start', id: 'text-1' },
+			{ type: 'text-delta', id: 'text-1', delta: 'partial answer' },
+			{ type: 'error', error: new Error('This operation was aborted') },
+			{ type: 'finish', finishReason: 'error' },
+		]);
+		const stream = service.streamChatResponse({
+			agentInstance: runtime.agent,
+			toolRegistry: runtime.toolRegistry,
+			agentId,
+			message: 'hello',
+			memory: { threadId: 'thread-1', resourceId: 'resource-1' },
+			projectId,
+			telemetry: telemetryContext,
+			sandboxPrincipalHash: userPrincipalHash,
+			abortSignal: abortController.signal,
+			onExecutionRecorded: vi.fn(),
+		});
+
+		await stream.next();
+		await stream.next();
+		abortController.abort(CHAT_RUN_INTERRUPTED_BY_SHUTDOWN);
+		await collect(stream);
+
+		expect(executionService.finalizeExecution).toHaveBeenCalledWith(
+			'execution-1',
+			expect.objectContaining({
+				record: expect.objectContaining({
+					assistantResponse: 'partial answer',
+					finishReason: 'error',
+					error: 'This operation was aborted',
 				}),
 			}),
 		);

--- a/packages/cli/src/modules/agents/agent-active-chat-run.registry.ts
+++ b/packages/cli/src/modules/agents/agent-active-chat-run.registry.ts
@@ -1,0 +1,53 @@
+import { Service } from '@n8n/di';
+
+/**
+ * Index of the agent chat runs currently streaming, so an explicit Stop can
+ * abort one.
+ *
+ * A dropped SSE connection deliberately does not abort a run: the turn keeps
+ * going, is recorded, and the client picks it up on reload. Stopping is
+ * therefore an explicit request, not a side effect of the socket closing.
+ *
+ * Keyed per (agent, user) rather than per thread, so it covers the resume path
+ * too: there the controller has only a `runId`, and the thread id appears no
+ * earlier than the checkpoint load inside `resumeForChat`. The cost is that one
+ * user running the same agent in two sessions stops both. Narrowing the key to
+ * the thread means carrying it on the resume DTO and on the cancel request —
+ * worth doing, but a change to the request contract rather than a cleanup.
+ *
+ * In-process only. In a multi-main deployment the cancel request can land on an
+ * instance that does not hold the run; the run then finishes normally and the
+ * client still settles its own view.
+ */
+@Service()
+export class AgentActiveChatRunRegistry {
+	private readonly runs = new Map<string, Set<AbortController>>();
+
+	/** Track `controller` as an active run. Returns the disposer for the caller's `finally`. */
+	register(agentId: string, userId: string, controller: AbortController): () => void {
+		const key = runKey(agentId, userId);
+		const controllers = this.runs.get(key) ?? new Set<AbortController>();
+		controllers.add(controller);
+		this.runs.set(key, controllers);
+
+		return () => {
+			const current = this.runs.get(key);
+			if (!current) return;
+			current.delete(controller);
+			if (current.size === 0) this.runs.delete(key);
+		};
+	}
+
+	/** Abort every run this user has streaming on this agent. */
+	cancel(agentId: string, userId: string): boolean {
+		const controllers = this.runs.get(runKey(agentId, userId));
+		if (controllers === undefined) return false;
+
+		for (const controller of controllers) controller.abort();
+		return true;
+	}
+}
+
+function runKey(agentId: string, userId: string): string {
+	return `${agentId}:${userId}`;
+}

--- a/packages/cli/src/modules/agents/agent-active-chat-run.registry.ts
+++ b/packages/cli/src/modules/agents/agent-active-chat-run.registry.ts
@@ -1,4 +1,20 @@
+import { OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+
+/**
+ * Abort reason for a run this process tore down on its way out. It marks the
+ * abort as "nobody asked for this", so the run keeps the error it raised
+ * instead of being recorded as a clean cancel — see
+ * `normalizeAbortedMessageRecord`.
+ */
+export const CHAT_RUN_INTERRUPTED_BY_SHUTDOWN = 'chat-run-interrupted-by-shutdown';
+
+/** Identifies one streaming chat run: a thread, plus who is allowed to stop it. */
+export interface ActiveChatRunKey {
+	agentId: string;
+	userId: string;
+	threadId: string;
+}
 
 /**
  * Index of the agent chat runs currently streaming, so an explicit Stop can
@@ -8,12 +24,10 @@ import { Service } from '@n8n/di';
  * going, is recorded, and the client picks it up on reload. Stopping is
  * therefore an explicit request, not a side effect of the socket closing.
  *
- * Keyed per (agent, user) rather than per thread, so it covers the resume path
- * too: there the controller has only a `runId`, and the thread id appears no
- * earlier than the checkpoint load inside `resumeForChat`. The cost is that one
- * user running the same agent in two sessions stops both. Narrowing the key to
- * the thread means carrying it on the resume DTO and on the cancel request —
- * worth doing, but a change to the request contract rather than a cleanup.
+ * The key carries the thread so that stopping one conversation leaves the
+ * user's other conversations with the same agent running. It carries the user
+ * because a thread has no recorded owner yet, and the caller's own id is what
+ * keeps one user from stopping another's run.
  *
  * In-process only. In a multi-main deployment the cancel request can land on an
  * instance that does not hold the run; the run then finishes normally and the
@@ -24,30 +38,48 @@ export class AgentActiveChatRunRegistry {
 	private readonly runs = new Map<string, Set<AbortController>>();
 
 	/** Track `controller` as an active run. Returns the disposer for the caller's `finally`. */
-	register(agentId: string, userId: string, controller: AbortController): () => void {
-		const key = runKey(agentId, userId);
-		const controllers = this.runs.get(key) ?? new Set<AbortController>();
+	register(key: ActiveChatRunKey, controller: AbortController): () => void {
+		const runKey = toRunKey(key);
+		const controllers = this.runs.get(runKey) ?? new Set<AbortController>();
 		controllers.add(controller);
-		this.runs.set(key, controllers);
+		this.runs.set(runKey, controllers);
 
 		return () => {
-			const current = this.runs.get(key);
+			const current = this.runs.get(runKey);
 			if (!current) return;
 			current.delete(controller);
-			if (current.size === 0) this.runs.delete(key);
+			if (current.size === 0) this.runs.delete(runKey);
 		};
 	}
 
-	/** Abort every run this user has streaming on this agent. */
-	cancel(agentId: string, userId: string): boolean {
-		const controllers = this.runs.get(runKey(agentId, userId));
+	/**
+	 * Abort the runs streaming on this thread for this user. More than one can be
+	 * registered — a resumed turn overlaps the turn it continues — and they all
+	 * belong to the conversation being stopped.
+	 */
+	cancel(key: ActiveChatRunKey): boolean {
+		const controllers = this.runs.get(toRunKey(key));
 		if (controllers === undefined) return false;
 
 		for (const controller of controllers) controller.abort();
 		return true;
 	}
+
+	/**
+	 * Tear down every run still streaming when the process stops. Without this a
+	 * rolling update leaves them mid-turn, and the row stays `running` until the
+	 * interrupted-execution sweep notices minutes later. Aborting here lets each
+	 * run persist what it produced, and the reason keeps its error intact so the
+	 * turn reads as failed rather than as something the user cancelled.
+	 */
+	@OnShutdown()
+	abortAll(): void {
+		for (const controllers of this.runs.values()) {
+			for (const controller of controllers) controller.abort(CHAT_RUN_INTERRUPTED_BY_SHUTDOWN);
+		}
+	}
 }
 
-function runKey(agentId: string, userId: string): string {
-	return `${agentId}:${userId}`;
+function toRunKey({ agentId, userId, threadId }: ActiveChatRunKey): string {
+	return `${agentId}:${userId}:${threadId}`;
 }

--- a/packages/cli/src/modules/agents/agent-chat.controller.ts
+++ b/packages/cli/src/modules/agents/agent-chat.controller.ts
@@ -20,6 +20,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentsCredentialProvider } from './adapters/agents-credential-provider';
+import { AgentActiveChatRunRegistry } from './agent-active-chat-run.registry';
 import {
 	AgentChatAttachmentService,
 	type StoredAttachmentRef,
@@ -45,6 +46,7 @@ export class AgentChatController {
 		private readonly credentialsService: CredentialsService,
 		private readonly agentsService: AgentsService,
 		private readonly agentChatAttachmentService: AgentChatAttachmentService,
+		private readonly activeChatRunRegistry: AgentActiveChatRunRegistry,
 	) {}
 
 	/** Decode, sniff, and persist inbound chat attachments; returns refs for the user turn. */
@@ -116,9 +118,17 @@ export class AgentChatController {
 		);
 
 		const { send } = initSseStream(res);
+		// The run is NOT tied to this connection: a dropped SSE stream lets the
+		// turn finish and be recorded, so a reload shows the completed response.
+		// Only an explicit Stop (see `cancelActiveChatRun`) aborts it.
 		const abortController = new AbortController();
-		const abortOnClose = () => abortController.abort();
-		res.once('close', abortOnClose);
+		// Registered before the first await: the client enables Stop as soon as it
+		// posts, so a stop during preparation has to reach this run too.
+		const unregisterRun = this.activeChatRunRegistry.register(
+			agentId,
+			req.user.id,
+			abortController,
+		);
 		let executionId: string | undefined;
 		let storedAttachments: StoredAttachmentRef[] | undefined;
 		try {
@@ -128,7 +138,6 @@ export class AgentChatController {
 				sessionId,
 				credentialProvider,
 			});
-			if (abortController.signal.aborted) return;
 			if (prepared.status === 'session_not_found') {
 				send({ type: 'error', message: 'Session not found' });
 				return;
@@ -184,7 +193,7 @@ export class AgentChatController {
 				send({ type: 'error', message: errorMessage });
 			}
 		} finally {
-			res.off('close', abortOnClose);
+			unregisterRun();
 			res.end();
 		}
 	}
@@ -201,9 +210,13 @@ export class AgentChatController {
 		const { runId, toolCallId, resumeData } = payload;
 		const { send } = initSseStream(res);
 
+		// Same lifetime rule as `chat`: the resumed turn survives its connection.
 		const abortController = new AbortController();
-		const abortOnClose = () => abortController.abort();
-		res.once('close', abortOnClose);
+		const unregisterRun = this.activeChatRunRegistry.register(
+			agentId,
+			req.user.id,
+			abortController,
+		);
 		try {
 			let executionId: string | undefined;
 			const suspended = await pumpChunks(
@@ -232,9 +245,32 @@ export class AgentChatController {
 				send({ type: 'error', message: errorMessage });
 			}
 		} finally {
-			res.off('close', abortOnClose);
+			unregisterRun();
 			res.end();
 		}
+	}
+
+	/**
+	 * Stop the turn this user is streaming on this agent. Dropping the SSE
+	 * connection no longer cancels a run, so the client asks for the stop it
+	 * means — otherwise the turn would finish and reappear on the next reload.
+	 *
+	 * Returns `cancelled: false` when no run was found, which is expected: the
+	 * turn may have just ended, or (multi-main) be held by another instance.
+	 */
+	@Delete('/:agentId/chat/active-run')
+	@ProjectScope('agent:execute')
+	async cancelActiveChatRun(
+		req: AuthenticatedRequest<{ projectId: string }>,
+		_res: Response,
+		@Param('agentId') agentId: string,
+	) {
+		const { projectId } = req.params;
+		const agent = await this.agentsService.findById(agentId, projectId);
+		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
+
+		const cancelled = this.activeChatRunRegistry.cancel(agentId, req.user.id);
+		return { cancelled };
 	}
 
 	@Delete('/:agentId/chat/runs/:runId')

--- a/packages/cli/src/modules/agents/agent-chat.controller.ts
+++ b/packages/cli/src/modules/agents/agent-chat.controller.ts
@@ -13,6 +13,7 @@ import { Body, Delete, Get, Param, Post, ProjectScope, RestController } from '@n
 import { sanitizeFilename } from '@n8n/utils/files/sanitize-filename';
 import type { Response } from 'express';
 import { FileNotFoundError, getHtmlSandboxCSP } from 'n8n-core';
+import { randomUUID } from 'node:crypto';
 import { pipeline } from 'node:stream/promises';
 
 import { CredentialsService } from '@/credentials/credentials.service';
@@ -122,11 +123,12 @@ export class AgentChatController {
 		// turn finish and be recorded, so a reload shows the completed response.
 		// Only an explicit Stop (see `cancelActiveChatRun`) aborts it.
 		const abortController = new AbortController();
-		// Registered before the first await: the client enables Stop as soon as it
-		// posts, so a stop during preparation has to reach this run too.
+		// Minted here rather than in `prepareDraftRun` so the thread is known
+		// before the first await, which is what lets the run be registered — and
+		// therefore stoppable — while it is still being prepared.
+		const threadId = sessionId ?? randomUUID();
 		const unregisterRun = this.activeChatRunRegistry.register(
-			agentId,
-			req.user.id,
+			{ agentId, userId: req.user.id, threadId },
 			abortController,
 		);
 		let executionId: string | undefined;
@@ -135,7 +137,7 @@ export class AgentChatController {
 			const prepared = await this.agentTestRunService.prepareDraftRun({
 				agentId,
 				projectId,
-				sessionId,
+				sessionId: threadId,
 				credentialProvider,
 			});
 			if (prepared.status === 'session_not_found') {
@@ -152,7 +154,6 @@ export class AgentChatController {
 				return;
 			}
 
-			const threadId = prepared.sessionId;
 			storedAttachments = await this.storeChatAttachments({
 				attachments,
 				agentId,
@@ -207,14 +208,13 @@ export class AgentChatController {
 		@Body payload: AgentChatResumeDto,
 	) {
 		const { projectId } = req.params;
-		const { runId, toolCallId, resumeData } = payload;
+		const { runId, toolCallId, resumeData, sessionId } = payload;
 		const { send } = initSseStream(res);
 
 		// Same lifetime rule as `chat`: the resumed turn survives its connection.
 		const abortController = new AbortController();
 		const unregisterRun = this.activeChatRunRegistry.register(
-			agentId,
-			req.user.id,
+			{ agentId, userId: req.user.id, threadId: sessionId },
 			abortController,
 		);
 		try {
@@ -251,25 +251,32 @@ export class AgentChatController {
 	}
 
 	/**
-	 * Stop the turn this user is streaming on this agent. Dropping the SSE
+	 * Stop the turn this user is streaming on this thread. Dropping the SSE
 	 * connection no longer cancels a run, so the client asks for the stop it
 	 * means — otherwise the turn would finish and reappear on the next reload.
+	 * Scoped to the thread so stopping one conversation leaves the user's other
+	 * conversations with the same agent running.
 	 *
 	 * Returns `cancelled: false` when no run was found, which is expected: the
 	 * turn may have just ended, or (multi-main) be held by another instance.
 	 */
-	@Delete('/:agentId/chat/active-run')
+	@Delete('/:agentId/chat/:threadId/active-run')
 	@ProjectScope('agent:execute')
 	async cancelActiveChatRun(
 		req: AuthenticatedRequest<{ projectId: string }>,
 		_res: Response,
 		@Param('agentId') agentId: string,
+		@Param('threadId') threadId: string,
 	) {
 		const { projectId } = req.params;
 		const agent = await this.agentsService.findById(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
 
-		const cancelled = this.activeChatRunRegistry.cancel(agentId, req.user.id);
+		const cancelled = this.activeChatRunRegistry.cancel({
+			agentId,
+			userId: req.user.id,
+			threadId,
+		});
 		return { cancelled };
 	}
 

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -198,6 +198,17 @@ function getMaxIterationsChunks(): StreamChunk[] {
 	];
 }
 
+/**
+ * Record an aborted run as a clean stop rather than a failure, dropping the
+ * teardown error the run raised on its way out.
+ *
+ * A lost connection no longer aborts a chat run, so for the chat controller
+ * this signal means an explicit Stop. It is not the only producer, though:
+ * Instance AI threads its own session signal in through `executeDraftRun`, and
+ * that one also fires on shutdown — so a run killed by a restart still records
+ * as `cancelled` with no error. Carrying the intent on the signal itself
+ * (`abort(reason)`) would make this true by construction.
+ */
 function normalizeAbortedMessageRecord(
 	record: MessageRecord,
 	abortSignal?: AbortSignal,

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -17,6 +17,7 @@ import { ExternalHooks } from '@/external-hooks';
 import type { AgentRunTelemetryType, IAgentConfigurationTelemetryProperties } from '@/interfaces';
 import { Telemetry } from '@/telemetry';
 
+import { CHAT_RUN_INTERRUPTED_BY_SHUTDOWN } from './agent-active-chat-run.registry';
 import {
 	AgentExecutionService,
 	type RecordMessageParams,
@@ -200,20 +201,20 @@ function getMaxIterationsChunks(): StreamChunk[] {
 
 /**
  * Record an aborted run as a clean stop rather than a failure, dropping the
- * teardown error the run raised on its way out.
+ * teardown error the run raised on its way out. A lost connection no longer
+ * aborts a chat run, so an abort here means somebody asked for it — the chat
+ * Stop, or Instance AI clearing its thread.
  *
- * A lost connection no longer aborts a chat run, so for the chat controller
- * this signal means an explicit Stop. It is not the only producer, though:
- * Instance AI threads its own session signal in through `executeDraftRun`, and
- * that one also fires on shutdown — so a run killed by a restart still records
- * as `cancelled` with no error. Carrying the intent on the signal itself
- * (`abort(reason)`) would make this true by construction.
+ * Shutdown is the exception: nobody asked, and collapsing it to `cancelled`
+ * would erase the only explanation the user ever gets for the truncated turn.
+ * Those runs keep their error and land as failed instead.
  */
 function normalizeAbortedMessageRecord(
 	record: MessageRecord,
 	abortSignal?: AbortSignal,
 ): MessageRecord {
 	if (!abortSignal?.aborted) return record;
+	if (abortSignal.reason === CHAT_RUN_INTERRUPTED_BY_SHUTDOWN) return record;
 	return { ...record, finishReason: 'cancelled', error: null };
 }
 

--- a/packages/cli/src/modules/agents/agent-sse-stream.ts
+++ b/packages/cli/src/modules/agents/agent-sse-stream.ts
@@ -43,7 +43,10 @@ export function initSseStream(res: FlushableResponse) {
 	res.once('finish', stopHeartbeat);
 	res.once('close', stopHeartbeat);
 
+	// A run outlives its connection — the client can be gone while chunks still
+	// arrive — so every write checks the response is still open first.
 	const send = (event: AgentSseEvent) => {
+		if (res.writableEnded || res.destroyed) return;
 		res.write(`data: ${JSON.stringify(event)}\n\n`);
 		res.flush?.();
 	};

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ref, nextTick, effectScope } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 import { APPROVAL_TOOL_NAME, N8N_CHAT_ACTION_TOOL_NAME, type AgentSseEvent } from '@n8n/api-types';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 
 vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore: () => ({ restApiContext: { baseUrl: 'http://localhost:5678' } }),
@@ -12,8 +13,10 @@ vi.mock('@n8n/i18n', () => ({
 	useI18n: () => ({ baseText: (k: string) => k }),
 }));
 
+const showErrorSpy = vi.fn();
+
 vi.mock('@n8n/composables/useToast', () => ({
-	useToast: () => ({ showError: vi.fn() }),
+	useToast: () => ({ showError: showErrorSpy }),
 }));
 
 const getChatMessagesMock = vi.fn();
@@ -168,6 +171,7 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		cancelAgentChatRunMock.mockResolvedValue({ cancelled: true });
 		cancelActiveAgentChatRunMock.mockReset();
 		cancelActiveAgentChatRunMock.mockResolvedValue({ cancelled: true });
+		showErrorSpy.mockClear();
 		getTestChatMessagesMock.mockReset();
 	});
 
@@ -2323,6 +2327,7 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 		cancelAgentChatRunMock.mockResolvedValue({ cancelled: true });
 		cancelActiveAgentChatRunMock.mockReset();
 		cancelActiveAgentChatRunMock.mockResolvedValue({ cancelled: true });
+		showErrorSpy.mockClear();
 		getTestChatMessagesMock.mockReset();
 	});
 
@@ -2435,7 +2440,40 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 		await hook.stopGenerating();
 		await send;
 
+		// The request has to have been made, or the rejection proves nothing.
+		expect(cancelActiveAgentChatRunMock).toHaveBeenCalledWith(expect.anything(), 'p1', 'a1');
+		expect(showErrorSpy).toHaveBeenCalled();
 		expect(hook.isStreaming.value).toBe(false);
+		expect(hook.isCancelling.value).toBe(false);
+	});
+
+	it('keeps the composer closed until the backend stop resolves', async () => {
+		// A turn started in that gap registers under the same key server-side, so
+		// the in-flight cancel would abort the new turn instead of the stopped one.
+		const stopRequest = createDeferredPromise<{ cancelled: boolean }>();
+		cancelActiveAgentChatRunMock.mockReturnValue(stopRequest.promise);
+		globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) =>
+			makeAbortableSseResponse([], init.signal ?? null),
+		) as unknown as typeof fetch;
+
+		const hook = buildHook();
+		const send = hook.sendMessage('take your time');
+		await vi.waitFor(() => expect(hook.isStreaming.value).toBe(true));
+
+		const stopping = hook.stopGenerating();
+		await vi.waitFor(() => expect(cancelActiveAgentChatRunMock).toHaveBeenCalled());
+
+		// The local abort already cleared `isStreaming`; `isCancelling` is what
+		// keeps `sendMessage` from starting a second run in the gap.
+		expect(hook.isStreaming.value).toBe(false);
+		expect(hook.isCancelling.value).toBe(true);
+		await hook.sendMessage('too soon');
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+		stopRequest.resolve({ cancelled: true });
+		await stopping;
+		await send;
+
 		expect(hook.isCancelling.value).toBe(false);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -19,6 +19,7 @@ vi.mock('@n8n/composables/useToast', () => ({
 const getChatMessagesMock = vi.fn();
 const getTestChatMessagesMock = vi.fn();
 const cancelAgentChatRunMock = vi.fn();
+const cancelActiveAgentChatRunMock = vi.fn();
 
 const pushListeners: Array<(event: unknown) => void> = [];
 const pushConnectMock = vi.fn();
@@ -43,6 +44,7 @@ vi.mock('../composables/useAgentApi', async (importOriginal) => {
 		getChatMessages: (...args: unknown[]) => getChatMessagesMock(...args),
 		getTestChatMessages: (...args: unknown[]) => getTestChatMessagesMock(...args),
 		cancelAgentChatRun: (...args: unknown[]) => cancelAgentChatRunMock(...args),
+		cancelActiveAgentChatRun: (...args: unknown[]) => cancelActiveAgentChatRunMock(...args),
 	};
 });
 
@@ -164,6 +166,8 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		});
 		cancelAgentChatRunMock.mockReset();
 		cancelAgentChatRunMock.mockResolvedValue({ cancelled: true });
+		cancelActiveAgentChatRunMock.mockReset();
+		cancelActiveAgentChatRunMock.mockResolvedValue({ cancelled: true });
 		getTestChatMessagesMock.mockReset();
 	});
 
@@ -2317,6 +2321,8 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 		vi.stubGlobal('localStorage', { getItem: vi.fn(() => '') });
 		cancelAgentChatRunMock.mockReset();
 		cancelAgentChatRunMock.mockResolvedValue({ cancelled: true });
+		cancelActiveAgentChatRunMock.mockReset();
+		cancelActiveAgentChatRunMock.mockResolvedValue({ cancelled: true });
 		getTestChatMessagesMock.mockReset();
 	});
 
@@ -2391,8 +2397,46 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 		await nextTick();
 
 		expect(hook.messages.value[1].toolCalls?.[0].state).toBe('cancelled');
-		// No backend cancel call — there is no runId/suspension to cancel.
+		// No backend cancel call — there is no runId/suspension to cancel, and no
+		// live run either, so the stop is purely local recovery.
 		expect(cancelAgentChatRunMock).not.toHaveBeenCalled();
+		expect(cancelActiveAgentChatRunMock).not.toHaveBeenCalled();
+	});
+
+	it('asks the backend to stop a live turn before dropping the connection', async () => {
+		// The run outlives its connection now, so aborting the fetch alone would
+		// leave it going and it would reappear, finished, on the next reload.
+		globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) =>
+			makeAbortableSseResponse([], init.signal ?? null),
+		) as unknown as typeof fetch;
+
+		const hook = buildHook();
+		const send = hook.sendMessage('take your time');
+		await vi.waitFor(() => expect(hook.isStreaming.value).toBe(true));
+
+		await hook.stopGenerating();
+		await send;
+
+		expect(cancelActiveAgentChatRunMock).toHaveBeenCalledWith(expect.anything(), 'p1', 'a1');
+		expect(hook.isStreaming.value).toBe(false);
+		expect(hook.isCancelling.value).toBe(false);
+	});
+
+	it('still settles the chat when the stop request fails', async () => {
+		cancelActiveAgentChatRunMock.mockRejectedValue(new Error('request failed'));
+		globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) =>
+			makeAbortableSseResponse([], init.signal ?? null),
+		) as unknown as typeof fetch;
+
+		const hook = buildHook();
+		const send = hook.sendMessage('take your time');
+		await vi.waitFor(() => expect(hook.isStreaming.value).toBe(true));
+
+		await hook.stopGenerating();
+		await send;
+
+		expect(hook.isStreaming.value).toBe(false);
+		expect(hook.isCancelling.value).toBe(false);
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -2415,14 +2415,19 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 			makeAbortableSseResponse([], init.signal ?? null),
 		) as unknown as typeof fetch;
 
-		const hook = buildHook();
+		const hook = buildHook('thread-1');
 		const send = hook.sendMessage('take your time');
 		await vi.waitFor(() => expect(hook.isStreaming.value).toBe(true));
 
 		await hook.stopGenerating();
 		await send;
 
-		expect(cancelActiveAgentChatRunMock).toHaveBeenCalledWith(expect.anything(), 'p1', 'a1');
+		expect(cancelActiveAgentChatRunMock).toHaveBeenCalledWith(
+			expect.anything(),
+			'p1',
+			'a1',
+			'thread-1',
+		);
 		expect(hook.isStreaming.value).toBe(false);
 		expect(hook.isCancelling.value).toBe(false);
 	});
@@ -2433,7 +2438,7 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 			makeAbortableSseResponse([], init.signal ?? null),
 		) as unknown as typeof fetch;
 
-		const hook = buildHook();
+		const hook = buildHook('thread-1');
 		const send = hook.sendMessage('take your time');
 		await vi.waitFor(() => expect(hook.isStreaming.value).toBe(true));
 
@@ -2441,7 +2446,12 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 		await send;
 
 		// The request has to have been made, or the rejection proves nothing.
-		expect(cancelActiveAgentChatRunMock).toHaveBeenCalledWith(expect.anything(), 'p1', 'a1');
+		expect(cancelActiveAgentChatRunMock).toHaveBeenCalledWith(
+			expect.anything(),
+			'p1',
+			'a1',
+			'thread-1',
+		);
 		expect(showErrorSpy).toHaveBeenCalled();
 		expect(hook.isStreaming.value).toBe(false);
 		expect(hook.isCancelling.value).toBe(false);
@@ -2456,7 +2466,7 @@ describe('useAgentChatStream — stuck/desync recovery', () => {
 			makeAbortableSseResponse([], init.signal ?? null),
 		) as unknown as typeof fetch;
 
-		const hook = buildHook();
+		const hook = buildHook('thread-1');
 		const send = hook.sendMessage('take your time');
 		await vi.waitFor(() => expect(hook.isStreaming.value).toBe(true));
 

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
@@ -520,6 +520,22 @@ export const clearTestChatMessages = async (
 	);
 };
 
+/**
+ * Stop the turn currently streaming for this user on this agent. Closing the
+ * SSE connection does not stop a run, so Stop has to say so explicitly.
+ */
+export const cancelActiveAgentChatRun = async (
+	context: IRestApiContext,
+	projectId: string,
+	agentId: string,
+): Promise<{ cancelled: boolean }> => {
+	return await makeRestApiRequest<{ cancelled: boolean }>(
+		context,
+		'DELETE',
+		`/projects/${projectId}/agents/v2/${agentId}/chat/active-run`,
+	);
+};
+
 export const cancelAgentChatRun = async (
 	context: IRestApiContext,
 	projectId: string,

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
@@ -521,18 +521,20 @@ export const clearTestChatMessages = async (
 };
 
 /**
- * Stop the turn currently streaming for this user on this agent. Closing the
- * SSE connection does not stop a run, so Stop has to say so explicitly.
+ * Stop the turn currently streaming on this thread. Closing the SSE connection
+ * does not stop a run, so Stop has to say so explicitly. Scoped to the thread:
+ * the user's other conversations with this agent keep running.
  */
 export const cancelActiveAgentChatRun = async (
 	context: IRestApiContext,
 	projectId: string,
 	agentId: string,
+	threadId: string,
 ): Promise<{ cancelled: boolean }> => {
 	return await makeRestApiRequest<{ cancelled: boolean }>(
 		context,
 		'DELETE',
-		`/projects/${projectId}/agents/v2/${agentId}/chat/active-run`,
+		`/projects/${projectId}/agents/v2/${agentId}/chat/${threadId}/active-run`,
 	);
 };
 

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -994,20 +994,30 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 			: undefined;
 		if (!openSuspension) {
 			const wasStreaming = isStreaming.value;
-			// Abort first so the stream ends through the local AbortError path. The
-			// backend sends no terminal event on an explicit stop, so letting its
-			// `res.end()` win the race would render the turn as interrupted.
-			activeController?.abort();
-			await activeStreamSettlement;
-			// Only then tell the backend, because closing the stream no longer stops
-			// the run — without this the turn keeps going and reappears, finished,
-			// on the next reload.
-			if (wasStreaming) {
-				await cancelActiveAgentChatRun(
-					rootStore.restApiContext,
-					params.projectId.value,
-					params.agentId.value,
-				).catch((error) => showError(error, locale.baseText('agents.chat.stop.error')));
+			// Held across the whole stop, not just the request: the local abort
+			// clears `isStreaming` immediately, and without this the composer would
+			// reopen while the cancel is still in flight. A turn started in that gap
+			// registers under the same key server-side, so the late cancel would
+			// abort the new turn instead of the stopped one.
+			if (wasStreaming) isCancelling.value = true;
+			try {
+				// Abort first so the stream ends through the local AbortError path. The
+				// backend sends no terminal event on an explicit stop, so letting its
+				// `res.end()` win the race would render the turn as interrupted.
+				activeController?.abort();
+				await activeStreamSettlement;
+				// Only then tell the backend, because closing the stream no longer stops
+				// the run — without this the turn keeps going and reappears, finished,
+				// on the next reload.
+				if (wasStreaming) {
+					await cancelActiveAgentChatRun(
+						rootStore.restApiContext,
+						params.projectId.value,
+						params.agentId.value,
+					).catch((error) => showError(error, locale.baseText('agents.chat.stop.error')));
+				}
+			} finally {
+				isCancelling.value = false;
 			}
 			// Desync recovery: the stream already ended but tool calls are still
 			// pulsing because their terminal events never arrived. There is no

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -12,6 +12,7 @@ import { applyForwardedChildChunk, APPROVAL_TOOL_NAME, emptyChildTrace } from '@
 import { useToast } from '@n8n/composables/useToast';
 import { convertFileToBinaryData } from '@/app/utils/fileUtils';
 import {
+	cancelActiveAgentChatRun,
 	cancelAgentChatRun,
 	clearTestChatMessages,
 	getChatMessages,
@@ -992,8 +993,22 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 			? streamSettlements.get(activeController)
 			: undefined;
 		if (!openSuspension) {
+			const wasStreaming = isStreaming.value;
+			// Abort first so the stream ends through the local AbortError path. The
+			// backend sends no terminal event on an explicit stop, so letting its
+			// `res.end()` win the race would render the turn as interrupted.
 			activeController?.abort();
 			await activeStreamSettlement;
+			// Only then tell the backend, because closing the stream no longer stops
+			// the run — without this the turn keeps going and reappears, finished,
+			// on the next reload.
+			if (wasStreaming) {
+				await cancelActiveAgentChatRun(
+					rootStore.restApiContext,
+					params.projectId.value,
+					params.agentId.value,
+				).catch((error) => showError(error, locale.baseText('agents.chat.stop.error')));
+			}
 			// Desync recovery: the stream already ended but tool calls are still
 			// pulsing because their terminal events never arrived. There is no
 			// backend run left to cancel — settle the stale state locally so

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -908,6 +908,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		const { outcome } = await postAndConsume(url, {
 			runId: payload.runId,
 			toolCallId: payload.toolCallId,
+			sessionId: params.continueSessionId?.value,
 			resumeData,
 		});
 		let reconciled = false;
@@ -1009,11 +1010,15 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 				// Only then tell the backend, because closing the stream no longer stops
 				// the run — without this the turn keeps going and reappears, finished,
 				// on the next reload.
-				if (wasStreaming) {
+				// Addressed to this conversation, so the user's other threads with the
+				// same agent keep running.
+				const threadId = params.continueSessionId?.value;
+				if (wasStreaming && threadId) {
 					await cancelActiveAgentChatRun(
 						rootStore.restApiContext,
 						params.projectId.value,
 						params.agentId.value,
+						threadId,
 					).catch((error) => showError(error, locale.baseText('agents.chat.stop.error')));
 				}
 			} finally {


### PR DESCRIPTION
## Summary

An agent chat run was bound to the lifetime of its SSE response, so any disconnect killed it:

- `agent-chat.controller.ts` wired `res.once('close', () => abortController.abort())` into the run.
- On abort, `normalizeAbortedMessageRecord` rewrote the record to `finishReason: 'cancelled', error: null`, discarding the real error the run had already recorded.
- `executionStatus()` therefore stored `cancelled`, and `computeExecutionFailureSummary()` adds an execution-level failure only for `error` / `interrupted` — so the turn left no trace anywhere.
- The chat meanwhile showed "The connection was interrupted. Refresh the page to see the latest response." On reload the user got partial output, no error, and no way to continue.

That last part is the reported symptom: *"the agent quietly failed and didn't come back on my request."*

**A run now outlives its connection.** It finishes, is recorded, and a reload shows the completed answer.

### Stopping becomes explicit

Dropping the connection was also the only thing that stopped a run, so Stop needed its own path:

- `AgentActiveChatRunRegistry` indexes the runs that are streaming, keyed by `agentId:userId:threadId` — stopping one conversation leaves the user's other conversations with the same agent running. The user stays in the key because a thread has no recorded owner yet, so the caller's own id is what keeps one user from stopping another's run.
- `DELETE /projects/:projectId/agents/v2/:agentId/chat/:threadId/active-run` aborts that conversation's runs.
- The run is registered **before the first await**. The client enables Stop the moment it posts, so the handler mints the thread id up front rather than waiting for `prepareDraftRun` — otherwise a Stop during preparation found nothing and the run started anyway.
- The resume request carries `sessionId`, because there the checkpoint load is the first place the thread id would otherwise appear.
- The client aborts its own stream **first**, then calls the endpoint, and holds the composer closed until it resolves. The backend sends no terminal event on an explicit stop, so letting `res.end()` win the race would render the stopped turn as interrupted — and a turn started in that gap would be aborted by the late cancel.
- `send()` now checks the response is still open, since chunks keep arriving after the client is gone.

### Shutdown

Nothing aborted a run when the process stopped, so a rolling update left turns mid-flight and their rows `running` until the interrupted-execution sweep noticed minutes later. The registry now tears them down on shutdown, inside the graceful window, so each run persists what it produced.

Those aborts carry a reason. An aborted run is otherwise recorded as a clean cancel with its error dropped, which would report a restart as something the user asked for and leave the truncated turn with no explanation. Only runs this hook aborts are affected — an explicit Stop, and Instance AI clearing a thread, still record as `cancelled`.

### Known limitation

The registry is in-process. In a multi-main deployment the cancel can land on an instance that does not hold the run; it returns `cancelled: false` and the run completes. The UI still settles. Documented in the registry, follow-up filed.

## How to test

1. Open an agent preview chat and send a message that takes a while (a slow tool call works well).
2. **Disconnect mid-run** — reload the page, or kill the network briefly.
3. Wait for the turn to finish, then reload. The full answer is there. On `master` the turn is gone.
4. **Press Stop** during a run. The chat settles and the run stops server-side; the answer does *not* reappear after a reload.
5. **Press Stop immediately** after sending, while the agent is still being prepared. The run is aborted rather than starting anyway.
6. **Two sessions, same agent**, both running. Stop one — the other keeps streaming.
7. **Restart the instance** mid-run. The turn is recorded as failed straight away, rather than sitting `running` until the sweep.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-694

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)