### PR TITLE
feat(engine): Add an instance-wide default engine type

### DIFF
--- a/packages/@n8n/config/src/configs/engine.config.ts
+++ b/packages/@n8n/config/src/configs/engine.config.ts
@@ -62,4 +62,15 @@ export class EngineConfig {
 	/** Where the engine dials the control plane server. Defaults to loopback; set it when that is not reachable. */
 	@Env('N8N_ENGINE_CONTROL_PLANE_BASE_URL')
 	controlPlaneBaseUrl: string = '';
+
+	/**
+	 * Engine a workflow runs on when it carries no `engineType` setting of its
+	 * own. `v2` points an instance's whole manual traffic at engine 2.0, for
+	 * dogfooding and e2e runs where setting it per workflow is impractical. A
+	 * workflow that names an engine always keeps it.
+	 *
+	 * This is in development and not ready for use.
+	 */
+	@Env('N8N_ENGINE_DEFAULT_ENGINE_TYPE', z.enum(['v1', 'v2']))
+	defaultEngineType: 'v1' | 'v2' = 'v1';
 }

--- a/packages/cli/src/services/__tests__/engine-v2-dispatcher.service.test.ts
+++ b/packages/cli/src/services/__tests__/engine-v2-dispatcher.service.test.ts
@@ -1,3 +1,4 @@
+import { EngineConfig } from '@n8n/config';
 import { UUID_V7_PATTERN } from '@n8n/constants';
 import type {
 	INode,
@@ -74,6 +75,7 @@ describe('EngineV2Dispatcher', () => {
 	const proxy = mock<EngineDataPlaneProxyService>();
 	const credentialsPermissionChecker = mock<CredentialsPermissionChecker>();
 	const pushRegistry = mock<EngineV2PushRegistry>();
+	let engineConfig: EngineConfig;
 
 	let dispatcher: EngineV2Dispatcher;
 
@@ -81,7 +83,13 @@ describe('EngineV2Dispatcher', () => {
 		vi.clearAllMocks();
 		proxy.isAvailable.mockReturnValue(true);
 		proxy.startExecution.mockResolvedValue({ executionId: 'dp-uuid' });
-		dispatcher = new EngineV2Dispatcher(proxy, credentialsPermissionChecker, pushRegistry);
+		engineConfig = new EngineConfig();
+		dispatcher = new EngineV2Dispatcher(
+			proxy,
+			credentialsPermissionChecker,
+			pushRegistry,
+			engineConfig,
+		);
 	});
 
 	describe('routesToEngineV2', () => {
@@ -94,6 +102,20 @@ describe('EngineV2Dispatcher', () => {
 			{ name: 'engineType v1', settings: { engineType: 'v1' as const } },
 		])('does not route a workflow with $name', ({ settings }) => {
 			const data = runData({ workflowData: workflow({ settings }) });
+
+			expect(dispatcher.routesToEngineV2(data)).toBe(false);
+		});
+
+		it('routes a workflow with no engineType when the instance defaults to v2', () => {
+			engineConfig.defaultEngineType = 'v2';
+			const data = runData({ workflowData: workflow({ settings: {} }) });
+
+			expect(dispatcher.routesToEngineV2(data)).toBe(true);
+		});
+
+		it('does not route a workflow pinned to v1 when the instance defaults to v2', () => {
+			engineConfig.defaultEngineType = 'v2';
+			const data = runData({ workflowData: workflow({ settings: { engineType: 'v1' } }) });
 
 			expect(dispatcher.routesToEngineV2(data)).toBe(false);
 		});

--- a/packages/cli/src/services/engine-v2-dispatcher.service.ts
+++ b/packages/cli/src/services/engine-v2-dispatcher.service.ts
@@ -1,3 +1,4 @@
+import { EngineConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import type { StepSlots, TriggerOutputs } from '@n8n/engine';
 import type { INodeExecutionData, IWorkflowExecutionDataProcess } from 'n8n-workflow';
@@ -33,21 +34,26 @@ export class EngineV2Dispatcher {
 		private readonly proxy: EngineDataPlaneProxyService,
 		private readonly credentialsPermissionChecker: CredentialsPermissionChecker,
 		private readonly pushRegistry: EngineV2PushRegistry,
+		private readonly engineConfig: EngineConfig,
 	) {}
 
 	/**
 	 * Manual runs only for now: webhook (CAT-2920) and trigger (CAT-2921) entry
 	 * paths reuse this seam later. A resume must not start a fresh data-plane
 	 * execution, hence the `existingExecution` check.
+	 *
+	 * A workflow with no `engineType` follows the instance default, so an
+	 * instance can be pointed at engine 2.0 wholesale.
 	 */
 	routesToEngineV2(
 		data: IWorkflowExecutionDataProcess,
 		existingExecution?: ResumableExecution,
 	): boolean {
+		const engineType =
+			data.workflowData.settings?.engineType ?? this.engineConfig.defaultEngineType;
+
 		return (
-			data.workflowData.settings?.engineType === 'v2' &&
-			data.executionMode === 'manual' &&
-			existingExecution === undefined
+			engineType === 'v2' && data.executionMode === 'manual' && existingExecution === undefined
 		);
 	}
 


### PR DESCRIPTION
## Summary

Engine 2.0 is opt-in per workflow via `settings.engineType`. That is the right default, but it means pointing a whole instance at the new engine requires editing every workflow's settings — which is impractical for running the existing E2E suite against engine 2.0, and for dogfooding an instance on it.

This adds `N8N_ENGINE_DEFAULT_ENGINE_TYPE` (`v1` | `v2`, default `v1`). It supplies the engine for a workflow that names none. A workflow that names one keeps it, so an explicit `engineType: 'v1'` still runs on v1 even when the instance default is `v2`.

Nothing changes unless the variable is set.

Note this is not a soft rollout: with the default set to `v2`, a workflow shape the v2 path cannot handle yet still fails with a user-facing reason rather than falling back to v1. That is the existing `assertSupported` behaviour and it is deliberate — a silent fallback would run a workflow on an engine the operator did not pick.

## How to test

Boot an instance with the engine-v2 module enabled and the default set to `v2`:

```
N8N_ENABLED_MODULES=engine-v2
N8N_ENGINE_DATABASE_URL=postgres://<user>:<pass>@<host>:<port>/<engine-db>
N8N_ENGINE_DEFAULT_ENGINE_TYPE=v2
```

Run a workflow with a Manual Trigger manually, with no `engineType` in its settings. It executes on engine 2.0 — the returned execution id is a UUID rather than a control-plane integer, and rows appear in the engine database's `workflow_execution` and `workflow_step_execution` tables.

Then set `settings.engineType` to `v1` on that workflow and run it again: it goes back to the v1 engine.

With the variable unset, or set to `v1`, only workflows that opt in with `engineType: 'v2'` reach the engine, exactly as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4395 — listed there as a prerequisite for tracking engine 2.0 parity in CI.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

