### PR TITLE
test(editor): Cover the otel settings label through the store and the render (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/SettingsSidebar.moduleItems.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/SettingsSidebar.moduleItems.test.ts
@@ -1,0 +1,81 @@
+import { OtelModule } from '@n8n/frontend-module-otel';
+import { i18nInstance, setLanguage } from '@n8n/i18n';
+import { useRBACStore } from '@n8n/stores/rbac.store';
+import { useSettingsStore } from '@n8n/stores/settings.store';
+import { createPinia, setActivePinia } from 'pinia';
+import { nextTick, ref } from 'vue';
+
+import { createComponentRenderer } from '@/__tests__/render';
+import { registerModuleRoutes } from '@/app/moduleInitializer/moduleInitializer';
+import router from '@/app/router';
+import { useUIStore } from '@/app/stores/ui.store';
+
+import SettingsSidebar from './SettingsSidebar.vue';
+
+/**
+ * Renders the sidebar a user actually sees, with the real descriptor, router and stores —
+ * the only layer that covers the whole chain from `OtelModule.settingsPages` to the DOM.
+ *
+ * `SettingsSidebar.test.ts` mocks `useSettingsItems`, and both descriptor- and store-level
+ * suites stop short of a render, so no test asserted that a module's label reaches the
+ * screen or repaints on a language change.
+ */
+vi.mock('../composables/useAiGateway', () => ({
+	useAiGateway: () => ({ fetchWallet: vi.fn(), isEnabled: ref(false), balance: ref(0) }),
+}));
+vi.mock('../composables/useAiGatewayTopUp', () => ({
+	useAiGatewayTopUp: () => ({ openTopUp: vi.fn() }),
+}));
+
+// The module routes the shell manifest registers at boot, so `canUserAccessRouteByName`
+// resolves every sidebar item the way it does in the app.
+registerModuleRoutes(router);
+
+describe('SettingsSidebar module pages', () => {
+	const OTEL_LABEL_KEY = 'settings.opentelemetry';
+
+	let pinia: ReturnType<typeof createPinia>;
+
+	beforeEach(() => {
+		pinia = createPinia();
+		setActivePinia(pinia);
+
+		const settingsStore = useSettingsStore();
+		settingsStore.settings = {
+			...settingsStore.settings,
+			activeModules: [OtelModule.id],
+		};
+		useRBACStore().setGlobalScopes(['otel:manage']);
+		useUIStore().registerSettingsPages(OtelModule.id, OtelModule.settingsPages ?? []);
+	});
+
+	afterEach(() => {
+		setLanguage('en');
+	});
+
+	const renderSidebar = () =>
+		createComponentRenderer(SettingsSidebar, { pinia, global: { plugins: [router] } })();
+
+	it('should render the translated label of a module settings page', () => {
+		const { getByText } = renderSidebar();
+
+		expect(getByText('OpenTelemetry')).toBeVisible();
+	});
+
+	it('should repaint the label after a language change', async () => {
+		const { getByText, queryByText } = renderSidebar();
+		expect(getByText('OpenTelemetry')).toBeVisible();
+
+		// `Object.fromEntries`, because a dotted i18n key is not a lintable
+		// object-literal property name.
+		i18nInstance.global.mergeLocaleMessage(
+			'de',
+			Object.fromEntries([[OTEL_LABEL_KEY, 'OpenTelemetrie']]),
+		);
+		setLanguage('de');
+		await nextTick();
+
+		expect(getByText('OpenTelemetrie')).toBeVisible();
+		expect(queryByText('OpenTelemetry')).toBeNull();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.settingsPages.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.settingsPages.test.ts
@@ -1,4 +1,5 @@
 import { OtelModule } from '@n8n/frontend-module-otel';
+import { i18nInstance, setLanguage } from '@n8n/i18n';
 import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { createPinia, setActivePinia } from 'pinia';
@@ -47,5 +48,53 @@ describe('uiStore.settingsSidebarItems', () => {
 		const uiStore = registerOtel({ moduleActive: false });
 
 		expect(otelItem(uiStore)).toBeUndefined();
+	});
+
+	/**
+	 * `settingsSidebarItems` spreads each page into `{ available: true, ...item }`, which
+	 * resolves the descriptor's `label` and `available` getters into plain values. That only
+	 * keeps following i18n and rbac because the spread runs inside this computed, so the
+	 * getters' reactive reads become the computed's own dependencies.
+	 *
+	 * `otel.module.test.ts` reads the descriptor directly and so cannot see that: it passes
+	 * either way. Moving the spread out of the computed, or resolving pages once in
+	 * `registerSettingsPages`, re-freezes the label with every descriptor-level test green.
+	 */
+	describe('reactivity through the spread', () => {
+		const OTEL_LABEL_KEY = 'settings.opentelemetry';
+
+		afterEach(() => {
+			setLanguage('en');
+		});
+
+		it('should expose the translated label of a module page', () => {
+			const uiStore = registerOtel({ moduleActive: true });
+
+			expect(otelItem(uiStore)?.label).toBe('OpenTelemetry');
+		});
+
+		it('should follow a language change', () => {
+			const uiStore = registerOtel({ moduleActive: true });
+			expect(otelItem(uiStore)?.label).toBe('OpenTelemetry');
+
+			// `Object.fromEntries`, because a dotted i18n key is not a lintable
+			// object-literal property name.
+			i18nInstance.global.mergeLocaleMessage(
+				'de',
+				Object.fromEntries([[OTEL_LABEL_KEY, 'OpenTelemetrie']]),
+			);
+			setLanguage('de');
+
+			expect(otelItem(uiStore)?.label).toBe('OpenTelemetrie');
+		});
+
+		it('should follow a scope change', () => {
+			const uiStore = registerOtel({ moduleActive: true });
+			expect(otelItem(uiStore)?.available).toBe(true);
+
+			useRBACStore().setGlobalScopes([]);
+
+			expect(otelItem(uiStore)?.available).toBe(false);
+		});
 	});
 });

--- a/packages/modules/otel/frontend/src/otel.module.test.ts
+++ b/packages/modules/otel/frontend/src/otel.module.test.ts
@@ -1,3 +1,4 @@
+import { i18nInstance, setLanguage } from '@n8n/i18n';
 import type { Scope } from '@n8n/permissions';
 import { useRBACStore } from '@n8n/stores/rbac.store';
 import { createPinia, setActivePinia } from 'pinia';
@@ -48,6 +49,44 @@ describe('OtelModule', () => {
 			useRBACStore().addGlobalScope('otel:manage');
 
 			expect(item?.available).toBe(true);
+		});
+	});
+
+	describe('label', () => {
+		const OTEL_LABEL_KEY = 'settings.opentelemetry';
+
+		afterEach(() => {
+			setLanguage('en');
+		});
+
+		it('should read the label from i18n', () => {
+			expect(settingsPage()?.label).toBe('OpenTelemetry');
+		});
+
+		it('should follow a language change after registration', () => {
+			const item = settingsPage();
+			expect(item?.label).toBe('OpenTelemetry');
+
+			// `Object.fromEntries`, because a dotted i18n key is not a lintable
+			// object-literal property name.
+			i18nInstance.global.mergeLocaleMessage(
+				'de',
+				Object.fromEntries([[OTEL_LABEL_KEY, 'OpenTelemetrie']]),
+			);
+			setLanguage('de');
+
+			expect(item?.label).toBe('OpenTelemetrie');
+		});
+
+		it('should read i18n lazily, not when the descriptor is imported', () => {
+			// The descriptor is imported by the shell manifest at boot, before `App.vue`
+			// calls `setLanguage`. A resolved string here would freeze the boot locale,
+			// and would put an i18n read at module scope — which the import-light rule
+			// for `*.module.ts` bans.
+			const descriptor = Object.getOwnPropertyDescriptor(settingsPage(), 'label');
+
+			expect(typeof descriptor?.get).toBe('function');
+			expect(descriptor?.value).toBeUndefined();
 		});
 	});
 

--- a/packages/modules/otel/frontend/src/otel.module.ts
+++ b/packages/modules/otel/frontend/src/otel.module.ts
@@ -4,8 +4,6 @@ import { useRBACStore } from '@n8n/stores/rbac.store';
 
 import { OTEL_SETTINGS_VIEW } from './otel.constants';
 
-const i18n = useI18n();
-
 // typescript-eslint reads an SFC import as `any`, because only vue-tsc can type one.
 // `pnpm turbo typecheck` is what checks this component for real.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -39,11 +37,16 @@ export const OtelModule: FrontendModuleDescription = {
 		{
 			id: 'settings-opentelemetry',
 			icon: 'telescope',
-			label: i18n.baseText('settings.opentelemetry'),
+			// Getters, not values: the descriptor object is built once, at import,
+			// outside any reactive scope and before `setLanguage` runs. Reading here
+			// instead means each read happens inside `settingsSidebarItems`, so the
+			// label follows a language change and the scope check follows a
+			// permission change.
+			get label() {
+				return useI18n().baseText('settings.opentelemetry');
+			},
 			position: 'top',
 			route: { to: { name: OTEL_SETTINGS_VIEW } },
-			// Getter, not a value: the item is registered once at init, but the
-			// scope check must re-run whenever the sidebar recomputes.
 			get available() {
 				return useRBACStore().hasScope('otel:manage');
 			},

--- a/packages/modules/otel/frontend/src/otel.module.ts
+++ b/packages/modules/otel/frontend/src/otel.module.ts
@@ -37,11 +37,6 @@ export const OtelModule: FrontendModuleDescription = {
 		{
 			id: 'settings-opentelemetry',
 			icon: 'telescope',
-			// Getters, not values: the descriptor object is built once, at import,
-			// outside any reactive scope and before `setLanguage` runs. Reading here
-			// instead means each read happens inside `settingsSidebarItems`, so the
-			// label follows a language change and the scope check follows a
-			// permission change.
 			get label() {
 				return useI18n().baseText('settings.opentelemetry');
 			},


### PR DESCRIPTION
## Summary

Adds the test coverage that #37768 leaves open. Stacked on `agent/palette/cbf3a04ade49`, because both language-change cases fail without that branch's descriptor fix.

`otel.module.test.ts` reads `OtelModule.settingsPages` directly, so it stops short of two layers the label has to survive.

1. **The store spread.** `ui.store`'s `settingsSidebarItems` spreads each page into `{ available: true, ...item }`, which resolves the `label` and `available` getters into plain values. That keeps following i18n and rbac only because the spread runs inside that computed, so the getters' reactive reads become the computed's own dependencies. Move the spread out of the computed, or resolve pages once in `registerSettingsPages`, and the label freezes again with every descriptor-level test still green.
2. **The render.** `SettingsSidebar.test.ts` mocks `useSettingsItems`, so no test asserted that a module's label reaches the DOM or repaints on a language change.

## Changes

- `ui.store.settingsPages.test.ts` — a `reactivity through the spread` group: label value, label after `setLanguage`, `available` after a scope change.
- `SettingsSidebar.moduleItems.test.ts` (new) — renders the real `SettingsSidebar` with the real descriptor, router and stores; asserts the label is visible and repaints after `setLanguage`.

## Verification

- The two language-change cases fail against the pre-fix descriptor (`44ddbbd28ce`) and pass on this branch. The English-label cases pass either way — which is why a stock instance, shipping `en.json` only, saw no impact.
- `pnpm --filter @n8n/frontend-module-otel test` — 111 passed. `lint` and `typecheck` clean.
- `editor-ui` `pnpm typecheck` clean; `vitest run src/app` — 3746 passed with these files added.
- Checked in a real browser on a local instance (v2.37.0, owner account, otel active by default): the `OpenTelemetry` settings item renders and the page loads with zero console errors.

## Note, not part of this PR

`vitest run src/app` has two pre-existing flakes, unrelated to otel — reproduced on the base commit `44ddbbd28ce`, which failed 3 of 3 runs:

- `router.test.ts > router > should resolve / to WorkflowsView`
- `useWorkflowSaving.test.ts > ... > drops a scheduled autosave if navigation lands on an unhydrated document before it fires`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

