### PR TITLE
fix(editor): Clear tag loading state after failed requests

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/tags/tags.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/tags/tags.store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
-import { useTagsStore } from './tags.store';
+import { useAnnotationTagsStore, useTagsStore } from './tags.store';
 import { mockedStore } from '@/__tests__/utils';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import type { ITag } from '@n8n/rest-api-client/api/tags';
@@ -29,6 +29,85 @@ vi.mock('./tags.api', () => ({
 }));
 
 const mockTag: ITag = { id: '1', name: 'test-tag', usageCount: 0, createdAt: '', updatedAt: '' };
+
+describe.each([
+	['useTagsStore', useTagsStore],
+	['useAnnotationTagsStore', useAnnotationTagsStore],
+])('%s — fetchAll loading state', (_, useStore) => {
+	let tagsStore: ReturnType<typeof useTagsStore>;
+
+	beforeEach(() => {
+		createTestingPinia({ stubActions: false });
+		vi.clearAllMocks();
+		mockApi.getTags.mockReset();
+		hasPermission.mockReturnValue(true);
+		const rootStore = mockedStore(useRootStore);
+		rootStore.restApiContext = { baseUrl: 'http://localhost', pushRef: '' };
+		tagsStore = useStore();
+	});
+
+	it('sets loading while the request is pending and clears it after success', async () => {
+		const request = Promise.withResolvers<ITag[]>();
+		mockApi.getTags.mockReturnValueOnce(request.promise);
+
+		expect(tagsStore.isLoading).toBe(false);
+
+		const result = tagsStore.fetchAll();
+
+		expect(tagsStore.isLoading).toBe(true);
+
+		request.resolve([mockTag]);
+
+		await expect(result).resolves.toEqual([mockTag]);
+		expect(tagsStore.isLoading).toBe(false);
+		expect(tagsStore.allTags).toEqual([mockTag]);
+	});
+
+	it('clears loading after a failed request and allows a successful retry', async () => {
+		const request = Promise.withResolvers<ITag[]>();
+		const error = new Error('Could not load tags');
+		mockApi.getTags.mockReturnValueOnce(request.promise);
+
+		const result = tagsStore.fetchAll();
+		const rejection = expect(result).rejects.toBe(error);
+
+		expect(tagsStore.isLoading).toBe(true);
+
+		request.reject(error);
+
+		await rejection;
+		expect(tagsStore.isLoading).toBe(false);
+
+		const retryRequest = Promise.withResolvers<ITag[]>();
+		mockApi.getTags.mockReturnValueOnce(retryRequest.promise);
+
+		const retry = tagsStore.fetchAll();
+
+		expect(tagsStore.isLoading).toBe(true);
+
+		retryRequest.resolve([mockTag]);
+
+		await expect(retry).resolves.toEqual([mockTag]);
+		expect(tagsStore.isLoading).toBe(false);
+		expect(tagsStore.allTags).toEqual([mockTag]);
+		expect(mockApi.getTags).toHaveBeenCalledTimes(2);
+	});
+
+	it('keeps cached tags and clears loading after a failed forced refresh', async () => {
+		mockApi.getTags.mockResolvedValueOnce([mockTag]);
+		await tagsStore.fetchAll();
+
+		const error = new Error('Could not refresh tags');
+		mockApi.getTags.mockRejectedValueOnce(error);
+
+		await expect(tagsStore.fetchAll({ force: true })).rejects.toBe(error);
+
+		expect(tagsStore.isLoading).toBe(false);
+		expect(tagsStore.allTags).toEqual([mockTag]);
+		await expect(tagsStore.fetchAll()).resolves.toEqual([mockTag]);
+		expect(mockApi.getTags).toHaveBeenCalledTimes(2);
+	});
+});
 
 describe('useTagsStore — permission guards', () => {
 	let tagsStore: ReturnType<typeof useTagsStore>;

--- a/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
@@ -105,12 +105,15 @@ const createTagsStore = (id: typeof STORES.TAGS | typeof STORES.ANNOTATION_TAGS)
 				}
 
 				loading.value = true;
-				const retrievedTags = await tagsApi.getTags(rootStore.restApiContext, {
-					withUsageCount,
-				});
-				setAllTags(retrievedTags);
-				loading.value = false;
-				return retrievedTags;
+				try {
+					const retrievedTags = await tagsApi.getTags(rootStore.restApiContext, {
+						withUsageCount,
+					});
+					setAllTags(retrievedTags);
+					return retrievedTags;
+				} finally {
+					loading.value = false;
+				}
 			};
 
 			const create = async (


### PR DESCRIPTION
## Summary

A failed tag-list request leaves the tag store in a loading state. When the tag manager already has tags, the error message can appear while search and Add new remain disabled and the table keeps its loading overlay.

Reset loading in `finally` so it clears after success or failure. Keep the original error for the caller. Keep cached tags when a refresh fails. The shared implementation covers workflow tags and execution annotation tags.

## How to test

From `packages/frontend/editor-ui`, run:

```sh
pnpm test src/features/shared/tags/tags.store.test.ts src/features/shared/tags/components/WorkflowTagsDropdown.test.ts src/features/shared/tags/components/TagsDropdown.innerSelect.test.ts src/features/shared/tags/components/TagsManager/TagsView/TagsTableHeader.test.ts
pnpm lint
pnpm typecheck
```

The six new cases cover both store types:

- Loading stays active while a request is pending and clears after success.
- A rejected request clears loading and propagates the same error. A later request succeeds.
- A failed forced refresh clears loading and keeps cached tags available.

Apply only this PR's test-file changes to base revision `909a6bc60aaaf926653a5f802f6a503f73c2a439` to reproduce the failure. Run the tag-store suite. Four cases fail and ten pass. Each failure shows that `isLoading` remains `true` after the API rejects. With the production fix, all 14 store cases pass. The 12 related component cases also pass.

The tests mock the tag API. No live service is required. Browser interaction was not used for validation. The UI effects in the summary follow from the component bindings.

Local validation also passed editor lint and typecheck, repository typecheck, and repository lint. The repository lint check combined package checks, 129 successful tasks, and two valid cached results. The initial main run reached Node's default heap limit in the CLI package. Recovery used an 8 GB heap setting.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/37900.

Internal tracking: https://linear.app/n8n/issue/GHC-9417.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

