### PR TITLE
fix(core): Throw on malformed input in String.urlDecode

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
@@ -214,10 +214,14 @@ export function toDateTime(value: string, extraArgs: [string] = ['']): DateTime 
 
 function urlDecode(value: string, extraArgs: boolean[]): string {
 	const [entireString = false] = extraArgs;
-	if (entireString) {
-		return decodeURI(value.toString());
+	try {
+		if (entireString) {
+			return decodeURI(value.toString());
+		}
+		return decodeURIComponent(value.toString());
+	} catch {
+		throw new ExpressionExtensionError('cannot decode URI component');
 	}
-	return decodeURIComponent(value.toString());
 }
 
 function urlEncode(value: string, extraArgs: boolean[]): string {

--- a/packages/workflow/src/extensions/string-extensions.ts
+++ b/packages/workflow/src/extensions/string-extensions.ts
@@ -254,10 +254,14 @@ export function toDateTime(value: string, extraArgs: [string] = ['']): DateTime 
 
 function urlDecode(value: string, extraArgs: boolean[]): string {
 	const [entireString = false] = extraArgs;
-	if (entireString) {
-		return decodeURI(value.toString());
+	try {
+		if (entireString) {
+			return decodeURI(value.toString());
+		}
+		return decodeURIComponent(value.toString());
+	} catch {
+		throw new ExpressionExtensionError('cannot decode URI component');
 	}
-	return decodeURIComponent(value.toString());
 }
 
 function urlEncode(value: string, extraArgs: boolean[]): string {

--- a/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
@@ -65,6 +65,10 @@ describe('Data Transformation Functions', () => {
 			);
 		});
 
+		test('.urlDecode should throw on malformed input (#37794)', () => {
+			expect(() => evaluate('={{ "%%%".urlDecode() }}')).toThrow(ExpressionExtensionError);
+		});
+
 		test('.urlEncode should work correctly on a string', () => {
 			expect(evaluate('={{ "string with spaces".urlEncode(false) }}')).toEqual(
 				'string%20with%20spaces',


### PR DESCRIPTION
## Summary

`String.urlDecode()` called `decodeURI`/`decodeURIComponent` unwrapped, so malformed percent-encoding threw a raw `URIError` that expressions swallowed into silent `undefined`. It now throws `ExpressionExtensionError` like every other string converter. The same one-block fix is applied to the duplicated implementation in `@n8n/expression-runtime` (used by the vm/quickjs engines).

## How to test

1. Evaluate `={{ "%%%".urlDecode() }}` as a node parameter.
2. Observe an `ExpressionExtensionError` now. Before the fix, it returned `undefined`.
3. Run `pnpm vitest run test/ExpressionExtensions/string-extensions.test.ts` in `packages/workflow`. All 132 tests pass in 3 engines, including the new regression test (red without the fix on all 3 engines, green with it).

## Related issues

Fixes #37794

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

