### PR TITLE
perf(Supabase Node): Fetch the API schema once for all column dropdowns

### DIFF
--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -11,6 +11,7 @@ import type {
 	IRequestOptions,
 } from 'n8n-workflow';
 import { NodeApiError, UserError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
 
 export function getSchemaHeader(
 	context: IExecuteFunctions | ILoadOptionsFunctions,
@@ -83,6 +84,44 @@ export async function supabaseApiRequest(
 			error.message = `${error.message}: ${error.description}`;
 		}
 		throw new NodeApiError(this.getNode(), error as JsonObject);
+	}
+}
+
+type SupabaseApiDefinition = {
+	paths?: IDataObject;
+	definitions?: {
+		[table: string]: { properties?: { [column: string]: { type: string } } } | undefined;
+	};
+};
+
+const apiDefinitionsInFlight = new Map<string, Promise<SupabaseApiDefinition>>();
+
+/**
+ * Reads the PostgREST root document, which lists every table and column and so can run to
+ * several megabytes. The editor opens one column dropdown per field and they all ask at
+ * once, so overlapping callers share one request instead of a parsed copy each.
+ */
+export async function getApiDefinition(
+	this: ILoadOptionsFunctions,
+): Promise<SupabaseApiDefinition> {
+	const { host, serviceRole } = await this.getCredentials<{
+		host: string;
+		serviceRole: string;
+	}>('supabaseApi');
+	const header = getSchemaHeader(this, 'GET', 'loadOptions');
+	const key = createHash('sha256')
+		.update(JSON.stringify([host, serviceRole, header]))
+		.digest('hex');
+
+	const inFlight = apiDefinitionsInFlight.get(key);
+	if (inFlight) return await inFlight;
+
+	const request = supabaseApiRequest.call(this, 'GET', '/', {}, {}, undefined, header);
+	apiDefinitionsInFlight.set(key, request);
+	try {
+		return await request;
+	} finally {
+		apiDefinitionsInFlight.delete(key);
 	}
 }
 

--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -17,6 +17,7 @@ import {
 	buildGetQuery,
 	buildOrQuery,
 	buildQuery,
+	getApiDefinition,
 	getSchemaHeader,
 	mapPairedItemsFrom,
 	supabaseApiRequest,
@@ -102,17 +103,8 @@ export class Supabase implements INodeType {
 		loadOptions: {
 			async getTables(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const header = getSchemaHeader(this, 'GET', 'loadOptions');
-				const { paths } = await supabaseApiRequest.call(
-					this,
-					'GET',
-					'/',
-					{},
-					{},
-					undefined,
-					header,
-				);
-				for (const path of Object.keys(paths as IDataObject)) {
+				const { paths } = await getApiDefinition.call(this);
+				for (const path of Object.keys(paths ?? {})) {
 					// omit introspection path and skip RPCs, leaving only tables
 					if (path === '/' || path.startsWith('/rpc/')) {
 						continue;
@@ -128,20 +120,9 @@ export class Supabase implements INodeType {
 			async getTableColumns(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				const tableName = this.getCurrentNodeParameter('tableId') as string;
-				const header = getSchemaHeader(this, 'GET', 'loadOptions');
-				const { definitions } = await supabaseApiRequest.call(
-					this,
-					'GET',
-					'/',
-					{},
-					{},
-					undefined,
-					header,
-				);
+				const { definitions } = await getApiDefinition.call(this);
 
-				const properties = definitions[tableName]?.properties as
-					| { [column: string]: { type: string } }
-					| undefined;
+				const properties = definitions?.[tableName]?.properties;
 				if (!properties) {
 					return returnData;
 				}

--- a/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
+++ b/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
@@ -1,4 +1,3 @@
-import { mock, mockDeep } from 'vitest-mock-extended';
 import get from 'lodash/get';
 import {
 	type ILoadOptionsFunctions,
@@ -9,10 +8,11 @@ import {
 	type IPairedItemData,
 	NodeOperationError,
 } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import { mock, mockDeep } from 'vitest-mock-extended';
 
 import * as utils from '../GenericFunctions';
 import { Supabase } from '../Supabase.node';
-import type { Mock } from 'vitest';
 
 describe('Test Supabase Node', () => {
 	const node = new Supabase();
@@ -61,6 +61,23 @@ describe('Test Supabase Node', () => {
 			},
 		} as unknown as IExecuteFunctions;
 		return fakeExecuteFunction;
+	};
+
+	// getNodeParameter is only ever asked for these two names on the loadOptions path
+	const createMockLoadOptionsFunction = (
+		schema?: string,
+		getCredentials: typeof mockGetCredentials = mockGetCredentials,
+	) => {
+		const context = mockDeep<ILoadOptionsFunctions>({
+			getCredentials,
+			helpers: {
+				requestWithAuthentication: mockRequestWithAuthentication,
+			},
+		});
+		context.getNodeParameter.mockImplementation((name: string) =>
+			name === 'useCustomSchema' ? schema !== undefined : schema,
+		);
+		return context;
 	};
 
 	describe('filter query builders', () => {
@@ -517,13 +534,7 @@ describe('Test Supabase Node', () => {
 	describe('loadOptions', () => {
 		describe('getTables', () => {
 			it('should return the tables and skip RPCs', async () => {
-				const mockLoadOptionsFunctions = mockDeep<ILoadOptionsFunctions>({
-					getCredentials: mockGetCredentials,
-					helpers: {
-						requestWithAuthentication: mockRequestWithAuthentication,
-					},
-				});
-				mockLoadOptionsFunctions.getNodeParameter.mockReturnValue(false); // useCustomSchema is false
+				const mockLoadOptionsFunctions = createMockLoadOptionsFunction();
 				mockRequestWithAuthentication.mockResolvedValue({
 					paths: {
 						'/': {
@@ -547,13 +558,7 @@ describe('Test Supabase Node', () => {
 
 		describe('getTableColumns', () => {
 			it('should return table columns with their types', async () => {
-				const mockLoadOptionsFunctions = mockDeep<ILoadOptionsFunctions>({
-					getCredentials: mockGetCredentials,
-					helpers: {
-						requestWithAuthentication: mockRequestWithAuthentication,
-					},
-				});
-				mockLoadOptionsFunctions.getNodeParameter.mockReturnValue(false); // useCustomSchema is false
+				const mockLoadOptionsFunctions = createMockLoadOptionsFunction();
 				mockLoadOptionsFunctions.getCurrentNodeParameter.mockReturnValue('users');
 				mockRequestWithAuthentication.mockResolvedValue({
 					definitions: {
@@ -578,13 +583,7 @@ describe('Test Supabase Node', () => {
 			});
 
 			it('should return empty array when table definition has no properties', async () => {
-				const mockLoadOptionsFunctions = mockDeep<ILoadOptionsFunctions>({
-					getCredentials: mockGetCredentials,
-					helpers: {
-						requestWithAuthentication: mockRequestWithAuthentication,
-					},
-				});
-				mockLoadOptionsFunctions.getNodeParameter.mockReturnValue(false); // useCustomSchema is false
+				const mockLoadOptionsFunctions = createMockLoadOptionsFunction();
 				mockLoadOptionsFunctions.getCurrentNodeParameter.mockReturnValue('users');
 				mockRequestWithAuthentication.mockResolvedValue({
 					definitions: {
@@ -596,6 +595,95 @@ describe('Test Supabase Node', () => {
 					await node.methods.loadOptions.getTableColumns.call(mockLoadOptionsFunctions);
 
 				expect(columns).toEqual([]);
+			});
+
+			it('should fetch the schema document once for concurrent calls sharing a schema', async () => {
+				const createColumnsContext = (schema?: string) => {
+					const context = createMockLoadOptionsFunction(schema);
+					context.getCurrentNodeParameter.mockReturnValue('users');
+					return context;
+				};
+
+				mockRequestWithAuthentication.mockResolvedValue({
+					definitions: {
+						users: {
+							properties: {
+								id: { type: 'integer' },
+								email: { type: 'string' },
+							},
+						},
+					},
+				});
+
+				const publicSchemaColumns = await Promise.all(
+					Array.from(
+						{ length: 25 },
+						async () => await node.methods.loadOptions.getTableColumns.call(createColumnsContext()),
+					),
+				);
+
+				for (const columns of publicSchemaColumns) {
+					expect(columns).toEqual([
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased, n8n-nodes-base/node-param-display-name-miscased-id
+						{ name: 'id - (integer)', value: 'id' },
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						{ name: 'email - (string)', value: 'email' },
+					]);
+				}
+				expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
+
+				await Promise.all(
+					Array.from(
+						{ length: 5 },
+						async () =>
+							await node.methods.loadOptions.getTableColumns.call(
+								createColumnsContext('analytics'),
+							),
+					),
+				);
+
+				expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(2);
+			});
+
+			it('should not share a request between callers whose credentials differ', async () => {
+				const createColumnsContext = (serviceRole: string) => {
+					const context = createMockLoadOptionsFunction(
+						undefined,
+						vi.fn().mockResolvedValue({ host: 'https://api.supabase.io', serviceRole }),
+					);
+					context.getCurrentNodeParameter.mockReturnValue('users');
+					return context;
+				};
+				mockRequestWithAuthentication.mockResolvedValue({ definitions: { users: {} } });
+
+				await Promise.all([
+					node.methods.loadOptions.getTableColumns.call(createColumnsContext('role-a')),
+					node.methods.loadOptions.getTableColumns.call(createColumnsContext('role-b')),
+				]);
+
+				expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(2);
+			});
+
+			it('should issue a fresh request after a shared request fails', async () => {
+				const createColumnsContext = () => {
+					const context = createMockLoadOptionsFunction();
+					context.getCurrentNodeParameter.mockReturnValue('users');
+					return context;
+				};
+				mockRequestWithAuthentication.mockRejectedValueOnce(new Error('schema unavailable'));
+
+				await expect(
+					Promise.all([
+						node.methods.loadOptions.getTableColumns.call(createColumnsContext()),
+						node.methods.loadOptions.getTableColumns.call(createColumnsContext()),
+					]),
+				).rejects.toThrow();
+				expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
+
+				mockRequestWithAuthentication.mockResolvedValue({ definitions: { users: {} } });
+				await node.methods.loadOptions.getTableColumns.call(createColumnsContext());
+
+				expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(2);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

The Supabase node builds its column dropdowns from the PostgREST root document at `GET /rest/v1/`. That document describes every table and every column in the schema, so it can run to several megabytes.

Both `getTables` and `getTableColumns` downloaded it on each call. The editor renders one column dropdown for each **Fields to Send** entry, and all of them load at the same moment. A node with 25 fields therefore made 26 requests for the same document at once, and parsed 26 copies of it.

This PR routes both load-options methods through a new `getApiDefinition` helper. Callers that overlap share one request, so one node open costs one download and one parse.

Measured against a mock PostgREST server that returns a 1.83 MiB document:

| Fields to Send | Requests before | Requests after |
|---|---|---|
| 25 | 26 | 1 |
| 50 | 51 | 2 |
| 100 | 101 | 3 |

So this PR is a large reduction in duplicated network and parsing work. It is not the fix for the OOM crash itself (probably a factor of multiple things), will try to investigate that some more. Follow up ticket: https://linear.app/n8n/issue/CAT-4383/concurrent-requests-each-build-two-unbounded-v8-expression-isolates


## How to test

You do not need a real Supabase account. Any HTTP server that answers `GET /rest/v1/` with a PostgREST-shaped document works.

1. Start a stub that serves a large document at `GET /rest/v1/` and logs each request. See below
2. Create a **Supabase API** credential. Set **Host** to the stub's base URLand **Secret Key** to any non-empty string.
3. Add a **Supabase** node, and set **Resource** to `Row` and **Operation** to `Create`.
4. Select the target table, then set **Data to Send** to **Define Below for Each Column**.
5. Add 25 **Fields to Send**.
6. Clear the stub's log, close the node, and open it again.

<details>
<summary>Stub Code save as supabase-stub.mjs and then run `node supabase-stub.mjs 5099` </summary>

```
#!/usr/bin/env node
/**
 * Minimal PostgREST stand-in for NODE-5387.
 *
 * Serves a ~1.6 MB OpenAPI root document at GET /rest/v1/ — the same shape the
 * Supabase node's `getTables` / `getTableColumns` loadOptions methods read.
 * Every request is logged with a running counter, so you can count how many
 * times n8n downloads the document when you open the node.
 *
 * Usage: node .context/node-5387/mock-supabase.mjs [port]
 */
import { createServer } from 'node:http';

const PORT = Number(process.argv[2] ?? 5599);

const TARGET_TABLE = 'n8n_repro_target';
const ENTITY_TABLES = Number(process.env.ENTITY_TABLES ?? 95);
const VIEWS = Number(process.env.VIEWS ?? 20);
const COLUMNS_PER_TABLE = 30;

function buildColumns(prefix) {
	const properties = {};
	for (let i = 0; i < COLUMNS_PER_TABLE; i++) {
		properties[`${prefix}_column_${i}`] = {
			type: i % 3 === 0 ? 'integer' : 'string',
			format: i % 3 === 0 ? 'bigint' : 'text',
			description: `Note:\nThis is a Primary Key.<pk/>\n${'padding '.repeat(Number(process.env.PADDING ?? 20))}`,
		};
	}
	return properties;
}

function buildPath(table) {
	return {
		get: {
			tags: [table],
			parameters: Array.from({ length: COLUMNS_PER_TABLE }, (_, i) => ({
				name: `${table}_column_${i}`,
				in: 'query',
				type: 'string',
				format: 'text',
				description: 'padding '.repeat(Number(process.env.PADDING ?? 20)),
			})),
			responses: { 200: { description: 'OK' }, 206: { description: 'Partial Content' } },
		},
		post: { tags: [table], parameters: [], responses: { 201: { description: 'Created' } } },
	};
}

const document = { swagger: '2.0', info: { title: 'standard public schema' }, paths: {}, definitions: {} };
document.paths['/'] = { get: { responses: { 200: { description: 'OK' } } } };

const tables = [
	TARGET_TABLE,
	...Array.from({ length: ENTITY_TABLES }, (_, i) => `n8n_repro_entity_${i}`),
	...Array.from({ length: VIEWS }, (_, i) => `n8n_repro_view_${i}`),
];
for (const table of tables) {
	document.paths[`/${table}`] = buildPath(table);
	document.definitions[table] = { properties: buildColumns(table) };
}

const body = Buffer.from(JSON.stringify(document));
console.log(
	`Schema document: ${(body.byteLength / 1024 / 1024).toFixed(2)} MiB, ${tables.length} tables/views`,
);

let requestCount = 0;

createServer((req, res) => {
	const url = new URL(req.url, `http://localhost:${PORT}`);
	if (url.pathname === '/__count') {
		res.writeHead(200, { 'content-type': 'application/json' });
		res.end(JSON.stringify({ count: requestCount }));
		return;
	}
	if (url.pathname === '/rest/v1/' || url.pathname === '/rest/v1') {
		requestCount++;
		console.log(
			`[${new Date().toISOString()}] #${String(requestCount).padStart(3)} GET ${url.pathname} -> ${(body.byteLength / 1024 / 1024).toFixed(2)} MiB`,
		);
		res.writeHead(200, { 'content-type': 'application/openapi+json', 'content-length': body.byteLength });
		res.end(body);
		return;
	}
	res.writeHead(200, { 'content-type': 'application/json' });
	res.end('[]');
}).listen(PORT, () => {
	console.log(`Mock Supabase listening on http://localhost:${PORT}`);
	console.log('Credential -> Host: http://localhost:' + PORT + '  Secret Key: anything');
});

```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5387
Related to https://linear.app/n8n/issue/CAT-4383/concurrent-requests-each-build-two-unbounded-v8-expression-isolates

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

