### PR TITLE
fix(core): Attribute agent session metrics to users (no-changelog)

### DIFF
--- a/packages/@n8n/telemetry/src/events/agents.ts
+++ b/packages/@n8n/telemetry/src/events/agents.ts
@@ -211,10 +211,11 @@ export const AGENTS_TELEMETRY = defineTelemetryEvents({
 	AGENT_SESSION_METRICS: {
 		name: 'Agent session metrics',
 		description:
-			'Six-hourly pulse of agent session and turn metrics, bucketed by agent, run type, turn status and configuration. Two token numbers exist across the agent events and they measure different things: token_count_sum here covers only the recorded turns, from the same usage as cost_sum so the two reconcile, while token_count on "Agent execution count" additionally covers LLM calls belonging to no turn (title generation, observational/episodic memory, embeddings) and so runs higher.',
+			'Six-hourly pulse of agent session and turn metrics, bucketed by agent, optional user, run type, turn status and configuration. Two token numbers exist across the agent events and they measure different things: token_count_sum here covers only the recorded turns, from the same usage as cost_sum so the two reconcile, while token_count on "Agent execution count" additionally covers LLM calls belonging to no turn (title generation, observational/episodic memory, embeddings) and so runs higher.',
 		properties: z.object({
 			event_version: z.literal('1'),
 			agent_id: z.string(),
+			user_id: z.string().optional(),
 			agent_type: z.literal('inline').optional(),
 			run_type: agentRunType,
 			turn_status: z.enum(['succeeded', 'failed']),

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -250,6 +250,7 @@ export interface IAgentConfigurationTelemetryProperties {
 
 export interface IAgentTurnFinishedTrackProperties extends ITelemetryTrackProperties {
 	agent_id: string;
+	user_id?: string;
 	/** Internal aggregation key only. This must never be emitted to telemetry. */
 	thread_id: string;
 	run_type: AgentRunTelemetryType;

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -403,6 +403,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				source: 'instance-ai',
 				taskId: undefined,
 				telemetry: {
+					userId,
 					runType: 'test',
 					configuration: runtime.telemetryConfiguration,
 				},

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -476,6 +476,7 @@ export class AgentExecutionOrchestratorService {
 				userMessage: null,
 				...(executionSource !== undefined ? { source: executionSource } : {}),
 				telemetry: {
+					userId: user?.id,
 					runType,
 					configuration: runtime.telemetryConfiguration,
 				},
@@ -517,6 +518,7 @@ export class AgentExecutionOrchestratorService {
 						record: messageRecord,
 						hitlStatus: recorder.suspended ? 'suspended' : 'resumed',
 						telemetry: {
+							userId: user?.id,
 							runType,
 							configuration: runtime.telemetryConfiguration,
 						},
@@ -799,7 +801,7 @@ export class AgentExecutionOrchestratorService {
 				source,
 				taskId,
 				taskVersionId,
-				telemetry,
+				telemetry: { ...telemetry, userId },
 			};
 			executionId = await this.tryStartExecution(
 				startParams,
@@ -848,7 +850,7 @@ export class AgentExecutionOrchestratorService {
 					source,
 					taskId,
 					taskVersionId,
-					telemetry,
+					telemetry: { ...telemetry, userId },
 				},
 			});
 		}

--- a/packages/cli/src/modules/agents/agent-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution.service.ts
@@ -51,6 +51,7 @@ export interface RecordMessageParams {
 	taskVersionId?: string;
 	/** Backend heartbeat telemetry context for this recorded run. */
 	telemetry?: {
+		userId?: string;
 		runType: AgentRunTelemetryType;
 		configuration: IAgentConfigurationTelemetryProperties;
 	};
@@ -370,6 +371,7 @@ export class AgentExecutionService {
 			try {
 				this.telemetry.trackAgentTurnFinished({
 					agent_id: agentId,
+					user_id: params.telemetry.userId,
 					thread_id: threadId,
 					run_type: params.telemetry.runType,
 					turn_status: status === 'success' ? 'succeeded' : 'failed',

--- a/packages/cli/src/modules/agents/agent-workflow-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-workflow-execution.service.ts
@@ -583,6 +583,7 @@ export class AgentWorkflowExecutionService {
 				userMessage: message,
 				source: AGENT_WORKFLOW_TRIGGER_TYPE,
 				telemetry: {
+					userId: telemetryUserId,
 					runType,
 					configuration: telemetryConfiguration,
 				},
@@ -609,6 +610,7 @@ export class AgentWorkflowExecutionService {
 					record: run.messageRecord,
 					source: AGENT_WORKFLOW_TRIGGER_TYPE,
 					telemetry: {
+						userId: telemetryUserId,
 						runType,
 						configuration: telemetryConfiguration,
 					},
@@ -733,6 +735,7 @@ export class AgentWorkflowExecutionService {
 		try {
 			this.telemetry.trackAgentTurnFinished({
 				agent_id: syntheticAgentId,
+				user_id: telemetryUserId,
 				thread_id: threadId,
 				run_type: runType,
 				agent_type: 'inline',

--- a/packages/cli/src/modules/agents/sub-agents/sub-agent-runner.ts
+++ b/packages/cli/src/modules/agents/sub-agents/sub-agent-runner.ts
@@ -293,6 +293,7 @@ export class SubAgentRunner {
 							parentAgentId: context.parentAgentId,
 						},
 						telemetry: {
+							userId: context.user?.id,
 							runType: context.runType,
 							configuration: buildAgentConfigurationTelemetryFromConfig(
 								runtimeSource.source.config,
@@ -331,6 +332,7 @@ export class SubAgentRunner {
 				userMessage,
 				record: messageRecord,
 				executionId,
+				userId: context.user?.id,
 				...(hitlStatus !== undefined ? { hitlStatus } : {}),
 			});
 			recorded = true;
@@ -361,6 +363,7 @@ export class SubAgentRunner {
 					userMessage,
 					record: recorder.getMessageRecord(),
 					executionId,
+					userId: context.user?.id,
 					...(operation.type === 'resume' ? { hitlStatus: 'resumed' as const } : {}),
 				});
 			}
@@ -413,6 +416,7 @@ export class SubAgentRunner {
 		userMessage: string | null;
 		record: MessageRecord;
 		executionId?: string;
+		userId?: string;
 		hitlStatus?: 'suspended' | 'resumed';
 	}): Promise<void> {
 		const {
@@ -426,6 +430,7 @@ export class SubAgentRunner {
 			userMessage,
 			record,
 			executionId,
+			userId,
 			hitlStatus,
 		} = params;
 
@@ -445,6 +450,7 @@ export class SubAgentRunner {
 					...(parentAgentId !== undefined ? { parentAgentId } : {}),
 				},
 				telemetry: {
+					userId,
 					runType,
 					configuration: buildAgentConfigurationTelemetryFromConfig(runtimeSource.config),
 				},

--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -648,6 +648,7 @@ describe('Telemetry', () => {
 			] as const) {
 				telemetry.trackAgentTurnFinished({
 					agent_id: 'agent-1',
+					user_id: 'user-1',
 					thread_id,
 					run_type: 'test',
 					turn_status: 'succeeded',
@@ -668,6 +669,7 @@ describe('Telemetry', () => {
 			expect(payload).toEqual({
 				event_version: '1',
 				agent_id: 'agent-1',
+				user_id: 'user-1',
 				...configuration,
 				run_type: 'test',
 				turn_status: 'succeeded',

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -93,6 +93,7 @@ interface IAgentSessionMetrics {
 interface IAgentSessionMetricsBuffer {
 	[bufferKey: string]: {
 		agent_id: string;
+		user_id?: string;
 		agent_type: IAgentTurnFinishedTrackProperties['agent_type'];
 		run_type: IAgentTurnFinishedTrackProperties['run_type'];
 		turn_status: IAgentTurnFinishedTrackProperties['turn_status'];
@@ -325,6 +326,7 @@ export class Telemetry {
 	private getAgentSessionMetricsBufferKey(properties: IAgentTurnFinishedTrackProperties) {
 		return [
 			properties.agent_id,
+			properties.user_id,
 			properties.run_type,
 			properties.turn_status,
 			JSON.stringify(properties.configuration),
@@ -349,6 +351,7 @@ export class Telemetry {
 			this.track(TELEMETRY_EVENT.AGENTS.AGENT_SESSION_METRICS, {
 				event_version: '1',
 				agent_id: bucket.agent_id,
+				...(bucket.user_id ? { user_id: bucket.user_id } : {}),
 				...(bucket.agent_type ? { agent_type: bucket.agent_type } : {}),
 				...bucket.configuration,
 				run_type: bucket.run_type,
@@ -460,6 +463,7 @@ export class Telemetry {
 		const bufferKey = this.getAgentSessionMetricsBufferKey(properties);
 		this.agentSessionMetricsBuffer[bufferKey] = this.agentSessionMetricsBuffer[bufferKey] ?? {
 			agent_id: properties.agent_id,
+			user_id: properties.user_id,
 			agent_type: properties.agent_type,
 			run_type: properties.run_type,
 			turn_status: properties.turn_status,


### PR DESCRIPTION
## Summary

Add optional user attribution to the Agent session metrics event.
Keep instance-only attribution for runs without an n8n user.

## How to test

1. Go to `packages/cli`.
2. Run `pnpm test src/telemetry/__tests__/telemetry.test.ts`.
3. Confirm the session metrics payload includes `user_id`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-807

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

