### PR TITLE
feat(engine): Route poll trigger runs to the engine 2.0 data plane

### DIFF
--- a/packages/cli/src/services/__tests__/engine-v2-payload-guard.service.test.ts
+++ b/packages/cli/src/services/__tests__/engine-v2-payload-guard.service.test.ts
@@ -85,6 +85,25 @@ describe('EngineV2PayloadGuard', () => {
 		});
 	});
 
+	describe('hasFiles', () => {
+		it.each([
+			{ name: 'no slots', slots: [] },
+			{ name: 'an empty slot', slots: [[]] },
+			{ name: 'a null slot', slots: [null] },
+			{ name: 'items with no binary key', slots: [[{ json: {} }]] },
+			{ name: 'an empty binary map', slots: [[{ json: {}, binary: {} }]] },
+		])('answers false for a payload with $name', ({ slots }) => {
+			expect(guard.hasFiles(slots)).toBe(false);
+		});
+
+		it.each([
+			{ name: 'a stored file', file: stored('filesystem:abc') },
+			{ name: 'an in-memory file', file: inMemory() },
+		])('answers true for a payload with $name', ({ file }) => {
+			expect(guard.hasFiles([[{ json: {}, binary: { attachment: file } }]])).toBe(true);
+		});
+	});
+
 	describe('discardFiles', () => {
 		it('deletes the stored files without refusing', async () => {
 			const slots = [[{ json: {}, binary: { attachment: stored('filesystem:abc') } }]];

--- a/packages/cli/src/services/__tests__/engine-v2-payload-guard.service.test.ts
+++ b/packages/cli/src/services/__tests__/engine-v2-payload-guard.service.test.ts
@@ -34,21 +34,21 @@ describe('EngineV2PayloadGuard', () => {
 			{ name: 'a null slot', slots: [null] },
 			{ name: 'items with no binary key', slots: [[{ json: {} }]] },
 			{ name: 'an empty binary map', slots: [[{ json: {}, binary: {} }]] },
-		])('allows a payload with $name', async ({ slots }) => {
-			await expect(guard.assertNoFiles(slots, REASON)).resolves.toBeUndefined();
+		])('allows a payload with $name', ({ slots }) => {
+			expect(() => guard.assertNoFiles(slots, REASON)).not.toThrow();
 			expect(binaryDataService.deleteManyByBinaryDataId).not.toHaveBeenCalled();
 		});
 
-		it('refuses a stored file and deletes it, because no execution will own it', async () => {
+		it('refuses a stored file and deletes it, because no execution will own it', () => {
 			const slots = [[{ json: {}, binary: { attachment: stored('filesystem:abc') } }]];
 
-			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(REASON);
+			expect(() => guard.assertNoFiles(slots, REASON)).toThrow(REASON);
 			expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
 				'filesystem:abc',
 			]);
 		});
 
-		it('deletes every stored file across slots and items', async () => {
+		it('deletes every stored file across slots and items', () => {
 			const slots: Array<INodeExecutionData[] | null> = [
 				[
 					{ json: {}, binary: { a: stored('filesystem:1') } },
@@ -58,7 +58,7 @@ describe('EngineV2PayloadGuard', () => {
 				[{ json: {}, binary: { d: stored('filesystem:3') } }],
 			];
 
-			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(UserError);
+			expect(() => guard.assertNoFiles(slots, REASON)).toThrow(UserError);
 			expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
 				'filesystem:1',
 				'filesystem:2',
@@ -66,10 +66,10 @@ describe('EngineV2PayloadGuard', () => {
 			]);
 		});
 
-		it('refuses an in-memory file without a delete, as it has no id', async () => {
+		it('refuses an in-memory file without a delete, as it has no id', () => {
 			const slots = [[{ json: {}, binary: { attachment: inMemory() } }]];
 
-			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(REASON);
+			expect(() => guard.assertNoFiles(slots, REASON)).toThrow(REASON);
 			expect(binaryDataService.deleteManyByBinaryDataId).not.toHaveBeenCalled();
 		});
 
@@ -77,54 +77,13 @@ describe('EngineV2PayloadGuard', () => {
 			binaryDataService.deleteManyByBinaryDataId.mockRejectedValue(new Error('store is down'));
 			const slots = [[{ json: {}, binary: { attachment: stored('s3:abc') } }]];
 
-			await expect(guard.assertNoFiles(slots, REASON)).rejects.toThrow(REASON);
-			expect(logger.error).toHaveBeenCalledWith(
-				'Failed to delete the files of a rejected engine 2.0 payload',
-				expect.objectContaining({ error: expect.any(Error) }),
+			expect(() => guard.assertNoFiles(slots, REASON)).toThrow(REASON);
+			await vi.waitFor(() =>
+				expect(logger.error).toHaveBeenCalledWith(
+					'Failed to delete the files of a rejected engine 2.0 payload',
+					expect.objectContaining({ error: expect.any(Error) }),
+				),
 			);
-		});
-	});
-
-	describe('hasFiles', () => {
-		it.each([
-			{ name: 'no slots', slots: [] },
-			{ name: 'an empty slot', slots: [[]] },
-			{ name: 'a null slot', slots: [null] },
-			{ name: 'items with no binary key', slots: [[{ json: {} }]] },
-			{ name: 'an empty binary map', slots: [[{ json: {}, binary: {} }]] },
-		])('answers false for a payload with $name', ({ slots }) => {
-			expect(guard.hasFiles(slots)).toBe(false);
-		});
-
-		it.each([
-			{ name: 'a stored file', file: stored('filesystem:abc') },
-			{ name: 'an in-memory file', file: inMemory() },
-		])('answers true for a payload with $name', ({ file }) => {
-			expect(guard.hasFiles([[{ json: {}, binary: { attachment: file } }]])).toBe(true);
-		});
-	});
-
-	describe('discardFiles', () => {
-		it('deletes the stored files without refusing', async () => {
-			const slots = [[{ json: {}, binary: { attachment: stored('filesystem:abc') } }]];
-
-			await expect(guard.discardFiles(slots)).resolves.toBeUndefined();
-			expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
-				'filesystem:abc',
-			]);
-		});
-
-		it('does nothing for a payload with no files', async () => {
-			await expect(guard.discardFiles([[{ json: {} }]])).resolves.toBeUndefined();
-			expect(binaryDataService.deleteManyByBinaryDataId).not.toHaveBeenCalled();
-		});
-
-		it('never throws when the delete fails, so the caller keeps its own answer', async () => {
-			binaryDataService.deleteManyByBinaryDataId.mockRejectedValue(new Error('store is down'));
-			const slots = [[{ json: {}, binary: { attachment: stored('s3:abc') } }]];
-
-			await expect(guard.discardFiles(slots)).resolves.toBeUndefined();
-			expect(logger.error).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/services/engine-v2-payload-guard.service.ts
+++ b/packages/cli/src/services/engine-v2-payload-guard.service.ts
@@ -34,12 +34,20 @@ export class EngineV2PayloadGuard {
 	 * served rather than a generic message.
 	 */
 	async assertNoFiles(slots: PayloadSlots, reason: string): Promise<void> {
-		const files = this.filesIn(slots);
-		if (files.length === 0) return;
+		if (!this.hasFiles(slots)) return;
 
-		await this.deleteStoredFiles(files);
+		await this.deleteStoredFiles(this.filesIn(slots));
 
 		throw new UserError(reason);
+	}
+
+	/**
+	 * Whether a payload carries a file, checked synchronously so a caller that
+	 * cannot await (a poll's `__emit`) can still refuse before doing anything
+	 * that only makes sense for a run it is about to start.
+	 */
+	hasFiles(slots: PayloadSlots): boolean {
+		return this.filesIn(slots).length > 0;
 	}
 
 	/**

--- a/packages/cli/src/services/engine-v2-payload-guard.service.ts
+++ b/packages/cli/src/services/engine-v2-payload-guard.service.ts
@@ -32,33 +32,19 @@ export class EngineV2PayloadGuard {
 	 *
 	 * `reason` names the surface, so the user hears which trigger could not be
 	 * served rather than a generic message.
+	 *
+	 * Refuses synchronously, so a caller that cannot await (a poll's `__emit`)
+	 * still refuses before doing anything that only makes sense for a run it is
+	 * about to start. The delete runs detached: nobody reads its result, and
+	 * {@link deleteStoredFiles} never throws.
 	 */
-	async assertNoFiles(slots: PayloadSlots, reason: string): Promise<void> {
-		if (!this.hasFiles(slots)) return;
-
-		await this.deleteStoredFiles(this.filesIn(slots));
-
-		throw new UserError(reason);
-	}
-
-	/**
-	 * Whether a payload carries a file, checked synchronously so a caller that
-	 * cannot await (a poll's `__emit`) can still refuse before doing anything
-	 * that only makes sense for a run it is about to start.
-	 */
-	hasFiles(slots: PayloadSlots): boolean {
-		return this.filesIn(slots).length > 0;
-	}
-
-	/**
-	 * Deletes the files of a payload that is being discarded for some other
-	 * reason. Never throws: the caller's own refusal is the answer.
-	 */
-	async discardFiles(slots: PayloadSlots): Promise<void> {
+	assertNoFiles(slots: PayloadSlots, reason: string): void {
 		const files = this.filesIn(slots);
 		if (files.length === 0) return;
 
-		await this.deleteStoredFiles(files);
+		void this.deleteStoredFiles(files);
+
+		throw new UserError(reason);
 	}
 
 	/** An empty `binary` map carries no file, so it does not count. */
@@ -68,8 +54,9 @@ export class EngineV2PayloadGuard {
 
 	/**
 	 * Only stored modes give a file an id; in memory the data rides on the item and
-	 * there is nothing to delete. A failed delete leaks a file, which must not
-	 * replace the caller's reason with a storage error.
+	 * there is nothing to delete. Never throws: a failed delete leaks a file, which
+	 * must not replace the caller's reason with a storage error, and callers detach
+	 * this call.
 	 */
 	private async deleteStoredFiles(files: IBinaryData[]): Promise<void> {
 		const storedIds = files.map((file) => file.id).filter((id) => id !== undefined);

--- a/packages/cli/src/webhooks/engine-v2-webhooks.ts
+++ b/packages/cli/src/webhooks/engine-v2-webhooks.ts
@@ -113,8 +113,8 @@ export class EngineV2Webhooks {
 	 * Only the webhook node's own output says whether the request brought a file,
 	 * so this runs after the node, unlike {@link assertSupported}.
 	 */
-	async assertPayloadSupported(webhookResultData: IWebhookResponseData): Promise<void> {
-		await this.payloadGuard.assertNoFiles(
+	assertPayloadSupported(webhookResultData: IWebhookResponseData): void {
+		this.payloadGuard.assertNoFiles(
 			webhookResultData.workflowData ?? [],
 			'Engine 2.0 cannot receive files from a webhook yet.',
 		);

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -916,7 +916,7 @@ export async function executeWebhook(
 
 		// The node's output is the only place a file shows up, so this cannot run with
 		// the checks above.
-		if (routesToEngineV2) await engineV2Webhooks.assertPayloadSupported(webhookResultData);
+		if (routesToEngineV2) engineV2Webhooks.assertPayloadSupported(webhookResultData);
 
 		// Reactive credential-status gate. Runs only once we know the workflow will
 		// execute (workflowData is defined), so a falsy "Only Run If" short-circuits

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -414,6 +414,96 @@ describe('WorkflowExecutionService', () => {
 		});
 	});
 
+	describe('runPolledWorkflowV2()', () => {
+		const node = mock<INode>({ id: 'node-1', name: 'Poll Node' });
+		const workflow = mock<IWorkflowBase>({
+			id: 'wf-1',
+			active: true,
+			activeVersionId: 'some-version-id',
+			nodes: [node],
+		});
+		const cursor = { lastItemId: 'a' };
+		const pollItems = [[{ json: { id: 1 } }]];
+		let responsePromise: MockProxy<IDeferredPromise<IExecuteResponsePromiseData>>;
+
+		const runPolledWorkflowV2 = async () =>
+			await workflowExecutionService.runPolledWorkflowV2(
+				workflow,
+				node,
+				pollItems,
+				additionalData,
+				'trigger',
+				cursor,
+				responsePromise,
+			);
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			responsePromise = mock<IDeferredPromise<IExecuteResponsePromiseData>>();
+			workflowRunner.run.mockResolvedValue('exec-v2');
+			pollCursorService.commitCursorOnly.mockResolvedValue(true);
+		});
+
+		test('starts the run before committing the cursor, and returns its id', async () => {
+			const returned = await runPolledWorkflowV2();
+
+			expect(returned).toBe('exec-v2');
+			expect(workflowRunner.run).toHaveBeenCalledWith(
+				expect.objectContaining({ workflowData: workflow }),
+				true,
+				undefined,
+				undefined,
+				responsePromise,
+			);
+			expect(pollCursorService.commitCursorOnly).toHaveBeenCalledWith({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor,
+				fence: undefined,
+			});
+		});
+
+		test('never commits the cursor when the run fails to start', async () => {
+			const runError = new Error('engine 2.0 rejected the run');
+			workflowRunner.run.mockRejectedValue(runError);
+
+			await expect(runPolledWorkflowV2()).rejects.toBe(runError);
+
+			expect(pollCursorService.commitCursorOnly).not.toHaveBeenCalled();
+		});
+
+		test('logs, but does not fail the run, when the lease is gone by the time it commits', async () => {
+			pollCursorService.commitCursorOnly.mockResolvedValue(false);
+
+			const returned = await runPolledWorkflowV2();
+
+			expect(returned).toBe('exec-v2');
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Poll cursor commit skipped after its execution already started: the poll no longer holds its lease',
+				{ workflowId: 'wf-1', nodeId: 'node-1', nodeName: 'Poll Node', executionId: 'exec-v2' },
+			);
+		});
+
+		test('passes the fence through to the cursor commit', async () => {
+			const fence = { taskId: 'task-1', leaseEpoch: 3 };
+
+			await workflowExecutionService.runPolledWorkflowV2(
+				workflow,
+				node,
+				pollItems,
+				additionalData,
+				'trigger',
+				cursor,
+				responsePromise,
+				fence,
+			);
+
+			expect(pollCursorService.commitCursorOnly).toHaveBeenCalledWith(
+				expect.objectContaining({ fence }),
+			);
+		});
+	});
+
 	describe('executeManually()', () => {
 		beforeEach(() => {
 			workflowRunner.run.mockClear();

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -449,7 +449,14 @@ describe('WorkflowExecutionService', () => {
 
 			expect(returned).toBe('exec-v2');
 			expect(workflowRunner.run).toHaveBeenCalledWith(
-				expect.objectContaining({ workflowData: workflow }),
+				expect.objectContaining({
+					workflowData: workflow,
+					executionData: expect.objectContaining({
+						executionData: expect.objectContaining({
+							nodeExecutionStack: [{ node, data: { main: pollItems }, source: null }],
+						}),
+					}),
+				}),
 				true,
 				undefined,
 				undefined,
@@ -461,6 +468,11 @@ describe('WorkflowExecutionService', () => {
 				cursor,
 				fence: undefined,
 			});
+			// The cursor must not advance until the data plane has confirmed the
+			// run: a commit before that could advance past items nothing carried.
+			expect(workflowRunner.run.mock.invocationCallOrder[0]).toBeLessThan(
+				pollCursorService.commitCursorOnly.mock.invocationCallOrder[0],
+			);
 		});
 
 		test('never commits the cursor when the run fails to start', async () => {

--- a/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
@@ -18,6 +18,7 @@ describe('EngineV2ActiveTriggers', () => {
 		vi.clearAllMocks();
 		payloadGuard.assertNoFiles.mockResolvedValue(undefined);
 		payloadGuard.discardFiles.mockResolvedValue(undefined);
+		payloadGuard.hasFiles.mockReturnValue(false);
 		engineV2ActiveTriggers = new EngineV2ActiveTriggers(dispatcher, payloadGuard);
 	});
 
@@ -88,12 +89,21 @@ describe('EngineV2ActiveTriggers', () => {
 		});
 	});
 
-	describe('assertPollSupported', () => {
-		it('always refuses', () => {
-			expect(() => engineV2ActiveTriggers.assertPollSupported()).toThrow(UserError);
-			expect(() => engineV2ActiveTriggers.assertPollSupported()).toThrow(
-				'Engine 2.0 cannot run polling triggers yet.',
+	describe('assertPollPayloadSupported', () => {
+		it('allows a payload with no files', () => {
+			payloadGuard.hasFiles.mockReturnValue(false);
+
+			expect(() => engineV2ActiveTriggers.assertPollPayloadSupported([[]])).not.toThrow();
+		});
+
+		it('refuses a payload that carries files', () => {
+			const slots = [[{ json: {}, binary: { data: mock<IBinaryData>() } }]];
+			payloadGuard.hasFiles.mockReturnValue(true);
+
+			expect(() => engineV2ActiveTriggers.assertPollPayloadSupported(slots)).toThrow(
+				'Engine 2.0 cannot receive files from a trigger yet.',
 			);
+			expect(payloadGuard.hasFiles).toHaveBeenCalledWith(slots);
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/engine-v2-active-triggers.test.ts
@@ -16,9 +16,7 @@ describe('EngineV2ActiveTriggers', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		payloadGuard.assertNoFiles.mockResolvedValue(undefined);
-		payloadGuard.discardFiles.mockResolvedValue(undefined);
-		payloadGuard.hasFiles.mockReturnValue(false);
+		payloadGuard.assertNoFiles.mockReturnValue(undefined);
 		engineV2ActiveTriggers = new EngineV2ActiveTriggers(dispatcher, payloadGuard);
 	});
 
@@ -61,10 +59,10 @@ describe('EngineV2ActiveTriggers', () => {
 	});
 
 	describe('assertPayloadSupported', () => {
-		it('asks the guard to refuse files, naming the trigger surface', async () => {
+		it('asks the guard to refuse files, naming the trigger surface', () => {
 			const slots = [[{ json: {}, binary: { data: mock<IBinaryData>() } }]];
 
-			await engineV2ActiveTriggers.assertPayloadSupported(slots);
+			engineV2ActiveTriggers.assertPayloadSupported(slots);
 
 			expect(payloadGuard.assertNoFiles).toHaveBeenCalledWith(
 				slots,
@@ -72,38 +70,12 @@ describe('EngineV2ActiveTriggers', () => {
 			);
 		});
 
-		it('surfaces the refusal the guard raises', async () => {
-			payloadGuard.assertNoFiles.mockRejectedValue(new UserError('nope'));
+		it('surfaces the refusal the guard raises, synchronously', () => {
+			payloadGuard.assertNoFiles.mockImplementation(() => {
+				throw new UserError('nope');
+			});
 
-			await expect(engineV2ActiveTriggers.assertPayloadSupported([[]])).rejects.toThrow('nope');
-		});
-	});
-
-	describe('discardFiles', () => {
-		it('hands the payload to the guard', async () => {
-			const slots = [[{ json: {} }]];
-
-			await engineV2ActiveTriggers.discardFiles(slots);
-
-			expect(payloadGuard.discardFiles).toHaveBeenCalledWith(slots);
-		});
-	});
-
-	describe('assertPollPayloadSupported', () => {
-		it('allows a payload with no files', () => {
-			payloadGuard.hasFiles.mockReturnValue(false);
-
-			expect(() => engineV2ActiveTriggers.assertPollPayloadSupported([[]])).not.toThrow();
-		});
-
-		it('refuses a payload that carries files', () => {
-			const slots = [[{ json: {}, binary: { data: mock<IBinaryData>() } }]];
-			payloadGuard.hasFiles.mockReturnValue(true);
-
-			expect(() => engineV2ActiveTriggers.assertPollPayloadSupported(slots)).toThrow(
-				'Engine 2.0 cannot receive files from a trigger yet.',
-			);
-			expect(payloadGuard.hasFiles).toHaveBeenCalledWith(slots);
+			expect(() => engineV2ActiveTriggers.assertPayloadSupported([[]])).toThrow('nope');
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1884,6 +1884,38 @@ describe('TriggerExecutionContextFactory', () => {
 				expect(workflowExecutionService.runWorkflow).toHaveBeenCalled();
 				expect(workflowExecutionService.runPolledWorkflowV2).not.toHaveBeenCalled();
 			});
+
+			test('re-checks the payload against fresh data when the registration snapshot missed the transition to engine 2.0', async () => {
+				const staleWorkflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const freshWorkflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				// The registration snapshot still says v1; only the fresh read reflects
+				// the workflow having since been republished onto engine 2.0.
+				engineV2Dispatcher.handlesWorkflow.mockImplementation((wf) => wf === freshWorkflowData);
+
+				const getPollFunctions = factory.getExecutePollFunctions(
+					staleWorkflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => freshWorkflowData,
+				);
+				const context = getPollFunctions(
+					workflow,
+					mock<INode>({ name: 'Poll Node' }),
+					additionalData,
+					mode,
+					activation,
+				);
+
+				const data: INodeExecutionData[][] = [[{ json: {}, binary: { attachment: storedFile } }]];
+				context.__emit(data);
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+				expect(binaryDataService.deleteManyByBinaryDataId).toHaveBeenCalledExactlyOnceWith([
+					'filesystem:abc',
+				]);
+			});
 		});
 
 		describe('a workflow that did not opt in', () => {

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -947,6 +947,47 @@ describe('TriggerExecutionContextFactory', () => {
 			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
 		});
 
+		test('routes to runPolledWorkflowV2, not the transactional runPolledWorkflow, on engine 2.0', async () => {
+			engineV2Dispatcher.handlesWorkflow.mockReturnValue(true);
+			workflowExecutionService.runPolledWorkflowV2.mockResolvedValue('exec-v2');
+			const responsePromise = createDeferredPromise<IExecuteResponsePromiseData>();
+
+			await context.__runPoll(async () => {
+				Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+				context.__emit(pollData, responsePromise);
+			});
+			await sleep(0);
+
+			expect(workflowExecutionService.runPolledWorkflowV2).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				node,
+				pollData,
+				additionalData,
+				mode,
+				{ lastItemId: 'a' },
+				responsePromise,
+				undefined,
+			);
+			expect(workflowExecutionService.runPolledWorkflow).not.toHaveBeenCalled();
+			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+		});
+
+		test('refuses a migrated poll that carries a file, and commits no cursor, on engine 2.0', async () => {
+			engineV2Dispatcher.handlesWorkflow.mockReturnValue(true);
+			const storedFile = mock<IBinaryData>({ id: 'filesystem:abc', mimeType: 'text/plain' });
+			const fileData: INodeExecutionData[][] = [[{ json: {}, binary: { attachment: storedFile } }]];
+
+			await context.__runPoll(async () => {
+				Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+				expect(() => context.__emit(fileData)).toThrow(
+					'Engine 2.0 cannot receive files from a trigger yet.',
+				);
+			});
+
+			expect(pollCursorService.commitCursorOnly).not.toHaveBeenCalled();
+			expect(workflowExecutionService.runPolledWorkflowV2).not.toHaveBeenCalled();
+		});
+
 		// A poll that neither emitted nor committed leaves its mutation behind; the next
 		// poll must not pick it up and commit an advance past items nobody carried.
 		const abandonedStaging = [
@@ -1823,15 +1864,25 @@ describe('TriggerExecutionContextFactory', () => {
 				]);
 			});
 
-			test('refuses the emit and commits no cursor', () => {
-				expect(() => pollContext().__emit([[{ json: {} }]])).toThrow(
-					'Engine 2.0 cannot run polling triggers yet.',
+			test('refuses an emit carrying a file, and commits no cursor', () => {
+				const data: INodeExecutionData[][] = [[{ json: {}, binary: { attachment: storedFile } }]];
+
+				expect(() => pollContext().__emit(data)).toThrow(
+					'Engine 2.0 cannot receive files from a trigger yet.',
 				);
 				expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
-				expect(workflowExecutionService.runPolledWorkflow).not.toHaveBeenCalled();
+				expect(workflowExecutionService.runPolledWorkflowV2).not.toHaveBeenCalled();
 				expect(pollCursorService.commitWithExecution).not.toHaveBeenCalled();
 				expect(pollCursorService.commitCursorOnly).not.toHaveBeenCalled();
 				expect(workflowStaticDataService.saveStaticData).not.toHaveBeenCalled();
+			});
+
+			test('hands an unmigrated emit to the plain runner, which dispatches it', async () => {
+				pollContext().__emit([[{ json: {} }]]);
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalled();
+				expect(workflowExecutionService.runPolledWorkflowV2).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
+++ b/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
@@ -85,13 +85,14 @@ export class EngineV2ActiveTriggers {
 	}
 
 	/**
-	 * Rejects a polled emit.
-	 *
-	 * A migrated poll node commits its cursor in the same transaction as the
-	 * execution row, which a v2 run does not create.
-	 * TODO(CAT-4078): commit the cursor against a data-plane execution instead.
+	 * Rejects a polled emit that carries files, synchronously so the refusal
+	 * happens before the poll's cursor is taken. The caller discards any files
+	 * already stored separately, since deleting them needs an await `__emit`
+	 * cannot give.
 	 */
-	assertPollSupported(): never {
-		throw new UserError('Engine 2.0 cannot run polling triggers yet.');
+	assertPollPayloadSupported(slots: Array<INodeExecutionData[] | null>): void {
+		if (!this.payloadGuard.hasFiles(slots)) return;
+
+		throw new UserError('Engine 2.0 cannot receive files from a trigger yet.');
 	}
 }

--- a/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
+++ b/packages/cli/src/workflows/triggers/engine-v2-active-triggers.ts
@@ -68,31 +68,11 @@ export class EngineV2ActiveTriggers {
 	 * the node's own output says whether it produced one, so this runs on the emit
 	 * rather than at activation. Email Read IMAP is the case that matters today:
 	 * it downloads attachments and passes no promise, so nothing else refuses it.
+	 *
+	 * Refuses synchronously, so a poll's `__emit` can call it before it takes the
+	 * staged cursor.
 	 */
-	async assertPayloadSupported(slots: Array<INodeExecutionData[] | null>): Promise<void> {
-		await this.payloadGuard.assertNoFiles(
-			slots,
-			'Engine 2.0 cannot receive files from a trigger yet.',
-		);
-	}
-
-	/**
-	 * Deletes the files of an emit refused for another reason, so a payload the
-	 * poll path turns away does not leave them behind. Never throws.
-	 */
-	async discardFiles(slots: Array<INodeExecutionData[] | null>): Promise<void> {
-		await this.payloadGuard.discardFiles(slots);
-	}
-
-	/**
-	 * Rejects a polled emit that carries files, synchronously so the refusal
-	 * happens before the poll's cursor is taken. The caller discards any files
-	 * already stored separately, since deleting them needs an await `__emit`
-	 * cannot give.
-	 */
-	assertPollPayloadSupported(slots: Array<INodeExecutionData[] | null>): void {
-		if (!this.payloadGuard.hasFiles(slots)) return;
-
-		throw new UserError('Engine 2.0 cannot receive files from a trigger yet.');
+	assertPayloadSupported(slots: Array<INodeExecutionData[] | null>): void {
+		this.payloadGuard.assertNoFiles(slots, 'Engine 2.0 cannot receive files from a trigger yet.');
 	}
 }

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -377,7 +377,7 @@ export class TriggerExecutionContextFactory {
 					void this.engineV2ActiveTriggers
 						.discardFiles(data)
 						.catch((error: unknown) => this.logTriggerExecutionFailure(error, workflowData, node));
-					this.engineV2ActiveTriggers.assertPollSupported();
+					this.engineV2ActiveTriggers.assertPollPayloadSupported(data);
 				}
 
 				const cursor = takeStagedCursor();
@@ -390,15 +390,28 @@ export class TriggerExecutionContextFactory {
 				// TODO(CAT-3202): resolves workflow data via callback so we
 				// can feature-flag between in-memory data and the published data
 				// service. Once the flag is removed, we'll call the service directly.
-				const executePromise = resolveWorkflowData().then(async (freshWorkflowData) =>
-					cursor === null
-						? await this.workflowExecutionService.runWorkflow(
+				const executePromise = resolveWorkflowData().then(async (freshWorkflowData) => {
+					if (cursor === null) {
+						return await this.workflowExecutionService.runWorkflow(
+							freshWorkflowData,
+							node,
+							data,
+							additionalData,
+							mode,
+							responsePromise,
+						);
+					}
+
+					return this.engineV2ActiveTriggers.handles(freshWorkflowData, mode)
+						? await this.workflowExecutionService.runPolledWorkflowV2(
 								freshWorkflowData,
 								node,
 								data,
 								additionalData,
 								mode,
+								cursor,
 								responsePromise,
+								fence,
 							)
 						: await this.workflowExecutionService.runPolledWorkflow(
 								freshWorkflowData,
@@ -409,8 +422,8 @@ export class TriggerExecutionContextFactory {
 								cursor,
 								responsePromise,
 								fence,
-							),
-				);
+							);
+				});
 
 				if (donePromise) this.settleDonePromise(executePromise, donePromise);
 

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -391,6 +391,20 @@ export class TriggerExecutionContextFactory {
 				// can feature-flag between in-memory data and the published data
 				// service. Once the flag is removed, we'll call the service directly.
 				const executePromise = resolveWorkflowData().then(async (freshWorkflowData) => {
+					// The registration snapshot above can be stale by the time this
+					// resolves (e.g. the workflow was just republished onto engine 2.0),
+					// so a payload that slipped past that check is guarded again here,
+					// against the copy that actually decides where this run goes.
+					const routesToV2 = this.engineV2ActiveTriggers.handles(freshWorkflowData, mode);
+					if (routesToV2) {
+						try {
+							await this.engineV2ActiveTriggers.assertPayloadSupported(data);
+						} catch (error) {
+							responsePromise?.reject(ensureError(error));
+							throw error;
+						}
+					}
+
 					if (cursor === null) {
 						return await this.workflowExecutionService.runWorkflow(
 							freshWorkflowData,
@@ -402,7 +416,7 @@ export class TriggerExecutionContextFactory {
 						);
 					}
 
-					return this.engineV2ActiveTriggers.handles(freshWorkflowData, mode)
+					return routesToV2
 						? await this.workflowExecutionService.runPolledWorkflowV2(
 								freshWorkflowData,
 								node,

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -116,15 +116,15 @@ export class TriggerExecutionContextFactory {
 	 * The done promise needs no help here: {@link settleDonePromise} rejects it
 	 * from the returned promise chain.
 	 */
-	private async assertEngineV2Supported(
+	private assertEngineV2Supported(
 		data: INodeExecutionData[][],
 		emit: EngineV2ActiveTriggerEmit,
-	): Promise<void> {
+	): void {
 		try {
 			// Files first, because this check deletes what it refuses: a refusal for
 			// any other reason would otherwise leave the stored files behind, owned by
 			// no execution.
-			await this.engineV2ActiveTriggers.assertPayloadSupported(data);
+			this.engineV2ActiveTriggers.assertPayloadSupported(data);
 			this.engineV2ActiveTriggers.assertSupported(emit);
 		} catch (error) {
 			emit.responsePromise?.reject(ensureError(error));
@@ -209,7 +209,7 @@ export class TriggerExecutionContextFactory {
 						// Checked against the fresh data, so this agrees with the dispatcher,
 						// which decides on the same copy.
 						if (this.engineV2ActiveTriggers.handles(freshWorkflowData, mode)) {
-							await this.assertEngineV2Supported(data, { responsePromise, donePromise });
+							this.assertEngineV2Supported(data, { responsePromise, donePromise });
 						}
 
 						return await this.workflowExecutionService.runWorkflow(
@@ -372,12 +372,7 @@ export class TriggerExecutionContextFactory {
 				// retried. Reads the registration's copy of the workflow rather than the
 				// fresh one for the same reason: the fresh read comes too late.
 				if (this.engineV2ActiveTriggers.handles(workflowData, mode)) {
-					// Detached because `__emit` is synchronous. The poll may have stored
-					// attachments, and no execution will ever own them.
-					void this.engineV2ActiveTriggers
-						.discardFiles(data)
-						.catch((error: unknown) => this.logTriggerExecutionFailure(error, workflowData, node));
-					this.engineV2ActiveTriggers.assertPollPayloadSupported(data);
+					this.engineV2ActiveTriggers.assertPayloadSupported(data);
 				}
 
 				const cursor = takeStagedCursor();
@@ -398,7 +393,7 @@ export class TriggerExecutionContextFactory {
 					const routesToV2 = this.engineV2ActiveTriggers.handles(freshWorkflowData, mode);
 					if (routesToV2) {
 						try {
-							await this.engineV2ActiveTriggers.assertPayloadSupported(data);
+							this.engineV2ActiveTriggers.assertPayloadSupported(data);
 						} catch (error) {
 							responsePromise?.reject(ensureError(error));
 							throw error;

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -259,6 +259,53 @@ export class WorkflowExecutionService {
 	}
 
 	/**
+	 * Starts a polled execution on engine 2.0, then advances the cursor.
+	 *
+	 * The v2 path keeps no control-plane execution row, so the cursor cannot
+	 * commit in the same transaction as the run the way {@link runPolledWorkflow}
+	 * does. It commits after the data plane confirms the run started instead: a
+	 * crash between the two calls can duplicate a poll, never lose one.
+	 * TODO(CAT-4078): add a dedup key once `StartExecutionRequest` supports one.
+	 */
+	async runPolledWorkflowV2(
+		workflowData: IWorkflowBase,
+		node: INode,
+		data: INodeExecutionData[][],
+		additionalData: IWorkflowExecuteAdditionalData,
+		mode: WorkflowExecuteMode,
+		cursor: PollCursor,
+		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
+		fence?: PollLeaseFence,
+	): Promise<string> {
+		const executionId = await this.runWorkflow(
+			workflowData,
+			node,
+			data,
+			additionalData,
+			mode,
+			responsePromise,
+		);
+
+		const committed = await this.pollCursorService.commitCursorOnly({
+			workflowId: workflowData.id,
+			nodeId: node.id,
+			cursor,
+			fence,
+		});
+
+		if (!committed) {
+			// The run already started; the lease loss only means a concurrent
+			// poller may repeat the same window, not that anything was lost.
+			this.logger.warn(
+				'Poll cursor commit skipped after its execution already started: the poll no longer holds its lease',
+				{ workflowId: workflowData.id, nodeId: node.id, nodeName: node.name, executionId },
+			);
+		}
+
+		return executionId;
+	}
+
+	/**
 	 * Marks a committed row that failed to start as crashed, so it does not sit at
 	 * `new` indefinitely.
 	 */


### PR DESCRIPTION
## Summary

Route poll trigger runs of an `engineType=v2` workflow to the engine 2.0 data
plane, completing what CAT-2921 started for active triggers.

A v2 run keeps no control-plane execution row, so a migrated poll's cursor
can't commit in the same transaction as the execution, like `v1` does. This
starts the run first, then advances the cursor with
`PollCursorService.commitCursorOnly`. A crash between the two can duplicate a
poll, never lose one — accepted per CAT-4078 (no dedup key yet).

An emit with files is still refused, reusing the active-trigger rule. An
unmigrated poll (no cursor) already worked via the existing `runWorkflow`
call.

## How to test

Requires `N8N_ENABLED_MODULES=engine-v2` and `N8N_ENGINE_DATABASE_URL`, regular mode.

1. Activate a migrated poll node with `settings.engineType: 'v2'`. Expect a
   new execution per tick with items.
2. A poll node that downloads a file → refused, "Engine 2.0 cannot receive
   files from a trigger yet."
3. Set `engineType` back to `'v1'` → today's behaviour.

### Automated tests

```bash
cd packages/cli
pnpm test src/workflows src/services/__tests__/engine-v2-payload-guard.service.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4379

Stacked on https://github.com/n8n-io/n8n/pull/37726 (CAT-2921). Retarget to
`master` once that merges.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
