### PR TITLE
fix(Postgres Trigger Node): Release the direct database connection on cleanup

### DIFF
--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -301,7 +301,19 @@ export class PostgresTrigger implements INodeType {
 			throw error;
 		}
 
+		// Cleanup runs at most once. A manual execution reaches it twice: the 60s
+		// timeout below calls it before rejecting, and n8n then calls closeFunction
+		// as that execution unwinds. Releasing the connection makes the second pass
+		// consequential — its `SELECT 1` health probe fails against a connection the
+		// first pass already returned, turning a cleanup that fully succeeded into a
+		// TriggerCloseError warning. Nothing is lost by skipping it: the connection is
+		// gone, so a second pass could not issue UNLISTEN or DROP either way.
+		let cleanedUp = false;
+
 		const cleanUpDb = async () => {
+			if (cleanedUp) return;
+			cleanedUp = true;
+
 			try {
 				try {
 					// check if the connection is healthy

--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -306,14 +306,12 @@ export class PostgresTrigger implements INodeType {
 		// as that execution unwinds. Releasing the connection makes the second pass
 		// consequential — its `SELECT 1` health probe fails against a connection the
 		// first pass already returned, turning a cleanup that fully succeeded into a
-		// TriggerCloseError warning. Nothing is lost by skipping it: the connection is
-		// gone, so a second pass could not issue UNLISTEN or DROP either way.
-		let cleanedUp = false;
+		// TriggerCloseError warning. The second caller joins the first pass instead:
+		// the connection is gone either way, so there is no UNLISTEN or DROP left for it
+		// to issue, but it must not be told cleanup finished before it actually has.
+		let cleanUp: Promise<void> | undefined;
 
-		const cleanUpDb = async () => {
-			if (cleanedUp) return;
-			cleanedUp = true;
-
+		const runCleanUp = async () => {
 			try {
 				try {
 					// check if the connection is healthy
@@ -357,6 +355,15 @@ export class PostgresTrigger implements INodeType {
 					// cleanup error we may be unwinding from.
 				}
 			}
+		};
+
+		const cleanUpDb = async () => {
+			// Holding the promise rather than a boolean means a caller that arrives while
+			// the first pass is still awaiting UNLISTEN joins that pass instead of
+			// returning early. Deactivation must not report itself finished while the
+			// trigger is still being dropped, or a reactivation could recreate it first.
+			cleanUp ??= runCleanUp();
+			await cleanUp;
 		};
 
 		connection.client.on('notification', onNotification);

--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -335,6 +335,15 @@ export class PostgresTrigger implements INodeType {
 				}
 			} finally {
 				connection.client.removeListener('notification', onNotification);
+				try {
+					// Direct connections are only returned to the pool by done(), the same way the
+					// setup-failure path above releases them.
+					await connection.done();
+				} catch {
+					// Already released - by an earlier cleanup, or automatically by pg-promise when the
+					// connection was lost. done() throws in that state, and that must not mask the
+					// cleanup error we may be unwinding from.
+				}
 			}
 		};
 

--- a/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
@@ -143,11 +143,20 @@ describe('pgTriggerFunction', () => {
 
 describe('PostgresTrigger.trigger (Table Row Change Events mode)', () => {
 	const setup = (additionalFields: IDataObject = {}, firesOn = 'INSERT') => {
+		// A pg-promise direct connection only answers queries until done() returns
+		// it; after that pg-promise throws. The mock mirrors that, because whether
+		// a second cleanup pass is harmless depends on exactly this behaviour.
+		let released = false;
 		const connection = {
 			none: vi.fn().mockResolvedValue(undefined),
 			any: vi.fn().mockResolvedValue([]),
-			query: vi.fn().mockResolvedValue([]),
-			done: vi.fn().mockResolvedValue(undefined),
+			query: vi.fn(async () => {
+				if (released) throw new Error('Loose request outside of an expired connection');
+				return [];
+			}),
+			done: vi.fn(async () => {
+				released = true;
+			}),
 			client: { on: vi.fn(), removeListener: vi.fn() },
 		};
 		const db = {
@@ -221,10 +230,27 @@ describe('PostgresTrigger.trigger (Table Row Change Events mode)', () => {
 		const { connection, fns } = setup();
 		// pg-promise throws from done() once the connection context is gone — because it was
 		// released by an earlier cleanup or dropped automatically when the connection was lost.
-		connection.done.mockRejectedValue(new Error('Cannot invoke done() on a disconnected client'));
+		// It throws synchronously there, not as a rejected promise, so model that.
+		connection.done.mockImplementation(() => {
+			throw new Error('Cannot invoke done() on a disconnected client');
+		});
 		const response = await new PostgresTrigger().trigger.call(fns);
 
 		await expect(response.closeFunction?.()).resolves.toBeUndefined();
+	});
+
+	it('cleans up once, so a second close cannot fail against a released connection', async () => {
+		const { connection, fns } = setup();
+		const response = await new PostgresTrigger().trigger.call(fns);
+
+		// A manual execution reaches cleanup twice: its 60s timeout cleans up before
+		// rejecting, and n8n then calls closeFunction as the execution unwinds. The
+		// second pass must not probe a connection the first one returned to the pool.
+		await response.closeFunction?.();
+		await expect(response.closeFunction?.()).resolves.toBeUndefined();
+
+		expect(connection.done).toHaveBeenCalledTimes(1);
+		expect(connection.query).toHaveBeenCalledTimes(1);
 	});
 });
 
@@ -232,6 +258,9 @@ describe('PostgresTrigger.trigger (Advanced mode)', () => {
 	const setup = (channelName: string) => {
 		const connection = {
 			none: vi.fn().mockResolvedValue(undefined),
+			any: vi.fn().mockResolvedValue([]),
+			query: vi.fn().mockResolvedValue([]),
+			done: vi.fn().mockResolvedValue(undefined),
 			client: { on: vi.fn(), removeListener: vi.fn() },
 		};
 		const db = { connect: vi.fn().mockResolvedValue(connection) };
@@ -274,6 +303,17 @@ describe('PostgresTrigger.trigger (Advanced mode)', () => {
 		await expect(new PostgresTrigger().trigger.call(fns)).rejects.toThrow(/Channel name must/);
 		expect(db.connect).not.toHaveBeenCalled();
 		expect(connection.none).not.toHaveBeenCalled();
+	});
+
+	// Both trigger modes share cleanUpDb, so the release has to hold here too.
+	it('releases the connection when the trigger is closed', async () => {
+		const { connection, fns } = setup('my_channel');
+		const response = await new PostgresTrigger().trigger.call(fns);
+
+		await response.closeFunction?.();
+
+		expect(connection.none).toHaveBeenCalledWith('UNLISTEN $1:name', ['my_channel']);
+		expect(connection.done).toHaveBeenCalled();
 	});
 });
 

--- a/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
@@ -252,6 +252,41 @@ describe('PostgresTrigger.trigger (Table Row Change Events mode)', () => {
 		expect(connection.done).toHaveBeenCalledTimes(1);
 		expect(connection.query).toHaveBeenCalledTimes(1);
 	});
+
+	it('makes a concurrent close join the in-flight cleanup rather than return early', async () => {
+		const { connection, fns } = setup();
+		const response = await new PostgresTrigger().trigger.call(fns);
+
+		// Park the first pass inside UNLISTEN. A guard that only records that cleanup
+		// has started lets the second caller resolve here, so deactivation reports
+		// itself finished while the trigger is still being dropped — and a reactivation
+		// can recreate that trigger before the first pass gets round to dropping it.
+		let releaseUnlisten: () => void = () => {};
+		connection.none.mockImplementationOnce(
+			async () =>
+				await new Promise<void>((resolve) => {
+					releaseUnlisten = resolve;
+				}),
+		);
+
+		const first = response.closeFunction?.();
+		const second = response.closeFunction?.();
+		let secondSettled = false;
+		void second?.then(() => {
+			secondSettled = true;
+		});
+
+		await new Promise((resolve) => setImmediate(resolve));
+		// LISTEN during setup, then the UNLISTEN we are holding.
+		expect(connection.none).toHaveBeenCalledTimes(2);
+		expect(secondSettled).toBe(false);
+
+		releaseUnlisten();
+		await Promise.all([first, second]);
+
+		expect(secondSettled).toBe(true);
+		expect(connection.done).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe('PostgresTrigger.trigger (Advanced mode)', () => {

--- a/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
@@ -207,6 +207,25 @@ describe('PostgresTrigger.trigger (Table Row Change Events mode)', () => {
 		await expect(new PostgresTrigger().trigger.call(fns)).rejects.toThrow();
 		expect(connection.done).toHaveBeenCalled();
 	});
+
+	it('releases the connection when the trigger is closed', async () => {
+		const { connection, fns } = setup();
+		const response = await new PostgresTrigger().trigger.call(fns);
+
+		await response.closeFunction?.();
+
+		expect(connection.done).toHaveBeenCalled();
+	});
+
+	it('does not surface a release failure when the connection is already gone', async () => {
+		const { connection, fns } = setup();
+		// pg-promise throws from done() once the connection context is gone — because it was
+		// released by an earlier cleanup or dropped automatically when the connection was lost.
+		connection.done.mockRejectedValue(new Error('Cannot invoke done() on a disconnected client'));
+		const response = await new PostgresTrigger().trigger.call(fns);
+
+		await expect(response.closeFunction?.()).resolves.toBeUndefined();
+	});
 });
 
 describe('PostgresTrigger.trigger (Advanced mode)', () => {


### PR DESCRIPTION
## Root cause

`PostgresTrigger.node.ts:270` opens a dedicated session rather than borrowing from the pool:

```ts
const connection = await db.connect({ direct: true });
```

In pg-promise a connection acquired this way is only handed back when `done()` is called on it.
The node already knows this — the setup-failure path at `:299` does exactly that, under a comment
the codebase wrote itself about not leaking on failure:

```ts
} catch (error) {
    await connection.done();
    throw error;
}
```

But `cleanUpDb` (`:304`), which is the body of `closeFunction` (`:345`) and therefore what n8n
calls on every deactivation, ends like this:

```ts
} finally {
    connection.client.removeListener('notification', onNotification);
}
```

It issues `UNLISTEN`, drops the function and trigger, detaches the listener — and never releases
the connection. The socket stays open. Each activate/deactivate cycle leaves one more `idle`
session behind, which is what both reporters observed in `pg_stat_activity`, ending at
`FATAL: 53300: remaining connection slots are reserved`.

`connection.done()` is the established release idiom in this node family: `PostgresTrigger.node.ts:299`,
`Postgres/v1/PostgresV1.node.ts:320`, `Postgres/v2/methods/credentialTest.ts:43`. This is a
missing call, not a behavioural choice.

## Why the release is guarded

`await connection.done()` on its own would introduce a second bug, so it is wrapped:

```ts
try {
    await connection.done();
} catch {
    // already released
}
```

`done()` is not idempotent. In `pg-promise@11.9.1`, `lib/database.js:256`:

```js
done(kill) {
    if (!ctx.db) {
        throw new Error(npm.text.looseQuery);
    }
    return ctx.disconnect(kill);
}
```

Two situations reach a cleared `ctx.db`:

1. `cleanUpDb` has more than one caller. Besides `closeFunction`, the manual-execution timeout at
   `:355` calls it, and n8n may still invoke `closeFunction` afterwards. The second pass would
   throw on `done()`.
2. pg-promise releases lost connections by itself — its own docs say *"You do not need to call
   `done` on lost connections, as it happens automatically."*

Both cases matter here because `cleanUpDb` may already be unwinding a `TriggerCloseError` (the
`level: 'warning'` one raised at `:311` when the health check fails). An exception thrown from a
`finally` replaces the in-flight one, so an unguarded release would turn that warning into an
unrelated `looseQuery` error on workflow close. The `catch` keeps the original error intact.

## Tests

Both added to `PostgresTrigger.test.ts`, next to the existing
`releases the connection when setup fails`, which is the mirror of the first one and already had
`done: vi.fn()` on the connection mock:

- `releases the connection when the trigger is closed` — drives `closeFunction` and asserts
  `connection.done` was called. **This is the regression test and it fails on master.**
- `does not surface a release failure when the connection is already gone` — makes `done()`
  reject and asserts `closeFunction` still resolves, covering the guard above.

Reverting only `PostgresTrigger.node.ts` to its master state with `git show`, keeping both new
tests:

```
# source at master (188e285), tests from this branch
 × PostgresTrigger.trigger (Table Row Change Events mode) > releases the connection when the trigger is closed
      Tests  1 failed | 266 passed (267)

# with this branch's fix
      Tests  267 passed (267)
```

## Commands run

```
$ npx vitest run nodes/Postgres/test/PostgresTrigger.test.ts
  Tests  36 passed (36)

$ npx vitest run nodes/Postgres
  Test Files  1 failed | 7 passed (8)
  Tests  267 passed (267)
  # the failing file is nodes/Postgres/test/v1/PostgresV1.node.test.ts, which does not run at all
  # for me: "Failed to resolve entry for package n8n-core". It fails identically on unmodified
  # master and no test inside it executes.

$ npx eslint nodes/Postgres/PostgresTrigger.node.ts nodes/Postgres/test/PostgresTrigger.test.ts --quiet
  exit 0

$ npx biome check nodes/Postgres/PostgresTrigger.node.ts nodes/Postgres/test/PostgresTrigger.test.ts
  Checked 2 files. No fixes applied.   # exit 0
```

## What I did not verify

- **I did not reproduce the leak against a real PostgreSQL server.** The evidence here is the
  source path, the pg-promise contract, and unit tests against the existing mock — not a
  `pg_stat_activity` count before and after. If you want that before merging, say so; the two
  issues have the observed numbers from real instances.
- The `Advanced mode` (`listenTrigger`) suite has its own `setup` at `:214` whose connection mock
  has no `done`. The fix covers that path too, since both modes share `cleanUpDb`, but I did not
  extend that mock, so the Advanced-mode close path has no assertion on the release. Happy to add
  it if you would rather have both covered.
- `npx tsc --noEmit` does not pass for `nodes-base` on this machine, so the change is lint- and
  test-verified rather than typecheck-verified. The errors are in files this branch does not touch
  — implicit-any parameters in `test/nodes/TriggerHelpers.ts` and `Cannot find module 'n8n-core'`
  in `utils/sendAndWait/utils.ts`, the latter an unbuilt workspace package locally — so I have no
  green baseline to compare against.
- #21731 reports the same leak and would also be fixed. I have not referenced it with a closing
  keyword because its body additionally claims the trigger is never dropped, which is not what the
  current code does — `DROP TRIGGER` does execute — so someone on your side should decide whether
  that one closes with this.

Closes #17795
