### PR TITLE
fix(Mistral Cloud Chat Model Node): Handle Request objects in undici-backed proxyFetch

### DIFF
--- a/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
+++ b/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
@@ -1,5 +1,7 @@
 import { lookup as dnsLookup } from 'node:dns';
+import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
+import type { AddressInfo } from 'node:net';
 import { Agent, ProxyAgent, fetch as undiciFetch } from 'undici';
 import type { MockedFunction } from 'vitest';
 
@@ -430,20 +432,7 @@ describe('proxyFetch', () => {
 			const url = new URL('https://api.openai.com/v1');
 			await proxyFetch({ input: url, lookup: dnsLookup });
 
-			expect(mockFetch).toHaveBeenCalledWith(url, {
-				dispatcher: expect.objectContaining({ type: 'Agent' }),
-			});
-		});
-
-		it('should handle Request objects', async () => {
-			const request = new Request('https://api.openai.com/v1', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ test: 'data' }),
-			});
-			await proxyFetch({ input: request, lookup: dnsLookup });
-
-			expect(mockFetch).toHaveBeenCalledWith(request, {
+			expect(mockFetch).toHaveBeenCalledWith(url.href, {
 				dispatcher: expect.objectContaining({ type: 'Agent' }),
 			});
 		});
@@ -490,7 +479,7 @@ describe('proxyFetch', () => {
 			await proxyFetch({ input: url, lookup: dnsLookup });
 
 			expect(ProxyAgent).toHaveBeenCalledWith(expect.objectContaining({ uri: proxyUrl }));
-			expect(mockFetch).toHaveBeenCalledWith(url, {
+			expect(mockFetch).toHaveBeenCalledWith(url.href, {
 				dispatcher: expect.objectContaining({ type: 'ProxyAgent' }),
 			});
 		});
@@ -503,9 +492,10 @@ describe('proxyFetch', () => {
 			await proxyFetch({ input: request, lookup: dnsLookup });
 
 			expect(ProxyAgent).toHaveBeenCalledWith(expect.objectContaining({ uri: proxyUrl }));
-			expect(mockFetch).toHaveBeenCalledWith(request, {
-				dispatcher: expect.objectContaining({ type: 'ProxyAgent' }),
-			});
+			expect(mockFetch).toHaveBeenCalledWith(
+				request.url,
+				expect.objectContaining({ dispatcher: expect.objectContaining({ type: 'ProxyAgent' }) }),
+			);
 		});
 
 		it('should respect NO_PROXY environment variable', async () => {
@@ -609,5 +599,65 @@ describe('getNodeProxyAgent', () => {
 
 		expect(agent).toBeDefined();
 		expect(agent).toMatchObject({ keepAlive: true, keepAliveMsecs: 30_000 });
+	});
+});
+
+describe('proxyFetch with the real undici', () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		delete process.env.HTTP_PROXY;
+		delete process.env.http_proxy;
+		delete process.env.HTTPS_PROXY;
+		delete process.env.https_proxy;
+	});
+
+	afterAll(() => {
+		process.env = originalEnv;
+	});
+
+	// The Mistral SDK builds its requests with the global Request class and hands
+	// them to the fetcher; the package's undici fetch only recognizes its own
+	// Request class and used to stringify these to '[object Request]'.
+	it('should send a Request built with the global Request class', async () => {
+		vi.doUnmock('undici');
+		vi.resetModules();
+		const { proxyFetch: realProxyFetch } = await import('../../utils/http-proxy-agent.js');
+
+		const received: { method?: string; contentType?: string; body?: string } = {};
+		const server = createServer((req, res) => {
+			let body = '';
+			req.on('data', (chunk: Buffer) => (body += chunk.toString()));
+			req.on('end', () => {
+				Object.assign(received, {
+					method: req.method,
+					contentType: req.headers['content-type'],
+					body,
+				});
+				res.end('ok');
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		const { port } = server.address() as AddressInfo;
+
+		try {
+			const request = new Request(`http://127.0.0.1:${port}/v1/chat/completions`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: '{"model":"mistral-small"}',
+			});
+			const response = await realProxyFetch({ input: request, lookup: dnsLookup });
+
+			expect(await response.text()).toBe('ok');
+			expect(received).toEqual({
+				method: 'POST',
+				contentType: 'application/json',
+				body: '{"model":"mistral-small"}',
+			});
+		} finally {
+			server.closeAllConnections();
+			await new Promise((resolve) => server.close(resolve));
+		}
 	});
 });

--- a/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
+++ b/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
@@ -619,11 +619,19 @@ describe('proxyFetch with the real undici', () => {
 
 	// The Mistral SDK builds its requests with the global Request class and hands
 	// them to the fetcher; the package's undici fetch only recognizes its own
-	// Request class and used to stringify these to '[object Request]'.
-	it('should send a Request built with the global Request class', async () => {
+	// Request class and used to stringify these to '[object Request]'. Either
+	// class can arrive, so both must reach the wire.
+	it.each([
+		['the global Request class', async () => Request],
+		[
+			'the undici Request class',
+			async () => (await import('undici')).Request as unknown as typeof Request,
+		],
+	])('should send a Request built with %s', async (_, loadRequestClass) => {
 		vi.doUnmock('undici');
 		vi.resetModules();
 		const { proxyFetch: realProxyFetch } = await import('../../utils/http-proxy-agent.js');
+		const RequestClass = await loadRequestClass();
 
 		const received: { method?: string; contentType?: string; body?: string } = {};
 		const server = createServer((req, res) => {
@@ -642,7 +650,7 @@ describe('proxyFetch with the real undici', () => {
 		const { port } = server.address() as AddressInfo;
 
 		try {
-			const request = new Request(`http://127.0.0.1:${port}/v1/chat/completions`, {
+			const request = new RequestClass(`http://127.0.0.1:${port}/v1/chat/completions`, {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: '{"model":"mistral-small"}',

--- a/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
+++ b/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
@@ -125,8 +125,18 @@ export async function proxyFetch({
 	const dispatcher = getProxyAgent(targetUrl, timeoutOptions, lookup);
 
 	// The dispatcher comes from this package's undici, so the request must use
-	// the same undici's fetch: the global fetch on Node >= 26 rejects it.
-	return (await undiciFetch(input as Parameters<typeof undiciFetch>[0], {
+	// the same undici's fetch: the global fetch on Node >= 26 rejects it. That
+	// fetch only recognizes its own Request class and stringifies any other, so
+	// a Request built with the global class (as the Mistral SDK does) is passed
+	// as url + init instead.
+	return (await undiciFetch(targetUrl, {
+		...(input instanceof Request && {
+			method: input.method,
+			headers: [...input.headers],
+			body: input.body === null ? undefined : await input.arrayBuffer(),
+			signal: input.signal,
+			redirect: input.redirect,
+		}),
 		...(init as Parameters<typeof undiciFetch>[1]),
 		dispatcher,
 	})) as unknown as Response;

--- a/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
+++ b/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
@@ -121,16 +121,19 @@ export async function proxyFetch({
 	timeoutOptions,
 	lookup,
 }: ProxyFetchOptions): Promise<Response> {
-	const targetUrl = input instanceof Request ? input.url : input.toString();
+	// Two Request classes exist at runtime (the global one and this package's
+	// undici), so detect a Request by exclusion instead of `instanceof`.
+	const isRequest = typeof input !== 'string' && !(input instanceof URL);
+	const targetUrl = isRequest ? input.url : input.toString();
 	const dispatcher = getProxyAgent(targetUrl, timeoutOptions, lookup);
 
 	// The dispatcher comes from this package's undici, so the request must use
 	// the same undici's fetch: the global fetch on Node >= 26 rejects it. That
 	// fetch only recognizes its own Request class and stringifies any other, so
-	// a Request built with the global class (as the Mistral SDK does) is passed
+	// a Request (the Mistral SDK builds one with the global class) is passed
 	// as url + init instead.
 	return (await undiciFetch(targetUrl, {
-		...(input instanceof Request && {
+		...(isRequest && {
 			method: input.method,
 			headers: [...input.headers],
 			body: input.body === null ? undefined : await input.arrayBuffer(),


### PR DESCRIPTION
## Summary

Every request from the Mistral Cloud Chat Model node fails with:

```
NodeOperationError: Unexpected HTTP client error: TypeError: Failed to parse URL from [object Request]
```

**Cause.** #36318 moved `proxyFetch` from the global `fetch` to the `fetch` of the `undici` package that `@n8n/ai-utilities` bundles. That change is required: the global `fetch` on Node >= 26 rejects the v7 dispatcher. But the Mistral SDK builds its request with the global `Request` class and hands that object to the injected fetcher. The `undici` `fetch` only recognizes its own `Request` class. It converts any other object with `String()`, which gives `[object Request]`, and `new URL()` throws. The other `proxyFetch` callers (OpenAI, Anthropic, Ollama, MCP client) pass a string URL and are not affected.

**Fix.** `proxyFetch` now unwraps a `Request` into `url + init` (method, headers, body, signal, redirect) before it calls the `undici` `fetch`. It detects a `Request` by exclusion (not a string, not a `URL`) instead of `instanceof Request`, because two `Request` classes exist at runtime (the global one and the package's `undici`) and either can arrive. String and `URL` inputs take the same path as before. The proxy resolution from the `Request` URL (#25516) is unchanged and now also works for `undici` `Request` inputs, which `master` silently sent past the proxy.

**Test.** A new test unmocks `undici` and sends a `Request` through `proxyFetch` to a local HTTP server, once built with the global `Request` class and once with the `undici` one. The global case fails on `master` with the production error (`ERR_INVALID_URL, input: '[object Request]'`); the `undici` case fails the same way against an `instanceof`-based fix. Both pass with this PR. The mock-based `Request` test that asserted the broken pass-through is replaced by it.

## How to test

1. Add a Mistral Cloud API credential.
2. Import the workflow below and select the credential on the Mistral Cloud Chat Model node.
3. Open the chat and send a message.
4. On `master` the AI Agent node fails with `Failed to parse URL from [object Request]`. With this PR the model answers.

<details>
<summary>Example workflow</summary>

```json
{
  "nodes": [
    {
      "parameters": { "options": {} },
      "name": "When chat message received",
      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
      "typeVersion": 1.1,
      "position": [0, 0]
    },
    {
      "parameters": { "options": {} },
      "name": "AI Agent",
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 3.1,
      "position": [300, 0]
    },
    {
      "parameters": { "model": "mistral-small-latest", "options": {} },
      "name": "Mistral Cloud Chat Model",
      "type": "@n8n/n8n-nodes-langchain.lmChatMistralCloud",
      "typeVersion": 1,
      "position": [300, 200]
    }
  ],
  "connections": {
    "When chat message received": { "main": [[{ "node": "AI Agent", "type": "main", "index": 0 }]] },
    "Mistral Cloud Chat Model": { "ai_languageModel": [[{ "node": "AI Agent", "type": "ai_languageModel", "index": 0 }]] }
  }
}
```

</details>

Unit test: `pnpm test src/__tests__/utils/http-proxy-agent.test.ts` in `packages/@n8n/ai-utilities`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2742
- Sentry: https://n8nio.sentry.io/issues/INSTANCE-BACKEND-27Z9 (194 events, 171 users on `n8n@2.37.6`)
- Regression from #36318 / #36418. Re-fixes what #25516 fixed at the previous `fetch` call.

Fixes INSTANCE-BACKEND-27Z9

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


