### PR TITLE
feat(Databricks Node): Add partner User-Agent to chat model requests

### DIFF
--- a/packages/@n8n/client-oauth2/src/client-oauth2.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2.ts
@@ -50,6 +50,13 @@ export interface ClientOAuth2Options {
 	resource?: string;
 	ignoreSSLIssues?: boolean;
 	/**
+	 * Extra headers to send on the token request (e.g. a caller-identifying
+	 * User-Agent). Only honored by the client-credentials grant today
+	 * ({@link CredentialsFlow}); applied before it sets its own `Authorization`,
+	 * so a caller can't use this to override the credential's auth header.
+	 */
+	headers?: Headers;
+	/**
 	 * When provided, token endpoint requests are validated against the host's
 	 * outbound network policy before dispatch, at DNS resolution time, and on
 	 * every redirect. Omit to leave the request unchecked. Narrowed to the

--- a/packages/@n8n/client-oauth2/src/credentials-flow.ts
+++ b/packages/@n8n/client-oauth2/src/credentials-flow.ts
@@ -31,7 +31,9 @@ export class CredentialsFlow {
 		const options = { ...this.client.options };
 		expects(options, 'clientId', 'accessTokenUri');
 
-		const headers: Headers = { ...DEFAULT_HEADERS };
+		// Caller-supplied headers (e.g. a partner User-Agent) first, so `Authorization`
+		// below always wins if a caller ever also set that.
+		const headers: Headers = { ...DEFAULT_HEADERS, ...options.headers };
 		const body: CredentialsFlowBody = {
 			grant_type: 'client_credentials',
 			...(options.additionalBodyProperties ?? {}),

--- a/packages/@n8n/client-oauth2/test/credentials-flow.test.ts
+++ b/packages/@n8n/client-oauth2/test/credentials-flow.test.ts
@@ -71,6 +71,23 @@ describe('CredentialsFlow', () => {
 			expect(body).toEqual('grant_type=client_credentials&scope=notifications');
 		});
 
+		it('should send caller-supplied headers on the token request, without dropping Authorization', async () => {
+			const authClient = new ClientOAuth2({
+				clientId: config.clientId,
+				clientSecret: config.clientSecret,
+				accessTokenUri: config.accessTokenUri,
+				authorizationGrants: ['credentials'],
+				headers: { 'User-Agent': 'test-agent/1.0' },
+			});
+			const requestPromise = mockTokenCall();
+
+			await authClient.credentials.getToken();
+
+			const { headers } = await requestPromise;
+			expect(headers['user-agent']).toBe('test-agent/1.0');
+			expect(headers.authorization).toBe('Basic YWJjOjEyMw==');
+		});
+
 		it('when scopes are undefined, it should not send scopes to an auth server', async () => {
 			const authClient = createAuthClient();
 			const requestPromise = mockTokenCall();

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/LmChatDatabricks.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/LmChatDatabricks.node.ts
@@ -17,7 +17,11 @@ import {
 } from 'n8n-workflow';
 
 import type { DatabricksOAuth2Credential } from './token-provider';
-import { createDatabricksFetch, getDatabricksTokenProvider } from './token-provider';
+import {
+	CHAT_MODEL_USER_AGENT,
+	createDatabricksFetch,
+	getDatabricksTokenProvider,
+} from './token-provider';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 
 // Every request carries a secret (bearer token, or the client secret on the
@@ -55,7 +59,7 @@ async function searchModels(
 		{
 			method: 'GET',
 			url: `${host}/api/2.0/serving-endpoints`,
-			headers: { Accept: 'application/json' },
+			headers: { Accept: 'application/json', 'User-Agent': CHAT_MODEL_USER_AGENT },
 			json: true,
 		},
 	);

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/test/LmChatDatabricks.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/test/LmChatDatabricks.test.ts
@@ -12,7 +12,11 @@ import { NodeOperationError } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 
 import { LmChatDatabricks } from '../LmChatDatabricks.node';
-import { createDatabricksFetch, getDatabricksTokenProvider } from '../token-provider';
+import {
+	CHAT_MODEL_USER_AGENT,
+	createDatabricksFetch,
+	getDatabricksTokenProvider,
+} from '../token-provider';
 
 vi.mock('@langchain/openai');
 vi.mock('@n8n/ai-utilities');
@@ -329,6 +333,15 @@ describe('LmChatDatabricks', () => {
 
 			const [, requestOptions] = httpRequestWithAuthentication.mock.calls[0];
 			expect(requestOptions.url).toBe('https://my.databricks.com/api/2.0/serving-endpoints');
+		});
+
+		it('should send the partner User-Agent on the endpoints listing request', async () => {
+			setupSearchContext('https://my.databricks.com', endpointsResponse);
+
+			await node.methods.listSearch.searchModels.call(mockContext);
+
+			const [, requestOptions] = httpRequestWithAuthentication.mock.calls[0];
+			expect(requestOptions.headers).toMatchObject({ 'User-Agent': CHAT_MODEL_USER_AGENT });
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/test/token-provider.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/test/token-provider.test.ts
@@ -2,7 +2,11 @@ import type { INode, NodeEgressFilter } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
 import type { DatabricksOAuth2Credential } from '../token-provider';
-import { createDatabricksFetch, getDatabricksTokenProvider } from '../token-provider';
+import {
+	CHAT_MODEL_USER_AGENT,
+	createDatabricksFetch,
+	getDatabricksTokenProvider,
+} from '../token-provider';
 
 const { MockClientOAuth2, mockGetToken } = vi.hoisted(() => {
 	const mockGetToken = vi.fn();
@@ -246,6 +250,20 @@ describe('createDatabricksFetch', () => {
 		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
 		expect(new Headers(init.headers).get('authorization')).toBe('Bearer fresh-token');
 		expect(init.method).toBe('POST');
+	});
+
+	it('should set the partner User-Agent, overwriting the SDK-supplied one', async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response('ok'));
+		globalThis.fetch = mockFetch;
+		const wrappedFetch = createDatabricksFetch(async () => 'fresh-token');
+
+		await wrappedFetch('https://my.databricks.com/serving-endpoints/chat/completions', {
+			method: 'POST',
+			headers: { 'user-agent': 'OpenAI/JS 4.0.0' },
+		});
+
+		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(new Headers(init.headers).get('user-agent')).toBe(CHAT_MODEL_USER_AGENT);
 	});
 
 	it('should preserve the headers of a Request input when init sets none', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/test/token-provider.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/test/token-provider.test.ts
@@ -84,6 +84,7 @@ describe('getDatabricksTokenProvider', () => {
 			accessTokenUri: 'https://my.databricks.com/oidc/v1/token',
 			scopes: ['all-apis'],
 			authentication: 'header',
+			headers: { 'User-Agent': CHAT_MODEL_USER_AGENT },
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
@@ -12,6 +12,11 @@ export interface DatabricksOAuth2Credential {
 	authentication?: 'header' | 'body';
 }
 
+// Partner User-Agent for Databricks traffic attribution (PWAF telemetry spec).
+// Set here, not via ChatOpenAI's `defaultHeaders`, so it also wins over the
+// OpenAI SDK's own User-Agent - Headers.set() overwrites case-insensitively.
+export const CHAT_MODEL_USER_AGENT = 'n8n_DatabricksChatModel/1.0';
+
 /**
  * Mints Databricks service-principal tokens on demand. Concurrent callers
  * share one in-flight mint, and tokens re-mint 60s before expiry so requests
@@ -44,6 +49,7 @@ export function getDatabricksTokenProvider(
 				scopes: credential.scope?.split(' '),
 				authentication: credential.authentication,
 				ssrfBridge: egressFilter,
+				headers: { 'User-Agent': CHAT_MODEL_USER_AGENT },
 			});
 			const token = await oAuthClient.credentials.getToken();
 			const expiresIn = Number(token.data.expires_in);
@@ -75,11 +81,6 @@ export function getDatabricksTokenProvider(
 		return await cached;
 	};
 }
-
-// Partner User-Agent for Databricks traffic attribution (PWAF telemetry spec).
-// Set here, not via ChatOpenAI's `defaultHeaders`, so it also wins over the
-// OpenAI SDK's own User-Agent - Headers.set() overwrites case-insensitively.
-export const CHAT_MODEL_USER_AGENT = 'n8n_DatabricksChatModel/1.0';
 
 /**
  * Wraps fetch to inject a fresh bearer token per request. Never reads or

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
@@ -76,6 +76,11 @@ export function getDatabricksTokenProvider(
 	};
 }
 
+// Partner User-Agent for Databricks traffic attribution (PWAF telemetry spec).
+// Set here, not via ChatOpenAI's `defaultHeaders`, so it also wins over the
+// OpenAI SDK's own User-Agent - Headers.set() overwrites case-insensitively.
+export const CHAT_MODEL_USER_AGENT = 'n8n_DatabricksChatModel/1.0';
+
 /**
  * Wraps fetch to inject a fresh bearer token per request. Never reads or
  * clones the body, so streaming responses pass through untouched. Redirects
@@ -94,6 +99,7 @@ export function createDatabricksFetch(
 			init?.headers ?? (input instanceof Request ? input.headers : undefined),
 		);
 		headers.set('authorization', `Bearer ${await getToken()}`);
+		headers.set('user-agent', CHAT_MODEL_USER_AGENT);
 		// The redirect loop takes a URL, so unwrap a Request input and carry its
 		// method/body/signal over (init still wins, per fetch spec). The body is
 		// buffered, which also lets 307/308 hops replay it.


### PR DESCRIPTION
## Summary

Databricks measures partner impact by usage attributed via the HTTP User-Agent header. This adds a static User-Agent (`n8n_DatabricksChatModel/1.0`) to every request the Databricks Chat Model node sends, so usage shows up as n8n traffic instead of anonymous SDK traffic on Databricks' side. No user-visible behavior changes; the node is still hidden and unreleased.

## How to test

Run a workflow with the Databricks Chat Model node (behind an AI Agent or Basic LLM Chain) against a real Databricks workspace, and confirm the outgoing requests carry `User-Agent: n8n_DatabricksChatModel/1.0`. Unit tests cover the header override behavior in `token-provider.test.ts` and `LmChatDatabricks.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-386

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

