### PR TITLE
fix(core): Return 503 when the AI assistant service is unreachable

### DIFF
--- a/packages/cli/src/controllers/__tests__/ai.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/ai.controller.test.ts
@@ -6,12 +6,13 @@ import type {
 	AiGatewayUsageQueryDto,
 } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
-import { APIResponseError, type AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
+import { APIResponseError, NetworkError, type AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
 import { mock } from 'vitest-mock-extended';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
 import type { AiGatewayService } from '@/services/ai-gateway.service';
 import type { AiUsageService } from '@/services/ai-usage.service';
 import type { WorkflowBuilderService } from '@/services/ai-workflow-builder.service';
@@ -86,6 +87,14 @@ describe('AiController', () => {
 			aiService.chat.mockRejectedValue(new APIResponseError('Session not found', 404));
 
 			await expect(controller.chat(request, response, payload)).rejects.toThrow(NotFoundError);
+		});
+
+		it('should map an unreachable AI assistant service to ServiceUnavailableError', async () => {
+			aiService.chat.mockRejectedValue(new NetworkError(new TypeError('fetch failed')));
+
+			await expect(controller.chat(request, response, payload)).rejects.toThrow(
+				ServiceUnavailableError,
+			);
 		});
 
 		it('should register a close handler on the response for abort', async () => {
@@ -507,6 +516,16 @@ describe('AiController', () => {
 				InternalServerError,
 			);
 			expect(workflowBuilderService.getBuilderInstanceCredits).toHaveBeenCalledWith(request.user);
+		});
+
+		it('should map an unreachable AI assistant service to ServiceUnavailableError', async () => {
+			workflowBuilderService.getBuilderInstanceCredits.mockRejectedValue(
+				new NetworkError(new TypeError('fetch failed')),
+			);
+
+			await expect(controller.getBuilderCredits(request, response)).rejects.toThrow(
+				ServiceUnavailableError,
+			);
 		});
 	});
 

--- a/packages/cli/src/controllers/ai.controller.ts
+++ b/packages/cli/src/controllers/ai.controller.ts
@@ -17,7 +17,7 @@ import {
 } from '@n8n/api-types';
 import { AuthenticatedRequest } from '@n8n/db';
 import { Body, Get, Licensed, Post, Query, RestController, GlobalScope } from '@n8n/decorators';
-import { type AiAssistantSDK, APIResponseError } from '@n8n_io/ai-assistant-sdk';
+import { type AiAssistantSDK, APIResponseError, NetworkError } from '@n8n_io/ai-assistant-sdk';
 import { Response } from 'express';
 import { strict as assert } from 'node:assert';
 import { WritableStream } from 'node:stream/web';
@@ -27,6 +27,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
 import { TooManyRequestsError } from '@/errors/response-errors/too-many-requests.error';
 import { AiGatewayService } from '@/services/ai-gateway.service';
 import { AiUsageService } from '@/services/ai-usage.service';
@@ -59,6 +60,19 @@ export class AiController {
 			default:
 				return new InternalServerError(error.message, error);
 		}
+	}
+
+	/** Maps a failure from a service call to the HTTP error the client should see. */
+	private toResponseError(error: unknown) {
+		// The AI assistant service could not be reached (DNS, refused connection, timeout).
+		if (error instanceof NetworkError) {
+			return new ServiceUnavailableError(error.message);
+		}
+		if (error instanceof APIResponseError) {
+			return this.toAiAssistantResponseError(error);
+		}
+		assert(error instanceof Error);
+		return new InternalServerError(error.message, error);
 	}
 
 	// Use usesTemplates flag to bypass the send() wrapper which would cause
@@ -179,11 +193,7 @@ export class AiController {
 			if (e instanceof DOMException && e.name === 'AbortError') {
 				return;
 			}
-			if (e instanceof APIResponseError) {
-				throw this.toAiAssistantResponseError(e);
-			}
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -196,8 +206,7 @@ export class AiController {
 		try {
 			return await this.aiService.applySuggestion(payload, req.user);
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -216,12 +225,7 @@ export class AiController {
 		try {
 			return await this.aiService.askAi(payload, req.user);
 		} catch (e) {
-			if (e instanceof APIResponseError) {
-				throw this.toAiAssistantResponseError(e);
-			}
-
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -230,8 +234,7 @@ export class AiController {
 		try {
 			return await this.freeAiCreditsService.claim(req.user, payload?.projectId);
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -250,8 +253,7 @@ export class AiController {
 			);
 			return sessions;
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -262,8 +264,7 @@ export class AiController {
 		try {
 			return await this.aiGatewayService.getGatewayConfig();
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -274,8 +275,7 @@ export class AiController {
 		try {
 			return await this.aiGatewayService.getWallet(req.user.id);
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -290,8 +290,7 @@ export class AiController {
 		try {
 			return await this.aiGatewayService.getUsage(req.user.id, query.offset, query.limit);
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -304,8 +303,7 @@ export class AiController {
 		try {
 			return await this.workflowBuilderService.getBuilderInstanceCredits(req.user);
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -325,8 +323,7 @@ export class AiController {
 			);
 			return { success };
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -341,8 +338,7 @@ export class AiController {
 			await this.workflowBuilderService.clearSession(payload.workflowId, req.user);
 			return { success: true };
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 
@@ -356,8 +352,7 @@ export class AiController {
 		try {
 			await this.aiUsageService.updateAiUsageSettings(payload.allowSendingParameterValues);
 		} catch (e) {
-			assert(e instanceof Error);
-			throw new InternalServerError(e.message, e);
+			throw this.toResponseError(e);
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ catalogs:
       specifier: ^0.6.0
       version: 0.6.0
     '@n8n_io/ai-assistant-sdk':
-      specifier: 1.26.0
-      version: 1.26.0
+      specifier: 1.27.0
+      version: 1.27.0
     '@openrouter/ai-sdk-provider':
       specifier: ^3.0.0
       version: 3.0.0
@@ -1301,7 +1301,7 @@ importers:
         version: link:../workflow-sdk
       '@n8n_io/ai-assistant-sdk':
         specifier: 'catalog:'
-        version: 1.26.0
+        version: 1.27.0
       axios:
         specifier: 1.18.0
         version: 1.18.0(patch_hash=149e256a2a7b632497650b32816716ced972ab02a5ab00fbd8a5158a51722c49)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -1401,7 +1401,7 @@ importers:
         version: link:../permissions
       '@n8n_io/ai-assistant-sdk':
         specifier: 'catalog:'
-        version: 1.26.0
+        version: 1.27.0
       n8n-workflow:
         specifier: workspace:*
         version: link:../../workflow
@@ -4317,7 +4317,7 @@ importers:
         version: link:../@n8n/workflow-sdk
       '@n8n_io/ai-assistant-sdk':
         specifier: 'catalog:'
-        version: 1.26.0
+        version: 1.27.0
       '@n8n_io/license-sdk':
         specifier: 3.0.0
         version: 3.0.0
@@ -10973,8 +10973,8 @@ packages:
       sqlite3:
         optional: true
 
-  '@n8n_io/ai-assistant-sdk@1.26.0':
-    resolution: {integrity: sha512-iVW3dfhg48WipFhiVUjOIqo0MvFv1wrGamvbTUZusMF13NjycicLZSE1Bd4V6nLsLtSqcOfZ1m8LXFrmZyxOOw==}
+  '@n8n_io/ai-assistant-sdk@1.27.0':
+    resolution: {integrity: sha512-xCELByG49K24I1rVx6o3FueAH1+cu66d7ojoQepkbfsphIK0HLZisTCZ3/MmgtZUjvXMUI0Ekg46NWHvMMcJtQ==}
     engines: {node: '>=20.15', pnpm: '>=8.14'}
 
   '@n8n_io/license-sdk@3.0.0':
@@ -30405,7 +30405,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@n8n_io/ai-assistant-sdk@1.26.0': {}
+  '@n8n_io/ai-assistant-sdk@1.27.0': {}
 
   '@n8n_io/license-sdk@3.0.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -116,7 +116,7 @@ catalog:
   '@modelcontextprotocol/sdk': 1.26.0
   '@modelcontextprotocol/server': 2.0.0
   '@mozilla/readability': ^0.6.0
-  '@n8n_io/ai-assistant-sdk': 1.26.0
+  '@n8n_io/ai-assistant-sdk': 1.27.0
   '@openrouter/ai-sdk-provider': ^3.0.0
   '@opentelemetry/api': 1.9.1
   '@pinecone-database/pinecone': ^5.0.2


### PR DESCRIPTION
## Summary

undici rejects an unreachable host with an opaque `TypeError: fetch failed`. The AI assistant SDK used to rewrap it as an `APIResponseError` without a status code, or let the bare `TypeError` escape, and `AiController` turned both into a 500 `InternalServerError`. Sentry then reported every network blip as "ResponseError: fetch failed".

- Bump `@n8n_io/ai-assistant-sdk` to 1.27.0. The SDK now wraps transport failures in a warning-level `NetworkError` with the undici cause attached ([ai-assistant-service PR 603](https://github.com/n8n-io/ai-assistant-service/pull/603)).
- Add one `toResponseError()` mapper in `ai.controller.ts` and use it in every catch block. `NetworkError` becomes a 503 `ServiceUnavailableError`, `APIResponseError` keeps the existing status mapping, everything else stays a 500. Behavior for non-SDK errors does not change.

The 503 has level `info` in n8n and the SDK error on `cause` has level `warning`, so `ErrorReporter` skips it and the Sentry issue stops.

## How to test

1. Set `N8N_AI_ASSISTANT_BASE_URL` to a host that does not resolve, for example `https://does-not-exist.n8n.invalid`.
2. Open the AI assistant chat and send a message, or call `GET /rest/ai/build/credits`.
3. Expect a 503 with the message `Could not reach the AI assistant service: getaddrinfo ENOTFOUND ...` instead of a 500 `fetch failed`, and no Sentry event.

Unit tests: `pnpm test src/controllers/__tests__/ai.controller.test.ts` in `packages/cli`. 35 tests pass, two are new and cover the 503 mapping for `chat` and `getBuilderCredits`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-512

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

