### PR TITLE
fix(core): Allow HITL tool nodes on platform interaction webhooks

### DIFF
--- a/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
@@ -257,6 +257,55 @@ describe('SlackInteractionWebhooks', () => {
 		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
 	});
 
+	it('routes a Slack HITL tool node into the shared resume', async () => {
+		const reference = buildHitlCallbackReference('exec-1', 'a', TEST_HMAC_SECRET);
+		const req = createRequest(reference);
+		const { res } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			waitingExecutionWithNode('node-1', 'SlackNode', 'n8n-nodes-base.slackHitlTool'),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toMatchObject({
+			executionId: 'exec-1',
+			suffix: 'node-1',
+		});
+		const routedReq = slackInteractionWebhooks.getWebhookExecutionDataArgs!.req;
+		expect(isSlackInteractionRequest(routedReq)).toBe(true);
+	});
+
+	it('responds 404 without resuming when the resumed node is another platform HITL tool', async () => {
+		const reference = buildHitlCallbackReference('exec-1', 'a', TEST_HMAC_SECRET);
+		const req = createRequest(reference);
+		const { res, status } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			waitingExecutionWithNode('node-1', 'SlackNode', 'n8n-nodes-base.telegramHitlTool'),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(404);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('responds 404 without resuming when the resumed node is an unrelated HITL tool', async () => {
+		const reference = buildHitlCallbackReference('exec-1', 'a', TEST_HMAC_SECRET);
+		const req = createRequest(reference);
+		const { res, status } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			waitingExecutionWithNode('node-1', 'SlackNode', 'n8n-nodes-base.gmailHitlTool'),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(404);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
 	it('resolves the node id from lastNodeExecuted and routes into the shared resume', async () => {
 		const reference = buildHitlCallbackReference('exec-1', 'a', TEST_HMAC_SECRET);
 		const req = createRequest(reference);

--- a/packages/cli/src/webhooks/__tests__/telegram-interaction-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/telegram-interaction-webhooks.test.ts
@@ -239,4 +239,84 @@ describe('TelegramInteractionWebhooks', () => {
 		expect(result).toEqual({ noWebhookResponse: true });
 		expect(getWebhookExecutionData).not.toHaveBeenCalled();
 	});
+
+	it('routes a Telegram HITL tool node into the shared resume', async () => {
+		const reference = buildHitlCallbackReference('e1', 'a', TEST_HMAC_SECRET);
+		const req = makeReq(reference);
+		const res = makeRes();
+
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({
+				status: 'waiting',
+				finished: false,
+				data: { resultData: { lastNodeExecuted: 'Telegram', error: undefined } },
+				workflowData: {
+					id: 'workflow-1',
+					name: 'Test Workflow',
+					active: true,
+					settings: {},
+					staticData: {},
+					connections: {},
+					nodes: [
+						{
+							name: 'Telegram',
+							id: 'node-1',
+							type: 'n8n-nodes-base.telegramHitlTool',
+							typeVersion: 1.2,
+							parameters: {},
+							position: [0, 0] as [number, number],
+						},
+					],
+				},
+			}),
+		);
+
+		await svc.executeWebhook(req, res);
+
+		expect(getWebhookExecutionData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				executionId: 'e1',
+				suffix: 'node-1',
+				lastNodeExecuted: 'Telegram',
+			}),
+		);
+	});
+
+	it('responds 404 and does not resume when the resumed node is another platform HITL tool', async () => {
+		const reference = buildHitlCallbackReference('e1', 'a', TEST_HMAC_SECRET);
+		const req = makeReq(reference);
+		const res = makeRes();
+
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({
+				status: 'waiting',
+				finished: false,
+				data: { resultData: { lastNodeExecuted: 'Slack HITL', error: undefined } },
+				workflowData: {
+					id: 'workflow-1',
+					name: 'Test Workflow',
+					active: true,
+					settings: {},
+					staticData: {},
+					connections: {},
+					nodes: [
+						{
+							name: 'Slack HITL',
+							id: 'node-1',
+							type: 'n8n-nodes-base.slackHitlTool',
+							typeVersion: 1,
+							parameters: {},
+							position: [0, 0] as [number, number],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await svc.executeWebhook(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(404);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(getWebhookExecutionData).not.toHaveBeenCalled();
+	});
 });

--- a/packages/cli/src/webhooks/hitl-interaction-webhooks.ts
+++ b/packages/cli/src/webhooks/hitl-interaction-webhooks.ts
@@ -34,7 +34,10 @@ export abstract class HitlInteractionWebhooks extends WaitingWebhooks {
 		req: WaitingWebhookRequest,
 	): Promise<ParsedHitlCallbackReference | null>;
 
-	/** The node type this route is allowed to resume (e.g. 'n8n-nodes-base.slack'). */
+	/**
+	 * The platform node this route may resume, e.g. `n8n-nodes-base.slack`.
+	 * The matching HITL tool variant (`${platformNodeType}HitlTool`) is also allowed.
+	 */
 	protected abstract readonly platformNodeType: string;
 
 	/**
@@ -68,7 +71,9 @@ export abstract class HitlInteractionWebhooks extends WaitingWebhooks {
 		const node = workflow.getNode(lastNodeExecuted);
 		if (!node) return { ok: false, status: 404 };
 
-		if (node.type !== this.platformNodeType) return { ok: false, status: 404 };
+		if (node.type !== this.platformNodeType && node.type !== `${this.platformNodeType}HitlTool`) {
+			return { ok: false, status: 404 };
+		}
 
 		return {
 			ok: true,

--- a/packages/cli/src/webhooks/hitl-interaction-webhooks.ts
+++ b/packages/cli/src/webhooks/hitl-interaction-webhooks.ts
@@ -37,6 +37,11 @@ export abstract class HitlInteractionWebhooks extends WaitingWebhooks {
 	/**
 	 * The platform node this route may resume, e.g. `n8n-nodes-base.slack`.
 	 * The matching HITL tool variant (`${platformNodeType}HitlTool`) is also allowed.
+	 *
+	 * HITL tool nodes (e.g. `n8n-nodes-base.slackHitlTool`) are AI Agent tool wrappers
+	 * that add human-in-the-loop approval gates with platform-specific Send and Wait
+	 * capabilities. They share the same interaction webhook endpoint as their base
+	 * platform node and must be accepted here to allow the approval flow to resume.
 	 */
 	protected abstract readonly platformNodeType: string;
 
@@ -71,6 +76,9 @@ export abstract class HitlInteractionWebhooks extends WaitingWebhooks {
 		const node = workflow.getNode(lastNodeExecuted);
 		if (!node) return { ok: false, status: 404 };
 
+		// Accept both the base platform node and its HITL tool variant (e.g. slack + slackHitlTool).
+		// This allows Send and Wait approval flows initiated by HITL tool nodes to resume through
+		// this platform's interaction webhook, while rejecting other platforms and unrelated tools.
 		if (node.type !== this.platformNodeType && node.type !== `${this.platformNodeType}HitlTool`) {
 			return { ok: false, status: 404 };
 		}


### PR DESCRIPTION
## Summary

Allow platform-specific HITL tool nodes to pass interaction webhook validation.

This fixes Slack and Telegram HITL interactions being rejected with a 404 before the waiting execution can resume.

The validation remains restricted to:

- the platform's regular node type
- the corresponding platform HITL tool node type

Unrelated and cross-platform node types remain rejected.

## Context / Motivation

PR #37586 introduced platform node validation for interaction webhooks.

For Slack, the webhook expected:

`n8n-nodes-base.slack`

but HITL approval flows wait on:

`n8n-nodes-base.slackHitlTool`

As a result, Slack HITL gates using Capture Responder were rejected before `getWebhookExecutionData()` could resume the execution.

The same validation path is shared by Telegram.

Fixes #37692
Internal reference: GHC-9397
https://linear.app/n8n/issue/GHC-9397

## Changes Made

- Allow the platform's corresponding `HitlTool` node type in interaction webhook validation.
- Add regression coverage for Slack HITL interactions.
- Add regression coverage for Telegram HITL interactions.
- Verify cross-platform and unrelated HITL node types remain rejected.

## Testing

Before the fix:

- 2 regression tests failed
- 25 existing tests passed

After the fix:

- Slack + Telegram interaction tests: 27/27 passed
- Waiting webhook tests: 32/32 passed
- Typecheck: passed
- Format check: passed
- Scoped ESLint: passed
- Biome check: passed
- `git diff --check`: passed

Full package ESLint was attempted but exceeded the local Node.js heap limit. The changed files pass scoped ESLint successfully.

## AI assistance

AI tools were used to help inspect the regression, draft the change, and run tests. I reviewed the diff and take responsibility for this code.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

