### PR TITLE
feat(Metabase Node): Add API key authentication

### DIFF
--- a/packages/nodes-base/credentials/MetabaseApiKeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/MetabaseApiKeyApi.credentials.ts
@@ -1,0 +1,53 @@
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class MetabaseApiKeyApi implements ICredentialType {
+	name = 'metabaseApiKeyApi';
+
+	displayName = 'Metabase API (API Key)';
+
+	documentationUrl = 'metabase';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'URL',
+			name: 'url',
+			type: 'string',
+			default: '',
+			placeholder: 'https://metabase.example.com',
+			required: true,
+		},
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			required: true,
+			description:
+				'Create an API key in Metabase under Admin Settings &gt; Authentication &gt; API Keys. The key inherits the permissions of the group it is assigned to.',
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				'X-API-Key': '={{$credentials.apiKey}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials.url.replace(new RegExp("/$"), "")}}',
+			url: '/api/user/current',
+		},
+	};
+}

--- a/packages/nodes-base/credentials/test/MetabaseApiKeyApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MetabaseApiKeyApi.credentials.test.ts
@@ -1,0 +1,41 @@
+import { MetabaseApiKeyApi } from '../MetabaseApiKeyApi.credentials';
+
+describe('MetabaseApiKeyApi Credential', () => {
+	const metabaseApiKeyApi = new MetabaseApiKeyApi();
+
+	it('should have correct properties', () => {
+		expect(metabaseApiKeyApi.name).toBe('metabaseApiKeyApi');
+		expect(metabaseApiKeyApi.displayName).toBe('Metabase API (API Key)');
+		expect(metabaseApiKeyApi.documentationUrl).toBe('metabase');
+		expect(metabaseApiKeyApi.properties.map((property) => property.name)).toEqual([
+			'url',
+			'apiKey',
+		]);
+	});
+
+	it('should mask the API key', () => {
+		const apiKeyProperty = metabaseApiKeyApi.properties.find(
+			(property) => property.name === 'apiKey',
+		);
+
+		expect(apiKeyProperty?.typeOptions).toEqual({ password: true });
+	});
+
+	it('should send the API key in the X-API-Key header', () => {
+		expect(metabaseApiKeyApi.authenticate).toEqual({
+			type: 'generic',
+			properties: {
+				headers: {
+					'X-API-Key': '={{$credentials.apiKey}}',
+				},
+			},
+		});
+	});
+
+	it('should test the credential against the current user endpoint', () => {
+		expect(metabaseApiKeyApi.test.request.baseURL).toBe(
+			'={{$credentials.url.replace(new RegExp("/$"), "")}}',
+		);
+		expect(metabaseApiKeyApi.test.request.url).toBe('/api/user/current');
+	});
+});

--- a/packages/nodes-base/nodes/Metabase/Metabase.node.ts
+++ b/packages/nodes-base/nodes/Metabase/Metabase.node.ts
@@ -25,6 +25,20 @@ export class Metabase implements INodeType {
 			{
 				name: 'metabaseApi',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['password'],
+					},
+				},
+			},
+			{
+				name: 'metabaseApiKeyApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
 			},
 		],
 		requestDefaults: {
@@ -33,6 +47,22 @@ export class Metabase implements INodeType {
 			headers: {},
 		},
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'API Key',
+						value: 'apiKey',
+					},
+					{
+						name: 'Username & Password',
+						value: 'password',
+					},
+				],
+				default: 'password',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Metabase/test/Metabase.node.test.ts
+++ b/packages/nodes-base/nodes/Metabase/test/Metabase.node.test.ts
@@ -1,36 +1,68 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
-import type { WorkflowTestData } from 'n8n-workflow';
+import type { INodePropertyOptions, WorkflowTestData } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import nock from 'nock';
+
+import { Metabase } from '../Metabase.node';
 
 describe('Metabase Node', () => {
 	const testHarness = new NodeTestHarness();
 
-	// Each credential type points at its own host, so the host that receives the
-	// request tells us which credential the node resolved.
-	const sessionBaseUrl = 'https://metabase-session.example.com';
-	const apiKeyBaseUrl = 'https://metabase-api-key.example.com';
+	describe('Authentication parameter', () => {
+		const { credentials = [], properties } = new Metabase().description;
+		const authentication = properties.find((property) => property.name === 'authentication');
 
-	const credentials = {
-		metabaseApi: {
-			url: sessionBaseUrl,
-			username: 'user@example.com',
-			password: 'password',
-			sessionToken: 'session-token',
-		},
-		metabaseApiKeyApi: {
-			// Trailing slash on purpose: the node must strip it before it builds the request URL
-			url: `${apiKeyBaseUrl}/`,
-			apiKey: 'mb_test_api_key',
-		},
-	};
+		const credentialTypesFor = (authenticationValue: string) =>
+			credentials
+				.filter((credential) =>
+					credential.displayOptions?.show?.authentication?.includes(authenticationValue),
+				)
+				.map((credential) => credential.name);
 
-	const databases = [{ id: 1, name: 'Sample Database', engine: 'h2' }];
+		it('should default to username & password so existing workflows keep their credential', () => {
+			expect(authentication?.default).toBe('password');
+		});
+
+		it('should map each authentication option to exactly one credential type', () => {
+			const options = (authentication?.options ?? []) as INodePropertyOptions[];
+
+			expect(options.map((option) => option.value)).toEqual(['apiKey', 'password']);
+			expect(credentialTypesFor('password')).toEqual(['metabaseApi']);
+			expect(credentialTypesFor('apiKey')).toEqual(['metabaseApiKeyApi']);
+		});
+	});
 
 	describe('Credentials', () => {
+		// Each credential type points at its own host, and each host returns its own
+		// fixture. The output of a node therefore shows which credential it resolved.
+		const sessionBaseUrl = 'https://metabase-session.example.com';
+		const apiKeyBaseUrl = 'https://metabase-api-key.example.com';
+
+		const credentials = {
+			metabaseApi: {
+				url: sessionBaseUrl,
+				username: 'user@example.com',
+				password: 'password',
+				sessionToken: 'session-token',
+			},
+			metabaseApiKeyApi: {
+				// Trailing slash on purpose: the node must strip it before it builds the request URL
+				url: `${apiKeyBaseUrl}/`,
+				apiKey: 'mb_test_api_key',
+			},
+		};
+
+		const sessionDatabases = [{ id: 1, name: 'Session database', engine: 'h2' }];
+		const apiKeyDatabases = [{ id: 2, name: 'API key database', engine: 'postgres' }];
+
+		let sessionScope: nock.Scope;
+		let apiKeyScope: nock.Scope;
+
 		beforeAll(() => {
-			nock(sessionBaseUrl).get('/api/database/').reply(200, { data: databases });
-			nock(apiKeyBaseUrl).get('/api/database/').reply(200, { data: databases });
+			sessionScope = nock(sessionBaseUrl)
+				.get('/api/database/')
+				.reply(200, { data: sessionDatabases });
+			apiKeyScope = nock(apiKeyBaseUrl).get('/api/database/').reply(200, { data: apiKeyDatabases });
 		});
 
 		const testData: WorkflowTestData = {
@@ -113,12 +145,19 @@ describe('Metabase Node', () => {
 			},
 			output: {
 				nodeData: {
-					'Metabase metabaseApi': [[{ json: databases[0] }]],
-					'Metabase metabaseApiKeyApi': [[{ json: databases[0] }]],
+					'Metabase metabaseApi': [[{ json: sessionDatabases[0] }]],
+					'Metabase metabaseApiKeyApi': [[{ json: apiKeyDatabases[0] }]],
 				},
 			},
 		};
 
-		testHarness.setupTest(testData, { credentials });
+		testHarness.setupTest(testData, {
+			credentials,
+			customAssertions: () => {
+				// Each host must have received exactly one request
+				expect(sessionScope.isDone()).toBe(true);
+				expect(apiKeyScope.isDone()).toBe(true);
+			},
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Metabase/test/Metabase.node.test.ts
+++ b/packages/nodes-base/nodes/Metabase/test/Metabase.node.test.ts
@@ -1,0 +1,124 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import type { WorkflowTestData } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+import nock from 'nock';
+
+describe('Metabase Node', () => {
+	const testHarness = new NodeTestHarness();
+
+	// Each credential type points at its own host, so the host that receives the
+	// request tells us which credential the node resolved.
+	const sessionBaseUrl = 'https://metabase-session.example.com';
+	const apiKeyBaseUrl = 'https://metabase-api-key.example.com';
+
+	const credentials = {
+		metabaseApi: {
+			url: sessionBaseUrl,
+			username: 'user@example.com',
+			password: 'password',
+			sessionToken: 'session-token',
+		},
+		metabaseApiKeyApi: {
+			// Trailing slash on purpose: the node must strip it before it builds the request URL
+			url: `${apiKeyBaseUrl}/`,
+			apiKey: 'mb_test_api_key',
+		},
+	};
+
+	const databases = [{ id: 1, name: 'Sample Database', engine: 'h2' }];
+
+	describe('Credentials', () => {
+		beforeAll(() => {
+			nock(sessionBaseUrl).get('/api/database/').reply(200, { data: databases });
+			nock(apiKeyBaseUrl).get('/api/database/').reply(200, { data: databases });
+		});
+
+		const testData: WorkflowTestData = {
+			description: 'should use the credential that matches the selected authentication',
+			input: {
+				workflowData: {
+					nodes: [
+						{
+							parameters: {},
+							id: 'a1b2c3d4-0000-4000-8000-000000000001',
+							name: 'When clicking ‘Execute workflow’',
+							type: 'n8n-nodes-base.manualTrigger',
+							position: [0, 0],
+							typeVersion: 1,
+						},
+						{
+							// No `authentication` parameter: existing workflows keep using username & password
+							parameters: {
+								resource: 'databases',
+								operation: 'getAll',
+								simple: false,
+							},
+							id: 'a1b2c3d4-0000-4000-8000-000000000002',
+							name: 'Metabase metabaseApi',
+							type: 'n8n-nodes-base.metabase',
+							position: [200, 0],
+							typeVersion: 1,
+							credentials: {
+								metabaseApi: {
+									id: '1',
+									name: 'Metabase account',
+								},
+							},
+						},
+						{
+							parameters: {
+								authentication: 'apiKey',
+								resource: 'databases',
+								operation: 'getAll',
+								simple: false,
+							},
+							id: 'a1b2c3d4-0000-4000-8000-000000000003',
+							name: 'Metabase metabaseApiKeyApi',
+							type: 'n8n-nodes-base.metabase',
+							position: [400, 0],
+							typeVersion: 1,
+							credentials: {
+								metabaseApiKeyApi: {
+									id: '2',
+									name: 'Metabase API key account',
+								},
+							},
+						},
+					],
+					connections: {
+						'When clicking ‘Execute workflow’': {
+							main: [
+								[
+									{
+										node: 'Metabase metabaseApi',
+										type: NodeConnectionTypes.Main,
+										index: 0,
+									},
+								],
+							],
+						},
+						'Metabase metabaseApi': {
+							main: [
+								[
+									{
+										node: 'Metabase metabaseApiKeyApi',
+										type: NodeConnectionTypes.Main,
+										index: 0,
+									},
+								],
+							],
+						},
+					},
+				},
+			},
+			output: {
+				nodeData: {
+					'Metabase metabaseApi': [[{ json: databases[0] }]],
+					'Metabase metabaseApiKeyApi': [[{ json: databases[0] }]],
+				},
+			},
+		};
+
+		testHarness.setupTest(testData, { credentials });
+	});
+});

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -255,6 +255,7 @@
       "dist/credentials/MetabaseApi.credentials.js",
       "dist/credentials/MessageBirdApi.credentials.js",
       "dist/credentials/MetabaseApi.credentials.js",
+      "dist/credentials/MetabaseApiKeyApi.credentials.js",
       "dist/credentials/MicrosoftAzureCosmosDbSharedKeyApi.credentials.js",
       "dist/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.js",
       "dist/credentials/MicrosoftDynamicsOAuth2Api.credentials.js",


### PR DESCRIPTION
## Summary

Metabase supports API keys (Admin settings > Settings > Authentication > API keys), but the Metabase node only accepts a username and password, which it exchanges for a session token. Users who enforce SSO in Metabase, or who do not want to store a personal password in n8n, cannot use the node today.

This PR adds an **Authentication** option to the Metabase node:

- **Username & Password** (default): the existing `metabaseApi` credential, unchanged.
- **API Key**: a new `metabaseApiKeyApi` credential ("Metabase API (API Key)") with a URL and an API key. The key is sent in the `X-API-Key` header, as documented by Metabase.

Design notes:

- The existing credential keeps its `metabaseApi` name and behaviour, so stored credentials and existing workflows keep working. The node stays at version 1 and the new parameter defaults to the current behaviour. This follows the review guidance on #16972, where renaming the existing credential was flagged as a breaking change.
- The pattern (an `authentication` options parameter plus `displayOptions` on each credential entry) mirrors other declarative nodes such as Gong and Zammad. The credential naming follows `OdooApiKeyApi` / "Odoo API (API Key)".
- The credential test calls `/api/user/current`, like the existing credential, and strips a trailing slash from the URL, like the node's `requestDefaults` already does.

Tests:

- `credentials/test/MetabaseApiKeyApi.credentials.test.ts`: unit test for the new credential (auth header, test request, masked key).
- `nodes/Metabase/test/Metabase.node.test.ts`: workflow test that runs the node once without an `authentication` parameter (an existing workflow) and once with `apiKey`, and checks that each run hits the host of the selected credential.

Manual verification: with an API key against a live Metabase instance, the credential test request (`GET /api/user/current`) returns 200 with the key's user, the same request without the key returns 401, and `Database > Get Many` / `Question > Get Many` return data.

This change was drafted with Claude Code (Anthropic). Lint, typecheck and the tests in this PR were run locally.

## How to test

1. In Metabase, go to Admin settings > Settings > Authentication > API keys and create a key. Assign it to a group that can see at least one database.
2. In n8n, add a Metabase node and set **Authentication** to **API Key**. Create a "Metabase API (API Key)" credential with the Metabase URL and the key. Click **Test**. The test must succeed.
3. Run **Database > Get Many**. The databases visible to the key's group are returned.
4. Regression: open an existing workflow that uses a Metabase node with a username/password credential. It must still show **Username & Password** and run unchanged.
5. Automated tests:
   ```
   cd packages/nodes-base && pnpm test Metabase
   ```

## Related Linear tickets, Github issues, and Community forum posts

- Forum: https://community.n8n.io/t/add-api-key-option-for-metabase-authentication/98056
- Forum: https://community.n8n.io/t/metabase-login-via-api-key/231390
- Issue: https://github.com/n8n-io/n8n/issues/16971 (closed as a feature request and moved to the forum, Linear GHC-2895)
- Supersedes https://github.com/n8n-io/n8n/pull/16972 (closed as stale, Linear GHC-2896). This PR applies the review guidance from that thread: add a new credential type instead of renaming the existing one.
- Docs: n8n-io/n8n-docs#5338 documents the new method on the [Metabase credentials page](https://docs.n8n.io/integrations/builtin/credentials/metabase/).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (n8n-io/n8n-docs#5338)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
