### PR TITLE
fix(editor): Restore Instance AI draft when thread creation fails

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -461,6 +461,18 @@ onMounted(() => {
 
 onUnmounted(clearPersonalizedPromptMetadataTimeout);
 
+function restoreDraftAfterFailedSubmit(message: string, restoreDraft?: () => boolean) {
+	void nextTick(() => {
+		// The input supplies the callback only when the draft has attachments.
+		// Restore text directly for a text-only draft.
+		if (!restoreDraft?.()) {
+			const input = chatInputRef.value;
+			if (input && !input.isDirty()) input.setText(message);
+		}
+		chatInputRef.value?.focus();
+	});
+}
+
 async function handleSubmit(
 	message: string,
 	attachments?: InstanceAiAttachment[],
@@ -495,6 +507,7 @@ async function handleSubmit(
 		});
 	} catch {
 		isStartingThread.value = false;
+		restoreDraftAfterFailedSubmit(message, restoreDraft);
 		toast.showError(new Error('Failed to start a new thread. Try again.'), 'Send failed');
 		return;
 	}
@@ -508,16 +521,7 @@ async function handleSubmit(
 	const sent = await thread.sendMessage(finalMessage, attachments, rootStore.pushRef);
 	if (!sent) {
 		isStartingThread.value = false;
-		void nextTick(() => {
-			// `restoreDraft` puts back text *and* attachments, but the input only supplies it
-			// when files were attached; fall back to the text alone otherwise. Mirrors the
-			// thread-view composer.
-			if (!restoreDraft?.()) {
-				const input = chatInputRef.value;
-				if (input && !input.isDirty()) input.setText(message);
-			}
-			chatInputRef.value?.focus();
-		});
+		restoreDraftAfterFailedSubmit(message, restoreDraft);
 		// `syncThread` already persisted the thread and `sendMessage` already opened its SSE,
 		// so without this every refusal would strand a blank thread in the sidebar and leave
 		// an EventSource open behind it (deleting disposes the runtime, which closes it).

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -463,11 +463,9 @@ onUnmounted(clearPersonalizedPromptMetadataTimeout);
 
 function restoreDraftAfterFailedSubmit(message: string, restoreDraft?: () => boolean) {
 	void nextTick(() => {
-		// The input supplies the callback only when the draft has attachments.
-		// Restore text directly for a text-only draft.
+		// Restore text without replacing new text or attachments.
 		if (!restoreDraft?.()) {
-			const input = chatInputRef.value;
-			if (input && !input.isDirty()) input.setText(message);
+			chatInputRef.value?.setTextIfEmpty(message);
 		}
 		chatInputRef.value?.focus();
 	});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -314,6 +314,10 @@ const InstanceAiInputStub = defineComponent({
 	setup(props, { emit, expose, slots }) {
 		const i18n = useI18n();
 		const currentText = ref('');
+		const submit = (message: string) => {
+			emit('submit', message);
+			currentText.value = '';
+		};
 		expose({
 			focus: vi.fn(),
 			isDirty: () => currentText.value.length > 0,
@@ -322,7 +326,7 @@ const InstanceAiInputStub = defineComponent({
 			},
 			// Mirror the real submitSuggestion: resolve the prompt + emit submit.
 			submitSuggestion: (payload: { promptKey: BaseTextKey }) =>
-				emit('submit', i18n.baseText(payload.promptKey)),
+				submit(i18n.baseText(payload.promptKey)),
 		});
 		return () =>
 			h('div', { 'data-test-id': 'instance-ai-input-stub' }, [
@@ -375,7 +379,7 @@ const InstanceAiInputStub = defineComponent({
 					'button',
 					{
 						'data-test-id': 'instance-ai-input-stub-submit',
-						onClick: () => emit('submit', currentText.value || 'hello'),
+						onClick: () => submit(currentText.value || 'hello'),
 					},
 					'submit',
 				),
@@ -1017,13 +1021,24 @@ describe('InstanceAiEmptyView', () => {
 		});
 	});
 
-	it('shows a toast and stays on the empty view when syncThread rejects', async () => {
+	it('restores the submitted draft when syncThread rejects', async () => {
+		templateExamplesEnabled.value = true;
 		store.syncThread.mockRejectedValue(new Error('persist failed'));
 		const { getByTestId } = renderView();
+
+		await fireEvent.click(getByTestId('template-example-card'));
+		await flushPromises();
+		expect(getByTestId('instance-ai-input-text')).toHaveTextContent(
+			'Build me an invoice automation',
+		);
 
 		await fireEvent.click(getByTestId('instance-ai-input-stub-submit'));
 		await flushPromises();
 
+		// INS-579: Keep the submitted text when thread creation fails.
+		expect(getByTestId('instance-ai-input-text')).toHaveTextContent(
+			'Build me an invoice automation',
+		);
 		expect(showErrorMock).toHaveBeenCalled();
 		expect(store.getOrCreateRuntime).not.toHaveBeenCalled();
 		expect(thread.sendMessage).not.toHaveBeenCalled();

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -320,7 +320,9 @@ const InstanceAiInputStub = defineComponent({
 		};
 		expose({
 			focus: vi.fn(),
-			isDirty: () => currentText.value.length > 0,
+			setTextIfEmpty: (text: string) => {
+				if (!currentText.value.trim()) currentText.value = text;
+			},
 			setText: (text: string) => {
 				currentText.value = text;
 			},
@@ -1022,28 +1024,54 @@ describe('InstanceAiEmptyView', () => {
 	});
 
 	it('restores the submitted draft when syncThread rejects', async () => {
-		templateExamplesEnabled.value = true;
 		store.syncThread.mockRejectedValue(new Error('persist failed'));
-		const { getByTestId } = renderView();
+		const { getByRole, getByTestId } = renderView({
+			global: { stubs: { InstanceAiInput: false } },
+		});
+		const textbox = getByRole('textbox');
 
-		await fireEvent.click(getByTestId('template-example-card'));
-		await flushPromises();
-		expect(getByTestId('instance-ai-input-text')).toHaveTextContent(
-			'Build me an invoice automation',
-		);
-
-		await fireEvent.click(getByTestId('instance-ai-input-stub-submit'));
+		await fireEvent.update(textbox, 'Build me an invoice automation');
+		await fireEvent.click(getByTestId('instance-ai-send-button'));
 		await flushPromises();
 
-		// INS-579: Keep the submitted text when thread creation fails.
-		expect(getByTestId('instance-ai-input-text')).toHaveTextContent(
-			'Build me an invoice automation',
-		);
+		expect(textbox).toHaveValue('Build me an invoice automation');
 		expect(showErrorMock).toHaveBeenCalled();
 		expect(store.getOrCreateRuntime).not.toHaveBeenCalled();
 		expect(thread.sendMessage).not.toHaveBeenCalled();
 		expect(replaceMock).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		{ newText: '', expectedText: 'Build me an invoice automation' },
+		{ newText: 'A new prompt', expectedText: 'A new prompt' },
+	])(
+		'keeps a pasted attachment and text $expectedText after failure',
+		async ({ newText, expectedText }) => {
+			const sync = Promise.withResolvers<void>();
+			store.syncThread.mockReturnValue(sync.promise);
+			const { getByRole, getByTestId } = renderView({
+				global: { stubs: { InstanceAiInput: false } },
+			});
+			const textbox = getByRole('textbox');
+
+			await fireEvent.update(textbox, 'Build me an invoice automation');
+			await fireEvent.click(getByTestId('instance-ai-send-button'));
+			expect(textbox).toHaveValue('');
+
+			await fireEvent.paste(textbox, {
+				clipboardData: { files: [new File(['image'], 'context.png', { type: 'image/png' })] },
+			});
+			await fireEvent.update(textbox, newText);
+			expect(getByRole('img', { name: 'context.png' })).toBeInTheDocument();
+
+			sync.reject(new Error('persist failed'));
+			await flushPromises();
+
+			expect(textbox).toHaveValue(expectedText);
+			expect(getByRole('img', { name: 'context.png' })).toBeInTheDocument();
+			expect(replaceMock).not.toHaveBeenCalled();
+		},
+	);
 
 	it('shows an upfront unavailable state and does not start a thread when the builder is unavailable', async () => {
 		useSettingsStore().moduleSettings = {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -165,6 +165,10 @@ function setText(text: string) {
 	inputText.value = text;
 }
 
+function setTextIfEmpty(text: string) {
+	if (!inputText.value.trim()) inputText.value = text;
+}
+
 function clearTextIfMatches(text: string) {
 	if (inputText.value === text) inputText.value = '';
 }
@@ -177,6 +181,7 @@ defineExpose({
 	focus,
 	appendText,
 	setText,
+	setTextIfEmpty,
 	clearTextIfMatches,
 	isDirty,
 	// Experiment cleanup: remove with instanceAiSplitEmptyState.


### PR DESCRIPTION
## Summary

Restore the submitted Instance AI draft when thread creation fails.

## How to test

Run `pnpm test src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts` from `packages/frontend/editor-ui`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-579

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

