### PR TITLE
fix(core): Surface RangeError on legacy expression path

### DIFF
--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -35,6 +35,9 @@ const isExpressionError = (error: unknown): error is ExpressionError =>
 const isTypeError = (error: unknown): error is TypeError =>
 	error instanceof TypeError || (error instanceof Error && error.name === 'TypeError');
 
+const isRangeError = (error: unknown): error is RangeError =>
+	error instanceof RangeError || (error instanceof Error && error.name === 'RangeError');
+
 // Make sure that error get forwarded
 setErrorHandler((error: Error) => {
 	if (isExpressionError(error)) throw error;
@@ -675,6 +678,8 @@ export class Expression {
 			if (isExpressionError(error)) throw error;
 
 			if (isSyntaxError(error)) throw new UserError('invalid syntax');
+
+			if (isRangeError(error)) throw new UserError('expression is too complex to evaluate');
 
 			if (isTypeError(error) && IS_FRONTEND && error.message.endsWith('is not a function')) {
 				const match = error.message.match(/(?<msg>[^.]+is not a function)/);

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -1556,3 +1556,36 @@ describe('Expression', () => {
 		});
 	});
 });
+
+describe('legacy stack exhaustion (#37786)', () => {
+	const nodeTypes = Helpers.NodeTypes();
+	const workflow = new Workflow({
+		id: '1',
+		nodes: [
+			{
+				name: 'node',
+				typeVersion: 1,
+				type: 'test.set',
+				id: 'uuid-1234',
+				position: [0, 0],
+				parameters: {},
+			},
+		],
+		connections: {},
+		active: false,
+		nodeTypes,
+	});
+	const expression = workflow.expression;
+
+	const evaluate = (value: string) =>
+		expression.getParameterValue(value, null, 0, 0, 'node', [], 'manual', {});
+
+	it('fails loudly instead of returning null', () => {
+		const bigAdd = '={{ ' + '1+'.repeat(20000) + '1 }}';
+		if (process.env.N8N_EXPRESSION_ENGINE === 'legacy') {
+			expect(() => evaluate(bigAdd)).toThrow('expression is too complex to evaluate');
+		} else {
+			expect(() => evaluate(bigAdd)).toThrow();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

On the legacy expression path, a stack-blowing expression evaluates to `null` instead of failing. The workflow then runs with wrong data and reports success.

## How to test

1. Set `N8N_EXPRESSION_ENGINE=legacy`.
2. Evaluate `={{ 1+1+...+1 }}` (20000 additions) as a node parameter.
3. Observe an error now. Before the fix, it returned `null` (correct value 20001).
4. Run `pnpm vitest run test/expression.test.ts` in `packages/workflow`. All tests pass in 3 engines.

## Related issues

Fixes #37786

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

