### PR TITLE
feat(core): Log a decision audit line when a policy blocks an action (no-changelog)

### DIFF
--- a/packages/cli/src/modules/policy-infrastructure/README.md
+++ b/packages/cli/src/modules/policy-infrastructure/README.md
@@ -32,7 +32,7 @@ flowchart LR
     end
 
     subgraph module["policy-infrastructure module (opt-in)"]
-        pds["PolicyDecisionService<br/>deadline per check · all checks must pass<br/>crash or timeout = fail closed"]
+        pds["PolicyDecisionService<br/>deadline per check · all checks must pass<br/>crash or timeout = fail closed<br/>one audit line per veto"]
         registry["PolicyCheckMetadata<br/>registry in @n8n/decorators"]
         checks["@PolicyCheck() classes<br/>onWorkflowSave · onWorkflowPublish · …"]
     end
@@ -138,6 +138,49 @@ package, a source-control pull skips and reports the workflow.
   in `checkErrors` next to the other results, so a crash never reads as "no
   violations".
 
+## The decision audit line
+
+Every veto writes one line, from one place: `PolicyDecisionService.audit`. A policy
+feature gets uniform enforcement logging without building any. If SIEM-forwardable
+enforcement events are wanted later, they land here too.
+
+```
+warn  Policy blocked workflowSave  {
+  "point": "workflowSave", "outcome": "violation", "durationMs": 12,
+  "checkIds": ["node-types"],
+  "violations": [{ "checkId": "node-types", "kind": "node-type-unavailable",
+                   "subject": "n8n-nodes-base.slack", "subjectType": "nodeType",
+                   "scope": "instance", "matchedRuleId": "rule-7" }],
+  "policyVersions": [{ "scope": "instance", "version": 4 }],
+  "workflowId": "wf-1", "workflowName": "My workflow", "projectId": "proj-1",
+  "scopes": ["policy"]
+}
+```
+
+- **Both ways of blocking write a line.** A violation gives `outcome: "violation"`.
+  A check that threw or overran gives `outcome: "checkFailure"` with `correlationIds`,
+  which tie it to the per-check error lines holding the real errors.
+- **`evaluate*` writes nothing.** Previews must not pollute the trail.
+- **The violation `message` is not on the line.** It is free text saying what the
+  structured fields already say.
+- **A create has no `workflowId`.** It logs `null` and the name instead. The line does
+  not reproduce the `PolicyCleared` subject, which hashes a create's content — that is
+  the enforcement point's to compute, and mirroring it here would let the two drift.
+- **`warn`, not `info`**, so the line survives an operator quietening logs. It matches
+  the `warning` level `PolicyViolationError` already gives itself.
+
+Two logging facts to know before relying on this:
+
+- **The default text format prints the message only.** The structured half needs
+  `N8N_LOG_FORMAT=json`, file output, or `debug` level. The message names the point on
+  its own for that reason.
+- **`N8N_LOG_SCOPES` can drop the line.** A configured scope set drops every line
+  outside it, unscoped lines included, so no log line is immune. `N8N_LOG_SCOPES=policy`
+  is the switch that keeps only these.
+
+Policy *mutation* audit — who changed a policy — is a different surface, owned by the
+feature that has a policy to mutate, on the existing audit-event infrastructure.
+
 ## The seal
 
 A cleared write needs a `PolicyCleared` token minted by the enforcement point.
@@ -182,7 +225,8 @@ registry is read on every decision, so load order cannot hide a check.
 | File | Role |
 |---|---|
 | `policy-infrastructure.module.ts` | Registers `PolicyDecisionService` into the enforcement point and loads the lifecycle handler |
-| `policy-decision.service.ts` | Runs the checks with deadlines and combines their results |
+| `policy-decision.service.ts` | Runs the checks with deadlines, combines their results, and emits the audit line |
+| `policy-decision-audit.ts` | The audit line's shape and how it reads a target off each context |
 | `policy-lifecycle-handler.ts` | The `workflowStart` host, one hook for every way an execution starts |
 | `policy-check-failed.error.ts` | The 503 for a check that did not answer |
 | `../../policy/policy-enforcement.service.ts` | The enforcement point the hosts call, always loaded |

--- a/packages/cli/src/modules/policy-infrastructure/README.md
+++ b/packages/cli/src/modules/policy-infrastructure/README.md
@@ -159,13 +159,17 @@ warn  Policy blocked workflowSave  {
 
 - **Both ways of blocking write a line.** A violation gives `outcome: "violation"`.
   A check that threw or overran gives `outcome: "checkFailure"` with `correlationIds`,
-  which tie it to the per-check error lines holding the real errors.
+  which tie it to the per-check error lines holding the real errors. A `checkFailure`
+  line still carries the `violations` and `policyVersions` the checks that *did* answer
+  reported, so a partial run stays diagnosable.
 - **`evaluate*` writes nothing.** Previews must not pollute the trail.
 - **The violation `message` is not on the line.** It is free text saying what the
   structured fields already say.
-- **A create has no `workflowId`.** It logs `null` and the name instead. The line does
-  not reproduce the `PolicyCleared` subject, which hashes a create's content — that is
-  the enforcement point's to compute, and mirroring it here would let the two drift.
+- **A create logs `workflowId: null` and the name.** A save is a create until it has a
+  stored row, and any id on its payload is the client's claim rather than a committed
+  row — the seal discards it for the same reason, binding a create to its content. The
+  line does not reproduce that content subject: computing it is the enforcement point's
+  job, and mirroring it here would let the two drift.
 - **`warn`, not `info`**, so the line survives an operator quietening logs. It matches
   the `warning` level `PolicyViolationError` already gives itself.
 

--- a/packages/cli/src/modules/policy-infrastructure/README.md
+++ b/packages/cli/src/modules/policy-infrastructure/README.md
@@ -140,9 +140,8 @@ package, a source-control pull skips and reports the workflow.
 
 ## The decision audit line
 
-Every veto writes one line, from one place: `PolicyDecisionService.audit`. A policy
-feature gets uniform enforcement logging without building any. If SIEM-forwardable
-enforcement events are wanted later, they land here too.
+Every veto writes one line, from one place: `PolicyDecisionService.audit`. A check
+never logs its own — it reports violations and the line follows.
 
 ```
 warn  Policy blocked workflowSave  {

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
@@ -65,6 +65,19 @@ const createContext: WorkflowSaveContext = {
 	projectId: 'proj-1',
 };
 
+/** `saveContext` is a create — a save is an update only once it has a stored row. */
+const updateContext: WorkflowSaveContext = {
+	...saveContext,
+	storedWorkflow: saveContext.workflow,
+};
+
+/** A create is a save with no stored row, whatever id the client put on the payload. */
+const createWithClaimedIdContext: WorkflowSaveContext = {
+	workflow: { id: 'wf-claimed', name: 'Untitled workflow', nodes: [] },
+	storedWorkflow: null,
+	projectId: 'proj-1',
+};
+
 const transferContext: WorkflowTransferContext = {
 	workflow: { id: 'wf-1', name: 'My workflow', nodes: [] },
 	targetProjectId: 'proj-2',
@@ -324,7 +337,7 @@ describe('PolicyDecisionService', () => {
 		it('writes one line naming the point, the objecting check and the violation', async () => {
 			const { service, audit } = auditedServiceWith(SlackCheck);
 
-			await service.enforce('workflowSave', saveContext);
+			await service.enforce('workflowSave', updateContext);
 
 			expect(audit).toHaveBeenCalledTimes(1);
 			expect(audit).toHaveBeenCalledWith('Policy blocked workflowSave', {
@@ -371,6 +384,18 @@ describe('PolicyDecisionService', () => {
 			});
 		});
 
+		it('does not record a create id the client supplied, which the seal discards too', async () => {
+			const { service, audit } = auditedServiceWith(SlackCheck);
+
+			await service.enforce('workflowSave', createWithClaimedIdContext);
+
+			expect(audit.mock.calls[0][1]).toMatchObject({
+				workflowId: null,
+				workflowName: 'Untitled workflow',
+			});
+			expect(JSON.stringify(audit.mock.calls[0][1])).not.toContain('wf-claimed');
+		});
+
 		it('records the project a transfer moves into', async () => {
 			const { service, audit } = auditedServiceWith(OtherPointsCheck);
 
@@ -410,6 +435,18 @@ describe('PolicyDecisionService', () => {
 					correlationIds: error.meta.correlationIds,
 				}),
 			);
+		});
+
+		it('keeps what the answered checks said on a check failure line', async () => {
+			const { service, audit } = auditedServiceWith(SlackCheck, BrokenCheck);
+
+			await service.enforce('workflowSave', saveContext).catch(() => {});
+
+			expect(audit.mock.calls[0][1]).toMatchObject({
+				outcome: 'checkFailure',
+				violations: [slackAudited],
+				policyVersions: [{ scope: 'instance', version: 4 }],
+			});
 		});
 
 		it('stays silent when every check is silent', async () => {

--- a/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
+++ b/packages/cli/src/modules/policy-infrastructure/__tests__/policy-decision.service.test.ts
@@ -1,11 +1,13 @@
 import { mockLogger } from '@n8n/backend-test-utils';
 import {
+	type CredentialDecryptContext,
 	type PolicyCheckClass,
 	type PolicyCheckMetadata,
 	type PolicyCheckResult,
 	type RegisteredPolicyCheck,
 	type WorkflowSaveContext,
 	type WorkflowStartContext,
+	type WorkflowTransferContext,
 	workflowContentSubject,
 } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
@@ -24,6 +26,20 @@ const slackBlocked = {
 	kind: 'node-type-unavailable',
 	checkId: 'node-types',
 	message: 'n8n-nodes-base.slack is not available',
+	subject: 'n8n-nodes-base.slack',
+	subjectType: 'nodeType',
+	scope: 'instance',
+	matchedRuleId: 'rule-7',
+};
+
+/** `slackBlocked` as the audit line records it — no `message`. */
+const slackAudited = {
+	kind: 'node-type-unavailable',
+	checkId: 'node-types',
+	subject: 'n8n-nodes-base.slack',
+	subjectType: 'nodeType',
+	scope: 'instance',
+	matchedRuleId: 'rule-7',
 };
 
 const codeBlocked = {
@@ -40,6 +56,24 @@ const saveContext: WorkflowSaveContext = {
 
 const startContext: WorkflowStartContext = {
 	workflow: { id: 'wf-1', name: 'My workflow', nodes: [] },
+	projectId: 'proj-1',
+};
+
+const createContext: WorkflowSaveContext = {
+	workflow: { id: null, name: 'Untitled workflow', nodes: [] },
+	storedWorkflow: null,
+	projectId: 'proj-1',
+};
+
+const transferContext: WorkflowTransferContext = {
+	workflow: { id: 'wf-1', name: 'My workflow', nodes: [] },
+	targetProjectId: 'proj-2',
+};
+
+const decryptContext: CredentialDecryptContext = {
+	credentialType: 'slackApi',
+	credentialId: 'cred-1',
+	consumer: { nodeType: 'n8n-nodes-base.slack' },
 	projectId: 'proj-1',
 };
 
@@ -108,6 +142,20 @@ class AbortAwareCheck implements RegisteredPolicyCheck {
 	}
 }
 
+/** Objects at the two points whose context is not a plain `{ workflow, projectId }`. */
+@Service()
+class OtherPointsCheck implements RegisteredPolicyCheck {
+	readonly id = 'other-points';
+
+	async onWorkflowTransfer(): Promise<PolicyCheckResult> {
+		return { violations: [slackBlocked] };
+	}
+
+	async onCredentialDecrypt(): Promise<PolicyCheckResult> {
+		return { violations: [slackBlocked] };
+	}
+}
+
 /** Only implements `onWorkflowStart`, so it must not be called at other points. */
 @Service()
 class StartOnlyCheck implements RegisteredPolicyCheck {
@@ -120,6 +168,20 @@ const serviceWith = (...classes: PolicyCheckClass[]) => {
 	const metadata = mock<PolicyCheckMetadata>({ getClasses: () => classes });
 
 	return new PolicyDecisionService(mockLogger(), metadata);
+};
+
+/**
+ * The service logs through the return value of `scoped()`, not the injected mock. `mockLogger`
+ * hands back the same inner mock every call, so `audit` is the object the service writes to.
+ */
+const auditedServiceWith = (...classes: PolicyCheckClass[]) => {
+	const logger = mockLogger();
+	const metadata = mock<PolicyCheckMetadata>({ getClasses: () => classes });
+
+	return {
+		service: new PolicyDecisionService(logger, metadata),
+		audit: vi.mocked(logger.scoped('policy').warn),
+	};
 };
 
 describe('PolicyDecisionService', () => {
@@ -255,6 +317,147 @@ describe('PolicyDecisionService', () => {
 			expect(decision.checkErrors).toHaveLength(1);
 			expect(decision.checkErrors?.[0].checkId).toBe('broken');
 			expect(decision.checkErrors?.[0].correlationId).toMatch(/^[0-9a-f-]{36}$/);
+		});
+	});
+
+	describe('decision audit line', () => {
+		it('writes one line naming the point, the objecting check and the violation', async () => {
+			const { service, audit } = auditedServiceWith(SlackCheck);
+
+			await service.enforce('workflowSave', saveContext);
+
+			expect(audit).toHaveBeenCalledTimes(1);
+			expect(audit).toHaveBeenCalledWith('Policy blocked workflowSave', {
+				point: 'workflowSave',
+				outcome: 'violation',
+				durationMs: expect.any(Number),
+				checkIds: ['node-types'],
+				violations: [slackAudited],
+				policyVersions: [{ scope: 'instance', version: 4 }],
+				workflowId: 'wf-1',
+				workflowName: 'My workflow',
+				projectId: 'proj-1',
+			});
+		});
+
+		it('keeps the violation message out of the line', async () => {
+			const { service, audit } = auditedServiceWith(SlackCheck);
+
+			await service.enforce('workflowSave', saveContext);
+
+			expect(JSON.stringify(audit.mock.calls[0][1])).not.toContain('is not available');
+		});
+
+		it('writes one line for the decision, not one per objecting check', async () => {
+			const { service, audit } = auditedServiceWith(SilentCheck, SlackCheck, CodeCheck);
+
+			await service.enforce('workflowSave', saveContext);
+
+			expect(audit).toHaveBeenCalledTimes(1);
+			expect(audit.mock.calls[0][1]).toMatchObject({
+				checkIds: ['silent', 'node-types', 'other'],
+				violations: [slackAudited, { checkId: 'other' }],
+			});
+		});
+
+		it('names the workflow when a create has no id to name', async () => {
+			const { service, audit } = auditedServiceWith(SlackCheck);
+
+			await service.enforce('workflowSave', createContext);
+
+			expect(audit.mock.calls[0][1]).toMatchObject({
+				workflowId: null,
+				workflowName: 'Untitled workflow',
+			});
+		});
+
+		it('records the project a transfer moves into', async () => {
+			const { service, audit } = auditedServiceWith(OtherPointsCheck);
+
+			await service.enforce('workflowTransfer', transferContext);
+
+			expect(audit.mock.calls[0][1]).toMatchObject({ projectId: 'proj-2' });
+		});
+
+		it('records the credential and the node asking for it', async () => {
+			const { service, audit } = auditedServiceWith(OtherPointsCheck);
+
+			await service.enforce('credentialDecrypt', decryptContext);
+
+			expect(audit.mock.calls[0][1]).toMatchObject({
+				credentialId: 'cred-1',
+				credentialType: 'slackApi',
+				consumerNodeType: 'n8n-nodes-base.slack',
+				projectId: 'proj-1',
+			});
+			expect(audit.mock.calls[0][1]).not.toHaveProperty('workflowId');
+		});
+
+		it('writes a line when a check failure blocks, tied to the check error logs', async () => {
+			const { service, audit } = auditedServiceWith(SilentCheck, BrokenCheck);
+
+			const error = (await service
+				.enforce('workflowSave', saveContext)
+				.catch((e: unknown) => e)) as PolicyCheckFailedError;
+
+			expect(audit).toHaveBeenCalledTimes(1);
+			expect(audit).toHaveBeenCalledWith(
+				'Policy could not be verified for workflowSave, so it was blocked',
+				expect.objectContaining({
+					outcome: 'checkFailure',
+					checkIds: ['silent', 'broken'],
+					violations: [],
+					correlationIds: error.meta.correlationIds,
+				}),
+			);
+		});
+
+		it('stays silent when every check is silent', async () => {
+			const { service, audit } = auditedServiceWith(SilentCheck);
+
+			await service.enforce('workflowSave', saveContext);
+
+			expect(audit).not.toHaveBeenCalled();
+		});
+
+		it('stays silent when no check is registered', async () => {
+			const { service, audit } = auditedServiceWith();
+
+			await service.enforce('workflowSave', saveContext);
+
+			expect(audit).not.toHaveBeenCalled();
+		});
+
+		it('stays silent for an evaluate that finds violations', async () => {
+			const { service, audit } = auditedServiceWith(SlackCheck);
+
+			const decision = await service.evaluate('workflowSave', saveContext);
+
+			expect(decision.violations).toEqual([slackBlocked]);
+			expect(audit).not.toHaveBeenCalled();
+		});
+
+		it('stays silent for an evaluate that hits a broken check', async () => {
+			const { service, audit } = auditedServiceWith(BrokenCheck);
+
+			await service.evaluate('workflowSave', saveContext);
+
+			expect(audit).not.toHaveBeenCalled();
+		});
+
+		it('writes the line when the proxy vetoes a save', async () => {
+			const { service, audit } = auditedServiceWith(SlackCheck);
+			const proxy = new PolicyEnforcementService();
+			proxy.setImplementation(service);
+
+			await expect(proxy.enforceWorkflowSave(saveContext)).rejects.toBeInstanceOf(
+				PolicyViolationError,
+			);
+			expect(audit).toHaveBeenCalledTimes(1);
+			expect(audit).toHaveBeenCalledWith(
+				'Policy blocked workflowSave',
+				expect.objectContaining({ violations: [slackAudited] }),
+			);
 		});
 	});
 

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision-audit.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision-audit.ts
@@ -1,0 +1,127 @@
+import type {
+	EnforcementPoint,
+	PolicyCheckFailure,
+	PolicyDecision,
+	PolicyViolation,
+	PolicyVersionRef,
+} from '@n8n/decorators';
+
+import type { PolicyContext } from '@/policy/policy-enforcement-backend';
+
+/** Every context, as one union — a generic `PolicyContext<Point>` narrows against none. */
+type AnyPolicyContext = PolicyContext<EnforcementPoint>;
+
+/** The violation as the audit line records it. No `message`: free text saying what the fields say. */
+type AuditedViolation = Pick<
+	PolicyViolation,
+	'checkId' | 'kind' | 'subject' | 'subjectType' | 'scope' | 'matchedRuleId'
+>;
+
+/**
+ * One decision-audit line.
+ *
+ * A `type`, not an `interface`: an interface has no implicit index signature, so it would not
+ * assign to the logger's `LogMetadata`.
+ */
+export type PolicyDecisionAudit = {
+	point: EnforcementPoint;
+
+	/** `violation` — a check objected. `checkFailure` — a check did not answer, so nothing said yes. */
+	outcome: 'violation' | 'checkFailure';
+
+	durationMs: number;
+
+	/** Every check consulted at this point, whether it answered or not. */
+	checkIds: string[];
+
+	violations: AuditedViolation[];
+
+	policyVersions?: PolicyVersionRef[];
+
+	/** `checkFailure` only. Ties this line to the per-check error lines holding the real errors. */
+	correlationIds?: string[];
+
+	/** `null` for a create, which has no id yet — read `workflowName` instead. */
+	workflowId?: string | null;
+	workflowName?: string;
+	credentialId?: string;
+	credentialType?: string;
+	consumerNodeType?: string;
+	projectId: string | null;
+};
+
+const auditedViolation = ({
+	checkId,
+	kind,
+	subject,
+	subjectType,
+	scope,
+	matchedRuleId,
+}: PolicyViolation): AuditedViolation => ({
+	checkId,
+	kind,
+	subject,
+	subjectType,
+	scope,
+	matchedRuleId,
+});
+
+/**
+ * What was policed, read off the context.
+ *
+ * Deliberately not the `PolicyCleared` subject: that one hashes a create's content, and it is
+ * the enforcement point's to compute — mirroring it here would let the two drift.
+ */
+function targetOf(context: AnyPolicyContext) {
+	if ('credentialId' in context) {
+		return {
+			credentialId: context.credentialId,
+			credentialType: context.credentialType,
+			consumerNodeType: context.consumer?.nodeType,
+			projectId: context.projectId,
+		};
+	}
+
+	return {
+		workflowId: context.workflow.id,
+		// A create has no id, so this is all that identifies it.
+		workflowName: context.workflow.name,
+		projectId: 'targetProjectId' in context ? context.targetProjectId : context.projectId,
+	};
+}
+
+export function violationAudit(
+	point: EnforcementPoint,
+	context: AnyPolicyContext,
+	decision: PolicyDecision,
+	durationMs: number,
+	checkIds: string[],
+): PolicyDecisionAudit {
+	return {
+		point,
+		outcome: 'violation',
+		durationMs,
+		checkIds,
+		violations: decision.violations.map(auditedViolation),
+		policyVersions: decision.policyVersions,
+		...targetOf(context),
+	};
+}
+
+export function checkFailureAudit(
+	point: EnforcementPoint,
+	context: AnyPolicyContext,
+	failures: PolicyCheckFailure[],
+	durationMs: number,
+	checkIds: string[],
+): PolicyDecisionAudit {
+	return {
+		point,
+		outcome: 'checkFailure',
+		durationMs,
+		checkIds,
+		violations: [],
+		correlationIds: failures.map((failure) => failure.correlationId),
+		...targetOf(context),
+	};
+}

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision-audit.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision-audit.ts
@@ -1,4 +1,5 @@
 import type {
+	CredentialDecryptContext,
 	EnforcementPoint,
 	PolicyCheckFailure,
 	PolicyDecision,
@@ -34,6 +35,7 @@ export type PolicyDecisionAudit = {
 	/** Every check consulted at this point, whether it answered or not. */
 	checkIds: string[];
 
+	/** On a `checkFailure` these two hold what the checks that *did* answer said. */
 	violations: AuditedViolation[];
 
 	policyVersions?: PolicyVersionRef[];
@@ -67,11 +69,16 @@ const auditedViolation = ({
 });
 
 /**
- * What was policed, read off the context.
+ * The id of the row that was policed, or `null` when there is none yet.
  *
- * Deliberately not the `PolicyCleared` subject: that one hashes a create's content, and it is
- * the enforcement point's to compute — mirroring it here would let the two drift.
+ * A save with no stored row is a create, and any id on its payload is the client's claim rather
+ * than a committed row — the seal discards it for the same reason. `workflowName` is what
+ * identifies a create.
  */
+const policedWorkflowId = (context: Exclude<AnyPolicyContext, CredentialDecryptContext>) =>
+	'storedWorkflow' in context ? (context.storedWorkflow?.id ?? null) : context.workflow.id;
+
+/** What was policed, read off the context. */
 function targetOf(context: AnyPolicyContext) {
 	if ('credentialId' in context) {
 		return {
@@ -83,45 +90,41 @@ function targetOf(context: AnyPolicyContext) {
 	}
 
 	return {
-		workflowId: context.workflow.id,
-		// A create has no id, so this is all that identifies it.
+		workflowId: policedWorkflowId(context),
 		workflowName: context.workflow.name,
 		projectId: 'targetProjectId' in context ? context.targetProjectId : context.projectId,
 	};
 }
 
-export function violationAudit(
-	point: EnforcementPoint,
-	context: AnyPolicyContext,
-	decision: PolicyDecision,
-	durationMs: number,
-	checkIds: string[],
-): PolicyDecisionAudit {
+export type DecisionAuditInput = {
+	point: EnforcementPoint;
+	context: AnyPolicyContext;
+	/** Built from the checks that answered, so a partial run stays diagnosable. */
+	decision: PolicyDecision;
+	durationMs: number;
+	checkIds: string[];
+	/** Non-empty when a check did not answer, which blocks whatever the others said. */
+	failures?: PolicyCheckFailure[];
+};
+
+export function decisionAudit({
+	point,
+	context,
+	decision,
+	durationMs,
+	checkIds,
+	failures = [],
+}: DecisionAuditInput): PolicyDecisionAudit {
 	return {
 		point,
-		outcome: 'violation',
+		outcome: failures.length > 0 ? 'checkFailure' : 'violation',
 		durationMs,
 		checkIds,
 		violations: decision.violations.map(auditedViolation),
 		policyVersions: decision.policyVersions,
-		...targetOf(context),
-	};
-}
-
-export function checkFailureAudit(
-	point: EnforcementPoint,
-	context: AnyPolicyContext,
-	failures: PolicyCheckFailure[],
-	durationMs: number,
-	checkIds: string[],
-): PolicyDecisionAudit {
-	return {
-		point,
-		outcome: 'checkFailure',
-		durationMs,
-		checkIds,
-		violations: [],
-		correlationIds: failures.map((failure) => failure.correlationId),
+		...(failures.length > 0 && {
+			correlationIds: failures.map((failure) => failure.correlationId),
+		}),
 		...targetOf(context),
 	};
 }

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
@@ -14,8 +14,8 @@ import { randomUUID } from 'node:crypto';
 import type { PolicyContext, PolicyEnforcementBackend } from '@/policy/policy-enforcement-backend';
 
 import { PolicyCheckFailedError } from './policy-check-failed.error';
-import type { PolicyDecisionAudit } from './policy-decision-audit';
-import { checkFailureAudit, violationAudit } from './policy-decision-audit';
+import type { DecisionAuditInput } from './policy-decision-audit';
+import { decisionAudit } from './policy-decision-audit';
 
 /**
  * How long one check gets. Tight on the two points that sit inside a running execution: a wedged
@@ -124,9 +124,11 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 		const startedAt = Date.now();
 		const { checkIds, results, failures } = await this.runChecks(point, context);
 		const durationMs = Date.now() - startedAt;
+		// Built from the checks that answered, so a check failure still logs what the rest found.
+		const decision = decisionFrom(results);
 
 		if (failures.length > 0) {
-			this.audit(checkFailureAudit(point, context, failures, durationMs, checkIds));
+			this.audit({ point, context, decision, durationMs, checkIds, failures });
 
 			throw new PolicyCheckFailedError(
 				point,
@@ -134,11 +136,9 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 			);
 		}
 
-		const decision = decisionFrom(results);
-
 		// The proxy throws on any violation, so this is the veto — and the only place it is logged.
 		if (decision.violations.length > 0) {
-			this.audit(violationAudit(point, context, decision, durationMs, checkIds));
+			this.audit({ point, context, decision, durationMs, checkIds });
 		}
 
 		return decision;
@@ -167,7 +167,8 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 	 * structured half only reaches the console under `N8N_LOG_FORMAT=json` — the text format
 	 * prints the message alone — so the message names the point on its own.
 	 */
-	private audit(line: PolicyDecisionAudit) {
+	private audit(input: DecisionAuditInput) {
+		const line = decisionAudit(input);
 		const message =
 			line.outcome === 'violation'
 				? `Policy blocked ${line.point}`

--- a/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-decision.service.ts
@@ -14,6 +14,8 @@ import { randomUUID } from 'node:crypto';
 import type { PolicyContext, PolicyEnforcementBackend } from '@/policy/policy-enforcement-backend';
 
 import { PolicyCheckFailedError } from './policy-check-failed.error';
+import type { PolicyDecisionAudit } from './policy-decision-audit';
+import { checkFailureAudit, violationAudit } from './policy-decision-audit';
 
 /**
  * How long one check gets. Tight on the two points that sit inside a running execution: a wedged
@@ -102,6 +104,9 @@ function decisionFrom(results: PolicyCheckResult[]): PolicyDecision {
  *
  * Checks are combined by conjunction: all of them have to pass and every violation is reported,
  * so a user fixing a workflow sees the whole list rather than one at a time.
+ *
+ * Either way of blocking writes one audit line from here, the single emit site for enforcement
+ * observability. `evaluate` stays silent, so previews never pollute the trail.
  */
 @Service()
 export class PolicyDecisionService implements PolicyEnforcementBackend {
@@ -116,16 +121,27 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 		point: Point,
 		context: PolicyContext<Point>,
 	): Promise<PolicyDecision> {
-		const { results, failures } = await this.runChecks(point, context);
+		const startedAt = Date.now();
+		const { checkIds, results, failures } = await this.runChecks(point, context);
+		const durationMs = Date.now() - startedAt;
 
 		if (failures.length > 0) {
+			this.audit(checkFailureAudit(point, context, failures, durationMs, checkIds));
+
 			throw new PolicyCheckFailedError(
 				point,
 				failures.map((failure) => failure.correlationId),
 			);
 		}
 
-		return decisionFrom(results);
+		const decision = decisionFrom(results);
+
+		// The proxy throws on any violation, so this is the veto — and the only place it is logged.
+		if (decision.violations.length > 0) {
+			this.audit(violationAudit(point, context, decision, durationMs, checkIds));
+		}
+
+		return decision;
 	}
 
 	async evaluate<Point extends EnforcementPoint>(
@@ -143,12 +159,30 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 		return this.runnersFor(point).length > 0;
 	}
 
+	/**
+	 * The one emit site for enforcement observability, so every policy feature gets the same
+	 * line without building one.
+	 *
+	 * `warn`, not `info`: a blocked action must survive an operator quietening logs. The
+	 * structured half only reaches the console under `N8N_LOG_FORMAT=json` — the text format
+	 * prints the message alone — so the message names the point on its own.
+	 */
+	private audit(line: PolicyDecisionAudit) {
+		const message =
+			line.outcome === 'violation'
+				? `Policy blocked ${line.point}`
+				: `Policy could not be verified for ${line.point}, so it was blocked`;
+
+		this.logger.warn(message, line);
+	}
+
 	private async runChecks<Point extends EnforcementPoint>(
 		point: Point,
 		context: PolicyContext<Point>,
 	) {
+		const runners = this.runnersFor(point);
 		const outcomes = await Promise.all(
-			this.runnersFor(point).map(async ({ checkId, run }): Promise<CheckOutcome> => {
+			runners.map(async ({ checkId, run }): Promise<CheckOutcome> => {
 				try {
 					const result = await withDeadline(
 						async (signal) => await run(context, signal),
@@ -177,7 +211,7 @@ export class PolicyDecisionService implements PolicyEnforcementBackend {
 			else failures.push(outcome.failure);
 		}
 
-		return { results, failures };
+		return { checkIds: runners.map((runner) => runner.checkId), results, failures };
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds the single structured log line the policy infrastructure writes whenever it
blocks an action. The RFC makes this one emit site the enforcement-observability
surface for every future policy feature — built once here, not per feature.

One emit site, `PolicyDecisionService.audit`. Nothing is scattered per check.

```
warn  Policy blocked workflowSave  {
  "point": "workflowSave", "outcome": "violation", "durationMs": 12,
  "checkIds": ["node-types"],
  "violations": [{ "checkId": "node-types", "kind": "node-type-unavailable",
                   "subject": "n8n-nodes-base.slack", "subjectType": "nodeType",
                   "scope": "instance", "matchedRuleId": "rule-7" }],
  "policyVersions": [{ "scope": "instance", "version": 4 }],
  "workflowId": "wf-1", "workflowName": "My workflow", "projectId": "proj-1",
  "scopes": ["policy"]
}
```

Notes on the choices:

- **`evaluate*` writes nothing.** Advisory previews must not pollute the trail.
- **A check failure also writes a line** (`outcome: "checkFailure"`, with the
  `correlationIds` that tie it to the per-check error logs). The AC names only the
  violation case; the RFC says "on every veto", and a `PolicyCheckFailedError`
  blocks the action just as hard. Without it, "what did policy block today" misses
  every fail-closed block. Say the word and I will drop it.
- **`warn`, not `info`**, so the line survives an operator quietening logs. It
  matches the `warning` level `PolicyViolationError` already gives itself.
- **The violation `message` is not on the line** — free text saying what the
  structured fields already say.
- **A create logs `workflowId: null` plus the name.** The line deliberately does
  not reproduce the `PolicyCleared` subject, which hashes a create's content: that
  is the enforcement point's to compute, and mirroring it here would let the two
  drift.

Two logging facts worth knowing, both now in the module README:

- The default text log format prints the message only. The structured half needs
  `N8N_LOG_FORMAT=json`, file output, or `debug` level. That is why the message
  names the point on its own.
- `N8N_LOG_SCOPES` drops every line outside the configured set, unscoped lines
  included — no log line is immune. `N8N_LOG_SCOPES=policy` keeps only these.

## How to test

Unit tests cover it end to end, including through the enforcement proxy:

```bash
cd packages/cli
pnpm test src/policy src/modules/policy-infrastructure
```

By hand, with the module on (`N8N_ENABLED_MODULES=policy-infrastructure`) and a
registered `@PolicyCheck` that returns a violation: run n8n with
`N8N_LOG_FORMAT=json`, save a workflow the check objects to, and confirm exactly
one `Policy blocked workflowSave` line with the fields above — and that an
advisory `evaluate*` call writes none.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1118

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

