### PR TITLE
fix(editor): Refresh workflow checksum after publishing from an embedded editor

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
@@ -110,6 +110,7 @@ vi.mock('@n8n/i18n', () => ({
 // --- helpers ---
 
 const WORKFLOW_ID = 'wf-1';
+const OTHER_WORKFLOW_ID = 'wf-2';
 const VERSION_ID = 'v-1';
 
 function makePublishedWorkflowResponse() {
@@ -209,7 +210,7 @@ describe('useWorkflowActivate', () => {
 			expect(mockSetChecksum).not.toHaveBeenCalled();
 		});
 
-		it('does NOT refresh the checksum when the editor closed while the request was in flight', async () => {
+		it('does NOT refresh the checksum when the editor closed or switched workflows while the request was in flight', async () => {
 			mockDocumentStore.hydrated = true;
 			mockDocumentStore.checksum = 'before-publish';
 			mockPublishWorkflow.mockImplementationOnce(async () => {
@@ -229,24 +230,28 @@ describe('useWorkflowActivate', () => {
 			expect(mockSetChecksum).not.toHaveBeenCalled();
 		});
 
-		it('does NOT touch the newly opened workflow when the editor switched while the request was in flight', async () => {
+		it('resolves the document store by the published workflow id, not by the editor in the route', async () => {
+			// wf-1 is the routed editor, wf-2 is an embedded (artifact) editor; publish wf-2
 			mockDocumentStore.hydrated = true;
-			mockDocumentStore.checksum = 'before-publish';
-			mockPublishWorkflow.mockImplementationOnce(async () => {
-				// wf-1 is torn down and wf-2 hydrates before the response arrives
-				mockDocumentStore.hydrated = false;
-				otherDocumentStore.hydrated = true;
-				return makePublishedWorkflowResponse();
-			});
+			mockDocumentStore.checksum = 'wf-1-checksum';
+			otherDocumentStore.hydrated = true;
+			otherDocumentStore.checksum = 'wf-2-checksum';
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
 
 			const { publishWorkflow } = useWorkflowActivate();
-			const result = await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+			const result = await publishWorkflow(OTHER_WORKFLOW_ID, VERSION_ID);
 
 			expect(result).toEqual({ success: true });
-			expect(otherDocumentStore.setActiveState).not.toHaveBeenCalled();
-			expect(otherDocumentStore.setPublicationStatus).not.toHaveBeenCalled();
-			expect(otherDocumentStore.setVersionData).not.toHaveBeenCalled();
-			expect(otherDocumentStore.setChecksum).not.toHaveBeenCalled();
+			expect(mockPublishWorkflow).toHaveBeenCalledWith(
+				OTHER_WORKFLOW_ID,
+				expect.objectContaining({ expectedChecksum: 'wf-2-checksum' }),
+			);
+			expect(otherDocumentStore.setChecksum).toHaveBeenCalledWith('abc123');
+			expect(otherDocumentStore.setVersionData).toHaveBeenCalledWith(
+				expect.objectContaining({ versionId: 'v-2' }),
+			);
+			expect(mockSetActiveState).not.toHaveBeenCalled();
+			expect(mockSetVersionData).not.toHaveBeenCalled();
 			expect(mockSetChecksum).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
@@ -10,25 +10,32 @@ const mockSetPublicationStatus = vi.hoisted(() => vi.fn());
 const mockSetVersionData = vi.hoisted(() => vi.fn());
 const mockSetChecksum = vi.hoisted(() => vi.fn());
 
+// `hydrated` and `checksum` are set per-test to model a document that is
+// open in an editor (routed or embedded) versus one that is not.
+const mockDocumentStore = vi.hoisted(() => ({
+	setActiveState: mockSetActiveState,
+	setPublicationStatus: mockSetPublicationStatus,
+	setVersionData: mockSetVersionData,
+	setChecksum: mockSetChecksum,
+	checksum: undefined as string | undefined,
+	versionData: null,
+	hydrated: false,
+}));
+
 vi.mock('@/app/stores/workflowDocument.store', () => ({
-	useWorkflowDocumentStore: vi.fn().mockReturnValue({
-		setActiveState: mockSetActiveState,
-		setPublicationStatus: mockSetPublicationStatus,
-		setVersionData: mockSetVersionData,
-		setChecksum: mockSetChecksum,
-		checksum: undefined,
-		versionData: null,
-	}),
+	useWorkflowDocumentStore: vi.fn(() => mockDocumentStore),
 	createWorkflowDocumentId: vi.fn().mockReturnValue('doc-id'),
 }));
 
 const mockPublishWorkflow = vi.hoisted(() => vi.fn());
+const mockDeactivateWorkflow = vi.hoisted(() => vi.fn());
 const mockSetWorkflowActive = vi.hoisted(() => vi.fn());
 const mockSetWorkflowInactive = vi.hoisted(() => vi.fn());
 
 vi.mock('@/app/stores/workflows.store', () => ({
 	useWorkflowsStore: vi.fn().mockReturnValue({
 		publishWorkflow: mockPublishWorkflow,
+		deactivateWorkflow: mockDeactivateWorkflow,
 		setWorkflowActive: mockSetWorkflowActive,
 		setWorkflowInactive: mockSetWorkflowInactive,
 	}),
@@ -78,13 +85,6 @@ vi.mock('@n8n/composables/useStorage', () => ({
 	useStorage: vi.fn().mockReturnValue({ value: undefined }),
 }));
 
-vi.mock('@/app/composables/useWorkflowId', async () => {
-	const { computed } = await import('vue');
-	return {
-		useWorkflowId: () => computed(() => 'other-workflow-id'),
-	};
-});
-
 vi.mock('@/app/composables/useActivationError', () => ({
 	useActivationError: vi.fn().mockReturnValue({ errorMessage: { value: '' } }),
 }));
@@ -121,6 +121,8 @@ describe('useWorkflowActivate', () => {
 		setActivePinia(createPinia());
 		vi.clearAllMocks();
 		mockSettingsImpl.isWorkflowPublicationServiceEnabled = false;
+		mockDocumentStore.hydrated = false;
+		mockDocumentStore.checksum = undefined;
 	});
 
 	describe('publishWorkflow()', () => {
@@ -155,6 +157,70 @@ describe('useWorkflowActivate', () => {
 
 			expect(result).toEqual({ success: false, errorHandled: true });
 			expect(mockSetPublicationStatus).not.toHaveBeenCalled();
+		});
+
+		it('sends the document checksum and refreshes it when the document is open in an editor', async () => {
+			mockDocumentStore.hydrated = true;
+			mockDocumentStore.checksum = 'before-publish';
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
+
+			const { publishWorkflow } = useWorkflowActivate();
+			const result = await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(result).toEqual({ success: true });
+			expect(mockPublishWorkflow).toHaveBeenCalledWith(
+				WORKFLOW_ID,
+				expect.objectContaining({ versionId: VERSION_ID, expectedChecksum: 'before-publish' }),
+			);
+			expect(mockSetVersionData).toHaveBeenCalledWith(
+				expect.objectContaining({ versionId: 'v-2' }),
+			);
+			expect(mockSetChecksum).toHaveBeenCalledWith('abc123');
+		});
+
+		it('does NOT send or refresh the checksum when the document is not open in an editor', async () => {
+			mockDocumentStore.checksum = 'stale';
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
+
+			const { publishWorkflow } = useWorkflowActivate();
+			const result = await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(result).toEqual({ success: true });
+			expect(mockPublishWorkflow).toHaveBeenCalledWith(
+				WORKFLOW_ID,
+				expect.objectContaining({ expectedChecksum: undefined }),
+			);
+			expect(mockSetVersionData).not.toHaveBeenCalled();
+			expect(mockSetChecksum).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('unpublishWorkflowFromHistory()', () => {
+		it('sends the document checksum when the document is open in an editor', async () => {
+			mockDocumentStore.hydrated = true;
+			mockDocumentStore.checksum = 'after-publish';
+			mockDeactivateWorkflow.mockResolvedValueOnce(undefined);
+
+			const { unpublishWorkflowFromHistory } = useWorkflowActivate();
+			const result = await unpublishWorkflowFromHistory(WORKFLOW_ID);
+
+			expect(result).toBe(true);
+			expect(mockDeactivateWorkflow).toHaveBeenCalledWith(WORKFLOW_ID, 'after-publish');
+			expect(mockSetActiveState).toHaveBeenCalledWith({
+				activeVersionId: null,
+				activeVersion: null,
+			});
+		});
+
+		it('does NOT send a checksum when the document is not open in an editor', async () => {
+			mockDocumentStore.checksum = 'stale';
+			mockDeactivateWorkflow.mockResolvedValueOnce(undefined);
+
+			const { unpublishWorkflowFromHistory } = useWorkflowActivate();
+			const result = await unpublishWorkflowFromHistory(WORKFLOW_ID);
+
+			expect(result).toBe(true);
+			expect(mockDeactivateWorkflow).toHaveBeenCalledWith(WORKFLOW_ID, undefined);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
@@ -22,9 +22,23 @@ const mockDocumentStore = vi.hoisted(() => ({
 	hydrated: false,
 }));
 
+// A second workflow's document store, to model the editor switching to another
+// workflow (or artifact tab) while a request is in flight.
+const otherDocumentStore = vi.hoisted(() => ({
+	setActiveState: vi.fn(),
+	setPublicationStatus: vi.fn(),
+	setVersionData: vi.fn(),
+	setChecksum: vi.fn(),
+	checksum: 'other-checksum' as string | undefined,
+	versionData: null,
+	hydrated: false,
+}));
+
 vi.mock('@/app/stores/workflowDocument.store', () => ({
-	useWorkflowDocumentStore: vi.fn(() => mockDocumentStore),
-	createWorkflowDocumentId: vi.fn().mockReturnValue('doc-id'),
+	useWorkflowDocumentStore: vi.fn((documentId: string) =>
+		documentId === 'wf-2@latest' ? otherDocumentStore : mockDocumentStore,
+	),
+	createWorkflowDocumentId: vi.fn((workflowId: string) => `${workflowId}@latest`),
 }));
 
 const mockPublishWorkflow = vi.hoisted(() => vi.fn());
@@ -123,6 +137,7 @@ describe('useWorkflowActivate', () => {
 		mockSettingsImpl.isWorkflowPublicationServiceEnabled = false;
 		mockDocumentStore.hydrated = false;
 		mockDocumentStore.checksum = undefined;
+		otherDocumentStore.hydrated = false;
 	});
 
 	describe('publishWorkflow()', () => {
@@ -191,6 +206,47 @@ describe('useWorkflowActivate', () => {
 				expect.objectContaining({ expectedChecksum: undefined }),
 			);
 			expect(mockSetVersionData).not.toHaveBeenCalled();
+			expect(mockSetChecksum).not.toHaveBeenCalled();
+		});
+
+		it('does NOT refresh the checksum when the editor closed while the request was in flight', async () => {
+			mockDocumentStore.hydrated = true;
+			mockDocumentStore.checksum = 'before-publish';
+			mockPublishWorkflow.mockImplementationOnce(async () => {
+				mockDocumentStore.hydrated = false;
+				return makePublishedWorkflowResponse();
+			});
+
+			const { publishWorkflow } = useWorkflowActivate();
+			const result = await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(result).toEqual({ success: true });
+			expect(mockPublishWorkflow).toHaveBeenCalledWith(
+				WORKFLOW_ID,
+				expect.objectContaining({ expectedChecksum: 'before-publish' }),
+			);
+			expect(mockSetVersionData).not.toHaveBeenCalled();
+			expect(mockSetChecksum).not.toHaveBeenCalled();
+		});
+
+		it('does NOT touch the newly opened workflow when the editor switched while the request was in flight', async () => {
+			mockDocumentStore.hydrated = true;
+			mockDocumentStore.checksum = 'before-publish';
+			mockPublishWorkflow.mockImplementationOnce(async () => {
+				// wf-1 is torn down and wf-2 hydrates before the response arrives
+				mockDocumentStore.hydrated = false;
+				otherDocumentStore.hydrated = true;
+				return makePublishedWorkflowResponse();
+			});
+
+			const { publishWorkflow } = useWorkflowActivate();
+			const result = await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(result).toEqual({ success: true });
+			expect(otherDocumentStore.setActiveState).not.toHaveBeenCalled();
+			expect(otherDocumentStore.setPublicationStatus).not.toHaveBeenCalled();
+			expect(otherDocumentStore.setVersionData).not.toHaveBeenCalled();
+			expect(otherDocumentStore.setChecksum).not.toHaveBeenCalled();
 			expect(mockSetChecksum).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -106,13 +106,15 @@ export function useWorkflowActivate() {
 		}
 
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-		// A hydrated document is open in an editor, routed or embedded (assistant artifact).
-		// The route id is empty on the assistant page and the publish modal is global, so
-		// neither can tell whether this workflow is on screen.
-		const isOpenInEditor = workflowDocumentStore.hydrated;
 
 		try {
-			const expectedChecksum = isOpenInEditor ? workflowDocumentStore.checksum : undefined;
+			// A hydrated document is open in an editor, routed or embedded (assistant artifact).
+			// The route id is empty on the assistant page and the publish modal is global, so
+			// neither can tell whether this workflow is on screen. Re-read the flag after the
+			// request: the editor may have closed while it was in flight.
+			const expectedChecksum = workflowDocumentStore.hydrated
+				? workflowDocumentStore.checksum
+				: undefined;
 
 			const updatedWorkflow = await workflowsStore.publishWorkflow(workflowId, {
 				versionId,
@@ -134,7 +136,7 @@ export function useWorkflowActivate() {
 				workflowDocumentStore.setPublicationStatus({ status: 'publishing' });
 			}
 
-			if (isOpenInEditor) {
+			if (workflowDocumentStore.hydrated) {
 				workflowDocumentStore.setVersionData({
 					versionId: updatedWorkflow.versionId,
 					name: workflowDocumentStore.versionData?.name ?? null,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -12,7 +12,6 @@ import { useSettingsStore } from '@n8n/stores/settings.store';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useToast } from '@n8n/composables/useToast';
-import { useWorkflowId } from '@/app/composables/useWorkflowId';
 import { useI18n } from '@n8n/i18n';
 import { ref } from 'vue';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
@@ -30,7 +29,6 @@ export function useWorkflowActivate() {
 	const activationErrorNodeId = ref<string | undefined>();
 
 	const workflowsStore = useWorkflowsStore();
-	const currentWorkflowId = useWorkflowId();
 	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 	const telemetry = useTelemetry();
@@ -108,10 +106,13 @@ export function useWorkflowActivate() {
 		}
 
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+		// A hydrated document is open in an editor, routed or embedded (assistant artifact).
+		// The route id is empty on the assistant page and the publish modal is global, so
+		// neither can tell whether this workflow is on screen.
+		const isOpenInEditor = workflowDocumentStore.hydrated;
 
 		try {
-			const expectedChecksum =
-				workflowId === currentWorkflowId.value ? workflowDocumentStore.checksum : undefined;
+			const expectedChecksum = isOpenInEditor ? workflowDocumentStore.checksum : undefined;
 
 			const updatedWorkflow = await workflowsStore.publishWorkflow(workflowId, {
 				versionId,
@@ -133,7 +134,7 @@ export function useWorkflowActivate() {
 				workflowDocumentStore.setPublicationStatus({ status: 'publishing' });
 			}
 
-			if (workflowId === currentWorkflowId.value) {
+			if (isOpenInEditor) {
 				workflowDocumentStore.setVersionData({
 					versionId: updatedWorkflow.versionId,
 					name: workflowDocumentStore.versionData?.name ?? null,
@@ -201,8 +202,9 @@ export function useWorkflowActivate() {
 		void useExternalHooks().run('workflowActivate.updateWorkflowActivation', telemetryPayload);
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 		try {
-			const expectedChecksum =
-				workflowId === currentWorkflowId.value ? workflowDocumentStore.checksum : undefined;
+			const expectedChecksum = workflowDocumentStore.hydrated
+				? workflowDocumentStore.checksum
+				: undefined;
 
 			await workflowsStore.deactivateWorkflow(workflowId, expectedChecksum);
 			workflowDocumentStore.setActiveState({


### PR DESCRIPTION
## Summary

Publishing a workflow from the AI Assistant artifact panel and then unpublishing it from the same panel showed the toast "Workflow could not be deactivated: Your most recent changes may be lost, because someone else just updated this workflow".

Cause: the publish modal is a global modal. On the assistant page the route has no workflow id, so `useWorkflowActivate` treated the published workflow as "not the current one". It skipped two steps: it did not send the expected checksum with the publish request, and it did not refresh the stored checksum and version id after the publish. The checksum includes the active version id, so the stored value became stale. The unpublish button lives inside the embedded editor, saw the id match, and sent the stale checksum. The server reported a conflict.

Fix: gate both steps on the document store `hydrated` flag. A hydrated document is open in an editor, routed or embedded. Document stores reset when their editor unmounts, so the flag holds for both cases.

Side effect: a publish from the artifact panel now also sends the expected checksum. It gets the same conflict protection as the main editor.

## How to test

1. Open the AI Assistant and build a workflow with a trigger, so the artifact panel shows it.
2. In the artifact header, click Publish and confirm in the modal.
3. In the same header, unpublish the workflow.
4. Before this change: the "Workflow could not be deactivated" toast appears and the workflow stays published. After this change: the workflow unpublishes and no toast appears.
5. Publish and unpublish from a normal workflow page to confirm nothing changed there.

Unit tests live in `packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts`. The two new "open in an editor" tests fail on master.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-828

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

