### PR TITLE
fix(core): Preserve active SSH clients during connection cleanup

### DIFF
--- a/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
+++ b/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
@@ -53,11 +53,23 @@ describe('getClient', () => {
 		expect(client).toBeInstanceOf(Client);
 	});
 
-	it('should not create a new SSH client when connect fails', async () => {
-		connectSpy.mockImplementation(function (this: Client) {
-			throw new Error('Failed to connect');
+	it('should clear a failed connection before retrying the same credentials', async () => {
+		const error = new Error('Failed to connect');
+		const failedClients: Client[] = [];
+		connectSpy.mockImplementationOnce(function (this: Client) {
+			failedClients.push(this);
+			throw error;
 		});
-		await expect(sshClientsManager.getClient(credentials)).rejects.toThrow('Failed to connect');
+
+		await expect(sshClientsManager.getClient(credentials)).rejects.toBe(error);
+		expect(sshClientsManager.clients.size).toBe(0);
+		expect(sshClientsManager.clientsReversed.has(failedClients[0])).toBe(false);
+
+		const client = await sshClientsManager.getClient(credentials);
+
+		expect(client).not.toBe(failedClients[0]);
+		expect(await sshClientsManager.getClient(credentials)).toBe(client);
+		expect(connectSpy).toHaveBeenCalledTimes(2);
 	});
 
 	it('should reuse an existing SSH client', async () => {
@@ -93,6 +105,26 @@ describe('getClient', () => {
 		}
 		expect(connectSpy).toHaveBeenCalledTimes(1);
 	});
+
+	it.each(['close', 'end', 'error'])(
+		'should keep the replacement client when the previous client emits %s',
+		async (event) => {
+			const previousClient = await sshClientsManager.getClient(credentials);
+			previousClient.emit('end');
+
+			const abortController = new AbortController();
+			const replacementClient = await sshClientsManager.getClient(credentials, abortController);
+			endSpy.mockClear();
+
+			previousClient.emit(event, new Error('Previous connection ended'));
+
+			expect(endSpy).not.toHaveBeenCalled();
+			expect(abortController.signal.aborted).toBe(false);
+			expect(sshClientsManager.clients.size).toBe(1);
+			expect(await sshClientsManager.getClient(credentials)).toBe(replacementClient);
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+		},
+	);
 });
 
 describe('onShutdown', () => {
@@ -184,6 +216,21 @@ describe('cleanup', () => {
 
 			// ASSERT 1
 			expect(endSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('does not refresh the replacement client when the previous client is used', async () => {
+			const previousClient = await sshClientsManager.getClient(credentials);
+			previousClient.emit('end');
+			const replacementClient = await sshClientsManager.getClient(credentials);
+			endSpy.mockClear();
+
+			vi.advanceTimersByTime((idleTimeout - 1) * 1000);
+			sshClientsManager.updateLastUsed(previousClient);
+			vi.advanceTimersByTime((cleanUpInterval + 1) * 1000);
+
+			expect(endSpy).toHaveBeenCalledTimes(1);
+			expect(endSpy.mock.contexts[0]).toBe(replacementClient);
+			expect(sshClientsManager.clients.size).toBe(0);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/ssh-clients-manager.ts
+++ b/packages/core/src/execution-engine/ssh-clients-manager.ts
@@ -147,7 +147,12 @@ export class SSHClientsManager {
 		});
 		this.clientsReversed.set(sshClient, clientHash);
 
-		return await returnPromise;
+		try {
+			return await returnPromise;
+		} catch (error) {
+			this.cleanupClient(clientHash, sshClient);
+			throw error;
+		}
 	}
 
 	/**
@@ -157,30 +162,31 @@ export class SSHClientsManager {
 	private withCleanupHandler(sshClient: Client, abortController: AbortController, key: string) {
 		sshClient.on('error', (error) => {
 			this.logger.error('encountered error, calling cleanup', { error });
-			this.cleanupClient(key);
+			this.cleanupClient(key, sshClient);
 		});
 		sshClient.on('end', () => {
 			this.logger.debug('socket was disconnected, calling abort signal', {});
-			this.cleanupClient(key);
+			this.cleanupClient(key, sshClient);
 		});
 		sshClient.on('close', () => {
 			this.logger.debug('socket was closed, calling abort signal', {});
-			this.cleanupClient(key);
+			this.cleanupClient(key, sshClient);
 		});
 		abortController.signal.addEventListener('abort', () => {
 			this.logger.debug('Got abort signal, cleaning up ssh client.', {
 				reason: abortController.signal.reason,
 			});
-			this.cleanupClient(key);
+			this.cleanupClient(key, sshClient);
 		});
 
 		return sshClient;
 	}
 
-	private cleanupClient(key: string) {
+	private cleanupClient(key: string, expectedClient?: Client) {
 		const registration = this.clients.get(key);
-		if (registration) {
+		if (registration && (!expectedClient || registration.client === expectedClient)) {
 			this.clients.delete(key);
+			this.clientsReversed.delete(registration.client);
 			registration.client.end();
 			if (!registration.abortController.signal.aborted) {
 				registration.abortController.abort();


### PR DESCRIPTION
## Summary

A disconnected SSH client can emit a delayed close, end, or error event after a replacement client starts with the same settings. Cleanup previously selected the replacement by its configuration hash and closed it. Pass the source client into cleanup and check its identity before removing a registration.

Remove the reverse mapping during cleanup so an old client cannot update the replacement's idle timestamp. Also remove a registration when its connection promise rejects. A later request can then attempt a new connection instead of reusing a rejected promise.

This change is limited to the SSH client manager and its unit tests.

## How to test

From packages/core, run:

```sh
pnpm test src/execution-engine/__tests__/ssh-clients-manager.test.ts
pnpm lint
pnpm typecheck
```

The suite covers:

- A delayed close, end, or error event from an old client leaves its replacement registered and keeps the replacement's abort controller active.
- A usage update from the old client does not extend the replacement's idle lifetime.
- A synchronous connection failure clears the cache and reverse mapping. A later call with the same settings creates a new client.

To reproduce without the fix, apply only this PR's test-file changes to master and run the same test command. Against base revision 909a6bc60aaaf926653a5f802f6a503f73c2a439, 5 cases fail and 18 pass. With the production change, all 23 pass. The checks use mocked SSH transport and a fake clock; no external server is required.

Local validation:

- Focused unit suite: 23 passed.
- Full repository build: 70 tasks passed.
- Changed-file Biome check and git diff --check: passed.
- Full repository typecheck: passed (139 tasks, including dependency builds).
- Core package lint: passed.
- Repository lint: all tasks passed across the full run and retry. The first run reached 130 successful tasks, then n8n-nodes-base exceeded Node's default heap limit. The three remaining tasks passed when run sequentially with an 8 GB heap.
- Node.js 24.1.0 and pnpm 11.25.0 on macOS.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/37896.

Related implementation history: https://github.com/n8n-io/n8n/pull/16054.

This draft requests maintainer feedback on the core change.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


🤖 PR Summary generated by AI
