### PR TITLE
ci: Hide outdated cubic reviews on review submission (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -189,6 +189,7 @@ These only run if specific files changed:
 |----------------------------|-----------------------------|------------------------------------------------------|
 | Review approved            | `release-chromatic.yml` | + design files changed                               |
 | Any review                 | `util-notify-pr-status.yml` | not community-labeled                                |
+| cubic review submitted     | `util-hide-outdated-cubic-comments.yml` | minimizes cubic's older review summaries |
 
 **Why Instance AI evals fire once per PR state-change, not per push:** the
 workflow eval is the most expensive job in PR CI (LLM-bound builds). Running it

--- a/.github/workflows/util-hide-outdated-cubic-comments.yml
+++ b/.github/workflows/util-hide-outdated-cubic-comments.yml
@@ -22,6 +22,7 @@ permissions:
 
 concurrency:
   group: hide-cubic-reviews-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   hide-old-cubic-reviews:
@@ -47,15 +48,24 @@ jobs:
               per_page: 100,
             });
 
-            // Anchor on the event's review id rather than on a timestamp sort, so
-            // a stale read that omits the new review still leaves it visible.
+            // Never touch a review newer than the triggering one. Two reviews
+            // submitted close together start two runs; without this guard the
+            // older run minimizes the newer review, and the newer run keeps that
+            // review but never restores its visibility, hiding every summary.
+            //
+            // A stale read that omits the triggering review means everything
+            // listed predates it, so Infinity is the right cutoff there.
+            const keep = reviews.find((r) => r.id === keepId);
+            const keepAt = keep ? new Date(keep.submitted_at).getTime() : Infinity;
+
             const toHide = reviews.filter(
               (r) =>
                 r.id !== keepId &&
                 r.user &&
                 r.user.login === 'cubic-dev-ai[bot]' &&
                 r.body &&
-                r.body.trim().length > 0
+                r.body.trim().length > 0 &&
+                new Date(r.submitted_at).getTime() < keepAt
             );
 
             for (const review of toHide) {

--- a/.github/workflows/util-hide-outdated-cubic-comments.yml
+++ b/.github/workflows/util-hide-outdated-cubic-comments.yml
@@ -58,6 +58,15 @@ jobs:
             const keep = reviews.find((r) => r.id === keepId);
             const keepAt = keep ? new Date(keep.submitted_at).getTime() : Infinity;
 
+            // `submitted_at` has second granularity, so two reviews can tie.
+            // Review ids grow with submission order, which breaks the tie and
+            // makes this a total order -- without it a tie hides neither review
+            // and both summaries stay visible.
+            const precedesKeep = (r) => {
+              const at = new Date(r.submitted_at).getTime();
+              return at < keepAt || (at === keepAt && r.id < keepId);
+            };
+
             const toHide = reviews.filter(
               (r) =>
                 r.id !== keepId &&
@@ -65,7 +74,7 @@ jobs:
                 r.user.login === 'cubic-dev-ai[bot]' &&
                 r.body &&
                 r.body.trim().length > 0 &&
-                new Date(r.submitted_at).getTime() < keepAt
+                precedesKeep(r)
             );
 
             for (const review of toHide) {

--- a/.github/workflows/util-hide-outdated-cubic-comments.yml
+++ b/.github/workflows/util-hide-outdated-cubic-comments.yml
@@ -1,29 +1,36 @@
 name: Hide outdated cubic review comments
 
-# Every time cubic re-reviews a PR (e.g. after a new commit) it posts a brand new
-# "left a comment" review summary instead of updating the previous one, which
-# clutters the PR timeline. This workflow minimizes (hides) all but the most
-# recent cubic-dev-ai review comment on a PR, so only the latest summary is
-# visible by default. Hidden comments are collapsed, not deleted -- anyone can
-# still expand them.
+# Every time cubic re-reviews a PR it posts a brand new "left a comment" review
+# summary instead of updating the previous one, which clutters the PR timeline.
+# This workflow minimizes (hides) every cubic-dev-ai review except the one that
+# just arrived. Hidden comments are collapsed, not deleted -- anyone can still
+# expand them. Only review summaries are touched; cubic's issue comments and
+# inline threads are left alone.
 
-# Runs on `pull_request` (not `pull_request_target`) so it never executes with
-# elevated permissions against untrusted fork code. The tradeoff: GitHub only
-# grants a write-capable token to `pull_request` runs when the PR's head repo
-# is this same repo, so the job below is skipped for PRs from forks -- outdated
-# cubic comments on external-contributor PRs won't be minimized.
+# Triggered by the review itself, not by the push. cubic posts its review 2-11
+# minutes after a `synchronize`, so a push-triggered run cannot see the review it
+# is meant to supersede and always leaves the previous one visible.
+# `pull_request_review` runs in the base-repo context, so it also gets a
+# write-capable token on fork PRs. It checks out no code.
 
 on:
-  pull_request:
-    types: [synchronize]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: hide-cubic-reviews-${{ github.event.pull_request.number }}
 
 jobs:
   hide-old-cubic-reviews:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.review.user.login == 'cubic-dev-ai[bot]' &&
+      github.repository == 'n8n-io/n8n'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Minimize previous cubic-dev-ai review comments
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -31,6 +38,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pull_number = context.payload.pull_request.number;
+            const keepId = context.payload.review.id;
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
@@ -39,19 +47,16 @@ jobs:
               per_page: 100,
             });
 
-            // Only touch cubic's own reviews that actually have a comment body.
-            const cubicReviews = reviews
-              .filter(
-                (r) =>
-                  r.user &&
-                  r.user.login === 'cubic-dev-ai[bot]' &&
-                  r.body &&
-                  r.body.trim().length > 0
-              )
-              .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at));
-
-            // Keep the newest review visible, hide everything older.
-            const toHide = cubicReviews.slice(0, -1);
+            // Anchor on the event's review id rather than on a timestamp sort, so
+            // a stale read that omits the new review still leaves it visible.
+            const toHide = reviews.filter(
+              (r) =>
+                r.id !== keepId &&
+                r.user &&
+                r.user.login === 'cubic-dev-ai[bot]' &&
+                r.body &&
+                r.body.trim().length > 0
+            );
 
             for (const review of toHide) {
               try {


### PR DESCRIPTION
## Summary

**What is broken.** Every time cubic reviews a PR again, it posts a new review summary. The workflow `util-hide-outdated-cubic-comments.yml` is meant to collapse the old summaries so only the newest one is visible.
While it hides most of the comments, we can still see the last two comments on every PR. 

**Why.** The workflow ran when a commit was pushed. cubic posts its review 2 to 11 minutes later. So the workflow ran too early, before the new summary existed, and could not hide the one it replaced.

**The fix.** The workflow now runs when cubic submits a review. At that moment the new summary exists, so the workflow can collapse all older cubic summaries and keep the new one.

**What else changed**

- **Fork PRs are covered now.** The new trigger runs in the base repo, so the workflow gets a token that can edit comments on fork PRs too. The fork guard is gone.
- **Permissions are smaller.** The workflow reads nothing from the repo. Only the one job gets `pull-requests: write`.
- **Two reviews at the same time are handled.** Each run keeps the review that started it and hides only older ones. It never hides a newer review.
- **Added to `WORKFLOWS.md`.** The first PR forgot this.

**Not changed.** cubic's issue comments and inline review threads stay visible. Only review summaries are collapsed. Collapsed summaries are not deleted. Anyone can expand them.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #37495.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
