### PR TITLE
fix(core): Make scoped workspace path errors actionable for agents

### DIFF
--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-applies-multiple-string-replacements.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-applies-multiple-string-replacements.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -375,30 +375,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwR5XZhp5jvX2s1Rjm\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01XhVqxxnCeQAd5i2ZdhvYKQ\",\"name\":\"workspace_str_replace_file\",\"input\":{\"path\":\"/project/config.ts\",\"replacements\":[{\"old_str\":\"OLD_REGION\",\"new_str\":\"EU_CENTRAL\"},{\"old_str\":\"OLD_OWNER\",\"new_str\":\"API_TEAM\"},{\"old_str\":\"OLD_STATUS\",\"new_str\":\"READY\"}]},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2890,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":152,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii6FydDkrEpi6D9DN6Q\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_017moK7GRdnadwXaUezWNucw\",\"name\":\"workspace_str_replace_file\",\"input\":{\"path\":\"/project/config.ts\",\"replacements\":[{\"old_str\":\"OLD_REGION\",\"new_str\":\"EU_CENTRAL\"},{\"old_str\":\"OLD_OWNER\",\"new_str\":\"API_TEAM\"},{\"old_str\":\"OLD_STATUS\",\"new_str\":\"READY\"}]},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2929,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":152,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:56Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:11Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:56Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:11Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:55Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:10Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:56Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:11Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d686bea5ac3-VIE",
+			"cf-ray": "a35e57c73ed7c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:56 GMT",
-			"request-id": "req_011CdzCwQb1nPWokfQ8pNrEc",
+			"date": "Fri, 04 Sep 2026 16:24:11 GMT",
+			"request-id": "req_011Ceii6FKgYfW4zfX4wUbSF",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-4baa4ce303d012f7e4a4c3b7b2183c8e-ff660adcd132d02b-01",
+			"traceresponse": "00-3931c57d4a2b5659296e1f7e46d2efb8-5576840e2cac7fe8-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -432,7 +432,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_01XhVqxxnCeQAd5i2ZdhvYKQ",
+							"id": "toolu_017moK7GRdnadwXaUezWNucw",
 							"name": "workspace_str_replace_file",
 							"input": {
 								"path": "/project/config.ts",
@@ -462,7 +462,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01XhVqxxnCeQAd5i2ZdhvYKQ",
+							"tool_use_id": "toolu_017moK7GRdnadwXaUezWNucw",
 							"content": "{\"success\":true,\"result\":\"All 3 replacements applied successfully.\"}"
 						}
 					]
@@ -477,7 +477,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -540,7 +540,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -576,7 +576,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -820,30 +820,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwXAPkhyP5MqiH9wDC\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"done.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3065,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii6MRJ6GppiYC6ucBVS\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"done.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3104,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:57Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:11Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:57Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:11Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:56Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:11Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:57Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:11Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d7159665ac3-VIE",
+			"cf-ray": "a35e57cf7e04c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:57 GMT",
-			"request-id": "req_011CdzCwWi7SxsgDhiTHBtRX",
+			"date": "Fri, 04 Sep 2026 16:24:12 GMT",
+			"request-id": "req_011Ceii6LxmNNLEo6XwsFWi9",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-05a73aaa082b6fbdddaaa27d7239940d-ac9f8ff46ec3d68d-01",
+			"traceresponse": "00-f699558f3ad1b817ebcaaae0ad49ffd6-dc7ea6aed06c01e3-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-edits-files-with-append-copy-move-delete-and-rmdir-tools.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-edits-files-with-append-copy-move-delete-and-rmdir-tools.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -375,30 +375,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCvyf5B2vW5ZSPBpfJe\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_013CcQxtFGGv3c4Rt2x2jH18\",\"name\":\"workspace_append_file\",\"input\":{\"path\":\"/project/source.txt\",\"content\":\"-beta\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2953,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":79,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5oZe4d1kvnaJZ8pFD\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01JyJP8qk2rwiKJjPhg1X77Z\",\"name\":\"workspace_append_file\",\"input\":{\"path\":\"/project/source.txt\",\"content\":\"-beta\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2992,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":79,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:50Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:04Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:50Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:04Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:49Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:04Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:50Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:04Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d42cb0b5ac3-VIE",
+			"cf-ray": "a35e57a09f03c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:50 GMT",
-			"request-id": "req_011CdzCvxqCxdN5rjoXgQewg",
+			"date": "Fri, 04 Sep 2026 16:24:04 GMT",
+			"request-id": "req_011Ceii5nwvr253Scqntyfui",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-f57050db4da7d0c1c517f02dccb7c836-98291135959059d0-01",
+			"traceresponse": "00-1f7c91abc7c421ac03103b1fa82e19cf-9b7012903850aded-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -432,7 +432,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"name": "workspace_append_file",
 							"input": {
 								"path": "/project/source.txt",
@@ -449,7 +449,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"tool_use_id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -464,7 +464,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -527,7 +527,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -563,7 +563,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -807,30 +807,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCw4UncxYLsRi1M27dd\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"2. Now copying the file:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01Ew4RgnrPf7yhpZaawTk91u\",\"name\":\"workspace_copy_file\",\"input\":{\"src\":\"/project/source.txt\",\"dest\":\"/project/copied.txt\",\"overwrite\":true},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3048,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":108,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5sY1K34RcuwhBCi4f\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"2. Now calling workspace_copy_file:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01FxxywxaUgeZzdeRVSocgtA\",\"name\":\"workspace_copy_file\",\"input\":{\"src\":\"/project/source.txt\",\"dest\":\"/project/copied.txt\",\"overwrite\":true},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3087,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":111,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:50Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:05Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:51Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:05Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:50Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:05Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:50Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:05Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d4a585a5ac3-VIE",
+			"cf-ray": "a35e57a67b83c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:51 GMT",
-			"request-id": "req_011CdzCw42kKFg3V7D1yH3bw",
+			"date": "Fri, 04 Sep 2026 16:24:05 GMT",
+			"request-id": "req_011Ceii5rwHvwghsawjxTCtz",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-cf88df511d2197096ac12b80512ab38b-414cfef2a12555cf-01",
+			"traceresponse": "00-b22a7d84ea480163dfaafb67a6cebe45-0e5ca213ad25578f-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -864,7 +864,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"name": "workspace_append_file",
 							"input": {
 								"path": "/project/source.txt",
@@ -881,7 +881,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"tool_use_id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -891,11 +891,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "2. Now copying the file:"
+							"text": "2. Now calling workspace_copy_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"name": "workspace_copy_file",
 							"input": {
 								"src": "/project/source.txt",
@@ -913,7 +913,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"tool_use_id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -928,7 +928,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -991,7 +991,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -1027,7 +1027,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -1271,30 +1271,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCw8thEPZ5q3WG2kkdJ\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"3. Now moving the file:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01S3D6xx2i1V9BP78iKCQF65\",\"name\":\"workspace_move_file\",\"input\":{\"src\":\"/project/copied.txt\",\"dest\":\"/project/moved.txt\",\"overwrite\":true},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3172,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":108,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5x6qnp4ipYN4Xc7as\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"3. Now calling workspace_move_file:\"},{\"type\":\"tool_use\",\"id\":\"toolu_019VdV4KDwydxV3KjTKXqBJh\",\"name\":\"workspace_move_file\",\"input\":{\"src\":\"/project/copied.txt\",\"dest\":\"/project/moved.txt\",\"overwrite\":true},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3214,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":111,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:51Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:06Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:52Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:06Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:51Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:06Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:51Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:06Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d50ed735ac3-VIE",
+			"cf-ray": "a35e57ad48ebc2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:52 GMT",
-			"request-id": "req_011CdzCw8TA5tCKty3dZiwHp",
+			"date": "Fri, 04 Sep 2026 16:24:07 GMT",
+			"request-id": "req_011Ceii5wZbj3K3PXGbjGS7P",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-589aa5d8182b8d1d8e5c231c7c36f4cb-5c0a5baf5f0846b1-01",
+			"traceresponse": "00-b23077acfa37b4906366aa6dd38d47dc-c0d9d1b2cd8d5487-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -1328,7 +1328,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"name": "workspace_append_file",
 							"input": {
 								"path": "/project/source.txt",
@@ -1345,7 +1345,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"tool_use_id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -1355,11 +1355,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "2. Now copying the file:"
+							"text": "2. Now calling workspace_copy_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"name": "workspace_copy_file",
 							"input": {
 								"src": "/project/source.txt",
@@ -1377,7 +1377,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"tool_use_id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -1387,11 +1387,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "3. Now moving the file:"
+							"text": "3. Now calling workspace_move_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01S3D6xx2i1V9BP78iKCQF65",
+							"id": "toolu_019VdV4KDwydxV3KjTKXqBJh",
 							"name": "workspace_move_file",
 							"input": {
 								"src": "/project/copied.txt",
@@ -1409,7 +1409,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01S3D6xx2i1V9BP78iKCQF65",
+							"tool_use_id": "toolu_019VdV4KDwydxV3KjTKXqBJh",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -1424,7 +1424,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -1487,7 +1487,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -1523,7 +1523,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -1767,30 +1767,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwDeSkqumu32dwapCs\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"4. Now deleting the source file:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01S9etBEaBGXHKRxaDgSACKt\",\"name\":\"workspace_delete_file\",\"input\":{\"path\":\"/project/source.txt\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3296,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":70,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii63XGq2H8L6Uh9c5j1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"4. Now calling workspace_delete_file:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01T8j5wdbrwKUzcqVSN4MdRn\",\"name\":\"workspace_delete_file\",\"input\":{\"path\":\"/project/source.txt\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3341,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":71,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:53Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:07Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:53Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:07Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:52Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:07Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:53Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:07Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d5769ed5ac3-VIE",
+			"cf-ray": "a35e57b54fb9c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:53 GMT",
-			"request-id": "req_011CdzCwCyGSHHnFyzy5EqmL",
+			"date": "Fri, 04 Sep 2026 16:24:08 GMT",
+			"request-id": "req_011Ceii6331NH6D87YR7FESe",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-4103080f837d98fefbe2cc90d2474efb-faaa112c06430e22-01",
+			"traceresponse": "00-2bee2258f7e7a422e7906f014d5a5bec-11b4dc92a7ee4dd8-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -1824,7 +1824,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"name": "workspace_append_file",
 							"input": {
 								"path": "/project/source.txt",
@@ -1841,7 +1841,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"tool_use_id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -1851,11 +1851,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "2. Now copying the file:"
+							"text": "2. Now calling workspace_copy_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"name": "workspace_copy_file",
 							"input": {
 								"src": "/project/source.txt",
@@ -1873,7 +1873,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"tool_use_id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -1883,11 +1883,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "3. Now moving the file:"
+							"text": "3. Now calling workspace_move_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01S3D6xx2i1V9BP78iKCQF65",
+							"id": "toolu_019VdV4KDwydxV3KjTKXqBJh",
 							"name": "workspace_move_file",
 							"input": {
 								"src": "/project/copied.txt",
@@ -1905,7 +1905,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01S3D6xx2i1V9BP78iKCQF65",
+							"tool_use_id": "toolu_019VdV4KDwydxV3KjTKXqBJh",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -1915,11 +1915,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "4. Now deleting the source file:"
+							"text": "4. Now calling workspace_delete_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01S9etBEaBGXHKRxaDgSACKt",
+							"id": "toolu_01T8j5wdbrwKUzcqVSN4MdRn",
 							"name": "workspace_delete_file",
 							"input": {
 								"path": "/project/source.txt"
@@ -1935,7 +1935,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01S9etBEaBGXHKRxaDgSACKt",
+							"tool_use_id": "toolu_01T8j5wdbrwKUzcqVSN4MdRn",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -1950,7 +1950,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -2013,7 +2013,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -2049,7 +2049,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -2293,30 +2293,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwHXrNFuF3XrTp65ru\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"5. Now removing the directory:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01VgWvk68GzLDkPExuZ1RhaH\",\"name\":\"workspace_rmdir\",\"input\":{\"path\":\"/project/remove-me\",\"recursive\":true,\"force\":false},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3382,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":101,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii67sxqW7UEmL2ddjiV\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"5. Now calling workspace_rmdir:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01G7Ym5ZQ4iEyqFgZdvvpaXH\",\"name\":\"workspace_rmdir\",\"input\":{\"path\":\"/project/remove-me\",\"recursive\":true,\"force\":false},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3428,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":103,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:53Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:08Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:54Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:09Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:53Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:08Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:53Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:08Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d5d7d495ac3-VIE",
+			"cf-ray": "a35e57bbad17c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:54 GMT",
-			"request-id": "req_011CdzCwH74KUYFHgrK2cJue",
+			"date": "Fri, 04 Sep 2026 16:24:09 GMT",
+			"request-id": "req_011Ceii67QgVzyJKh8jdL8zW",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-4cb50b608ea542ecefbb88ea419fbfeb-1d4847ac5f7cdf85-01",
+			"traceresponse": "00-27408a72c32daa9f98d626f621118e4d-05d3123358af4929-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -2350,7 +2350,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"name": "workspace_append_file",
 							"input": {
 								"path": "/project/source.txt",
@@ -2367,7 +2367,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_013CcQxtFGGv3c4Rt2x2jH18",
+							"tool_use_id": "toolu_01JyJP8qk2rwiKJjPhg1X77Z",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -2377,11 +2377,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "2. Now copying the file:"
+							"text": "2. Now calling workspace_copy_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"name": "workspace_copy_file",
 							"input": {
 								"src": "/project/source.txt",
@@ -2399,7 +2399,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01Ew4RgnrPf7yhpZaawTk91u",
+							"tool_use_id": "toolu_01FxxywxaUgeZzdeRVSocgtA",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -2409,11 +2409,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "3. Now moving the file:"
+							"text": "3. Now calling workspace_move_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01S3D6xx2i1V9BP78iKCQF65",
+							"id": "toolu_019VdV4KDwydxV3KjTKXqBJh",
 							"name": "workspace_move_file",
 							"input": {
 								"src": "/project/copied.txt",
@@ -2431,7 +2431,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01S3D6xx2i1V9BP78iKCQF65",
+							"tool_use_id": "toolu_019VdV4KDwydxV3KjTKXqBJh",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -2441,11 +2441,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "4. Now deleting the source file:"
+							"text": "4. Now calling workspace_delete_file:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01S9etBEaBGXHKRxaDgSACKt",
+							"id": "toolu_01T8j5wdbrwKUzcqVSN4MdRn",
 							"name": "workspace_delete_file",
 							"input": {
 								"path": "/project/source.txt"
@@ -2461,7 +2461,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01S9etBEaBGXHKRxaDgSACKt",
+							"tool_use_id": "toolu_01T8j5wdbrwKUzcqVSN4MdRn",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -2471,11 +2471,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "5. Now removing the directory:"
+							"text": "5. Now calling workspace_rmdir:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01VgWvk68GzLDkPExuZ1RhaH",
+							"id": "toolu_01G7Ym5ZQ4iEyqFgZdvvpaXH",
 							"name": "workspace_rmdir",
 							"input": {
 								"path": "/project/remove-me",
@@ -2493,7 +2493,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01VgWvk68GzLDkPExuZ1RhaH",
+							"tool_use_id": "toolu_01G7Ym5ZQ4iEyqFgZdvvpaXH",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -2508,7 +2508,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -2571,7 +2571,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -2607,7 +2607,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -2851,30 +2851,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwMmMC2d4gqaXGWVxf\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"done.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3499,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii6CH8DgKjCSTSh4DaF\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"done.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3547,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9998000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:54Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9997000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:09Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:54Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:09Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:54Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:09Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11998000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:54Z",
+			"anthropic-ratelimit-tokens-remaining": "11997000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:09Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d6379385ac3-VIE",
+			"cf-ray": "a35e57c21aabc2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:54 GMT",
-			"request-id": "req_011CdzCwMG61dCxGtRqGDNRB",
+			"date": "Fri, 04 Sep 2026 16:24:09 GMT",
+			"request-id": "req_011Ceii6Bobzb4iKVbFFq73N",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-c303cba3bffbeaa6f32647d368f40af8-859d53649ce44b12-01",
+			"traceresponse": "00-9b3a2f57ea5cdb7cf6d77781478f2005-3e645c2809ea5006-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-handles-multi-step-workflow-mkdir-write-list-read.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-handles-multi-step-workflow-mkdir-write-list-read.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -375,30 +375,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwbJSG8Qg3Xcr8Mdqs\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll help you with these tasks. Let me execute them step by step.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01Kdm2JzfcvU22C5apQxbmUz\",\"name\":\"workspace_mkdir\",\"input\":{\"path\":\"/app\"},\"caller\":{\"type\":\"direct\"}},{\"type\":\"tool_use\",\"id\":\"toolu_01KjtGG2kqE7oS3bpc8FEJF5\",\"name\":\"workspace_write_file\",\"input\":{\"path\":\"/app/config.ts\",\"content\":\"export default {}\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2864,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":133,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii6QxNQK4RE8DFj2PrC\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll help you with these tasks step by step.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01Gvbubntr31a3rCKPQCrYFn\",\"name\":\"workspace_mkdir\",\"input\":{\"path\":\"/app\"},\"caller\":{\"type\":\"direct\"}},{\"type\":\"tool_use\",\"id\":\"toolu_01RhxmNjzPyjVGftYbdvULKp\",\"name\":\"workspace_write_file\",\"input\":{\"path\":\"/app/config.ts\",\"content\":\"export default {}\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2903,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":128,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:58Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:12Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:58Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:13Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:57Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:12Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:58Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:12Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d75dc275ac3-VIE",
+			"cf-ray": "a35e57d46a52c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:58 GMT",
-			"request-id": "req_011CdzCwZvLdpPMTgGkq1o33",
+			"date": "Fri, 04 Sep 2026 16:24:13 GMT",
+			"request-id": "req_011Ceii6QMuNb2uqxJLnGdvj",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-0763083be5a01f7a6495059febeffb6e-074fdd45ff1c532e-01",
+			"traceresponse": "00-3c042731dbb623591329fd004b6ec284-e32506a397a9afb4-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -432,11 +432,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "I'll help you with these tasks. Let me execute them step by step."
+							"text": "I'll help you with these tasks step by step."
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01Kdm2JzfcvU22C5apQxbmUz",
+							"id": "toolu_01Gvbubntr31a3rCKPQCrYFn",
 							"name": "workspace_mkdir",
 							"input": {
 								"path": "/app"
@@ -447,7 +447,7 @@
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01KjtGG2kqE7oS3bpc8FEJF5",
+							"id": "toolu_01RhxmNjzPyjVGftYbdvULKp",
 							"name": "workspace_write_file",
 							"input": {
 								"path": "/app/config.ts",
@@ -464,12 +464,12 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01Kdm2JzfcvU22C5apQxbmUz",
+							"tool_use_id": "toolu_01Gvbubntr31a3rCKPQCrYFn",
 							"content": "{\"success\":true}"
 						},
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01KjtGG2kqE7oS3bpc8FEJF5",
+							"tool_use_id": "toolu_01RhxmNjzPyjVGftYbdvULKp",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -484,7 +484,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -547,7 +547,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -583,7 +583,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -827,30 +827,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwgEqyT69jXZMUZwr1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Now let me list the files and read the config file:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01UWmHmjeCfvtj9Pagmf8c8w\",\"name\":\"workspace_list_files\",\"input\":{\"path\":\"/app\"},\"caller\":{\"type\":\"direct\"}},{\"type\":\"tool_use\",\"id\":\"toolu_01EAhG6VHkDp4kKfHyx33nhf\",\"name\":\"workspace_read_file\",\"input\":{\"path\":\"/app/config.ts\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3070,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":112,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii6XHsQUPN8MeNuaB2L\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Now let me list the files and read the content:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01Epuon9ScSu87Yfzw1oX6km\",\"name\":\"workspace_list_files\",\"input\":{\"path\":\"/app\"},\"caller\":{\"type\":\"direct\"}},{\"type\":\"tool_use\",\"id\":\"toolu_01Ddz82EXnvvCmn6iqfk2fLk\",\"name\":\"workspace_read_file\",\"input\":{\"path\":\"/app/config.ts\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3104,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":111,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:59Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:14Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:59Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:14Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:58Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:13Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:59Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:14Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d7e9a455ac3-VIE",
+			"cf-ray": "a35e57ddca92c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:59 GMT",
-			"request-id": "req_011CdzCwfjLLqgJpEayNEzLi",
+			"date": "Fri, 04 Sep 2026 16:24:15 GMT",
+			"request-id": "req_011Ceii6WkdMzLbQazPzTTHw",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-811dd8d88f0f5228d247eba8645965d7-2dd4531cfa96b7e3-01",
+			"traceresponse": "00-a165601b9691cbc454e20e3483001aae-507915b3a655ef01-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -884,11 +884,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "I'll help you with these tasks. Let me execute them step by step."
+							"text": "I'll help you with these tasks step by step."
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01Kdm2JzfcvU22C5apQxbmUz",
+							"id": "toolu_01Gvbubntr31a3rCKPQCrYFn",
 							"name": "workspace_mkdir",
 							"input": {
 								"path": "/app"
@@ -899,7 +899,7 @@
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01KjtGG2kqE7oS3bpc8FEJF5",
+							"id": "toolu_01RhxmNjzPyjVGftYbdvULKp",
 							"name": "workspace_write_file",
 							"input": {
 								"path": "/app/config.ts",
@@ -916,12 +916,12 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01Kdm2JzfcvU22C5apQxbmUz",
+							"tool_use_id": "toolu_01Gvbubntr31a3rCKPQCrYFn",
 							"content": "{\"success\":true}"
 						},
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01KjtGG2kqE7oS3bpc8FEJF5",
+							"tool_use_id": "toolu_01RhxmNjzPyjVGftYbdvULKp",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -931,11 +931,11 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "Now let me list the files and read the config file:"
+							"text": "Now let me list the files and read the content:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01UWmHmjeCfvtj9Pagmf8c8w",
+							"id": "toolu_01Epuon9ScSu87Yfzw1oX6km",
 							"name": "workspace_list_files",
 							"input": {
 								"path": "/app"
@@ -946,7 +946,7 @@
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01EAhG6VHkDp4kKfHyx33nhf",
+							"id": "toolu_01Ddz82EXnvvCmn6iqfk2fLk",
 							"name": "workspace_read_file",
 							"input": {
 								"path": "/app/config.ts"
@@ -962,12 +962,12 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01UWmHmjeCfvtj9Pagmf8c8w",
+							"tool_use_id": "toolu_01Epuon9ScSu87Yfzw1oX6km",
 							"content": "{\"entries\":[{\"name\":\"config.ts\",\"type\":\"file\"}]}"
 						},
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01EAhG6VHkDp4kKfHyx33nhf",
+							"tool_use_id": "toolu_01Ddz82EXnvvCmn6iqfk2fLk",
 							"content": "{\"content\":\"export default {}\"}"
 						}
 					]
@@ -982,7 +982,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -1045,7 +1045,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -1081,7 +1081,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -1325,30 +1325,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCwmHTXw7Z6DXv5BHhW\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Perfect! All tasks completed:\\n\\n1. ✅ Created directory `/app`\\n2. ✅ Wrote `\\\"export default {}\\\"` to `/app/config.ts`\\n3. ✅ Files in `/app`: `config.ts`\\n4. ✅ Contents of `/app/config.ts`: `export default {}`\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3272,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":83,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii6d9bdoM2wEe97Jan7\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Perfect! Here's a summary:\\n\\n1. ✓ Created directory `/app`\\n2. ✓ Wrote `\\\"export default {}\\\"` to `/app/config.ts`\\n3. ✓ Files in `/app`: \\n   - `config.ts` (file)\\n4. ✓ Contents of `/app/config.ts`: \\n   ```\\n   export default {}\\n   ```\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3305,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":98,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
 			"anthropic-ratelimit-input-tokens-remaining": "9998000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:37:00Z",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:15Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:37:00Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:16Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:59Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:15Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
 			"anthropic-ratelimit-tokens-remaining": "11998000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:37:00Z",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:15Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d853ec25ac3-VIE",
+			"cf-ray": "a35e57e66a06c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:37:00 GMT",
-			"request-id": "req_011CdzCwkV62qc7vwwpkCTQ6",
+			"date": "Fri, 04 Sep 2026 16:24:16 GMT",
+			"request-id": "req_011Ceii6cdqWZJrkFDrD7JSx",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-6ab9f6e7fd5b6818fe5aee49378c8b15-f12ec9900d19d681-01",
+			"traceresponse": "00-de8e7cdbbc418d3263d4e02b29f71caa-1d83dc0fc6d3ccae-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-execute-command-tool.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-execute-command-tool.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -375,30 +375,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCv5y3zVQrS4yca1QSQ\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01TF6SR7qEPBNo7wf9XQeUEi\",\"name\":\"workspace_execute_command\",\"input\":{\"command\":\"echo \\\"n8n workspace test\\\"\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2807,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":63,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5FDDMcsarcnmyPcRz\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_015hXViah7qhNtrdWPmw4jgt\",\"name\":\"workspace_execute_command\",\"input\":{\"command\":\"echo \\\"n8n workspace test\\\"\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2846,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":63,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:37Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:23:57Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:37Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:23:57Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:37Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:23:56Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:37Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:23:57Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55cf7dd915ac3-VIE",
+			"cf-ray": "a35e5771986ec2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:37 GMT",
-			"request-id": "req_011CdzCv5Yzz58SyPY7krqDp",
+			"date": "Fri, 04 Sep 2026 16:23:57 GMT",
+			"request-id": "req_011Ceii5EjgoxSXQPfWuR89b",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-752c8ef464768e2576ccd0f1fca5f441-54387c867312e514-01",
+			"traceresponse": "00-1b1c59264239e0cc26939372a5f1fbb4-6d528fd2d52ed301-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -432,7 +432,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_01TF6SR7qEPBNo7wf9XQeUEi",
+							"id": "toolu_015hXViah7qhNtrdWPmw4jgt",
 							"name": "workspace_execute_command",
 							"input": {
 								"command": "echo \"n8n workspace test\""
@@ -448,7 +448,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01TF6SR7qEPBNo7wf9XQeUEi",
+							"tool_use_id": "toolu_015hXViah7qhNtrdWPmw4jgt",
 							"content": "{\"success\":true,\"exitCode\":0,\"stdout\":\"n8n workspace test\\n\",\"stderr\":\"\",\"executionTimeMs\":1}"
 						}
 					]
@@ -463,7 +463,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -526,7 +526,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -562,7 +562,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -806,30 +806,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCvB58xujGEmKMfndPb\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"The command executed successfully. Output:\\n```\\nn8n workspace test\\n```\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2911,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":20,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5K6cqwaxtABhQSobt\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"The command executed successfully:\\n\\n**Output:**\\n```\\nn8n workspace test\\n```\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2950,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":22,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:38Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:23:57Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:38Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:23:57Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:38Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:23:57Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:38Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:23:57Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55cfe39685ac3-VIE",
+			"cf-ray": "a35e57772d13c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:38 GMT",
-			"request-id": "req_011CdzCv9xuTywBctsfJZvwV",
+			"date": "Fri, 04 Sep 2026 16:23:57 GMT",
+			"request-id": "req_011Ceii5JarvZk39Uvi4SA2u",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-e96b973259af71be56cb4c5ed4e370c8-414b271bef602569-01",
+			"traceresponse": "00-02432506585a2264aa47393e73fcd8f9-ac9b45d05ffa1f4f-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-file-stat-to-get-file-metadata.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-file-stat-to-get-file-metadata.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -375,30 +375,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCvqWBeQyF3FDe8vS6R\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_015G9eW7CkM1TaGdXDqhySy2\",\"name\":\"workspace_file_stat\",\"input\":{\"path\":\"/data.json\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2811,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":59,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5g4SUciVuKysZp7Xa\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll check the file information for /data.json.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01TnX2DdBDDUFR9SoxK8qNxS\",\"name\":\"workspace_file_stat\",\"input\":{\"path\":\"/data.json\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2850,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":71,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:48Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:02Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:48Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:03Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:47Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:02Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:48Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:02Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d377c5b5ac3-VIE",
+			"cf-ray": "a35e5795ddeec2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:48 GMT",
-			"request-id": "req_011CdzCvq77vo1hFZmLjptG3",
+			"date": "Fri, 04 Sep 2026 16:24:03 GMT",
+			"request-id": "req_011Ceii5fYS517zg2DvYDLPD",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-3bda4e01dd271888f79b8d557e579b2f-ac70e71bdf4ff168-01",
+			"traceresponse": "00-f0bbe906bbc42f6a932602d9a5930df3-d13674f355c4bd2f-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -431,8 +431,12 @@
 					"role": "assistant",
 					"content": [
 						{
+							"type": "text",
+							"text": "I'll check the file information for /data.json."
+						},
+						{
 							"type": "tool_use",
-							"id": "toolu_015G9eW7CkM1TaGdXDqhySy2",
+							"id": "toolu_01TnX2DdBDDUFR9SoxK8qNxS",
 							"name": "workspace_file_stat",
 							"input": {
 								"path": "/data.json"
@@ -448,7 +452,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_015G9eW7CkM1TaGdXDqhySy2",
+							"tool_use_id": "toolu_01TnX2DdBDDUFR9SoxK8qNxS",
 							"content": "{\"name\":\"data.json\",\"path\":\"/data.json\",\"type\":\"file\",\"size\":29,\"createdAt\":\"2026-01-01T00:00:00.000Z\",\"modifiedAt\":\"2026-01-01T00:00:00.000Z\"}"
 						}
 					]
@@ -463,7 +467,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -526,7 +530,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -562,7 +566,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -806,30 +810,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCvuEQpo8q7mGRTBscr\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"The file **/data.json** is a **file** with a size of **29 bytes**.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2944,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":25,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5jtsb1WNBYnx4Ms3N\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"The file **/data.json** is:\\n- **Type**: file\\n- **Size**: 29 bytes\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2995,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":28,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:48Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:03Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:48Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:03Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:48Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:03Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:48Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:03Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d3cef695ac3-VIE",
+			"cf-ray": "a35e579b7b3ec2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:49 GMT",
-			"request-id": "req_011CdzCvtpc6kQU7wCTqTyRr",
+			"date": "Fri, 04 Sep 2026 16:24:03 GMT",
+			"request-id": "req_011Ceii5jQrM5pkG2XgwK4ZF",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-5b10a9c82434a1ad0e872d6f046dfe53-05d38249ab2f62f9-01",
+			"traceresponse": "00-702b348a39873b8b7baa9d2af97c57c6-ffdcb8d7be8afbab-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-list-files-for-a-pre-existing-directory.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-list-files-for-a-pre-existing-directory.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -375,30 +375,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCvEgvSfA86JPTWs9Qs\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_016jNj9zxttJcRe6RETcp396\",\"name\":\"workspace_list_files\",\"input\":{\"path\":\"/project\",\"recursive\":false},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2834,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":74,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5N9vaToaiHXd65zea\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01QfYtJHbuE9Lmu1dciHKNy1\",\"name\":\"workspace_list_files\",\"input\":{\"path\":\"/project\",\"recursive\":false},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2873,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":74,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:40Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:23:58Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:40Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:23:58Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:39Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:23:58Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:40Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:23:58Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d049dd65ac3-VIE",
+			"cf-ray": "a35e577ba8b0c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:40 GMT",
-			"request-id": "req_011CdzCvEH7is4my5KozpmdZ",
+			"date": "Fri, 04 Sep 2026 16:23:59 GMT",
+			"request-id": "req_011Ceii5MdvLF7bKyfLSgWg9",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-f3fc94fb69a368363b08bf99b5507c0c-fb39af05c2496923-01",
+			"traceresponse": "00-b1b47b4670816551fd75c72f3577c51b-def368151b044fc6-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -432,7 +432,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_016jNj9zxttJcRe6RETcp396",
+							"id": "toolu_01QfYtJHbuE9Lmu1dciHKNy1",
 							"name": "workspace_list_files",
 							"input": {
 								"path": "/project",
@@ -449,7 +449,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_016jNj9zxttJcRe6RETcp396",
+							"tool_use_id": "toolu_01QfYtJHbuE9Lmu1dciHKNy1",
 							"content": "{\"entries\":[{\"name\":\"index.ts\",\"type\":\"file\"},{\"name\":\"README.md\",\"type\":\"file\"}]}"
 						}
 					]
@@ -464,7 +464,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -527,7 +527,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -563,7 +563,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -807,30 +807,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCvMgMnqtdVVhRNnCJf\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"The filenames are:\\n- index.ts\\n- README.md\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2947,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":18,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5SuRH9FhYUWggSF25\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"index.ts\\nREADME.md\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2986,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":10,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:43Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:23:59Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:43Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:23:59Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:40Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:23:59Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:43Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:23:59Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d0d0ab25ac3-VIE",
+			"cf-ray": "a35e5782bde7c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:44 GMT",
-			"request-id": "req_011CdzCvLBKPfP6EtC4KWsQZ",
+			"date": "Fri, 04 Sep 2026 16:23:59 GMT",
+			"request-id": "req_011Ceii5SRtxmkMeJvnWsZ3g",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-5f5baf061f5e98be87eed65c4c950b54-ab6d338b00e55e45-01",
+			"traceresponse": "00-0ce12a4918e1f113f21e08123528cfe8-47a3d38373fa0a74-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-write-file-and-workspace-read-file-tools.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/agent-uses-workspace-write-file-and-workspace-read-file-tools.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -375,30 +375,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCuqtiTKoNx4oTdupyb\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_016gagar3q8iJgk17e5VkRFs\",\"name\":\"workspace_write_file\",\"input\":{\"path\":\"/greeting.txt\",\"content\":\"Hello from n8n!\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2839,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":80,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii55HukBcpJ7cL9q8Sb\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll write the greeting to the file and then read it back.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01RuzwS1hk4bDWYCoMQa8yTZ\",\"name\":\"workspace_write_file\",\"input\":{\"path\":\"/greeting.txt\",\"content\":\"Hello from n8n!\"},\"caller\":{\"type\":\"direct\"}},{\"type\":\"tool_use\",\"id\":\"toolu_01U2oiMh929Q1eM6Fif71zGp\",\"name\":\"workspace_read_file\",\"input\":{\"path\":\"/greeting.txt\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2878,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":135,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:34Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:23:54Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:34Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:23:55Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:33Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:23:54Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:34Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:23:54Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55ce349365ac3-VIE",
+			"cf-ray": "a35e57630cb2c2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:34 GMT",
-			"request-id": "req_011CdzCuqVfCYy2CTXwUMbB5",
+			"date": "Fri, 04 Sep 2026 16:23:55 GMT",
+			"request-id": "req_011Ceii54n9nwLiHV5aSzFHS",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-d480155c57f4b60d91808f3069eb81fe-17ce1f3d4cbe8713-01",
+			"traceresponse": "00-ab717dde79fb781d87f7f7d85dd00a1b-7046a1a15f76fc99-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -431,8 +431,12 @@
 					"role": "assistant",
 					"content": [
 						{
+							"type": "text",
+							"text": "I'll write the greeting to the file and then read it back."
+						},
+						{
 							"type": "tool_use",
-							"id": "toolu_016gagar3q8iJgk17e5VkRFs",
+							"id": "toolu_01RuzwS1hk4bDWYCoMQa8yTZ",
 							"name": "workspace_write_file",
 							"input": {
 								"path": "/greeting.txt",
@@ -441,461 +445,10 @@
 							"caller": {
 								"type": "direct"
 							}
-						}
-					]
-				},
-				{
-					"role": "user",
-					"content": [
-						{
-							"type": "tool_result",
-							"tool_use_id": "toolu_016gagar3q8iJgk17e5VkRFs",
-							"content": "{\"success\":true}"
-						}
-					]
-				}
-			],
-			"tools": [
-				{
-					"name": "workspace_read_file",
-					"description": "Read the contents of a file from the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path to the file to read"
-							},
-							"encoding": {
-								"type": "string",
-								"enum": ["utf-8", "base64"],
-								"description": "File encoding (default: utf-8)"
-							}
-						},
-						"required": ["path"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_read_tool_result",
-					"description": "Inspect an oversized tool result stored in the workspace. Start with view=describe, then use view=json with relevant JSON Pointers and nextOffset values. Continue until you have enough evidence for the user request; do not assume the first page is complete when hasMore is true.",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Exact path from an oversized tool-result envelope"
-							},
-							"view": {
-								"type": "string",
-								"enum": ["describe", "json"],
-								"description": "Inspect the selected value shape, or read a bounded JSON value"
-							},
-							"pointer": {
-								"type": "string",
-								"description": "RFC 6901 JSON Pointer. Omit or use an empty string for the root value."
-							},
-							"offset": {
-								"type": "integer",
-								"minimum": 0,
-								"description": "String character or container child offset"
-							},
-							"maxChars": {
-								"type": "integer",
-								"minimum": 1,
-								"maximum": 20000,
-								"description": "Maximum characters to return from a selected JSON string"
-							},
-							"limit": {
-								"type": "integer",
-								"minimum": 1,
-								"maximum": 100,
-								"description": "Maximum object or array children to return"
-							}
-						},
-						"required": ["path"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_str_replace_file",
-					"description": "Apply one or more exact text replacements to a workspace file atomically. If any replacement fails, no changes are written.",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path to the file to edit"
-							},
-							"replacements": {
-								"type": "array",
-								"items": {
-									"type": "object",
-									"properties": {
-										"old_str": {
-											"type": "string",
-											"description": "Exact text to replace. Must match exactly and be unique."
-										},
-										"new_str": {
-											"type": "string",
-											"description": "Replacement text to write in place of old_str."
-										}
-									},
-									"required": ["old_str", "new_str"],
-									"additionalProperties": false
-								},
-								"minItems": 1,
-								"description": "Ordered exact string replacements applied atomically."
-							}
-						},
-						"required": ["path", "replacements"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_write_file",
-					"description": "Write content to a file in the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path to the file to write"
-							},
-							"content": {
-								"type": "string",
-								"description": "Content to write to the file"
-							},
-							"recursive": {
-								"type": "boolean",
-								"description": "Create parent directories if they do not exist"
-							}
-						},
-						"required": ["path", "content"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_list_files",
-					"description": "List files and directories in the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Directory path to list"
-							},
-							"recursive": {
-								"type": "boolean",
-								"description": "List files recursively"
-							}
-						},
-						"required": ["path"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_file_stat",
-					"description": "Get metadata about a file or directory",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path to the file or directory"
-							}
-						},
-						"required": ["path"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_mkdir",
-					"description": "Create a directory in the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path of the directory to create"
-							},
-							"recursive": {
-								"type": "boolean",
-								"description": "Create parent directories if needed"
-							}
-						},
-						"required": ["path"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_delete_file",
-					"description": "Delete a file or directory from the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path to the file or directory to delete"
-							},
-							"recursive": {
-								"type": "boolean",
-								"description": "Delete directories and their contents recursively"
-							},
-							"force": {
-								"type": "boolean",
-								"description": "Ignore errors if the file does not exist"
-							}
-						},
-						"required": ["path"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_append_file",
-					"description": "Append content to a file in the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path to the file to append to"
-							},
-							"content": {
-								"type": "string",
-								"description": "Content to append to the file"
-							}
-						},
-						"required": ["path", "content"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_copy_file",
-					"description": "Copy a file or directory in the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"src": {
-								"type": "string",
-								"description": "Source path of the file or directory to copy"
-							},
-							"dest": {
-								"type": "string",
-								"description": "Destination path for the copy"
-							},
-							"overwrite": {
-								"type": "boolean",
-								"description": "Overwrite the destination if it already exists"
-							}
-						},
-						"required": ["src", "dest"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_move_file",
-					"description": "Move or rename a file or directory in the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"src": {
-								"type": "string",
-								"description": "Source path of the file or directory to move"
-							},
-							"dest": {
-								"type": "string",
-								"description": "Destination path"
-							},
-							"overwrite": {
-								"type": "boolean",
-								"description": "Overwrite the destination if it already exists"
-							}
-						},
-						"required": ["src", "dest"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_rmdir",
-					"description": "Remove a directory from the workspace",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"path": {
-								"type": "string",
-								"description": "Path of the directory to remove"
-							},
-							"recursive": {
-								"type": "boolean",
-								"description": "Remove the directory and its contents recursively"
-							},
-							"force": {
-								"type": "boolean",
-								"description": "Ignore errors if the directory does not exist"
-							}
-						},
-						"required": ["path"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_execute_command",
-					"description": "Execute a shell command in the sandbox",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"command": {
-								"type": "string",
-								"description": "The shell command to execute"
-							},
-							"cwd": {
-								"type": "string",
-								"description": "Working directory for the command"
-							},
-							"timeout": {
-								"type": "number",
-								"description": "Timeout in milliseconds"
-							}
-						},
-						"required": ["command"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_list_processes",
-					"description": "List all background processes spawned in the sandbox",
-					"input_schema": {
-						"type": "object",
-						"properties": {},
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				},
-				{
-					"name": "workspace_kill_process",
-					"description": "Kill a background process in the sandbox by PID",
-					"input_schema": {
-						"type": "object",
-						"properties": {
-							"pid": {
-								"type": "number",
-								"description": "PID of the process to kill"
-							}
-						},
-						"required": ["pid"],
-						"additionalProperties": false,
-						"$schema": "http://json-schema.org/draft-07/schema#"
-					}
-				}
-			],
-			"tool_choice": {
-				"type": "auto"
-			}
-		},
-		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCuv6UeVbGQB2XWXydq\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Now let me read it back:\"},{\"type\":\"tool_use\",\"id\":\"toolu_013VnZoCxjuCWKMqyWNQM7ox\",\"name\":\"workspace_read_file\",\"input\":{\"path\":\"/greeting.txt\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2935,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":66,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
-		"rawHeaders": {
-			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:35Z",
-			"anthropic-ratelimit-output-tokens-limit": "2000000",
-			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:35Z",
-			"anthropic-ratelimit-requests-limit": "20000",
-			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:34Z",
-			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:35Z",
-			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55ce96c735ac3-VIE",
-			"connection": "keep-alive",
-			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
-			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:35 GMT",
-			"request-id": "req_011CdzCuugg2Hezx5hWPGWRv",
-			"server": "cloudflare",
-			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-35c5fc592373fc45d776cd67be06a956-bcf5253a4e9c0439-01",
-			"vary": "Accept-Encoding",
-			"x-robots-tag": "none"
-		},
-		"responseIsBinary": false
-	},
-	{
-		"scope": "https://api.anthropic.com:443",
-		"method": "POST",
-		"path": "/v1/messages",
-		"body": {
-			"model": "claude-haiku-4-5",
-			"max_tokens": 64000,
-			"system": [
-				{
-					"type": "text",
-					"text": "<built_in_rules>\n- When a tool result is offloaded, inspect it with workspace_read_tool_result before answering. Continue through relevant JSON Pointers and nextOffset pages until you have enough evidence for the user request. Do not read the entire result when the remaining content cannot affect the answer.\n</built_in_rules>\n\nYou are a file manager. When asked to create a file, use workspace_write_file. When asked to read a file, use workspace_read_file. Be concise.\n\nFake sandbox for executing commands.\n\nIn-memory filesystem. All file paths are relative to /mem."
-				}
-			],
-			"messages": [
-				{
-					"role": "user",
-					"content": [
-						{
-							"type": "text",
-							"text": "Write \"Hello from n8n!\" to /greeting.txt, then read it back and tell me the contents. You MUST call both tools"
-						}
-					]
-				},
-				{
-					"role": "assistant",
-					"content": [
-						{
-							"type": "tool_use",
-							"id": "toolu_016gagar3q8iJgk17e5VkRFs",
-							"name": "workspace_write_file",
-							"input": {
-								"path": "/greeting.txt",
-								"content": "Hello from n8n!"
-							},
-							"caller": {
-								"type": "direct"
-							}
-						}
-					]
-				},
-				{
-					"role": "user",
-					"content": [
-						{
-							"type": "tool_result",
-							"tool_use_id": "toolu_016gagar3q8iJgk17e5VkRFs",
-							"content": "{\"success\":true}"
-						}
-					]
-				},
-				{
-					"role": "assistant",
-					"content": [
-						{
-							"type": "text",
-							"text": "Now let me read it back:"
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_013VnZoCxjuCWKMqyWNQM7ox",
+							"id": "toolu_01U2oiMh929Q1eM6Fif71zGp",
 							"name": "workspace_read_file",
 							"input": {
 								"path": "/greeting.txt"
@@ -911,7 +464,12 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_013VnZoCxjuCWKMqyWNQM7ox",
+							"tool_use_id": "toolu_01RuzwS1hk4bDWYCoMQa8yTZ",
+							"content": "{\"success\":true}"
+						},
+						{
+							"type": "tool_result",
+							"tool_use_id": "toolu_01U2oiMh929Q1eM6Fif71zGp",
 							"content": "{\"content\":\"Hello from n8n!\"}"
 						}
 					]
@@ -926,7 +484,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -989,7 +547,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -1025,7 +583,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -1269,30 +827,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CdzCv1RTDazuu9sNEWWco\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Perfect! I've successfully written to and read from the file. The contents of `/greeting.txt` are:\\n\\n**Hello from n8n!**\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3022,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":35,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Ceii5ApHtLpXEGZKjeyfQ\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Perfect! I've successfully written to the file and read it back. The contents of `/greeting.txt` are:\\n\\n**Hello from n8n!**\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":3093,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":36,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9999000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:36Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9998000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:23:56Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:36Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:23:56Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:36Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:23:55Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11999000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:36Z",
+			"anthropic-ratelimit-tokens-remaining": "11998000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:23:56Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55cf018695ac3-VIE",
+			"cf-ray": "a35e576b1b9fc2fa-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Thu, 13 Aug 2026 05:36:36 GMT",
-			"request-id": "req_011CdzCuzGzpWkzj1wdAobJ1",
+			"date": "Fri, 04 Sep 2026 16:23:56 GMT",
+			"request-id": "req_011Ceii5AHHuhXrLfgPYNLkC",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-63ee32688edaee341695f72595c9bc1d-00e8eff0c0af037c-01",
+			"traceresponse": "00-6a01dccdee48187637fbcb1dd0d8dd0d-55d787f1c3169872-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/stream-agent-writes-a-file-and-streams-the-response.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/workspace-agent/stream-agent-writes-a-file-and-streams-the-response.json
@@ -32,7 +32,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -95,7 +95,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -131,7 +131,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -377,33 +377,33 @@
 		},
 		"status": 200,
 		"response": [
-			"1f8b0800000000000013cd564d8fd33010bdf75744734e21a9a876956b572c020921b4200141d634996d4c1d3bd89376d92aff1db96db6493f602fd0e6e6f9f0bcf766a2312d48731294e41cce483846cb831c19936005fcab2248a0e784b03d43b282d2e4a420814c619dd3b04039af87af86e3e1281a8de3288a210499fb3bdc4c44713cc91f278b6cc1b7a67cfb61449f5e5f4fbe1610ee558210ac51de80ce49c7a87dd9cc6826cd907cfb1e826353094be88c8644d74a6d4d8e7ed6a433ea19736294cab5b6ba452f7555b3603327ed20195dc7710819660589cc12b2345af443a2d66f09f353be36d757a0aaa0922c2a312e0fe377deb8d8f73621989a7bf8c62138b20b999160491612f0d2e46873afb2be27eb998b191948401b16b840a970aa089a26e87ecd60409bc66f45155365b2f9f1f61f0959d7cbe961c3baebf7a4b7796c8c12b5a37604fcb91651fcae9c4eefde4f6e8a2ff4f899efccf216df7cbc811034963e6f69ecdc559891585ac924eea55adfe1f58164d5789d95f2fc9f4ae5d252c65d963b8695d4b33d4a0178239c522127c5f86715d6213d1536961da44d3b7f38a39f822bb42c51ad8d90001c437b1624ab142ae422f5ca341781288597052905cf1bdbff04cabce0074ee1b2408541babd750fd7b981b11fa7141c5fc84859c2525ece3fa767c1d2f45b766e81e62e85a60be9f49a30d5dfb684a93a707a77b5cf89a3b47a4ee8d0e82dfcee6e79e6da6ffee1dedf5bd45757cda182bb47d4a1765d1fac937e03f6bc92d697090000"
+			"1f8b0800000000000013cd564d8fda3010bdf32ba2398736b04b59f9d60f690f2d52d54bd596ca9a4d06e2c5b1537b02dba2fcf7ca81b084856d2f2de4e699b1e7bd377666684986455490f73827e9191df7326414d11af8674920a0e384b85d8358436133d22020d55865d4cf512daafe757fd41f26c3d12049061083cac2197e2e93c1e02d2935fafcfae3d5fdf5646568f2cece6f32880f32410cceea6040ef956734216d6a0d936110dfbec7e0d996d2117a6b40984aebadc9d38f8a4c4a1d63468c4afbd656b5e895292b966c17643c88e1cd288921c53427993a4256d6c86ec8ceef08b353be766fc840654e0539d472543c8d7ff40ef2436f1d83adb883ef550c9edc52a52459910301419a0c5d50509919b9c05ccec982006359e21295c63b4d50d751f8ea5e8f3605df8a29efb44d17c7cb7e24a4c993d1c386edbe3f90ddee636bb5ac3cb5a50feb4a268351f1f57652fda255f9e9cdb8b8faf2fe76395b7c80180c1661dfcaba852f3125b9728a49ce946ece08ba8058d7415fad03ef5daa4c394ab965171d702c95991f908a2018e1940e1969c6e77568423a3a6c2c8fa03685bcf7d6ec824b74ac5037461000f533b5f84f18d6d30d8ce8a874678154e206d1996170be93e6cc484434859739c1f1eb7d16485adb17fcc0ddcb73664c71747897cf0c28b5e6129e78386eda5c22cfee229e1661a12eedaf63e651e83c9750303f851aead34dda967fead1b6dc83704ae6769e3bcaaae3843d169d896bbfc9ffe5dc55ffc3c1eb60521a8feba76c8fc9b7ef8346a2dfa6b97a5b100b0000"
 		],
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9998000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:44Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9999000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:00Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:44Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:00Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:44Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:00Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11998000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:44Z",
+			"anthropic-ratelimit-tokens-remaining": "11999000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:00Z",
 			"cache-control": "no-cache",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d2498dd5ac3-VIE",
+			"cf-ray": "a35e578739bdc2fa-VIE",
 			"connection": "keep-alive",
 			"content-encoding": "gzip",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "text/event-stream; charset=utf-8",
-			"date": "Thu, 13 Aug 2026 05:36:45 GMT",
-			"request-id": "req_011CdzCvcBF7Mv4P1ps4ckaz",
+			"date": "Fri, 04 Sep 2026 16:24:00 GMT",
+			"request-id": "req_011Ceii5VaAP1tXGjUY3VVzk",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-36f47c02adf95b01a770276051513429-9fc7717bcbf20592-01",
+			"traceresponse": "00-c92fa8284e11b8a33b457a136bf52dfe-fbb18fadfeadaefd-01",
 			"transfer-encoding": "chunked",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
@@ -438,7 +438,7 @@
 					"content": [
 						{
 							"type": "tool_use",
-							"id": "toolu_01KmbbTNCDhYezVtTowGaHRD",
+							"id": "toolu_015mZGMuzewpRB7m3YKGvfkL",
 							"name": "workspace_write_file",
 							"input": {
 								"path": "/hello.txt",
@@ -455,7 +455,7 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01KmbbTNCDhYezVtTowGaHRD",
+							"tool_use_id": "toolu_015mZGMuzewpRB7m3YKGvfkL",
 							"content": "{\"success\":true}"
 						}
 					]
@@ -470,7 +470,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to read"
+								"description": "Path to the file to read, relative to the workspace root (absolute paths must be under it)"
 							},
 							"encoding": {
 								"type": "string",
@@ -533,7 +533,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to edit"
+								"description": "Path to the file to edit, relative to the workspace root (absolute paths must be under it)"
 							},
 							"replacements": {
 								"type": "array",
@@ -569,7 +569,7 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the file to write"
+								"description": "Path to the file to write, relative to the workspace root (absolute paths must be under it)"
 							},
 							"content": {
 								"type": "string",
@@ -815,33 +815,33 @@
 		},
 		"status": 200,
 		"response": [
-			"1f8b0800000000000013c555b16edb3010ddfd15ec2d5de454326214e516a44bb7a01d9b82b988178b354daae4c9511ae8df0bda562c394eda25ae1641ef1defbd3b8a475a9363295614232e4845c6c0138d8c523c023fd40412462464fd37c84758794d162494161b4dd30acdb2999e4fe7d3593e9b17795e400646a71c71a1f2a2b8d4bf2fd7cb8f3fbf9aab16ababb67cf8d65c4076a00419046f1380319ac8e8926ce91d936390df7f6410d9d72a1046ef40bac6da1d14e95743aea411a889d1d8d8634defdeb8ba61c57e492e829c7dcacf3328b1ac489581908d776a1c92f77c20d42f71fddaa44075452b0a68d57cf53c7ecf16d521db65e01b1e42450691c2da94a4d8500009a9331a834e4d76771452e16a411e2438cf0ad7682cde5a82ae13427493096d777bd749756b7db93cbee74742362a9ada6da9433e55ba5bc7d4a6c0cd4b027443d9dab8c5818e8004c24bd63459c6d7ad6d4246d6b6c8d8d253d8ced867ef52574e2dfb4e7c79bf26b1f94348a7eef4cfc9ad08ae48dc194be2e6c37f355291b5fe8c5bbe11f786ab8daf5d5e710d7b6b2737163910ae8c5b887b1f96f11acea07be510f9fa6f67c8d7030ffb44fd783d5ac8888481f1d10004725a71131cfcf318ecde700e1e0caed9ac1b6fe0fe4279deb4210769cd1ff96b6c01a2060000"
+			"1f8b0800000000000013b554c172d33010bde72bc49e9d62871a26ba75caf0031c29a36ead25d658968cb44e031dff3be32426b693142ed5c5a3f79eb46f77b5a62d3996a2a61871432a32065e686494e205f857432061424232ec41be40ed35599050586c352d4b3455bbbc5de6cb55bacab334cd2001a3fb3be246a559764fc6e4c5c7fc0ef3dfd5fddda7edd7b5af219945820482b73d80319ac8e8fab085774c8e417efb9e4064dfa84018bd03e95a6b8f50a49f2db98226a0264663e380b5837be39a9615fb8a5c04b95adf7e48a0c0a22455044236dea9a9241df840a8af71c3d93e023525d514d0aabc3ed79fd8ac9cb35d02bee531942510296c4d418a0d0590d0574663d07d91dd0f0a7de26a431e2438cf0ab7682c3e5982ae13dd6241875e1feba89eac2faacb1dbf20d9c7d0b43b243ae6fb3c8fe79876bd70ff91009d18af9383c6b8cd2ca4801e846b2e3559c6d75dee2513970764eaeeafece8f1b37734f329aed6eacd5cbc135f8c25b17f39a405b2787c5f92b5fe8677fc289e0d978315f1009103616ddc463cfb50c507b881d7faeb9b7fb5d73723c7a78b86b9bf98f68484519a93c904725a711b1cfcf77c766f38a0f3895a77d71a7ffae79d976fccc1f9d3f903e33b8cf453050000"
 		],
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "10000000",
-			"anthropic-ratelimit-input-tokens-remaining": "9998000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-08-13T05:36:46Z",
+			"anthropic-ratelimit-input-tokens-remaining": "9999000",
+			"anthropic-ratelimit-input-tokens-reset": "2026-09-04T16:24:01Z",
 			"anthropic-ratelimit-output-tokens-limit": "2000000",
 			"anthropic-ratelimit-output-tokens-remaining": "2000000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-08-13T05:36:46Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-09-04T16:24:01Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-08-13T05:36:46Z",
+			"anthropic-ratelimit-requests-reset": "2026-09-04T16:24:01Z",
 			"anthropic-ratelimit-tokens-limit": "12000000",
-			"anthropic-ratelimit-tokens-remaining": "11998000",
-			"anthropic-ratelimit-tokens-reset": "2026-08-13T05:36:46Z",
+			"anthropic-ratelimit-tokens-remaining": "11999000",
+			"anthropic-ratelimit-tokens-reset": "2026-09-04T16:24:01Z",
 			"cache-control": "no-cache",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a2a55d2c5d515ac3-VIE",
+			"cf-ray": "a35e57901943c2fa-VIE",
 			"connection": "keep-alive",
 			"content-encoding": "gzip",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "text/event-stream; charset=utf-8",
-			"date": "Thu, 13 Aug 2026 05:36:46 GMT",
-			"request-id": "req_011CdzCvhVUVPFCNU2Y77TZQ",
+			"date": "Fri, 04 Sep 2026 16:24:01 GMT",
+			"request-id": "req_011Ceii5bc48bofgyMzQdAW6",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-4bf9c5d36d62537b31ce24b873e2d455-48916de6fcde9c36-01",
+			"traceresponse": "00-fffb78370d81b133bf9802bea3839cdd-7a01d90177eb7d92-01",
 			"transfer-encoding": "chunked",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"

--- a/packages/@n8n/agents/src/__tests__/workspace/scoped-workspace.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/scoped-workspace.test.ts
@@ -62,10 +62,10 @@ describe('createScopedWorkspace ensureRootExists', () => {
 		const { filesystem, scoped } = makeScopedWorkspace({ ensureRootExists: true });
 
 		await expect(scoped.filesystem!.readFile('../outside.md')).rejects.toThrow(
-			'Path escapes workspace root',
+			'is outside the workspace root',
 		);
 		await expect(scoped.sandbox!.executeCommand!('ls', [], { cwd: '../../etc' })).rejects.toThrow(
-			'Path escapes workspace root',
+			'is outside the workspace root',
 		);
 
 		expect(filesystem.mkdir).not.toHaveBeenCalled();

--- a/packages/@n8n/agents/src/workspace/__tests__/scoped-workspace.test.ts
+++ b/packages/@n8n/agents/src/workspace/__tests__/scoped-workspace.test.ts
@@ -95,7 +95,7 @@ describe('createScopedWorkspace', () => {
 
 		await expect(
 			workspace.filesystem?.readFile('/workspace/builders/agent-2/src/workflow.ts'),
-		).rejects.toThrow('Path escapes workspace root');
+		).rejects.toThrow('is outside the workspace root');
 		expect(filesystem.readFile).not.toHaveBeenCalled();
 	});
 
@@ -126,7 +126,7 @@ describe('createScopedWorkspace', () => {
 			workspace.sandbox?.executeCommand?.('npm test', [], {
 				cwd: '/workspace/builders/agent-2',
 			}),
-		).rejects.toThrow('Path escapes workspace root');
+		).rejects.toThrow('is outside the workspace root');
 		expect(executeCommand).not.toHaveBeenCalled();
 	});
 

--- a/packages/@n8n/agents/src/workspace/scoped-workspace.ts
+++ b/packages/@n8n/agents/src/workspace/scoped-workspace.ts
@@ -31,7 +31,10 @@ function resolvePath(root: string, path: string): string {
 		: posixNormalize(posixJoin(normalizedRoot, path));
 
 	if (!isInsideRoot(normalizedPath, normalizedRoot)) {
-		throw new Error(`Path escapes workspace root: ${path}`);
+		throw new Error(
+			`Path "${path}" is outside the workspace root "${normalizedRoot}". ` +
+				'Use a path relative to the workspace root, e.g. "tmp/output.txt".',
+		);
 	}
 
 	return normalizedPath;
@@ -81,7 +84,11 @@ class ScopedFilesystem implements WorkspaceFilesystem {
 
 	getInstructions(): string {
 		const base = this.filesystem.getInstructions?.() ?? '';
-		return [base, `Filesystem access is scoped to ${this.root}.`].filter(Boolean).join('\n');
+		const scope =
+			`Filesystem access is scoped to ${this.root}. ` +
+			'Paths are relative to the workspace root unless you pass an absolute path under that root. ' +
+			`Use ${this.root}/tmp for scratch files.`;
+		return [base, scope].filter(Boolean).join('\n');
 	}
 
 	/**

--- a/packages/@n8n/agents/src/workspace/tools/read-file.ts
+++ b/packages/@n8n/agents/src/workspace/tools/read-file.ts
@@ -9,7 +9,11 @@ export function createReadFileTool(filesystem: WorkspaceFilesystem): BuiltTool {
 		.description('Read the contents of a file from the workspace')
 		.input(
 			z.object({
-				path: z.string().describe('Path to the file to read'),
+				path: z
+					.string()
+					.describe(
+						'Path to the file to read, relative to the workspace root (absolute paths must be under it)',
+					),
 				encoding: z.enum(['utf-8', 'base64']).optional().describe('File encoding (default: utf-8)'),
 			}),
 		)

--- a/packages/@n8n/agents/src/workspace/tools/str-replace-file.ts
+++ b/packages/@n8n/agents/src/workspace/tools/str-replace-file.ts
@@ -12,7 +12,11 @@ const strReplacementSchema = z.object({
 });
 
 const inputSchema = z.object({
-	path: z.string().describe('Path to the file to edit'),
+	path: z
+		.string()
+		.describe(
+			'Path to the file to edit, relative to the workspace root (absolute paths must be under it)',
+		),
 	replacements: z
 		.array(strReplacementSchema)
 		.min(1)

--- a/packages/@n8n/agents/src/workspace/tools/write-file.ts
+++ b/packages/@n8n/agents/src/workspace/tools/write-file.ts
@@ -9,7 +9,11 @@ export function createWriteFileTool(filesystem: WorkspaceFilesystem): BuiltTool 
 		.description('Write content to a file in the workspace')
 		.input(
 			z.object({
-				path: z.string().describe('Path to the file to write'),
+				path: z
+					.string()
+					.describe(
+						'Path to the file to write, relative to the workspace root (absolute paths must be under it)',
+					),
 				content: z.string().describe('Content to write to the file'),
 				recursive: z
 					.boolean()


### PR DESCRIPTION
## Summary

When an agent passes a path outside its scoped workspace root (for example `/tmp/ids.txt`), the workspace tools reject the call with `Path escapes workspace root: /tmp/ids.txt`. The message does not name the root and does not say how to fix the call. The system prompt only says `Filesystem access is scoped to <root>.` and the tool schemas only say `Path to the file to write`. The model has no way to self-correct, and the user sees an opaque tool error in the agent preview.

This PR mirrors the guidance that Instance AI already gives its model, inside the shared `@n8n/agents` scoped workspace:

- **Rejection message** (`scoped-workspace.ts`): the error now names the offending path, the workspace root, and the remedy:
  `Path "/tmp/ids.txt" is outside the workspace root "/home/user/workspace". Use a path relative to the workspace root, e.g. "tmp/output.txt".`
  The tool runtime returns this text to the model, so the model can retry with a path under the root on the next turn.
- **Workspace instructions** (`ScopedFilesystem.getInstructions`): the text appended to the system prompt now explains that paths resolve against the root, that absolute paths must stay under the root, and that `<root>/tmp` is the place for scratch files.
- **Tool schemas** (`workspace_read_file`, `workspace_write_file`, `workspace_str_replace_file`): the `path` parameter now says it is relative to the workspace root and that absolute paths must be under it.

The scope check itself does not change. Instance AI shares `createScopedWorkspace` and only inherits the new error text; it keeps its own prompt guidance. The four existing test assertions that matched the old message prefix now match the new message.

## How to test

1. Start an instance with the agent sandbox enabled (`N8N_AGENTS_AI_SANDBOX_ENABLED=true` plus a configured sandbox provider).
2. Open an agent in the agent builder and start a preview conversation.
3. Ask the agent: "Use your workspace tools to write the text `hello` to `/tmp/hello.txt`."
4. Expected: the agent writes the file under `<root>/tmp` directly. If the agent still calls the tool with `/tmp/hello.txt`, the tool error names the workspace root and the agent retries with a path under the root and succeeds.
5. Unit tests: `cd packages/@n8n/agents && pnpm test src/workspace/__tests__/scoped-workspace.test.ts src/__tests__/workspace/scoped-workspace.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-691

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

