### PR TITLE
fix(core): Prefer service-specific credentials for HTTP requests

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -353,10 +353,17 @@ decision after testing.
   that the credential (or Gateway credits) is being used.
 - Never use raw credential objects like `{ id: '...', name: '...' }` in SDK
   code; replace them with `newCredential()` when editing roundtripped code.
-- If a required credential type is not listed, call
-  `credentials(action="search-types")` with the service name. Pick in this
-  order:
+- `credentials(action="list")` returns connected credential instances, not all
+  supported credential types. If it has no suitable instance for a named
+  service, call `credentials(action="search-types")` with the service name
+  before choosing generic authentication. Pick in this order:
   1. A **dedicated credential type** whenever search finds one.
+     For an HTTP Request node, use the most specific type for the target service
+     and operation. Set `authentication` to `'predefinedCredentialType'` and
+     `nodeCredentialType` to the returned type. If no credential instance
+     exists, leave `newCredential('Suggested Name')` unresolved for setup. Do
+     not use generic authentication only because the user has not connected an
+     account.
   2. **Simplified Custom Auth** (`httpTemplatedCustomAuth`) for any service
      without a dedicated type whose auth is expressible as header/query/body
      values — this covers API keys and bearer tokens. When the provider


### PR DESCRIPTION
## Summary

Instance AI can use generic authentication when an HTTP Request targets a service with a dedicated credential type.

This change explains that the credential list contains only connected instances. It tells the workflow builder to search supported credential types before it chooses generic authentication. It also tells the builder to keep a dedicated type unresolved when the user has not connected an account.

## How to test

1. Start Instance AI without a connected Google credential.
2. Ask it to create an HTTP Request for `sheets.googleapis.com`.
3. Verify that the node uses `predefinedCredentialType`.
4. Verify that `nodeCredentialType` is `googleSheetsOAuth2Api`.
5. Verify that the node does not contain an invented credential ID.

The local workflow eval selected `googleSheetsOAuth2Api` in five of five runs.

Package checks:

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`

### Evaluation

The synthetic capability-gap case is in LangTracer:

- [HTTP Request keeps a predefined type without an instance — case #698](https://lang-tracer.n8n-maintenance.workers.dev/test-cases/698)
- [Instance AI baseline suite — suite #8](https://lang-tracer.n8n-maintenance.workers.dev/suites/8)

The branch selected `googleSheetsOAuth2Api` in five of five calibration runs. An earlier master sample selected it in four of five runs. A later master sample selected it in five of five runs. This result shows that the master behavior is intermittent.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1307

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` if the fix needs an urgent backport.

## 🤖 PR Summary generated by AI

- Explain the difference between connected credential instances and supported credential types.
- Prefer the most specific predefined credential for an HTTP Request.
- Leave a missing credential connection unresolved for user setup.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


