### PR TITLE
feat(editor): Remove preview tag for reviews in nav bar

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.vue
@@ -129,7 +129,6 @@ const workflowReviews = computed<IMenuItem>(() => ({
 	icon: 'message-square-text',
 	label: locale.baseText('workflowReviews.menu.title'),
 	route: { to: { name: WORKFLOW_REVIEW_REQUESTS_VIEW } },
-	preview: true,
 }));
 const chat = computed<IMenuItem>(() => ({
 	id: 'chat',


### PR DESCRIPTION
## Summary

Removes preview tag for reviews in nav bar. It's still marked as Preview on Settings.

## Related Linear tickets, Github issues, and Community forum posts

LIGO-1117


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

