### PR TITLE
fix: Explain disabled MCP access on the OAuth consent page

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.controller.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.controller.api.test.ts
@@ -77,6 +77,45 @@ describe('GET /rest/consent/details', () => {
 		});
 	});
 
+	test('should name the disabled resource when MCP access is switched off', async () => {
+		const client = await oauthClientRepository.save({
+			id: 'disabled-client-id',
+			name: 'Test OAuth Client',
+			redirectUris: ['https://example.com/callback'],
+			grantTypes: ['authorization_code'],
+			tokenEndpointAuthMethod: 'none',
+		});
+
+		const sessionToken = createSessionToken({
+			clientId: client.id,
+			redirectUri: 'https://example.com/callback',
+			codeChallenge: 'test-challenge',
+			state: 'test-state',
+		});
+
+		const mcpSettingsService = Container.get(McpSettingsService);
+		await mcpSettingsService.setEnabled(false);
+		try {
+			const response = await testServer
+				.authAgentFor(owner)
+				.get('/consent/details')
+				.set('Cookie', `n8n-oauth-session=${sessionToken}`);
+
+			expect(response.statusCode).toBe(403);
+			expect(response.body).toEqual({
+				status: 'error',
+				message: 'The requested resource is disabled on this n8n instance',
+				meta: { reason: 'resource_disabled' },
+			});
+			// The pending session is cleared: the user has to start over from the client.
+			expect(response.headers['set-cookie']).toEqual(
+				expect.arrayContaining([expect.stringContaining('n8n-oauth-session=;')]),
+			);
+		} finally {
+			await mcpSettingsService.setEnabled(true);
+		}
+	});
+
 	test('should include the resource name when the session resource resolves', async () => {
 		const client = await oauthClientRepository.save({
 			id: 'resource-client-id',
@@ -145,6 +184,7 @@ describe('GET /rest/consent/details', () => {
 		expect(response.statusCode).toBe(422);
 		expect(response.body).toEqual({
 			status: 'error',
+			meta: { reason: 'resource_unavailable' },
 			message: 'Authorization target is no longer available',
 		});
 

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
@@ -8,6 +8,7 @@ import { OAuthAuthorizationCodeService } from '../oauth-authorization-code.servi
 import { OAuthConsentService } from '../oauth-consent.service';
 import { OAuthClientRepository } from '../database/repositories/oauth-client.repository';
 import { OAuthSessionService } from '../oauth-session.service';
+import { ProtectedResourceDisabledError } from '../oauth.errors';
 import type { UserConsent } from '../database/entities/oauth-user-consent.entity';
 import { UserConsentRepository } from '../database/repositories/oauth-user-consent.repository';
 import {
@@ -116,11 +117,60 @@ describe('OAuthConsentService', () => {
 			protectedResourceRegistry.getDefaultResource.mockReturnValue({
 				scopes: INSTANCE_SCOPES,
 				authorize: async () => false,
+				getResourceUrl: () => 'https://n8n.example.com/mcp-server/http',
 			} as unknown as ProtectedResource);
 
 			const result = await service.getConsentDetails('token', mock<User>({ id: 'user-1' }));
 
 			expect(result).toEqual({ ok: false, reason: 'forbidden' });
+		});
+
+		it('should report resource_disabled for a resource-less request when the default resource is switched off', async () => {
+			const sessionPayload = {
+				clientId: 'client-123',
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge',
+				state: 'state',
+			};
+			const authorize = vi.fn().mockResolvedValue(true);
+
+			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
+			oauthClientRepository.findOne.mockResolvedValue(mock<OAuthClient>({ id: 'client-123' }));
+			protectedResourceRegistry.getDefaultResource.mockReturnValue({
+				scopes: INSTANCE_SCOPES,
+				isAvailable: async () => false,
+				authorize,
+				getResourceUrl: () => 'https://n8n.example.com/mcp-server/http',
+			} as unknown as ProtectedResource);
+
+			const result = await service.getConsentDetails('token', mock<User>({ id: 'user-1' }));
+
+			expect(result).toEqual({ ok: false, reason: 'resource_disabled' });
+			// A switched-off resource is refused before the user's own access is judged.
+			expect(authorize).not.toHaveBeenCalled();
+		});
+
+		it('should report resource_disabled when the named resource is switched off', async () => {
+			const sessionPayload = {
+				clientId: 'client-123',
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge',
+				state: 'state',
+				resource: 'https://n8n.example.com/mcp-server/http',
+			};
+
+			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
+			oauthClientRepository.findOne.mockResolvedValue(mock<OAuthClient>({ id: 'client-123' }));
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue({
+				scopes: INSTANCE_SCOPES,
+				isAvailable: async () => false,
+				authorize: async () => true,
+				getResourceUrl: () => 'https://n8n.example.com/mcp-server/http',
+			} as unknown as ProtectedResource);
+
+			const result = await service.getConsentDetails('token', mock<User>({ id: 'user-1' }));
+
+			expect(result).toEqual({ ok: false, reason: 'resource_disabled' });
 		});
 
 		it('should return null when client not found', async () => {
@@ -468,6 +518,30 @@ describe('OAuthConsentService', () => {
 			await expect(
 				service.handleConsentDecision('token', mock<User>({ id: 'user-123' }), true),
 			).rejects.toThrow(ForbiddenError);
+
+			expect(authorizationCodeService.createAuthorizationCode).not.toHaveBeenCalled();
+			expect(userConsentRepository.upsert).not.toHaveBeenCalled();
+		});
+
+		it('should refuse approval with ProtectedResourceDisabledError when the default resource is switched off', async () => {
+			const sessionPayload = {
+				clientId: 'client-123',
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge',
+				state: 'state-xyz',
+			};
+
+			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
+			protectedResourceRegistry.getDefaultResource.mockReturnValue({
+				scopes: INSTANCE_SCOPES,
+				isAvailable: async () => false,
+				authorize: async () => true,
+				getResourceUrl: () => 'https://n8n.example.com/mcp-server/http',
+			} as unknown as ProtectedResource);
+
+			await expect(
+				service.handleConsentDecision('token', mock<User>({ id: 'user-123' }), true),
+			).rejects.toThrow(ProtectedResourceDisabledError);
 
 			expect(authorizationCodeService.createAuthorizationCode).not.toHaveBeenCalled();
 			expect(userConsentRepository.upsert).not.toHaveBeenCalled();

--- a/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
@@ -4,10 +4,17 @@ import { Body, Get, Post, RestController } from '@n8n/decorators';
 import type { Response } from 'express';
 import { UserError } from 'n8n-workflow';
 
-import { ApproveConsentRequestDto } from './dto/approve-consent-request.dto';
-import { OAuthConsentService } from './oauth-consent.service';
-import { OAuthSessionService } from './oauth-session.service';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+
+import { ApproveConsentRequestDto } from './dto/approve-consent-request.dto';
+import { OAuthConsentService, type ConsentRefusalReason } from './oauth-consent.service';
+import { OAuthSessionService } from './oauth-session.service';
+import { ProtectedResourceDisabledError } from './oauth.errors';
+
+const INSUFFICIENT_PERMISSIONS_MESSAGE =
+	'You do not have sufficient permissions to authorize this request';
+const RESOURCE_DISABLED_MESSAGE = 'The requested resource is disabled on this n8n instance';
+const RESOURCE_UNAVAILABLE_MESSAGE = 'Authorization target is no longer available';
 
 @RestController('/consent')
 export class OAuthConsentController {
@@ -32,15 +39,7 @@ export class OAuthConsentController {
 
 			if (!consentDetails.ok) {
 				this.oauthSessionService.clearSession(res);
-				if (consentDetails.reason === 'forbidden') {
-					this.sendErrorResponse(
-						res,
-						403,
-						'You do not have sufficient permissions to authorize this request',
-					);
-				} else {
-					this.sendErrorResponse(res, 422, 'Authorization target is no longer available');
-				}
+				this.sendRefusal(res, consentDetails.reason);
 				return;
 			}
 
@@ -92,12 +91,12 @@ export class OAuthConsentController {
 		} catch (error) {
 			this.logger.error('Failed to process consent', { error });
 			this.oauthSessionService.clearSession(res);
+			if (error instanceof ProtectedResourceDisabledError) {
+				this.sendRefusal(res, 'resource_disabled');
+				return;
+			}
 			if (error instanceof ForbiddenError) {
-				this.sendErrorResponse(
-					res,
-					403,
-					'You do not have sufficient permissions to authorize this request',
-				);
+				this.sendRefusal(res, 'forbidden');
 				return;
 			}
 			const message = error instanceof Error ? error.message : 'Failed to process authorization';
@@ -106,10 +105,34 @@ export class OAuthConsentController {
 		}
 	}
 
-	private sendErrorResponse(res: Response, statusCode: number, message: string): void {
+	/**
+	 * The reason travels in `meta` so the consent screen can pick its copy from
+	 * it directly instead of inferring it from the status code.
+	 */
+	private sendRefusal(res: Response, reason: ConsentRefusalReason): void {
+		switch (reason) {
+			case 'resource_disabled':
+				this.sendErrorResponse(res, 403, RESOURCE_DISABLED_MESSAGE, { reason });
+				break;
+			case 'forbidden':
+				this.sendErrorResponse(res, 403, INSUFFICIENT_PERMISSIONS_MESSAGE, { reason });
+				break;
+			case 'resource_unavailable':
+				this.sendErrorResponse(res, 422, RESOURCE_UNAVAILABLE_MESSAGE, { reason });
+				break;
+		}
+	}
+
+	private sendErrorResponse(
+		res: Response,
+		statusCode: number,
+		message: string,
+		meta?: { reason: ConsentRefusalReason },
+	): void {
 		res.status(statusCode).json({
 			status: 'error',
 			message,
+			...(meta && { meta }),
 		});
 	}
 

--- a/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
@@ -8,6 +8,7 @@ import { OAuthClientRepository } from './database/repositories/oauth-client.repo
 import { UserConsentRepository } from './database/repositories/oauth-user-consent.repository';
 import { OAuthAuthorizationCodeService } from './oauth-authorization-code.service';
 import { OAuthSessionService, type OAuthSessionPayload } from './oauth-session.service';
+import { ProtectedResourceDisabledError } from './oauth.errors';
 import { OAuthHelpers } from './oauth.helpers';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import {
@@ -39,7 +40,18 @@ type ConsentDetailsResult =
 			isFirstParty: boolean;
 	  }
 	| { ok: false; reason: 'resource_unavailable' }
+	| { ok: false; reason: 'resource_disabled' }
 	| { ok: false; reason: 'forbidden' };
+
+type ConsentRefusal = Extract<ConsentDetailsResult, { ok: false }>;
+
+/**
+ * Why a consent request was refused. `resource_unavailable`: the target no
+ * longer resolves. `resource_disabled`: the target exists but is switched off
+ * on this instance (e.g. instance MCP access). `forbidden`: this user may not
+ * grant access to the target.
+ */
+export type ConsentRefusalReason = ConsentRefusal['reason'];
 
 /**
  * Manages the consent flow for the shared OAuth server.
@@ -82,11 +94,8 @@ export class OAuthConsentService {
 					return { ok: false, reason: 'resource_unavailable' };
 				}
 
-				if (!(await resource.authorize(user)))
-					return {
-						ok: false,
-						reason: 'forbidden',
-					};
+				const refusal = await this.refusalFor(resource, user, client.id);
+				if (refusal) return refusal;
 
 				const scopes = this.grantableScopes(resource.scopes, sessionPayload.requestedScopes);
 
@@ -106,8 +115,9 @@ export class OAuthConsentService {
 
 			const defaultResource = this.protectedResourceRegistry.getDefaultResource();
 
-			if (defaultResource && !(await defaultResource.authorize(user))) {
-				return { ok: false, reason: 'forbidden' };
+			if (defaultResource) {
+				const refusal = await this.refusalFor(defaultResource, user, client.id);
+				if (refusal) return refusal;
 			}
 
 			const scopes = this.grantableScopes(
@@ -221,18 +231,49 @@ export class OAuthConsentService {
 		return await this.issueGrant(user, sessionPayload, grantedScopes);
 	}
 
+	/**
+	 * Why the consent screen must not offer a grant on `resource`, or `null` when
+	 * it may. A switched-off resource is reported apart from a permission
+	 * problem, so the screen can point the user at the setting rather than at
+	 * their role.
+	 */
+	private async refusalFor(
+		resource: ProtectedResource,
+		user: User,
+		clientId: string,
+	): Promise<ConsentRefusal | null> {
+		if (!((await resource.isAvailable?.()) ?? true)) {
+			this.logger.warn('Consent refused: target resource is disabled on this instance', {
+				clientId,
+				userId: user.id,
+				resourceUrl: resource.getResourceUrl(),
+			});
+			return { ok: false, reason: 'resource_disabled' };
+		}
+
+		if (!(await resource.authorize(user))) {
+			this.logger.warn('Consent refused: user is not authorized for the requested resource', {
+				clientId,
+				userId: user.id,
+				resourceUrl: resource.getResourceUrl(),
+			});
+			return { ok: false, reason: 'forbidden' };
+		}
+
+		return null;
+	}
+
 	private async assertAuthorized(
 		resource: ProtectedResource,
 		user: User,
 		clientId: string,
 	): Promise<void> {
-		if (await resource.authorize(user)) return;
+		const refusal = await this.refusalFor(resource, user, clientId);
+		if (!refusal) return;
 
-		this.logger.warn('User is not authorized for the requested resource', {
-			clientId,
-			userId: user.id,
-			resourceUrl: resource.getResourceUrl(),
-		});
+		if (refusal.reason === 'resource_disabled') {
+			throw new ProtectedResourceDisabledError();
+		}
 
 		throw new ForbiddenError('User is not authorized for the requested resource');
 	}

--- a/packages/cli/src/modules/oauth-server/oauth.errors.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.errors.ts
@@ -1,6 +1,7 @@
 import { ServerError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 
 import { AuthError } from '@/errors/response-errors/auth.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 // The wording references MCP because the instance MCP server is currently the
 // only protected resource; clients registered via its DCR endpoint see this
@@ -21,6 +22,19 @@ export class OAuthClientLimitReachedError extends ServerError {
 		super(buildOAuthClientLimitReachedMessage(limit));
 		this.name = 'OAuthClientLimitReachedError';
 		this.limit = limit;
+	}
+}
+
+/**
+ * Thrown from the consent flow when the target protected resource is switched
+ * off on this instance (e.g. instance MCP access disabled). Distinct from a
+ * plain `ForbiddenError` so the consent screen can tell the user which setting
+ * to change instead of reporting a permission problem.
+ */
+export class ProtectedResourceDisabledError extends ForbiddenError {
+	constructor() {
+		super('The requested resource is not available for authorization');
+		this.name = 'ProtectedResourceDisabledError';
 	}
 }
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2637,6 +2637,8 @@
 	"oauth.consentView.error.heading": "Authorization unavailable",
 	"oauth.consentView.error.resourceUnavailable": "This authorization can no longer be completed because the target is no longer available.",
 	"oauth.consentView.error.insufficientScope": "You do not have sufficient permissions to authorize this request.",
+	"oauth.consentView.error.mcpAccessDisabled": "MCP access is turned off for this n8n instance. Ask an instance owner or admin to turn it on, then start the connection again from your MCP client. <a href=\"{docsUrl}\" target=\"_blank\">Learn more</a>",
+	"oauth.consentView.error.mcpAccessDisabled.manage": "MCP access is turned off for this n8n instance. <a href=\"{settingsUrl}\">Turn it on in the MCP settings</a>, then start the connection again from your MCP client. <a href=\"{docsUrl}\" target=\"_blank\">Learn more</a>",
 	"oauth.consentView.success.title": "Success",
 	"oauth.consentView.success.description": "You will soon be redirected back to the client.",
 	"parameterInput.expressionResult": "e.g. {result}",

--- a/packages/frontend/editor-ui/src/app/stores/consent.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/consent.store.ts
@@ -7,11 +7,31 @@ import { type Ref, ref } from 'vue';
 import type { ConsentDetails } from '@n8n/rest-api-client/api/consent';
 import { ResponseError } from '@n8n/rest-api-client/utils';
 
+const CONSENT_ERROR_CODES = ['resource_unavailable', 'resource_disabled', 'forbidden'] as const;
+
+export type ConsentErrorCode = (typeof CONSENT_ERROR_CODES)[number];
+
+function isConsentErrorCode(value: unknown): value is ConsentErrorCode {
+	return typeof value === 'string' && (CONSENT_ERROR_CODES as readonly string[]).includes(value);
+}
+
+/**
+ * The server names the refusal in `meta.reason`; the status code is the
+ * fallback for responses that predate it.
+ */
+function toConsentErrorCode(error: ResponseError): ConsentErrorCode | null {
+	const reason = error.meta?.reason;
+	if (isConsentErrorCode(reason)) return reason;
+	if (error.httpStatusCode === 422) return 'resource_unavailable';
+	if (error.httpStatusCode === 403) return 'forbidden';
+	return null;
+}
+
 export const useConsentStore = defineStore(STORES.CONSENT, () => {
 	const consentDetails = ref<ConsentDetails | null>(null);
 	const isLoading = ref(false);
 	const error = ref<string | null>(null);
-	const errorCode: Ref<'resource_unavailable' | 'forbidden' | null> = ref(null);
+	const errorCode: Ref<ConsentErrorCode | null> = ref(null);
 
 	const rootStore = useRootStore();
 
@@ -24,10 +44,8 @@ export const useConsentStore = defineStore(STORES.CONSENT, () => {
 			consentDetails.value = await consentApi.getConsentDetails(rootStore.restApiContext);
 			return consentDetails.value;
 		} catch (err) {
-			if (err instanceof ResponseError && err.httpStatusCode === 422) {
-				errorCode.value = 'resource_unavailable';
-			} else if (err instanceof ResponseError && err.httpStatusCode === 403) {
-				errorCode.value = 'forbidden';
+			if (err instanceof ResponseError) {
+				errorCode.value = toConsentErrorCode(err);
 			}
 			error.value = err instanceof Error ? err.message : 'Failed to load consent details';
 			throw err;

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
@@ -1,12 +1,24 @@
 import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore, waitAllPromises } from '@/__tests__/utils';
 import { useConsentStore } from '@/app/stores/consent.store';
+import { hasPermission } from '@/app/utils/rbac/permissions';
 import OAuthConsentView from '@/app/views/OAuthConsentView.vue';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import { within } from '@testing-library/vue';
 
 vi.mock('@n8n/rest-api-client/api/consent');
+
+vi.mock('vue-router', async (importOriginal) => ({
+	...(await importOriginal<typeof import('vue-router')>()),
+	useRouter: () => ({
+		resolve: () => ({ href: '/settings/mcp' }),
+	}),
+}));
+
+vi.mock('@/app/utils/rbac/permissions', () => ({
+	hasPermission: vi.fn().mockReturnValue(false),
+}));
 
 const renderComponent = createComponentRenderer(OAuthConsentView);
 
@@ -18,6 +30,7 @@ describe('OAuthConsentView', () => {
 	beforeEach(() => {
 		createTestingPinia({ stubActions: false });
 		consentStore = mockedStore(useConsentStore);
+		vi.mocked(hasPermission).mockReturnValue(false);
 
 		const details = {
 			clientName: 'Test MCP Client',
@@ -117,6 +130,50 @@ describe('OAuthConsentView', () => {
 		// A rejected request must not present the broad instance permission grant.
 		expect(queryByText('Test MCP Client wants access to your n8n instance')).toBeNull();
 		expect(queryByText('Get a list of your workflows')).toBeNull();
+	});
+
+	it('should tell a member to ask an admin when MCP access is switched off', async () => {
+		consentStore.error = 'The requested resource is disabled on this n8n instance';
+		consentStore.errorCode = 'resource_disabled';
+		consentStore.fetchConsentDetails.mockResolvedValue(consentStore.consentDetails!);
+
+		const { getByTestId, queryByTestId } = renderComponent();
+		await waitAllPromises();
+
+		const notice = getByTestId('consent-error-notice');
+		expect(notice).toHaveTextContent(
+			'MCP access is turned off for this n8n instance. Ask an instance owner or admin to turn it on, then start the connection again from your MCP client. Learn more',
+		);
+		// No settings link for a user who cannot change the setting, only the docs.
+		expect(within(notice).getAllByRole('link')).toHaveLength(1);
+		expect(within(notice).getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+			'href',
+			'https://docs.n8n.io/connect/connect-to-n8n-mcp-server#enabling-mcp-access',
+		);
+		expect(queryByTestId('consent-allow-button')).toBeNull();
+		expect(getByTestId('consent-close-button')).toBeVisible();
+	});
+
+	it('should link a user who can manage MCP to the settings when MCP access is switched off', async () => {
+		vi.mocked(hasPermission).mockReturnValue(true);
+		consentStore.error = 'The requested resource is disabled on this n8n instance';
+		consentStore.errorCode = 'resource_disabled';
+		consentStore.fetchConsentDetails.mockResolvedValue(consentStore.consentDetails!);
+
+		const { getByTestId } = renderComponent();
+		await waitAllPromises();
+
+		const notice = getByTestId('consent-error-notice');
+		expect(notice).toHaveTextContent(
+			'MCP access is turned off for this n8n instance. Turn it on in the MCP settings, then start the connection again from your MCP client. Learn more',
+		);
+		expect(
+			within(notice).getByRole('link', { name: 'Turn it on in the MCP settings' }),
+		).toHaveAttribute('href', '/settings/mcp');
+		expect(within(notice).getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+			'href',
+			'https://docs.n8n.io/connect/connect-to-n8n-mcp-server#enabling-mcp-access',
+		);
 	});
 
 	it('should redirect to home page when deny is clicked', async () => {

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -4,6 +4,7 @@ import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useI18n } from '@n8n/i18n';
 import type { BaseTextKey } from '@n8n/i18n';
 import { onMounted, computed, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
 import type { ConsentDetails } from '@n8n/rest-api-client/api/consent';
 import {
 	N8nButton,
@@ -16,13 +17,19 @@ import {
 	N8nText,
 	N8nTooltip,
 } from '@n8n/design-system';
-import { MCP_SCOPE_GROUPS } from '@/features/ai/mcpAccess/mcp.constants';
+import {
+	MCP_DOCS_PAGE_URL,
+	MCP_SCOPE_GROUPS,
+	MCP_SETTINGS_VIEW,
+} from '@/features/ai/mcpAccess/mcp.constants';
 import { getClientBrand } from '@/features/ai/mcpAccess/clients.utils';
+import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useToast } from '@n8n/composables/useToast';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import ScopesSelector from '@/app/components/scopes/ScopesSelector.vue';
 
 const consentStore = useConsentStore();
+const router = useRouter();
 
 const i18n = useI18n();
 const documentTitle = useDocumentTitle();
@@ -38,13 +45,32 @@ const error = computed(() => consentStore.error);
 const loading = computed(() => consentStore.isLoading);
 const resourceName = computed(() => consentStore.consentDetails?.resourceName);
 
+// Today only the instance MCP server can be switched off, so a disabled target
+// is the MCP access setting. Users who can change it get the link.
+const canManageMcp = computed(() => hasPermission(['rbac'], { rbac: { scope: 'mcp:manage' } }));
+
 const errorMessage = computed(() => {
-	if (consentStore.errorCode === 'resource_unavailable') {
-		return i18n.baseText('oauth.consentView.error.resourceUnavailable');
-	} else if (consentStore.errorCode === 'forbidden') {
-		return i18n.baseText('oauth.consentView.error.insufficientScope');
+	switch (consentStore.errorCode) {
+		case 'resource_unavailable':
+			return i18n.baseText('oauth.consentView.error.resourceUnavailable');
+		case 'resource_disabled': {
+			const docsUrl = `${MCP_DOCS_PAGE_URL}#enabling-mcp-access`;
+			return canManageMcp.value
+				? i18n.baseText('oauth.consentView.error.mcpAccessDisabled.manage', {
+						interpolate: {
+							settingsUrl: router.resolve({ name: MCP_SETTINGS_VIEW }).href,
+							docsUrl,
+						},
+					})
+				: i18n.baseText('oauth.consentView.error.mcpAccessDisabled', {
+						interpolate: { docsUrl },
+					});
+		}
+		case 'forbidden':
+			return i18n.baseText('oauth.consentView.error.insufficientScope');
+		default:
+			return consentStore.error;
 	}
-	return consentStore.error;
 });
 
 const clientDetails = computed<ConsentDetails | null>(() => consentStore.consentDetails);
@@ -145,7 +171,10 @@ onMounted(async () => {
 			available_scopes_count: availableScopes.value.length,
 		});
 	} catch (err) {
-		toast.showError(err, i18n.baseText('oauth.consentView.error.fetchDetails'));
+		// A named refusal renders its own notice in place; a toast would repeat it.
+		if (consentStore.errorCode === null) {
+			toast.showError(err, i18n.baseText('oauth.consentView.error.fetchDetails'));
+		}
 	}
 });
 </script>


### PR DESCRIPTION
## Summary

When instance MCP access is off and a user still reaches the OAuth consent screen, it reports "You do not have sufficient permissions to authorize this request". The user's role is not the problem. The setting is off, and the message points the user at the wrong thing.

This PR makes the consent screen name the setting.

- The consent service checks whether the target resource is available before it checks whether the user may grant access. A switched-off resource is reported as a new reason, `resource_disabled`. The old `forbidden` reason stays for users who lack access to an available resource, such as a per-workflow trigger.
- Every refusal from the consent details endpoint carries its reason in `meta`. The frontend reads it instead of inferring it from the status code, with the status code kept as a fallback.
- The approve endpoint maps a switched-off resource to the same reason through a new `ProtectedResourceDisabledError`, so the rare case of the setting changing while the page is open gets the right message too.
- The consent view shows copy for the disabled case. Users who hold the `mcp:manage` scope get a link to the MCP settings page. Other users are told to ask an owner or admin. Both variants link to the docs section on enabling MCP access.
- The error toast is suppressed when the notice already explains the refusal, so the message is not shown twice.
- Both refusal paths on the details endpoint now log a warning. Before, the details path logged nothing, so an admin had no trace of a user's failed attempt.

The authorize step has a matching change in #37919. That PR renders a page for a browser when the resource is unavailable, so most users never reach the consent screen with MCP access off. This PR covers the case where they do.

## How to test

1. Turn MCP access on in Settings, Instance-level MCP.
2. Register an MCP client and open its authorize URL in a browser, or add `<instance>/mcp-server/http` as a connector in Claude. The consent screen with the scope picker appears. Do not press Allow.
3. In a second tab, turn MCP access off.
4. Reload the consent tab. As an owner or admin, the notice reads "MCP access is turned off for this n8n instance" with a link to the MCP settings and a "Learn more" link. No error toast appears.
5. Repeat as a member. The notice tells the member to ask an owner or admin, and shows only the docs link.
6. In the server log, look for "Consent refused: target resource is disabled on this instance".

## Related Linear tickets, Github issues, and Community forum posts

Companion to #37919, which covers the authorize step. No ticket. A user reported the consent message after connecting Claude Desktop to a new instance without enabling MCP access first.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)