### PR TITLE
ci: Resolve image SBOM licenses (no-changelog)

### DIFF
--- a/scripts/licenses/license-overrides.json
+++ b/scripts/licenses/license-overrides.json
@@ -55,6 +55,14 @@
       "license": "MIT",
       "source": "https://github.com/rhashimoto/wa-sqlite — LICENSE file in published tarball confirms MIT. Package is installed via GitHub tarball URL so npm registry metadata is absent; no license field in package.json. Version-agnostic: the PURL emitted by cdxgen for tarball installs can vary (version field vs. commit SHA vs. qualifiers) depending on lockfile format and cdxgen version; name-keyed matching is stable across those variations."
     },
+    "@kafkajs/confluent-schema-registry": {
+      "license": "MIT",
+      "source": "https://github.com/kafkajs/confluent-schema-registry/blob/b80b15f8dc287c8dce9a6205e171381bf50a492d/LICENSE — verbatim MIT for the commit published as 3.8.0. The published package has no license field in package.json."
+    },
+    "@getzep/zep-cloud": {
+      "license": "Apache-2.0",
+      "source": "https://github.com/getzep/zep-js/blob/main/LICENSE — 'Apache License, Version 2.0, January 2004'. The published package carries no license field (the npm registry reports null) and ships no LICENSE file."
+    },
     "@n8n_io/license-sdk": {
       "license": "LicenseRef-n8n-enterprise",
       "source": "n8n-io/license-management — ships LICENSE_EE.md (n8n Enterprise License). EE-only runtime component; not under the Sustainable Use License. Version-agnostic: license is stable across SDK versions. FIRST_PARTY_PATTERNS would otherwise incorrectly stamp it as LicenseRef-n8n-sustainable-use.",


### PR DESCRIPTION
## Summary

Add explicit license overrides for two packages in the 2.37 release image.

The overrides remove the release gate's dependency on GitHub license lookups for these packages. The GitHub API rate limit caused these lookups to fail during the 2.37.11 release.

## How to test

Run the focused license test suite:

```bash
node --test scripts/licenses/*.test.mjs
```

Confirm that all 106 tests pass.

## Related Linear tickets, Github issues, and Community forum posts

- Failed release run: https://github.com/n8n-io/n8n/actions/runs/34096169488
- Master implementation: https://github.com/n8n-io/n8n/pull/37344

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

