### PR TITLE
fix: Load Codespaces worker secrets before startup (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -68,6 +68,10 @@ same way as `ANTHROPIC_API_KEY`:
 - `OPENROUTER_API_KEY` — the model provider key for Sol.
 - `SLACK_BOT_TOKEN` — optional bot token for progress messages. It needs `chat:write` only.
 
+The worker explicitly reloads `/usr/local/lib/codespaces-env.sh` when its tmux
+session starts. An existing tmux server can otherwise retain an environment
+that did not load the Codespaces secrets.
+
 The dequeue payload can include `slack.channel` and `slack.thread_ts`. The
 worker posts one placeholder in that thread. It coalesces completed tool calls.
 It updates the message at most once every 1.5 seconds. It does not send reasoning

--- a/.devcontainer/codespaces/agent-worker.test.mjs
+++ b/.devcontainer/codespaces/agent-worker.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
 import { PassThrough } from 'node:stream';
 import { test } from 'node:test';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -10,6 +11,14 @@ const turn = {
 	turnId: 'turn-1',
 	slack: { channel: 'C123', thread_ts: '123.456' },
 };
+
+test('reloads Codespaces secrets before the worker starts', () => {
+	const postStart = readFileSync(new URL('./post-start.mjs', import.meta.url), 'utf8');
+	assert.match(
+		postStart,
+		/bash -lc "\. \/usr\/local\/lib\/codespaces-env\.sh; .*node \/workspaces\/n8n\/\.devcontainer\/codespaces\/agent-worker\.mjs/,
+	);
+});
 
 function slackRecorder() {
 	const calls = [];

--- a/.devcontainer/codespaces/post-start.mjs
+++ b/.devcontainer/codespaces/post-start.mjs
@@ -75,5 +75,5 @@ tryRun('worker start', 'tmux', [
 	'-d',
 	'-s',
 	'agent-worker',
-	'bash -lc "export CLAUDE_CODE_PLUGIN_PREFER_HTTPS=1 CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE=1; node /workspaces/n8n/.devcontainer/codespaces/agent-worker.mjs >> /tmp/agent-worker.log 2>&1"',
+	'bash -lc ". /usr/local/lib/codespaces-env.sh; export CLAUDE_CODE_PLUGIN_PREFER_HTTPS=1 CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE=1; node /workspaces/n8n/.devcontainer/codespaces/agent-worker.mjs >> /tmp/agent-worker.log 2>&1"',
 ]);


### PR DESCRIPTION
## Summary

Explicitly reload the Codespaces secret file inside the tmux worker command. This prevents an existing tmux server from starting the worker with an environment that did not load runtime secrets.

Add a regression test for the worker launch command. Document the tmux environment behavior in the Codespaces runbook.

## How to test

Run `pnpm --dir .github/scripts test`.

Start a Codespace from a prebuild while another tmux session starts first. Confirm that `agent-worker` receives the declared Codespaces secrets and starts without a missing-token warning.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://github.com/n8n-io/n8n/pull/37741

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

