### PR TITLE
feat(editor): Add agent card chat preview action

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types';
 import { getRandomAgentPersonalisationGradient } from '@n8n/api-types';
 import { agentsEventBus } from '../agents.eventBus';
+import { NEW_SESSION_PARAM } from '../constants';
 
 const routerPush = vi.fn();
 const routerReplace = vi.fn();
@@ -810,6 +811,18 @@ describe('AgentBuilderView — preview routing', { timeout: 60_000 }, () => {
 				},
 			}),
 		);
+	});
+
+	it('opens the preview dock with a new session when requested by the route', async () => {
+		localStorage.removeItem('N8N_AGENT_PREVIEW_OPEN:p1:a1');
+		routeQuery[NEW_SESSION_PARAM] = 'true';
+
+		const wrapper = await renderView();
+		const preview = wrapper.findComponent({ name: 'AgentPreviewDock' });
+
+		expect(preview.props('isOpen')).toBe(true);
+		expect(preview.props('effectiveSessionId')).toEqual(expect.any(String));
+		expect(preview.props('effectiveSessionId')).not.toBe('thread-1');
 	});
 
 	it('does not persist generated personalisation gradients for read-only agents', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCard.test.ts
@@ -176,6 +176,15 @@ describe('AgentCard', () => {
 		expect(badge.text()).toBe('agents.list.readonly');
 	});
 
+	it('starts a new chat from the dedicated button', async () => {
+		const wrapper = await renderComponent();
+
+		expect(wrapper.find('[data-action="newChat"]').exists()).toBe(false);
+		await wrapper.find('[data-test-id="agent-card-new-chat"]').trigger('click');
+
+		expect(wrapper.emitted('new-chat')).toEqual([['agent-1', 'project-1']]);
+	});
+
 	it('shows only the favorite toggle when no scopes grant publish or delete', async () => {
 		agentPermissionsMock.canDelete.value = false;
 		agentPermissionsMock.canPublish.value = false;

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentsListView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentsListView.test.ts
@@ -5,6 +5,7 @@ import type { AgentResource } from '../types';
 
 import AgentsListView from '../views/AgentsListView.vue';
 import { instanceAiCreateAgentRoute } from '@/features/ai/instanceAi/createAgentRoute';
+import { AGENT_BUILDER_VIEW, NEW_SESSION_PARAM } from '../constants';
 
 const mocks = vi.hoisted(() => ({
 	listAgentsPage: vi.fn(),
@@ -107,6 +108,7 @@ vi.mock('../components/AgentCard.vue', async () => {
 		default: defineComponent({
 			name: 'AgentCard',
 			props: ['agent', 'projectId'],
+			emits: ['new-chat'],
 			template: '<div data-test-id="agent-card">{{ agent.name }}</div>',
 		}),
 	};
@@ -170,6 +172,22 @@ describe('AgentsListView — project page', () => {
 		const layout = wrapper.findComponent({ name: 'ResourcesListLayout' });
 		expect(layout.props('type')).toBe('list-paginated');
 		expect(layout.props('dontPerformSortingAndFiltering')).toBe(true);
+	});
+
+	it('opens a new chat in the agent builder preview', async () => {
+		mocks.listAgentsPage.mockResolvedValueOnce({
+			count: 1,
+			data: [agent('agent-1', 'Support Agent')],
+		});
+		const wrapper = await mountView();
+
+		wrapper.findComponent({ name: 'AgentCard' }).vm.$emit('new-chat', 'agent-1', 'project-1');
+
+		expect(mocks.routerPush).toHaveBeenCalledWith({
+			name: AGENT_BUILDER_VIEW,
+			params: { projectId: 'project-1', agentId: 'agent-1' },
+			query: { [NEW_SESSION_PARAM]: 'true' },
+		});
 	});
 
 	it('refetches with backend search, pagination, and sorting parameters', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCard.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCard.vue
@@ -6,10 +6,11 @@ import {
 	N8nBadge,
 	N8nCard,
 	N8nIcon,
+	N8nIconButton,
 	N8nText,
 	N8nTooltip,
 } from '@n8n/design-system';
-import { useI18n, type BaseTextKey } from '@n8n/i18n';
+import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { MODAL_CONFIRM } from '@/app/constants';
 import TimeAgo from '@/app/components/TimeAgo.vue';
@@ -74,12 +75,7 @@ const favoriteStore = useFavoritesStore();
 const isFavorite = computed(() => favoriteStore.isFavorite(props.agent.id, 'agent'));
 
 const actions = computed(() => {
-	const items: Array<{ value: string; label: string; divided?: boolean }> = [
-		{
-			value: 'newChat',
-			label: locale.baseText('agents.list.actions.newChat' as BaseTextKey),
-		},
-	];
+	const items: Array<{ value: string; label: string; divided?: boolean }> = [];
 
 	if (isPublished.value && canUnpublish.value) {
 		items.push({
@@ -135,9 +131,7 @@ const formattedCreatedAtDate = computed(() => {
 });
 
 async function onAction(action: string) {
-	if (action === 'newChat') {
-		emit('new-chat', props.agent.id, props.projectId);
-	} else if (action === 'publish') {
+	if (action === 'publish') {
 		const updated = await publish(props.projectId, props.agent.id);
 		if (updated) emit('published', updated);
 	} else if (action === 'unpublish') {
@@ -220,6 +214,16 @@ async function toggleMCPAccess(enabled: boolean) {
 						{{ locale.baseText('agents.list.published') }}
 					</N8nText>
 				</div>
+				<N8nTooltip :content="locale.baseText('agents.list.actions.newChat')">
+					<N8nIconButton
+						icon="message-circle-plus"
+						variant="ghost"
+						size="medium"
+						:aria-label="locale.baseText('agents.list.actions.newChat')"
+						data-test-id="agent-card-new-chat"
+						@click="emit('new-chat', agent.id, projectId)"
+					/>
+				</N8nTooltip>
 				<N8nActionToggle
 					v-if="showActions"
 					:actions="actions"
@@ -273,7 +277,7 @@ async function toggleMCPAccess(enabled: boolean) {
 
 .cardActions {
 	display: flex;
-	gap: var(--spacing--2xs);
+	gap: var(--spacing--4xs);
 	flex-direction: row;
 	justify-content: center;
 	align-items: center;

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -1552,7 +1552,8 @@ async function initialize({ preserveState = false }: { preserveState?: boolean }
 			}
 		})();
 
-		if (isStandalonePreview.value && route.query[NEW_SESSION_PARAM] === 'true') {
+		if (!isArtifactMode.value && route.query[NEW_SESSION_PARAM] === 'true') {
+			persistedPreviewOpen.value = true;
 			onNewChat();
 		} else if (isPreviewActive.value) {
 			bindPreviewSession();

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentsListView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentsListView.vue
@@ -21,7 +21,7 @@ import {
 import { useAgentPermissions } from '../composables/useAgentPermissions';
 import { useAgentTelemetry } from '../composables/useAgentTelemetry';
 import type { AgentResource } from '../types';
-import { AGENT_BUILDER_VIEW, AGENT_PREVIEW_VIEW, NEW_SESSION_PARAM } from '../constants';
+import { AGENT_BUILDER_VIEW, NEW_SESSION_PARAM } from '../constants';
 import { instanceAiCreateAgentRoute } from '@/features/ai/instanceAi/createAgentRoute';
 import { generateNanoId } from '@n8n/utils/generate-nano-id';
 import AgentCard from '../components/AgentCard.vue';
@@ -114,7 +114,7 @@ function onSelectAgent(agentId: string, agentProjectId: string) {
 
 function onNewAgentChat(agentId: string, agentProjectId: string) {
 	void router.push({
-		name: AGENT_PREVIEW_VIEW,
+		name: AGENT_BUILDER_VIEW,
 		params: { projectId: agentProjectId, agentId },
 		query: { [NEW_SESSION_PARAM]: 'true' },
 	});


### PR DESCRIPTION
## Summary

- Move the New chat action from the agent card menu to a dedicated icon button.
- Open the agent builder with the preview panel visible.
- Start a new chat session when the preview opens.

<img width="2408" height="328" alt="CleanShot 2026-09-04 at 09 12 34@2x" src="https://github.com/user-attachments/assets/ae8f0bfa-6d4e-4ee5-86a6-0917caac3b12" />


## How to test

1. Open the Agents list.
2. Select the New chat icon on an agent card.
3. Confirm that the agent builder opens.
4. Confirm that the preview panel is visible.
5. Confirm that the preview starts a new chat session.
6. Confirm that the More options menu does not contain New chat.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-780

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)