### PR TITLE
feat(core): Enable workflow publication service by default

### DIFF
--- a/packages/@n8n/config/src/configs/workflows.config.ts
+++ b/packages/@n8n/config/src/configs/workflows.config.ts
@@ -28,9 +28,9 @@ export class WorkflowsConfig {
 	@Env('N8N_WORKFLOW_INDEX_BATCH_SIZE')
 	indexingBatchSize: number = 10;
 
-	/** Whether to use the workflow publication service. Still under development. */
+	/** Whether to use the workflow publication service. */
 	@Env('N8N_USE_WORKFLOW_PUBLICATION_SERVICE')
-	useWorkflowPublicationService: boolean = false;
+	useWorkflowPublicationService: boolean = true;
 
 	/** Interval in milliseconds between polls of the workflow publication outbox on the leader. */
 	@Env('N8N_WORKFLOW_PUBLICATION_OUTBOX_POLL_INTERVAL_MS')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -230,7 +230,7 @@ describe('GlobalConfig', () => {
 			callerPolicyDefaultOption: 'workflowsFromSameOwner',
 			activationBatchSize: 1,
 			indexingBatchSize: 10,
-			useWorkflowPublicationService: false,
+			useWorkflowPublicationService: true,
 			publicationOutboxPollIntervalMs: 15_000,
 			publicationOutboxLeaseSeconds: 120,
 			workflowPublicationConcurrency: 5,


### PR DESCRIPTION
## Summary

Enable the workflow publication service by default.

Keep `N8N_USE_WORKFLOW_PUBLICATION_SERVICE` available so operators can disable the service explicitly.

## How to test

1. Run `pnpm test config.test.ts` in `packages/@n8n/config`.
2. Confirm that the default global config enables the workflow publication service.
3. Set `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=false` to opt out when required.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

