### PR TITLE
chore: Fix seed assistant threads so the assistant page can list them (no-changelog)

### DIFF
--- a/scripts/instance-seeding/seedHistory.mjs
+++ b/scripts/instance-seeding/seedHistory.mjs
@@ -298,12 +298,20 @@ function main() {
 			// workflow, so a "what was I working on?" probe has something to find.
 			const threadId = uuid();
 			const threadAt = NOW - Math.floor(random() * DAYS * 86400e3);
+			// `resourceId` is the owning user: the assistant page lists threads by it, so a
+			// workflow id here makes the thread exist but never show. The workflow goes in
+			// `sourceContext`, where the runtime also puts it.
 			insThread.run(
 				threadId,
-				wf.id,
+				user.id,
 				project.id,
 				`Working on ${short}`,
-				`{${THREAD_MARKER}}`,
+				JSON.stringify({
+					seeded: true,
+					source: 'assistant_page',
+					origin: 'internal',
+					sourceContext: { workflowId: wf.id },
+				}),
 				iso(threadAt),
 				iso(threadAt + 600e3),
 			);
@@ -329,16 +337,20 @@ function main() {
 							`Added a Data Table insert named "Record Run" at the end of ${short}, writing to \`automation_runs\`, matching the other workflows here.`,
 						],
 					];
-			for (const [role, content] of turns) {
+			// `content` holds the whole agent message as JSON, the way the runtime stores it.
+			// A plain string is dropped on read, so the thread would open empty.
+			for (const [i, [role, text]] of turns.entries()) {
+				const messageId = uuid();
+				const createdAt = iso(threadAt + i * 30e3);
 				insMessage.run(
-					uuid(),
+					messageId,
 					threadId,
-					content,
+					JSON.stringify({ id: messageId, role, content: [{ type: 'text', text }], createdAt }),
 					role,
-					'message',
-					wf.id,
-					iso(threadAt),
-					iso(threadAt),
+					null,
+					user.id,
+					createdAt,
+					createdAt,
 				);
 				msgCount++;
 			}

--- a/scripts/instance-seeding/seedHistory.test.mjs
+++ b/scripts/instance-seeding/seedHistory.test.mjs
@@ -192,6 +192,40 @@ describe('seedHistory cleanup', () => {
 		assert.ok(c.seededActivity > 0, 'activity written');
 	});
 
+	// The assistant page lists threads by `resourceId = user id` and drops any message
+	// whose `content` is not an agent-message JSON object, so both must match the runtime.
+	it('writes threads and messages the assistant page can read', () => {
+		const dbFile = fixture();
+		run(dbFile);
+		const db = new DatabaseSync(dbFile, { readOnly: true });
+		const threads = db
+			.prepare(
+				`SELECT resourceId FROM instance_ai_threads WHERE metadata LIKE '%"seeded":true%' AND projectId = 'p-seed'`,
+			)
+			.all();
+		assert.ok(threads.length > 0);
+		assert.ok(
+			threads.every((t) => t.resourceId === 'u1'),
+			'threads owned by the first user',
+		);
+		const messages = db
+			.prepare(
+				`SELECT m.content, m.resourceId, m.type FROM instance_ai_messages m
+				 JOIN instance_ai_threads t ON t.id = m.threadId
+				 WHERE t.metadata LIKE '%"seeded":true%' AND t.projectId = 'p-seed'`,
+			)
+			.all();
+		assert.ok(messages.length > 0);
+		for (const m of messages) {
+			assert.equal(m.resourceId, 'u1');
+			assert.equal(m.type, null);
+			const parsed = JSON.parse(m.content);
+			assert.ok(['user', 'assistant'].includes(parsed.role));
+			assert.equal(parsed.content[0].type, 'text');
+		}
+		db.close();
+	});
+
 	it('leaves rows it did not create alone', () => {
 		const dbFile = fixture();
 		run(dbFile);


### PR DESCRIPTION
## Summary

`pnpm seed:preference` (and `pnpm seed:history`) wrote assistant threads that the assistant page could not show.

- The seeder put the workflow id into `resourceId` on `instance_ai_threads` and `instance_ai_messages`. The assistant page lists threads by `resourceId = user id`, so the seeded rows existed but never matched the logged-in owner. Chat history stayed at "No conversations yet".
- Message `content` was a plain string. The runtime stores each message as a JSON agent message (`{ id, role, content: [{ type: 'text', text }], createdAt }`) and drops other shapes on read, so an owned thread would still have opened empty.

This PR makes the seeder write what the runtime writes:

- Threads use the owner's user id as `resourceId`. The workflow id moves into `metadata.sourceContext.workflowId`, next to a valid `source` and `origin`. The `"seeded":true` marker that the clear step matches on is kept.
- Messages use the owner's user id, a null `type`, and the JSON content shape. Turns are 30 seconds apart so ordering is deterministic.
- One test asserts thread ownership and the message shape.

## How to test

1. Start a local instance with the `instance-ai` module enabled and create an owner plus a public API key.
2. From the repo root run `N8N_API_KEY=<jwt> N8N_USER_FOLDER=<instance user folder> pnpm seed:preference`.
3. Log in as the owner and open `/assistant`. Chat history shows 10 "Working on …" threads. Open one: the user and assistant turns render.
4. `pnpm seed:test` passes.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #37645 (dev tooling to seed an instance and inspect its activity feed).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGE6xutX83uVUYWWMyt8d


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


