### PR TITLE
fix(core): Reject non-positive sizes in Array.chunk

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/array-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/array-extensions.ts
@@ -203,8 +203,10 @@ function smartJoin(value: unknown[], extraArgs: string[]): object {
 
 function chunk(value: unknown[], extraArgs: number[]) {
 	const [chunkSize] = extraArgs;
-	if (typeof chunkSize !== 'number' || chunkSize === 0) {
-		throw new ExpressionExtensionError('chunk(): expected non-zero numeric arg, e.g. .chunk(5)');
+	if (typeof chunkSize !== 'number' || Number.isNaN(chunkSize) || chunkSize < 1) {
+		throw new ExpressionExtensionError(
+			'chunk(): expected chunk size of at least 1, e.g. .chunk(5)',
+		);
 	}
 	const chunks: unknown[][] = [];
 	for (let i = 0; i < value.length; i += chunkSize) {

--- a/packages/workflow/src/extensions/array-extensions.ts
+++ b/packages/workflow/src/extensions/array-extensions.ts
@@ -203,8 +203,10 @@ function smartJoin(value: unknown[], extraArgs: string[]): object {
 
 function chunk(value: unknown[], extraArgs: number[]) {
 	const [chunkSize] = extraArgs;
-	if (typeof chunkSize !== 'number' || chunkSize === 0) {
-		throw new ExpressionExtensionError('chunk(): expected non-zero numeric arg, e.g. .chunk(5)');
+	if (typeof chunkSize !== 'number' || Number.isNaN(chunkSize) || chunkSize < 1) {
+		throw new ExpressionExtensionError(
+			'chunk(): expected chunk size of at least 1, e.g. .chunk(5)',
+		);
 	}
 	const chunks: unknown[][] = [];
 	for (let i = 0; i < value.length; i += chunkSize) {

--- a/packages/workflow/test/ExpressionExtensions/array-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/array-extensions.test.ts
@@ -2,6 +2,7 @@
 
 import { evaluate } from './helpers';
 import { arrayExtensions } from '../../src/extensions/array-extensions';
+import { ExpressionExtensionError } from '../../src/errors';
 import { jsonParse } from '../../src/utils';
 
 describe('Data Transformation Functions', () => {
@@ -415,6 +416,13 @@ describe('Data Transformation Functions', () => {
 				[11, 12, 13, 14, 15],
 				[16, 17, 18, 19, 20],
 			]);
+		});
+
+		test('.chunk() should throw on non-positive size instead of hanging (#37796)', () => {
+			expect(() => evaluate('={{ numberList(1, 20).chunk(-1) }}')).toThrow(
+				ExpressionExtensionError,
+			);
+			expect(() => evaluate('={{ numberList(1, 20).chunk(0) }}')).toThrow(ExpressionExtensionError);
 		});
 
 		test('.toJsonString() should work on an array', () => {


### PR DESCRIPTION
## Summary

`Array.chunk()` with a negative size never returns: the guard rejects only non-numbers and `0`, so `chunk(-1)` steps the loop backwards forever (on the legacy engine it even OOMs the worker building an unbounded array). It now throws `ExpressionExtensionError` like other invalid arguments. The same one-block fix is applied to the mirrored copy in `@n8n/expression-runtime` (used by the vm/quickjs engines).

## How to test

1. Evaluate `={{ [1,2,3].chunk(-1) }}` as a node parameter.
2. Observe an `ExpressionExtensionError` now. Before the fix, evaluation hung forever (legacy engine run OOM-crashed instead of finishing).
3. Run `pnpm vitest run test/ExpressionExtensions/array-extensions.test.ts` in `packages/workflow`. All 150 tests pass in 3 engines, including the new regression test (red without the fix, green with it).

## Related issues

Fixes #37796

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

