### PR TITLE
fix(core): Make node type policy writes safe under concurrent requests (no-changelog)

### DIFF
--- a/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
@@ -197,20 +197,34 @@ describe('TypeAvailabilityPolicyService', () => {
 		it('throws NotFoundError when the document does not exist', async () => {
 			policyRepository.findById.mockResolvedValue(null);
 
-			await expect(service.updatePolicyDocument('missing', [RULE], 'user-1')).rejects.toThrow(
+			await expect(service.updatePolicyDocument('missing', [RULE], 0, 'user-1')).rejects.toThrow(
 				NotFoundError,
 			);
 			expect(policyRepository.updateRules).not.toHaveBeenCalled();
 		});
 
-		it('emits once with before/after rules and version', async () => {
+		it('throws ConflictError on a stale version and writes nothing', async () => {
+			policyRepository.findById.mockResolvedValue(makePolicy({ version: 2 }));
+
+			await expect(service.updatePolicyDocument('policy-1', [RULE], 1, 'user-2')).rejects.toThrow(
+				ConflictError,
+			);
+
+			expect(policyRepository.updateRules).not.toHaveBeenCalled();
+			expect(attachmentRepository.listScopeIdsAttachedToPolicy).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('emits once with before/after rules and version, and bumps every attached scope', async () => {
 			const before = makePolicy({ rules: [], version: 1 });
 			policyRepository.findById.mockResolvedValue(before);
 			const after = makePolicy({ rules: [RULE], version: 2 });
 			policyRepository.updateRules.mockResolvedValue(after);
+			attachmentRepository.listScopeIdsAttachedToPolicy.mockResolvedValue(['scope-1', 'scope-2']);
 
-			await service.updatePolicyDocument(before.id, [RULE], 'user-2');
+			await service.updatePolicyDocument(before.id, [RULE], 1, 'user-2');
 
+			expect(scopeRepository.bumpVersions).toHaveBeenCalledWith(['scope-1', 'scope-2'], ROOT);
 			expect(eventService.emit).toHaveBeenCalledTimes(1);
 			expect(eventService.emit).toHaveBeenCalledWith('node-type-policy-document-updated', {
 				updatedBy: 'user-2',

--- a/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
@@ -113,7 +113,28 @@ describe('TypeAvailabilityPolicyService', () => {
 				ConflictError,
 			);
 
-			expect(scopeRepository.createScope).not.toHaveBeenCalled();
+			expect(scopeRepository.findScopeByKindAndProject).toHaveBeenCalledWith(
+				KIND,
+				null,
+				ROOT,
+				true,
+			);
+			expect(scopeRepository.createScopeIfAbsent).not.toHaveBeenCalled();
+			expect(scopeRepository.updateDefaultAction).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('throws ConflictError when a racing first write created the scope first', async () => {
+			scopeRepository.findScopeByKindAndProject.mockResolvedValue(null);
+			scopeRepository.createScopeIfAbsent.mockResolvedValue({
+				scope: makeScope({ defaultAction: 'allow', version: 1 }),
+				created: false,
+			});
+
+			await expect(service.setDefaultAction(KIND, null, 'deny', 0, 'user-2')).rejects.toThrow(
+				ConflictError,
+			);
+
 			expect(scopeRepository.updateDefaultAction).not.toHaveBeenCalled();
 			expect(eventService.emit).not.toHaveBeenCalled();
 		});
@@ -121,12 +142,12 @@ describe('TypeAvailabilityPolicyService', () => {
 		it('lazily creates the scope on first write and emits once', async () => {
 			scopeRepository.findScopeByKindAndProject.mockResolvedValue(null);
 			const created = makeScope({ defaultAction: 'deny', version: 1 });
-			scopeRepository.createScope.mockResolvedValue(created);
+			scopeRepository.createScopeIfAbsent.mockResolvedValue({ scope: created, created: true });
 
 			const result = await service.setDefaultAction(KIND, null, 'deny', 0, 'user-2');
 
 			expect(result).toBe(created);
-			expect(scopeRepository.createScope).toHaveBeenCalledWith(
+			expect(scopeRepository.createScopeIfAbsent).toHaveBeenCalledWith(
 				{ kind: KIND, projectId: null, defaultAction: 'deny', updatedBy: 'user-2' },
 				ROOT,
 			);
@@ -194,6 +215,11 @@ describe('TypeAvailabilityPolicyService', () => {
 	});
 
 	describe('updatePolicyDocument', () => {
+		beforeEach(() => {
+			attachmentRepository.listScopeIdsAttachedToPolicy.mockResolvedValue([]);
+			scopeRepository.lockScopesByIds.mockResolvedValue([]);
+		});
+
 		it('throws NotFoundError when the document does not exist', async () => {
 			policyRepository.findById.mockResolvedValue(null);
 
@@ -210,20 +236,26 @@ describe('TypeAvailabilityPolicyService', () => {
 				ConflictError,
 			);
 
+			expect(policyRepository.findById).toHaveBeenCalledWith('policy-1', ROOT, true);
 			expect(policyRepository.updateRules).not.toHaveBeenCalled();
-			expect(attachmentRepository.listScopeIdsAttachedToPolicy).not.toHaveBeenCalled();
+			expect(scopeRepository.bumpVersions).not.toHaveBeenCalled();
 			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
-		it('emits once with before/after rules and version, and bumps every attached scope', async () => {
+		it('locks the attached scopes before the document, then bumps them and emits once', async () => {
 			const before = makePolicy({ rules: [], version: 1 });
 			policyRepository.findById.mockResolvedValue(before);
 			const after = makePolicy({ rules: [RULE], version: 2 });
 			policyRepository.updateRules.mockResolvedValue(after);
-			attachmentRepository.listScopeIdsAttachedToPolicy.mockResolvedValue(['scope-1', 'scope-2']);
+			attachmentRepository.listScopeIdsAttachedToPolicy.mockResolvedValue(['scope-2', 'scope-1']);
+			scopeRepository.lockScopesByIds.mockResolvedValue(['scope-1', 'scope-2']);
 
 			await service.updatePolicyDocument(before.id, [RULE], 1, 'user-2');
 
+			expect(scopeRepository.lockScopesByIds).toHaveBeenCalledWith(['scope-2', 'scope-1'], ROOT);
+			expect(scopeRepository.lockScopesByIds.mock.invocationCallOrder[0]).toBeLessThan(
+				policyRepository.findById.mock.invocationCallOrder[0],
+			);
 			expect(scopeRepository.bumpVersions).toHaveBeenCalledWith(['scope-1', 'scope-2'], ROOT);
 			expect(eventService.emit).toHaveBeenCalledTimes(1);
 			expect(eventService.emit).toHaveBeenCalledWith('node-type-policy-document-updated', {
@@ -233,6 +265,36 @@ describe('TypeAvailabilityPolicyService', () => {
 				before: { rules: [], version: 1 },
 				after: { rules: [RULE], version: 2 },
 			});
+		});
+
+		it('does not bump the attached scopes when the rules are unchanged', async () => {
+			const unchanged = makePolicy({ rules: [RULE], version: 1 });
+			policyRepository.findById.mockResolvedValue(unchanged);
+			policyRepository.updateRules.mockResolvedValue(unchanged);
+			attachmentRepository.listScopeIdsAttachedToPolicy.mockResolvedValue(['scope-1']);
+			scopeRepository.lockScopesByIds.mockResolvedValue(['scope-1']);
+
+			await service.updatePolicyDocument(unchanged.id, [RULE], 1, 'user-2');
+
+			expect(scopeRepository.bumpVersions).not.toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledTimes(1);
+		});
+
+		it('throws ConflictError when a scope was attached after the scopes were locked', async () => {
+			const before = makePolicy({ rules: [], version: 1 });
+			policyRepository.findById.mockResolvedValue(before);
+			policyRepository.updateRules.mockResolvedValue(makePolicy({ rules: [RULE], version: 2 }));
+			attachmentRepository.listScopeIdsAttachedToPolicy
+				.mockResolvedValueOnce(['scope-1'])
+				.mockResolvedValueOnce(['scope-1', 'scope-2']);
+			scopeRepository.lockScopesByIds.mockResolvedValue(['scope-1']);
+
+			await expect(service.updatePolicyDocument(before.id, [RULE], 1, 'user-2')).rejects.toThrow(
+				ConflictError,
+			);
+
+			expect(scopeRepository.bumpVersions).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 	});
 
@@ -265,7 +327,8 @@ describe('TypeAvailabilityPolicyService', () => {
 
 			await service.deletePolicyDocument(existing.id, 'user-1');
 
-			expect(policyRepository.deletePolicy).toHaveBeenCalledWith(existing.id, {});
+			expect(policyRepository.findById).toHaveBeenCalledWith(existing.id, ROOT, true);
+			expect(policyRepository.deletePolicy).toHaveBeenCalledWith(existing.id, ROOT);
 			expect(eventService.emit).toHaveBeenCalledTimes(1);
 			expect(eventService.emit).toHaveBeenCalledWith('node-type-policy-document-deleted', {
 				updatedBy: 'user-1',
@@ -335,6 +398,7 @@ describe('TypeAvailabilityPolicyService', () => {
 				'user-1',
 			);
 
+			expect(scopeRepository.findScopeById).toHaveBeenNthCalledWith(1, scope.id, ROOT, true);
 			expect(attachmentRepository.replaceAttachmentsForScope).toHaveBeenCalledWith(
 				scope.id,
 				[{ policyId: 'p1', priority: 0, isFloor: false }],
@@ -371,7 +435,34 @@ describe('TypeAvailabilityPolicyService', () => {
 				),
 			).rejects.toThrow(ConflictError);
 
-			expect(scopeRepository.createScope).not.toHaveBeenCalled();
+			expect(scopeRepository.findScopeByKindAndProject).toHaveBeenCalledWith(
+				KIND,
+				null,
+				ROOT,
+				true,
+			);
+			expect(scopeRepository.createScopeIfAbsent).not.toHaveBeenCalled();
+			expect(policyRepository.createPolicy).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('throws ConflictError when a racing first write created the scope first', async () => {
+			scopeRepository.findScopeByKindAndProject.mockResolvedValue(null);
+			scopeRepository.createScopeIfAbsent.mockResolvedValue({
+				scope: makeScope({ version: 2 }),
+				created: false,
+			});
+
+			await expect(
+				service.setEffectivePolicy(
+					KIND,
+					null,
+					{ rules: [RULE], defaultAction: 'deny' },
+					0,
+					'user-1',
+				),
+			).rejects.toThrow(ConflictError);
+
 			expect(policyRepository.createPolicy).not.toHaveBeenCalled();
 			expect(eventService.emit).not.toHaveBeenCalled();
 		});
@@ -379,7 +470,10 @@ describe('TypeAvailabilityPolicyService', () => {
 		it('creates the scope and its first document on first write', async () => {
 			scopeRepository.findScopeByKindAndProject.mockResolvedValue(null);
 			const createdScope = makeScope({ defaultAction: 'deny', version: 1 });
-			scopeRepository.createScope.mockResolvedValue(createdScope);
+			scopeRepository.createScopeIfAbsent.mockResolvedValue({
+				scope: createdScope,
+				created: true,
+			});
 			const createdPolicy = makePolicy({ rules: [RULE], version: 1 });
 			policyRepository.createPolicy.mockResolvedValue(createdPolicy);
 			scopeRepository.findScopeById.mockResolvedValue(

--- a/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
@@ -80,7 +80,7 @@ describe('TypeAvailabilityPolicyService', () => {
 				rules: [],
 				attachments: [],
 			});
-			expect(scopeRepository.createScope).not.toHaveBeenCalled();
+			expect(scopeRepository.createScopeIfAbsent).not.toHaveBeenCalled();
 			expect(attachmentRepository.listAttachmentsForScope).not.toHaveBeenCalled();
 		});
 
@@ -177,6 +177,24 @@ describe('TypeAvailabilityPolicyService', () => {
 				scopeId: updated.id,
 				before: { defaultAction: 'allow', version: 1 },
 				after: { defaultAction: 'deny', version: 2 },
+			});
+		});
+
+		it('falls back to the pre-update scope when the update unexpectedly finds no row', async () => {
+			const existing = makeScope({ defaultAction: 'allow', version: 1 });
+			scopeRepository.findScopeByKindAndProject.mockResolvedValue(existing);
+			scopeRepository.updateDefaultAction.mockResolvedValue(null);
+
+			const result = await service.setDefaultAction(KIND, null, 'deny', 1, 'user-2');
+
+			expect(result).toBe(existing);
+			expect(eventService.emit).toHaveBeenCalledWith('node-type-policy-scope-updated', {
+				updatedBy: 'user-2',
+				kind: KIND,
+				projectId: null,
+				scopeId: existing.id,
+				before: { defaultAction: 'allow', version: 1 },
+				after: { defaultAction: 'allow', version: 1 },
 			});
 		});
 	});
@@ -278,6 +296,18 @@ describe('TypeAvailabilityPolicyService', () => {
 
 			expect(scopeRepository.bumpVersions).not.toHaveBeenCalled();
 			expect(eventService.emit).toHaveBeenCalledTimes(1);
+		});
+
+		it('throws NotFoundError when the update unexpectedly finds no row', async () => {
+			policyRepository.findById.mockResolvedValue(makePolicy({ version: 1 }));
+			policyRepository.updateRules.mockResolvedValue(null);
+
+			await expect(service.updatePolicyDocument('policy-1', [RULE], 1, 'user-2')).rejects.toThrow(
+				NotFoundError,
+			);
+
+			expect(scopeRepository.bumpVersions).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
 		it('throws ConflictError when a scope was attached after the scopes were locked', async () => {
@@ -419,6 +449,20 @@ describe('TypeAvailabilityPolicyService', () => {
 				},
 			});
 		});
+
+		it('falls back to computing the version when the re-read finds no row', async () => {
+			const scope = makeScope({ version: 1 });
+			scopeRepository.findScopeById.mockResolvedValueOnce(scope).mockResolvedValueOnce(null);
+			attachmentRepository.listAttachmentsForScope.mockResolvedValue([]);
+
+			const result = await service.replaceAttachments(
+				scope.id,
+				[{ policyId: 'p1', priority: 0, isFloor: false }],
+				'user-1',
+			);
+
+			expect(result.version).toBe(2);
+		});
 	});
 
 	describe('setEffectivePolicy', () => {
@@ -542,6 +586,77 @@ describe('TypeAvailabilityPolicyService', () => {
 					after: { rules: [RULE], version: 2 },
 				}),
 			);
+		});
+
+		it('throws NotFoundError when the document update unexpectedly finds no row', async () => {
+			const scope = makeScope({ defaultAction: 'allow', version: 1 });
+			scopeRepository.findScopeByKindAndProject.mockResolvedValue(scope);
+			attachmentRepository.listAttachmentsForScope.mockResolvedValue([
+				{ policyId: 'policy-1', rules: [], priority: 0, isFloor: false },
+			]);
+			policyRepository.findById.mockResolvedValue(makePolicy({ rules: [], version: 1 }));
+			policyRepository.updateRules.mockResolvedValue(null);
+
+			await expect(
+				service.setEffectivePolicy(
+					KIND,
+					null,
+					{ rules: [RULE], defaultAction: 'allow' },
+					1,
+					'user-2',
+				),
+			).rejects.toThrow(NotFoundError);
+		});
+
+		it('reports no prior document when the existing document is unexpectedly missing', async () => {
+			const scope = makeScope({ defaultAction: 'allow', version: 1 });
+			scopeRepository.findScopeByKindAndProject.mockResolvedValue(scope);
+			attachmentRepository.listAttachmentsForScope.mockResolvedValue([
+				{ policyId: 'policy-1', rules: [], priority: 0, isFloor: false },
+			]);
+			policyRepository.findById.mockResolvedValue(null);
+			const updatedPolicy = makePolicy({ rules: [RULE], version: 2 });
+			policyRepository.updateRules.mockResolvedValue(updatedPolicy);
+			scopeRepository.findScopeById.mockResolvedValue(
+				makeScope({ defaultAction: 'allow', version: 2 }),
+			);
+
+			await service.setEffectivePolicy(
+				KIND,
+				null,
+				{ rules: [RULE], defaultAction: 'allow' },
+				1,
+				'user-2',
+			);
+
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'node-type-policy-document-updated',
+				expect.objectContaining({
+					before: { rules: [], version: 0 },
+					after: { rules: [RULE], version: 2 },
+				}),
+			);
+		});
+
+		it('falls back to computing the scope-after when the final read finds no row', async () => {
+			scopeRepository.findScopeByKindAndProject.mockResolvedValue(null);
+			scopeRepository.createScopeIfAbsent.mockResolvedValue({
+				scope: makeScope({ defaultAction: 'deny', version: 1 }),
+				created: true,
+			});
+			policyRepository.createPolicy.mockResolvedValue(makePolicy({ rules: [RULE], version: 1 }));
+			scopeRepository.findScopeById.mockResolvedValue(null);
+
+			const result = await service.setEffectivePolicy(
+				KIND,
+				null,
+				{ rules: [RULE], defaultAction: 'deny' },
+				0,
+				'user-1',
+			);
+
+			expect(result.defaultAction).toBe('deny');
+			expect(result.version).toBe(1);
 		});
 	});
 });

--- a/packages/cli/src/modules/type-availability-policies/database/repositories/__tests__/type-availability-policy-locks.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/repositories/__tests__/type-availability-policy-locks.test.ts
@@ -1,0 +1,247 @@
+import { generateNanoId, type OperationContext, type TransactionRunner } from '@n8n/db';
+import { UnexpectedError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { mockEntityManager } from '@test/mocking';
+
+import { TypeAvailabilityPolicyScope } from '../../entities/type-availability-policy-scope.entity';
+import { TypeAvailabilityPolicy } from '../../entities/type-availability-policy.entity';
+import { TypeAvailabilityPolicyScopeRepository } from '../type-availability-policy-scope.repository';
+import { TypeAvailabilityPolicyRepository } from '../type-availability-policy.repository';
+
+vi.mock('@n8n/db', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@n8n/db')>()),
+	generateNanoId: vi.fn(),
+}));
+
+const ROOT: OperationContext = {};
+
+function setDriver(
+	entityManager: ReturnType<typeof mockEntityManager>,
+	type: 'postgres' | 'sqlite',
+) {
+	Object.assign(entityManager.connection, { options: { type } });
+}
+
+/**
+ * The row lock is Postgres-only (see `forUpdateLock`'s doc comment): SQLite's single writer
+ * connection already serialises transactions, so a row lock there would be a no-op at best.
+ * These exercise both sides of that branch directly, since the integration suite runs against
+ * whichever driver the job configured and cannot be relied on to cover both.
+ */
+describe('row locks depend on the driver', () => {
+	describe('TypeAvailabilityPolicyScopeRepository', () => {
+		const entityManager = mockEntityManager(TypeAvailabilityPolicyScope);
+		const transactionRunner = mock<TransactionRunner>();
+		const repository = new TypeAvailabilityPolicyScopeRepository(
+			entityManager.connection,
+			transactionRunner,
+		);
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			transactionRunner.run.mockImplementation(async (_ctx, fn) => await fn(ROOT));
+			entityManager.findOne.mockResolvedValue(null);
+			entityManager.find.mockResolvedValue([]);
+		});
+
+		it('does not lock a plain read, even on Postgres', async () => {
+			setDriver(entityManager, 'postgres');
+
+			await repository.findScopeByKindAndProject('node-types', null, ROOT);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicyScope, {
+				where: { kind: 'node-types', projectId: expect.anything() },
+			});
+		});
+
+		it('does not lock on SQLite even when forUpdate is requested', async () => {
+			setDriver(entityManager, 'sqlite');
+
+			await repository.findScopeByKindAndProject('node-types', null, ROOT, true);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicyScope, {
+				where: { kind: 'node-types', projectId: expect.anything() },
+			});
+		});
+
+		it('locks the row on Postgres when forUpdate is requested', async () => {
+			setDriver(entityManager, 'postgres');
+
+			await repository.findScopeByKindAndProject('node-types', null, ROOT, true);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicyScope, {
+				where: { kind: 'node-types', projectId: expect.anything() },
+				lock: { mode: 'pessimistic_write' },
+			});
+		});
+
+		it('locks findScopeById on Postgres when forUpdate is requested', async () => {
+			setDriver(entityManager, 'postgres');
+
+			await repository.findScopeById('scope-1', ROOT, true);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicyScope, {
+				where: { id: 'scope-1' },
+				lock: { mode: 'pessimistic_write' },
+			});
+		});
+
+		it('does not lock findScopeById without forUpdate, even on Postgres', async () => {
+			setDriver(entityManager, 'postgres');
+
+			await repository.findScopeById('scope-1', ROOT);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicyScope, {
+				where: { id: 'scope-1' },
+			});
+		});
+
+		it('locks every batch on Postgres when locking several scopes', async () => {
+			setDriver(entityManager, 'postgres');
+			entityManager.find.mockResolvedValue([{ id: 'a' }, { id: 'b' }] as never);
+
+			const found = await repository.lockScopesByIds(['b', 'a'], ROOT);
+
+			expect(entityManager.find).toHaveBeenCalledWith(
+				TypeAvailabilityPolicyScope,
+				expect.objectContaining({ lock: { mode: 'pessimistic_write' } }),
+			);
+			expect(found).toEqual(['a', 'b']);
+		});
+
+		it('does not lock while locking scopes on SQLite', async () => {
+			setDriver(entityManager, 'sqlite');
+
+			await repository.lockScopesByIds(['a'], ROOT);
+
+			expect(entityManager.find).toHaveBeenCalledWith(
+				TypeAvailabilityPolicyScope,
+				expect.not.objectContaining({ lock: expect.anything() }),
+			);
+		});
+
+		it('returns null from updateDefaultAction when the scope does not exist', async () => {
+			entityManager.findOneBy.mockResolvedValue(null);
+
+			expect(await repository.updateDefaultAction('missing', 'deny', 'user-1', ROOT)).toBeNull();
+			expect(entityManager.update).not.toHaveBeenCalled();
+		});
+
+		it('bumps every batch when more ids are named than fit in one query', async () => {
+			// One batch per ID_QUERY_BATCH_SIZE (10,000) ids, so this forces a second batch.
+			const ids = Array.from({ length: 10_001 }, (_, i) => `id-${i}`);
+
+			await repository.bumpVersions(ids, ROOT);
+
+			expect(entityManager.increment).toHaveBeenCalledTimes(2);
+		});
+
+		describe('createScopeIfAbsent', () => {
+			const queryBuilder = {
+				insert: vi.fn().mockReturnThis(),
+				into: vi.fn().mockReturnThis(),
+				values: vi.fn().mockReturnThis(),
+				orIgnore: vi.fn().mockReturnThis(),
+				execute: vi.fn().mockResolvedValue(undefined),
+			};
+
+			beforeEach(() => {
+				queryBuilder.insert.mockClear().mockReturnThis();
+				queryBuilder.into.mockClear().mockReturnThis();
+				queryBuilder.values.mockClear().mockReturnThis();
+				queryBuilder.orIgnore.mockClear().mockReturnThis();
+				queryBuilder.execute.mockClear().mockResolvedValue(undefined);
+				entityManager.createQueryBuilder.mockReturnValue(queryBuilder as never);
+				vi.mocked(generateNanoId).mockReturnValue('generated-id');
+			});
+
+			it('reports created when the read-back row is the one just inserted', async () => {
+				const inserted = Object.assign(new TypeAvailabilityPolicyScope(), { id: 'generated-id' });
+				entityManager.findOne.mockResolvedValue(inserted);
+
+				const { scope, created } = await repository.createScopeIfAbsent(
+					{ kind: 'node-types', projectId: null, defaultAction: 'allow', updatedBy: 'user-1' },
+					ROOT,
+				);
+
+				expect(created).toBe(true);
+				expect(scope).toBe(inserted);
+			});
+
+			it('reports not created when a concurrent first write already exists', async () => {
+				const winner = Object.assign(new TypeAvailabilityPolicyScope(), { id: 'other-id' });
+				entityManager.findOne.mockResolvedValue(winner);
+
+				const { scope, created } = await repository.createScopeIfAbsent(
+					{ kind: 'node-types', projectId: null, defaultAction: 'allow', updatedBy: 'user-1' },
+					ROOT,
+				);
+
+				expect(created).toBe(false);
+				expect(scope).toBe(winner);
+			});
+
+			it('throws when the read-back finds no row at all', async () => {
+				entityManager.findOne.mockResolvedValue(null);
+
+				await expect(
+					repository.createScopeIfAbsent(
+						{ kind: 'node-types', projectId: null, defaultAction: 'allow', updatedBy: 'user-1' },
+						ROOT,
+					),
+				).rejects.toThrow(UnexpectedError);
+			});
+		});
+	});
+
+	describe('TypeAvailabilityPolicyRepository', () => {
+		const entityManager = mockEntityManager(TypeAvailabilityPolicy);
+		const transactionRunner = mock<TransactionRunner>();
+		const repository = new TypeAvailabilityPolicyRepository(
+			entityManager.connection,
+			transactionRunner,
+		);
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			entityManager.findOne.mockResolvedValue(null);
+		});
+
+		it('does not lock without forUpdate, even on Postgres', async () => {
+			setDriver(entityManager, 'postgres');
+
+			await repository.findById('policy-1', ROOT);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicy, {
+				where: { id: 'policy-1' },
+			});
+		});
+
+		it('does not lock on SQLite even when forUpdate is requested', async () => {
+			setDriver(entityManager, 'sqlite');
+
+			await repository.findById('policy-1', ROOT, true);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicy, {
+				where: { id: 'policy-1' },
+			});
+		});
+
+		it('locks the row on Postgres when forUpdate is requested', async () => {
+			setDriver(entityManager, 'postgres');
+
+			await repository.findById('policy-1', ROOT, true);
+
+			expect(entityManager.findOne).toHaveBeenCalledWith(TypeAvailabilityPolicy, {
+				where: { id: 'policy-1' },
+				lock: { mode: 'pessimistic_write' },
+			});
+		});
+
+		it('returns an empty list without querying for an empty id list', async () => {
+			expect(await repository.findManyByIds([], ROOT)).toEqual([]);
+			expect(entityManager.findBy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
@@ -1,6 +1,13 @@
-import { BaseRepository, TransactionRunner, chunkIds, type OperationContext } from '@n8n/db';
+import {
+	BaseRepository,
+	TransactionRunner,
+	chunkIds,
+	generateNanoId,
+	type OperationContext,
+} from '@n8n/db';
 import { Service } from '@n8n/di';
-import { DataSource, In, IsNull } from '@n8n/typeorm';
+import { DataSource, In, IsNull, type EntityManager } from '@n8n/typeorm';
+import { UnexpectedError } from 'n8n-workflow';
 
 import type { PolicyAction } from '../../policy-rule.types';
 import { TypeAvailabilityPolicyScope } from '../entities/type-availability-policy-scope.entity';
@@ -19,6 +26,16 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 	}
 
 	/**
+	 * `SELECT ... FOR UPDATE`, Postgres only. SQLite has a single writer, so a write
+	 * transaction already serialises against every other one and no row lock is needed.
+	 */
+	private forUpdateLock(manager: EntityManager) {
+		return manager.connection.options.type === 'postgres'
+			? { lock: { mode: 'pessimistic_write' as const } }
+			: {};
+	}
+
+	/**
 	 * `projectId: null` looks up the instance scope. At most one row can match either way —
 	 * the two partial unique indexes guarantee it.
 	 *
@@ -26,7 +43,8 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 	 * it, this is a plain read: on Postgres, two concurrent writers can both read the same
 	 * version, both pass the check, and the second commit silently overwrites the first. The
 	 * row lock makes the second writer wait for the first to commit, then re-read the bumped
-	 * version and correctly fail the check.
+	 * version and correctly fail the check. A row that does not exist yet cannot be locked —
+	 * first writes go through `createScopeIfAbsent` for that reason.
 	 */
 	async findScopeByKindAndProject(
 		kind: string,
@@ -37,9 +55,7 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 		const manager = this.managerFor(ctx);
 		return await manager.findOne(TypeAvailabilityPolicyScope, {
 			where: { kind, projectId: projectId ?? IsNull() },
-			...(forUpdate && manager.connection.options.type === 'postgres'
-				? { lock: { mode: 'pessimistic_write' as const } }
-				: {}),
+			...(forUpdate ? this.forUpdateLock(manager) : {}),
 		});
 	}
 
@@ -52,10 +68,40 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 		const manager = this.managerFor(ctx);
 		return await manager.findOne(TypeAvailabilityPolicyScope, {
 			where: { id },
-			...(forUpdate && manager.connection.options.type === 'postgres'
-				? { lock: { mode: 'pessimistic_write' as const } }
-				: {}),
+			...(forUpdate ? this.forUpdateLock(manager) : {}),
 		});
+	}
+
+	/**
+	 * Locks every named scope row, in id order, and returns the ids that exist.
+	 *
+	 * Every write path that touches both a scope and a policy document must lock the scope
+	 * first: `setEffectivePolicy` locks its scope and then updates the document, so a path
+	 * that locked the document first and then bumped scopes would deadlock against it on
+	 * Postgres. Sorting keeps two callers that overlap on several scopes from deadlocking on
+	 * each other the same way: the input is sorted so the batches lock in order, and each
+	 * batch is `ORDER BY id` because Postgres locks the rows in the order the statement
+	 * returns them, not in the order of the `IN` list.
+	 *
+	 * Must run inside a transaction — a row lock outside one is meaningless, and Postgres
+	 * rejects it.
+	 */
+	async lockScopesByIds(ids: string[], ctx: OperationContext): Promise<string[]> {
+		if (ids.length === 0) return [];
+
+		const manager = this.managerFor(ctx);
+		const found: string[] = [];
+		for (const batch of chunkIds([...ids].sort())) {
+			const rows = await manager.find(TypeAvailabilityPolicyScope, {
+				select: { id: true },
+				where: { id: In(batch) },
+				order: { id: 'ASC' },
+				...this.forUpdateLock(manager),
+			});
+			found.push(...rows.map((row) => row.id));
+		}
+
+		return found;
 	}
 
 	async createScope(
@@ -65,6 +111,41 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 		const scope = this.create({ ...input, version: 1 });
 
 		return await this.managerFor(ctx).save(TypeAvailabilityPolicyScope, scope);
+	}
+
+	/**
+	 * Inserts the scope row if `(kind, projectId)` has none yet, then reads back whichever row
+	 * exists. `created: false` means a concurrent first write got there first.
+	 *
+	 * A plain "read null, then insert" lets two first writes both pass the version check and
+	 * the loser hit the unique index with a raw driver error. Insert-or-ignore turns the
+	 * loser's insert into a no-op instead — on Postgres it waits for the winner's commit, so
+	 * the locked read-back returns the winner's row and the caller can report a conflict.
+	 *
+	 * Joins the caller's transaction when `ctx` carries one, so the read-back lock is held
+	 * for the rest of the caller's work; opens one otherwise, since the lock needs it.
+	 */
+	async createScopeIfAbsent(
+		input: NewPolicyScope,
+		ctx: OperationContext,
+	): Promise<{ scope: TypeAvailabilityPolicyScope; created: boolean }> {
+		return await this.runInTransaction(ctx, async (tx, txCtx) => {
+			const id = generateNanoId();
+			await tx
+				.createQueryBuilder()
+				.insert()
+				.into(TypeAvailabilityPolicyScope)
+				.values(this.create({ ...input, id, version: 1 }))
+				.orIgnore()
+				.execute();
+
+			const scope = await this.findScopeByKindAndProject(input.kind, input.projectId, txCtx, true);
+			if (!scope) {
+				throw new UnexpectedError('Policy scope is missing right after insert-or-ignore');
+			}
+
+			return { scope, created: scope.id === id };
+		});
 	}
 
 	/**

--- a/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
@@ -26,8 +26,10 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 	}
 
 	/**
-	 * `SELECT ... FOR UPDATE`, Postgres only. SQLite has a single writer, so a write
-	 * transaction already serialises against every other one and no row lock is needed.
+	 * `SELECT ... FOR UPDATE`, Postgres only. n8n's SQLite driver has one write connection
+	 * behind a mutex and opens every transaction with `BEGIN IMMEDIATE`, so a write
+	 * transaction already runs to completion before the next one starts — every read inside
+	 * it sees the previous writer's commit, and no row lock is needed.
 	 */
 	private forUpdateLock(manager: EntityManager) {
 		return manager.connection.options.type === 'postgres'

--- a/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
@@ -21,23 +21,41 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 	/**
 	 * `projectId: null` looks up the instance scope. At most one row can match either way —
 	 * the two partial unique indexes guarantee it.
+	 *
+	 * Pass `forUpdate: true` inside a write transaction that checks `expectedVersion`. Without
+	 * it, this is a plain read: on Postgres, two concurrent writers can both read the same
+	 * version, both pass the check, and the second commit silently overwrites the first. The
+	 * row lock makes the second writer wait for the first to commit, then re-read the bumped
+	 * version and correctly fail the check.
 	 */
 	async findScopeByKindAndProject(
 		kind: string,
 		projectId: string | null,
 		ctx: OperationContext,
+		forUpdate = false,
 	): Promise<TypeAvailabilityPolicyScope | null> {
-		return await this.managerFor(ctx).findOneBy(TypeAvailabilityPolicyScope, {
-			kind,
-			projectId: projectId ?? IsNull(),
+		const manager = this.managerFor(ctx);
+		return await manager.findOne(TypeAvailabilityPolicyScope, {
+			where: { kind, projectId: projectId ?? IsNull() },
+			...(forUpdate && manager.connection.options.type === 'postgres'
+				? { lock: { mode: 'pessimistic_write' as const } }
+				: {}),
 		});
 	}
 
+	/** See `findScopeByKindAndProject` for `forUpdate`. */
 	async findScopeById(
 		id: string,
 		ctx: OperationContext,
+		forUpdate = false,
 	): Promise<TypeAvailabilityPolicyScope | null> {
-		return await this.managerFor(ctx).findOneBy(TypeAvailabilityPolicyScope, { id });
+		const manager = this.managerFor(ctx);
+		return await manager.findOne(TypeAvailabilityPolicyScope, {
+			where: { id },
+			...(forUpdate && manager.connection.options.type === 'postgres'
+				? { lock: { mode: 'pessimistic_write' as const } }
+				: {}),
+		});
 	}
 
 	async createScope(

--- a/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository.ts
@@ -106,15 +106,6 @@ export class TypeAvailabilityPolicyScopeRepository extends BaseRepository<TypeAv
 		return found;
 	}
 
-	async createScope(
-		input: NewPolicyScope,
-		ctx: OperationContext,
-	): Promise<TypeAvailabilityPolicyScope> {
-		const scope = this.create({ ...input, version: 1 });
-
-		return await this.managerFor(ctx).save(TypeAvailabilityPolicyScope, scope);
-	}
-
 	/**
 	 * Inserts the scope row if `(kind, projectId)` has none yet, then reads back whichever row
 	 * exists. `created: false` means a concurrent first write got there first.

--- a/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy.repository.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy.repository.ts
@@ -28,8 +28,23 @@ export class TypeAvailabilityPolicyRepository extends BaseRepository<TypeAvailab
 		super(TypeAvailabilityPolicy, dataSource.manager, transactionRunner);
 	}
 
-	async findById(id: string, ctx: OperationContext): Promise<TypeAvailabilityPolicy | null> {
-		return await this.managerFor(ctx).findOneBy(TypeAvailabilityPolicy, { id });
+	/**
+	 * Pass `forUpdate: true` inside a write transaction that checks `expectedVersion` — see
+	 * `TypeAvailabilityPolicyScopeRepository.findScopeByKindAndProject` for why the lock
+	 * matters: without it, two concurrent writers can both pass the version check.
+	 */
+	async findById(
+		id: string,
+		ctx: OperationContext,
+		forUpdate = false,
+	): Promise<TypeAvailabilityPolicy | null> {
+		const manager = this.managerFor(ctx);
+		return await manager.findOne(TypeAvailabilityPolicy, {
+			where: { id },
+			...(forUpdate && manager.connection.options.type === 'postgres'
+				? { lock: { mode: 'pessimistic_write' as const } }
+				: {}),
+		});
 	}
 
 	async findManyByIds(ids: string[], ctx: OperationContext): Promise<TypeAvailabilityPolicy[]> {

--- a/packages/cli/src/modules/type-availability-policies/dto/update-policy-document.dto.ts
+++ b/packages/cli/src/modules/type-availability-policies/dto/update-policy-document.dto.ts
@@ -1,8 +1,11 @@
 import { Z } from '@n8n/api-types';
+import { z } from 'zod';
 
 import { policyRuleListSchema } from './policy-rule.schema';
 
 /** Request body for replacing a policy document's rules. */
 export class UpdatePolicyDocumentDto extends Z.class({
 	rules: policyRuleListSchema,
+	// Optimistic concurrency: callers send the version they last read, so a stale write is rejected.
+	version: z.number().int().nonnegative(),
 }) {}

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policy-instance.controller.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policy-instance.controller.ts
@@ -125,6 +125,7 @@ export class TypeAvailabilityPolicyInstanceController {
 		const { policy, warnings } = await this.service.updatePolicyDocument(
 			policyId,
 			dto.rules,
+			dto.version,
 			req.user.id,
 		);
 

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
@@ -126,9 +126,12 @@ export class TypeAvailabilityPolicyService {
 	}
 
 	/**
-	 * Sets the scope's default action, creating the scope on first write. The version check
-	 * runs inside the same transaction as the write, so two racing first-writes can't both
-	 * see "no row yet" and both succeed — the loser's `expectedVersion: 0` no longer matches.
+	 * Sets the scope's default action, creating the scope on first write.
+	 *
+	 * Locks the scope row for the duration of the transaction, so a racing writer blocks on
+	 * the read until this one commits, then re-reads the bumped version and correctly fails
+	 * the `expectedVersion` check — instead of both writers reading the same version and one
+	 * silently overwriting the other's change.
 	 */
 	async setDefaultAction(
 		kind: string,
@@ -138,7 +141,12 @@ export class TypeAvailabilityPolicyService {
 		updatedBy: string,
 	): Promise<TypeAvailabilityPolicyScope> {
 		const result = await this.transactionRunner.run({}, async (ctx) => {
-			const scope = await this.scopeRepository.findScopeByKindAndProject(kind, projectId, ctx);
+			const scope = await this.scopeRepository.findScopeByKindAndProject(
+				kind,
+				projectId,
+				ctx,
+				true,
+			);
 			const currentVersion = scope?.version ?? UNCONFIGURED_VERSION;
 
 			if (currentVersion !== expectedVersion) {
@@ -195,32 +203,57 @@ export class TypeAvailabilityPolicyService {
 		return { policy, warnings };
 	}
 
+	/**
+	 * Replaces a policy document's rules, guarded by optimistic concurrency: `expectedVersion`
+	 * must match the document's current version, checked and written inside one locked
+	 * transaction (see `TypeAvailabilityPolicyRepository.findById`).
+	 *
+	 * Also bumps every scope this document is attached to, in the same transaction — a scope's
+	 * `version` is its clients' freshness signal for the *effective* policy, and this document's
+	 * rules are part of that even though the edit never touches the scope row directly.
+	 */
 	async updatePolicyDocument(
 		policyId: string,
 		rules: readonly PolicyRule[],
+		expectedVersion: number,
 		updatedBy: string,
 	): Promise<PolicyDocumentWrite> {
 		const warnings = lintRulesForShadowing(rules);
 
-		const existing = await this.policyRepository.findById(policyId, {});
-		if (!existing) {
-			throw new NotFoundError(`Policy document not found: ${policyId}`);
-		}
+		const result = await this.transactionRunner.run({}, async (ctx) => {
+			const existing = await this.policyRepository.findById(policyId, ctx, true);
+			if (!existing) {
+				throw new NotFoundError(`Policy document not found: ${policyId}`);
+			}
 
-		const updated = await this.policyRepository.updateRules(policyId, rules, updatedBy, {});
-		if (!updated) {
-			throw new NotFoundError(`Policy document not found: ${policyId}`);
-		}
+			if (existing.version !== expectedVersion) {
+				throw new ConflictError(
+					`Policy document has changed since it was last read (expected version ${expectedVersion}, found ${existing.version})`,
+				);
+			}
+
+			const updated = await this.policyRepository.updateRules(policyId, rules, updatedBy, ctx);
+			// The row lock above holds for the rest of this transaction, so it can't have been
+			// deleted between the check and this write.
+			if (!updated) {
+				throw new NotFoundError(`Policy document not found: ${policyId}`);
+			}
+
+			const scopeIds = await this.attachmentRepository.listScopeIdsAttachedToPolicy(policyId, ctx);
+			await this.scopeRepository.bumpVersions(scopeIds, ctx);
+
+			return { existing, updated };
+		});
 
 		this.eventService.emit('node-type-policy-document-updated', {
 			updatedBy,
-			kind: existing.kind,
+			kind: result.existing.kind,
 			policyId,
-			before: { rules: existing.rules, version: existing.version },
-			after: { rules: updated.rules, version: updated.version },
+			before: { rules: result.existing.rules, version: result.existing.version },
+			after: { rules: result.updated.rules, version: result.updated.version },
 		});
 
-		return { policy: updated, warnings };
+		return { policy: result.updated, warnings };
 	}
 
 	/**
@@ -349,7 +382,12 @@ export class TypeAvailabilityPolicyService {
 		const warnings = lintRulesForShadowing(input.rules);
 
 		const result = await this.transactionRunner.run({}, async (ctx) => {
-			const scope = await this.scopeRepository.findScopeByKindAndProject(kind, projectId, ctx);
+			const scope = await this.scopeRepository.findScopeByKindAndProject(
+				kind,
+				projectId,
+				ctx,
+				true,
+			);
 			const currentVersion = scope?.version ?? UNCONFIGURED_VERSION;
 
 			if (currentVersion !== expectedVersion) {

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
@@ -17,8 +17,9 @@ import { lintRulesForShadowing, type ShadowWarning } from './policy-shadow-lint'
 
 /**
  * A scope that has never been written has no row. That "unconfigured" state behaves as
- * allow-all, and reports version `0` — so a first write can send `expectedVersion: 0` and
- * a racing second first-write correctly sees a mismatch once the row exists.
+ * allow-all, and reports version `0` — so a first write sends `expectedVersion: 0`. There is
+ * no row to lock at that point, so `createScopeOrConflict` decides which of two racing first
+ * writes wins.
  */
 const UNCONFIGURED_VERSION = 0;
 
@@ -128,10 +129,11 @@ export class TypeAvailabilityPolicyService {
 	/**
 	 * Sets the scope's default action, creating the scope on first write.
 	 *
-	 * Locks the scope row for the duration of the transaction, so a racing writer blocks on
-	 * the read until this one commits, then re-reads the bumped version and correctly fails
-	 * the `expectedVersion` check — instead of both writers reading the same version and one
-	 * silently overwriting the other's change.
+	 * On Postgres the scope row is locked for the duration of the transaction, so a racing
+	 * writer blocks on the read until this one commits, then re-reads the bumped version and
+	 * correctly fails the `expectedVersion` check — instead of both writers reading the same
+	 * version and one silently overwriting the other's change. A first write has no row to
+	 * lock; `createScopeOrConflict` covers that case.
 	 */
 	async setDefaultAction(
 		kind: string,
@@ -155,19 +157,18 @@ export class TypeAvailabilityPolicyService {
 				);
 			}
 
-			const before = scope ? { defaultAction: scope.defaultAction, version: scope.version } : null;
+			if (!scope) {
+				const created = await this.createScopeOrConflict(
+					{ kind, projectId, defaultAction, updatedBy },
+					ctx,
+				);
+				return { before: null, after: created };
+			}
 
-			const after = scope
-				? ((await this.scopeRepository.updateDefaultAction(
-						scope.id,
-						defaultAction,
-						updatedBy,
-						ctx,
-					)) ?? scope)
-				: await this.scopeRepository.createScope(
-						{ kind, projectId, defaultAction, updatedBy },
-						ctx,
-					);
+			const before = { defaultAction: scope.defaultAction, version: scope.version };
+			const after =
+				(await this.scopeRepository.updateDefaultAction(scope.id, defaultAction, updatedBy, ctx)) ??
+				scope;
 
 			return { before, after };
 		});
@@ -182,6 +183,31 @@ export class TypeAvailabilityPolicyService {
 		});
 
 		return result.after;
+	}
+
+	/**
+	 * `FOR UPDATE` finds nothing to lock when the scope has no row yet, so two first writes
+	 * can both pass the `expectedVersion: 0` check. Insert-or-ignore lets exactly one of them
+	 * create the row; the other learns it lost and reports the same conflict a stale version
+	 * would, instead of a raw unique-index error.
+	 */
+	private async createScopeOrConflict(
+		input: {
+			kind: string;
+			projectId: string | null;
+			defaultAction: PolicyAction;
+			updatedBy: string;
+		},
+		ctx: OperationContext,
+	): Promise<TypeAvailabilityPolicyScope> {
+		const { scope, created } = await this.scopeRepository.createScopeIfAbsent(input, ctx);
+		if (!created) {
+			throw new ConflictError(
+				`Policy scope was created concurrently (expected version ${UNCONFIGURED_VERSION}, found ${scope.version})`,
+			);
+		}
+
+		return scope;
 	}
 
 	async createPolicyDocument(
@@ -205,12 +231,14 @@ export class TypeAvailabilityPolicyService {
 
 	/**
 	 * Replaces a policy document's rules, guarded by optimistic concurrency: `expectedVersion`
-	 * must match the document's current version, checked and written inside one locked
-	 * transaction (see `TypeAvailabilityPolicyRepository.findById`).
+	 * must match the document's current version, checked and written inside one transaction
+	 * that (on Postgres) holds the document's row lock (see
+	 * `TypeAvailabilityPolicyRepository.findById`).
 	 *
 	 * Also bumps every scope this document is attached to, in the same transaction — a scope's
 	 * `version` is its clients' freshness signal for the *effective* policy, and this document's
-	 * rules are part of that even though the edit never touches the scope row directly.
+	 * rules are part of that even though the edit never touches the scope row directly. The
+	 * bump is skipped when the rules did not change, matching `updateRules`' own no-op.
 	 */
 	async updatePolicyDocument(
 		policyId: string,
@@ -221,6 +249,14 @@ export class TypeAvailabilityPolicyService {
 		const warnings = lintRulesForShadowing(rules);
 
 		const result = await this.transactionRunner.run({}, async (ctx) => {
+			// Scopes before the document: `setEffectivePolicy` locks its scope and then writes
+			// the document, and every path must take the two in the same order or they deadlock.
+			const attachedScopeIds = await this.attachmentRepository.listScopeIdsAttachedToPolicy(
+				policyId,
+				ctx,
+			);
+			const lockedScopeIds = await this.scopeRepository.lockScopesByIds(attachedScopeIds, ctx);
+
 			const existing = await this.policyRepository.findById(policyId, ctx, true);
 			if (!existing) {
 				throw new NotFoundError(`Policy document not found: ${policyId}`);
@@ -233,14 +269,29 @@ export class TypeAvailabilityPolicyService {
 			}
 
 			const updated = await this.policyRepository.updateRules(policyId, rules, updatedBy, ctx);
-			// The row lock above holds for the rest of this transaction, so it can't have been
-			// deleted between the check and this write.
+			// Defensive: the row was found above, and on Postgres it is locked, so it cannot be
+			// gone here.
 			if (!updated) {
 				throw new NotFoundError(`Policy document not found: ${policyId}`);
 			}
 
-			const scopeIds = await this.attachmentRepository.listScopeIdsAttachedToPolicy(policyId, ctx);
-			await this.scopeRepository.bumpVersions(scopeIds, ctx);
+			if (updated.version !== existing.version) {
+				// An attachment that committed between the scope read above and the document lock
+				// belongs to a scope this transaction does not hold. Locking it now would be
+				// document → scope, the order that deadlocks, so refuse and let the client retry.
+				const locked = new Set(lockedScopeIds);
+				const scopeIdsNow = await this.attachmentRepository.listScopeIdsAttachedToPolicy(
+					policyId,
+					ctx,
+				);
+				if (scopeIdsNow.some((id) => !locked.has(id))) {
+					throw new ConflictError(
+						'Policy document was attached to another scope while it was being updated',
+					);
+				}
+
+				await this.scopeRepository.bumpVersions(lockedScopeIds, ctx);
+			}
 
 			return { existing, updated };
 		});
@@ -260,24 +311,32 @@ export class TypeAvailabilityPolicyService {
 	 * Refuses to delete a policy that is still attached to any scope — the attachment FK is
 	 * `RESTRICT`, so this checks first and reports a clean count instead of letting a raw SQL
 	 * constraint violation reach the caller.
+	 *
+	 * The check and the delete share one transaction that (on Postgres) holds the document's
+	 * row lock. An attachment insert takes a key-share lock on the document it points at, so a
+	 * concurrent attach waits for this transaction rather than landing between the two.
 	 */
 	async deletePolicyDocument(policyId: string, updatedBy: string): Promise<void> {
-		const existing = await this.policyRepository.findById(policyId, {});
-		if (!existing) {
-			throw new NotFoundError(`Policy document not found: ${policyId}`);
-		}
+		const existing = await this.transactionRunner.run({}, async (ctx) => {
+			const policy = await this.policyRepository.findById(policyId, ctx, true);
+			if (!policy) {
+				throw new NotFoundError(`Policy document not found: ${policyId}`);
+			}
 
-		const attachedScopeIds = await this.attachmentRepository.listScopeIdsAttachedToPolicy(
-			policyId,
-			{},
-		);
-		if (attachedScopeIds.length > 0) {
-			throw new ConflictError(
-				`Cannot delete policy document: still attached to ${attachedScopeIds.length} scope(s)`,
+			const attachedScopeIds = await this.attachmentRepository.listScopeIdsAttachedToPolicy(
+				policyId,
+				ctx,
 			);
-		}
+			if (attachedScopeIds.length > 0) {
+				throw new ConflictError(
+					`Cannot delete policy document: still attached to ${attachedScopeIds.length} scope(s)`,
+				);
+			}
 
-		await this.policyRepository.deletePolicy(policyId, {});
+			await this.policyRepository.deletePolicy(policyId, ctx);
+
+			return policy;
+		});
 
 		this.eventService.emit('node-type-policy-document-deleted', {
 			updatedBy,
@@ -305,6 +364,10 @@ export class TypeAvailabilityPolicyService {
 	 * version field (unlike `PutInstancePolicyDto`), so this endpoint is last-write-wins. The
 	 * write still runs in one transaction with the scope's version bump, so a concurrent
 	 * reader never observes the attachments changed without the version moving.
+	 *
+	 * The scope is still locked up front — not for a version check, but so this path takes
+	 * the scope before it touches any policy row (the attachment inserts key-share the
+	 * policies), the same scope → policy order every other write path uses.
 	 */
 	async replaceAttachments(
 		scopeId: string,
@@ -314,7 +377,7 @@ export class TypeAvailabilityPolicyService {
 		assertNoDuplicateAttachmentSlots(attachments);
 
 		const result = await this.transactionRunner.run({}, async (ctx) => {
-			const scope = await this.scopeRepository.findScopeById(scopeId, ctx);
+			const scope = await this.scopeRepository.findScopeById(scopeId, ctx, true);
 			if (!scope) {
 				throw new NotFoundError(`Policy scope not found: ${scopeId}`);
 			}
@@ -403,7 +466,7 @@ export class TypeAvailabilityPolicyService {
 			const scopeId = scope
 				? scope.id
 				: (
-						await this.scopeRepository.createScope(
+						await this.createScopeOrConflict(
 							{ kind, projectId, defaultAction: input.defaultAction, updatedBy },
 							ctx,
 						)

--- a/packages/cli/test/integration/policy/type-availability-policy-instance.controller.test.ts
+++ b/packages/cli/test/integration/policy/type-availability-policy-instance.controller.test.ts
@@ -208,7 +208,7 @@ describe('node type availability policy instance controller admin happy path', (
 		const updated = await testServer
 			.authAgentFor(owner)
 			.patch(`/node-type-policies/policies/${policyId}`)
-			.send({ rules: [] });
+			.send({ rules: [], version: 1 });
 		expect(updated.statusCode).toBe(200);
 		expect(updated.body.data.policy.version).toBe(2);
 

--- a/packages/cli/test/integration/policy/type-availability-policy-instance.controller.test.ts
+++ b/packages/cli/test/integration/policy/type-availability-policy-instance.controller.test.ts
@@ -223,6 +223,93 @@ describe('node type availability policy instance controller admin happy path', (
 		expect(missing.statusCode).toBe(404);
 	});
 
+	test('PATCH /policies/:policyId with a stale version returns 409 and writes nothing', async () => {
+		const created = await testServer
+			.authAgentFor(owner)
+			.post('/node-type-policies/policies')
+			.send({ rules: [] });
+		const policyId = created.body.data.policy.id;
+
+		const first = await testServer
+			.authAgentFor(owner)
+			.patch(`/node-type-policies/policies/${policyId}`)
+			.send({
+				rules: [{ id: 'r1', action: 'deny', selector: { kind: 'name', value: 'a.b' } }],
+				version: 1,
+			});
+		expect(first.statusCode).toBe(200);
+		expect(first.body.data.policy.version).toBe(2);
+
+		const stale = await testServer
+			.authAgentFor(owner)
+			.patch(`/node-type-policies/policies/${policyId}`)
+			.send({ rules: [], version: 1 });
+		expect(stale.statusCode).toBe(409);
+
+		const fetched = await testServer
+			.authAgentFor(owner)
+			.get(`/node-type-policies/policies/${policyId}`);
+		expect(fetched.body.data.version).toBe(2);
+		expect(fetched.body.data.rules).toHaveLength(1);
+	});
+
+	test('PATCH /policies/:policyId without a version is rejected with 400', async () => {
+		const created = await testServer
+			.authAgentFor(owner)
+			.post('/node-type-policies/policies')
+			.send({ rules: [] });
+		const policyId = created.body.data.policy.id;
+
+		const response = await testServer
+			.authAgentFor(owner)
+			.patch(`/node-type-policies/policies/${policyId}`)
+			.send({ rules: [] });
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	test('PATCH on an attached document bumps the instance scope version', async () => {
+		const instancePut = await testServer
+			.authAgentFor(owner)
+			.put('/node-type-policies/instance')
+			.send({ rules: [], defaultAction: 'allow', version: 0 });
+		expect(instancePut.statusCode).toBe(200);
+		const versionBefore = instancePut.body.data.version;
+
+		const documents = await testServer.authAgentFor(owner).get('/node-type-policies/policies');
+		expect(documents.body.data).toHaveLength(1);
+		const document = documents.body.data[0];
+
+		const patched = await testServer
+			.authAgentFor(owner)
+			.patch(`/node-type-policies/policies/${document.id}`)
+			.send({
+				rules: [{ id: 'r1', action: 'deny', selector: { kind: 'name', value: 'a.b' } }],
+				version: document.version,
+			});
+		expect(patched.statusCode).toBe(200);
+
+		const instance = await testServer.authAgentFor(owner).get('/node-type-policies/instance');
+		expect(instance.body.data.version).toBeGreaterThan(versionBefore);
+		expect(instance.body.data.rules).toEqual([
+			{ id: 'r1', action: 'deny', selector: { kind: 'name', value: 'a.b' } },
+		]);
+
+		// Repeating the same rules is a no-op for the document, so the scope stays put too.
+		const repeated = await testServer
+			.authAgentFor(owner)
+			.patch(`/node-type-policies/policies/${document.id}`)
+			.send({
+				rules: [{ id: 'r1', action: 'deny', selector: { kind: 'name', value: 'a.b' } }],
+				version: patched.body.data.policy.version,
+			});
+		expect(repeated.statusCode).toBe(200);
+		const instanceAfterNoop = await testServer
+			.authAgentFor(owner)
+			.get('/node-type-policies/instance');
+		expect(instanceAfterNoop.body.data.version).toBe(instance.body.data.version);
+	});
+
 	test('DELETE /policies/:policyId on an attached policy returns 409, not a raw SQL error', async () => {
 		const created = await testServer
 			.authAgentFor(owner)

--- a/packages/cli/test/integration/policy/type-availability-policy-repositories.test.ts
+++ b/packages/cli/test/integration/policy/type-availability-policy-repositories.test.ts
@@ -247,6 +247,54 @@ describe('type availability policy repositories', () => {
 			expect((await scopeRepo.findScopeById(instanceScope.id, ROOT))?.version).toBe(2);
 			expect((await scopeRepo.findScopeById(projectScope.id, ROOT))?.version).toBe(2);
 		});
+
+		it('creates the scope when absent and reports it as created', async () => {
+			const { scope, created } = await scopeRepo.createScopeIfAbsent(
+				{ kind: KIND, projectId: null, defaultAction: 'deny', updatedBy: 'user-1' },
+				ROOT,
+			);
+
+			expect(created).toBe(true);
+			expect(scope.version).toBe(1);
+			expect(scope.defaultAction).toBe('deny');
+			expect((await scopeRepo.findScopeByKindAndProject(KIND, null, ROOT))?.id).toBe(scope.id);
+		});
+
+		it('returns the existing scope untouched, not created, when one already exists', async () => {
+			const existing = await createInstanceScope();
+
+			const { scope, created } = await scopeRepo.createScopeIfAbsent(
+				{ kind: KIND, projectId: null, defaultAction: 'deny', updatedBy: 'user-2' },
+				ROOT,
+			);
+
+			expect(created).toBe(false);
+			expect(scope.id).toBe(existing.id);
+			expect(scope.defaultAction).toBe('allow');
+			expect(scope.updatedBy).toBe('user-1');
+		});
+
+		it('locks only the scopes that exist and returns their ids', async () => {
+			const project = await createTeamProject();
+			const instanceScope = await createInstanceScope();
+			const projectScope = await scopeRepo.createScope(
+				{ kind: KIND, projectId: project.id, defaultAction: 'allow', updatedBy: 'user-1' },
+				ROOT,
+			);
+
+			const locked = await transactionRunner.run(ROOT, async (ctx) => {
+				return await scopeRepo.lockScopesByIds(
+					[projectScope.id, 'does-not-exist', instanceScope.id],
+					ctx,
+				);
+			});
+
+			expect(locked).toEqual([instanceScope.id, projectScope.id].sort());
+		});
+
+		it('locks nothing and returns an empty list for an empty input', async () => {
+			expect(await scopeRepo.lockScopesByIds([], ROOT)).toEqual([]);
+		});
 	});
 
 	describe('TypeAvailabilityPolicyAttachmentRepository', () => {

--- a/packages/cli/test/integration/policy/type-availability-policy-repositories.test.ts
+++ b/packages/cli/test/integration/policy/type-availability-policy-repositories.test.ts
@@ -5,7 +5,10 @@ import { Container } from '@n8n/di';
 import { TypeAvailabilityPolicyAttachmentRepository } from '@/modules/type-availability-policies/database/repositories/type-availability-policy-attachment.repository';
 import { TypeAvailabilityPolicyScopeRepository } from '@/modules/type-availability-policies/database/repositories/type-availability-policy-scope.repository';
 import { TypeAvailabilityPolicyRepository } from '@/modules/type-availability-policies/database/repositories/type-availability-policy.repository';
-import type { PolicyRule } from '@/modules/type-availability-policies/policy-rule.types';
+import type {
+	PolicyAction,
+	PolicyRule,
+} from '@/modules/type-availability-policies/policy-rule.types';
 
 const KIND = 'node-types';
 
@@ -56,10 +59,19 @@ describe('type availability policy repositories', () => {
 	}
 
 	async function createInstanceScope() {
-		return await scopeRepo.createScope(
+		const { scope } = await scopeRepo.createScopeIfAbsent(
 			{ kind: KIND, projectId: null, defaultAction: 'allow', updatedBy: 'user-1' },
 			ROOT,
 		);
+		return scope;
+	}
+
+	async function createProjectScope(projectId: string, defaultAction: PolicyAction = 'allow') {
+		const { scope } = await scopeRepo.createScopeIfAbsent(
+			{ kind: KIND, projectId, defaultAction, updatedBy: 'user-1' },
+			ROOT,
+		);
+		return scope;
 	}
 
 	describe('TypeAvailabilityPolicyRepository', () => {
@@ -200,10 +212,7 @@ describe('type availability policy repositories', () => {
 		it('does not confuse a project scope with the instance scope', async () => {
 			const project = await createTeamProject();
 			await createInstanceScope();
-			const projectScope = await scopeRepo.createScope(
-				{ kind: KIND, projectId: project.id, defaultAction: 'deny', updatedBy: 'user-1' },
-				ROOT,
-			);
+			const projectScope = await createProjectScope(project.id, 'deny');
 
 			const found = await scopeRepo.findScopeByKindAndProject(KIND, project.id, ROOT);
 
@@ -211,10 +220,18 @@ describe('type availability policy repositories', () => {
 			expect(found?.defaultAction).toBe('deny');
 		});
 
-		it('rejects a second instance scope for the same kind', async () => {
+		it('rejects a second instance scope for the same kind at the database level', async () => {
 			await createInstanceScope();
 
-			await expect(createInstanceScope()).rejects.toThrow();
+			const secondRow = scopeRepo.create({
+				kind: KIND,
+				projectId: null,
+				defaultAction: 'deny',
+				updatedBy: 'user-2',
+				version: 1,
+			});
+
+			await expect(scopeRepo.save(secondRow)).rejects.toThrow();
 		});
 
 		it('bumps the version when the default action changes', async () => {
@@ -237,10 +254,7 @@ describe('type availability policy repositories', () => {
 		it('bumps many versions at once', async () => {
 			const project = await createTeamProject();
 			const instanceScope = await createInstanceScope();
-			const projectScope = await scopeRepo.createScope(
-				{ kind: KIND, projectId: project.id, defaultAction: 'allow', updatedBy: 'user-1' },
-				ROOT,
-			);
+			const projectScope = await createProjectScope(project.id);
 
 			await scopeRepo.bumpVersions([instanceScope.id, projectScope.id], ROOT);
 
@@ -277,10 +291,7 @@ describe('type availability policy repositories', () => {
 		it('locks only the scopes that exist and returns their ids', async () => {
 			const project = await createTeamProject();
 			const instanceScope = await createInstanceScope();
-			const projectScope = await scopeRepo.createScope(
-				{ kind: KIND, projectId: project.id, defaultAction: 'allow', updatedBy: 'user-1' },
-				ROOT,
-			);
+			const projectScope = await createProjectScope(project.id);
 
 			const locked = await transactionRunner.run(ROOT, async (ctx) => {
 				return await scopeRepo.lockScopesByIds(
@@ -499,10 +510,7 @@ describe('type availability policy repositories', () => {
 			const project = await createTeamProject();
 			const policy = await createPolicy();
 			const instanceScope = await createInstanceScope();
-			const projectScope = await scopeRepo.createScope(
-				{ kind: KIND, projectId: project.id, defaultAction: 'allow', updatedBy: 'user-1' },
-				ROOT,
-			);
+			const projectScope = await createProjectScope(project.id);
 			for (const scopeId of [instanceScope.id, projectScope.id]) {
 				await attachmentRepo.replaceAttachmentsForScope(
 					scopeId,


### PR DESCRIPTION
## Summary
Follow-up to #37648, addressing the concurrency findings left open on that PR and on this one.

- **Lost updates on the scope version check.** `setDefaultAction` / `setEffectivePolicy` read the scope with a plain `findOneBy`, so two concurrent writers on Postgres could both pass the `expectedVersion` check and the second silently overwrote the first. The scope row is now locked (`FOR UPDATE`, Postgres only — SQLite has a single writer) for the duration of the write transaction.
- **First write had no row to lock.** Two racing first writes both passed the version-0 check and the loser hit the unique index with a raw driver error (500). The scope is now created with `INSERT … ON CONFLICT DO NOTHING` and read back under the lock; the loser gets a 409.
- **`PATCH /node-type-policies/policies/:policyId` had no optimistic concurrency** and never bumped the version of the scopes the document is attached to. `UpdatePolicyDocumentDto` now requires `version`; the service checks it in a locked transaction and bumps every attached scope — but only when the rules actually changed, matching `updateRules`' own no-op.
- **Consistent lock order.** PATCH locked document → scope while `PUT /instance` locked scope → document, which Postgres would abort as a deadlock. Every write path now locks scopes first (`lockScopesByIds`, sorted and `ORDER BY id`), including `replaceAttachments`.
- **Document delete** runs its attachment check and the delete in one locked transaction, so an attach cannot slip between them.

Linear: https://linear.app/n8n/issue/IAM-1329

## Test plan
- [x] `pnpm typecheck` (packages/cli)
- [x] Unit tests for `TypeAvailabilityPolicyService`: stale version → 409, lost first-write race → 409, no-op PATCH does not bump scopes, scope attached mid-update → 409, scopes locked before the document, locks requested on every guarded path
- [x] Integration (controller): PATCH stale → 409, PATCH without `version` → 400, PATCH on an attached document bumps `GET /instance` version, no-op PATCH leaves it alone
- [x] Integration (repositories): `createScopeIfAbsent` created / not-created, `lockScopesByIds` returns existing ids in order
- [x] Both integration suites run locally on **SQLite and Postgres 18**
- [x] `eslint` on changed files — 0 errors

Not covered: true concurrent-request tests. The lock and insert-or-ignore SQL executes in the Postgres runs; the interleavings themselves are reasoned about in the code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)