### PR TITLE
fix(core): Keep reporting the original job error when the job key is gone

### DIFF
--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -5,6 +5,7 @@ import type { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import * as BullModule from 'bull';
 import { InstanceSettings } from 'n8n-core';
+import type { ErrorReporter } from 'n8n-core';
 import { UnexpectedError } from 'n8n-workflow';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -94,6 +95,7 @@ describe('ScalingService', () => {
 	// The service scopes its logger on construction, so assertions go to the scoped mock.
 	const scopedLogger = mock<Logger>();
 	const logger = mock<Logger>({ scoped: () => scopedLogger });
+	const errorReporter = mock<ErrorReporter>();
 	const activeExecutions = mock<ActiveExecutions>();
 	const jobProcessor = mock<JobProcessor>();
 	const executionRepository = mock<ExecutionRepository>();
@@ -132,7 +134,7 @@ describe('ScalingService', () => {
 
 		scalingService = new ScalingService(
 			logger,
-			mock(),
+			errorReporter,
 			activeExecutions,
 			jobProcessor,
 			globalConfig,
@@ -299,6 +301,28 @@ describe('ScalingService', () => {
 			instanceSettings.instanceType = 'worker';
 
 			expect(() => scalingService.setupWorker(5)).toThrow();
+		});
+
+		it('should report the original error even if notifying main of the failure fails', async () => {
+			// @ts-expect-error readonly property
+			instanceSettings.instanceType = 'worker';
+			await scalingService.setupQueue();
+			scalingService.setupWorker(5);
+			const processFn = queue.process.mock.calls[0][2] as (job: Job) => Promise<void>;
+
+			const job = mock<Job>({ id: '1', data: { executionId: '123', loadStaticData: false } });
+			const originalError = new Error('execution errored');
+			jobProcessor.processJob.mockRejectedValueOnce(originalError);
+			// e.g. the job key was already deleted from Redis by a stall sweep
+			job.progress.mockRejectedValueOnce(new Error('Missing key for job 1 updateProgress'));
+
+			await expect(processFn(job)).rejects.toThrow(originalError);
+
+			expect(scopedLogger.warn).toHaveBeenCalledWith(
+				'Failed to notify main of failed execution 123 (job 1)',
+				expect.objectContaining({ executionId: '123', jobId: '1' }),
+			);
+			expect(errorReporter.error).toHaveBeenCalledWith(originalError, { executionId: '123' });
 		});
 	});
 

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -308,7 +308,7 @@ describe('ScalingService', () => {
 			instanceSettings.instanceType = 'worker';
 			await scalingService.setupQueue();
 			scalingService.setupWorker(5);
-			const processFn = queue.process.mock.calls[0][2] as (job: Job) => Promise<void>;
+			const processFn = queue.process.mock.calls[0][2] as unknown as (job: Job) => Promise<void>;
 
 			const job = mock<Job>({ id: '1', data: { executionId: '123', loadStaticData: false } });
 			const originalError = new Error('execution errored');

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -202,7 +202,17 @@ export class ScalingService {
 			errorStack: error.stack ?? '',
 		};
 
-		await job.progress(msg);
+		try {
+			await job.progress(msg);
+		} catch (progressError) {
+			// e.g. the job key was already deleted by a stall sweep - do not let
+			// this secondary error mask the original one from being reported below
+			this.logger.warn(`Failed to notify main of failed execution ${executionId} (job ${job.id})`, {
+				error: progressError,
+				executionId,
+				jobId: job.id,
+			});
+		}
 
 		this.errorReporter.error(error, { executionId });
 


### PR DESCRIPTION
## Summary

When a queue-mode worker errors on a job whose Redis key no longer exists, the failure report is lost. The stall sweep on another worker can fail a job and delete its key while the owning worker still runs it. The owning worker's error handler then throws from `job.progress()` (`Missing key for job X updateProgress`) before it reports the original error. The original error never reaches Sentry, and the logs show only Redis bookkeeping noise.

This PR wraps the `job.progress()` call in a try/catch. A failed progress update now logs a warning. The original error is always reported and rethrown.

**NOTE:** this does not fix the stall itself. It ensures a stall incident no longer destroys the evidence of what failed on the worker.

## How to test

`pnpm --filter=n8n test src/scaling/__tests__/scaling.service.test.ts`

The new test rejects `job.progress()` with a `Missing key` error and asserts that the original job error is still reported and rethrown. It fails without the fix.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4388

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

