### PR TITLE
docs: Add optional eval source observations

### DIFF
--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -53,7 +53,7 @@ trim), **calibration** (classify each red and resolve keep/loosen/drop), and
 
 | Level | Who decides when to stop | Behaviour |
 |---|---|---|
-| **autonomous** | agent | Runs all four gates start-to-finish; reports a **decision log** at the end for the driver to review — with the pushed case, its suite, and the source thread as **links** ([Share links, never bare ids](#share-links-never-bare-ids)), and a Linear ticket **proposal** for any kept capability-gap red ([Capability gap → propose a Linear ticket](#capability-gap--propose-a-linear-ticket)). |
+| **autonomous** | agent | Runs all four gates start-to-finish; reports a **decision log** at the end for the driver to review — with the pushed case, its suite, and the source thread as **links** ([Share links, never bare ids](#share-links-never-bare-ids)); includes the observation id when the driver opted to record one; and includes a Linear ticket **proposal** for any kept capability-gap red ([Capability gap → propose a Linear ticket](#capability-gap--propose-a-linear-ticket)). |
 | **checkpoint** | driver, per gate | Stops at each gate with a compact **proposal + recommendation**; driver says "go" or redirects. At the **calibration** gate, hands the driver a link to the just-built thread on the live instance plus login credentials so they can review the real conversation and workflow themselves before confirming (below). |
 
 **Calibration is special-cased at both levels.** A calibration verdict that
@@ -62,6 +62,15 @@ any loosening that would let a known-bad build pass — is **surfaced explicitly
 (interactively in checkpoint; in the decision log in autonomous), never silently
 committed. It's the one call where a quiet mistake corrupts the suite, so it
 never fully auto-commits.
+
+**Recording a source observation is optional, not a fifth gate.** After a real
+thread passes selection, offer to save why it was selected and what the developer
+observed with LangTracer's `create_observation` tool (see
+[`sourcing-cases.md`](sourcing-cases.md#optional-record-the-selection-as-an-observation)).
+If the driver declines, has not stated a preference in autonomous mode, or the
+write fails, continue with the eval. Never block drafting, calibration, or push
+on an observation. `create_observation` and `update_observation` write only to
+LangTracer; do not add a LangSmith feedback or sync step.
 
 **Checkpoint calibration — review the real thread on the instance.** Because the
 calibration verdict is trust-critical, in checkpoint mode you don't ask the
@@ -198,7 +207,8 @@ the combinatorial bulk. A case that never builds tests nothing.
 ## Workflow
 
 These steps map to the four gates from [Set the autonomy level first](#set-the-autonomy-level-first):
-sourcing (before step 1) is the **selection** gate; steps 1–2 are the **shape +
+sourcing (before step 1) is the **selection** gate, including the optional offer
+to record a source observation; steps 1–2 are the **shape +
 expectations** gate; steps 5–6 are the **calibration** gate; steps 7–8 are the
 **push** gate. In *autonomous* mode you flow through all of them and summarize in
 a decision log; in *checkpoint* mode you pause at each with a proposal, and at

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -62,17 +62,62 @@ ids. Full table in
    content-dependent claim ("invented ID", "missing node") can be wrong when it
    couldn't see the built workflow. Confirm against the raw trace before building
    a case around it.
-4. **Encode a durable synthetic case** — turn the confirmed failure into an
+4. **Optionally record the selection as an observation.** Offer to save why this
+   thread was selected and what the developer observed. This is a best-effort
+   LangTracer note, not a gate: skip it when the developer declines or has not
+   stated a preference, and continue if the write fails. See
+   [Optional: record the selection as an observation](#optional-record-the-selection-as-an-observation).
+5. **Encode a durable synthetic case** — turn the confirmed failure into an
    authored case ([SKILL.md](SKILL.md), [`case-shapes.md`](case-shapes.md)). The
    failure mode is the anchor; the conversation is yours to write, in the user's
    voice.
-5. **Push it to a curated suite** (don't commit the JSON) with
+6. **Push it to a curated suite** (don't commit the JSON) with
    `eval:langtracer-push` — see
    [Push to a lang-tracer suite](SKILL.md#push-to-a-lang-tracer-suite). An `inline`
    seed rides along with the case. Exception: a `replay` case is refused and listed
    under `skipped:` — it's reconstructed from a trace at run time, so it dies when
-   that trace is pruned and has no durable home; that's exactly why step 4 turns the
+   that trace is pruned and has no durable home; that's exactly why step 5 turns the
    confirmed failure into a durable synthetic case.
+
+## Optional: record the selection as an observation
+
+After the raw trace confirms the finding, offer the developer one optional
+record before drafting:
+
+- **Why did you choose this thread?** Capture why it is useful eval coverage,
+  such as impact, recurrence, reproducibility, or a gap in the current suite.
+- **What did you observe?** Capture the concrete behavior, the expected behavior,
+  and the run or turn that contains the strongest evidence.
+
+If the developer opts in, call LangTracer's `create_observation` tool. Map the
+record like this:
+
+- `sourceThreadId`: the selected imported thread.
+- `sourceRunId` and `anchorRunId`: the evidence run, when the finding is narrower
+  than the whole conversation.
+- `kind`: `capability_gap` for a confirmed failure, `regression` for successful
+  behavior worth protecting, or `binary_check` when that is the intended output.
+- `description`: why the developer selected this thread.
+- `openCodeNote`: what the developer observed, in reviewer voice.
+- `expectedBehavior`, `failurePattern`, and `proposedCheck`: the rule, the
+  observed deviation, and the check the eval should enforce.
+- `severity` and `failureClass`: include them only when the evidence supports the
+  classification.
+- `isTestCaseCandidate`: `true` because the developer selected it for eval
+  authoring.
+
+This record is optional. Do not pause an autonomous run to request it when the
+driver has not already opted in. In checkpoint mode, offer it once with the
+selection proposal. A declined offer, unavailable MCP tool, or failed write must
+not stop the eval workflow. Report a successful observation by id with the source
+conversation link; otherwise omit it from the handoff.
+
+Calibration can sharpen the note. If an observation exists, use
+`update_observation` only for mutable details such as the expected behavior,
+failure pattern, proposed check, severity, failure class, or reviewer note. Its
+`kind` and source provenance are immutable, so classify the source evidence
+before creation. Both observation tools are LangTracer-local. Do not create or
+update LangSmith feedback for this record.
 
 ## Was the workflow handed over? (sourcing an `attach` opening)
 


### PR DESCRIPTION
## Summary

- Add an optional source-observation step to the Instance AI eval authoring skill.
- Ask why the developer selected the thread and what behavior they observed.
- Keep a declined offer, an unknown preference, an unavailable MCP tool, or a failed write from blocking the eval workflow.
- Keep observation writes local to LangTracer. Do not add LangSmith feedback or synchronization.

## How to test

1. Run `pnpm check:skill-links`.
2. Run `pnpm exec prettier --check .agents/skills/create-instance-ai-eval/SKILL.md .agents/skills/create-instance-ai-eval/sourcing-cases.md`.
3. Confirm that both commands pass.
4. Read the selection flow and confirm that observation creation is optional and non-blocking.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

