### PR TITLE
feat: Add OpenCode Codespace sessions (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/Dockerfile
+++ b/.devcontainer/codespaces/Dockerfile
@@ -24,8 +24,8 @@ COPY gitcredential-refresh.sh /usr/local/bin/gitcredential-refresh.sh
 COPY gh-shim.sh /usr/local/bin/gh
 RUN chmod +x /usr/local/bin/gitcredential-refresh.sh /usr/local/bin/gh
 
-# VS Code terminals are non-login shells: they read bashrc, not profile.d
-RUN echo '. /usr/local/lib/codespaces-env.sh' >> /etc/bash.bashrc
+# VS Code terminals load secrets here because they do not read profile.d.
+RUN echo '[ "${N8N_SKIP_CODESPACE_SECRETS:-}" = "1" ] || . /usr/local/lib/codespaces-env.sh' >> /etc/bash.bashrc
 
 COPY tmux.conf /etc/tmux.conf
 

--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -12,8 +12,8 @@ Playwright system deps, and Docker-in-Docker (for testcontainers and
 ## One-time setup (~5 min)
 
 1. Add provider keys at [github.com/settings/codespaces](https://github.com/settings/codespaces).
-   Add `ANTHROPIC_API_KEY` for Claude Code. Add `OPENROUTER_API_KEY` for Flaky's
-   OpenCode worker. Give both secrets access to `n8n-io/n8n`.
+   Add `ANTHROPIC_API_KEY` for Claude Code. Add `OPENROUTER_API_KEY` for OpenCode.
+   Give both secrets access to `n8n-io/n8n`.
    (Alternative for Max subscriptions: `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`.)
 2. Give the GitHub CLI the codespace scope:
 
@@ -24,18 +24,24 @@ Playwright system deps, and Docker-in-Docker (for testcontainers and
 ## Daily flow
 
 ```bash
-pnpm session              # attach the default agent session (creates everything on first run)
-pnpm session fix-flaky    # a second, parallel agent in its own git worktree
-pnpm session ls           # what's running
-pnpm session tunnel       # forward n8n ports (default 5678, 8080) to localhost; Ctrl-C to stop
-pnpm session stop         # end of day: billing stops, disk survives
-pnpm session rm           # delete the codespace
+pnpm session                       # attach Claude Code (creates everything on first run)
+pnpm session:shell                 # open a shell in the default checkout
+pnpm session:opencode              # attach OpenCode in auto mode
+pnpm session:opencode fix-flaky    # OpenCode in a separate worktree
+pnpm session fix-flaky             # Claude Code in a separate worktree
+pnpm session ls                    # what's running
+pnpm session tunnel                # forward n8n ports (default 5678, 8080); Ctrl-C to stop
+pnpm session stop                  # end of day: billing stops, disk survives
+pnpm session rm                    # delete the codespace
 ```
+
+The dev container supports Codespaces with 2, 4, or 8 cores. The session commands
+create an 8-core Codespace by default.
 
 - **Detach** with `Ctrl-b d` — the agent keeps working without you.
 - **Scroll** with the mouse wheel (tmux mouse mode is on). To use the
   terminal's own text selection, hold **Shift** and drag.
-- **Reattach** by running the same `pnpm session <name>` from any machine.
+- **Reattach** by running the same session command from any machine.
 - Each named session gets its own worktree (`/workspaces/wt-<name>`, branch
   `session/<name>`), so parallel agents never touch each other's tree. Builds
   in fresh worktrees are cache-hits via a shared turbo cache.
@@ -78,7 +84,7 @@ It updates the message at most once every 1.5 seconds. It does not send reasonin
 text. The worker replaces the placeholder with the final answer.
 If the Slack API fails, the turn still completes through the n8n resume URL.
 The worker does not export its dequeue or Slack credentials to OpenCode.
-Interactive Claude Code sessions unset all worker-only credentials before they start.
+Interactive sessions remove all worker-only credentials before they start.
 
 The log is at `/tmp/agent-worker.log`. The tmux session is `agent-worker`. To
 watch it, run `tmux attach -t agent-worker`. The worker does not start if a

--- a/.devcontainer/codespaces/cloud-session.test.mjs
+++ b/.devcontainer/codespaces/cloud-session.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const sessionScript = join(repoRoot, 'scripts/cloud-session.mjs');
+let fixtureDir;
+let invocation = 0;
+
+before(() => {
+	fixtureDir = mkdtempSync(join(tmpdir(), 'cloud-session-'));
+	const mockGh = join(fixtureDir, 'gh');
+	writeFileSync(
+		mockGh,
+		`#!/usr/bin/env node
+const { writeFileSync } = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'codespace' && args[1] === 'list') {
+	process.stdout.write('[{"name":"test-codespace","state":"Available"}]\\n');
+} else {
+	writeFileSync(process.env.GH_CAPTURE, JSON.stringify(args));
+}
+`,
+	);
+	chmodSync(mockGh, 0o755);
+});
+
+after(() => rmSync(fixtureDir, { recursive: true, force: true }));
+
+function runSession(args) {
+	const capture = join(fixtureDir, `invocation-${invocation++}.json`);
+	const result = spawnSync(process.execPath, [sessionScript, ...args], {
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GH_CAPTURE: capture,
+			PATH: `${fixtureDir}:${process.env.PATH}`,
+		},
+	});
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	return JSON.parse(readFileSync(capture, 'utf8'));
+}
+
+function remoteCommand(args) {
+	const invocationArgs = runSession(args);
+	assert.deepEqual(invocationArgs.slice(0, 6), [
+		'codespace',
+		'ssh',
+		'-c',
+		'test-codespace',
+		'--',
+		'-t',
+	]);
+	return invocationArgs[6];
+}
+
+test('starts a named OpenCode session in a worktree', () => {
+	const command = remoteCommand(['--opencode', 'fix-flaky', '--model', 'test']);
+
+	assert.match(command, /tmux new -As fix-flaky-opencode/);
+	assert.match(command, /unset AGENT_WORKER_TOKEN N8N_DEQUEUE_URL SLACK_BOT_TOKEN/);
+	assert.match(command, /OPENCODE_CONFIG_CONTENT/);
+	assert.match(command, /git -C \/workspaces\/n8n worktree add "\/workspaces\/wt-fix-flaky"/);
+	assert.match(command, /cd "\/workspaces\/wt-fix-flaky" && opencode --auto --model test/);
+	assert.doesNotMatch(command, /unset OPENROUTER_API_KEY/);
+	assert.doesNotMatch(command, /claude plugin/);
+});
+
+test('keeps removed credentials out of the login shell', () => {
+	const command = remoteCommand(['--shell']);
+	const profile = readFileSync(new URL('./codespaces-secrets.sh', import.meta.url), 'utf8');
+	const dockerfile = readFileSync(new URL('./Dockerfile', import.meta.url), 'utf8');
+
+	assert.match(command, /tmux new -As agent-shell/);
+	assert.match(
+		command,
+		/unset AGENT_WORKER_TOKEN N8N_DEQUEUE_URL SLACK_BOT_TOKEN; unset OPENROUTER_API_KEY/,
+	);
+	assert.match(command, /export N8N_SKIP_CODESPACE_SECRETS=1; exec "\$\{SHELL:-\/bin\/bash\}" -l/);
+	assert.ok(profile.includes('[ "${N8N_SKIP_CODESPACE_SECRETS:-}" = "1" ] && return'));
+	assert.ok(
+		dockerfile.includes(
+			'RUN echo \'[ "${N8N_SKIP_CODESPACE_SECRETS:-}" = "1" ] || . /usr/local/lib/codespaces-env.sh\'',
+		),
+	);
+	assert.doesNotMatch(command, /claude plugin|OPENCODE_CONFIG_CONTENT/);
+});
+
+test('keeps the existing Claude session behavior', () => {
+	const command = remoteCommand(['agent', '--model', 'test']);
+
+	assert.match(command, /tmux new -As agent/);
+	assert.match(command, /unset OPENROUTER_API_KEY/);
+	assert.match(command, /claude plugin marketplace add/);
+	assert.match(command, /cd \/workspaces\/n8n && claude --model test/);
+	assert.doesNotMatch(command, /OPENCODE_CONFIG_CONTENT|N8N_SKIP_CODESPACE_SECRETS/);
+});

--- a/.devcontainer/codespaces/codespaces-secrets.sh
+++ b/.devcontainer/codespaces/codespaces-secrets.sh
@@ -1,3 +1,6 @@
+# Interactive shell sessions set this guard after they remove worker credentials.
+[ "${N8N_SKIP_CODESPACE_SECRETS:-}" = "1" ] && return
+
 # Login-shell setup for ssh/tmux sessions: export secrets, then do the
 # one-time registrations.
 . /usr/local/lib/codespaces-env.sh

--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -5,9 +5,9 @@
 	// Codespaces clones the repo into /workspaces/<repo>, unlike the laptop config
 	"workspaceFolder": "/workspaces/n8n",
 	"hostRequirements": {
-		"cpus": 8,
-		"memory": "32gb",
-		"storage": "64gb"
+		"cpus": 2,
+		"memory": "8gb",
+		"storage": "32gb"
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {},

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "dev-metrics:reset": "node scripts/dev-metrics/setup.mjs --reset",
     "clean": "turbo run clean",
     "session": "node scripts/cloud-session.mjs",
+    "session:opencode": "node scripts/cloud-session.mjs --opencode",
+    "session:shell": "node scripts/cloud-session.mjs --shell",
     "reset": "node scripts/ensure-zx.mjs && zx scripts/reset.mjs",
     "format": "turbo run format && node scripts/format.mjs",
     "grind": "node scripts/grind.mjs",

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -98,7 +98,9 @@ const ENSURE_PLUGINS = [
 function remoteCommand(session, launcher, extraArgs) {
 	const executable = launcher === 'opencode' ? 'opencode --auto' : launcher;
 	const command =
-		launcher === 'shell' ? 'exec "${SHELL:-/bin/bash}" -l' : `${executable} ${extraArgs}`.trim();
+		launcher === 'shell'
+			? 'export N8N_SKIP_CODESPACE_SECRETS=1; exec "${SHELL:-/bin/bash}" -l'
+			: `${executable} ${extraArgs}`.trim();
 	const prelude = [
 		SESSION_SECRETS,
 		launcher === 'opencode' ? OPENCODE_CONFIG : 'unset OPENROUTER_API_KEY',

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -3,19 +3,22 @@
 // git worktree per agent, so parallel sessions never trample each other's tree.
 // Requires `gh` with the codespace scope (gh auth refresh -s codespace).
 //
-//   pnpm session            attach the default session (main checkout, /workspaces/n8n)
-//   pnpm session <name>     attach a named session in its own worktree (/workspaces/wt-<name>)
-//   pnpm session ls         list codespaces and the tmux sessions inside
-//   pnpm session tunnel [port…]  forward ports (default 5678, 8080) to localhost; Ctrl-C to stop
-//   pnpm session stop       stop the codespace (compute billing stops; disk survives)
-//   pnpm session rm         delete the codespace
+//   pnpm session                   attach Claude Code in the main checkout
+//   pnpm session <name>            attach Claude Code in a separate worktree
+//   pnpm session:shell [name]      attach a shell
+//   pnpm session:opencode [name]   attach OpenCode in auto mode
+//   pnpm session ls                list Codespaces and tmux sessions
+//   pnpm session tunnel [port…]    forward ports to localhost
+//   pnpm session stop              stop the Codespace
+//   pnpm session rm                delete the Codespace
 import { execFileSync, spawnSync } from 'node:child_process';
 
 import { MARKETPLACE, PLUGINS } from '../.devcontainer/codespaces/plugins.mjs';
 
 const REPO = 'n8n-io/n8n';
 const DEVCONTAINER = '.devcontainer/codespaces/devcontainer.json';
-const MACHINE = 'premiumLinux'; // 8-core/32GB — the only size we use
+// Keep scripted sessions fast. The dev container also permits smaller Codespaces.
+const MACHINE = 'premiumLinux';
 
 const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8' }).trim();
 const ghTty = (...args) => spawnSync('gh', args, { stdio: 'inherit' });
@@ -35,8 +38,8 @@ function findCodespace(retry = false) {
 }
 
 function requestCodespaceScope() {
-	console.log("Requesting codespace scope");
-	ghTty("auth", "refresh", "-h", "github.com", "-s", "codespace")
+	console.log('Requesting codespace scope');
+	ghTty('auth', 'refresh', '-h', 'github.com', '-s', 'codespace');
 }
 
 function ensureCodespace() {
@@ -68,14 +71,17 @@ function ensureCodespace() {
 	return created.name;
 }
 
-// The preludes go inside tmux's '…' argument: do not use single quotes in them.
-// tmux commands are not login shells. Source the shared secrets so Claude Code
-// finds ${FLAKY_MCP_TOKEN} in its process env.
-const SECRETS =
-	'. /usr/local/lib/codespaces-env.sh 2>/dev/null || true; unset AGENT_WORKER_TOKEN N8N_DEQUEUE_URL OPENROUTER_API_KEY SLACK_BOT_TOKEN';
+// These values run inside a single-quoted tmux argument. Do not use single quotes.
+// tmux does not start a login shell. Load shared secrets before each tool starts.
+// Remove worker credentials because interactive tools do not use them.
+const SESSION_SECRETS =
+	'. /usr/local/lib/codespaces-env.sh 2>/dev/null || true; unset AGENT_WORKER_TOKEN N8N_DEQUEUE_URL SLACK_BOT_TOKEN';
+const OPENCODE_CONFIG =
+	'export OPENCODE_CONFIG_CONTENT="{\\"provider\\":{\\"openrouter\\":{\\"options\\":{\\"apiKey\\":\\"{env:OPENROUTER_API_KEY}\\"}}}}"';
 // Worktrees share the pnpm store but not the turbo cache; a shared TURBO_CACHE_DIR
 // (seeded from the main checkout) keeps new-worktree builds at cache-hit speed.
-const CACHE = 'export TURBO_CACHE_DIR=/workspaces/.turbo-cache; [ -d "$TURBO_CACHE_DIR" ] || cp -r /workspaces/n8n/.turbo/cache "$TURBO_CACHE_DIR" 2>/dev/null || mkdir -p "$TURBO_CACHE_DIR"';
+const CACHE =
+	'export TURBO_CACHE_DIR=/workspaces/.turbo-cache; [ -d "$TURBO_CACHE_DIR" ] || cp -r /workspaces/n8n/.turbo/cache "$TURBO_CACHE_DIR" 2>/dev/null || mkdir -p "$TURBO_CACHE_DIR"';
 // On a freshly created codespace, post-start.mjs installs the skills plugins via a
 // network clone that takes tens of seconds. If `claude` boots first it builds its
 // skill registry before a plugin exists on disk, and /reload-plugins can't
@@ -89,23 +95,34 @@ const ENSURE_PLUGINS = [
 	...PLUGINS.map((plugin) => `claude plugin install ${plugin} >/dev/null 2>&1 || true`),
 ].join('; ');
 
-function remoteCommand(session, extraArgs) {
-	const claude = `claude ${extraArgs}`.trim();
-	if (session === 'agent') return `${SECRETS}; ${CACHE}; ${ENSURE_PLUGINS}; cd /workspaces/n8n && ${claude}`;
+function remoteCommand(session, launcher, extraArgs) {
+	const executable = launcher === 'opencode' ? 'opencode --auto' : launcher;
+	const command =
+		launcher === 'shell' ? 'exec "${SHELL:-/bin/bash}" -l' : `${executable} ${extraArgs}`.trim();
+	const prelude = [
+		SESSION_SECRETS,
+		launcher === 'opencode' ? OPENCODE_CONFIG : 'unset OPENROUTER_API_KEY',
+		CACHE,
+		...(launcher === 'claude' ? [ENSURE_PLUGINS] : []),
+	].join('; ');
+	if (session === 'agent') return `${prelude}; cd /workspaces/n8n && ${command}`;
 	const wt = `/workspaces/wt-${session}`;
 	const branch = `session/${session}`;
 	return [
-		SECRETS,
-		CACHE,
-		ENSURE_PLUGINS,
+		prelude,
 		`if [ ! -d "${wt}" ]; then echo "Setting up worktree ${wt}…"`,
 		`git -C /workspaces/n8n worktree add "${wt}" -b "${branch}" 2>/dev/null || git -C /workspaces/n8n worktree add "${wt}" "${branch}"`,
 		`(cd "${wt}" && pnpm install); fi`,
-		`cd "${wt}" && ${claude}`,
+		`cd "${wt}" && ${command}`,
 	].join('; ');
 }
 
-const [cmd = 'agent', ...rest] = process.argv.slice(2);
+const args = process.argv.slice(2);
+let launcher = 'claude';
+if (args[0] === '--shell') launcher = 'shell';
+else if (args[0] === '--opencode') launcher = 'opencode';
+if (launcher !== 'claude') args.shift();
+const [cmd = 'agent', ...rest] = args;
 
 switch (cmd) {
 	case 'ls': {
@@ -116,7 +133,14 @@ switch (cmd) {
 		}
 		console.log(`${cs.name} [${cs.state}]`);
 		if (cs.state === 'Available') {
-			ghTty('codespace', 'ssh', '-c', cs.name, '--', 'tmux ls 2>/dev/null || echo "  no active sessions"');
+			ghTty(
+				'codespace',
+				'ssh',
+				'-c',
+				cs.name,
+				'--',
+				'tmux ls 2>/dev/null || echo "  no active sessions"',
+			);
 		}
 		break;
 	}
@@ -138,11 +162,20 @@ switch (cmd) {
 			console.error(`${cs.name} is ${cs.state} — run \`pnpm session\` to start it first.`);
 			process.exit(1);
 		}
-		console.log(`Forwarding ${ports.map((p) => `localhost:${p}`).join(', ')} from ${cs.name} — Ctrl-C to stop…`);
+		console.log(
+			`Forwarding ${ports.map((p) => `localhost:${p}`).join(', ')} from ${cs.name} — Ctrl-C to stop…`,
+		);
 		// ssh -L over `gh codespace ports forward`: gh binds all interfaces (LAN-exposed),
 		// ssh binds loopback only. ExitOnForwardFailure fails fast if a port is taken.
 		const { status } = ghTty(
-			'codespace', 'ssh', '-c', cs.name, '--', '-N', '-o', 'ExitOnForwardFailure=yes',
+			'codespace',
+			'ssh',
+			'-c',
+			cs.name,
+			'--',
+			'-N',
+			'-o',
+			'ExitOnForwardFailure=yes',
 			...ports.flatMap((p) => ['-L', `${p}:localhost:${p}`]),
 		);
 		process.exitCode = status ?? 1;
@@ -168,10 +201,16 @@ switch (cmd) {
 			process.exit(1);
 		}
 		const name = ensureCodespace();
-		console.log(`Attaching to session '${cmd}' on ${name} (detach: Ctrl-b d)…`);
+		const tmuxSession = launcher === 'claude' ? cmd : `${cmd}-${launcher}`;
+		console.log(`Attaching to ${launcher} session '${tmuxSession}' on ${name} (detach: Ctrl-b d)…`);
 		const { status } = ghTty(
-			'codespace', 'ssh', '-c', name, '--', '-t',
-			`tmux new -As ${cmd} '${remoteCommand(cmd, rest.join(' '))}'`,
+			'codespace',
+			'ssh',
+			'-c',
+			name,
+			'--',
+			'-t',
+			`tmux new -As ${tmuxSession} '${remoteCommand(cmd, launcher, rest.join(' '))}'`,
 		);
 		process.exitCode = status ?? 1;
 	}


### PR DESCRIPTION
## Summary

Add explicit commands for interactive OpenCode and shell sessions in a GitHub Codespace.

Keep worker-only credentials out of all interactive sessions. Provide `OPENROUTER_API_KEY` only to OpenCode.

Lower the dev container minimum to two cores. Keep the scripted session default at eight cores.

## How to test

1. Run `pnpm session:opencode` and confirm that OpenCode starts in the main checkout.
2. Run `pnpm session:opencode test-session` and confirm that OpenCode starts in a separate worktree.
3. Run `pnpm session:shell` and confirm that a login shell starts.
4. Run `pnpm session` and confirm that Claude Code still starts.
5. Confirm that OpenCode receives `OPENROUTER_API_KEY` but no worker-only credentials.
6. Confirm that Claude Code and shell sessions receive no OpenRouter or worker-only credentials.

I verified the launcher commands and credential boundaries with a mocked `gh` executable. I also ran Node syntax, Prettier, Biome, and diff checks.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## 🤖 PR Summary generated by AI

This PR adds interactive OpenCode and shell launchers for Codespaces. It also permits smaller Codespace machines without changing the scripted default.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

