### PR TITLE
ci: Improve pnpm install performance (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -23,11 +23,11 @@ inputs:
     required: false
     default: 'pnpm build'
   install-command:
-    description: 'Command to execute for installing project dependencies. Leave empty to skip install step.'
+    description: 'Command to install project dependencies. The default trusts the committed lockfile because SafeChain enforces the CI supply-chain policy. Leave empty to skip the install step.'
     required: false
-    default: 'pnpm install --frozen-lockfile'
+    default: 'pnpm install --frozen-lockfile --trust-lockfile'
   cache-dependency-path:
-    description: 'Path(s) to the lockfile(s) used to compute the pnpm-store cache key. Scope this down (e.g. to `.github/scripts/pnpm-lock.yaml`) when only installing a subset, to avoid restoring the full workspace store.'
+    description: 'Path(s) to the lockfile(s) used to compute the pnpm store and metadata cache keys. Scope this down (e.g. to `.github/scripts/pnpm-lock.yaml`) when only installing a subset.'
     required: false
     default: 'pnpm-lock.yaml'
 
@@ -47,7 +47,7 @@ runs:
       uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
       with:
         install: false
-        version: 11.22.0
+        version: 11.25.0
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     # Cache the Node toolcache so setup-node skips the ~33s nodejs.org download
@@ -103,6 +103,26 @@ runs:
         if [ ! -d "$PNPM_STORE_PATH" ]; then
             mkdir -p "$PNPM_STORE_PATH"
         fi
+
+    # pnpm keeps registry metadata and its lockfile verification log outside the package store.
+    - name: Resolve pnpm metadata cache directory
+      if: ${{ inputs.install-command != '' }}
+      id: pnpm-metadata-cache
+      shell: bash
+      run: |
+        PNPM_CACHE_PATH="$(pnpm cache path --silent)"
+        mkdir -p "$PNPM_CACHE_PATH"
+        echo "path=$PNPM_CACHE_PATH" >> "$GITHUB_OUTPUT"
+        echo "version=$(pnpm --version)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore pnpm metadata cache
+      if: ${{ inputs.install-command != '' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ${{ steps.pnpm-metadata-cache.outputs.path }}
+        key: pnpm-metadata-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-metadata-cache.outputs.version }}-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          pnpm-metadata-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-metadata-cache.outputs.version }}-
 
     - name: Configure SafeChain
       shell: bash

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -23,9 +23,9 @@ inputs:
     required: false
     default: 'pnpm build'
   install-command:
-    description: 'Command to install project dependencies. The default trusts the committed lockfile because SafeChain enforces the CI supply-chain policy. Leave empty to skip the install step.'
+    description: 'Command to install project dependencies. The action trusts the committed lockfile because SafeChain enforces the CI supply-chain policy. Leave empty to skip the install step.'
     required: false
-    default: 'pnpm install --frozen-lockfile --trust-lockfile'
+    default: 'pnpm install --frozen-lockfile'
   cache-dependency-path:
     description: 'Path(s) to the lockfile(s) used to compute the pnpm store and metadata cache keys. Scope this down (e.g. to `.github/scripts/pnpm-lock.yaml`) when only installing a subset.'
     required: false
@@ -232,6 +232,7 @@ runs:
 
         set +o pipefail
         timeout --kill-after=30s 600s $INSTALL_COMMAND \
+          --trust-lockfile \
           --config.logs-dir="$PNPM_DIAG_DIR/pnpm-logs" \
           --reporter=append-only --config.loglevel=info 2>&1 | tee "$INSTALL_LOG"
         rc=${PIPESTATUS[0]}

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -121,8 +121,6 @@ runs:
       with:
         path: ${{ steps.pnpm-metadata-cache.outputs.path }}
         key: pnpm-metadata-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-metadata-cache.outputs.version }}-${{ hashFiles(inputs.cache-dependency-path) }}
-        restore-keys: |
-          pnpm-metadata-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm-metadata-cache.outputs.version }}-
 
     - name: Configure SafeChain
       shell: bash

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -2,9 +2,9 @@
   "name": "workflow-scripts",
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=11.22.0"
+    "pnpm": ">=11.25.0"
   },
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.25.0",
   "scripts": {
     "test": "node --test --experimental-test-module-mocks ./*.test.mjs ./docker/*.test.mjs ./owners/*.test.mjs ./quality/*.test.mjs ./slack/*.test.mjs ./stale/*.test.mjs ../../.devcontainer/codespaces/*.test.mjs ../../scripts/licenses/*.test.mjs ../../scripts/mutation-health/*.test.mjs",
     "generate-sbom": "FETCH_LICENSE=true cdxgen -t pnpm --no-install-deps --profile license-compliance --spec-version 1.6 -o ../../sbom-source.cdx.json ../../compiled/",

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=26.7.0
-ARG PNPM_VERSION=11.22.0
+ARG PNPM_VERSION=11.25.0
 ARG PYTHON_VERSION=3.13
 
 # ==============================================================================

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -13,7 +13,7 @@
 # ==============================================================================
 
 ARG NODE_VERSION=26.7.0
-ARG PNPM_VERSION=11.22.0
+ARG PNPM_VERSION=11.25.0
 ARG PYTHON_VERSION=3.13
 
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=11.22.0"
+    "pnpm": ">=11.25.0"
   },
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.25.0",
   "scripts": {
     "prepare": "node scripts/prepare.mjs",
     "preinstall": "node scripts/block-npm-install.js",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,6 @@ allowUnusedPatches: true
 verifyDepsBeforeRun: false
 
 pmOnFail: warn
-fund: false
 updateNotifier: false
 loglevel: warn
 packageImportMethod: clone-or-copy


### PR DESCRIPTION
## Summary

- Update the root workspace, workflow scripts, and runner images to pnpm 11.25.
- Trust the committed lockfile during each CI install. SafeChain remains active and enforces the CI supply-chain policy.
- Cache pnpm registry metadata and lockfile verification data by platform, pnpm version, and lockfile.
- Remove the `fund` workspace setting because pnpm 11.25 reports that it is ignored.

This avoids pnpm's duplicate full-lockfile policy scan in CI. Local installs continue to apply `minimumReleaseAge` because the setup action adds the trust flag only in CI.

## How to test

1. Run `pnpm install --frozen-lockfile --trust-lockfile`.
2. Run `pnpm test` from `.github/scripts`.
3. Run `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec turbo run lint --concurrency=1`.
4. Run `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec turbo run typecheck --concurrency=1`.
5. Confirm that CI verifies SafeChain before it installs dependencies.
6. Confirm that the install log does not contain `Lockfile passes supply-chain policies`.

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/pnpm/pnpm/issues/12114

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
