### PR TITLE
test: Remove unstable staged TCR test

### DIFF
--- a/packages/testing/janitor/src/core/tcr-executor.test.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.test.ts
@@ -150,39 +150,6 @@ describe('TcrExecutor', () => {
 			expect(hasTestInChanged || hasTestInAffected).toBe(true);
 		});
 
-		it('detects new test files in new directories (staged)', () => {
-			// Create a new directory with a test file and stage it
-			const newDir = path.join(tempDir, 'tests', 'e2e', 'staged-feature');
-			fs.mkdirSync(newDir, { recursive: true });
-			// Use valid TypeScript without external imports to pass typecheck
-			fs.writeFileSync(
-				path.join(newDir, 'staged-feature.spec.ts'),
-				'export const test = { name: "staged feature test" };\n',
-			);
-
-			// A real `tsc` isn't resolvable in this ephemeral temp dir (no
-			// node_modules), and this test exercises affected-test detection, not
-			// typechecking — stub the typecheck step to a deterministic pass so
-			// run() reaches findAffectedTests instead of bailing at typecheck.
-			fs.writeFileSync(
-				path.join(tempDir, 'package.json'),
-				JSON.stringify({ name: 'tcr-test', scripts: { typecheck: 'node -e ""' } }),
-			);
-
-			// Stage the new file
-			execSync('git add -A', { cwd: tempDir, stdio: 'pipe' });
-
-			const tcr = new TcrExecutor();
-			const result = tcr.run({ verbose: false });
-
-			// Should detect the actual test file, not just the directory
-			expect(result.changedFiles.some((f) => f.includes('staged-feature.spec.ts'))).toBe(true);
-			// Should NOT include directory paths
-			expect(result.changedFiles.some((f) => f.endsWith('staged-feature/'))).toBe(false);
-			// Should include in affected tests
-			expect(result.affectedTests.some((t) => t.includes('staged-feature.spec.ts'))).toBe(true);
-		});
-
 		it('detects deleted files', () => {
 			// Create and commit a file first
 			fs.writeFileSync(


### PR DESCRIPTION
## Summary

Remove the staged new-directory test from `TcrExecutor`. The test can exceed the 30-second timeout in CI.

## How to test

Run `pnpm test src/core/tcr-executor.test.ts` in `packages/testing/janitor`.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

