### PR TITLE
feat(Airtable Node): Add pagination options to record search operation

### DIFF
--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -12,7 +12,7 @@ export class Airtable extends VersionedNodeType {
 			icon: 'file:airtable.svg',
 			group: ['input'],
 			description: 'Read, update, write and delete data from Airtable',
-			defaultVersion: 2.2,
+			defaultVersion: 2.3,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -20,6 +20,7 @@ export class Airtable extends VersionedNodeType {
 			2: new AirtableV2(baseDescription),
 			2.1: new AirtableV2(baseDescription),
 			2.2: new AirtableV2(baseDescription),
+			2.3: new AirtableV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../../../v2/transport', async () => {
 							},
 						},
 					],
+					offset: 'itrNextPage/recYYY',
 				};
 			}
 		}),
@@ -165,6 +166,110 @@ describe('Test AirtableV2, search operation', () => {
 				},
 			],
 		});
+	});
+
+	it('should send pagination options and return the next offset for v2.3', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: '',
+			returnAll: false,
+			limit: 100,
+			options: {
+				pageSize: 50,
+				offset: 'itrPreviousPage/recXXX',
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2.3),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		// maxRecords must not be sent, it suppresses the next-page offset in the response
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'appYoLbase/tblltable',
+			{},
+			{ pageSize: 50, offset: 'itrPreviousPage/recXXX' },
+		);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			json: {
+				id: 'recYYY',
+				fields: { foo: 'foo 2', bar: 'bar 2' },
+				offset: 'itrNextPage/recYYY',
+			},
+			pairedItem: [
+				{
+					item: 0,
+				},
+			],
+		});
+	});
+
+	it('should cap the page size to the limit for v2.3', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: '',
+			returnAll: false,
+			limit: 1,
+			options: {
+				pageSize: 50,
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2.3),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'appYoLbase/tblltable',
+			{},
+			{ pageSize: 1 },
+		);
+	});
+
+	it('should pass the page size when returning all records for v2.3', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: '',
+			returnAll: true,
+			options: {
+				pageSize: 25,
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2.3),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(transport.apiRequestAllItems).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequestAllItems).toHaveBeenCalledWith(
+			'GET',
+			'appYoLbase/tblltable',
+			{},
+			{ pageSize: 25 },
+		);
 	});
 
 	afterEach(() => vi.clearAllMocks());

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -367,6 +367,37 @@ describe('Test AirtableV2, search operation', () => {
 		expect(result[0].json).not.toHaveProperty('offset');
 	});
 
+	it('should not send the pageSize and offset options for v2.2', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: '',
+			returnAll: false,
+			limit: 1,
+			options: {
+				pageSize: 50,
+				offset: 'itrPreviousPage/recXXX',
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2.2),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		// v2.2 keeps its old request shape: pageSize and offset must not be sent
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'appYoLbase/tblltable',
+			{},
+			{ maxRecords: 1 },
+		);
+	});
+
 	afterEach(() => vi.clearAllMocks());
 
 	it('should search records with attachments and nested fields structure for v2.2', async () => {

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -272,6 +272,101 @@ describe('Test AirtableV2, search operation', () => {
 		);
 	});
 
+	it('should not include an offset in the output on the last page for v2.3', async () => {
+		vi.mocked(transport.apiRequest).mockResolvedValueOnce({
+			records: [
+				{
+					id: 'recYYY',
+					fields: { foo: 'foo 2', bar: 'bar 2' },
+				},
+			],
+		});
+
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: '',
+			returnAll: false,
+			limit: 100,
+			options: {},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2.3),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].json).toEqual({ id: 'recYYY', fields: { foo: 'foo 2', bar: 'bar 2' } });
+		expect(result[0].json).not.toHaveProperty('offset');
+	});
+
+	it('should keep the offset in the output on the downloadFields path for v2.3', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: '',
+			returnAll: false,
+			limit: 100,
+			options: {
+				downloadFields: ['attachment'],
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2.3),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(transport.downloadRecordAttachments).toHaveBeenCalledTimes(1);
+		expect(result[0].json).toEqual({
+			id: 'recYYY',
+			fields: {
+				foo: 'foo 2',
+				bar: 'bar 2',
+				attachment: [{ url: 'http://example.com/file.png' }],
+			},
+			offset: 'itrNextPage/recYYY',
+		});
+	});
+
+	it('should not forward the response offset for v2.2', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: '',
+			returnAll: false,
+			limit: 1,
+			options: {},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2.2),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		// v2.2 uses maxRecords and must not forward the response offset to the output
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'appYoLbase/tblltable',
+			{},
+			{ maxRecords: 1 },
+		);
+		expect(result[0].json).not.toHaveProperty('offset');
+	});
+
 	afterEach(() => vi.clearAllMocks());
 
 	it('should search records with attachments and nested fields structure for v2.2', async () => {

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -67,6 +67,20 @@ const properties: INodeProperties[] = [
 				description: "The fields of type 'attachment' that should be downloaded",
 			},
 			{
+				displayName: 'Offset',
+				name: 'offset',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g. itrLXPvNkVIEDMLos/rec0KcTCi7apBl8IV',
+				description:
+					'The pagination token to continue from, as returned in the "offset" field of a previous run\'s output. Used to fetch the next page of records when "Return All" is disabled.',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 2.3 } }],
+					},
+				},
+			},
+			{
 				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-multi-options
 				displayName: 'Output Fields',
 				name: 'fields',
@@ -78,6 +92,22 @@ const properties: INodeProperties[] = [
 				default: [],
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 				description: 'The fields you want to include in the output',
+			},
+			{
+				displayName: 'Page Size',
+				name: 'pageSize',
+				type: 'number',
+				typeOptions: {
+					minValue: 1,
+					maxValue: 100,
+				},
+				default: 100,
+				description: 'The number of records returned in each API request (page)',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 2.3 } }],
+					},
+				},
 			},
 			viewRLC,
 		],
@@ -194,14 +224,33 @@ export async function execute(
 				qs.view = (options.view as IDataObject).value as string;
 			}
 
+			if (options.pageSize) {
+				qs.pageSize = options.pageSize;
+			}
+
+			if (options.offset) {
+				qs.offset = options.offset;
+			}
+
 			let responseData;
 
 			if (returnAll) {
 				responseData = await apiRequestAllItems.call(this, 'GET', endpoint, body, qs);
 			} else {
-				qs.maxRecords = this.getNodeParameter('limit', i);
+				const limit = this.getNodeParameter('limit', i) as number;
+				if (nodeVersion >= 2.3) {
+					// Airtable omits the next-page offset once maxRecords is reached,
+					// so cap the request via pageSize instead to keep manual pagination working
+					qs.pageSize = Math.min(limit, (qs.pageSize as number) ?? 100);
+				} else {
+					qs.maxRecords = limit;
+				}
 				responseData = await apiRequest.call(this, 'GET', endpoint, body, qs);
 			}
+
+			// so the next page can be requested via the 'offset' option
+			const pagination =
+				nodeVersion >= 2.3 && responseData.offset ? { offset: responseData.offset } : {};
 
 			if (options.downloadFields) {
 				const itemWithAttachments = await downloadRecordAttachments.call(
@@ -213,7 +262,7 @@ export async function execute(
 				returnData.push(
 					...itemWithAttachments.map((item) => ({
 						...item,
-						json: legacyFlattenOutput(item.json, nodeVersion),
+						json: { ...legacyFlattenOutput(item.json, nodeVersion), ...pagination },
 					})),
 				);
 				continue;
@@ -222,7 +271,7 @@ export async function execute(
 			let records = responseData.records;
 
 			records = (records as IDataObject[]).map((record) => ({
-				json: legacyFlattenOutput(record, nodeVersion),
+				json: { ...legacyFlattenOutput(record, nodeVersion), ...pagination },
 			})) as INodeExecutionData[];
 
 			const itemData = fallbackPairedItems || [{ item: i }];

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -224,13 +224,14 @@ export async function execute(
 				qs.view = (options.view as IDataObject).value as string;
 			}
 
+			// pageSize and offset are 2.3+ only, so a node pinned to <2.3 keeps its old request shape
 			const pageSize = options.pageSize as number | undefined;
 
-			if (pageSize) {
+			if (nodeVersion >= 2.3 && pageSize) {
 				qs.pageSize = pageSize;
 			}
 
-			if (options.offset) {
+			if (nodeVersion >= 2.3 && options.offset) {
 				qs.offset = options.offset;
 			}
 

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -224,8 +224,10 @@ export async function execute(
 				qs.view = (options.view as IDataObject).value as string;
 			}
 
-			if (options.pageSize) {
-				qs.pageSize = options.pageSize;
+			const pageSize = options.pageSize as number | undefined;
+
+			if (pageSize) {
+				qs.pageSize = pageSize;
 			}
 
 			if (options.offset) {
@@ -241,7 +243,7 @@ export async function execute(
 				if (nodeVersion >= 2.3) {
 					// Airtable omits the next-page offset once maxRecords is reached,
 					// so cap the request via pageSize instead to keep manual pagination working
-					qs.pageSize = Math.min(limit, (qs.pageSize as number) ?? 100);
+					qs.pageSize = Math.min(limit, pageSize ?? 100);
 				} else {
 					qs.maxRecords = limit;
 				}

--- a/packages/nodes-base/nodes/Airtable/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/versionDescription.ts
@@ -9,7 +9,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'airtable',
 	icon: 'file:airtable.svg',
 	group: ['input'],
-	version: [2, 2.1, 2.2],
+	version: [2, 2.1, 2.2, 2.3],
 	subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
 	description: 'Read, update, write and delete data from Airtable',
 	defaults: {

--- a/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
@@ -66,7 +66,7 @@ export async function apiRequestAllItems(
 	if (query === undefined) {
 		query = {};
 	}
-	query.pageSize = 100;
+	query.pageSize = query.pageSize ?? 100;
 
 	const returnData: IDataObject[] = [];
 


### PR DESCRIPTION
## Summary

The Airtable `record:search` operation could only fetch everything ("Return All") or a single capped request with no way to continue — the [list records API](https://airtable.com/developers/web/api/list-records) pagination parameters were not exposed, and the response's `offset` token was discarded, making page-by-page fetching impossible.

This PR adds the missing pagination support (node version 2.3):

- **Page Size** option — sent as the `pageSize` query parameter, controls how many records each API request/page returns (1–100). Also respected by the "Return All" batching, which previously hardcoded 100.
- **Offset** option — sent as the `offset` query parameter; accepts the pagination token from a previous run to fetch the next page.
- When **Return All** is disabled and more records are available, the response's `offset` token is now included on each output item, so it can be fed back into the Offset option to fetch the next page. The request is capped via `pageSize` instead of `maxRecords`, because Airtable omits the next-page token once `maxRecords` is reached.

Since the output shape changes (new `offset` field), the new behavior and options are gated behind node version 2.3 (`@version` display conditions). Existing workflows on ≤2.2 behave exactly as before; 2.3 is the new default version.

> This PR supersedes #33437 (closed). It addresses the review feedback from that PR: the page size option is read once (dead `qs.pageSize` assignment removed), and test coverage now includes the last page (no `offset` in output), the download-attachments path keeping the `offset`, and an explicit 2.2 check that the response `offset` is not forwarded.

## How to test

1. Add an **Airtable** node (version 2.3), operation **Search**, pointing at a table with more than 100 records.
2. Disable **Return All**, and set **Options → Page Size** (e.g. 50).
3. Execute: each output item contains an `offset` field.
4. Copy that value into **Options → Offset** and execute again: the next page is returned. On the last page, `offset` disappears from the output.
5. Loop workflow: connect the node's output through a **Limit** node (max 1 item) into an **If** node checking that `{{ $json.offset }}` exists, and loop the true branch back into the Airtable node with Offset set to `{{ $json.offset || '' }}` — it fetches all pages and stops on the last one.
6. Regression: a node pinned to version ≤ 2.2 shows no new options and produces unchanged output.

Unit tests cover the new query parameters, the `min(limit, pageSize)` capping, the offset field in the output for 2.3, and the unchanged 2.2 output.

## Related Linear tickets, Github issues, and Community forum posts

- Community forum post: https://community.n8n.io/t/add-manual-pagination-to-airtable-search-for-large-datasets/311170
- Supersedes #33437.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

