### PR TITLE
fix(editor): Truncate long AIA context chips

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
@@ -37,6 +37,7 @@ withDefaults(defineProps<TagProps>(), {
 	border-radius: var(--tag--radius);
 	font-size: var(--tag--font-size);
 	transition: background-color 0.3s ease;
+	user-select: none;
 
 	&.clickable {
 		cursor: pointer;

--- a/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
@@ -17,7 +17,7 @@ withDefaults(defineProps<TagProps>(), {
 		v-bind="$attrs"
 	>
 		<slot v-if="$slots['tag']" name="tag" />
-		<span v-else>{{ text }}</span>
+		<span v-else :class="$style.text">{{ text }}</span>
 	</span>
 </template>
 
@@ -26,9 +26,10 @@ withDefaults(defineProps<TagProps>(), {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	min-width: max-content;
+	min-width: 0;
 	height: var(--tag--height);
 	padding: var(--tag--padding);
+	max-width: var(--tag--max-width, 100%);
 	line-height: var(--tag--line-height);
 	color: var(--tag--color--text);
 	background-color: var(--tag--color--background);
@@ -45,6 +46,13 @@ withDefaults(defineProps<TagProps>(), {
 			border-color: var(--tag--border-color--hover);
 		}
 	}
+}
+
+.text {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .sm {

--- a/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
@@ -26,10 +26,10 @@ withDefaults(defineProps<TagProps>(), {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	min-width: 0;
+	min-width: var(--tag--min-width, max-content);
 	height: var(--tag--height);
 	padding: var(--tag--padding);
-	max-width: var(--tag--max-width, 100%);
+	max-width: var(--tag--max-width);
 	line-height: var(--tag--line-height);
 	color: var(--tag--color--text);
 	background-color: var(--tag--color--background);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -576,31 +576,29 @@ const resizable = computed(() => {
 					:class="$style.contextChip"
 					:data-test-id="props.contextChip.testId ?? 'instance-ai-handoff-context-chip'"
 				>
-					<N8nTooltip :content="props.contextChip.label">
-						<N8nTag :text="props.contextChip.label" :clickable="false" size="lg">
-							<template #tag>
-								<span :class="$style.contextChipContent">
-									<N8nIcon
-										:icon="props.contextChip.icon ?? 'robot'"
-										size="medium"
-										:class="$style.contextChipIcon"
-										data-test-id="instance-ai-handoff-context-chip-icon"
-									/>
-									<span :class="$style.contextChipText">{{ props.contextChip.label }}</span>
-								</span>
-								<N8nIconButton
-									icon="x"
-									size="xsmall"
-									variant="ghost"
-									:class="$style.contextChipClose"
-									:title="i18n.baseText('generic.close')"
-									:aria-label="i18n.baseText('generic.close')"
-									data-test-id="instance-ai-handoff-context-chip-dismiss"
-									@click.stop="emit('dismiss-context-chip')"
+					<N8nTag :text="props.contextChip.label" :clickable="false" size="lg">
+						<template #tag>
+							<span :class="$style.contextChipContent">
+								<N8nIcon
+									:icon="props.contextChip.icon ?? 'robot'"
+									size="medium"
+									:class="$style.contextChipIcon"
+									data-test-id="instance-ai-handoff-context-chip-icon"
 								/>
-							</template>
-						</N8nTag>
-					</N8nTooltip>
+								<span :class="$style.contextChipText">{{ props.contextChip.label }}</span>
+							</span>
+							<N8nIconButton
+								icon="x"
+								size="xsmall"
+								variant="ghost"
+								:class="$style.contextChipClose"
+								:title="i18n.baseText('generic.close')"
+								:aria-label="i18n.baseText('generic.close')"
+								data-test-id="instance-ai-handoff-context-chip-dismiss"
+								@click.stop="emit('dismiss-context-chip')"
+							/>
+						</template>
+					</N8nTag>
 				</div>
 				<div
 					v-if="!props.isPlanEditMode && attachedResources.length > 0"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, nextTick, onBeforeUnmount, ref, watch, type Component } from 'vue';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
-import { N8nIcon, N8nTag, N8nTooltip } from '@n8n/design-system';
+import { N8nIcon, N8nIconButton, N8nTag, N8nTooltip } from '@n8n/design-system';
 import type { ITelemetryTrackProperties } from 'n8n-workflow';
 import ChatInputBase from '@/features/ai/shared/components/ChatInputBase.vue';
 import { EXTENDED_PROMPT_MAX_LENGTH } from '@/features/ai/shared/constants';
@@ -557,16 +557,16 @@ const resizable = computed(() => {
 								<span :class="$style.contextChipText">{{
 									i18n.baseText('instanceAi.planReview.askForEdits')
 								}}</span>
-								<button
-									type="button"
+								<N8nIconButton
+									icon="x"
+									size="xsmall"
+									variant="ghost"
 									:class="$style.contextChipClose"
 									:title="i18n.baseText('generic.close')"
 									:aria-label="i18n.baseText('generic.close')"
 									data-test-id="instance-ai-plan-edit-cancel"
 									@click.stop="emit('cancel-plan-edit')"
-								>
-									<N8nIcon icon="x" size="xsmall" />
-								</button>
+								/>
 							</span>
 						</template>
 					</N8nTag>
@@ -576,31 +576,31 @@ const resizable = computed(() => {
 					:class="$style.contextChip"
 					:data-test-id="props.contextChip.testId ?? 'instance-ai-handoff-context-chip'"
 				>
-					<N8nTag :text="props.contextChip.label" :clickable="false" size="lg">
-						<template #tag>
-							<span :class="$style.contextChipContent">
-								<N8nIcon
-									:icon="props.contextChip.icon ?? 'robot'"
-									size="small"
-									:class="$style.contextChipIcon"
-									data-test-id="instance-ai-handoff-context-chip-icon"
-								/>
-								<N8nTooltip :content="props.contextChip.label">
+					<N8nTooltip :content="props.contextChip.label">
+						<N8nTag :text="props.contextChip.label" :clickable="false" size="lg">
+							<template #tag>
+								<span :class="$style.contextChipContent">
+									<N8nIcon
+										:icon="props.contextChip.icon ?? 'robot'"
+										size="medium"
+										:class="$style.contextChipIcon"
+										data-test-id="instance-ai-handoff-context-chip-icon"
+									/>
 									<span :class="$style.contextChipText">{{ props.contextChip.label }}</span>
-								</N8nTooltip>
-								<button
-									type="button"
+								</span>
+								<N8nIconButton
+									icon="x"
+									size="xsmall"
+									variant="ghost"
 									:class="$style.contextChipClose"
 									:title="i18n.baseText('generic.close')"
 									:aria-label="i18n.baseText('generic.close')"
 									data-test-id="instance-ai-handoff-context-chip-dismiss"
 									@click.stop="emit('dismiss-context-chip')"
-								>
-									<N8nIcon icon="x" size="xsmall" />
-								</button>
-							</span>
-						</template>
-					</N8nTag>
+								/>
+							</template>
+						</N8nTag>
+					</N8nTooltip>
 				</div>
 				<div
 					v-if="!props.isPlanEditMode && attachedResources.length > 0"
@@ -685,7 +685,7 @@ const resizable = computed(() => {
 .contextChipContent {
 	display: inline-flex;
 	align-items: center;
-	gap: var(--spacing--4xs);
+	gap: var(--spacing--3xs);
 	line-height: var(--line-height--xs);
 	overflow: hidden;
 }
@@ -699,21 +699,12 @@ const resizable = computed(() => {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	line-height: 1.2;
 }
 
 .contextChipClose {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
 	flex: 0 0 auto;
-	width: var(--spacing--xs);
-	height: var(--spacing--xs);
-	padding: 0;
-	color: inherit;
-	cursor: pointer;
-	background: none;
-	border: 0;
-	border-radius: var(--radius--3xs);
+	margin-right: calc(var(--spacing--2xs) * -1);
 }
 
 .planEditInput {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, nextTick, onBeforeUnmount, ref, watch, type Component } from 'vue';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
-import { N8nIcon, N8nTag } from '@n8n/design-system';
+import { N8nIcon, N8nTag, N8nTooltip } from '@n8n/design-system';
 import type { ITelemetryTrackProperties } from 'n8n-workflow';
 import ChatInputBase from '@/features/ai/shared/components/ChatInputBase.vue';
 import { EXTENDED_PROMPT_MAX_LENGTH } from '@/features/ai/shared/constants';
@@ -585,7 +585,9 @@ const resizable = computed(() => {
 									:class="$style.contextChipIcon"
 									data-test-id="instance-ai-handoff-context-chip-icon"
 								/>
-								<span :class="$style.contextChipText">{{ props.contextChip.label }}</span>
+								<N8nTooltip :content="props.contextChip.label">
+									<span :class="$style.contextChipText">{{ props.contextChip.label }}</span>
+								</N8nTooltip>
 								<button
 									type="button"
 									:class="$style.contextChipClose"
@@ -673,6 +675,7 @@ const resizable = computed(() => {
 }
 
 .contextChip {
+	--tag--min-width: 0;
 	--tag--max-width: 80%;
 
 	align-self: flex-start;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -582,6 +582,7 @@ const resizable = computed(() => {
 								<N8nIcon
 									:icon="props.contextChip.icon ?? 'robot'"
 									size="small"
+									:class="$style.contextChipIcon"
 									data-test-id="instance-ai-handoff-context-chip-icon"
 								/>
 								<span :class="$style.contextChipText">{{ props.contextChip.label }}</span>
@@ -672,6 +673,8 @@ const resizable = computed(() => {
 }
 
 .contextChip {
+	--tag--max-width: 80%;
+
 	align-self: flex-start;
 	max-width: 100%;
 }
@@ -681,9 +684,17 @@ const resizable = computed(() => {
 	align-items: center;
 	gap: var(--spacing--4xs);
 	line-height: var(--line-height--xs);
+	overflow: hidden;
+}
+
+.contextChipIcon {
+	flex-shrink: 0;
 }
 
 .contextChipText {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, nextTick, onBeforeUnmount, ref, watch, type Component } from 'vue';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
-import { N8nIcon, N8nIconButton, N8nTag, N8nTooltip } from '@n8n/design-system';
+import { N8nIcon, N8nIconButton, N8nTag } from '@n8n/design-system';
 import type { ITelemetryTrackProperties } from 'n8n-workflow';
 import ChatInputBase from '@/features/ai/shared/components/ChatInputBase.vue';
 import { EXTENDED_PROMPT_MAX_LENGTH } from '@/features/ai/shared/constants';


### PR DESCRIPTION
## Summary

* Truncate long AI context chip labels so that they stay inside the input container.
* Keep the chip icon visible when the label is long.
* Allow `N8nTag` text to shrink and use an optional maximum width.

<!-- linear:table-colwidths:403,403 -->
| **Before** | **After** |
| -- | -- |
| <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/aca4c97c-7cde-406c-86bd-2b8ec62e75d0/dad3a173-e0bb-409e-a14c-c917c8e68fb3?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9hY2E0Yzk3Yy03Y2RlLTQwNmMtODZiZC0yYjhlYzYyZTc1ZDAvZGFkM2ExNzMtZTBiYi00MDllLWExNGMtYzkxN2M4ZTY4ZmIzIiwiaWF0IjoxNzg4NTMzMTAxLCJleHAiOjE4MjAxMDM2NjF9.DWv_L83Z3iHvyKg9BHU-w6dKU8Jr2qPrMLT0usZzZC0 " alt="image.png" width="936" data-linear-height="236" /> | <img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/500ae3a0-7c65-4cb4-be0a-311ed87181e3/7529e10d-70ec-4c19-9292-76e59d33ac4d?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi81MDBhZTNhMC03YzY1LTRjYjQtYmUwYS0zMTFlZDg3MTgxZTMvNzUyOWUxMGQtNzBlYy00YzE5LTkyOTItNzZlNTlkMzNhYzRkIiwiaWF0IjoxNzg4NTMzMTAxLCJleHAiOjE4MjAxMDM2NjF9.bmf7dYdQEgPdqzAawx6YrfvP4cGGRiur2jX9vq-xxuc " alt="CleanShot 2026-09-04 at 15.44.42@2x.png" width="820" data-linear-height="414" /> |

## How to test

1. Open the Instance AI input.
2. Add a context chip with a long label.
3. Confirm that the chip stays inside the input container.
4. Confirm that the label ends with an ellipsis.
5. Confirm that the icon remains visible.

## Related Linear tickets, Github issues, and Community forum posts

[AI-2752](https://linear.app/n8n/issue/AI-2752)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)