### PR TITLE
test: Stop the janitor TCR test from installing playwright over the network

### DIFF
--- a/packages/testing/janitor/src/core/tcr-executor.test.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.test.ts
@@ -76,6 +76,13 @@ describe('TcrExecutor', () => {
 				excludeTypes: ['Page'],
 			},
 			fixtureObjectName: 'app',
+			tcr: {
+				// The default test command is `npx playwright test`. These cases run in an
+				// ephemeral temp dir with no node_modules, so npx resolves playwright from
+				// the registry and blocks on its install prompt behind `stdio: 'pipe'` —
+				// a multi-minute hang instead of a 30s test. Keep the command local.
+				testCommand: 'echo',
+			},
 		});
 		setConfig(config);
 


### PR DESCRIPTION
## Summary

`master` is red. `@n8n/playwright-janitor#test:unit` fails in `Backend Unit Tests` with:

```
FAIL  src/core/tcr-executor.test.ts > TcrExecutor > getChangedFiles > detects new test files in new directories (staged)
Error: Test timed out in 30000ms.
```

The case is the only one in the file that both passes typecheck (it stubs the
script to `node -e ""`) and finds an affected test, so it is the only one that
reaches `TcrExecutor.runTests`. That step runs the default TCR test command,
`npx playwright test` (`src/utils/test-command.ts:10`), inside an ephemeral temp
dir with no `node_modules`. `npx` therefore resolves `playwright` from the
registry and blocks on its install prompt behind `stdio: 'pipe'`. The test file
takes 205–311 s instead of a few seconds.

The case asserts on `result.affectedTests`, which is computed before the test
command runs, so the command only has to exit. This pins it to `echo` in the
shared `beforeEach` config — the same stub the sibling `testCommand config`
cases already use. No unit test in the package can reach the network now.

Failures observed, all on the same test:

| Run | Commit | Result |
| --- | --- | --- |
| master `33850254553`, Node 24.18.1 | `a9b713be5` | timeout |
| master `33850254553`, Node 26.5.1 | `a9b713be5` | timeout |
| PR #37101 `33851418421` | `cf2e747c8` | timeout |
| PR #37101, after re-run | `cf2e747c8` | timeout |

4/4 since `a9b713be5`, so this is not a flake that a re-run clears. It blocks
#37101 and every other PR.

## How to test

```bash
cd packages/testing/janitor
pnpm vitest run src/core/tcr-executor.test.ts
```

23 passed. The `staged` case now completes in about a second instead of
resolving `playwright` from the registry.

## Related Linear tickets, Github issues, and Community forum posts

Found while unblocking #37101.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

