### PR TITLE
fix(Anthropic Chat Model Node, AI Agent Node): Send disabled thinking to the provider and parse content-block output

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -424,7 +424,8 @@ export const getAgentStepsParser =
 
 		// Otherwise, if the steps contain a returnValues field, try to parse them manually.
 		if (outputParser && typeof steps === 'object' && (steps as AgentFinish).returnValues) {
-			const finalResponse = (steps as AgentFinish).returnValues;
+			// Thinking models return content-block arrays; the parser needs the text block(s) only.
+			const finalResponse = (handleAgentFinishOutput(steps) as AgentFinish).returnValues;
 			let parserInput: string;
 
 			if (finalResponse instanceof Object) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -330,10 +330,12 @@ export function fixEmptyContentMessage(
  * ```
  *
  * @param steps - The agent finish or agent action steps.
+ * @param textOnly - Skip the thinking fallback: a finish without text blocks yields an empty output.
  * @returns The modified agent finish steps or the original steps.
  */
 export function handleAgentFinishOutput(
 	steps: AgentFinish | AgentAction[],
+	{ textOnly = false } = {},
 ): AgentFinish | AgentAction[] {
 	type AgentMultiOutputFinish = AgentFinish & {
 		returnValues: { output: Array<{ text: string; type: string; index: number }> };
@@ -359,6 +361,8 @@ export function handleAgentFinishOutput(
 
 			if (textOutputs) {
 				agentFinishSteps.returnValues.output = textOutputs;
+			} else if (textOnly) {
+				agentFinishSteps.returnValues.output = '';
 			} else {
 				const thinkingOutputs = multiOutputSteps
 					.filter((output) => output.type === 'thinking' && output.thinking)
@@ -424,8 +428,10 @@ export const getAgentStepsParser =
 
 		// Otherwise, if the steps contain a returnValues field, try to parse them manually.
 		if (outputParser && typeof steps === 'object' && (steps as AgentFinish).returnValues) {
-			// Thinking models return content-block arrays; the parser needs the text block(s) only.
-			const finalResponse = (handleAgentFinishOutput(steps) as AgentFinish).returnValues;
+			// Thinking models return content-block arrays. The parser gets the text block(s) only; a
+			// thinking-only finish becomes an empty output, which the parser reports as an empty response.
+			const finalResponse = (handleAgentFinishOutput(steps, { textOnly: true }) as AgentFinish)
+				.returnValues;
 			let parserInput: string;
 
 			if (finalResponse instanceof Object) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
@@ -1051,6 +1051,32 @@ describe('getAgentStepsParser', () => {
 				log: 'Final response formatted',
 			});
 		});
+
+		it('should hand the parser the text block when the model returns content blocks', async () => {
+			// Anthropic with thinking on: a (display-omitted) thinking block precedes the answer
+			const steps: AgentFinish = {
+				returnValues: {
+					output: [
+						{ type: 'thinking', thinking: '', signature: 'sig', index: 0 },
+						{ type: 'text', text: '{"city":"Berlin","temperature":15}', index: 1 },
+					],
+				},
+				log: '',
+			};
+
+			const mockOutputParser = createMockOutputParser({ city: 'Berlin', temperature: 15 });
+
+			const parser = getAgentStepsParser(mockOutputParser, undefined);
+			const result = await parser(steps);
+
+			expect(mockOutputParser.parse).toHaveBeenCalledWith(
+				'{"output":{"city":"Berlin","temperature":15}}',
+			);
+			expect(result).toEqual({
+				returnValues: { city: 'Berlin', temperature: 15 },
+				log: 'Final response formatted',
+			});
+		});
 	});
 
 	describe('without output parser', () => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
@@ -1077,6 +1077,23 @@ describe('getAgentStepsParser', () => {
 				log: 'Final response formatted',
 			});
 		});
+
+		it('should hand the parser an empty string when the model returns only thinking blocks', async () => {
+			// Token budget spent on thinking: no text block exists, so there is no answer to parse
+			const steps: AgentFinish = {
+				returnValues: {
+					output: [{ type: 'thinking', thinking: 'Let me work out the temperature…', index: 0 }],
+				},
+				log: '',
+			};
+
+			const mockOutputParser = createMockOutputParser({});
+
+			const parser = getAgentStepsParser(mockOutputParser, undefined);
+			await parser(steps);
+
+			expect(mockOutputParser.parse).toHaveBeenCalledWith('');
+		});
 	});
 
 	describe('without output parser', () => {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -439,7 +439,8 @@ export class LmChatAnthropic implements INodeType {
 						name: 'thinkingMode',
 						type: 'options',
 						default: 'disabled',
-						description: 'How extended thinking should be configured for the model',
+						description:
+							'How extended thinking is configured. Leave the option unset to use the model default.',
 						options: [
 							{
 								name: 'Disabled',
@@ -600,6 +601,11 @@ export class LmChatAnthropic implements INodeType {
 				: options.thinking
 					? 'manual'
 					: 'disabled';
+		// langchain no longer defaults `thinking` to disabled, and Sonnet 5 / Opus 5 think adaptively
+		// when the field is absent. Only a Disabled the user added is sent; an unset option leaves the
+		// field out so the model default applies (models such as Fable reject an explicit disabled).
+		const thinkingExplicitlyDisabled =
+			version >= 1.5 ? options.thinkingMode === 'disabled' : options.thinking === false;
 
 		if (thinkingMode === 'manual' && isOpus47Model) {
 			throw new NodeOperationError(
@@ -637,6 +643,8 @@ export class LmChatAnthropic implements INodeType {
 				top_p: undefined,
 				temperature: undefined,
 			};
+		} else if (thinkingExplicitlyDisabled) {
+			invocationKwargs = { thinking: { type: 'disabled' } };
 		}
 
 		if (options.promptCaching && options.promptCaching !== 'disabled') {
@@ -718,9 +726,10 @@ export class LmChatAnthropic implements INodeType {
 		// Same shape as the sampling-parameter backstop above, for the same reason: newer Claude
 		// generations drop the legacy manual thinking mode, and the pre-flight check below only
 		// recognises the models we have confirmed. This catches the rest — including gateway
-		// traffic, whose capabilities we cannot infer from the model name.
-		const manualThinkingErrorHandler = (error: unknown) => {
-			if (thinkingMode !== 'manual') return;
+		// traffic, whose capabilities we cannot infer from the model name. Models that always think
+		// (Fable, Mythos) reject an explicit disabled the same way.
+		const thinkingErrorHandler = (error: unknown) => {
+			if (thinkingMode !== 'manual' && !thinkingExplicitlyDisabled) return;
 			const message = error instanceof Error ? error.message : String(error);
 			const mentionsThinking = /thinking|budget_tokens/i.test(message);
 			// Match the verb stem rather than the participle: providers phrase this both ways
@@ -733,7 +742,9 @@ export class LmChatAnthropic implements INodeType {
 			if (mentionsThinking && isRejection) {
 				throw new NodeOperationError(
 					this.getNode(),
-					`The model "${modelName}" does not support the legacy Manual thinking mode. Set Thinking Mode to Adaptive and choose an Effort level.`,
+					thinkingMode === 'manual'
+						? `The model "${modelName}" does not support the legacy Manual thinking mode. Set Thinking Mode to Adaptive and choose an Effort level.`
+						: `The model "${modelName}" does not support disabling thinking. Set Thinking Mode to Adaptive, or remove the Thinking Mode option to use the model default.`,
 					{ itemIndex },
 				);
 			}
@@ -742,7 +753,7 @@ export class LmChatAnthropic implements INodeType {
 		const failedAttemptHandler = (error: unknown) => {
 			gatewayErrorHandler?.(error);
 			deprecatedSamplingParamErrorHandler(error);
-			manualThinkingErrorHandler(error);
+			thinkingErrorHandler(error);
 		};
 
 		const chatAnthropicParams: ChatAnthropicInput = {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -740,11 +740,25 @@ export class LmChatAnthropic implements INodeType {
 					message,
 				);
 			if (mentionsThinking && isRejection) {
+				// Node versions below 1.5 have the Enable Thinking toggle instead of Thinking Mode.
+				const guidance =
+					version >= 1.5
+						? {
+								manual: 'Set Thinking Mode to Adaptive and choose an Effort level.',
+								disabled:
+									'Set Thinking Mode to Adaptive, or remove the Thinking Mode option to use the model default.',
+							}
+						: {
+								manual:
+									'Turn off Enable Thinking, or add a new Anthropic Chat Model node to use Adaptive thinking.',
+								disabled:
+									'Remove the Enable Thinking option, or add a new Anthropic Chat Model node to use Adaptive thinking.',
+							};
 				throw new NodeOperationError(
 					this.getNode(),
 					thinkingMode === 'manual'
-						? `The model "${modelName}" does not support the legacy Manual thinking mode. Set Thinking Mode to Adaptive and choose an Effort level.`
-						: `The model "${modelName}" does not support disabling thinking. Set Thinking Mode to Adaptive, or remove the Thinking Mode option to use the model default.`,
+						? `The model "${modelName}" does not support the legacy Manual thinking mode. ${guidance.manual}`
+						: `The model "${modelName}" does not support disabling thinking. ${guidance.disabled}`,
 					{ itemIndex },
 				);
 			}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -662,6 +662,39 @@ describe('LmChatAnthropic', () => {
 			).not.toThrow();
 		});
 
+		it('should sanitize a disabled-thinking rejection only when Disabled was set explicitly', async () => {
+			// Verbatim Anthropic 400 for models that always think (Fable, Mythos)
+			const rejection = new Error(
+				'"thinking.type.disabled" is not supported for this model. Thinking defaults to adaptive mode when not specified; use "thinking.type.enabled" with "budget_tokens" for extended thinking.',
+			);
+			const captureHandler = async (options: Record<string, unknown>) => {
+				const mockContext = setupMockContext({ typeVersion: 1.6 });
+				mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+					if (paramName === 'model.value') return 'claude-fable-5';
+					if (paramName === 'options') return options;
+					return undefined;
+				});
+				let capturedHandler: ((error: unknown) => void) | undefined;
+				mockedMakeN8nLlmFailedAttemptHandler.mockImplementation((_ctx, handler) => {
+					capturedHandler = handler as (error: unknown) => void;
+					return vi.fn();
+				});
+				await lmChatAnthropic.supplyData.call(mockContext, 0);
+				return capturedHandler!;
+			};
+
+			const explicitlyDisabled = await captureHandler({ thinkingMode: 'disabled' });
+			expect(() => explicitlyDisabled(rejection)).toThrow(NodeOperationError);
+			expect(() => explicitlyDisabled(rejection)).toThrow(
+				/"claude-fable-5" does not support disabling thinking/,
+			);
+			expect(() => explicitlyDisabled(new Error('rate limit exceeded'))).not.toThrow();
+
+			// Unset Thinking Mode never sends `disabled`, so the rejection cannot be ours
+			const unset = await captureHandler({});
+			expect(() => unset(rejection)).not.toThrow();
+		});
+
 		it('should throw when model is empty (v1.3)', async () => {
 			const mockContext = setupMockContext({ typeVersion: 1.3 });
 
@@ -800,7 +833,7 @@ describe('LmChatAnthropic', () => {
 	});
 
 	describe('thinking modes (v1.5)', () => {
-		it('should not set thinking-related invocationKwargs when thinkingMode is disabled', async () => {
+		it('should send thinking disabled and keep sampling params when thinkingMode is explicitly disabled', async () => {
 			const mockContext = setupMockContext({ typeVersion: 1.5 });
 
 			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
@@ -818,7 +851,7 @@ describe('LmChatAnthropic', () => {
 					temperature: 0.5,
 					topK: 10,
 					topP: 0.8,
-					invocationKwargs: {},
+					invocationKwargs: { thinking: { type: 'disabled' } },
 				}),
 			);
 		});
@@ -985,7 +1018,7 @@ describe('LmChatAnthropic', () => {
 			);
 		});
 
-		it('should emit empty invocationKwargs when thinking=false on v1.4', async () => {
+		it('should send thinking disabled when thinking=false on v1.4', async () => {
 			const mockContext = setupMockContext({ typeVersion: 1.4 });
 
 			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
@@ -997,7 +1030,7 @@ describe('LmChatAnthropic', () => {
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 
 			expect(MockedChatAnthropic).toHaveBeenCalledWith(
-				expect.objectContaining({ invocationKwargs: {} }),
+				expect.objectContaining({ invocationKwargs: { thinking: { type: 'disabled' } } }),
 			);
 		});
 

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.test.ts
@@ -277,7 +277,7 @@ describe('N8nStructuredOutputParser', () => {
 			);
 		});
 
-		it('should handle empty output', async () => {
+		it.each(['{}', ''])('should handle empty output %j', async (emptyOutput) => {
 			const schema = z.object({
 				output: z.object({
 					message: z.string(),
@@ -285,8 +285,6 @@ describe('N8nStructuredOutputParser', () => {
 			});
 
 			const parser = new N8nStructuredOutputParser(mockContext, schema);
-
-			const emptyOutput = '{}';
 
 			await expect(parser.parse(emptyOutput)).rejects.toThrow(
 				'The AI model returned an empty response to the Structured Output Parser',

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -84,7 +84,7 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 			return result;
 		} catch (e) {
 			const isEmptyOutput =
-				(typeof text === 'string' && text.trim() === '{}') ||
+				(typeof text === 'string' && ['', '{}'].includes(text.trim())) ||
 				(e instanceof z.ZodError &&
 					e.issues?.[0] &&
 					e.issues?.[0].code === 'invalid_type' &&


### PR DESCRIPTION
## Summary

Since n8n 2.37.0 (`@langchain/anthropic` 1.5.6), the Anthropic Chat Model node no longer disables thinking when the user sets **Thinking Mode: Disabled**. The library stopped defaulting the `thinking` field to `disabled`, and the node did not send the field at all. Claude Sonnet 5 and Opus 5 think adaptively when the field is absent. The model spends the token budget on thinking and returns an empty text block, or a `[thinking, text]` content-block array. The AI Agent then fails in the Structured Output Parser with `Model output doesn't fit required format`.

This PR fixes both nodes:

**Anthropic Chat Model node**
- Send `thinking: { type: 'disabled' }` when the user explicitly sets **Thinking Mode: Disabled** (node v1.5+: `thinkingMode === 'disabled'`, older versions: `thinking === false`).
- Keep the field out of the request when the option is not set. The model default applies.
- Map a provider rejection of the explicit `disabled` value (models that always think, for example Fable) to an actionable `NodeOperationError`: `The model "…" does not support disabling thinking. Set Thinking Mode to Adaptive, or remove the Thinking Mode option to use the model default.`
- Clarify the option description: an unset option uses the model default.

**AI Agent node**
- Normalise a content-block array to its text block(s) with `handleAgentFinishOutput` before the output reaches the Structured Output Parser. Before this change, the parser received the stringified array (or an empty string) and failed.

## How to test

Use an Anthropic credential. Build this workflow:

**Manual Trigger → AI Agent** (toggle **Require Specific Output Format** on)
- Chat model: **Anthropic Chat Model**, model `claude-sonnet-5`, option **Thinking Mode: Disabled**, option **Max Tokens to Sample: 300**
- Output parser: **Structured Output Parser** with a small schema, for example `{ "answer": "string" }`
- Prompt: a short question that the model can answer in one sentence

1. **Bug 1 (thinking disabled is not sent)**
   - Before: the model node's `invocation_kwargs` are empty, the run hits max tokens, and the model returns an empty text block. The agent output is empty.
   - After: `invocation_kwargs` contain `{ "thinking": { "type": "disabled" } }` and the agent returns the parsed JSON.
2. **Bug 2 (content-block array reaches the parser)**
   - Set **Thinking Mode: Adaptive**, **Effort: Medium**, **Max Tokens to Sample: 4000**. Ask a question that needs a few reasoning steps.
   - Before: the parser fails with `Model output doesn't fit required format`.
   - After: the parser receives only the text block and returns the parsed JSON.
3. **Guard (models that always think)**
   - Switch the model to `claude-fable-5` and keep **Thinking Mode: Disabled**.
   - Expected: the node fails with the new actionable error that points to Adaptive or to removing the option.
   - Remove the **Thinking Mode** option. Expected: the run succeeds with the model default.

Unit tests: `cd packages/@n8n/nodes-langchain && pnpm test nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts nodes/agents/Agent/test/ToolsAgent/commons.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2757
- fixes #37730

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

