### PR TITLE
fix(core): Report the provider response when a chat model returns no choices

### DIFF
--- a/patches/@langchain__openai@1.4.4.patch
+++ b/patches/@langchain__openai@1.4.4.patch
@@ -1,3 +1,33 @@
+diff --git a/dist/chat_models/completions.cjs b/dist/chat_models/completions.cjs
+index 170a396ce0b6c16ff536c27f62dc011bfd8154a2..ef4056370af2d3385ef053489c61f2442897eba0 100644
+--- a/dist/chat_models/completions.cjs
++++ b/dist/chat_models/completions.cjs
+@@ -129,6 +129,10 @@ var ChatOpenAICompletions = class extends require_base.BaseChatOpenAI {
+ 				generation.message = new _langchain_core_messages.AIMessage(Object.fromEntries(Object.entries(generation.message).filter(([key]) => !key.startsWith("lc_"))));
+ 				generations.push(generation);
+ 			}
++			if (generations.length === 0) {
++				const body = typeof data === "string" ? data : JSON.stringify(data) ?? "";
++				throw new Error(`Received empty response from chat model call (no choices). Response body: ${body.slice(0, 500)}`);
++			}
+ 			return {
+ 				generations,
+ 				llmOutput: { tokenUsage: {
+diff --git a/dist/chat_models/completions.js b/dist/chat_models/completions.js
+index 57d3e6a4e2e0046f6d1bb10c320414224443b1b3..23d84e0159310a17347a4f088dde5a0f596f8c6f 100644
+--- a/dist/chat_models/completions.js
++++ b/dist/chat_models/completions.js
+@@ -129,6 +129,10 @@ var ChatOpenAICompletions = class extends BaseChatOpenAI {
+ 				generation.message = new AIMessage(Object.fromEntries(Object.entries(generation.message).filter(([key]) => !key.startsWith("lc_"))));
+ 				generations.push(generation);
+ 			}
++			if (generations.length === 0) {
++				const body = typeof data === "string" ? data : JSON.stringify(data) ?? "";
++				throw new Error(`Received empty response from chat model call (no choices). Response body: ${body.slice(0, 500)}`);
++			}
+ 			return {
+ 				generations,
+ 				llmOutput: { tokenUsage: {
 diff --git a/dist/converters/completions.cjs b/dist/converters/completions.cjs
 index 791756ca4ec9fed98ecb44b90e090ad8d00db40a..f1fd00d4c699a34b342443bed84f2b4aeb6de021 100644
 --- a/dist/converters/completions.cjs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,7 +859,7 @@ overrides:
 patchedDependencies:
   '@confluentinc/kafka-javascript@1.9.1': c597d3e3d9d6d0d33588b7dc1e88d55f270ba155721aad464bd7fb03e28f5003
   '@langchain/google-common@2.1.24': b50436a6c7b0a82d54472dff331ba1b42ab8b816995f83295eef2ee4b482a87d
-  '@langchain/openai@1.4.4': 0160a23d307d3bb4aedce23be0d1df4224738bee9184dd4b56bc03eaa37c9a87
+  '@langchain/openai@1.4.4': e16bcc93cf9037198faacf494fb81afba6e9abba749dc9a09c3abfb33e68d5c2
   '@lezer/highlight': 97f85e6fe46f23015ea0dd420e33d584bc2dc71633910cf131321da31b27ca8c
   '@types/express-serve-static-core@5.0.6': d602248fcd302cf5a794d1e85a411633ba9635ea5d566d6f2e0429c7ae0fa3eb
   '@types/ws@8.18.1': 682b44b740be55e5d7018e6fe335880851dadf2524b6c723c9ed0c29cb2fa7fb
@@ -1162,7 +1162,7 @@ importers:
         version: 1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 1.4.4(patch_hash=0160a23d307d3bb4aedce23be0d1df4224738bee9184dd4b56bc03eaa37c9a87)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.4.4(patch_hash=e16bcc93cf9037198faacf494fb81afba6e9abba749dc9a09c3abfb33e68d5c2)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@langchain/textsplitters':
         specifier: 1.0.1
         version: 1.0.1(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
@@ -1271,7 +1271,7 @@ importers:
         version: 1.0.0(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 1.4.4(patch_hash=0160a23d307d3bb4aedce23be0d1df4224738bee9184dd4b56bc03eaa37c9a87)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.4.4(patch_hash=e16bcc93cf9037198faacf494fb81afba6e9abba749dc9a09c3abfb33e68d5c2)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@mozilla/readability':
         specifier: 'catalog:'
         version: 0.6.0
@@ -3289,7 +3289,7 @@ importers:
         version: 1.2.6(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 1.4.4(patch_hash=0160a23d307d3bb4aedce23be0d1df4224738bee9184dd4b56bc03eaa37c9a87)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.4.4(patch_hash=e16bcc93cf9037198faacf494fb81afba6e9abba749dc9a09c3abfb33e68d5c2)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@langchain/pinecone':
         specifier: 1.0.1
         version: 1.0.1(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@pinecone-database/pinecone@5.1.2)
@@ -29869,7 +29869,7 @@ snapshots:
       - '@smithy/signature-v4'
       - ws
 
-  '@langchain/openai@1.4.4(patch_hash=0160a23d307d3bb4aedce23be0d1df4224738bee9184dd4b56bc03eaa37c9a87)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@1.4.4(patch_hash=e16bcc93cf9037198faacf494fb81afba6e9abba749dc9a09c3abfb33e68d5c2)(@aws-sdk/credential-provider-node@3.972.80)(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@langchain/core': 1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       js-tiktoken: 1.0.21


### PR DESCRIPTION
## Summary

When an OpenAI-compatible chat-completions endpoint answers with HTTP 2xx but without `choices` (an `error` object under status 200, `choices: []`, an empty body, or a non-JSON body such as an HTML page from a wrong base URL), `@langchain/openai` returned `{ generations: [] }`. `@langchain/core` then read `generations[0][0].message` on that empty array, and the node failed with:

```
Cannot read properties of undefined (reading 'message')
```

The user could not see what the provider had sent. Upstream has the same defect open (langchain-ai/langchainjs#9545); `main` is unchanged.

This PR extends the existing pnpm patch for `@langchain/openai@1.4.4`. The non-streaming `_generate` now throws when the response has no choices. The message includes the first 500 characters of the response body:

```
Received empty response from chat model call (no choices). Response body: {"error":{"message":"Rate limit exceeded","code":429}}
```

The fix applies to every node that builds `ChatOpenAI`: OpenAI Chat Model (including custom base URLs), Azure OpenAI, OpenRouter, DeepSeek, xAI Grok, Vercel AI Gateway, Moonshot, MiniMax, NVIDIA, Databricks, Alibaba Cloud, and Lemonade. It reaches every consumer: AI Agent, Basic LLM Chain, Text Classifier, and the other chains.

The existing DeepSeek `reasoning_content` hunks in the patch are unchanged. The patched module was verified with a local HTTP server that returns `{}`, `{"choices":[]}`, an `error` object, and an HTML page with status 200; a valid completion still returns normally.

## How to test

1. Start a server that answers `200 {}` on every request:
   ```
   node -e "require('http').createServer((_, res) => { res.setHeader('content-type', 'application/json'); res.end('{}'); }).listen(8081)"
   ```
2. Create an OpenAI credential with any API key and Base URL `http://localhost:8081/v1`.
3. Add an AI Agent or a Basic LLM Chain with an OpenAI Chat Model that uses this credential. Run the workflow.
4. Before this PR, the node fails with `Cannot read properties of undefined (reading 'message')`.
   After this PR, the node fails with `Received empty response from chat model call (no choices). Response body: {}`.
5. Replace `'{}'` in the server with `'{"error":{"message":"Rate limit exceeded","code":429}}'` and run again. The error message now shows the provider error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2741

Sentry:
Fixes INSTANCE-BACKEND-27YQ
Fixes INSTANCE-BACKEND-28AK
Fixes INSTANCE-BACKEND-28BK
Fixes INSTANCE-BACKEND-1ZVK
Fixes INSTANCE-BACKEND-20TE

Upstream: https://github.com/langchain-ai/langchainjs/issues/9545

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

