### PR TITLE
fix(editor): Preserve node parameters when serialization cannot normalize them

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.test.ts
@@ -445,6 +445,33 @@ describe('serializeNode', () => {
 		expect(normalizedNode).not.toHaveProperty('webhookId');
 	});
 
+	it('preserves parameters when parameter normalization returns null', () => {
+		const knownNodeType = {
+			name: 'n8n-nodes-base.ssh',
+			displayName: 'SSH',
+			version: 1,
+			description: '',
+			defaults: { name: 'SSH' },
+			inputs: ['main'],
+			outputs: ['main'],
+			properties: [],
+			group: ['input'],
+		} as INodeTypeDescription;
+		nodeTypeProvider.getNodeType.mockReturnValue(knownNodeType);
+		vi.mocked(NodeHelpers.getNodeParameters).mockReturnValue(null);
+
+		const parameters = {
+			authentication: 'privateKey',
+			resource: 'command',
+			operation: 'execute',
+			command: 'python3 -c "print(1)"',
+			cwd: '/srv/app',
+		};
+		const node = createNode({ type: knownNodeType.name, parameters });
+
+		expect(serializeNode(nodeTypeProvider, node).parameters).toEqual(parameters);
+	});
+
 	describe('credential filtering', () => {
 		// Mirrors how the HTTP Request node declares credentials: only httpSslAuth is
 		// declared; generic/predefined auth types come from the genericAuthType and

--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
@@ -232,7 +232,7 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 			node,
 			nodeType,
 		);
-		nodeData.parameters = nodeParameters !== null ? nodeParameters : {};
+		nodeData.parameters = nodeParameters !== null ? nodeParameters : nodeParametersInput;
 
 		// Add the node credentials if there are some set and if they should be displayed
 		if (


### PR DESCRIPTION
## Summary

Preserve existing node parameters when workflow serialization cannot normalize them. This prevents untouched node configuration from being replaced with an empty object when another node is edited and the workflow is saved.

## How to test

From `packages/frontend/editor-ui`, run:

`pnpm test src/app/utils/nodes/nodeTransforms.test.ts`

The regression test covers a known SSH node whose parameter normalization returns `null`.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #37688

## Reviewers

Jan Kalkan, Tuukka Kantola

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

