### PR TITLE
chore: Add publication module ownership to catalysts (no-changelog)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -81,6 +81,7 @@ packages/cli/src/events/                                @n8n-io/catalysts
 packages/cli/src/security-audit/                        @n8n-io/catalysts
 packages/cli/src/modules/workflow-index/                @n8n-io/catalysts
 packages/cli/src/modules/breaking-changes/              @n8n-io/catalysts
+packages/cli/src/workflows/publication/                 @n8n-io/catalysts
 packages/cli/src/modules/otel/                          @n8n-io/ligo
 
 packages/cli/src/auth/                                  @n8n-io/iam

--- a/OWNERS
+++ b/OWNERS
@@ -81,7 +81,7 @@ packages/cli/src/events/                                @n8n-io/catalysts
 packages/cli/src/security-audit/                        @n8n-io/catalysts
 packages/cli/src/modules/workflow-index/                @n8n-io/catalysts
 packages/cli/src/modules/breaking-changes/              @n8n-io/catalysts
-packages/cli/src/workflows/publication/                 @n8n-io/catalysts
+packages/cli/src/workflows/publication/                 @n8n-io/catalysts required
 packages/cli/src/modules/otel/                          @n8n-io/ligo
 
 packages/cli/src/auth/                                  @n8n-io/iam


### PR DESCRIPTION
## Summary

Add `packages/cli/src/workflows/publication/` as an explicit entry in
`OWNERS`, assigned to `@n8n-io/catalysts`. The path falls under
`packages/cli/`, which the team already owns, but this makes ownership
of the publication module explicit.

## How to test

Not applicable. This is an ownership metadata change only.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/37998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

