### PR TITLE
feat(core): Enforce content-import policy on package import (no-changelog)

### DIFF
--- a/packages/@n8n/decorators/src/policy-check/policy-check.ts
+++ b/packages/@n8n/decorators/src/policy-check/policy-check.ts
@@ -86,9 +86,19 @@ export type CredentialDecryptContext = {
 	readonly projectId: string | null;
 };
 
+/**
+ * How the content reached the instance.
+ *
+ * A check needs this to hold an unattended sync to a different standard than a hand-run
+ * import, and the host reads it to pick its fail posture — a batch sync reports, a direct
+ * import refuses before writing.
+ */
+export type ContentImportTransport = 'cli' | 'source-control' | 'package' | 'git-connection';
+
 export type ContentImportContext = {
 	readonly workflow: PolicedWorkflow;
 	readonly projectId: string | null;
+	readonly transport: ContentImportTransport;
 };
 
 /** A policy version a check read, recorded on the audit log. */

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-package-policy.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-package-policy.integration.test.ts
@@ -14,7 +14,7 @@ import {
 	testDb,
 	testModules,
 } from '@n8n/backend-test-utils';
-import { WorkflowRepository } from '@n8n/db';
+import { WorkflowHistoryRepository, WorkflowRepository } from '@n8n/db';
 import type {
 	ContentImportContext,
 	PolicyCheckResult,
@@ -152,20 +152,9 @@ describe('contentImport on a direct package import', () => {
 		await expect(Container.get(WorkflowRepository).count()).resolves.toBe(0);
 	});
 
-	it('reports the package transport to the check', async () => {
-		const owner = await createOwner();
-
-		await importPackage({
-			user: owner,
-			packageBuffer: await buildImportPackageBuffer([
-				serializedWorkflow({ id: 'wf-1', name: 'Unremarkable Workflow' }),
-			]),
-		});
-
-		expect(seenTransports).toEqual(['package']);
-	});
-
-	it('imports normally when no check objects', async () => {
+	// The registry short-circuit (nothing registered for `contentImport`) cannot be covered here:
+	// `@PolicyCheck` registers per process, so this file always has one. See the gate's unit test.
+	it('imports the workflow when the check admits it', async () => {
 		const owner = await createOwner();
 
 		const result = await importPackage({
@@ -175,6 +164,8 @@ describe('contentImport on a direct package import', () => {
 			]),
 		});
 
+		// Proves the check ran and allowed it, rather than never running at all.
+		expect(seenTransports).toEqual(['package']);
 		expect(result.workflows).toHaveLength(1);
 		await expect(Container.get(WorkflowRepository).count()).resolves.toBe(1);
 	});
@@ -235,6 +226,18 @@ describe('contentImport on a git pull', () => {
 
 		expect(seenTransports).toEqual(['git-connection']);
 		expect(error).toBeInstanceOf(UnprocessableRequestError);
+
+		// "Writes nothing" means the target is untouched, not empty: the pull would have
+		// rewritten this workflow, so its row must still carry the version it had before.
+		const workflowRepository = Container.get(WorkflowRepository);
+		await expect(workflowRepository.count()).resolves.toBe(1);
+		await expect(workflowRepository.findOneBy({ id: workflow.id })).resolves.toMatchObject({
+			name: workflow.name,
+			versionId: workflow.versionId,
+			activeVersionId: workflow.activeVersionId,
+		});
+		await expect(Container.get(WorkflowHistoryRepository).count()).resolves.toBe(0);
+
 		expect((error as UnprocessableRequestError).meta?.issues).toContainEqual({
 			type: 'policy-violation',
 			sourceWorkflowId: workflow.id,

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-package-policy.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-package-policy.integration.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Pins the `contentImport` wiring on the package import path through the real policy decision
+ * pipeline. Unit tests mock `PolicyEnforcementService`, so they prove the gate is called with
+ * the right arguments but not that a registered check actually runs.
+ *
+ * A refusal takes down the whole package on both transports, unlike a source-control pull, which
+ * skips the blocked workflow and lets the rest land.
+ */
+import { LicenseState } from '@n8n/backend-common';
+import {
+	createTeamProject,
+	createWorkflow,
+	mockInstance,
+	testDb,
+	testModules,
+} from '@n8n/backend-test-utils';
+import { WorkflowRepository } from '@n8n/db';
+import type {
+	ContentImportContext,
+	PolicyCheckResult,
+	RegisteredPolicyCheck,
+} from '@n8n/decorators';
+import { PolicyCheck, PolicyCheckMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
+import { PolicyDecisionService } from '@/modules/policy-infrastructure/policy-decision.service';
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+import { initNodeTypes } from '@test-integration/utils';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import { importPackageRequest } from './fixtures/import-request';
+import { buildImportPackageBuffer, serializedWorkflow } from './fixtures/package-fixtures';
+import type { BlockingIssue, ImportPackageRequest, ImportRequest } from '../n8n-packages.types';
+
+const CHECK_ID = 'test-package-content-import-deny';
+const VIOLATION_KIND = 'test-package-content-import-denied';
+
+const deniedMessage = (name: string) => `Workflow "${name}" is denied on import`;
+
+/** The decorator registers once per process, so each test names the workflow it wants denied. */
+const deniedWorkflowNames = new Set<string>();
+const seenTransports: string[] = [];
+
+@PolicyCheck()
+class PackageContentImportDenyCheck implements RegisteredPolicyCheck {
+	readonly id = CHECK_ID;
+
+	async onContentImport({ workflow, transport }: ContentImportContext): Promise<PolicyCheckResult> {
+		seenTransports.push(transport);
+
+		if (!deniedWorkflowNames.has(workflow.name)) return { violations: [] };
+
+		return {
+			violations: [
+				{
+					kind: VIOLATION_KIND,
+					checkId: this.id,
+					message: deniedMessage(workflow.name),
+					subject: workflow.name,
+					subjectType: 'workflow',
+					scope: 'instance',
+				},
+			],
+		};
+	}
+}
+
+const licenseMocker = new LicenseMocker();
+
+mockInstance(ActiveWorkflowManager);
+
+async function importPackage(
+	params: Pick<ImportPackageRequest, 'user' | 'packageBuffer'> & Partial<ImportPackageRequest>,
+) {
+	return await Container.get(N8nPackagesService).importPackage(
+		importPackageRequest({ variableParentPolicy: 'project', ...params }),
+	);
+}
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	await initNodeTypes();
+	licenseMocker.mockLicenseState(Container.get(LicenseState));
+	licenseMocker.setDefaults({
+		features: ['feat:projectRole:admin', 'feat:folders'],
+		quotas: { 'quota:maxTeamProjects': 100 },
+	});
+
+	expect(Container.get(PolicyCheckMetadata).getClasses()).toContain(PackageContentImportDenyCheck);
+
+	Container.get(PolicyEnforcementService).setImplementation(Container.get(PolicyDecisionService));
+});
+
+beforeEach(() => {
+	deniedWorkflowNames.clear();
+	seenTransports.length = 0;
+});
+
+afterEach(async () => {
+	await testDb.truncate([
+		'Folder',
+		'WorkflowEntity',
+		'SharedWorkflow',
+		'WorkflowHistory',
+		'ProjectRelation',
+		'Project',
+	]);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('contentImport on a direct package import', () => {
+	it('refuses the package before anything is written', async () => {
+		const owner = await createOwner();
+		deniedWorkflowNames.add('Denied Workflow');
+
+		const packageBuffer = await buildImportPackageBuffer([
+			serializedWorkflow({ id: 'wf-clean', name: 'Clean Workflow' }),
+			serializedWorkflow({ id: 'wf-denied', name: 'Denied Workflow' }),
+		]);
+
+		const error = await importPackage({ user: owner, packageBuffer }).catch((e: unknown) => e);
+
+		expect(error).toBeInstanceOf(UnprocessableRequestError);
+		expect((error as UnprocessableRequestError).meta?.issues).toContainEqual({
+			type: 'policy-violation',
+			sourceWorkflowId: 'wf-denied',
+			name: 'Denied Workflow',
+			violations: [
+				{
+					kind: VIOLATION_KIND,
+					checkId: CHECK_ID,
+					message: deniedMessage('Denied Workflow'),
+					subject: 'Denied Workflow',
+					subjectType: 'workflow',
+					scope: 'instance',
+				},
+			],
+		} satisfies BlockingIssue);
+
+		// The whole package is refused, not just the denied workflow.
+		await expect(Container.get(WorkflowRepository).count()).resolves.toBe(0);
+	});
+
+	it('reports the package transport to the check', async () => {
+		const owner = await createOwner();
+
+		await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({ id: 'wf-1', name: 'Unremarkable Workflow' }),
+			]),
+		});
+
+		expect(seenTransports).toEqual(['package']);
+	});
+
+	it('imports normally when no check objects', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({ id: 'wf-1', name: 'Unremarkable Workflow' }),
+			]),
+		});
+
+		expect(result.workflows).toHaveLength(1);
+		await expect(Container.get(WorkflowRepository).count()).resolves.toBe(1);
+	});
+});
+
+describe('contentImport on a git pull', () => {
+	/** Mirrors what a git-connections pull runs: the working copy is source of truth. */
+	const pullPolicy: Omit<ImportRequest, 'user'> = {
+		projectConflictPolicy: 'overwrite',
+		workflowConflictPolicy: 'new-version',
+		workflowIdPolicy: 'source',
+		workflowPublishingPolicy: 'match-source',
+		missingNodeTypeMode: 'fail',
+		credentialMatchingMode: 'id-only',
+		credentialMissingMode: 'create-stub',
+		folderConflictPolicy: 'overwrite',
+		overwriteDeletionPolicy: 'hard-delete',
+		dataTableMatchingMode: 'by-id',
+		dataTableMissingMode: 'create',
+		dataTableSchemaConflictPolicy: 'fail',
+		variableMissingMode: 'create-with-value',
+		variableConflictPolicy: 'overwrite',
+		tagMissingMode: 'create',
+		tagConflictPolicy: 'rename',
+	};
+
+	let sourceDir: string;
+
+	beforeEach(async () => {
+		sourceDir = await mkdtemp(path.join(tmpdir(), 'n8n-package-policy-'));
+	});
+
+	afterEach(async () => {
+		await rm(sourceDir, { recursive: true, force: true });
+	});
+
+	it('refuses the whole pull and writes nothing', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Pulled Project', owner);
+		const workflow = await createWorkflow(
+			{ name: 'Pulled Workflow', nodes: [], connections: {} },
+			project,
+		);
+
+		const service = Container.get(N8nPackagesService);
+		await service.exportPackageToDirectory(
+			{ user: owner, projectIds: [project.id] },
+			{ targetDir: sourceDir },
+		);
+
+		// Only now, so the export itself is not admitted.
+		deniedWorkflowNames.add('Pulled Workflow');
+		seenTransports.length = 0;
+
+		const error = await service
+			.importPackageFromDirectory({ user: owner, ...pullPolicy }, { sourceDir })
+			.catch((e: unknown) => e);
+
+		expect(seenTransports).toEqual(['git-connection']);
+		expect(error).toBeInstanceOf(UnprocessableRequestError);
+		expect((error as UnprocessableRequestError).meta?.issues).toContainEqual({
+			type: 'policy-violation',
+			sourceWorkflowId: workflow.id,
+			name: 'Pulled Workflow',
+			violations: [
+				{
+					kind: VIOLATION_KIND,
+					checkId: CHECK_ID,
+					message: deniedMessage('Pulled Workflow'),
+					subject: 'Pulled Workflow',
+					subjectType: 'workflow',
+					scope: 'instance',
+				},
+			],
+		} satisfies BlockingIssue);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/content-import-policy.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/content-import-policy.test.ts
@@ -1,0 +1,158 @@
+import type { PolicyViolation } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
+import type { WorkflowEntity } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { PolicyCleared } from '@n8n/decorators';
+
+import type { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
+
+import type { WorkflowPlanItem } from '../../entities/workflow/workflow-import.types';
+import { ContentImportPolicyGate, contentImportTransport } from '../content-import-policy';
+
+const violation: PolicyViolation = {
+	kind: 'node-type-unavailable',
+	checkId: 'test.check',
+	message: 'Node type is not available here',
+};
+
+const cleared = mock<PolicyCleared<'contentImport'>>();
+
+const entity = (name: string) => ({ name, nodes: [] }) as unknown as WorkflowEntity;
+
+const createItem = (sourceWorkflowId: string, decidedId = 'local-1'): WorkflowPlanItem =>
+	({
+		action: 'create',
+		decidedId,
+		sourceWorkflowId,
+		entity: entity(sourceWorkflowId),
+	}) as WorkflowPlanItem;
+
+const updateItem = (sourceWorkflowId: string, existingId: string): WorkflowPlanItem =>
+	({
+		action: 'update',
+		sourceWorkflowId,
+		entity: entity(sourceWorkflowId),
+		existing: { id: existingId } as WorkflowEntity,
+	}) as WorkflowPlanItem;
+
+const skipItem = (sourceWorkflowId: string): WorkflowPlanItem =>
+	({
+		action: 'skip',
+		sourceWorkflowId,
+		entity: entity(sourceWorkflowId),
+		existing: { id: 'existing' } as WorkflowEntity,
+	}) as WorkflowPlanItem;
+
+describe('contentImportTransport', () => {
+	it.each([
+		['git-pull', 'git-connection'],
+		['package-import', 'package'],
+		[undefined, 'package'],
+	] as const)('maps %s to %s', (source, expected) => {
+		expect(contentImportTransport(source)).toBe(expected);
+	});
+});
+
+describe('ContentImportPolicyGate', () => {
+	const policyEnforcementService = mock<PolicyEnforcementService>();
+	const gate = new ContentImportPolicyGate(policyEnforcementService, mock<Logger>());
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('admits nothing when no check is registered', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(false);
+
+		expect(await gate.refusedWorkflows([createItem('W1')], 'project-1', 'package')).toEqual([]);
+		expect(policyEnforcementService.hasChecksFor).toHaveBeenCalledTimes(1);
+		expect(policyEnforcementService.enforceContentImport).not.toHaveBeenCalled();
+	});
+
+	it('admits every workflow the import will write', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		policyEnforcementService.enforceContentImport.mockResolvedValue(cleared);
+
+		expect(
+			await gate.refusedWorkflows([createItem('W1'), createItem('W2')], 'project-1', 'package'),
+		).toEqual([]);
+		expect(policyEnforcementService.enforceContentImport).toHaveBeenCalledTimes(2);
+	});
+
+	it('skips workflows the import will not write', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		policyEnforcementService.enforceContentImport.mockResolvedValue(cleared);
+
+		await gate.refusedWorkflows([skipItem('W1'), createItem('W2')], 'project-1', 'package');
+
+		expect(policyEnforcementService.enforceContentImport).toHaveBeenCalledTimes(1);
+	});
+
+	it('passes the transport and the id the workflow will be written under', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		policyEnforcementService.enforceContentImport.mockResolvedValue(cleared);
+
+		await gate.refusedWorkflows(
+			[createItem('W1', 'new-id'), updateItem('W2', 'existing-id')],
+			'project-1',
+			'git-connection',
+		);
+
+		expect(policyEnforcementService.enforceContentImport).toHaveBeenNthCalledWith(1, {
+			workflow: { id: 'new-id', name: 'W1', nodes: [] },
+			projectId: 'project-1',
+			transport: 'git-connection',
+		});
+		expect(policyEnforcementService.enforceContentImport).toHaveBeenNthCalledWith(2, {
+			workflow: { id: 'existing-id', name: 'W2', nodes: [] },
+			projectId: 'project-1',
+			transport: 'git-connection',
+		});
+	});
+
+	it('reports every refusal, not just the first', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		policyEnforcementService.enforceContentImport.mockRejectedValue(
+			new PolicyViolationError([violation]),
+		);
+
+		const refused = await gate.refusedWorkflows(
+			[createItem('W1'), createItem('W2')],
+			'project-1',
+			'package',
+		);
+
+		expect(refused).toEqual([
+			{ type: 'policy-violation', sourceWorkflowId: 'W1', name: 'W1', violations: [violation] },
+			{ type: 'policy-violation', sourceWorkflowId: 'W2', name: 'W2', violations: [violation] },
+		]);
+	});
+
+	it('carries on past a refusal to admit the rest', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		policyEnforcementService.enforceContentImport
+			.mockRejectedValueOnce(new PolicyViolationError([violation]))
+			.mockResolvedValue(cleared);
+
+		const refused = await gate.refusedWorkflows(
+			[createItem('W1'), createItem('W2')],
+			'project-1',
+			'package',
+		);
+
+		expect(refused).toHaveLength(1);
+		expect(policyEnforcementService.enforceContentImport).toHaveBeenCalledTimes(2);
+	});
+
+	it('fails the import when a check breaks, rather than reading as a refusal', async () => {
+		policyEnforcementService.hasChecksFor.mockReturnValue(true);
+		const checkFailure = new Error('check exploded');
+		policyEnforcementService.enforceContentImport.mockRejectedValue(checkFailure);
+
+		await expect(gate.refusedWorkflows([createItem('W1')], 'project-1', 'package')).rejects.toBe(
+			checkFailure,
+		);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/engine/content-import-policy.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/content-import-policy.ts
@@ -1,0 +1,83 @@
+import { Logger } from '@n8n/backend-common';
+import type { ContentImportTransport } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+
+import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
+import { PolicyViolationError } from '@/policy/policy-violation.error';
+
+import type { WorkflowPlanItem } from '../entities/workflow/workflow-import.types';
+import type { BlockingIssue, PackageImportSource } from '../n8n-packages.types';
+
+export function contentImportTransport(
+	source: PackageImportSource | undefined,
+): ContentImportTransport {
+	return source === 'git-pull' ? 'git-connection' : 'package';
+}
+
+@Service()
+export class ContentImportPolicyGate {
+	constructor(
+		private readonly policyEnforcementService: PolicyEnforcementService,
+		private readonly logger: Logger,
+	) {}
+
+	/**
+	 * Admits every workflow the import would write, and reports the ones policy refused.
+	 *
+	 * A refusal takes down the whole package rather than skipping the workflow, unlike a
+	 * source-control pull: the plan rewrites cross-workflow references to the ids each workflow
+	 * *would* get, so dropping one leaves the workflows that call it pointing at a row nothing
+	 * ever wrote.
+	 *
+	 * Reads the nodes off the plan, before credential bindings are applied — rebinding swaps
+	 * credential ids, never node types or parameters, so it cannot change a verdict.
+	 */
+	async refusedWorkflows(
+		items: WorkflowPlanItem[],
+		projectId: string,
+		transport: ContentImportTransport,
+	): Promise<BlockingIssue[]> {
+		// Skips the whole loop rather than paying a per-workflow guard: a package can hold
+		// hundreds, and having no policy at all is the common case.
+		if (!this.policyEnforcementService.hasChecksFor('contentImport')) return [];
+
+		const refused: BlockingIssue[] = [];
+
+		for (const item of items) {
+			if (item.action === 'skip') continue;
+
+			try {
+				// The clearance is discarded: these writes still go through `WorkflowCreationService`
+				// and `WorkflowService`, which mint their own `workflowSave` one. Threading this token
+				// into them instead is its own change.
+				await this.policyEnforcementService.enforceContentImport({
+					workflow: {
+						id: item.action === 'create' ? item.decidedId : item.existing.id,
+						name: item.entity.name,
+						nodes: item.entity.nodes,
+					},
+					projectId,
+					transport,
+				});
+			} catch (error) {
+				// Every refusal is collected, so the caller reports the whole package's worth at once.
+				// A check that broke is not scoped to one workflow, so it fails the import outright
+				// rather than reading as a refusal of the workflow it happened to be running for.
+				if (!(error instanceof PolicyViolationError)) throw error;
+
+				this.logger.warn(`Workflow "${item.entity.name}" is blocked by the content-import policy`, {
+					violations: error.violations,
+				});
+
+				refused.push({
+					type: 'policy-violation',
+					sourceWorkflowId: item.sourceWorkflowId,
+					name: item.entity.name,
+					violations: error.violations,
+				});
+			}
+		}
+
+		return refused;
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
@@ -66,6 +66,7 @@ import type {
 	ResolvedImportFolderProperties,
 } from '../n8n-packages.types';
 import type { PackageWorkflowRequirement } from '../spec/requirements.schema';
+import { ContentImportPolicyGate, contentImportTransport } from './content-import-policy';
 import { toImportBlockedError } from './import-blocked.error';
 import { assertVariableWritesAllowed } from './import-gates';
 
@@ -133,6 +134,7 @@ export class ImportOrchestrator {
 		private readonly workflowImporter: WorkflowImporter,
 		private readonly workflowRemover: WorkflowRemover,
 		private readonly workflowPublisher: WorkflowPublisher,
+		private readonly contentImportPolicyGate: ContentImportPolicyGate,
 		private readonly nodeTypes: NodeTypes,
 		private readonly licenseState: LicenseState,
 	) {}
@@ -248,6 +250,12 @@ export class ImportOrchestrator {
 			(nodeType) => this.nodeTypes.getSupportedVersions(nodeType),
 		);
 
+		const refusedByPolicy = await this.contentImportPolicyGate.refusedWorkflows(
+			workflowPlan.items,
+			context.projectId,
+			contentImportTransport(input.importSource),
+		);
+
 		const blockingIssues = this.collectBlockingIssues({
 			workflowPlan,
 			credentialPlan,
@@ -262,6 +270,8 @@ export class ImportOrchestrator {
 			missingNodeTypes,
 			missingNodeTypeMode: options.missingNodeTypeMode,
 		});
+
+		blockingIssues.push(...refusedByPolicy);
 
 		return {
 			input,

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -1,3 +1,4 @@
+import type { PolicyViolation } from '@n8n/api-types';
 import type { User } from '@n8n/db';
 import type { Readable } from 'node:stream';
 
@@ -499,6 +500,12 @@ export type BlockingIssue =
 			nodeType: string;
 			typeVersion: number;
 			usedByWorkflows: string[];
+	  }
+	| {
+			type: 'policy-violation';
+			sourceWorkflowId: string;
+			name: string;
+			violations: PolicyViolation[];
 	  };
 
 /**

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -1659,6 +1659,7 @@ describe('SourceControlImportService', () => {
 						nodes: mockWorkflowData.nodes,
 					},
 					projectId: 'personal-project-id-123',
+					transport: 'source-control',
 				});
 			});
 

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -856,6 +856,7 @@ export class SourceControlImportService {
 			cleared = await this.policyEnforcementService.enforceContentImport({
 				workflow: { id, name: importedWorkflow.name, nodes },
 				projectId: targetOwnerProject.id,
+				transport: 'source-control',
 			});
 		} catch (error) {
 			// A blocked workflow is skipped, not fatal — the rest of the pull still lands. A check

--- a/packages/cli/src/policy/__tests__/policy-enforcement.service.test.ts
+++ b/packages/cli/src/policy/__tests__/policy-enforcement.service.test.ts
@@ -41,7 +41,11 @@ const enforceCalls = (service: PolicyEnforcementService) => ({
 			projectId: 'proj-1',
 		}),
 	contentImport: async () =>
-		await service.enforceContentImport({ workflow: savedWorkflow, projectId: 'proj-1' }),
+		await service.enforceContentImport({
+			workflow: savedWorkflow,
+			projectId: 'proj-1',
+			transport: 'cli',
+		}),
 });
 
 const evaluateCalls = (service: PolicyEnforcementService) => ({
@@ -68,7 +72,11 @@ const evaluateCalls = (service: PolicyEnforcementService) => ({
 			projectId: 'proj-1',
 		}),
 	contentImport: async () =>
-		await service.evaluateContentImport({ workflow: savedWorkflow, projectId: 'proj-1' }),
+		await service.evaluateContentImport({
+			workflow: savedWorkflow,
+			projectId: 'proj-1',
+			transport: 'cli',
+		}),
 });
 
 describe('PolicyEnforcementService', () => {
@@ -174,7 +182,7 @@ describe('PolicyEnforcementService', () => {
 				checkErrors: [{ checkId: 'flaky', correlationId: 'abc' }],
 			};
 			backend.evaluate.mockResolvedValue(decision);
-			const context = { workflow: savedWorkflow, projectId: null };
+			const context = { workflow: savedWorkflow, projectId: null, transport: 'cli' } as const;
 
 			expect(await service.evaluateContentImport(context)).toBe(decision);
 			expect(backend.evaluate).toHaveBeenCalledWith('contentImport', context);

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
@@ -402,3 +402,28 @@ oneOf:
         items:
           type: string
         description: Package workflow ids that reference any of the listed variables.
+  - type: object
+    description: >
+      A workflow the content-import policy refused. Takes down the whole package
+      rather than skipping the workflow: the import rewrites cross-workflow
+      references to the ids each workflow would get, so dropping one leaves the
+      workflows that call it pointing at a row nothing ever wrote.
+    required:
+      - type
+      - sourceWorkflowId
+      - name
+      - violations
+    properties:
+      type:
+        type: string
+        enum:
+          - policy-violation
+      sourceWorkflowId:
+        type: string
+        description: Workflow id as it appears in the package.
+      name:
+        type: string
+      violations:
+        type: array
+        items:
+          $ref: '../../../../shared/spec/schemas/policyViolation.yml'

--- a/packages/cli/src/public-api/v1/shared/spec/schemas/policyViolation.yml
+++ b/packages/cli/src/public-api/v1/shared/spec/schemas/policyViolation.yml
@@ -1,0 +1,31 @@
+type: object
+description: >
+  One reason a policy check objected. `kind`, `subjectType` and `scope` are open
+  strings, not enums, so later policy features can add values — a reader must
+  cope with values it does not recognise.
+required:
+  - kind
+  - checkId
+  - message
+properties:
+  kind:
+    type: string
+    description: 'e.g. `node-type-unavailable`. Do not assume you know every value.'
+  checkId:
+    type: string
+    description: Id of the check that objected.
+  message:
+    type: string
+    description: Readable on its own. Do not parse details out of it — use the fields below.
+  subject:
+    type: string
+    description: 'What was objected to: a node type name, a credential type name, …'
+  subjectType:
+    type: string
+    description: What kind of name `subject` is — node and credential type names can look alike.
+  scope:
+    type: string
+    description: Which level objected. Usually `instance` or `project`, but treat it as open.
+  matchedRuleId:
+    type: string
+    description: The rule that decided, if a rule did rather than a fallback default.

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -176,6 +176,7 @@ export class ImportService {
 				cleared = await this.policyEnforcementService.enforceContentImport({
 					workflow: { id: workflow.id ?? null, name: workflow.name, nodes: workflow.nodes },
 					projectId: policyProjectId,
+					transport: 'cli',
 				});
 			} catch (error) {
 				// A blocked workflow is skipped, not fatal — the operator gets the rest of the batch.

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -2049,6 +2049,7 @@ describe('SourceControlImportService', () => {
 				expect(mockPolicyEnforcementService.enforceContentImport).toHaveBeenCalledWith({
 					workflow: { id: workflow.id, name: workflow.name, nodes: workflow.nodes },
 					projectId: importingUserProject.id,
+					transport: 'source-control',
 				});
 			});
 

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -513,10 +513,12 @@ describe('ImportService', () => {
 			expect(mockPolicyEnforcementService.enforceContentImport).toHaveBeenCalledWith({
 				workflow: { id: first.id, name: first.name, nodes: first.nodes },
 				projectId: ownerPersonalProject.id,
+				transport: 'cli',
 			});
 			expect(mockPolicyEnforcementService.enforceContentImport).toHaveBeenCalledWith({
 				workflow: { id: second.id, name: second.name, nodes: second.nodes },
 				projectId: ownerPersonalProject.id,
+				transport: 'cli',
 			});
 		});
 
@@ -594,6 +596,7 @@ describe('ImportService', () => {
 					nodes: workflowToReimport.nodes,
 				},
 				projectId: memberPersonalProject.id,
+				transport: 'cli',
 			});
 		});
 


### PR DESCRIPTION
## Summary

The `.n8np` package import path never called the `contentImport` policy host point, and neither did `git-connections`, which is built entirely on it. The path was not unpoliced, which is what made this easy to miss: `WorkflowImporter` writes through `WorkflowCreationService` and `WorkflowService`, so `workflowSave` fired and a valid clearance reached the sealed write. But `WorkflowSaveContext` carries no signal that the content came from outside the instance, so a check could not hold imported content to a different standard than content a user typed here.

This PR adds a `transport` discriminator to `ContentImportContext` (`cli` / `source-control` / `package` / `git-connection`), then admits every workflow the import would write from `ImportOrchestrator.plan` through a new `ContentImportPolicyGate`. Refusals are collected and reported together as `policy-violation` blocking issues, alongside every other blocker the plan found, before anything is written.

A refusal takes down the whole package on both transports. This differs from a source-control pull, which (as of #37481) skips the blocked workflow and lets the rest land — that does not transfer here, because `collectPlannedWorkflowBindings` maps every planned workflow to the id it *would* get, so dropping one leaves the workflows that call it pointing at a row nothing ever wrote.

Three things are deliberately out of scope and recorded as follow-ups on the ticket: the write seal stays on `workflowSave` (moving it needs `WorkflowCreationService` to accept a caller-supplied token); export has no host point at all, which is where the `credential.exporter.ts` bypass of `CredentialsHelper` lives; and the non-workflow entities the importer writes (projects, folders, tags, variables, data tables) remain unpoliced.

## How to test

The `n8n-packages` module is on by default, so no extra configuration is needed for the unit and integration tests:

```bash
pnpm --filter n8n test src/modules/n8n-packages/engine/__tests__/content-import-policy.test.ts
pnpm --filter n8n test:integration src/modules/n8n-packages/__tests__/import-package-policy.integration.test.ts
```

The integration test registers a real `@PolicyCheck` and drives it through `PolicyDecisionService`, so it exercises the wiring rather than a mock. It builds the git-pull working copy with a real `exportPackageToDirectory` round trip.

To exercise it by hand you need a policy check registered for `contentImport`; with none registered the gate short-circuits before the per-workflow loop and import behaviour is unchanged. `git-connections` is opt-in and licensed: set `N8N_ENABLED_MODULES=git-connections` and a licence with `feat:gitConnections`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1338

Built on top of #37481 and rebased onto `master` after it merged.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI