### PR TITLE
fix(Chat Trigger Node): Re-authenticate hosted chat on session change

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/GenericFunctions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/GenericFunctions.ts
@@ -5,6 +5,7 @@ import type { ICredentialDataDecryptedObject, IUser, IWebhookFunctions } from 'n
 import { ChatTriggerAuthorizationError } from './error';
 import {
 	clearChatOAuthToken,
+	clearChatRefreshToken,
 	isChatOAuth2Enabled,
 	readChatOAuthToken,
 	readChatRefreshToken,
@@ -25,6 +26,34 @@ function expiryFrom(expiresIn: number): number {
  */
 function secondsUntil(expiresAt: number): number {
 	return Math.max(0, (expiresAt - Date.now()) / 1000);
+}
+
+function getCookie(cookieHeader: string | undefined, name: string): string {
+	const value = `; ${cookieHeader ?? ''}`;
+	const parts = value.split(`; ${name}=`);
+
+	if (parts.length === 2) {
+		return parts.pop()?.split(';').shift() ?? '';
+	}
+	return '';
+}
+
+/**
+ * The id of whoever is logged into the browser's *current* n8n session, independent of
+ * any chat-specific grant. `null` when there is no active session to compare against
+ * (e.g. it expired on its own shorter lifetime) — callers treat that as "nothing to
+ * contradict the cached grant", not as a mismatch.
+ */
+async function resolveCurrentSessionUserId(context: IWebhookFunctions): Promise<string | null> {
+	const authCookie = getCookie(context.getHeaderData()?.cookie, 'n8n-auth');
+	if (!authCookie) return null;
+
+	try {
+		const user = await context.validateCookieAuth(authCookie);
+		return user.id;
+	} catch {
+		return null;
+	}
 }
 
 /**
@@ -67,16 +96,6 @@ export async function validateAuth(context: IWebhookFunctions): Promise<IUser | 
 		const webhookName = context.getWebhookName();
 
 		if (webhookName !== 'setup') {
-			function getCookie(name: string) {
-				const value = `; ${headers.cookie}`;
-				const parts = value.split(`; ${name}=`);
-
-				if (parts.length === 2) {
-					return parts.pop()?.split(';').shift();
-				}
-				return '';
-			}
-
 			// The sandboxed frame carries this instead of the session cookie, which an opaque
 			// origin never sends. Checked first so the frame doesn't depend on that cookie.
 			// Verified against n8n's internal AS (not just decoded) so the token also seeds
@@ -100,7 +119,7 @@ export async function validateAuth(context: IWebhookFunctions): Promise<IUser | 
 				}
 			}
 
-			const authCookie = getCookie('n8n-auth');
+			const authCookie = getCookie(headers.cookie, 'n8n-auth');
 			if (!authCookie) {
 				throw new ChatTriggerAuthorizationError(401, 'User not authenticated!');
 			}
@@ -183,18 +202,24 @@ export async function establishChatSessionIdentity(
 		// Not an AS callback. If we just completed the flow, the token rides in the
 		// one-hop cookie set on the redirect above — leave it for the frame's own GET
 		// to consume, just confirm it's still good before rendering the shell around it.
+		const currentUserId = await resolveCurrentSessionUserId(context);
+
 		const session = readChatOAuthToken(req);
 		if (session) {
 			const validation = await context.validateN8nOAuth2Token(session.token, resourceUrl);
 			if (validation.valid) {
-				await context.establishTriggerIdentity(session.token, resourceUrl, validation.user.id);
-				return {
-					visitor: validation.user,
-					authToken: session.token,
-					expiresIn: secondsUntil(session.expiresAt),
-				};
+				if (currentUserId === null || validation.user.id === currentUserId) {
+					await context.establishTriggerIdentity(session.token, resourceUrl, validation.user.id);
+					return {
+						visitor: validation.user,
+						authToken: session.token,
+						expiresIn: secondsUntil(session.expiresAt),
+					};
+				}
+				clearChatOAuthToken(res, req, resourceUrl);
+				clearChatRefreshToken(res, req, resourceUrl);
 			}
-			// Stale/invalid cookie — fall through to restart the OAuth2 flow.
+			// Invalid cookie — fall through to restart the OAuth2 flow.
 		} else {
 			// A reload mid-conversation: the one-hop cookie is long gone, but the grant
 			// is still live in the refresh cookie. Rotating is cheaper than a full
@@ -206,15 +231,22 @@ export async function establishChatSessionIdentity(
 				// rendered for.
 				const validation = await context.validateN8nOAuth2Token(refreshed.token, resourceUrl);
 				if (validation.valid) {
-					await context.establishTriggerIdentity(refreshed.token, resourceUrl, validation.user.id);
-					return {
-						visitor: validation.user,
-						authToken: refreshed.token,
-						expiresIn: refreshed.expiresIn,
-					};
+					if (currentUserId === null || validation.user.id === currentUserId) {
+						await context.establishTriggerIdentity(
+							refreshed.token,
+							resourceUrl,
+							validation.user.id,
+						);
+						return {
+							visitor: validation.user,
+							authToken: refreshed.token,
+							expiresIn: refreshed.expiresIn,
+						};
+					}
+					clearChatOAuthToken(res, req, resourceUrl);
+					clearChatRefreshToken(res, req, resourceUrl);
 				}
 			}
-			// Refresh failed — fall through to restart the OAuth2 flow, which handles it.
 		}
 	}
 
@@ -298,6 +330,18 @@ export async function handleChatTokenRefresh(
 		res.status(401).json({ error: 'invalid_grant' });
 		res.end();
 		return;
+	}
+
+	const currentUserId = await resolveCurrentSessionUserId(context);
+	if (currentUserId !== null) {
+		const validation = await context.validateN8nOAuth2Token(refreshed.token, resourceUrl);
+		if (!validation.valid || validation.user.id !== currentUserId) {
+			clearChatOAuthToken(res, req, resourceUrl);
+			clearChatRefreshToken(res, req, resourceUrl);
+			res.status(401).json({ error: 'invalid_grant' });
+			res.end();
+			return;
+		}
 	}
 
 	// Only the access token crosses the wire; the rotated refresh token stays in its

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/GenericFunctions.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/GenericFunctions.test.ts
@@ -300,6 +300,10 @@ describe('establishChatSessionIdentity', () => {
 		vi.clearAllMocks();
 		mockContext.getResponseObject.mockReturnValue(mockRes());
 		mockContext.logger = { warn: vi.fn() } as never;
+		// Default: no current n8n session to compare a cached grant against, so tests
+		// that don't care about the session-mismatch check keep their prior behaviour
+		// regardless of what an earlier test left on this mock.
+		mockContext.getHeaderData.mockReturnValue({});
 	});
 
 	it('starts the AS flow on a fresh request with no cookie', async () => {
@@ -397,6 +401,56 @@ describe('establishChatSessionIdentity', () => {
 		expect(mockContext.refreshN8nOAuth2Flow).not.toHaveBeenCalled();
 	});
 
+	// A grant issued to test@n8n.io must not keep authenticating this page after the
+	// browser's own n8n session has since logged in as someone else in another tab.
+	it('restarts the flow and discards the grant when the one-hop cookie belongs to a different user than the current n8n session', async () => {
+		const expiresAt = Date.now() + 3_600_000;
+		const cookie = `${oauthCookie('as-token', expiresAt)}; n8n-auth=session.jwt`;
+		mockContext.getRequestObject.mockReturnValue({
+			query: {},
+			headers: { cookie },
+			originalUrl: '/webhook/abc/chat',
+		} as never);
+		mockContext.getHeaderData.mockReturnValue({ cookie });
+		mockContext.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user });
+		mockContext.validateCookieAuth.mockResolvedValue({ ...user, id: 'user-2' });
+		mockContext.beginN8nOAuth2Flow.mockResolvedValue('https://as.example.com/authorize');
+
+		const result = await establishChatSessionIdentity(mockContext, resourceUrl);
+
+		expect(result).toBeNull();
+		expect(mockContext.establishTriggerIdentity).not.toHaveBeenCalled();
+		expect(mockContext.getResponseObject().clearCookie).toHaveBeenCalledWith(
+			'n8n-chat-oauth',
+			expect.any(Object),
+		);
+		expect(mockContext.getResponseObject().clearCookie).toHaveBeenCalledWith(
+			'n8n-chat-oauth-refresh',
+			expect.any(Object),
+		);
+		expect(mockContext.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl);
+	});
+
+	// No current session to contradict the grant (it's a normal expired-independently
+	// case, not a different-user case), so the cached grant is trusted as before.
+	it('trusts the one-hop cookie when the current n8n-auth cookie fails to validate', async () => {
+		const expiresAt = Date.now() + 3_600_000;
+		const cookie = `${oauthCookie('as-token', expiresAt)}; n8n-auth=expired.jwt`;
+		mockContext.getRequestObject.mockReturnValue({
+			query: {},
+			headers: { cookie },
+			originalUrl: '/webhook/abc/chat',
+		} as never);
+		mockContext.getHeaderData.mockReturnValue({ cookie });
+		mockContext.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user });
+		mockContext.validateCookieAuth.mockRejectedValue(new Error('expired'));
+
+		const result = await establishChatSessionIdentity(mockContext, resourceUrl);
+
+		expect(result).toMatchObject({ visitor: user, authToken: 'as-token' });
+		expect(mockContext.getResponseObject().clearCookie).not.toHaveBeenCalled();
+	});
+
 	it('restarts the flow when the one-hop cookie fails to validate', async () => {
 		mockContext.getRequestObject.mockReturnValue({
 			query: {},
@@ -454,6 +508,41 @@ describe('establishChatSessionIdentity', () => {
 			'rotated-token',
 			expect.objectContaining({ httpOnly: true }),
 		);
+	});
+
+	// Same identity-binding check on the refresh path: rotating the grant still
+	// resolves to test@n8n.io, but the browser is now logged in as someone else.
+	it('restarts the flow and discards the grant when the refreshed token belongs to a different user than the current n8n session', async () => {
+		const cookie = 'n8n-chat-oauth-refresh=refresh-token; n8n-auth=session.jwt';
+		mockContext.getRequestObject.mockReturnValue({
+			query: {},
+			headers: { cookie },
+			originalUrl: '/webhook/abc/chat',
+		} as never);
+		mockContext.getHeaderData.mockReturnValue({ cookie });
+		mockContext.refreshN8nOAuth2Flow.mockResolvedValue({
+			valid: true,
+			token: 'fresh-token',
+			refreshToken: 'rotated-token',
+			expiresIn: 3600,
+		});
+		mockContext.validateN8nOAuth2Token.mockResolvedValue({ valid: true, user });
+		mockContext.validateCookieAuth.mockResolvedValue({ ...user, id: 'user-2' });
+		mockContext.beginN8nOAuth2Flow.mockResolvedValue('https://as.example.com/authorize');
+
+		const result = await establishChatSessionIdentity(mockContext, resourceUrl);
+
+		expect(result).toBeNull();
+		expect(mockContext.establishTriggerIdentity).not.toHaveBeenCalled();
+		expect(mockContext.getResponseObject().clearCookie).toHaveBeenCalledWith(
+			'n8n-chat-oauth',
+			expect.any(Object),
+		);
+		expect(mockContext.getResponseObject().clearCookie).toHaveBeenCalledWith(
+			'n8n-chat-oauth-refresh',
+			expect.any(Object),
+		);
+		expect(mockContext.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl);
 	});
 
 	it('restarts the flow when the refresh cookie is refused', async () => {
@@ -552,6 +641,10 @@ describe('handleChatTokenRefresh', () => {
 		vi.clearAllMocks();
 		mockContext.getResponseObject.mockReturnValue(mockRes());
 		mockContext.logger = { warn: vi.fn() } as never;
+		// Default: no current n8n session to compare the rotated grant against, so
+		// tests that don't care about the session-mismatch check keep their prior
+		// behaviour regardless of what an earlier test left on this mock.
+		mockContext.getHeaderData.mockReturnValue({});
 	});
 
 	it('rotates the grant and returns only the access token and its lifetime', async () => {
@@ -581,6 +674,38 @@ describe('handleChatTokenRefresh', () => {
 			expect.objectContaining({ httpOnly: true }),
 		);
 		expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+	});
+
+	// Mid-conversation background refresh must not keep minting tokens for a visitor
+	// who is no longer the one logged into this browser's n8n session.
+	it('discards the grant and answers 401 when the rotated token belongs to a different user than the current n8n session', async () => {
+		const cookie = 'n8n-chat-oauth-refresh=refresh-token; n8n-auth=session.jwt';
+		mockContext.getRequestObject.mockReturnValue({ headers: { cookie } } as never);
+		mockContext.getHeaderData.mockReturnValue({ cookie });
+		mockContext.refreshN8nOAuth2Flow.mockResolvedValue({
+			valid: true,
+			token: 'fresh-token',
+			refreshToken: 'rotated-token',
+			expiresIn: 3600,
+		});
+		mockContext.validateN8nOAuth2Token.mockResolvedValue({
+			valid: true,
+			user: { id: 'user-1', email: 'visitor@example.com', firstName: 'Vi', lastName: 'Sitor' },
+		});
+		mockContext.validateCookieAuth.mockResolvedValue({
+			id: 'user-2',
+			email: 'other@example.com',
+			firstName: 'Other',
+			lastName: 'User',
+		});
+
+		await handleChatTokenRefresh(mockContext, resourceUrl);
+
+		const res = mockContext.getResponseObject();
+		expect(res.status).toHaveBeenCalledWith(401);
+		expect(res.json).toHaveBeenCalledWith({ error: 'invalid_grant' });
+		expect(res.clearCookie).toHaveBeenCalledWith('n8n-chat-oauth', expect.any(Object));
+		expect(res.clearCookie).toHaveBeenCalledWith('n8n-chat-oauth-refresh', expect.any(Object));
 	});
 
 	it('answers 401 without calling the AS when there is no refresh cookie', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/connect-panel.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/connect-panel.test.ts
@@ -116,10 +116,17 @@ describe('connectBarText', () => {
 		expect(connectBarText(vm)).toBe('2 more accounts needed to start this chat');
 	});
 
-	it('confirms readiness once every account is connected', () => {
+	// "All 1 account" doesn't read correctly, so the singular case drops "All".
+	it('confirms readiness for a single account without saying "All 1"', () => {
 		expect(connectBarText(buildChatShellViewModel([configuredCred()]))).toBe(
-			'All 1 account connected · ready to chat',
+			'Account connected · ready to chat',
 		);
+	});
+
+	it('confirms readiness for two or more accounts', () => {
+		const vm = buildChatShellViewModel([configuredCred(), configuredCred({ credentialId: 'x' })]);
+
+		expect(connectBarText(vm)).toBe('All 2 accounts connected · ready to chat');
 	});
 
 	// Test mode resolves identity from the builder's own credentials, so once they are

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/connect-panel.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/connect-panel.ts
@@ -49,9 +49,13 @@ export function buildChatShellViewModel(
 export function connectBarText(vm: ChatShellViewModel, testMode?: boolean): string {
 	const remaining = Math.max(vm.total - vm.connectedCount, 0);
 	if (remaining === 0) {
-		return testMode
-			? "You're testing with your own connected accounts. Visitors will need to connect their own."
-			: `All ${vm.total} ${accountsLabel(vm.total)} connected \u00b7 ready to chat`;
+		if (testMode) {
+			return "You're testing with your own connected accounts. Visitors will need to connect their own.";
+		}
+		// "All" only reads correctly once there's more than one account to be "all" of.
+		return vm.total === 1
+			? 'Account connected \u00b7 ready to chat'
+			: `All ${vm.total} accounts connected \u00b7 ready to chat`;
 	}
 	if (vm.total === 1) {
 		return `Connect ${vm.credentials[0].name} to start this chat`;

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/shell.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/shell.ts
@@ -186,6 +186,10 @@ export function readChatRefreshToken(req: Request): string | null {
 	return readRawCookie(req, CHAT_OAUTH_REFRESH_COOKIE_NAME);
 }
 
+export function clearChatRefreshToken(res: Response, req: Request, resourceUrl: string): void {
+	res.clearCookie(CHAT_OAUTH_REFRESH_COOKIE_NAME, chatOAuthCookieOptions(req, resourceUrl));
+}
+
 /**
  * Whether this GET is the shell asking for a fresh access token rather than for a page.
  *


### PR DESCRIPTION
## Summary

The hosted chat page's OAuth shell reused a cached grant (the one-hop cookie,
or the longer-lived refresh-token cookie) purely based on whether it existed
and was still valid — it never checked who is currently logged into the
browser's n8n session.

If a visitor logs out of the main app and logs in as someone else in another
tab, the chat page kept silently re-authenticating as the original visitor on
every refresh, for as long as the 30-day refresh grant lived. Clearing
cookies was the only way to force it to pick up the new session.

`establishChatSessionIdentity` (the shell's own load path) and
`handleChatTokenRefresh` (its background token-refresh leg) now compare the
cached grant's user against whoever the browser's current `n8n-auth` cookie
resolves to on every load:

- Same user, or no current session to compare against (e.g. it expired
  independently, shorter-lived than the chat grant) — unchanged fast path,
  no extra round trip through the authorization server.
- A different, currently logged-in user — the cached grant is discarded and
  the flow restarts through the real OAuth handshake, which picks up
  whoever is actually logged in.

Concurrent-tab refresh races are unaffected: a *failed* refresh (e.g. a
second tab winning the token rotation) still leaves cookies alone, as
before — only a *confirmed* mismatch clears them.

Also includes a small, unrelated copy fix found while testing this: the
"ready to chat" banner said "All 1 account connected", which doesn't read
correctly for a single credential. It now says "Account connected" for one,
and keeps "All N accounts connected" for two or more.

## How to test

**Session re-authentication:**
1. Enable `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2` and the `dynamic-credentials`
   module.
2. Publish a workflow with a public Chat Trigger, `n8n User Auth` enabled,
   and at least one node with an end-user credential.
3. Log in as user A, open the chat page, accept the OAuth consent, and
   connect the credential.
4. In another tab, log out of user A and log in as user B.
5. Refresh the chat tab.

Before this change: the page keeps showing user A's connection state.
After: it re-authenticates and correctly asks user B to connect their own
credentials.

**Banner copy:** connect a single end-user credential and check the bar
above the chat input reads "Account connected · ready to chat", not
"All 1 account connected · ready to chat".

Both covered by new/updated unit tests in `GenericFunctions.test.ts` and
`connect-panel.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1349/chat-trigger-when-logging-out-of-one-account-and-into-another-the-user

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (n/a — feature is still behind `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2`, unreleased)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (n/a — unreleased flag)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

