### PR TITLE
fix(core): Stop npm audit from stalling Instance AI sandbox setup

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -386,7 +386,7 @@ describe('setupSandboxWorkspace', () => {
 		expect(initialized).toBe(false);
 		expect(runInSandbox).not.toHaveBeenCalledWith(
 			expect.anything(),
-			'npm install --ignore-scripts',
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-offline',
 			'/sandbox',
 		);
 		const writtenPaths = writeFile.mock.calls.map(([path]) => path);

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
@@ -196,7 +196,9 @@ describe('SnapshotManager.ensureImage', () => {
 		expect(image.dockerfile).toContain(
 			'mkdir -p /home/daytona/workspace/src /home/daytona/workspace/chunks /home/daytona/workspace/node-types',
 		);
-		expect(image.dockerfile).toContain('npm install --ignore-scripts');
+		expect(image.dockerfile).toContain(
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-offline',
+		);
 
 		const stagingDir = image.contextList[0]?.sourcePath;
 		expect(stagingDir).toBeDefined();

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -98,6 +98,16 @@ function resolveHostDepVersion(name: string): string {
 }
 
 /**
+ * Flags for every `npm install` that runs inside a sandbox or a snapshot build.
+ * `--no-audit` matters most: npm otherwise posts the whole tree to the registry's
+ * advisories endpoint and blocks until it answers or its 300s fetch timeout expires,
+ * so a slow registry turns a 10s install into minutes. Nobody reads the audit or
+ * funding output in a sandbox. `--prefer-offline` lets a warm npm cache skip
+ * freshness checks against the registry.
+ */
+export const NPM_INSTALL_FLAGS = '--ignore-scripts --no-audit --no-fund --prefer-offline';
+
+/**
  * Versions pinned from the host's installed packages. Pinning is load-bearing
  * for two reasons:
  *   1. `npm install '@n8n/workflow-sdk': '*'` inside the sandbox resolves to
@@ -210,7 +220,7 @@ export async function linkWorkspaceSdkIfEnabled(
 		.join(' ');
 	const install = await runInSandbox(
 		workspace,
-		`npm install ${tarballArgs} --no-save --ignore-scripts --force`,
+		`npm install ${tarballArgs} --no-save --force ${NPM_INSTALL_FLAGS}`,
 		root,
 	);
 	if (install.exitCode !== 0) {
@@ -485,7 +495,7 @@ export async function setupSandboxWorkspace(
 
 	// npm install (must run after package.json is in place)
 	await setupStep('install-dependencies', async () => {
-		const npmResult = await runInSandbox(workspace, 'npm install --ignore-scripts', root);
+		const npmResult = await runInSandbox(workspace, `npm install ${NPM_INSTALL_FLAGS}`, root);
 		if (npmResult.exitCode !== 0) {
 			throw new Error(`Sandbox npm install failed: ${npmResult.stderr}`);
 		}

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -26,7 +26,7 @@ import {
 	BuilderTemplatesService,
 	builderTemplatesOptionsFromEnv,
 } from './builder-templates-service';
-import { PACKAGE_JSON, TSCONFIG_JSON, BUILD_MJS } from './sandbox-setup';
+import { PACKAGE_JSON, TSCONFIG_JSON, BUILD_MJS, NPM_INSTALL_FLAGS } from './sandbox-setup';
 import { stageWorkspaceFilesForImage } from './snapshot-image-context';
 import { buildRuntimeSkillWorkspaceBundle } from '../skills/materialize-runtime-skills';
 import { loadInstanceAiRuntimeSkillSource } from '../skills/runtime-skills';
@@ -227,7 +227,7 @@ export class SnapshotManager {
 		const image = Image.base(base)
 			.addLocalDir(stagingDir, DAYTONA_WORKSPACE_BAKE_ROOT)
 			.runCommands(
-				`cp -a ${DAYTONA_WORKSPACE_BAKE_ROOT}/. ${DAYTONA_WORKSPACE_ROOT}/ && mkdir -p ${layoutDirs} && cd ${DAYTONA_WORKSPACE_ROOT} && npm install --ignore-scripts`,
+				`cp -a ${DAYTONA_WORKSPACE_BAKE_ROOT}/. ${DAYTONA_WORKSPACE_ROOT}/ && mkdir -p ${layoutDirs} && cd ${DAYTONA_WORKSPACE_ROOT} && npm install ${NPM_INSTALL_FLAGS}`,
 			);
 
 		this.logger.info('Builder image descriptor prepared', {


### PR DESCRIPTION
## Summary

Every fresh Instance AI sandbox runs `npm install --ignore-scripts` to set up the workflow builder workspace. As part of that install, npm posts the whole dependency tree to the registry's advisories endpoint and blocks until it answers or its 300 s fetch timeout expires. Nobody reads the audit result, but the build waits for it.

Right now that endpoint takes 60 to 300 s to answer. Measured in the sandbox image on 2026-09-04: with nothing to install, `npm install` took 76 s with audit and 1 s without. With the package.json n8n writes, it took 430 s with audit and 12 s without.

The Instance AI preview E2E specs wait 120 s for the first canvas node, so they landed on either side of that line and Currents quarantined them as flaky. Users see the same thing as a "Generating workflow" step that sits for minutes.

This PR adds `--no-audit --no-fund --prefer-offline` to the three `npm install` calls in the instance-ai package (runtime workspace setup, linked-SDK install, and the Daytona snapshot build) through one shared `NPM_INSTALL_FLAGS` constant.

## How to test

Unit tests:

```bash
cd packages/@n8n/instance-ai
pnpm vitest run src/workspace/__tests__/sandbox-setup.test.ts src/workspace/__tests__/snapshot-manager.test.ts
```

End to end in replay mode (no Anthropic key needed):

```bash
pnpm build:docker > build.log 2>&1
cd packages/testing/playwright
pnpm test:container:sqlite:e2e tests/e2e/instance-ai/instance-ai-workflow-preview.spec.ts tests/e2e/instance-ai/instance-ai-artifacts.spec.ts --workers 1
```

Before this change the same run took 13.8 min locally with 3 of 6 tests failing at the 120 s wait. With it, all 6 pass in 3.7 min, each between 23 s and 36 s. The quarantined tests are skipped locally by `fixtures/quarantine.ts`; set `CURRENTS_RECORD_KEY` to any value to run them.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-1340
- https://linear.app/n8n/issue/INS-1341
- https://linear.app/n8n/issue/INS-1342
- https://linear.app/n8n/issue/INS-1343
- https://linear.app/n8n/issue/INS-1344

Four more quarantined Instance AI tests sit on the same build path and should recover too: "should display artifact card in timeline after workflow build", "should show run workflow button in preview", "should preserve a submitted workflow when mocked credential verification needs setup", and "should list archived workflows and restore one via Instance AI".

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

