### PR TITLE
build: Improve task runner deployment speed (no-changelog)

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -10,34 +10,23 @@ COPY ./dist/task-runner-javascript /app/task-runner-javascript
 
 WORKDIR /app/task-runner-javascript
 
-# Pin pnpm to the repo's packageManager version. `pnpm deploy` drops the
-# packageManager field from the deployed package.json, so nothing else here pins it.
-ARG PNPM_VERSION
-RUN npm i -g "pnpm@${PNPM_VERSION}"
-
-# Remove `catalog` and `workspace` references from package.json to allow `pnpm add` in extended images
+# Remove workspace-only references from package.json to allow `pnpm add` in extended images.
 RUN node -e "const pkg = require('./package.json'); \
     Object.keys(pkg.dependencies || {}).forEach(k => { \
         const val = pkg.dependencies[k]; \
-        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
+        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:') || val.startsWith('file:') || val.includes('@file:')) \
             delete pkg.dependencies[k]; \
     }); \
     Object.keys(pkg.devDependencies || {}).forEach(k => { \
         const val = pkg.devDependencies[k]; \
-        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
+        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:') || val.startsWith('file:') || val.includes('@file:')) \
             delete pkg.devDependencies[k]; \
     }); \
     delete pkg.devDependencies; \
     require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2));"
 
-# `--config.minimum-release-age=0`: pnpm 11 defaults it to 1440 (24h), which would make
-# this reject any dependency published less than a day ago — e.g. a first-party
-# @n8n_io/ai-assistant-sdk bump landed within hours of its npm publish. This step only
-# re-resolves an already-vetted, already-pinned dependency set; the real supply-chain age
-# policy is enforced by the host install (pnpm-workspace.yaml + SafeChain).
-# Install moment (special case for backwards compatibility)
-RUN rm -f node_modules/.modules.yaml && \
-    pnpm add moment@2.30.1 --prod --no-lockfile --config.minimum-release-age=0
+# Remove deploy metadata that points to workspace-only settings and patch files.
+RUN rm -f pnpm-lock.yaml node_modules/.modules.yaml node_modules/.pnpm/lock.yaml node_modules/.pnpm-workspace-state-v1.json
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -13,7 +13,6 @@
 # ==============================================================================
 
 ARG NODE_VERSION=26.7.0
-ARG PNPM_VERSION=11.25.0
 ARG PYTHON_VERSION=3.13
 
 
@@ -22,37 +21,6 @@ ARG PYTHON_VERSION=3.13
 # ==============================================================================
 FROM node:${NODE_VERSION}-bookworm-slim AS javascript-runner-builder
 COPY ./dist/task-runner-javascript /app/task-runner-javascript
-
-WORKDIR /app/task-runner-javascript
-
-# Pin pnpm to the repo's packageManager version. `pnpm deploy` drops the
-# packageManager field from the deployed package.json, so nothing else here pins it.
-ARG PNPM_VERSION
-RUN npm i -g "pnpm@${PNPM_VERSION}"
-
-# Remove `catalog` and `workspace` references from package.json to allow `pnpm add`
-RUN node -e "const pkg = require('./package.json'); \
-    Object.keys(pkg.dependencies || {}).forEach(k => { \
-        const val = pkg.dependencies[k]; \
-        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
-            delete pkg.dependencies[k]; \
-    }); \
-    Object.keys(pkg.devDependencies || {}).forEach(k => { \
-        const val = pkg.devDependencies[k]; \
-        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
-            delete pkg.devDependencies[k]; \
-    }); \
-    delete pkg.devDependencies; \
-    require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2));"
-
-# `--config.minimum-release-age=0`: pnpm 11 defaults it to 1440 (24h), which would make
-# this reject any dependency published less than a day ago — e.g. a first-party
-# @n8n_io/ai-assistant-sdk bump landed within hours of its npm publish. This step only
-# re-resolves an already-vetted, already-pinned dependency set; the real supply-chain age
-# policy is enforced by the host install (pnpm-workspace.yaml + SafeChain).
-# Install moment by default (special case for n8n cloud)
-RUN rm -f node_modules/.modules.yaml && \
-    pnpm add moment@2.30.1 --prod --no-lockfile --config.minimum-release-age=0
 
 # Rebuild isolated-vm for the container platform. Install build tools as
 # fallback in case prebuild-install cannot find a prebuilt binary.

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -47,6 +47,7 @@
     "acorn-walk": "8.3.4",
     "lodash": "catalog:",
     "luxon": "catalog:",
+    "moment": "2.30.1",
     "n8n-core": "workspace:*",
     "n8n-workflow": "workspace:*",
     "nanoid": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3784,6 +3784,9 @@ importers:
       luxon:
         specifier: 'catalog:'
         version: 3.7.2
+      moment:
+        specifier: 2.30.1
+        version: 2.30.1
       n8n-core:
         specifier: workspace:*
         version: link:../../core

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -423,7 +423,7 @@ try {
 	// orders of magnitude smaller than the n8n one, so the strips above are not
 	// worth duplicating here — the closure figure they report covers the n8n image
 	// only, not the shipped total.
-	await $`cd ${config.rootDir} && NODE_ENV=production DOCKER_BUILD=true pnpm --filter=@n8n/task-runner --prod --legacy deploy --no-optional ${config.compiledTaskRunnerDir}`;
+	await $`cd ${config.rootDir} && NODE_ENV=production DOCKER_BUILD=true pnpm --filter=@n8n/task-runner --prod --config.inject-workspace-packages=true deploy --no-optional ${config.compiledTaskRunnerDir}`;
 
 	// Check the production closure for single-instance dependency duplication. A curated
 	// library resolving to more than one physical copy silently breaks instanceof /


### PR DESCRIPTION
## Summary

Use the modern pnpm deploy implementation for the JavaScript task runner. Keep the main n8n deployment on the legacy implementation because the modern path regresses its build time and closure size.

Declare `moment` as a task runner production dependency. The distroless runner is the production artifact used by n8n Cloud, so its default runtime dependencies must already exist in the deployed closure. Remove the duplicate pnpm installation and package mutation from the standard and distroless image builds.

Blacksmith logs contain 4,639 matched runner deployments over the last 30 days. The legacy runner phase takes 20.3 seconds on average, 19.0 seconds at the median, and 38.4 seconds at p95. These deployments consume 26.18 aggregate CI job-hours.

This PR takes 3.32 seconds in the normal PR amd64 build, 2.77 seconds in the no-cache amd64 build, and 8.44 seconds in the no-cache arm64 build. Applying those measured timings to the historical architecture mix projects an average saving of 17.1 seconds for each build, an 84% reduction. This saves approximately 22 aggregate CI job-hours each month.

PR image preparation accounts for 3,693 deployments and approximately 16.8 of those saved job-hours. Release publishing saves approximately 30 seconds for each build. The parallel no-cache Docker workflow saves approximately 51 seconds on its slower arm64 job.

## How to test

1. Run `pnpm build:docker`.
2. Run `DOCKER_BUILD_DISTROLESS=true node scripts/dockerize-n8n.mjs`.
3. Confirm that `moment@2.30.1` resolves in both runner images.
4. Confirm that the Node and Python interpreters run in both runner images.

The standard and distroless images build locally. The native amd64 and arm64 no-cache Docker CI jobs pass. Both CI jobs verify the images against the live n8n Cloud Helm chart.

The task runner lint and typecheck commands pass. The full repository typecheck passes. The full repository lint reaches an unrelated heap limit in `n8n-nodes-base`; the task runner lint passes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-440

Related runner dependency history:

- https://github.com/n8n-io/n8n/pull/22079
- https://github.com/n8n-io/n8n/pull/22212

Related upstream performance issue: https://github.com/pnpm/pnpm/issues/10147

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

PR Summary generated by AI.
