### PR TITLE
refactor(editor): Extract the icon parameter input into a frontend module (no-changelog)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -184,6 +184,10 @@ packages/frontend/editor-ui/src/features/credentials/   @n8n-io/iam
 packages/frontend/editor-ui/src/features/execution/     @n8n-io/ligo
 packages/frontend/editor-ui/src/features/integrations/  @n8n-io/ligo
 
+# Frontend module packages. Without an entry a module falls through to the
+# catch-all, so extracting code out of editor-ui would move its owner.
+packages/modules/parameter-input-icon/frontend/         @n8n-io/frontend
+
 packages/frontend/@n8n/design-system/                   @n8n-io/design
 packages/frontend/@n8n/stores/                          @n8n-io/frontend
 packages/frontend/@n8n/composables/                     @n8n-io/frontend

--- a/packages/@n8n/module-cli/README.md
+++ b/packages/@n8n/module-cli/README.md
@@ -9,6 +9,11 @@ pnpm n8n-module-sdk create my-feature --stack=frontend
 
 `create` writes `packages/modules/<name>/<frontend|backend>`.
 
+**Pick `<name>` by class.** A module with a backend half takes its backend module directory
+name and no prefix (`otel`). A contribution-only module — no backend half, so its id never
+reaches `/rest/module-settings` — takes a prefix naming the descriptor contribution point it
+feeds (`parameter-input-icon` feeds `parameterInputs`). See `packages/modules/README.md`.
+
 ## Frontend
 
 A real, resolvable workspace package: source-only (`main: "src/index.ts"`, no
@@ -22,6 +27,20 @@ second copy of any of them.
 Biome runs over the new package and over every edited file at the end, because
 a registration line can be longer than the 100-column limit. Without that step
 the next `format:check` in CI fails on a module nobody touched by hand.
+
+## Running a module's checks
+
+```bash
+pnpm turbo typecheck --filter=@n8n/frontend-module-<name>
+pnpm turbo lint --filter=@n8n/frontend-module-<name>
+pnpm turbo test --filter=@n8n/frontend-module-<name>
+```
+
+Go through turbo, not the bare `pnpm --filter <pkg> <task>` form. A frontend module
+is consumed from source, so nothing builds its platform dependencies for it: on a cold
+tree `pnpm --filter <pkg> test` fails to resolve `n8n-workflow` and
+`@n8n/vitest-config/frontend`. Turbo builds them first. The generated README repeats
+this for the new package.
 
 ## Backend
 

--- a/packages/@n8n/module-cli/src/templates/frontend/module.ts.template
+++ b/packages/@n8n/module-cli/src/templates/frontend/module.ts.template
@@ -23,6 +23,7 @@ export const {{PascalName}}Module: FrontendModuleDescription = {
 	// settingsPages: [ /* IMenuItem[]; feeds SettingsSidebar */ ],
 	// pushHandlers: { /* keyed by push message type */ },
 	// commands: [ /* CommandBarEntry[] */ ],
+	// parameterInputs: [ /* ParameterInputContribution[]; resolved by `parameter.type` */ ],
 
 	// The SDK types the fields below, but no host in the shell reads them yet.
 	// A value here does nothing at runtime: locales, shortcuts, banners, setup.

--- a/packages/frontend/@n8n/frontend-module-sdk/src/types/parameterInput.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/types/parameterInput.ts
@@ -39,6 +39,12 @@ export type ParameterInputProps = {
 	 */
 	parameterIssues: string[];
 	droppable: boolean;
+	/**
+	 * The shell draws the field without its label, so an input of a fixed size can
+	 * render a smaller variant. Set for a repeated parameter (`MultipleParameter`),
+	 * for an inline parameter list, and for an assignment or filter row.
+	 */
+	hideLabel: boolean;
 	eventBus?: EventBus;
 };
 

--- a/packages/frontend/@n8n/frontend-vite-config/index.ts
+++ b/packages/frontend/@n8n/frontend-vite-config/index.ts
@@ -44,6 +44,10 @@ export const sourcePackages = [
  * The module tsconfig base holds that boundary.
  */
 export const modulePackages: Array<{ name: string; dir: string; entry?: boolean }> = [
+	{
+		name: '@n8n/frontend-module-parameter-input-icon',
+		dir: 'modules/parameter-input-icon/frontend',
+	},
 	{ name: '@n8n/frontend-module-instance-registry', dir: 'modules/instance-registry/frontend' },
 	{ name: '@n8n/frontend-module-otel', dir: 'modules/otel/frontend' },
 ];

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2657,6 +2657,8 @@
 	"parameterInput.formatHtml": "Format HTML",
 	"parameterInput.issues": "Issues",
 	"parameterInput.loadingOptions": "Loading options...",
+	"parameterInput.loadFailed": "This field could not be loaded",
+	"parameterInput.loadFailed.reload": "Reload",
 	"parameterInput.loadOptionsErrorService": "Error fetching options from {service}",
 	"parameterInput.loadOptionsError": "Error fetching options",
 	"parameterInput.loadOptionsCredentialsRequired": "Set up credential to see options",

--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -49,6 +49,7 @@
     "@n8n/constants": "workspace:*",
     "@n8n/design-system": "workspace:*",
     "@n8n/frontend-constants": "workspace:*",
+    "@n8n/frontend-module-parameter-input-icon": "workspace:*",
     "@n8n/frontend-module-instance-registry": "workspace:*",
     "@n8n/frontend-module-otel": "workspace:*",
     "@n8n/frontend-module-sdk": "workspace:*",

--- a/packages/frontend/editor-ui/src/app/init/index.test.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.test.ts
@@ -11,6 +11,7 @@ import { useUsersStore } from '@n8n/stores/users.store';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useVersionsStore } from '@n8n/stores/versions.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { Cloud, CurrentUserResponse } from '@n8n/rest-api-client';
 import type { IUser } from '@n8n/rest-api-client/api/users';
 import { STORES } from '@n8n/stores';
@@ -89,6 +90,7 @@ describe('Init', () => {
 	let ssoStore: ReturnType<typeof mockedStore<typeof useSSOStore>>;
 	let rootStore: ReturnType<typeof mockedStore<typeof useRootStore>>;
 	let bannersStore: ReturnType<typeof mockedStore<typeof useBannersStore>>;
+	let projectsStore: ReturnType<typeof mockedStore<typeof useProjectsStore>>;
 
 	beforeEach(() => {
 		setActivePinia(
@@ -109,6 +111,7 @@ describe('Init', () => {
 		ssoStore = mockedStore(useSSOStore);
 		rootStore = mockedStore(useRootStore);
 		bannersStore = mockedStore(useBannersStore);
+		projectsStore = mockedStore(useProjectsStore);
 	});
 
 	describe('initializeCore()', () => {
@@ -288,6 +291,35 @@ describe('Init', () => {
 			expect(sourceControlSpy).not.toHaveBeenCalled();
 			expect(nodeTranslationSpy).not.toHaveBeenCalled();
 			expect(versionsSpy).not.toHaveBeenCalled();
+		});
+
+		// The registry is what gives a claimed `parameter.type` something to render. This
+		// function tolerates its own failures — the router logs them and carries on — so a
+		// registration behind a rejected fetch would leave those fields empty.
+		it('should register parameter inputs before anything that can fail', async () => {
+			vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValue();
+			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
+			usersStore.currentUser = mock<IUser>({ id: '123', globalScopes: ['user:list'] });
+
+			await initializeAuthenticatedFeatures(false);
+
+			expect(moduleInitializer.registerModuleParameterInputs).toHaveBeenCalledTimes(1);
+			expect(
+				vi.mocked(moduleInitializer.registerModuleParameterInputs).mock.invocationCallOrder[0],
+			).toBeLessThan(sourceControlSpy.mock.invocationCallOrder[0]);
+		});
+
+		// `getMyProjects` sits in a bare `Promise.all`, so its rejection leaves this function
+		// through the router's catch and every registration after it is skipped.
+		it('should register parameter inputs even when a later fetch rejects', async () => {
+			vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValue();
+			vi.spyOn(projectsStore, 'getMyProjects').mockRejectedValue(new Error('offline'));
+			usersStore.currentUser = mock<IUser>({ id: '123', globalScopes: ['user:list'] });
+
+			await expect(initializeAuthenticatedFeatures(false)).rejects.toThrow('offline');
+
+			expect(moduleInitializer.registerModuleParameterInputs).toHaveBeenCalledTimes(1);
+			expect(moduleInitializer.registerModuleCommands).not.toHaveBeenCalled();
 		});
 
 		it('should init authenticated features only once if user is logged in', async () => {

--- a/packages/frontend/editor-ui/src/app/init/index.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.ts
@@ -116,6 +116,13 @@ export async function initializeAuthenticatedFeatures(
 		return;
 	}
 
+	// Ahead of the other module registrations, and ahead of every await below. A
+	// parameter input is what draws a field: a claimed type with nothing registered
+	// renders an empty field, and this function tolerates its own failures — the
+	// router logs them and carries on. The registry reads the manifest only, so it
+	// needs none of the state the awaits fetch.
+	registerModuleParameterInputs();
+
 	const i18n = useI18n();
 	const toast = useToast();
 	const sourceControlStore = useSourceControlStore();
@@ -242,7 +249,6 @@ export async function initializeAuthenticatedFeatures(
 	registerModuleSettingsPages();
 	registerModulePushHandlers();
 	registerModuleCommands();
-	registerModuleParameterInputs();
 
 	// Initialize run data worker and load node types
 	if (isDataWorkerEnabled()) {

--- a/packages/frontend/editor-ui/src/app/moduleInitializer/moduleInitializer.ts
+++ b/packages/frontend/editor-ui/src/app/moduleInitializer/moduleInitializer.ts
@@ -136,6 +136,10 @@ export const registerModuleCommands = () => {
  * primitive, not a feature. A gated renderer leaves a parameter with nothing to
  * render it, which is a broken field rather than a hidden feature. Availability
  * is enforced backend-side.
+ *
+ * For the same reason `init.ts` calls this before the awaits the other module
+ * registrations sit behind: a failed projects or roles fetch must not decide
+ * whether a field has something to draw it.
  */
 export const registerModuleParameterInputs = () => {
 	modules.forEach((module) => {

--- a/packages/frontend/editor-ui/src/app/modules.manifest.ts
+++ b/packages/frontend/editor-ui/src/app/modules.manifest.ts
@@ -9,6 +9,7 @@ import { WorkflowReviewsModule } from '@/features/workflow-reviews/module.descri
 import { InstanceRegistryModule } from '@n8n/frontend-module-instance-registry';
 import { OtelModule } from '@n8n/frontend-module-otel';
 import { PromotionsModule } from '@/features/integrations/promotions.ee/module.descriptor';
+import { ParameterInputIconModule } from '@n8n/frontend-module-parameter-input-icon';
 
 /**
  * Hard-coding modules list until we have a dynamic way to load modules.
@@ -24,4 +25,5 @@ export const modules: FrontendModuleDescription[] = [
 	WorkflowReviewsModule,
 	InstanceRegistryModule,
 	PromotionsModule,
+	ParameterInputIconModule,
 ];

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.iconModule.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.iconModule.test.ts
@@ -1,0 +1,408 @@
+/**
+ * The `icon` parameter type is drawn by `@n8n/frontend-module-parameter-input-icon`, not by a
+ * branch in `ParameterInput.vue`. That puts three seams between a node parameter and its
+ * picker — the registry lookup, an async component boundary, and a debounced
+ * `update:modelValue` — and none of them existed while the branch was inline.
+ *
+ * These cases drive the real module through the real shell, so a break in any of the
+ * three fails here. The module's own suite covers the adapter in isolation; what is
+ * guarded here is the wiring, plus the two fallbacks the shell keeps for a type it does
+ * not own: the expression editor, and a built-in input for a type no module claims.
+ */
+
+// The suite-wide `reka-ui` stub in `src/__tests__/setup.ts` toggles the popover from a
+// capture-phase handler. `N8nIconPicker` toggles its own `v-model:open` from a
+// `@click.stop` on the trigger, which cannot stop a capture-phase listener, so the two
+// toggles cancel and the popup never opens under the stub. The real Reka trigger toggles
+// on bubble, where `.stop` does reach it. Opening the picker is the point of half these
+// cases, so this file runs against the real popover.
+vi.unmock('reka-ui');
+
+import { ParameterInputIconModule } from '@n8n/frontend-module-parameter-input-icon';
+import { parameterInputRegistry } from '@n8n/frontend-module-sdk';
+import { createTestingPinia } from '@pinia/testing';
+import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/vue';
+import { flushPromises } from '@vue/test-utils';
+import type { INodeProperties } from 'n8n-workflow';
+import { computed, defineComponent, h } from 'vue';
+
+import { createComponentRenderer } from '@/__tests__/render';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import ParameterInput from './ParameterInput.vue';
+
+const ndvState = {
+	hasInputData: true,
+	activeNode: {
+		id: 'node-id',
+		name: 'When chat message received',
+		parameters: {},
+		position: [0, 0] as [number, number],
+		type: '@n8n/n8n-nodes-langchain.chatTrigger',
+		typeVersion: 1.2,
+	},
+	isInputPanelEmpty: false,
+	isOutputPanelEmpty: false,
+	ndvInputDataWithPinnedData: [],
+	getHoveringItem: undefined,
+	expressionOutputItemIndex: 0,
+	isTableHoverOnboarded: false,
+	setHighlightDraggables: vi.fn(),
+	setNDVPanelDataIsEmpty: vi.fn(),
+	setNDVBranchIndex: vi.fn(),
+};
+
+vi.mock('@/features/ndv/shared/ndv.store', () => ({
+	useNDVStore: vi.fn(() => ndvState),
+	injectNDVStore: vi.fn(() => ({ value: ndvState })),
+	injectNDVStoreIfProvided: vi.fn(() => ({ value: ndvState })),
+}));
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: vi.fn(() => ({
+		allNodeTypes: [],
+		getNodeType: vi.fn().mockReturnValue(null),
+		getAllNodeTypes: vi.fn().mockReturnValue({
+			nodeTypes: {},
+			init: async () => {},
+			getByNameAndVersion: () => undefined,
+		}),
+	})),
+}));
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({ push: vi.fn(), resolve: vi.fn().mockReturnValue({ href: '/' }) }),
+	useRoute: () => ({}),
+	RouterLink: vi.fn(),
+}));
+
+vi.mock('@/features/ai/assistant/builder.store', () => ({
+	useBuilderStore: vi.fn(() => ({
+		trackWorkflowBuilderJourney: vi.fn(),
+		isAIBuilderEnabled: false,
+	})),
+}));
+
+/** The `agentIcon` field of `ChatTrigger.node.ts` — one of the two shipped `icon` fields. */
+const agentIconParameter: INodeProperties = {
+	displayName: 'Agent Icon',
+	name: 'agentIcon',
+	type: 'icon',
+	default: { type: 'icon', value: 'bot' },
+	noDataExpression: true,
+	description: 'The icon of the agent on n8n Chat',
+};
+
+/**
+ * The `icon` field inside the `Prompts` collection of `ChatTrigger.node.ts` — the other
+ * one, and the only shipped `icon` parameter that the shell draws with `hideLabel`.
+ */
+const promptsIconParameter: INodeProperties = {
+	displayName: 'Icon',
+	name: 'icon',
+	type: 'icon',
+	noDataExpression: true,
+	default: { type: 'icon', value: 'comment' },
+};
+
+/**
+ * An `icon` parameter that permits an expression. No node ships one — both shipped fields
+ * set `noDataExpression`, which makes `isValueExpression` return false whatever the value
+ * is. The type still has to keep the expression path, because the module claims the
+ * render branch only, so this fixture is what exercises it.
+ */
+const expressionableIconParameter: INodeProperties = {
+	displayName: 'Agent Icon',
+	name: 'agentIcon',
+	type: 'icon',
+	default: { type: 'icon', value: 'bot' },
+};
+
+const renderComponent = createComponentRenderer(ParameterInput, {
+	pinia: createTestingPinia(),
+	global: {
+		provide: {
+			[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+		},
+	},
+});
+
+function registerIconModule() {
+	const contribution = ParameterInputIconModule.parameterInputs?.[0];
+	if (!contribution) throw new Error('ParameterInputIconModule contributes no parameter input');
+	parameterInputRegistry.register(contribution);
+}
+
+/**
+ * Mounts the field and waits for the module's chunk. The first `import()` of the SFC
+ * settles over an unknown number of microtask turns, so the wait is an auto-waiting query
+ * rather than a fixed number of `flushPromises` rounds.
+ */
+async function renderIconField(props: Record<string, unknown> = {}) {
+	const rendered = renderComponent({
+		props: {
+			path: 'parameters.agentIcon',
+			parameter: agentIconParameter,
+			modelValue: { type: 'icon', value: 'bot' },
+			...props,
+		},
+	});
+	await rendered.findByTestId('icon-picker-button');
+	return rendered;
+}
+
+/** Mounts the field without assuming a picker ever appears. */
+async function renderField(props: Record<string, unknown>) {
+	const rendered = renderComponent({ props });
+	await flushPromises();
+	return rendered;
+}
+
+/** The last `update` the shell emitted for the field. */
+function lastUpdate(emitted: Record<string, unknown[]>) {
+	const updates = emitted.update as Array<[{ name: string; value: unknown }]> | undefined;
+	if (!updates?.length) throw new Error('the shell emitted no update');
+	return updates[updates.length - 1][0];
+}
+
+describe('ParameterInput.vue — the icon parameter module', () => {
+	afterEach(() => {
+		parameterInputRegistry.clear();
+	});
+
+	describe('the picker the module contributes', () => {
+		beforeEach(registerIconModule);
+
+		it('draws the field with the module picker and no built-in input', async () => {
+			const { getByTestId, container } = await renderIconField();
+
+			expect(getByTestId('icon-picker-button')).toBeInTheDocument();
+			expect(container.querySelector('input')).not.toBeInTheDocument();
+		});
+
+		it('opens the picker on the trigger', async () => {
+			const { getByTestId, findAllByTestId } = await renderIconField();
+
+			await userEvent.click(getByTestId('icon-picker-button'));
+
+			expect(getByTestId('icon-picker-popup')).toBeVisible();
+			expect(getByTestId('icon-picker-tabs')).toBeVisible();
+			expect((await findAllByTestId('icon-picker-icon')).length).toBeGreaterThan(0);
+		});
+
+		it('sends a picked icon to the shell as the parameter value', async () => {
+			const { getByTestId, findAllByTestId, emitted } = await renderIconField();
+
+			await userEvent.click(getByTestId('icon-picker-button'));
+			const icons = await findAllByTestId('icon-picker-icon');
+			const pickedLabel = icons[0].getAttribute('aria-label');
+
+			await userEvent.click(icons[0]);
+
+			// The shell debounces the update by 100 ms.
+			await waitFor(() => expect(emitted().update).toBeTruthy());
+			const update = lastUpdate(emitted());
+			expect(update.name).toBe('parameters.agentIcon');
+			expect(update.value).toEqual({ type: 'icon', value: expect.any(String) });
+			expect(pickedLabel).toBeTruthy();
+		});
+
+		/**
+		 * The emoji grid is not reachable here: `N8nIconPicker` filters every emoji through
+		 * `is-emoji-supported`, which measures a glyph on a canvas that jsdom does not have, so
+		 * the grid comes up empty. That package is not a dependency of editor-ui either, so
+		 * `vi.mock` cannot resolve it from this file. Emoji selection is guarded in
+		 * `IconPicker.test.ts` ("is able to select an emoji"), and the emoji shape of the value
+		 * is guarded in the module's own suite. What stays here is that an emoji value the shell
+		 * holds reaches the trigger.
+		 */
+		it('shows an emoji value the shell holds', async () => {
+			const { getByTestId } = await renderIconField({
+				modelValue: { type: 'emoji', value: '\u{1F436}' },
+			});
+
+			expect(getByTestId('icon-picker-button')).toHaveTextContent('\u{1F436}');
+		});
+
+		/**
+		 * The built-in branch updated the value with no debounce. The contributed slot goes
+		 * through `valueChangedDebounced`, so the module holds the picked value until the
+		 * shell's own value returns. Without that hold the trigger shows the previous icon for
+		 * 100 ms.
+		 */
+		it('shows the picked value at once, with no flash of the previous one', async () => {
+			const { getByTestId, findAllByTestId } = await renderIconField({
+				modelValue: { type: 'icon', value: 'bot' },
+			});
+
+			expect(getByTestId('icon-picker-button').innerHTML).toContain('data-icon="bot"');
+
+			await userEvent.click(getByTestId('icon-picker-button'));
+			const icons = await findAllByTestId('icon-picker-icon');
+			const picked = icons.find((i) => i.getAttribute('aria-label') !== 'Bot') as HTMLElement;
+
+			await userEvent.click(picked);
+
+			// `modelValue` still holds `bot` here: the shell has not sent a new value back, and
+			// the trigger must already have stopped drawing it.
+			expect(getByTestId('icon-picker-button').innerHTML).not.toContain('data-icon="bot"');
+		});
+
+		it('yields to the shell once the new value arrives', async () => {
+			const { getByTestId, rerender } = await renderIconField({
+				modelValue: { type: 'icon', value: 'bot' },
+			});
+
+			await rerender({
+				path: 'parameters.agentIcon',
+				parameter: agentIconParameter,
+				modelValue: { type: 'emoji', value: '\u{1F436}' },
+			});
+
+			expect(getByTestId('icon-picker-button')).toHaveTextContent('\u{1F436}');
+		});
+
+		it('holds the read-only state and opens no picker', async () => {
+			const { getByTestId, queryByTestId } = await renderIconField({ isReadOnly: true });
+
+			expect(getByTestId('icon-picker-button')).toBeDisabled();
+
+			await userEvent.click(getByTestId('icon-picker-button'));
+
+			expect(queryByTestId('icon-picker-popup')).not.toBeInTheDocument();
+		});
+
+		// `hideLabel` reached the built-in branch directly. It reaches the module as a prop,
+		// so the size rule breaks silently if the shell stops passing it.
+		it.each([
+			['large', false],
+			['small', true],
+		])('sizes the trigger %s for hideLabel=%s', async (size, hideLabel) => {
+			const { getByTestId } = await renderIconField({
+				path: 'parameters.prompts[0].icon',
+				parameter: promptsIconParameter,
+				modelValue: { type: 'icon', value: 'comment' },
+				hideLabel,
+			});
+
+			expect(getByTestId('icon-picker-button').className).toContain(size);
+		});
+
+		/**
+		 * The module declares no `ownsExpressionRendering`, so the shell keeps the expression
+		 * editor for `icon` — the rule the `!isModelValueExpression && !forceShowExpression`
+		 * guard on the built-in branch had.
+		 */
+		it('keeps the expression editor for an icon parameter holding an expression', async () => {
+			const { queryByTestId, container } = await renderField({
+				path: 'parameters.agentIcon',
+				parameter: expressionableIconParameter,
+				modelValue: '={{ $json.icon }}',
+			});
+
+			await waitFor(() => expect(container.querySelector('.cm-editor')).toBeInTheDocument());
+			expect(queryByTestId('icon-picker-button')).not.toBeInTheDocument();
+		});
+
+		it('keeps the expression editor when the shell forces it', async () => {
+			const { queryByTestId, container } = await renderField({
+				path: 'parameters.agentIcon',
+				parameter: agentIconParameter,
+				modelValue: { type: 'icon', value: 'bot' },
+				forceShowExpression: true,
+			});
+
+			await waitFor(() => expect(container.querySelector('.cm-editor')).toBeInTheDocument());
+			expect(queryByTestId('icon-picker-button')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('the fallbacks the shell keeps', () => {
+		it('draws the built-in input for a type no module claims', async () => {
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			const { container, queryByTestId } = await renderField({
+				path: 'parameters.custom',
+				parameter: { displayName: 'Custom', name: 'custom', type: 'string', default: '' },
+				modelValue: 'plain',
+			});
+
+			expect(queryByTestId('icon-picker-button')).not.toBeInTheDocument();
+			expect(container.querySelector('input')).toBeInTheDocument();
+			expect(consoleError).not.toHaveBeenCalled();
+
+			consoleError.mockRestore();
+		});
+
+		it('keeps the field row when the contributed chunk fails to load', async () => {
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const rejections: unknown[] = [];
+			const onRejection = (event: PromiseRejectionEvent) => rejections.push(event.reason);
+			window.addEventListener('unhandledrejection', onRejection);
+
+			parameterInputRegistry.register({
+				type: 'icon',
+				component: async () => {
+					throw new Error('chunk 404');
+				},
+			});
+
+			const { findByTestId } = await renderField({
+				path: 'parameters.agentIcon',
+				parameter: agentIconParameter,
+				modelValue: { type: 'icon', value: 'bot' },
+			});
+
+			// One retry, then the error state. Both attempts have to settle first.
+			const row = await findByTestId('parameter-input-load-error');
+			expect(row).toHaveAttribute('role', 'alert');
+			expect(consoleError).toHaveBeenCalledWith(
+				'Failed to load a contributed parameter input',
+				expect.any(Error),
+			);
+
+			window.removeEventListener('unhandledrejection', onRejection);
+			consoleError.mockRestore();
+			expect(rejections).toEqual([]);
+		});
+
+		it('reserves the field row while the contributed chunk is still loading', async () => {
+			vi.useFakeTimers();
+			let release: (component: unknown) => void = () => {};
+			const LateInput = defineComponent({
+				setup: () => () => h('span', { 'data-test-id': 'late-input' }),
+			});
+
+			parameterInputRegistry.register({
+				type: 'icon',
+				component: async () =>
+					await new Promise((resolve) => {
+						release = resolve;
+					}),
+			});
+
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					path: 'parameters.agentIcon',
+					parameter: agentIconParameter,
+					modelValue: { type: 'icon', value: 'bot' },
+				},
+			});
+
+			// `defineAsyncComponent` holds the placeholder back for its default 200 ms delay,
+			// so a chunk that arrives quickly never flashes one.
+			await flushPromises();
+			expect(queryByTestId('parameter-input-loading')).not.toBeInTheDocument();
+
+			await vi.advanceTimersByTimeAsync(200);
+			expect(getByTestId('parameter-input-loading')).toBeInTheDocument();
+
+			release(LateInput);
+			await flushPromises();
+
+			expect(queryByTestId('parameter-input-loading')).not.toBeInTheDocument();
+			expect(getByTestId('late-input')).toBeInTheDocument();
+			vi.useRealTimers();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -1840,6 +1840,7 @@ describe('ParameterInput.vue', () => {
 			},
 			parameterIssues: { type: Array as PropType<string[]>, required: true as const },
 			droppable: { type: Boolean, required: true as const },
+			hideLabel: { type: Boolean, required: true as const },
 			eventBus: { type: Object as PropType<EventBus>, required: false as const },
 		};
 
@@ -1868,6 +1869,45 @@ describe('ParameterInput.vue', () => {
 
 		afterEach(() => {
 			parameterInputRegistry.clear();
+			delete window.n8nExternalHooks;
+		});
+
+		/**
+		 * `parameterInput.mount` is an external-hook surface, and a contributed input
+		 * resolves its chunk after this component mounts. A payload assembled in
+		 * `onMounted` therefore hands the hook `undefined` where a built-in branch hands
+		 * it the input.
+		 */
+		test('should hand the mount hook the contributed input once its chunk resolves', async () => {
+			const mount = vi.fn();
+			window.n8nExternalHooks = { parameterInput: { mount: [mount] } };
+			parameterInputRegistry.register({
+				type: 'string',
+				component: async () => ContributedInput,
+			});
+
+			const { getByTestId } = renderComponent({
+				props: { path: 'custom', parameter: stringParameter, modelValue: 'from-shell' },
+			});
+			await waitFor(() => expect(getByTestId('contributed-input')).toBeInTheDocument());
+
+			await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
+			expect(mount.mock.calls[0][1]).toMatchObject({ parameter: stringParameter });
+			expect(mount.mock.calls[0][1].inputFieldRef).toBeDefined();
+		});
+
+		test('should keep firing the mount hook from mount for a built-in input', async () => {
+			const mount = vi.fn();
+			window.n8nExternalHooks = { parameterInput: { mount: [mount] } };
+
+			const { container } = renderComponent({
+				props: { path: 'custom', parameter: stringParameter, modelValue: 'built-in' },
+			});
+			await nextTick();
+
+			expect(container.querySelector('input')).toBeInTheDocument();
+			expect(mount).toHaveBeenCalledTimes(1);
+			expect(mount.mock.calls[0][1].inputFieldRef).toBeDefined();
 		});
 
 		test('should render the built-in input when no module claims the type', () => {
@@ -1888,6 +1928,43 @@ describe('ParameterInput.vue', () => {
 			await nextTick();
 
 			expect(getByTestId('contributed-input')).toHaveTextContent('from-shell');
+		});
+
+		test.each([
+			[false, 'false'],
+			[true, 'true'],
+		])('should pass hideLabel=%s to a contributed input', async (hideLabel, expected) => {
+			const HideLabelProbe = defineComponent({
+				props: contractProps,
+				setup: (props) => () =>
+					h('span', { 'data-test-id': 'contributed-input' }, String(props.hideLabel)),
+			});
+			parameterInputRegistry.register({ type: 'string', component: HideLabelProbe });
+
+			const { getByTestId } = renderComponent({
+				props: { path: 'custom', parameter: stringParameter, modelValue: '', hideLabel },
+			});
+			await nextTick();
+
+			expect(getByTestId('contributed-input')).toHaveTextContent(expected);
+		});
+
+		/**
+		 * The contributed slot goes through `valueChangedDebounced`, which `useDebounce`
+		 * builds on the leading edge. A single update therefore reaches the shell in the
+		 * same tick, and only a second one inside the window waits for the trailing edge.
+		 */
+		test('should emit a single contributed update without waiting for the debounce', async () => {
+			parameterInputRegistry.register({ type: 'string', component: ContributedInput });
+
+			const { getByTestId, emitted } = renderComponent({
+				props: { path: 'custom', parameter: stringParameter, modelValue: '' },
+			});
+			await nextTick();
+
+			await fireEvent.click(getByTestId('contributed-input'));
+
+			expect(emitted().update).toHaveLength(1);
 		});
 
 		test('should emit the parameter update a contributed input sends', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -18,14 +18,11 @@ import type {
 } from 'n8n-workflow';
 import {
 	CREDENTIAL_EMPTY_VALUE,
-	IconOrEmojiSchema,
 	isResourceLocatorValue,
 	jsonParse,
 	NodeHelpers,
 	resolveRelativePath,
 } from 'n8n-workflow';
-
-import type { IconOrEmoji as DesignSystemIconOrEmoji } from '@n8n/design-system';
 
 import type { CodeNodeLanguageOption } from '@/features/shared/editors/components/CodeNodeEditor/CodeNodeEditor.vue';
 import CodeNodeEditor from '@/features/shared/editors/components/CodeNodeEditor/CodeNodeEditor.vue';
@@ -104,7 +101,6 @@ import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { ElColorPicker, ElDatePicker, ElDialog, ElSwitch } from 'element-plus';
 import {
 	N8nIcon,
-	N8nIconPicker,
 	N8nInput,
 	N8nInputNumber,
 	N8nOption,
@@ -382,22 +378,6 @@ const modelValueExpressionEdit = computed<NodeParameterValueType>(() => {
 			? (props.modelValue as INodeParameterResourceLocator).value
 			: ''
 		: props.modelValue;
-});
-
-const iconPickerValue = computed<DesignSystemIconOrEmoji | undefined>({
-	get() {
-		const result = IconOrEmojiSchema.safeParse(props.modelValue);
-		if (result.success) {
-			return {
-				type: result.data.type,
-				value: result.data.value,
-			} as DesignSystemIconOrEmoji;
-		}
-		return undefined;
-	},
-	set(_value: DesignSystemIconOrEmoji | undefined) {
-		// Handled by valueChanged
-	},
 });
 
 const editorRows = computed(() => {
@@ -1333,6 +1313,34 @@ async function optionSelected(command: string) {
 	}
 }
 
+/**
+ * `parameterInput.mount` hands an external hook the input that draws the field. A
+ * module-contributed input resolves its chunk after this component mounts, so
+ * `inputField` is still empty in `onMounted` — waiting for it keeps the payload the
+ * hook got while the input was a branch in this file. The flag holds it to one call per
+ * field, and the built-in branches keep firing from `onMounted` as before.
+ *
+ * A chunk that never resolves leaves the hook unfired. `defineAsyncComponent` forwards
+ * the ref to the resolved component only, not to the loading or the error one, and a
+ * field drawn by `ParameterInputLoadError` has no input to hand over.
+ */
+let hasRunMountHook = false;
+
+function runParameterInputMountHook() {
+	if (hasRunMountHook) return;
+	hasRunMountHook = true;
+
+	void externalHooks.run('parameterInput.mount', {
+		parameter: props.parameter,
+
+		inputFieldRef: inputField.value as InstanceType<typeof N8nInput>,
+	});
+}
+
+watch(inputField, (value) => {
+	if (value && showContributedComponent.value) runParameterInputMountHook();
+});
+
 onMounted(() => {
 	props.eventBus.on('optionSelected', optionSelected);
 
@@ -1358,11 +1366,9 @@ onMounted(() => {
 		}
 	}
 
-	void externalHooks.run('parameterInput.mount', {
-		parameter: props.parameter,
-
-		inputFieldRef: inputField.value as InstanceType<typeof N8nInput>,
-	});
+	if (!showContributedComponent.value) {
+		runParameterInputMountHook();
+	}
 });
 
 const { height } = useElementSize(wrapper);
@@ -1541,6 +1547,7 @@ onUpdated(async () => {
 			<component
 				:is="contributedComponent"
 				v-if="showContributedComponent"
+				ref="inputField"
 				:parameter="parameter"
 				:model-value="modelValue"
 				:path="path"
@@ -1553,6 +1560,7 @@ onUpdated(async () => {
 				:dependent-parameters-values="dependentParametersValues"
 				:parameter-issues="getIssues"
 				:droppable="droppable ?? false"
+				:hide-label="hideLabel ?? false"
 				:event-bus="eventBus"
 				@update:model-value="valueChangedDebounced"
 				@modal-opener-click="openExpressionEditorModal"
@@ -1617,19 +1625,6 @@ onUpdated(async () => {
 				@focus="setFocus"
 				@blur="onBlur"
 				@drop="onResourceLocatorDrop"
-			/>
-			<N8nIconPicker
-				v-else-if="parameter.type === 'icon' && !isModelValueExpression && !forceShowExpression"
-				ref="inputField"
-				v-model="iconPickerValue"
-				:button-tooltip="
-					parameter.placeholder || i18n.baseText('parameterInput.iconPicker.tooltip')
-				"
-				:button-size="hideLabel ? 'small' : 'large'"
-				:is-read-only="isReadOnly"
-				@update:model-value="valueChanged"
-				@focus="setFocus"
-				@blur="onBlur"
 			/>
 			<ExpressionParameterInput
 				v-else-if="isModelValueExpression || forceShowExpression"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoadError.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoadError.test.ts
@@ -1,0 +1,45 @@
+import userEvent from '@testing-library/user-event';
+import { createComponentRenderer } from '@/__tests__/render';
+
+import ParameterInputLoadError from './ParameterInputLoadError.vue';
+
+const renderComponent = createComponentRenderer(ParameterInputLoadError);
+
+describe('ParameterInputLoadError', () => {
+	it('announces the failure and keeps the row occupied', () => {
+		const { getByRole, getByTestId } = renderComponent();
+
+		expect(getByRole('alert')).toBeVisible();
+		expect(getByTestId('parameter-input-load-error')).toHaveTextContent(
+			'This field could not be loaded',
+		);
+	});
+
+	it('reloads the page on the recovery action', async () => {
+		const reload = vi.fn();
+		const original = window.location;
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: { ...original, reload },
+		});
+
+		try {
+			const { getByRole } = renderComponent();
+			await userEvent.click(getByRole('button', { name: 'Reload' }));
+
+			expect(reload).toHaveBeenCalledTimes(1);
+		} finally {
+			Object.defineProperty(window, 'location', { configurable: true, value: original });
+		}
+	});
+
+	it('drops the shell input props instead of putting them on the DOM', () => {
+		const { getByTestId } = renderComponent({
+			attrs: { path: 'parameters.tableId', displayTitle: 'Table' },
+		});
+
+		const root = getByTestId('parameter-input-load-error');
+		expect(root).not.toHaveAttribute('path');
+		expect(root).not.toHaveAttribute('displaytitle');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoadError.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoadError.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
+import { useI18n } from '@n8n/i18n';
+
+/**
+ * Rendered in place of a module-contributed input whose chunk failed to load.
+ *
+ * Without it `defineAsyncComponent` renders nothing, so the field disappears
+ * from the panel and the load rejection escapes as an uncaught error. Keeping
+ * the row occupied is the point: a missing field reads as "this node has no
+ * such parameter", which is worse than a visible failure.
+ *
+ * A stale chunk after a deploy is normally recovered by the app-level
+ * `vite:preloadError` handler, which reloads the page once per 10s. This state
+ * is what remains when that reload was throttled or did not help, so the offer
+ * here is a manual reload rather than a second automatic one.
+ *
+ * The shell passes `ParameterInputProps` to whatever occupies the input slot;
+ * this component needs none of them, so they are dropped rather than landing on
+ * the DOM as attributes.
+ */
+defineOptions({ inheritAttrs: false });
+
+const i18n = useI18n();
+
+function reload() {
+	window.location.reload();
+}
+</script>
+
+<template>
+	<div :class="$style.container" role="alert" data-test-id="parameter-input-load-error">
+		<N8nIcon :class="$style.icon" icon="triangle-alert" size="small" color="danger" />
+		<N8nText :class="$style.message" size="small" color="danger">
+			{{ i18n.baseText('parameterInput.loadFailed') }}
+		</N8nText>
+		<N8nButton variant="subtle" size="mini" @click="reload">
+			{{ i18n.baseText('parameterInput.loadFailed.reload') }}
+		</N8nButton>
+	</div>
+</template>
+
+<style lang="scss" module>
+.container {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+	width: 100%;
+	min-height: var(--height--lg);
+}
+
+.icon {
+	flex-shrink: 0;
+}
+
+.message {
+	flex-grow: 1;
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoading.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoading.test.ts
@@ -1,0 +1,13 @@
+import { createComponentRenderer } from '@/__tests__/render';
+
+import ParameterInputLoading from './ParameterInputLoading.vue';
+
+const renderComponent = createComponentRenderer(ParameterInputLoading);
+
+describe('ParameterInputLoading', () => {
+	it('reserves the field row while the chunk loads', () => {
+		const { getByTestId } = renderComponent();
+
+		expect(getByTestId('parameter-input-loading')).toBeVisible();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoading.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputLoading.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { N8nLoading2 } from '@n8n/design-system';
+
+/**
+ * Placeholder for a module-contributed input while its chunk loads.
+ *
+ * `defineAsyncComponent` renders nothing until the loader settles, so without
+ * this the field is absent and everything below it moves once the real input
+ * arrives. The row is reserved at the standard input height instead.
+ *
+ * The shell passes `ParameterInputProps` to whatever occupies the input slot;
+ * this placeholder needs none of them, so they are dropped rather than landing
+ * on the DOM as attributes.
+ */
+defineOptions({ inheritAttrs: false });
+</script>
+
+<template>
+	<div :class="$style.container" data-test-id="parameter-input-loading">
+		<N8nLoading2 variant="rect" :class="$style.skeleton" />
+	</div>
+</template>
+
+<style lang="scss" module>
+.container {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	height: var(--height--lg);
+}
+
+.skeleton {
+	width: 100%;
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useParameterInputContribution.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useParameterInputContribution.test.ts
@@ -1,10 +1,17 @@
-import { ref } from 'vue';
+import { defineComponent, h, ref } from 'vue';
+import { render, waitFor } from '@testing-library/vue';
+import type { Component } from 'vue';
 import type { NodePropertyTypes } from 'n8n-workflow';
 import { parameterInputRegistry } from '@n8n/frontend-module-sdk';
 
 import { useParameterInputContribution } from './useParameterInputContribution';
 
 const stubComponent = { render: () => null };
+
+/** Mounts a resolved contribution, which is the only way the async wrapper runs. */
+function renderResolved(component: Component) {
+	return render(defineComponent(() => () => h(component)));
+}
 
 describe('useParameterInputContribution', () => {
 	beforeEach(() => {
@@ -48,6 +55,60 @@ describe('useParameterInputContribution', () => {
 
 		type.value = 'string';
 		expect(contributedComponent.value).toBe(stubComponent);
+	});
+
+	describe('a chunk that fails to load', () => {
+		beforeEach(() => {
+			vi.spyOn(console, 'error').mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it('retries once, then renders the error state instead of an empty field', async () => {
+			const loader = vi.fn(async () => await Promise.reject(new Error('chunk 404')));
+			parameterInputRegistry.register({ type: 'string', component: loader });
+
+			const { contributedComponent } = useParameterInputContribution(
+				ref<NodePropertyTypes>('string'),
+			);
+			const { getByTestId } = renderResolved(contributedComponent.value!);
+
+			await waitFor(() => expect(getByTestId('parameter-input-load-error')).toBeVisible());
+			expect(loader).toHaveBeenCalledTimes(2);
+		});
+
+		it('does not leave the load rejection uncaught', async () => {
+			const onUnhandled = vi.fn();
+			window.addEventListener('unhandledrejection', onUnhandled);
+			const loader = async () => await Promise.reject(new Error('chunk 404'));
+			parameterInputRegistry.register({ type: 'string', component: loader });
+
+			const { contributedComponent } = useParameterInputContribution(
+				ref<NodePropertyTypes>('string'),
+			);
+			const { getByTestId } = renderResolved(contributedComponent.value!);
+
+			await waitFor(() => expect(getByTestId('parameter-input-load-error')).toBeVisible());
+			expect(onUnhandled).not.toHaveBeenCalled();
+			window.removeEventListener('unhandledrejection', onUnhandled);
+		});
+
+		it('recovers when a retry succeeds', async () => {
+			const loader = vi
+				.fn()
+				.mockRejectedValueOnce(new Error('dropped request'))
+				.mockResolvedValue({ render: () => h('div', { 'data-test-id': 'contributed' }) });
+			parameterInputRegistry.register({ type: 'string', component: loader });
+
+			const { contributedComponent } = useParameterInputContribution(
+				ref<NodePropertyTypes>('string'),
+			);
+			const { getByTestId } = renderResolved(contributedComponent.value!);
+
+			await waitFor(() => expect(getByTestId('contributed')).toBeVisible());
+		});
 	});
 
 	describe('capabilities', () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useParameterInputContribution.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useParameterInputContribution.ts
@@ -4,8 +4,20 @@ import { parameterInputRegistry } from '@n8n/frontend-module-sdk';
 import type { ParameterInputCapabilities } from '@n8n/frontend-module-sdk';
 
 import { isResourceLocatorParameterType } from '@/features/ndv/shared/ndv.utils';
+import ParameterInputLoadError from '../components/ParameterInputLoadError.vue';
+import ParameterInputLoading from '../components/ParameterInputLoading.vue';
 
 type ResolvedCapabilities = Required<ParameterInputCapabilities>;
+
+/**
+ * One extra attempt covers a dropped request. Beyond that the chunk is gone
+ * rather than late — a stale hashed filename after a rolling deploy — and
+ * retrying only repeats the 404.
+ */
+const LOAD_RETRY_LIMIT = 1;
+
+/** A loader that never settles would keep the placeholder up forever. */
+const LOAD_TIMEOUT_MS = 30_000;
 
 /**
  * `defineAsyncComponent` wrappers, kept per factory. A fresh wrapper on every
@@ -19,7 +31,23 @@ function resolveComponent(component: Component | (() => Promise<Component>)): Co
 	const factory = component as () => Promise<Component>;
 	let resolved = asyncComponentCache.get(factory);
 	if (!resolved) {
-		resolved = defineAsyncComponent(factory);
+		resolved = defineAsyncComponent({
+			loader: factory,
+			loadingComponent: ParameterInputLoading,
+			errorComponent: ParameterInputLoadError,
+			timeout: LOAD_TIMEOUT_MS,
+			onError(error, retry, fail, attempts) {
+				if (attempts <= LOAD_RETRY_LIMIT) {
+					retry();
+					return;
+				}
+
+				// Not reported to Sentry: `app/plugins/sentry.ts` drops dynamic-import
+				// failures on purpose, because a stale chunk is expected after a deploy.
+				console.error('Failed to load a contributed parameter input', error);
+				fail();
+			},
+		});
 		asyncComponentCache.set(factory, resolved);
 	}
 

--- a/packages/frontend/editor-ui/tsconfig.json
+++ b/packages/frontend/editor-ui/tsconfig.json
@@ -25,6 +25,12 @@
 			"@n8n/composables*": ["../@n8n/composables/src*"],
 			"@n8n/constants*": ["../../@n8n/constants/src*"],
 			"@n8n/frontend-module-sdk": ["../@n8n/frontend-module-sdk/src/index.ts"],
+			"@n8n/frontend-module-parameter-input-icon": [
+				"../../modules/parameter-input-icon/frontend/src/index.ts"
+			],
+			"@n8n/frontend-module-parameter-input-icon/*": [
+				"../../modules/parameter-input-icon/frontend/src/*"
+			],
 			"@n8n/frontend-module-instance-registry": [
 				"../../modules/instance-registry/frontend/src/index.ts"
 			],

--- a/packages/modules/README.md
+++ b/packages/modules/README.md
@@ -4,6 +4,28 @@ Feature modules carved out of `packages/frontend/editor-ui`. Each one is a works
 `<name>/frontend`: source-only (`main: "src/index.ts"`, no `dist`), consumed by the editor-ui shell
 through Vite aliases.
 
+## Naming: two classes of module
+
+A **feature module** owns a product area — routes, views, stores, a settings page. Its `<name>` must
+equal its backend module directory name under `packages/cli/src/modules/`, because
+`isModuleActive(id)` tests the descriptor `id` against `activeModules` from `/rest/module-settings`.
+A prefix would break its route guard and its settings toggle, so a feature module carries **no
+prefix**: `otel`, `instance-registry`.
+
+A **contribution-only module** has no backend half. Its id never reaches `/rest/module-settings`, so
+the id is free — and it takes a **prefix naming the descriptor contribution point it feeds**:
+`parameter-input-icon` feeds `parameterInputs`.
+
+    <contribution-point>-<what-it-renders>       parameter-input-icon
+    <backend module directory name>              otel
+
+So the directory name answers "does this have a backend half?" without opening a file, and every
+sorted list — this directory, the `modulePackages` table in `@n8n/frontend-vite-config`, the `paths`
+in `editor-ui/tsconfig.json`, `OWNERS` — groups the classes.
+
+Both classes keep the `@n8n/frontend-module-` package prefix. The planned cross-module boundary rule
+pattern-matches it.
+
 `<name>/backend` is a reserved path rather than a workspace package — the backend runtime discovers
 modules under `packages/cli/src/modules/<name>`. The extra nesting level is what lets both halves of
 a module sit together later.

--- a/packages/modules/instance-registry/frontend/README.md
+++ b/packages/modules/instance-registry/frontend/README.md
@@ -9,9 +9,11 @@ pnpm turbo lint --filter=@n8n/frontend-module-instance-registry
 pnpm turbo test --filter=@n8n/frontend-module-instance-registry
 ```
 
-Go through turbo, not `pnpm --filter <pkg> typecheck`: this package is consumed
-from source, and on a cold tree its platform dependencies have not been built
-yet. Turbo builds them first; the bare pnpm form does not.
+Go through turbo, not the bare `pnpm --filter <pkg> <task>` form: this package is
+consumed from source, and on a cold tree its platform dependencies have not been
+built yet. Turbo builds them first; the bare pnpm form does not. **`test` needs
+this as much as `typecheck` does** — `pnpm --filter <pkg> test` fails to resolve
+`n8n-workflow` and `@n8n/vitest-config/frontend` until they are built.
 
 ## Import rules
 

--- a/packages/modules/otel/frontend/README.md
+++ b/packages/modules/otel/frontend/README.md
@@ -10,9 +10,11 @@ pnpm turbo lint --filter=@n8n/frontend-module-otel
 pnpm turbo test --filter=@n8n/frontend-module-otel
 ```
 
-Go through turbo, not `pnpm --filter <pkg> typecheck`: this package is consumed
-from source, and on a cold tree its platform dependencies have not been built
-yet. Turbo builds them first; the bare pnpm form does not.
+Go through turbo, not the bare `pnpm --filter <pkg> <task>` form: this package is
+consumed from source, and on a cold tree its platform dependencies have not been
+built yet. Turbo builds them first; the bare pnpm form does not. **`test` needs
+this as much as `typecheck` does** — `pnpm --filter <pkg> test` fails to resolve
+`n8n-workflow` and `@n8n/vitest-config/frontend` until they are built.
 
 ## What this module contributes
 

--- a/packages/modules/parameter-input-icon/frontend/README.md
+++ b/packages/modules/parameter-input-icon/frontend/README.md
@@ -1,12 +1,30 @@
-# @n8n/frontend-module-{{name}}
+# @n8n/frontend-module-parameter-input-icon
+
+Owns the **`icon` parameter input** — the icon and emoji picker the NDV draws for a
+node parameter of `type: 'icon'`. The module claims that type through the
+`parameterInputs` field of its descriptor; the shell resolves it by `parameter.type`
+at render time and holds no import of the component.
+
+The `parameter-input-` prefix marks a **contribution-only module**: no backend half,
+so the id is absent from `/rest/module-settings` and is free to name the contribution
+point the module feeds. A feature module carries no prefix, because its id has to
+equal its backend module directory name for `isModuleActive(id)` to work.
+
+It contributes nothing else: no route, no store, no settings page, and no backend
+half. `registerModuleParameterInputs` does not gate on `isModuleActive`, because a
+parameter input is a render primitive rather than a feature — a gated renderer would
+leave the field with nothing to draw it.
+
+The shell keeps expression rendering, the from-AI override and the drop target for
+this type, so the contribution declares no capabilities.
 
 Frontend feature module. Consumed from source by the editor-ui shell through
 `src/app/modules.manifest.ts`; there is no build step and no `dist`.
 
 ```bash
-pnpm turbo typecheck --filter=@n8n/frontend-module-{{name}}
-pnpm turbo lint --filter=@n8n/frontend-module-{{name}}
-pnpm turbo test --filter=@n8n/frontend-module-{{name}}
+pnpm turbo typecheck --filter=@n8n/frontend-module-parameter-input-icon
+pnpm turbo lint --filter=@n8n/frontend-module-parameter-input-icon
+pnpm turbo test --filter=@n8n/frontend-module-parameter-input-icon
 ```
 
 Go through turbo, not the bare `pnpm --filter <pkg> <task>` form: this package is
@@ -33,4 +51,4 @@ this as much as `typecheck` does** — `pnpm --filter <pkg> test` fails to resol
 
 `@vitejs/plugin-vue` is already wired into `vite.config.ts`, so a `.vue` file
 compiles in tests without further setup. Route components must load lazily —
-see the note in `src/{{name}}.module.ts`.
+see the note in `src/parameter-input-icon.module.ts`.

--- a/packages/modules/parameter-input-icon/frontend/biome.jsonc
+++ b/packages/modules/parameter-input-icon/frontend/biome.jsonc
@@ -1,0 +1,4 @@
+{
+	"$schema": "../../../../node_modules/@biomejs/biome/configuration_schema.json",
+	"extends": ["../../../../biome.jsonc"]
+}

--- a/packages/modules/parameter-input-icon/frontend/eslint.config.mjs
+++ b/packages/modules/parameter-input-icon/frontend/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { defineConfig } from 'eslint/config';
+import { frontendConfig } from '@n8n/eslint-config/frontend';
+
+export default defineConfig(frontendConfig);

--- a/packages/modules/parameter-input-icon/frontend/package.json
+++ b/packages/modules/parameter-input-icon/frontend/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@n8n/frontend-module-parameter-input-icon",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "clean": "rimraf .turbo",
+    "typecheck": "vue-tsc --noEmit",
+    "test": "vitest run",
+    "test:changed": "janitor test-scoped",
+    "test:dev": "vitest",
+    "lint": "eslint src --quiet",
+    "lint:fix": "eslint src --fix",
+    "format": "biome format --write . && prettier --write . --ignore-path ../../../../.prettierignore",
+    "format:check": "biome ci . && prettier --check . --ignore-path ../../../../.prettierignore"
+  },
+  "dependencies": {
+    "@n8n/api-types": "workspace:*",
+    "@n8n/composables": "workspace:*",
+    "@n8n/design-system": "workspace:*",
+    "@n8n/frontend-module-sdk": "workspace:*",
+    "@n8n/i18n": "workspace:*",
+    "@n8n/permissions": "workspace:*",
+    "@n8n/rest-api-client": "workspace:*",
+    "@n8n/stores": "workspace:*",
+    "n8n-workflow": "workspace:*",
+    "pinia": "catalog:frontend",
+    "vue": "catalog:frontend",
+    "vue-router": "catalog:frontend"
+  },
+  "devDependencies": {
+    "@iconify/json": "catalog:",
+    "@n8n/eslint-config": "workspace:*",
+    "@n8n/frontend-test-utils": "workspace:*",
+    "@n8n/frontend-vite-config": "workspace:*",
+    "@n8n/playwright-janitor": "workspace:*",
+    "@n8n/typescript-config": "workspace:*",
+    "@n8n/vitest-config": "workspace:*",
+    "@testing-library/jest-dom": "catalog:frontend",
+    "@testing-library/user-event": "catalog:frontend",
+    "@testing-library/vue": "catalog:frontend",
+    "@vitejs/plugin-vue": "catalog:frontend",
+    "eslint": "catalog:",
+    "typescript": "catalog:",
+    "unplugin-icons": "catalog:frontend",
+    "vite": "catalog:",
+    "vite-svg-loader": "catalog:frontend",
+    "vitest": "catalog:",
+    "vue-tsc": "catalog:frontend"
+  },
+  "license": "LicenseRef-n8n-sustainable-use"
+}

--- a/packages/modules/parameter-input-icon/frontend/package.json
+++ b/packages/modules/parameter-input-icon/frontend/package.json
@@ -18,18 +18,11 @@
     "format:check": "biome ci . && prettier --check . --ignore-path ../../../../.prettierignore"
   },
   "dependencies": {
-    "@n8n/api-types": "workspace:*",
-    "@n8n/composables": "workspace:*",
     "@n8n/design-system": "workspace:*",
     "@n8n/frontend-module-sdk": "workspace:*",
     "@n8n/i18n": "workspace:*",
-    "@n8n/permissions": "workspace:*",
-    "@n8n/rest-api-client": "workspace:*",
-    "@n8n/stores": "workspace:*",
     "n8n-workflow": "workspace:*",
-    "pinia": "catalog:frontend",
-    "vue": "catalog:frontend",
-    "vue-router": "catalog:frontend"
+    "vue": "catalog:frontend"
   },
   "devDependencies": {
     "@iconify/json": "catalog:",

--- a/packages/modules/parameter-input-icon/frontend/src/IconParameterInput.test.ts
+++ b/packages/modules/parameter-input-icon/frontend/src/IconParameterInput.test.ts
@@ -1,0 +1,226 @@
+import type { IconOrEmoji } from '@n8n/design-system';
+import { createComponentRenderer } from '@n8n/frontend-test-utils';
+import userEvent from '@testing-library/user-event';
+import type { INodeProperties } from 'n8n-workflow';
+import { defineComponent, type PropType } from 'vue';
+
+import IconParameterInput from './IconParameterInput.vue';
+
+/**
+ * Stands in for `N8nIconPicker`, whose own behaviour design-system tests. What is
+ * under test here is the adapter: the props this module hands down, and the value
+ * it emits back up.
+ */
+const IconPickerStub = defineComponent({
+	name: 'N8nIconPicker',
+	props: {
+		modelValue: { type: Object as PropType<IconOrEmoji | undefined>, default: undefined },
+		buttonTooltip: { type: String, default: '' },
+		buttonSize: { type: String, default: '' },
+		isReadOnly: { type: Boolean, default: false },
+	},
+	emits: ['update:modelValue', 'focus', 'blur'],
+	template: `<button
+		data-test-id="picker"
+		:data-model="JSON.stringify(modelValue ?? null)"
+		:data-tooltip="buttonTooltip"
+		:data-size="buttonSize"
+		:data-read-only="String(isReadOnly)"
+		@click="$emit('update:modelValue', { type: 'emoji', value: '\u{1F60E}' })"
+		@focus="$emit('focus')"
+		@blur="$emit('blur')"
+	/>`,
+});
+
+const parameter = (overrides: Partial<INodeProperties> = {}): INodeProperties => ({
+	displayName: 'Agent Icon',
+	name: 'agentIcon',
+	type: 'icon',
+	default: { type: 'icon', value: 'bot' },
+	...overrides,
+});
+
+const renderComponent = createComponentRenderer(IconParameterInput, {
+	props: {
+		parameter: parameter(),
+		modelValue: { type: 'icon', value: 'bot' },
+		isReadOnly: false,
+		hideLabel: false,
+	},
+	global: {
+		// eslint-disable-next-line @typescript-eslint/naming-convention -- a stub key is a component name
+		stubs: { N8nIconPicker: IconPickerStub },
+	},
+});
+
+describe('IconParameterInput', () => {
+	describe('the value it shows', () => {
+		it('reads the icon out of the parameter value', () => {
+			const { getByTestId } = renderComponent();
+
+			expect(getByTestId('picker')).toHaveAttribute(
+				'data-model',
+				JSON.stringify({ type: 'icon', value: 'bot' }),
+			);
+		});
+
+		it('shows an emoji value', () => {
+			const { getByTestId } = renderComponent({
+				props: { modelValue: { type: 'emoji', value: '🐶' } },
+			});
+
+			expect(getByTestId('picker')).toHaveAttribute(
+				'data-model',
+				JSON.stringify({ type: 'emoji', value: '🐶' }),
+			);
+		});
+
+		// The old built-in adapter returned `undefined` for anything the schema rejects,
+		// which is what puts the picker on its placeholder icon.
+		it.each([
+			['an expression', '={{ $json.icon }}'],
+			['an empty string', ''],
+			['a wrong shape', { type: 'sticker', value: 'x' }],
+		])('shows no selection for %s', (_label, modelValue) => {
+			const { getByTestId } = renderComponent({ props: { modelValue } });
+
+			expect(getByTestId('picker')).toHaveAttribute('data-model', 'null');
+		});
+
+		// The schema carries `type` and `value` only. A stored `color` is not part of the
+		// contract and must not reach the picker.
+		it('drops any extra key the stored value carries', () => {
+			const { getByTestId } = renderComponent({
+				props: { modelValue: { type: 'icon', value: 'bot', color: '--node--icon--color--blue' } },
+			});
+
+			expect(getByTestId('picker')).toHaveAttribute(
+				'data-model',
+				JSON.stringify({ type: 'icon', value: 'bot' }),
+			);
+		});
+	});
+
+	describe('the value it emits', () => {
+		it('emits the picked value as a plain type/value pair', async () => {
+			const { getByTestId, emitted } = renderComponent();
+
+			await userEvent.click(getByTestId('picker'));
+
+			expect(emitted('update:modelValue')).toEqual([[{ type: 'emoji', value: '😎' }]]);
+		});
+
+		// The shell debounces `update:modelValue` by 100 ms before the value returns on
+		// `modelValue`. The picker renders from the prop, so without the optimistic hold
+		// the button would show the previous icon until then.
+		it('shows the picked value before the shell sends it back', async () => {
+			const { getByTestId } = renderComponent();
+
+			await userEvent.click(getByTestId('picker'));
+
+			expect(getByTestId('picker')).toHaveAttribute(
+				'data-model',
+				JSON.stringify({ type: 'emoji', value: '😎' }),
+			);
+		});
+
+		it('yields to the shell once a new value arrives', async () => {
+			const { getByTestId, rerender } = renderComponent();
+			await userEvent.click(getByTestId('picker'));
+
+			await rerender({ modelValue: { type: 'icon', value: 'star' } });
+
+			expect(getByTestId('picker')).toHaveAttribute(
+				'data-model',
+				JSON.stringify({ type: 'icon', value: 'star' }),
+			);
+		});
+
+		it('passes focus and blur through to the shell', () => {
+			const { getByTestId, emitted } = renderComponent();
+
+			getByTestId('picker').focus();
+			getByTestId('picker').blur();
+
+			expect(emitted('focus')).toHaveLength(1);
+			expect(emitted('blur')).toHaveLength(1);
+		});
+	});
+
+	// One render against the real picker, so this suite fails if the module stops being
+	// able to mount a design-system component at all. The stubbed cases above cover the
+	// adapter; design-system tests the picker itself.
+	describe('against the real picker', () => {
+		const renderReal = createComponentRenderer(IconParameterInput, {
+			props: {
+				parameter: parameter(),
+				modelValue: { type: 'icon', value: 'star' },
+				isReadOnly: false,
+				hideLabel: false,
+			},
+		});
+
+		it('names the trigger with the tooltip', () => {
+			const { getByRole } = renderReal();
+
+			expect(getByRole('button', { name: 'Select icon or emoji' })).toBeEnabled();
+		});
+
+		it('disables the trigger for a read-only parameter', () => {
+			const { getByRole } = renderReal({ props: { isReadOnly: true } });
+
+			expect(getByRole('button', { name: 'Select icon or emoji' })).toBeDisabled();
+		});
+
+		it('shows an emoji value on the trigger', () => {
+			const { getByRole } = renderReal({
+				props: { modelValue: { type: 'emoji', value: '\u{1F436}' } },
+			});
+
+			expect(getByRole('button', { name: 'Select icon or emoji' })).toHaveTextContent('\u{1F436}');
+		});
+	});
+
+	describe('the props it hands down', () => {
+		it('uses the placeholder of the parameter as the button tooltip', () => {
+			const { getByTestId } = renderComponent({
+				props: { parameter: parameter({ placeholder: 'Pick the agent icon' }) },
+			});
+
+			expect(getByTestId('picker')).toHaveAttribute('data-tooltip', 'Pick the agent icon');
+		});
+
+		it('falls back to the shared tooltip string', () => {
+			const { getByTestId } = renderComponent();
+
+			expect(getByTestId('picker')).toHaveAttribute('data-tooltip', 'Select icon or emoji');
+		});
+
+		it.each([
+			[false, 'large'],
+			[true, 'small'],
+		])('sizes the button for hideLabel=%s', (hideLabel, size) => {
+			const { getByTestId } = renderComponent({ props: { hideLabel } });
+
+			expect(getByTestId('picker')).toHaveAttribute('data-size', size);
+		});
+
+		it('passes the read-only state', () => {
+			const { getByTestId } = renderComponent({ props: { isReadOnly: true } });
+
+			expect(getByTestId('picker')).toHaveAttribute('data-read-only', 'true');
+		});
+
+		// The shell hands every `ParameterInputProps` to the input slot. `inheritAttrs: false`
+		// is what keeps the ones this input does not read off the DOM.
+		it('keeps the props it does not read off the DOM', () => {
+			const { getByTestId } = renderComponent({
+				attrs: { path: 'parameters.agentIcon', displayTitle: 'Agent Icon' },
+			});
+
+			const picker = getByTestId('picker');
+			expect(picker).not.toHaveAttribute('path');
+			expect(picker).not.toHaveAttribute('displaytitle');
+		});
+	});
+});

--- a/packages/modules/parameter-input-icon/frontend/src/IconParameterInput.vue
+++ b/packages/modules/parameter-input-icon/frontend/src/IconParameterInput.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { N8nIconPicker, type IconOrEmoji } from '@n8n/design-system';
+import type { ParameterInputEmits, ParameterInputProps } from '@n8n/frontend-module-sdk';
+import { useI18n } from '@n8n/i18n';
+import { IconOrEmojiSchema } from 'n8n-workflow';
+import { computed, ref, watch } from 'vue';
+
+/**
+ * The `icon` parameter input. The picker, the tooltip fallback, the size rule and the
+ * value adapter all come over unchanged from `ParameterInput.vue`'s built-in branch.
+ *
+ * The shell keeps expression rendering for this type, so this component only ever
+ * mounts for a fixed value: `capabilities.ownsExpressionRendering` stays false, and
+ * `showContributedComponent` then yields to the expression editor first — the same
+ * rule the old `!isModelValueExpression && !forceShowExpression` guard had.
+ *
+ * `inheritAttrs: false`, because the shell hands every `ParameterInputProps` to
+ * whatever occupies the input slot. This input reads four of them, and the rest must
+ * not fall through onto the DOM — `eventBus` alone would land there as
+ * `[object Object]`.
+ */
+defineOptions({ inheritAttrs: false });
+
+const props =
+	defineProps<Pick<ParameterInputProps, 'parameter' | 'modelValue' | 'isReadOnly' | 'hideLabel'>>();
+
+const emit = defineEmits<Pick<ParameterInputEmits, 'update:modelValue' | 'focus' | 'blur'>>();
+
+const i18n = useI18n();
+
+/**
+ * The picked value, held until the shell's value returns. `N8nIconPicker` renders from
+ * the prop rather than from its own local state (it sees a bound value plus a listener,
+ * so `defineModel` does not update locally), so the trigger shows the previous icon for
+ * as long as `modelValue` takes to come back.
+ *
+ * The shell debounces `update:modelValue` on the **leading** edge — `useDebounce` passes
+ * `{ leading: true }` when `trailing` is omitted — so a single pick reaches the store in
+ * the same tick and needs no hold. What needs it is a second pick inside the 100 ms
+ * window: lodash defers that one to the trailing edge, and without the hold the trigger
+ * would show the first icon until it lands.
+ */
+const pendingValue = ref<IconOrEmoji>();
+
+watch(
+	() => props.modelValue,
+	() => {
+		pendingValue.value = undefined;
+	},
+);
+
+const selectedValue = computed<IconOrEmoji | undefined>(() => {
+	if (pendingValue.value) return pendingValue.value;
+
+	const result = IconOrEmojiSchema.safeParse(props.modelValue);
+	if (result.success) {
+		return {
+			type: result.data.type,
+			value: result.data.value,
+		} as IconOrEmoji;
+	}
+	return undefined;
+});
+
+const buttonTooltip = computed(
+	() =>
+		// `||`, not `??`: an empty `placeholder` has to fall back too. This is the rule the
+		// built-in branch had.
+		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+		props.parameter.placeholder || i18n.baseText('parameterInput.iconPicker.tooltip'),
+);
+
+function onPick(value: IconOrEmoji | undefined) {
+	pendingValue.value = value;
+	emit('update:modelValue', value ? { type: value.type, value: value.value } : undefined);
+}
+</script>
+
+<template>
+	<N8nIconPicker
+		:model-value="selectedValue"
+		:button-tooltip="buttonTooltip"
+		:button-size="props.hideLabel ? 'small' : 'large'"
+		:is-read-only="props.isReadOnly"
+		@update:model-value="onPick"
+		@focus="emit('focus')"
+		@blur="emit('blur')"
+	/>
+</template>

--- a/packages/modules/parameter-input-icon/frontend/src/__tests__/setup.ts
+++ b/packages/modules/parameter-input-icon/frontend/src/__tests__/setup.ts
@@ -1,0 +1,4 @@
+// The shared frontend test harness: the jsdom environment, english messages, and a fresh pinia
+// per test. It lives in `@n8n/frontend-test-utils` rather than in `@n8n/vitest-config`, because
+// `@n8n/i18n` devDepends on the latter and importing i18n there closes a cycle in the turbo graph.
+import '@n8n/frontend-test-utils/setup';

--- a/packages/modules/parameter-input-icon/frontend/src/index.ts
+++ b/packages/modules/parameter-input-icon/frontend/src/index.ts
@@ -1,0 +1,4 @@
+// The module's only public entry. The shell imports the descriptor from here via
+// `modules.manifest.ts`; anything else the shell (or a test) needs must be exported
+// here too — deep paths into `src/` are not part of the contract.
+export { ParameterInputIconModule } from './parameter-input-icon.module';

--- a/packages/modules/parameter-input-icon/frontend/src/parameter-input-icon.module.test.ts
+++ b/packages/modules/parameter-input-icon/frontend/src/parameter-input-icon.module.test.ts
@@ -1,0 +1,29 @@
+import { ParameterInputIconModule } from './parameter-input-icon.module';
+
+describe('ParameterInputIconModule', () => {
+	it('claims the icon parameter type', () => {
+		expect(ParameterInputIconModule.parameterInputs).toHaveLength(1);
+		expect(ParameterInputIconModule.parameterInputs?.[0].type).toBe('icon');
+	});
+
+	// The shell owns expression rendering, the from-AI override and the drop target for
+	// this type. Declaring any flag here would change behaviour the built-in branch had.
+	it('declares no capabilities', () => {
+		expect(ParameterInputIconModule.parameterInputs?.[0].capabilities).toBeUndefined();
+	});
+
+	// Import-light: the descriptor must not pull the component into the shell chunk.
+	it('loads the component lazily', () => {
+		expect(typeof ParameterInputIconModule.parameterInputs?.[0].component).toBe('function');
+	});
+
+	// No backend half, so `isModuleActive(id)` is always false here.
+	// `registerModulePushHandlers` gates on it directly, so a handler would never
+	// fire; a route registers, but `checkModuleAvailability` then blocks navigation
+	// once the route opts into `custom` middleware. The other surfaces are ungated,
+	// so they are deliberately not asserted.
+	it('contributes no gated surface', () => {
+		expect(ParameterInputIconModule.routes).toBeUndefined();
+		expect(ParameterInputIconModule.pushHandlers).toBeUndefined();
+	});
+});

--- a/packages/modules/parameter-input-icon/frontend/src/parameter-input-icon.module.ts
+++ b/packages/modules/parameter-input-icon/frontend/src/parameter-input-icon.module.ts
@@ -1,0 +1,35 @@
+import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+
+// typescript-eslint reads an SFC import as `any`, because only vue-tsc can type one.
+// `pnpm turbo typecheck` is what checks this component for real.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+const IconParameterInput = async () => await import('./IconParameterInput.vue');
+
+/**
+ * Owns the `icon` parameter input.
+ *
+ * The `parameter-input-` prefix on the id marks a contribution-only module: it has no
+ * backend half, so its id is absent from `/rest/module-settings` and it is free to
+ * name the contribution point it feeds. A feature module cannot do that — its id has
+ * to equal its backend module directory name, because `isModuleActive(id)` tests it.
+ *
+ * `registerModuleParameterInputs` does not gate on `isModuleActive`, because a
+ * parameter input is a render primitive rather than a feature. A gated renderer would
+ * leave the field with nothing to draw it.
+ */
+export const ParameterInputIconModule: FrontendModuleDescription = {
+	id: 'parameter-input-icon',
+	name: 'Icon Parameter Input',
+	description: 'Renders the icon and emoji picker for parameters of type `icon`',
+	icon: 'smile',
+	parameterInputs: [
+		{
+			type: 'icon',
+			component: IconParameterInput,
+			// Every flag stays at its default, which is what keeps today's behaviour:
+			// the shell owns expression rendering for `icon` (the built-in branch was
+			// guarded by `!isModelValueExpression && !forceShowExpression`), the shell
+			// keeps its own from-AI override, and the field stays a drop target.
+		},
+	],
+};

--- a/packages/modules/parameter-input-icon/frontend/tsconfig.json
+++ b/packages/modules/parameter-input-icon/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"extends": "@n8n/typescript-config/tsconfig.frontend-module.json",
+	"compilerOptions": {
+		// `rootDirs`, `types` and `include` cannot be inherited from the base: relative entries in
+		// them resolve against this file, so a copy in the base would point at the base's directory.
+		// (`paths` is the exception and does come from the base.)
+		"rootDirs": [".", "../../../frontend/@n8n/design-system/src"],
+		// The two `.d.ts` entries are ambient declarations this package never imports, so nothing
+		// pulls them into the program: `~icons/*` and `markdown-it-task-lists` for design-system's
+		// source, `window.BASE_PATH` for `@n8n/stores`'s. Consuming those packages from source is
+		// what makes them the consumer's problem — a built `dist` would have carried them.
+		"types": [
+			"vite/client",
+			"vitest/globals",
+			"unplugin-icons/types/vue",
+			"../../../frontend/@n8n/design-system/src/shims-modules.d.ts",
+			"../../../frontend/@n8n/stores/src/shims.d.ts"
+		]
+	},
+	"include": ["src/**/*.ts", "src/**/*.vue", "vite.config.ts"]
+}

--- a/packages/modules/parameter-input-icon/frontend/tsconfig.json
+++ b/packages/modules/parameter-input-icon/frontend/tsconfig.json
@@ -5,16 +5,16 @@
 		// them resolve against this file, so a copy in the base would point at the base's directory.
 		// (`paths` is the exception and does come from the base.)
 		"rootDirs": [".", "../../../frontend/@n8n/design-system/src"],
-		// The two `.d.ts` entries are ambient declarations this package never imports, so nothing
+		// The `.d.ts` entry holds ambient declarations this package never imports, so nothing
 		// pulls them into the program: `~icons/*` and `markdown-it-task-lists` for design-system's
-		// source, `window.BASE_PATH` for `@n8n/stores`'s. Consuming those packages from source is
-		// what makes them the consumer's problem — a built `dist` would have carried them.
+		// source. Consuming design-system from source is what makes them the consumer's problem —
+		// a built `dist` would have carried them. A module that consumes `@n8n/stores` from source
+		// needs its shim here too, for `window.BASE_PATH`; this one does not reach that source.
 		"types": [
 			"vite/client",
 			"vitest/globals",
 			"unplugin-icons/types/vue",
-			"../../../frontend/@n8n/design-system/src/shims-modules.d.ts",
-			"../../../frontend/@n8n/stores/src/shims.d.ts"
+			"../../../frontend/@n8n/design-system/src/shims-modules.d.ts"
 		]
 	},
 	"include": ["src/**/*.ts", "src/**/*.vue", "vite.config.ts"]

--- a/packages/modules/parameter-input-icon/frontend/vite.config.ts
+++ b/packages/modules/parameter-input-icon/frontend/vite.config.ts
@@ -1,0 +1,51 @@
+import vue from '@vitejs/plugin-vue';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import icons from 'unplugin-icons/vite';
+import svgLoader from 'vite-svg-loader';
+import { defineConfig, mergeConfig } from 'vite';
+import { frontendAliases } from '@n8n/frontend-vite-config';
+import { vitestConfig } from '@n8n/vitest-config/frontend';
+
+const packageDir = fileURLToPath(new URL('.', import.meta.url));
+const packagesDir = resolve(packageDir, '..', '..', '..');
+
+export default mergeConfig(
+	defineConfig({
+		// `@n8n/design-system`'s icon set reaches for two things Vite does not handle on its
+		// own: `~icons/lucide/*` virtual modules and `./custom/*.svg` single-file components.
+		// Consuming design-system from source makes both the consumer's problem — without
+		// `svgLoader` an `.svg` import returns a data-URI string, which Vue then renders as a
+		// tag name and jsdom rejects. Every module that renders a design-system component
+		// needs these two plugins.
+		plugins: [
+			vue(),
+			// Off, so a test never reaches the network for a missing collection.
+			icons({ compiler: 'vue3', autoInstall: false }),
+			svgLoader({
+				svgoConfig: {
+					plugins: [
+						{
+							name: 'preset-default',
+							params: {
+								overrides: {
+									// The icons rely on their ids, and on a viewBox to stay scalable.
+									cleanupIds: false,
+									removeViewBox: false,
+								},
+							},
+						},
+					],
+				},
+			}),
+		],
+		resolve: {
+			// The same platform mapping the editor-ui dev server uses, so a test resolves
+			// `@n8n/stores/...` from source rather than from a stale `dist` — the two disagreeing is
+			// what put 1,111 specifiers on the wrong side of the src/dist line. Sibling modules are
+			// deliberately absent: nothing here should make a cross-module import resolve.
+			alias: frontendAliases(packagesDir),
+		},
+	}),
+	vitestConfig,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6710,12 +6710,6 @@ importers:
 
   packages/modules/parameter-input-icon/frontend:
     dependencies:
-      '@n8n/api-types':
-        specifier: workspace:*
-        version: link:../../../@n8n/api-types
-      '@n8n/composables':
-        specifier: workspace:*
-        version: link:../../../frontend/@n8n/composables
       '@n8n/design-system':
         specifier: workspace:*
         version: link:../../../frontend/@n8n/design-system
@@ -6725,27 +6719,12 @@ importers:
       '@n8n/i18n':
         specifier: workspace:*
         version: link:../../../frontend/@n8n/i18n
-      '@n8n/permissions':
-        specifier: workspace:*
-        version: link:../../../@n8n/permissions
-      '@n8n/rest-api-client':
-        specifier: workspace:*
-        version: link:../../../frontend/@n8n/rest-api-client
-      '@n8n/stores':
-        specifier: workspace:*
-        version: link:../../../frontend/@n8n/stores
       n8n-workflow:
         specifier: workspace:*
         version: link:../../../workflow
-      pinia:
-        specifier: catalog:frontend
-        version: 2.2.4(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
       vue:
         specifier: catalog:frontend
         version: 3.5.26(typescript@6.0.2)
-      vue-router:
-        specifier: catalog:frontend
-        version: 4.5.0(vue@3.5.26(typescript@6.0.2))
     devDependencies:
       '@iconify/json':
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6125,6 +6125,9 @@ importers:
       '@n8n/frontend-module-otel':
         specifier: workspace:*
         version: link:../../modules/otel/frontend
+      '@n8n/frontend-module-parameter-input-icon':
+        specifier: workspace:*
+        version: link:../../modules/parameter-input-icon/frontend
       '@n8n/frontend-module-sdk':
         specifier: workspace:*
         version: link:../@n8n/frontend-module-sdk
@@ -6686,6 +6689,100 @@ importers:
       stylelint:
         specifier: 'catalog:'
         version: 16.23.0(supports-color@8.1.1)(typescript@6.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+      unplugin-icons:
+        specifier: catalog:frontend
+        version: 23.0.1(@vue/compiler-sfc@3.5.26)
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)
+      vite-svg-loader:
+        specifier: catalog:frontend
+        version: 5.1.0(vue@3.5.26(typescript@6.0.2))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(supports-color@8.1.1)(utf-8-validate@5.0.10))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+      vue-tsc:
+        specifier: ^2.2.8
+        version: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@6.0.2)
+
+  packages/modules/parameter-input-icon/frontend:
+    dependencies:
+      '@n8n/api-types':
+        specifier: workspace:*
+        version: link:../../../@n8n/api-types
+      '@n8n/composables':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/composables
+      '@n8n/design-system':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/design-system
+      '@n8n/frontend-module-sdk':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/frontend-module-sdk
+      '@n8n/i18n':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/i18n
+      '@n8n/permissions':
+        specifier: workspace:*
+        version: link:../../../@n8n/permissions
+      '@n8n/rest-api-client':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/rest-api-client
+      '@n8n/stores':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/stores
+      n8n-workflow:
+        specifier: workspace:*
+        version: link:../../../workflow
+      pinia:
+        specifier: catalog:frontend
+        version: 2.2.4(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
+      vue:
+        specifier: catalog:frontend
+        version: 3.5.26(typescript@6.0.2)
+      vue-router:
+        specifier: catalog:frontend
+        version: 4.5.0(vue@3.5.26(typescript@6.0.2))
+    devDependencies:
+      '@iconify/json':
+        specifier: 'catalog:'
+        version: 2.2.488
+      '@n8n/eslint-config':
+        specifier: workspace:*
+        version: link:../../../@n8n/eslint-config
+      '@n8n/frontend-test-utils':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/frontend-test-utils
+      '@n8n/frontend-vite-config':
+        specifier: workspace:*
+        version: link:../../../frontend/@n8n/frontend-vite-config
+      '@n8n/playwright-janitor':
+        specifier: workspace:*
+        version: link:../../../testing/janitor
+      '@n8n/typescript-config':
+        specifier: workspace:*
+        version: link:../../../@n8n/typescript-config
+      '@n8n/vitest-config':
+        specifier: workspace:*
+        version: link:../../../@n8n/vitest-config
+      '@testing-library/jest-dom':
+        specifier: catalog:frontend
+        version: 6.6.3
+      '@testing-library/user-event':
+        specifier: catalog:frontend
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@testing-library/vue':
+        specifier: catalog:frontend
+        version: 8.1.0(@vue/compiler-sfc@3.5.26)(vue@3.5.26(typescript@6.0.2))
+      '@vitejs/plugin-vue':
+        specifier: catalog:frontend
+        version: 6.0.8(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.29.0(jiti@2.6.1)(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2


### PR DESCRIPTION
## Summary

This PR is stage 2 of [CAT-4398](https://linear.app/n8n/issue/CAT-4398). It is the first frontend module that owns a parameter input type. `@n8n/frontend-module-parameter-input-icon` registers the `icon` type at the `parameterInputs` contribution point from #37100. The shell keeps no import of the component.

#37936 and #37940 merged into this branch, so this PR now carries the whole stack.

### Why the target changed

The issue asked for the Resource Locator. That input cannot move. It has 23 outbound imports that a module package cannot make: 12 kernel modules, 5 sibling features and 6 shell components. Two of the kernel modules are `nodeTypes.store` and `workflowDocument.store`. The `ExpressionParameterInput` cascade also reaches `features/shared/editors`, the inline expression editor of approximately 48K lines. `ResourceLocatorDropdown.vue` is a shared primitive too, and two inputs that stay in the shell use it.

`icon` was the measured alternative. It has five runtime dependencies: `@n8n/design-system`, `@n8n/frontend-module-sdk`, `@n8n/i18n`, `n8n-workflow` and `vue`. It has zero kernel imports and zero feature imports.

The scaffolder template declared 12 runtime dependencies, and this PR removes the 7 that the source never imports. Turbo hashes a package by its declared dependencies, so an unused declaration invalidates the cache of this module when that package changes. 3 of the 7 give a real gain: `@n8n/stores`, `@n8n/permissions` and `@n8n/rest-api-client` reach this module through no other path. The other 4 stay in the graph as transitive dependencies of `@n8n/design-system`, `@n8n/frontend-module-sdk` and `@n8n/frontend-test-utils`. Nothing is undeclared in the other direction.

### Naming: two classes of module

A **feature module** owns a product area. Its `<name>` must be the same as the name of its backend module directory under `packages/cli/src/modules/`. `isModuleActive(id)` tests the descriptor `id` against `activeModules` from `/rest/module-settings`. A feature module carries no prefix, because a prefix breaks its route guard and its settings toggle.

A **contribution-only module** has no backend half. Its id never reaches `/rest/module-settings`, so the id is free. The module takes a prefix, and the prefix names the descriptor contribution point that it supplies:

```
<contribution-point>-<what-it-renders>       parameter-input-icon
<backend module directory name>              otel
```

The directory name now answers one question: does this module have a backend half? You open no file to see it. Every sorted list also groups the two classes: `packages/modules`, the `modulePackages` table, the editor-ui tsconfig `paths` and `OWNERS`. Both classes keep the `@n8n/frontend-module-` package prefix. The planned boundary rule between modules matches that prefix as a pattern. `packages/modules/README.md` and the scaffolder README record the rule.

The component keeps the name `IconParameterInput`. That name matches `WorkflowSelectorParameterInput` and `AgentSelectorParameterInput`, the two components next to it in the shell. Only the module identity carries the prefix.

### The move

`icon` had no directory of its own, so this PR contains no `git mv`. `ParameterInput.vue` loses the `N8nIconPicker` branch, the `iconPickerValue` computed value and three imports. Four things move into the module without a change:

- the picker bindings;
- the tooltip fallback, which uses `||`, so an empty `placeholder` still falls back;
- the size rule `hideLabel ? 'small' : 'large'`;
- the `IconOrEmojiSchema` value adapter.

The diff is the proof.

### The panel must survive a load failure first

`resolveComponent` in `useParameterInputContribution.ts` wrapped a contributed loader in a plain `defineAsyncComponent`. That wrapper had no `errorComponent` and no `onError`. So a rejected chunk rendered nothing in the place of the field, and the rejection escaped uncaught. Only the built-in branch hid this. When a module serves a type, a failed chunk removes the field from the panel. A missing field then tells the user "this node has no such parameter".

- `ParameterInputLoadError.vue` occupies the row with `role="alert"` and offers a page reload.
- `ParameterInputLoading.vue` reserves the row at `var(--height--lg)`, so the panel does not shift when the real input arrives. The default delay of Vue is 200 ms, so a fast chunk shows no flash.
- `onError` retries one time, because a dropped request can succeed on a second attempt. After that retry the chunk is absent and not late, so `onError` calls `fail()`.
- `timeout` is 30 s, so a loader that never settles cannot hold the placeholder forever.

This PR adds no automatic reload. `app/plugins/vitePreloadError.ts` already reloads the page one time in each 10 s window on `vite:preloadError`. This error state remains when the throttle stops that reload, or when the reload does not help. This PR also sends no Sentry report, because `app/plugins/sentry.ts` drops dynamic-import failures on purpose.

### Supporting changes that keep the behaviour

- **`hideLabel` joins `ParameterInputProps`.** The built-in branch read it for `button-size`. The prop is additive, and it changes no default.
- **The contributed slot takes the `inputField` ref**, as every built-in branch does.
- **`parameterInput.mount` fires when the contributed chunk resolves.** `onMounted` assembles the payload, and a contributed input resolves after that moment. So a cloud hook received `undefined` in the place of the `IconPicker` instance. A watcher on the ref restores the payload, and it limits the hook to one call for each field. Built-in branches still fire from `onMounted`.
- **The module component holds the value.** The shell function `valueChangedDebounced` uses a *leading*-edge debounce: `useDebounce` passes `{ leading: true }` when the caller omits `trailing`. So one pick reaches the store in the same tick. A second pick inside the 100 ms window lands on the trailing edge. The picker draws its trigger button from the prop it gets. The value hold shows the second pick on that button while the store waits for the trailing edge.
- **`registerModuleParameterInputs()` now runs before the awaits in `initializeAuthenticatedFeatures`.** It ran after `getMyProjects` and `fetchRoles`. The router discards a failure from that function on purpose, so a rejected fetch leaves `icon` fields with no component to render them. The call stays post-login and stays ungated.

### Capabilities: none

`!isModelValueExpression && !forceShowExpression` guarded the built-in branch. `showContributedComponent` does exactly the same test when `ownsExpressionRendering` is false. The picker binds no `@drop` handler and draws no from-AI override. So `disableDrop` and `ownsFromAiOverride` also stay at their defaults. Both shipped `icon` parameters in `ChatTrigger.node.ts` set `noDataExpression: true`, so the expression path is unreachable for them today.

### Three acceptance criteria that did not fit, and why

- **This package cannot set `"private": true`.** `n8n-editor-ui` is publishable, and it now depends on this package. So `scripts/check-workspace-private-deps.mjs` fails with: `n8n-editor-ui → @n8n/frontend-module-parameter-input-icon (… is "private": true)`. The package matches `@n8n/frontend-module-otel` instead. That package has no `private` flag and uses `LicenseRef-n8n-sustainable-use`.
- **This PR adds no `no-restricted-imports` ratchet entry.** The ratchet bans the `@/features/<name>` path that a module leaves. `icon` was an inline branch, and it left no path, so there is nothing to ban. `extractedFeatures` in `editor-ui/eslint.config.mjs` does not change.
- **This PR moves no test.** `ParameterInput.test.ts` had no `icon` coverage: `grep -i icon` over that file returned nothing. So all the coverage here is new, and none of it is relocated.

## How to test

Run the commands below.

```
pnpm turbo typecheck test lint --filter=@n8n/frontend-module-parameter-input-icon \
  --filter=@n8n/frontend-module-sdk --filter=@n8n/module-cli
pnpm --filter n8n-editor-ui exec vitest run src/features/ndv src/app/init src/app/moduleInitializer vite/aliases.test.ts
pnpm --filter n8n-editor-ui typecheck
node scripts/check-workspace-private-deps.mjs && node .github/scripts/owners/owners.mjs --check
pnpm install --frozen-lockfile
```

The results below come from `a2dc504b56`:

| Check | Result |
| --- | --- |
| `@n8n/frontend-module-parameter-input-icon` | 23/23 |
| `@n8n/frontend-module-sdk` | 87/87 |
| `@n8n/module-cli` | 19/19 |
| editor-ui, the four touched paths | 1172/1172 across 84 files |
| `vue-tsc --noEmit` on editor-ui | clean |
| eslint · stylelint · biome · prettier | clean |
| `owners.mjs --check` · private-deps · boundaries ratchet | pass |
| `pnpm install --frozen-lockfile` | clean |

Three suites guard against a regression. `ParameterInput.iconModule.test.ts` holds 12 cases across the module seam. The module's own suite and the contributed-input cases in `ParameterInput.test.ts` hold the others.

Do a manual check in the app:

1. Open a Chat Trigger node.
2. Select **Options → Agent Icon**.
3. Make sure that the picker, the current icon, the tooltip and the read-only state do not change.
4. Open the `Prompts` collection. Its second `icon` field uses the `hideLabel` path.

Two verification cases stay open end to end, and each one has a cause. First, jsdom cannot reach emoji selection: the picker filters emojis through `is-emoji-supported`, and that package measures a glyph on a canvas. jsdom has no canvas. `IconPicker.test.ts` covers this case one level down. Second, expression rendering needs an `icon` parameter without `noDataExpression`. Both shipped fields set that flag, so the path is unreachable in production today.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4398/stage-2-extract-the-resource-locator-input-into-a-frontend-module

Follows #37100. Includes #37936 and #37940.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
