### PR TITLE
feat(core): Make chat trigger OAuth2 identity pipeline unconditional

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -41,7 +41,6 @@ import {
 	buildChatRefreshUrl,
 	buildInnerFrameSrc,
 	CHAT_FRAME_SANDBOX,
-	isChatOAuth2Enabled,
 	isChatRefreshRequest,
 	isShellInnerRequest,
 } from './shell';
@@ -56,10 +55,9 @@ const isPublicChatTriggerDisabled = () => Container.get(ChatTriggerConfig).disab
  * Under `n8nUserAuth` the `user` key belongs to the server. The item's `json` starts as
  * the caller's own request body, so any `user` the caller sent is dropped — whether or
  * not a verified one replaces it, since a workflow reading `json.user` must never get an
- * attacker-controlled value in the slot the trusted one occupies. That holds even when
- * the rollout flag is off and no verified value is written: the flag can change under a
- * workflow that already trusts the key. Under the other auth modes no server identity
- * exists, `user` is ordinary body data, and the body passes through untouched.
+ * attacker-controlled value in the slot the trusted one occupies. Under the other auth
+ * modes no server identity exists, `user` is ordinary body data, and the body passes
+ * through untouched.
  *
  * Only a plain object body is merged into. A string (`text/plain`), a scalar or an array
  * body can carry no `user` key, and object rest would silently shred it into
@@ -101,9 +99,6 @@ const includeUserInOutputOption: INodeProperties = {
 	name: 'includeUserInOutput',
 	type: 'boolean',
 	default: true,
-	// Hidden until the chat OAuth2 rollout reaches GA. Display only — `webhook()`
-	// checks the same flag itself.
-	envFeatureFlag: 'CHAT_TRIGGER_OAUTH2',
 	// No `mode` gate, unlike its neighbour: `n8nUserAuth` also works in `webhook`
 	// mode through the cookie check, and that path emits an item too.
 	description: "Whether to include the logged-in user's ID, email and name in the trigger output",
@@ -978,7 +973,7 @@ export class ChatTrigger extends Node {
 			// report them under the same conditions production would. This lookup is identity,
 			// not authorization: it stays outside the `catch` below, which reads its error as
 			// an auth challenge and would answer with an undefined status code.
-			if (isChatOAuth2Enabled() && authentication === 'n8nUserAuth') {
+			if (authentication === 'n8nUserAuth') {
 				authedUser = await ctx.getTestWebhookUser?.();
 			}
 		} else {
@@ -1029,7 +1024,7 @@ export class ChatTrigger extends Node {
 				// success channel, `localStorage`), so nothing author-shaped may live there.
 				let frameIdentity: ChatFrameIdentity | undefined;
 
-				if (isChatOAuth2Enabled() && authentication === 'n8nUserAuth') {
+				if (authentication === 'n8nUserAuth') {
 					const resourceUrl = ctx.getWebhookResourceUrl('default');
 					if (!resourceUrl) {
 						throw new NodeOperationError(ctx.getNode(), 'Default webhook url not set');
@@ -1201,17 +1196,13 @@ export class ChatTrigger extends Node {
 		const isMultipart = req.contentType === 'multipart/form-data';
 		const item = isMultipart ? await this.handleFormData(ctx) : { json: bodyData };
 
-		// Ownership of the `user` key follows the auth mode alone, never the rollout flag. A
-		// workflow built while the flag was on keeps trusting `json.user`, and it travels
-		// between instances — export/import, a rollback, drifted env on one main — while the
-		// env var does not. So a claimed `user` is dropped on every `n8nUserAuth` chat.
+		// Ownership of the `user` key follows the auth mode alone. So a claimed `user` is
+		// dropped on every `n8nUserAuth` chat, regardless of what the caller sent.
 		const serverOwnsUserKey = authentication === 'n8nUserAuth';
-		// Only writing the verified identity is gated until GA. The declared `default` drives
-		// the editor alone; an absent parameter resolves to this fallback, so it is what
-		// decides for a node that never had the key saved.
+		// The declared `default` drives the editor alone; an absent parameter resolves to
+		// this fallback, so it is what decides for a node that never had the key saved.
 		const includeUser =
 			serverOwnsUserKey &&
-			isChatOAuth2Enabled() &&
 			ctx.getNodeParameter('includeUserInOutput', ctx.getNode().typeVersion >= 1.5) !== false;
 
 		// The single merge point for all three emission paths — see `withAuthenticatedUser`.

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/GenericFunctions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/GenericFunctions.ts
@@ -6,7 +6,6 @@ import { ChatTriggerAuthorizationError } from './error';
 import {
 	clearChatOAuthToken,
 	clearChatRefreshToken,
-	isChatOAuth2Enabled,
 	readChatOAuthToken,
 	readChatRefreshToken,
 	setChatOAuthToken,
@@ -104,7 +103,7 @@ export async function validateAuth(context: IWebhookFunctions): Promise<IUser | 
 			// so a token from it must never authenticate a webhook-mode call — e.g. a stale
 			// token replayed after the node's mode was switched from hostedChat to webhook.
 			const mode = context.getNodeParameter('mode', 'hostedChat') as 'hostedChat' | 'webhook';
-			if (isChatOAuth2Enabled() && mode === 'hostedChat') {
+			if (mode === 'hostedChat') {
 				const chatToken = headers['x-auth-token'];
 				if (typeof chatToken === 'string' && chatToken) {
 					const resourceUrl = context.getWebhookResourceUrl('default');

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -575,7 +575,6 @@ describe('ChatTrigger Node', () => {
 			(result.workflowData as INodeExecutionData[][])[0][0].json;
 
 		beforeEach(() => {
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 			vi.mocked(validateAuth).mockResolvedValue(authedUser);
 		});
 
@@ -590,7 +589,6 @@ describe('ChatTrigger Node', () => {
 			expect(includeUserParams[0]).toMatchObject({
 				type: 'boolean',
 				default: true,
-				envFeatureFlag: 'CHAT_TRIGGER_OAUTH2',
 				displayOptions: {
 					show: {
 						authentication: ['n8nUserAuth'],
@@ -603,7 +601,6 @@ describe('ChatTrigger Node', () => {
 			expect(includeUserParams[1]).toMatchObject({
 				type: 'boolean',
 				default: false,
-				envFeatureFlag: 'CHAT_TRIGGER_OAUTH2',
 				displayOptions: {
 					show: {
 						authentication: ['n8nUserAuth'],
@@ -719,22 +716,6 @@ describe('ChatTrigger Node', () => {
 
 			expect(emittedJson(result)).toEqual({ message: 'Hello', user: authedUser });
 		});
-
-		// The flag gates writing the verified user, not ownership of the key. A claimed
-		// `user` is still dropped, so a workflow built while the flag was on cannot be
-		// spoofed if the flag is later turned off.
-		it('emits no user but still strips a claimed one when the feature flag is off', async () => {
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
-			mockContext.getBodyData.mockReturnValue({
-				message: 'Hello',
-				user: { email: 'ceo@acme.com' },
-			});
-			setParams();
-
-			const result = await chatTrigger.webhook(mockContext);
-
-			expect(emittedJson(result)).toEqual({ message: 'Hello' });
-		});
 	});
 
 	// The editor's canvas chat can't supply webhook credentials, so its session-scoped
@@ -768,7 +749,6 @@ describe('ChatTrigger Node', () => {
 			(result.workflowData as INodeExecutionData[][])[0][0].json;
 
 		beforeEach(() => {
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 			mockContext.getMode.mockReturnValue('manual');
 			mockContext.isChatSessionTest.mockReturnValue(true);
 			getTestWebhookUser.mockResolvedValue(editorUser);
@@ -855,7 +835,6 @@ describe('ChatTrigger Node', () => {
 			(result.workflowData as INodeExecutionData[][])[0][0].json;
 
 		beforeEach(() => {
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 			mockContext.getBodyData.mockReturnValue({ chatInput: 'hi', user: forgedUser });
 			vi.mocked(validateAuth).mockResolvedValue(authedUser);
 		});
@@ -888,17 +867,6 @@ describe('ChatTrigger Node', () => {
 
 		it('strips a caller-supplied user when the toggle is off', async () => {
 			setParams({ includeUserInOutput: false });
-
-			const result = await chatTrigger.webhook(mockContext);
-
-			expect(emittedJson(result)).toEqual({ chatInput: 'hi' });
-		});
-
-		// The key's owner is the auth mode, not the rollout flag. An instance that turns the
-		// flag off must not start trusting a claimed `user` in a workflow built while it was on.
-		it('strips a caller-supplied user with the feature flag off', async () => {
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
-			setParams();
 
 			const result = await chatTrigger.webhook(mockContext);
 
@@ -996,12 +964,6 @@ describe('ChatTrigger Node', () => {
 			};
 			mockRequest.query = {};
 			mockRequest.originalUrl = '/webhook/abc/chat';
-
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
-		});
-
-		afterEach(() => {
-			vi.unstubAllEnvs();
 		});
 
 		it('renders the shell with the author chat in a sandboxed frame', async () => {
@@ -1102,20 +1064,6 @@ describe('ChatTrigger Node', () => {
 			);
 			expect(mockContext.validateCookieAuth).not.toHaveBeenCalled();
 			expect(everySentResponse()).not.toContain('/signin');
-		});
-
-		it('renders the page unsplit when the flag is off', async () => {
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
-
-			await renderSetupPage();
-
-			expect(mockResponse.setHeader).not.toHaveBeenCalled();
-			expect(establishChatSessionIdentity).not.toHaveBeenCalled();
-			expect(renderedPage()).toContain('createChat');
-			expect(renderedPage()).not.toContain('n8nShellInner');
-			// The unsplit render is the page itself, not a shell around a frame.
-			expect(mockResponse.render).not.toHaveBeenCalled();
-			expect(renderedPage()).not.toContain('n8nChatRefresh');
 		});
 
 		it.each(['none', 'basicAuth'])(

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/GenericFunctions.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/GenericFunctions.test.ts
@@ -176,11 +176,6 @@ describe('validateAuth', () => {
 				mockContext.getWebhookName.mockReturnValue('default');
 				mockContext.getNodeParameter.calledWith('mode', 'hostedChat').mockReturnValue('hostedChat');
 				mockContext.getWebhookResourceUrl.mockReturnValue(resourceUrl);
-				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
-			});
-
-			afterEach(() => {
-				vi.unstubAllEnvs();
 			});
 
 			it('establishes the trigger identity and passes for a valid token', async () => {
@@ -219,19 +214,6 @@ describe('validateAuth', () => {
 				await expect(validateAuth(mockContext)).rejects.toMatchObject({
 					responseCode: 401,
 					message: 'Invalid authentication token',
-				});
-				expect(mockContext.validateN8nOAuth2Token).not.toHaveBeenCalled();
-			});
-
-			// The header only means anything on the split page, so with the flag off it
-			// must not become a second way in.
-			it('should ignore the header when the flag is off', async () => {
-				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
-				mockContext.getHeaderData.mockReturnValue({ 'x-auth-token': 'as-token' });
-
-				await expect(validateAuth(mockContext)).rejects.toMatchObject({
-					responseCode: 401,
-					message: 'User not authenticated!',
 				});
 				expect(mockContext.validateN8nOAuth2Token).not.toHaveBeenCalled();
 			});

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/shell.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/shell.test.ts
@@ -4,7 +4,6 @@ import {
 	buildChatRefreshUrl,
 	buildInnerFrameSrc,
 	clearChatOAuthToken,
-	isChatOAuth2Enabled,
 	isChatRefreshRequest,
 	isShellInnerRequest,
 	readChatOAuthToken,
@@ -21,22 +20,6 @@ const request = (overrides: Partial<Request> = {}) =>
 		protocol: 'http',
 		...overrides,
 	}) as unknown as Request;
-
-describe('isChatOAuth2Enabled', () => {
-	afterEach(() => {
-		vi.unstubAllEnvs();
-	});
-
-	it.each([
-		['true', true],
-		['false', false],
-		[undefined, false],
-	])('is %s for N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2=%s', (value, expected) => {
-		vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', value);
-
-		expect(isChatOAuth2Enabled()).toBe(expected);
-	});
-});
 
 describe('isShellInnerRequest', () => {
 	it('honors the flag for an iframe navigation', () => {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/shell.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/shell.ts
@@ -1,10 +1,5 @@
 import type { Request, Response } from 'express';
 
-/** Opt-in: with the flag off the hosted chat page renders as a single document, as before. */
-export function isChatOAuth2Enabled(): boolean {
-	return process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 === 'true';
-}
-
 /** Query flag that asks the `setup` GET for the inner render instead of the shell. */
 export const CHAT_SHELL_INNER_PARAM = 'n8nShellInner';
 

--- a/packages/cli/src/constants/oauth2-triggers.ts
+++ b/packages/cli/src/constants/oauth2-triggers.ts
@@ -1,8 +1,0 @@
-/**
- * Chat-trigger OAuth2 is opt-in. When the
- * flag is off, `n8nUserAuth` chat triggers keep their existing auth and must not be
- * exposed as OAuth protected resources, so the resolvers short-circuit.
- */
-export function isChatOAuth2Enabled(): boolean {
-	return process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 === 'true';
-}

--- a/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
@@ -93,14 +93,9 @@ const resolveResource = async (path: string) =>
 	await Container.get(ProtectedResourceRegistry).getByResourcePath(`/${webhookEndpoint}/${path}`);
 
 beforeAll(async () => {
-	process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 = 'true'; // gates the chat-trigger resolver
 	owner = await createOwner();
 	member = await createMember();
 	webhookEndpoint = Container.get(GlobalConfig).endpoints.webhook;
-});
-
-afterAll(() => {
-	delete process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2;
 });
 
 afterEach(async () => {
@@ -198,20 +193,6 @@ describe('protected resource metadata for chat triggers', () => {
 		const response = await testServer.restlessAgent.get(prmPathFor(path));
 
 		expect(response.statusCode).toBe(404);
-	});
-
-	test('should not resolve when the feature flag is disabled', async () => {
-		const path = chatPath();
-		await createPublishedChatWorkflow(path, chatTriggerNode());
-
-		delete process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2;
-		try {
-			// Also proves the generic webhook resolver does not pick a chat path up itself.
-			const response = await testServer.restlessAgent.get(prmPathFor(path));
-			expect(response.statusCode).toBe(404);
-		} finally {
-			process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 = 'true';
-		}
 	});
 
 	test('should not resolve when public chat is disabled instance-wide', async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-test-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-test-resource.resolver.api.test.ts
@@ -109,17 +109,12 @@ const resolveResource = async (path: string) =>
 	);
 
 beforeAll(async () => {
-	process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 = 'true'; // gates the chat-trigger resolver
 	owner = await createOwner();
 	member = await createMember();
 	const { endpoints } = Container.get(GlobalConfig);
 	webhookEndpoint = endpoints.webhook;
 	webhookTestEndpoint = endpoints.webhookTest;
 	registrations = Container.get(TestWebhookRegistrationsService);
-});
-
-afterAll(() => {
-	delete process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2;
 });
 
 afterEach(async () => {
@@ -213,19 +208,6 @@ describe('protected resource metadata for test chat triggers', () => {
 		const response = await testServer.restlessAgent.get(prmPathFor(path));
 
 		expect(response.statusCode).toBe(404);
-	});
-
-	test('should not resolve when the feature flag is disabled', async () => {
-		const path = chatPath();
-		await registerTestWebhook(path, chatTriggerNode());
-
-		delete process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2;
-		try {
-			const response = await testServer.restlessAgent.get(prmPathFor(path));
-			expect(response.statusCode).toBe(404);
-		} finally {
-			process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 = 'true';
-		}
 	});
 
 	test('should not resolve when public chat is disabled instance-wide', async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-flow.service.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-flow.service.api.test.ts
@@ -122,7 +122,6 @@ const authorizeAndMintCode = async (
 };
 
 beforeAll(async () => {
-	process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 = 'true'; // gates the chat-trigger resolver
 	owner = await createOwner();
 	member = await createMember();
 	const { endpoints } = Container.get(GlobalConfig);
@@ -132,10 +131,6 @@ beforeAll(async () => {
 	codes = Container.get(OAuthAuthorizationCodeService);
 	oauthServer = Container.get(OAuthServerService);
 	tokenService = Container.get(OAuthTokenService);
-});
-
-afterAll(() => {
-	delete process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2;
 });
 
 afterEach(async () => {

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/chat-trigger-resource.base.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/chat-trigger-resource.base.ts
@@ -3,7 +3,6 @@ import type { GlobalConfig } from '@n8n/config';
 import type { INode } from 'n8n-workflow';
 import { CHAT_TRIGGER_PATH_SUFFIX } from 'n8n-workflow';
 
-import { isChatOAuth2Enabled } from '@/constants/oauth2-triggers';
 import type {
 	ProtectedResource,
 	ProtectedResourceResolver,
@@ -68,10 +67,6 @@ export abstract class ChatTriggerResourceResolverBase implements ProtectedResour
 	}
 
 	async resolveByPath(pathname: string): Promise<ProtectedResource | undefined> {
-		if (!isChatOAuth2Enabled()) {
-			return undefined;
-		}
-
 		const { endpoint } = this;
 		if (!pathname.startsWith(`/${endpoint}/`)) {
 			return undefined;
@@ -101,8 +96,8 @@ export abstract class ChatTriggerResourceResolverBase implements ProtectedResour
 		const resourceUrl = `${trimTrailingSlash(this.baseUrl)}/${endpoint}/${path}`;
 		const audiences = [resourceUrl];
 		// Opt-in, unlike the MCP/webhook resolvers' `!== false`: defaulting off preserves the
-		// existing any-authenticated-visitor behaviour, so turning the chat OAuth2 flag on does
-		// not change who may chat with an already-published workflow.
+		// existing any-authenticated-visitor behaviour for a workflow that never touched this
+		// setting.
 		const requireExecute = node.parameters.requireExecuteAccess === true;
 		return {
 			// Path included, like the webhook resolver's id: one workflow can hold several chat

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -331,13 +331,8 @@ describe('TestWebhooks', () => {
 				executionContextService.buildManualExecutionCredentials.mockResolvedValue(carrier);
 			});
 
-			afterEach(() => {
-				vi.unstubAllEnvs();
-			});
-
 			test('mints and stores the carrier for an identity-bearing chat trigger', async () => {
 				// ARRANGE
-				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(chatWorkflow(IDENTITY_BEARING));
 				vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([chatWebhook()]);
 
@@ -353,7 +348,6 @@ describe('TestWebhooks', () => {
 
 			test('mints only once for a trigger that registers several webhooks', async () => {
 				// ARRANGE
-				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(chatWorkflow(IDENTITY_BEARING));
 				vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([
 					chatWebhook(),
@@ -369,17 +363,9 @@ describe('TestWebhooks', () => {
 
 			test.each([
 				{
-					reason: 'the feature flag is off',
-					flag: 'false',
-					parameters: IDENTITY_BEARING,
-					type: CHAT_TRIGGER_NODE_TYPE,
-					cookie: n8nAuthCookie,
-				},
-				{
 					// A `n8nOAuth2` webhook node is identity-bearing too, but establishes its own
 					// stronger carrier while its webhook runs, so this gate stays out of its way.
 					reason: 'the trigger is not a chat trigger',
-					flag: 'true',
 					parameters: { authentication: 'n8nOAuth2' },
 					type: 'n8n-nodes-base.webhook',
 					cookie: n8nAuthCookie,
@@ -389,42 +375,36 @@ describe('TestWebhooks', () => {
 					// granting it identity in test mode would diverge from production. Expected to
 					// start minting once IAM-1263 makes it identity-bearing.
 					reason: 'the chat trigger is n8nUserAuth but not available in chat',
-					flag: 'true',
 					parameters: { authentication: 'n8nUserAuth' },
 					type: CHAT_TRIGGER_NODE_TYPE,
 					cookie: n8nAuthCookie,
 				},
 				{
 					reason: 'authentication is basicAuth',
-					flag: 'true',
 					parameters: { authentication: 'basicAuth' },
 					type: CHAT_TRIGGER_NODE_TYPE,
 					cookie: n8nAuthCookie,
 				},
 				{
 					reason: 'the chat trigger carries no relevant parameters',
-					flag: 'true',
 					parameters: {},
 					type: CHAT_TRIGGER_NODE_TYPE,
 					cookie: n8nAuthCookie,
 				},
 				{
 					reason: 'availableInChat is an unresolved expression',
-					flag: 'true',
 					parameters: { availableInChat: '={{ $json.inChat }}' },
 					type: CHAT_TRIGGER_NODE_TYPE,
 					cookie: n8nAuthCookie,
 				},
 				{
 					reason: 'no cookie was supplied',
-					flag: 'true',
 					parameters: IDENTITY_BEARING,
 					type: CHAT_TRIGGER_NODE_TYPE,
 					cookie: undefined,
 				},
-			])('does not mint a carrier when $reason', async ({ flag, parameters, type, cookie }) => {
+			])('does not mint a carrier when $reason', async ({ parameters, type, cookie }) => {
 				// ARRANGE
-				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', flag);
 				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(chatWorkflow(parameters, type));
 				vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([chatWebhook()]);
 
@@ -438,7 +418,6 @@ describe('TestWebhooks', () => {
 
 			test('stores the carrier only on the chat trigger registration', async () => {
 				// ARRANGE
-				vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'true');
 				vi.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(
 					mock<Workflow>({
 						id: workflowEntity.id,

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -19,7 +19,6 @@ import type {
 } from 'n8n-workflow';
 
 import { TEST_WEBHOOK_TIMEOUT } from '@/constants';
-import { isChatOAuth2Enabled } from '@/constants/oauth2-triggers';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
 import { SingleWebhookTriggerError } from '@/errors/single-webhook-trigger.error';
@@ -359,9 +358,7 @@ export class TestWebhooks implements IWebhookManager {
 
 		if (node?.type !== CHAT_TRIGGER_NODE_TYPE) return false;
 
-		return classifyTriggerIdentity(node.type, node.parameters, {
-			isChatOAuth2Enabled: isChatOAuth2Enabled(),
-		}).providesN8nIdentity;
+		return classifyTriggerIdentity(node.type, node.parameters).providesN8nIdentity;
 	}
 
 	/**
@@ -380,7 +377,7 @@ export class TestWebhooks implements IWebhookManager {
 		webhooks: IWebhookData[],
 		n8nAuthCookie?: string,
 	) {
-		if (!n8nAuthCookie || !isChatOAuth2Enabled()) return undefined;
+		if (!n8nAuthCookie) return undefined;
 
 		const anyEstablishesIdentity = webhooks.some((webhook) =>
 			this.establishesRunnerIdentity(workflow, webhook.node),

--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -709,13 +709,6 @@ describe('WorkflowValidationService', () => {
 
 		beforeEach(() => {
 			mockNodeTypes = mock<NodeTypes>();
-			// Pin the flag off so the expected copy never depends on the ambient env.
-			// Tests that need it on opt in with `withChatOAuth2(true)`.
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', 'false');
-		});
-
-		afterEach(() => {
-			vi.unstubAllEnvs();
 		});
 
 		it('should return valid when no credentials are used', async () => {
@@ -1168,9 +1161,6 @@ describe('WorkflowValidationService', () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		const withChatOAuth2 = (enabled: boolean) =>
-			vi.stubEnv('N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2', enabled ? 'true' : 'false');
-
 		describe('webhook trigger', () => {
 			const validateWithOAuth2Webhook = async () => {
 				const nodes: INode[] = [
@@ -1294,28 +1284,19 @@ describe('WorkflowValidationService', () => {
 				return await service.validateDynamicCredentials(nodes, mockNodeTypes);
 			};
 
-			// A chat trigger establishes no identity at runtime through `none`/`basicAuth`, so
-			// the flag being on must not let publish accept a configuration that would only
-			// fail later, mid-execution.
-			it.each(['none', 'basicAuth'])(
-				'should reject authentication %s even when chat OAuth2 is enabled',
-				async (authentication) => {
-					withChatOAuth2(true);
+			// A chat trigger establishes no identity at runtime through `none`/`basicAuth`.
+			it.each(['none', 'basicAuth'])('should reject authentication %s', async (authentication) => {
+				const result = await validateWithChatTrigger({ authentication });
 
-					const result = await validateWithChatTrigger({ authentication });
-
-					expect(result.isValid).toBe(false);
-					expect(result.error).toBe(
-						'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
-					);
-				},
-			);
+				expect(result.isValid).toBe(false);
+				expect(result.error).toBe(
+					'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
+				);
+			});
 
 			it.each([{}, { mode: 'hostedChat' }])(
-				'should return valid for public n8nUserAuth in hosted-chat mode when chat OAuth2 is enabled (%o)',
+				'should return valid for public n8nUserAuth in hosted-chat mode (%o)',
 				async (modeParams) => {
-					withChatOAuth2(true);
-
 					const result = await validateWithChatTrigger({
 						public: true,
 						authentication: 'n8nUserAuth',
@@ -1325,21 +1306,6 @@ describe('WorkflowValidationService', () => {
 					expect(result.isValid).toBe(true);
 				},
 			);
-
-			// With the flag off (the default), hosted-chat `n8nUserAuth` falls back to a cookie
-			// check that never binds the visitor's identity — publish must not accept an
-			// end-user credential it can't actually resolve at runtime.
-			it('should reject public n8nUserAuth in hosted-chat mode when chat OAuth2 is disabled', async () => {
-				const result = await validateWithChatTrigger({
-					public: true,
-					authentication: 'n8nUserAuth',
-				});
-
-				expect(result.isValid).toBe(false);
-				expect(result.error).toBe(
-					'Cannot publish workflow: end-user credentials ("My OAuth2") are only supported with manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication. To use another trigger, switch the credential to Fixed.',
-				);
-			});
 
 			// A non-public trigger 404s on every production request and skips auth entirely
 			// in test mode, so it never reaches the code that establishes identity.

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -23,7 +23,6 @@ import type {
 } from 'n8n-workflow';
 
 import { STARTING_NODES } from '@/constants';
-import { isChatOAuth2Enabled } from '@/constants/oauth2-triggers';
 import { CredentialTypes } from '@/credential-types';
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { NodeTypes } from '@/node-types';
@@ -420,9 +419,8 @@ export class WorkflowValidationService {
 	 * Describes which trigger configurations the system resolver currently accepts,
 	 * for the publish-error copy. Chat qualifies when available in Chat Hub, or with
 	 * `n8nUserAuth` in hosted-chat mode specifically — embedded/webhook-mode chat has
-	 * no page to run the OAuth2 handshake on, so it establishes no identity regardless
-	 * of the chat OAuth2 flag; MCP only with n8n user auth (OAuth2). Mirrors
-	 * `classifyTriggerIdentity`.
+	 * no page to run the OAuth2 handshake on, so it establishes no identity there; MCP
+	 * only with n8n user auth (OAuth2). Mirrors `classifyTriggerIdentity`.
 	 */
 	private getN8nUserAuthTriggersList(): string {
 		return 'manual and sub-workflow triggers, chat triggers available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, form, or webhook triggers with n8n user authentication';
@@ -482,7 +480,6 @@ export class WorkflowValidationService {
 			const { providesExternalIdentity, providesN8nIdentity } = classifyTriggerIdentity(
 				node.type,
 				node.parameters,
-				{ isChatOAuth2Enabled: isChatOAuth2Enabled() },
 			);
 			allTriggersProvideExternalIdentity &&= providesExternalIdentity;
 			allTriggersProvideN8nIdentity &&= providesN8nIdentity;

--- a/packages/cli/test/integration/dynamic-credentials.ee/chat-trigger-test-run.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/chat-trigger-test-run.api.test.ts
@@ -52,7 +52,6 @@ import { loadNodesFromDist } from '../shared/utils/node-types-data';
 mockInstance(Telemetry);
 
 process.env.N8N_ENV_FEAT_DYNAMIC_CREDENTIALS = 'true';
-process.env.N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2 = 'true';
 
 const testServer = setupTestServer({
 	endpointGroups: ['workflows', 'credentials'],

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -898,7 +898,6 @@ describe('useNodeHelpers()', () => {
 			// incompatible-trigger issue is copy about the workflow, so it doesn't read
 			// anything off the trigger's node type.
 			mockedStore(useNodeTypesStore).getNodeType = vi.fn(() => notionNodeType);
-			mockedStore(useSettingsStore).settings.envFeatureFlags = {};
 		});
 
 		afterEach(() => {
@@ -906,7 +905,6 @@ describe('useNodeHelpers()', () => {
 			mockDocumentStore.connectionsBySourceNode = {};
 			mockDocumentStore.connectionsByDestinationNode = {};
 			mockDocumentStore.settings = {};
-			mockedStore(useSettingsStore).settings.envFeatureFlags = {};
 		});
 
 		describe('not connected', () => {
@@ -1075,13 +1073,6 @@ describe('useNodeHelpers()', () => {
 				expect(result).toBeNull();
 			});
 
-			const setChatOAuth2 = (enabled: boolean) => {
-				mockedStore(useSettingsStore).settings.envFeatureFlags = {
-					...mockedStore(useSettingsStore).settings.envFeatureFlags,
-					N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2: enabled ? 'true' : 'false',
-				};
-			};
-
 			it('warns with the base message when a private credential is used under a webhook trigger not using n8n User Auth', () => {
 				mockConnectedPrivateCred(true);
 				mockDocumentStore.workflowTriggerNodes = [buildTriggerNode(WEBHOOK_TRIGGER)];
@@ -1182,29 +1173,22 @@ describe('useNodeHelpers()', () => {
 						},
 					});
 
-				// A chat trigger establishes no identity at runtime through `none`/`basicAuth`,
-				// so the flag being on must not clear this warning — that would tell the
-				// builder a fix works when it doesn't.
-				it.each(['none', 'basicAuth'])(
-					'warns for authentication %s even when chat OAuth2 is enabled',
-					(authentication) => {
-						setChatOAuth2(true);
-						mockConnectedPrivateCred(true);
-						mockDocumentStore.workflowTriggerNodes = [buildChatUserAuthTrigger(authentication)];
+				// A chat trigger establishes no identity at runtime through `none`/`basicAuth`.
+				it.each(['none', 'basicAuth'])('warns for authentication %s', (authentication) => {
+					mockConnectedPrivateCred(true);
+					mockDocumentStore.workflowTriggerNodes = [buildChatUserAuthTrigger(authentication)];
 
-						const { getNodeCredentialIssues } = useNodeHelpers();
-						const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+					const { getNodeCredentialIssues } = useNodeHelpers();
+					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-						expect(result?.credentials?.[NOTION_API]).toEqual([
-							"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
-						]);
-					},
-				);
+					expect(result?.credentials?.[NOTION_API]).toEqual([
+						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
+					]);
+				});
 
 				it.each([undefined, 'hostedChat'])(
-					'does not warn for public n8nUserAuth in hosted-chat mode when chat OAuth2 is enabled (mode: %s)',
+					'does not warn for public n8nUserAuth in hosted-chat mode (mode: %s)',
 					(mode) => {
-						setChatOAuth2(true);
 						mockConnectedPrivateCred(true);
 						mockDocumentStore.workflowTriggerNodes = [
 							buildChatUserAuthTrigger('n8nUserAuth', mode, true),
@@ -1216,23 +1200,6 @@ describe('useNodeHelpers()', () => {
 						expect(result).toBeNull();
 					},
 				);
-
-				// With the flag off (the default), hosted-chat `n8nUserAuth` falls back to a
-				// cookie check that never binds the visitor's identity for credential
-				// resolution — the warning must still show.
-				it('warns for public n8nUserAuth in hosted-chat mode when chat OAuth2 is disabled', () => {
-					mockConnectedPrivateCred(true);
-					mockDocumentStore.workflowTriggerNodes = [
-						buildChatUserAuthTrigger('n8nUserAuth', 'hostedChat', true),
-					];
-
-					const { getNodeCredentialIssues } = useNodeHelpers();
-					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
-
-					expect(result?.credentials?.[NOTION_API]).toEqual([
-						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Sub-workflow, Chat available in n8n Chat Hub or using n8n user authentication in hosted chat mode, and MCP, Form, or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
-					]);
-				});
 
 				// A non-public trigger 404s on every production request and skips auth
 				// entirely in test mode, so it never reaches the code that establishes identity.

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -49,7 +49,6 @@ import { EnableNodeToggleCommand } from '@/app/models/history';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useCanvasStore } from '@/app/stores/canvas.store';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { injectWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
@@ -72,7 +71,6 @@ export function useNodeHelpers() {
 	const settingsStore = useSettingsStore();
 	const i18n = useI18n();
 	const canvasStore = useCanvasStore();
-	const { check: envFeatureFlag } = useEnvFeatureFlag();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 	const { isEnabled: isPrivateCredentialsEnabled } = usePrivateCredentials();
@@ -459,7 +457,6 @@ export function useNodeHelpers() {
 			const { providesN8nIdentity, providesExternalIdentity } = classifyTriggerIdentity(
 				trigger.type,
 				trigger.parameters,
-				{ isChatOAuth2Enabled: envFeatureFlag.value('CHAT_TRIGGER_OAUTH2') },
 			);
 			return isSystemResolver ? !providesN8nIdentity : !providesExternalIdentity;
 		};

--- a/packages/workflow/src/trigger-identity.ts
+++ b/packages/workflow/src/trigger-identity.ts
@@ -39,20 +39,12 @@ function hasContextEstablishmentHook(parameters: INodeParameters | undefined): b
 
 /**
  * Whether a Chat Trigger's `n8nUserAuth` establishes the visitor's n8n identity: only in
- * hosted-chat mode (embedded/webhook mode has no page to run the OAuth2 handshake on), only
- * when public (a non-public trigger never reaches the auth code at all), and only when the
- * chat-trigger OAuth2 pipeline is enabled — with it off, `n8nUserAuth` falls back to a plain
- * cookie check that authenticates the request but never binds the visitor's identity for
- * credential resolution (`GenericFunctions.ts`'s `validateAuth`). Absent `mode` counts as
- * `hostedChat`, its default.
+ * hosted-chat mode (embedded/webhook mode has no page to run the OAuth2 handshake on) and
+ * only when public (a non-public trigger never reaches the auth code at all). Absent
+ * `mode` counts as `hostedChat`, its default.
  */
-function isHostedChatUserAuthTrigger(
-	nodeType: string,
-	parameters: INodeParameters | undefined,
-	isChatOAuth2Enabled: boolean,
-) {
+function isHostedChatUserAuthTrigger(nodeType: string, parameters: INodeParameters | undefined) {
 	return (
-		isChatOAuth2Enabled &&
 		nodeType === CHAT_TRIGGER_NODE_TYPE &&
 		parameters?.public === true &&
 		parameters?.authentication === 'n8nUserAuth' &&
@@ -68,17 +60,10 @@ function isHostedChatUserAuthTrigger(
  * sync with how the engine establishes identity (`execution-context.ts`,
  * manual/parent inheritance) and the resolvers' identifiers (e.g. `N8NIdentifier`):
  * when a new trigger or identity source is added there, reflect it here too.
- *
- * `isChatOAuth2Enabled` mirrors the `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2` opt-in flag: it
- * gates the Chat Trigger's hosted-chat `n8nUserAuth` branch, since that configuration
- * only establishes identity through the flagged pipeline. Defaults to `false` so a
- * caller that forgets to pass it gets the safe (no-identity) answer rather than a false
- * positive.
  */
 export function classifyTriggerIdentity(
 	nodeType: string,
 	parameters: INodeParameters | undefined,
-	{ isChatOAuth2Enabled = false }: { isChatOAuth2Enabled?: boolean } = {},
 ): TriggerIdentityCapabilities {
 	// Sub-workflows inherit identity from the parent; Chat Hub and MCP-over-n8nOAuth2
 	// inject it. All provide both identity families.
@@ -98,7 +83,7 @@ export function classifyTriggerIdentity(
 	if (
 		isSubWorkflowTrigger ||
 		isChatHubTrigger ||
-		isHostedChatUserAuthTrigger(nodeType, parameters, isChatOAuth2Enabled) ||
+		isHostedChatUserAuthTrigger(nodeType, parameters) ||
 		isMcpTrigger ||
 		isFormTrigger ||
 		isOAuth2Webhook

--- a/packages/workflow/test/trigger-identity.test.ts
+++ b/packages/workflow/test/trigger-identity.test.ts
@@ -63,61 +63,31 @@ describe('classifyTriggerIdentity', () => {
 		);
 
 		// Only the hosted-chat page runs the OAuth2 handshake that establishes the
-		// visitor's identity — `mode` absent or explicit defaults to hosted. Requires the
-		// chat-trigger OAuth2 flag: with it off, `n8nUserAuth` falls back to a plain cookie
-		// check that never binds the visitor's identity for credential resolution.
+		// visitor's identity — `mode` absent or explicit defaults to hosted.
 		it.each([{}, { mode: 'hostedChat' }])(
-			'provides both identities for public n8nUserAuth in hosted-chat mode when chat OAuth2 is enabled (%o)',
+			'provides both identities for public n8nUserAuth in hosted-chat mode (%o)',
 			(modeParams) => {
 				expect(
-					classifyTriggerIdentity(
-						CHAT_TRIGGER_NODE_TYPE,
-						{
-							public: true,
-							authentication: 'n8nUserAuth',
-							...modeParams,
-						},
-						{ isChatOAuth2Enabled: true },
-					),
+					classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {
+						public: true,
+						authentication: 'n8nUserAuth',
+						...modeParams,
+					}),
 				).toEqual({ providesN8nIdentity: true, providesExternalIdentity: true });
 			},
 		);
 
-		// With the flag off (the default), the cookie fallback authenticates the request but
-		// never binds the visitor's identity — publish must not advertise identity it can't
-		// actually establish.
-		it.each([{}, { isChatOAuth2Enabled: false }])(
-			'provides no identity for public n8nUserAuth in hosted-chat mode when chat OAuth2 is disabled (%o)',
-			(options) => {
-				expect(
-					classifyTriggerIdentity(
-						CHAT_TRIGGER_NODE_TYPE,
-						{ public: true, authentication: 'n8nUserAuth' },
-						options,
-					),
-				).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
-			},
-		);
-
 		// Embedded/webhook-mode chat has no hosted page to run the OAuth2 handshake on, so
-		// `n8nUserAuth` establishes no identity there despite being selected (IAM-1262/IAM-1272),
-		// regardless of the chat OAuth2 flag.
-		it.each([{}, { isChatOAuth2Enabled: true }])(
-			'provides no identity for n8nUserAuth in webhook mode (%o)',
-			(options) => {
-				expect(
-					classifyTriggerIdentity(
-						CHAT_TRIGGER_NODE_TYPE,
-						{
-							public: true,
-							authentication: 'n8nUserAuth',
-							mode: 'webhook',
-						},
-						options,
-					),
-				).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
-			},
-		);
+		// `n8nUserAuth` establishes no identity there despite being selected (IAM-1262/IAM-1272).
+		it('provides no identity for n8nUserAuth in webhook mode', () => {
+			expect(
+				classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {
+					public: true,
+					authentication: 'n8nUserAuth',
+					mode: 'webhook',
+				}),
+			).toEqual({ providesN8nIdentity: false, providesExternalIdentity: false });
+		});
 
 		// A non-public trigger 404s on every production request and skips auth entirely in
 		// test mode (`ChatTrigger.node.ts`'s `webhook()`), so it never reaches the code that


### PR DESCRIPTION
## Summary

- Remove `N8N_ENV_FEAT_CHAT_TRIGGER_OAUTH2` and `isChatOAuth2Enabled()` from the codebase.
- The OAuth2 identity pipeline for `n8nUserAuth` on the chat trigger now runs unconditionally, matching Form Trigger's own flag removal at GA.
- Remove the frontend's matching `envFeatureFlag` check and the now-dead `envFeatureFlag` property on the `includeUserInOutput` node parameter.
- Leave the `mode === 'hostedChat'` guard untouched — that restriction is permanent and independent of this flag.

**Behavior change:** existing `n8nUserAuth` chat triggers that ran with the flag off now run the OAuth2 identity pipeline instead of falling back to the legacy session-cookie check. This should be called out in the release notes.

## How to test

- Create a Chat Trigger node with `Public` on, `Authentication` set to `n8nUserAuth`, and `Mode` set to `hostedChat` (the default). No env var is needed anymore — the OAuth2 handshake and identity pipeline should run as before when the flag used to be `true`.
- Confirm `webhook` mode still falls back to the plain session-cookie check.
- Existing automated coverage coverage: `packages/workflow`, `packages/cli`, and `packages/@n8n/nodes-langchain` unit/integration tests, plus `useNodeHelpers.test.ts` in the frontend.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1344

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

