### PR TITLE
fix(node-cli): Escape GitHub Actions expressions in template workflows

### DIFF
--- a/packages/@n8n/node-cli/src/commands/new/index.test.ts
+++ b/packages/@n8n/node-cli/src/commands/new/index.test.ts
@@ -74,6 +74,15 @@ describe('new command', () => {
 			'export class Example implements INodeType',
 		);
 
+		await expect(tmpdir).toHaveFileContaining(
+			'n8n-nodes-my-awesome-api/.github/workflows/ci.yml',
+			'group: ci-${{ github.ref }}',
+		);
+		await expect(tmpdir).toHaveFileContaining(
+			'n8n-nodes-my-awesome-api/.github/workflows/publish.yml',
+			'NPM_TOKEN: ${{ secrets.NPM_TOKEN }}',
+		);
+
 		// Check if credentials files exist
 		try {
 			const credentialsPath = `${tmpdir}/n8n-nodes-my-awesome-api/credentials`;

--- a/packages/@n8n/node-cli/src/commands/release.test.ts
+++ b/packages/@n8n/node-cli/src/commands/release.test.ts
@@ -147,6 +147,7 @@ describe('release command', () => {
 			expect(content).toContain('pnpm install');
 			expect(content).toContain('pnpm run release');
 			expect(content).not.toContain('{{packageManager');
+			expect(content).toContain('NPM_TOKEN: ${{ secrets.NPM_TOKEN }}');
 			expect(result.getLogMessages('success')).toEqual(
 				expect.arrayContaining([expect.stringContaining('publish.yml')]),
 			);

--- a/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/ci.yml
+++ b/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 # Cancel in-progress runs for the same branch/PR to avoid wasting CI minutes.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-$\{{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/publish.yml
+++ b/packages/@n8n/node-cli/src/template/templates/shared/default/.github/workflows/publish.yml
@@ -96,4 +96,4 @@ jobs:
           [ -n "$NPM_TOKEN" ] && npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           {{packageManager.name}} run release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: $\{{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

When scaffolding a new custom community node with `npm create @n8n/node@latest` or running `n8n-node release --init-workflow`, the CLI uses Handlebars to compile template files.

Because `.github/workflows/publish.yml` and `.github/workflows/ci.yml` had unescaped `${{ secrets.NPM_TOKEN }}` and `${{ github.ref }}`, Handlebars treated them as undefined template expressions and collapsed them to empty strings (leaving `NPM_TOKEN: $` and `group: ci-$`).

This PR escapes the `${{` expressions using `$\{{` in Handlebars so that they render as literal `${{ secrets.NPM_TOKEN }}` and `${{ github.ref }}` in the generated workflow files.

## How to test

1. Run unit tests for release command:
   ```bash
   pnpm --filter @n8n/node-cli test src/commands/release.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
## Related Linear tickets, Github issues, and Community forum posts

Closes #37932

