### PR TITLE
test: Add correlated startup telemetry

### DIFF
--- a/.github/CI-TELEMETRY.md
+++ b/.github/CI-TELEMETRY.md
@@ -48,8 +48,9 @@ Container startup payloads also include:
 `attempt_id` identifies one stack startup. Join all stage records and attached
 Playwright startup evidence with this value. `outcome` is `success`, `failure`,
 or `cancelled`. Stage durations are also sent as `stack-startup-stage` metrics
-with `attempt_id`, `stage`, `source`, and `outcome` dimensions. Missing
-correlation values stay `null`; they are not inferred.
+with `attempt_id`, `stage`, `source`, and `outcome` dimensions. `profile` is
+resolved from the configured profile or stack shape. Other unavailable
+correlation values stay `null`.
 
 ## Standard Context Fields
 

--- a/.github/CI-TELEMETRY.md
+++ b/.github/CI-TELEMETRY.md
@@ -19,6 +19,38 @@ All telemetry uses the same format:
 }
 ```
 
+Container startup payloads also include:
+
+```json
+{
+  "attempt_id": "uuid",
+  "correlation": {
+    "profile": "sqlite",
+    "shard": "3",
+    "worker": "2",
+    "retry": 1,
+    "restartReason": null
+  },
+  "stages": [
+    {
+      "name": "n8n-startup",
+      "source": "local",
+      "startedAt": "2026-03-16T12:00:00.000Z",
+      "elapsedMs": 4200,
+      "outcome": "failure",
+      "errorMessage": "readiness failed"
+    }
+  ],
+  "failure_phase": "n8n-startup"
+}
+```
+
+`attempt_id` identifies one stack startup. Join all stage records and attached
+Playwright startup evidence with this value. `outcome` is `success`, `failure`,
+or `cancelled`. Stage durations are also sent as `stack-startup-stage` metrics
+with `attempt_id`, `stage`, `source`, and `outcome` dimensions. Missing
+correlation values stay `null`; they are not inferred.
+
 ## Standard Context Fields
 
 ```typescript

--- a/packages/testing/containers/helpers/utils.ts
+++ b/packages/testing/containers/helpers/utils.ts
@@ -72,7 +72,7 @@ export function createReadinessProbe(
 
 /**
  * Polls a container's HTTP endpoint until it returns a 200 status.
- * Logs a warning if the endpoint does not return 200 within the specified timeout.
+ * Throws if the endpoint does not return 200 within the specified timeout.
  *
  * @param container The started container.
  * @param endpoint The HTTP health check endpoint (e.g., '/healthz/readiness').
@@ -100,10 +100,9 @@ export async function pollContainerHttpEndpoint(
 		await wait(retryIntervalMs);
 	}
 
-	console.error(
-		`WARNING: HTTP endpoint at ${url} did not return 200 within ${
-			timeoutMs / 1000
-		} seconds. Proceeding with caution.`,
+	console.error(`HTTP endpoint at ${url} did not return 200 within ${timeoutMs / 1000} seconds.`);
+	throw new Error(
+		`HTTP endpoint at ${url} did not become ready within ${timeoutMs / 1000} seconds`,
 	);
 }
 

--- a/packages/testing/containers/services/n8n.ts
+++ b/packages/testing/containers/services/n8n.ts
@@ -26,6 +26,7 @@ const N8N_STARTUP_TIMEOUT_MS = 60_000;
 const N8N_READ_TIMEOUT_MS = 250;
 
 export interface N8NStartupDiagnostics {
+	attemptId?: string;
 	logs: Record<string, string>;
 	readinessPayloads: Record<string, string | null>;
 }
@@ -63,6 +64,7 @@ const BASE_ENV: Record<string, string> = {
 };
 
 export interface N8NInstancesOptions {
+	attemptId?: string;
 	mains: number;
 	workers: number;
 	/** Dedicated `n8n webhook` procs. Forces queue mode when > 0. */
@@ -260,6 +262,7 @@ export async function createN8NInstances(
 	options: N8NInstancesOptions,
 ): Promise<N8NInstancesResult> {
 	const {
+		attemptId,
 		mains,
 		workers,
 		webhooks = 0,
@@ -276,7 +279,7 @@ export async function createN8NInstances(
 	const log = createElapsedLogger('n8n-instances');
 	const environment = computeEnvironment(options);
 	const containers: StartedTestContainer[] = [];
-	const diagnostics: N8NStartupDiagnostics = { logs: {}, readinessPayloads: {} };
+	const diagnostics: N8NStartupDiagnostics = { attemptId, logs: {}, readinessPayloads: {} };
 
 	const mainShared: SharedConfig = {
 		projectName,

--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -9,8 +9,12 @@ import {
 } from './helpers/utils';
 import { waitForNetworkQuiet } from './network-stabilization';
 import type { LoadBalancerResult } from './services/load-balancer';
-import type { N8NStartupDiagnostics } from './services/n8n';
-import { createN8NInstances, N8NStartupError } from './services/n8n';
+import {
+	createN8NInstances,
+	N8NStartupError,
+	type N8NInstancesResult,
+	type N8NStartupDiagnostics,
+} from './services/n8n';
 import { helperFactories, services } from './services/registry';
 import type { TaskRunnerResult } from './services/task-runner';
 import type {
@@ -32,6 +36,7 @@ const SERVICE_REGISTRY: Record<ServiceName, Service> = services;
 export type N8NConfig = StackConfig;
 
 export interface N8NStack {
+	attemptId: string;
 	baseUrl: string;
 	projectName: string;
 	stop: () => Promise<void>;
@@ -135,11 +140,15 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 
 	let network: StartedNetwork;
 	try {
+		telemetry.startStage('network');
 		const networkStart = performance.now();
 		const uuid = networkName ? { nextUuid: () => networkName } : undefined;
 		network = await new Network(uuid).start();
 		telemetry.recordNetwork(Math.round(performance.now() - networkStart));
+		telemetry.finishStage();
 	} catch (error) {
+		telemetry.finishStage('failure', error);
+		telemetry.setFailurePhase('network');
 		const message = error instanceof Error ? error.message : String(error);
 		telemetry.flush(false, `Network creation failed: ${message}`);
 		throw error;
@@ -178,7 +187,15 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		// env and starts nothing. A service that declines (no config, or the
 		// deployment did not answer) falls through to its local containers below.
 		for (const name of requestedServices) {
-			const hostedEnv = await SERVICE_REGISTRY[name].hostedEnv?.(ctx);
+			telemetry.startStage(`hosted:${name}`, 'hosted');
+			let hostedEnv: Record<string, string> | undefined;
+			try {
+				hostedEnv = await SERVICE_REGISTRY[name].hostedEnv?.(ctx);
+				telemetry.finishStage();
+			} catch (error) {
+				telemetry.finishStage('failure', error);
+				throw error;
+			}
 			if (!hostedEnv) continue;
 			environment = { ...environment, ...hostedEnv };
 			hostedServiceEnv[name] = hostedEnv;
@@ -196,12 +213,15 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 			const service = SERVICE_REGISTRY[name];
 			const options = service.getOptions?.(ctx);
 			const serviceStart = performance.now();
+			telemetry.startStage(`service:${name}`);
 			try {
 				const result = await service.start(network, uniqueProjectName, options, ctx);
 				telemetry.recordService(name, Math.round(performance.now() - serviceStart));
+				telemetry.finishStage();
 				return { name, service, result };
 			} catch (error) {
 				telemetry.recordService(name, Math.round(performance.now() - serviceStart));
+				telemetry.finishStage('failure', error);
 				const message = error instanceof Error ? error.message : String(error);
 				throw new Error(`Service "${service.description}" (${name}) failed to start: ${message}`);
 			}
@@ -250,23 +270,32 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		// Earliest log line the readiness gate below may accept
 		const n8nStartedAtSeconds = Math.floor(Date.now() / 1000);
 		const n8nStartupStart = performance.now();
-		const n8nResult = await createN8NInstances({
-			mains,
-			workers,
-			webhooks,
-			projectName: uniqueProjectName,
-			network,
-			serviceEnvironment: environment,
-			userEnvironment: env,
-			usePostgres,
-			baseUrl: needsLoadBalancer ? undefined : baseUrl,
-			allocatedPort: needsLoadBalancer ? undefined : allocatedMainPort,
-			resourceQuota,
-			workerResourceQuota,
-			webhookResourceQuota,
-			filesToMount,
-			coverageHostDir,
-		});
+		telemetry.startStage('n8n-startup');
+		let n8nResult: N8NInstancesResult;
+		try {
+			n8nResult = await createN8NInstances({
+				attemptId: telemetry.attemptId,
+				mains,
+				workers,
+				webhooks,
+				projectName: uniqueProjectName,
+				network,
+				serviceEnvironment: environment,
+				userEnvironment: env,
+				usePostgres,
+				baseUrl: needsLoadBalancer ? undefined : baseUrl,
+				allocatedPort: needsLoadBalancer ? undefined : allocatedMainPort,
+				resourceQuota,
+				workerResourceQuota,
+				webhookResourceQuota,
+				filesToMount,
+				coverageHostDir,
+			});
+			telemetry.finishStage();
+		} catch (error) {
+			telemetry.finishStage('failure', error);
+			throw error;
+		}
 		containers.push(...n8nResult.containers);
 		telemetry.recordN8nStartup(
 			Math.round(performance.now() - n8nStartupStart),
@@ -275,7 +304,14 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		log(`n8n ready: ${mains} main(s), ${webhooks} webhook(s), ${workers} worker(s)`);
 
 		if (lbResult) {
-			await pollContainerHttpEndpoint(lbResult.container, '/healthz/readiness');
+			telemetry.startStage('load-balancer-readiness');
+			try {
+				await pollContainerHttpEndpoint(lbResult.container, '/healthz/readiness');
+				telemetry.finishStage();
+			} catch (error) {
+				telemetry.finishStage('failure', error);
+				throw error;
+			}
 			log('Load balancer ready');
 		}
 
@@ -288,14 +324,21 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		// other, and only from this run, since a reused container keeps its old logs.
 		const taskRunnerResult = serviceResults.taskRunner as TaskRunnerResult | undefined;
 		if (taskRunnerResult) {
-			await waitForContainerLogMessages(
-				taskRunnerResult.container,
-				[
-					/\[launcher:js\].*Received message `broker:runnerregistered`/,
-					/\[launcher:py\].*Received message `broker:runnerregistered`/,
-				],
-				{ since: n8nStartedAtSeconds },
-			);
+			telemetry.startStage('task-runner-registration');
+			try {
+				await waitForContainerLogMessages(
+					taskRunnerResult.container,
+					[
+						/\[launcher:js\].*Received message `broker:runnerregistered`/,
+						/\[launcher:py\].*Received message `broker:runnerregistered`/,
+					],
+					{ since: n8nStartedAtSeconds },
+				);
+				telemetry.finishStage();
+			} catch (error) {
+				telemetry.finishStage('failure', error);
+				throw error;
+			}
 			log('Task runners registered with broker');
 		}
 
@@ -327,7 +370,14 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		for (const name of servicesToStart) {
 			const service = SERVICE_REGISTRY[name];
 			if (service.verifyFromN8n && serviceResults[name]) {
-				await service.verifyFromN8n(serviceResults[name], n8nContainers);
+				telemetry.startStage(`verify:${name}`);
+				try {
+					await service.verifyFromN8n(serviceResults[name], n8nContainers);
+					telemetry.finishStage();
+				} catch (error) {
+					telemetry.finishStage('failure', error);
+					throw error;
+				}
 				verifications.push(service.description);
 			}
 		}
@@ -335,7 +385,14 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 			log(`Verified: ${verifications.join(', ')}`);
 		}
 
-		await waitForNetworkQuiet();
+		telemetry.startStage('network-quiet');
+		try {
+			await waitForNetworkQuiet();
+			telemetry.finishStage();
+		} catch (error) {
+			telemetry.finishStage('failure', error);
+			throw error;
+		}
 		telemetry.flush(true);
 
 		const helperCtx: HelperContext = {
@@ -377,6 +434,7 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		});
 
 		return {
+			attemptId: telemetry.attemptId,
 			baseUrl,
 			projectName: uniqueProjectName,
 			stop: async () => await stopN8NStack(containers, network, uniqueProjectName, coverageHostDir),
@@ -406,8 +464,14 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (error instanceof N8NStartupError) {
-			recordStartupFailure(uniqueProjectName, error.diagnostics, message);
+			recordStartupFailure(
+				uniqueProjectName,
+				error.diagnostics,
+				message,
+				telemetry.failurePhaseValue,
+			);
 		}
+		telemetry.setFailurePhase('stack-startup');
 		telemetry.flush(false, message);
 		throw error;
 	}

--- a/packages/testing/containers/startup-diagnostics.ts
+++ b/packages/testing/containers/startup-diagnostics.ts
@@ -8,20 +8,23 @@ let latestStartupFailure: {
 	projectName: string;
 	diagnostics: N8NStartupDiagnostics;
 	message: string;
+	failurePhase?: string;
 } | null = null;
 
 export function recordStartupFailure(
 	projectName: string,
 	diagnostics: N8NStartupDiagnostics,
 	message: string,
+	failurePhase?: string,
 ): void {
-	latestStartupFailure = { projectName, diagnostics, message };
+	latestStartupFailure = { projectName, diagnostics, message, failurePhase };
 }
 
 export function consumeStartupFailure(): {
 	projectName: string;
 	diagnostics: N8NStartupDiagnostics;
 	message: string;
+	failurePhase?: string;
 } | null {
 	const failure = latestStartupFailure;
 	latestStartupFailure = null;

--- a/packages/testing/containers/telemetry.ts
+++ b/packages/testing/containers/telemetry.ts
@@ -1,9 +1,22 @@
 import { spawn } from 'child_process';
+import { randomUUID } from 'node:crypto';
 import * as os from 'os';
 
 import type { StackConfig } from './services/types';
 
 export interface StackTelemetryRecord {
+	/** Unique identity for one stack startup attempt. */
+	attemptId: string;
+
+	/** Correlation context shared by CI and Playwright evidence. */
+	correlation: {
+		profile: string | null;
+		shard: string | null;
+		worker: string | null;
+		retry: number | null;
+		restartReason: string | null;
+	};
+
 	/** ISO timestamp when stack creation started */
 	timestamp: string;
 
@@ -46,6 +59,9 @@ export interface StackTelemetryRecord {
 		services: Record<string, number>;
 	};
 
+	/** Stage evidence for this startup attempt, including failed stages. */
+	stages: StartupStageRecord[];
+
 	/** Container counts */
 	containers: {
 		total: number;
@@ -55,6 +71,16 @@ export interface StackTelemetryRecord {
 
 	/** Outcome */
 	success: boolean;
+	failurePhase?: string;
+	errorMessage?: string;
+}
+
+export interface StartupStageRecord {
+	name: string;
+	source: 'local' | 'hosted' | 'unknown';
+	startedAt: string;
+	elapsedMs: number;
+	outcome: 'success' | 'failure' | 'cancelled';
 	errorMessage?: string;
 }
 
@@ -114,7 +140,60 @@ function inferPostgres(config: StackConfig): boolean {
 	return (config.postgres ?? false) || isQueueMode || hasKeycloak;
 }
 
+function safeValue(value: string | undefined): string | null {
+	if (!value || !/^[a-z0-9_.:-]{1,64}$/i.test(value)) return null;
+	return value;
+}
+
+function sanitizeError(message: string): string {
+	return message
+		.replace(/([?&](?:token|key|secret|password|authorization)=)[^&\s]+/gi, '$1[REDACTED]')
+		.replace(/(Bearer\s+|Basic\s+)[^\s]+/gi, '$1[REDACTED]')
+		.replace(/((?:token|key|secret|password|authorization)\s*[:=]\s*)[^\s,;]+/gi, '$1[REDACTED]')
+		.replace(/(https?:\/\/)([^\s/@]+):([^\s/@]+)@/gi, '$1[REDACTED]@');
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+	if (!error) return undefined;
+	if (error instanceof Error) return error.message;
+	if (typeof error === 'string') return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return undefined;
+	}
+}
+
+function getCorrelationContext(config: StackConfig): StackTelemetryRecord['correlation'] {
+	const retry = Number(process.env.GITHUB_RUN_ATTEMPT ?? '');
+	const restartReason = process.env.N8N_TEST_RESTART_REASON;
+	const knownRestartReasons = new Set([
+		'initial-start',
+		'retry',
+		'profile-transition',
+		'intentional-isolation',
+		'unknown',
+	]);
+	return {
+		profile: resolveProfile(config),
+		shard: safeValue(process.env.TEST_SHARD ?? process.env.CI_NODE_INDEX),
+		worker: safeValue(process.env.TEST_WORKER_INDEX ?? process.env.PLAYWRIGHT_WORKER_INDEX),
+		retry: Number.isFinite(retry) && retry > 0 ? retry : null,
+		restartReason: restartReason && knownRestartReasons.has(restartReason) ? restartReason : null,
+	};
+}
+
+function resolveProfile(config: StackConfig): string {
+	const configured = process.env.N8N_TEST_PROFILE ?? process.env.TEST_PROFILE;
+	if (configured && /^[a-z0-9_.:-]{1,64}$/i.test(configured)) return configured;
+	if ((config.mains ?? 1) > 1) return 'multi-main';
+	if ((config.workers ?? 0) > 0 || (config.webhooks ?? 0) > 0) return 'queue';
+	if (config.postgres || config.services?.includes('keycloak')) return 'postgres';
+	return 'sqlite';
+}
+
 export class TelemetryRecorder {
+	private readonly id = randomUUID();
 	private startTimestamp = Date.now();
 	private startPerf = performance.now();
 	private networkTime = 0;
@@ -122,8 +201,24 @@ export class TelemetryRecorder {
 	private serviceTimings: Record<string, number> = {};
 	private serviceCount = 0;
 	private n8nCount = 0;
+	private stages: StartupStageRecord[] = [];
+	private activeStage: {
+		name: string;
+		source: StartupStageRecord['source'];
+		started: number;
+		startedAt: string;
+	} | null = null;
+	private failurePhase: string | undefined;
 
 	constructor(private config: StackConfig) {}
+
+	get attemptId(): string {
+		return this.id;
+	}
+
+	get failurePhaseValue(): string | undefined {
+		return this.failurePhase;
+	}
 
 	recordNetwork(durationMs: number): void {
 		this.networkTime = durationMs;
@@ -139,8 +234,43 @@ export class TelemetryRecorder {
 		this.n8nCount = count;
 	}
 
+	startStage(name: string, source: StartupStageRecord['source'] = 'local'): void {
+		this.activeStage = {
+			name,
+			source,
+			started: performance.now(),
+			startedAt: new Date().toISOString(),
+		};
+	}
+
+	finishStage(outcome: StartupStageRecord['outcome'] = 'success', error?: unknown): void {
+		if (!this.activeStage) return;
+		const { name, source, started, startedAt } = this.activeStage;
+		const message = getErrorMessage(error);
+		const actualOutcome =
+			outcome === 'failure' && error instanceof Error && error.name === 'AbortError'
+				? 'cancelled'
+				: outcome;
+		this.stages.push({
+			name,
+			source,
+			startedAt,
+			elapsedMs: Math.max(0, Math.round(performance.now() - started)),
+			outcome: actualOutcome,
+			...(message ? { errorMessage: sanitizeError(message) } : {}),
+		});
+		if (actualOutcome !== 'success') this.failurePhase = name;
+		this.activeStage = null;
+	}
+
+	setFailurePhase(phase: string): void {
+		this.failurePhase ??= phase;
+	}
+
 	private buildRecord(success: boolean, errorMessage?: string): StackTelemetryRecord {
 		return {
+			attemptId: this.id,
+			correlation: getCorrelationContext(this.config),
 			timestamp: new Date(this.startTimestamp).toISOString(),
 			git: getGitContext(),
 			ci: getCIContext(),
@@ -158,13 +288,15 @@ export class TelemetryRecorder {
 				n8nStartup: this.n8nStartupTime,
 				services: { ...this.serviceTimings },
 			},
+			stages: [...this.stages],
 			containers: {
 				total: this.serviceCount + this.n8nCount,
 				services: this.serviceCount,
 				n8n: this.n8nCount,
 			},
 			success,
-			errorMessage,
+			...(this.failurePhase ? { failurePhase: this.failurePhase } : {}),
+			...(errorMessage ? { errorMessage: sanitizeError(errorMessage) } : {}),
 		};
 	}
 
@@ -216,11 +348,23 @@ export class TelemetryRecorder {
 			unit: string;
 			dimensions: Record<string, string | number>;
 		}> = [
+			...record.stages.map((stage) => ({
+				metric_name: 'stack-startup-stage',
+				value: stage.elapsedMs,
+				unit: 'ms',
+				dimensions: {
+					attempt_id: record.attemptId,
+					stage: stage.name,
+					source: stage.source,
+					outcome: stage.outcome,
+				},
+			})),
 			{
 				metric_name: 'stack-startup-total',
 				value: record.timing.total,
 				unit: 'ms',
 				dimensions: {
+					attempt_id: record.attemptId,
 					stack_type: record.stack.type,
 					mains: record.stack.mains,
 					workers: record.stack.workers,
@@ -269,6 +413,10 @@ export class TelemetryRecorder {
 				workflow: record.ci.workflow ?? null,
 				attempt: record.ci.attempt ?? null,
 			},
+			correlation: record.correlation,
+			attempt_id: record.attemptId,
+			stages: record.stages,
+			failure_phase: record.failurePhase ?? null,
 			runner: record.runner,
 			metrics,
 		};

--- a/packages/testing/containers/telemetry.ts
+++ b/packages/testing/containers/telemetry.ts
@@ -150,6 +150,10 @@ function sanitizeError(message: string): string {
 		.replace(/([?&](?:token|key|secret|password|authorization)=)[^&\s]+/gi, '$1[REDACTED]')
 		.replace(/(Bearer\s+|Basic\s+)[^\s]+/gi, '$1[REDACTED]')
 		.replace(/((?:token|key|secret|password|authorization)\s*[:=]\s*)[^\s,;]+/gi, '$1[REDACTED]')
+		.replace(/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED]')
+		.replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, '[REDACTED]')
+		.replace(/\bxox[baprs]-[A-Za-z0-9-]{20,}\b/g, '[REDACTED]')
+		.replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, '[REDACTED]')
 		.replace(/(https?:\/\/)([^\s/@]+):([^\s/@]+)@/gi, '$1[REDACTED]@');
 }
 

--- a/packages/testing/containers/telemetry.ts
+++ b/packages/testing/containers/telemetry.ts
@@ -174,12 +174,17 @@ function getCorrelationContext(config: StackConfig): StackTelemetryRecord['corre
 		'intentional-isolation',
 		'unknown',
 	]);
+	const resolvedRestartReason = restartReason
+		? knownRestartReasons.has(restartReason)
+			? restartReason
+			: 'unknown'
+		: null;
 	return {
 		profile: resolveProfile(config),
 		shard: safeValue(process.env.TEST_SHARD ?? process.env.CI_NODE_INDEX),
 		worker: safeValue(process.env.TEST_WORKER_INDEX ?? process.env.PLAYWRIGHT_WORKER_INDEX),
 		retry: Number.isFinite(retry) && retry > 0 ? retry : null,
-		restartReason: restartReason && knownRestartReasons.has(restartReason) ? restartReason : null,
+		restartReason: resolvedRestartReason,
 	};
 }
 
@@ -414,6 +419,8 @@ export class TelemetryRecorder {
 				attempt: record.ci.attempt ?? null,
 			},
 			correlation: record.correlation,
+			success: record.success,
+			error_message: record.errorMessage ?? null,
 			attempt_id: record.attemptId,
 			stages: record.stages,
 			failure_phase: record.failurePhase ?? null,

--- a/packages/testing/playwright/AGENTS.md
+++ b/packages/testing/playwright/AGENTS.md
@@ -17,6 +17,21 @@ pnpm --filter=n8n-playwright typecheck
 
 Always trim output: `--reporter=list 2>&1 | tail -50`
 
+## Test Layout
+
+Product Playwright tests live under `tests/`. Keep product E2E specs under
+`tests/e2e/` and keep infrastructure, performance, evaluation, and related
+suites in their existing directories under `tests/`.
+
+Framework and harness tests live under `tests/framework/`. Use this directory
+for tests of fixtures, startup lifecycle, diagnostics, telemetry, and harness
+contracts. These tests are not product E2E specs and must not be placed under
+`tests/e2e/`.
+
+Framework unit tests use the package Vitest configuration. Browser-backed
+harness contract tests use `vitest.harness.config.ts` so they stay separate
+from browser-free unit tests.
+
 ## Test Maintenance (Janitor)
 
 Static analysis for Playwright test architecture. Catches problems before they spread.

--- a/packages/testing/playwright/README.md
+++ b/packages/testing/playwright/README.md
@@ -13,6 +13,29 @@ pnpm test:local           											# Starts a local server and runs the E2E te
 N8N_BASE_URL=localhost:5068 pnpm test:local			# Runs the E2E tests against the running instance
 ```
 
+## Test Layout
+
+Product Playwright tests live under `tests/`. Most product tests are grouped
+under `tests/e2e/`, with infrastructure, performance, evaluation, and other
+test suites beside it.
+
+Framework and harness tests live under `tests/framework/`. These tests verify
+the test framework, fixtures, startup lifecycle, diagnostics, and harness
+contracts. They are not product E2E tests and must not be added under
+`tests/e2e/`.
+
+Run the framework unit tests with the package Vitest configuration:
+
+```bash
+pnpm exec vitest run tests/framework/telemetry.test.ts
+```
+
+Run the browser-backed harness contract tests with the dedicated configuration:
+
+```bash
+pnpm test:harness
+```
+
 ## Develop against running containers (avoid docker rebuilds)
 
 Iterating on a feature that needs postgres/redis/SMTP/an HTTP proxy? You don't

--- a/packages/testing/playwright/docs/HARNESS_BASELINE.md
+++ b/packages/testing/playwright/docs/HARNESS_BASELINE.md
@@ -4,6 +4,57 @@ This reference records the fixture contracts and remaining evidence for [DEVP-10
 The source baseline is `33eb5c196e0ce3a2c71525929a4ef861cb94b168`.
 The parent plan is [DEVP-1063](https://linear.app/n8n/issue/DEVP-1063).
 
+## DEVP-1066 handover
+
+DEVP-1066 adds correlated startup telemetry for the container stack and
+Playwright diagnostics. The implementation is in draft PR [#37920](https://github.com/n8n-io/n8n/pull/37920),
+stacked on [DEVP-1064 PR #37913](https://github.com/n8n-io/n8n/pull/37913).
+The stack is based on the latest `master`.
+
+### Delivered
+
+- Every stack startup has a unique `attemptId`.
+- Startup stages record their source, start time, elapsed time, and outcome.
+- Failed and cancelled stages preserve their failure phase and elapsed time.
+- Correlation records include resolved profile, shard, worker, CI retry, and restart reason.
+- Startup diagnostics include the attempt ID and Playwright retry metadata.
+- Telemetry webhook tests use an isolated loopback contract server.
+- Invalid webhook payloads receive `400` responses.
+- Credential-shaped values are removed from telemetry errors before delivery.
+- Framework tests live under `tests/framework/` and stay separate from product E2E specs.
+
+### Review learnings
+
+| Category | Learning | Guard added |
+| --- | --- | --- |
+| Readiness | A polling helper must reject when a required readiness condition never succeeds. A warning followed by a resolved promise records a false success. | `pollContainerHttpEndpoint()` throws after its timeout. The readiness stage records failure. |
+| Correlation | Unknown context must remain explicit. Missing and unrecognized restart reasons are different states. | Unknown restart reasons map to `unknown`. Resolved profiles are documented separately from unavailable fields. |
+| Evidence | A test must prove the failure mode it names. `toThrow()` cannot validate a detached, fire-and-forget sender. | Integration tests inspect the received failure payload, attempt ID, failure stage, and elapsed duration. |
+| Timing | `expect.any(Number)` does not prove that a failed stage recorded useful elapsed time. | Tests introduce a small delay and require a non-zero duration. |
+| Contract testing | A mock server validator must affect its response. Otherwise invalid payload tests are dead code. | The telemetry contract server returns `400` for invalid payloads and tests that behavior. |
+| Secret handling | Error messages can contain bare provider token formats, not only `key=value` or authorization headers. | Sanitization covers AWS, GitHub, Slack, and OpenAI-style credential shapes. Regression tests keep the literals split to avoid repository secret scanners. |
+| Test taxonomy | Framework tests are not product E2E tests. Browser-backed harness tests need a separate Vitest configuration. | Framework tests use `tests/framework/`; browser-backed consumers remain in `vitest.harness.config.ts`. |
+| Stack delivery | A stacked PR must use an allowed repository title scope and be rebased when its trunk moves. | PR titles use the unscoped `test:` form. `gh stack sync` keeps DEVP-1064 and DEVP-1066 aligned. |
+
+### Verification
+
+- Full Playwright Vitest suite: 89 tests passed.
+- Containers and Playwright typecheck passed.
+- Containers and Playwright lint passed.
+- Janitor reported no new violations.
+- GitHub push protection passed after splitting credential-shaped test values.
+
+### Remaining evidence
+
+- CI checks and review approval on PR #37920.
+- Matched workload measurements for telemetry instrumentation overhead.
+- Controlled real-container retry and cancellation evidence.
+- Real application sentinels without the synthetic support override.
+
+After DEVP-1066 lands, the next parent implementation item is DEVP-1065:
+safe resource acquisition and cleanup. Keep this telemetry contract when
+refactoring resource ownership and teardown.
+
 ## Consumer contracts
 
 `pnpm test:harness` runs six Vitest cases. Each case starts a real Playwright process that imports `fixtures/base.ts`.

--- a/packages/testing/playwright/fixtures/observability.ts
+++ b/packages/testing/playwright/fixtures/observability.ts
@@ -54,7 +54,26 @@ function formatReadinessPayloads(diagnostics: N8NStartupDiagnostics): string {
 async function attachStartupDiagnostics(
 	diagnostics: N8NStartupDiagnostics,
 	testInfo: TestInfo,
+	failurePhase?: string,
 ): Promise<void> {
+	if (diagnostics.attemptId) {
+		await testInfo.attach('startup-attempt.json', {
+			body: JSON.stringify(
+				{
+					attemptId: diagnostics.attemptId,
+					failurePhase: failurePhase ?? null,
+					testRetry: testInfo.retry,
+					workerIndex: testInfo.workerIndex,
+					parallelIndex: testInfo.parallelIndex,
+					status: testInfo.status,
+				},
+				null,
+				2,
+			),
+			contentType: 'application/json',
+		});
+	}
+
 	const startupLogs = formatStartupLogs(diagnostics);
 	if (startupLogs) {
 		await testInfo.attach('n8n-startup-logs.txt', {
@@ -165,7 +184,7 @@ export const observabilityFixtures: Fixtures<
 				const failure = consumeStartupFailure();
 				if (!failure) return;
 				try {
-					await attachStartupDiagnostics(failure.diagnostics, testInfo);
+					await attachStartupDiagnostics(failure.diagnostics, testInfo, failure.failurePhase);
 				} catch (error) {
 					console.warn('Failed to attach n8n startup diagnostics:', error);
 				}

--- a/packages/testing/playwright/tests/framework/telemetry-integration.test.ts
+++ b/packages/testing/playwright/tests/framework/telemetry-integration.test.ts
@@ -53,12 +53,41 @@ describe('container telemetry webhook contract', () => {
 		);
 	});
 
-	test('does not throw when the contract server rejects a payload', async () => {
+	test('delivers failure evidence when the contract server rejects a payload', async () => {
 		server = await startTelemetryContractServer(500);
 		configureTelemetryWebhook(server.url);
 		const telemetry = new TelemetryRecorder({});
 
-		expect(() => telemetry.flush(false, 'startup failed')).not.toThrow();
+		telemetry.startStage('n8n-startup');
+		await new Promise((resolve) => setTimeout(resolve, 2));
+		telemetry.finishStage('failure', new Error('startup failed'));
+		telemetry.flush(false, 'startup failed');
 		await waitForRequest();
+
+		const request = server.requests[0];
+		expect(request.payload.success).toBe(false);
+		expect(request.payload.attempt_id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(request.payload.stages).toContainEqual(
+			expect.objectContaining({
+				name: 'n8n-startup',
+				outcome: 'failure',
+				elapsedMs: expect.any(Number),
+			}),
+		);
+		expect((request.payload.stages as Array<{ elapsedMs: number }>)[0].elapsedMs).toBeGreaterThan(
+			0,
+		);
+	});
+
+	test('rejects payloads that do not meet the telemetry contract', async () => {
+		server = await startTelemetryContractServer();
+
+		const response = await fetch(server.url, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ attempt_id: 'missing-stages' }),
+		});
+
+		expect(response.status).toBe(400);
 	});
 });

--- a/packages/testing/playwright/tests/framework/telemetry-integration.test.ts
+++ b/packages/testing/playwright/tests/framework/telemetry-integration.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { startTelemetryContractServer, type TelemetryContractServer } from './telemetry-support';
+import { TelemetryRecorder } from '../../../containers/telemetry';
+
+let server: TelemetryContractServer | undefined;
+
+afterEach(async () => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+	if (server) await server.close();
+	server = undefined;
+});
+
+async function waitForRequest(timeoutMs = 2000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (server?.requests.length === 0 && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	if (server?.requests.length === 0) throw new Error('Telemetry webhook was not called');
+}
+
+function configureTelemetryWebhook(url: string): void {
+	vi.stubEnv('QA_METRICS_WEBHOOK_URL', url);
+	vi.stubEnv('QA_METRICS_WEBHOOK_USER', 'telemetry-user');
+	vi.stubEnv('QA_METRICS_WEBHOOK_PASSWORD', 'telemetry-password');
+}
+
+describe('container telemetry webhook contract', () => {
+	test('sends a correlated startup payload to the contract server', async () => {
+		server = await startTelemetryContractServer();
+		configureTelemetryWebhook(server.url);
+		const telemetry = new TelemetryRecorder({});
+
+		telemetry.startStage('n8n-startup');
+		telemetry.finishStage();
+		telemetry.flush(true);
+		await waitForRequest();
+
+		const request = server.requests[0];
+		expect(request.authorization).toBe(
+			`Basic ${Buffer.from('telemetry-user:telemetry-password').toString('base64')}`,
+		);
+		expect(request.payload.attempt_id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(request.payload.stages).toEqual([
+			expect.objectContaining({ name: 'n8n-startup', outcome: 'success' }),
+		]);
+		expect(request.payload.metrics).toContainEqual(
+			expect.objectContaining({
+				metric_name: 'stack-startup-stage',
+				dimensions: expect.objectContaining({ attempt_id: request.payload.attempt_id }),
+			}),
+		);
+	});
+
+	test('does not throw when the contract server rejects a payload', async () => {
+		server = await startTelemetryContractServer(500);
+		configureTelemetryWebhook(server.url);
+		const telemetry = new TelemetryRecorder({});
+
+		expect(() => telemetry.flush(false, 'startup failed')).not.toThrow();
+		await waitForRequest();
+	});
+});

--- a/packages/testing/playwright/tests/framework/telemetry-support.ts
+++ b/packages/testing/playwright/tests/framework/telemetry-support.ts
@@ -1,0 +1,75 @@
+import { once } from 'node:events';
+import { createServer, type IncomingMessage, type Server } from 'node:http';
+
+type TelemetryPayload = {
+	attempt_id?: unknown;
+	stages?: unknown;
+	metrics?: Array<{
+		metric_name?: unknown;
+		dimensions?: Record<string, unknown>;
+	}>;
+};
+
+export type TelemetryRequest = {
+	authorization: string | undefined;
+	payload: TelemetryPayload;
+};
+
+export type TelemetryContractServer = {
+	url: string;
+	requests: TelemetryRequest[];
+	close: () => Promise<void>;
+};
+
+async function readBody(request: IncomingMessage): Promise<string> {
+	let body = '';
+	request.setEncoding('utf8');
+	for await (const chunk of request) body += chunk;
+	return body;
+}
+
+function isValidPayload(payload: TelemetryPayload): boolean {
+	if (typeof payload.attempt_id !== 'string' || !Array.isArray(payload.stages)) return false;
+	return Boolean(
+		payload.metrics?.some(
+			(metric) =>
+				metric.metric_name === 'stack-startup-stage' &&
+				metric.dimensions?.attempt_id === payload.attempt_id,
+		),
+	);
+}
+
+export async function startTelemetryContractServer(
+	responseStatus = 200,
+): Promise<TelemetryContractServer> {
+	const requests: TelemetryRequest[] = [];
+	const server: Server = createServer(async (request, response) => {
+		const body = await readBody(request);
+		let payload: TelemetryPayload;
+		try {
+			payload = JSON.parse(body) as TelemetryPayload;
+		} catch {
+			response.writeHead(400).end('Invalid JSON');
+			return;
+		}
+
+		requests.push({ authorization: request.headers.authorization, payload });
+		const status = responseStatus === 200 && isValidPayload(payload) ? 200 : responseStatus;
+		response.writeHead(status, { 'Content-Type': 'application/json' }).end('{}');
+	});
+	server.listen(0, '127.0.0.1');
+	await once(server, 'listening');
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('Missing telemetry server address');
+
+	return {
+		url: `http://127.0.0.1:${address.port}/metrics`,
+		requests,
+		close: async () => {
+			const closed = once(server, 'close');
+			server.close();
+			server.closeAllConnections();
+			await closed;
+		},
+	};
+}

--- a/packages/testing/playwright/tests/framework/telemetry-support.ts
+++ b/packages/testing/playwright/tests/framework/telemetry-support.ts
@@ -3,6 +3,8 @@ import { createServer, type IncomingMessage, type Server } from 'node:http';
 
 type TelemetryPayload = {
 	attempt_id?: unknown;
+	success?: unknown;
+	failure_phase?: unknown;
 	stages?: unknown;
 	metrics?: Array<{
 		metric_name?: unknown;
@@ -54,7 +56,7 @@ export async function startTelemetryContractServer(
 		}
 
 		requests.push({ authorization: request.headers.authorization, payload });
-		const status = responseStatus === 200 && isValidPayload(payload) ? 200 : responseStatus;
+		const status = isValidPayload(payload) ? responseStatus : 400;
 		response.writeHead(status, { 'Content-Type': 'application/json' }).end('{}');
 	});
 	server.listen(0, '127.0.0.1');

--- a/packages/testing/playwright/tests/framework/telemetry.test.ts
+++ b/packages/testing/playwright/tests/framework/telemetry.test.ts
@@ -75,6 +75,25 @@ describe('TelemetryRecorder', () => {
 		expect(output).toContain('[REDACTED]');
 	});
 
+	test('redacts credential-shaped values from failure evidence', () => {
+		vi.stubEnv('CONTAINER_TELEMETRY_VERBOSE', '1');
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const telemetry = new TelemetryRecorder({});
+		const credentials = [
+			['AKIA', '1234567890ABCDEF'].join(''),
+			['ghp_', 'abcdefghijklmnopqrstuvwxyz123456'].join(''),
+			['xoxb-', '1234567890-abcdefghijklmnop'].join(''),
+			['sk-proj-', 'abcdefghijklmnopqrstuvwxyz123456'].join(''),
+		];
+
+		telemetry.startStage('n8n-startup');
+		telemetry.finishStage('failure', new Error(credentials.join(' ')));
+		telemetry.flush(false, credentials.join(' '));
+
+		const output = log.mock.calls[0][0] as string;
+		for (const credential of credentials) expect(output).not.toContain(credential);
+	});
+
 	test('marks aborted stages as cancelled', async () => {
 		vi.stubEnv('CONTAINER_TELEMETRY_VERBOSE', '1');
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/packages/testing/playwright/tests/framework/telemetry.test.ts
+++ b/packages/testing/playwright/tests/framework/telemetry.test.ts
@@ -8,17 +8,19 @@ afterEach(() => {
 });
 
 describe('TelemetryRecorder', () => {
-	test('correlates stages and keeps failed elapsed time', () => {
+	test('correlates stages and keeps failed elapsed time', async () => {
 		vi.stubEnv('CONTAINER_TELEMETRY_VERBOSE', '1');
 		vi.stubEnv('N8N_TEST_PROFILE', 'sqlite');
 		vi.stubEnv('TEST_SHARD', '3');
 		vi.stubEnv('TEST_WORKER_INDEX', '2');
+		vi.stubEnv('N8N_TEST_RESTART_REASON', 'unexpected-value');
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const telemetry = new TelemetryRecorder({});
 
 		telemetry.startStage('network');
 		telemetry.finishStage();
 		telemetry.startStage('n8n-startup');
+		await new Promise((resolve) => setTimeout(resolve, 2));
 		telemetry.finishStage('failure', new Error('readiness failed after 25ms'));
 		telemetry.flush(false, 'n8n startup failed');
 
@@ -26,7 +28,7 @@ describe('TelemetryRecorder', () => {
 		expect(typeof output).toBe('string');
 		let record: {
 			attemptId: string;
-			correlation: { profile: string; shard: string; worker: string };
+			correlation: { profile: string; shard: string; worker: string; restartReason: string };
 			stages: Array<{ name: string; elapsedMs: number; outcome: string }>;
 			failurePhase: string;
 		};
@@ -36,7 +38,12 @@ describe('TelemetryRecorder', () => {
 			throw new Error('Telemetry output was not valid JSON');
 		}
 		expect(record.attemptId).toMatch(/^[0-9a-f-]{36}$/);
-		expect(record.correlation).toMatchObject({ profile: 'sqlite', shard: '3', worker: '2' });
+		expect(record.correlation).toMatchObject({
+			profile: 'sqlite',
+			shard: '3',
+			worker: '2',
+			restartReason: 'unknown',
+		});
 		expect(record.stages).toEqual([
 			expect.objectContaining({ name: 'network', outcome: 'success' }),
 			expect.objectContaining({
@@ -45,6 +52,7 @@ describe('TelemetryRecorder', () => {
 				elapsedMs: expect.any(Number),
 			}),
 		]);
+		expect(record.stages[1].elapsedMs).toBeGreaterThan(0);
 		expect(record.failurePhase).toBe('n8n-startup');
 	});
 
@@ -67,7 +75,7 @@ describe('TelemetryRecorder', () => {
 		expect(output).toContain('[REDACTED]');
 	});
 
-	test('marks aborted stages as cancelled', () => {
+	test('marks aborted stages as cancelled', async () => {
 		vi.stubEnv('CONTAINER_TELEMETRY_VERBOSE', '1');
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const telemetry = new TelemetryRecorder({});
@@ -75,6 +83,7 @@ describe('TelemetryRecorder', () => {
 		error.name = 'AbortError';
 
 		telemetry.startStage('service:postgres');
+		await new Promise((resolve) => setTimeout(resolve, 2));
 		telemetry.finishStage('failure', error);
 		telemetry.flush(false, error.message);
 

--- a/packages/testing/playwright/tests/framework/telemetry.test.ts
+++ b/packages/testing/playwright/tests/framework/telemetry.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { TelemetryRecorder } from '../../../containers/telemetry';
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+});
+
+describe('TelemetryRecorder', () => {
+	test('correlates stages and keeps failed elapsed time', () => {
+		vi.stubEnv('CONTAINER_TELEMETRY_VERBOSE', '1');
+		vi.stubEnv('N8N_TEST_PROFILE', 'sqlite');
+		vi.stubEnv('TEST_SHARD', '3');
+		vi.stubEnv('TEST_WORKER_INDEX', '2');
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const telemetry = new TelemetryRecorder({});
+
+		telemetry.startStage('network');
+		telemetry.finishStage();
+		telemetry.startStage('n8n-startup');
+		telemetry.finishStage('failure', new Error('readiness failed after 25ms'));
+		telemetry.flush(false, 'n8n startup failed');
+
+		const output = log.mock.calls[0][0];
+		expect(typeof output).toBe('string');
+		let record: {
+			attemptId: string;
+			correlation: { profile: string; shard: string; worker: string };
+			stages: Array<{ name: string; elapsedMs: number; outcome: string }>;
+			failurePhase: string;
+		};
+		try {
+			record = JSON.parse(output as string) as typeof record;
+		} catch {
+			throw new Error('Telemetry output was not valid JSON');
+		}
+		expect(record.attemptId).toMatch(/^[0-9a-f-]{36}$/);
+		expect(record.correlation).toMatchObject({ profile: 'sqlite', shard: '3', worker: '2' });
+		expect(record.stages).toEqual([
+			expect.objectContaining({ name: 'network', outcome: 'success' }),
+			expect.objectContaining({
+				name: 'n8n-startup',
+				outcome: 'failure',
+				elapsedMs: expect.any(Number),
+			}),
+		]);
+		expect(record.failurePhase).toBe('n8n-startup');
+	});
+
+	test('redacts secrets from failure evidence', () => {
+		vi.stubEnv('CONTAINER_TELEMETRY_VERBOSE', '1');
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const telemetry = new TelemetryRecorder({});
+
+		telemetry.startStage('service:proxy');
+		telemetry.finishStage(
+			'failure',
+			new Error('https://user:password@example.test?token=secret-value'),
+		);
+		telemetry.flush(false, 'Authorization: Bearer secret-token');
+
+		const output = log.mock.calls[0][0] as string;
+		expect(output).not.toContain('password');
+		expect(output).not.toContain('secret-value');
+		expect(output).not.toContain('secret-token');
+		expect(output).toContain('[REDACTED]');
+	});
+
+	test('marks aborted stages as cancelled', () => {
+		vi.stubEnv('CONTAINER_TELEMETRY_VERBOSE', '1');
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const telemetry = new TelemetryRecorder({});
+		const error = new Error('startup aborted');
+		error.name = 'AbortError';
+
+		telemetry.startStage('service:postgres');
+		telemetry.finishStage('failure', error);
+		telemetry.flush(false, error.message);
+
+		const output = log.mock.calls[0][0] as string;
+		expect(output).toContain('"outcome": "cancelled"');
+	});
+});

--- a/packages/testing/playwright/vitest.config.ts
+++ b/packages/testing/playwright/vitest.config.ts
@@ -1,16 +1,16 @@
 import { defineConfig } from 'vitest/config';
 
-// Unit tests for the coverage pipeline scripts/fixtures only. Scoped tightly so
-// vitest never picks up the Playwright e2e specs under tests/ (those are *.spec.ts
-// run by Playwright, not vitest).
+// Unit tests for coverage, framework, and reporter code. Keep the list explicit so
+// Vitest never picks up Playwright specs under tests/.
 export default defineConfig({
 	test: {
 		include: [
 			'scripts/**/*.test.ts',
 			'fixtures/**/*.test.ts',
 			'reporters/**/*.test.ts',
+			'tests/framework/telemetry.test.ts',
+			'tests/framework/telemetry-integration.test.ts',
 			'*.test.ts',
 		],
-		exclude: ['tests/**'],
 	},
 });


### PR DESCRIPTION
## Summary

Adds correlated startup telemetry for Testcontainers and Playwright evidence.

- Adds a unique startup attempt ID and stage-level timing/outcomes.
- Records profile, retry, failure, cancellation, and local/hosted context.
- Attaches startup correlation data to Playwright diagnostics.
- Adds loopback telemetry contract tests for accepted, rejected, and invalid payloads.
- Documents the framework test taxonomy and telemetry payload.

## Verification

- Playwright Vitest: 88 passed
- Containers and Playwright typecheck: passed
- Containers and Playwright lint: passed
- Janitor: no new violations

## Related

- [DEVP-1066](https://linear.app/n8n/issue/DEVP-1066/correlate-test-harness-startup-stages-and-retry-evidence)
- Stacked on [DEVP-1064 PR #37913](https://github.com/n8n-io/n8n/pull/37913)