### PR TITLE
docs(core): Correct and extend the policy infrastructure README

### DIFF
--- a/packages/cli/src/modules/policy-infrastructure/README.md
+++ b/packages/cli/src/modules/policy-infrastructure/README.md
@@ -8,6 +8,10 @@ The module holds no policy of its own. A policy feature adds a check class and a
 store for its rules. It does not add an enforcement path, an error shape, or an
 audit gap.
 
+Why these six points, why every check must pass, and why a check that does not
+answer blocks: read the policy infrastructure RFC in Notion. This README is the
+working reference for writing a check. It does not restate the RFC.
+
 Opt-in while it is built out: `N8N_ENABLED_MODULES=policy-infrastructure`.
 With the module off, nothing is checked and everything is allowed. That is the
 documented break-glass lever.
@@ -91,11 +95,34 @@ request. A check can compare it with `workflow` to judge only what the save adds
 | `workflowPublish` | 1000 ms | row id | activate, publication applier, activation on startup |
 | `workflowStart` | 250 ms | row id | `workflowExecuteBefore` on main, workers, sub-executions, manual runs |
 | `workflowTransfer` | 1000 ms | row id | move to another project |
-| `contentImport` | 1000 ms | row id | CLI import, source control import |
+| `contentImport` | 1000 ms | row id | CLI import, source control import, package and git-connection import |
 | `credentialDecrypt` | 250 ms | credential id | credential resolution during a run or a test |
 
 Deadlines are tight on the two points that sit inside a running execution. A
 wedged policy store there pins worker slots instead of failing one request.
+
+## Contexts
+
+Each point hands its check a different context. The types are in
+`@n8n/decorators/src/policy-check/policy-check.ts`.
+
+| Point | Context type | Fields |
+|---|---|---|
+| `workflowSave` | `WorkflowSaveContext` | `workflow`, `storedWorkflow` (`null` for a create), `projectId` |
+| `workflowPublish` | `WorkflowPublishContext` | `workflow`, `projectId` |
+| `workflowStart` | `WorkflowStartContext` | `workflow`, `projectId` |
+| `workflowTransfer` | `WorkflowTransferContext` | `workflow`, `targetProjectId` — the project it moves *into*, whose policy applies |
+| `contentImport` | `ContentImportContext` | `workflow`, `projectId`, `transport` |
+| `credentialDecrypt` | `CredentialDecryptContext` | `credentialType`, `credentialId`, `consumer` (`null` for a credential test), `projectId` |
+
+`workflow` is a `PolicedWorkflow`: `id` (`null` before the first save), `name`,
+`nodes`. Nothing else, so a check cannot start to depend on unrelated fields.
+Every field is `readonly` — a check reads, it never writes.
+
+`transport` is `cli`, `source-control`, `package`, or `git-connection`. Read it
+to hold an unattended sync to a different standard than a hand-run import. The
+host reads it too, to pick its fail posture: a package import refuses the whole
+package, a source-control pull skips and reports the workflow.
 
 ## Fail posture
 
@@ -160,5 +187,5 @@ registry is read on every decision, so load order cannot hide a check.
 | `policy-check-failed.error.ts` | The 503 for a check that did not answer |
 | `../../policy/policy-enforcement.service.ts` | The enforcement point the hosts call, always loaded |
 | `../../policy/policy-violation.error.ts` | The 403 that carries `meta.violations` |
-| `../../policy/evaluate-content-import-safely.ts` | Advisory `contentImport` evaluation that reports a broken check instead of throwing |
+| `../../policy/policy-enforcement-backend.ts` | The interface `PolicyDecisionService` implements and the module registers |
 | `@n8n/decorators/src/policy-check/` | `@PolicyCheck()`, the registry, the contexts, the `PolicyCleared` token |


### PR DESCRIPTION
## Summary

The `policy-infrastructure` module README did not document the context that each enforcement point gives a check, so an author had to open `policy-check.ts` to learn that `workflowTransfer` passes `targetProjectId` and that `CredentialDecryptContext.consumer` is `null` for a credential test. This PR adds a Contexts table for all six points, plus notes on `PolicedWorkflow` and the four `transport` values. It also names the third `contentImport` host (package and git-connection import, through `ContentImportPolicyGate`), points at the RFC for the design rationale, and replaces a Files row that named `evaluate-content-import-safely.ts` — a file that does not exist, since advisory evaluation is now `PolicyEnforcementService.evaluateContentImport()`. The RFC is named but not linked, because this repository is public.

Documentation only. No runtime change.

## How to test

Read `packages/cli/src/modules/policy-infrastructure/README.md` and check the new claims against the source:

- The Contexts table against the context types in `packages/@n8n/decorators/src/policy-check/policy-check.ts`.
- The `transport` values against `ContentImportTransport` in the same file.
- The two `contentImport` fail postures against `modules/n8n-packages/engine/content-import-policy.ts` (refuses the whole package) and `modules/source-control.ee/source-control-import.service.ee.ts` (skips and reports the one workflow).
- The Files table paths, which all resolve now.

The rest of the README was checked against the code and left alone: the six point names, all six deadlines, the fail posture, the subject binding, both lint rules, and every host call site already matched.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1121

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

