### PR TITLE
fix(editor): Keep CSV imports tied to the selected file

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.test.ts
@@ -1,8 +1,27 @@
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
+import { mockedStore } from '@n8n/frontend-test-utils';
+import userEvent from '@testing-library/user-event';
+import { flushPromises } from '@vue/test-utils';
 import { vi } from 'vitest';
 import ImportCsvModal from '@/features/core/dataTable/components/ImportCsvModal.vue';
 import type { DataTable } from '@/features/core/dataTable/dataTable.types';
+import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
+import { useUIStore } from '@/app/stores/ui.store';
+
+const { showError, showMessage, track } = vi.hoisted(() => ({
+	showError: vi.fn(),
+	showMessage: vi.fn(),
+	track: vi.fn(),
+}));
+
+vi.mock('@n8n/composables/useToast', () => ({
+	useToast: () => ({ showError, showMessage }),
+}));
+
+vi.mock('@n8n/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track }),
+}));
 
 const ModalStub = {
 	template: `
@@ -69,10 +88,50 @@ const renderComponent = createComponentRenderer(ImportCsvModal, {
 	},
 });
 
+type UploadResponse = Awaited<ReturnType<ReturnType<typeof useDataTableStore>['uploadCsvFile']>>;
+
+const firstFile = new File(['name,age\nFirst,1'], 'first.csv', { type: 'text/csv' });
+const secondFile = new File(['name,age\nSecond,2'], 'second.csv', { type: 'text/csv' });
+const uploadResponse = (id: string): UploadResponse => ({
+	id,
+	originalName: `${id}.csv`,
+	rowCount: 1,
+	columnCount: 2,
+	columns: [
+		{ name: 'name', type: 'string', compatibleTypes: ['string'] },
+		{ name: 'age', type: 'number', compatibleTypes: ['number'] },
+	],
+});
+
+function renderUploads() {
+	const first = Promise.withResolvers<UploadResponse>();
+	const second = Promise.withResolvers<UploadResponse>();
+	const store = mockedStore(useDataTableStore);
+	store.uploadCsvFile.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+	store.importCsvToDataTable.mockResolvedValue({
+		importedRowCount: 1,
+		systemColumnsIgnored: [],
+	});
+	const rendered = renderComponent();
+	const input = rendered.getByTestId('import-csv-upload').querySelector('input');
+	if (!input) throw new Error('Upload input is missing');
+
+	return {
+		...rendered,
+		first,
+		second,
+		store,
+		input,
+		user: userEvent.setup(),
+		importButton: rendered.getByTestId('import-csv-confirm'),
+	};
+}
+
 describe('ImportCsvModal', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		createTestingPinia();
+		mockedStore(useUIStore).modalsById = { 'import-csv-modal': { open: true } };
 	});
 
 	it('should render the upload area', () => {
@@ -88,10 +147,155 @@ describe('ImportCsvModal', () => {
 
 	it('should emit close when cancel is clicked', async () => {
 		const { getByTestId, emitted } = renderComponent();
-		const { default: userEvent } = await import('@testing-library/user-event');
 
 		await userEvent.click(getByTestId('import-csv-cancel'));
 
 		expect(emitted().close).toBeTruthy();
+	});
+
+	it('should import the completed upload', async () => {
+		const { user, input, first, store, importButton, emitted } = renderUploads();
+		await user.upload(input, firstFile);
+		expect(store.uploadCsvFile).toHaveBeenCalledWith(firstFile, true);
+		expect(importButton).toBeDisabled();
+
+		first.resolve(uploadResponse('first'));
+		await flushPromises();
+		await user.click(importButton);
+
+		expect(store.importCsvToDataTable).toHaveBeenCalledWith('dt-1', 'proj-1', 'first');
+		expect(emitted().imported).toHaveLength(1);
+	});
+
+	it('should block import until a replacement upload completes', async () => {
+		const { user, input, first, second, store, importButton, getByText, queryByTestId } =
+			renderUploads();
+		await user.upload(input, firstFile);
+		first.resolve(uploadResponse('first'));
+		await flushPromises();
+		expect(importButton).toBeEnabled();
+
+		await user.upload(input, secondFile);
+		expect(getByText('second.csv')).toBeInTheDocument();
+		expect(getByText('Uploading...')).toBeInTheDocument();
+		expect(queryByTestId('import-csv-ready-to-import')).not.toBeInTheDocument();
+		expect(importButton).toBeDisabled();
+		await user.click(importButton);
+		expect(store.importCsvToDataTable).not.toHaveBeenCalled();
+
+		second.resolve(uploadResponse('second'));
+		await flushPromises();
+		await user.click(importButton);
+		expect(store.importCsvToDataTable).toHaveBeenCalledWith('dt-1', 'proj-1', 'second');
+	});
+
+	it('should keep the replacement when an earlier upload completes last', async () => {
+		const { user, input, first, second, store, importButton, getByText } = renderUploads();
+		await user.upload(input, firstFile);
+		await user.upload(input, secondFile);
+		second.resolve(uploadResponse('second'));
+		await flushPromises();
+		first.resolve(uploadResponse('first'));
+		await flushPromises();
+
+		expect(getByText('second.csv')).toBeInTheDocument();
+		await user.click(importButton);
+		expect(store.importCsvToDataTable).toHaveBeenCalledWith('dt-1', 'proj-1', 'second');
+	});
+
+	it('should keep the replacement when an earlier upload fails', async () => {
+		const { user, input, first, second, store, importButton, getByText } = renderUploads();
+		await user.upload(input, firstFile);
+		await user.upload(input, secondFile);
+		second.resolve(uploadResponse('second'));
+		await flushPromises();
+		first.reject(new Error('Earlier upload failed'));
+		await flushPromises();
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(getByText('second.csv')).toBeInTheDocument();
+		expect(importButton).toBeEnabled();
+		await user.click(importButton);
+		expect(store.importCsvToDataTable).toHaveBeenCalledWith('dt-1', 'proj-1', 'second');
+	});
+
+	it('should keep loading when an earlier upload completes before the replacement', async () => {
+		const { user, input, first, second, importButton, getByText, queryByText } = renderUploads();
+		await user.upload(input, firstFile);
+		await user.upload(input, secondFile);
+		first.resolve(uploadResponse('first'));
+		await flushPromises();
+
+		expect(getByText('Uploading...')).toBeInTheDocument();
+		expect(importButton).toBeDisabled();
+		second.resolve(uploadResponse('second'));
+		await flushPromises();
+		expect(queryByText('Uploading...')).not.toBeInTheDocument();
+		expect(importButton).toBeEnabled();
+	});
+
+	it('should clear loading and report the current upload failure', async () => {
+		const { user, input, first, importButton, queryByText, getByText } = renderUploads();
+		await user.upload(input, firstFile);
+		const error = new Error('Upload failed');
+		first.reject(error);
+		await flushPromises();
+
+		expect(showError).toHaveBeenCalledWith(error, 'dataTable.upload.error');
+		expect(queryByText('Uploading...')).not.toBeInTheDocument();
+		expect(getByText('Drop file here or click to upload')).toBeInTheDocument();
+		expect(importButton).toBeDisabled();
+	});
+
+	it.each([
+		['cancel', 'success'],
+		['cancel', 'error'],
+		['modal close', 'success'],
+		['modal close', 'error'],
+	])('should ignore a late upload result after %s (%s)', async (resetAction, outcome) => {
+		const { user, input, first, importButton, getByTestId, queryByText, getByText } =
+			renderUploads();
+		await user.upload(input, firstFile);
+		if (resetAction === 'cancel') {
+			await user.click(getByTestId('import-csv-cancel'));
+		} else {
+			mockedStore(useUIStore).modalsById = { 'import-csv-modal': { open: false } };
+			await flushPromises();
+		}
+		expect(queryByText('Uploading...')).not.toBeInTheDocument();
+
+		if (outcome === 'success') first.resolve(uploadResponse('first'));
+		else first.reject(new Error('Upload failed after close'));
+		await flushPromises();
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(getByText('Drop file here or click to upload')).toBeInTheDocument();
+		expect(queryByText('Uploading...')).not.toBeInTheDocument();
+		expect(importButton).toBeDisabled();
+	});
+
+	it('should ignore an upload error after unmount', async () => {
+		const { user, input, first, unmount } = renderUploads();
+		await user.upload(input, firstFile);
+		unmount();
+		first.reject(new Error('Upload failed after unmount'));
+		await flushPromises();
+
+		expect(showError).not.toHaveBeenCalled();
+	});
+
+	it('should distinguish uploads with the same filename', async () => {
+		const { user, input, first, second, store, importButton } = renderUploads();
+		const replacement = new File(['name,age\nUpdated,2'], firstFile.name, { type: 'text/csv' });
+		await user.upload(input, firstFile);
+		await user.upload(input, replacement);
+		expect(store.uploadCsvFile).toHaveBeenCalledTimes(2);
+		second.resolve(uploadResponse('second'));
+		await flushPromises();
+		first.resolve(uploadResponse('first'));
+		await flushPromises();
+		await user.click(importButton);
+
+		expect(store.importCsvToDataTable).toHaveBeenCalledWith('dt-1', 'proj-1', 'second');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.vue
@@ -1,10 +1,11 @@
 <script lang="ts" setup>
 import { useI18n } from '@n8n/i18n';
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onBeforeUnmount } from 'vue';
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useToast } from '@n8n/composables/useToast';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
+import { useLatestFetch } from '@/app/composables/useLatestFetch';
 import { DATA_TABLE_SYSTEM_COLUMNS } from 'n8n-workflow';
 
 import { N8nButton, N8nIcon, N8nText, N8nCallout } from '@n8n/design-system';
@@ -30,6 +31,7 @@ const uiStore = useUIStore();
 const i18n = useI18n();
 const toast = useToast();
 const telemetry = useTelemetry();
+const { next: nextUpload } = useLatestFetch();
 
 const selectedFile = ref<File | null>(null);
 const uploadedFileId = ref<string | null>(null);
@@ -57,6 +59,7 @@ const canImport = computed(() => {
 		uploaded.value &&
 		matchedColumns.value.length > 0 &&
 		unrecognizedColumns.value.length === 0 &&
+		!isUploading.value &&
 		!isImporting.value
 	);
 });
@@ -69,16 +72,22 @@ const handleFileChange = (uploadFile: UploadFile) => {
 };
 
 const processUpload = async () => {
-	if (!selectedFile.value) return;
+	const file = selectedFile.value;
+	if (!file) return;
 
+	const isCurrent = nextUpload();
 	isUploading.value = true;
+	uploadedFileId.value = null;
+	csvRowCount.value = 0;
+	matchedColumns.value = [];
+	unrecognizedColumns.value = [];
+
 	try {
-		const response = await dataTableStore.uploadCsvFile(selectedFile.value, true);
+		const response = await dataTableStore.uploadCsvFile(file, true);
+		if (!isCurrent()) return;
+
 		uploadedFileId.value = response.id;
 		csvRowCount.value = response.rowCount;
-
-		matchedColumns.value = [];
-		unrecognizedColumns.value = [];
 
 		for (const csvCol of response.columns) {
 			if (DATA_TABLE_SYSTEM_COLUMNS.includes(csvCol.name)) {
@@ -90,10 +99,12 @@ const processUpload = async () => {
 			}
 		}
 	} catch (error) {
+		if (!isCurrent()) return;
+
 		toast.showError(error, i18n.baseText('dataTable.upload.error'));
 		reset();
 	} finally {
-		isUploading.value = false;
+		if (isCurrent()) isUploading.value = false;
 	}
 };
 
@@ -133,6 +144,8 @@ const onImport = async () => {
 };
 
 const reset = () => {
+	nextUpload();
+	isUploading.value = false;
 	selectedFile.value = null;
 	uploadedFileId.value = null;
 	csvRowCount.value = 0;
@@ -152,6 +165,10 @@ const onClose = () => {
 	reset();
 	emit('close');
 };
+
+onBeforeUnmount(() => {
+	nextUpload();
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/ImportCsvModal.vue
@@ -64,6 +64,13 @@ const canImport = computed(() => {
 	);
 });
 
+const clearUploadMetadata = () => {
+	uploadedFileId.value = null;
+	csvRowCount.value = 0;
+	matchedColumns.value = [];
+	unrecognizedColumns.value = [];
+};
+
 const handleFileChange = (uploadFile: UploadFile) => {
 	if (uploadFile.raw) {
 		selectedFile.value = uploadFile.raw;
@@ -77,10 +84,7 @@ const processUpload = async () => {
 
 	const isCurrent = nextUpload();
 	isUploading.value = true;
-	uploadedFileId.value = null;
-	csvRowCount.value = 0;
-	matchedColumns.value = [];
-	unrecognizedColumns.value = [];
+	clearUploadMetadata();
 
 	try {
 		const response = await dataTableStore.uploadCsvFile(file, true);
@@ -104,6 +108,7 @@ const processUpload = async () => {
 		toast.showError(error, i18n.baseText('dataTable.upload.error'));
 		reset();
 	} finally {
+		// On a current failure, reset() advances the generation and clears isUploading.
 		if (isCurrent()) isUploading.value = false;
 	}
 };
@@ -147,10 +152,7 @@ const reset = () => {
 	nextUpload();
 	isUploading.value = false;
 	selectedFile.value = null;
-	uploadedFileId.value = null;
-	csvRowCount.value = 0;
-	matchedColumns.value = [];
-	unrecognizedColumns.value = [];
+	clearUploadMetadata();
 };
 
 const isModalOpen = computed(() => uiStore.modalsById[props.modalName]?.open);


### PR DESCRIPTION
## Summary

Replacing a CSV in the data-table import dialog can leave the previous upload ID active. Import can then send the old file ID while the dialog displays the new file's name. An older upload that finishes last can cause the same result after both uploads complete.

Clear completed upload metadata when a new upload starts. Disable Import until the current upload is ready. Reuse `useLatestFetch` to guard upload results, errors, and loading cleanup. Invalidate pending uploads when the dialog resets or the component unmounts.

Codex assisted with the implementation, regression tests, and draft text.

## How to test

From `packages/frontend/editor-ui`, run:

```sh
pnpm test src/features/core/dataTable/components/ImportCsvModal.test.ts src/app/composables/useLatestFetch.test.ts
pnpm lint
pnpm typecheck
```

The component tests use the real upload control and deferred API responses. They cover file replacement, reversed response order, old errors, loading state, dialog reset, unmount, and files with the same name. The import assertion checks the current file ID sent to the store action.

For manual verification, use an existing data table with `name` and `age` columns. Upload A.csv, then replace it with B.csv while delaying B's response. Import must stay disabled until B is ready. Complete B before A in a separate run. Import must still use B after both responses arrive.

Automated validation uses a rendered test DOM and mocked API actions. No live browser, backend, or database was used. See the linked issue for sample CSV contents and detailed steps.

Validation results:

- Base revision `33eb5c196e0ce3a2c71525929a4ef861cb94b168` with the regression tests: 10 failed and 9 passed. The failures reproduce the enabled Import button and the old file ID.
- Fixed revision: 19 passed. This includes 15 component tests and 4 existing helper tests.
- Editor lint and typecheck: passed.
- Repository lint and typecheck: passed. The run for the other packages completed all 208 tasks, including dependency builds. The editor checks ran separately.
- Repository style lint: passed. All 7 tasks completed.
- Biome, Prettier, and Git whitespace checks: passed.

The full repository test suite was not run.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/37905

https://linear.app/n8n/issue/GHC-9419

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

