### PR TITLE
fix(core): Allow a fallback model alongside the primary on AI nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -116,6 +116,51 @@ const agent = node({
   }
 });
 </pattern>
+
+<pattern title="Agent with a fallback model (primary + backup provider)">
+// Give ONE agent a backup model with a FLAT model array: the first entry is the
+// primary, the second fills the agent's Fallback Model input. The agent retries
+// on the second model when the first call fails.
+// Do NOT build a second agent or an error-output branch for this — one agent.
+// A NESTED array (model: [[a, b]]) means something else: both models on the SAME
+// input, which is not a fallback.
+
+const primaryModel = languageModel({
+  type: '@n8n/n8n-nodes-langchain.lmChatAnthropic',
+  version: 1.6,
+  config: {
+    name: 'Claude (Primary)',
+    parameters: { model: { __rl: true, mode: 'list', value: 'claude-sonnet-4-5' } }
+  }
+});
+
+const fallbackModel = languageModel({
+  type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+  version: 1.3,
+  config: {
+    name: 'OpenAI (Fallback)',
+    parameters: { model: { __rl: true, mode: 'list', value: 'gpt-5.4' } }
+  }
+});
+
+const agentWithFallback = node({
+  type: '@n8n/n8n-nodes-langchain.agent',
+  version: 3.1,
+  config: {
+    name: 'AI Agent',
+    parameters: {
+      promptType: 'define',
+      text: expr('{{ $json.prompt }}'),
+      options: { systemMessage: 'You are an expert...' },
+      // REQUIRED with a second model: the agent only declares its Fallback Model
+      // input when this is on. Without it the second model is wired to an input
+      // that does not exist and never runs.
+      needsFallback: true
+    },
+    subnodes: { model: [primaryModel, fallbackModel] }
+  }
+});
+</pattern>
 </patterns>`,
 					},
 				],

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -493,6 +493,17 @@ export interface StickyNoteConfig {
  * Subnode configuration for AI nodes
  */
 export interface SubnodeConfig {
+	/**
+	 * Language model(s) for the parent node.
+	 *
+	 * - single instance, or `[m]` — the primary model, on input index 0.
+	 * - flat `[primary, fallback]` — sequential input indices (0, 1, …). On an Agent
+	 *   or Basic LLM Chain, index 1 is the Fallback Model input, which the node only
+	 *   declares when its `needsFallback` parameter is `true` — set that alongside,
+	 *   or the fallback never runs. Model Selector takes many models this way and
+	 *   has no such toggle.
+	 * - nested `[[m1, m2]]` — every model on the SAME input index; not a fallback.
+	 */
 	model?: LanguageModelInstance | LanguageModelInstance[] | LanguageModelInstance[][];
 	memory?: MemoryInstance;
 	tools?: ToolInstance[];

--- a/packages/@n8n/workflow-sdk/src/validation/validate-workflow.test.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/validate-workflow.test.ts
@@ -245,6 +245,176 @@ describe('Validation', () => {
 				0,
 			);
 		});
+
+		it('should not warn when a primary and a fallback model use different input indices', () => {
+			const result = validateWorkflow({
+				id: 'test-id',
+				name: 'Test',
+				nodes: [
+					{
+						id: '1',
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						id: '2',
+						name: 'Agent',
+						type: '@n8n/n8n-nodes-langchain.agent',
+						typeVersion: 3.1,
+						position: [200, 0],
+						parameters: { needsFallback: true },
+					},
+					{
+						id: '3',
+						name: 'Primary Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatAnthropic',
+						typeVersion: 1.6,
+						position: [0, 200],
+						parameters: {},
+					},
+					{
+						id: '4',
+						name: 'Fallback Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1.3,
+						position: [200, 200],
+						parameters: {},
+					},
+				],
+				connections: {
+					Trigger: { main: [[{ node: 'Agent', type: 'main', index: 0 }]] },
+					'Primary Model': {
+						ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]],
+					},
+					'Fallback Model': {
+						ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 1 }]],
+					},
+				},
+			});
+
+			expect(result.warnings.filter((w) => w.code === 'DUPLICATE_SUBNODE_CONNECTION')).toHaveLength(
+				0,
+			);
+			expect(result.warnings.filter((w) => w.code === 'MISSING_FALLBACK_MODEL_FLAG')).toHaveLength(
+				0,
+			);
+		});
+
+		it('should warn when a fallback model is wired but needsFallback is not enabled', () => {
+			const result = validateWorkflow({
+				id: 'test-id',
+				name: 'Test',
+				nodes: [
+					{
+						id: '1',
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						id: '2',
+						name: 'Agent',
+						type: '@n8n/n8n-nodes-langchain.agent',
+						typeVersion: 3.1,
+						position: [200, 0],
+						// needsFallback left off, so the node declares no Fallback Model input.
+						parameters: {},
+					},
+					{
+						id: '3',
+						name: 'Primary Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatAnthropic',
+						typeVersion: 1.6,
+						position: [0, 200],
+						parameters: {},
+					},
+					{
+						id: '4',
+						name: 'Fallback Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1.3,
+						position: [200, 200],
+						parameters: {},
+					},
+				],
+				connections: {
+					Trigger: { main: [[{ node: 'Agent', type: 'main', index: 0 }]] },
+					'Primary Model': {
+						ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]],
+					},
+					'Fallback Model': {
+						ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 1 }]],
+					},
+				},
+			});
+
+			const fallbackWarnings = result.warnings.filter(
+				(w) => w.code === 'MISSING_FALLBACK_MODEL_FLAG',
+			);
+			expect(fallbackWarnings).toHaveLength(1);
+			expect(fallbackWarnings[0].message).toContain('needsFallback');
+			expect(fallbackWarnings[0].nodeName).toBe('Agent');
+		});
+
+		it('should not warn about needsFallback for a node type that has no fallback input', () => {
+			const result = validateWorkflow({
+				id: 'test-id',
+				name: 'Test',
+				nodes: [
+					{
+						id: '1',
+						name: 'Trigger',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+					},
+					{
+						id: '2',
+						name: 'Model Selector',
+						type: '@n8n/n8n-nodes-langchain.modelSelector',
+						typeVersion: 1,
+						position: [200, 0],
+						parameters: {},
+					},
+					{
+						id: '3',
+						name: 'Model A',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1.3,
+						position: [0, 200],
+						parameters: {},
+					},
+					{
+						id: '4',
+						name: 'Model B',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1.3,
+						position: [200, 200],
+						parameters: {},
+					},
+				],
+				connections: {
+					Trigger: { main: [[{ node: 'Model Selector', type: 'main', index: 0 }]] },
+					'Model A': {
+						ai_languageModel: [[{ node: 'Model Selector', type: 'ai_languageModel', index: 0 }]],
+					},
+					'Model B': {
+						ai_languageModel: [[{ node: 'Model Selector', type: 'ai_languageModel', index: 1 }]],
+					},
+				},
+			});
+
+			// Model Selector genuinely has many model slots and no needsFallback toggle.
+			expect(result.warnings.filter((w) => w.code === 'MISSING_FALLBACK_MODEL_FLAG')).toHaveLength(
+				0,
+			);
+			expect(result.warnings.filter((w) => w.code === 'DUPLICATE_SUBNODE_CONNECTION')).toHaveLength(
+				0,
+			);
+		});
 	});
 
 	describe('ValidationError', () => {

--- a/packages/@n8n/workflow-sdk/src/validation/validate-workflow.ts
+++ b/packages/@n8n/workflow-sdk/src/validation/validate-workflow.ts
@@ -40,6 +40,7 @@ export type ValidationErrorCode =
 	| 'INVALID_OUTPUT_INDEX'
 	| 'SUBNODE_NOT_CONNECTED'
 	| 'DUPLICATE_SUBNODE_CONNECTION'
+	| 'MISSING_FALLBACK_MODEL_FLAG'
 	| 'SUBNODE_PARAMETER_MISMATCH'
 	| 'UNSUPPORTED_SUBNODE_INPUT'
 	| 'MISSING_REQUIRED_INPUT'
@@ -282,6 +283,11 @@ function reconstructSubnodesFromConnections(
  * Single-value AI inputs (model, memory, embedding, …) accept exactly one connection
  * at runtime. Subnode reconstruction keeps only the last source, so surface duplicates
  * here instead of letting an earlier malformed subnode escape validation.
+ *
+ * Scoped per input INDEX, not per connection type: a node can declare several slots
+ * of one type that each take a single connection. An Agent with `needsFallback` on
+ * has two `ai_languageModel` slots — primary at 0, fallback at 1 — and keying only
+ * on the type rejected that legitimate pair, which blocked the save outright.
  */
 function checkDuplicateSingleValueAiConnections(
 	json: WorkflowJSON,
@@ -299,7 +305,7 @@ function checkDuplicateSingleValueAiConnections(
 			for (const outputs of aiConns) {
 				if (!outputs) continue;
 				for (const conn of outputs) {
-					const key = `${conn.node}:${connType}`;
+					const key = `${conn.node}:${connType}:${conn.index ?? 0}`;
 					const firstSource = firstSourceByInput.get(key);
 					if (firstSource === undefined) {
 						firstSourceByInput.set(key, sourceNodeName);
@@ -317,6 +323,64 @@ function checkDuplicateSingleValueAiConnections(
 				}
 			}
 		}
+	}
+}
+
+/**
+ * Node types whose description declares a `needsFallback` toggle gating a second
+ * `ai_languageModel` input (the "Fallback Model" slot). Other multi-model nodes —
+ * Model Selector, for one — take many models with no such toggle.
+ */
+const FALLBACK_MODEL_NODE_TYPES = new Set([
+	'@n8n/n8n-nodes-langchain.agent',
+	'@n8n/n8n-nodes-langchain.agentTool',
+	'@n8n/n8n-nodes-langchain.chainLlm',
+	'@n8n/n8n-nodes-langchain.microsoftAgent365Trigger',
+]);
+
+/**
+ * A model wired to the second `ai_languageModel` slot only takes effect when
+ * `needsFallback` is on — the node hides that input otherwise (see `getInputs` in
+ * the Agent node), leaving the connection pointing at an input the node does not
+ * declare. The workflow then advertises a backup model and has none.
+ *
+ * Reported rather than silently corrected: flipping the flag would start issuing
+ * real (billable) calls to a model the workflow never used.
+ *
+ * Informational, so it never blocks a save. Real workflows already carry this
+ * shape — a user can wire a fallback and switch the toggle back off, and n8n keeps
+ * the orphaned connection — and those users must still be able to save unrelated
+ * edits. It guides the author; it does not gate them.
+ */
+function checkFallbackModelFlag(json: WorkflowJSON, warnings: ValidationWarning[]): void {
+	const nodesWithFallbackModel = new Set<string>();
+
+	for (const nodeConnections of Object.values(json.connections)) {
+		for (const outputs of nodeConnections.ai_languageModel ?? []) {
+			for (const conn of outputs ?? []) {
+				if ((conn.index ?? 0) >= 1) nodesWithFallbackModel.add(conn.node);
+			}
+		}
+	}
+
+	if (nodesWithFallbackModel.size === 0) return;
+
+	for (const node of json.nodes) {
+		if (!node.name || !nodesWithFallbackModel.has(node.name)) continue;
+		if (!FALLBACK_MODEL_NODE_TYPES.has(node.type)) continue;
+		if (node.parameters?.needsFallback === true) continue;
+
+		warnings.push(
+			new ValidationWarning(
+				'MISSING_FALLBACK_MODEL_FLAG',
+				`'${node.name}' has a model wired to its Fallback Model input, but 'needsFallback' is not enabled, so the node does not declare that input and the fallback never runs. Set parameters.needsFallback: true, or remove the second model.`,
+				node.name,
+				undefined,
+				undefined,
+				'major',
+				'informational',
+			),
+		);
 	}
 }
 
@@ -710,6 +774,7 @@ export function validateWorkflow(
 
 	// Duplicate connections to single-value AI inputs
 	checkDuplicateSingleValueAiConnections(json, warnings);
+	checkFallbackModelFlag(json, warnings);
 
 	return {
 		valid: errors.length === 0,


### PR DESCRIPTION
## Summary

The AI Assistant could not build an Agent with a fallback model. The SDK blocked the save.

`checkDuplicateSingleValueAiConnections` keyed its duplicate check on node plus connection type and ignored the input index. An Agent declares two `ai_languageModel` slots when `needsFallback` is on: the primary at index 0 and the fallback at index 1. Those two legitimate connections collided on one key, so the validator raised an error:

```
error  DUPLICATE_SUBNODE_CONNECTION  'Support Agent' has multiple 'ai_languageModel'
connections ('Claude (Primary)' and 'OpenAI (Fallback)'), but this input accepts only one.
```

Errors block a `build-workflow` save, so the assistant could not ship the workflow the user asked for. It tried `model: [[claude, openai]]` and `model: [claude, openai]`, was blocked both times, then improvised a wrong shape: in one run a second Agent node on an error branch, in another a single agent with the OpenAI node deleted. Model Selector, which takes models at indices 0 to 3, was mis-flagged the same way.

Changes:

1. **Add the input index to the duplicate key.** Two models on different slots no longer collide. Two models on the *same* slot still warn.
2. **Add a `MISSING_FALLBACK_MODEL_FLAG` check.** It reports a model wired to the Fallback Model input while `needsFallback` is off. The node hides that input in that state, so the workflow advertises a backup model and has none.
3. **Document the pattern.** The Agent `builderHint` and the `model` subnode config said nothing about fallback models. Both now show the flat-array form and the required `needsFallback: true`.

Two deliberate choices:

- **The flag is not set automatically.** Deriving `needsFallback` from the connections was the first approach, and it was dropped. Real workflows already carry "fallback wired, flag off" (4 of the round-trip fixtures do). Setting the flag would activate a dormant model and start real, billable calls on someone's workflow during an unrelated edit.
- **The new check is `informational`, not `warning`.** A `warning` blocks a `build-workflow` save. Those same existing workflows must stay saveable for unrelated edits. The CLI still shows the issue to the author.

## How to test

The bug is in the SDK validator, so any path that builds an Agent through `@n8n/workflow-sdk` reproduces it. Requires `N8N_ENABLED_MODULES=instance-ai` and a working sandbox.

Ask the AI Assistant:

> Our support tool calls n8n over HTTP every time a customer writes in, and I want the workflow to answer them with an AI agent using Claude. Anthropic has had a few outages and I can't let those requests fail, so the agent needs a backup model: if the Claude call fails it should automatically retry the same request on OpenAI. I don't want two agents to maintain — just the one agent with a backup model on it.

Expected result: **one** Agent node with `needsFallback: true`, an Anthropic model on `ai_languageModel` index 0, and an OpenAI model on index 1.

Before this change the build produced either two Agent nodes joined by an error branch, or one agent with the second model dropped.

Unit tests:

```bash
cd packages/@n8n/workflow-sdk && pnpm vitest run src/validation/validate-workflow.test.ts
```

Eval case [#702 `agent-fallback-model`](https://lang-tracer.n8n-maintenance.workers.dev/test-cases/702) in the `baseline` suite covers this. It went from 33% and 71% across two pre-fix runs to **85.7%**, with all five expectations green. The one remaining red is a known harness limit, not a build defect: the harness pins an AI Agent node to a simulated success, so no fixture can make the primary model fail and exercise the fallback at run time. The case is currently `capability_gap` and should flip to `regression` once this merges.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1363

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

