### PR TITLE
fix(editor): Keep the typed AI Assistant prompt when no project is selected

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -481,6 +481,7 @@ async function handleSubmit(
 	}
 
 	if (!selectedProject.value) {
+		restoreDraftAfterFailedSubmit(message, restoreDraft);
 		toast.showError(new Error('Please select a project before starting a thread.'), 'Send failed');
 		return;
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -1073,6 +1073,23 @@ describe('InstanceAiEmptyView', () => {
 		},
 	);
 
+	it('restores the submitted draft when no project is selected', async () => {
+		const projectsStore = mockedStore(useProjectsStore);
+		projectsStore.personalProject = null;
+		const { getByRole, getByTestId } = renderView({
+			global: { stubs: { InstanceAiInput: false } },
+		});
+		const textbox = getByRole('textbox');
+
+		await fireEvent.update(textbox, 'Build me an invoice automation');
+		await fireEvent.click(getByTestId('instance-ai-send-button'));
+		await flushPromises();
+
+		expect(store.syncThread).not.toHaveBeenCalled();
+		expect(textbox).toHaveValue('Build me an invoice automation');
+		expect(showErrorMock).toHaveBeenCalled();
+	});
+
 	it('shows an upfront unavailable state and does not start a thread when the builder is unavailable', async () => {
 		useSettingsStore().moduleSettings = {
 			'instance-ai': {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiInput.test.ts
@@ -479,6 +479,7 @@ describe('InstanceAiInput', () => {
 		expect(emitted().submit?.[0]).toEqual([
 			'I want to build a new agent. Help me figure out what to build. Ask me what the main purpose of the agent is, what should trigger it into action, what apps, tools, or knowledge it should have access to, and whether I have a preference for the AI model used.',
 			undefined,
+			expect.any(Function),
 		]);
 		expect(textbox).toHaveValue('');
 	});
@@ -645,6 +646,25 @@ describe('InstanceAiInput', () => {
 		});
 	});
 
+	it('emits a draft recovery callback for a text-only message', async () => {
+		const { emitted, getByRole, getByTestId } = renderComponent({
+			props: { isStreaming: false },
+		});
+
+		const textbox = getByRole('textbox');
+		await userEvent.type(textbox, 'Build me an invoice workflow');
+		await userEvent.click(getByTestId('instance-ai-send-button'));
+
+		await waitFor(() => expect(emitted().submit?.[0]).toBeDefined());
+		expect(textbox).toHaveValue('');
+
+		const restoreDraft = emittedArgument(emitted().submit?.[0], 2);
+		expect(restoreDraft).toBeTypeOf('function');
+		if (typeof restoreDraft !== 'function') throw new Error('Expected a draft recovery callback');
+		expect(restoreDraft()).toBe(true);
+		await waitFor(() => expect(textbox).toHaveValue('Build me an invoice workflow'));
+	});
+
 	it('opens the hidden file picker from the input menu', async () => {
 		const fileInputClick = vi.spyOn(HTMLInputElement.prototype, 'click');
 		const { getByTestId, queryByTestId } = renderComponent({
@@ -805,7 +825,9 @@ describe('InstanceAiInput', () => {
 		await userEvent.type(textbox, 'Make the first workflow simpler');
 		await userEvent.click(getByTestId('instance-ai-send-button'));
 
-		expect(emitted().submit).toEqual([['Make the first workflow simpler', undefined]]);
+		expect(emitted().submit).toEqual([
+			['Make the first workflow simpler', undefined, expect.any(Function)],
+		]);
 	});
 
 	it('emits cancel-plan-edit and clears the draft when the plan edit context is closed', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -94,6 +94,9 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
+	// `restoreDraft` puts the cleared draft back when the send fails. It returns
+	// false when the user has already typed something newer, so the caller can
+	// tell whether the draft was recovered.
 	submit: [message: string, attachments?: InstanceAiAttachment[], restoreDraft?: () => boolean];
 	stop: [];
 	'cancel-plan-edit': [];
@@ -294,15 +297,11 @@ watch(
 
 function emitSubmittedMessage(
 	message: string,
-	attachments?: InstanceAiAttachment[],
-	restoreDraft?: () => boolean,
+	attachments: InstanceAiAttachment[] | undefined,
+	restoreDraft: () => boolean,
 ) {
 	previewPrompt.value = null;
-	if (restoreDraft) {
-		emit('submit', message, attachments, restoreDraft);
-		return;
-	}
-	emit('submit', message, attachments);
+	emit('submit', message, attachments, restoreDraft);
 }
 
 function resetDraftComposer() {
@@ -336,12 +335,8 @@ function submitComposerMessage(message: string, attachments?: InstanceAiAttachme
 
 	const submittedFiles = [...attachedFiles.value];
 	const submittedResources = [...attachedResources.value];
-	emitSubmittedMessage(
-		message,
-		attachments,
-		submittedFiles.length > 0 || submittedResources.length > 0
-			? () => restoreSubmittedDraft(message, submittedFiles, submittedResources)
-			: undefined,
+	emitSubmittedMessage(message, attachments, () =>
+		restoreSubmittedDraft(message, submittedFiles, submittedResources),
 	);
 	resetDraftComposer();
 }


### PR DESCRIPTION
## Summary

The AI Assistant composer clears its draft when you send a message. On the empty view (the new-thread entry point), the bail-out for "no project selected" did not put the draft back, so the text was lost. The user saw only an error toast and an empty input.

That bail-out now calls `restoreDraftAfterFailedSubmit`, the same recovery the other failure paths already use.

The composer also always hands the caller its draft recovery callback. Before, it supplied the callback only when the user attached a file or a resource, and the caller had to fall back to restoring the text alone. The callback keeps its existing guard: it does not overwrite content the user typed after the failed send.

> [!NOTE]
> #37874 landed the same fix for the `syncThread` failure and refused-send paths while this PR was open. This PR is now rebased on it and holds only what it did not cover: the no-project bail-out, plus the composer change above.

## How to test

1. Open the AI Assistant empty view (`/assistant`).
2. Type a prompt.
3. Make the project selection empty. In devtools, clear the selected project (or run against an account whose personal project has not loaded).
4. Send the prompt.
5. The error toast appears **and** the prompt stays in the composer.
6. Select a project and send again. The thread starts and the composer clears.

No env var, license, or feature flag is needed beyond a normal AI Assistant setup.

Automated coverage:

```bash
cd packages/frontend/editor-ui
pnpm test src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts src/features/ai/instanceAi/__tests__/InstanceAiInput.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-206

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
