### PR TITLE
perf(core): Bound peak memory during source control push

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/project-relation.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/project-relation.repository.test.ts
@@ -1,0 +1,56 @@
+import { Container } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import type { SelectQueryBuilder } from '@n8n/typeorm';
+import { mock } from 'vitest-mock-extended';
+
+import { ProjectRelation } from '../../entities';
+import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
+import { ProjectRelationRepository } from '../project-relation.repository';
+
+describe('ProjectRelationRepository', () => {
+	mockEntityManager(ProjectRelation);
+	const projectRelationRepository = Container.get(ProjectRelationRepository);
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('findPersonalOwnerEmails', () => {
+		it('should map each personal project id to the email of its owner', async () => {
+			const queryBuilder = mock<SelectQueryBuilder<ProjectRelation>>();
+			queryBuilder.innerJoin.mockReturnThis();
+			queryBuilder.select.mockReturnThis();
+			queryBuilder.addSelect.mockReturnThis();
+			queryBuilder.where.mockReturnThis();
+			queryBuilder.andWhere.mockReturnThis();
+			queryBuilder.getRawMany.mockResolvedValue([
+				{ projectId: 'project1', email: 'owner@example.com' },
+			]);
+			vi.spyOn(projectRelationRepository, 'createQueryBuilder').mockReturnValue(queryBuilder);
+
+			const result = await projectRelationRepository.findPersonalOwnerEmails([
+				'project1',
+				'project1',
+				'project2',
+			]);
+
+			expect(queryBuilder.where).toHaveBeenCalledWith(
+				'projectRelation.projectId IN (:...projectIds)',
+				{ projectIds: ['project1', 'project2'] },
+			);
+			expect(queryBuilder.andWhere).toHaveBeenCalledWith('projectRelation.role = :role', {
+				role: PROJECT_OWNER_ROLE_SLUG,
+			});
+			expect(result).toEqual(new Map([['project1', 'owner@example.com']]));
+		});
+
+		it('should not query when there are no project ids', async () => {
+			const createQueryBuilder = vi.spyOn(projectRelationRepository, 'createQueryBuilder');
+
+			const result = await projectRelationRepository.findPersonalOwnerEmails([]);
+
+			expect(createQueryBuilder).not.toHaveBeenCalled();
+			expect(result).toEqual(new Map());
+		});
+	});
+});

--- a/packages/@n8n/db/src/repositories/__tests__/shared-credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/shared-credentials.repository.test.ts
@@ -3,6 +3,7 @@ import { In, type SelectQueryBuilder } from '@n8n/typeorm';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import type { Project } from '../../entities';
 import { SharedCredentials } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { SharedCredentialsRepository } from '../shared-credentials.repository';
@@ -35,13 +36,29 @@ describe('SharedCredentialsRepository', () => {
 			await sharedCredentialsRepository.findByCredentialIds(credentialIds, role);
 
 			expect(entityManager.find).toHaveBeenCalledWith(SharedCredentials, {
-				relations: { credentials: true, project: { projectRelations: { user: true, role: true } } },
-				loadEagerRelations: false,
+				relations: { credentials: true },
 				where: {
 					credentialsId: In(credentialIds),
 					role,
 				},
 			});
+		});
+	});
+
+	describe('findOwnerProjectsByCredentialIds', () => {
+		it('should map each credential id to its owner project', async () => {
+			const project = mock<Project>({ id: 'project1' });
+			entityManager.find.mockResolvedValueOnce([
+				mock<SharedCredentials>({ credentialsId: 'cred1', project }),
+			]);
+
+			const result = await sharedCredentialsRepository.findOwnerProjectsByCredentialIds(['cred1']);
+
+			expect(entityManager.find).toHaveBeenCalledWith(SharedCredentials, {
+				where: { credentialsId: In(['cred1']), role: 'credential:owner' },
+				relations: { project: true },
+			});
+			expect(result).toEqual(new Map([['cred1', project]]));
 		});
 	});
 

--- a/packages/@n8n/db/src/repositories/__tests__/shared-credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/shared-credentials.repository.test.ts
@@ -36,6 +36,7 @@ describe('SharedCredentialsRepository', () => {
 
 			expect(entityManager.find).toHaveBeenCalledWith(SharedCredentials, {
 				relations: { credentials: true, project: { projectRelations: { user: true, role: true } } },
+				loadEagerRelations: false,
 				where: {
 					credentialsId: In(credentialIds),
 					role,

--- a/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
@@ -121,28 +121,6 @@ describe('SharedWorkflowRepository', () => {
 		});
 	});
 
-	describe('findByWorkflowIds', () => {
-		it('merges owner rows returned from different chunks', async () => {
-			const first = mock<SharedWorkflow>({ workflowId: 'first' });
-			const last = mock<SharedWorkflow>({ workflowId: 'last' });
-			entityManager.find.mockResolvedValueOnce([first]).mockResolvedValueOnce([last]);
-			const workflowIds = Array.from({ length: 10_001 }, (_, index) => `workflow-${index}`);
-
-			const result = await sharedWorkflowRepository.findByWorkflowIds(workflowIds);
-
-			expect(entityManager.find).toHaveBeenCalledTimes(2);
-			expect(entityManager.find).toHaveBeenNthCalledWith(2, SharedWorkflow, {
-				where: {
-					role: 'workflow:owner',
-					workflowId: In(['workflow-10000']),
-				},
-				relations: { project: { projectRelations: { user: true, role: true } } },
-				loadEagerRelations: false,
-			});
-			expect(result).toEqual([first, last]);
-		});
-	});
-
 	describe('findWorkflowIdsInUserProjects', () => {
 		it('returns an empty set without querying when there are no workflow ids', async () => {
 			const result = await sharedWorkflowRepository.findWorkflowIdsInUserProjects([], 'user-1', [

--- a/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/shared-workflow.repository.test.ts
@@ -137,6 +137,7 @@ describe('SharedWorkflowRepository', () => {
 					workflowId: In(['workflow-10000']),
 				},
 				relations: { project: { projectRelations: { user: true, role: true } } },
+				loadEagerRelations: false,
 			});
 			expect(result).toEqual([first, last]);
 		});

--- a/packages/@n8n/db/src/repositories/project-relation.repository.ts
+++ b/packages/@n8n/db/src/repositories/project-relation.repository.ts
@@ -3,11 +3,27 @@ import { PROJECT_OWNER_ROLE_SLUG, type ProjectRole } from '@n8n/permissions';
 import { DataSource, In, Repository } from '@n8n/typeorm';
 
 import { ProjectRelation } from '../entities';
+import { chunkIds } from '../utils/chunk-ids';
 
 @Service()
 export class ProjectRelationRepository extends Repository<ProjectRelation> {
 	constructor(dataSource: DataSource) {
 		super(ProjectRelation, dataSource.manager);
+	}
+
+	async findPersonalOwnerEmails(projectIds: string[]): Promise<Map<string, string>> {
+		const ownerEmails = new Map<string, string>();
+		for (const chunk of chunkIds([...new Set(projectIds)])) {
+			const rows = await this.createQueryBuilder('projectRelation')
+				.innerJoin('projectRelation.user', 'user')
+				.select('projectRelation.projectId', 'projectId')
+				.addSelect('user.email', 'email')
+				.where('projectRelation.projectId IN (:...projectIds)', { projectIds: chunk })
+				.andWhere('projectRelation.role = :role', { role: PROJECT_OWNER_ROLE_SLUG })
+				.getRawMany<{ projectId: string; email: string }>();
+			for (const { projectId, email } of rows) ownerEmails.set(projectId, email);
+		}
+		return ownerEmails;
 	}
 
 	async getPersonalProjectOwners(projectIds: string[]) {

--- a/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
@@ -6,6 +6,7 @@ import { DataSource, In, Not, Repository } from '@n8n/typeorm';
 
 import type { User } from '../entities';
 import { Project, ProjectRelation, SharedCredentials } from '../entities';
+import { chunkIds } from '../utils/chunk-ids';
 
 @Service()
 export class SharedCredentialsRepository extends Repository<SharedCredentials> {
@@ -15,13 +16,24 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 
 	async findByCredentialIds(credentialIds: string[], role: CredentialSharingRole) {
 		return await this.find({
-			relations: { credentials: true, project: { projectRelations: { user: true, role: true } } },
-			loadEagerRelations: false,
+			relations: { credentials: true },
 			where: {
 				credentialsId: In(credentialIds),
 				role,
 			},
 		});
+	}
+
+	async findOwnerProjectsByCredentialIds(credentialIds: string[]): Promise<Map<string, Project>> {
+		const ownerProjects = new Map<string, Project>();
+		for (const chunk of chunkIds(credentialIds)) {
+			const rows = await this.find({
+				where: { credentialsId: In(chunk), role: 'credential:owner' },
+				relations: { project: true },
+			});
+			for (const { credentialsId, project } of rows) ownerProjects.set(credentialsId, project);
+		}
+		return ownerProjects;
 	}
 
 	async makeOwnerOfAllCredentials(project: Project) {

--- a/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
@@ -16,6 +16,7 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 	async findByCredentialIds(credentialIds: string[], role: CredentialSharingRole) {
 		return await this.find({
 			relations: { credentials: true, project: { projectRelations: { user: true, role: true } } },
+			loadEagerRelations: false,
 			where: {
 				credentialsId: In(credentialIds),
 				role,

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -53,24 +53,6 @@ export class SharedWorkflowRepository extends BaseRepository<SharedWorkflow> {
 		return found;
 	}
 
-	async findByWorkflowIds(workflowIds: string[]) {
-		const rows = new Map<string, SharedWorkflow>();
-
-		for (const chunk of chunkIds(workflowIds)) {
-			const found = await this.find({
-				where: {
-					role: 'workflow:owner',
-					workflowId: In(chunk),
-				},
-				relations: { project: { projectRelations: { user: true, role: true } } },
-				loadEagerRelations: false,
-			});
-			for (const row of found) rows.set(row.workflowId, row);
-		}
-
-		return [...rows.values()];
-	}
-
 	/** Owner project of each workflow, keyed by workflow id. */
 	async findOwnerProjectsByWorkflowIds(workflowIds: string[]): Promise<Map<string, Project>> {
 		const ownerRows: SharedWorkflow[] = [];

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -63,6 +63,7 @@ export class SharedWorkflowRepository extends BaseRepository<SharedWorkflow> {
 					workflowId: In(chunk),
 				},
 				relations: { project: { projectRelations: { user: true, role: true } } },
+				loadEagerRelations: false,
 			});
 			for (const row of found) rows.set(row.workflowId, row);
 		}

--- a/packages/cli/src/modules/n8n-packages/entities/variable/__tests__/variable.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/variable/__tests__/variable.exporter.test.ts
@@ -1,4 +1,4 @@
-import type { Project, SharedWorkflow, SharedWorkflowRepository, User, Variables } from '@n8n/db';
+import type { Project, SharedWorkflowRepository, User, Variables } from '@n8n/db';
 import { jsonParse } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
@@ -57,9 +57,12 @@ function wireVariables(
 ) {
 	deps.variablesService.getAllCached.mockResolvedValue(opts.all);
 	deps.variablesService.getAllForUser.mockResolvedValue(opts.accessible ?? opts.all);
-	deps.sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue(
-		opts.workflowProjects.map(([workflowId, projectId]) =>
-			mock<SharedWorkflow>({ workflowId, project: { id: projectId } as Project }),
+	deps.sharedWorkflowRepository.findOwnerProjectsByWorkflowIds.mockResolvedValue(
+		new Map(
+			opts.workflowProjects.map(([workflowId, projectId]) => [
+				workflowId,
+				{ id: projectId } as Project,
+			]),
 		),
 	);
 }
@@ -82,7 +85,7 @@ describe('VariableExporter', () => {
 			expect(writer.directories).toEqual([]);
 
 			expect(variablesService.getAllCached).not.toHaveBeenCalled();
-			expect(sharedWorkflowRepository.findByWorkflowIds).not.toHaveBeenCalled();
+			expect(sharedWorkflowRepository.findOwnerProjectsByWorkflowIds).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/n8n-packages/entities/variable/variable.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/variable/variable.exporter.ts
@@ -155,8 +155,8 @@ export class VariableExporter {
 	}
 
 	private async resolveWorkflowProjects(workflowIds: string[]): Promise<Map<string, string>> {
-		const owners = await this.sharedWorkflowRepository.findByWorkflowIds(workflowIds);
-		return new Map(owners.map((owner) => [owner.workflowId, owner.project.id]));
+		const owners = await this.sharedWorkflowRepository.findOwnerProjectsByWorkflowIds(workflowIds);
+		return new Map([...owners].map(([workflowId, project]) => [workflowId, project.id]));
 	}
 
 	/**

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -416,6 +416,7 @@ describe('SourceControlExportService', () => {
 			});
 			tagRepository.find.mockResolvedValue([mockTag]);
 			workflowTagMappingRepository.find.mockResolvedValue([mockWorkflow]);
+			workflowRepository.find.mockResolvedValue([]);
 			const fileName = '/mock/n8n/git/tags.json';
 
 			// Act
@@ -459,6 +460,44 @@ describe('SourceControlExportService', () => {
 			expect(result.count).toBe(0);
 			expect(result.files).toHaveLength(1);
 			expect(result.files[0]).toMatchObject({ id: '', name: fileName });
+		});
+
+		it('should load only workflow ids and replace mappings of accessible workflows', async () => {
+			// Arrange
+			const mockTag = mock<TagEntity>({
+				id: 'tag1',
+				name: 'Tag 1',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+			const accessibleMapping = { tagId: 'tag1', workflowId: 'workflow1' } as WorkflowTagMapping;
+			const inaccessibleMapping = { tagId: 'tag2', workflowId: 'workflow2' };
+			tagRepository.find.mockResolvedValue([mockTag]);
+			workflowTagMappingRepository.find.mockResolvedValue([accessibleMapping]);
+			workflowRepository.find.mockResolvedValue([
+				Object.assign(new WorkflowEntity(), { id: 'workflow1' }),
+			]);
+			fsReadFile.mockResolvedValueOnce(
+				JSON.stringify({
+					tags: [],
+					mappings: [{ tagId: 'stale', workflowId: 'workflow1' }, inaccessibleMapping],
+				}),
+			);
+
+			// Act
+			await service.exportTagsToWorkFolder(globalAdminContext);
+
+			// Assert
+			expect(workflowRepository.find).toHaveBeenCalledTimes(1);
+			expect(workflowRepository.find).toHaveBeenCalledWith(
+				expect.objectContaining({ select: { id: true } }),
+			);
+			const dataCaptor = captor<string>();
+			expect(fsWriteFile).toHaveBeenCalledWith('/mock/n8n/git/tags.json', dataCaptor);
+			expect(JSON.parse(dataCaptor.value).mappings).toEqual([
+				inaccessibleMapping,
+				accessibleMapping,
+			]);
 		});
 	});
 
@@ -681,6 +720,67 @@ describe('SourceControlExportService', () => {
 			const exported = JSON.parse(dataCaptor.value);
 			expect('description' in exported).toBe(true);
 			expect(exported.description).toBeNull();
+		});
+
+		it('should load and write workflows in batches', async () => {
+			// Arrange
+			const workflowIds = Array.from({ length: 45 }, (_, index) => `wf-${index}`);
+			sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue(
+				workflowIds.map(
+					(workflowId) =>
+						mock<SharedWorkflow>({
+							workflowId,
+							project: mock({ type: 'team', id: 'team-1', name: 'Team 1' }),
+							workflow: mock(),
+						} as never) as SharedWorkflow,
+				),
+			);
+			const toWorkflowEntity = (id: string) =>
+				Object.assign(new WorkflowEntity(), {
+					id,
+					name: `Workflow ${id}`,
+					nodes: [],
+					connections: {},
+					settings: {},
+					triggerCount: 0,
+					versionId: 'v1',
+					parentFolder: null,
+					isArchived: false,
+					nodeGroups: [],
+				});
+			workflowRepository.find
+				.mockResolvedValueOnce(workflowIds.slice(0, 20).map(toWorkflowEntity))
+				.mockResolvedValueOnce(workflowIds.slice(20, 40).map(toWorkflowEntity))
+				.mockResolvedValueOnce(workflowIds.slice(40).map(toWorkflowEntity));
+
+			// Act
+			const result = await service.exportWorkflowsToWorkFolder(
+				workflowIds.map((id) => mock<SourceControlledFile>({ id })),
+			);
+
+			// Assert
+			expect(workflowRepository.find).toHaveBeenCalledTimes(3);
+			expect(workflowRepository.find).toHaveBeenNthCalledWith(1, {
+				where: { id: In(workflowIds.slice(0, 20)) },
+				relations: ['parentFolder'],
+			});
+			expect(workflowRepository.find).toHaveBeenNthCalledWith(2, {
+				where: { id: In(workflowIds.slice(20, 40)) },
+				relations: ['parentFolder'],
+			});
+			expect(workflowRepository.find).toHaveBeenNthCalledWith(3, {
+				where: { id: In(workflowIds.slice(40)) },
+				relations: ['parentFolder'],
+			});
+
+			const findOrder = workflowRepository.find.mock.invocationCallOrder;
+			const writeOrder = fsWriteFile.mock.invocationCallOrder;
+			expect(writeOrder).toHaveLength(45);
+			expect(writeOrder[19]).toBeLessThan(findOrder[1]);
+			expect(writeOrder[39]).toBeLessThan(findOrder[2]);
+
+			expect(result.count).toBe(45);
+			expect(result.files.map((file) => file.id)).toEqual(workflowIds);
 		});
 
 		it('should throw an error if workflow has no owner', async () => {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -3,10 +3,10 @@ import type {
 	Folder,
 	FolderRepository,
 	Project,
+	ProjectRelationRepository,
 	ProjectRepository,
 	SharedCredentials,
 	SharedCredentialsRepository,
-	SharedWorkflow,
 	SharedWorkflowRepository,
 	TagEntity,
 	TagRepository,
@@ -15,7 +15,7 @@ import type {
 	WorkflowTagMappingRepository,
 	Variables,
 } from '@n8n/db';
-import { GLOBAL_ADMIN_ROLE, In, PROJECT_OWNER_ROLE, User, WorkflowEntity } from '@n8n/db';
+import { GLOBAL_ADMIN_ROLE, In, User, WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { Cipher, type InstanceSettings } from 'n8n-core';
 import fsp from 'node:fs/promises';
@@ -42,6 +42,7 @@ describe('SourceControlExportService', () => {
 	const folderRepository = mock<FolderRepository>();
 	const sourceControlScopedService = mock<SourceControlScopedService>();
 	const dataTableRepository = mock<DataTableRepository>();
+	const projectRelationRepository = mock<ProjectRelationRepository>();
 
 	const globalAdminContext = new SourceControlContext(
 		Object.assign(new User(), { role: GLOBAL_ADMIN_ROLE }),
@@ -62,7 +63,11 @@ describe('SourceControlExportService', () => {
 		sourceControlScopedService,
 		mock<InstanceSettings>({ n8nFolder: '/mock/n8n' }),
 		dataTableRepository,
+		projectRelationRepository,
 	);
+
+	const personalProject = mock<Project>({ type: 'personal', id: 'personal-1', name: 'Personal' });
+	const teamProject = mock<Project>({ type: 'team', id: 'team1', name: 'Test Team' });
 
 	const fsWriteFile = vi.spyOn(fsp, 'writeFile');
 	const fsReadFile = vi.spyOn(fsp, 'readFile');
@@ -70,6 +75,9 @@ describe('SourceControlExportService', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter.mockReturnValue({});
+		sharedWorkflowRepository.findOwnerProjectsByWorkflowIds.mockResolvedValue(new Map());
+		sharedCredentialsRepository.findOwnerProjectsByCredentialIds.mockResolvedValue(new Map());
+		projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(new Map());
 	});
 
 	describe('exportCredentialsToWorkFolder', () => {
@@ -96,18 +104,16 @@ describe('SourceControlExportService', () => {
 		it('should export credentials to work folder', async () => {
 			sharedCredentialsRepository.findByCredentialIds.mockResolvedValue([
 				mock<SharedCredentials>({
+					credentialsId: mockCredentials.id,
 					credentials: mockCredentials,
-					project: mock({
-						type: 'personal',
-						projectRelations: [
-							{
-								role: PROJECT_OWNER_ROLE,
-								user: mock({ email: 'user@example.com' }),
-							},
-						],
-					}),
 				} as never) as SharedCredentials,
 			]);
+			sharedCredentialsRepository.findOwnerProjectsByCredentialIds.mockResolvedValue(
+				new Map([[mockCredentials.id, personalProject]]),
+			);
+			projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(
+				new Map([[personalProject.id, 'user@example.com']]),
+			);
 
 			// Act
 			const result = await service.exportCredentialsToWorkFolder([mock()]);
@@ -133,6 +139,8 @@ describe('SourceControlExportService', () => {
 				},
 				ownedBy: {
 					type: 'personal',
+					projectId: 'personal-1',
+					projectName: 'Personal',
 					personalEmail: 'user@example.com',
 				},
 			});
@@ -141,14 +149,13 @@ describe('SourceControlExportService', () => {
 		it('should handle team project credentials', async () => {
 			sharedCredentialsRepository.findByCredentialIds.mockResolvedValue([
 				mock<SharedCredentials>({
+					credentialsId: mockCredentials.id,
 					credentials: mockCredentials,
-					project: mock({
-						type: 'team',
-						id: 'team1',
-						name: 'Test Team',
-					}),
 				} as never) as SharedCredentials,
 			]);
+			sharedCredentialsRepository.findOwnerProjectsByCredentialIds.mockResolvedValue(
+				new Map([[mockCredentials.id, teamProject]]),
+			);
 
 			// Act
 			const result = await service.exportCredentialsToWorkFolder([
@@ -209,14 +216,13 @@ describe('SourceControlExportService', () => {
 
 			sharedCredentialsRepository.findByCredentialIds.mockResolvedValue([
 				mock<SharedCredentials>({
+					credentialsId: mockGlobalCredential.id,
 					credentials: mockGlobalCredential,
-					project: mock({
-						type: 'team',
-						id: 'team1',
-						name: 'Test Team',
-					}),
 				} as never) as SharedCredentials,
 			]);
+			sharedCredentialsRepository.findOwnerProjectsByCredentialIds.mockResolvedValue(
+				new Map([[mockGlobalCredential.id, teamProject]]),
+			);
 
 			// Act
 			const result = await service.exportCredentialsToWorkFolder([
@@ -269,18 +275,16 @@ describe('SourceControlExportService', () => {
 
 			sharedCredentialsRepository.findByCredentialIds.mockResolvedValue([
 				mock<SharedCredentials>({
+					credentialsId: mockNonGlobalCredential.id,
 					credentials: mockNonGlobalCredential,
-					project: mock({
-						type: 'personal',
-						projectRelations: [
-							{
-								role: PROJECT_OWNER_ROLE,
-								user: mock({ email: 'user@example.com' }),
-							},
-						],
-					}),
 				} as never) as SharedCredentials,
 			]);
+			sharedCredentialsRepository.findOwnerProjectsByCredentialIds.mockResolvedValue(
+				new Map([[mockNonGlobalCredential.id, personalProject]]),
+			);
+			projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(
+				new Map([[personalProject.id, 'user@example.com']]),
+			);
 
 			// Act
 			const result = await service.exportCredentialsToWorkFolder([
@@ -309,6 +313,8 @@ describe('SourceControlExportService', () => {
 				},
 				ownedBy: {
 					type: 'personal',
+					projectId: 'personal-1',
+					projectName: 'Personal',
 					personalEmail: 'user@example.com',
 				},
 				isGlobal: false,
@@ -367,18 +373,16 @@ describe('SourceControlExportService', () => {
 
 			sharedCredentialsRepository.findByCredentialIds.mockResolvedValue([
 				mock<SharedCredentials>({
+					credentialsId: mockCredentialWithoutIsGlobal.id,
 					credentials: mockCredentialWithoutIsGlobal,
-					project: mock({
-						type: 'personal',
-						projectRelations: [
-							{
-								role: PROJECT_OWNER_ROLE,
-								user: mock({ email: 'user@example.com' }),
-							},
-						],
-					}),
 				} as never) as SharedCredentials,
 			]);
+			sharedCredentialsRepository.findOwnerProjectsByCredentialIds.mockResolvedValue(
+				new Map([[mockCredentialWithoutIsGlobal.id, personalProject]]),
+			);
+			projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(
+				new Map([[personalProject.id, 'user@example.com']]),
+			);
 
 			// Act
 			const result = await service.exportCredentialsToWorkFolder([
@@ -410,11 +414,13 @@ describe('SourceControlExportService', () => {
 					type: 'httpBasicAuth',
 					data: cipher.encrypt({ user: 'u', password: 'p' }),
 				}),
-				project: mock({ type: 'team', id: 'team-1', name: 'Team 1' }),
 			} as never) as SharedCredentials;
 
 		it('should load and write credentials in batches', async () => {
 			const credentialIds = Array.from({ length: 45 }, (_, index) => `cred-${index}`);
+			sharedCredentialsRepository.findOwnerProjectsByCredentialIds.mockResolvedValue(
+				new Map(credentialIds.map((id) => [id, teamProject])),
+			);
 			sharedCredentialsRepository.findByCredentialIds
 				.mockResolvedValueOnce(credentialIds.slice(0, 20).map(toSharing))
 				.mockResolvedValueOnce(credentialIds.slice(20, 40).map(toSharing))
@@ -424,6 +430,11 @@ describe('SourceControlExportService', () => {
 				credentialIds.map((id) => mock<SourceControlledFile>({ id })),
 			);
 
+			expect(sharedCredentialsRepository.findOwnerProjectsByCredentialIds).toHaveBeenCalledTimes(1);
+			expect(sharedCredentialsRepository.findOwnerProjectsByCredentialIds).toHaveBeenCalledWith(
+				credentialIds,
+			);
+			expect(projectRelationRepository.findPersonalOwnerEmails).toHaveBeenCalledTimes(1);
 			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenCalledTimes(3);
 			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenNthCalledWith(
 				1,
@@ -707,18 +718,12 @@ describe('SourceControlExportService', () => {
 					nodeGroups,
 				}),
 			]);
-			sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue([
-				mock<SharedWorkflow>({
-					workflowId,
-					project: mock({
-						type: 'personal',
-						projectRelations: [
-							{ role: PROJECT_OWNER_ROLE, user: mock({ email: 'user@test.com' }) },
-						],
-					}),
-					workflow: mock(),
-				} as never) as SharedWorkflow,
-			]);
+			sharedWorkflowRepository.findOwnerProjectsByWorkflowIds.mockResolvedValue(
+				new Map([[workflowId, personalProject]]),
+			);
+			projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(
+				new Map([[personalProject.id, 'user@test.com']]),
+			);
 
 			// Act
 			const result = await service.exportWorkflowsToWorkFolder([
@@ -744,7 +749,12 @@ describe('SourceControlExportService', () => {
 				parentFolderId: null,
 				isArchived: false,
 				nodeGroups,
-				owner: { type: 'personal', personalEmail: 'user@test.com' },
+				owner: {
+					type: 'personal',
+					projectId: 'personal-1',
+					projectName: 'Personal',
+					personalEmail: 'user@test.com',
+				},
 			});
 		});
 
@@ -764,18 +774,12 @@ describe('SourceControlExportService', () => {
 					nodeGroups: [],
 				}),
 			]);
-			sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue([
-				mock<SharedWorkflow>({
-					workflowId,
-					project: mock({
-						type: 'personal',
-						projectRelations: [
-							{ role: PROJECT_OWNER_ROLE, user: mock({ email: 'user@test.com' }) },
-						],
-					}),
-					workflow: mock(),
-				} as never) as SharedWorkflow,
-			]);
+			sharedWorkflowRepository.findOwnerProjectsByWorkflowIds.mockResolvedValue(
+				new Map([[workflowId, personalProject]]),
+			);
+			projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(
+				new Map([[personalProject.id, 'user@test.com']]),
+			);
 
 			await service.exportWorkflowsToWorkFolder([mock<SourceControlledFile>({ id: workflowId })]);
 
@@ -788,15 +792,8 @@ describe('SourceControlExportService', () => {
 
 		it('should load and write workflows in batches', async () => {
 			const workflowIds = Array.from({ length: 45 }, (_, index) => `wf-${index}`);
-			sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue(
-				workflowIds.map(
-					(workflowId) =>
-						mock<SharedWorkflow>({
-							workflowId,
-							project: mock({ type: 'team', id: 'team-1', name: 'Team 1' }),
-							workflow: mock(),
-						} as never) as SharedWorkflow,
-				),
+			sharedWorkflowRepository.findOwnerProjectsByWorkflowIds.mockResolvedValue(
+				new Map(workflowIds.map((id) => [id, teamProject])),
 			);
 			const toWorkflowEntity = (id: string) =>
 				Object.assign(new WorkflowEntity(), {
@@ -846,22 +843,13 @@ describe('SourceControlExportService', () => {
 
 		it('should throw an error if workflow has no owner', async () => {
 			// Arrange
-			sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue([
-				mock<SharedWorkflow>({
-					project: mock({
-						type: 'personal',
-						projectRelations: [],
-					}),
-					workflow: mock({
-						id: 'test-workflow-id',
-						name: 'TestWorkflow',
-					}),
-				} as never) as SharedWorkflow,
-			]);
+			sharedWorkflowRepository.findOwnerProjectsByWorkflowIds.mockResolvedValue(
+				new Map([['test-workflow-id', personalProject]]),
+			);
 
 			// Act & Assert
 			await expect(service.exportWorkflowsToWorkFolder([mock()])).rejects.toThrow(
-				'Workflow "TestWorkflow" (ID: test-workflow-id) has no owner',
+				'Workflow test-workflow-id has no owner',
 			);
 		});
 	});
@@ -1118,7 +1106,7 @@ describe('SourceControlExportService', () => {
 			expect(dataTableRepository.find).toHaveBeenCalledWith(
 				expect.objectContaining({
 					where: expect.objectContaining(scopedFilter),
-					loadEagerRelations: false,
+					relations: ['columns', 'project'],
 				}),
 			);
 		});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -414,19 +414,16 @@ describe('SourceControlExportService', () => {
 			} as never) as SharedCredentials;
 
 		it('should load and write credentials in batches', async () => {
-			// Arrange
 			const credentialIds = Array.from({ length: 45 }, (_, index) => `cred-${index}`);
 			sharedCredentialsRepository.findByCredentialIds
 				.mockResolvedValueOnce(credentialIds.slice(0, 20).map(toSharing))
 				.mockResolvedValueOnce(credentialIds.slice(20, 40).map(toSharing))
 				.mockResolvedValueOnce(credentialIds.slice(40).map(toSharing));
 
-			// Act
 			const result = await service.exportCredentialsToWorkFolder(
 				credentialIds.map((id) => mock<SourceControlledFile>({ id })),
 			);
 
-			// Assert
 			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenCalledTimes(3);
 			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenNthCalledWith(
 				1,
@@ -456,18 +453,15 @@ describe('SourceControlExportService', () => {
 		});
 
 		it('should report credentials missing from any batch', async () => {
-			// Arrange
 			const credentialIds = Array.from({ length: 25 }, (_, index) => `cred-${index}`);
 			sharedCredentialsRepository.findByCredentialIds
 				.mockResolvedValueOnce(credentialIds.slice(0, 19).map(toSharing))
 				.mockResolvedValueOnce(credentialIds.slice(21).map(toSharing));
 
-			// Act
 			const result = await service.exportCredentialsToWorkFolder(
 				credentialIds.map((id) => mock<SourceControlledFile>({ id })),
 			);
 
-			// Assert
 			expect(result.count).toBe(23);
 			expect(result.missingIds).toEqual(['cred-19', 'cred-20']);
 		});
@@ -536,7 +530,6 @@ describe('SourceControlExportService', () => {
 		});
 
 		it('should load only workflow ids and replace mappings of accessible workflows', async () => {
-			// Arrange
 			const mockTag = mock<TagEntity>({
 				id: 'tag1',
 				name: 'Tag 1',
@@ -557,10 +550,8 @@ describe('SourceControlExportService', () => {
 				}),
 			);
 
-			// Act
 			await service.exportTagsToWorkFolder(globalAdminContext);
 
-			// Assert
 			expect(workflowRepository.find).toHaveBeenCalledTimes(1);
 			expect(workflowRepository.find).toHaveBeenCalledWith(
 				expect.objectContaining({ select: { id: true } }),
@@ -796,7 +787,6 @@ describe('SourceControlExportService', () => {
 		});
 
 		it('should load and write workflows in batches', async () => {
-			// Arrange
 			const workflowIds = Array.from({ length: 45 }, (_, index) => `wf-${index}`);
 			sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue(
 				workflowIds.map(
@@ -826,12 +816,10 @@ describe('SourceControlExportService', () => {
 				.mockResolvedValueOnce(workflowIds.slice(20, 40).map(toWorkflowEntity))
 				.mockResolvedValueOnce(workflowIds.slice(40).map(toWorkflowEntity));
 
-			// Act
 			const result = await service.exportWorkflowsToWorkFolder(
 				workflowIds.map((id) => mock<SourceControlledFile>({ id })),
 			);
 
-			// Assert
 			expect(workflowRepository.find).toHaveBeenCalledTimes(3);
 			expect(workflowRepository.find).toHaveBeenNthCalledWith(1, {
 				where: { id: In(workflowIds.slice(0, 20)) },

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -1130,6 +1130,7 @@ describe('SourceControlExportService', () => {
 			expect(dataTableRepository.find).toHaveBeenCalledWith(
 				expect.objectContaining({
 					where: expect.objectContaining(scopedFilter),
+					loadEagerRelations: false,
 				}),
 			);
 		});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -400,6 +400,79 @@ describe('SourceControlExportService', () => {
 		});
 	});
 
+	describe('exportCredentialsToWorkFolder batching', () => {
+		const toSharing = (credentialsId: string) =>
+			mock<SharedCredentials>({
+				credentialsId,
+				credentials: mock({
+					id: credentialsId,
+					name: `Credential ${credentialsId}`,
+					type: 'httpBasicAuth',
+					data: cipher.encrypt({ user: 'u', password: 'p' }),
+				}),
+				project: mock({ type: 'team', id: 'team-1', name: 'Team 1' }),
+			} as never) as SharedCredentials;
+
+		it('should load and write credentials in batches', async () => {
+			// Arrange
+			const credentialIds = Array.from({ length: 45 }, (_, index) => `cred-${index}`);
+			sharedCredentialsRepository.findByCredentialIds
+				.mockResolvedValueOnce(credentialIds.slice(0, 20).map(toSharing))
+				.mockResolvedValueOnce(credentialIds.slice(20, 40).map(toSharing))
+				.mockResolvedValueOnce(credentialIds.slice(40).map(toSharing));
+
+			// Act
+			const result = await service.exportCredentialsToWorkFolder(
+				credentialIds.map((id) => mock<SourceControlledFile>({ id })),
+			);
+
+			// Assert
+			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenCalledTimes(3);
+			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenNthCalledWith(
+				1,
+				credentialIds.slice(0, 20),
+				'credential:owner',
+			);
+			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenNthCalledWith(
+				2,
+				credentialIds.slice(20, 40),
+				'credential:owner',
+			);
+			expect(sharedCredentialsRepository.findByCredentialIds).toHaveBeenNthCalledWith(
+				3,
+				credentialIds.slice(40),
+				'credential:owner',
+			);
+
+			const findOrder = sharedCredentialsRepository.findByCredentialIds.mock.invocationCallOrder;
+			const writeOrder = fsWriteFile.mock.invocationCallOrder;
+			expect(writeOrder).toHaveLength(45);
+			expect(writeOrder[19]).toBeLessThan(findOrder[1]);
+			expect(writeOrder[39]).toBeLessThan(findOrder[2]);
+
+			expect(result.count).toBe(45);
+			expect(result.missingIds).toEqual([]);
+			expect(result.files.map((file) => file.id)).toEqual(credentialIds);
+		});
+
+		it('should report credentials missing from any batch', async () => {
+			// Arrange
+			const credentialIds = Array.from({ length: 25 }, (_, index) => `cred-${index}`);
+			sharedCredentialsRepository.findByCredentialIds
+				.mockResolvedValueOnce(credentialIds.slice(0, 19).map(toSharing))
+				.mockResolvedValueOnce(credentialIds.slice(21).map(toSharing));
+
+			// Act
+			const result = await service.exportCredentialsToWorkFolder(
+				credentialIds.map((id) => mock<SourceControlledFile>({ id })),
+			);
+
+			// Assert
+			expect(result.count).toBe(23);
+			expect(result.missingIds).toEqual(['cred-19', 'cred-20']);
+		});
+	});
+
 	describe('exportTagsToWorkFolder', () => {
 		it('should export tags to work folder', async () => {
 			// Arrange

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -1111,6 +1111,40 @@ describe('SourceControlExportService', () => {
 			);
 		});
 
+		it('should export the owner email of a personal project', async () => {
+			dataTableRepository.find.mockResolvedValue([
+				{
+					id: 'dt1',
+					name: 'Personal Table',
+					projectId: personalProject.id,
+					columns: [],
+					createdAt: new Date('2024-01-01'),
+					updatedAt: new Date('2024-01-02'),
+					project: personalProject,
+				},
+			] as never);
+			projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(
+				new Map([[personalProject.id, 'owner@example.com']]),
+			);
+
+			await service.exportDataTablesToWorkFolder(
+				[mock<SourceControlledFile>({ id: 'dt1' })],
+				globalAdminContext,
+			);
+
+			expect(projectRelationRepository.findPersonalOwnerEmails).toHaveBeenCalledWith([
+				personalProject.id,
+			]);
+			const dataCaptor = captor<string>();
+			expect(fsWriteFile).toHaveBeenCalledWith('/mock/n8n/git/datatables/dt1.json', dataCaptor);
+			expect(JSON.parse(dataCaptor.value).ownedBy).toEqual({
+				type: 'personal',
+				projectId: 'personal-1',
+				projectName: 'Personal',
+				personalEmail: 'owner@example.com',
+			});
+		});
+
 		it('should handle export errors gracefully', async () => {
 			// Arrange
 			const candidates = [

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -3946,6 +3946,10 @@ describe('SourceControlImportService', () => {
 		});
 
 		describe('getLocalDataTablesFromDb', () => {
+			beforeEach(() => {
+				projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(new Map());
+			});
+
 			it('should return data tables from database', async () => {
 				// Arrange
 				const mockDataTables = [
@@ -3986,13 +3990,7 @@ describe('SourceControlImportService', () => {
 					updatedAt: '2024-01-02T00:00:00.000Z',
 				});
 				expect(dataTableRepository.find).toHaveBeenCalledWith({
-					relations: [
-						'columns',
-						'project',
-						'project.projectRelations',
-						'project.projectRelations.role',
-					],
-					loadEagerRelations: false,
+					relations: ['columns', 'project'],
 					where: {},
 				});
 			});
@@ -4014,13 +4012,7 @@ describe('SourceControlImportService', () => {
 					sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter,
 				).toHaveBeenCalledWith(globalMemberContext);
 				expect(dataTableRepository.find).toHaveBeenCalledWith({
-					relations: [
-						'columns',
-						'project',
-						'project.projectRelations',
-						'project.projectRelations.role',
-					],
-					loadEagerRelations: false,
+					relations: ['columns', 'project'],
 					where,
 				});
 			});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -3992,6 +3992,7 @@ describe('SourceControlImportService', () => {
 						'project.projectRelations',
 						'project.projectRelations.role',
 					],
+					loadEagerRelations: false,
 					where: {},
 				});
 			});
@@ -4019,6 +4020,7 @@ describe('SourceControlImportService', () => {
 						'project.projectRelations',
 						'project.projectRelations.role',
 					],
+					loadEagerRelations: false,
 					where,
 				});
 			});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -3995,6 +3995,58 @@ describe('SourceControlImportService', () => {
 				});
 			});
 
+			const dataTableIn = (id: string, project: { id: string; name: string; type: string }) => ({
+				id,
+				name: `Table ${id}`,
+				projectId: project.id,
+				columns: [],
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-02'),
+				project,
+			});
+			const teamProject = { id: 'team1', name: 'Team Project 1', type: 'team' };
+			const personalProject = { id: 'personal1', name: 'Personal Project', type: 'personal' };
+
+			it('should resolve the owner of a personal project from the owner email lookup', async () => {
+				dataTableRepository.find.mockResolvedValue([dataTableIn('dt1', personalProject)] as never);
+				projectRelationRepository.findPersonalOwnerEmails.mockResolvedValue(
+					new Map([['personal1', 'owner@example.com']]),
+				);
+
+				const result = await service.getLocalDataTablesFromDb(globalAdminContext);
+
+				expect(result[0].ownedBy).toEqual({
+					type: 'personal',
+					projectId: 'personal1',
+					projectName: 'Personal Project',
+				});
+			});
+
+			it('should report no owner for a personal project without an owner relation', async () => {
+				dataTableRepository.find.mockResolvedValue([dataTableIn('dt1', personalProject)] as never);
+
+				const result = await service.getLocalDataTablesFromDb(globalAdminContext);
+
+				expect(result[0].ownedBy).toBeNull();
+			});
+
+			it('should look up owner emails only for personal projects', async () => {
+				const otherPersonalProject = { id: 'personal2', name: 'Other Personal', type: 'personal' };
+				dataTableRepository.find.mockResolvedValue([
+					dataTableIn('dt1', teamProject),
+					dataTableIn('dt2', personalProject),
+					dataTableIn('dt3', otherPersonalProject),
+				] as never);
+
+				await service.getLocalDataTablesFromDb(globalAdminContext);
+
+				expect(projectRelationRepository.findPersonalOwnerEmails).toHaveBeenCalledTimes(1);
+				expect(projectRelationRepository.findPersonalOwnerEmails).toHaveBeenCalledWith([
+					'personal1',
+					'personal2',
+				]);
+			});
+
 			it('should scope database query to data tables in authorized projects', async () => {
 				// Arrange
 				const where = { project: { id: 'project1' } };

--- a/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
@@ -1,8 +1,9 @@
 import type { SourceControlledFile } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import type { IWorkflowDb, SharedCredentials } from '@n8n/db';
+import type { IWorkflowDb, Project, SharedCredentials } from '@n8n/db';
 import {
 	FolderRepository,
+	ProjectRelationRepository,
 	ProjectRepository,
 	SharedCredentialsRepository,
 	SharedWorkflowRepository,
@@ -11,7 +12,6 @@ import {
 	WorkflowTagMappingRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { In } from '@n8n/typeorm';
 import chunk from 'lodash/chunk';
 import { Credentials, InstanceSettings } from 'n8n-core';
@@ -20,7 +20,6 @@ import { rm as fsRm, writeFile as fsWriteFile } from 'node:fs/promises';
 import path from 'path';
 
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
-import { formatWorkflow } from '@/workflows/workflow.formatter';
 
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
@@ -51,7 +50,11 @@ import type { ExportableFolder } from './types/exportable-folders';
 import { ExportableProject } from './types/exportable-project';
 import { ExportableVariable } from './types/exportable-variable';
 import type { ExportableWorkflow } from './types/exportable-workflow';
-import type { RemoteResourceOwner } from './types/resource-owner';
+import type {
+	PersonalResourceOwner,
+	RemoteResourceOwner,
+	TeamResourceOwner,
+} from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
 import { VariablesService } from '../../environments.ee/variables/variables.service.ee';
 
@@ -80,6 +83,7 @@ export class SourceControlExportService {
 		private readonly sourceControlScopedService: SourceControlScopedService,
 		instanceSettings: InstanceSettings,
 		private readonly dataTableRepository: DataTableRepository,
+		private readonly projectRelationRepository: ProjectRelationRepository,
 	) {
 		this.gitFolder = path.join(instanceSettings.n8nFolder, SOURCE_CONTROL_GIT_FOLDER);
 		this.workflowExportFolder = path.join(this.gitFolder, SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER);
@@ -120,6 +124,25 @@ export class SourceControlExportService {
 		return filesToBeDeleted;
 	}
 
+	private async getPersonalOwnerEmails(projects: Iterable<Project>) {
+		const personalProjectIds = [...projects]
+			.filter((project) => project.type === 'personal')
+			.map((project) => project.id);
+		return await this.projectRelationRepository.findPersonalOwnerEmails(personalProjectIds);
+	}
+
+	private getResourceOwner(
+		project: Project,
+		ownerEmails: Map<string, string>,
+	): PersonalResourceOwner | TeamResourceOwner | null {
+		if (project.type === 'team') {
+			return { type: 'team', teamId: project.id, teamName: project.name };
+		}
+		const personalEmail = ownerEmails.get(project.id);
+		if (personalEmail === undefined) return null;
+		return { type: 'personal', projectId: project.id, projectName: project.name, personalEmail };
+	}
+
 	private async writeExportableWorkflowsToExportFolder(
 		workflowsToBeExported: IWorkflowDb[],
 		owners: Record<string, RemoteResourceOwner>,
@@ -151,46 +174,18 @@ export class SourceControlExportService {
 		try {
 			sourceControlFoldersExistCheck([this.workflowExportFolder]);
 			const workflowIds = candidates.map((e) => e.id);
-			const sharedWorkflows = await this.sharedWorkflowRepository.findByWorkflowIds(workflowIds);
+			const ownerProjects =
+				await this.sharedWorkflowRepository.findOwnerProjectsByWorkflowIds(workflowIds);
+			const ownerEmails = await this.getPersonalOwnerEmails(ownerProjects.values());
 
-			// determine owner of each workflow to be exported
 			const owners: Record<string, RemoteResourceOwner> = {};
-			sharedWorkflows.forEach((sharedWorkflow) => {
-				const project = sharedWorkflow.project;
-
-				if (!project) {
-					throw new UnexpectedError(
-						`Workflow ${formatWorkflow(sharedWorkflow.workflow)} has no owner`,
-					);
+			for (const [workflowId, project] of ownerProjects) {
+				const owner = this.getResourceOwner(project, ownerEmails);
+				if (!owner) {
+					throw new UnexpectedError(`Workflow ${workflowId} has no owner`);
 				}
-
-				if (project.type === 'personal') {
-					const ownerRelation = project.projectRelations.find(
-						(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
-					);
-					if (!ownerRelation) {
-						throw new UnexpectedError(
-							`Workflow ${formatWorkflow(sharedWorkflow.workflow)} has no owner`,
-						);
-					}
-					owners[sharedWorkflow.workflowId] = {
-						type: 'personal',
-						projectId: project.id,
-						projectName: project.name,
-						personalEmail: ownerRelation.user.email,
-					};
-				} else if (project.type === 'team') {
-					owners[sharedWorkflow.workflowId] = {
-						type: 'team',
-						teamId: project.id,
-						teamName: project.name,
-					};
-				} else {
-					throw new UnexpectedError(
-						`Workflow belongs to unknown project type: ${project.type as string}`,
-					);
-				}
-			});
+				owners[workflowId] = owner;
+			}
 
 			const files: ExportResult['files'] = [];
 			for (const workflowIdChunk of chunk(workflowIds, SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE)) {
@@ -208,7 +203,7 @@ export class SourceControlExportService {
 			}
 
 			return {
-				count: sharedWorkflows.length,
+				count: ownerProjects.size,
 				folder: this.workflowExportFolder,
 				files,
 			};
@@ -280,14 +275,7 @@ export class SourceControlExportService {
 					id: In(candidateIds),
 					...this.sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter(context),
 				},
-				relations: [
-					'columns',
-					'project',
-					'project.projectRelations',
-					'project.projectRelations.role',
-					'project.projectRelations.user',
-				],
-				loadEagerRelations: false,
+				relations: ['columns', 'project'],
 				select: {
 					id: true,
 					name: true,
@@ -304,43 +292,20 @@ export class SourceControlExportService {
 						id: true,
 						name: true,
 						type: true,
-						projectRelations: {
-							userId: true,
-							role: {
-								slug: true,
-							},
-							user: {
-								email: true,
-							},
-						},
 					},
 				},
 			});
+			const ownerEmails = await this.getPersonalOwnerEmails(
+				dataTables.flatMap((table) => table.project ?? []),
+			);
 
 			const exportedFiles: Array<{ id: string; name: string }> = [];
 
 			// Write each data table to its own file
 			for (const table of dataTables) {
-				let owner: DataTableResourceOwner | null = null;
-				if (table.project?.type === 'personal') {
-					const ownerRelation = table.project.projectRelations?.find(
-						(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
-					);
-					if (ownerRelation) {
-						owner = {
-							type: 'personal',
-							projectId: table.project.id,
-							projectName: table.project.name,
-							personalEmail: ownerRelation.user.email,
-						};
-					}
-				} else if (table.project?.type === 'team') {
-					owner = {
-						type: 'team',
-						teamId: table.project.id,
-						teamName: table.project.name,
-					};
-				}
+				const owner: DataTableResourceOwner | null = table.project
+					? this.getResourceOwner(table.project, ownerEmails)
+					: null;
 
 				const exportableDataTable: ExportableDataTable = {
 					id: table.id,
@@ -515,7 +480,11 @@ export class SourceControlExportService {
 		}
 	}
 
-	private async writeExportableCredentialsToExportFolder(sharings: SharedCredentials[]) {
+	private async writeExportableCredentialsToExportFolder(
+		sharings: SharedCredentials[],
+		ownerProjects: Map<string, Project>,
+		ownerEmails: Map<string, string>,
+	) {
 		await Promise.all(
 			sharings.map(async (sharing) => {
 				const {
@@ -529,26 +498,8 @@ export class SourceControlExportService {
 				} = sharing.credentials;
 				const credentials = new Credentials({ id, name }, type, data);
 
-				let owner: RemoteResourceOwner | null = null;
-				if (sharing.project.type === 'personal') {
-					const ownerRelation = sharing.project.projectRelations.find(
-						(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
-					);
-					if (ownerRelation) {
-						owner = {
-							type: 'personal',
-							projectId: sharing.project.id,
-							projectName: sharing.project.name,
-							personalEmail: ownerRelation.user.email,
-						};
-					}
-				} else if (sharing.project.type === 'team') {
-					owner = {
-						type: 'team',
-						teamId: sharing.project.id,
-						teamName: sharing.project.name,
-					};
-				}
+				const project = ownerProjects.get(sharing.credentialsId);
+				const owner = project ? this.getResourceOwner(project, ownerEmails) : null;
 
 				const sanitizedData = sanitizeCredentialData(await credentials.getData());
 
@@ -575,6 +526,9 @@ export class SourceControlExportService {
 		try {
 			sourceControlFoldersExistCheck([this.credentialExportFolder]);
 			const credentialIds = candidates.map((e) => e.id);
+			const ownerProjects =
+				await this.sharedCredentialsRepository.findOwnerProjectsByCredentialIds(credentialIds);
+			const ownerEmails = await this.getPersonalOwnerEmails(ownerProjects.values());
 			const foundCredentialIds = new Set<string>();
 			const files: ExportResult['files'] = [];
 
@@ -583,7 +537,11 @@ export class SourceControlExportService {
 					credentialIdChunk,
 					'credential:owner',
 				);
-				await this.writeExportableCredentialsToExportFolder(credentialsToBeExported);
+				await this.writeExportableCredentialsToExportFolder(
+					credentialsToBeExported,
+					ownerProjects,
+					ownerEmails,
+				);
 				for (const sharing of credentialsToBeExported) {
 					foundCredentialIds.add(sharing.credentialsId);
 					files.push({

--- a/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
@@ -1,6 +1,6 @@
 import type { SourceControlledFile } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import type { IWorkflowDb } from '@n8n/db';
+import type { IWorkflowDb, SharedCredentials } from '@n8n/db';
 import {
 	FolderRepository,
 	ProjectRepository,
@@ -514,81 +514,93 @@ export class SourceControlExportService {
 		}
 	}
 
+	private async writeExportableCredentialsToExportFolder(sharings: SharedCredentials[]) {
+		await Promise.all(
+			sharings.map(async (sharing) => {
+				const {
+					name,
+					type,
+					data,
+					id,
+					isGlobal = false,
+					isResolvable = false,
+					resolvableAllowFallback = false,
+				} = sharing.credentials;
+				const credentials = new Credentials({ id, name }, type, data);
+
+				let owner: RemoteResourceOwner | null = null;
+				if (sharing.project.type === 'personal') {
+					const ownerRelation = sharing.project.projectRelations.find(
+						(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
+					);
+					if (ownerRelation) {
+						owner = {
+							type: 'personal',
+							projectId: sharing.project.id,
+							projectName: sharing.project.name,
+							personalEmail: ownerRelation.user.email,
+						};
+					}
+				} else if (sharing.project.type === 'team') {
+					owner = {
+						type: 'team',
+						teamId: sharing.project.id,
+						teamName: sharing.project.name,
+					};
+				}
+
+				const sanitizedData = sanitizeCredentialData(await credentials.getData());
+
+				const stub: ExportableCredential = {
+					id,
+					name,
+					type,
+					data: sanitizedData,
+					ownedBy: owner,
+					isGlobal,
+					isResolvable,
+					resolvableAllowFallback,
+				};
+
+				const filePath = this.getCredentialsPath(id);
+				this.logger.debug(`Writing credentials stub "${name}" (ID ${id}) to: ${filePath}`);
+
+				return await fsWriteFile(filePath, JSON.stringify(stub, null, 2));
+			}),
+		);
+	}
+
 	async exportCredentialsToWorkFolder(candidates: SourceControlledFile[]): Promise<ExportResult> {
 		try {
 			sourceControlFoldersExistCheck([this.credentialExportFolder]);
 			const credentialIds = candidates.map((e) => e.id);
-			const credentialsToBeExported = await this.sharedCredentialsRepository.findByCredentialIds(
-				credentialIds,
-				'credential:owner',
-			);
+			const foundCredentialIds = new Set<string>();
+			const files: ExportResult['files'] = [];
+
+			for (const credentialIdChunk of chunk(credentialIds, SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE)) {
+				const credentialsToBeExported = await this.sharedCredentialsRepository.findByCredentialIds(
+					credentialIdChunk,
+					'credential:owner',
+				);
+				await this.writeExportableCredentialsToExportFolder(credentialsToBeExported);
+				for (const sharing of credentialsToBeExported) {
+					foundCredentialIds.add(sharing.credentialsId);
+					files.push({
+						id: sharing.credentials.id,
+						name: path.join(this.credentialExportFolder, `${sharing.credentials.name}.json`),
+					});
+				}
+			}
 
 			let missingIds: string[] = [];
-			const foundCredentialIds = new Set(credentialsToBeExported.map((e) => e.credentialsId));
 			if (foundCredentialIds.size !== credentialIds.length) {
 				missingIds = credentialIds.filter((remote) => !foundCredentialIds.has(remote));
 			}
-			await Promise.all(
-				credentialsToBeExported.map(async (sharing) => {
-					const {
-						name,
-						type,
-						data,
-						id,
-						isGlobal = false,
-						isResolvable = false,
-						resolvableAllowFallback = false,
-					} = sharing.credentials;
-					const credentials = new Credentials({ id, name }, type, data);
-
-					let owner: RemoteResourceOwner | null = null;
-					if (sharing.project.type === 'personal') {
-						const ownerRelation = sharing.project.projectRelations.find(
-							(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
-						);
-						if (ownerRelation) {
-							owner = {
-								type: 'personal',
-								projectId: sharing.project.id,
-								projectName: sharing.project.name,
-								personalEmail: ownerRelation.user.email,
-							};
-						}
-					} else if (sharing.project.type === 'team') {
-						owner = {
-							type: 'team',
-							teamId: sharing.project.id,
-							teamName: sharing.project.name,
-						};
-					}
-
-					const sanitizedData = sanitizeCredentialData(await credentials.getData());
-
-					const stub: ExportableCredential = {
-						id,
-						name,
-						type,
-						data: sanitizedData,
-						ownedBy: owner,
-						isGlobal,
-						isResolvable,
-						resolvableAllowFallback,
-					};
-
-					const filePath = this.getCredentialsPath(id);
-					this.logger.debug(`Writing credentials stub "${name}" (ID ${id}) to: ${filePath}`);
-
-					return await fsWriteFile(filePath, JSON.stringify(stub, null, 2));
-				}),
-			);
 
 			return {
-				count: credentialsToBeExported.length,
+				count: files.length,
 				folder: this.credentialExportFolder,
-				files: credentialsToBeExported.map((e) => ({
-					id: e.credentials.id,
-					name: path.join(this.credentialExportFolder, `${e.credentials.name}.json`),
-				})),
+				files,
 				missingIds,
 			};
 		} catch (error) {

--- a/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
@@ -124,30 +124,27 @@ export class SourceControlExportService {
 		workflowsToBeExported: IWorkflowDb[],
 		owners: Record<string, RemoteResourceOwner>,
 	) {
-		const workflowChunks = chunk(workflowsToBeExported, SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE);
-		for (const workflowChunk of workflowChunks) {
-			await Promise.all(
-				workflowChunk.map(async (workflow) => {
-					const fileName = this.getWorkflowPath(workflow.id);
-					const sanitizedWorkflow: ExportableWorkflow = {
-						id: workflow.id,
-						name: workflow.name,
-						description: workflow.description ?? null,
-						nodes: workflow.nodes,
-						connections: workflow.connections,
-						settings: workflow.settings,
-						triggerCount: workflow.triggerCount,
-						versionId: workflow.versionId,
-						owner: owners[workflow.id],
-						parentFolderId: workflow.parentFolder?.id ?? null,
-						isArchived: workflow.isArchived,
-						nodeGroups: workflow.nodeGroups ?? [],
-					};
-					this.logger.debug(`Writing workflow ${workflow.id} to ${fileName}`);
-					return await fsWriteFile(fileName, JSON.stringify(sanitizedWorkflow, null, 2));
-				}),
-			);
-		}
+		await Promise.all(
+			workflowsToBeExported.map(async (workflow) => {
+				const fileName = this.getWorkflowPath(workflow.id);
+				const sanitizedWorkflow: ExportableWorkflow = {
+					id: workflow.id,
+					name: workflow.name,
+					description: workflow.description ?? null,
+					nodes: workflow.nodes,
+					connections: workflow.connections,
+					settings: workflow.settings,
+					triggerCount: workflow.triggerCount,
+					versionId: workflow.versionId,
+					owner: owners[workflow.id],
+					parentFolderId: workflow.parentFolder?.id ?? null,
+					isArchived: workflow.isArchived,
+					nodeGroups: workflow.nodeGroups ?? [],
+				};
+				this.logger.debug(`Writing workflow ${workflow.id} to ${fileName}`);
+				return await fsWriteFile(fileName, JSON.stringify(sanitizedWorkflow, null, 2));
+			}),
+		);
 	}
 
 	async exportWorkflowsToWorkFolder(candidates: SourceControlledFile[]): Promise<ExportResult> {
@@ -155,10 +152,6 @@ export class SourceControlExportService {
 			sourceControlFoldersExistCheck([this.workflowExportFolder]);
 			const workflowIds = candidates.map((e) => e.id);
 			const sharedWorkflows = await this.sharedWorkflowRepository.findByWorkflowIds(workflowIds);
-			const workflows = await this.workflowRepository.find({
-				where: { id: In(workflowIds) },
-				relations: ['parentFolder'],
-			});
 
 			// determine owner of each workflow to be exported
 			const owners: Record<string, RemoteResourceOwner> = {};
@@ -199,17 +192,25 @@ export class SourceControlExportService {
 				}
 			});
 
-			// write the workflows to the export folder as json files
-			await this.writeExportableWorkflowsToExportFolder(workflows, owners);
+			const files: ExportResult['files'] = [];
+			for (const workflowIdChunk of chunk(workflowIds, SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE)) {
+				const workflows = await this.workflowRepository.find({
+					where: { id: In(workflowIdChunk) },
+					relations: ['parentFolder'],
+				});
+				await this.writeExportableWorkflowsToExportFolder(workflows, owners);
+				files.push(
+					...workflows.map((workflow) => ({
+						id: workflow.id,
+						name: this.getWorkflowPath(workflow.name),
+					})),
+				);
+			}
 
-			// await fsWriteFile(ownersFileName, JSON.stringify(owners, null, 2));
 			return {
 				count: sharedWorkflows.length,
 				folder: this.workflowExportFolder,
-				files: workflows.map((e) => ({
-					id: e?.id,
-					name: this.getWorkflowPath(e?.name),
-				})),
+				files,
 			};
 		} catch (error) {
 			if (error instanceof UnexpectedError) throw error;
@@ -477,18 +478,18 @@ export class SourceControlExportService {
 			});
 
 			const allowedWorkflows = await this.workflowRepository.find({
+				select: { id: true },
 				where:
 					this.sourceControlScopedService.getWorkflowsInAdminProjectsFromContextFilter(context),
 			});
+			const allowedWorkflowIds = new Set(allowedWorkflows.map((workflow) => workflow.id));
 
 			const existingTagsAndMapping = await readTagAndMappingsFromSourceControlFile(fileName);
 
 			// keep all mappings that are not accessible by the current user
-			const mappingsToKeep = existingTagsAndMapping.mappings.filter((mapping) => {
-				return !allowedWorkflows.some(
-					(allowedWorkflow) => allowedWorkflow.id === mapping.workflowId,
-				);
-			});
+			const mappingsToKeep = existingTagsAndMapping.mappings.filter(
+				(mapping) => !allowedWorkflowIds.has(mapping.workflowId),
+			);
 
 			await fsWriteFile(
 				fileName,

--- a/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
@@ -287,6 +287,7 @@ export class SourceControlExportService {
 					'project.projectRelations.role',
 					'project.projectRelations.user',
 				],
+				loadEagerRelations: false,
 				select: {
 					id: true,
 					name: true,

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -26,7 +26,7 @@ import {
 } from '@n8n/db';
 import type { PolicyCleared } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import { PROJECT_ADMIN_ROLE_SLUG } from '@n8n/permissions';
 import { In, type DataSourceOptions, type EntityManager } from '@n8n/typeorm';
 import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import glob from 'fast-glob';
@@ -524,23 +524,17 @@ export class SourceControlImportService {
 	): Promise<StatusExportableDataTable[]> {
 		try {
 			const dataTables = await this.dataTableRepository.find({
-				relations: [
-					'columns',
-					'project',
-					'project.projectRelations',
-					'project.projectRelations.role',
-				],
-				loadEagerRelations: false,
+				relations: ['columns', 'project'],
 				where:
 					this.sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter(context),
 			});
+			const ownerEmails = await this.projectRelationRepository.findPersonalOwnerEmails(
+				dataTables.flatMap((table) => (table.project?.type === 'personal' ? table.project.id : [])),
+			);
 			return dataTables.map((table) => {
 				let ownedBy: StatusResourceOwner | null = null;
 				if (table.project?.type === 'personal') {
-					const ownerRelation = table.project.projectRelations?.find(
-						(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
-					);
-					if (ownerRelation) {
+					if (ownerEmails.has(table.project.id)) {
 						ownedBy = {
 							type: 'personal',
 							projectId: table.project.id,

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -530,6 +530,7 @@ export class SourceControlImportService {
 					'project.projectRelations',
 					'project.projectRelations.role',
 				],
+				loadEagerRelations: false,
 				where:
 					this.sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter(context),
 			});


### PR DESCRIPTION
## Summary

Source control push, and the status computation behind the push and pull modal, can exhaust the heap on large instances. The status file reads are already bounded (#33837). Three allocations in the push export were still unbounded, and the data table loaders in status and export scaled with project membership times role scopes. This PR bounds all of them.

**1. Tag export loaded every accessible workflow in full.**
`exportTagsToWorkFolder` ran `workflowRepository.find()` with the scoped filter and no `select`. It loaded nodes and connections for every workflow the user can see, only to compare ids. This ran on every push, also when no workflow was selected. Measured: +341 MB for 1500 workflows.
Fix: select only `id`, and test membership with a `Set` instead of an O(n·m) `some()`.

**2. Workflow export loaded all selected workflows in one query.**
`exportWorkflowsToWorkFolder` loaded all selected workflows with one `find()`, then wrote them in chunks of `SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE`. The write was bounded, the load was not. Measured: +358 to +379 MB for 1500 workflows.
Fix: load and write the workflows in chunks of `SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE` (20). At most one chunk of full workflow entities is in memory. The write helper no longer chunks on its own, because it now receives one chunk.

**3. Credential export loaded and wrote all selected credentials at once.**
`exportCredentialsToWorkFolder` loaded all sharings with one query and then ran one `Promise.all` over all credentials: decrypt, serialise and open a file for each at the same time. Measured: +621 MB for 3000 credentials.
Fix: load and write the credentials in chunks of `SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE`.

**4. Owner resolution loaded every member of every project, times every role scope.**
The workflow, credential and data table exports, and the data table status loader, resolved the owner of a resource by loading `project.projectRelations.role` and `.user`. `Role.scopes` is an eager relation with 47 to 175 scopes per role, so the raw rows grew as items × members × scopes: about 189k rows for 3000 credentials, and 2.37 GB for 114 data tables on an instance with 31 members per team project, which killed the owner's status call at a 1536 MB heap.
Fix: resolve owners per project instead of per item. `ProjectRelationRepository.findPersonalOwnerEmails(projectIds)` returns a `Map<projectId, email>` from one raw query over `project_relation` and `user`, filtered on the personal owner role. The item queries load only `project`. `findByWorkflowIds` is removed because `findOwnerProjectsByWorkflowIds` already does the slim version. This costs one extra small query per export type and removes the member and scope factors from memory entirely. No entity graph with a half-loaded `Role` leaves the persistence layer.

**Why not `loadEagerRelations: false`.** Earlier commits on this branch kept the member joins and passed `loadEagerRelations: false` so that `Role.scopes` stopped hydrating. That removed the scope factor but kept two problems. The returned `Role` entities had `scopes` typed as `Scope[]` while the runtime left it undefined, so any future caller of those repository methods would fail at runtime with no compile error. And the raw rows still grew with the number of project members, only without the scope multiplier. The final change removes the member joins instead. Owners are resolved per project from one raw query that returns plain values, so there is no partially loaded entity to lie about, and the member count drops out of the memory profile entirely. The flag is gone from every query.

Return shapes, ownership checks and error handling do not change, with one exception: the "has no owner" error for a workflow now names the workflow id. The old message formatted the `workflow` relation, which that query never loaded, so in production the path threw a TypeError that was rewrapped as a generic failure.

Local measurement with `phase-profile` on the repro instance, all rows re-measured on the final commit: 1500 workflows of ~250 KB each in 30 team projects, 3050 credentials, instance owner, `force: true` push of everything as modified. Master numbers come from the same corpus and heap.

| Measurement | master | this branch |
|---|---|---|
| Push, 1500 workflows, 768 MB heap | peak 763 MB (+398 to +431 MB), GC-bound | peak 355 MB (+104 MB) |
| Push, 1500 workflows, 512 MB heap | `FATAL ERROR: Ineffective mark-compacts near heap limit` | completes, peak 354 MB |
| Push, 1500 workflows + 3050 credentials, 768 MB heap | dies | completes, peak 376 MB |
| Push, 1500 workflows + 3050 credentials, 512 MB heap | dies | completes, peak 369 MB |
| Push, 1500 workflows + 3050 credentials, 1536 MB heap | peak 1014 MB | peak 521 MB |
| `exportWorkflowsToWorkFolder`, 1500 workflows | +358 to +379 MB | +68 to +108 MB |
| `exportCredentialsToWorkFolder`, 3050 credentials | +621 MB (owner lookup alone) | +4 to +18 MB |
| `exportTagsToWorkFolder` | +341 MB | +8 MB |

Second instance: 31 members per team project, owner account, 1536 MB heap. This corpus held 114 data tables when master was measured and 14 when the final commit was measured, so the loader row is not like for like. The member count, which is the factor this change removes, is the same in both.

| Measurement | master | this branch |
|---|---|---|
| `getLocalDataTablesFromDb`, run alone | +2.37 GB on 114 tables, dies | +1 MB on 14 tables |
| Status call (modal), owner | dies | completes, +143 MB |
| Status call (modal), project admin | 137 MB | completes, +101 MB |

**Conclusion.** On the same corpus and the same 768 MB heap, the peak heap of a push drops from 763 MB to 355 MB, about 53 % lower, and the memory the push itself allocates drops from about 415 MB to 104 MB, about 75 % lower. With 3050 credentials added, the peak at a 1536 MB heap drops from 1014 MB to 521 MB, about 49 % lower, and the push now completes in a 512 MB heap where master dies at 768 MB. The fixed phases allocate 75 % to 98 % less: workflow export about 75 %, credential export 97 %, tag export 98 %. Peak memory during export is O(batch × workflow size) instead of O(items × workflow size), and owner resolution is O(projects) instead of O(items × members × scopes), so it no longer grows with the number of items pushed, the size of the workflows, or the number of project members. Push time is unchanged to slightly faster on these runs, 9.5 to 10.7 s against 9.9 to 12.6 s on master, and pull is untouched.

## How to test

Source control needs an Enterprise licence with the `sourceControl` feature.

1. Connect an instance to a git repository and create a few hundred workflows and credentials across team projects.
2. Start n8n with a small heap, for example `NODE_OPTIONS=--max-old-space-size=512`.
3. Open the push modal, select everything and push. Before this change the process can crash with `Ineffective mark-compacts near heap limit`. After this change the push completes.
4. Push with tags present and no workflow selected. The push completes and `tags.json` still contains all mappings.
5. Pull the pushed commit into a second instance. Every workflow keeps its parent folder and owner. Every credential stub keeps its owner.
6. Add many members to each team project and create data tables in them. Open the push modal as the instance owner. Before this change the status computation can crash the process. After this change it completes, and each data table still shows its owner.

Unit tests added:

- `source-control-export.service.test.ts`
  - `exportTagsToWorkFolder` › should load only workflow ids and replace mappings of accessible workflows
  - `exportWorkflowsToWorkFolder` › should load and write workflows in batches (45 ids → 3 queries of ≤ 20 ids, each batch is written before the next one is loaded, result keeps the candidate order)
  - `exportCredentialsToWorkFolder batching` › should load and write credentials in batches (same shape as above)
  - `exportCredentialsToWorkFolder batching` › should report credentials missing from any batch
- `project-relation.repository.test.ts` › `findPersonalOwnerEmails` maps project ids to owner emails and skips the query for an empty list
- `shared-credentials.repository.test.ts` › `findOwnerProjectsByCredentialIds` maps credential ids to owner projects
- `source-control-import.service.ee.test.ts` and `source-control-export.service.test.ts` assert that the data table loaders load only `columns` and `project`
- `source-control-import.service.ee.test.ts` › `getLocalDataTablesFromDb` resolves a personal owner from the email lookup, reports `null` for a personal project without an owner relation, and calls the lookup once with only the personal project ids
- `source-control-export.service.test.ts` › `exportDataTablesToWorkFolder` writes the personal owner email into the stub

```bash
cd packages/cli && pnpm test src/modules/source-control.ee
cd packages/@n8n/db && pnpm test src/repositories/__tests__/shared-credentials.repository.test.ts src/repositories/__tests__/shared-workflow.repository.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-832

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
