### PR TITLE
feat(core): Declare agents as a scheduled job owner (no-changelog)

### DIFF
--- a/packages/@n8n/constants/src/scheduler.ts
+++ b/packages/@n8n/constants/src/scheduler.ts
@@ -163,6 +163,8 @@ export const ScheduledJobOwnerType = {
 	Workflow: 'workflow',
 	/** An instance-level maintenance job, self-owned: `ownerId` is the job's own name. */
 	SystemTask: 'system-task',
+	/** A published agent. `ownerId` is the agent id, `ownerMemberId` is the scheduled task id. */
+	Agent: 'agent',
 } as const;
 
 /** Longest accepted `ownerType`. */

--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -227,9 +227,9 @@ the job row — three fields, none of which this package interprets:
 
 | Field | Meaning |
 |---|---|
-| `ownerType` | what kind of thing owns the job (`workflow`, `system-task`, …) |
+| `ownerType` | what kind of thing owns the job (`workflow`, `system-task`, `agent`, …) |
 | `ownerId` | which one (a workflow id, a task name, an agent id) |
-| `ownerMemberId` | optionally, which part of it (the trigger node, for a workflow) |
+| `ownerMemberId` | optionally, which part of it (the trigger node for a workflow, the scheduled task for an agent) |
 
 Because ownership is data rather than a schema relationship, any part of the product
 can own scheduled jobs without the scheduler learning what its owners are, and

--- a/packages/cli/src/modules/agents/repositories/agent.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent.repository.ts
@@ -4,6 +4,7 @@ import {
 	DataSource,
 	In,
 	IsNull,
+	Not,
 	Repository,
 	type EntityManager,
 	type SelectQueryBuilder,
@@ -302,6 +303,17 @@ export class AgentRepository extends Repository<Agent> {
 		return await this.createQueryBuilder('agent')
 			.innerJoinAndSelect('agent.activeVersion', 'activeVersion')
 			.getMany();
+	}
+
+	/** The ids, from the given list, that belong to an agent with a published version. */
+	async findPublishedIds(agentIds: string[]): Promise<Set<string>> {
+		if (agentIds.length === 0) return new Set();
+
+		const rows = await this.find({
+			where: { id: In(agentIds), activeVersionId: Not(IsNull()) },
+			select: ['id'],
+		});
+		return new Set(rows.map((row) => row.id));
 	}
 
 	/**

--- a/packages/cli/src/scheduling/__tests__/agent-scheduled-job-owner.test.ts
+++ b/packages/cli/src/scheduling/__tests__/agent-scheduled-job-owner.test.ts
@@ -1,0 +1,63 @@
+import type { ModuleRegistry } from '@n8n/backend-common';
+import { Container } from '@n8n/di';
+import { mock } from 'vitest-mock-extended';
+
+import { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+
+import { AgentScheduledJobOwner } from '../agent-scheduled-job-owner';
+
+const AGENT_ID = 'agent-1';
+const TASK_ID = 'task-1';
+
+describe('AgentScheduledJobOwner', () => {
+	const moduleRegistry = mock<ModuleRegistry>();
+	const agentRepository = mock<AgentRepository>();
+
+	const makeOwner = () => new AgentScheduledJobOwner(moduleRegistry);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		moduleRegistry.isActive.mockReturnValue(true);
+		Container.set(AgentRepository, agentRepository);
+	});
+
+	it('names a task as an owner member and the agent as an owner', () => {
+		const owner = makeOwner();
+
+		expect(owner.member(AGENT_ID, TASK_ID)).toEqual({
+			ownerType: 'agent',
+			ownerId: AGENT_ID,
+			ownerMemberId: TASK_ID,
+		});
+		expect(owner.ref(AGENT_ID)).toEqual({ ownerType: 'agent', ownerId: AGENT_ID });
+	});
+
+	describe('findExisting', () => {
+		it('reports only the agents that still have a published version', async () => {
+			agentRepository.findPublishedIds.mockResolvedValue(new Set([AGENT_ID]));
+
+			const existing = await makeOwner().findExisting([AGENT_ID, 'agent-unpublished']);
+
+			expect(agentRepository.findPublishedIds).toHaveBeenCalledWith([
+				AGENT_ID,
+				'agent-unpublished',
+			]);
+			expect(existing).toEqual(new Set([AGENT_ID]));
+		});
+
+		it('throws when the agents module is inactive, so the sweep leaves agent jobs alone', async () => {
+			moduleRegistry.isActive.mockReturnValue(false);
+
+			await expect(makeOwner().findExisting([AGENT_ID])).rejects.toThrow(
+				'agents module is not active',
+			);
+			expect(agentRepository.findPublishedIds).not.toHaveBeenCalled();
+		});
+
+		it('propagates a lookup failure instead of reporting the agents gone', async () => {
+			agentRepository.findPublishedIds.mockRejectedValue(new Error('db down'));
+
+			await expect(makeOwner().findExisting([AGENT_ID])).rejects.toThrow('db down');
+		});
+	});
+});

--- a/packages/cli/src/scheduling/__tests__/agent-scheduled-job-owner.test.ts
+++ b/packages/cli/src/scheduling/__tests__/agent-scheduled-job-owner.test.ts
@@ -21,6 +21,10 @@ describe('AgentScheduledJobOwner', () => {
 		Container.set(AgentRepository, agentRepository);
 	});
 
+	afterEach(() => {
+		Container.reset();
+	});
+
 	it('names a task as an owner member and the agent as an owner', () => {
 		const owner = makeOwner();
 

--- a/packages/cli/src/scheduling/__tests__/durable-job-provisioner.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-job-provisioner.test.ts
@@ -13,6 +13,7 @@ import type { Tracing } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
 import { DurableJobProvisioner } from '../durable-job-provisioner';
+import type { AgentScheduledJobOwner } from '../agent-scheduled-job-owner';
 import type { WorkflowScheduledJobOwner } from '../workflow-scheduled-job-owner';
 
 const CLOCK = new Date('2026-01-05T09:00:00.000Z');
@@ -57,6 +58,7 @@ describe('DurableJobProvisioner', () => {
 	const tasks = mock<ScheduledTaskRepository>();
 	const tracing = mock<Tracing>();
 	const workflowOwner = mock<WorkflowScheduledJobOwner>();
+	const agentOwner = mock<AgentScheduledJobOwner>();
 
 	let provisioner: DurableJobProvisioner;
 	let logger: Logger;
@@ -82,6 +84,7 @@ describe('DurableJobProvisioner', () => {
 			tasks,
 			globalConfig,
 			workflowOwner,
+			agentOwner,
 			tracing,
 		);
 	};
@@ -967,7 +970,7 @@ describe('DurableJobProvisioner', () => {
 			jobs.deleteByOwnerRef.mockResolvedValue(1);
 
 			await expect(
-				provisioner.deprovisionOwner({ ownerType: 'agent', ownerId: 'agent-1' }),
+				provisioner.deprovisionOwner({ ownerType: 'unknown-thing', ownerId: 'thing-1' }),
 			).resolves.toEqual({ removed: 1 });
 		});
 	});
@@ -1004,10 +1007,10 @@ describe('DurableJobProvisioner', () => {
 		it('refuses an owner type the manifest registry does not declare', async () => {
 			await expect(
 				provisioner.provision({
-					owner: { ownerType: 'agent', ownerId: 'agent-1', ownerMemberId: null },
-					taskType: 'agent:task',
+					owner: { ownerType: 'unknown-thing', ownerId: 'thing-1', ownerMemberId: null },
+					taskType: 'unknown-thing:task',
 					payload: {},
-					desired: [desiredJob('agent-1:0')],
+					desired: [desiredJob('thing-1:0')],
 					misfirePolicy: ScheduledJobMisfirePolicy.Skip,
 				}),
 			).rejects.toThrow('no registered liveness resolver');

--- a/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
@@ -14,6 +14,7 @@ import { POLL_TRIGGER_TASK_TYPE } from '../poll-trigger-node/poll-trigger-task';
 import type { PollTriggerTaskHandler } from '../poll-trigger-node/poll-trigger-task-handler';
 import { SCHEDULE_TRIGGER_TASK_TYPE } from '../schedule-trigger-node/schedule-trigger-task';
 import type { ScheduleTriggerTaskHandler } from '../schedule-trigger-node/schedule-trigger-task-handler';
+import type { AgentScheduledJobOwner } from '../agent-scheduled-job-owner';
 import type { WorkflowScheduledJobOwner } from '../workflow-scheduled-job-owner';
 
 // Keep the real exports (e.g. pollLookaheadSeconds) so the wiring is tested
@@ -52,6 +53,7 @@ describe('DurableScheduler', () => {
 		const tasks = mock<ScheduledTaskRepository>();
 		tasks.readDbTime.mockResolvedValue(new Date());
 		const workflowOwner = mock<WorkflowScheduledJobOwner>();
+		const agentOwner = mock<AgentScheduledJobOwner>();
 		const scheduler = new DurableScheduler(
 			logger,
 			mock<DataSource>(),
@@ -86,8 +88,9 @@ describe('DurableScheduler', () => {
 			pollTriggerTaskHandler,
 			mock<PrometheusSchedulerMetricsService>(),
 			workflowOwner,
+			agentOwner,
 		);
-		return { scheduler, inner, logger, tracing, tasks, workflowOwner };
+		return { scheduler, inner, logger, tracing, tasks, workflowOwner, agentOwner };
 	}
 
 	describe('composition', () => {
@@ -325,12 +328,15 @@ describe('DurableScheduler', () => {
 	});
 
 	describe('owner registration', () => {
-		it('composes the reconciliation pass over a registry declaring the workflow owner', () => {
-			const { workflowOwner } = makeScheduler();
+		it('composes the reconciliation pass over a registry declaring the workflow and agent owners', () => {
+			const { workflowOwner, agentOwner } = makeScheduler();
 
 			const deps = vi.mocked(createScheduler).mock.calls.at(-1)?.[0];
 			expect(deps?.reconciliation?.owners.resolverFor(ScheduledJobOwnerType.Workflow)).toBe(
 				workflowOwner,
+			);
+			expect(deps?.reconciliation?.owners.resolverFor(ScheduledJobOwnerType.Agent)).toBe(
+				agentOwner,
 			);
 			expect(deps?.reconciliation?.options).toMatchObject({
 				settleSeconds: 300,

--- a/packages/cli/src/scheduling/__tests__/scheduled-job-owner-registry.test.ts
+++ b/packages/cli/src/scheduling/__tests__/scheduled-job-owner-registry.test.ts
@@ -1,15 +1,18 @@
 import { ScheduledJobOwnerType } from '@n8n/constants';
 import { mock } from 'vitest-mock-extended';
 
+import type { AgentScheduledJobOwner } from '../agent-scheduled-job-owner';
 import { createScheduledJobOwnerRegistry } from '../scheduled-job-owner-registry';
 import type { WorkflowScheduledJobOwner } from '../workflow-scheduled-job-owner';
 
 describe('createScheduledJobOwnerRegistry', () => {
-	it('declares the workflow owner type, so provisioning workflow jobs is never refused', () => {
+	it('declares the workflow and agent owner types, so provisioning their jobs is never refused', () => {
 		const workflowOwner = mock<WorkflowScheduledJobOwner>();
+		const agentOwner = mock<AgentScheduledJobOwner>();
 
-		const owners = createScheduledJobOwnerRegistry(workflowOwner);
+		const owners = createScheduledJobOwnerRegistry(workflowOwner, agentOwner);
 
 		expect(owners.resolverFor(ScheduledJobOwnerType.Workflow)).toBe(workflowOwner);
+		expect(owners.resolverFor(ScheduledJobOwnerType.Agent)).toBe(agentOwner);
 	});
 });

--- a/packages/cli/src/scheduling/agent-scheduled-job-owner.ts
+++ b/packages/cli/src/scheduling/agent-scheduled-job-owner.ts
@@ -1,0 +1,41 @@
+import { ModuleRegistry } from '@n8n/backend-common';
+import { ScheduledJobOwnerType } from '@n8n/constants';
+import type { ScheduledJobOwner, ScheduledJobOwnerRef } from '@n8n/db';
+import { Container, Service } from '@n8n/di';
+import type { ScheduledJobOwnerResolver } from '@n8n/scheduler';
+import { UnexpectedError } from 'n8n-workflow';
+
+/**
+ * Marks an agent as the owner of the scheduled jobs that its published tasks create.
+ * For reconciliation, an agent exists while it has a published version.
+ *
+ * The agents module is optional, so this resolver loads the agent repository on
+ * demand. When the module is not active on this instance, the resolver cannot
+ * tell liveness. Then it throws, and the reconciliation sweep does not touch
+ * agent-owned jobs.
+ */
+@Service()
+export class AgentScheduledJobOwner implements ScheduledJobOwnerResolver {
+	readonly ownerType = ScheduledJobOwnerType.Agent;
+
+	constructor(private readonly moduleRegistry: ModuleRegistry) {}
+
+	/** The owner of the job that one agent task provisions. */
+	member(agentId: string, taskId: string): ScheduledJobOwner {
+		return { ownerType: this.ownerType, ownerId: agentId, ownerMemberId: taskId };
+	}
+
+	/** The owner of all jobs of the agent, whichever task provisioned them. */
+	ref(agentId: string): ScheduledJobOwnerRef {
+		return { ownerType: this.ownerType, ownerId: agentId };
+	}
+
+	async findExisting(ownerIds: string[]): Promise<Set<string>> {
+		if (!this.moduleRegistry.isActive('agents')) {
+			throw new UnexpectedError('Cannot resolve agent liveness: the agents module is not active');
+		}
+
+		const { AgentRepository } = await import('@/modules/agents/repositories/agent.repository.js');
+		return await Container.get(AgentRepository).findPublishedIds(ownerIds);
+	}
+}

--- a/packages/cli/src/scheduling/durable-job-provisioner.ts
+++ b/packages/cli/src/scheduling/durable-job-provisioner.ts
@@ -27,6 +27,7 @@ import type {
 } from '@n8n/scheduler';
 import { Tracing } from 'n8n-core';
 
+import { AgentScheduledJobOwner } from './agent-scheduled-job-owner';
 import { rowSchedule, scheduleColumns } from './schedule-columns';
 import { createScheduledJobOwnerRegistry } from './scheduled-job-owner-registry';
 import { createSchedulerTracer } from './scheduler-tracer';
@@ -122,13 +123,14 @@ export class DurableJobProvisioner {
 		private readonly tasks: ScheduledTaskRepository,
 		private readonly globalConfig: GlobalConfig,
 		workflowOwner: WorkflowScheduledJobOwner,
+		agentOwner: AgentScheduledJobOwner,
 		tracing: Tracing,
 	) {
 		this.logger = this.logger.scoped('scheduler');
 		this.provisioner = createJobProvisioner<ProvisionScope, DeprovisionScope>({
 			provisionTransaction: (scope) => this.provisionTransaction(scope),
 			deprovisionTransaction: (scope) => this.deprovisionTransaction(scope),
-			owners: createScheduledJobOwnerRegistry(workflowOwner),
+			owners: createScheduledJobOwnerRegistry(workflowOwner, agentOwner),
 			tracer: createSchedulerTracer(tracing),
 		});
 		this.materializerOptions = {

--- a/packages/cli/src/scheduling/durable-scheduler.ts
+++ b/packages/cli/src/scheduling/durable-scheduler.ts
@@ -14,6 +14,7 @@ import { InstanceSettings, Tracing } from 'n8n-core';
 
 import { PrometheusSchedulerMetricsService } from '@/metrics/prometheus/scheduler-metrics.service';
 
+import { AgentScheduledJobOwner } from './agent-scheduled-job-owner';
 import { isDurablePollerChainEnabled } from './poll-trigger-node/durable-poller-chain';
 import { PollTriggerTaskHandler } from './poll-trigger-node/poll-trigger-task-handler';
 import { ScheduleTriggerTaskHandler } from './schedule-trigger-node/schedule-trigger-task-handler';
@@ -43,6 +44,7 @@ export class DurableScheduler implements Scheduler {
 		pollTriggerTaskHandler: PollTriggerTaskHandler,
 		metrics: PrometheusSchedulerMetricsService,
 		workflowOwner: WorkflowScheduledJobOwner,
+		agentOwner: AgentScheduledJobOwner,
 	) {
 		const config = globalConfig.scheduler;
 		const enabled = config.enabled && instanceSettings.instanceType === 'main';
@@ -77,7 +79,7 @@ export class DurableScheduler implements Scheduler {
 					reconciliation: config.ownerReconciliationEnabled
 						? {
 								jobStore: jobs,
-								owners: createScheduledJobOwnerRegistry(workflowOwner),
+								owners: createScheduledJobOwnerRegistry(workflowOwner, agentOwner),
 								options: {
 									settleSeconds: config.ownerSettleSeconds,
 									quarantineGraceSeconds: config.ownerQuarantineGraceSeconds,

--- a/packages/cli/src/scheduling/scheduled-job-owner-registry.ts
+++ b/packages/cli/src/scheduling/scheduled-job-owner-registry.ts
@@ -1,6 +1,7 @@
 import { ScheduledJobOwnerType } from '@n8n/constants';
 import { ScheduledJobOwnerRegistry } from '@n8n/scheduler';
 
+import type { AgentScheduledJobOwner } from './agent-scheduled-job-owner';
 import type { WorkflowScheduledJobOwner } from './workflow-scheduled-job-owner';
 
 /**
@@ -9,8 +10,10 @@ import type { WorkflowScheduledJobOwner } from './workflow-scheduled-job-owner';
  */
 export function createScheduledJobOwnerRegistry(
 	workflowOwner: WorkflowScheduledJobOwner,
+	agentOwner: AgentScheduledJobOwner,
 ): ScheduledJobOwnerRegistry {
 	const owners = new ScheduledJobOwnerRegistry();
 	owners.register(ScheduledJobOwnerType.Workflow, workflowOwner);
+	owners.register(ScheduledJobOwnerType.Agent, agentOwner);
 	return owners;
 }

--- a/packages/cli/test/integration/database/repositories/agent.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/agent.repository.test.ts
@@ -315,4 +315,38 @@ describe('AgentRepository', () => {
 			).resolves.toBe(false);
 		});
 	});
+
+	describe('findPublishedIds', () => {
+		/** An agent with a published version, so it owns scheduled jobs. */
+		async function createPublishedAgent(): Promise<Agent> {
+			const versionId = uuid();
+			const agent = await createAgent();
+			await createHistory(agent.id, versionId);
+			await agentRepo.update({ id: agent.id }, { activeVersionId: versionId });
+			return agent;
+		}
+
+		it('keeps the agents that have a published version and drops the drafts', async () => {
+			const published = await createPublishedAgent();
+			const draft = await createAgent();
+
+			const ids = await agentRepo.findPublishedIds([published.id, draft.id]);
+
+			expect(ids).toEqual(new Set([published.id]));
+		});
+
+		it('drops an id that belongs to no agent', async () => {
+			const published = await createPublishedAgent();
+
+			const ids = await agentRepo.findPublishedIds([published.id, uuid()]);
+
+			expect(ids).toEqual(new Set([published.id]));
+		});
+
+		it('answers an empty list without a query', async () => {
+			await createPublishedAgent();
+
+			await expect(agentRepo.findPublishedIds([])).resolves.toEqual(new Set());
+		});
+	});
 });

--- a/packages/cli/test/integration/scheduling/durable-scheduler-lifecycle.test.ts
+++ b/packages/cli/test/integration/scheduling/durable-scheduler-lifecycle.test.ts
@@ -8,6 +8,7 @@ import type { InstanceSettings } from 'n8n-core';
 import { Tracing } from 'n8n-core';
 
 import { PrometheusSchedulerMetricsService } from '@/metrics/prometheus/scheduler-metrics.service';
+import { AgentScheduledJobOwner } from '@/scheduling/agent-scheduled-job-owner';
 import { DurableScheduler } from '@/scheduling/durable-scheduler';
 import { PollTriggerTaskHandler } from '@/scheduling/poll-trigger-node/poll-trigger-task-handler';
 import { ScheduleTriggerTaskHandler } from '@/scheduling/schedule-trigger-node/schedule-trigger-task-handler';
@@ -79,6 +80,7 @@ describe('durable scheduler process lifecycle and flag gating', () => {
 			Container.get(PollTriggerTaskHandler),
 			Container.get(PrometheusSchedulerMetricsService),
 			Container.get(WorkflowScheduledJobOwner),
+			Container.get(AgentScheduledJobOwner),
 		);
 	};
 


### PR DESCRIPTION
## Summary

This PR declares agents as a scheduled job owner in the durable scheduler manifest. It is the core half of the move of agent scheduled tasks to the durable scheduler. The agents module half follows in a stacked PR.

- Adds `AgentScheduledJobOwner` to `packages/cli/src/scheduling/` and registers it in `createScheduledJobOwnerRegistry` next to the workflow owner. The liveness resolver loads `AgentRepository` on demand. When the agents module is not active, the resolver throws. Then the reconciliation sweep does not touch agent-owned jobs (the README rule "throw when you cannot tell").
- Adds `ScheduledJobOwnerType.Agent`. The `ownerId` is the agent id, and the `ownerMemberId` is the task id.
- Adds `AgentRepository.findPublishedIds`.
- Adds the `agent` row to the README owner table.

There is no schema change. Owner-as-data (#37132 to #37135, #37685, #37719) replaces the link-table approach of #36655. That PR will be closed.

### Design note for the scheduler team

The manifest stays a static list. `DurableJobProvisioner` and `DurableScheduler` both build the registry in their constructors, before module init. A registration that depends on module activity at that time is not reliable. So the resolver is module-aware at call time instead. If you prefer a core that knows nothing about modules, the alternative is a registry `@Service()`. Modules then register into it at init.

## How to test

1. In `packages/cli`, run `pnpm test src/scheduling`. This runs the new `agent-scheduled-job-owner.test.ts` and the updated provisioner, scheduler, and registry tests.
2. In `packages/cli`, run `pnpm test:integration test/integration/scheduling`. The owner reconciliation, teardown, and lifecycle suites pass with the new manifest.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-697

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
