### PR TITLE
fix: Refuse to seed history when the target is a remote instance

### DIFF
--- a/scripts/instance-seeding/seedHistory.mjs
+++ b/scripts/instance-seeding/seedHistory.mjs
@@ -27,6 +27,35 @@ const DB_PATH =
 	process.env.DB_SQLITE_DATABASE ??
 	path.join(process.env.N8N_USER_FOLDER ?? os.homedir(), '.n8n', 'database.sqlite');
 
+/**
+ * This script writes SQLite on the local filesystem and never makes a request, so a
+ * remote `N8N_BASE_URL` cannot reach the instance it names. Left unchecked it silently
+ * rewrites the developer's own history instead, which is what `pnpm seed:preference`
+ * does when pointed at a preview environment: the estate lands remotely and the
+ * history lands here.
+ *
+ * An explicit `DB_SQLITE_DATABASE` means the target was chosen deliberately, so it
+ * overrides the check.
+ */
+function assertLocalTarget() {
+	if (process.env.DB_SQLITE_DATABASE) return;
+	const raw = process.env.N8N_BASE_URL;
+	if (!raw) return;
+	let host;
+	try {
+		host = new URL(raw).hostname.toLowerCase();
+	} catch {
+		return; // Unparseable, so nothing to conclude from it.
+	}
+	if (['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0'].includes(host)) return;
+	console.error(`N8N_BASE_URL points at ${host}, but this script only writes local SQLite.`);
+	console.error('Executions, assistant threads and activity have no public-API create route,');
+	console.error(`so a remote instance cannot be seeded from here. It would have written to:`);
+	console.error(`  ${DB_PATH}`);
+	console.error('Set DB_SQLITE_DATABASE explicitly if that is genuinely what you want.');
+	process.exit(1);
+}
+
 const SEED_PREFIX = '[seed] ';
 // Threads have no name to prefix, so they carry this in `metadata` instead. It is how
 // the clear step tells its own rows from a developer's real assistant threads.
@@ -151,6 +180,7 @@ function runData(wf, failure) {
 }
 
 function main() {
+	assertLocalTarget();
 	const db = new DatabaseSync(DB_PATH);
 	db.exec('PRAGMA foreign_keys = ON');
 

--- a/scripts/instance-seeding/seedHistory.test.mjs
+++ b/scripts/instance-seeding/seedHistory.test.mjs
@@ -264,6 +264,41 @@ describe('seedHistory cleanup', () => {
 		assert.match(out, /Cleared prior: \d+ executions, 2 threads, \d+ activity entries/);
 	});
 
+	// `pnpm seed:preference` sends the estate to N8N_BASE_URL but the history to a
+	// local file, so a remote URL used to mean silently rewriting your own history.
+	it('refuses a remote N8N_BASE_URL unless the database is named explicitly', () => {
+		const dbFile = fixture();
+		const remote = { N8N_BASE_URL: 'https://test-foo.stage-app.n8n.cloud' };
+		assert.throws(
+			() =>
+				execFileSync(process.execPath, [SCRIPT], {
+					env: { ...process.env, ...remote, DB_SQLITE_DATABASE: undefined, HISTORY_DAYS: '2' },
+					encoding: 'utf8',
+				}),
+			/only writes local SQLite/,
+		);
+		// Naming the database is an explicit choice, so it still runs.
+		const out = execFileSync(process.execPath, [SCRIPT], {
+			env: { ...process.env, ...remote, DB_SQLITE_DATABASE: dbFile, HISTORY_DAYS: '2' },
+			encoding: 'utf8',
+		});
+		assert.match(out, /Database: /);
+	});
+
+	it('allows a loopback N8N_BASE_URL', () => {
+		const dbFile = fixture();
+		const out = execFileSync(process.execPath, [SCRIPT], {
+			env: {
+				...process.env,
+				N8N_BASE_URL: 'http://localhost:5678',
+				DB_SQLITE_DATABASE: dbFile,
+				HISTORY_DAYS: '2',
+			},
+			encoding: 'utf8',
+		});
+		assert.match(out, /Database: /);
+	});
+
 	it('exits with a message when nothing is seeded', () => {
 		const file = join(mkdtempSync(join(tmpdir(), 'seed-history-empty-')), 'database.sqlite');
 		const db = new DatabaseSync(file);


### PR DESCRIPTION
## TL;DR

`pnpm seed:preference` sent the estate to `N8N_BASE_URL` but the history to a **local** SQLite file, silently rewriting the developer's own history. The history writer now refuses a non-loopback URL.

## The bug

`seed:preference` is `PROFILE=preference pnpm seed:account && pnpm seed:history`.

| Step | Target | Result |
| --- | --- | --- |
| `seed:account` | the remote URL | project, credentials, data tables, 10 workflows |
| `seed:history` | a **local** SQLite file | nothing remote; rewrites your own history |

`seedHistory.mjs` reads neither `N8N_BASE_URL` nor `N8N_API_KEY`. It writes SQLite directly, because executions, assistant threads and activity have no public-API create route, so it cannot know a remote instance was named.

Demonstrated: with `N8N_BASE_URL=https://test-foo.stage-app.n8n.cloud` set, it wrote 175 executions locally and never opened a socket.

With no local seeded instance you get a confusing `No [seed] workflows in …`. With one, it silently overwrites it.

## The fix

Refuse when `N8N_BASE_URL` names a non-loopback host, printing the path it would have written to and why a remote instance cannot be seeded from here. `DB_SQLITE_DATABASE` is an explicit choice of target, so it overrides the check.

| `N8N_BASE_URL` | `DB_SQLITE_DATABASE` | Result |
| --- | --- | --- |
| remote | unset | refuses, exit 1 |
| remote | set | runs |
| loopback | either | runs |
| unset | either | runs |

## How to test

```bash
# refuses
N8N_BASE_URL=https://test-foo.stage-app.n8n.cloud pnpm seed:history

# still runs
N8N_BASE_URL=http://localhost:5678 DB_SQLITE_DATABASE=/path/to/database.sqlite pnpm seed:history

pnpm seed:test   # 20 tests, 2 of them new
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CONTEXT-117

Follows https://linear.app/n8n/issue/CONTEXT-108 (#37645), which merged before this fix was ready.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

