### PR TITLE
fix(MCP Client Tool): Reuse the MCP client and tool list in one execution

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
@@ -115,6 +115,8 @@ function createSupplyDataCtx(overrides: Record<string, unknown> = {}) {
 		logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 		addInputData: vi.fn(() => ({ index: 0 })),
 		addOutputData: vi.fn(),
+		// Empty id keeps these helpers on the uncached supplyData path.
+		getExecutionId: vi.fn(() => ''),
 		...egressHelpers<ISupplyDataFunctions>(),
 		...overrides,
 	} as Partial<ISupplyDataFunctions>);
@@ -278,6 +280,195 @@ describe('runtime', () => {
 			const tools = await buildRegistryTools(undefined);
 
 			expect(tools[0]).not.toHaveProperty('metadata.attribution');
+		});
+	});
+
+	describe('buildMcpToolkit session cache', () => {
+		let manager: McpClientsManager;
+
+		function createCachedSupplyCtx(executionId: string, overrides: Record<string, unknown> = {}) {
+			return createSupplyDataCtx({
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1.4, name: 'MCP', type: 'mcp' })),
+				getExecutionId: vi.fn(() => executionId),
+				getExecutionCancelSignal: vi.fn(() => undefined),
+				onExecutionCancellation: vi.fn(),
+				onExecutionFinish: vi.fn(),
+				...overrides,
+			});
+		}
+
+		beforeEach(() => {
+			manager = new McpClientsManager({
+				cacheTtl: 300_000,
+				cacheMaxSize: 500,
+			} as never);
+			vi.mocked(Container.get).mockReturnValue(manager as never);
+		});
+
+		afterEach(() => {
+			manager.shutdown();
+		});
+
+		it('reuses one connection and tools/list within the same execution', async () => {
+			const connect = vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			const listTools = vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [sampleTool],
+			});
+			const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createCachedSupplyCtx('exec-1');
+			const first = await buildMcpToolkit(ctx, 0, baseConfig);
+			const second = await buildMcpToolkit(ctx, 0, baseConfig);
+
+			expect(connect).toHaveBeenCalledTimes(1);
+			expect(listTools).toHaveBeenCalledTimes(1);
+			expect(close).not.toHaveBeenCalled();
+			expect(manager.size).toBe(1);
+
+			await first.closeFunction?.();
+			await second.closeFunction?.();
+			expect(close).not.toHaveBeenCalled();
+			expect(manager.size).toBe(1);
+		});
+
+		it('does not share the cache across different executions', async () => {
+			const connect = vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			const listTools = vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [sampleTool],
+			});
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			await buildMcpToolkit(createCachedSupplyCtx('exec-1'), 0, baseConfig);
+			await buildMcpToolkit(createCachedSupplyCtx('exec-2'), 0, baseConfig);
+
+			expect(connect).toHaveBeenCalledTimes(2);
+			expect(listTools).toHaveBeenCalledTimes(2);
+			expect(manager.size).toBe(2);
+		});
+
+		it('does not share the cache across different MCP Client Tool nodes', async () => {
+			const connect = vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			const listTools = vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [sampleTool],
+			});
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			await buildMcpToolkit(
+				createCachedSupplyCtx('exec-1', {
+					getNode: vi.fn(() => mock<INode>({ typeVersion: 1.4, name: 'MCP A', type: 'mcp' })),
+				}),
+				0,
+				baseConfig,
+			);
+			await buildMcpToolkit(
+				createCachedSupplyCtx('exec-1', {
+					getNode: vi.fn(() => mock<INode>({ typeVersion: 1.4, name: 'MCP B', type: 'mcp' })),
+				}),
+				0,
+				baseConfig,
+			);
+
+			expect(connect).toHaveBeenCalledTimes(2);
+			expect(listTools).toHaveBeenCalledTimes(2);
+			expect(manager.size).toBe(2);
+		});
+
+		it('retries after a failed initialization instead of caching the failure', async () => {
+			const connect = vi
+				.spyOn(Client.prototype, 'connect')
+				.mockRejectedValueOnce(new Error('boom'))
+				.mockResolvedValueOnce();
+			const listTools = vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [sampleTool],
+			});
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createCachedSupplyCtx('exec-1');
+			await expect(buildMcpToolkit(ctx, 0, baseConfig)).rejects.toThrow(NodeOperationError);
+			expect(manager.size).toBe(0);
+
+			const result = await buildMcpToolkit(ctx, 0, baseConfig);
+			expect(result.response).toBeInstanceOf(StructuredToolkit);
+			expect(connect).toHaveBeenCalledTimes(2);
+			expect(listTools).toHaveBeenCalledTimes(1);
+			expect(manager.size).toBe(1);
+		});
+
+		it('does not cache an empty tool list', async () => {
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [] });
+			const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+			const ctx = createCachedSupplyCtx('exec-1');
+
+			await expect(buildMcpToolkit(ctx, 0, baseConfig)).rejects.toThrow(
+				'MCP Server returned no tools',
+			);
+			expect(close).toHaveBeenCalled();
+			expect(manager.size).toBe(0);
+		});
+
+		it('shares one in-flight initialization across concurrent supplyData calls', async () => {
+			let releaseConnect: () => void = () => {};
+			const connectStarted = new Promise<void>((resolve) => {
+				releaseConnect = resolve;
+			});
+			const connect = vi.spyOn(Client.prototype, 'connect').mockImplementation(async () => {
+				await connectStarted;
+			});
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createCachedSupplyCtx('exec-1');
+			const first = buildMcpToolkit(ctx, 0, baseConfig);
+			const second = buildMcpToolkit(ctx, 0, baseConfig);
+			releaseConnect();
+			await Promise.all([first, second]);
+
+			expect(connect).toHaveBeenCalledTimes(1);
+			expect(Client.prototype.listTools).toHaveBeenCalledTimes(1);
+			expect(manager.size).toBe(1);
+		});
+
+		it.each(['onExecutionCancellation', 'onExecutionFinish'] as const)(
+			'closes and evicts the cached client on %s',
+			async (hookName) => {
+				vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+				vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+				const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+				let fire: () => void = () => {};
+				const ctx = createCachedSupplyCtx('exec-1', {
+					[hookName]: vi.fn((handler: () => void) => {
+						fire = handler;
+					}),
+				});
+
+				await buildMcpToolkit(ctx, 0, baseConfig);
+				expect(manager.size).toBe(1);
+
+				fire();
+				expect(close).toHaveBeenCalledTimes(1);
+				expect(manager.size).toBe(0);
+			},
+		);
+
+		it('still exposes working tools from the cached client', async () => {
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'ok' }],
+			});
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const first = await buildMcpToolkit(createCachedSupplyCtx('exec-1'), 0, baseConfig);
+			const second = await buildMcpToolkit(createCachedSupplyCtx('exec-1'), 0, baseConfig);
+
+			const tools = (second.response as StructuredToolkit).getTools();
+			await expect(tools[0].invoke({ query: 'hello' })).resolves.toEqual(
+				JSON.stringify([{ type: 'text', text: 'ok' }]),
+			);
+			expect(Client.prototype.callTool).toHaveBeenCalledTimes(1);
+			expect((first.response as StructuredToolkit).getTools()).toHaveLength(1);
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
@@ -429,6 +429,45 @@ describe('runtime', () => {
 			expect(manager.size).toBe(1);
 		});
 
+		it('evicts the client when cancellation fires while tools/list is still in flight', async () => {
+			const abort = new AbortController();
+			let releaseList: (value: { tools: Array<typeof sampleTool> }) => void = () => {};
+			let markListStarted: () => void = () => {};
+			const listStarted = new Promise<void>((resolve) => {
+				markListStarted = resolve;
+			});
+
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockImplementation(
+				async () =>
+					await new Promise((resolve) => {
+						releaseList = resolve;
+						markListStarted();
+					}),
+			);
+			const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createCachedSupplyCtx('exec-1', {
+				getExecutionCancelSignal: vi.fn(() => abort.signal),
+				onExecutionCancellation: vi.fn((handler: () => void) => {
+					const fn = () => {
+						abort.signal.removeEventListener('abort', fn);
+						handler();
+					};
+					abort.signal.addEventListener('abort', fn);
+				}),
+			});
+
+			const pending = buildMcpToolkit(ctx, 0, baseConfig);
+			await listStarted;
+			abort.abort();
+			releaseList({ tools: [sampleTool] });
+
+			await expect(pending).rejects.toThrow('Execution was cancelled');
+			expect(manager.size).toBe(0);
+			expect(close).toHaveBeenCalled();
+		});
+
 		it.each(['onExecutionCancellation', 'onExecutionFinish'] as const)(
 			'closes and evicts the cached client on %s',
 			async (hookName) => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
@@ -113,12 +113,42 @@ async function connectAndGetTools(
 	}
 }
 
+async function connectOrThrowForToolkit(
+	ctx: ISupplyDataFunctions | IExecuteFunctions,
+	config: ResolvedMcpConfig,
+	itemIndex: number,
+): Promise<{ client: Client; mcpTools: McpTool[] }> {
+	const node = ctx.getNode();
+	const { client, mcpTools, error } = await connectAndGetTools(ctx, config);
+
+	if (error) {
+		throw mapToNodeOperationError(node, error);
+	}
+	if (!mcpTools?.length) {
+		await client.close();
+		throw new NodeOperationError(node, 'MCP Server returned no tools', {
+			itemIndex,
+			description:
+				'Connected successfully to your MCP server but it returned an empty list of tools.',
+		});
+	}
+
+	return { client, mcpTools };
+}
+
 /**
  * Build a {@link StructuredToolkit} from a connected MCP server.
  *
  * Used by `supplyData` on every MCP-client-style node. Connects, lists tools,
  * filters them, wraps each in a `DynamicStructuredTool`, and returns the toolkit
- * along with a `closeFunction` that releases the client.
+ * along with a `closeFunction`.
+ *
+ * When the context has an execution id, the connected client and tool list are
+ * kept in {@link McpClientsManager} and reused for later `supplyData` calls in
+ * the same execution (Agent V3 re-resolves tools before every model call).
+ * `closeFunction` then only refreshes the idle timer — the manager closes the
+ * client when the execution finishes or is cancelled. Without an execution id
+ * the previous per-call connect/close behaviour is kept.
  */
 export async function buildMcpToolkit(
 	ctx: ISupplyDataFunctions,
@@ -137,25 +167,45 @@ export async function buildMcpToolkit(
 		return setError(new NodeOperationError(node, 'Execution was cancelled', { itemIndex }));
 	}
 
-	const { client, mcpTools, error } = await connectAndGetTools(ctx, config);
+	const executionId = ctx.getExecutionId();
+	const manager = executionId ? Container.get(McpClientsManager) : undefined;
+	const cacheKey = executionId ? `${executionId}:${node.name}` : undefined;
 
-	if (error) {
-		ctx.logger.error('MCP client: Failed to connect to MCP Server', { error });
-		return setError(mapToNodeOperationError(node, error));
+	let client: Client;
+	let mcpTools: McpTool[];
+
+	try {
+		if (manager && cacheKey) {
+			({ client, mcpTools } = await manager.getOrConnect(
+				cacheKey,
+				async () => await connectOrThrowForToolkit(ctx, config, itemIndex),
+				{
+					logger: ctx.logger,
+					onExecutionCancellation: ctx.onExecutionCancellation?.bind(ctx),
+					onExecutionFinish: ctx.onExecutionFinish?.bind(ctx),
+				},
+			));
+		} else {
+			({ client, mcpTools } = await connectOrThrowForToolkit(ctx, config, itemIndex));
+		}
+	} catch (error) {
+		if (error instanceof NodeOperationError) {
+			if (error.message !== 'MCP Server returned no tools') {
+				ctx.logger.error('MCP client: Failed to connect to MCP Server', { error });
+			}
+			return setError(error);
+		}
+		throw error;
+	}
+
+	// getOrConnect registers abort cleanup only after the factory resolves.
+	// An abort during connect/listTools does not fire that handler, so evict now.
+	if (manager && cacheKey && signal?.aborted) {
+		manager.remove(cacheKey, ctx.logger);
+		return setError(new NodeOperationError(node, 'Execution was cancelled', { itemIndex }));
 	}
 
 	ctx.logger.debug('MCP client: Successfully connected to MCP Server');
-
-	if (!mcpTools?.length) {
-		await client.close();
-		return setError(
-			new NodeOperationError(node, 'MCP Server returned no tools', {
-				itemIndex,
-				description:
-					'Connected successfully to your MCP server but it returned an empty list of tools.',
-			}),
-		);
-	}
 
 	const attribution = config.registryCredential?.connection.attribution;
 
@@ -188,9 +238,22 @@ export async function buildMcpToolkit(
 
 		const toolkit = new StructuredToolkit(tools);
 
-		return { response: toolkit, closeFunction: async () => await client.close() };
+		return {
+			response: toolkit,
+			closeFunction: async () => {
+				if (manager && cacheKey) {
+					manager.refresh(cacheKey);
+					return;
+				}
+				await client.close();
+			},
+		};
 	} catch (e) {
-		await client.close();
+		if (manager && cacheKey) {
+			manager.remove(cacheKey, ctx.logger);
+		} else {
+			await client.close();
+		}
 		throw e;
 	}
 }


### PR DESCRIPTION
## Summary

AI Agent V3 resolves connected tools before every model call. For MCP Client Tool nodes, the `supplyData` path was creating a new MCP connection and calling `tools/list` on each iteration.

This change reuses the existing execution-scoped `McpClientsManager` from `buildMcpToolkit`, so the MCP client and tool definitions are initialized once per execution + MCP node and reused across agent iterations.

The client remains scoped to the workflow execution and is closed when the execution finishes or is cancelled.

## Context / Motivation

The MCP Client Tool execution path already uses `McpClientsManager`, but `supplyData` did not.

The relevant flow was:

AI Agent V3
→ `getTools` / `getConnectedTools`
→ `getInputConnectionData`
→ `McpClientTool.supplyData`
→ `buildMcpToolkit`
→ `connectAndGetTools`
→ MCP connect + `listTools()`

Because Agent V3 resolves tools again before each model call, `supplyData` repeated the connection and `tools/list` work every iteration.

Before this change, two toolkit resolutions within the same execution resulted in:

- connect: 2
- listTools: 2

After this change:

- connect: 1
- listTools: 1

A separate workflow execution still creates its own MCP session.

Fixes #37354
Internal reference: GHC-9373

## Changes Made

- Reuse the existing `McpClientsManager` from `buildMcpToolkit` when an execution ID is available.
- Keep MCP sessions scoped to execution ID + MCP node.
- Avoid closing the cached client at the end of each agent-node iteration.
- Preserve execution-finish and execution-cancellation cleanup.
- Preserve retry behavior after failed initialization.
- Preserve the existing uncached behavior when no execution ID is available.
- Add regression coverage for:
  - same-execution reuse
  - separate execution isolation
  - separate node isolation
  - failed initialization retry
  - concurrent single-flight initialization
  - lifecycle cleanup
  - normal tool invocation behavior

## How to test

1. Attach an MCP Client Tool sub-node to an AI Agent V3 workflow.
2. Run a task that needs more than one model call.
3. Confirm the MCP server sees one session and one `tools/list` per execution, not one per model call.
4. Run the workflow a second time and confirm that execution opens a new session.
5. Cancel or fail an execution and confirm the session is closed.

Targeted MCP tests:

```bash
cd packages/@n8n/nodes-langchain

pnpm test \
  nodes/mcp/shared/runtime.test.ts \
  nodes/mcp/shared/__test__/McpClientsManager.test.ts \
  nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts \
  nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
```

Result: 118 passed, 0 failed.

The new same-execution regression failed on current master (`connect`/`listTools` = 2) and passed after this change (`connect`/`listTools` = 1).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-9373
https://github.com/n8n-io/n8n/issues/37354

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

## AI assistance

Cursor was used as a coding assistant while preparing this change. I reviewed the implementation and tests and take responsibility for them.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

