### PR TITLE
feat: Add eval-driven development loop for Instance AI changes (no-changelog)

### DIFF
--- a/.agents/skills/instance-ai-edd/SKILL.md
+++ b/.agents/skills/instance-ai-edd/SKILL.md
@@ -156,6 +156,18 @@ The running node process holds the old dist in memory. Rebuilding on disk
 changes nothing until the restart, and a "no measurable effect" result from a
 stale process is the most demoralising way to waste an hour.
 
+**Editing a skill's markdown needs the restart too, and no build at all.**
+`skills/*/SKILL.md` is read from the package root at runtime, not compiled — so
+`pnpm build` does nothing for it and it is tempting to conclude a restart is
+unnecessary either. But `loadInstanceAiRuntimeSkillSource()` memoises the whole
+registry (`cachedRuntimeSkillSource ??= …`), so a process that has already
+served one build keeps the old text for its lifetime. Skip the restart here and
+the after-run silently re-measures the before-state.
+
+Whatever you changed, prove it was live before you believe an unchanged result
+— confirm the process started after your edit, and check the run's transcript
+for the thing you touched (e.g. a `load_skill` call for the skill you edited).
+
 ### 4. Measure
 
 Same command, same N, same instance — only the output dir changes:

--- a/.agents/skills/instance-ai-edd/SKILL.md
+++ b/.agents/skills/instance-ai-edd/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: n8n:instance-ai-edd
+description: >-
+  Eval-driven development for an Instance AI change — state a falsifiable claim,
+  find or author the unit that guards it, baseline the unchanged tree, make the
+  change, and measure before/after locally with `eval:compare-local`. Use when
+  changing Instance AI behaviour (prompts, tools, subagents, skills, routing,
+  the workflow loop), when asked "will this regress anything", "how do I test
+  this change", or "prove this change works".
+---
+
+# Eval-driven development for an Instance AI change
+
+Instance AI has no compilable spec. A unit test can tell you a function returns
+what you typed into it; nothing but an eval can tell you the agent still builds
+the right workflow. So a behavioural change is only finished when you can say
+**which measured unit moved, in which direction, and what else moved with it.**
+
+This skill drives that loop. It does not teach you to write a case — that's
+[`n8n:create-instance-ai-eval`](../create-instance-ai-eval/SKILL.md), which this
+skill hands off to at exactly one gate.
+
+> **Never export `LANGSMITH_API_KEY` anywhere in this loop.**
+>
+> It is a single switch with four effects: it flips the CLI to the LangSmith
+> driver, records an experiment, **writes your throwaway run into the shared
+> dataset**, and (per `lang-tracer/docs/eval-dispatchers.md`) turns on builder
+> trace capture. Leave it unset and every command below runs on the direct
+> driver, entirely locally. `cli/index.ts` selects the driver on
+> `Boolean(process.env.LANGSMITH_API_KEY)` — nothing else.
+
+## When this applies — and when it doesn't
+
+**Applies** when the diff touches a path the PR gate watches *and* you can name
+a behaviour that should change:
+
+```
+packages/@n8n/instance-ai/src/**            packages/cli/src/modules/instance-ai/**
+packages/@n8n/instance-ai/skills/**         packages/core/src/execution-engine/eval-mock-helpers.ts
+packages/@n8n/instance-ai/knowledge-base/** packages/@n8n/agents/src/**
+```
+
+**Does not apply** to a pure refactor, a type-only change, or plumbing with no
+behavioural claim. Say so and stop — `pnpm test` is the right instrument, and
+running a build eval to confirm nothing changed burns ~3 minutes and a sandbox
+per case to learn nothing. A skill that demands an eval for every diff gets
+ignored for the diffs that need one.
+
+Changes to `evaluations/**` itself are a **different** loop (you'd be proving
+your harness change does *not* alter verdicts on a frozen case set). Not covered
+here.
+
+## The loop
+
+Gates 1, 5 and 6 are the driver's calls, not yours to make silently: gate 1
+decides whether a case gets authored, gate 5 decides whether the change ships,
+gate 6 decides what a red *means*. Propose and confirm at those three; flow
+through the rest.
+
+### 0. State the claim
+
+One falsifiable sentence naming an observable behaviour:
+
+> *"After this change the builder stops adding a Set node when the trigger
+> already emits the field."*
+
+Not "improves node selection" — you can't measure that. If you can't write the
+sentence, go back to **When this applies**.
+
+### 1. Find the unit that guards the claim
+
+A *unit* is what the comparison actually grades: one execution scenario
+(`file/scenario`) or one evaluated build expectation
+(`file#expectation:text`). Look for one whose verdict flips on your claim:
+
+- **lang-tracer suites** — the durable home of the corpus
+  (`--source langtracer --suite baseline`); search there first.
+- **`evaluations/data/workflows/*.json`** — local disk cases (since the corpus
+  migration this holds only the `agents` tier and `replay`-seeded cases).
+- **`evaluations/discovery/`** — routing cases, if the claim is about which path
+  the agent takes.
+
+Three outcomes:
+
+| What you find | Do |
+|---|---|
+| A unit that is **already red** for your reason | That red is your target. Go to gate 2. |
+| A unit that is green and would **stay** green either way | It does not guard the claim. Treat it as absent. |
+| Nothing | **Author one now, before touching `src/`** — hand off to [`create-instance-ai-eval`](../create-instance-ai-eval/SKILL.md). |
+
+**Write the case against the failure, not against your fix.** A case authored
+after the fix encodes the fix's shape: it passes because your code is what it
+was written to describe, and it will not catch the next regression. This is the
+one genuinely test-first move in the loop and it is where the loop earns its
+keep.
+
+*If the fix is already in your working tree* — the common case — don't skip the
+gate. Stash it, capture the red, restore it:
+
+```bash
+git stash push -- packages/@n8n/instance-ai/src
+# ...author the case, run it, confirm it is red for the right reason...
+git stash pop
+```
+
+A case you never saw fail is a case you have no evidence guards anything.
+
+### 2. Baseline the unchanged tree
+
+Same instance, same model, same session as the "after" run will be. A baseline
+captured last week under a different model is not a baseline.
+
+```bash
+cd packages/@n8n/instance-ai
+# with your usual env loaded and LANGSMITH_API_KEY unset
+pnpm eval:instance-ai --filter <slug> --iterations 3 --output-dir .output/edd/before
+```
+
+`.output/` is gitignored, so these artifacts never reach a commit.
+
+Pick the lane by claim type before you pick N — a routing claim graded by
+`eval:discovery` costs a fraction of a build. See
+[`coverage-map.md`](coverage-map.md).
+
+**Choosing N.** See [Reading a comparison](#reading-a-comparison) for why this
+matters more than it looks:
+
+| Claim | N |
+|---|---|
+| The build fails outright / a deterministic structural check | 1 is honest |
+| Any behavioural claim | **3 minimum** |
+| Something you'll cite as evidence in review | 5+ |
+
+**Smoke the environment with one case first.** If a single case crashes at
+execution — especially with an error you'd expect on every case — fix that
+before spending a batch. The failure shapes and their fixes (stale dist,
+out-of-sync `node_modules`) are catalogued under *"A red is signal → first rule
+out the environment"* in [`create-instance-ai-eval`](../create-instance-ai-eval/SKILL.md).
+
+### 3. Make the change — then rebuild **and restart**
+
+```bash
+cd packages/@n8n/instance-ai && pnpm build   # tsc && tsc-alias
+kill "$(lsof -t -iTCP:<port>)"               # the real PID — an env-var pattern match misses it
+# ...restart the instance...
+```
+
+The running node process holds the old dist in memory. Rebuilding on disk
+changes nothing until the restart, and a "no measurable effect" result from a
+stale process is the most demoralising way to waste an hour.
+
+### 4. Measure
+
+Same command, same N, same instance — only the output dir changes:
+
+```bash
+pnpm eval:instance-ai --filter <slug> --iterations 3 --output-dir .output/edd/after
+pnpm eval:compare-local --before .output/edd/before --after .output/edd/after
+```
+
+`eval:compare-local` keys and grades units with the same `comparison/` code the
+CI PR comment uses, so a local read and a CI read can't drift about what a unit
+*is*. It needs no LangSmith and no workspace build — it depends only on `zod`
+and node builtins, so it still runs in a half-broken checkout.
+
+Three readings, in priority order:
+
+1. **Target unit moved the way you claimed** — the claim is supported.
+2. **Something you weren't aiming at moved** — that's the blast radius, and it
+   is the whole reason to run a before/after rather than just running the new
+   case. Account for every line under `WORSE AFTER` before you push.
+3. **Target unit didn't move** — the claim is unproven. Your change may be a
+   no-op on measured behaviour, or the unit doesn't guard what you thought
+   (back to gate 1). Do not talk yourself into shipping on a green that was
+   already green.
+
+Also read `ONLY IN AFTER` / `ONLY IN BEFORE`. A non-empty list means the two
+runs covered different cases and the units you care about may not have been
+compared at all.
+
+### 5. Blast radius
+
+Widen before opening the PR. Scope it deliberately rather than maximally —
+`coverage-map.md` covers how to find the cases that share your code path:
+
+```bash
+pnpm eval:instance-ai --filter <case-a>,<case-b>,<case-c> --iterations 3 --output-dir .output/edd/after-wide
+```
+
+Reserve `--tier pr` for a genuinely broad change. **The build is capped at 4
+concurrent builds per instance**, and a case queued behind that cap reports
+`BUILD FAILED: Run timed out` — a capacity artifact, not a defect. If you see
+that, re-run the suspect solo (`--concurrency 1`) before believing it.
+
+You'll want a matching before-side. Either capture one at gate 2 with the wider
+filter, or re-run the wide set on the stashed tree.
+
+### 6. Classify what's still red
+
+Every remaining red is one of three things — real capability gap, harness
+limitation, or genuine non-determinism. The taxonomy, the `Harness note:` /
+`Capability-gap finding:` description prefixes, and the Linear-ticket step for a
+real gap all live in *"A red is signal — surface it, don't work around it"* in
+[`create-instance-ai-eval`](../create-instance-ai-eval/SKILL.md). Follow it there.
+
+The rule that matters most here: **never weaken a case to make your change look
+clean.** If you catch yourself editing a case so that the pre-change build would
+now pass, stop.
+
+### 7. Write the EDD summary
+
+Paste into the PR body. This is the auditable trace — it's what lets a reviewer
+tell measurement from vibes:
+
+```
+### EDD summary
+
+Claim:  builder stops adding a redundant Set node when the trigger already emits the field
+Unit:   set-node-redundancy/happy-path  [authored in this PR — confirmed red before the fix]
+Lane:   eval:instance-ai --filter set-node-redundancy --iterations 3  (direct driver, no LangSmith)
+
+Before → After
+  set-node-redundancy/happy-path                       0/3 → 3/3   +100.0pp   ← target
+  set-node-redundancy#expectation:no redundant Set     0/3 → 3/3   +100.0pp
+  webhook-digest/happy-path                            3/3 → 2/3    -33.3pp   ← see below
+
+Blast radius:  --filter set-node-redundancy,webhook-digest,slack-alert  N=3 — 5 units, 3 moved
+Collateral:    webhook-digest lost one trial of three. Not significant at N=3; re-ran at
+               N=5 → 5/5, treating as noise.
+Kept reds:     none
+```
+
+State N. State what you did about anything under `WORSE AFTER` — "not
+significant" is an acceptable answer only with the re-run that supports it.
+
+## Reading a comparison
+
+The `verdict` column is the CI-grade statistical tier, and **at local N most
+real movement does not reach it.** Measured against the actual classifier:
+
+| Movement | N=3 verdict | N=5 verdict |
+|---|---|---|
+| 3/3 → 0/3 (total flip) | `hard_regression` | `hard_regression` |
+| 3/3 → 1/3 | `soft_regression` | — |
+| 3/3 → 2/3 (lost one trial) | **`stable`** | — |
+| 5/5 → 3/5 | — | `watch` |
+| 5/5 → 4/5 (lost one trial) | — | **`stable`** |
+
+A unit that loses a single trial grades `stable` at any N you can afford
+locally. That is correct behaviour — one trial in three is genuinely weak
+evidence — but it means **you read the counts, not the verdict.** The verdict
+becomes the thing to read on the CI run, at its higher N.
+
+This cuts both ways. A local `stable` is not proof you broke nothing, and a
+single red trial is not proof you did. When a collateral line matters, the
+answer is more iterations on that one unit, not a longer argument about it.
+
+## What this skill does not cover
+
+- **Authoring or calibrating a case** — [`create-instance-ai-eval`](../create-instance-ai-eval/SKILL.md).
+- **Running mechanics, env, sandbox, parallel lanes** — [`running-evals.md`](../create-instance-ai-eval/running-evals.md).
+- **The PR gate.** `ci-instance-ai-evals.yml` delegates to
+  `test-evals-instance-ai.yml` with `secrets: inherit`, and that workflow *does*
+  set `LANGSMITH_API_KEY` — its baseline comparison is LangSmith-side. Nothing
+  in your local loop touches it; it is simply not the same instrument, and its
+  numbers come from a different N against a pinned baseline.
+- **Recording the run anywhere durable.** Today the loop is local and its
+  artifacts are gitignored; the EDD summary block is the only thing that
+  survives. Dispatching the same case set through a personal lang-tracer
+  dispatcher would give it run history, a version matrix and a revision trail —
+  worth doing once this loop has proven itself, but not part of it today.

--- a/.agents/skills/instance-ai-edd/SKILL.md
+++ b/.agents/skills/instance-ai-edd/SKILL.md
@@ -113,14 +113,21 @@ captured last week under a different model is not a baseline.
 ```bash
 cd packages/@n8n/instance-ai
 # with your usual env loaded and LANGSMITH_API_KEY unset
+
+# routing / skill-loading claim — in-process, no instance, no sandbox
+pnpm eval:discovery --filter <slug> --trials 5 --output-dir .output/edd/before
+
+# built-workflow claim — needs a running instance with a working sandbox
 pnpm eval:instance-ai --filter <slug> --iterations 3 --output-dir .output/edd/before
 ```
 
-`.output/` is gitignored, so these artifacts never reach a commit.
+`--output-dir` is the part that matters: it writes the `eval-results.json`
+gate 4 compares. `.output/` is gitignored, so these artifacts never reach a
+commit.
 
 Pick the lane by claim type before you pick N — a routing claim graded by
-`eval:discovery` costs a fraction of a build. See
-[`coverage-map.md`](coverage-map.md).
+`eval:discovery` costs a fraction of a build, and needs only
+`ANTHROPIC_API_KEY`. See [`coverage-map.md`](coverage-map.md).
 
 **Choosing N.** See [Reading a comparison](#reading-a-comparison) for why this
 matters more than it looks:

--- a/.agents/skills/instance-ai-edd/coverage-map.md
+++ b/.agents/skills/instance-ai-edd/coverage-map.md
@@ -1,0 +1,95 @@
+# Coverage map — picking the lane and scoping the blast radius
+
+Two jobs: **which instrument grades your claim**, and **which cases share your
+code path** so gate 5 can be scoped deliberately instead of maximally.
+
+Every command below assumes `LANGSMITH_API_KEY` is unset and `cd
+packages/@n8n/instance-ai`.
+
+## What counts as an Instance AI change
+
+The PR gate's own path filter (`.github/workflows/ci-instance-ai-evals.yml`) is
+the authoritative list:
+
+```
+packages/@n8n/instance-ai/src/**
+packages/@n8n/instance-ai/skills/**
+packages/@n8n/instance-ai/knowledge-base/**
+packages/@n8n/instance-ai/evaluations/**
+packages/cli/src/modules/instance-ai/**
+packages/core/src/execution-engine/eval-mock-helpers.ts
+packages/@n8n/agents/src/**
+```
+
+## Pick the lane by what your claim is about
+
+Cost is the point of this table. A routing claim graded by a full workflow eval
+costs a sandbox build per case to learn something the in-process discovery lane
+answers in a fraction of the time.
+
+| Your claim is about | Lane | Command | What it costs |
+|---|---|---|---|
+| Which tool/subagent the agent reaches for first; whether a skill loads | **discovery** | `pnpm eval:discovery --filter <slug> --trials 5 --verbose --fail-on-zero-pass` | In-process orchestrator. No build, no sandbox. Cheapest by far. |
+| One subagent's behaviour given correct input | **subagent** | `pnpm eval:subagent --filter <slug> --verbose` | One build per case. |
+| The built workflow's structure, or how it executes on mocked data | **workflow** | `pnpm eval:instance-ai --filter <slug> --iterations 3` | ~3 min build + execution per iteration, per case. The expensive one. |
+| Agent-tier behaviour | **agents** | `pnpm eval:agents --filter <slug>` | Pinned to `--source langtracer --suite agents --tier agents`. |
+
+Not in this table: `eval:pairwise`. It imports the LangSmith client at module
+load and its default dataset is a LangSmith dataset, so it is out of scope for
+this loop by construction.
+
+**Escalate, don't start wide.** If a discovery case can express your claim, use
+it and stop. Reach for the workflow lane when the claim is genuinely about what
+got built or whether it runs.
+
+## Where the cases live
+
+| Set | Location | Count today |
+|---|---|---|
+| Discovery (routing / skill loading) | `evaluations/data/discovery/*.json` | 18 |
+| Subagent | `evaluations/data/subagent/*.json` | 11 |
+| Workflow, on disk | `evaluations/data/workflows/*.json` | 7 — the `agents` tier and `replay`-seeded cases only |
+| Workflow, the corpus | lang-tracer suites (`--source langtracer --suite baseline`) | the bulk of it |
+
+Since the corpus migration, `data/workflows/` is **not** the suite. A new case
+is authored there as a local file and then pushed to a lang-tracer suite — see
+[`create-instance-ai-eval`](../create-instance-ai-eval/SKILL.md).
+
+## Scoping gate 5
+
+There is no static map from a source path to the cases that exercise it, and a
+hand-maintained one would rot within a release. Use the artifacts instead:
+
+1. **Grep the local case sets** for what your change touches — a tool name, a
+   node type, a skill id:
+
+   ```bash
+   grep -rl "data-table" evaluations/data/discovery evaluations/data/subagent
+   grep -rl "n8n-nodes-base.httpRequest" evaluations/data/workflows
+   ```
+
+2. **Query the suite** for corpus cases (lang-tracer MCP or REST) on the same
+   terms — tags, node types, the case's conversation text.
+
+3. **Let the first comparison tell you.** A `WORSE AFTER` line on a case you
+   didn't expect *is* the coverage map, discovered empirically. Add it to the
+   filter and re-run.
+
+4. **`--tier pr`** only for a genuinely broad change. It is the curated set the
+   gate runs, and at `--iterations 3` on one instance it is a long wall-clock
+   run — the build is capped at **4 concurrent builds per instance**, and a case
+   queued behind that cap reports `BUILD FAILED: Run timed out`, which is a
+   capacity artifact and not a defect. Re-run a suspect solo with
+   `--concurrency 1` before believing it.
+
+The honest default is a hand-picked `--filter a,b,c` of three to six cases:
+your target, plus the nearest neighbours from steps 1–2.
+
+## Tiers
+
+A case's `datasets` array is free-form. The two that matter:
+
+- **`pr`** — the curated thin set the gate runs. High baseline reliability plus
+  capability diversity. Only promote a case here after `--iterations 5+` shows
+  it reliably green; a flaky case in the gate poisons it.
+- **`full`** — everything, for nightly and full-suite runs.

--- a/.agents/skills/instance-ai-edd/coverage-map.md
+++ b/.agents/skills/instance-ai-edd/coverage-map.md
@@ -29,10 +29,17 @@ answers in a fraction of the time.
 
 | Your claim is about | Lane | Command | What it costs |
 |---|---|---|---|
-| Which tool/subagent the agent reaches for first; whether a skill loads | **discovery** | `pnpm eval:discovery --filter <slug> --trials 5 --verbose --fail-on-zero-pass` | In-process orchestrator. No build, no sandbox. Cheapest by far. |
-| One subagent's behaviour given correct input | **subagent** | `pnpm eval:subagent --filter <slug> --verbose` | One build per case. |
-| The built workflow's structure, or how it executes on mocked data | **workflow** | `pnpm eval:instance-ai --filter <slug> --iterations 3` | ~3 min build + execution per iteration, per case. The expensive one. |
+| Which tool/subagent the agent reaches for first; whether a skill loads | **discovery** | `pnpm eval:discovery --filter <slug> --trials 5 --output-dir .output/edd/before` | In-process orchestrator. **No n8n instance, no build, no sandbox — only `ANTHROPIC_API_KEY`.** Cheapest by far. |
+| One subagent's behaviour given correct input | **subagent** | `pnpm eval:subagent --filter <slug> --verbose` | Needs a running instance. One build per case. **Writes no artifact — not comparable.** |
+| The built workflow's structure, or how it executes on mocked data | **workflow** | `pnpm eval:instance-ai --filter <slug> --iterations 3 --output-dir .output/edd/before` | ~3 min build + execution per iteration, per case, plus a sandbox. The expensive one. |
 | Agent-tier behaviour | **agents** | `pnpm eval:agents --filter <slug>` | Pinned to `--source langtracer --suite agents --tier agents`. |
+
+**`--output-dir` is what makes a lane measurable.** Discovery and the workflow
+lane both write an `eval-results.json` there, and `eval:compare-local` reads
+either — a discovery scenario reports as one unit keyed
+`<slug>/tool-discovery`. The subagent lane writes nothing, so a claim routed
+there has no before/after tooling; prefer discovery or the workflow lane when
+you need a measured delta.
 
 Not in this table: `eval:pairwise`. It imports the LangSmith client at module
 load and its default dataset is a LangSmith dataset, so it is out of scope for

--- a/.claude/plugins/n8n/skills/instance-ai-edd
+++ b/.claude/plugins/n8n/skills/instance-ai-edd
@@ -1,0 +1,1 @@
+../../../../.agents/skills/instance-ai-edd

--- a/packages/@n8n/instance-ai/evaluations/__tests__/bucket-from-results-json.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/bucket-from-results-json.test.ts
@@ -48,8 +48,12 @@ function resultsJson(overrides: Record<string, unknown> = {}): unknown {
 	};
 }
 
-function bucket(raw: unknown = resultsJson()) {
+function project(raw: unknown = resultsJson()) {
 	return bucketFromResultsJson(parseEvalResults(raw, 'fixture'), 'after');
+}
+
+function bucket(raw: unknown = resultsJson()) {
+	return project(raw).bucket;
 }
 
 describe('bucketFromResultsJson', () => {
@@ -84,9 +88,27 @@ describe('bucketFromResultsJson', () => {
 		expect(result.failureCategoryTotals).toEqual({ builder_issue: 1 });
 	});
 
-	it('throws when a test case carries no testCaseFile', () => {
-		expect(() => bucket(resultsJson({ testCaseFile: undefined }))).toThrow(EvalResultsParseError);
-		expect(() => bucket(resultsJson({ testCaseFile: undefined }))).toThrow(/no testCaseFile/);
+	it('skips and reports a case with no testCaseFile rather than failing the comparison', () => {
+		// Real artifacts land like this: `persist.ts` cannot build slugByTestCase on
+		// the crash-recovery path, and lang-tracer's dispatcher fixtures show whole
+		// files with `testCaseFile: null`. Three of its four are shaped this way.
+		const scenarios = [{ name: 'happy', passCount: 1, evaluatedCount: 2, runs: RUNS }];
+		const result = project({
+			testCases: [
+				{ name: 'keyed case', testCaseFile: 'my-case', scenarios, buildExpectations: [] },
+				{ name: 'unkeyable case', scenarios, buildExpectations: [] },
+			],
+		});
+
+		expect(result.skipped).toEqual(['unkeyable case']);
+		// The keyed case still contributes its unit — a partial comparison beats none.
+		expect([...result.bucket.evaluationUnits.keys()]).toEqual(['my-case/happy']);
+	});
+
+	it('throws only when every case is unkeyable, because then nothing can be compared', () => {
+		const raw = resultsJson({ testCaseFile: undefined });
+		expect(() => project(raw)).toThrow(EvalResultsParseError);
+		expect(() => project(raw)).toThrow(/Every test case/);
 	});
 
 	it('tolerates a run artifact that carries no per-run scenario detail', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/bucket-from-results-json.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/bucket-from-results-json.test.ts
@@ -124,6 +124,28 @@ describe('bucketFromResultsJson', () => {
 		expect(result.trialTotal).toBe(0);
 	});
 
+	it('yields a keyed case with no units when a failed build left every expectation unjudged', () => {
+		// The real shape of a failed sandbox build: the case is present and
+		// keyable, but nothing was graded. `compare-local` distinguishes this from
+		// "the two runs covered different cases" — telling someone to check their
+		// --filter when the filter was right sends them after a bug that isn't there.
+		const result = project({
+			testCases: [
+				{
+					name: 'build a thing',
+					testCaseFile: 'ai-gateway-respects-named-web-search-tool',
+					scenarios: [],
+					buildExpectations: [
+						{ expectation: 'honoured the named tool', passCount: 0, evaluatedCount: 0 },
+					],
+				},
+			],
+		});
+
+		expect(result.skipped).toEqual([]);
+		expect(result.bucket.evaluationUnits.size).toBe(0);
+	});
+
 	it('rejects a file that is not an eval-results.json', () => {
 		expect(() => parseEvalResults({ hello: 'world' }, 'notes.json')).toThrow(EvalResultsParseError);
 		expect(() => parseEvalResults({ hello: 'world' }, 'notes.json')).toThrow(/notes\.json/);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/bucket-from-results-json.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/bucket-from-results-json.test.ts
@@ -1,0 +1,189 @@
+import { bucketFromEvaluation } from '../comparison/bucket-from-evaluation';
+import {
+	EvalResultsParseError,
+	bucketFromResultsJson,
+	parseEvalResults,
+} from '../comparison/bucket-from-results-json';
+import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import type {
+	BuildExpectationAggregation,
+	ExecutionScenarioAggregation,
+	MultiRunEvaluation,
+	WorkflowTestCase,
+} from '../types';
+
+// One logical run, expressed twice: as the in-memory aggregate the LangSmith
+// driver projects, and as the persisted artifact every run writes. The last
+// test asserts the two projections agree — that is the whole point of this
+// module, and the drift it guards against is silent.
+const RUNS = [
+	{ passed: true },
+	{ passed: false, failureCategory: 'builder_issue' },
+	{ passed: false, incomplete: true },
+];
+
+function resultsJson(overrides: Record<string, unknown> = {}): unknown {
+	return {
+		timestamp: '2026-09-04T00:00:00.000Z',
+		totalRuns: 3,
+		testCases: [
+			{
+				name: 'build it',
+				testCaseFile: 'my-case',
+				scenarios: [
+					{
+						name: 'happy',
+						passCount: 1,
+						evaluatedCount: 2,
+						runs: RUNS,
+					},
+				],
+				buildExpectations: [
+					{ expectation: 'asks before building', passCount: 2, evaluatedCount: 3 },
+					{ expectation: 'never judged', passCount: 0, evaluatedCount: 0 },
+				],
+				...overrides,
+			},
+		],
+	};
+}
+
+function bucket(raw: unknown = resultsJson()) {
+	return bucketFromResultsJson(parseEvalResults(raw, 'fixture'), 'after');
+}
+
+describe('bucketFromResultsJson', () => {
+	it('emits scenario and evaluated-expectation units under their kind-specific keys', () => {
+		const result = bucket();
+
+		expect(result.evaluationUnits.get('my-case/happy')).toMatchObject({
+			kind: 'scenario',
+			name: 'happy',
+			passed: 1,
+			total: 2,
+		});
+		expect(result.evaluationUnits.get('my-case#expectation:asks before building')).toMatchObject({
+			kind: 'expectation',
+			name: 'asks before building',
+			passed: 2,
+			total: 3,
+		});
+	});
+
+	it('excludes expectations with no evaluated verdicts', () => {
+		const result = bucket();
+
+		expect(result.evaluationUnits.get('my-case#expectation:never judged')).toBeUndefined();
+		expect(result.evaluationUnits.size).toBe(2);
+	});
+
+	it('keeps trialTotal and failure categories scenario-only, skipping incomplete runs', () => {
+		const result = bucket();
+
+		expect(result.trialTotal).toBe(2);
+		expect(result.failureCategoryTotals).toEqual({ builder_issue: 1 });
+	});
+
+	it('throws when a test case carries no testCaseFile', () => {
+		expect(() => bucket(resultsJson({ testCaseFile: undefined }))).toThrow(EvalResultsParseError);
+		expect(() => bucket(resultsJson({ testCaseFile: undefined }))).toThrow(/no testCaseFile/);
+	});
+
+	it('tolerates a run artifact that carries no per-run scenario detail', () => {
+		// A crash-recovered artifact can land without `runs`; the unit counts are
+		// still comparable, only the failure-category drift table goes empty.
+		const result = bucket(
+			resultsJson({
+				scenarios: [{ name: 'happy', passCount: 1, evaluatedCount: 2 }],
+			}),
+		);
+
+		expect(result.evaluationUnits.get('my-case/happy')).toMatchObject({ passed: 1, total: 2 });
+		expect(result.trialTotal).toBe(0);
+	});
+
+	it('rejects a file that is not an eval-results.json', () => {
+		expect(() => parseEvalResults({ hello: 'world' }, 'notes.json')).toThrow(EvalResultsParseError);
+		expect(() => parseEvalResults({ hello: 'world' }, 'notes.json')).toThrow(/notes\.json/);
+	});
+});
+
+describe('agreement with bucketFromEvaluation', () => {
+	function testCase(): WorkflowTestCase {
+		return {
+			conversation: [{ role: 'user', text: 'build it' }],
+			complexity: 'simple',
+			tags: [],
+			datasets: ['full'],
+		} as WorkflowTestCase;
+	}
+
+	function scenarioAggregation(): ExecutionScenarioAggregation {
+		const scenario = { name: 'happy', description: '', dataSetup: '', successCriteria: '' };
+		return {
+			scenario,
+			runs: RUNS.map((run) => ({
+				scenario,
+				success: run.passed,
+				score: run.passed ? 1 : 0,
+				reasoning: '',
+				failureCategory: run.failureCategory,
+				...(run.incomplete ? { incomplete: true } : {}),
+			})),
+			evaluatedCount: 2,
+			passCount: 1,
+			passRate: 0.5,
+			passAtK: [],
+			passHatK: [],
+		};
+	}
+
+	function expectationAggregation(
+		expectation: string,
+		passCount: number,
+		evaluatedCount: number,
+	): BuildExpectationAggregation {
+		return {
+			expectation,
+			runs: [],
+			evaluatedCount,
+			passCount,
+			passRate: evaluatedCount > 0 ? passCount / evaluatedCount : 0,
+			passAtK: [],
+			passHatK: [],
+		};
+	}
+
+	it('produces the same unit keys, counts and trial totals from either source', () => {
+		const tc = testCase();
+		const evaluation: MultiRunEvaluation = {
+			totalRuns: 3,
+			testCases: [
+				{
+					testCase: tc,
+					runs: [],
+					buildSuccessCount: 3,
+					executionScenarios: [scenarioAggregation()],
+					buildExpectations: [
+						expectationAggregation('asks before building', 2, 3),
+						expectationAggregation('never judged', 0, 0),
+					],
+					status: 'verified',
+				},
+			],
+		};
+		const withFiles: WorkflowTestCaseWithFile[] = [{ testCase: tc, fileSlug: 'my-case' }];
+
+		const fromEvaluation = bucketFromEvaluation(evaluation, withFiles, 'x');
+		const fromJson = bucket();
+
+		expect([...fromJson.evaluationUnits.keys()].sort()).toEqual(
+			[...fromEvaluation.evaluationUnits.keys()].sort(),
+		);
+		for (const [key, counts] of fromEvaluation.evaluationUnits) {
+			expect(fromJson.evaluationUnits.get(key)).toEqual(counts);
+		}
+		expect(fromJson.trialTotal).toBe(fromEvaluation.trialTotal);
+		expect(fromJson.failureCategoryTotals).toEqual(fromEvaluation.failureCategoryTotals);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/discovery-results-artifact.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/discovery-results-artifact.test.ts
@@ -1,0 +1,110 @@
+import { bucketFromResultsJson, parseEvalResults } from '../comparison/bucket-from-results-json';
+import { compareBuckets } from '../comparison/compare';
+import {
+	DISCOVERY_UNIT_NAME,
+	buildDiscoveryEvalResults,
+	type DiscoveryScenarioAggregate,
+} from '../discovery/results-artifact';
+import type { DiscoveryRunResult } from '../discovery/runner';
+import type { DiscoveryTestCase } from '../discovery/types';
+
+function scenario(id: string): DiscoveryTestCase {
+	return {
+		id,
+		userMessage: 'list my data tables',
+		expectedToolInvocations: { anyOf: ['data-tables'] },
+	};
+}
+
+function trial(
+	pass: boolean,
+	overrides: Partial<Pick<DiscoveryRunResult, 'runError' | 'streamStatus'>> = {},
+): DiscoveryRunResult {
+	return {
+		scenario: scenario('x'),
+		check: {
+			pass,
+			comment: pass ? 'invoked data-tables' : 'never invoked data-tables',
+			invokedTools: [],
+			spawnedAgents: [],
+		},
+		events: [],
+		outcome: { toolCalls: [], agentActivities: [] },
+		durationMs: 1200,
+		streamStatus: 'completed',
+		...overrides,
+	} as DiscoveryRunResult;
+}
+
+function aggregate(fileSlug: string, trials: DiscoveryRunResult[]): DiscoveryScenarioAggregate {
+	return {
+		scenario: scenario(fileSlug),
+		fileSlug,
+		results: trials,
+		passCount: trials.filter((t) => t.check.pass).length,
+	};
+}
+
+describe('buildDiscoveryEvalResults', () => {
+	it('produces an artifact the local comparison can key and read', () => {
+		const raw = buildDiscoveryEvalResults(
+			[aggregate('data-table-skill-loading', [trial(true), trial(false), trial(true)])],
+			3,
+			5000,
+		);
+
+		const { bucket, skipped } = bucketFromResultsJson(parseEvalResults(raw, 'x'), 'run');
+
+		expect(skipped).toEqual([]);
+		expect(
+			bucket.evaluationUnits.get(`data-table-skill-loading/${DISCOVERY_UNIT_NAME}`),
+		).toMatchObject({ kind: 'scenario', passed: 2, total: 3 });
+		expect(bucket.trialTotal).toBe(3);
+	});
+
+	it('separates a routing failure from a run that never got that far', () => {
+		// The drift table is the only place this distinction survives, and
+		// "your change started causing timeouts" is a different finding from
+		// "your change started routing to the wrong tool".
+		const raw = buildDiscoveryEvalResults(
+			[
+				aggregate('routing', [trial(false)]),
+				aggregate('timing-out', [trial(false, { streamStatus: 'timed-out' })]),
+				aggregate('erroring', [trial(false, { runError: 'boom' })]),
+			],
+			1,
+			100,
+		);
+
+		const { bucket } = bucketFromResultsJson(parseEvalResults(raw, 'x'), 'run');
+
+		expect(bucket.failureCategoryTotals).toEqual({ builder_issue: 1, framework_issue: 2 });
+	});
+
+	it('round-trips through a real before/after comparison', () => {
+		const before = buildDiscoveryEvalResults(
+			[aggregate('routing', [trial(false), trial(false), trial(false)])],
+			3,
+			100,
+		);
+		const after = buildDiscoveryEvalResults(
+			[aggregate('routing', [trial(true), trial(true), trial(true)])],
+			3,
+			100,
+		);
+
+		const result = compareBuckets(
+			bucketFromResultsJson(parseEvalResults(after, 'a'), 'after').bucket,
+			bucketFromResultsJson(parseEvalResults(before, 'b'), 'before').bucket,
+		);
+
+		expect(result.evaluationUnits).toHaveLength(1);
+		expect(result.evaluationUnits[0]).toMatchObject({
+			name: DISCOVERY_UNIT_NAME,
+			testCaseFile: 'routing',
+			baselinePasses: 0,
+			prPasses: 3,
+			verdict: 'improvement',
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/compare-local.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/compare-local.ts
@@ -158,7 +158,12 @@ function maxTrialsPerUnit(result: ComparisonResult): number {
 	return max;
 }
 
-function render(result: ComparisonResult, beforePath: string, afterPath: string): string[] {
+function render(
+	result: ComparisonResult,
+	beforePath: string,
+	afterPath: string,
+	skipped: { before: string[]; after: string[] },
+): string[] {
 	const lines: string[] = [];
 	const title = 'Instance AI — local before/after';
 	lines.push(title);
@@ -167,6 +172,22 @@ function render(result: ComparisonResult, beforePath: string, afterPath: string)
 	lines.push(`${INDENT}before  ${beforePath}`);
 	lines.push(`${INDENT}after   ${afterPath}`);
 	lines.push('');
+
+	// Announced before the numbers, not after: these cases contributed no units,
+	// so every total below is computed over less than the run actually covered.
+	const totalSkipped = skipped.before.length + skipped.after.length;
+	if (totalSkipped > 0) {
+		lines.push(
+			`${INDENT}NOT COMPARED  ${String(totalSkipped)} case(s) carry no \`testCaseFile\` and cannot be keyed`,
+		);
+		for (const [side, names] of [
+			['before', skipped.before],
+			['after', skipped.after],
+		] as const) {
+			for (const name of names) lines.push(`${INDENT.repeat(2)}${side.padEnd(8)}${name}`);
+		}
+		lines.push('');
+	}
 
 	const { aggregate } = result;
 	lines.push(
@@ -263,12 +284,13 @@ function main(): void {
 	const afterPath = resolveResultsPath(args.after);
 
 	let result: ComparisonResult;
+	let skipped: { before: string[]; after: string[] };
 	try {
+		const after = bucketFromResultsJson(readEvalResults(afterPath), 'after');
+		const before = bucketFromResultsJson(readEvalResults(beforePath), 'before');
 		// pr = after, baseline = before: a negative delta means the change made it worse.
-		result = compareBuckets(
-			bucketFromResultsJson(readEvalResults(afterPath), 'after'),
-			bucketFromResultsJson(readEvalResults(beforePath), 'before'),
-		);
+		result = compareBuckets(after.bucket, before.bucket);
+		skipped = { before: before.skipped, after: after.skipped };
 	} catch (error: unknown) {
 		if (error instanceof EvalResultsParseError) {
 			console.error(error.message);
@@ -278,9 +300,9 @@ function main(): void {
 	}
 
 	if (args.json) {
-		console.log(JSON.stringify({ before: beforePath, after: afterPath, result }, null, 2));
+		console.log(JSON.stringify({ before: beforePath, after: afterPath, skipped, result }, null, 2));
 	} else {
-		console.log(`\n${render(result, beforePath, afterPath).join('\n')}`);
+		console.log(`\n${render(result, beforePath, afterPath, skipped).join('\n')}`);
 	}
 
 	if (args.failOnRegression && result.evaluationUnits.some((unit) => unit.delta < 0)) {

--- a/packages/@n8n/instance-ai/evaluations/cli/compare-local.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/compare-local.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// Compare two LOCAL eval runs — the measurement step of eval-driven
+// development on Instance AI.
+//
+//   pnpm eval:compare-local --before .output/edd/before --after .output/edd/after
+//
+// Both sides are `eval-results.json` artifacts written by any run (the direct
+// driver writes one with no LangSmith involvement at all). Units are keyed and
+// graded by the same `comparison/` code the CI PR comment uses, so a local
+// verdict and a CI verdict cannot drift into disagreeing about what a unit is.
+//
+// Deliberately NOT reusing `formatComparisonTerminal`: that renderer takes a
+// MultiRunEvaluation, which a persisted artifact cannot faithfully rebuild, and
+// it renders a whole eval report. What the EDD loop wants is narrower — which
+// units moved, in which direction, and did anything move that you weren't
+// aiming at.
+//
+// Read the output as direction and blast radius, not as a verdict. The verdict
+// column is the CI-grade tier, and at the iteration counts a local loop can
+// afford most real movement grades 'stable' (3/3 -> 2/3 is not significant) —
+// the run prints a power note saying so whenever N is small.
+// ---------------------------------------------------------------------------
+
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+	bucketFromResultsJson,
+	readEvalResults,
+	EvalResultsParseError,
+} from '../comparison/bucket-from-results-json';
+import { compareBuckets, unitKeyOf } from '../comparison/compare';
+import type { ComparisonResult, EvaluationUnitComparison, UnitRef } from '../comparison/compare';
+
+const USAGE = `
+Compare two local eval runs (no LangSmith required).
+
+  pnpm eval:compare-local --before <path> --after <path> [options]
+
+  --before <path>          Baseline side: a run's --output-dir, or its eval-results.json
+  --after  <path>          Changed side: same
+  --json                   Emit the raw comparison as JSON instead of the report
+  --fail-on-regression     Exit 1 when any unit's pass rate dropped
+  --help                   This message
+
+Typical use, from packages/@n8n/instance-ai/ with LANGSMITH_API_KEY unset:
+
+  pnpm eval:instance-ai --filter my-case --iterations 3 --output-dir .output/edd/before
+  # ...make the change, rebuild, restart the instance...
+  pnpm eval:instance-ai --filter my-case --iterations 3 --output-dir .output/edd/after
+  pnpm eval:compare-local --before .output/edd/before --after .output/edd/after
+`;
+
+interface CliArgs {
+	before: string;
+	after: string;
+	json: boolean;
+	failOnRegression: boolean;
+}
+
+function nextArg(argv: string[], index: number, flag: string): string {
+	const value = argv[index + 1];
+	if (value === undefined || value.startsWith('--')) {
+		throw new Error(`${flag} needs a value`);
+	}
+	return value;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	let before: string | undefined;
+	let after: string | undefined;
+	let json = false;
+	let failOnRegression = false;
+
+	for (let i = 0; i < argv.length; i++) {
+		switch (argv[i]) {
+			case '--before':
+				before = nextArg(argv, i, '--before');
+				i++;
+				break;
+			case '--after':
+				after = nextArg(argv, i, '--after');
+				i++;
+				break;
+			case '--json':
+				json = true;
+				break;
+			case '--fail-on-regression':
+				failOnRegression = true;
+				break;
+			case '--help':
+			case '-h':
+				console.log(USAGE);
+				process.exit(0);
+				break;
+			default:
+				throw new Error(`Unknown argument: ${String(argv[i])}`);
+		}
+	}
+
+	if (!before || !after) throw new Error('Both --before and --after are required.');
+	return { before, after, json, failOnRegression };
+}
+
+/** Accept either a run's output directory or the results file inside it. */
+function resolveResultsPath(input: string): string {
+	try {
+		if (statSync(input).isDirectory()) return join(input, 'eval-results.json');
+	} catch {
+		// Fall through — readEvalResults reports the missing path with guidance.
+	}
+	return input;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const INDENT = '  ';
+// Wide enough to leave a gap after the longest kind name ('expectation').
+const KIND_WIDTH = 13;
+const KEY_WIDTH = 58;
+
+function pct(rate: number): string {
+	return `${(rate * 100).toFixed(1)}%`;
+}
+
+function pp(delta: number): string {
+	const points = delta * 100;
+	return `${points >= 0 ? '+' : ''}${points.toFixed(1)}pp`;
+}
+
+function truncate(text: string, width: number): string {
+	return text.length <= width ? text.padEnd(width) : `${text.slice(0, width - 1)}…`;
+}
+
+function unitLine(unit: EvaluationUnitComparison): string {
+	const counts = `${String(unit.baselinePasses)}/${String(unit.baselineTotal)} → ${String(unit.prPasses)}/${String(unit.prTotal)}`;
+	return `${INDENT.repeat(2)}${unit.kind.padEnd(KIND_WIDTH)}${truncate(unitKeyOf(unit), KEY_WIDTH)}  ${counts.padEnd(13)}  ${pp(unit.delta).padStart(8)}  ${unit.verdict}`;
+}
+
+function refLine(ref: UnitRef): string {
+	return `${INDENT.repeat(2)}${ref.kind.padEnd(KIND_WIDTH)}${unitKeyOf(ref)}`;
+}
+
+/**
+ * Largest per-unit trial count on either side. Drives the statistical-power
+ * note: at the iteration counts a local loop can afford, the strict tier is
+ * mathematically unreachable and reporting a "no regressions" result without
+ * saying so would be misleading.
+ */
+function maxTrialsPerUnit(result: ComparisonResult): number {
+	let max = 0;
+	for (const unit of result.evaluationUnits) {
+		max = Math.max(max, unit.prTotal, unit.baselineTotal);
+	}
+	return max;
+}
+
+function render(result: ComparisonResult, beforePath: string, afterPath: string): string[] {
+	const lines: string[] = [];
+	const title = 'Instance AI — local before/after';
+	lines.push(title);
+	lines.push('═'.repeat(title.length));
+
+	lines.push(`${INDENT}before  ${beforePath}`);
+	lines.push(`${INDENT}after   ${afterPath}`);
+	lines.push('');
+
+	const { aggregate } = result;
+	lines.push(
+		`${INDENT}Aggregate  ${pct(aggregate.baselineAggregatePassRate)} → ${pct(aggregate.prAggregatePassRate)}  (${pp(aggregate.delta)} over ${String(aggregate.intersectionSize)} shared unit(s))`,
+	);
+	lines.push('');
+
+	const regressed = result.evaluationUnits
+		.filter((unit) => unit.delta < 0)
+		.sort((a, b) => a.delta - b.delta);
+	const improved = result.evaluationUnits
+		.filter((unit) => unit.delta > 0)
+		.sort((a, b) => b.delta - a.delta);
+	const unchanged = result.evaluationUnits.length - regressed.length - improved.length;
+
+	if (regressed.length > 0) {
+		lines.push(`${INDENT}WORSE AFTER  (blast radius — account for every line before you push)`);
+		lines.push(...regressed.map(unitLine));
+		lines.push('');
+	}
+	if (improved.length > 0) {
+		lines.push(`${INDENT}BETTER AFTER`);
+		lines.push(...improved.map(unitLine));
+		lines.push('');
+	}
+	if (unchanged > 0) {
+		lines.push(`${INDENT}UNCHANGED  ${String(unchanged)} unit(s)`);
+		lines.push('');
+	}
+
+	// A changed case set is the single most common way a local comparison
+	// misleads: the units you care about silently drop out of the intersection.
+	if (result.prOnly.length > 0) {
+		lines.push(`${INDENT}ONLY IN AFTER  (no before-side counterpart — not compared)`);
+		lines.push(...result.prOnly.map(refLine));
+		lines.push('');
+	}
+	if (result.baselineOnly.length > 0) {
+		lines.push(`${INDENT}ONLY IN BEFORE  (disappeared from the after run — not compared)`);
+		lines.push(...result.baselineOnly.map(refLine));
+		lines.push('');
+	}
+
+	const notable = result.failureCategories.filter((category) => category.notable);
+	if (notable.length > 0) {
+		lines.push(`${INDENT}FAILURE-CATEGORY DRIFT`);
+		for (const category of notable) {
+			lines.push(
+				`${INDENT.repeat(2)}${category.category.padEnd(22)}${pct(category.baselineRate)} → ${pct(category.prRate)}  (${pp(category.delta)})`,
+			);
+		}
+		lines.push('');
+	}
+
+	if (result.evaluationUnits.length === 0) {
+		lines.push(
+			`${INDENT}No shared units. The two runs covered different cases — check the --filter/--tier on both.`,
+		);
+		lines.push('');
+		return lines;
+	}
+
+	const maxTrials = maxTrialsPerUnit(result);
+	if (maxTrials < 6) {
+		lines.push(
+			`${INDENT}N is small (at most ${String(maxTrials)} trial(s) per unit). At this N only a near-total`,
+		);
+		lines.push(
+			`${INDENT}flip clears the high-confidence 'regression' tier — a unit that loses a single`,
+		);
+		lines.push(
+			`${INDENT}trial still grades 'stable'. Read the counts, not the verdict column, and raise`,
+		);
+		lines.push(`${INDENT}--iterations before calling any one line a regression.`);
+		lines.push('');
+	}
+
+	return lines;
+}
+
+// ---------------------------------------------------------------------------
+
+function main(): void {
+	let args: CliArgs;
+	try {
+		args = parseArgs(process.argv.slice(2));
+	} catch (error: unknown) {
+		console.error(error instanceof Error ? error.message : String(error));
+		console.error(USAGE);
+		process.exit(1);
+	}
+
+	const beforePath = resolveResultsPath(args.before);
+	const afterPath = resolveResultsPath(args.after);
+
+	let result: ComparisonResult;
+	try {
+		// pr = after, baseline = before: a negative delta means the change made it worse.
+		result = compareBuckets(
+			bucketFromResultsJson(readEvalResults(afterPath), 'after'),
+			bucketFromResultsJson(readEvalResults(beforePath), 'before'),
+		);
+	} catch (error: unknown) {
+		if (error instanceof EvalResultsParseError) {
+			console.error(error.message);
+			process.exit(1);
+		}
+		throw error;
+	}
+
+	if (args.json) {
+		console.log(JSON.stringify({ before: beforePath, after: afterPath, result }, null, 2));
+	} else {
+		console.log(`\n${render(result, beforePath, afterPath).join('\n')}`);
+	}
+
+	if (args.failOnRegression && result.evaluationUnits.some((unit) => unit.delta < 0)) {
+		process.exit(1);
+	}
+}
+
+main();

--- a/packages/@n8n/instance-ai/evaluations/cli/compare-local.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/compare-local.ts
@@ -243,9 +243,24 @@ function render(
 	}
 
 	if (result.evaluationUnits.length === 0) {
+		// Two very different situations, and telling a developer to go check their
+		// --filter when the filter was right sends them hunting a bug that isn't
+		// there. If either side contributed units that simply didn't pair up, the
+		// runs really did cover different cases; if neither side produced a unit
+		// at all, the cases ran and were ungradeable — a failed build leaves every
+		// expectation unjudged, which is the common cause.
+		const eitherSideHadUnits = result.prOnly.length > 0 || result.baselineOnly.length > 0;
 		lines.push(
-			`${INDENT}No shared units. The two runs covered different cases — check the --filter/--tier on both.`,
+			eitherSideHadUnits
+				? `${INDENT}No shared units — the two runs covered different cases. Check the --filter/--tier on both.`
+				: `${INDENT}Neither run produced a graded unit, so there is nothing to compare. A build that`,
 		);
+		if (!eitherSideHadUnits) {
+			lines.push(
+				`${INDENT}fails leaves every expectation unjudged; check the run log and the HTML report`,
+			);
+			lines.push(`${INDENT}before reading anything into this.`);
+		}
 		lines.push('');
 		return lines;
 	}

--- a/packages/@n8n/instance-ai/evaluations/comparison/bucket-from-results-json.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/bucket-from-results-json.ts
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------
+// Local comparison bucket: project a PERSISTED eval-results.json onto the
+// ExperimentBucket shape used by compareBuckets.
+//
+// The sibling `bucket-from-evaluation.ts` projects the in-memory
+// MultiRunEvaluation and is reachable only from the LangSmith driver, whose
+// other side comes from `fetchBaselineBucket`. The direct driver writes
+// eval-results.json and never compares — so two local runs of the same cases
+// had no comparison path at all, even though the statistics that grade them
+// (comparison/statistics.ts) have no LangSmith dependency whatsoever.
+//
+// This reads the artifact back under the SAME unit keys, which is what lets a
+// before/after pair be graded by the same code CI grades a PR with, offline.
+// ---------------------------------------------------------------------------
+
+import { readFileSync } from 'node:fs';
+import { z } from 'zod';
+
+import {
+	expectationUnitKey,
+	scenarioUnitKey,
+	type EvaluationUnitCounts,
+	type ExperimentBucket,
+} from './compare';
+
+// The subset of eval-results.json a unit comparison needs. Unknown keys are
+// stripped rather than rejected: the artifact also carries transcripts,
+// workflow JSON and per-run verifier detail that this projection has no use
+// for, and pinning those here would make the reader brittle against harness
+// changes it does not care about. The fields below are the load-bearing ones —
+// the writer side is pinned by `__tests__/eval-results-dispatcher-contract.test.ts`.
+const scenarioRunSchema = z.object({
+	passed: z.boolean(),
+	incomplete: z.boolean().optional(),
+	failureCategory: z.string().optional(),
+});
+
+const scenarioSchema = z.object({
+	name: z.string(),
+	passCount: z.number(),
+	evaluatedCount: z.number(),
+	runs: z.array(scenarioRunSchema).default([]),
+});
+
+const buildExpectationSchema = z.object({
+	expectation: z.string(),
+	passCount: z.number(),
+	evaluatedCount: z.number(),
+});
+
+const testCaseSchema = z.object({
+	name: z.string().optional(),
+	testCaseFile: z.string().optional(),
+	scenarios: z.array(scenarioSchema).default([]),
+	buildExpectations: z.array(buildExpectationSchema).default([]),
+});
+
+const evalResultsSchema = z.object({
+	timestamp: z.string().optional(),
+	totalRuns: z.number().optional(),
+	testCases: z.array(testCaseSchema),
+});
+
+export type ParsedEvalResults = z.infer<typeof evalResultsSchema>;
+
+/** Thrown when the file exists but is not an eval-results.json we can compare. */
+export class EvalResultsParseError extends Error {}
+
+/**
+ * Parse an already-read eval-results.json payload.
+ *
+ * Separate from the file read so callers that already hold the JSON (a test, a
+ * future sweep-side consumer) don't have to round-trip through disk.
+ */
+export function parseEvalResults(raw: unknown, source: string): ParsedEvalResults {
+	const parsed = evalResultsSchema.safeParse(raw);
+	if (!parsed.success) {
+		const issue = parsed.error.issues[0];
+		const where = issue?.path.join('.') ?? '(root)';
+		throw new EvalResultsParseError(
+			`${source} is not a readable eval-results.json — at \`${where}\`: ${issue?.message ?? 'unknown parse error'}`,
+		);
+	}
+	return parsed.data;
+}
+
+/** Read and parse an eval-results.json from disk. */
+export function readEvalResults(path: string): ParsedEvalResults {
+	let text: string;
+	try {
+		text = readFileSync(path, 'utf8');
+	} catch {
+		throw new EvalResultsParseError(
+			`Cannot read ${path}. Point --before/--after at a run's --output-dir (or directly at its eval-results.json).`,
+		);
+	}
+	let json: unknown;
+	try {
+		json = JSON.parse(text);
+	} catch (error: unknown) {
+		throw new EvalResultsParseError(
+			`${path} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	return parseEvalResults(json, path);
+}
+
+/**
+ * Project parsed results onto an ExperimentBucket.
+ *
+ * Unit semantics are deliberately identical to `bucketFromEvaluation`, because
+ * the two buckets are compared against each other in the CI path and must not
+ * disagree about what counts:
+ *
+ * - a scenario contributes a unit keyed `file/scenario`;
+ * - a build expectation contributes one keyed `file#expectation:text`, and only
+ *   when it was actually evaluated (an unevaluated expectation is unmeasured,
+ *   not a zero);
+ * - `trialTotal` and `failureCategoryTotals` stay scenario-only, and skip
+ *   verifier-incomplete runs — those carry no verdict, so they are not trials.
+ *
+ * A case with no `testCaseFile` throws rather than being skipped: the whole
+ * comparison is keyed on that slug, so dropping the case would quietly shrink
+ * the intersection and read as "this unit is new" on the other side.
+ */
+export function bucketFromResultsJson(
+	results: ParsedEvalResults,
+	experimentName: string,
+): ExperimentBucket {
+	const evaluationUnits = new Map<string, EvaluationUnitCounts>();
+	const failureCategoryTotals: Record<string, number> = {};
+	let trialTotal = 0;
+
+	for (const tc of results.testCases) {
+		const fileSlug = tc.testCaseFile;
+		if (!fileSlug) {
+			throw new EvalResultsParseError(
+				`bucketFromResultsJson: no testCaseFile for test case "${(tc.name ?? '(unnamed)').slice(0, 60)}" in ${experimentName} — cannot key its units for comparison`,
+			);
+		}
+
+		for (const scenario of tc.scenarios) {
+			const failureCategories: Record<string, number> = {};
+			for (const run of scenario.runs) {
+				if (run.incomplete) continue;
+				trialTotal++;
+				if (!run.passed && run.failureCategory) {
+					failureCategories[run.failureCategory] =
+						(failureCategories[run.failureCategory] ?? 0) + 1;
+					failureCategoryTotals[run.failureCategory] =
+						(failureCategoryTotals[run.failureCategory] ?? 0) + 1;
+				}
+			}
+			evaluationUnits.set(scenarioUnitKey(fileSlug, scenario.name), {
+				kind: 'scenario',
+				testCaseFile: fileSlug,
+				name: scenario.name,
+				passed: scenario.passCount,
+				total: scenario.evaluatedCount,
+				failureCategories,
+			});
+		}
+
+		for (const expectation of tc.buildExpectations) {
+			if (expectation.evaluatedCount === 0) continue;
+			evaluationUnits.set(expectationUnitKey(fileSlug, expectation.expectation), {
+				kind: 'expectation',
+				testCaseFile: fileSlug,
+				name: expectation.expectation,
+				passed: expectation.passCount,
+				total: expectation.evaluatedCount,
+			});
+		}
+	}
+
+	return { experimentName, evaluationUnits, failureCategoryTotals, trialTotal };
+}

--- a/packages/@n8n/instance-ai/evaluations/comparison/bucket-from-results-json.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/bucket-from-results-json.ts
@@ -105,6 +105,16 @@ export function readEvalResults(path: string): ParsedEvalResults {
 	return parseEvalResults(json, path);
 }
 
+export interface ResultsBucket {
+	bucket: ExperimentBucket;
+	/**
+	 * Display names of cases dropped for carrying no `testCaseFile`. Never
+	 * discard this silently — it is the difference between "that unit didn't
+	 * move" and "that unit was never compared".
+	 */
+	skipped: string[];
+}
+
 /**
  * Project parsed results onto an ExperimentBucket.
  *
@@ -119,24 +129,30 @@ export function readEvalResults(path: string): ParsedEvalResults {
  * - `trialTotal` and `failureCategoryTotals` stay scenario-only, and skip
  *   verifier-incomplete runs — those carry no verdict, so they are not trials.
  *
- * A case with no `testCaseFile` throws rather than being skipped: the whole
- * comparison is keyed on that slug, so dropping the case would quietly shrink
- * the intersection and read as "this unit is new" on the other side.
+ * **A case with no `testCaseFile` is skipped and reported, not thrown on.**
+ * `testCaseFile` comes from `slugByTestCase`, which `persist.ts` cannot build
+ * on the crash-recovery path when `testCasesWithFiles` is absent — so a whole
+ * artifact can land without slugs, and real dispatcher output does exactly
+ * that. Failing the comparison outright would take away the tool at the moment
+ * a run died and you most need to see what survived. Skipping quietly would be
+ * worse still, so the count rides back out with the bucket and the caller is
+ * expected to show it. If *every* case is unkeyable there is nothing to
+ * compare and that is an error.
  */
 export function bucketFromResultsJson(
 	results: ParsedEvalResults,
 	experimentName: string,
-): ExperimentBucket {
+): ResultsBucket {
 	const evaluationUnits = new Map<string, EvaluationUnitCounts>();
 	const failureCategoryTotals: Record<string, number> = {};
+	const skipped: string[] = [];
 	let trialTotal = 0;
 
 	for (const tc of results.testCases) {
 		const fileSlug = tc.testCaseFile;
 		if (!fileSlug) {
-			throw new EvalResultsParseError(
-				`bucketFromResultsJson: no testCaseFile for test case "${(tc.name ?? '(unnamed)').slice(0, 60)}" in ${experimentName} — cannot key its units for comparison`,
-			);
+			skipped.push((tc.name ?? '(unnamed)').slice(0, 70));
+			continue;
 		}
 
 		for (const scenario of tc.scenarios) {
@@ -173,5 +189,14 @@ export function bucketFromResultsJson(
 		}
 	}
 
-	return { experimentName, evaluationUnits, failureCategoryTotals, trialTotal };
+	if (results.testCases.length > 0 && skipped.length === results.testCases.length) {
+		throw new EvalResultsParseError(
+			`Every test case in ${experimentName} is missing \`testCaseFile\`, so none of them can be keyed for comparison. This artifact cannot be compared.`,
+		);
+	}
+
+	return {
+		bucket: { experimentName, evaluationUnits, failureCategoryTotals, trialTotal },
+		skipped,
+	};
 }

--- a/packages/@n8n/instance-ai/evaluations/discovery/cli.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/cli.ts
@@ -6,13 +6,19 @@
 //   pnpm eval:discovery                                # run all scenarios, 3 trials each
 //   pnpm eval:discovery --filter slack-oauth --verbose
 //   pnpm eval:discovery --trials 5
+//   pnpm eval:discovery --filter slack-oauth --trials 5 --output-dir .output/edd/before
 //
 // Loads scenarios from evaluations/data/discovery/, runs each scenario × N
 // trials via the in-process runner, reports per-scenario pass-rates, exits
 // non-zero on any scenario below threshold, or on any scenario with zero passes
 // when --fail-on-zero-pass is set.
+//
+// With --output-dir it also writes an eval-results.json in the workflow lane's
+// shape, so `pnpm eval:compare-local` can diff two discovery runs the same way
+// it diffs two workflow runs.
 // ---------------------------------------------------------------------------
 
+import { writeDiscoveryEvalResults } from './results-artifact';
 import { runDiscoveryScenario, type DiscoveryRunResult } from './runner';
 import type { DiscoveryTestCase } from './types';
 import { loadDiscoveryTestCasesWithFiles } from '../data/discovery';
@@ -33,6 +39,8 @@ interface CliArgs {
 	concurrency: number;
 	nodesJsonPath?: string;
 	failOnZeroPass: boolean;
+	/** When set, write an eval-results.json here for `eval:compare-local`. */
+	outputDir?: string;
 }
 
 const DEFAULT_MODEL = process.env.N8N_INSTANCE_AI_EVAL_MODEL ?? 'anthropic/claude-sonnet-4-6';
@@ -125,6 +133,9 @@ function parseArgs(argv: string[]): CliArgs {
 			case '--fail-on-zero-pass':
 				args.failOnZeroPass = true;
 				break;
+			case '--output-dir':
+				args.outputDir = argv[++i];
+				break;
 			default:
 				break;
 		}
@@ -139,12 +150,15 @@ function parseArgs(argv: string[]): CliArgs {
 
 interface ScenarioAggregate {
 	scenario: DiscoveryTestCase;
+	/** Case filename without .json — the key the comparison joins on. */
+	fileSlug: string;
 	results: DiscoveryRunResult[];
 	passCount: number;
 	passRate: number;
 }
 
 async function runLocalMode(args: CliArgs): Promise<void> {
+	const startedAt = Date.now();
 	const cases = loadDiscoveryTestCasesWithFiles(args.filter);
 
 	if (cases.length === 0) {
@@ -211,10 +225,21 @@ async function runLocalMode(args: CliArgs): Promise<void> {
 			}
 		}
 
-		aggregates.push({ scenario: testCase, results: trialResults, passCount, passRate });
+		aggregates.push({ scenario: testCase, fileSlug, results: trialResults, passCount, passRate });
 	}
 
 	printSummary(aggregates, args);
+
+	if (args.outputDir !== undefined) {
+		const written = writeDiscoveryEvalResults(
+			args.outputDir,
+			aggregates,
+			args.trials,
+			Date.now() - startedAt,
+		);
+		console.log(`\nWrote ${written}`);
+		console.log('Compare two runs with: pnpm eval:compare-local --before <dir> --after <dir>');
+	}
 
 	const failingScenarios = aggregates.filter((a) => a.passRate < args.passThreshold);
 	const zeroPassScenarios = aggregates.filter((a) => a.passCount === 0);

--- a/packages/@n8n/instance-ai/evaluations/discovery/results-artifact.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/results-artifact.ts
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------------------
+// Persist a discovery run as an `eval-results.json` the local comparison
+// (`cli/compare-local.ts`) can read.
+//
+// Discovery is the cheapest lane — in-process, no build, no sandbox — which
+// makes it the one a developer reaches for most while iterating. It used to
+// print pass rates and exit, leaving the before/after step of the EDD loop with
+// nothing to diff on exactly that lane. Writing the workflow lane's artifact
+// shape means one comparison tool serves both.
+//
+// The shape is a deliberate SUBSET: a discovery scenario has no built workflow,
+// no execution scenarios and no build expectations, so each scenario becomes a
+// single scenario unit keyed `<fileSlug>/tool-discovery`. Everything the
+// comparison actually reads (unit keys, pass/evaluated counts, per-trial
+// verdicts, failure categories) is present; nothing else is invented.
+// ---------------------------------------------------------------------------
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { DiscoveryRunResult } from './runner';
+import type { DiscoveryTestCase } from './types';
+
+/**
+ * The single unit name every discovery scenario reports under. A discovery
+ * scenario carries exactly one pass condition, so the scenario file IS the
+ * unit; a constant here keeps the key readable (`my-scenario/tool-discovery`)
+ * without repeating the slug on both sides of the separator.
+ */
+export const DISCOVERY_UNIT_NAME = 'tool-discovery';
+
+export interface DiscoveryScenarioAggregate {
+	scenario: DiscoveryTestCase;
+	fileSlug: string;
+	results: DiscoveryRunResult[];
+	passCount: number;
+}
+
+/**
+ * Which failure category a failed trial reports.
+ *
+ * The distinction is load-bearing for the comparison's failure-category drift
+ * table: a change that starts making runs time out is a different finding from
+ * one that starts routing to the wrong tool, and reporting both as one category
+ * would hide the former behind the latter.
+ */
+function failureCategoryFor(result: DiscoveryRunResult): string {
+	if (result.runError !== undefined) return 'framework_issue';
+	if (result.streamStatus === 'errored' || result.streamStatus === 'timed-out') {
+		return 'framework_issue';
+	}
+	return 'builder_issue';
+}
+
+export function buildDiscoveryEvalResults(
+	aggregates: DiscoveryScenarioAggregate[],
+	trials: number,
+	durationMs: number,
+): unknown {
+	const scenariosTotal = aggregates.length;
+	const evaluated = aggregates.reduce((sum, a) => sum + a.results.length, 0);
+	const passed = aggregates.reduce((sum, a) => sum + a.passCount, 0);
+
+	return {
+		timestamp: new Date().toISOString(),
+		duration: durationMs,
+		totalRuns: trials,
+		summary: {
+			testCases: aggregates.length,
+			scenariosTotal,
+			passRatePerIter: evaluated > 0 ? passed / evaluated : 0,
+		},
+		comparisonStatus: 'not_attempted',
+		testCases: aggregates.map((aggregate) => ({
+			// `testCaseFile` is what the comparison keys on — never omit it.
+			testCaseFile: aggregate.fileSlug,
+			name: aggregate.scenario.userMessage.slice(0, 70),
+			status: 'verified',
+			totalRuns: trials,
+			scenarios: [
+				{
+					name: DISCOVERY_UNIT_NAME,
+					passCount: aggregate.passCount,
+					evaluatedCount: aggregate.results.length,
+					totalRuns: trials,
+					runs: aggregate.results.map((result) => ({
+						passed: result.check.pass,
+						score: result.check.pass ? 1 : 0,
+						reasoning: result.check.comment,
+						...(result.check.pass ? {} : { failureCategory: failureCategoryFor(result) }),
+					})),
+				},
+			],
+			buildExpectations: [],
+		})),
+	};
+}
+
+/** Write the artifact into `outputDir`, creating it if needed. Returns the path. */
+export function writeDiscoveryEvalResults(
+	outputDir: string,
+	aggregates: DiscoveryScenarioAggregate[],
+	trials: number,
+	durationMs: number,
+): string {
+	mkdirSync(outputDir, { recursive: true });
+	const target = join(outputDir, 'eval-results.json');
+	writeFileSync(
+		target,
+		`${JSON.stringify(buildDiscoveryEvalResults(aggregates, trials, durationMs), null, 2)}\n`,
+	);
+	return target;
+}

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -17,6 +17,7 @@
     "eval:agents": "tsx evaluations/cli/index.ts --source langtracer --suite agents --tier agents",
     "eval:build-mcp-manifest": "tsx evaluations/cli/build-mcp-manifest.ts",
     "eval:langtracer-push": "tsx evaluations/cli/langtracer-push.ts",
+    "eval:compare-local": "tsx evaluations/cli/compare-local.ts",
     "eval:serve-fixture": "tsx evaluations/cli/serve-fixture.ts",
     "eval:pairwise": "tsx evaluations/cli/pairwise.ts",
     "eval:pairwise:report": "tsx evaluations/cli/report.ts",


### PR DESCRIPTION
## Summary

Adds the developer-facing loop for making an Instance AI **behaviour** change: state a falsifiable claim, find or author the unit that guards it, baseline the unchanged tree, make the change, and measure before/after.

**The measurement step did not exist.** `evaluations/comparison/` already holds the whole apparatus — `compareBuckets`, `classifyScenario` (Fisher's exact + Wilson), the regression tiering — and `compare.ts` / `statistics.ts` / `format.ts` / `gate.ts` import nothing from LangSmith. But `bucketFromEvaluation` is reachable only from `run/langsmith-driver.ts`. The direct driver writes `eval-results.json` and never compares, so two local runs of the same cases had no comparison path at all.

Three pieces:

- **`comparison/bucket-from-results-json.ts`** — projects a persisted `eval-results.json` onto `ExperimentBucket` under the *same* `scenarioUnitKey` / `expectationUnitKey`, with the same rules about what counts (unevaluated expectations are unmeasured, not zeros; verifier-incomplete runs are not trials). A test asserts this projection and `bucketFromEvaluation` agree on keys, counts and trial totals for the same logical run — that drift would otherwise be silent.
- **`cli/compare-local.ts`** (`pnpm eval:compare-local`) — renders the pair as *unit flips* rather than a full eval report. Deliberately not reusing `formatComparisonTerminal`, which needs a `MultiRunEvaluation` a persisted artifact can't faithfully rebuild.
- **`.agents/skills/instance-ai-edd/`** — the gated loop, plus a coverage map that routes a claim to the cheapest lane that can grade it (discovery → subagent → workflow) and covers how to scope the blast-radius run.

### On reading small-N results honestly

The CLI prints a power note when N is small, because the numbers are easy to over-read. Measured against the real classifier:

| Movement | N=3 | N=5 |
|---|---|---|
| 3/3 → 0/3 | `hard_regression` | `hard_regression` |
| 3/3 → 1/3 | `soft_regression` | — |
| 3/3 → 2/3 (lost one trial) | **`stable`** | — |
| 5/5 → 4/5 (lost one trial) | — | **`stable`** |

A unit that loses a single trial grades `stable` at any N a local loop can afford. That's correct — one trial in three is weak evidence — but it means the skill tells developers to read the counts, not the verdict column, and reserves verdicts for the higher-N CI run.

### No LangSmith

Everything here runs on the direct driver. The CLI's dependency closure is `zod` plus node builtins, so it also runs in a half-built checkout. The skill's one operational rule is "never export `LANGSMITH_API_KEY` in this loop" — it's a single switch that flips the driver, records an experiment, writes into the shared dataset, and turns on builder trace capture.

The PR gate itself is unchanged and still LangSmith-backed (`ci-instance-ai-evals.yml` → `test-evals-instance-ai.yml` with `secrets: inherit`); the skill says so rather than implying the whole path is clean.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm vitest run evaluations/__tests__/bucket-from-results-json.test.ts

# against two real runs (LANGSMITH_API_KEY unset)
pnpm eval:instance-ai --filter <slug> --iterations 3 --output-dir .output/edd/before
# ...change something, pnpm build, restart the instance...
pnpm eval:instance-ai --filter <slug> --iterations 3 --output-dir .output/edd/after
pnpm eval:compare-local --before .output/edd/before --after .output/edd/after
```

`--before` / `--after` accept a run's output dir or the `eval-results.json` directly. `--json` emits the raw `ComparisonResult`; `--fail-on-regression` exits 1 when any unit's pass rate dropped.

Verified in this branch: the 7 unit tests pass, and the CLI was exercised end to end against synthetic `eval-results.json` pairs covering improved units, a collateral drop, a case present on only one side, failure-category drift, and the error paths (missing file, non-JSON, wrong-shaped JSON, missing args — all exit 1). `eslint` and `prettier --check` are clean on the new files.

## Related Linear tickets, Github issues, and Community forum posts

_None — raise one if this should be tracked._

## Follow-up worth taking: record EDD runs in lang-tracer

This loop is deliberately local. Both runs write to a gitignored `.output/edd/`, `eval:compare-local` prints to a terminal, and the only thing that survives is the EDD summary block someone pastes into a PR body by hand. That is the right first step — cheap, no CI dependency, works offline — but it throws away the run.

The upgrade is to dispatch the same case set through the developer's **personal lang-tracer dispatcher** instead of (or after) the local run. lang-tracer already has everything the local loop lacks:

- **Run history and pass rates per case**, so "was this unit always flaky?" is a lookup rather than an argument.
- **The version matrix**, so a regression is attributed to an n8n version rather than guessed at.
- **The case-revision trail**, which distinguishes *"n8n regressed"* from *"someone edited the case"* — precisely the ambiguity that leaves a red case sitting in CI for weeks with no owner.
- **Attribution.** A recorded run ties a behaviour change to the change that caused it, so finding the owner of a regression later is a lookup instead of a bisect.

Personal-dispatcher runs are already quarantined from shared history (`case_runs.source='personal_eval'`, read through the `case_runs_shared` view), so this wouldn't pollute the team's numbers.

Worth doing once the local loop has proven itself in practice. Not in this PR.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- dev tooling only; the skill and coverage map are the docs -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Td9NVDefJrvGEoVS57oaF


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

