### PR TITLE
feat(core): Add agent entity to n8n packages export and import (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -130,6 +130,9 @@ describe('LogStreamingEventRelay', () => {
 						skipped: 0,
 						requirements: 1,
 					},
+					agents: {
+						created: 0,
+					},
 				},
 			};
 
@@ -196,6 +199,7 @@ describe('LogStreamingEventRelay', () => {
 					dataTables: 1,
 					variables: 1,
 					tags: 1,
+					agents: 0,
 				},
 				// Telemetry-only; must not appear in the audit payload below.
 				credentialExportPolicy: 'expression-values-only',

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2343,6 +2343,9 @@ describe('TelemetryEventRelay', () => {
 						skipped: 9,
 						requirements: 10,
 					},
+					agents: {
+						created: 0,
+					},
 				},
 			};
 
@@ -2406,6 +2409,7 @@ describe('TelemetryEventRelay', () => {
 					dataTables: 1,
 					variables: 4,
 					tags: 2,
+					agents: 0,
 				},
 				credentialExportPolicy: 'expression-values-only',
 			};

--- a/packages/cli/src/modules/agents/agent-knowledge.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge.service.ts
@@ -1,17 +1,19 @@
+import { N8nPdfLoader } from '@n8n/ai-utilities';
 import {
 	MAX_AGENT_KNOWLEDGE_BASE_SIZE_BYTES,
 	MAX_AGENT_KNOWLEDGE_BASE_SIZE_GB,
 	type AgentFileDto,
 } from '@n8n/api-types';
-import { N8nPdfLoader } from '@n8n/ai-utilities';
 import { Logger } from '@n8n/backend-common';
 import { isUniqueConstraintError } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { generateNanoId } from '@n8n/utils/generate-nano-id';
+import { UnexpectedError } from 'n8n-workflow';
 import { createReadStream } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import path from 'node:path';
 import type { Readable } from 'node:stream';
+
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
@@ -71,6 +73,61 @@ export class AgentKnowledgeService {
 		await this.ensureAgentBelongsToProject(agentId, projectId);
 		const files = await this.agentFileRepository.findByAgentId(agentId);
 		return files.map((file) => toAgentFileDto(file));
+	}
+
+	/** Every knowledge file's row and stored bytes, for package export. */
+	async getFilesWithContent(agentId: string): Promise<Array<{ file: AgentFile; content: Buffer }>> {
+		const files = await this.agentFileRepository.findByAgentId(agentId);
+		const result: Array<{ file: AgentFile; content: Buffer }> = [];
+		for (const file of files) {
+			const content = await this.agentKnowledgeFileStore.readAsBuffer({
+				storedAt: file.storedAt,
+				storageKey: file.storageKey,
+			});
+			if (!content) {
+				throw new UnexpectedError('Knowledge file content is missing from storage', {
+					extra: { agentId, fileId: file.id },
+				});
+			}
+			result.push({ file, content });
+		}
+		return result;
+	}
+
+	/**
+	 * Writes an already-prepared file's bytes and row, for package import. The
+	 * bytes come from another instance's store, so no PDF extraction runs here;
+	 * `fileSizeBytes` carries the source row's value.
+	 */
+	async importFile(
+		agentId: string,
+		meta: { fileName: string; mimeType: string; fileSizeBytes: number },
+		content: Buffer,
+	): Promise<AgentFile> {
+		const fileId = generateNanoId();
+		const stored = await this.agentKnowledgeFileStore.write({ agentId, fileId }, content, {
+			fileName: storageFileNameForOriginalFileName(meta.fileName),
+			mimeType: meta.mimeType,
+		});
+
+		try {
+			const agentFile = this.agentFileRepository.create({
+				id: fileId,
+				agentId,
+				storedAt: stored.storedAt,
+				storageKey: stored.storageKey,
+				fileName: meta.fileName,
+				mimeType: meta.mimeType,
+				fileSizeBytes: meta.fileSizeBytes,
+			});
+			return await this.agentFileRepository.save(agentFile);
+		} catch (error) {
+			await this.agentKnowledgeFileStore.delete([stored]).catch(() => {});
+			if (isUniqueConstraintError(error)) {
+				throw this.duplicateFileNameError(meta.fileName);
+			}
+			throw error;
+		}
 	}
 
 	async warmKnowledgeSandbox(agentId: string, projectId: string): Promise<void> {

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -16,16 +16,18 @@ import { v4 as uuid } from 'uuid';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { EventService } from '@/events/event.service';
 
 import { AgentChatAttachmentService } from './agent-chat-attachment.service';
-import { AgentKnowledgeService } from './agent-knowledge.service';
 import { AgentExecutionService } from './agent-execution.service';
+import { AgentKnowledgeService } from './agent-knowledge.service';
 import { AgentRuntimeCacheService } from './agent-runtime-cache.service';
 import { AgentTestChatService } from './agent-test-chat.service';
+import type { AgentTask } from './entities/agent-task.entity';
 import { Agent } from './entities/agent.entity';
 import { ChatIntegrationService } from './integrations/chat-integration.service';
-import { AgentTaskRepository } from './repositories/agent-task.repository';
 import { decomposeJsonConfig } from './json-config/agent-config-composition';
+import { AgentTaskRepository } from './repositories/agent-task.repository';
 import {
 	AgentRepository,
 	type AgentSummary,
@@ -33,7 +35,6 @@ import {
 } from './repositories/agent.repository';
 import { SubAgentCleanupService } from './sub-agents/sub-agent-cleanup.service';
 import { isUnconfiguredAgent } from './utils/agent-capabilities';
-import { EventService } from '@/events/event.service';
 
 @Service()
 export class AgentsService {
@@ -72,15 +73,26 @@ export class AgentsService {
 			defaultModel,
 			schema,
 			skills,
+			tools,
+			tasks,
 		}: {
 			availableInMCP?: boolean;
 			id?: string;
 			adoptUnconfiguredOnCollision?: boolean;
 			defaultModel?: { model: string; credential: string };
 			/** Create with this config instead of the empty draft below, so eval thread
-			 *  seeding can recreate an already-built agent in one insert. */
+			 *  seeding and package import can recreate an already-built agent in one insert. */
 			schema?: AgentJsonConfig;
 			skills?: Record<string, AgentSkill>;
+			tools?: Agent['tools'];
+			/** Task bodies to create alongside, ids preserved (package import). */
+			tasks?: Array<{
+				id: string;
+				name: string;
+				objective: string;
+				cronExpression: string;
+				timezone: string | null;
+			}>;
 		} = {},
 	): Promise<Agent> {
 		const defaultConfig: AgentJsonConfig = {
@@ -110,6 +122,7 @@ export class AgentsService {
 			schema: schemaConfig,
 			...(integrations.length > 0 ? { integrations } : {}),
 			...(skills ? { skills } : {}),
+			...(tools ? { tools } : {}),
 			versionId: uuid(),
 			availableInMCP,
 		});
@@ -130,9 +143,25 @@ export class AgentsService {
 			return existing;
 		}
 
+		if (tasks?.length) {
+			await this.agentTaskRepository.save(
+				tasks.map((task) => this.agentTaskRepository.create({ ...task, agentId: saved.id })),
+			);
+		}
+
 		this.logger.debug('Created SDK agent', { agentId: saved.id, projectId });
 
 		return saved;
+	}
+
+	async getTasks(agentId: string): Promise<AgentTask[]> {
+		return await this.agentTaskRepository.findByAgentId(agentId);
+	}
+
+	/** Which of the given ids exist at all, regardless of access. */
+	async findExistingAgentIds(agentIds: string[]): Promise<Set<string>> {
+		const rows = await this.agentRepository.find({ where: { id: In(agentIds) }, select: ['id'] });
+		return new Set(rows.map(({ id }) => id));
 	}
 
 	async findByProjectId(projectId: string): Promise<Agent[]> {

--- a/packages/cli/src/modules/git-connections.ee/__tests__/git-connections.service.test.ts
+++ b/packages/cli/src/modules/git-connections.ee/__tests__/git-connections.service.test.ts
@@ -288,6 +288,7 @@ describe('GitConnectionsService (credential state machine)', () => {
 							dataTables: 0,
 							variables: 0,
 							tags: 0,
+							agents: 0,
 						},
 					};
 				},
@@ -344,6 +345,7 @@ describe('GitConnectionsService (credential state machine)', () => {
 					dataTables: 0,
 					variables: 0,
 					tags: 0,
+					agents: 0,
 				},
 				commitSha: 'newsha',
 			});

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-import-agent.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-import-agent.integration.test.ts
@@ -1,0 +1,294 @@
+import type { AgentJsonConfig } from '@n8n/api-types';
+import { LicenseState } from '@n8n/backend-common';
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { jsonParse } from 'n8n-workflow';
+
+import { AgentKnowledgeService } from '@/modules/agents/agent-knowledge.service';
+import { AgentsService } from '@/modules/agents/agents.service';
+import { AgentFileRepository } from '@/modules/agents/repositories/agent-file.repository';
+import { AgentTaskRepository } from '@/modules/agents/repositories/agent-task.repository';
+import { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+import { initNodeTypes } from '@test-integration/utils';
+
+import { PackageExportBlockedError } from '../entities/package-export.errors';
+import { PackageExportConfig } from '../n8n-packages.config';
+import { N8nPackagesService } from '../n8n-packages.service';
+import type { PackageManifest } from '../spec/manifest.schema';
+import { importPackageRequest } from './fixtures/import-request';
+import { readExport, streamToBuffer, unpackTar, type UnpackedEntry } from './utils/tar-support';
+import type { SerializedAgent } from '../spec/serialized/agent.schema';
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages', 'agents']);
+	await testDb.init();
+	await initNodeTypes();
+	new LicenseMocker().mockLicenseState(Container.get(LicenseState));
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	// Agent tables are module entities the truncate util does not know about.
+	await Container.get(AgentFileRepository).delete({});
+	await Container.get(AgentTaskRepository).delete({});
+	await Container.get(AgentRepository).delete({});
+	await testDb.truncate([
+		'WorkflowEntity',
+		'WorkflowHistory',
+		'SharedWorkflow',
+		'ProjectRelation',
+		'Project',
+	]);
+});
+
+const SKILL_ID = 'skill_refund01';
+const TOOL_ID = 'lookup_order';
+const TASK_ID = 'task_digest01';
+const SOURCE_CREDENTIAL_ID = 'srcCred12345';
+const KNOWLEDGE_CONTENT = 'Refunds close after 30 days.';
+
+function agentConfig(workflowId: string, workflowName: string): AgentJsonConfig {
+	return {
+		name: 'Support Agent',
+		model: 'openai/gpt-4.1',
+		credential: SOURCE_CREDENTIAL_ID,
+		instructions: 'Help customers with refunds.',
+		tools: [
+			{ type: 'workflow', workflowId, workflow: workflowName },
+			{ type: 'custom', id: TOOL_ID },
+		],
+		skills: [{ type: 'skill', id: SKILL_ID }],
+		tasks: [{ type: 'task', id: TASK_ID, enabled: true }],
+	};
+}
+
+async function createSourceAgent(projectId: string, workflowId: string, workflowName: string) {
+	const agentsService = Container.get(AgentsService);
+	const agent = await agentsService.create(projectId, 'Support Agent', {
+		availableInMCP: true,
+		schema: agentConfig(workflowId, workflowName),
+		skills: {
+			[SKILL_ID]: {
+				name: 'Refund policy',
+				description: 'How refunds work',
+				instructions: 'Follow the refund playbook.',
+			},
+		},
+		tools: {
+			[TOOL_ID]: {
+				code: 'return { found: true };',
+				descriptor: {
+					name: TOOL_ID,
+					description: 'Looks up an order',
+					systemInstruction: null,
+					inputSchema: null,
+					outputSchema: null,
+					hasSuspend: false,
+					hasResume: false,
+					hasToMessage: false,
+					requireApproval: false,
+					providerOptions: null,
+				},
+			},
+		},
+		tasks: [
+			{
+				id: TASK_ID,
+				name: 'Daily digest',
+				objective: 'Summarise open refund requests.',
+				cronExpression: '0 9 * * *',
+				timezone: null,
+			},
+		],
+	});
+
+	await Container.get(AgentKnowledgeService).importFile(
+		agent.id,
+		{ fileName: 'refund-policy.md', mimeType: 'text/markdown', fileSizeBytes: 28 },
+		Buffer.from(KNOWLEDGE_CONTENT),
+	);
+
+	return agent;
+}
+
+function manifestOf(entries: UnpackedEntry[]): PackageManifest {
+	const file = entries.find((entry) => entry.name === 'manifest.json');
+	if (!file) throw new Error('missing manifest.json');
+	return jsonParse<PackageManifest>(file.content.toString());
+}
+
+function agentJson(entries: UnpackedEntry[], target: string): SerializedAgent {
+	const file = entries.find((entry) => entry.name === `${target}/agent.json`);
+	if (!file) throw new Error(`missing ${target}/agent.json`);
+	return jsonParse<SerializedAgent>(file.content.toString());
+}
+
+describe('agent package export and import', () => {
+	let service: N8nPackagesService;
+	let owner: User;
+
+	beforeAll(() => {
+		service = Container.get(N8nPackagesService);
+	});
+
+	beforeEach(async () => {
+		owner = await createOwner();
+	});
+
+	it('exports an agent with its config, bodies, knowledge, and workflow tool', async () => {
+		const project = await createTeamProject('Source', owner);
+		const workflow = await createWorkflow({ name: 'Order Lookup' }, project);
+		const agent = await createSourceAgent(project.id, workflow.id, workflow.name);
+
+		const { stream, counts } = await service.exportPackage({
+			user: owner,
+			agentIds: [agent.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		expect(counts.agents).toBe(1);
+		expect(manifest.agents).toEqual([
+			{ id: agent.id, name: 'Support Agent', target: 'agents/support-agent' },
+		]);
+		expect(manifest.workflows).toEqual([
+			expect.objectContaining({ id: workflow.id, target: 'workflows/order-lookup' }),
+		]);
+
+		const serialized = agentJson(entries, 'agents/support-agent');
+		expect(serialized.id).toBe(agent.id);
+		expect(serialized.config?.credential).toBe(SOURCE_CREDENTIAL_ID);
+		expect(serialized.skills[SKILL_ID].name).toBe('Refund policy');
+		expect(serialized.tools[TOOL_ID].code).toBe('return { found: true };');
+		expect(serialized.tasks).toEqual([
+			expect.objectContaining({ id: TASK_ID, cronExpression: '0 9 * * *' }),
+		]);
+		expect(serialized.availableInMCP).toBe(true);
+		expect(serialized.files).toEqual([
+			{
+				fileName: 'refund-policy.md',
+				mimeType: 'text/markdown',
+				fileSizeBytes: 28,
+				target: 'agents/support-agent/files/file-1',
+			},
+		]);
+
+		const blob = entries.find((entry) => entry.name === 'agents/support-agent/files/file-1');
+		expect(blob?.content.toString()).toBe(KNOWLEDGE_CONTENT);
+	});
+
+	it('round-trips an agent: workflow tool rebinds, credential blanks, bodies and knowledge land', async () => {
+		const source = await createTeamProject('Source', owner);
+		const destination = await createTeamProject('Destination', owner);
+		const workflow = await createWorkflow({ name: 'Order Lookup' }, source);
+		const agent = await createSourceAgent(source.id, workflow.id, workflow.name);
+
+		const { stream } = await service.exportPackage({ user: owner, agentIds: [agent.id] });
+		const packageBuffer = await streamToBuffer(stream);
+
+		const agentsService = Container.get(AgentsService);
+		await agentsService.delete(agent.id, source.id);
+
+		const result = await service.importPackage(
+			importPackageRequest({ user: owner, projectId: destination.id, packageBuffer }),
+		);
+
+		expect(result.agents).toEqual([
+			{
+				sourceAgentId: agent.id,
+				localId: agent.id,
+				name: 'Support Agent',
+				status: 'created',
+				files: 1,
+			},
+		]);
+
+		const imported = await agentsService.findById(agent.id, destination.id);
+		expect(imported).not.toBeNull();
+		expect(imported!.availableInMCP).toBe(true);
+		expect(imported!.skills[SKILL_ID].instructions).toBe('Follow the refund playbook.');
+		expect(imported!.tools[TOOL_ID].descriptor.description).toBe('Looks up an order');
+
+		// The workflow imported under a fresh id (workflowIdPolicy=new); the agent's tool follows it.
+		const importedWorkflowId = result.workflows[0].localId;
+		expect(importedWorkflowId).not.toBe(workflow.id);
+		const workflowTool = imported!.schema?.tools?.find((tool) => tool.type === 'workflow');
+		expect(workflowTool).toEqual(expect.objectContaining({ workflowId: importedWorkflowId }));
+
+		// No credential travelled and none was bound, so the reference blanks.
+		expect(imported!.schema?.credential).toBe('');
+
+		const tasks = await agentsService.getTasks(agent.id);
+		expect(tasks).toEqual([expect.objectContaining({ id: TASK_ID, name: 'Daily digest' })]);
+
+		const files = await Container.get(AgentKnowledgeService).getFilesWithContent(agent.id);
+		expect(files).toHaveLength(1);
+		expect(files[0].file.fileName).toBe('refund-policy.md');
+		expect(files[0].content.toString()).toBe(KNOWLEDGE_CONTENT);
+	});
+
+	it('blocks the import when the agent id is already taken in the target project', async () => {
+		const source = await createTeamProject('Source', owner);
+		const workflow = await createWorkflow({ name: 'Order Lookup' }, source);
+		const agent = await createSourceAgent(source.id, workflow.id, workflow.name);
+
+		const { stream } = await service.exportPackage({ user: owner, agentIds: [agent.id] });
+		const packageBuffer = await streamToBuffer(stream);
+
+		await expect(
+			service.importPackage(
+				importPackageRequest({ user: owner, projectId: source.id, packageBuffer }),
+			),
+		).rejects.toThrow('Import blocked');
+	});
+
+	it('fails the export when the agent knowledge exceeds the cap', async () => {
+		const project = await createTeamProject('Source', owner);
+		const workflow = await createWorkflow({ name: 'Order Lookup' }, project);
+		const agent = await createSourceAgent(project.id, workflow.id, workflow.name);
+
+		const exportConfig = Container.get(PackageExportConfig);
+		const originalCap = exportConfig.maxAgentKnowledgeBytes;
+		exportConfig.maxAgentKnowledgeBytes = 4;
+		try {
+			await expect(service.exportPackage({ user: owner, agentIds: [agent.id] })).rejects.toThrow(
+				PackageExportBlockedError,
+			);
+		} finally {
+			exportConfig.maxAgentKnowledgeBytes = originalCap;
+		}
+	});
+
+	it('carries agents inside a project package and imports them with the project', async () => {
+		const source = await createTeamProject('Acme Ops', owner);
+		const workflow = await createWorkflow({ name: 'Order Lookup' }, source);
+		const agent = await createSourceAgent(source.id, workflow.id, workflow.name);
+
+		const { stream } = await service.exportPackage({ user: owner, projectIds: [source.id] });
+		const packageBuffer = await streamToBuffer(stream);
+		const manifest = manifestOf(await unpackTar(packageBuffer));
+
+		expect(manifest.agents).toEqual([
+			{ id: agent.id, name: 'Support Agent', target: 'projects/acme-ops/agents/support-agent' },
+		]);
+
+		const agentsService = Container.get(AgentsService);
+		await agentsService.delete(agent.id, source.id);
+		await testDb.truncate(['SharedWorkflow', 'WorkflowHistory', 'WorkflowEntity']);
+
+		const result = await service.importPackage(
+			importPackageRequest({ user: owner, packageBuffer }),
+		);
+
+		expect(result.agents).toEqual([
+			expect.objectContaining({ sourceAgentId: agent.id, status: 'created', files: 1 }),
+		]);
+		const imported = await agentsService.findById(agent.id, source.id);
+		expect(imported).not.toBeNull();
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-package.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-package.integration.test.ts
@@ -1182,6 +1182,9 @@ describe('Package import event emission', () => {
 					skipped: 0,
 					requirements: 0,
 				},
+				agents: {
+					created: 0,
+				},
 			});
 		} finally {
 			emitSpy.mockRestore();
@@ -1281,6 +1284,9 @@ describe('Package import event emission', () => {
 					skipped: 0,
 					requirements: 0,
 				},
+				agents: {
+					created: 0,
+				},
 			});
 		} finally {
 			emitSpy.mockRestore();
@@ -1349,6 +1355,9 @@ describe('Package import event emission', () => {
 					reconciled: 0,
 					skipped: 0,
 					requirements: 0,
+				},
+				agents: {
+					created: 0,
 				},
 			});
 		} finally {
@@ -1420,6 +1429,9 @@ describe('Package import event emission', () => {
 					reconciled: 0,
 					skipped: 0,
 					requirements: 0,
+				},
+				agents: {
+					created: 0,
 				},
 			});
 		} finally {

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/import-telemetry.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/import-telemetry.test.ts
@@ -93,6 +93,7 @@ const scope = (input: {
 		removedWorkflows: input.removedWorkflows ?? [],
 		removedFolders: input.removedFolders ?? [],
 		folderSummaries: [],
+		agentResult: [],
 		bindings: { workflows: new Map(), credentials: new Map() },
 		credentialResult: input.credentialResult,
 		dataTablePlan: { creations: new Array(dt.created), failures: [], matchedCount: dt.matched },
@@ -262,6 +263,7 @@ describe('emitPackageImportedEvent', () => {
 			variables: { matched: 1, missing: 0, created: 1, stubbed: 1, updated: 1, requirements: 4 },
 			// T2 and its requirement appear in both scopes but count once (unique tag ids).
 			tags: { matched: 1, created: 1, renamed: 1, reconciled: 1, skipped: 1, requirements: 5 },
+			agents: { created: 0 },
 		});
 		expect(payload.packageSourceId).toBe('src-1');
 		expect(payload.options.variableMissingMode).toBe('create-stub');

--- a/packages/cli/src/modules/n8n-packages/engine/import-blocked.error.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-blocked.error.ts
@@ -21,6 +21,7 @@ export function toImportBlockedError(
 				issue.type === 'variable-conflict' ||
 				(issue.type === 'data-table-unresolved' &&
 					(issue.kind === 'id-conflict' || issue.kind === 'name-conflict')) ||
+				(issue.type === 'agent-unresolved' && issue.kind === 'id-exists') ||
 				(issue.type === 'tag-unresolved' &&
 					(issue.kind === 'rename-drift' || issue.kind === 'name-collision')),
 		)

--- a/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
@@ -3,6 +3,10 @@ import { Service } from '@n8n/di';
 
 import { NodeTypes } from '@/node-types';
 
+import { toImportBlockedError } from './import-blocked.error';
+import { assertVariableWritesAllowed } from './import-gates';
+import { AgentImporter } from '../entities/agent/agent-importer';
+import type { AgentImportPlan, AgentImportRequest } from '../entities/agent/agent.types';
 import { CredentialImporter } from '../entities/credential/credential-importer';
 import { workflowsBlockedFromPublish } from '../entities/credential/credential-missing-mode';
 import type {
@@ -16,12 +20,12 @@ import type {
 	DataTableImportPlan,
 	DataTableImportRequest,
 } from '../entities/data-table/data-table.types';
+import { removesUnpackagedWorkflows } from '../entities/folder/folder-conflict-policy';
 import type {
 	FolderImportContext,
 	FolderImportPlan,
 	PreparedFolder,
 } from '../entities/folder/folder-import.types';
-import { removesUnpackagedWorkflows } from '../entities/folder/folder-conflict-policy';
 import { FolderImporter } from '../entities/folder/folder-importer';
 import type { FolderRemovalPlan } from '../entities/folder/folder-removal.types';
 import { FolderRemover } from '../entities/folder/folder-remover';
@@ -47,15 +51,16 @@ import type {
 	WorkflowImportPlan,
 } from '../entities/workflow/workflow-import.types';
 import { WorkflowImporter } from '../entities/workflow/workflow-importer';
-import type { WorkflowRemovalPlan } from '../entities/workflow/workflow-removal.types';
-import { WorkflowRemover } from '../entities/workflow/workflow-remover';
 import { WorkflowPublisher } from '../entities/workflow/workflow-publisher';
 import type { WorkflowPublishingBlockedReason } from '../entities/workflow/workflow-publishing-policy.types';
+import type { WorkflowRemovalPlan } from '../entities/workflow/workflow-removal.types';
+import { WorkflowRemover } from '../entities/workflow/workflow-remover';
 import { createBindings } from '../n8n-packages.types';
 import type {
 	BlockingIssue,
 	ImportBindingMap,
 	ImportContext,
+	ImportedAgentSummary,
 	ImportedFolderSummary,
 	ImportWorkflowProperties,
 	MissingNodeTypeMode,
@@ -66,8 +71,6 @@ import type {
 	ResolvedImportFolderProperties,
 } from '../n8n-packages.types';
 import type { PackageWorkflowRequirement } from '../spec/requirements.schema';
-import { toImportBlockedError } from './import-blocked.error';
-import { assertVariableWritesAllowed } from './import-gates';
 
 export interface ImportOrchestrationInput {
 	context: ImportContext;
@@ -77,6 +80,7 @@ export interface ImportOrchestrationInput {
 	dataTableRequest: DataTableImportRequest;
 	variableRequest: VariableImportRequest;
 	tagRequest: TagImportRequest;
+	agentRequest: AgentImportRequest;
 	options: ImportWorkflowProperties & ResolvedImportFolderProperties;
 	/** The target project does not exist yet and will be created by this import (project packages). */
 	projectPendingCreation?: boolean;
@@ -100,6 +104,7 @@ export interface ImportContentResult {
 	variablePlan: VariableImportPlan;
 	variableResult: VariableApplyResult;
 	tagPlan: TagImportPlan;
+	agentResult: ImportedAgentSummary[];
 }
 
 export interface ImportPlan {
@@ -111,6 +116,7 @@ export interface ImportPlan {
 	dataTablePlan: DataTableImportPlan;
 	variablePlan: VariableImportPlan;
 	tagPlan: TagImportPlan;
+	agentPlan: AgentImportPlan;
 	removalPlan: WorkflowRemovalPlan;
 	folderRemovalPlan: FolderRemovalPlan;
 	missingNodeTypes: MissingNodeTypeRequirement[];
@@ -131,6 +137,7 @@ export class ImportOrchestrator {
 		private readonly folderImporter: FolderImporter,
 		private readonly folderRemover: FolderRemover,
 		private readonly workflowImporter: WorkflowImporter,
+		private readonly agentImporter: AgentImporter,
 		private readonly workflowRemover: WorkflowRemover,
 		private readonly workflowPublisher: WorkflowPublisher,
 		private readonly nodeTypes: NodeTypes,
@@ -198,6 +205,7 @@ export class ImportOrchestrator {
 			dataTableRequest,
 			variableRequest,
 			tagRequest,
+			agentRequest,
 			options,
 		} = input;
 
@@ -220,6 +228,7 @@ export class ImportOrchestrator {
 		);
 		const folderContext = { ...context, folderConflictPolicy: options.folderConflictPolicy };
 		const folderPlan = await this.folderImporter.plan(folderContext, folders);
+		const agentPlan = await this.agentImporter.plan(context, agentRequest);
 
 		const packageFolderIds = folders.map(({ sourceFolderId }) => sourceFolderId);
 		const removalPlan = await this.workflowRemover.plan(context, {
@@ -257,6 +266,7 @@ export class ImportOrchestrator {
 			variableRequest,
 			variablePlan,
 			tagPlan,
+			agentPlan,
 			removalPlan,
 			folderRemovalPlan,
 			missingNodeTypes,
@@ -272,6 +282,7 @@ export class ImportOrchestrator {
 			dataTablePlan,
 			variablePlan,
 			tagPlan,
+			agentPlan,
 			removalPlan,
 			folderRemovalPlan,
 			missingNodeTypes,
@@ -338,6 +349,10 @@ export class ImportOrchestrator {
 			}),
 		);
 
+		// After the workflows: agent workflow-tool references rebind through the
+		// bindings the workflow write just produced.
+		const agentResult = await this.agentImporter.apply(context, plan.agentPlan, bindings);
+
 		// Last of the writes: an overwrite is the only step that rewrites pre-existing data, and no
 		// step above reads a variable, since `$vars` resolves by name at runtime. Still ahead of the
 		// publish sweep, which evaluates trigger parameters against variable values.
@@ -363,6 +378,7 @@ export class ImportOrchestrator {
 			variablePlan,
 			variableResult,
 			tagPlan,
+			agentResult,
 		};
 	}
 
@@ -375,6 +391,7 @@ export class ImportOrchestrator {
 		variableRequest,
 		variablePlan,
 		tagPlan,
+		agentPlan,
 		removalPlan,
 		folderRemovalPlan,
 		missingNodeTypes,
@@ -388,6 +405,7 @@ export class ImportOrchestrator {
 		variableRequest: VariableImportRequest;
 		variablePlan: VariableImportPlan;
 		tagPlan: TagImportPlan;
+		agentPlan: AgentImportPlan;
 		removalPlan: WorkflowRemovalPlan;
 		folderRemovalPlan: FolderRemovalPlan;
 		missingNodeTypes: MissingNodeTypeRequirement[];
@@ -414,6 +432,9 @@ export class ImportOrchestrator {
 			),
 			...dataTablePlan.failures.map(
 				(failure): BlockingIssue => ({ type: 'data-table-unresolved', ...failure }),
+			),
+			...agentPlan.failures.map(
+				(failure): BlockingIssue => ({ type: 'agent-unresolved', ...failure }),
 			),
 			...tagPlan.failures.map((failure): BlockingIssue => ({ type: 'tag-unresolved', ...failure })),
 			...this.credentialImporter

--- a/packages/cli/src/modules/n8n-packages/engine/import-result.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-result.ts
@@ -12,6 +12,7 @@ import type {
 	ImportBindingMap,
 	ImportCredentialSummary,
 	ImportDataTableSummary,
+	ImportedAgentSummary,
 	ImportedFolderSummary,
 	ImportedProjectSummary,
 	ImportedWorkflowSummary,
@@ -67,6 +68,7 @@ export function buildImportResult(input: {
 	removedFolders: RemovedFolderSummary[];
 	folders: ImportedFolderSummary[];
 	projects: ImportedProjectSummary[];
+	agents: ImportedAgentSummary[];
 	bindings: PackageImportBindings;
 	credentials: ImportCredentialSummary;
 	dataTables: ImportDataTableSummary;
@@ -80,6 +82,7 @@ export function buildImportResult(input: {
 		removedFolders: input.removedFolders,
 		folders: input.folders,
 		projects: input.projects,
+		agents: input.agents,
 		bindings: serializeBindings(input.bindings),
 		credentials: input.credentials,
 		dataTables: input.dataTables,

--- a/packages/cli/src/modules/n8n-packages/engine/import-telemetry.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-telemetry.ts
@@ -172,6 +172,9 @@ export function emitPackageImportedEvent(
 				skipped: uniqueTagIds((plan) => plan.dropped),
 				requirements: tagRequirements,
 			},
+			agents: {
+				created: scopes.reduce((total, { imported }) => total + imported.agentResult.length, 0),
+			},
 		},
 	});
 }

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -8,7 +8,13 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NodeTypes } from '@/node-types';
 import * as WorkflowHelpers from '@/workflow-helpers';
 
-import { deriveParentFolderId, foldersInScope, workflowsInScope } from './package-layout';
+import {
+	agentsInScope,
+	deriveParentFolderId,
+	foldersInScope,
+	workflowsInScope,
+} from './package-layout';
+import type { PreparedAgent, PreparedAgentFile } from '../entities/agent/agent.types';
 import type { PreparedFolder } from '../entities/folder/folder-import.types';
 import type { PreparedProject } from '../entities/project/project-import.types';
 import type { PreparedWorkflow } from '../entities/workflow/workflow-import.types';
@@ -16,6 +22,7 @@ import { WorkflowSerializer } from '../entities/workflow/workflow.serializer';
 import type { PackageReader } from '../io/package-reader';
 import type { ManifestEntry, PackageManifest } from '../spec/manifest.schema';
 import { packageManifestSchema } from '../spec/manifest.schema';
+import { serializedAgentSchema, type SerializedAgent } from '../spec/serialized/agent.schema';
 import { serializedDataTableSchema } from '../spec/serialized/data-table.schema';
 import type { SerializedDataTable } from '../spec/serialized/data-table.schema';
 import { serializedFolderSchema, type SerializedFolder } from '../spec/serialized/folder.schema';
@@ -71,6 +78,17 @@ export class N8nPackageParser {
 			folders.push(await this.readFolder(reader, entry));
 		}
 		return folders;
+	}
+
+	/** Agents in scope, with their file payloads loaded. */
+	async getAgents(reader: PackageReader, basePrefix = ''): Promise<PreparedAgent[]> {
+		const manifest = await this.getManifest(reader);
+
+		const agents: PreparedAgent[] = [];
+		for (const entry of agentsInScope(manifest.agents, basePrefix)) {
+			agents.push(await this.readAgent(reader, entry));
+		}
+		return agents;
 	}
 
 	/** Reads the package's data table schemas. */
@@ -153,6 +171,59 @@ export class N8nPackageParser {
 		for (const warning of WorkflowHelpers.sanitizeNodeGroupDescriptions(entity)) {
 			this.logger.warn(`Package workflow file at ${path}: ${warning}`);
 		}
+	}
+
+	private async readAgent(reader: PackageReader, entry: ManifestEntry): Promise<PreparedAgent> {
+		const path = `${entry.target}/agent.json`;
+		const wire = await this.readJson(reader, path, 'agent');
+
+		let agent: SerializedAgent;
+		try {
+			agent = serializedAgentSchema.parse(wire);
+		} catch (cause) {
+			if (cause instanceof ZodError) {
+				throw new UserError(`Package agent file at ${path} failed schema validation.`, { cause });
+			}
+			throw cause;
+		}
+
+		// Agents are created under agent.json's id, but the manifest is the package's
+		// index — a mismatch would import an agent under an undeclared identity.
+		if (agent.id !== entry.id) {
+			throw new UserError(
+				`Package agent at ${path} declares id "${agent.id}" but the manifest lists it as "${entry.id}".`,
+			);
+		}
+
+		const files: PreparedAgentFile[] = [];
+		for (const file of agent.files) {
+			let content: Buffer;
+			try {
+				content = await reader.readFile(file.target);
+			} catch (cause) {
+				throw new UserError(
+					`Package agent at ${path} references a missing knowledge file at ${file.target}.`,
+					{ cause },
+				);
+			}
+			files.push({
+				fileName: file.fileName,
+				mimeType: file.mimeType,
+				fileSizeBytes: file.fileSizeBytes,
+				content,
+			});
+		}
+
+		return {
+			sourceAgentId: agent.id,
+			name: agent.name,
+			config: agent.config,
+			tools: agent.tools,
+			skills: agent.skills,
+			tasks: agent.tasks,
+			availableInMCP: agent.availableInMCP,
+			files,
+		};
 	}
 
 	private async readFolder(reader: PackageReader, entry: ManifestEntry): Promise<PreparedFolder> {

--- a/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
@@ -26,6 +26,13 @@ export function workflowsInScope(
 	);
 }
 
+export function agentsInScope(
+	entries: ManifestEntry[] | undefined,
+	basePrefix = '',
+): ManifestEntry[] {
+	return (entries ?? []).filter((entry) => entry.target.startsWith(`${basePrefix}agents/`));
+}
+
 export function needsBundledVariableValues(
 	request: ImportVariableProperties,
 	hasRequirements: boolean,

--- a/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
@@ -17,6 +17,7 @@ import type {
 	RemovedWorkflowSummary,
 	BlockingIssue,
 	ImportBindingMap,
+	ImportedAgentSummary,
 	ImportedFolderSummary,
 	ImportedWorkflowSummary,
 	ResolvedImportRequest,
@@ -160,6 +161,7 @@ export class ProjectPackageImporter {
 		const removedWorkflows: RemovedWorkflowSummary[] = [];
 		const removedFolders: RemovedFolderSummary[] = [];
 		const folders: ImportedFolderSummary[] = [];
+		const agents: ImportedAgentSummary[] = [];
 		const scopedBindings: PackageImportBindings[] = [];
 		const matched: string[] = [];
 		const stubbed: string[] = [];
@@ -181,6 +183,7 @@ export class ProjectPackageImporter {
 			removedWorkflows.push(...content.removedWorkflows);
 			removedFolders.push(...content.removedFolders);
 			folders.push(...content.folderSummaries);
+			agents.push(...content.agentResult);
 			scopedBindings.push(content.bindings);
 			matched.push(...content.credentialResult.matched);
 			stubbed.push(...content.credentialResult.stubbed);
@@ -210,6 +213,7 @@ export class ProjectPackageImporter {
 			removedFolders,
 			folders,
 			projects: projectSummaries,
+			agents,
 			bindings: mergeBindings(...scopedBindings),
 			credentials: { matched, stubbed },
 			dataTables: { matched: dataTablesMatched, created: dataTablesCreated },
@@ -292,6 +296,7 @@ export class ProjectPackageImporter {
 			dataTableRequest,
 			variableRequest,
 			tagRequest,
+			agentRequest: { agents: await this.packageParser.getAgents(reader, basePrefix) },
 			options: request,
 			projectPendingCreation,
 			importSource,

--- a/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
@@ -120,6 +120,7 @@ export class WorkflowPackageImporter {
 			dataTableRequest,
 			variableRequest,
 			tagRequest,
+			agentRequest: { agents: await this.packageParser.getAgents(reader) },
 			options: request,
 			subWorkflowRequirements: identifyRequirements(manifest.requirements?.workflows, workflows),
 		});
@@ -161,6 +162,7 @@ export class WorkflowPackageImporter {
 			removedFolders: content.removedFolders,
 			folders: content.folderSummaries,
 			projects: [],
+			agents: content.agentResult,
 			bindings: content.bindings,
 			credentials: {
 				matched: content.credentialResult.matched,

--- a/packages/cli/src/modules/n8n-packages/entities/agent/agent-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/agent/agent-importer.ts
@@ -1,0 +1,102 @@
+import { ModuleRegistry } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+
+import { AgentKnowledgeService } from '@/modules/agents/agent-knowledge.service';
+import { AgentsService } from '@/modules/agents/agents.service';
+
+import { rebindAgentConfig } from './agent-reference-rebinding';
+import type {
+	AgentImportPlan,
+	AgentImportRequest,
+	AgentResolutionFailure,
+	PreparedAgent,
+} from './agent.types';
+import type {
+	ImportContext,
+	ImportedAgentSummary,
+	PackageImportBindings,
+} from '../../n8n-packages.types';
+
+/**
+ * Package agents keep their source id on the target — sub-agent and MCP
+ * references address agents by id, so a minted id would strand them. An
+ * occupied id in the target project blocks the import.
+ */
+@Service()
+export class AgentImporter {
+	constructor(
+		private readonly agentsService: AgentsService,
+		private readonly agentKnowledgeService: AgentKnowledgeService,
+		private readonly moduleRegistry: ModuleRegistry,
+	) {}
+
+	async plan(context: ImportContext, request: AgentImportRequest): Promise<AgentImportPlan> {
+		if (request.agents.length === 0) return { creations: [], failures: [] };
+
+		if (!this.moduleRegistry.isActive('agents')) {
+			return {
+				creations: [],
+				failures: [{ kind: 'module-disabled' }],
+			};
+		}
+
+		const existingIds = new Set(
+			(await this.agentsService.findByProjectId(context.projectId)).map(({ id }) => id),
+		);
+
+		const creations: PreparedAgent[] = [];
+		const failures: AgentResolutionFailure[] = [];
+		for (const agent of request.agents) {
+			if (existingIds.has(agent.sourceAgentId)) {
+				failures.push({ kind: 'id-exists', sourceId: agent.sourceAgentId, name: agent.name });
+			} else {
+				creations.push(agent);
+			}
+		}
+
+		return { creations, failures };
+	}
+
+	async apply(
+		context: ImportContext,
+		plan: AgentImportPlan,
+		bindings: PackageImportBindings,
+	): Promise<ImportedAgentSummary[]> {
+		const summaries: ImportedAgentSummary[] = [];
+
+		for (const agent of plan.creations) {
+			const config = agent.config ? rebindAgentConfig(agent.config, bindings) : undefined;
+
+			const created = await this.agentsService.create(context.projectId, agent.name, {
+				id: agent.sourceAgentId,
+				availableInMCP: agent.availableInMCP,
+				...(config ? { schema: config } : {}),
+				skills: agent.skills,
+				tools: agent.tools,
+				tasks: agent.tasks,
+			});
+
+			for (const file of agent.files) {
+				await this.agentKnowledgeService.importFile(
+					created.id,
+					{
+						fileName: file.fileName,
+						mimeType: file.mimeType,
+						fileSizeBytes: file.fileSizeBytes,
+					},
+					file.content,
+				);
+			}
+
+			summaries.push({
+				sourceAgentId: agent.sourceAgentId,
+				localId: created.id,
+				name: created.name,
+				status: 'created',
+				files: agent.files.length,
+			});
+		}
+
+		return summaries;
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/agent/agent-reference-rebinding.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/agent/agent-reference-rebinding.ts
@@ -1,0 +1,73 @@
+import {
+	AgentJsonConfigSchema,
+	AI_GATEWAY_MANAGED_TAG,
+	MANAGED_CREDENTIAL_TOKEN,
+	type AgentJsonConfig,
+} from '@n8n/api-types';
+
+import type { PackageImportBindings } from '../../n8n-packages.types';
+
+const MANAGED_CREDENTIAL_IDS = new Set<string>([MANAGED_CREDENTIAL_TOKEN, AI_GATEWAY_MANAGED_TAG]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Managed tokens and blanks pass through; anything else maps via bindings or blanks. */
+function rebindCredentialId(value: unknown, credentials: Map<string, string>): unknown {
+	if (typeof value !== 'string' || value === '' || MANAGED_CREDENTIAL_IDS.has(value)) return value;
+	return credentials.get(value) ?? '';
+}
+
+function rebindValue(value: unknown, bindings: PackageImportBindings): unknown {
+	if (Array.isArray(value)) {
+		return value.map((entry) => rebindValue(entry, bindings));
+	}
+
+	if (!isRecord(value)) return value;
+
+	const rebound: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if ((key === 'credential' || key === 'credentialId') && typeof entry === 'string') {
+			rebound[key] = rebindCredentialId(entry, bindings.credentials);
+			continue;
+		}
+
+		if (key === 'credentials' && isRecord(entry)) {
+			rebound[key] = Object.fromEntries(
+				Object.entries(entry).map(([credType, credRef]) => {
+					if (!isRecord(credRef) || typeof credRef.id !== 'string') return [credType, credRef];
+					return [
+						credType,
+						{ ...credRef, id: rebindCredentialId(credRef.id, bindings.credentials) },
+					];
+				}),
+			);
+			continue;
+		}
+
+		// A workflow tool the package carried maps to its imported id; an unbound
+		// reference keeps its source id, which may already resolve on the target.
+		if (key === 'workflowId' && typeof entry === 'string') {
+			rebound[key] = bindings.workflows.get(entry) ?? entry;
+			continue;
+		}
+
+		rebound[key] = rebindValue(entry, bindings);
+	}
+
+	return rebound;
+}
+
+/**
+ * Rewrites a package agent config's external references for the target instance:
+ * workflow tool ids map through the import's workflow bindings, credential ids map
+ * through the credential bindings, and credential ids with no binding are blanked
+ * so the imported agent starts unbound instead of pointing at a foreign id.
+ */
+export function rebindAgentConfig(
+	config: AgentJsonConfig,
+	bindings: PackageImportBindings,
+): AgentJsonConfig {
+	return AgentJsonConfigSchema.parse(rebindValue(config, bindings));
+}

--- a/packages/cli/src/modules/n8n-packages/entities/agent/agent.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/agent/agent.exporter.ts
@@ -1,0 +1,147 @@
+import { ModuleRegistry } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { AgentKnowledgeService } from '@/modules/agents/agent-knowledge.service';
+import { AgentsService } from '@/modules/agents/agents.service';
+import type { Agent } from '@/modules/agents/entities/agent.entity';
+import { composeJsonConfig } from '@/modules/agents/json-config/agent-config-composition';
+
+import { AgentSerializer } from './agent.serializer';
+import type { PackageWriter } from '../../io/package-writer';
+import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
+import { PackageExportConfig } from '../../n8n-packages.config';
+import type { ManifestEntry } from '../../spec/manifest.schema';
+import type { SerializedAgentFile } from '../../spec/serialized/agent.schema';
+import {
+	assertEveryRequestedEntityAccessible,
+	PackageExportBlockedError,
+} from '../package-export.errors';
+
+export interface AgentExportRequest {
+	user: User;
+	agentIds: string[];
+	writer: PackageWriter;
+
+	// Directory the agent is written under, e.g. `projects/{slug}`.
+	basePrefix?: string;
+}
+
+export interface AgentExportResult {
+	entries: ManifestEntry[];
+	/** Workflows the exported agents use as tools; the caller bundles them as workflow entities. */
+	referencedWorkflowIds: string[];
+}
+
+@Service()
+export class AgentExporter {
+	constructor(
+		private readonly agentsService: AgentsService,
+		private readonly agentKnowledgeService: AgentKnowledgeService,
+		private readonly agentSerializer: AgentSerializer,
+		private readonly exportConfig: PackageExportConfig,
+		private readonly moduleRegistry: ModuleRegistry,
+	) {}
+
+	async export(request: AgentExportRequest): Promise<AgentExportResult> {
+		if (!this.moduleRegistry.isActive('agents')) {
+			throw new PackageExportBlockedError(
+				'Cannot export agents: the agents module is not active on this instance.',
+			);
+		}
+
+		const agents: Agent[] = [];
+		for (const agentId of request.agentIds) {
+			const agent = await this.agentsService.findByIdForUser(agentId, request.user);
+			if (agent) agents.push(agent);
+		}
+
+		await assertEveryRequestedEntityAccessible(
+			'agent',
+			request.agentIds,
+			agents,
+			async (ids) => await this.agentsService.findExistingAgentIds(ids),
+		);
+
+		const entries: ManifestEntry[] = [];
+		const referencedWorkflowIds = new Set<string>();
+		const fileNames = new UniqueFilenameAllocator(
+			request.basePrefix ? `${request.basePrefix}/agents` : 'agents',
+			'agent',
+		);
+
+		for (const agent of agents) {
+			const target = fileNames.allocate(agent.name);
+			await request.writer.writeDirectory(target);
+
+			const files = await this.exportKnowledgeFiles(agent, target, request.writer);
+			const tasks = (await this.agentsService.getTasks(agent.id)).map(
+				({ id, name, objective, cronExpression, timezone }) => ({
+					id,
+					name,
+					objective,
+					cronExpression,
+					timezone,
+				}),
+			);
+
+			const serialized = this.agentSerializer.serialize(agent, { tasks, files });
+			await request.writer.writeFile(
+				`${target}/agent.json`,
+				JSON.stringify(serialized, null, '\t'),
+			);
+
+			entries.push({ id: agent.id, name: agent.name, target });
+
+			for (const workflowId of workflowToolIds(agent)) {
+				referencedWorkflowIds.add(workflowId);
+			}
+		}
+
+		return { entries, referencedWorkflowIds: [...referencedWorkflowIds] };
+	}
+
+	/**
+	 * Writes the agent's knowledge blobs under `<target>/files/` and returns their
+	 * index for agent.json. File entries are named by position — the real file
+	 * name stays in the index — so package paths never depend on user input.
+	 */
+	private async exportKnowledgeFiles(
+		agent: Agent,
+		target: string,
+		writer: PackageWriter,
+	): Promise<SerializedAgentFile[]> {
+		const stored = await this.agentKnowledgeService.getFilesWithContent(agent.id);
+		if (stored.length === 0) return [];
+
+		const totalBytes = stored.reduce((total, { content }) => total + content.byteLength, 0);
+		if (totalBytes > this.exportConfig.maxAgentKnowledgeBytes) {
+			throw new PackageExportBlockedError(
+				`Agent "${agent.name}" has ${totalBytes} bytes of knowledge files, above the export limit of ${this.exportConfig.maxAgentKnowledgeBytes} bytes (N8N_EXPORT_MAX_AGENT_KNOWLEDGE_BYTES).`,
+			);
+		}
+
+		await writer.writeDirectory(`${target}/files`);
+
+		const files: SerializedAgentFile[] = [];
+		for (const [index, { file, content }] of stored.entries()) {
+			const fileTarget = `${target}/files/file-${index + 1}`;
+			await writer.writeFile(fileTarget, content);
+			files.push({
+				fileName: file.fileName,
+				mimeType: file.mimeType,
+				fileSizeBytes: file.fileSizeBytes,
+				target: fileTarget,
+			});
+		}
+		return files;
+	}
+}
+
+function workflowToolIds(agent: Agent): string[] {
+	const config = composeJsonConfig(agent);
+	return (config?.tools ?? [])
+		.filter((tool) => tool.type === 'workflow')
+		.map((tool) => tool.workflowId)
+		.filter((workflowId): workflowId is string => typeof workflowId === 'string');
+}

--- a/packages/cli/src/modules/n8n-packages/entities/agent/agent.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/agent/agent.serializer.ts
@@ -1,0 +1,60 @@
+import { Service } from '@n8n/di';
+
+import type { Agent } from '@/modules/agents/entities/agent.entity';
+import { composeJsonConfig } from '@/modules/agents/json-config/agent-config-composition';
+
+import {
+	serializedAgentSchema,
+	type SerializedAgent,
+	type SerializedAgentFile,
+	type SerializedAgentTask,
+} from '../../spec/serialized/agent.schema';
+import { definePackageSerializationPayload } from '../package-serialization.types';
+
+type AgentPackageKeyHandling = {
+	id: 'copy';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	name: 'copy';
+	project: 'exclude';
+	projectId: 'exclude';
+	schema: 'transform';
+	integrations: 'transform';
+	tools: 'copy';
+	skills: 'copy';
+	availableInMCP: 'copy';
+	setupCompletedAt: 'exclude';
+	versionId: 'exclude';
+	activeVersionId: 'exclude';
+	activeVersion: 'exclude';
+	revision: 'exclude';
+};
+
+const serializePayload = definePackageSerializationPayload<
+	Agent,
+	SerializedAgent,
+	AgentPackageKeyHandling
+>();
+
+@Service()
+export class AgentSerializer {
+	serialize(
+		agent: Agent,
+		extras: { tasks: SerializedAgentTask[]; files: SerializedAgentFile[] },
+	): SerializedAgent {
+		return serializedAgentSchema.parse(
+			serializePayload({
+				id: agent.id,
+				name: agent.name,
+				// `schema` and `integrations` fold into the composed config, the same
+				// shape the config API serves; import decomposes them again.
+				config: composeJsonConfig(agent),
+				tools: agent.tools ?? {},
+				skills: agent.skills ?? {},
+				availableInMCP: agent.availableInMCP,
+				tasks: extras.tasks,
+				files: extras.files,
+			}),
+		);
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/agent/agent.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/agent/agent.types.ts
@@ -1,0 +1,38 @@
+import type { ToolDescriptor } from '@n8n/agents';
+import type { AgentJsonConfig, AgentSkill } from '@n8n/api-types';
+
+import type { SerializedAgentTask } from '../../spec/serialized/agent.schema';
+
+export interface PreparedAgentFile {
+	fileName: string;
+	mimeType: string;
+	fileSizeBytes: number;
+	content: Buffer;
+}
+
+/** One package agent, parsed and ready to plan: config, bodies, and file bytes. */
+export interface PreparedAgent {
+	sourceAgentId: string;
+	name: string;
+	config: AgentJsonConfig | null;
+	tools: Record<string, { code: string; descriptor: ToolDescriptor }>;
+	skills: Record<string, AgentSkill>;
+	tasks: SerializedAgentTask[];
+	availableInMCP: boolean;
+	files: PreparedAgentFile[];
+}
+
+export interface AgentImportRequest {
+	agents: PreparedAgent[];
+}
+
+export interface AgentResolutionFailure {
+	kind: 'id-exists' | 'module-disabled';
+	sourceId?: string;
+	name?: string;
+}
+
+export interface AgentImportPlan {
+	creations: PreparedAgent[];
+	failures: AgentResolutionFailure[];
+}

--- a/packages/cli/src/modules/n8n-packages/entities/project/__tests__/project.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/__tests__/project.exporter.test.ts
@@ -1,12 +1,15 @@
+import type { ModuleRegistry } from '@n8n/backend-common';
 import type { Project, User } from '@n8n/db';
 import type { Readable } from 'node:stream';
 import { mock } from 'vitest-mock-extended';
 
+import type { AgentsService } from '@/modules/agents/agents.service';
 import type { FolderFinderService } from '@/services/folder-finder.service';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import type { PackageWriter } from '../../../io/package-writer';
+import type { AgentExporter } from '../../agent/agent.exporter';
 import type { FolderExporter } from '../../folder/folder.exporter';
 import {
 	PackageEntityAccessDeniedError,
@@ -72,6 +75,11 @@ function makeExporter({
 
 	const folderExporter = mock<FolderExporter>();
 	const workflowExporter = mock<WorkflowExporter>();
+	const agentExporter = mock<AgentExporter>();
+	const agentsService = mock<AgentsService>();
+	agentsService.findByProjectId.mockResolvedValue([]);
+	const moduleRegistry = mock<ModuleRegistry>();
+	moduleRegistry.isActive.mockReturnValue(true);
 
 	const exporter = new ProjectExporter(
 		projectService,
@@ -80,6 +88,9 @@ function makeExporter({
 		workflowFinder,
 		folderExporter,
 		workflowExporter,
+		agentExporter,
+		agentsService,
+		moduleRegistry,
 	);
 	return {
 		exporter,
@@ -88,6 +99,8 @@ function makeExporter({
 		workflowFinder,
 		folderExporter,
 		workflowExporter,
+		agentExporter,
+		agentsService,
 	};
 }
 

--- a/packages/cli/src/modules/n8n-packages/entities/project/project.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project.exporter.ts
@@ -1,6 +1,8 @@
+import { ModuleRegistry } from '@n8n/backend-common';
 import type { Project, User } from '@n8n/db';
 import { Service } from '@n8n/di';
 
+import { AgentsService } from '@/modules/agents/agents.service';
 import { FolderFinderService } from '@/services/folder-finder.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -8,8 +10,10 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { ProjectSerializer } from './project.serializer';
 import type { PackageWriter } from '../../io/package-writer';
 import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
-import type { ManifestEntry } from '../../spec/manifest.schema';
 import type { WorkflowVersionPolicy } from '../../n8n-packages.types';
+import type { ManifestEntry } from '../../spec/manifest.schema';
+import { AgentExporter } from '../agent/agent.exporter';
+import type { AgentExportResult } from '../agent/agent.exporter';
 import { FolderExporter } from '../folder/folder.exporter';
 import type { FolderExportResult } from '../folder/folder.exporter';
 import { assertEveryRequestedEntityAccessible } from '../package-export.errors';
@@ -30,6 +34,7 @@ interface ProjectExportResult {
 	entries: ManifestEntry[];
 	folderEntries: ManifestEntry[];
 	workflowEntries: ManifestEntry[];
+	agentEntries: ManifestEntry[];
 	requirements: WorkflowExportRequirements;
 	projectTargetsById: Map<string, string>;
 }
@@ -43,6 +48,9 @@ export class ProjectExporter {
 		private readonly workflowFinder: WorkflowFinderService,
 		private readonly folderExporter: FolderExporter,
 		private readonly workflowExporter: WorkflowExporter,
+		private readonly agentExporter: AgentExporter,
+		private readonly agentsService: AgentsService,
+		private readonly moduleRegistry: ModuleRegistry,
 	) {}
 
 	async export(request: ProjectExportRequest): Promise<ProjectExportResult> {
@@ -78,11 +86,13 @@ export class ProjectExporter {
 		await this.exportProjectShell(project, target, request.writer);
 		const folders = await this.exportProjectFolders(project.id, target, request);
 		const rootWorkflows = await this.exportProjectRootWorkflows(project.id, target, request);
+		const agents = await this.exportProjectAgents(project.id, target, request);
 
 		return {
 			entries: [{ id: project.id, name: project.name, target }],
 			folderEntries: folders.entries,
 			workflowEntries: [...folders.workflowEntries, ...rootWorkflows.entries],
+			agentEntries: agents.entries,
 			requirements: mergeRequirements(folders.requirements, rootWorkflows.requirements),
 			projectTargetsById: new Map([[project.id, target]]),
 		};
@@ -142,11 +152,39 @@ export class ProjectExporter {
 		});
 	}
 
+	/**
+	 * A project's agents ride along with it. Their workflow tools are the
+	 * project's own workflows, which the folder and root exports already carry;
+	 * a reference into another project is not followed.
+	 */
+	private async exportProjectAgents(
+		projectId: string,
+		target: string,
+		request: ProjectExportRequest,
+	): Promise<AgentExportResult> {
+		if (!this.moduleRegistry.isActive('agents')) {
+			return { entries: [], referencedWorkflowIds: [] };
+		}
+
+		const agents = await this.agentsService.findByProjectId(projectId);
+		if (agents.length === 0) {
+			return { entries: [], referencedWorkflowIds: [] };
+		}
+
+		return await this.agentExporter.export({
+			user: request.user,
+			agentIds: agents.map(({ id }) => id),
+			writer: request.writer,
+			basePrefix: target,
+		});
+	}
+
 	private mergeProjectExportResults(results: ProjectExportResult[]): ProjectExportResult {
 		return {
 			entries: results.flatMap((result) => result.entries),
 			folderEntries: results.flatMap((result) => result.folderEntries),
 			workflowEntries: results.flatMap((result) => result.workflowEntries),
+			agentEntries: results.flatMap((result) => result.agentEntries),
 			requirements: mergeRequirements(...results.map((result) => result.requirements)),
 			projectTargetsById: new Map(results.flatMap((result) => [...result.projectTargetsById])),
 		};

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.config.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.config.ts
@@ -20,3 +20,10 @@ export class PackageImportConfig {
 	@Env('N8N_IMPORT_MAX_PATH_LENGTH')
 	maxPathLength: number = 1024;
 }
+
+@Config
+export class PackageExportConfig {
+	/** Maximum total size in bytes of one agent's knowledge files in an export. */
+	@Env('N8N_EXPORT_MAX_AGENT_KNOWLEDGE_BYTES')
+	maxAgentKnowledgeBytes: number = 250 * MiB;
+}

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -12,6 +12,7 @@ import { emitPackageImportedEvent, type ImportOutcome } from './engine/import-te
 import { N8nPackageParser } from './engine/n8n-package-parser';
 import { ProjectPackageImporter } from './engine/project-package-importer';
 import { WorkflowPackageImporter } from './engine/workflow-package-importer';
+import { AgentExporter } from './entities/agent/agent.exporter';
 import { CredentialExporter } from './entities/credential/credential.exporter';
 import { DataTableExporter } from './entities/data-table/data-table.exporter';
 import {
@@ -77,6 +78,7 @@ export class N8nPackagesService {
 		private readonly projectExporter: ProjectExporter,
 		private readonly workflowExporter: WorkflowExporter,
 		private readonly folderExporter: FolderExporter,
+		private readonly agentExporter: AgentExporter,
 		private readonly credentialExporter: CredentialExporter,
 		private readonly dataTableExporter: DataTableExporter,
 		private readonly variableExporter: VariableExporter,
@@ -138,6 +140,7 @@ export class N8nPackagesService {
 		const workflowIds = request.workflowIds ?? [];
 		const folderIds = request.folderIds ?? [];
 		const projectIds = request.projectIds ?? [];
+		const agentIds = request.agentIds ?? [];
 		const includeTags = (request.includeTags ?? true) && !this.globalConfig.tags.disabled;
 		const workflowVersionPolicy = request.workflowVersionPolicy ?? WorkflowVersionPolicy.Latest;
 		const credentialExportPolicy =
@@ -154,9 +157,23 @@ export class N8nPackagesService {
 					})
 				: undefined;
 
+		const agentExportResult =
+			agentIds.length > 0
+				? await this.agentExporter.export({
+						user: request.user,
+						agentIds,
+						writer,
+					})
+				: undefined;
+
+		// An agent's workflow tools travel as ordinary workflow entities.
+		const requestedWorkflowIds = [
+			...new Set([...workflowIds, ...(agentExportResult?.referencedWorkflowIds ?? [])]),
+		];
+
 		const workflowsForExport = this.filterWorkflowsAlreadyInFolders(
 			folderExportResult?.workflowEntries,
-			workflowIds,
+			requestedWorkflowIds,
 		);
 
 		const workflowExportResult =
@@ -256,6 +273,10 @@ export class N8nPackagesService {
 			...allWorkflowsBeforeAutoInclude,
 			...(autoIncludedExportResult?.workflowEntries ?? []),
 		]);
+		const allAgents = this.dedupeManifestEntries([
+			...(agentExportResult?.entries ?? []),
+			...(projectExportResult?.agentEntries ?? []),
+		]);
 
 		// Reference-only records missing dependencies as requirements instead of aborting.
 		if (!isReferenceOnly) {
@@ -334,6 +355,7 @@ export class N8nPackagesService {
 			...(allWorkflowsInPackage.length > 0 ? { workflows: allWorkflowsInPackage } : {}),
 			...(allFolders.length > 0 ? { folders: allFolders } : {}),
 			...(allProjects.length > 0 ? { projects: allProjects } : {}),
+			...(allAgents.length > 0 ? { agents: allAgents } : {}),
 		});
 
 		await writer.writeFile('manifest.json', JSON.stringify(manifest, null, '\t'));
@@ -345,6 +367,7 @@ export class N8nPackagesService {
 			dataTables: dataTableExportResult.entries.length,
 			variables: variableExportResult.entries.length,
 			tags: tagExportResult.entries.length,
+			agents: allAgents.length,
 		};
 
 		return {
@@ -476,6 +499,7 @@ function hasContentWithoutProjects(manifest: PackageManifest): boolean {
 			manifest.dataTables,
 			manifest.variables,
 			manifest.tags,
+			manifest.agents,
 		].some((entries) => (entries?.length ?? 0) > 0) || manifest.requirements !== undefined
 	);
 }
@@ -488,6 +512,7 @@ function emptyImportResult(manifest: PackageManifest): ImportResult {
 		removedFolders: [],
 		folders: [],
 		projects: [],
+		agents: [],
 		bindings: createBindings(),
 		credentials: { matched: [], stubbed: [] },
 		dataTables: { matched: 0, created: 0 },

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -1,6 +1,7 @@
 import type { User } from '@n8n/db';
 import type { Readable } from 'node:stream';
 
+import type { AgentResolutionFailure } from './entities/agent/agent.types';
 import type { DataTableResolutionFailure } from './entities/data-table/data-table.types';
 import type { TagResolutionFailure } from './entities/tag/tag.types';
 import type {
@@ -222,6 +223,7 @@ export interface ExportPackageRequest {
 	workflowIds?: string[];
 	folderIds?: string[];
 	projectIds?: string[];
+	agentIds?: string[];
 	includeVariableValues?: boolean;
 	canExportVariableValues?: boolean;
 	includeTags?: boolean;
@@ -376,6 +378,9 @@ export type ImportPackageEventCounts = {
 		skipped: number;
 		requirements: number;
 	};
+	agents: {
+		created: number;
+	};
 };
 
 /** Per-entity counts for an export, carried on `n8n-package-exported` for telemetry. */
@@ -386,6 +391,7 @@ export type ExportPackageEventCounts = {
 	dataTables: number;
 	variables: number;
 	tags: number;
+	agents: number;
 };
 
 /**
@@ -464,6 +470,15 @@ export interface ImportedProjectSummary {
 	status: 'created' | 'updated' | 'skipped';
 }
 
+export interface ImportedAgentSummary {
+	sourceAgentId: string;
+	localId: string;
+	name: string;
+	status: 'created';
+	/** Knowledge files written for this agent. */
+	files: number;
+}
+
 /**
  * A reason the import cannot proceed, produced by some policy from any subsystem.
  * Discriminated by `type` so new gates add a variant rather than a new throw site.
@@ -489,6 +504,7 @@ export type BlockingIssue =
 	| ({ type: 'workflow-removal-forbidden' } & WorkflowRemovalFailure)
 	| ({ type: 'folder-removal-forbidden' } & FolderRemovalFailure)
 	| ({ type: 'data-table-unresolved' } & DataTableResolutionFailure)
+	| ({ type: 'agent-unresolved' } & AgentResolutionFailure)
 	| ({ type: 'tag-unresolved' } & TagResolutionFailure)
 	| ({ type: 'variable-unresolved' } & VariableResolutionFailure)
 	| ({ type: 'variable-conflict' } & VariableConflict)
@@ -620,6 +636,7 @@ export interface ImportResult {
 	removedFolders: RemovedFolderSummary[];
 	folders: ImportedFolderSummary[];
 	projects: ImportedProjectSummary[];
+	agents: ImportedAgentSummary[];
 	bindings: SerializedBindings;
 	credentials: ImportCredentialSummary;
 	dataTables: ImportDataTableSummary;

--- a/packages/cli/src/modules/n8n-packages/spec/manifest.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/manifest.schema.ts
@@ -42,6 +42,7 @@ export const packageManifestSchema = z
 		dataTables: z.array(manifestEntrySchema).optional(),
 		variables: z.array(manifestEntrySchema).optional(),
 		tags: z.array(manifestEntrySchema).optional(),
+		agents: z.array(manifestEntrySchema).optional(),
 		requirements: packageRequirementsSchema.optional(),
 	})
 	.superRefine((manifest, ctx) => {
@@ -52,6 +53,7 @@ export const packageManifestSchema = z
 		assertNoDuplicateIds(manifest.dataTables, 'data table', ctx);
 		assertNoDuplicateIds(manifest.variables, 'variable', ctx);
 		assertNoDuplicateIds(manifest.tags, 'tag', ctx);
+		assertNoDuplicateIds(manifest.agents, 'agent', ctx);
 	});
 
 export type ManifestEntry = z.infer<typeof manifestEntrySchema>;

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/agent.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/agent.schema.ts
@@ -1,0 +1,40 @@
+import type { ToolDescriptor } from '@n8n/agents';
+import { AgentJsonConfigSchema, agentSkillSchema } from '@n8n/api-types';
+import { z } from 'zod';
+
+const serializedAgentTaskSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().min(1),
+	objective: z.string(),
+	cronExpression: z.string().min(1),
+	timezone: z.string().nullable(),
+});
+
+// `target` is the package path of the file's bytes: the manifest has no
+// per-file entries, so agent.json is the index of its own binary payloads.
+const serializedAgentFileSchema = z.object({
+	fileName: z.string().min(1),
+	mimeType: z.string().min(1),
+	fileSizeBytes: z.number().int().nonnegative(),
+	target: z.string().min(1),
+});
+
+const toolDescriptorSchema = z.custom<ToolDescriptor>(
+	(value) => typeof value === 'object' && value !== null && !Array.isArray(value),
+);
+
+export const serializedAgentSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().min(1),
+	// The composed view (integrations inlined), the same shape the config API serves.
+	config: AgentJsonConfigSchema.nullable(),
+	tools: z.record(z.object({ code: z.string(), descriptor: toolDescriptorSchema })),
+	skills: z.record(agentSkillSchema),
+	tasks: z.array(serializedAgentTaskSchema),
+	availableInMCP: z.boolean(),
+	files: z.array(serializedAgentFileSchema),
+});
+
+export type SerializedAgent = z.infer<typeof serializedAgentSchema>;
+export type SerializedAgentTask = z.infer<typeof serializedAgentTaskSchema>;
+export type SerializedAgentFile = z.infer<typeof serializedAgentFileSchema>;

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -46,6 +46,7 @@ const EXPORT_COUNTS = {
 	dataTables: 0,
 	variables: 0,
 	tags: 0,
+	agents: 0,
 };
 
 describe('n8n-packages handler', () => {


### PR DESCRIPTION
## Summary

POC: agents become a first-class entity in the .n8np package model, like workflows are today.

**What travels in an agent package:**
- The agent config (the composed JSON the config API serves), skills, custom tool bodies, and scheduled tasks — all inside `agents/<slug>/agent.json`.
- Knowledge files as binary payloads under `agents/<slug>/files/`, indexed by `agent.json`.
- The agent's workflow tools, bundled as ordinary workflow entities in the same package.

**Two entry points:**
- Standalone: `exportPackage({ agentIds })`.
- Project child: a project export carries its agents under `projects/<slug>/agents/`, and the project import brings them back.

**Import behaviour:**
- Agents keep their source id. An occupied id in the target project blocks the import as a structured issue.
- Workflow tool references rebind through the import's workflow bindings.
- Credential ids rebind through the credential bindings; an unbound id blanks to `''`, so the destination binds its own.
- Knowledge files write back through the byte store. No embedding runs at import time — vector stores are external and credential-bound.

**Safety rails:**
- An agent's knowledge payload is capped on export (default 250 MB, `N8N_EXPORT_MAX_AGENT_KNOWLEDGE_BYTES`). Over the cap, the export fails with a clear error.
- Both export paths and the import plan check `ModuleRegistry.isActive('agents')`, so instances without the agents module degrade cleanly.

**Small extensions in the agents module:** `AgentsService.create` accepts `tools` and `tasks` bodies, and `AgentKnowledgeService` gains `getFilesWithContent` / `importFile` for the package read/write paths.

**Out of scope for this POC** (production follow-ups):
- Public API DTO + OpenAPI spec and `@n8n/cli` flags — export runs through the service only.
- Agent credential deps are not declared in the manifest requirements section yet, so the destination cannot offer bindings for agent-only credentials.
- The tar import cap is 5 MiB per entry (`N8N_IMPORT_MAX_ENTRY_BYTES`), so a bigger knowledge file passes export but fails import until raised.
- Sub-agent references and cross-project workflow references do not travel.

## How to test

The agents module is not on by default. Start the instance with `N8N_ENABLED_MODULES=agents`.

1. Create an agent with skills, a custom tool, a scheduled task, a workflow tool, and a knowledge file.
2. Export it: the integration test `export-import-agent.integration.test.ts` covers the full round trip (export → delete → import → assert fidelity, plus the conflict, cap, and project-package cases).
3. Run it with: `pnpm test:integration src/modules/n8n-packages/__tests__/export-import-agent.integration.test.ts` from `packages/cli`.

## Related Linear tickets, Github issues, and Community forum posts

POC — no ticket yet.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

