### PR TITLE
fix(core): Allow webhook nodes to set Set-Cookie response headers

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-response-headers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-response-headers.test.ts
@@ -77,13 +77,10 @@ describe('WebhookResponseHeaders', () => {
 		});
 
 		it.each([
-			'set-cookie',
 			'strict-transport-security',
 			'clear-site-data',
-			'Set-Cookie',
 			'Strict-Transport-Security',
 			'Clear-Site-Data',
-			'SET-COOKIE',
 			'STRICT-TRANSPORT-SECURITY',
 			'CLEAR-SITE-DATA',
 		])('should not allow overriding the protected header %s', (headerName) => {
@@ -98,11 +95,11 @@ describe('WebhookResponseHeaders', () => {
 
 		it('should log a warning when dropping a protected header', () => {
 			const headers = new WebhookResponseHeaders();
-			headers.set('Set-Cookie', 'a=b');
+			headers.set('Strict-Transport-Security', 'max-age=0');
 
 			expect(logger.warn).toHaveBeenCalledWith(
 				expect.any(String),
-				expect.objectContaining({ headerName: 'Set-Cookie' }),
+				expect.objectContaining({ headerName: 'Strict-Transport-Security' }),
 			);
 		});
 
@@ -205,7 +202,6 @@ describe('WebhookResponseHeaders', () => {
 			const headers = new WebhookResponseHeaders();
 			headers.addFromObject({
 				'x-valid': 'value',
-				'Set-Cookie': 'a=b',
 				'Strict-Transport-Security': 'max-age=0',
 				'Clear-Site-Data': '"cache"',
 			});
@@ -299,7 +295,6 @@ describe('WebhookResponseHeaders', () => {
 			const headers = new WebhookResponseHeaders();
 			headers.addFromNodeHeaders({
 				entries: [
-					{ name: 'Set-Cookie', value: 'a=b' },
 					{ name: 'strict-transport-security', value: 'max-age=0' },
 					{ name: 'CLEAR-SITE-DATA', value: '"cache"' },
 					{ name: 'x-valid', value: 'ok' },

--- a/packages/cli/src/webhooks/webhook-response-headers.ts
+++ b/packages/cli/src/webhooks/webhook-response-headers.ts
@@ -25,7 +25,6 @@ export type WebhookNodeResponseHeaders = {
  */
 const PROTECTED_HEADERS = new Set([
 	'content-security-policy',
-	'set-cookie',
 	'strict-transport-security',
 	'clear-site-data',
 ]);


### PR DESCRIPTION
## Summary

Webhook response headers block `set-cookie`. This drops the block, so a webhook response can set cookies again.

## How to test

1. Add a Webhook node in Respond mode "Using 'Respond to Webhook' Node".
2. Add a Respond to Webhook node.
3. In its response headers, add a header named `Set-Cookie` with a value such as `session=abc123`.
4. Call the webhook.
5. Check the response: the `Set-Cookie` header is present.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4373

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

