### PR TITLE
fix: Sign Microsoft Dynamics OAuth2 requests with the access token

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -205,9 +205,6 @@ export const getOAuth2AdditionalParameters = (nodeCredentialType: string) => {
 		microsoftAzureMonitorOAuth2Api: {
 			tokenExpiredStatusCode: 403,
 		},
-		microsoftDynamicsOAuth2Api: {
-			property: 'id_token',
-		},
 		philipsHueOAuth2Api: {
 			tokenType: 'Bearer',
 		},

--- a/packages/nodes-base/nodes/HttpRequest/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/GenericFunctions.test.ts
@@ -1,7 +1,11 @@
 import { mock } from 'vitest-mock-extended';
 import type { INode } from 'n8n-workflow';
 
-import { getAllowedDomains, updadeQueryParameterConfig } from '../GenericFunctions';
+import {
+	getAllowedDomains,
+	getOAuth2AdditionalParameters,
+	updadeQueryParameterConfig,
+} from '../GenericFunctions';
 
 describe('updadeQueryParameterConfig', () => {
 	describe('version < 4.3 (legacy behavior)', () => {
@@ -117,5 +121,12 @@ describe('getAllowedDomains', () => {
 		});
 
 		expect(result).toBe('example.com, *.api.io');
+	});
+});
+
+describe('getOAuth2AdditionalParameters', () => {
+	it('should return undefined for microsoftDynamicsOAuth2Api so the stored access token is used', () => {
+		const result = getOAuth2AdditionalParameters('microsoftDynamicsOAuth2Api');
+		expect(result).toBeUndefined();
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -42,9 +42,7 @@ export async function microsoftApiRequest(
 		if (Object.keys(option).length !== 0) {
 			options = Object.assign({}, options, option);
 		}
-		return await this.helpers.requestOAuth2.call(this, 'microsoftDynamicsOAuth2Api', options, {
-			property: 'id_token',
-		});
+		return await this.helpers.requestOAuth2.call(this, 'microsoftDynamicsOAuth2Api', options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/test/GenericFunctions.test.ts
@@ -1,0 +1,19 @@
+import { mock } from 'vitest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { microsoftApiRequest } from '../GenericFunctions';
+
+describe('microsoftApiRequest', () => {
+	it('should call requestOAuth2 without oAuth2Options so the stored access token is used', async () => {
+		const requestOAuth2 = vi.fn().mockResolvedValue({});
+		const context = mock<IExecuteFunctions>({
+			helpers: mock<IExecuteFunctions['helpers']>({ requestOAuth2 }),
+		});
+		context.getCredentials.mockResolvedValue({ subdomain: 'org', region: 'crm.dynamics.com' });
+
+		await microsoftApiRequest.call(context, 'GET', '/accounts');
+
+		expect(requestOAuth2).toHaveBeenCalledWith('microsoftDynamicsOAuth2Api', expect.any(Object));
+		expect(requestOAuth2.mock.calls[0]).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## Summary

Every request made with the Microsoft Dynamics OAuth2 credential was signed with the OpenID Connect ID token instead of the Dataverse access token. This worked by accident for years until Microsoft tightened token validation on some tenants, which now rejects the ID token and breaks the connection.

This PR removes the token override so requests use the access token, like every other OAuth2 credential type. No reconnect or migration is needed: the correct access token is already stored on every existing connection.

**Release note:** if you enabled Custom Scopes on this credential and removed the default Dataverse scope (`https://{subdomain}.{region}/.default`), your connection was, until now, only working because of this bug. After this change, it will fail with a 401. Restore that scope and reconnect the credential to fix it.

## How to test

1. Create a Microsoft Dynamics OAuth2 API credential and connect it.
2. Add an HTTP Request node with Authentication -> Predefined Credential Type -> Microsoft Dynamics OAuth2 API, pointed at a request inspector (e.g. a Webhook node).
3. Execute and decode the JWT in the `Authorization: Bearer` header.
4. Before this change: `aud` is the OAuth client app ID (the ID token). After this change: `aud` is the Dataverse org URL (the access token).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-404

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

