### PR TITLE
fix(Microsoft SQL Node): Fix TLS error when the IP is used to connect to the server

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
@@ -7,6 +7,10 @@ import type { IDataObject, IExecuteFunctions, INodeExecutionData } from 'n8n-wor
 
 import type { ITables, OperationInputData } from './interfaces';
 
+function toOptionalNumber(value: unknown) {
+	return value === undefined || value === null || value === '' ? undefined : Number(value);
+}
+
 /**
  * Returns a copy of the item which only contains the json data and
  * of that only the defined properties
@@ -97,13 +101,13 @@ export function formatColumns(columns: string) {
 export function configurePool(credentials: IDataObject) {
 	const config = {
 		server: credentials.server as string,
-		port: Number(credentials.port),
+		port: toOptionalNumber(credentials.port),
 		database: credentials.database as string,
 		user: credentials.user as string,
 		password: credentials.password as string,
 		domain: credentials.domain ? (credentials.domain as string) : undefined,
-		connectionTimeout: Number(credentials.connectTimeout),
-		requestTimeout: Number(credentials.requestTimeout),
+		connectionTimeout: toOptionalNumber(credentials.connectTimeout),
+		requestTimeout: toOptionalNumber(credentials.requestTimeout),
 		options: {
 			encrypt: credentials.tls as boolean,
 			enableArithAbort: false,

--- a/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
@@ -97,13 +97,13 @@ export function formatColumns(columns: string) {
 export function configurePool(credentials: IDataObject) {
 	const config = {
 		server: credentials.server as string,
-		port: credentials.port as number,
+		port: Number(credentials.port),
 		database: credentials.database as string,
 		user: credentials.user as string,
 		password: credentials.password as string,
 		domain: credentials.domain ? (credentials.domain as string) : undefined,
-		connectionTimeout: credentials.connectTimeout as number,
-		requestTimeout: credentials.requestTimeout as number,
+		connectionTimeout: Number(credentials.connectTimeout),
+		requestTimeout: Number(credentials.requestTimeout),
 		options: {
 			encrypt: credentials.tls as boolean,
 			enableArithAbort: false,

--- a/packages/nodes-base/nodes/Microsoft/Sql/test/MicrosoftSql.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/test/MicrosoftSql.node.test.ts
@@ -4,6 +4,7 @@ import type * as mssql from 'mssql';
 import { constructExecutionMetaData, returnJsonArray } from 'n8n-core';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
+import { configurePool } from '../GenericFunctions';
 import { MicrosoftSql } from '../MicrosoftSql.node';
 import type { MockedClass } from 'vitest';
 
@@ -40,6 +41,30 @@ describe('MicrosoftSql Node', () => {
 
 	beforeEach(() => {
 		mockedConnectionPool = mssqlDefault.ConnectionPool as MockedClass<typeof mssql.ConnectionPool>;
+	});
+
+	test('converts numeric credential strings in the pool configuration', () => {
+		configurePool({ port: '1433', connectTimeout: '1000', requestTimeout: '10000' });
+
+		expect(mockedConnectionPool).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				port: 1433,
+				connectionTimeout: 1000,
+				requestTimeout: 10000,
+			}),
+		);
+	});
+
+	test('preserves driver defaults for empty numeric credentials', () => {
+		configurePool({ port: undefined, connectTimeout: '', requestTimeout: null });
+
+		expect(mockedConnectionPool).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				port: undefined,
+				connectionTimeout: undefined,
+				requestTimeout: undefined,
+			}),
+		);
 	});
 
 	test('handles connection error with continueOnFail', async () => {

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -992,7 +992,7 @@
     "mongodb": "6.11.0",
     "mqtt": "5.7.2",
     "mqtt-packet": "catalog:",
-    "mssql": "10.0.2",
+    "mssql": "12.7.0",
     "mysql2": "catalog:",
     "n8n-workflow": "workspace:*",
     "node-html-markdown": "1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,7 @@ overrides:
   '@lezer/common': ^1.2.0
   '@mistralai/mistralai': ^1.10.0
   '@n8n/typeorm>@sentry/node': 10.70.0
+  mssql@12.7.0>tedious: 20.0.5
   '@opentelemetry/api': 1.9.1
   '@opentelemetry/core': 2.10.0
   '@opentelemetry/propagator-jaeger': 2.10.0
@@ -6910,8 +6911,8 @@ importers:
         specifier: 'catalog:'
         version: 9.0.0(supports-color@8.1.1)
       mssql:
-        specifier: 10.0.2
-        version: 10.0.2(supports-color@8.1.1)
+        specifier: 12.7.0
+        version: 12.7.0(supports-color@8.1.1)
       mysql2:
         specifier: 'catalog:'
         version: 3.23.1(@types/node@20.19.41)
@@ -8244,6 +8245,10 @@ packages:
     peerDependencies:
       playwright-core: '>= 1.0.0'
 
+  '@azure-rest/core-client@2.8.0':
+    resolution: {integrity: sha512-F1ybHeN+++QhyFCF/ehLUEvrOB6fehPdFBFtGdj0C3B2lpQ9zkPiO5JDgsqc6IfjuUe6b3dAbXK0a7+VgSGfhw==}
+    engines: {node: '>=22.0.0'}
+
   '@azure/abort-controller@1.1.0':
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
@@ -8260,10 +8265,6 @@ packages:
     resolution: {integrity: sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/core-http-compat@1.3.0':
-    resolution: {integrity: sha512-ZN9avruqbQ5TxopzG3ih3KRy52n8OAbitX3fnZT5go4hzu0J+KVPSzkL+Wt3hpJpdG8WIfg1sBD1tWkgUdEpBA==}
-    engines: {node: '>=12.0.0'}
-
   '@azure/core-http-compat@2.4.0':
     resolution: {integrity: sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==}
     engines: {node: '>=20.0.0'}
@@ -8274,6 +8275,10 @@ packages:
   '@azure/core-lro@2.4.0':
     resolution: {integrity: sha512-F65+rYkll1dpw3RGm8/SSiSj+/QkMeYDanzS/QKlM1dmuneVyXbO46C88V1MRHluLGdMP6qfD3vDRYALn0z0tQ==}
     engines: {node: '>=12.0.0'}
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
 
   '@azure/core-paging@1.6.2':
     resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
@@ -8299,9 +8304,13 @@ packages:
     resolution: {integrity: sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/keyvault-keys@4.6.0':
-    resolution: {integrity: sha512-0112LegxeR03L8J4k+q6HwBVvrpd9y+oInG0FG3NaHXN7YUubVBon/eb5jFI6edGrvNigpxSR0XIsprFXdkzCQ==}
-    engines: {node: '>=12.0.0'}
+  '@azure/keyvault-common@2.1.0':
+    resolution: {integrity: sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-keys@4.10.2':
+    resolution: {integrity: sha512-VmUSLbXRAbSzDD8grXHGPaknYs0SKr3yuf6U+d4XMpX4XuVYskNqbTTwXce0zR1LyxfTZm9rWEBcvs3vdYwCmQ==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/keyvault-secrets@4.8.0':
     resolution: {integrity: sha512-RGfpFk6XUXHfWuTAiokOe8t6ej5C4ijf4HVyJUmTfN6VjDBVPvTtoiOi/C5072/ENHScYZFhiYOgIjLgYjfJ/A==}
@@ -10033,8 +10042,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@js-joda/core@5.6.1':
-    resolution: {integrity: sha512-Xla/d7ZMMR6+zRd6lTio0wRZECfcfFJP7GGe9A9L4tDOlD5CX4YcZ4YZle9w58bBYzssojVapI84RraKWDQZRg==}
+  '@js-joda/core@6.1.0':
+    resolution: {integrity: sha512-H8NTMRDJqad/leyv/D/A3kSOsf5/58Ydj4DJGDyaCWk9OU/zuZOLhndVffJgQjsgrn5GC0znHMHie7TfvPPG4w==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -13550,8 +13559,8 @@ packages:
   '@techteamer/ocsp@1.0.1':
     resolution: {integrity: sha512-q4pW5wAC6Pc3JI8UePwE37CkLQ5gDGZMgjSX4MEEm4D4Di59auDQ8UNIDzC4gRnPNmmcwjpPxozq8p5pjiOmOw==}
 
-  '@tediousjs/connection-string@0.5.0':
-    resolution: {integrity: sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ==}
+  '@tediousjs/connection-string@1.1.0':
+    resolution: {integrity: sha512-z9ZBWEG+8pIB5V1zYzlRPXx0oRJ5H7coPnMQK8EZOw03UTPI9Umn6viL36f5w+CuqkKsnCM50RVStpjZmR0Bng==}
 
   '@testcontainers/k3s@11.13.0':
     resolution: {integrity: sha512-2JsvTBsOVvGzVPeTcJGt7SPqz95SzAzbmI/yy7noglI764NGnlUPxlQ0Ld4Pe9HaUVhm0YBOdc2OygQnhWKaQw==}
@@ -15730,6 +15739,9 @@ packages:
   bl@6.0.12:
     resolution: {integrity: sha512-EnEYHilP93oaOa2MnmNEjAcovPS3JlQZOyzGXi3EyEpPhm9qWvdDp7BmAVEVusGzp8LlwQK56Av+OkDoRjzE0w==}
 
+  bl@6.1.6:
+    resolution: {integrity: sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==}
+
   bluebird@2.11.0:
     resolution: {integrity: sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==}
 
@@ -17311,10 +17323,6 @@ packages:
 
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
-    engines: {node: '>= 0.4'}
-
-  es-aggregate-error@1.0.12:
-    resolution: {integrity: sha512-j0PupcmELoVbYS2NNrsn5zcLLEsryQwP02x8fRawh7c2eEaPHwJFAxltZsqV7HJjsF57+SMpYyVRWgbVLfOagg==}
     engines: {node: '>= 0.4'}
 
   es-array-method-boxes-properly@1.0.0:
@@ -19072,9 +19080,6 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
-  jsbi@4.3.0:
-    resolution: {integrity: sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==}
-
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
@@ -20396,9 +20401,9 @@ packages:
   msgpackr@1.11.2:
     resolution: {integrity: sha512-F9UngXRlPyWCDEASDpTf6c9uNhGPTqnTeLVt7bN+bU1eajoR/8V9ys2BRaV5C/e5ihE6sJ9uPIKaYt6bFuO32g==}
 
-  mssql@10.0.2:
-    resolution: {integrity: sha512-GrQ6gzv2xA7ndOvONyZ++4RZsNkr8qDiIpvuFn2pR3TPiSk/cKdmvOrDU3jWgon7EPj7CPgmDiMh7Hgtft2xLg==}
-    engines: {node: '>=14'}
+  mssql@12.7.0:
+    resolution: {integrity: sha512-J6SJKXi1jYbhHjjooLNtPnX7+s3cq5IJ701Wgy/UW1SXRpgFlJJsYi3IPve9RVgCUkq0Cqv2aaaSJ4IXtIF3mg==}
+    engines: {node: '>=18.19.0'}
     hasBin: true
 
   muggle-string@0.4.1:
@@ -20529,9 +20534,6 @@ packages:
   node-abi@4.28.0:
     resolution: {integrity: sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==}
     engines: {node: '>=22.12.0'}
-
-  node-abort-controller@3.1.1:
-    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
@@ -23132,9 +23134,9 @@ packages:
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
-  tedious@16.7.1:
-    resolution: {integrity: sha512-NmedZS0NJiTv3CoYnf1FtjxIDUgVYzEmavrc8q2WHRb+lP4deI9BpQfmNnBZZaWusDbP5FVFZCcvzb3xOlNVlQ==}
-    engines: {node: '>=16'}
+  tedious@20.0.5:
+    resolution: {integrity: sha512-OUkbPGwB/RFNS3dEsy3C5sBP8q4LSe7VJ3sYR1RTPU7asmitn+YpK4Y95dvTL+2Bb8lJacdAXlBnXxB+hw7ueQ==}
+    engines: {node: '>=22'}
 
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
@@ -26296,6 +26298,17 @@ snapshots:
       axe-core: 4.13.0
       playwright-core: 1.62.1
 
+  '@azure-rest/core-client@2.8.0(supports-color@8.1.1)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1(supports-color@8.1.1)
+      '@azure/core-rest-pipeline': 1.24.0(supports-color@8.1.1)
+      '@azure/core-tracing': 1.3.1
+      '@typespec/ts-http-runtime': 0.3.6(supports-color@8.1.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/abort-controller@1.1.0':
     dependencies:
       tslib: 2.8.1
@@ -26324,14 +26337,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-http-compat@1.3.0(supports-color@8.1.1)':
-    dependencies:
-      '@azure/abort-controller': 1.1.0
-      '@azure/core-client': 1.10.2(supports-color@8.1.1)
-      '@azure/core-rest-pipeline': 1.24.0(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.2(supports-color@8.1.1))(@azure/core-rest-pipeline@1.24.0(supports-color@8.1.1))':
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -26341,6 +26346,15 @@ snapshots:
   '@azure/core-lro@2.4.0(supports-color@8.1.1)':
     dependencies:
       '@azure/abort-controller': 1.1.0
+      '@azure/logger': 1.3.0(supports-color@8.1.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-lro@2.7.2(supports-color@8.1.1)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1(supports-color@8.1.1)
       '@azure/logger': 1.3.0(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -26395,17 +26409,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/keyvault-keys@4.6.0(supports-color@8.1.1)':
+  '@azure/keyvault-common@2.1.0(supports-color@8.1.1)':
     dependencies:
-      '@azure/abort-controller': 1.1.0
+      '@azure-rest/core-client': 2.8.0(supports-color@8.1.1)
+      '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.10.1(supports-color@8.1.1)
-      '@azure/core-client': 1.10.2(supports-color@8.1.1)
-      '@azure/core-http-compat': 1.3.0(supports-color@8.1.1)
-      '@azure/core-lro': 2.4.0(supports-color@8.1.1)
+      '@azure/core-rest-pipeline': 1.24.0(supports-color@8.1.1)
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1(supports-color@8.1.1)
+      '@azure/logger': 1.3.0(supports-color@8.1.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-keys@4.10.2(supports-color@8.1.1)':
+    dependencies:
+      '@azure-rest/core-client': 2.8.0(supports-color@8.1.1)
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1(supports-color@8.1.1)
+      '@azure/core-lro': 2.7.2(supports-color@8.1.1)
       '@azure/core-paging': 1.6.2
       '@azure/core-rest-pipeline': 1.24.0(supports-color@8.1.1)
       '@azure/core-tracing': 1.3.1
       '@azure/core-util': 1.13.1(supports-color@8.1.1)
+      '@azure/keyvault-common': 2.1.0(supports-color@8.1.1)
       '@azure/logger': 1.3.0(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -26492,7 +26519,7 @@ snapshots:
       '@azure/core-auth': 1.10.1(supports-color@8.1.1)
       '@azure/core-client': 1.10.2(supports-color@8.1.1)
       '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.2(supports-color@8.1.1))(@azure/core-rest-pipeline@1.24.0(supports-color@8.1.1))
-      '@azure/core-lro': 2.4.0(supports-color@8.1.1)
+      '@azure/core-lro': 2.7.2(supports-color@8.1.1)
       '@azure/core-paging': 1.6.2
       '@azure/core-rest-pipeline': 1.24.0(supports-color@8.1.1)
       '@azure/core-tracing': 1.3.1
@@ -29383,7 +29410,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-joda/core@5.6.1': {}
+  '@js-joda/core@6.1.0': {}
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -32997,7 +33024,7 @@ snapshots:
       async: 3.2.4
       simple-lru-cache: 0.0.2
 
-  '@tediousjs/connection-string@0.5.0': {}
+  '@tediousjs/connection-string@1.1.0': {}
 
   '@testcontainers/k3s@11.13.0(supports-color@8.1.1)':
     dependencies:
@@ -35701,6 +35728,13 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 4.5.2
 
+  bl@6.1.6:
+    dependencies:
+      '@types/readable-stream': 4.0.10
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 4.5.2
+
   bluebird@2.11.0: {}
 
   bluebird@3.4.7: {}
@@ -37565,17 +37599,6 @@ snapshots:
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.19
-
-  es-aggregate-error@1.0.12:
-    dependencies:
-      define-data-property: 1.1.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      globalthis: 1.0.4
-      has-property-descriptors: 1.0.2
-      set-function-name: 2.0.2
 
   es-array-method-boxes-properly@1.0.0: {}
 
@@ -39853,8 +39876,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsbi@4.3.0: {}
-
   jsbn@0.1.1: {}
 
   jsbn@1.1.0: {}
@@ -41599,14 +41620,13 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.2
 
-  mssql@10.0.2(supports-color@8.1.1):
+  mssql@12.7.0(supports-color@8.1.1):
     dependencies:
-      '@tediousjs/connection-string': 0.5.0
+      '@tediousjs/connection-string': 1.1.0
       commander: 11.1.0
       debug: 4.4.3(supports-color@8.1.1)
-      rfdc: 1.3.0
       tarn: 3.0.2
-      tedious: 16.7.1(supports-color@8.1.1)
+      tedious: 20.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -41734,8 +41754,6 @@ snapshots:
   node-abi@4.28.0:
     dependencies:
       semver: 7.7.3
-
-  node-abort-controller@3.1.1: {}
 
   node-addon-api@1.7.2:
     optional: true
@@ -45061,18 +45079,17 @@ snapshots:
     dependencies:
       bintrees: 1.0.2
 
-  tedious@16.7.1(supports-color@8.1.1):
+  tedious@20.0.5(supports-color@8.1.1):
     dependencies:
+      '@azure/core-auth': 1.10.1(supports-color@8.1.1)
       '@azure/identity': 4.13.0(supports-color@8.1.1)
-      '@azure/keyvault-keys': 4.6.0(supports-color@8.1.1)
-      '@js-joda/core': 5.6.1
-      bl: 6.0.12
-      es-aggregate-error: 1.0.12
-      iconv-lite: 0.6.3
+      '@azure/keyvault-keys': 4.10.2(supports-color@8.1.1)
+      '@js-joda/core': 6.1.0
+      '@types/node': 20.19.41
+      bl: 6.1.6
+      iconv-lite: 0.7.3
       js-md4: 0.3.2
-      jsbi: 4.3.0
       native-duplexpair: 1.0.0
-      node-abort-controller: 3.1.1
       sprintf-js: 1.1.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -354,6 +354,7 @@ overrides:
   '@lezer/common': ^1.2.0
   '@mistralai/mistralai': ^1.10.0
   '@n8n/typeorm>@sentry/node': catalog:sentry
+  'mssql@12.7.0>tedious': 20.0.5
   '@opentelemetry/api': 'catalog:'
   '@opentelemetry/core': 2.10.0
   '@opentelemetry/propagator-jaeger': 2.10.0


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

Microsoft SQL connections through an IP address fail when TLS is enabled on Node.js 25 or newer. The current `tedious` driver (used by `mssql` library) uses the configured IP address as the TLS Server Name Indication (SNI). SNI only accepts hostnames. Older Node.js versions emitted a warning, but newer versions reject the connection. This updates `mssql` to 12.7.0 and pins `tedious` to 20.0.5, which contains the upstream fix. The updated driver omits SNI for IP addresses while continuing to validate the server certificate. Hostname-based connections keep their existing behavior.

### Changes in the library
Two breaking changes introduced by updating `mssql` to 12.7.0 do not affect n8n: 
- `mssql` 11 requires Node.js 18 or newer, which n8n already exceeds
- `mssql` 12 no longer clones connection configuration objects, but n8n creates a new configuration for each pool and does not modify it afterward

### Extra changes
This PR also converts raw credential data to numbers for `port`, `connectionTimeout` and `requestTimeout` fields. This is due to a bug introduced recently where values from numeric input fields are returned as string. A bug report is already created: https://linear.app/n8n/issue/ADO-5879/

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

1. Launch MS SQL server with TLS (see Linear for instructions)
2. Launch n8n with Node.js 26: `nvm i 26 && nvm use 26`
3. Create credentials for MS SQL server:
    - Server: `127.0.0.1` (important: use the IP)
    - Database: `master`
    - User: `sa`
    - Password: your password
    - Port: `1433`
    - TLS: enabled
    - Ignore SSL Issues (Insecure): disabled
4. Try saving the credentials and running a simple query: `SELECT 1;`
    - Prior to the fix you get the error (... Setting the TLS ServerName to an IP address is not permitted. ...)
    - After the fix it succeeds
5. Make sure the node still works as expected by playing around with a workflow provided in the Linear ticket

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

Fixes #37675
https://linear.app/n8n/issue/NODE-5878/community-issue-mssql-credential-tls-error

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

