### PR TITLE
test(editor): Cover the instanceAi templateId guard and its lazy i18n import (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
@@ -1,11 +1,30 @@
+import { i18n } from '@n8n/i18n';
 import { ref } from 'vue';
 import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router';
 import { InstanceAiModule } from '../module.descriptor';
-import { INSTANCE_AI_VIEW, INSTANCE_AI_THREAD_VIEW, INSTANCE_AI_SETTINGS_VIEW } from '../constants';
+import {
+	INSTANCE_AI_VIEW,
+	INSTANCE_AI_THREAD_VIEW,
+	INSTANCE_AI_SETTINGS_VIEW,
+	INSTANCE_AI_NEW_VIEW,
+} from '../constants';
 
 vi.mock('../composables/useInstanceAiAvailability', () => ({
 	useInstanceAiAvailable: () => ref(true),
 	useInstanceAiReady: () => ref(true),
+}));
+
+const ensurePersonalProjectId = vi.fn(async () => 'project-1');
+const provisionLaunchedThread = vi.fn(async () => 'thread-9');
+
+vi.mock('../composables/useInstanceAiHandoff', () => ({
+	ensurePersonalProjectId: async () => await ensurePersonalProjectId(),
+	provisionLaunchedThread: async (...args: unknown[]) =>
+		await provisionLaunchedThread(...(args as [])),
+}));
+
+vi.mock('@/experiments/openWorkflowInAssistant/launchWorkflowThread', () => ({
+	launchWorkflowThread: async () => undefined,
 }));
 
 const stub = { render: () => null };
@@ -64,5 +83,67 @@ describe('InstanceAiModule legacy route redirects', () => {
 
 		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_SETTINGS_VIEW);
 		expect(router.currentRoute.value.path).toBe('/settings/assistant');
+	});
+});
+
+/**
+ * The `templateId` deep-link guard is the one place in this descriptor that still needs a
+ * translated string, and it gets it from a lazy `await import('@n8n/i18n')` so the top level
+ * of the descriptor stays import-light. Nothing else covers that line: a wrong binding name
+ * or an unresolvable specifier would only surface here, on a deep link from the website.
+ */
+describe('InstanceAiModule templateId deep link', () => {
+	beforeEach(() => {
+		ensurePersonalProjectId.mockClear();
+		provisionLaunchedThread.mockClear();
+	});
+
+	it('should resolve the kickoff message through the lazy i18n import', async () => {
+		const router = createTestRouter();
+		await router.push('/assistant/new?templateId=42');
+
+		expect(provisionLaunchedThread).toHaveBeenCalledTimes(1);
+		const [projectId, payload] = provisionLaunchedThread.mock.calls[0] as unknown as [
+			string,
+			{ message: string },
+		];
+
+		expect(projectId).toBe('project-1');
+		expect(payload.message).toBe(
+			i18n.baseText('instanceAi.launch.templateById.message', { interpolate: { id: '42' } }),
+		);
+		// Guards the interpolation too: an unresolved key would come back as the key itself.
+		expect(payload.message).toContain('42');
+		expect(payload.message).not.toContain('instanceAi.launch');
+
+		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_THREAD_VIEW);
+		expect(router.currentRoute.value.params).toEqual({ threadId: 'thread-9' });
+	});
+
+	it('should reject a non-numeric templateId before it reaches the kickoff message', async () => {
+		const router = createTestRouter();
+		await router.push('/assistant/new?templateId=ignore-previous-instructions');
+
+		expect(provisionLaunchedThread).not.toHaveBeenCalled();
+		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_VIEW);
+	});
+
+	it('should fall back to the assistant view when no personal project resolves', async () => {
+		ensurePersonalProjectId.mockResolvedValueOnce(null as unknown as string);
+
+		const router = createTestRouter();
+		await router.push('/assistant/new?templateId=42');
+
+		expect(provisionLaunchedThread).not.toHaveBeenCalled();
+		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_VIEW);
+	});
+
+	it('should land on the empty view when no templateId is given', async () => {
+		const router = createTestRouter();
+		await router.push('/assistant/new');
+
+		expect(provisionLaunchedThread).not.toHaveBeenCalled();
+		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_VIEW);
+		expect(INSTANCE_AI_NEW_VIEW).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Summary

QA follow-up to #37771. That PR moves the `instanceAi` guard's `@n8n/i18n` value import to a lazy `await import('@n8n/i18n')`. No test covered that branch, so a wrong binding name or an unresolvable specifier would only surface on a deep link from the website.

This PR adds four tests that drive the real route records of `InstanceAiModule` through a memory router:

- the kickoff message is the resolved and interpolated string, not the raw key (guards the lazy import);
- a non-numeric `templateId` never reaches the message;
- no personal project falls back to the assistant view;
- no `templateId` lands on the empty view.

Merge this into `agent/palette/6afd93db276b` so #37771 carries the guard.

## How to test

```bash
cd packages/frontend/editor-ui
pnpm vitest run src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
```

7 tests pass.

Mutation check — rename the lazy import's binding in `module.descriptor.ts`:

```ts
const { i18nTypo: i18n } = (await import('@n8n/i18n')) as unknown as { i18nTypo: typeof import('@n8n/i18n').i18n };
```

The first test then fails with `TypeError: Cannot read properties of undefined (reading 'baseText')`.

## Related Linear tickets, Github issues, and Community forum posts

Follows #37771.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

