### PR TITLE
fix: Keep dev-metrics shims off pnpm-managed binaries (no-changelog)

### DIFF
--- a/scripts/dev-metrics/setup.mjs
+++ b/scripts/dev-metrics/setup.mjs
@@ -149,10 +149,23 @@ function isOurShim(path) {
 
 const pathDirs = () => (process.env.PATH ?? '').split(':').filter(Boolean);
 
-/** First executable `bin` on PATH (may be our shim). */
+// Binaries that pnpm manages itself: the `packageManager` version store
+// (`<PNPM_HOME>/store/vN/links/...`) and its `.tools` install dir. pnpm prepends
+// the running binary's dir to PATH for lifecycle scripts, so a `pnpm install`
+// under a version-switched pnpm puts these first on PATH. Shimming them corrupts
+// pnpm's version switching — never touch them, target the durable install instead.
+function isPnpmManagedPath(p) {
+	if (/\/store\/v\d+\/links\//.test(p) || /\/\.tools\//.test(p)) return true;
+	const home = process.env.PNPM_HOME;
+	if (!home) return false;
+	return p.startsWith(join(home, 'store') + '/') || p.startsWith(join(home, '.tools') + '/');
+}
+
+/** First shimmable `bin` on PATH (may be our shim; never a pnpm-managed one). */
 function whichOnPath(bin) {
 	for (const d of pathDirs()) {
 		const p = join(d, bin);
+		if (isPnpmManagedPath(p)) continue;
 		if (isExecutable(p)) return p;
 	}
 	return '';
@@ -162,6 +175,7 @@ function whichOnPath(bin) {
 function resolveRealBinary(bin) {
 	for (const d of pathDirs()) {
 		const p = join(d, bin);
+		if (isPnpmManagedPath(p)) continue;
 		if (!isExecutable(p)) continue;
 		if (!isOurShim(p)) return p; // genuine
 		const saved = p + SAVED_SUFFIX;
@@ -190,7 +204,22 @@ function renderShim(file, realExec, bin) {
 	chmodSync(file, 0o755);
 }
 
+/** Put the saved original back in place of a shim (or remove a stray shim). */
+function restoreOne(p) {
+	const saved = p + SAVED_SUFFIX;
+	if (existsSync(saved))
+		renameSync(saved, p); // restore original
+	else rmSync(p, { force: true }); // stray shim with no saved original
+}
+
 function installOne(bin) {
+	// Heal installs made before the pnpm-managed-path guard existed: restore any
+	// shim inside a pnpm-managed dir, then shim the durable binary below.
+	for (const d of pathDirs()) {
+		const p = join(d, bin);
+		if (isPnpmManagedPath(p) && isOurShim(p)) restoreOne(p);
+	}
+
 	const front = whichOnPath(bin);
 
 	// Already shimmed: re-render only if this checkout's template is newer
@@ -255,10 +284,7 @@ function uninstallBinaries() {
 	const restored = [];
 	for (const p of new Set([...recorded, ...onPath])) {
 		if (!isOurShim(p)) continue;
-		const saved = p + SAVED_SUFFIX;
-		if (existsSync(saved))
-			renameSync(saved, p); // restore original
-		else rmSync(p, { force: true }); // stray shim with no saved original
+		restoreOne(p);
 		restored.push(p);
 	}
 	return restored;

--- a/scripts/dev-metrics/setup.mjs
+++ b/scripts/dev-metrics/setup.mjs
@@ -150,12 +150,14 @@ function isOurShim(path) {
 const pathDirs = () => (process.env.PATH ?? '').split(':').filter(Boolean);
 
 // Binaries that pnpm manages itself: the `packageManager` version store
-// (`<PNPM_HOME>/store/vN/links/...`) and its `.tools` install dir. pnpm prepends
-// the running binary's dir to PATH for lifecycle scripts, so a `pnpm install`
-// under a version-switched pnpm puts these first on PATH. Shimming them corrupts
-// pnpm's version switching — never touch them, target the durable install instead.
+// (`<PNPM_HOME>/store/vN/links/...`) and its self-update install dir
+// (`<PNPM_HOME>/.tools/pnpm/<version>/...`). pnpm prepends the running binary's
+// dir to PATH for lifecycle scripts, so a `pnpm install` under a version-switched
+// pnpm puts these first on PATH. Shimming them corrupts pnpm's version switching
+// — never touch them, target the durable install instead. The shape checks match
+// on any prefix because PNPM_HOME is not always set in the environment.
 function isPnpmManagedPath(p) {
-	if (/\/store\/v\d+\/links\//.test(p) || /\/\.tools\//.test(p)) return true;
+	if (/\/store\/v\d+\/links\//.test(p) || /\/\.tools\/pnpm\//.test(p)) return true;
 	const home = process.env.PNPM_HOME;
 	if (!home) return false;
 	return p.startsWith(join(home, 'store') + '/') || p.startsWith(join(home, '.tools') + '/');
@@ -217,7 +219,12 @@ function installOne(bin) {
 	// shim inside a pnpm-managed dir, then shim the durable binary below.
 	for (const d of pathDirs()) {
 		const p = join(d, bin);
-		if (isPnpmManagedPath(p) && isOurShim(p)) restoreOne(p);
+		if (!isPnpmManagedPath(p) || !isOurShim(p)) continue;
+		try {
+			restoreOne(p);
+		} catch {
+			// unwritable managed dir — the durable binary below still gets the shim
+		}
 	}
 
 	const front = whichOnPath(bin);

--- a/scripts/dev-metrics/shadow-shim.sh
+++ b/scripts/dev-metrics/shadow-shim.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# n8n-shadow-shim-version: 1
+# n8n-shadow-shim-version: 2
 #
 # n8n dev metrics — binary shim (template). setup.mjs renders this per shadowed
 # CLI and installs it in place of the real binary (the original is saved next to
@@ -19,9 +19,12 @@ __bindir='__N8N_BINDIR__'
 __tracker='__N8N_TRACKER__' # installed copy of track.mjs, refreshed on each install
 
 # If the baked real binary moved (e.g. corepack/pnpm upgrade), re-resolve it via
-# PATH with our own directory removed — never resolving back to this shim.
+# PATH with our own directory removed — never resolving back to this shim. Also
+# skip pnpm-managed dirs (version store, .tools): resolving to one of those can
+# run a different pnpm version than the project pinned.
 if [ ! -x "$__real" ]; then
-	__cp=$(printf '%s' "${PATH:-}" | tr ':' '\n' | grep -vxF "$__bindir" | paste -sd: -)
+	__cp=$(printf '%s' "${PATH:-}" | tr ':' '\n' | grep -vxF "$__bindir" \
+		| grep -v -e '/store/v[0-9]*/links/' -e '/\.tools/' | paste -sd: -)
 	__real=$(PATH="$__cp" command -v "$__bin" 2>/dev/null)
 	[ -n "$__real" ] || exec env PATH="$__cp" "$__bin" "$@" # last resort, no loop
 fi

--- a/scripts/dev-metrics/shadow-shim.sh
+++ b/scripts/dev-metrics/shadow-shim.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# n8n-shadow-shim-version: 3
+# n8n-shadow-shim-version: 2
 #
 # n8n dev metrics — binary shim (template). setup.mjs renders this per shadowed
 # CLI and installs it in place of the real binary (the original is saved next to

--- a/scripts/dev-metrics/shadow-shim.sh
+++ b/scripts/dev-metrics/shadow-shim.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# n8n-shadow-shim-version: 2
+# n8n-shadow-shim-version: 3
 #
 # n8n dev metrics — binary shim (template). setup.mjs renders this per shadowed
 # CLI and installs it in place of the real binary (the original is saved next to
@@ -20,11 +20,11 @@ __tracker='__N8N_TRACKER__' # installed copy of track.mjs, refreshed on each ins
 
 # If the baked real binary moved (e.g. corepack/pnpm upgrade), re-resolve it via
 # PATH with our own directory removed — never resolving back to this shim. Also
-# skip pnpm-managed dirs (version store, .tools): resolving to one of those can
-# run a different pnpm version than the project pinned.
+# skip pnpm-managed dirs (version store, .tools/pnpm): resolving to one of those
+# can run a different pnpm version than the project pinned.
 if [ ! -x "$__real" ]; then
 	__cp=$(printf '%s' "${PATH:-}" | tr ':' '\n' | grep -vxF "$__bindir" \
-		| grep -v -e '/store/v[0-9]*/links/' -e '/\.tools/' | paste -sd: -)
+		| grep -v -e '/store/v[0-9]*/links/' -e '/\.tools/pnpm/' | paste -sd: -)
 	__real=$(PATH="$__cp" command -v "$__bin" 2>/dev/null)
 	[ -n "$__real" ] || exec env PATH="$__cp" "$__bin" "$@" # last resort, no loop
 fi

--- a/scripts/dev-metrics/test/selfcheck.sh
+++ b/scripts/dev-metrics/test/selfcheck.sh
@@ -77,5 +77,30 @@ grep -q "n8n-shadow-shim-version" "$BIN/pnpm" && fail "shim left after reset"
 	echo "$out" | grep -q "NEW probe" || fail "upgrade downgraded via stale .n8n-real"
 )
 
+# Regression: never shim a binary inside pnpm's own management dirs (the
+# packageManager version store, .tools) — a shim there corrupts pnpm's version
+# switching. The durable binary further down PATH gets the shim instead, and a
+# managed binary that an older setup already shimmed is restored.
+(
+	PH="$T/pnpm-home"; STORE="$PH/store/v11/links/@/pnpm/9.9.9/hash/bin"; DUR="$T/bin3"
+	mkdir -p "$STORE" "$DUR"
+	printf '#!/bin/sh\necho "STORE $*"\n' > "$STORE/pnpm"; chmod +x "$STORE/pnpm"
+	printf '#!/bin/sh\necho "DURABLE $*"\n' > "$DUR/pnpm"; chmod +x "$DUR/pnpm"
+	export N8N_USER_FOLDER="$T/uf3" N8N_DEV_TELEMETRY=0 PNPM_HOME="$PH" PATH="$STORE:$DUR:$PATH"
+	node "$SRC/setup.mjs" --enable >/dev/null
+	grep -q "n8n-shadow-shim-version" "$STORE/pnpm" && fail "pnpm-managed store binary was shimmed"
+	grep -q "n8n-shadow-shim-version" "$DUR/pnpm" || fail "durable binary not shimmed behind a store binary"
+
+	# Simulate an older setup that shimmed the store binary: re-enable must heal it.
+	mv "$STORE/pnpm" "$STORE/pnpm.n8n-real"
+	sed "s|__N8N_BIN__|pnpm|;s|__N8N_REAL__|$STORE/pnpm.n8n-real|;s|__N8N_BINDIR__|$STORE|;s|__N8N_TRACKER__|/nonexistent|" \
+		"$SRC/shadow-shim.sh" > "$STORE/pnpm"
+	chmod +x "$STORE/pnpm"
+	node "$SRC/setup.mjs" --enable >/dev/null
+	grep -q "n8n-shadow-shim-version" "$STORE/pnpm" && fail "pre-existing store shim not healed"
+	out=$("$STORE/pnpm" probe 2>&1) || true
+	echo "$out" | grep -q "STORE probe" || fail "store binary not restored to the original"
+)
+
 rm -rf "$T" "$EV"
 echo "ALL PASS"

--- a/scripts/dev-metrics/test/selfcheck.sh
+++ b/scripts/dev-metrics/test/selfcheck.sh
@@ -102,5 +102,37 @@ grep -q "n8n-shadow-shim-version" "$BIN/pnpm" && fail "shim left after reset"
 	echo "$out" | grep -q "STORE probe" || fail "store binary not restored to the original"
 )
 
+# Regression: the `.tools` match is scoped to pnpm's own layout
+# (.tools/pnpm/<version>/...) and works without PNPM_HOME. A durable binary
+# under an unrelated .tools dir must still get the shim.
+(
+	TOOLS="$T/dev/.tools/bin"; MANAGED="$T/ph2/.tools/pnpm/9.9.9/bin"
+	mkdir -p "$TOOLS" "$MANAGED"
+	printf '#!/bin/sh\necho "TOOLS $*"\n' > "$TOOLS/pnpm"; chmod +x "$TOOLS/pnpm"
+	printf '#!/bin/sh\necho "MANAGED $*"\n' > "$MANAGED/pnpm"; chmod +x "$MANAGED/pnpm"
+	export N8N_USER_FOLDER="$T/uf4" N8N_DEV_TELEMETRY=0 PATH="$MANAGED:$TOOLS:$PATH"
+	unset PNPM_HOME
+	node "$SRC/setup.mjs" --enable >/dev/null
+	grep -q "n8n-shadow-shim-version" "$MANAGED/pnpm" && fail "managed .tools binary was shimmed without PNPM_HOME"
+	grep -q "n8n-shadow-shim-version" "$TOOLS/pnpm" || fail "durable binary under unrelated .tools not shimmed"
+)
+
+# Regression: a heal failure (unwritable managed dir) must not abort the
+# install — the durable binary still gets the shim.
+(
+	PH="$T/ph3"; STORE="$PH/store/v11/links/@/pnpm/9.9.9/hash/bin"; DUR="$T/bin4"
+	mkdir -p "$STORE" "$DUR"
+	printf '#!/bin/sh\necho "DURABLE $*"\n' > "$DUR/pnpm"; chmod +x "$DUR/pnpm"
+	printf '#!/bin/sh\necho "STORE-REAL $*"\n' > "$STORE/pnpm.n8n-real"; chmod +x "$STORE/pnpm.n8n-real"
+	sed "s|__N8N_BIN__|pnpm|;s|__N8N_REAL__|$STORE/pnpm.n8n-real|;s|__N8N_BINDIR__|$STORE|;s|__N8N_TRACKER__|/nonexistent|" \
+		"$SRC/shadow-shim.sh" > "$STORE/pnpm"
+	chmod +x "$STORE/pnpm"
+	chmod a-w "$STORE"  # healing the store shim cannot rename here
+	export N8N_USER_FOLDER="$T/uf5" N8N_DEV_TELEMETRY=0 PNPM_HOME="$PH" PATH="$STORE:$DUR:$PATH"
+	node "$SRC/setup.mjs" --enable >/dev/null
+	chmod u+w "$STORE"  # so cleanup can remove the temp dir
+	grep -q "n8n-shadow-shim-version" "$DUR/pnpm" || fail "heal failure aborted the durable shim install"
+)
+
 rm -rf "$T" "$EV"
 echo "ALL PASS"


### PR DESCRIPTION
## Summary

The dev-metrics setup replaced binaries inside pnpm's own version management directories with shims. pnpm prepends the running binary's directory to `PATH` for lifecycle scripts. When a version-switched pnpm runs `pnpm install`, the consent bootstrap finds the store-managed binary first on `PATH` and shims it. A shim inside the version store corrupts pnpm's `packageManager` version switching: a shim with a stale baked path can silently run a different pnpm version than the project pins. This surfaced as `ERR_PNPM_UNSUPPORTED_ENGINE` ("Got: 11.22.0") on a machine where every durable install and the project pin said 11.25.0.

Changes:

- `setup.mjs`: new `isPnpmManagedPath()` guard. The `PATH` scans skip `<PNPM_HOME>/store/`, `<PNPM_HOME>/.tools/`, and paths that match `store/vN/links`. Shims now only land on the durable install (npm-global, standalone, nvm).
- `setup.mjs`: `installOne` heals earlier installs — it restores any shim found inside a pnpm-managed directory, then shims the durable binary.
- `shadow-shim.sh`: template version bumped to 2, so deployed shims re-render on the next install. The `PATH` fallback in the shim also skips pnpm-managed directories.
- `test/selfcheck.sh`: regression block — a store binary first on `PATH` must not receive a shim, the durable binary behind it must, and a pre-existing store shim must be healed on `--enable`.

## How to test

Run the self-check:

```
sh scripts/dev-metrics/test/selfcheck.sh
```

It prints `ALL PASS`. The new block at the end covers the pnpm-managed-path guard and the heal path.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-585 (the dev-metrics system this fixes; no dedicated bug ticket exists)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

