### PR TITLE
fix(Databricks Node): Drop the version from the partner User-Agent (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
@@ -16,7 +16,7 @@ export interface DatabricksOAuth2Credential {
 // Unversioned by agreement with Databricks.
 // Set here, not via ChatOpenAI's `defaultHeaders`, so it also wins over the
 // OpenAI SDK's own User-Agent - Headers.set() overwrites case-insensitively.
-export const CHAT_MODEL_USER_AGENT = 'n8n_DatabricksChatModel';
+export const CHAT_MODEL_USER_AGENT = 'n8n_DatabricksNode';
 
 /**
  * Mints Databricks service-principal tokens on demand. Concurrent callers

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDatabricks/token-provider.ts
@@ -13,9 +13,10 @@ export interface DatabricksOAuth2Credential {
 }
 
 // Partner User-Agent for Databricks traffic attribution (PWAF telemetry spec).
+// Unversioned by agreement with Databricks.
 // Set here, not via ChatOpenAI's `defaultHeaders`, so it also wins over the
 // OpenAI SDK's own User-Agent - Headers.set() overwrites case-insensitively.
-export const CHAT_MODEL_USER_AGENT = 'n8n_DatabricksChatModel/1.0';
+export const CHAT_MODEL_USER_AGENT = 'n8n_DatabricksChatModel';
 
 /**
  * Mints Databricks service-principal tokens on demand. Concurrent callers

--- a/packages/nodes-base/nodes/Databricks/constants.ts
+++ b/packages/nodes-base/nodes/Databricks/constants.ts
@@ -1,17 +1,10 @@
 // Kept dependency-free: loaded eagerly whenever either credential type is loaded.
 
-/**
- * Single source of truth for the integration version: feeds both
- * `description.version` in Databricks.node.ts and the partner User-Agent, so the
- * two cannot drift. Deliberately not read from a node's `typeVersion` — that is a
- * per-workflow compatibility marker frozen into saved workflows, so it would report
- * how old a workflow is rather than which integration version is running.
- */
 export const DATABRICKS_NODE_VERSION = 1;
 
 /**
  * Partner User-Agent so Databricks can attribute traffic to n8n in audit logs.
- * The `.0` keeps the wire format Databricks expects; bumping to a fractional node
- * version needs this format revisited first.
+ * Unversioned by agreement with Databricks; all Databricks nodes (action node,
+ * AI sub-nodes) must send this exact string.
  */
-export const databricksUserAgent = () => `n8n_DatabricksNode/${DATABRICKS_NODE_VERSION}.0`;
+export const databricksUserAgent = () => 'n8n_DatabricksNode';

--- a/packages/nodes-base/nodes/Databricks/test/Databricks.node.test.ts
+++ b/packages/nodes-base/nodes/Databricks/test/Databricks.node.test.ts
@@ -72,7 +72,7 @@ describe('Databricks', () => {
 				// Proves the UA comes from the node helper: the harness only invokes a
 				// function-style `authenticate`, and this credential's is a generic object,
 				// so the credential contributes no headers here.
-				.matchHeader('user-agent', 'n8n_DatabricksNode/1.0')
+				.matchHeader('user-agent', 'n8n_DatabricksNode')
 				.reply(200, {
 					statement_id: 'stmt-abc123',
 					status: { state: 'SUCCEEDED' },
@@ -201,7 +201,7 @@ describe('Databricks', () => {
 		beforeAll(() => {
 			nock(HOST)
 				.get('/api/2.0/fs/files/Volumes/main/default/my_volume/data/logo.png')
-				.matchHeader('user-agent', 'n8n_DatabricksNode/1.0')
+				.matchHeader('user-agent', 'n8n_DatabricksNode')
 				.reply(200, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe]), {
 					'content-type': 'application/octet-stream',
 				});

--- a/packages/nodes-base/nodes/Databricks/test/Databricks.oauth2.test.ts
+++ b/packages/nodes-base/nodes/Databricks/test/Databricks.oauth2.test.ts
@@ -13,7 +13,7 @@ describe('Databricks with OAuth2', () => {
 	beforeAll(() => {
 		nock(HOST)
 			.get('/api/2.1/unity-catalog/catalogs')
-			.matchHeader('user-agent', 'n8n_DatabricksNode/1.0')
+			.matchHeader('user-agent', 'n8n_DatabricksNode')
 			.reply(200, { catalogs: [{ name: 'main', comment: 'Main catalog' }] });
 	});
 

--- a/packages/nodes-base/nodes/Databricks/test/helpers.test.ts
+++ b/packages/nodes-base/nodes/Databricks/test/helpers.test.ts
@@ -3,7 +3,7 @@ import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { databricksApiRequest } from '../actions/helpers';
-import { DATABRICKS_NODE_VERSION, databricksUserAgent } from '../constants';
+import { databricksUserAgent } from '../constants';
 
 describe('databricksApiRequest', () => {
 	let httpRequestWithAuthentication: Mock;
@@ -29,7 +29,7 @@ describe('databricksApiRequest', () => {
 
 		expect(capturedOptions().headers).toEqual({
 			'Content-Type': 'application/octet-stream',
-			'User-Agent': 'n8n_DatabricksNode/1.0',
+			'User-Agent': 'n8n_DatabricksNode',
 		});
 	});
 
@@ -39,7 +39,7 @@ describe('databricksApiRequest', () => {
 			url: 'https://example.databricks.com/api/2.1/unity-catalog/catalogs',
 		});
 
-		expect(capturedOptions().headers).toEqual({ 'User-Agent': 'n8n_DatabricksNode/1.0' });
+		expect(capturedOptions().headers).toEqual({ 'User-Agent': 'n8n_DatabricksNode' });
 	});
 
 	it('should override a caller-supplied User-Agent', async () => {
@@ -49,7 +49,7 @@ describe('databricksApiRequest', () => {
 			headers: { 'User-Agent': 'something-else' },
 		});
 
-		expect(capturedOptions().headers).toEqual({ 'User-Agent': 'n8n_DatabricksNode/1.0' });
+		expect(capturedOptions().headers).toEqual({ 'User-Agent': 'n8n_DatabricksNode' });
 	});
 
 	it('should pass non-header options through untouched', async () => {
@@ -69,7 +69,7 @@ describe('databricksApiRequest', () => {
 			returnFullResponse: true,
 			qs: { page_token: 'abc' },
 			json: true,
-			headers: { 'User-Agent': 'n8n_DatabricksNode/1.0' },
+			headers: { 'User-Agent': 'n8n_DatabricksNode' },
 		});
 	});
 
@@ -108,7 +108,7 @@ describe('databricksApiRequest', () => {
 		});
 	});
 
-	it('should derive the User-Agent from the integration version constant', () => {
-		expect(databricksUserAgent()).toBe(`n8n_DatabricksNode/${DATABRICKS_NODE_VERSION}.0`);
+	it('should send the unversioned partner User-Agent', () => {
+		expect(databricksUserAgent()).toBe('n8n_DatabricksNode');
 	});
 });


### PR DESCRIPTION
## Summary

Action item from the Databricks partner meeting: all n8n traffic to Databricks must carry one partner User-Agent, `n8n_DatabricksNode`, so Databricks can attribute it in `system.access.audit`.

This PR covers the REST action node: `databricksUserAgent()` now returns the unversioned string `n8n_DatabricksNode` instead of `n8n_DatabricksNode/1.0`, and the User-Agent no longer derives from the node version constant.

The chat model node gets its User-Agent in #37774, which should use the same unified string.

## How to test

Unit tests assert the header on API requests and OAuth token requests. To verify live, run a Databricks action node operation and check `system.access.audit` in the workspace: `user_agent` should read `n8n_DatabricksNode`.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up action item from the Databricks partner meeting. Related: #37774

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)